### PR TITLE
feat(chat): presence statuses — manual Away/DND + per-resource render (epic phase 1)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,7 +75,7 @@ The single Show a given resource actually broadcasts, after resolving precedence
 _Avoid_: Computed presence.
 
 **Most-available-wins**:
-The rule a *receiving* client uses to collapse a contact's several resources into one rendered Show: the most available resource wins (Available > Away > Extended Away > Offline). A Do Not Disturb set as a synced Manual status appears on every resource, so it is never masked by a more-available device.
+The rule a *receiving* client uses to collapse a contact's several resources into one rendered Show. Order: Do Not Disturb > Available > Away > Extended Away > Offline — a deliberate Do Not Disturb wins over every other online state, so it is always shown even when another resource is available, and Offline is the floor.
 _Avoid_: Highest priority (priority is the routing concept, not the render rule).
 
 ### In a call

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -4,6 +4,8 @@ Glossary of domain terms used across the Waddle XMPP server and chat client. Thi
 
 ## Presence
 
+### Availability states
+
 **Presence**:
 A user's network availability, broadcast to roster subscribers and reflected into joined rooms. Carries an availability state (the `<show>`), optional free-text status, and a priority. Distinct from *rich status* (mood/activity/tune), which is published separately via PEP.
 _Avoid_: Online/offline (that is only two of the states).
@@ -25,8 +27,8 @@ Online but away from the computer for a longer period. This is the state meant b
 _Avoid_: Long away, gone.
 
 **Do Not Disturb** (`dnd`):
-Online but does not want to be interrupted. Busy.
-_Avoid_: Busy, offline-to-others.
+The `<show>dnd</show>` availability state — online but does not want to be interrupted, broadcast to contacts. Distinct from the *DND schedule* (`urn:waddle:dnd:0`), which silences push notifications on a timetable; this term is only ever the Show.
+_Avoid_: Busy, offline-to-others; and do not conflate with the DND schedule.
 
 **Chat**:
 Online and actively interested in conversing ("free for chat").
@@ -36,14 +38,72 @@ _Avoid_: Active.
 Not connected / no available resource. Sent as an `unavailable` presence.
 _Avoid_: Invisible (invisibility is a separate, unimplemented concept).
 
+### Idle & auto-away
+
 **Idle**:
 How long since the user last interacted, stamped on a presence via XEP-0319 (`urn:xmpp:idle:1`). Orthogonal to the Show — an Away presence may also carry an idle timestamp so others can render "away, idle 20m."
 _Avoid_: Last seen (that is the offline XEP-0012 concept).
 
-**Manual status**:
-A Show the local user deliberately selected. Overrides auto-away.
+**Auto-away**:
+A Show the client sets on the user's behalf from a per-device inactivity timer (Available → Away after ~10 min without interaction or with the tab hidden → Extended Away after ~30 min), stamped with an idle timestamp. Browser clients approximate idle from in-page input and tab visibility only; they cannot see OS-level idle. Auto-away is never synced across devices.
+_Avoid_: Auto-idle.
+
+### Manual control & cross-device sync
+
+**Automatic**:
+The default presence mode: the per-device idle timer governs the Show. The user has not pinned a Manual status.
+_Avoid_: Default presence.
+
+**Manual status** (Manual override):
+A Show the user deliberately selected — Available, Away, or Do Not Disturb. Sticky: it suspends Auto-away on that account until the user resets.
 _Avoid_: Custom presence.
 
-**Auto-away**:
-A Show the client sets on the user's behalf after detected inactivity (Available → Away → Extended Away), stamped with an idle timestamp.
-_Avoid_: Auto-idle.
+**Pinned Available**:
+A Manual status of Available — keeps the user shown as Available against the idle timer. Distinct from Automatic, where the timer would eventually mark them Away.
+_Avoid_: Force online.
+
+**Reset to automatic**:
+The action that clears a Manual status and returns the client to Automatic mode.
+_Avoid_: Clear presence.
+
+**Status preference**:
+The user's current Manual status, stored account-wide in the `urn:waddle:status-preference:0` PEP node (XEP-0223 persistent private storage) so all of the user's resources adopt it and it survives reconnects. Auto-away is *not* part of the preference — it stays per-device.
+_Avoid_: Saved presence.
+
+**Effective Show**:
+The single Show a given resource actually broadcasts, after resolving precedence on that device: Manual status (if set) over the Auto-away computation. The In-call overlay never changes the Effective Show.
+_Avoid_: Computed presence.
+
+**Most-available-wins**:
+The rule a *receiving* client uses to collapse a contact's several resources into one rendered Show: the most available resource wins (Available > Away > Extended Away > Offline). A Do Not Disturb set as a synced Manual status appears on every resource, so it is never masked by a more-available device.
+_Avoid_: Highest priority (priority is the routing concept, not the render rule).
+
+### In a call
+
+**In-call overlay**:
+An orthogonal signal that a user is in a live call, layered *on top of* their Show and never replacing it — a user can be "Available + in a call" or "DND + in a call." Derived automatically from joining a call (1:1 or MUC) and retracted on leave. Pauses Auto-away while active.
+_Avoid_: In-call status, Busy (it is not a Show).
+
+**In-call activity** (roster-facing):
+The XEP-0108 User Activity publication — `<activity><talking><on_the_phone/></talking>` or `<on_video_phone/>` — that tells roster contacts (outside the call room) that the user is in a call.
+_Avoid_: Conflating with the In-call substate below.
+
+**In-call substate** (in-room):
+The `urn:waddle:in-call:0` presence markers (`<hand-raised/>`, `<muted/>`) visible to fellow occupants of a call room. Distinct from the roster-facing In-call activity; it carries call-internal state that no XEP models.
+_Avoid_: Calling it presence-DND or an availability state.
+
+### Notification suppression
+
+**DND schedule** (Quiet hours):
+The user's push-notification suppression policy — a one-shot snooze plus weekly quiet-hours rules — stored in the `urn:waddle:dnd:0` PEP node and evaluated server-side. Distinct from the **Do Not Disturb** Show: the schedule silences pushes on a timetable; the Show tells contacts not to disturb you right now.
+_Avoid_: Calling either one just "DND" without qualifying which.
+
+### Deferred (committed scope, design not yet done)
+
+**Custom status**:
+A free-text status line with an emoji and optional expiry (e.g. "🌴 On vacation, back Monday"). Independent of the Show. Wire carrier not yet decided.
+_Avoid_: Mood (mood is the XEP-0107 concept).
+
+**Out-of-office**:
+An away-message / auto-reply state (Teams-style), separate from availability. Needs message storage and an auto-reply path.
+_Avoid_: Extended Away (that is only a Show, with no message).

--- a/chat/src/components/chat/PresencePicker.vue
+++ b/chat/src/components/chat/PresencePicker.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useStore } from "@nanostores/vue";
+import { Check } from "lucide-vue-next";
+import { $presenceMode, $selfShow, pickPresence } from "@/presence/presence-store";
+import type { ManualStatus } from "@/presence/effective-show";
+
+const mode = useStore($presenceMode);
+const selfShow = useStore($selfShow);
+
+const options: { status: ManualStatus; label: string; dot: string }[] = [
+  { status: "available", label: "Available", dot: "bg-success/75" },
+  { status: "away", label: "Away", dot: "bg-warning/75" },
+  { status: "dnd", label: "Do Not Disturb", dot: "bg-destructive/75" },
+];
+
+const isAutomatic = computed(() => mode.value.kind === "automatic");
+
+function isActive(status: ManualStatus): boolean {
+  return mode.value.kind === "manual" && mode.value.status === status;
+}
+
+const current = computed(() => options.find((o) => o.status === selfShow.value) ?? options[0]!);
+</script>
+
+<template>
+  <div role="radiogroup" aria-label="Set your status" class="flex flex-col gap-0.5">
+    <div class="flex items-center gap-2 px-2.5 py-1">
+      <span class="h-2 w-2 flex-shrink-0 rounded-full" :class="current.dot" aria-hidden="true" />
+      <span class="type-meta text-muted-foreground">
+        {{ current.label }}<template v-if="isAutomatic"> · Automatic</template>
+      </span>
+    </div>
+    <button
+      v-for="opt in options"
+      :key="opt.status"
+      role="radio"
+      type="button"
+      :aria-checked="isActive(opt.status)"
+      class="type-menu-item flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-foreground transition-colors duration-200 hover:bg-muted"
+      @click="pickPresence(opt.status)"
+    >
+      <span class="h-2 w-2 flex-shrink-0 rounded-full" :class="opt.dot" aria-hidden="true" />
+      <span class="flex-1">{{ opt.label }}</span>
+      <Check v-if="isActive(opt.status)" class="h-3.5 w-3.5 flex-shrink-0 text-primary/70" />
+    </button>
+    <button
+      v-if="!isAutomatic"
+      type="button"
+      class="type-menu-item flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-muted-foreground transition-colors duration-200 hover:bg-muted"
+      @click="pickPresence('reset')"
+    >
+      <span class="flex-1">Reset to automatic</span>
+    </button>
+  </div>
+</template>

--- a/chat/src/components/chat/ProfilePanel.vue
+++ b/chat/src/components/chat/ProfilePanel.vue
@@ -2,6 +2,7 @@
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import { Bell, BellOff, ChevronUp, LogOut, Settings, Volume2, VolumeX } from "lucide-vue-next";
 import AppAvatar from "@/components/ui/AppAvatar.vue";
