### PR TITLE
feat(chat): cross-device manual-status sync — XEP-0223 (presence epic phase 4)

### DIFF
--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -181,6 +181,10 @@ import type {
 } from "./wasm-types";
 import type { VCard4Profile } from "./vcard4-types";
 import { escapeXml } from "./extension-commands/xml";
+// Type-only: the status-preference wire shape (`{ mode, status? }`). The
+// PresenceMode <-> wire mapping lives in the presence layer; this wrapper just
+// carries the wire shape across the wasm boundary.
+import type { StatusPreferenceWire } from "@/presence/status-preference";
 
 export { dmMessageFromArchived, roomMessageFromArchived } from "./wasm-message-codecs";
 
@@ -660,6 +664,10 @@ type XmppClientInstance = Partial<WasmClient> & CompatEmitter & {
   set_on_session_lifecycle?: (cb: (event: string) => void) => void;
   set_on_mds_displayed?: (cb: (entry: WasmMdsDisplayedEntry) => void) => void;
   set_on_pubsub_event?: (cb: (event: WasmPubsubEvent) => void) => void;
+  status_preference_publish?: (
+    input: StatusPreferenceWire,
+  ) => Promise<StatusPreferenceWire | null>;
+  status_preference_fetch?: () => Promise<StatusPreferenceWire | null>;
   send_in_call_reaction?: (to: string, type: "chat" | "groupchat", sid: string, emoji: string) => Promise<void>;
   get_resume_state?: () => XmppResumeState | null;
   get_resume_state_handle?: () => XmppResumeStateHandle | undefined;
@@ -2719,6 +2727,28 @@ export class BrowserXmppClient {
       storyReadsToWasm(reads),
     )) as WasmStoryReads | undefined;
     return storyReadsFromWasm(result);
+  }
+
+  /**
+   * Publish the user's picked presence mode to their private
+   * `urn:waddle:status-preference:0` PEP node (ADR-010 Phase 4), so it
+   * syncs to their other devices. Reset publishes `mode='automatic'`
+   * rather than retracting (the node never fans out retracts).
+   */
+  async publishStatusPreference(pref: StatusPreferenceWire): Promise<void> {
+    const xmpp = await this.requireConnectedXmpp();
+    await xmpp.status_preference_publish?.(pref);
+  }
+
+  /**
+   * Fetch the user's stored status preference from their own PEP node,
+   * or `null` when nothing is stored. The preference is non-critical:
+   * any failure resolves to `null` (the chat layer then keeps the
+   * device's current mode).
+   */
+  async fetchStatusPreference(): Promise<StatusPreferenceWire | null> {
+    const xmpp = await this.requireConnectedXmpp();
+    return (await xmpp.status_preference_fetch?.()) ?? null;
   }
 
   /**

--- a/chat/src/presence/status-preference-coordinator.ts
+++ b/chat/src/presence/status-preference-coordinator.ts
@@ -1,0 +1,120 @@
+// Sole publisher of the user's status-preference PEP node (ADR-010 Phase 4).
+// The node holds one item (`current`); this device's picked `PresenceMode` is
+// the intent, and the coordinator keeps the node in sync with it while avoiding
+// the obvious failure modes of two-way sync:
+//
+//   - Echo loop: adopting a pick that arrived from another resource must NOT
+//     re-publish it (or two devices ping-pong forever). `applyRemote` seeds the
+//     baseline before writing the store so the store-driven reconcile no-ops.
+//   - Fresh-login clobber: a new device defaults to Automatic; it must adopt
+//     the server's stored pick rather than publish its default over a peer's
+//     manual status. `syncOnConnect` fetches and adopts unless this device has
+//     an unpublished local pick.
+//   - Logout clobber: signing out is local-only (a manual status must follow
+//     the user to their other devices), so `suspend` stops the logout-time
+//     reset from publishing Automatic.
+//
+// Diff-driven like ActivityCoordinator: writes report whether they reached the
+// wire, so a pick made while disconnected is retried on the next reconcile.
+
+import type { PresenceMode } from "./effective-show";
+
+/** Structural equality for two presence modes (null = "unknown baseline"). */
+export function sameMode(a: PresenceMode | null, b: PresenceMode | null): boolean {
+  if (a === null || b === null) return a === b;
+  if (a.kind !== b.kind) return false;
+  return a.kind === "manual" && b.kind === "manual" ? a.status === b.status : true;
+}
+
+export interface StatusPreferenceCoordinatorDeps {
+  /** Publish the mode to the PEP node; returns whether it reached the wire. */
+  publish: (mode: PresenceMode) => boolean;
+  /** This device's current picked mode (reads `$presenceMode`). */
+  mode: () => PresenceMode;
+  /** Adopt a mode locally (writes `$presenceMode`). */
+  setMode: (mode: PresenceMode) => void;
+}
+
+export class StatusPreferenceCoordinator {
+  /** Last mode we know is on the wire; `null` until the first sync/publish. */
+  private lastPublished: PresenceMode | null = null;
+  private suspended = false;
+
+  constructor(private readonly deps: StatusPreferenceCoordinatorDeps) {}
+
+  /**
+   * Publish the current mode if it differs from the wire baseline. Idempotent;
+   * only advances the baseline when the write was actually sent, so a pick made
+   * while disconnected is retried on the next reconcile (session-ready).
+   */
+  reconcile(): void {
+    if (this.suspended) return;
+    const desired = this.deps.mode();
+    if (this.lastPublished !== null && sameMode(desired, this.lastPublished)) return;
+    if (this.deps.publish(desired)) this.lastPublished = desired;
+  }
+
+  /**
+   * Adopt a mode that arrived from another of the user's resources, WITHOUT
+   * re-publishing it. The baseline is seeded first so the store write's
+   * reconcile is a no-op — otherwise the two devices would echo forever.
+   */
+  applyRemote(mode: PresenceMode): void {
+    this.lastPublished = mode;
+    this.deps.setMode(mode);
+  }
+
+  /** True when this device holds a pick that has not reached the wire yet. */
+  hasPendingLocalPick(): boolean {
+    return this.lastPublished !== null && !sameMode(this.deps.mode(), this.lastPublished);
+  }
+
+  /**
+   * Reconcile the local state against the node on (re)connect. An unpublished
+   * local pick (e.g. chosen while disconnected) wins and is published;
+   * otherwise the server's stored preference is adopted — a fresh device thus
+   * inherits the user's pick rather than overwriting it with its default.
+   */
+  async syncOnConnect(fetch: () => Promise<PresenceMode | null>): Promise<void> {
+    this.resume();
+    if (this.hasPendingLocalPick()) {
+      this.reconcile();
+      return;
+    }
+    this.hydrate(await fetch());
+  }
+
+  /**
+   * Apply a fetched preference. A stored pick is adopted. When nothing is
+   * stored, a deliberate local manual pick is published, but the default
+   * Automatic is treated as already-synced — publishing it would clobber a
+   * peer's stored manual status on the peer's own next connect.
+   */
+  hydrate(fetched: PresenceMode | null): void {
+    if (fetched) {
+      this.applyRemote(fetched);
+      return;
+    }
+    if (this.deps.mode().kind === "manual") {
+      this.lastPublished = null;
+      this.reconcile();
+    } else {
+      this.lastPublished = { kind: "automatic" };
+    }
+  }
+
+  /**
+   * Stop publishing and forget the baseline (logout). Signing out is local; the
+   * cross-device preference must persist, so the local reset-to-Automatic that
+   * follows must not publish. The next session re-syncs from a clean baseline.
+   */
+  suspend(): void {
+    this.suspended = true;
+    this.lastPublished = null;
+  }
+
+  /** Re-enable publishing (called on session-ready before fetch/hydrate). */
+  resume(): void {
+    this.suspended = false;
+  }
+}

--- a/chat/src/presence/status-preference-coordinator.ts
+++ b/chat/src/presence/status-preference-coordinator.ts
@@ -72,6 +72,13 @@ export class StatusPreferenceCoordinator {
       this.publishing = false;
     }
     if (!sent) return; // baseline unchanged → retried on the next trigger
+    // `suspend()` (logout) may have fired while the publish was in flight,
+    // zeroing the baseline so the reset-to-Automatic that follows never
+    // publishes. Re-advancing it here would resurrect the pre-logout pick and,
+    // on the next login, `hasPendingLocalPick` would publish Automatic over it —
+    // clobbering the synced preference for every device. Leave the baseline as
+    // suspend left it.
+    if (this.suspended) return;
     this.lastPublished = desired;
     // A pick made while the publish was in flight needs another pass to
     // converge. Only recurse on success, so a persistent failure can't loop.

--- a/chat/src/presence/status-preference-coordinator.ts
+++ b/chat/src/presence/status-preference-coordinator.ts
@@ -21,6 +21,13 @@
 // the wire: `publish` resolves `true` iff the IQ was sent, and `reconcile`
 // awaits it. A publish that fails (disconnected, session not ready, server
 // error) leaves the baseline untouched so the next reconcile retries.
+//
+// Because publishing is async, the baseline can be changed *while a publish is
+// in flight*. An `epoch` counter disowns a publish whose baseline was moved
+// under it (by `suspend` or `applyRemote`), so its late success can neither
+// echo an adopted remote pick nor resurrect a pre-logout one. A trigger that
+// fires mid-publish is coalesced (`rerunRequested`) rather than dropped, so a
+// pick made during a publish is honored even if that publish then fails.
 
 import type { PresenceMode } from "./effective-show";
 
