### PR TITLE
feat(chat): Phase 5a — DND quiets own notifications (tested gate seam)

### DIFF
--- a/chat/src/presence/own-notification-gate.ts
+++ b/chat/src/presence/own-notification-gate.ts
@@ -1,0 +1,12 @@
+// Phase 5a (ADR-010): when the user's own Effective Show is Do Not Disturb,
+// their client silences its own message banners + sounds. This is the
+// presence-driven "Do Not Disturb" Show — distinct from, and composable with,
+// the server-side `urn:waddle:dnd:0` quiet-hours schedule, which gates pushes
+// on a timetable. Badge / unread counts are unaffected (a separate path).
+
+import type { EffectiveShow } from "./effective-show";
+
+/** Does the user's own Effective Show currently suppress their own banners/sounds? */
+export function presenceSuppressesOwnNotifications(show: EffectiveShow): boolean {
+  return show === "dnd";
+}

--- a/chat/src/presence/presence-store.ts
+++ b/chat/src/presence/presence-store.ts
@@ -5,12 +5,23 @@
 import { atom, computed } from "nanostores";
 
 import { applyPick, resolveShow, type PresenceMode, type PresencePick } from "./effective-show";
+import { presenceSuppressesOwnNotifications } from "./own-notification-gate";
 
 /** The user's chosen presence mode on this device. Defaults to Automatic. */
 export const $presenceMode = atom<PresenceMode>({ kind: "automatic" });
 
 /** The Show this device currently broadcasts, derived from the mode. */
 export const $selfShow = computed($presenceMode, (mode) => resolveShow(mode));