+import PresencePicker from "@/components/chat/PresencePicker.vue";
 import ThemeSwitcher from "@/components/chat/ThemeSwitcher.vue";
 import VersionFooter from "@/components/chat/VersionFooter.vue";
 import type { XmppServerVersion } from "@/shell/version";
@@ -177,6 +178,9 @@ onUnmounted(() => {
         </div>
         <ThemeSwitcher />
       </div>
+      <div class="mt-2 border-t border-border pt-2">
+        <PresencePicker />
+      </div>
       <div class="mt-2 flex flex-col gap-1 border-t border-border pt-2">
         <button
           class="type-menu-item flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-foreground transition-colors duration-200 hover:bg-muted"
@@ -263,6 +267,8 @@ onUnmounted(() => {
         role="menu"
         :aria-label="`${session.username} account menu`"
       >
+        <PresencePicker />
+        <div class="my-1 border-t border-border" aria-hidden="true" />
         <button
           role="menuitem"
           class="type-menu-item flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-foreground transition-colors duration-200 hover:bg-muted"

--- a/chat/src/components/chat/ProfilePanel.vue
+++ b/chat/src/components/chat/ProfilePanel.vue
@@ -264,13 +264,12 @@ onUnmounted(() => {
       <div
         v-if="accountMenuOpen"
         class="z-floating animate-fade-in absolute bottom-full left-0 mb-2 flex w-[var(--chat-account-menu-width)] flex-col gap-1 rounded-lg border border-border bg-popover/95 p-2 text-popover-foreground shadow-xl backdrop-blur-xl"
-        role="menu"
+        role="dialog"
         :aria-label="`${session.username} account menu`"
       >
         <PresencePicker />
         <div class="my-1 border-t border-border" aria-hidden="true" />
         <button
-          role="menuitem"
           class="type-menu-item flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-foreground transition-colors duration-200 hover:bg-muted"
           type="button"
           @click="handleOpenSettings"
@@ -279,10 +278,9 @@ onUnmounted(() => {
           <span>Settings</span>
         </button>
         <button
-          role="menuitemcheckbox"
           class="type-menu-item flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-foreground transition-colors duration-200 hover:bg-muted"
           type="button"
-          :aria-checked="messageSoundsEnabled !== false"
+          :aria-pressed="messageSoundsEnabled !== false"
           @click="handleToggleMessageSounds"
         >
           <Volume2 v-if="messageSoundsEnabled !== false" class="h-3.5 w-3.5 text-primary/70" />
@@ -290,7 +288,6 @@ onUnmounted(() => {
           <span>{{ messageSoundsEnabled !== false ? "Message sounds on" : "Message sounds off" }}</span>
         </button>
         <button
-          role="menuitem"
           class="type-menu-item flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-muted-foreground transition-colors duration-200 hover:bg-muted hover:text-destructive"
           type="button"
           @click="handleLogout"

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1,6 +1,7 @@
 import { withSpan } from "@/lib/telemetry";
 import { inferredFileDisposition } from "@/lib/chat-ui";
 import type { ThreadsSort, ThreadsStatusFilter } from "@/lib/threads-view-filters";
+import type { EffectiveShow } from "@/presence/effective-show";
 import type { MemberSummary, UserSearchResult } from "../chat-types";
 import type { WaddleSession } from "../server-auth";
 import {
@@ -38,7 +39,7 @@ import {
   isInCallReactionForActiveCall,
   receiveInCallReaction,
 } from "@/lib/calls/in-call-reactions";
-import { barePeerJid, fullJidIdentityKey, jidDomain, roomBareJidFor } from "./jid";
+import { barePeerJid, fullJidIdentityKey, jidDomain, resourceOf, roomBareJidFor } from "./jid";
 import type {
   ChatStateEvent,
   ChatStateType,
@@ -3103,6 +3104,8 @@ export class BrowserXmppClient {
     return parsed.filter(({ message }) => !!message.body).map(({ archived, message }) => ({ id: message.id, ...(archived.mam_id ? { archiveId: archived.mam_id } : {}), nick: message.nick, body: message.body, createdAt: message.createdAt, ...(message.threadId ? { threadId: message.threadId } : {}), ...(message.parentThreadId ? { parentThreadId: message.parentThreadId } : {}), peerJid: message.peerJid }));
   }
   async subscribeToPeerPresence(peerJid: string): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await xmpp.subscribe_to_presence?.(barePeerJid(peerJid)); }
+  /** Publish the user's own Show. RFC 6121 §4.7.2.1: Available is the absence of a `<show>`, so it sends no show element. */
+  async setPresence(show: EffectiveShow): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await xmpp.send_presence?.(undefined, show === "available" ? undefined : show); }
   async listRosterContacts(): Promise<RosterContact[]> { const xmpp = await this.requireConnectedXmpp(); const roster = await xmpp.list_roster_contacts?.() as WasmRosterContact[]; return (roster ?? []).map((item) => { const jid = barePeerJid(item.jid); return { jid, name: item.name, username: item.name?.trim() || jid.split("@")[0] || jid, subscription: (item.subscription ?? "none") as RosterContact["subscription"], groups: item.groups ?? [] }; }); }
   async getServerVersion(): Promise<WasmServerVersion | null> { const xmpp = await this.requireConnectedXmpp(); return await xmpp.get_server_version?.() as WasmServerVersion | null; }
   async discoverSpaceChannels(): Promise<any[]> { const xmpp = await this.requireConnectedXmpp(); return discoverChannels(xmpp as WasmClient, this.session.jid); }
@@ -3598,7 +3601,7 @@ export class BrowserXmppClient {
       }
       return;
     }
-    const bare = barePeerJid(from); if (!bare) return; if (presence.presence_type === "subscribe") return; this.presenceUpdateHandler?.({ bareJid: bare, show: mapPresenceShow(presence), ...(presence.status ? { status: presence.status } : {}) });
+    const bare = barePeerJid(from); if (!bare) return; if (presence.presence_type === "subscribe") return; this.presenceUpdateHandler?.({ bareJid: bare, resource: resourceOf(from), show: mapPresenceShow(presence), ...(presence.status ? { status: presence.status } : {}) });
   }
   private handleMessage(message: InboundWasmMessage) {
     const inboxPush = message.inboxPush ?? (message.inbox_push ? inboxEntryFromWasm(message.inbox_push) : undefined);

--- a/chat/src/lib/xmpp/jid.ts
+++ b/chat/src/lib/xmpp/jid.ts
@@ -10,6 +10,12 @@ export function barePeerJid(fullJid: string): string {
   return fullJid.split("/")[0] ?? "";
 }
 
+/** The resource part of a full JID (everything after the first `/`), or `""` for a bare JID. */
+export function resourceOf(fullJid: string): string {
+  const separator = fullJid.indexOf("/");
+  return separator < 0 ? "" : fullJid.slice(separator + 1);
+}
+
 export function fullJidIdentityKey(fullJid?: string | null): string {
   const trimmed = fullJid?.trim() ?? "";
   if (!trimmed) return "";

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -394,6 +394,8 @@ export interface DmReactionEvent {
 
 export interface PresenceUpdateEvent {
   bareJid: string;
+  /** The sending resource (full-JID part after `/`), or `""` if bare. Used to aggregate a contact's devices via most-available-wins. */
+  resource: string;
   show: "available" | "away" | "xa" | "dnd" | "offline";
   status?: string;
 }

--- a/chat/src/presence/effective-show.ts
+++ b/chat/src/presence/effective-show.ts
@@ -16,6 +16,7 @@ export function resolveShow(mode: PresenceMode): EffectiveShow {
 
 export type PresencePick = ManualStatus | "reset";
 
-export function applyPick(_mode: PresenceMode, pick: PresencePick): PresenceMode {
+/** Map a picker choice to the next mode: a status pins manual, `reset` returns to Automatic. */
+export function applyPick(pick: PresencePick): PresenceMode {
   return pick === "reset" ? { kind: "automatic" } : { kind: "manual", status: pick };
 }

--- a/chat/src/presence/effective-show.ts
+++ b/chat/src/presence/effective-show.ts
@@ -1,0 +1,21 @@
+// The outbound "brain": resolves the user's presence mode into the Show
+// to broadcast. Automatic mode lets the (future) idle timer govern;
+// a Manual pick overrides it. See docs/adr/010-presence-statuses.md.
+
+export type ManualStatus = "available" | "away" | "dnd";
+
+export type EffectiveShow = "available" | "away" | "dnd";
+
+export type PresenceMode =
+  | { kind: "automatic" }
+  | { kind: "manual"; status: ManualStatus };
+
+export function resolveShow(mode: PresenceMode): EffectiveShow {
+  return mode.kind === "manual" ? mode.status : "available";
+}
+
+export type PresencePick = ManualStatus | "reset";
+
+export function applyPick(_mode: PresenceMode, pick: PresencePick): PresenceMode {
+  return pick === "reset" ? { kind: "automatic" } : { kind: "manual", status: pick };
+}

--- a/chat/src/presence/most-available.ts
+++ b/chat/src/presence/most-available.ts
@@ -1,0 +1,17 @@
+// Inbound render: collapse a contact's several resource presences into the
+// single Show to render (one dot). Most-available wins. See
+// docs/adr/010-presence-statuses.md.
+
+export type RenderedShow = "available" | "away" | "xa" | "dnd" | "offline";
+
+// Render priority, highest first. A deliberate Do Not Disturb wins over
+// any other online state so an explicit "do not disturb me" is never
+// masked by another resource (ADR-010). Offline is the implicit floor.
+const AVAILABILITY_ORDER: RenderedShow[] = ["dnd", "available", "away", "xa"];
+
+export function mostAvailableShow(shows: RenderedShow[]): RenderedShow {
+  for (const show of AVAILABILITY_ORDER) {
+    if (shows.includes(show)) return show;
+  }
+  return "offline";
+}

--- a/chat/src/presence/presence-registry.ts
+++ b/chat/src/presence/presence-registry.ts
@@ -32,4 +32,13 @@ export class PresenceRegistry {
     if (!resources || resources.size === 0) return "offline";
     return mostAvailableShow([...resources.values()]);
   }
+
+  /**
+   * Forget all tracked presence. Call on logout and on a fresh reconnect:
+   * across a disconnect we may never observe a resource's `unavailable`, so
+   * its entry would otherwise linger and distort the aggregated Show.
+   */
+  clear(): void {
+    this.byBare.clear();
+  }
 }

--- a/chat/src/presence/presence-registry.ts
+++ b/chat/src/presence/presence-registry.ts
@@ -1,0 +1,35 @@
+// Tracks a contact's presence per resource (full JID) and collapses it to
+// the single Show to render, via most-available-wins (ADR-010). Inbound
+// presence is per-resource; this is where several resources of one contact
+// become one dot.
+
+import { mostAvailableShow, type RenderedShow } from "./most-available";
+
+export class PresenceRegistry {
+  private byBare = new Map<string, Map<string, RenderedShow>>();
+
+  /** Record one resource's Show and return the contact's rendered Show. */
+  apply(bareJid: string, resource: string, show: RenderedShow): RenderedShow {
+    const resources = this.byBare.get(bareJid) ?? new Map<string, RenderedShow>();
+    // Offline means that resource is gone — drop it rather than retain a
+    // dead entry. XMPP hands out a fresh resource id per reconnect, so
+    // keeping offline resources would grow this map without bound.
+    if (show === "offline") {
+      resources.delete(resource);
+    } else {
+      resources.set(resource, show);
+    }
+    if (resources.size === 0) {
+      this.byBare.delete(bareJid);
+    } else {
+      this.byBare.set(bareJid, resources);
+    }
+    return this.renderedFor(bareJid);
+  }
+
+  renderedFor(bareJid: string): RenderedShow {
+    const resources = this.byBare.get(bareJid);
+    if (!resources || resources.size === 0) return "offline";
+    return mostAvailableShow([...resources.values()]);
+  }
+}

--- a/chat/src/presence/presence-store.ts
+++ b/chat/src/presence/presence-store.ts
@@ -1,0 +1,18 @@
+// This device's own presence mode, as a nanostore so the account-menu
+// picker can drive it directly without threading props through the shell.
+// In-memory for now — cross-device sync + persistence is Phase 4 (ADR-010).
+
+import { atom, computed } from "nanostores";
+
+import { applyPick, resolveShow, type PresenceMode, type PresencePick } from "./effective-show";
+
+/** The user's chosen presence mode on this device. Defaults to Automatic. */
+export const $presenceMode = atom<PresenceMode>({ kind: "automatic" });
+
+/** The Show this device currently broadcasts, derived from the mode. */
+export const $selfShow = computed($presenceMode, (mode) => resolveShow(mode));
+
+/** Apply a picker choice — Available / Away / Do Not Disturb, or `reset` to Automatic. */
+export function pickPresence(pick: PresencePick): void {
+  $presenceMode.set(applyPick($presenceMode.get(), pick));
+}

--- a/chat/src/presence/presence-store.ts
+++ b/chat/src/presence/presence-store.ts
@@ -16,3 +16,12 @@ export const $selfShow = computed($presenceMode, (mode) => resolveShow(mode));
 export function pickPresence(pick: PresencePick): void {
   $presenceMode.set(applyPick(pick));
 }
+
+/**
+ * Reset to Automatic. Call on logout: this store is module-global, so a
+ * manual Away/DND chosen by one account would otherwise leak to the next
+ * account signing in within the same tab.
+ */
+export function resetPresenceMode(): void {
+  $presenceMode.set({ kind: "automatic" });
+}

--- a/chat/src/presence/presence-store.ts
+++ b/chat/src/presence/presence-store.ts
@@ -14,5 +14,5 @@ export const $selfShow = computed($presenceMode, (mode) => resolveShow(mode));
 
 /** Apply a picker choice — Available / Away / Do Not Disturb, or `reset` to Automatic. */
 export function pickPresence(pick: PresencePick): void {
-  $presenceMode.set(applyPick($presenceMode.get(), pick));
+  $presenceMode.set(applyPick(pick));
 }

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -941,9 +941,6 @@ export function useChatAppController(giphyApiKey: string) {
       dmConversations.updatePresence({ ...event, show: rendered });
       rosterContacts.updatePresence(event.bareJid, rendered);
     });
-    // Broadcast this device's chosen Show on (re)connect so a manually-set
-    // status survives a reconnect.
-    void client.setPresence(resolveShow(presenceMode.value));
     client.setMemberJidHandler((nick, bareJid) => {
       memberJidByNick.value = { ...memberJidByNick.value, [nick]: bareJid };
     });
@@ -990,6 +987,14 @@ export function useChatAppController(giphyApiKey: string) {
       void socialFeed.refresh();
       void stories.refresh();
       void communityEvents.refresh();
+      // Re-broadcast this device's chosen Show on every session-ready. A
+      // fresh reconnect (resume window expired / server restart) starts the
+      // session with no directed presence and the client layer never
+      // auto-sends one, so a manually-set Away/DND would otherwise silently
+      // revert; a resumed session re-sends the same Show idempotently. This
+      // also lands a pick made while disconnected (setPresence then rejects
+      // unqueued) on the next session-ready.
+      void client.setPresence(resolveShow(presenceMode.value));
       // Re-hydrate XEP-0492 notification settings only on *fresh*
       // reconnects. A stream resume is by definition gap-free —
       // any bookmark publish from another tab during the disconnect

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -769,7 +769,10 @@ export function useChatAppController(giphyApiKey: string) {
   const presenceMode = useStore($presenceMode);
   const selfPresenceShow = computed(() => resolveShow(presenceMode.value));
   watch(presenceMode, (mode) => {
-    void xmppClient.value?.setPresence(resolveShow(mode));
+    // A pick while disconnected rejects (setPresence is not queued); swallow
+    // it — the session-ready handler re-broadcasts the current mode on the
+    // next connect. Without the catch this is an unhandled rejection.
+    xmppClient.value?.setPresence(resolveShow(mode)).catch(() => undefined);
   });
   const appUpdate = useServiceWorkerUpdate();
   const version = useDeploymentVersionInfo(xmppClient);
@@ -894,7 +897,12 @@ export function useChatAppController(giphyApiKey: string) {
   });
 
   watch(xmppClient, (client) => {
-    if (!client || !session.value) return;
+    if (!client || !session.value) {
+      // Client torn down (logout) — drop aggregated presence so a later
+      // session never inherits another account's / a stale resource's Show.
+      presenceRegistry.clear();
+      return;
+    }
     client.setDirectMessageHandler((msg) => {
       dmMessaging.onIncomingMessage(msg);
       dmConversations.receiveIncomingDm(msg);
@@ -993,8 +1001,9 @@ export function useChatAppController(giphyApiKey: string) {
       // auto-sends one, so a manually-set Away/DND would otherwise silently
       // revert; a resumed session re-sends the same Show idempotently. This
       // also lands a pick made while disconnected (setPresence then rejects
-      // unqueued) on the next session-ready.
-      void client.setPresence(resolveShow(presenceMode.value));
+      // unqueued) on the next session-ready. Guard the rejection in case the
+      // lifecycle event fires during teardown.
+      client.setPresence(resolveShow(presenceMode.value)).catch(() => undefined);
       // Re-hydrate XEP-0492 notification settings only on *fresh*
       // reconnects. A stream resume is by definition gap-free —
       // any bookmark publish from another tab during the disconnect
@@ -1005,6 +1014,11 @@ export function useChatAppController(giphyApiKey: string) {
       // headlines on `urn:xmpp:bookmarks:1` (deferred follow-up),
       // fresh-only hydrate is the correct cadence.
       if (event.type === "fresh") {
+        // A fresh session may have missed contacts' `unavailable` while we
+        // were gone; drop the stale per-resource map so the fresh presence
+        // probes repopulate it cleanly. A resumed session is gap-free, so
+        // its registry is preserved.
+        presenceRegistry.clear();
         // Belt-and-braces: hydrate already catches lower-layer
         // throws, but call-site .catch defends against any future
         // regression so an unhandled rejection doesn't propagate

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -24,6 +24,9 @@ import {
 } from "@/shell/structure-retry";
 import { useDeploymentVersionInfo } from "@/shell/version";
 import { useXmppRosterContacts } from "@/contacts/roster";
+import { resolveShow } from "@/presence/effective-show";
+import { PresenceRegistry } from "@/presence/presence-registry";
+import { $presenceMode } from "@/presence/presence-store";
 import { matchLocation, navigate, type RouteMatch } from "@/router";
 import { resolveChannelBySlug } from "@/shell/route-helpers";
 import { barePeerJid, jidDomain, parseManagedRoomBareJid, type LiveDmMessage, type RoomActivityEvent } from "@/lib/xmpp-client";
@@ -758,7 +761,16 @@ export function useChatAppController(giphyApiKey: string) {
 
   const notifications = usePushNotifications();
   const messageSound = createBrowserMessageTonePlayer();
-  const selfPresenceShow = ref<"available" | "away" | "xa" | "dnd" | "offline">("available");
+  // Aggregates each contact's resources into one rendered Show
+  // (most-available-wins, ADR-010); inbound presence is per-resource.
+  const presenceRegistry = new PresenceRegistry();
+  // This device's own mode drives the Show we broadcast and the local
+  // DND checks; the picker writes it via the presence store.
+  const presenceMode = useStore($presenceMode);
+  const selfPresenceShow = computed(() => resolveShow(presenceMode.value));
+  watch(presenceMode, (mode) => {
+    void xmppClient.value?.setPresence(resolveShow(mode));
+  });
   const appUpdate = useServiceWorkerUpdate();
   const version = useDeploymentVersionInfo(xmppClient);
   // RFC 363 PR 6: include DM peers in the iterate-and-pull avatar
@@ -923,12 +935,15 @@ export function useChatAppController(giphyApiKey: string) {
       else queueMdsDisplayed(key, displayed);
     });
     client.setPresenceUpdateHandler((event) => {
-      if (barePeerJid(event.bareJid) === barePeerJid(session.value?.jid ?? "")) {
-        selfPresenceShow.value = event.show;
-      }
-      dmConversations.updatePresence(event);
-      rosterContacts.updatePresence(event.bareJid, event.show);
+      // Collapse the contact's resources into one rendered Show before it
+      // reaches the per-bare conversation/roster stores.
+      const rendered = presenceRegistry.apply(event.bareJid, event.resource, event.show);
+      dmConversations.updatePresence({ ...event, show: rendered });
+      rosterContacts.updatePresence(event.bareJid, rendered);
     });
+    // Broadcast this device's chosen Show on (re)connect so a manually-set
+    // status survives a reconnect.
+    void client.setPresence(resolveShow(presenceMode.value));
     client.setMemberJidHandler((nick, bareJid) => {
       memberJidByNick.value = { ...memberJidByNick.value, [nick]: bareJid };
     });

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -26,7 +26,7 @@ import { useDeploymentVersionInfo } from "@/shell/version";
 import { useXmppRosterContacts } from "@/contacts/roster";
 import { resolveShow } from "@/presence/effective-show";
 import { PresenceRegistry } from "@/presence/presence-registry";
-import { $presenceMode } from "@/presence/presence-store";
+import { $presenceMode, resetPresenceMode } from "@/presence/presence-store";
 import { matchLocation, navigate, type RouteMatch } from "@/router";
 import { resolveChannelBySlug } from "@/shell/route-helpers";
 import { barePeerJid, jidDomain, parseManagedRoomBareJid, type LiveDmMessage, type RoomActivityEvent } from "@/lib/xmpp-client";
@@ -2294,6 +2294,11 @@ export function useChatAppController(giphyApiKey: string) {
     // sign-in does not leak the previous account's per-chat modes
     // into UI reads while the fresh `hydrate` is still in flight.
     notifySettings.reset();
+    // Drop the module-global presence mode and the aggregated per-resource
+    // presence so the next account in this tab doesn't inherit a manual
+    // Away/DND or another user's contact presence.
+    resetPresenceMode();
+    presenceRegistry.clear();
     ui.showPinnedPanel.value = false;
     navigate({ id: "home" });
     await connectionStore.logout();

--- a/chat/tests/dm-conversations.test.ts
+++ b/chat/tests/dm-conversations.test.ts
@@ -423,7 +423,7 @@ describe("useDirectMessageConversations", () => {
   test("updatePresence updates conversation presence", async () => {
     const { composable } = makeComposable();
     await composable.openDm("bob@example.com");
-    composable.updatePresence({ bareJid: "bob@example.com", show: "away" });
+    composable.updatePresence({ bareJid: "bob@example.com", resource: "phone", show: "away" });
     expect(composable.conversations.value[0].presenceShow).toBe("away");
   });
 

--- a/chat/tests/effective-show.test.ts
+++ b/chat/tests/effective-show.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import { applyPick, resolveShow, type PresenceMode } from "../src/presence/effective-show";
+
+describe("effective-show: resolveShow", () => {
+  test("automatic mode resolves to available", () => {
+    const mode: PresenceMode = { kind: "automatic" };
+    expect(resolveShow(mode)).toBe("available");
+  });
+
+  test("a manual away pick resolves to away", () => {
+    const mode: PresenceMode = { kind: "manual", status: "away" };
+    expect(resolveShow(mode)).toBe("away");
+  });
+
+  test("a manual do-not-disturb pick resolves to dnd", () => {
+    const mode: PresenceMode = { kind: "manual", status: "dnd" };
+    expect(resolveShow(mode)).toBe("dnd");
+  });
+});
+
+describe("effective-show: applyPick", () => {
+  test("picking a status from automatic yields a sticky manual mode", () => {
+    expect(applyPick({ kind: "automatic" }, "away")).toEqual({
+      kind: "manual",
+      status: "away",
+    });
+  });
+
+  test("reset returns to automatic mode", () => {
+    expect(applyPick({ kind: "manual", status: "away" }, "reset")).toEqual({
+      kind: "automatic",
+    });
+  });
+
+  test("picking available is a pinned manual mode, distinct from automatic", () => {
+    expect(applyPick({ kind: "automatic" }, "available")).toEqual({
+      kind: "manual",
+      status: "available",
+    });
+  });
+});

--- a/chat/tests/effective-show.test.ts
+++ b/chat/tests/effective-show.test.ts
@@ -20,23 +20,15 @@ describe("effective-show: resolveShow", () => {
 });
 
 describe("effective-show: applyPick", () => {
-  test("picking a status from automatic yields a sticky manual mode", () => {
-    expect(applyPick({ kind: "automatic" }, "away")).toEqual({
-      kind: "manual",
-      status: "away",
-    });
+  test("picking a status yields a sticky manual mode", () => {
+    expect(applyPick("away")).toEqual({ kind: "manual", status: "away" });
   });
 
   test("reset returns to automatic mode", () => {
-    expect(applyPick({ kind: "manual", status: "away" }, "reset")).toEqual({
-      kind: "automatic",
-    });
+    expect(applyPick("reset")).toEqual({ kind: "automatic" });
   });
 
   test("picking available is a pinned manual mode, distinct from automatic", () => {
-    expect(applyPick({ kind: "automatic" }, "available")).toEqual({
-      kind: "manual",
-      status: "available",
-    });
+    expect(applyPick("available")).toEqual({ kind: "manual", status: "available" });
   });
 });

--- a/chat/tests/most-available.test.ts
+++ b/chat/tests/most-available.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+import { mostAvailableShow } from "../src/presence/most-available";
+
+describe("most-available: mostAvailableShow", () => {
+  test("available on one resource and offline on another renders available", () => {
+    expect(mostAvailableShow(["available", "offline"])).toBe("available");
+  });
+
+  test("no resources renders offline", () => {
+    expect(mostAvailableShow([])).toBe("offline");
+  });
+
+  test("away beats offline", () => {
+    expect(mostAvailableShow(["away", "offline"])).toBe("away");
+  });
+
+  test("available outranks away", () => {
+    expect(mostAvailableShow(["away", "available"])).toBe("available");
+  });
+
+  test("extended away beats offline but loses to away", () => {
+    expect(mostAvailableShow(["xa", "offline"])).toBe("xa");
+    expect(mostAvailableShow(["away", "xa"])).toBe("away");
+  });
+
+  test("a deliberate do-not-disturb wins over any other online state", () => {
+    expect(mostAvailableShow(["available", "dnd"])).toBe("dnd");
+    expect(mostAvailableShow(["dnd", "away"])).toBe("dnd");
+    expect(mostAvailableShow(["dnd", "offline"])).toBe("dnd");
+  });
+});

--- a/chat/tests/presence-picker.test.ts
+++ b/chat/tests/presence-picker.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { renderVueComponent } from "./helpers/render-vue-sfc";
+import { $presenceMode } from "../src/presence/presence-store";
+
+function render() {
+  return renderVueComponent("../src/components/chat/PresencePicker.vue", {}, import.meta.url);
+}
+
+describe("PresencePicker", () => {
+  afterEach(() => {
+    $presenceMode.set({ kind: "automatic" });
+  });
+
+  test("renders the three pickable statuses as a radiogroup", async () => {
+    const html = await render();
+    expect(html).toContain('role="radiogroup"');
+    expect(html).toContain("Available");
+    expect(html).toContain("Away");
+    expect(html).toContain("Do Not Disturb");
+  });
+
+  test("shows the Automatic hint by default and no reset action", async () => {
+    const html = await render();
+    expect(html).toContain("Automatic");
+    expect(html).not.toContain("Reset to automatic");
+  });
+
+  test("offers Reset to automatic once a manual status is set", async () => {
+    $presenceMode.set({ kind: "manual", status: "dnd" });
+    const html = await render();
+    expect(html).toContain("Reset to automatic");
+    expect(html).toContain('aria-checked="true"');
+  });
+});

--- a/chat/tests/presence-registry.test.ts
+++ b/chat/tests/presence-registry.test.ts
@@ -38,4 +38,13 @@ describe("PresenceRegistry", () => {
     reg.apply("alice@waddle.test", "laptop", "available");
     expect(reg.apply("alice@waddle.test", "laptop", "dnd")).toBe("dnd");
   });
+
+  test("clear forgets all tracked presence", () => {
+    const reg = new PresenceRegistry();
+    reg.apply("alice@waddle.test", "laptop", "available");
+    reg.apply("bob@waddle.test", "phone", "dnd");
+    reg.clear();
+    expect(reg.renderedFor("alice@waddle.test")).toBe("offline");
+    expect(reg.renderedFor("bob@waddle.test")).toBe("offline");
+  });
 });

--- a/chat/tests/presence-registry.test.ts
+++ b/chat/tests/presence-registry.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+
+import { PresenceRegistry } from "../src/presence/presence-registry";
+
+describe("PresenceRegistry", () => {
+  test("a single available resource renders available", () => {
+    const reg = new PresenceRegistry();
+    expect(reg.apply("alice@waddle.test", "laptop", "available")).toBe("available");
+    expect(reg.renderedFor("alice@waddle.test")).toBe("available");
+  });
+
+  test("a contact with no known resources renders offline", () => {
+    const reg = new PresenceRegistry();
+    expect(reg.renderedFor("ghost@waddle.test")).toBe("offline");
+  });
+
+  test("do-not-disturb on one device wins over available on another", () => {
+    const reg = new PresenceRegistry();
+    reg.apply("alice@waddle.test", "laptop", "available");
+    expect(reg.apply("alice@waddle.test", "phone", "dnd")).toBe("dnd");
+  });
+
+  test("a resource going offline stops counting; the rest still shows", () => {
+    const reg = new PresenceRegistry();
+    reg.apply("alice@waddle.test", "laptop", "away");
+    reg.apply("alice@waddle.test", "phone", "available");
+    expect(reg.apply("alice@waddle.test", "phone", "offline")).toBe("away");
+  });
+
+  test("every resource offline renders the contact offline", () => {
+    const reg = new PresenceRegistry();
+    reg.apply("alice@waddle.test", "laptop", "available");
+    expect(reg.apply("alice@waddle.test", "laptop", "offline")).toBe("offline");
+  });
+
+  test("a fresh Show for the same resource replaces the prior one", () => {
+    const reg = new PresenceRegistry();
+    reg.apply("alice@waddle.test", "laptop", "available");
+    expect(reg.apply("alice@waddle.test", "laptop", "dnd")).toBe("dnd");
+  });
+});

--- a/chat/tests/presence-store.test.ts
+++ b/chat/tests/presence-store.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { $presenceMode, pickPresence, resetPresenceMode } from "../src/presence/presence-store";
+
+describe("presence-store", () => {
+  afterEach(() => {
+    $presenceMode.set({ kind: "automatic" });
+  });
+
+  test("pickPresence pins a manual status", () => {
+    pickPresence("dnd");
+    expect($presenceMode.get()).toEqual({ kind: "manual", status: "dnd" });
+  });
+
+  test("pickPresence reset returns to automatic", () => {
+    pickPresence("away");
+    pickPresence("reset");
+    expect($presenceMode.get()).toEqual({ kind: "automatic" });
+  });
+
+  test("resetPresenceMode clears a manual status (logout)", () => {
+    pickPresence("dnd");
+    resetPresenceMode();
+    expect($presenceMode.get()).toEqual({ kind: "automatic" });
+  });
+});

--- a/docs/adr/010-presence-statuses.md
+++ b/docs/adr/010-presence-statuses.md
@@ -149,8 +149,12 @@ What keeps this XMPP-native is fixed by these invariants:
 - **In-call pauses auto-away.** While the overlay is active, the idle
   timer does not downgrade the Effective Show — being in a call is proof
   of presence. Prevents broadcasting "Away + in a call."
-- **Most-available ordering.** Available > Away > Extended Away > Offline.
-  A synced Manual DND shows on every resource, so it is never masked.
+- **Most-available ordering.** Do Not Disturb > Available > Away > Extended
+  Away > Offline. A deliberate Do Not Disturb wins over every other online
+  state, so an explicit "do not disturb" is always shown even when another
+  resource is available — it is never masked. (Once cross-device sync lands
+  in Phase 4 a manual DND is on every resource anyway; until then this rule
+  also resolves the per-device case the same way.)
 - **Manual Available is a pin.** Selecting Available is a sticky Manual
   status that defeats the idle timer; "Reset to automatic" is the only
   way back to Automatic mode. The picker must make Available (pinned) and

--- a/docs/adr/010-presence-statuses.md
+++ b/docs/adr/010-presence-statuses.md
@@ -82,7 +82,9 @@ branch and the rejected alternatives:
   account-wide and persisted; auto-away per-device. vs. *per-device
   ephemeral* vs. *fully account-global*. Per-device manual status is
   self-defeating under most-available-wins (your own active phone masks
-  the DND you set on your laptop). Fully-global is wrong for idle (one
+  the Away you set on your laptop — Away loses to Available; only a
+  deliberate DND is exempt, since it outranks every online state).
+  Fully-global is wrong for idle (one
   idle device should not mark the whole account away). Hybrid is the only
   coherent split: idle is inherently per-device; a deliberate choice is a
   human-level intent that should follow the user.

--- a/docs/adr/010-presence-statuses.md
+++ b/docs/adr/010-presence-statuses.md
@@ -1,0 +1,201 @@
+# ADR-010: Presence Statuses — Availability States, Auto-Away, and the In-Call Overlay
+
+## Status
+
+Proposed
+
+## Date
+
+2026-06-24
+
+## Context
+
+Presence in Waddle is *experienced* as online/offline only, but that is a
+reachability gap, not a data-model gap:
+
+- The server already models the full RFC 6121 Show set —
+  `Available, Away, Xa, Dnd, Chat` (`waddle-xmpp-core/src/presence/mod.rs`)
+  — stores show/status/priority per resource, persists it across
+  XEP-0198 resume, and relays it to roster subscribers and MUC occupants.
+- The client already *renders* away/xa/dnd (green/yellow/red/grey dots in
+  the DM panel, avatar, chat header, profile drawer);
+  `PresenceUpdateEvent.show` is `available | away | xa | dnd | offline`.
+- XEP-0319 idle (`urn:xmpp:idle:1`) is implemented server-side.
+
+What is missing is the ability to *reach* those states:
+
+1. **No outbound presence-publish path.** The client only *receives*
+   presence; self-presence is reactive. Nobody can ever *become* away or
+   dnd, which is why presence feels binary.
+2. **No auto-away.** Idle/visibility is tracked (`shell/window-visibility.ts`)
+   but wired only to notifications, never to presence.
+3. **No manual status picker.**
+4. **"In a call" is not a presence concept.** It exists only as the
+   in-room `urn:waddle:in-call:0` substate (hand-raised/muted) and Muji
+   (XEP-0272) participant tracking. A roster/DM contact outside the call
+   room has no signal that a user is in a call.
+
+Goal: Slack/Teams-parity presence — Away (manual + automatic) and an
+"in a call" indicator — without violating the CLAUDE.md XEP-conformance
+hard rule (prefer conformant XEP shapes; custom `urn:waddle:*` only where
+no XEP shape fits; advertised official namespaces must conform exactly).
+
+Note: a `urn:waddle:dnd:0` node already exists. It is a **push-notification
+suppression schedule** (snooze + weekly quiet-hours), *not* the presence
+`<show>dnd</show>`. The two are disambiguated in `CONTEXT.md`. This ADR is
+about the presence Show; it does not touch the DND schedule.
+
+### Options considered
+
+The design was resolved as a sequence of forks. For each, the chosen
+branch and the rejected alternatives:
+
+- **In-call model.** *Overlay* (orthogonal to the Show, **chosen**) vs.
+  *replacement* Show (Teams-style "In a call" that overrides
+  Available/Away) vs. *auto-DND* (reuse `<show>dnd</show>`). Rejected
+  replacement and auto-DND: both destroy the user's chosen Show and cannot
+  distinguish "I'm on a call" from "I set DND" / "I'm heads-down." Overlay
+  matches the existing Waddle instinct that call state sits *beside*
+  presence, never inside it.
+- **In-call carrier.** *Layered* (**chosen**): XEP-0108 User Activity
+  for the roster-facing overlay **and** `urn:waddle:in-call:0` for the
+  in-room substate. vs. XEP-0108 alone vs. extending
+  `urn:waddle:in-call:0` to roster presence. The hard rule forbids a
+  custom namespace where a XEP shape fits, and XEP-0108
+  `<talking><on_the_phone/>` *is* "in a call" — so the roster overlay must
+  be XEP-0108. The custom namespace is justified only for the substate
+  (hand-raised/muted), which no XEP models.
+- **Auto-away policy.** *Input-timer* (**chosen**) vs. *conservative*
+  (visible+focused is always present) vs. *visibility-only*. Input-timer
+  (Available → Away after ~10 min without interaction or tab hidden →
+  Extended Away after ~30 min) tracks "are they interacting" most
+  closely, accepting that reading-without-moving on the Waddle tab can
+  read as Away. A browser cannot see OS-level idle, so all three are
+  proxies; this one biases toward catching at-desk-but-gone.
+- **Manual-vs-auto precedence.** *Automatic default + sticky manual +
+  Reset* (**chosen**) vs. *sticky Away/DND only, no pin* vs. *manual
+  expires (Teams duration)*. Automatic is the default mode (idle timer
+  governs); any manual pick (Available/Away/DND) is sticky and suspends
+  auto-away until "Reset to automatic." This is the only option that lets
+  a user pin themselves Available against the idle timer.
+- **Cross-device sync.** *Hybrid* (**chosen**): manual status synced
+  account-wide and persisted; auto-away per-device. vs. *per-device
+  ephemeral* vs. *fully account-global*. Per-device manual status is
+  self-defeating under most-available-wins (your own active phone masks
+  the DND you set on your laptop). Fully-global is wrong for idle (one
+  idle device should not mark the whole account away). Hybrid is the only
+  coherent split: idle is inherently per-device; a deliberate choice is a
+  human-level intent that should follow the user.
+
+## Decision
+
+Adopt the overlay-based, XEP-conformant presence model below.
+
+1. **Effective Show precedence (per device):** Manual status (if set)
+   over Auto-away computation. The In-call overlay never changes the
+   Effective Show.
+2. **In-call overlay** is automatic (derived from joining a 1:1 or MUC
+   call, retracted on leave), orthogonal to the Show, and **pauses
+   auto-away** while active.
+3. **Roster-facing in-call** rides **XEP-0108 User Activity**
+   (`on_the_phone` / `on_video_phone`) via PEP; **in-room in-call**
+   stays on `urn:waddle:in-call:0`.
+4. **Auto-away** is the per-device input-timer (Available → Away → Extended
+   Away), stamped with **XEP-0319** `<idle since=…/>`.
+5. **Manual status** is synced account-wide and persisted via a new
+   `urn:waddle:status-preference:0` PEP node (XEP-0223 persistent private
+   storage); every resource adopts it; it survives reconnect. Auto-away is
+   never synced.
+6. **Incoming render** collapses a contact's resources with
+   **most-available-wins**.
+
+### Compliance invariants
+
+What keeps this XMPP-native is fixed by these invariants:
+
+1. **RFC 6121 Show values are used verbatim** — `away`, `xa`, `dnd`,
+   `chat`, plain Available, `unavailable`. No new Show values are minted.
+2. **XEP-0319 idle is byte-conformant** — `urn:xmpp:idle:1`, `since`
+   xs:dateTime; idle is orthogonal to the Show and may ride any presence.
+3. **The roster in-call overlay is byte-conformant XEP-0108** — namespace
+   `http://jabber.org/protocol/activity`, the official `<talking>` /
+   `<on_the_phone>` / `<on_video_phone>` values, published over PEP
+   (XEP-0163). Waddle uses the XEP; it does not fork it.
+4. **`urn:waddle:in-call:0` carries only call-internal substate**
+   (`<hand-raised/>`, `<muted/>`) for which no XEP shape exists. It is
+   never used for the roster-facing "in a call" signal that XEP-0108
+   already covers, and never squats an official namespace.
+5. **`urn:waddle:status-preference:0` is a Waddle-custom preference node,
+   not an official namespace.** It mirrors the established
+   `urn:waddle:dnd:0` transport conventions: owner-only PEP, single item
+   id `current`, `access_model=whitelist`, publisher-must-equal-owner.
+   It stores the user's chosen Show, which is a Waddle UX preference, not
+   a wire presence shape — no XEP defines a "synced chosen presence."
+
+### Sub-decisions
+
+- **Ghost-call cleanup.** The XEP-0108 activity item is account-global and
+  durable, so it must be actively cleared. Belt-and-suspenders: explicit
+  PEP retract on call-leave **and** on graceful disconnect; for hard
+  crashes, the *receiving* client clears a contact's in-call overlay
+  locally when that contact's presence goes `unavailable`. No ghost
+  "in a call" survives.
+- **Activity-node ownership.** In-call is the **sole publisher** of the
+  XEP-0108 activity node for now (there is no user-activity-setting UI).
+  If manual User Activity ever ships, it must save/restore the prior
+  activity around in-call. Documented constraint.
+- **Audio vs video** is carried on the wire (`on_the_phone` vs
+  `on_video_phone`); the UI decides whether to differentiate the icon.
+- **In-call pauses auto-away.** While the overlay is active, the idle
+  timer does not downgrade the Effective Show — being in a call is proof
+  of presence. Prevents broadcasting "Away + in a call."
+- **Most-available ordering.** Available > Away > Extended Away > Offline.
+  A synced Manual DND shows on every resource, so it is never masked.
+- **Manual Available is a pin.** Selecting Available is a sticky Manual
+  status that defeats the idle timer; "Reset to automatic" is the only
+  way back to Automatic mode. The picker must make Available (pinned) and
+  Automatic (timer-governed) legible — e.g. only surface "Reset to
+  automatic" while a Manual status is active.
+- **Presence-DND may suppress own notifications.** When the Effective
+  Show is `dnd`, the client may silence its own banners/sounds (in-scope
+  extra). This is orthogonal to the server-side `urn:waddle:dnd:0`
+  quiet-hours gating; both can suppress, for different reasons.
+
+## Consequences
+
+- **An outbound presence-publish path must be built in the client** — it
+  does not exist today, and it is the enabling primitive for every state
+  here. This is Phase 1's spine.
+- The client gains an **XEP-0108 publish** path (it currently only reads
+  activity) and an **XEP-0223 `status-preference`** publish/subscribe +
+  own-resource apply path.
+- Each Waddle-custom namespace requires a dedicated Rust test suite
+  (CLAUDE.md XEP custom test-suite hard rule): the new
+  `urn:waddle:status-preference:0`, and any expansion of
+  `urn:waddle:in-call:0`.
+- The `:0` version suffix marks both custom nodes as Waddle-experimental;
+  if the XSF later standardizes a synced-presence or call-presence
+  carrier, migration is a bounded re-key.
+
+### Phasing (this is an epic, not a PR)
+
+1. **Manual presence + render.** Outbound presence publish; manual picker
+   (Automatic / Available / Away / Do Not Disturb / Reset to automatic);
+   most-available-wins on the receiving side. Lights up the states that
+   already render.
+2. **Auto-away.** Per-device input-timer + XEP-0319 idle stamp; manual
+   suspends it.
+3. **In-call overlay.** XEP-0108 publish on call lifecycle (1:1 + MUC);
+   receiver render; ghost cleanup; in-call pauses auto-away.
+4. **Cross-device sync.** `urn:waddle:status-preference:0` (XEP-0223);
+   resources adopt and persist the Manual status.
+5. **DND quiets own notifications; Chat surfaced in the picker.**
+
+### Out of scope (committed, design not yet done)
+
+- **Custom status** (emoji + text + expiry) — needs its own design pass to
+  pick a carrier (`<status>` text + a custom/XEP-0107-style emoji+expiry
+  shape). A separate ADR.
+- **Out-of-office** (away message + auto-reply) — a separate epic; needs
+  message storage and an auto-reply path.
+- The DND **schedule** (`urn:waddle:dnd:0`, quiet hours) is unchanged.

--- a/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
@@ -224,11 +224,11 @@ impl WaddleClient {
     pub fn send_presence(&self, status: Option<String>, show: Option<String>) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let stanza = waddle_xmpp_client::messaging::build_presence_stanza(
+            let presence = waddle_xmpp_client::messaging::build_presence_stanza(
                 status.as_deref(),
                 show.as_deref(),
             );
-            send_stanza_command(inner, stanza).await?;
+            send_stanza_command(inner, presence.into()).await?;
             Ok(JsValue::UNDEFINED)
         })
     }

--- a/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
@@ -226,7 +226,8 @@ impl WaddleClient {
         future_to_promise(async move {
             let presence = waddle_xmpp_client::messaging::build_presence_stanza(
                 status.as_deref(),
-                show.as_deref(),
+                show.as_deref()
+                    .and_then(waddle_xmpp_client::messaging::parse_show),
             );
             send_stanza_command(inner, presence.into()).await?;
             Ok(JsValue::UNDEFINED)

--- a/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_rooms.rs
@@ -215,19 +215,20 @@ impl WaddleClient {
         })
     }
 
+    /// Publish the user's own presence (RFC 6121 §4.7). `show` is an RFC
+    /// 6121 `<show>` value (`away` / `xa` / `dnd` / `chat`) or `None` for
+    /// plain Available (the absence of a `<show>`); `status` is the optional
+    /// free-text line. Shares `build_presence_stanza` with the native + FFI
+    /// `send_presence`, so every Waddle client emits byte-identical presence
+    /// including the XEP-0115 caps advertisement.
     pub fn send_presence(&self, status: Option<String>, show: Option<String>) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            let mut builder = Element::builder("presence", NS_CLIENT);
-            if let Some(status) = status.as_deref() {
-                builder =
-                    builder.append(Element::builder("status", NS_CLIENT).append(status).build());
-            }
-            if let Some(show) = show.as_deref() {
-                builder = builder.append(Element::builder("show", NS_CLIENT).append(show).build());
-            }
-            builder = builder.append(waddle_xmpp_client::caps::build_client_caps_element());
-            send_stanza_command(inner, builder.build()).await?;
+            let stanza = waddle_xmpp_client::messaging::build_presence_stanza(
+                status.as_deref(),
+                show.as_deref(),
+            );
+            send_stanza_command(inner, stanza).await?;
             Ok(JsValue::UNDEFINED)
         })
     }

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -43,7 +43,7 @@ pub use parsing::{
     parse_markable_marker_payload, parse_moderation_payload, parse_reaction_payload,
     parse_retraction_payload,
 };
-pub use presence::build_presence_stanza;
+pub use presence::{build_presence_stanza, parse_show};
 pub use types::{
     ChatStatePayload, CorrectionPayload, DisplayedMarkerPayload, ExtensionCapabilityData,
     ExtensionCommandNode, ExtensionDisplayText, ExtensionEnrichmentData, ExtensionEnvelopeData,

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -36,6 +36,7 @@ pub use namespaces::{
     NS_CLIENT, NS_JINGLE_RTP, NS_MESSAGE_CORRECT, NS_MESSAGE_MODERATE, NS_MESSAGE_RETRACT, NS_MUJI,
     NS_REACTIONS, NS_WADDLE_IN_CALL, NS_WADDLE_PIN_V0,
 };
+pub use presence::build_presence_stanza;
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 pub use native::MessagingExt;
 pub use parsing::{

--- a/server/crates/waddle-xmpp-client/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging.rs
@@ -36,7 +36,6 @@ pub use namespaces::{
     NS_CLIENT, NS_JINGLE_RTP, NS_MESSAGE_CORRECT, NS_MESSAGE_MODERATE, NS_MESSAGE_RETRACT, NS_MUJI,
     NS_REACTIONS, NS_WADDLE_IN_CALL, NS_WADDLE_PIN_V0,
 };
-pub use presence::build_presence_stanza;
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 pub use native::MessagingExt;
 pub use parsing::{
@@ -44,6 +43,7 @@ pub use parsing::{
     parse_markable_marker_payload, parse_moderation_payload, parse_reaction_payload,
     parse_retraction_payload,
 };
+pub use presence::build_presence_stanza;
 pub use types::{
     ChatStatePayload, CorrectionPayload, DisplayedMarkerPayload, ExtensionCapabilityData,
     ExtensionCommandNode, ExtensionDisplayText, ExtensionEnrichmentData, ExtensionEnvelopeData,

--- a/server/crates/waddle-xmpp-client/src/messaging/native.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/native.rs
@@ -107,15 +107,8 @@ impl MessagingExt for ClientHandle {
     }
 
     async fn send_presence(&self, status: Option<&str>, show: Option<&str>) -> ClientResult<()> {
-        let mut builder = Element::builder("presence", NS_CLIENT);
-        if let Some(s) = status {
-            builder = builder.append(Element::builder("status", NS_CLIENT).append(s).build());
-        }
-        if let Some(s) = show {
-            builder = builder.append(Element::builder("show", NS_CLIENT).append(s).build());
-        }
-        builder = builder.append(crate::caps::build_client_caps_element());
-        self.send_stanza(builder.build()).await
+        self.send_stanza(super::presence::build_presence_stanza(status, show))
+            .await
     }
 
     async fn send_chat_state(

--- a/server/crates/waddle-xmpp-client/src/messaging/native.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/native.rs
@@ -107,7 +107,10 @@ impl MessagingExt for ClientHandle {
     }
 
     async fn send_presence(&self, status: Option<&str>, show: Option<&str>) -> ClientResult<()> {
-        let presence = super::presence::build_presence_stanza(status, show);
+        let presence = super::presence::build_presence_stanza(
+            status,
+            show.and_then(super::presence::parse_show),
+        );
         self.send_stanza(presence.into()).await
     }
 

--- a/server/crates/waddle-xmpp-client/src/messaging/native.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/native.rs
@@ -107,8 +107,8 @@ impl MessagingExt for ClientHandle {
     }
 
     async fn send_presence(&self, status: Option<&str>, show: Option<&str>) -> ClientResult<()> {
-        self.send_stanza(super::presence::build_presence_stanza(status, show))
-            .await
+        let presence = super::presence::build_presence_stanza(status, show);
+        self.send_stanza(presence.into()).await
     }
 
     async fn send_chat_state(

--- a/server/crates/waddle-xmpp-client/src/messaging/presence.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/presence.rs
@@ -1,4 +1,5 @@
 use minidom::Element;
+use xmpp_parsers::presence::{Presence, Show, Type as PresenceType};
 
 use super::namespaces::*;
 use super::types::*;
@@ -126,25 +127,36 @@ fn muji_content_media(content: &Element) -> impl Iterator<Item = &str> {
         .into_iter()
 }
 
-/// Build the user's own outbound presence (RFC 6121 §4.7). `show` is an
-/// RFC 6121 `<show>` value (`away`, `xa`, `dnd`, `chat`); `None` is plain
-/// Available (no `<show>` child). An optional free-text `<status>` line is
-/// appended when present. Every broadcast presence advertises XEP-0115
-/// caps so contacts can resolve the client's features.
+/// Build the user's own outbound presence (RFC 6121 §4.7) as a typed
+/// [`xmpp_parsers::Presence`]. `show` is an RFC 6121 `<show>` token
+/// (`away` / `xa` / `dnd` / `chat`); an unknown or absent token is plain
+/// Available (no `<show>`, never an invalid one). An optional free-text
+/// `<status>` is set, and the presence advertises XEP-0115 caps.
 ///
-/// Shared by the native [`super::MessagingExt::send_presence`] and the
-/// wasm `send_presence` binding so both emit byte-identical presence
-/// (same child order, same caps advertisement).
-pub fn build_presence_stanza(status: Option<&str>, show: Option<&str>) -> Element {
-    let mut builder = Element::builder("presence", NS_CLIENT);
-    if let Some(status) = status {
-        builder = builder.append(Element::builder("status", NS_CLIENT).append(status).build());
+/// The signature mirrors the server's
+/// `waddle_xmpp_core::presence::subscription::build_available_presence`, so
+/// client and server presence builders stay consistent. Shared by the
+/// native [`super::MessagingExt::send_presence`] and the wasm
+/// `send_presence` binding; the caller serialises to an [`Element`] at the
+/// I/O boundary (`send_stanza`).
+pub fn build_presence_stanza(status: Option<&str>, show: Option<&str>) -> Presence {
+    let mut presence = Presence::new(PresenceType::None);
+    presence.show = show.and_then(|token| match token {
+        "away" => Some(Show::Away),
+        "chat" => Some(Show::Chat),
+        "dnd" => Some(Show::Dnd),
+        "xa" => Some(Show::Xa),
+        _ => None,
+    });
+    if let Some(text) = status {
+        presence
+            .statuses
+            .insert(xmpp_parsers::message::Lang::new(), text.to_string());
     }
-    if let Some(show) = show {
-        builder = builder.append(Element::builder("show", NS_CLIENT).append(show).build());
-    }
-    builder = builder.append(crate::caps::build_client_caps_element());
-    builder.build()
+    presence
+        .payloads
+        .push(crate::caps::build_client_caps_element());
+    presence
 }
 
 #[cfg(test)]
@@ -153,24 +165,18 @@ mod tests {
 
     #[test]
     fn builds_presence_with_show_status_and_caps() {
-        let el = build_presence_stanza(Some("Out for lunch"), Some("away"));
-        assert_eq!(el.name(), "presence");
-        assert!(
-            el.attr("type").is_none(),
-            "an available presence has no type"
-        );
+        let presence = build_presence_stanza(Some("Out for lunch"), Some("away"));
+        assert_eq!(presence.type_, PresenceType::None);
+        assert_eq!(presence.show, Some(Show::Away));
         assert_eq!(
-            el.get_child("show", NS_CLIENT).map(|c| c.text()).as_deref(),
-            Some("away")
-        );
-        assert_eq!(
-            el.get_child("status", NS_CLIENT)
-                .map(|c| c.text())
-                .as_deref(),
+            presence
+                .statuses
+                .get(&xmpp_parsers::message::Lang::new())
+                .map(String::as_str),
             Some("Out for lunch")
         );
         assert!(
-            el.children().any(|c| c.name() == "c"),
+            presence.payloads.iter().any(|p| p.name() == "c"),
             "presence advertises XEP-0115 caps"
         );
     }
@@ -178,14 +184,21 @@ mod tests {
     #[test]
     fn available_presence_omits_show() {
         // RFC 6121 §4.7.2.1: Available is the absence of a <show>.
-        let el = build_presence_stanza(None, None);
-        assert!(el.get_child("show", NS_CLIENT).is_none());
-        assert!(el.get_child("status", NS_CLIENT).is_none());
-        assert!(el.attr("type").is_none());
+        let presence = build_presence_stanza(None, None);
+        assert_eq!(presence.type_, PresenceType::None);
+        assert!(presence.show.is_none());
+        assert!(presence.statuses.is_empty());
         assert!(
-            el.children().any(|c| c.name() == "c"),
+            presence.payloads.iter().any(|p| p.name() == "c"),
             "even bare Available advertises caps"
         );
+    }
+
+    #[test]
+    fn unknown_show_token_degrades_to_available() {
+        // A bogus token must never produce an RFC-invalid `<show>`.
+        let presence = build_presence_stanza(None, Some("bogus"));
+        assert!(presence.show.is_none());
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/messaging/presence.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/presence.rs
@@ -155,13 +155,18 @@ mod tests {
     fn builds_presence_with_show_status_and_caps() {
         let el = build_presence_stanza(Some("Out for lunch"), Some("away"));
         assert_eq!(el.name(), "presence");
-        assert!(el.attr("type").is_none(), "an available presence has no type");
+        assert!(
+            el.attr("type").is_none(),
+            "an available presence has no type"
+        );
         assert_eq!(
             el.get_child("show", NS_CLIENT).map(|c| c.text()).as_deref(),
             Some("away")
         );
         assert_eq!(
-            el.get_child("status", NS_CLIENT).map(|c| c.text()).as_deref(),
+            el.get_child("status", NS_CLIENT)
+                .map(|c| c.text())
+                .as_deref(),
             Some("Out for lunch")
         );
         assert!(

--- a/server/crates/waddle-xmpp-client/src/messaging/presence.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/presence.rs
@@ -127,27 +127,35 @@ fn muji_content_media(content: &Element) -> impl Iterator<Item = &str> {
         .into_iter()
 }
 
-/// Build the user's own outbound presence (RFC 6121 §4.7) as a typed
-/// [`xmpp_parsers::Presence`]. `show` is an RFC 6121 `<show>` token
-/// (`away` / `xa` / `dnd` / `chat`); an unknown or absent token is plain
-/// Available (no `<show>`, never an invalid one). An optional free-text
-/// `<status>` is set, and the presence advertises XEP-0115 caps.
-///
-/// The signature mirrors the server's
-/// `waddle_xmpp_core::presence::subscription::build_available_presence`, so
-/// client and server presence builders stay consistent. Shared by the
-/// native [`super::MessagingExt::send_presence`] and the wasm
-/// `send_presence` binding; the caller serialises to an [`Element`] at the
-/// I/O boundary (`send_stanza`).
-pub fn build_presence_stanza(status: Option<&str>, show: Option<&str>) -> Presence {
-    let mut presence = Presence::new(PresenceType::None);
-    presence.show = show.and_then(|token| match token {
+/// Parse an RFC 6121 `<show>` token into the typed [`Show`]. This is the
+/// single point where the untyped wire / JS token becomes typed; the native
+/// and wasm `send_presence` boundaries convert their `&str` / `String` here
+/// before handing a typed `Option<Show>` to [`build_presence_stanza`]. An
+/// unknown token yields `None` (plain Available) so an invalid value never
+/// reaches the wire.
+pub fn parse_show(token: &str) -> Option<Show> {
+    match token {
         "away" => Some(Show::Away),
         "chat" => Some(Show::Chat),
         "dnd" => Some(Show::Dnd),
         "xa" => Some(Show::Xa),
         _ => None,
-    });
+    }
+}
+
+/// Build the user's own outbound presence (RFC 6121 §4.7) as a typed
+/// [`xmpp_parsers::Presence`]. `show` is the typed availability state (or
+/// `None` for plain Available); `status` is an optional free-text `<status>`
+/// line. The presence advertises XEP-0115 caps.
+///
+/// Protocol data stays typed at this boundary (per the CLAUDE.md
+/// typed-payloads rule): `show` is `Option<Show>`, not a raw token. Shared
+/// by the native [`super::MessagingExt::send_presence`] and the wasm
+/// `send_presence` binding; the caller serialises to an [`Element`] at the
+/// I/O boundary (`send_stanza`).
+pub fn build_presence_stanza(status: Option<&str>, show: Option<Show>) -> Presence {
+    let mut presence = Presence::new(PresenceType::None);
+    presence.show = show;
     if let Some(text) = status {
         presence
             .statuses
@@ -165,7 +173,7 @@ mod tests {
 
     #[test]
     fn builds_presence_with_show_status_and_caps() {
-        let presence = build_presence_stanza(Some("Out for lunch"), Some("away"));
+        let presence = build_presence_stanza(Some("Out for lunch"), Some(Show::Away));
         assert_eq!(presence.type_, PresenceType::None);
         assert_eq!(presence.show, Some(Show::Away));
         assert_eq!(
@@ -195,10 +203,14 @@ mod tests {
     }
 
     #[test]
-    fn unknown_show_token_degrades_to_available() {
-        // A bogus token must never produce an RFC-invalid `<show>`.
-        let presence = build_presence_stanza(None, Some("bogus"));
-        assert!(presence.show.is_none());
+    fn parse_show_maps_rfc6121_tokens_and_rejects_others() {
+        assert_eq!(parse_show("away"), Some(Show::Away));
+        assert_eq!(parse_show("chat"), Some(Show::Chat));
+        assert_eq!(parse_show("dnd"), Some(Show::Dnd));
+        assert_eq!(parse_show("xa"), Some(Show::Xa));
+        // A bogus token degrades to Available so it never reaches the wire.
+        assert_eq!(parse_show("bogus"), None);
+        assert_eq!(parse_show(""), None);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/messaging/presence.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/presence.rs
@@ -126,9 +126,62 @@ fn muji_content_media(content: &Element) -> impl Iterator<Item = &str> {
         .into_iter()
 }
 
+/// Build the user's own outbound presence (RFC 6121 §4.7). `show` is an
+/// RFC 6121 `<show>` value (`away`, `xa`, `dnd`, `chat`); `None` is plain
+/// Available (no `<show>` child). An optional free-text `<status>` line is
+/// appended when present. Every broadcast presence advertises XEP-0115
+/// caps so contacts can resolve the client's features.
+///
+/// Shared by the native [`super::MessagingExt::send_presence`] and the
+/// wasm `send_presence` binding so both emit byte-identical presence
+/// (same child order, same caps advertisement).
+pub fn build_presence_stanza(status: Option<&str>, show: Option<&str>) -> Element {
+    let mut builder = Element::builder("presence", NS_CLIENT);
+    if let Some(status) = status {
+        builder = builder.append(Element::builder("status", NS_CLIENT).append(status).build());
+    }
+    if let Some(show) = show {
+        builder = builder.append(Element::builder("show", NS_CLIENT).append(show).build());
+    }
+    builder = builder.append(crate::caps::build_client_caps_element());
+    builder.build()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn builds_presence_with_show_status_and_caps() {
+        let el = build_presence_stanza(Some("Out for lunch"), Some("away"));
+        assert_eq!(el.name(), "presence");
+        assert!(el.attr("type").is_none(), "an available presence has no type");
+        assert_eq!(
+            el.get_child("show", NS_CLIENT).map(|c| c.text()).as_deref(),
+            Some("away")
+        );
+        assert_eq!(
+            el.get_child("status", NS_CLIENT).map(|c| c.text()).as_deref(),
+            Some("Out for lunch")
+        );
+        assert!(
+            el.children().any(|c| c.name() == "c"),
+            "presence advertises XEP-0115 caps"
+        );
+    }
+
+    #[test]
+    fn available_presence_omits_show() {
+        // RFC 6121 §4.7.2.1: Available is the absence of a <show>.
+        let el = build_presence_stanza(None, None);
+        assert!(el.get_child("show", NS_CLIENT).is_none());
+        assert!(el.get_child("status", NS_CLIENT).is_none());
+        assert!(el.attr("type").is_none());
+        assert!(
+            el.children().any(|c| c.name() == "c"),
+            "even bare Available advertises caps"
+        );
+    }
 
     #[test]
     fn parses_muji_active_with_content() {


### PR DESCRIPTION
## Presence statuses — Slack/Teams parity (epic · Phase 1)

Today presence is *experienced* as online/offline only, even though the
server already models the full RFC 6121 Show set and the client renders
away/xa/dnd. The real gap was reachability: **the browser client had no way
to set its own Show**, no auto-away, no manual picker, and "in a call" was
not a presence concept.

Design resolved in a grilling session and captured in
**`docs/adr/010-presence-statuses.md`** (+ glossary in `CONTEXT.md`).

### What ships in this PR (Phase 1 — manual presence + render)

**Outbound — set your own status**
- A status picker in the account menu (`PresencePicker.vue`): Available /
  Away / Do Not Disturb / Reset to automatic, wired through the
  `effective-show` state machine (Automatic default; a manual pick is
  sticky and suspends auto-away; Reset returns to Automatic; pinned
  Available is its own mode).
- `client.setPresence(show)` over the existing wasm `send_presence`
  binding. Available sends **no** `<show>` (RFC 6121 §4.7.2.1).
- The controller derives the local Show from the mode and broadcasts it on
  every session-ready (so a manual Away/DND survives a fresh reconnect).

**Inbound — render contacts correctly across devices**
- `PresenceUpdateEvent` now carries the sending resource; a
  `PresenceRegistry` collapses a contact's resources into one Show via
  **most-available-wins** (`dnd > available > away > xa > offline` — a
  deliberate Do Not Disturb is always shown). Aggregation happens in the
  controller's presence handler, so the conversation/roster stores are
  unchanged.

**Server**
- Extracted a shared `build_presence_stanza` (status + show + XEP-0115
  caps) so native, FFI, and wasm emit byte-identical presence. Deduped two
  inline copies. Unit-tested.

### Conformance

All wire shapes are RFC 6121 / XEP-0319 / XEP-0108 / XEP-0223 conformant
(see ADR-010 "Compliance invariants"). No new `urn:waddle:*` namespace in
this phase. No out-of-band APIs.

### Tests / gates

- New TDD suites: `effective-show`, `most-available`, `presence-registry`,
  `presence-picker` (chat) + `build_presence_stanza` unit tests (Rust).
  Full chat suite green (the one failing `startup-loading` test is the
  known build-order spurious failure).
- `knip` clean; `astro check` clean (pre-existing `cloudflare:workers`
  ambient error only); `clippy -D warnings` clean (native + wasm).
- Reviewed by three adversarial passes (XEP/wire, TS/Vue, architecture) +
  a confirmation pass; all findings fixed (ARIA menu nesting, dead param,
  doc wording, presence-on-fresh-reconnect).

### Phased plan (tracked in ADR-010)

- [x] **Phase 1 — Manual presence + render (this PR).**
- [ ] Phase 2 — Auto-away (per-device input-timer + XEP-0319 idle).
- [ ] Phase 3 — In-call overlay (XEP-0108 publish on call lifecycle +
      receiver render + ghost cleanup; in-call pauses auto-away).
- [ ] Phase 4 — Cross-device manual-status sync (XEP-0223
      `urn:waddle:status-preference:0`); persistence.
- [ ] Phase 5 — DND quiets own notifications; surface Chat in the picker.

Deferred to their own epics: custom status (emoji+text+expiry),
out-of-office / auto-reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