@@ -50,47 +57,76 @@ export class StatusPreferenceCoordinator {
   private suspended = false;
   /** Guards against overlapping publishes (an async publish is in flight). */
   private publishing = false;
+  /** A reconcile trigger that arrived mid-publish, to be honored once on settle. */
+  private rerunRequested = false;
+  /**
+   * Bumped whenever the baseline is changed out from under an in-flight publish
+   * — by logout (`suspend`) or by adopting a remote pick (`applyRemote`). A
+   * publish that resolves after the epoch moved no longer owns the baseline and
+   * must not advance it (which would echo an adopted pick or resurrect a
+   * pre-logout one). Robust to a `resume()` that flips `suspended` back.
+   */
+  private epoch = 0;
 
   constructor(private readonly deps: StatusPreferenceCoordinatorDeps) {}
 
   /**
    * Publish the current mode if it differs from the wire baseline, advancing
    * the baseline only when the publish is confirmed sent. A publish that fails
-   * leaves the baseline untouched, so the next reconcile (a later pick or
-   * session-ready) retries. Overlapping publishes are deduped via `publishing`;
-   * a mode that changed mid-flight triggers one more pass on success.
+   * leaves the baseline untouched, so the next reconcile retries. A trigger
+   * arriving mid-publish is coalesced into one rerun (never dropped), so a pick
+   * made while a publish is in flight is honored even if that publish fails. A
+   * baseline moved mid-flight by `suspend`/`applyRemote` is left untouched.
    */
   async reconcile(): Promise<void> {
-    if (this.suspended || this.publishing) return;
+    if (this.suspended) return;
+    // Coalesce, don't drop: a pick that fires while a publish is in flight must
+    // still be published once the current one settles — including when it fails
+    // (the success-only recursion below would otherwise strand it).
+    if (this.publishing) {
+      this.rerunRequested = true;
+      return;
+    }
     const desired = this.deps.mode();
     if (this.lastPublished !== null && sameMode(desired, this.lastPublished)) return;
     this.publishing = true;
+    const startEpoch = this.epoch;
     let sent = false;
     try {
       sent = await this.deps.publish(desired);
     } finally {
       this.publishing = false;
     }
-    if (!sent) return; // baseline unchanged → retried on the next trigger
-    // `suspend()` (logout) may have fired while the publish was in flight,
-    // zeroing the baseline so the reset-to-Automatic that follows never
-    // publishes. Re-advancing it here would resurrect the pre-logout pick and,
-    // on the next login, `hasPendingLocalPick` would publish Automatic over it —
-    // clobbering the synced preference for every device. Leave the baseline as
-    // suspend left it.
-    if (this.suspended) return;
-    this.lastPublished = desired;
-    // A pick made while the publish was in flight needs another pass to
-    // converge. Only recurse on success, so a persistent failure can't loop.
-    if (!sameMode(this.deps.mode(), this.lastPublished)) await this.reconcile();
+    // The baseline moved under us while the publish was in flight: logout
+    // (`suspend`) zeroed it, or a remote pick was adopted (`applyRemote`).
+    // Advancing it now would resurrect a stale value — re-publishing an adopted
+    // remote pick (echo), or clobbering the synced preference after logout.
+    // Leave the baseline as the newer writer left it.
+    if (this.epoch !== startEpoch) {
+      this.rerunRequested = false;
+      return;
+    }
+    if (sent) this.lastPublished = desired;
+    // Converge once more if a trigger landed during the flight (coalesced
+    // rerun) or a successful publish still trails the current mode. Only a real
+    // external trigger re-arms `rerunRequested`, so a persistent failure retries
+    // the stranded pick exactly once and then waits for the next trigger — no
+    // hot loop.
+    const rerun = this.rerunRequested || (sent && !sameMode(this.deps.mode(), this.lastPublished));
+    this.rerunRequested = false;
+    if (rerun) await this.reconcile();
   }
 
   /**
    * Adopt a mode that arrived from another of the user's resources, WITHOUT
    * re-publishing it. The baseline is seeded first so the store write's
-   * reconcile is a no-op — otherwise the two devices would echo forever.
+   * reconcile is a no-op — otherwise the two devices would echo forever. The
+   * epoch bump disowns any in-flight publish so its late success can't clobber
+   * this adopted baseline back onto the wire.
    */
   applyRemote(mode: PresenceMode): void {
+    if (this.suspended) return; // a post-logout event must not revive the store
+    this.epoch += 1;
     this.lastPublished = mode;
     this.deps.setMode(mode);
   }
@@ -126,6 +162,11 @@ export class StatusPreferenceCoordinator {
     }
     const before = this.deps.mode();
     const fetched = await fetch();
+    // Logout may have raced the fetch (suspend() + reset-to-Automatic ran while
+    // the IQ was in flight). Drop the stored value rather than write it into the
+    // store after the reset — it would otherwise leak the signed-out user's pick
+    // into the next account opened in this tab.
+    if (this.suspended) return;
     // A newer intent may have landed while the fetch was in flight: a local
     // pick (the `$presenceMode` subscriber fired `reconcile()`) or an inbound
     // peer update (`applyRemote`). Either is fresher than the snapshot we just
@@ -151,6 +192,7 @@ export class StatusPreferenceCoordinator {
   suspend(): void {
     this.suspended = true;
     this.lastPublished = null;
+    this.epoch += 1; // disown any in-flight publish so its late success can't re-advance the baseline
   }
 
   /** Re-enable publishing (called on session-ready before fetch/sync). */

--- a/chat/src/presence/status-preference-coordinator.ts
+++ b/chat/src/presence/status-preference-coordinator.ts
@@ -117,7 +117,18 @@ export class StatusPreferenceCoordinator {
       await this.reconcile();
       return;
     }
+    const before = this.deps.mode();
     const fetched = await fetch();
+    // A newer intent may have landed while the fetch was in flight: a local
+    // pick (the `$presenceMode` subscriber fired `reconcile()`) or an inbound
+    // peer update (`applyRemote`). Either is fresher than the snapshot we just
+    // fetched, so adopting `fetched` here would overwrite it. If the mode
+    // changed, reconcile instead — it publishes a local pick and no-ops an
+    // already-applied remote one, never clobbering the newer value.
+    if (!sameMode(before, this.deps.mode())) {
+      await this.reconcile();
+      return;
+    }
     if (fetched) {
       this.applyRemote(fetched);
     } else {

--- a/chat/src/presence/status-preference-coordinator.ts
+++ b/chat/src/presence/status-preference-coordinator.ts
@@ -101,9 +101,14 @@ export class StatusPreferenceCoordinator {
     // (`suspend`) zeroed it, or a remote pick was adopted (`applyRemote`).
     // Advancing it now would resurrect a stale value — re-publishing an adopted
     // remote pick (echo), or clobbering the synced preference after logout.
-    // Leave the baseline as the newer writer left it.
+    // Leave the baseline as the newer writer left it. But a trigger that landed
+    // mid-flight (e.g. a local pick made after the adopted remote) must still
+    // reconcile against the NEW baseline — recursing is safe, it re-reads the
+    // mode and no-ops if it already matches (and bails if suspended).
     if (this.epoch !== startEpoch) {
+      const rerun = this.rerunRequested;
       this.rerunRequested = false;
+      if (rerun) await this.reconcile();
       return;
     }
     if (sent) this.lastPublished = desired;

--- a/chat/src/presence/status-preference-coordinator.ts
+++ b/chat/src/presence/status-preference-coordinator.ts
@@ -9,13 +9,18 @@
 //   - Fresh-login clobber: a new device defaults to Automatic; it must adopt
 //     the server's stored pick rather than publish its default over a peer's
 //     manual status. `syncOnConnect` fetches and adopts unless this device has
-//     an unpublished local pick.
+//     a pending local pick.
+//   - Disconnected-pick loss: a manual pick made before any successful publish
+//     (offline, or before the first session) must win on connect, not be
+//     overwritten by the stale stored value — see `hasPendingLocalPick`.
 //   - Logout clobber: signing out is local-only (a manual status must follow
 //     the user to their other devices), so `suspend` stops the logout-time
 //     reset from publishing Automatic.
 //
-// Diff-driven like ActivityCoordinator: writes report whether they reached the
-// wire, so a pick made while disconnected is retried on the next reconcile.
+// The baseline (`lastPublished`) only advances when a publish actually reaches
+// the wire: `publish` resolves `true` iff the IQ was sent, and `reconcile`
+// awaits it. A publish that fails (disconnected, session not ready, server
+// error) leaves the baseline untouched so the next reconcile retries.
 
 import type { PresenceMode } from "./effective-show";
 
@@ -27,8 +32,12 @@ export function sameMode(a: PresenceMode | null, b: PresenceMode | null): boolea
 }
 
 export interface StatusPreferenceCoordinatorDeps {
-  /** Publish the mode to the PEP node; returns whether it reached the wire. */
-  publish: (mode: PresenceMode) => boolean;
+  /**
+   * Publish the mode to the PEP node. Resolves `true` IFF it reached the wire;
+   * resolves `false` on any failure (disconnected, session not ready, server
+   * error) so the baseline is not advanced and the next reconcile retries.
+   */
+  publish: (mode: PresenceMode) => Promise<boolean>;
   /** This device's current picked mode (reads `$presenceMode`). */
   mode: () => PresenceMode;
   /** Adopt a mode locally (writes `$presenceMode`). */
@@ -36,22 +45,37 @@ export interface StatusPreferenceCoordinatorDeps {
 }
 
 export class StatusPreferenceCoordinator {
-  /** Last mode we know is on the wire; `null` until the first sync/publish. */
+  /** Last mode confirmed on the wire; `null` until the first success/hydrate. */
   private lastPublished: PresenceMode | null = null;
   private suspended = false;
+  /** Guards against overlapping publishes (an async publish is in flight). */
+  private publishing = false;
 
   constructor(private readonly deps: StatusPreferenceCoordinatorDeps) {}
 
   /**
-   * Publish the current mode if it differs from the wire baseline. Idempotent;
-   * only advances the baseline when the write was actually sent, so a pick made
-   * while disconnected is retried on the next reconcile (session-ready).
+   * Publish the current mode if it differs from the wire baseline, advancing
+   * the baseline only when the publish is confirmed sent. A publish that fails
+   * leaves the baseline untouched, so the next reconcile (a later pick or
+   * session-ready) retries. Overlapping publishes are deduped via `publishing`;
+   * a mode that changed mid-flight triggers one more pass on success.
    */
-  reconcile(): void {
-    if (this.suspended) return;
+  async reconcile(): Promise<void> {
+    if (this.suspended || this.publishing) return;
     const desired = this.deps.mode();
     if (this.lastPublished !== null && sameMode(desired, this.lastPublished)) return;
-    if (this.deps.publish(desired)) this.lastPublished = desired;
+    this.publishing = true;
+    let sent = false;
+    try {
+      sent = await this.deps.publish(desired);
+    } finally {
+      this.publishing = false;
+    }
+    if (!sent) return; // baseline unchanged → retried on the next trigger
+    this.lastPublished = desired;
+    // A pick made while the publish was in flight needs another pass to
+    // converge. Only recurse on success, so a persistent failure can't loop.
+    if (!sameMode(this.deps.mode(), this.lastPublished)) await this.reconcile();
   }
 
   /**
@@ -64,42 +88,40 @@ export class StatusPreferenceCoordinator {
     this.deps.setMode(mode);
   }
 
-  /** True when this device holds a pick that has not reached the wire yet. */
+  /**
+   * Whether this device holds a pick that should be published rather than
+   * overwritten by the stored value on connect. With no confirmed baseline yet
+   * (`lastPublished === null`), a deliberate Manual pick counts as pending
+   * intent — so a status chosen while disconnected wins over the stale stored
+   * value — but the default Automatic does not (a fresh device must adopt a
+   * peer's stored pick, not clobber it with its default). With a baseline, any
+   * divergence from it is a pending pick.
+   */
   hasPendingLocalPick(): boolean {
-    return this.lastPublished !== null && !sameMode(this.deps.mode(), this.lastPublished);
+    const mode = this.deps.mode();
+    if (this.lastPublished === null) return mode.kind === "manual";
+    return !sameMode(mode, this.lastPublished);
   }
 
   /**
-   * Reconcile the local state against the node on (re)connect. An unpublished
-   * local pick (e.g. chosen while disconnected) wins and is published;
-   * otherwise the server's stored preference is adopted — a fresh device thus
-   * inherits the user's pick rather than overwriting it with its default.
+   * Reconcile the local state against the node on (re)connect. A pending local
+   * pick (offline pick, or a pick made before the first successful publish)
+   * wins and is published; otherwise the server's stored preference is adopted
+   * — a fresh device thus inherits the user's pick rather than overwriting it
+   * with its default. When nothing is stored and there is no pending pick, the
+   * current (Automatic) state is the synced baseline.
    */
   async syncOnConnect(fetch: () => Promise<PresenceMode | null>): Promise<void> {
     this.resume();
     if (this.hasPendingLocalPick()) {
-      this.reconcile();
+      await this.reconcile();
       return;
     }
-    this.hydrate(await fetch());
-  }
-
-  /**
-   * Apply a fetched preference. A stored pick is adopted. When nothing is
-   * stored, a deliberate local manual pick is published, but the default
-   * Automatic is treated as already-synced — publishing it would clobber a
-   * peer's stored manual status on the peer's own next connect.
-   */
-  hydrate(fetched: PresenceMode | null): void {
+    const fetched = await fetch();
     if (fetched) {
       this.applyRemote(fetched);
-      return;
-    }
-    if (this.deps.mode().kind === "manual") {
-      this.lastPublished = null;
-      this.reconcile();
     } else {
-      this.lastPublished = { kind: "automatic" };
+      this.lastPublished = this.deps.mode();
     }
   }
 
@@ -113,7 +135,7 @@ export class StatusPreferenceCoordinator {
     this.lastPublished = null;
   }
 
-  /** Re-enable publishing (called on session-ready before fetch/hydrate). */
+  /** Re-enable publishing (called on session-ready before fetch/sync). */
   resume(): void {
     this.suspended = false;
   }

--- a/chat/src/presence/status-preference.ts
+++ b/chat/src/presence/status-preference.ts
@@ -1,0 +1,108 @@
+// Wire mapping + inbound half of cross-device manual-status sync (ADR-010
+// Phase 4). The user's picked presence mode is persisted as a single PEP item
+// on their own JID (`urn:waddle:status-preference:0`, XEP-0223). This module
+// maps between the local `PresenceMode` and the wasm/wire form, and resolves an
+// inbound pubsub event into the mode this device should adopt.
+//
+// Split into pure mappers plus a thin DOMParser shell (à la in-call-activity.ts)
+// so the decisions are unit-tested without a real DOM.
+
+import { barePeerJid } from "@/lib/xmpp/jid";
+
+import type { ManualStatus, PresenceMode } from "./effective-show";
+
+const NS_STATUS_PREFERENCE = "urn:waddle:status-preference:0";
+
+/** The PEP node the preference is published to (equal to its namespace). */
+const STATUS_PREFERENCE_PEP_NODE = NS_STATUS_PREFERENCE;
+
+const MANUAL_STATUSES: readonly ManualStatus[] = ["available", "away", "dnd"];
+
+function isManualStatus(value: string | null | undefined): value is ManualStatus {
+  return value != null && (MANUAL_STATUSES as readonly string[]).includes(value);
+}
+
+/** The `{ mode, status? }` shape exchanged with the wasm bridge. */
+export interface StatusPreferenceWire {
+  mode: string;
+  status?: string;
+}
+
+/**
+ * Map a wire `{ mode, status }` to a `PresenceMode`, or `null` when it is not a
+ * recognised shape (unknown mode, missing/invalid status on a manual pick).
+ * Shared by the connect-time fetch and the live receive path.
+ */
+export function presenceModeFromWire(
+  wire: StatusPreferenceWire | null | undefined,
+): PresenceMode | null {
+  if (!wire) return null;
+  if (wire.mode === "automatic") return { kind: "automatic" };
+  if (wire.mode === "manual" && isManualStatus(wire.status)) {
+    return { kind: "manual", status: wire.status };
+  }
+  return null;
+}
+
+/** Map a `PresenceMode` to the wire form for publishing. */
+export function presenceModeToWire(mode: PresenceMode): StatusPreferenceWire {
+  return mode.kind === "manual"
+    ? { mode: "manual", status: mode.status }
+    : { mode: "automatic" };
+}
+
+/** One inbound pubsub item, structural subset of the wasm `WasmPubsubEventItem`. */
+interface StatusPreferencePubsubItem {
+  retracted?: boolean;
+  payload: { kind: string; xml?: string };
+}
+
+/** One inbound pubsub event, structural subset of the wasm `WasmPubsubEvent`. */
+interface StatusPreferencePubsubEvent {
+  from?: string;
+  node: string;
+  items: StatusPreferencePubsubItem[];
+}
+
+/**
+ * Resolve an inbound pubsub event into the `PresenceMode` this device should
+ * adopt, or `null` when it carries no preference signal: a foreign node, no
+ * sender, or a sender that is not our own bare JID. The node is owner-only
+ * (whitelist), so in practice the only `from` we ever see is our own — but we
+ * guard explicitly, since adopting another user's pick would be a takeover.
+ *
+ * The node is single-item (`id = current`); if several items arrive the last
+ * wins. A retraction reads as Automatic — reset normally publishes an explicit
+ * `automatic` item, but a stray retract must not strand a manual status.
+ */
+export function statusPreferenceUpdate(
+  event: StatusPreferencePubsubEvent,
+  selfBareJid: string,
+): PresenceMode | null {
+  if (event.node !== STATUS_PREFERENCE_PEP_NODE || !event.from) return null;
+  if (barePeerJid(event.from) !== barePeerJid(selfBareJid)) return null;
+  let update: PresenceMode | null = null;
+  for (const item of event.items) {
+    if (item.retracted) {
+      update = { kind: "automatic" };
+      continue;
+    }
+    if (item.payload.kind === "opaque" && item.payload.xml !== undefined) {
+      update = parseStatusPreference(item.payload.xml);
+    }
+  }
+  return update;
+}
+
+/** Parse incoming opaque `<status-preference/>` XML into a `PresenceMode`. */
+export function parseStatusPreference(xml: string): PresenceMode | null {
+  if (typeof DOMParser === "undefined") return null;
+  const element = new DOMParser()
+    .parseFromString(xml, "text/xml")
+    .getElementsByTagNameNS(NS_STATUS_PREFERENCE, "status-preference")[0];
+  if (!element) return null;
+  return presenceModeFromWire({
+    mode: element.getAttribute("mode") ?? "",
+    status: element.getAttribute("status") ?? undefined,
+  });
+}

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -30,6 +30,12 @@ import { PresenceRegistry } from "@/presence/presence-registry";
 import { $presenceMode, resetPresenceMode } from "@/presence/presence-store";
 import { activityOverlayUpdate } from "@/presence/in-call-activity";
 import {
+  presenceModeFromWire,
+  presenceModeToWire,
+  statusPreferenceUpdate,
+} from "@/presence/status-preference";
+import { StatusPreferenceCoordinator } from "@/presence/status-preference-coordinator";
+import {
   clearInCallOverlay,
   resetInCallOverlays,
   setInCallOverlay,
@@ -838,6 +844,26 @@ export function useChatAppController(giphyApiKey: string) {
   // Vue watcher would let the refresh race ahead of the publish.
   $callState.subscribe(() => activityCoordinator.reconcile());
   $manualActivity.subscribe(() => activityCoordinator.reconcile());
+  // Cross-device manual-status sync (ADR-010 Phase 4): publish the picked mode
+  // to the private `urn:waddle:status-preference:0` PEP node so it follows the
+  // user across devices and survives reconnects. Auto-away stays per-device and
+  // is NOT synced (it is never written here — only the chosen mode is).
+  const statusPreferenceCoordinator = new StatusPreferenceCoordinator({
+    publish: (mode) => {
+      const client = xmppClient.value;
+      if (!client) return false;
+      client.publishStatusPreference(presenceModeToWire(mode)).catch(() => undefined);
+      return true;
+    },
+    mode: () => $presenceMode.get(),
+    setMode: (mode) => $presenceMode.set(mode),
+  });
+  // Sync subscription (not a Vue `watch`): the baseline seeded by `applyRemote`
+  // must already be in place when this reconcile fires, or an adopted remote
+  // pick would echo back to the wire. `applyRemote` sets the baseline before
+  // writing `$presenceMode`, so this reconcile no-ops for adopted picks and
+  // only publishes genuine local ones.
+  $presenceMode.subscribe(() => statusPreferenceCoordinator.reconcile());
   const appUpdate = useServiceWorkerUpdate();
   const version = useDeploymentVersionInfo(xmppClient);
   // RFC 363 PR 6: include DM peers in the iterate-and-pull avatar
@@ -1035,6 +1061,14 @@ export function useChatAppController(giphyApiKey: string) {
       const update = activityOverlayUpdate(event, session.value?.jid ?? "");
       if (update) setInCallOverlay(update.jid, update.inCall);
     });
+    // Cross-device manual-status sync receive side (ADR-010 Phase 4): a pick
+    // made on another of our resources arrives as an opaque
+    // `<status-preference/>` on our own status-preference node. Adopt it
+    // without re-publishing (the coordinator seeds its baseline first).
+    client.addPubsubEventHandler((event) => {
+      const mode = statusPreferenceUpdate(event, session.value?.jid ?? "");
+      if (mode) statusPreferenceCoordinator.applyRemote(mode);
+    });
     client.setMemberJidHandler((nick, bareJid) => {
       memberJidByNick.value = { ...memberJidByNick.value, [nick]: bareJid };
     });
@@ -1101,6 +1135,18 @@ export function useChatAppController(giphyApiKey: string) {
       // call ended during a stream drop) is retried here, so neither a stale
       // in-call overlay nor a missing manual activity survives a reconnect.
       activityCoordinator.reconcile();
+      // Sync the cross-device manual status (ADR-010 Phase 4). On a *fresh*
+      // session, read the node and adopt the stored pick (unless this device
+      // has an unpublished local pick, which then wins). A *resumed* session is
+      // gap-free, so just flush a pick made while the stream was down rather
+      // than burn an items-get round-trip.
+      if (event.type === "fresh") {
+        void statusPreferenceCoordinator.syncOnConnect(() =>
+          client.fetchStatusPreference().then(presenceModeFromWire),
+        );
+      } else {
+        statusPreferenceCoordinator.reconcile();
+      }
       // Re-hydrate XEP-0492 notification settings only on *fresh*
       // reconnects. A stream resume is by definition gap-free —
       // any bookmark publish from another tab during the disconnect
@@ -2397,7 +2443,11 @@ export function useChatAppController(giphyApiKey: string) {
     notifySettings.reset();
     // Drop the module-global presence mode and the aggregated per-resource
     // presence so the next account in this tab doesn't inherit a manual
-    // Away/DND or another user's contact presence.
+    // Away/DND or another user's contact presence. Suspend the sync coordinator
+    // FIRST: signing out is local-only — the chosen status must persist on the
+    // user's other devices — so the reset-to-Automatic below must not publish
+    // (which would clear the synced preference for every device).
+    statusPreferenceCoordinator.suspend();
     resetPresenceMode();
     presenceRegistry.clear();
     // Graceful disconnect (ADR-010 ghost cleanup): if a call is live the wire

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -1141,9 +1141,9 @@ export function useChatAppController(giphyApiKey: string) {
       // gap-free, so just flush a pick made while the stream was down rather
       // than burn an items-get round-trip.
       if (event.type === "fresh") {
-        void statusPreferenceCoordinator.syncOnConnect(() =>
-          client.fetchStatusPreference().then(presenceModeFromWire),
-        );
+        statusPreferenceCoordinator
+          .syncOnConnect(() => client.fetchStatusPreference().then(presenceModeFromWire))
+          .catch(() => undefined);
       } else {
         statusPreferenceCoordinator.reconcile();
       }

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -849,11 +849,19 @@ export function useChatAppController(giphyApiKey: string) {
   // user across devices and survives reconnects. Auto-away stays per-device and
   // is NOT synced (it is never written here — only the chosen mode is).
   const statusPreferenceCoordinator = new StatusPreferenceCoordinator({
-    publish: (mode) => {
+    // Resolve `true` only when the publish is confirmed on the wire. A
+    // not-yet-ready session makes `publishStatusPreference` reject (via
+    // `requireConnectedXmpp`); returning `false` then keeps the coordinator's
+    // baseline unadvanced so the pick is retried on the next reconcile.
+    publish: async (mode) => {
       const client = xmppClient.value;
       if (!client) return false;
-      client.publishStatusPreference(presenceModeToWire(mode)).catch(() => undefined);
-      return true;
+      try {
+        await client.publishStatusPreference(presenceModeToWire(mode));
+        return true;
+      } catch {
+        return false;
+      }
     },
     mode: () => $presenceMode.get(),
     setMode: (mode) => $presenceMode.set(mode),
@@ -863,7 +871,9 @@ export function useChatAppController(giphyApiKey: string) {
   // pick would echo back to the wire. `applyRemote` sets the baseline before
   // writing `$presenceMode`, so this reconcile no-ops for adopted picks and
   // only publishes genuine local ones.
-  $presenceMode.subscribe(() => statusPreferenceCoordinator.reconcile());
+  $presenceMode.subscribe(() => {
+    statusPreferenceCoordinator.reconcile().catch(() => undefined);
+  });
   const appUpdate = useServiceWorkerUpdate();
   const version = useDeploymentVersionInfo(xmppClient);
   // RFC 363 PR 6: include DM peers in the iterate-and-pull avatar
@@ -1145,7 +1155,7 @@ export function useChatAppController(giphyApiKey: string) {
           .syncOnConnect(() => client.fetchStatusPreference().then(presenceModeFromWire))
           .catch(() => undefined);
       } else {
-        statusPreferenceCoordinator.reconcile();
+        statusPreferenceCoordinator.reconcile().catch(() => undefined);
       }
       // Re-hydrate XEP-0492 notification settings only on *fresh*
       // reconnects. A stream resume is by definition gap-free —

--- a/chat/tests/community-events.test.ts
+++ b/chat/tests/community-events.test.ts
@@ -332,7 +332,11 @@ describe("useCommunityEvents", () => {
   });
 
   test("findMaster recovers the unexpanded master by uid", async () => {
-    const dtstart = Date.parse("2026-06-05T19:00:00Z");
+    // Anchor the series to "now" so the weekly expansion always has upcoming
+    // Fridays to emit — a hardcoded past DTSTART would expand to zero surviving
+    // instances once that date slips behind the run-time clock (expandInstances
+    // drops occurrences whose end is <= Date.now()).
+    const dtstart = Date.now();
     const client = makeClient([
       {
         id: "evt-series",

--- a/chat/tests/status-preference-coordinator.test.ts
+++ b/chat/tests/status-preference-coordinator.test.ts
@@ -141,6 +141,44 @@ describe("StatusPreferenceCoordinator", () => {
     await h.coord.reconcile();
     expect(h.published).toEqual([AWAY]); // automatic was NOT published
   });
+
+  test("suspend racing an in-flight publish does not re-advance the baseline (no next-login clobber)", async () => {
+    // The logout-time `suspend()` lands while a publish is still in flight. When
+    // that publish resolves, the baseline must stay as suspend left it (null) —
+    // otherwise the pre-logout pick is resurrected and the next login publishes
+    // Automatic over the synced preference, clobbering it for every device.
+    let resolveFirst: ((v: boolean) => void) | undefined;
+    const published: PresenceMode[] = [];
+    let mode: PresenceMode = AWAY;
+    let first = true;
+    const coord = new StatusPreferenceCoordinator({
+      publish: (m) => {
+        published.push(m);
+        if (first) {
+          first = false;
+          return new Promise<boolean>((res) => {
+            resolveFirst = res;
+          });
+        }
+        return Promise.resolve(true);
+      },
+      mode: () => mode,
+      setMode: (m) => {
+        mode = m;
+      },
+    });
+    const inFlight = coord.reconcile(); // publishing AWAY (pending)
+    coord.suspend(); // logout fires mid-publish → baseline zeroed
+    mode = AUTO; // logout-time reset-to-Automatic
+    resolveFirst?.(true); // the in-flight AWAY publish now confirms
+    await inFlight;
+    // Next login: the server still holds AWAY (the synced pick). A resurrected
+    // baseline would make `hasPendingLocalPick` publish AUTO over it; a baseline
+    // left null lets the fresh device adopt the stored AWAY and publish nothing.
+    await coord.syncOnConnect(async () => AWAY);
+    expect(mode).toEqual(AWAY); // adopted the stored pick
+    expect(published).toEqual([AWAY]); // only the original publish; no AUTO clobber
+  });
 });
 
 describe("StatusPreferenceCoordinator.hasPendingLocalPick", () => {

--- a/chat/tests/status-preference-coordinator.test.ts
+++ b/chat/tests/status-preference-coordinator.test.ts
@@ -142,6 +142,72 @@ describe("StatusPreferenceCoordinator", () => {
     expect(h.published).toEqual([AWAY]); // automatic was NOT published
   });
 
+  test("a remote pick adopted while a local publish is in flight is not echoed back", async () => {
+    // A peer update lands via applyRemote while this device's own publish is
+    // mid-flight. When the publish resolves the coordinator must NOT overwrite
+    // the adopted baseline and re-publish it — that is the echo applyRemote
+    // exists to prevent.
+    let resolveFirst: ((v: boolean) => void) | undefined;
+    const published: PresenceMode[] = [];
+    let mode: PresenceMode = DND;
+    let first = true;
+    const coord = new StatusPreferenceCoordinator({
+      publish: (m) => {
+        published.push(m);
+        if (first) {
+          first = false;
+          return new Promise<boolean>((res) => {
+            resolveFirst = res;
+          });
+        }
+        return Promise.resolve(true);
+      },
+      mode: () => mode,
+      setMode: (m) => {
+        mode = m;
+      },
+    });
+    const inFlight = coord.reconcile(); // publishing DND (pending)
+    coord.applyRemote(AWAY); // a peer update lands mid-publish
+    resolveFirst?.(true); // the DND publish confirms
+    await inFlight;
+    expect(mode).toEqual(AWAY); // the adopted remote value is kept
+    expect(published).toEqual([DND]); // AWAY is NOT re-published (no echo)
+  });
+
+  test("a pick made while a publish is failing is retried, not stranded", async () => {
+    // The user picks DND while AWAY's publish is in flight; that publish then
+    // FAILS. The mid-flight DND pick must still be retried once the failure
+    // settles — it must not be silently dropped by the in-flight guard.
+    let resolveFirst: ((v: boolean) => void) | undefined;
+    const published: PresenceMode[] = [];
+    let mode: PresenceMode = AWAY;
+    let first = true;
+    const coord = new StatusPreferenceCoordinator({
+      publish: (m) => {
+        published.push(m);
+        if (first) {
+          first = false;
+          return new Promise<boolean>((res) => {
+            resolveFirst = res;
+          });
+        }
+        return Promise.resolve(true);
+      },
+      mode: () => mode,
+      setMode: (m) => {
+        mode = m;
+      },
+    });
+    const inFlight = coord.reconcile(); // publishing AWAY (pending)
+    mode = DND; // user picks DND mid-flight
+    await coord.reconcile(); // coalesced (a publish is in flight) — not dropped
+    resolveFirst?.(false); // the AWAY publish FAILS
+    await inFlight;
+    expect(published).toEqual([AWAY, DND]); // DND is retried after the failure
+    expect(mode).toEqual(DND);
+  });
+
   test("suspend racing an in-flight publish does not re-advance the baseline (no next-login clobber)", async () => {
     // The logout-time `suspend()` lands while a publish is still in flight. When
     // that publish resolves, the baseline must stay as suspend left it (null) —
@@ -279,6 +345,21 @@ describe("StatusPreferenceCoordinator.syncOnConnect", () => {
     });
     expect(h.getMode()).toEqual(DND); // the live update is kept, not overwritten
     expect(h.published).toEqual([]); // applyRemote does not echo
+  });
+
+  test("logout during the connect-time fetch does not leak the stored status into the store", async () => {
+    // A fresh connect begins syncing (fetch in flight) and the user logs out
+    // before it returns: suspend() + reset-to-Automatic run, then the server's
+    // stored AWAY resolves. It must NOT be written into $presenceMode after the
+    // reset, or the next account in this tab inherits the signed-out user's pick.
+    const h = harness(AUTO);
+    await h.coord.syncOnConnect(async () => {
+      h.coord.suspend(); // logout fires mid-fetch
+      h.setMode(AUTO); // resetPresenceMode()
+      return AWAY; // stored value resolves after the logout reset
+    });
+    expect(h.getMode()).toEqual(AUTO); // the stored AWAY is dropped, not adopted
+    expect(h.published).toEqual([]);
   });
 
   test("resume re-enables publishing after a suspend/login cycle", async () => {

--- a/chat/tests/status-preference-coordinator.test.ts
+++ b/chat/tests/status-preference-coordinator.test.ts
@@ -220,6 +220,29 @@ describe("StatusPreferenceCoordinator.syncOnConnect", () => {
     expect(h.published).toEqual([AWAY]); // adopted, not re-published
   });
 
+  test("a local pick made WHILE the fetch is in flight is not clobbered by the stale fetched value", async () => {
+    const h = harness(AUTO);
+    // The fetch resolves the server's stale value, but the user picks DND
+    // before it returns. The pick must win and be published, not be
+    // overwritten by the fetched AWAY.
+    await h.coord.syncOnConnect(async () => {
+      h.setMode(DND); // user picks mid-fetch (the store subscriber would also fire reconcile)
+      return AWAY;
+    });
+    expect(h.getMode()).toEqual(DND);
+    expect(h.published).toEqual([DND]);
+  });
+
+  test("an inbound update arriving WHILE the fetch is in flight wins over the stale fetched value", async () => {
+    const h = harness(AUTO);
+    await h.coord.syncOnConnect(async () => {
+      h.coord.applyRemote(DND); // a live peer update lands mid-fetch
+      return AWAY; // stale snapshot
+    });
+    expect(h.getMode()).toEqual(DND); // the live update is kept, not overwritten
+    expect(h.published).toEqual([]); // applyRemote does not echo
+  });
+
   test("resume re-enables publishing after a suspend/login cycle", async () => {
     const h = harness();
     h.setMode(AWAY);

--- a/chat/tests/status-preference-coordinator.test.ts
+++ b/chat/tests/status-preference-coordinator.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+
+import { sameMode, StatusPreferenceCoordinator } from "../src/presence/status-preference-coordinator";
+import type { PresenceMode } from "../src/presence/effective-show";
+
+const AUTO: PresenceMode = { kind: "automatic" };
+const AWAY: PresenceMode = { kind: "manual", status: "away" };
+const DND: PresenceMode = { kind: "manual", status: "dnd" };
+
+function harness(initial: PresenceMode = AUTO) {
+  let mode = initial;
+  let online = true;
+  const published: PresenceMode[] = [];
+  const coord = new StatusPreferenceCoordinator({
+    publish: (m) => {
+      if (!online) return false;
+      published.push(m);
+      return true;
+    },
+    mode: () => mode,
+    setMode: (m) => {
+      mode = m;
+    },
+  });
+  return {
+    coord,
+    published,
+    getMode: () => mode,
+    setMode: (m: PresenceMode) => {
+      mode = m;
+    },
+    setOnline: (o: boolean) => {
+      online = o;
+    },
+  };
+}
+
+describe("sameMode", () => {
+  test("compares kind and manual status", () => {
+    expect(sameMode(AUTO, AUTO)).toBe(true);
+    expect(sameMode(AWAY, AWAY)).toBe(true);
+    expect(sameMode(AWAY, DND)).toBe(false);
+    expect(sameMode(AUTO, AWAY)).toBe(false);
+    expect(sameMode(null, null)).toBe(true);
+    expect(sameMode(null, AUTO)).toBe(false);
+  });
+});
+
+describe("StatusPreferenceCoordinator", () => {
+  test("a local pick publishes it", () => {
+    const h = harness();
+    h.setMode(AWAY);
+    h.coord.reconcile();
+    expect(h.published).toEqual([AWAY]);
+  });
+
+  test("does not re-publish an unchanged mode", () => {
+    const h = harness();
+    h.setMode(AWAY);
+    h.coord.reconcile();
+    h.coord.reconcile();
+    h.coord.reconcile();
+    expect(h.published).toHaveLength(1);
+  });
+
+  test("applyRemote adopts the mode without re-publishing (no echo loop)", () => {
+    const h = harness();
+    h.coord.applyRemote(DND);
+    expect(h.getMode()).toEqual(DND);
+    h.coord.reconcile(); // the store-write would trigger this in the controller
+    expect(h.published).toEqual([]);
+  });
+
+  test("a pick made while offline is retried and published on the next reconcile", () => {
+    const h = harness();
+    // Establish a baseline first (so this isn't the fresh-login path).
+    h.setMode(AWAY);
+    h.coord.reconcile();
+    expect(h.published).toEqual([AWAY]);
+    // Now go offline and pick DND.
+    h.setOnline(false);
+    h.setMode(DND);
+    h.coord.reconcile(); // attempted, not sent
+    expect(h.published).toEqual([AWAY]);
+    // Reconnect: session-ready reconcile flushes it.
+    h.setOnline(true);
+    h.coord.reconcile();
+    expect(h.published).toEqual([AWAY, DND]);
+  });
+
+  test("suspend stops publishing so a logout reset does not clobber the synced pick", () => {
+    const h = harness();
+    h.setMode(AWAY);
+    h.coord.reconcile();
+    expect(h.published).toEqual([AWAY]);
+    // Logout: suspend, then the local reset-to-automatic fires reconcile.
+    h.coord.suspend();
+    h.setMode(AUTO);
+    h.coord.reconcile();
+    expect(h.published).toEqual([AWAY]); // automatic was NOT published
+  });
+});
+
+describe("StatusPreferenceCoordinator.syncOnConnect", () => {
+  test("fresh login adopts the server's stored pick", async () => {
+    const h = harness(AUTO);
+    await h.coord.syncOnConnect(async () => AWAY);
+    expect(h.getMode()).toEqual(AWAY);
+    expect(h.published).toEqual([]); // adopting must not echo
+  });
+
+  test("fresh login with nothing stored keeps the default and publishes nothing", async () => {
+    const h = harness(AUTO);
+    await h.coord.syncOnConnect(async () => null);
+    expect(h.getMode()).toEqual(AUTO);
+    expect(h.published).toEqual([]);
+  });
+
+  test("a local manual pick before the first connect is published when nothing is stored", async () => {
+    const h = harness(AWAY); // user picked Away before the socket was ready
+    await h.coord.syncOnConnect(async () => null);
+    expect(h.published).toEqual([AWAY]);
+  });
+
+  test("an unpublished local pick wins over the (stale) server value on reconnect", async () => {
+    const h = harness();
+    // Live: publish AWAY (baseline = AWAY).
+    h.setMode(AWAY);
+    h.coord.reconcile();
+    // Offline pick DND (not sent).
+    h.setOnline(false);
+    h.setMode(DND);
+    h.coord.reconcile();
+    h.setOnline(true);
+    // Reconnect: server still holds the stale AWAY, but our pending DND wins.
+    let fetched = false;
+    await h.coord.syncOnConnect(async () => {
+      fetched = true;
+      return AWAY;
+    });
+    expect(fetched).toBe(false); // skipped the fetch; pushed local intent
+    expect(h.published).toEqual([AWAY, DND]);
+    expect(h.getMode()).toEqual(DND);
+  });
+
+  test("a normal reconnect with no local change adopts a peer's update", async () => {
+    const h = harness();
+    h.setMode(AWAY);
+    h.coord.reconcile(); // baseline = AWAY
+    // Another device switched to DND while we were briefly gone.
+    await h.coord.syncOnConnect(async () => DND);
+    expect(h.getMode()).toEqual(DND);
+    expect(h.published).toEqual([AWAY]); // adopted, not re-published
+  });
+
+  test("resume re-enables publishing after a suspend/login cycle", async () => {
+    const h = harness();
+    h.setMode(AWAY);
+    h.coord.reconcile();
+    h.coord.suspend();
+    h.setMode(AUTO); // logout-time reset
+    // New login on the same tab; server has DND from another device.
+    await h.coord.syncOnConnect(async () => DND);
+    expect(h.getMode()).toEqual(DND);
+  });
+});

--- a/chat/tests/status-preference-coordinator.test.ts
+++ b/chat/tests/status-preference-coordinator.test.ts
@@ -10,10 +10,11 @@ const DND: PresenceMode = { kind: "manual", status: "dnd" };
 function harness(initial: PresenceMode = AUTO) {
   let mode = initial;
   let online = true;
+  let failNext = false;
   const published: PresenceMode[] = [];
   const coord = new StatusPreferenceCoordinator({
-    publish: (m) => {
-      if (!online) return false;
+    publish: async (m) => {
+      if (!online || failNext) return false;
       published.push(m);
       return true;
     },
@@ -32,6 +33,9 @@ function harness(initial: PresenceMode = AUTO) {
     setOnline: (o: boolean) => {
       online = o;
     },
+    setFailNext: (f: boolean) => {
+      failNext = f;
+    },
   };
 }
 
@@ -47,57 +51,115 @@ describe("sameMode", () => {
 });
 
 describe("StatusPreferenceCoordinator", () => {
-  test("a local pick publishes it", () => {
+  test("a local pick publishes it", async () => {
     const h = harness();
     h.setMode(AWAY);
-    h.coord.reconcile();
+    await h.coord.reconcile();
     expect(h.published).toEqual([AWAY]);
   });
 
-  test("does not re-publish an unchanged mode", () => {
+  test("does not re-publish an unchanged mode", async () => {
     const h = harness();
     h.setMode(AWAY);
-    h.coord.reconcile();
-    h.coord.reconcile();
-    h.coord.reconcile();
+    await h.coord.reconcile();
+    await h.coord.reconcile();
+    await h.coord.reconcile();
     expect(h.published).toHaveLength(1);
   });
 
-  test("applyRemote adopts the mode without re-publishing (no echo loop)", () => {
+  test("applyRemote adopts the mode without re-publishing (no echo loop)", async () => {
     const h = harness();
     h.coord.applyRemote(DND);
     expect(h.getMode()).toEqual(DND);
-    h.coord.reconcile(); // the store-write would trigger this in the controller
+    await h.coord.reconcile(); // the store-write would trigger this in the controller
     expect(h.published).toEqual([]);
   });
 
-  test("a pick made while offline is retried and published on the next reconcile", () => {
+  test("a publish that fails (offline) does NOT advance the baseline and is retried", async () => {
     const h = harness();
-    // Establish a baseline first (so this isn't the fresh-login path).
     h.setMode(AWAY);
-    h.coord.reconcile();
-    expect(h.published).toEqual([AWAY]);
-    // Now go offline and pick DND.
     h.setOnline(false);
-    h.setMode(DND);
-    h.coord.reconcile(); // attempted, not sent
-    expect(h.published).toEqual([AWAY]);
-    // Reconnect: session-ready reconcile flushes it.
+    await h.coord.reconcile(); // attempted, not sent
+    expect(h.published).toEqual([]);
     h.setOnline(true);
-    h.coord.reconcile();
-    expect(h.published).toEqual([AWAY, DND]);
+    await h.coord.reconcile(); // session-ready self-heal retries
+    expect(h.published).toEqual([AWAY]);
   });
 
-  test("suspend stops publishing so a logout reset does not clobber the synced pick", () => {
+  test("a publish that REJECTS while online (session not ready) is retried, not recorded as sent", async () => {
     const h = harness();
     h.setMode(AWAY);
-    h.coord.reconcile();
+    h.setFailNext(true); // online but the publish rejects/returns false
+    await h.coord.reconcile();
+    expect(h.published).toEqual([]);
+    // The baseline was NOT advanced, so the very next reconcile retries even
+    // though the mode is unchanged — this is the contract the fix guarantees.
+    h.setFailNext(false);
+    await h.coord.reconcile();
     expect(h.published).toEqual([AWAY]);
-    // Logout: suspend, then the local reset-to-automatic fires reconcile.
+  });
+
+  test("a pick made while a publish was in flight converges on success", async () => {
+    // Model an in-flight change: publish AWAY succeeds, but by the time it
+    // resolves the mode is DND; the coordinator must publish DND too.
+    let resolveFirst: ((v: boolean) => void) | undefined;
+    const published: PresenceMode[] = [];
+    let mode: PresenceMode = AWAY;
+    let first = true;
+    const coord = new StatusPreferenceCoordinator({
+      publish: (m) => {
+        published.push(m);
+        if (first) {
+          first = false;
+          return new Promise<boolean>((res) => {
+            resolveFirst = res;
+          });
+        }
+        return Promise.resolve(true);
+      },
+      mode: () => mode,
+      setMode: (m) => {
+        mode = m;
+      },
+    });
+    const inFlight = coord.reconcile(); // starts publishing AWAY (pending)
+    mode = DND; // pick changes mid-flight
+    await coord.reconcile(); // deduped: a publish is in flight, no-op
+    expect(published).toEqual([AWAY]);
+    resolveFirst?.(true); // AWAY confirmed
+    await inFlight; // recurses, publishes DND
+    expect(published).toEqual([AWAY, DND]);
+  });
+
+  test("suspend stops publishing so a logout reset does not clobber the synced pick", async () => {
+    const h = harness();
+    h.setMode(AWAY);
+    await h.coord.reconcile();
+    expect(h.published).toEqual([AWAY]);
     h.coord.suspend();
     h.setMode(AUTO);
-    h.coord.reconcile();
+    await h.coord.reconcile();
     expect(h.published).toEqual([AWAY]); // automatic was NOT published
+  });
+});
+
+describe("StatusPreferenceCoordinator.hasPendingLocalPick", () => {
+  test("a manual pick is pending even with no baseline yet (offline pick)", () => {
+    const h = harness(AWAY);
+    expect(h.coord.hasPendingLocalPick()).toBe(true);
+  });
+
+  test("the default automatic is NOT pending with no baseline (fresh device adopts remote)", () => {
+    const h = harness(AUTO);
+    expect(h.coord.hasPendingLocalPick()).toBe(false);
+  });
+
+  test("once a baseline exists, only a divergence is pending", async () => {
+    const h = harness(AWAY);
+    await h.coord.reconcile(); // baseline = AWAY
+    expect(h.coord.hasPendingLocalPick()).toBe(false);
+    h.setMode(DND);
+    expect(h.coord.hasPendingLocalPick()).toBe(true);
   });
 });
 
@@ -116,29 +178,35 @@ describe("StatusPreferenceCoordinator.syncOnConnect", () => {
     expect(h.published).toEqual([]);
   });
 
-  test("a local manual pick before the first connect is published when nothing is stored", async () => {
-    const h = harness(AWAY); // user picked Away before the socket was ready
-    await h.coord.syncOnConnect(async () => null);
+  test("a manual pick made while disconnected is published, NOT overwritten by the fetched value", async () => {
+    // The user picked Away before the socket was ready (no successful publish,
+    // so lastPublished is null). On connect the server still holds an older
+    // value — but the local pick must win and be published.
+    const h = harness(AWAY);
+    let fetched = false;
+    await h.coord.syncOnConnect(async () => {
+      fetched = true;
+      return DND; // stale stored value that must NOT clobber the local pick
+    });
+    expect(fetched).toBe(false); // local pick is pending → fetch is skipped
+    expect(h.getMode()).toEqual(AWAY);
     expect(h.published).toEqual([AWAY]);
   });
 
   test("an unpublished local pick wins over the (stale) server value on reconnect", async () => {
     const h = harness();
-    // Live: publish AWAY (baseline = AWAY).
     h.setMode(AWAY);
-    h.coord.reconcile();
-    // Offline pick DND (not sent).
+    await h.coord.reconcile(); // baseline = AWAY
     h.setOnline(false);
     h.setMode(DND);
-    h.coord.reconcile();
+    await h.coord.reconcile(); // offline pick, not sent
     h.setOnline(true);
-    // Reconnect: server still holds the stale AWAY, but our pending DND wins.
     let fetched = false;
     await h.coord.syncOnConnect(async () => {
       fetched = true;
       return AWAY;
     });
-    expect(fetched).toBe(false); // skipped the fetch; pushed local intent
+    expect(fetched).toBe(false);
     expect(h.published).toEqual([AWAY, DND]);
     expect(h.getMode()).toEqual(DND);
   });
@@ -146,8 +214,7 @@ describe("StatusPreferenceCoordinator.syncOnConnect", () => {
   test("a normal reconnect with no local change adopts a peer's update", async () => {
     const h = harness();
     h.setMode(AWAY);
-    h.coord.reconcile(); // baseline = AWAY
-    // Another device switched to DND while we were briefly gone.
+    await h.coord.reconcile(); // baseline = AWAY
     await h.coord.syncOnConnect(async () => DND);
     expect(h.getMode()).toEqual(DND);
     expect(h.published).toEqual([AWAY]); // adopted, not re-published
@@ -156,10 +223,9 @@ describe("StatusPreferenceCoordinator.syncOnConnect", () => {
   test("resume re-enables publishing after a suspend/login cycle", async () => {
     const h = harness();
     h.setMode(AWAY);
-    h.coord.reconcile();
+    await h.coord.reconcile();
     h.coord.suspend();
     h.setMode(AUTO); // logout-time reset
-    // New login on the same tab; server has DND from another device.
     await h.coord.syncOnConnect(async () => DND);
     expect(h.getMode()).toEqual(DND);
   });

--- a/chat/tests/status-preference-coordinator.test.ts
+++ b/chat/tests/status-preference-coordinator.test.ts
@@ -4,6 +4,7 @@ import { sameMode, StatusPreferenceCoordinator } from "../src/presence/status-pr
 import type { PresenceMode } from "../src/presence/effective-show";
 
 const AUTO: PresenceMode = { kind: "automatic" };
+const AVAIL: PresenceMode = { kind: "manual", status: "available" };
 const AWAY: PresenceMode = { kind: "manual", status: "away" };
 const DND: PresenceMode = { kind: "manual", status: "dnd" };
 
@@ -175,6 +176,41 @@ describe("StatusPreferenceCoordinator", () => {
     expect(published).toEqual([DND]); // AWAY is NOT re-published (no echo)
   });
 
+  test("a local pick made after an adopted remote, both mid-flight, is still published", async () => {
+    // While AWAY's publish is in flight: a peer update (AVAIL) is adopted, THEN
+    // the user picks DND locally. The epoch bump from applyRemote must not
+    // swallow the coalesced DND pick — DND must still reach the wire, not be
+    // stranded off-device until the next reconnect.
+    let resolveFirst: ((v: boolean) => void) | undefined;
+    const published: PresenceMode[] = [];
+    let mode: PresenceMode = AWAY;
+    let first = true;
+    const coord = new StatusPreferenceCoordinator({
+      publish: (m) => {
+        published.push(m);
+        if (first) {
+          first = false;
+          return new Promise<boolean>((res) => {
+            resolveFirst = res;
+          });
+        }
+        return Promise.resolve(true);
+      },
+      mode: () => mode,
+      setMode: (m) => {
+        mode = m;
+      },
+    });
+    const inFlight = coord.reconcile(); // publishing AWAY (pending)
+    coord.applyRemote(AVAIL); // a peer update is adopted mid-flight (mode = AVAIL)
+    mode = DND; // the user then picks DND locally
+    await coord.reconcile(); // coalesced (a publish is in flight) — arms a rerun
+    resolveFirst?.(true); // the AWAY publish confirms; epoch moved via applyRemote
+    await inFlight;
+    expect(mode).toEqual(DND);
+    expect(published).toEqual([AWAY, DND]); // DND is published, not stranded
+  });
+
   test("a pick made while a publish is failing is retried, not stranded", async () => {
     // The user picks DND while AWAY's publish is in flight; that publish then
     // FAILS. The mid-flight DND pick must still be retried once the failure
@@ -206,6 +242,40 @@ describe("StatusPreferenceCoordinator", () => {
     await inFlight;
     expect(published).toEqual([AWAY, DND]); // DND is retried after the failure
     expect(mode).toEqual(DND);
+  });
+
+  test("a rerun armed mid-flight before logout publishes nothing after suspend", async () => {
+    // A pick fires mid-publish (arming a coalesced rerun), THEN logout suspends.
+    // When the publish settles the epoch has moved AND a rerun is armed — the
+    // epoch-branch recursion must hit the suspend guard and publish nothing.
+    let resolveFirst: ((v: boolean) => void) | undefined;
+    const published: PresenceMode[] = [];
+    let mode: PresenceMode = AWAY;
+    let first = true;
+    const coord = new StatusPreferenceCoordinator({
+      publish: (m) => {
+        published.push(m);
+        if (first) {
+          first = false;
+          return new Promise<boolean>((res) => {
+            resolveFirst = res;
+          });
+        }
+        return Promise.resolve(true);
+      },
+      mode: () => mode,
+      setMode: (m) => {
+        mode = m;
+      },
+    });
+    const inFlight = coord.reconcile(); // publishing AWAY (pending)
+    mode = DND; // user picks DND mid-flight
+    await coord.reconcile(); // coalesced — arms a rerun
+    coord.suspend(); // logout: suspended, baseline zeroed, epoch bumped
+    mode = AUTO; // reset-to-Automatic
+    resolveFirst?.(true); // AWAY confirms; epoch moved AND a rerun is armed
+    await inFlight;
+    expect(published).toEqual([AWAY]); // the armed rerun bails on suspend — nothing else published
   });
 
   test("suspend racing an in-flight publish does not re-advance the baseline (no next-login clobber)", async () => {

--- a/chat/tests/status-preference.test.ts
+++ b/chat/tests/status-preference.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseStatusPreference,
+  presenceModeFromWire,
+  presenceModeToWire,
+  statusPreferenceUpdate,
+} from "../src/presence/status-preference";
+import { withFakeDomParser } from "./helpers/disco-xml";
+
+const NODE = "urn:waddle:status-preference:0";
+const SELF = "me@waddle.test";
+
+function opaque(xml: string) {
+  return { payload: { kind: "opaque", xml } };
+}
+function event(from: string | undefined, items: Array<Record<string, unknown>>, node = NODE) {
+  return { from, node, items } as Parameters<typeof statusPreferenceUpdate>[0];
+}
+
+describe("presenceModeFromWire / presenceModeToWire", () => {
+  test("automatic round-trips", () => {
+    expect(presenceModeFromWire({ mode: "automatic" })).toEqual({ kind: "automatic" });
+    expect(presenceModeToWire({ kind: "automatic" })).toEqual({ mode: "automatic" });
+  });
+
+  test("each manual status round-trips", () => {
+    for (const status of ["available", "away", "dnd"] as const) {
+      expect(presenceModeFromWire({ mode: "manual", status })).toEqual({ kind: "manual", status });
+      expect(presenceModeToWire({ kind: "manual", status })).toEqual({ mode: "manual", status });
+    }
+  });
+
+  test("invalid shapes map to null", () => {
+    expect(presenceModeFromWire(null)).toBeNull();
+    expect(presenceModeFromWire(undefined)).toBeNull();
+    expect(presenceModeFromWire({ mode: "invisible" })).toBeNull();
+    expect(presenceModeFromWire({ mode: "manual" })).toBeNull();
+    expect(presenceModeFromWire({ mode: "manual", status: "xa" })).toBeNull();
+  });
+});
+
+describe("statusPreferenceUpdate (incoming pubsub event → mode to adopt)", () => {
+  test("our own manual pick from another resource is adopted", async () => {
+    await withFakeDomParser(async () => {
+      expect(
+        statusPreferenceUpdate(
+          event(`${SELF}/phone`, [
+            opaque(`<status-preference xmlns="${NODE}" mode="manual" status="away"/>`),
+          ]),
+          SELF,
+        ),
+      ).toEqual({ kind: "manual", status: "away" });
+    });
+  });
+
+  test("our own automatic (reset) from another resource is adopted", async () => {
+    await withFakeDomParser(async () => {
+      expect(
+        statusPreferenceUpdate(
+          event(`${SELF}/phone`, [opaque(`<status-preference xmlns="${NODE}" mode="automatic"/>`)]),
+          SELF,
+        ),
+      ).toEqual({ kind: "automatic" });
+    });
+  });
+
+  test("a retracted item reads as automatic", () => {
+    expect(
+      statusPreferenceUpdate(
+        event(`${SELF}/phone`, [{ retracted: true, payload: { kind: "empty" } }]),
+        SELF,
+      ),
+    ).toEqual({ kind: "automatic" });
+  });
+
+  test("a foreign node is ignored", () => {
+    expect(
+      statusPreferenceUpdate(
+        event(`${SELF}/phone`, [{ payload: { kind: "empty" } }], "urn:xmpp:mood:0"),
+        SELF,
+      ),
+    ).toBeNull();
+  });
+
+  test("an event with no sender is ignored", () => {
+    expect(statusPreferenceUpdate(event(undefined, [{ payload: { kind: "empty" } }]), SELF)).toBeNull();
+  });
+
+  test("another user's preference is never adopted (owner-only)", async () => {
+    await withFakeDomParser(async () => {
+      expect(
+        statusPreferenceUpdate(
+          event("someone-else@waddle.test/x", [
+            opaque(`<status-preference xmlns="${NODE}" mode="manual" status="dnd"/>`),
+          ]),
+          SELF,
+        ),
+      ).toBeNull();
+    });
+  });
+
+  test("the last item wins for a multi-item event", async () => {
+    await withFakeDomParser(async () => {
+      const awayThenAuto = [
+        opaque(`<status-preference xmlns="${NODE}" mode="manual" status="away"/>`),
+        opaque(`<status-preference xmlns="${NODE}" mode="automatic"/>`),
+      ];
+      expect(statusPreferenceUpdate(event(`${SELF}/phone`, awayThenAuto), SELF)).toEqual({
+        kind: "automatic",
+      });
+    });
+  });
+});
+
+describe("parseStatusPreference", () => {
+  test("parses manual + automatic XML", async () => {
+    await withFakeDomParser(async () => {
+      expect(parseStatusPreference(`<status-preference xmlns="${NODE}" mode="manual" status="dnd"/>`)).toEqual({
+        kind: "manual",
+        status: "dnd",
+      });
+      expect(parseStatusPreference(`<status-preference xmlns="${NODE}" mode="automatic"/>`)).toEqual({
+        kind: "automatic",
+      });
+    });
+  });
+
+  test("returns null without a DOMParser", () => {
+    expect(parseStatusPreference(`<status-preference xmlns="${NODE}" mode="automatic"/>`)).toBeNull();
+  });
+});

--- a/server/crates/waddle-server/src/pubsub/item.rs
+++ b/server/crates/waddle-server/src/pubsub/item.rs
@@ -188,6 +188,69 @@ impl DatabasePubSubStorage {
         } else {
             None
         };
+        // Validate `urn:waddle:status-preference:0` publishes up-front
+        // (ADR-010 Phase 4). The synced manual-status payload is
+        // user-identity state, so the same invariants as `urn:waddle:dnd:0`
+        // apply: only the node owner may publish, and the single-item PEP
+        // idiom (`id="current"`) is enforced so a later retract of
+        // `current` reliably clears the state. Unlike DND there is no
+        // server-side projection — the payload is pure owner↔own-devices
+        // sync — so the parsed value is discarded after validation; we
+        // still parse it to reject a malformed `<status-preference>` with
+        // `<bad-request/>` instead of persisting garbage other resources
+        // would choke on.
+        if is_status_preference_node(node_name) {
+            match publisher {
+                Some(publisher_jid) if publisher_jid == owner => {}
+                _ => {
+                    warn!(
+                        owner = %owner,
+                        publisher = ?publisher,
+                        "urn:waddle:status-preference:0 publish rejected: publisher is not the node owner"
+                    );
+                    return Err(XmppError::forbidden(Some(
+                        "urn:waddle:status-preference:0 may only be published by the node owner"
+                            .to_string(),
+                    )));
+                }
+            }
+            match item.id.as_deref() {
+                Some(id)
+                    if id
+                        == waddle_xmpp_core::waddle_status_preference::PEP_ITEM_WADDLE_STATUS_PREFERENCE => {}
+                _ => {
+                    warn!(
+                        owner = %owner,
+                        item_id = ?item.id,
+                        "urn:waddle:status-preference:0 publish rejected: item id is not 'current'"
+                    );
+                    return Err(XmppError::pubsub_invalid_payload(Some(format!(
+                        "urn:waddle:status-preference:0 publish must use item id '{}'",
+                        waddle_xmpp_core::waddle_status_preference::PEP_ITEM_WADDLE_STATUS_PREFERENCE,
+                    ))));
+                }
+            }
+            let payload = item.payload.as_ref().ok_or_else(|| {
+                warn!(
+                    owner = %owner,
+                    "urn:waddle:status-preference:0 publish rejected: missing <status-preference> payload"
+                );
+                XmppError::pubsub_payload_required(Some(
+                    "urn:waddle:status-preference:0 publish requires a <status-preference> payload"
+                        .to_string(),
+                ))
+            })?;
+            waddle_xmpp_core::waddle_status_preference::StatusPreference::parse(payload).map_err(
+                |error| {
+                    warn!(
+                        owner = %owner,
+                        %error,
+                        "urn:waddle:status-preference:0 publish rejected: invalid <status-preference> payload"
+                    );
+                    XmppError::pubsub_invalid_payload(Some(error.to_string()))
+                },
+            )?;
+        }
 
         let (node, node_created) = match self.get_node_impl(owner, node_name).await? {
             Some(node) => (node, false),
@@ -875,4 +938,8 @@ fn is_bookmarks_node(node_name: &str) -> bool {
 
 fn is_dnd_node(node_name: &str) -> bool {
     node_name == waddle_xmpp::xep::xep_waddle_dnd::PEP_NODE_WADDLE_DND
+}
+
+fn is_status_preference_node(node_name: &str) -> bool {
+    node_name == waddle_xmpp_core::waddle_status_preference::PEP_NODE_WADDLE_STATUS_PREFERENCE
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
@@ -95,7 +95,16 @@ pub async fn fan_out_publish(state: &WebSocketState, req: FanOutRequest<'_>) {
     let is_private_bookmarks_node = is_pep && node == waddle_xmpp::xep::xep0402::PEP_NODE;
     let is_private_story_reads_node =
         is_pep && node == waddle_xmpp_core::waddle_story_reads::PEP_NODE_WADDLE_STORY_READS;
-    let is_private_pep_node = is_private_bookmarks_node || is_private_story_reads_node;
+    // ADR-010 Phase 4: the synced manual-status node is owner-only. Skip
+    // the §3 roster pass so a contact advertising
+    // `urn:waddle:status-preference:0+notify` never learns the user's
+    // picked mode; the §3.4 owner-self pass still runs so the user's own
+    // resources adopt it live.
+    let is_private_status_preference_node = is_pep
+        && node == waddle_xmpp_core::waddle_status_preference::PEP_NODE_WADDLE_STATUS_PREFERENCE;
+    let is_private_pep_node = is_private_bookmarks_node
+        || is_private_story_reads_node
+        || is_private_status_preference_node;
     let storage = &state.deps.protocol.pubsub_storage;
 
     let node_cfg = match storage.get_node(owner, node).await {

--- a/server/crates/waddle-server/tests/waddle_status_preference_pep_sync_ws.rs
+++ b/server/crates/waddle-server/tests/waddle_status_preference_pep_sync_ws.rs
@@ -17,16 +17,22 @@
 //! - The private-PEP carve-out suppresses roster fan-out.
 //! - The owner's OTHER resource (advertising `…+notify` caps) DOES
 //!   receive the headline event — the live cross-device sync path.
+//!
+//! Every stanza is assembled with `minidom::Element` builders and
+//! serialized (never `format!`-interpolated XML markup), per the
+//! CLAUDE.md XML-generation hard rule.
 
 mod ws_common;
 
 use std::time::Duration;
 use tokio::sync::Mutex;
 use ws_common::{extract_attr_after, TestServer, WsXmppClient};
+use xmpp_parsers::minidom::Element;
 
 const DOMAIN: &str = "localhost";
 const NODE: &str = "urn:waddle:status-preference:0";
 const NS: &str = "urn:waddle:status-preference:0";
+const CLIENT_NS: &str = "jabber:client";
 const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
 const NS_CAPS: &str = "http://jabber.org/protocol/caps";
 const NS_DISCO_INFO: &str = "http://jabber.org/protocol/disco#info";
@@ -65,38 +71,84 @@ async fn connect_two_accounts() -> (TestServer, WsXmppClient, WsXmppClient) {
     (server, alice, bob)
 }
 
-/// Build the `<status-preference>` payload XML for a mode.
-fn pref_body(mode: &str, status: Option<&str>) -> String {
-    match status {
-        Some(status) => {
-            format!(r#"<status-preference xmlns="{NS}" mode="{mode}" status="{status}"/>"#)
-        }
-        None => format!(r#"<status-preference xmlns="{NS}" mode="{mode}"/>"#),
+// ── Stanza builders ─────────────────────────────────────────────────
+// All XML is built via `minidom::Element` and serialized; only attribute
+// *values* (jids, the caps `node#ver`, the `+notify` feature var) are
+// computed as plain strings, which minidom escapes on serialization.
+
+fn attr(name: &str) -> minidom::rxml::NcName {
+    // The builder API wants an owned NcName; this keeps call sites terse for
+    // the (statically valid) attribute names used throughout the file.
+    <minidom::rxml::NcName as std::convert::TryFrom<&str>>::try_from(name)
+        .expect("static ncname is valid")
+}
+
+fn element_to_xml(element: Element) -> String {
+    let mut bytes = Vec::new();
+    element.write_to(&mut bytes).expect("serialize element");
+    String::from_utf8(bytes).expect("serializer emits utf-8")
+}
+
+/// `<iq>` wrapper around a payload, with optional `to` / `from`.
+fn iq(iq_type: &str, id: &str, to: Option<&str>, from: Option<&str>, payload: Element) -> String {
+    let mut builder = Element::builder("iq", CLIENT_NS)
+        .attr(attr("type"), iq_type)
+        .attr(attr("id"), id);
+    if let Some(to) = to {
+        builder = builder.attr(attr("to"), to);
     }
+    if let Some(from) = from {
+        builder = builder.attr(attr("from"), from);
+    }
+    element_to_xml(builder.append(payload).build())
+}
+
+/// The `<status-preference>` payload for a mode.
+fn status_preference_payload(mode: &str, status: Option<&str>) -> Element {
+    let mut builder = Element::builder("status-preference", NS).attr(attr("mode"), mode);
+    if let Some(status) = status {
+        builder = builder.attr(attr("status"), status);
+    }
+    builder.build()
+}
+
+/// A `<pubsub><publish node=…><item id=…>[payload]</item>…` element.
+fn publish_pubsub(item_id: &str, payload: Option<Element>) -> Element {
+    let mut item = Element::builder("item", NS_PUBSUB).attr(attr("id"), item_id);
+    if let Some(payload) = payload {
+        item = item.append(payload);
+    }
+    let publish = Element::builder("publish", NS_PUBSUB)
+        .attr(attr("node"), NODE)
+        .append(item)
+        .build();
+    Element::builder("pubsub", NS_PUBSUB)
+        .append(publish)
+        .build()
 }
 
 /// Self-publish IQ (no `to`, addressed to the account's own PEP service).
-fn publish_iq(id: &str, item_id: &str, body_xml: &str) -> String {
-    format!(
-        r#"<iq type="set" id="{id}">
-          <pubsub xmlns="{NS_PUBSUB}">
-            <publish node="{NODE}">
-              <item id="{item_id}">{body_xml}</item>
-            </publish>
-          </pubsub>
-        </iq>"#
+fn publish_iq(id: &str, item_id: &str, payload: Element) -> String {
+    iq(
+        "set",
+        id,
+        None,
+        None,
+        publish_pubsub(item_id, Some(payload)),
     )
 }
 
 fn items_get_iq(id: &str, to: Option<&str>) -> String {
-    let to_attr = to.map(|jid| format!(r#" to="{jid}""#)).unwrap_or_default();
-    format!(
-        r#"<iq type="get" id="{id}"{to_attr}>
-          <pubsub xmlns="{NS_PUBSUB}">
-            <items node="{NODE}" max_items="1"/>
-          </pubsub>
-        </iq>"#
-    )
+    let items = Element::builder("items", NS_PUBSUB)
+        .attr(attr("node"), NODE)
+        .attr(attr("max_items"), "1")
+        .build();
+    let pubsub = Element::builder("pubsub", NS_PUBSUB).append(items).build();
+    iq("get", id, to, None, pubsub)
+}
+
+fn bare_presence() -> String {
+    element_to_xml(Element::builder("presence", CLIENT_NS).build())
 }
 
 fn assert_invalid_payload(xml: &str) {
@@ -120,7 +172,7 @@ async fn publish_then_owner_fetch_round_trips() {
         .send(&publish_iq(
             "pub-1",
             "current",
-            &pref_body("manual", Some("away")),
+            status_preference_payload("manual", Some("away")),
         ))
         .await
         .expect("send publish");
@@ -166,7 +218,7 @@ async fn republish_overwrites_item() {
         .send(&publish_iq(
             "pub-auto",
             "current",
-            &pref_body("automatic", None),
+            status_preference_payload("automatic", None),
         ))
         .await
         .expect("send first publish");
@@ -179,7 +231,7 @@ async fn republish_overwrites_item() {
         .send(&publish_iq(
             "pub-manual",
             "current",
-            &pref_body("manual", Some("dnd")),
+            status_preference_payload("manual", Some("dnd")),
         ))
         .await
         .expect("send second publish");
@@ -217,7 +269,7 @@ async fn publish_with_wrong_item_id_rejected() {
         .send(&publish_iq(
             "pub-wrong-id",
             "not-current",
-            &pref_body("manual", Some("away")),
+            status_preference_payload("manual", Some("away")),
         ))
         .await
         .expect("send publish");
@@ -235,25 +287,24 @@ async fn publish_malformed_payload_rejected() {
     let _guard = TEST_SERIAL.lock().await;
     let (_server, mut client) = connect_admin().await;
 
-    // A few representative malformed shapes, each rejected by the strict
-    // parser at the publish boundary and never persisted: unknown mode, a
-    // status on automatic, and a stray child element. (The full rejection
-    // matrix is exercised by the parser's unit suite; these prove the server
-    // publish path actually runs that parser.)
-    let cases: &[(&str, String)] = &[
-        ("pub-bad-mode", pref_body("invisible", None)),
+    // A `<status-preference>` payload carrying a stray child element — the
+    // strict parser rejects it (the full rejection matrix is in the parser's
+    // unit suite; this proves the server publish path runs that parser).
+    let stray_child = Element::builder("status-preference", NS)
+        .attr(attr("mode"), "automatic")
+        .append(Element::builder("x", NS).build())
+        .build();
+    let cases: Vec<(&str, Element)> = vec![
+        ("pub-bad-mode", status_preference_payload("invisible", None)),
         (
             "pub-bad-status-on-auto",
-            pref_body("automatic", Some("away")),
+            status_preference_payload("automatic", Some("away")),
         ),
-        (
-            "pub-bad-child",
-            format!(r#"<status-preference xmlns="{NS}" mode="automatic"><x/></status-preference>"#),
-        ),
+        ("pub-bad-child", stray_child),
     ];
-    for (id, body) in cases {
+    for (id, payload) in cases {
         client
-            .send(&publish_iq(id, "current", body))
+            .send(&publish_iq(id, "current", payload))
             .await
             .expect("send publish");
         let result = client
@@ -265,12 +316,12 @@ async fn publish_malformed_payload_rejected() {
 
     // A publish carrying no `<status-preference>` payload at all is refused.
     client
-        .send(&format!(
-            r#"<iq type="set" id="pub-empty">
-              <pubsub xmlns="{NS_PUBSUB}">
-                <publish node="{NODE}"><item id="current"/></publish>
-              </pubsub>
-            </iq>"#
+        .send(&iq(
+            "set",
+            "pub-empty",
+            None,
+            None,
+            publish_pubsub("current", None),
         ))
         .await
         .expect("send empty publish");
@@ -290,19 +341,20 @@ async fn publish_malformed_payload_rejected() {
 async fn non_owner_publish_is_rejected() {
     let _guard = TEST_SERIAL.lock().await;
     let (_server, mut alice, mut bob) = connect_two_accounts().await;
+    let alice_jid = format!("alice@{DOMAIN}");
 
     // Bob addresses alice's PEP service directly and tries to write her
     // status preference. The node owner is alice; the publisher is bob,
     // so the publish MUST be refused.
-    bob.send(&format!(
-        r#"<iq type="set" id="bob-spoof" to="alice@{DOMAIN}">
-          <pubsub xmlns="{NS_PUBSUB}">
-            <publish node="{NODE}">
-              <item id="current">{}</item>
-            </publish>
-          </pubsub>
-        </iq>"#,
-        pref_body("manual", Some("dnd"))
+    bob.send(&iq(
+        "set",
+        "bob-spoof",
+        Some(&alice_jid),
+        None,
+        publish_pubsub(
+            "current",
+            Some(status_preference_payload("manual", Some("dnd"))),
+        ),
     ))
     .await
     .expect("bob spoof publish");
@@ -342,7 +394,7 @@ async fn node_is_private_to_non_owner() {
         .send(&publish_iq(
             "alice-pub",
             "current",
-            &pref_body("manual", Some("away")),
+            status_preference_payload("manual", Some("away")),
         ))
         .await
         .expect("alice publish");
@@ -378,17 +430,24 @@ async fn private_pep_does_not_fan_out_to_roster() {
     let _guard = TEST_SERIAL.lock().await;
     let (_server, mut alice, mut bob) = connect_two_accounts().await;
 
-    alice.send("<presence/>").await.expect("alice presence");
-    bob.send("<presence/>").await.expect("bob presence");
+    alice.send(&bare_presence()).await.expect("alice presence");
+    bob.send(&bare_presence()).await.expect("bob presence");
 
-    // Bob best-effort subscribes to alice's node (whitelist should
-    // refuse, but the fan-out carve-out is the real guard under test).
-    bob.send(&format!(
-        r#"<iq type="set" id="bob-sub" to="alice@{DOMAIN}">
-          <pubsub xmlns="{NS_PUBSUB}">
-            <subscribe node="{NODE}" jid="bob@{DOMAIN}"/>
-          </pubsub>
-        </iq>"#
+    // Bob best-effort subscribes to alice's node (whitelist should refuse, but
+    // the fan-out carve-out is the real guard under test).
+    let subscribe = Element::builder("subscribe", NS_PUBSUB)
+        .attr(attr("node"), NODE)
+        .attr(attr("jid"), format!("bob@{DOMAIN}"))
+        .build();
+    let subscribe_pubsub = Element::builder("pubsub", NS_PUBSUB)
+        .append(subscribe)
+        .build();
+    bob.send(&iq(
+        "set",
+        "bob-sub",
+        Some(&format!("alice@{DOMAIN}")),
+        None,
+        subscribe_pubsub,
     ))
     .await
     .expect("bob subscribe");
@@ -401,7 +460,7 @@ async fn private_pep_does_not_fan_out_to_roster() {
         .send(&publish_iq(
             "alice-pub",
             "current",
-            &pref_body("manual", Some("dnd")),
+            status_preference_payload("manual", Some("dnd")),
         ))
         .await
         .expect("alice publish");
@@ -450,12 +509,15 @@ async fn announce_status_preference_notify_caps(client: &mut WsXmppClient) {
     let ver = caps_verification_string(&features);
     let full = client.full_jid.clone().expect("full jid");
 
-    client
-        .send(&format!(
-            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{caps_node}" ver="{ver}"/></presence>"#
-        ))
-        .await
-        .expect("presence with caps");
+    // `<presence><c hash node ver/></presence>`
+    let caps = Element::builder("c", NS_CAPS)
+        .attr(attr("hash"), "sha-1")
+        .attr(attr("node"), caps_node)
+        .attr(attr("ver"), ver.as_str())
+        .build();
+    let presence = element_to_xml(Element::builder("presence", CLIENT_NS).append(caps).build());
+    client.send(&presence).await.expect("presence with caps");
+
     let disco_query = client
         .recv_matching(|frame| {
             frame.contains("<iq")
@@ -465,14 +527,26 @@ async fn announce_status_preference_notify_caps(client: &mut WsXmppClient) {
         .await
         .expect("server queries caps");
     let iq_id = extract_attr_after(&disco_query, "<iq", "id").expect("disco iq id");
-    let feature_xml: String = features
-        .iter()
-        .map(|f| format!(r#"<feature var="{f}"/>"#))
-        .collect();
+
+    // `<iq type=result from=…><query node=caps#ver><identity/><feature/>…`
+    let mut query = Element::builder("query", NS_DISCO_INFO)
+        .attr(attr("node"), format!("{caps_node}#{ver}"))
+        .append(
+            Element::builder("identity", NS_DISCO_INFO)
+                .attr(attr("category"), "client")
+                .attr(attr("type"), "pc")
+                .attr(attr("name"), "Waddle")
+                .build(),
+        );
+    for feature in features {
+        query = query.append(
+            Element::builder("feature", NS_DISCO_INFO)
+                .attr(attr("var"), feature)
+                .build(),
+        );
+    }
     client
-        .send(&format!(
-            r#"<iq xmlns="jabber:client" type="result" id="{iq_id}" from="{full}"><query xmlns="{NS_DISCO_INFO}" node="{caps_node}#{ver}"><identity category="client" type="pc" name="Waddle"/>{feature_xml}</query></iq>"#
-        ))
+        .send(&iq("result", &iq_id, None, Some(&full), query.build()))
         .await
         .expect("disco#info reply");
 }
@@ -489,7 +563,7 @@ async fn self_fanout_reaches_owner_other_resource() {
 
     // r1 is online (the publisher); r2 advertises +notify caps so the
     // §3.4 owner-self pass delivers the headline to it.
-    r1.send("<presence/>").await.expect("r1 presence");
+    r1.send(&bare_presence()).await.expect("r1 presence");
     announce_status_preference_notify_caps(&mut r2).await;
 
     // r1 publishes a pick. r2 — alice's other resource — MUST receive
@@ -497,7 +571,7 @@ async fn self_fanout_reaches_owner_other_resource() {
     r1.send(&publish_iq(
         "r1-pub",
         "current",
-        &pref_body("manual", Some("away")),
+        status_preference_payload("manual", Some("away")),
     ))
     .await
     .expect("r1 publish");
@@ -533,13 +607,13 @@ async fn self_fanout_skips_owner_resource_without_notify_caps() {
     // `urn:waddle:status-preference:0+notify`. The §3.4 owner-self pass is
     // caps-gated, so r2 MUST NOT receive the headline: the `+notify` filter is
     // the real gate, not mere co-ownership of the account.
-    r1.send("<presence/>").await.expect("r1 presence");
-    r2.send("<presence/>").await.expect("r2 presence");
+    r1.send(&bare_presence()).await.expect("r1 presence");
+    r2.send(&bare_presence()).await.expect("r2 presence");
 
     r1.send(&publish_iq(
         "noflt-pub",
         "current",
-        &pref_body("manual", Some("away")),
+        status_preference_payload("manual", Some("away")),
     ))
     .await
     .expect("r1 publish");
@@ -581,7 +655,7 @@ async fn preference_survives_disconnect_and_fresh_reconnect() {
         r1.send(&publish_iq(
             "persist-pub",
             "current",
-            &pref_body("manual", Some("dnd")),
+            status_preference_payload("manual", Some("dnd")),
         ))
         .await
         .expect("publish");

--- a/server/crates/waddle-server/tests/waddle_status_preference_pep_sync_ws.rs
+++ b/server/crates/waddle-server/tests/waddle_status_preference_pep_sync_ws.rs
@@ -235,21 +235,53 @@ async fn publish_malformed_payload_rejected() {
     let _guard = TEST_SERIAL.lock().await;
     let (_server, mut client) = connect_admin().await;
 
-    // Unknown mode value — rejected by the strict parser at the publish
-    // boundary, never persisted.
+    // A few representative malformed shapes, each rejected by the strict
+    // parser at the publish boundary and never persisted: unknown mode, a
+    // status on automatic, and a stray child element. (The full rejection
+    // matrix is exercised by the parser's unit suite; these prove the server
+    // publish path actually runs that parser.)
+    let cases: &[(&str, String)] = &[
+        ("pub-bad-mode", pref_body("invisible", None)),
+        (
+            "pub-bad-status-on-auto",
+            pref_body("automatic", Some("away")),
+        ),
+        (
+            "pub-bad-child",
+            format!(r#"<status-preference xmlns="{NS}" mode="automatic"><x/></status-preference>"#),
+        ),
+    ];
+    for (id, body) in cases {
+        client
+            .send(&publish_iq(id, "current", body))
+            .await
+            .expect("send publish");
+        let result = client
+            .recv_matching(|frame| frame.contains(&format!("id='{id}'")))
+            .await
+            .expect("publish result");
+        assert_invalid_payload(&result);
+    }
+
+    // A publish carrying no `<status-preference>` payload at all is refused.
     client
-        .send(&publish_iq(
-            "pub-bad",
-            "current",
-            &pref_body("invisible", None),
+        .send(&format!(
+            r#"<iq type="set" id="pub-empty">
+              <pubsub xmlns="{NS_PUBSUB}">
+                <publish node="{NODE}"><item id="current"/></publish>
+              </pubsub>
+            </iq>"#
         ))
         .await
-        .expect("send publish");
-    let result = client
-        .recv_matching(|frame| frame.contains(r#"id='pub-bad'"#))
+        .expect("send empty publish");
+    let empty = client
+        .recv_matching(|frame| frame.contains(r#"id='pub-empty'"#))
         .await
-        .expect("publish result");
-    assert_invalid_payload(&result);
+        .expect("empty publish result");
+    assert!(
+        empty.contains(r#"type='error'"#),
+        "missing payload must error: {empty}"
+    );
 
     let _ = client.close().await;
 }
@@ -486,5 +518,104 @@ async fn self_fanout_reaches_owner_other_resource() {
     );
 
     let _ = r1.close().await;
+    let _ = r2.close().await;
+}
+
+#[tokio::test]
+async fn self_fanout_skips_owner_resource_without_notify_caps() {
+    let _guard = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("alice", &alice_password)]);
+    let mut r1 = connect_account(&server, "alice", &alice_password).await;
+    let mut r2 = connect_account(&server, "alice", &alice_password).await;
+
+    // Both online, but r2 advertises NO caps — so it does not opt into
+    // `urn:waddle:status-preference:0+notify`. The §3.4 owner-self pass is
+    // caps-gated, so r2 MUST NOT receive the headline: the `+notify` filter is
+    // the real gate, not mere co-ownership of the account.
+    r1.send("<presence/>").await.expect("r1 presence");
+    r2.send("<presence/>").await.expect("r2 presence");
+
+    r1.send(&publish_iq(
+        "noflt-pub",
+        "current",
+        &pref_body("manual", Some("away")),
+    ))
+    .await
+    .expect("r1 publish");
+    let _ = r1
+        .recv_matching(|f| f.contains(r#"id='noflt-pub'"#))
+        .await
+        .expect("r1 publish result");
+
+    let mut received: Option<String> = None;
+    for _ in 0..3 {
+        match r2.recv_timeout(Duration::from_millis(250)).await {
+            Ok(frame) => {
+                if frame.contains(NODE) {
+                    received = Some(frame);
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    assert!(
+        received.is_none(),
+        "a resource without +notify caps must NOT receive the headline: {received:?}"
+    );
+
+    let _ = r1.close().await;
+    let _ = r2.close().await;
+}
+
+#[tokio::test]
+async fn preference_survives_disconnect_and_fresh_reconnect() {
+    let _guard = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("alice", &alice_password)]);
+
+    // First session publishes a manual pick, then fully disconnects.
+    {
+        let mut r1 = connect_account(&server, "alice", &alice_password).await;
+        r1.send(&publish_iq(
+            "persist-pub",
+            "current",
+            &pref_body("manual", Some("dnd")),
+        ))
+        .await
+        .expect("publish");
+        let res = r1
+            .recv_matching(|f| f.contains(r#"id='persist-pub'"#))
+            .await
+            .expect("publish result");
+        assert!(res.contains(r#"type='result'"#), "publish: {res}");
+        let _ = r1.close().await;
+    }
+
+    // A brand-new connection (fresh login, same account) reads the stored pick
+    // back — proving the preference persists across sessions, replacing the
+    // Phase 1 in-memory store (AC3).
+    let mut r2 = connect_account(&server, "alice", &alice_password).await;
+    r2.send(&items_get_iq("persist-fetch", None))
+        .await
+        .expect("fetch");
+    let fetched = r2
+        .recv_matching(|f| f.contains(r#"id='persist-fetch'"#))
+        .await
+        .expect("fetch result");
+    assert!(
+        fetched.contains(r#"id='current'"#),
+        "stored item id must be 'current': {fetched}"
+    );
+    assert!(
+        fetched.contains(r#"mode="manual""#) || fetched.contains(r#"mode='manual'"#),
+        "persisted mode missing: {fetched}"
+    );
+    assert!(
+        fetched.contains(r#"status="dnd""#) || fetched.contains(r#"status='dnd'"#),
+        "persisted status missing: {fetched}"
+    );
+
     let _ = r2.close().await;
 }

--- a/server/crates/waddle-server/tests/waddle_status_preference_pep_sync_ws.rs
+++ b/server/crates/waddle-server/tests/waddle_status_preference_pep_sync_ws.rs
@@ -1,0 +1,490 @@
+//! Integration tests for the private `urn:waddle:status-preference:0`
+//! PEP node (ADR-010 Phase 4 — cross-device manual-status sync) over
+//! WebSocket C2S.
+//!
+//! The node mirrors the `urn:waddle:dnd:0` server conventions: owner-only
+//! publish, `access_model=whitelist`, single item id `current`. Unlike
+//! DND there is no server-side projection — the payload is pure
+//! owner↔own-devices sync. Covered here:
+//!
+//! - Publish round-trips; the owner reads it back via `<items/>` get
+//!   (item id `current`, payload preserved).
+//! - Item id MUST be `current` (`<bad-request/>` + `<invalid-payload/>`).
+//! - A malformed `<status-preference>` payload is rejected
+//!   (`<bad-request/>` + `<invalid-payload/>`).
+//! - A non-owner publish to the node is rejected (`<error/>`).
+//! - A non-owner fetch is blocked by the whitelist access model.
+//! - The private-PEP carve-out suppresses roster fan-out.
+//! - The owner's OTHER resource (advertising `…+notify` caps) DOES
+//!   receive the headline event — the live cross-device sync path.
+
+mod ws_common;
+
+use std::time::Duration;
+use tokio::sync::Mutex;
+use ws_common::{extract_attr_after, TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const NODE: &str = "urn:waddle:status-preference:0";
+const NS: &str = "urn:waddle:status-preference:0";
+const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+const NS_CAPS: &str = "http://jabber.org/protocol/caps";
+const NS_DISCO_INFO: &str = "http://jabber.org/protocol/disco#info";
+const NS_PUBSUB_ERRORS: &str = "http://jabber.org/protocol/pubsub#errors";
+
+static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+async fn connect_account(server: &TestServer, user: &str, password: &str) -> WsXmppClient {
+    WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        user,
+        password,
+        &format!("{user}-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .unwrap_or_else(|err| panic!("{user} connect: {err}"))
+}
+
+async fn connect_admin() -> (TestServer, WsXmppClient) {
+    let server = TestServer::start();
+    let password = server.fixed_account_password().to_string();
+    let client = connect_account(&server, "admin", &password).await;
+    (server, client)
+}
+
+async fn connect_two_accounts() -> (TestServer, WsXmppClient, WsXmppClient) {
+    let alice_password = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+    let alice = connect_account(&server, "alice", &alice_password).await;
+    let bob = connect_account(&server, "bob", &bob_password).await;
+    (server, alice, bob)
+}
+
+/// Build the `<status-preference>` payload XML for a mode.
+fn pref_body(mode: &str, status: Option<&str>) -> String {
+    match status {
+        Some(status) => {
+            format!(r#"<status-preference xmlns="{NS}" mode="{mode}" status="{status}"/>"#)
+        }
+        None => format!(r#"<status-preference xmlns="{NS}" mode="{mode}"/>"#),
+    }
+}
+
+/// Self-publish IQ (no `to`, addressed to the account's own PEP service).
+fn publish_iq(id: &str, item_id: &str, body_xml: &str) -> String {
+    format!(
+        r#"<iq type="set" id="{id}">
+          <pubsub xmlns="{NS_PUBSUB}">
+            <publish node="{NODE}">
+              <item id="{item_id}">{body_xml}</item>
+            </publish>
+          </pubsub>
+        </iq>"#
+    )
+}
+
+fn items_get_iq(id: &str, to: Option<&str>) -> String {
+    let to_attr = to.map(|jid| format!(r#" to="{jid}""#)).unwrap_or_default();
+    format!(
+        r#"<iq type="get" id="{id}"{to_attr}>
+          <pubsub xmlns="{NS_PUBSUB}">
+            <items node="{NODE}" max_items="1"/>
+          </pubsub>
+        </iq>"#
+    )
+}
+
+fn assert_invalid_payload(xml: &str) {
+    assert!(xml.contains(r#"type='error'"#), "expected error iq: {xml}");
+    assert!(
+        xml.contains("bad-request") || xml.contains("not-acceptable"),
+        "expected <bad-request/> stanza error: {xml}"
+    );
+    assert!(
+        xml.contains("invalid-payload"),
+        "expected XEP-0060 <invalid-payload/> ({NS_PUBSUB_ERRORS}) extension: {xml}"
+    );
+}
+
+#[tokio::test]
+async fn publish_then_owner_fetch_round_trips() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = connect_admin().await;
+
+    client
+        .send(&publish_iq(
+            "pub-1",
+            "current",
+            &pref_body("manual", Some("away")),
+        ))
+        .await
+        .expect("send publish");
+    let publish_result = client
+        .recv_matching(|frame| frame.contains(r#"id='pub-1'"#))
+        .await
+        .expect("publish result");
+    assert!(
+        publish_result.contains(r#"type='result'"#),
+        "publish failed: {publish_result}"
+    );
+
+    client
+        .send(&items_get_iq("fetch-1", None))
+        .await
+        .expect("send fetch");
+    let fetch_result = client
+        .recv_matching(|frame| frame.contains(r#"id='fetch-1'"#))
+        .await
+        .expect("fetch result");
+    assert!(
+        fetch_result.contains(r#"id='current'"#),
+        "fetched item id must be 'current': {fetch_result}"
+    );
+    assert!(
+        fetch_result.contains(r#"mode="manual""#) || fetch_result.contains(r#"mode='manual'"#),
+        "fetched payload missing mode=manual: {fetch_result}"
+    );
+    assert!(
+        fetch_result.contains(r#"status="away""#) || fetch_result.contains(r#"status='away'"#),
+        "fetched payload missing status=away: {fetch_result}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn republish_overwrites_item() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = connect_admin().await;
+
+    client
+        .send(&publish_iq(
+            "pub-auto",
+            "current",
+            &pref_body("automatic", None),
+        ))
+        .await
+        .expect("send first publish");
+    let _ = client
+        .recv_matching(|frame| frame.contains(r#"id='pub-auto'"#))
+        .await
+        .expect("first publish result");
+
+    client
+        .send(&publish_iq(
+            "pub-manual",
+            "current",
+            &pref_body("manual", Some("dnd")),
+        ))
+        .await
+        .expect("send second publish");
+    let _ = client
+        .recv_matching(|frame| frame.contains(r#"id='pub-manual'"#))
+        .await
+        .expect("second publish result");
+
+    client
+        .send(&items_get_iq("fetch-after", None))
+        .await
+        .expect("send fetch");
+    let fetch_result = client
+        .recv_matching(|frame| frame.contains(r#"id='fetch-after'"#))
+        .await
+        .expect("fetch result");
+    assert!(
+        fetch_result.contains("dnd"),
+        "republish failed to surface latest mode: {fetch_result}"
+    );
+    assert!(
+        !fetch_result.contains("automatic"),
+        "max_items=1 should have evicted the prior item: {fetch_result}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn publish_with_wrong_item_id_rejected() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = connect_admin().await;
+
+    client
+        .send(&publish_iq(
+            "pub-wrong-id",
+            "not-current",
+            &pref_body("manual", Some("away")),
+        ))
+        .await
+        .expect("send publish");
+    let result = client
+        .recv_matching(|frame| frame.contains(r#"id='pub-wrong-id'"#))
+        .await
+        .expect("publish result");
+    assert_invalid_payload(&result);
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn publish_malformed_payload_rejected() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = connect_admin().await;
+
+    // Unknown mode value — rejected by the strict parser at the publish
+    // boundary, never persisted.
+    client
+        .send(&publish_iq(
+            "pub-bad",
+            "current",
+            &pref_body("invisible", None),
+        ))
+        .await
+        .expect("send publish");
+    let result = client
+        .recv_matching(|frame| frame.contains(r#"id='pub-bad'"#))
+        .await
+        .expect("publish result");
+    assert_invalid_payload(&result);
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn non_owner_publish_is_rejected() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut alice, mut bob) = connect_two_accounts().await;
+
+    // Bob addresses alice's PEP service directly and tries to write her
+    // status preference. The node owner is alice; the publisher is bob,
+    // so the publish MUST be refused.
+    bob.send(&format!(
+        r#"<iq type="set" id="bob-spoof" to="alice@{DOMAIN}">
+          <pubsub xmlns="{NS_PUBSUB}">
+            <publish node="{NODE}">
+              <item id="current">{}</item>
+            </publish>
+          </pubsub>
+        </iq>"#,
+        pref_body("manual", Some("dnd"))
+    ))
+    .await
+    .expect("bob spoof publish");
+    let result = bob
+        .recv_matching(|frame| frame.contains(r#"id='bob-spoof'"#))
+        .await
+        .expect("bob spoof result");
+    assert!(
+        result.contains(r#"type='error'"#),
+        "non-owner publish must be refused: {result}"
+    );
+
+    // And alice's node holds nothing bob wrote: a fetch yields no item.
+    alice
+        .send(&items_get_iq("alice-check", None))
+        .await
+        .expect("alice fetch");
+    let alice_result = alice
+        .recv_matching(|frame| frame.contains(r#"id='alice-check'"#))
+        .await
+        .expect("alice fetch result");
+    assert!(
+        !alice_result.contains("dnd"),
+        "bob's spoofed status must not appear in alice's node: {alice_result}"
+    );
+
+    let _ = alice.close().await;
+    let _ = bob.close().await;
+}
+
+#[tokio::test]
+async fn node_is_private_to_non_owner() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut alice, mut bob) = connect_two_accounts().await;
+
+    alice
+        .send(&publish_iq(
+            "alice-pub",
+            "current",
+            &pref_body("manual", Some("away")),
+        ))
+        .await
+        .expect("alice publish");
+    let _ = alice
+        .recv_matching(|frame| frame.contains(r#"id='alice-pub'"#))
+        .await
+        .expect("alice publish result");
+
+    // Bob tries to fetch alice's private preference node. The whitelist
+    // access_model (from the well-known node defaults) MUST reject this.
+    bob.send(&items_get_iq("bob-snoop", Some(&format!("alice@{DOMAIN}"))))
+        .await
+        .expect("bob fetch");
+    let bob_result = bob
+        .recv_matching(|frame| frame.contains(r#"id='bob-snoop'"#))
+        .await
+        .expect("bob fetch result");
+    assert!(
+        bob_result.contains(r#"type='error'"#),
+        "non-owner fetch must error on a whitelist PEP node: {bob_result}"
+    );
+    assert!(
+        bob_result.contains("forbidden") || bob_result.contains("item-not-found"),
+        "expected forbidden or item-not-found, got: {bob_result}"
+    );
+
+    let _ = alice.close().await;
+    let _ = bob.close().await;
+}
+
+#[tokio::test]
+async fn private_pep_does_not_fan_out_to_roster() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut alice, mut bob) = connect_two_accounts().await;
+
+    alice.send("<presence/>").await.expect("alice presence");
+    bob.send("<presence/>").await.expect("bob presence");
+
+    // Bob best-effort subscribes to alice's node (whitelist should
+    // refuse, but the fan-out carve-out is the real guard under test).
+    bob.send(&format!(
+        r#"<iq type="set" id="bob-sub" to="alice@{DOMAIN}">
+          <pubsub xmlns="{NS_PUBSUB}">
+            <subscribe node="{NODE}" jid="bob@{DOMAIN}"/>
+          </pubsub>
+        </iq>"#
+    ))
+    .await
+    .expect("bob subscribe");
+    let _ = bob
+        .recv_matching(|f| f.contains(r#"id='bob-sub'"#))
+        .await
+        .expect("bob subscribe response");
+
+    alice
+        .send(&publish_iq(
+            "alice-pub",
+            "current",
+            &pref_body("manual", Some("dnd")),
+        ))
+        .await
+        .expect("alice publish");
+    let _ = alice
+        .recv_matching(|f| f.contains(r#"id='alice-pub'"#))
+        .await
+        .expect("alice publish result");
+
+    // Bob's stream MUST stay silent for the preference node.
+    let mut leaked: Option<String> = None;
+    for _ in 0..3 {
+        match bob.recv_timeout(Duration::from_millis(250)).await {
+            Ok(frame) => {
+                if frame.contains(NODE) {
+                    leaked = Some(frame);
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    assert!(
+        leaked.is_none(),
+        "private PEP node leaked to roster contact: {leaked:?}"
+    );
+
+    let _ = alice.close().await;
+    let _ = bob.close().await;
+}
+
+fn caps_verification_string(features: &[&str]) -> String {
+    use waddle_xmpp::disco::info::{Feature, Identity};
+    use waddle_xmpp::xep::xep0115::compute_caps_hash;
+    let identities = vec![Identity::new("client", "pc", Some("Waddle"))];
+    let features: Vec<Feature> = features.iter().map(|f| Feature::new(f)).collect();
+    compute_caps_hash(&identities, &features)
+}
+
+/// Bring a resource "online" advertising `urn:waddle:status-preference:0+notify`
+/// in its XEP-0115 caps, completing the server's disco round-trip so the
+/// §3.4 owner-self fan-out will deliver headline events to it.
+async fn announce_status_preference_notify_caps(client: &mut WsXmppClient) {
+    let notify_var = format!("{NODE}+notify");
+    let features = [NS_DISCO_INFO, notify_var.as_str()];
+    let caps_node = "https://waddle.example/caps";
+    let ver = caps_verification_string(&features);
+    let full = client.full_jid.clone().expect("full jid");
+
+    client
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{caps_node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("presence with caps");
+    let disco_query = client
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type='get'"#)
+                && frame.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server queries caps");
+    let iq_id = extract_attr_after(&disco_query, "<iq", "id").expect("disco iq id");
+    let feature_xml: String = features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    client
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="result" id="{iq_id}" from="{full}"><query xmlns="{NS_DISCO_INFO}" node="{caps_node}#{ver}"><identity category="client" type="pc" name="Waddle"/>{feature_xml}</query></iq>"#
+        ))
+        .await
+        .expect("disco#info reply");
+}
+
+#[tokio::test]
+async fn self_fanout_reaches_owner_other_resource() {
+    let _guard = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("alice", &alice_password)]);
+
+    // Two resources of the SAME account.
+    let mut r1 = connect_account(&server, "alice", &alice_password).await;
+    let mut r2 = connect_account(&server, "alice", &alice_password).await;
+
+    // r1 is online (the publisher); r2 advertises +notify caps so the
+    // §3.4 owner-self pass delivers the headline to it.
+    r1.send("<presence/>").await.expect("r1 presence");
+    announce_status_preference_notify_caps(&mut r2).await;
+
+    // r1 publishes a pick. r2 — alice's other resource — MUST receive
+    // the headline event (this is the live cross-device sync path).
+    r1.send(&publish_iq(
+        "r1-pub",
+        "current",
+        &pref_body("manual", Some("away")),
+    ))
+    .await
+    .expect("r1 publish");
+    let _ = r1
+        .recv_matching(|f| f.contains(r#"id='r1-pub'"#))
+        .await
+        .expect("r1 publish result");
+
+    let event = r2
+        .recv_matching(|frame| frame.contains("<message") && frame.contains(NODE))
+        .await
+        .expect("alice's other resource MUST receive the status-preference headline via §3.4 self fan-out");
+    assert!(
+        event.contains(r#"mode="away""#)
+            || event.contains(r#"status="away""#)
+            || event.contains("away"),
+        "headline must carry the published payload: {event}"
+    );
+
+    let _ = r1.close().await;
+    let _ = r2.close().await;
+}

--- a/server/crates/waddle-server/tests/waddle_status_preference_pep_sync_ws.rs
+++ b/server/crates/waddle-server/tests/waddle_status_preference_pep_sync_ws.rs
@@ -151,6 +151,71 @@ fn bare_presence() -> String {
     element_to_xml(Element::builder("presence", CLIENT_NS).build())
 }
 
+/// `<presence type=… to=…/>` (subscription-management presence).
+fn presence_typed(presence_type: &str, to: &str) -> String {
+    element_to_xml(
+        Element::builder("presence", CLIENT_NS)
+            .attr(attr("type"), presence_type)
+            .attr(attr("to"), to)
+            .build(),
+    )
+}
+
+/// `<iq type='get'><query xmlns='jabber:iq:roster'/></iq>` — priming the
+/// roster establishes roster interest so the server later pushes subscription
+/// state changes to the client.
+fn roster_get_iq(id: &str) -> String {
+    let query = Element::builder("query", "jabber:iq:roster").build();
+    iq("get", id, None, None, query)
+}
+
+/// Establish bob → alice presence subscription so alice's roster carries bob
+/// with `subscription = from`. That makes bob a target of alice's XEP-0163 §3
+/// roster+CAPS PEP fan-out — so a non-private node WOULD deliver the headline to
+/// him. The private-node carve-out is what must suppress it. Mirrors
+/// `establish_bob_subscribes_to_alice` in `xep0163_pep_ws.rs`.
+async fn establish_roster_from(
+    alice: &mut WsXmppClient,
+    bob: &mut WsXmppClient,
+    alice_bare: &str,
+    bob_bare: &str,
+) {
+    // Prime both rosters first (roster interest), or the subscription-state
+    // pushes below are not delivered.
+    alice
+        .send(&roster_get_iq("roster-init-a"))
+        .await
+        .expect("alice roster get");
+    let _ = alice
+        .recv_matching(|f| f.contains("roster-init-a"))
+        .await
+        .expect("alice roster result");
+    bob.send(&roster_get_iq("roster-init-b"))
+        .await
+        .expect("bob roster get");
+    let _ = bob
+        .recv_matching(|f| f.contains("roster-init-b"))
+        .await
+        .expect("bob roster result");
+
+    alice.send(&bare_presence()).await.expect("alice presence");
+    bob.send(&presence_typed("subscribe", alice_bare))
+        .await
+        .expect("bob subscribes to alice");
+    let _ = alice
+        .recv_matching(|f| f.contains(r#"type='subscribe'"#))
+        .await
+        .expect("alice receives subscribe request");
+    alice
+        .send(&presence_typed("subscribed", bob_bare))
+        .await
+        .expect("alice approves subscription");
+    let _ = bob
+        .recv_matching(|f| f.contains(r#"type='subscribed'"#))
+        .await
+        .expect("bob receives approval");
+}
+
 fn assert_invalid_payload(xml: &str) {
     assert!(xml.contains(r#"type='error'"#), "expected error iq: {xml}");
     assert!(
@@ -429,32 +494,17 @@ async fn node_is_private_to_non_owner() {
 async fn private_pep_does_not_fan_out_to_roster() {
     let _guard = TEST_SERIAL.lock().await;
     let (_server, mut alice, mut bob) = connect_two_accounts().await;
+    let alice_bare = format!("alice@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
 
-    alice.send(&bare_presence()).await.expect("alice presence");
-    bob.send(&bare_presence()).await.expect("bob presence");
-
-    // Bob best-effort subscribes to alice's node (whitelist should refuse, but
-    // the fan-out carve-out is the real guard under test).
-    let subscribe = Element::builder("subscribe", NS_PUBSUB)
-        .attr(attr("node"), NODE)
-        .attr(attr("jid"), format!("bob@{DOMAIN}"))
-        .build();
-    let subscribe_pubsub = Element::builder("pubsub", NS_PUBSUB)
-        .append(subscribe)
-        .build();
-    bob.send(&iq(
-        "set",
-        "bob-sub",
-        Some(&format!("alice@{DOMAIN}")),
-        None,
-        subscribe_pubsub,
-    ))
-    .await
-    .expect("bob subscribe");
-    let _ = bob
-        .recv_matching(|f| f.contains(r#"id='bob-sub'"#))
-        .await
-        .expect("bob subscribe response");
+    // Make bob a genuine fan-out candidate for alice's §3 roster+CAPS pass:
+    // (1) bob is a roster contact of alice with `subscription = from`, and
+    // (2) bob advertises `urn:waddle:status-preference:0+notify` in his caps.
+    // For a NON-private node both conditions together would deliver the headline
+    // to bob — so this setup is what makes the carve-out the real thing under
+    // test (delete `is_private_pep_node` for this node and this test fails).
+    establish_roster_from(&mut alice, &mut bob, &alice_bare, &bob_bare).await;
+    announce_status_preference_notify_caps(&mut bob).await;
 
     alice
         .send(&publish_iq(
@@ -469,7 +519,9 @@ async fn private_pep_does_not_fan_out_to_roster() {
         .await
         .expect("alice publish result");
 
-    // Bob's stream MUST stay silent for the preference node.
+    // Despite being a roster-`from` contact WITH matching `+notify` caps, bob's
+    // stream MUST stay silent for the preference node — the picked status is
+    // private and never leaks to contacts.
     let mut leaked: Option<String> = None;
     for _ in 0..3 {
         match bob.recv_timeout(Duration::from_millis(250)).await {

--- a/server/crates/waddle-xmpp-client-wasm/src/client_status_preference.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_status_preference.rs
@@ -94,6 +94,18 @@ pub(crate) fn build_status_preference_fetch_iq() -> Element {
         .build()
 }
 
+/// Whether a fetch result IQ's `from` is acceptable per XEP-0223 §Security
+/// Considerations (CVE-2023-28686): the stored preference may be read only
+/// from the account's own bare JID. An absent `from` is the account's own
+/// (PEP) service and is accepted; any other sender is treated as spoofed so
+/// a contact cannot inject a forged preference into the user's other devices.
+fn accept_fetch_from(result_from: Option<&str>, own_bare: &str) -> bool {
+    match result_from {
+        None => true,
+        Some(from) => from == own_bare,
+    }
+}
+
 /// Parse the items result from [`build_status_preference_fetch_iq`].
 ///
 /// Returns `None` when the node has no item, the result shape doesn't
@@ -151,10 +163,8 @@ impl WaddleClient {
                 Ok(r) => r,
                 Err(_) => return Ok(JsValue::NULL),
             };
-            if let Some(from) = result.attr("from") {
-                if from != own_bare {
-                    return Ok(JsValue::NULL);
-                }
+            if !accept_fetch_from(result.attr("from"), &own_bare) {
+                return Ok(JsValue::NULL);
             }
             match parse_status_preference_fetch_result(&result) {
                 Some(pref) => to_js_value(&JsStatusPreference::from(pref)),
@@ -234,5 +244,37 @@ mod tests {
             .parse()
             .expect("valid");
         assert_eq!(parse_status_preference_fetch_result(&iq), None);
+    }
+
+    #[test]
+    fn fetch_from_guard_accepts_absent_or_own_bare() {
+        // The PEP service answers as the account's own bare JID; an absent
+        // `from` is equally the own account. Both are legitimate.
+        assert!(accept_fetch_from(None, "alice@localhost"));
+        assert!(accept_fetch_from(
+            Some("alice@localhost"),
+            "alice@localhost"
+        ));
+    }
+
+    #[test]
+    fn fetch_from_guard_rejects_spoofed_sender() {
+        // CVE-2023-28686: a result purporting to come from anyone other than the
+        // account's own bare JID (a contact, or a look-alike domain) must be
+        // rejected so it cannot inject a forged preference cross-device.
+        assert!(!accept_fetch_from(
+            Some("mallory@localhost"),
+            "alice@localhost"
+        ));
+        assert!(!accept_fetch_from(
+            Some("alice@evil.example"),
+            "alice@localhost"
+        ));
+        // A full JID (resource-qualified) is not the bare-JID PEP service form
+        // and is likewise not accepted.
+        assert!(!accept_fetch_from(
+            Some("alice@localhost/phone"),
+            "alice@localhost"
+        ));
     }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/client_status_preference.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_status_preference.rs
@@ -1,0 +1,238 @@
+//! Cross-device manual-status sync — wasm bridge surface (ADR-010
+//! Phase 4).
+//!
+//! The user's picked presence mode is stored as a single PEP item
+//! (`id = current`) on their own JID per XEP-0223, in the Waddle-custom
+//! `urn:waddle:status-preference:0` namespace. The server pins the
+//! node's privacy (owner-only, `whitelist`) via its well-known-node
+//! defaults — mirroring `urn:waddle:dnd:0` — so no `<publish-options>`
+//! precondition is sent here (contrast `client_story_reads`, whose node
+//! is not well-known and must pin its own config on every publish).
+//!
+//! Live cross-device adoption rides the generic incoming-pubsub-event
+//! path (`on_pubsub_event`): a peer-resource publish arrives as an
+//! opaque `<status-preference/>` and is parsed by the chat layer, the
+//! same shape the XEP-0108 in-call overlay uses.
+
+use minidom::Element;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use waddle_xmpp_core::waddle_status_preference::{
+    StatusPreference, NS_WADDLE_STATUS_PREFERENCE, PEP_ITEM_WADDLE_STATUS_PREFERENCE,
+    PEP_NODE_WADDLE_STATUS_PREFERENCE,
+};
+use wasm_bindgen::prelude::*;
+
+use super::{js_error, send_iq_command, to_js_value, WaddleClient};
+use crate::NS_CLIENT;
+
+const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+
+/// JS-facing status preference: `{ mode, status? }`, mapping 1:1 to the
+/// chat client's `PresenceMode` (`automatic` | `manual` + status).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct JsStatusPreference {
+    pub mode: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+impl From<StatusPreference> for JsStatusPreference {
+    fn from(pref: StatusPreference) -> Self {
+        Self {
+            mode: pref.mode_token().to_string(),
+            status: pref.status_token().map(ToOwned::to_owned),
+        }
+    }
+}
+
+fn status_preference_from_js(input: JsStatusPreference) -> Result<StatusPreference, JsValue> {
+    StatusPreference::from_tokens(&input.mode, input.status.as_deref())
+        .map_err(|err| js_error(format!("invalid status preference: {err}")))
+}
+
+pub(crate) fn build_status_preference_publish_iq(pref: &StatusPreference) -> Element {
+    let id = format!("status-preference-publish-{}", Uuid::new_v4());
+    let item = Element::builder("item", NS_PUBSUB)
+        .attr(
+            minidom::rxml::xml_ncname!("id").to_owned(),
+            PEP_ITEM_WADDLE_STATUS_PREFERENCE,
+        )
+        .append(pref.build_element())
+        .build();
+    let publish = Element::builder("publish", NS_PUBSUB)
+        .attr(
+            minidom::rxml::xml_ncname!("node").to_owned(),
+            PEP_NODE_WADDLE_STATUS_PREFERENCE,
+        )
+        .append(item)
+        .build();
+    let pubsub = Element::builder("pubsub", NS_PUBSUB)
+        .append(publish)
+        .build();
+    Element::builder("iq", NS_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+        .append(pubsub)
+        .build()
+}
+
+pub(crate) fn build_status_preference_fetch_iq() -> Element {
+    let id = format!("status-preference-fetch-{}", Uuid::new_v4());
+    let items = Element::builder("items", NS_PUBSUB)
+        .attr(
+            minidom::rxml::xml_ncname!("node").to_owned(),
+            PEP_NODE_WADDLE_STATUS_PREFERENCE,
+        )
+        .attr(minidom::rxml::xml_ncname!("max_items").to_owned(), "1")
+        .build();
+    let pubsub = Element::builder("pubsub", NS_PUBSUB).append(items).build();
+    Element::builder("iq", NS_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+        .append(pubsub)
+        .build()
+}
+
+/// Parse the items result from [`build_status_preference_fetch_iq`].
+///
+/// Returns `None` when the node has no item, the result shape doesn't
+/// match, or the payload is malformed — "no preference" degrades to
+/// Automatic at the chat layer, so a hard error here would be worse
+/// than absence.
+pub(crate) fn parse_status_preference_fetch_result(iq: &Element) -> Option<StatusPreference> {
+    let pubsub = iq.get_child("pubsub", NS_PUBSUB)?;
+    let items = pubsub.get_child("items", NS_PUBSUB)?;
+    items
+        .children()
+        .filter(|el| el.name() == "item" && el.ns() == NS_PUBSUB)
+        .find_map(|item| {
+            item.children()
+                .find(|c| c.name() == "status-preference" && c.ns() == NS_WADDLE_STATUS_PREFERENCE)
+                .and_then(|el| StatusPreference::parse(el).ok())
+        })
+}
+
+#[wasm_bindgen]
+impl WaddleClient {
+    /// Publish the user's picked presence mode. Overwrites the single
+    /// `current` item on every call (reset publishes `mode='automatic'`
+    /// rather than retracting, so the change fans out to other devices).
+    pub fn status_preference_publish(&self, input: JsValue) -> js_sys::Promise {
+        let inner = self.inner.clone();
+        wasm_bindgen_futures::future_to_promise(async move {
+            let input: JsStatusPreference = serde_wasm_bindgen::from_value(input)
+                .map_err(|err| js_error(format!("invalid status_preference input: {err}")))?;
+            let pref = status_preference_from_js(input)?;
+            let iq = build_status_preference_publish_iq(&pref);
+            send_iq_command(inner, iq).await?;
+            to_js_value(&JsStatusPreference::from(pref))
+        })
+    }
+
+    /// Fetch the user's stored preference from their own PEP node.
+    /// Resolves to `null` when nothing is stored.
+    ///
+    /// Per XEP-0223 §Security Considerations (CVE-2023-28686), the
+    /// result IQ's `from` MUST be absent or the account's bare JID;
+    /// anything else is treated as spoofed and yields `null`.
+    pub fn status_preference_fetch(&self) -> js_sys::Promise {
+        let inner = self.inner.clone();
+        wasm_bindgen_futures::future_to_promise(async move {
+            let own_bare = {
+                let jid_str = inner.borrow().config.jid.clone();
+                let parsed: jid::Jid = jid_str
+                    .parse()
+                    .map_err(|err| js_error(format!("invalid own JID: {err}")))?;
+                parsed.to_bare().to_string()
+            };
+            let iq = build_status_preference_fetch_iq();
+            let result = match send_iq_command(inner, iq).await {
+                Ok(r) => r,
+                Err(_) => return Ok(JsValue::NULL),
+            };
+            if let Some(from) = result.attr("from") {
+                if from != own_bare {
+                    return Ok(JsValue::NULL);
+                }
+            }
+            match parse_status_preference_fetch_result(&result) {
+                Some(pref) => to_js_value(&JsStatusPreference::from(pref)),
+                None => Ok(JsValue::NULL),
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use waddle_xmpp_core::waddle_status_preference::ManualStatus;
+
+    #[test]
+    fn publish_iq_targets_node_and_current_item() {
+        let iq = build_status_preference_publish_iq(&StatusPreference::Manual(ManualStatus::Away));
+        let publish = iq
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|p| p.get_child("publish", NS_PUBSUB))
+            .expect("publish element");
+        assert_eq!(
+            publish.attr("node"),
+            Some(PEP_NODE_WADDLE_STATUS_PREFERENCE)
+        );
+        let item = publish.get_child("item", NS_PUBSUB).expect("item");
+        assert_eq!(item.attr("id"), Some(PEP_ITEM_WADDLE_STATUS_PREFERENCE));
+        let payload = item
+            .get_child("status-preference", NS_WADDLE_STATUS_PREFERENCE)
+            .expect("payload");
+        assert_eq!(payload.attr("mode"), Some("manual"));
+        assert_eq!(payload.attr("status"), Some("away"));
+    }
+
+    #[test]
+    fn publish_iq_omits_publish_options() {
+        // The node is server-well-known, so the client does NOT pin its
+        // own config (contrast story-reads). A stray `<publish-options>`
+        // would needlessly risk a precondition mismatch.
+        let iq = build_status_preference_publish_iq(&StatusPreference::Automatic);
+        let pubsub = iq.get_child("pubsub", NS_PUBSUB).expect("pubsub");
+        assert!(pubsub.get_child("publish-options", NS_PUBSUB).is_none());
+    }
+
+    #[test]
+    fn fetch_iq_targets_node() {
+        let iq = build_status_preference_fetch_iq();
+        let items = iq
+            .get_child("pubsub", NS_PUBSUB)
+            .and_then(|p| p.get_child("items", NS_PUBSUB))
+            .expect("items element");
+        assert_eq!(items.attr("node"), Some(PEP_NODE_WADDLE_STATUS_PREFERENCE));
+        assert_eq!(items.attr("max_items"), Some("1"));
+    }
+
+    #[test]
+    fn parse_fetch_returns_manual_status() {
+        let xml = "<iq xmlns='jabber:client' type='result' id='x'>\
+            <pubsub xmlns='http://jabber.org/protocol/pubsub'>\
+              <items node='urn:waddle:status-preference:0'>\
+                <item id='current'>\
+                  <status-preference xmlns='urn:waddle:status-preference:0' mode='manual' status='dnd'/>\
+                </item>\
+              </items>\
+            </pubsub>\
+          </iq>";
+        let iq: Element = xml.parse().expect("valid");
+        assert_eq!(
+            parse_status_preference_fetch_result(&iq),
+            Some(StatusPreference::Manual(ManualStatus::Dnd))
+        );
+    }
+
+    #[test]
+    fn parse_fetch_returns_none_when_empty() {
+        let iq: Element = "<iq xmlns='jabber:client' type='result' id='x'/>"
+            .parse()
+            .expect("valid");
+        assert_eq!(parse_status_preference_fetch_result(&iq), None);
+    }
+}

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -75,6 +75,7 @@ mod client_history;
 mod client_messaging;
 mod client_rooms;
 mod client_social_feed;
+mod client_status_preference;
 mod client_stories;
 mod client_story_reads;
 mod client_xcal;

--- a/server/crates/waddle-xmpp-client/src/caps.rs
+++ b/server/crates/waddle-xmpp-client/src/caps.rs
@@ -22,6 +22,11 @@ pub fn client_caps_features() -> Vec<&'static str> {
         // fans their in-call overlay (ADR-010 Phase 3) out to us. Without this
         // the activity PEP node is published but no contact is ever notified.
         crate::pep::NS_ACTIVITY_NOTIFY,
+        // XEP-0163 §3.4: advertise interest in our OWN status-preference node
+        // (ADR-010 Phase 4) so the server's owner-self fan-out delivers a pick
+        // made on one device to our other resources live. Without this the
+        // node is published but no resource is ever notified.
+        crate::pep::NS_STATUS_PREFERENCE_NOTIFY,
     ]
 }
 
@@ -135,6 +140,21 @@ mod tests {
         // ADR-010 Phase 3: the in-call overlay receive path depends on this
         // being advertised, or the server never fans a peer's activity to us.
         assert!(client_caps_features().contains(&crate::pep::NS_ACTIVITY_NOTIFY));
+        // ADR-010 Phase 4: the cross-device manual-status sync depends on
+        // this, or the server's §3.4 owner-self fan-out never delivers the
+        // user's pick to their other resources.
+        assert!(client_caps_features().contains(&crate::pep::NS_STATUS_PREFERENCE_NOTIFY));
+    }
+
+    #[test]
+    fn status_preference_notify_matches_core_node() {
+        assert_eq!(
+            crate::pep::NS_STATUS_PREFERENCE_NOTIFY,
+            format!(
+                "{}+notify",
+                waddle_xmpp_core::waddle_status_preference::PEP_NODE_WADDLE_STATUS_PREFERENCE
+            )
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/pep.rs
+++ b/server/crates/waddle-xmpp-client/src/pep.rs
@@ -18,6 +18,12 @@ pub const NS_ACTIVITY: &str = "http://jabber.org/protocol/activity";
 /// receives a peer's in-call overlay (ADR-010 Phase 3) only if it advertises
 /// this in its XEP-0115 caps.
 pub const NS_ACTIVITY_NOTIFY: &str = "http://jabber.org/protocol/activity+notify";
+/// XEP-0163 §3.4 notification filter for the Waddle status-preference node:
+/// the user's own resources receive a manual-status pick (ADR-010 Phase 4)
+/// only if they advertise this in their XEP-0115 caps. Pinned to
+/// `waddle_xmpp_core::waddle_status_preference::PEP_NODE_WADDLE_STATUS_PREFERENCE`
+/// by `caps::tests::status_preference_notify_matches_core_node`.
+pub const NS_STATUS_PREFERENCE_NOTIFY: &str = "urn:waddle:status-preference:0+notify";
 pub const NS_TUNE: &str = "http://jabber.org/protocol/tune";
 pub const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
 pub const NS_PUBSUB_EVENT: &str = "http://jabber.org/protocol/pubsub#event";

--- a/server/crates/waddle-xmpp-core/src/lib.rs
+++ b/server/crates/waddle-xmpp-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod pubsub;
 pub mod roster;
 pub mod stanza;
 pub mod types;
+pub mod waddle_status_preference;
 pub mod waddle_story_reads;
 pub mod xcal;
 pub mod xep0201;

--- a/server/crates/waddle-xmpp-core/src/pubsub/node.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/node.rs
@@ -333,8 +333,41 @@ impl NodeConfig {
             config = Self::waddle_dnd_defaults();
         } else if node == super::pep::PEP_NODE_WADDLE_DM_BOOKMARKS {
             config = Self::waddle_dm_bookmarks_defaults();
+        } else if node == crate::waddle_status_preference::PEP_NODE_WADDLE_STATUS_PREFERENCE {
+            config = Self::waddle_status_preference_defaults();
         }
         config
+    }
+
+    /// Defaults for the Waddle status-preference PEP node (ADR-010
+    /// Phase 4).
+    ///
+    /// The synced manual-status payload is owner-only private state: it
+    /// follows the user across their own resources but no roster contact
+    /// needs to read it (contacts see only the resulting `<show>` on the
+    /// normal presence broadcast). Force `whitelist` access and `never`
+    /// send-last-published so a fresh roster subscription never receives
+    /// it; the user's own resources read it via `<items/>` GET on connect
+    /// and adopt live changes via the XEP-0163 §3.4 self fan-out.
+    /// `max_items = 1` keeps the node single-slot (`id = current`).
+    ///
+    /// `notify_retract` / `notify_delete` are `false` because the server
+    /// does not emit the XEP-0060 §7.2.2 / §9.1.5 retract/delete events
+    /// on the wire — advertising them as `true` would lie to subscribers,
+    /// and reset is published as an explicit `mode='automatic'` item
+    /// rather than a retract precisely so it fans out as a publish.
+    pub fn waddle_status_preference_defaults() -> Self {
+        Self {
+            access_model: AccessModel::Whitelist,
+            publish_model: PublishModel::Publishers,
+            node_type: None,
+            max_items: 1,
+            persist_items: true,
+            deliver_payloads: true,
+            notify_retract: false,
+            notify_delete: false,
+            send_last_published_item: SendLastPublishedItem::Never,
+        }
     }
 
     /// Defaults for the Waddle DM-bookmarks PEP node (issue #720).
@@ -700,6 +733,36 @@ mod tests {
         assert_eq!(
             NodeConfig::pep_for_node(super::super::pep::PEP_NODE_WADDLE_DM_BOOKMARKS),
             NodeConfig::waddle_dm_bookmarks_defaults()
+        );
+    }
+
+    #[test]
+    fn waddle_status_preference_pep_config_is_single_slot_whitelist() {
+        // The synced manual-status payload (ADR-010 Phase 4) is owner-only
+        // private state — only the user's own resources read it, never
+        // roster contacts — so it must stay off the roster fan-out
+        // (whitelist + send-last=never), single-slot (`id = current`).
+        let node = crate::waddle_status_preference::PEP_NODE_WADDLE_STATUS_PREFERENCE;
+        let config = NodeConfig::pep_for_node(node);
+        assert_eq!(config.access_model, AccessModel::Whitelist);
+        assert_eq!(config.publish_model, PublishModel::Publishers);
+        assert_eq!(config.max_items, 1);
+        assert!(config.persist_items);
+        assert!(config.deliver_payloads);
+        assert!(!config.notify_retract);
+        assert!(!config.notify_delete);
+        assert_eq!(
+            config.send_last_published_item,
+            SendLastPublishedItem::Never
+        );
+    }
+
+    #[test]
+    fn waddle_status_preference_defaults_helper_matches_pep_for_node() {
+        let node = crate::waddle_status_preference::PEP_NODE_WADDLE_STATUS_PREFERENCE;
+        assert_eq!(
+            NodeConfig::pep_for_node(node),
+            NodeConfig::waddle_status_preference_defaults()
         );
     }
 

--- a/server/crates/waddle-xmpp-core/src/pubsub/pep.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/pep.rs
@@ -103,6 +103,7 @@ impl PepHandler {
             || node == PEP_NODE_VCARD4
             || node == PEP_NODE_WADDLE_DND
             || node == PEP_NODE_WADDLE_DM_BOOKMARKS
+            || node == crate::waddle_status_preference::PEP_NODE_WADDLE_STATUS_PREFERENCE
             || node == "http://jabber.org/protocol/nick"
             || node == "http://jabber.org/protocol/mood"
             || node == "http://jabber.org/protocol/activity"
@@ -117,6 +118,7 @@ impl PepHandler {
             || node == PEP_NODE_MDS_DISPLAYED
             || node == PEP_NODE_WADDLE_DND
             || node == PEP_NODE_WADDLE_DM_BOOKMARKS
+            || node == crate::waddle_status_preference::PEP_NODE_WADDLE_STATUS_PREFERENCE
         {
             return AccessModel::Whitelist;
         }
@@ -214,6 +216,16 @@ mod tests {
         assert!(PepHandler::is_well_known_node(PEP_NODE_WADDLE_DM_BOOKMARKS));
         assert_eq!(
             PepHandler::default_access_model_for_node(PEP_NODE_WADDLE_DM_BOOKMARKS),
+            AccessModel::Whitelist
+        );
+    }
+
+    #[test]
+    fn waddle_status_preference_node_is_well_known_and_whitelisted() {
+        let node = crate::waddle_status_preference::PEP_NODE_WADDLE_STATUS_PREFERENCE;
+        assert!(PepHandler::is_well_known_node(node));
+        assert_eq!(
+            PepHandler::default_access_model_for_node(node),
             AccessModel::Whitelist
         );
     }

--- a/server/crates/waddle-xmpp-core/src/waddle_status_preference.rs
+++ b/server/crates/waddle-xmpp-core/src/waddle_status_preference.rs
@@ -1,0 +1,425 @@
+//! Waddle status preference: the user's manually-picked presence mode,
+//! synced across their own devices (ADR-010 Phase 4).
+//!
+//! Phase 1 stores the chosen mode in-memory on one device only. This
+//! payload persists it as a single pubsub item on the user's own JID
+//! per XEP-0223 "Persistent Storage of Private Data via PubSub", so the
+//! pick follows the user across resources and survives a reconnect. No
+//! XEP models a "synced chosen-presence", so the payload lives in the
+//! project-local `urn:waddle:status-preference:0` namespace per the
+//! CLAUDE.md XEP-conformance hard rule. The server-side transport
+//! conventions mirror `urn:waddle:dnd:0` (owner-only, `whitelist`
+//! access, single item id `current`).
+//!
+//! Auto-away (Phase 2) is deliberately NOT part of this payload — it
+//! stays per-device.
+//!
+//! ## XML Format
+//!
+//! ```xml
+//! <status-preference xmlns='urn:waddle:status-preference:0' mode='automatic'/>
+//! <status-preference xmlns='urn:waddle:status-preference:0' mode='manual' status='away'/>
+//! ```
+//!
+//! * `mode` — required, `automatic` | `manual`.
+//! * `status` — required iff `mode='manual'`, one of `available` |
+//!   `away` | `dnd` (the Phase 1 manual-status set). Forbidden when
+//!   `mode='automatic'`.
+//!
+//! Reset-to-automatic is published as an explicit `mode='automatic'`
+//! item rather than a retract: the node defaults pin `notify_retract =
+//! false` (mirroring dnd), so a retract would not fan out to the user's
+//! other online resources. An explicit publish makes every mode change
+//! — including reset — a normal publish that the XEP-0163 §3.4 self
+//! fan-out delivers live.
+//!
+//! The parser is strict (dnd style): unknown attributes, child
+//! elements, text content, and namespaced attributes are rejected so a
+//! client that wants to extend the shape must bump the namespace.
+
+use minidom::rxml::xml_ncname;
+use minidom::Element;
+use thiserror::Error;
+
+/// XML namespace + PEP node id for the status-preference payload. They
+/// coincide deliberately, matching XEP-0163's one-node-per-namespace
+/// convention; the two constants exist for call-site readability.
+pub const NS_WADDLE_STATUS_PREFERENCE: &str = "urn:waddle:status-preference:0";
+
+/// PEP node id for the status-preference payload. Equal to
+/// [`NS_WADDLE_STATUS_PREFERENCE`] by design.
+pub const PEP_NODE_WADDLE_STATUS_PREFERENCE: &str = NS_WADDLE_STATUS_PREFERENCE;
+
+/// Single fixed item id (the XEP-0163 single-item idiom), overwritten
+/// in place on every publish.
+pub const PEP_ITEM_WADDLE_STATUS_PREFERENCE: &str = "current";
+
+const ELEMENT_STATUS_PREFERENCE: &str = "status-preference";
+const ATTR_MODE: &str = "mode";
+const ATTR_STATUS: &str = "status";
+
+const MODE_AUTOMATIC: &str = "automatic";
+const MODE_MANUAL: &str = "manual";
+
+const STATUS_AVAILABLE: &str = "available";
+const STATUS_AWAY: &str = "away";
+const STATUS_DND: &str = "dnd";
+
+/// The user's manually-picked status when not in Automatic mode. Mirrors
+/// the chat client's `ManualStatus` (`available | away | dnd`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManualStatus {
+    Available,
+    Away,
+    Dnd,
+}
+
+impl ManualStatus {
+    /// The wire token for this status (`available` | `away` | `dnd`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ManualStatus::Available => STATUS_AVAILABLE,
+            ManualStatus::Away => STATUS_AWAY,
+            ManualStatus::Dnd => STATUS_DND,
+        }
+    }
+
+    /// Parse a wire token into a [`ManualStatus`].
+    pub fn from_token(raw: &str) -> Result<Self, StatusPreferenceParseError> {
+        match raw {
+            STATUS_AVAILABLE => Ok(ManualStatus::Available),
+            STATUS_AWAY => Ok(ManualStatus::Away),
+            STATUS_DND => Ok(ManualStatus::Dnd),
+            other => Err(StatusPreferenceParseError::UnknownStatus(other.to_string())),
+        }
+    }
+}
+
+/// The user's chosen presence mode. `Automatic` lets the per-device
+/// auto-away timer govern; `Manual` pins a specific status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusPreference {
+    Automatic,
+    Manual(ManualStatus),
+}
+
+/// Errors raised while parsing a `<status-preference>` element.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum StatusPreferenceParseError {
+    #[error(
+        "expected <status-preference xmlns='{NS_WADDLE_STATUS_PREFERENCE}'> root, \
+         got <{name} xmlns='{ns}'>"
+    )]
+    WrongRoot { name: String, ns: String },
+    #[error("<status-preference> requires the 'mode' attribute")]
+    MissingMode,
+    #[error("unknown mode '{0}' (expected 'automatic' or 'manual')")]
+    UnknownMode(String),
+    #[error("mode='manual' requires the 'status' attribute")]
+    MissingStatus,
+    #[error("'status' attribute is not allowed when mode='automatic'")]
+    UnexpectedStatus,
+    #[error("unknown status '{0}' (expected 'available', 'away', or 'dnd')")]
+    UnknownStatus(String),
+    #[error("unknown attribute '{0}' on <status-preference>")]
+    UnknownAttribute(String),
+    #[error("namespaced attribute '{0}' is not allowed on <status-preference>")]
+    NamespacedAttribute(String),
+    #[error("unexpected child element <{0}> in <status-preference>")]
+    UnexpectedChild(String),
+    #[error("unexpected text content in <status-preference>")]
+    UnexpectedTextContent,
+}
+
+impl StatusPreference {
+    /// The wire `mode` token (`automatic` | `manual`).
+    pub fn mode_token(&self) -> &'static str {
+        match self {
+            StatusPreference::Automatic => MODE_AUTOMATIC,
+            StatusPreference::Manual(_) => MODE_MANUAL,
+        }
+    }
+
+    /// The wire `status` token, present only for a manual pick.
+    pub fn status_token(&self) -> Option<&'static str> {
+        match self {
+            StatusPreference::Automatic => None,
+            StatusPreference::Manual(status) => Some(status.as_str()),
+        }
+    }
+
+    /// Build a [`StatusPreference`] from its `mode` + optional `status`
+    /// wire tokens. The single source of truth for the mode×status
+    /// validation rules, shared by [`parse`](Self::parse) (XML) and the
+    /// wasm/JS bridge (camelCase string fields).
+    pub fn from_tokens(
+        mode: &str,
+        status: Option<&str>,
+    ) -> Result<Self, StatusPreferenceParseError> {
+        match mode {
+            MODE_AUTOMATIC => {
+                if status.is_some() {
+                    return Err(StatusPreferenceParseError::UnexpectedStatus);
+                }
+                Ok(StatusPreference::Automatic)
+            }
+            MODE_MANUAL => {
+                let status = status.ok_or(StatusPreferenceParseError::MissingStatus)?;
+                Ok(StatusPreference::Manual(ManualStatus::from_token(status)?))
+            }
+            other => Err(StatusPreferenceParseError::UnknownMode(other.to_string())),
+        }
+    }
+
+    /// Serialize to a `<status-preference>` element for a PEP publish.
+    pub fn build_element(&self) -> Element {
+        let mut builder = Element::builder(ELEMENT_STATUS_PREFERENCE, NS_WADDLE_STATUS_PREFERENCE)
+            .attr(xml_ncname!("mode").to_owned(), self.mode_token());
+        if let Some(status) = self.status_token() {
+            builder = builder.attr(xml_ncname!("status").to_owned(), status);
+        }
+        builder.build()
+    }
+
+    /// Parse a `<status-preference xmlns='urn:waddle:status-preference:0'>`
+    /// element into a typed [`StatusPreference`].
+    pub fn parse(element: &Element) -> Result<Self, StatusPreferenceParseError> {
+        if element.name() != ELEMENT_STATUS_PREFERENCE
+            || element.ns() != NS_WADDLE_STATUS_PREFERENCE
+        {
+            return Err(StatusPreferenceParseError::WrongRoot {
+                name: element.name().to_string(),
+                ns: element.ns().to_string(),
+            });
+        }
+
+        reject_unknown_attrs(element, &[ATTR_MODE, ATTR_STATUS])?;
+        reject_any_children(element)?;
+
+        let mode = element
+            .attr(ATTR_MODE)
+            .ok_or(StatusPreferenceParseError::MissingMode)?;
+        Self::from_tokens(mode, element.attr(ATTR_STATUS))
+    }
+}
+
+fn reject_unknown_attrs(
+    element: &Element,
+    known: &[&str],
+) -> Result<(), StatusPreferenceParseError> {
+    for ((ns, name), _value) in element.attrs().iter() {
+        let attr_name = name.as_str();
+        // Prefixed attributes (non-empty namespace) are never part of
+        // this XEP's contract — reject them so a client can't sneak
+        // `foo:mode='bar'` past the strict-parser gate.
+        if !ns.as_str().is_empty() {
+            return Err(StatusPreferenceParseError::NamespacedAttribute(
+                attr_name.to_string(),
+            ));
+        }
+        if !known.contains(&attr_name) {
+            return Err(StatusPreferenceParseError::UnknownAttribute(
+                attr_name.to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// `<status-preference>` is a leaf element: reject both child elements
+/// and any (non-whitespace) text content, which would otherwise be
+/// silently persisted into `pubsub_items` as raw XML.
+fn reject_any_children(element: &Element) -> Result<(), StatusPreferenceParseError> {
+    if let Some(child) = element.children().next() {
+        return Err(StatusPreferenceParseError::UnexpectedChild(
+            child.name().to_string(),
+        ));
+    }
+    if !element.text().trim().is_empty() {
+        return Err(StatusPreferenceParseError::UnexpectedTextContent);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_trip(pref: StatusPreference) {
+        let element = pref.build_element();
+        let parsed = StatusPreference::parse(&element).expect("round-trip parse");
+        assert_eq!(parsed, pref);
+    }
+
+    #[test]
+    fn round_trip_automatic() {
+        round_trip(StatusPreference::Automatic);
+    }
+
+    #[test]
+    fn round_trip_manual_statuses() {
+        round_trip(StatusPreference::Manual(ManualStatus::Available));
+        round_trip(StatusPreference::Manual(ManualStatus::Away));
+        round_trip(StatusPreference::Manual(ManualStatus::Dnd));
+    }
+
+    fn parse_str(xml: &str) -> Result<StatusPreference, StatusPreferenceParseError> {
+        let element: Element = xml.parse().expect("test fixture must be valid XML");
+        StatusPreference::parse(&element)
+    }
+
+    #[test]
+    fn build_automatic_omits_status() {
+        let element = StatusPreference::Automatic.build_element();
+        assert_eq!(element.attr("mode"), Some("automatic"));
+        assert_eq!(element.attr("status"), None);
+    }
+
+    #[test]
+    fn build_manual_carries_status() {
+        let element = StatusPreference::Manual(ManualStatus::Dnd).build_element();
+        assert_eq!(element.attr("mode"), Some("manual"));
+        assert_eq!(element.attr("status"), Some("dnd"));
+    }
+
+    #[test]
+    fn parse_known_manual_status_tokens() {
+        assert_eq!(
+            parse_str("<status-preference xmlns='urn:waddle:status-preference:0' mode='manual' status='available'/>"),
+            Ok(StatusPreference::Manual(ManualStatus::Available))
+        );
+    }
+
+    #[test]
+    fn parse_wrong_element_rejected() {
+        assert!(matches!(
+            parse_str("<status xmlns='urn:waddle:status-preference:0' mode='automatic'/>"),
+            Err(StatusPreferenceParseError::WrongRoot { .. })
+        ));
+    }
+
+    #[test]
+    fn parse_wrong_namespace_rejected() {
+        assert!(matches!(
+            parse_str("<status-preference xmlns='urn:example:other' mode='automatic'/>"),
+            Err(StatusPreferenceParseError::WrongRoot { .. })
+        ));
+    }
+
+    #[test]
+    fn parse_missing_mode_rejected() {
+        assert_eq!(
+            parse_str("<status-preference xmlns='urn:waddle:status-preference:0'/>"),
+            Err(StatusPreferenceParseError::MissingMode)
+        );
+    }
+
+    #[test]
+    fn parse_unknown_mode_rejected() {
+        assert!(matches!(
+            parse_str(
+                "<status-preference xmlns='urn:waddle:status-preference:0' mode='invisible'/>"
+            ),
+            Err(StatusPreferenceParseError::UnknownMode(_))
+        ));
+    }
+
+    #[test]
+    fn parse_manual_missing_status_rejected() {
+        assert_eq!(
+            parse_str("<status-preference xmlns='urn:waddle:status-preference:0' mode='manual'/>"),
+            Err(StatusPreferenceParseError::MissingStatus)
+        );
+    }
+
+    #[test]
+    fn parse_automatic_with_status_rejected() {
+        assert_eq!(
+            parse_str("<status-preference xmlns='urn:waddle:status-preference:0' mode='automatic' status='away'/>"),
+            Err(StatusPreferenceParseError::UnexpectedStatus)
+        );
+    }
+
+    #[test]
+    fn parse_unknown_status_rejected() {
+        assert!(matches!(
+            parse_str("<status-preference xmlns='urn:waddle:status-preference:0' mode='manual' status='xa'/>"),
+            Err(StatusPreferenceParseError::UnknownStatus(_))
+        ));
+    }
+
+    #[test]
+    fn parse_unknown_attribute_rejected() {
+        assert!(matches!(
+            parse_str("<status-preference xmlns='urn:waddle:status-preference:0' mode='automatic' foo='bar'/>"),
+            Err(StatusPreferenceParseError::UnknownAttribute(_))
+        ));
+    }
+
+    #[test]
+    fn parse_namespaced_attribute_rejected() {
+        assert!(matches!(
+            parse_str(
+                "<status-preference xmlns='urn:waddle:status-preference:0' \
+                 xmlns:other='urn:example:other' mode='automatic' other:mode='manual'/>"
+            ),
+            Err(StatusPreferenceParseError::NamespacedAttribute(_))
+        ));
+    }
+
+    #[test]
+    fn parse_unexpected_child_rejected() {
+        assert!(matches!(
+            parse_str("<status-preference xmlns='urn:waddle:status-preference:0' mode='automatic'><extra/></status-preference>"),
+            Err(StatusPreferenceParseError::UnexpectedChild(_))
+        ));
+    }
+
+    #[test]
+    fn parse_unexpected_text_content_rejected() {
+        assert_eq!(
+            parse_str("<status-preference xmlns='urn:waddle:status-preference:0' mode='automatic'>oops</status-preference>"),
+            Err(StatusPreferenceParseError::UnexpectedTextContent)
+        );
+    }
+
+    #[test]
+    fn from_tokens_round_trips_via_token_accessors() {
+        for pref in [
+            StatusPreference::Automatic,
+            StatusPreference::Manual(ManualStatus::Available),
+            StatusPreference::Manual(ManualStatus::Away),
+            StatusPreference::Manual(ManualStatus::Dnd),
+        ] {
+            let rebuilt =
+                StatusPreference::from_tokens(pref.mode_token(), pref.status_token()).expect("ok");
+            assert_eq!(rebuilt, pref);
+        }
+    }
+
+    #[test]
+    fn from_tokens_enforces_mode_status_rules() {
+        assert_eq!(
+            StatusPreference::from_tokens("automatic", Some("away")),
+            Err(StatusPreferenceParseError::UnexpectedStatus)
+        );
+        assert_eq!(
+            StatusPreference::from_tokens("manual", None),
+            Err(StatusPreferenceParseError::MissingStatus)
+        );
+        assert!(matches!(
+            StatusPreference::from_tokens("bogus", None),
+            Err(StatusPreferenceParseError::UnknownMode(_))
+        ));
+    }
+
+    #[test]
+    fn parse_whitespace_only_text_accepted() {
+        // Pretty-printed XML carries formatting whitespace; treat it as
+        // equivalent to no text.
+        assert_eq!(
+            parse_str("<status-preference xmlns='urn:waddle:status-preference:0' mode='automatic'>\n  </status-preference>"),
+            Ok(StatusPreference::Automatic)
+        );
+    }
+}

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -477,6 +477,21 @@ export class WaddleClient {
      */
     set_room_notification_mode(options: any): Promise<any>;
     /**
+     * Fetch the user's stored preference from their own PEP node.
+     * Resolves to `null` when nothing is stored.
+     *
+     * Per XEP-0223 §Security Considerations (CVE-2023-28686), the
+     * result IQ's `from` MUST be absent or the account's bare JID;
+     * anything else is treated as spoofed and yields `null`.
+     */
+    status_preference_fetch(): Promise<any>;
+    /**
+     * Publish the user's picked presence mode. Overwrites the single
+     * `current` item on every call (reset publishes `mode='automatic'`
+     * rather than retracting, so the change fans out to other devices).
+     */
+    status_preference_publish(input: any): Promise<any>;
+    /**
      * Fetch the latest stories from the community stories node on
      * `community_jid`. Returns ALL items including expired ones —
      * the chat filters active vs expired locally so a story fades

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=122ac825757f";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=122ac825757f";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=122ac825757f";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=fee832e70413";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=fee832e70413";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=fee832e70413";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=122ac825757f";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=fee832e70413";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=fb30b7571c47";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=fb30b7571c47";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=fb30b7571c47";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=122ac825757f";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=122ac825757f";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=122ac825757f";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=fb30b7571c47";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=122ac825757f";


### PR DESCRIPTION
## Presence Phase 4 — cross-device manual-status sync (XEP-0223)

Closes #1074. Part of the presence epic #1071 (ADR-010); follows Phase 1 (#1070), Phase 2 (#1077), Phase 3 (#1078).

### Context

A manually-picked presence status (`$presenceMode`) previously lived **only** in an in-memory nanostore on the device that picked it — it didn't follow the user to their other devices and didn't survive a reconnect/fresh login. This phase persists the chosen mode in a XEP-0223 persistent private PEP node so it syncs across the user's own resources and is restored on connect. Auto-away (Phase 2) stays **per-device** and is untouched (it is never written to the node — only the chosen mode is).

### Wire contract — `urn:waddle:status-preference:0`

Waddle-custom payload (no XEP models a synced chosen-presence) over standard XEP-0223 transport, mirroring the established `urn:waddle:dnd:0` server conventions: owner-only, `access_model=whitelist`, single item id `current`, publisher-must-equal-owner.

```xml
<status-preference xmlns='urn:waddle:status-preference:0' mode='automatic'/>
<status-preference xmlns='urn:waddle:status-preference:0' mode='manual' status='away'/>
```

* `mode` — required, `automatic` | `manual`.
* `status` — required iff `mode='manual'`, one of `available` | `away` | `dnd` (the Phase 1 `ManualStatus` set); forbidden when `mode='automatic'`.
* Strict parser (dnd style): unknown attrs/children/text/namespaced-attrs rejected.

**Reset = explicit `mode='automatic'` publish, not a retract.** The dnd-style defaults set `notify_retract=false`, so a retract would not fan out to the user's other online resources — a reset would silently fail to propagate live. Publishing an explicit `automatic` item makes every mode change (including reset) a normal publish that fans out via XEP-0163 §3.4.

### Design

**Server enforcement mirrors `dnd`** (well-known node + forced privacy defaults + owner/item-id checks); **the wire type lives in `waddle-xmpp-core`** so the wasm/FFI client can build+parse it (like `urn:waddle:story:reads:0`); **live `+notify` receive mirrors Phase 3's activity-overlay receive** (opaque PEP event → TS DOMParser shell). Unlike dnd, status-preference is **not** server-consumed, so **no projection table** is added — the server stores the PEP item, enforces the invariants, serves it on `<items/>` get, and fans it out to the owner's other resources.

**Privacy:** added to `is_private_pep_node` so the §3 **roster** pass is skipped (contacts must not learn the picked mode) while the §3.4 **owner-self** pass still runs; that self pass is caps-gated, so the client advertises `urn:waddle:status-preference:0+notify`.

**Cross-device conflict handling** (`StatusPreferenceCoordinator`): `applyRemote` seeds the publish baseline before writing the store, so an adopted remote pick never echoes back (no ping-pong); a fresh device adopts the server's stored pick rather than clobbering it with its default; an unpublished local pick (chosen while disconnected) wins over the stale server value on reconnect; logout `suspend()`s the coordinator so the local reset-to-Automatic never publishes (the preference must persist for the user's other devices).

### What changed

- **`waddle-xmpp-core`**: new `waddle_status_preference` module (`StatusPreference` type, strict parse/build, tokens); node registered in `pubsub/pep.rs` + `pubsub/node.rs` (`waddle_status_preference_defaults`).
- **`waddle-server`**: owner-only + item-id + payload-validate enforcement in `pubsub/item.rs`; `is_private_pep_node` carve-out in `pubsub_fanout.rs`.
- **`waddle-xmpp-client` / `-wasm`**: `+notify` cap; `client_status_preference` wasm bridge (`status_preference_publish` / `status_preference_fetch`). wasm-only — the UniFFI/Apple surface is untouched.
- **`chat`**: `presence/status-preference.ts` (wire mapping + receive), `presence/status-preference-coordinator.ts` (diff-driven publisher); `client.ts` thin wrappers; controller wiring (publish on pick, adopt inbound, sync on fresh connect, suspend on logout).

### Tests

- Rust unit: full strict-parser matrix + round-trip (`waddle_status_preference.rs`), node-config defaults (`node.rs`/`pep.rs`), caps pin (`caps.rs`), wasm IQ build/parse (`client_status_preference.rs`).
- Rust WS integration (`waddle_status_preference_pep_sync_ws.rs`, 10 tests): publish round-trip + owner fetch, item-id enforcement, malformed/empty payload rejection, non-owner publish refused, whitelist blocks non-owner fetch, no roster fan-out, **owner's other resource (with `+notify`) receives the headline** and **a resource without `+notify` does not**, and **persistence across a disconnect + fresh reconnect**.
- TS: wire mapping + owner-only receive (`status-preference.test.ts`), coordinator echo/fresh-login/offline-pick/logout-suspend logic (`status-preference-coordinator.test.ts`).

### Acceptance criteria

- [x] Picking a status publishes it to `urn:waddle:status-preference:0` (owner-only whitelist, item id `current`, non-owner publish rejected).
- [x] The user's other connected resources adopt the picked status via `+notify`.
- [x] The status survives a reconnect / fresh login (persisted), replacing the in-memory store.
- [x] Auto-away remains per-device (not synced).
- [x] Dedicated Rust test suite for the namespace: parse / build / round-trip, owner-only publish, item-id enforcement.

### Verification

- `cargo test` (core unit + WS suite) and `cargo clippy -D warnings`, `cargo fmt` — green.
- `cd chat && bun run build` (wasm + `astro check` ⇒ 0 errors) and `bun test` (presence + coordinator suites green); `knip` clean.
- Manual two-tab check: pick Away in tab A → tab B adopts it live; reload tab B → still Away; pick Reset → both return to Automatic.

### Post-review hardening

Addressed all bot review comments (codex/qodo/greptile) plus several rounds of
adversarial self-review:

- **Coordinator in-flight races.** The publish baseline is now epoch-guarded so a
  publish that resolves *after* its baseline moved (logout `suspend`, or an
  adopted remote pick) is disowned — no echo of an adopted value, no
  resurrection of a pre-logout pick (robust even if `resume()` flips
  `suspended` back, which a plain flag was not). A trigger that fires
  mid-publish is coalesced (not dropped) so a pick made while a publish is in
  flight is retried once on settle — including when that publish fails — without
  hot-looping. A local pick that lands *after* an adopted remote during the same
  flight is still published rather than stranded. Logout racing the connect-time
  fetch now drops the stored value instead of leaking it into the next account.
- **Genuine privacy test.** `private_pep_does_not_fan_out_to_roster` now makes
  the contact a `subscription=from` roster peer advertising
  `…status-preference:0+notify`, so it actually exercises the `is_private_pep_node`
  carve-out (verified: disabling the carve-out makes the test fail with a leaked
  headline).
- **Fetch from-guard test.** The XEP-0223 §Security (CVE-2023-28686)
  `from`-spoof check is extracted into a pure helper and unit-tested (accepts
  absent/own-bare, rejects a contact / look-alike domain / resource-qualified
  sender).
- **CI hygiene.** Fixed an unrelated date-bomb test (`community-events` series
  anchored to a now-past date) that fails any build dated after its hardcoded
  occurrences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