+
+/**
+ * Whether this device should silence its OWN message banners/sounds because
+ * the Effective Show is Do Not Disturb (ADR-010 Phase 5a). Badge / unread
+ * counts are unaffected. Orthogonal to the server-side `urn:waddle:dnd:0`
+ * quiet-hours schedule; both can suppress, for different reasons.
+ */
+export const $ownNotificationsSuppressed = computed($selfShow, (show) =>
+  presenceSuppressesOwnNotifications(show)
+);
 
 /** Apply a picker choice — Available / Away / Do Not Disturb, or `reset` to Automatic. */
 export function pickPresence(pick: PresencePick): void {

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -24,10 +24,9 @@ import {
 } from "@/shell/structure-retry";
 import { useDeploymentVersionInfo } from "@/shell/version";
 import { useXmppRosterContacts } from "@/contacts/roster";
-import { resolveShow } from "@/presence/effective-show";
 import { IdleTracker } from "@/presence/idle-tracker";
 import { PresenceRegistry } from "@/presence/presence-registry";
-import { $presenceMode, resetPresenceMode } from "@/presence/presence-store";
+import { $ownNotificationsSuppressed, $presenceMode, resetPresenceMode } from "@/presence/presence-store";
 import { activityOverlayUpdate } from "@/presence/in-call-activity";
 import {
   presenceModeFromWire,
@@ -784,7 +783,13 @@ export function useChatAppController(giphyApiKey: string) {
   // This device's own mode drives the Show we broadcast and the local
   // DND checks; the picker writes it via the presence store.
   const presenceMode = useStore($presenceMode);
-  const selfPresenceShow = computed(() => resolveShow(presenceMode.value));
+  // Presence-DND silences this device's own message banners + sounds
+  // (ADR-010 Phase 5a). Derived from the picker store so Reset-to-automatic
+  // restores notifications live; badge / unread counts are unaffected, and
+  // this is orthogonal to the server-side `urn:waddle:dnd:0` quiet-hours
+  // schedule (both can suppress, for different reasons).
+  const ownNotificationsSuppressed = useStore($ownNotificationsSuppressed);
+  const isSelfDoNotDisturb = (): boolean => ownNotificationsSuppressed.value;
   // Per-device auto-away (ADR-010 Phase 2): the tracker watches in-tab
   // interaction + visibility and broadcasts Away/Extended Away with an
   // XEP-0319 idle stamp while Automatic; a Manual status suspends it.
@@ -982,7 +987,7 @@ export function useChatAppController(giphyApiKey: string) {
       messageSound,
       messageSoundsEnabled: () => notifications.messageSoundsEnabled.value,
       canShowForegroundNotification: () => notifications.canShowForegroundNotifications.value,
-      isDoNotDisturb: () => selfPresenceShow.value === "dnd",
+      isDoNotDisturb: isSelfDoNotDisturb,
       isTabFocused: () => isWindowFocused.value,
       sessionJid: connectionStore.session?.jid,
       resolveChannelNameFromJid,
@@ -1015,7 +1020,7 @@ export function useChatAppController(giphyApiKey: string) {
         messageSound,
         messageSoundsEnabled: () => notifications.messageSoundsEnabled.value,
         canShowForegroundNotification: () => notifications.canShowForegroundNotifications.value,
-        isDoNotDisturb: () => selfPresenceShow.value === "dnd",
+        isDoNotDisturb: isSelfDoNotDisturb,
         isTabFocused: () => isWindowFocused.value,
         sessionJid: session.value?.jid,
         activePeerJid: ui.sidebarMode.value === "dms" ? dmConversations.activePeerJid.value : null,

--- a/chat/tests/own-notification-gate.test.ts
+++ b/chat/tests/own-notification-gate.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { presenceSuppressesOwnNotifications } from "../src/presence/own-notification-gate";
+import {
+  $ownNotificationsSuppressed,
+  pickPresence,
+  resetPresenceMode,
+} from "../src/presence/presence-store";
+
+describe("own-notification-gate: presenceSuppressesOwnNotifications", () => {
+  test("a Do Not Disturb Show suppresses the user's own notifications", () => {
+    expect(presenceSuppressesOwnNotifications("dnd")).toBe(true);
+  });
+
+  test("Available and Away Shows do not suppress own notifications", () => {
+    expect(presenceSuppressesOwnNotifications("available")).toBe(false);
+    expect(presenceSuppressesOwnNotifications("away")).toBe(false);
+  });
+});
+
+describe("own-notification-gate: $ownNotificationsSuppressed driven by the picker", () => {
+  afterEach(() => {
+    resetPresenceMode();
+  });
+
+  test("picking Do Not Disturb suppresses own notifications", () => {
+    pickPresence("dnd");
+    expect($ownNotificationsSuppressed.get()).toBe(true);
+  });
+
+  test("Reset to automatic restores notifications", () => {
+    pickPresence("dnd");
+    resetPresenceMode();
+    expect($ownNotificationsSuppressed.get()).toBe(false);
+  });
+
+  test("Available and Away do not suppress own notifications", () => {
+    pickPresence("available");
+    expect($ownNotificationsSuppressed.get()).toBe(false);
+    pickPresence("away");
+    expect($ownNotificationsSuppressed.get()).toBe(false);
+  });
+
+  test("the default Automatic mode does not suppress own notifications", () => {
+    expect($ownNotificationsSuppressed.get()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Issue

Closes #1075 — Presence Phase 5a: *DND quiets own notifications* (epic #1071, ADR-010 §"Presence-DND may suppress own notifications").

## Finding: the core behavior already ships on `main`

When the user's effective Show is **Do Not Disturb**, their own client already suppresses message banners **and** sounds, while badge/unread counts keep updating:

- The gate sits in `showForegroundNotificationForChannelActivity` / `showForegroundNotificationForDmActivity` (`chat-app-controller.ts`) — `if (deps.isDoNotDisturb?.() === true) return;` is evaluated **before** both `messageSound.play(...)` and the banner call, so banner + sound are both suppressed.
- Both call sites pass `isDoNotDisturb: () => selfPresenceShow.value === "dnd"`, where `selfPresenceShow = resolveShow(presenceMode.value)` and `presenceMode = useStore($presenceMode)` (the Phase 1 picker store). Pick DND → suppress; Reset to automatic → restore.
- Unread/badge live on a **separate** path (`inbox` push → `channelUnread.onInboxPush` / `dmConversations.onInboxPush`) that takes no presence/DND input.

The `isDoNotDisturb` hook + the `selfPresenceShow.value === "dnd"` wiring landed in **#968** (notification sounds); Phase 1 (**#1070**) made `selfPresenceShow` derive from the real picker store. So the behavior #1075 describes was effectively completed by Phase 1.

## What this PR does (hardening)

The behaviour exists but its junction — the mapping *effective Show → suppress own notifications* — was an **untested inline lambda duplicated** at the two call sites. This PR gives it a tested, named seam:

1. **Extract** `presenceSuppressesOwnNotifications(show: EffectiveShow)` into `src/presence/own-notification-gate.ts` — mirrors the existing `resolveShow` (pure) / `$selfShow` (store) split, and documents that the presence-DND *Show* is distinct from the server-side `urn:waddle:dnd:0` quiet-hours *schedule*.
2. **Dedup** the two `() => selfPresenceShow.value === "dnd"` lambdas into one `isSelfDoNotDisturb`, fed by a derived store `$ownNotificationsSuppressed` (drops the now-dead `resolveShow` import and `selfPresenceShow` local — a duplicate of `$selfShow`).
3. **Tests** (`tests/own-notification-gate.test.ts`) driving the gate from the **live presence store** (`pickPresence("dnd")` → suppress; `resetPresenceMode()` / Available / Away → restore) — closing the gap that existing tests injected `doNotDisturb: true` directly rather than proving the wiring.

## Acceptance criteria

- [x] Effective Show = DND → no banners, no sounds — gate before sound+banner; covered by `foreground-notifications.test.ts` + new gate tests.
- [x] Badge / unread counts still update — structurally independent (unread path takes no DND input); covered by `channel-unread.test.ts` / `dm-conversations.test.ts`.
- [x] Clearing DND / Reset to automatic restores notifications — new store-driven gate tests.
- [x] Independent of, and composable with, `urn:waddle:dnd:0` — the presence-DND **foreground** gate (in-app banners/sounds) and the server-side `urn:waddle:dnd:0` **push** schedule (#317) act on different surfaces and are independent by construction; no client-side schedule evaluation exists or is required here.
- [x] Tests cover the DND notification gate.

## Verification

- `bun test tests/own-notification-gate.test.ts` → 6 pass. Full chat suite → 2802 pass (the lone `startup-loading` failure is the known environmental one needing prior `bun run build` output).
- `bunx knip` → exit 0 (clean). `bunx astro check` → 0 errors.

## Out of scope

- Incoming **call** banners/ringtone (`audio-alerts.ts`) still ring under DND — the issue scopes to "channel and DM activity". Tracked as a follow-up: #1081.
- The service-worker push path (`sw-template.js`) — server-side `urn:waddle:dnd:0` schedule's domain (#317).
