### PR TITLE
feat(chat): surface Chat (free to chat) in the presence picker (epic phase 5b)

### DIFF
--- a/chat/src/components/chat/PresencePicker.vue
+++ b/chat/src/components/chat/PresencePicker.vue
@@ -10,6 +10,9 @@ const selfShow = useStore($selfShow);
 
 const options: { status: ManualStatus; label: string; dot: string }[] = [
   { status: "available", label: "Available", dot: "bg-success/75" },
+  // RFC 6121 `<show>chat</show>` — "free for chat". An available substate, so
+  // it shares the green dot; contacts render it as Available (ADR-010 fold).
+  { status: "chat", label: "Free to chat", dot: "bg-success/75" },
   { status: "away", label: "Away", dot: "bg-warning/75" },
   { status: "dnd", label: "Do Not Disturb", dot: "bg-destructive/75" },
 ];

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -41,6 +41,9 @@ export function parsePresenceShow(show: string | undefined): OccupantPresence {
       return "away";
     case "dnd":
       return "dnd";
+    // RFC 6121 `chat` ("free for chat") folds into online — an available
+    // substate, rendered the same as plain Available (ADR-010 Phase 5b).
+    case "chat":
     default:
       return "online";
   }
@@ -55,6 +58,9 @@ export function mapPresenceShow(presence: WasmPresence): PresenceUpdateEvent["sh
       return "xa";
     case "dnd":
       return "dnd";
+    // RFC 6121 `chat` ("free for chat") folds into available — an available
+    // substate, rendered the same as plain Available (ADR-010 Phase 5b).
+    case "chat":
     default:
       return "available";
   }

--- a/chat/src/presence/effective-show.ts
+++ b/chat/src/presence/effective-show.ts
@@ -4,9 +4,9 @@
 
 import type { AutoAway } from "./idle";
 
-export type ManualStatus = "available" | "away" | "dnd";
+export type ManualStatus = "available" | "chat" | "away" | "dnd";
 
-export type EffectiveShow = "available" | "away" | "dnd";
+export type EffectiveShow = "available" | "chat" | "away" | "dnd";
 
 export type PresenceMode =
   | { kind: "automatic" }
@@ -18,7 +18,7 @@ export function resolveShow(mode: PresenceMode): EffectiveShow {
 
 /** The Show this device actually broadcasts. Adds `xa` over the manual set —
  * Extended Away is only ever reached automatically, never picked. */
-export type BroadcastShow = "available" | "away" | "xa" | "dnd";
+export type BroadcastShow = "available" | "chat" | "away" | "xa" | "dnd";
 
 /** The full outbound presence this device should advertise: a Show plus the
  * XEP-0319 idle instant (epoch ms) to stamp, or `null` for none. */

--- a/chat/src/presence/presence-store.ts
+++ b/chat/src/presence/presence-store.ts
@@ -23,7 +23,7 @@ export const $ownNotificationsSuppressed = computed($selfShow, (show) =>
   presenceSuppressesOwnNotifications(show)
 );
 
-/** Apply a picker choice — Available / Away / Do Not Disturb, or `reset` to Automatic. */
+/** Apply a picker choice — Available / Free to chat / Away / Do Not Disturb, or `reset` to Automatic. */
 export function pickPresence(pick: PresencePick): void {
   $presenceMode.set(applyPick(pick));
 }

--- a/chat/src/presence/status-preference.ts
+++ b/chat/src/presence/status-preference.ts
@@ -16,7 +16,7 @@ const NS_STATUS_PREFERENCE = "urn:waddle:status-preference:0";
 /** The PEP node the preference is published to (equal to its namespace). */
 const STATUS_PREFERENCE_PEP_NODE = NS_STATUS_PREFERENCE;
 
-const MANUAL_STATUSES: readonly ManualStatus[] = ["available", "away", "dnd"];
+const MANUAL_STATUSES: readonly ManualStatus[] = ["available", "chat", "away", "dnd"];
 
 function isManualStatus(value: string | null | undefined): value is ManualStatus {
   return value != null && (MANUAL_STATUSES as readonly string[]).includes(value);

--- a/chat/tests/effective-show.test.ts
+++ b/chat/tests/effective-show.test.ts
@@ -22,6 +22,11 @@ describe("effective-show: resolveShow", () => {
     const mode: PresenceMode = { kind: "manual", status: "dnd" };
     expect(resolveShow(mode)).toBe("dnd");
   });
+
+  test("a manual free-to-chat pick resolves to chat", () => {
+    const mode: PresenceMode = { kind: "manual", status: "chat" };
+    expect(resolveShow(mode)).toBe("chat");
+  });
 });
 
 describe("effective-show: applyPick", () => {
@@ -35,6 +40,10 @@ describe("effective-show: applyPick", () => {
 
   test("picking available is a pinned manual mode, distinct from automatic", () => {
     expect(applyPick("available")).toEqual({ kind: "manual", status: "available" });
+  });
+
+  test("picking free-to-chat is a sticky manual mode", () => {
+    expect(applyPick("chat")).toEqual({ kind: "manual", status: "chat" });
   });
 });
 
@@ -52,6 +61,15 @@ describe("effective-show: resolveBroadcast", () => {
     expect(resolveBroadcast({ kind: "automatic" }, { show: "away", idleSince: 500 })).toEqual({
       show: "away",
       idleSince: 500,
+    });
+  });
+
+  test("a manual free-to-chat pick broadcasts chat and suspends auto-away", () => {
+    // Manual suspends auto-away even mid-idle: chat goes out with no idle stamp.
+    const longIdle = { show: "xa", idleSince: 999 } as const;
+    expect(resolveBroadcast({ kind: "manual", status: "chat" }, longIdle)).toEqual({
+      show: "chat",
+      idleSince: null,
     });
   });
 });

--- a/chat/tests/presence-idle-codec.test.ts
+++ b/chat/tests/presence-idle-codec.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect, test } from "bun:test";
 
-import { mapPresenceIdleSince } from "../src/lib/xmpp/wasm-message-codecs";
+import {
+  mapPresenceIdleSince,
+  mapPresenceShow,
+  parsePresenceShow,
+} from "../src/lib/xmpp/wasm-message-codecs";
 import type { WasmPresence } from "../src/lib/xmpp/wasm-types";
 
 function presence(idle_since?: string): WasmPresence {
   return { presence_type: "available", hats: [], ...(idle_since ? { idle_since } : {}) };
+}
+
+function presenceWithShow(show: string): WasmPresence {
+  return { presence_type: "available", hats: [], show };
 }
 
 describe("mapPresenceIdleSince", () => {
@@ -21,5 +29,19 @@ describe("mapPresenceIdleSince", () => {
   test("a malformed since degrades to undefined, never NaN", () => {
     const result = mapPresenceIdleSince(presence("not-a-date"));
     expect(result).toBeUndefined();
+  });
+});
+
+// ADR-010 fold: an incoming `<show>chat</show>` ("free for chat") is a
+// substate of Available, so the receiver renders it as Available rather than
+// minting a new rendered Show. These guard that the fold is deliberate — a
+// later refactor of the codec must not silently surface or drop `chat`.
+describe("inbound chat folds into available", () => {
+  test("mapPresenceShow folds a contact's chat into available", () => {
+    expect(mapPresenceShow(presenceWithShow("chat"))).toBe("available");
+  });
+
+  test("parsePresenceShow folds a MUC occupant's chat into online", () => {
+    expect(parsePresenceShow("chat")).toBe("online");
   });
 });

--- a/chat/tests/presence-picker.test.ts
+++ b/chat/tests/presence-picker.test.ts
@@ -12,10 +12,11 @@ describe("PresencePicker", () => {
     $presenceMode.set({ kind: "automatic" });
   });
 
-  test("renders the three pickable statuses as a radiogroup", async () => {
+  test("renders the four pickable statuses as a radiogroup", async () => {
     const html = await render();
     expect(html).toContain('role="radiogroup"');
     expect(html).toContain("Available");
+    expect(html).toContain("Free to chat");
     expect(html).toContain("Away");
     expect(html).toContain("Do Not Disturb");
   });
@@ -31,5 +32,13 @@ describe("PresencePicker", () => {
     const html = await render();
     expect(html).toContain("Reset to automatic");
     expect(html).toContain('aria-checked="true"');
+  });
+
+  test("a manual free-to-chat pick is sticky and offers Reset to automatic", async () => {
+    $presenceMode.set({ kind: "manual", status: "chat" });
+    const html = await render();
+    expect(html).toContain("Free to chat");
+    expect(html).toContain('aria-checked="true"');
+    expect(html).toContain("Reset to automatic");
   });
 });

--- a/chat/tests/status-preference.test.ts
+++ b/chat/tests/status-preference.test.ts
@@ -25,7 +25,9 @@ describe("presenceModeFromWire / presenceModeToWire", () => {
   });
 
   test("each manual status round-trips", () => {
-    for (const status of ["available", "away", "dnd"] as const) {
+    // `chat` ("free for chat", ADR-010 Phase 5b) syncs across devices like the
+    // other manual picks — both directions of the wire mapping must carry it.
+    for (const status of ["available", "chat", "away", "dnd"] as const) {
       expect(presenceModeFromWire({ mode: "manual", status })).toEqual({ kind: "manual", status });
       expect(presenceModeToWire({ kind: "manual", status })).toEqual({ mode: "manual", status });
     }

--- a/server/crates/waddle-server/tests/waddle_status_preference_pep_sync_ws.rs
+++ b/server/crates/waddle-server/tests/waddle_status_preference_pep_sync_ws.rs
@@ -275,6 +275,48 @@ async fn publish_then_owner_fetch_round_trips() {
 }
 
 #[tokio::test]
+async fn publish_chat_status_round_trips() {
+    // RFC 6121 `chat` ("free for chat") became a pickable manual status in
+    // ADR-010 Phase 5b. Before that it was an UnknownStatus the strict payload
+    // validator rejected with <bad-request/>. This guards the full wire path:
+    // the server now ACCEPTS the publish and round-trips `status='chat'`.
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = connect_admin().await;
+
+    client
+        .send(&publish_iq(
+            "pub-chat",
+            "current",
+            status_preference_payload("manual", Some("chat")),
+        ))
+        .await
+        .expect("send publish");
+    let publish_result = client
+        .recv_matching(|frame| frame.contains(r#"id='pub-chat'"#))
+        .await
+        .expect("publish result");
+    assert!(
+        publish_result.contains(r#"type='result'"#),
+        "chat publish must be accepted, not rejected: {publish_result}"
+    );
+
+    client
+        .send(&items_get_iq("fetch-chat", None))
+        .await
+        .expect("send fetch");
+    let fetch_result = client
+        .recv_matching(|frame| frame.contains(r#"id='fetch-chat'"#))
+        .await
+        .expect("fetch result");
+    assert!(
+        fetch_result.contains(r#"status="chat""#) || fetch_result.contains(r#"status='chat'"#),
+        "fetched payload missing status=chat: {fetch_result}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
 async fn republish_overwrites_item() {
     let _guard = TEST_SERIAL.lock().await;
     let (_server, mut client) = connect_admin().await;

--- a/server/crates/waddle-xmpp-core/src/waddle_status_preference.rs
+++ b/server/crates/waddle-xmpp-core/src/waddle_status_preference.rs
@@ -23,8 +23,8 @@
 //!
 //! * `mode` — required, `automatic` | `manual`.
 //! * `status` — required iff `mode='manual'`, one of `available` |
-//!   `away` | `dnd` (the Phase 1 manual-status set). Forbidden when
-//!   `mode='automatic'`.
+//!   `chat` | `away` | `dnd` (the pickable manual-status set). Forbidden
+//!   when `mode='automatic'`.
 //!
 //! Reset-to-automatic is published as an explicit `mode='automatic'`
 //! item rather than a retract: the node defaults pin `notify_retract =
@@ -62,23 +62,27 @@ const MODE_AUTOMATIC: &str = "automatic";
 const MODE_MANUAL: &str = "manual";
 
 const STATUS_AVAILABLE: &str = "available";
+const STATUS_CHAT: &str = "chat";
 const STATUS_AWAY: &str = "away";
 const STATUS_DND: &str = "dnd";
 
 /// The user's manually-picked status when not in Automatic mode. Mirrors
-/// the chat client's `ManualStatus` (`available | away | dnd`).
+/// the chat client's `ManualStatus` (`available | chat | away | dnd`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ManualStatus {
     Available,
+    /// RFC 6121 `<show>chat</show>` — "free for chat" (ADR-010 Phase 5b).
+    Chat,
     Away,
     Dnd,
 }
 
 impl ManualStatus {
-    /// The wire token for this status (`available` | `away` | `dnd`).
+    /// The wire token for this status (`available` | `chat` | `away` | `dnd`).
     pub fn as_str(self) -> &'static str {
         match self {
             ManualStatus::Available => STATUS_AVAILABLE,
+            ManualStatus::Chat => STATUS_CHAT,
             ManualStatus::Away => STATUS_AWAY,
             ManualStatus::Dnd => STATUS_DND,
         }
@@ -88,6 +92,7 @@ impl ManualStatus {
     pub fn from_token(raw: &str) -> Result<Self, StatusPreferenceParseError> {
         match raw {
             STATUS_AVAILABLE => Ok(ManualStatus::Available),
+            STATUS_CHAT => Ok(ManualStatus::Chat),
             STATUS_AWAY => Ok(ManualStatus::Away),
             STATUS_DND => Ok(ManualStatus::Dnd),
             other => Err(StatusPreferenceParseError::UnknownStatus(other.to_string())),
@@ -119,7 +124,7 @@ pub enum StatusPreferenceParseError {
     MissingStatus,
     #[error("'status' attribute is not allowed when mode='automatic'")]
     UnexpectedStatus,
-    #[error("unknown status '{0}' (expected 'available', 'away', or 'dnd')")]
+    #[error("unknown status '{0}' (expected 'available', 'chat', 'away', or 'dnd')")]
     UnknownStatus(String),
     #[error("unknown attribute '{0}' on <status-preference>")]
     UnknownAttribute(String),
@@ -259,6 +264,7 @@ mod tests {
     #[test]
     fn round_trip_manual_statuses() {
         round_trip(StatusPreference::Manual(ManualStatus::Available));
+        round_trip(StatusPreference::Manual(ManualStatus::Chat));
         round_trip(StatusPreference::Manual(ManualStatus::Away));
         round_trip(StatusPreference::Manual(ManualStatus::Dnd));
     }
@@ -287,6 +293,16 @@ mod tests {
         assert_eq!(
             parse_str("<status-preference xmlns='urn:waddle:status-preference:0' mode='manual' status='available'/>"),
             Ok(StatusPreference::Manual(ManualStatus::Available))
+        );
+    }
+
+    #[test]
+    fn parse_chat_status_token() {
+        // RFC 6121 `chat` ("free for chat") is a pickable manual status
+        // (ADR-010 Phase 5b), so it must round-trip across the user's devices.
+        assert_eq!(
+            parse_str("<status-preference xmlns='urn:waddle:status-preference:0' mode='manual' status='chat'/>"),
+            Ok(StatusPreference::Manual(ManualStatus::Chat))
         );
     }
 
@@ -388,6 +404,7 @@ mod tests {
         for pref in [
             StatusPreference::Automatic,
             StatusPreference::Manual(ManualStatus::Available),
+            StatusPreference::Manual(ManualStatus::Chat),
             StatusPreference::Manual(ManualStatus::Away),
             StatusPreference::Manual(ManualStatus::Dnd),
         ] {

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=fee832e70413";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=fee832e70413";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=fee832e70413";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=cf5a38601dcb";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=cf5a38601dcb";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=cf5a38601dcb";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=fee832e70413";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=cf5a38601dcb";


### PR DESCRIPTION
## Issue

Closes #1076 — Presence Phase 5b: surface **Chat (free to chat)** in the picker.
Parent epic: #1071 / ADR-010 (`docs/adr/010-presence-statuses.md`).

## What & why

RFC 6121 defines `<show>chat</show>` ("online and actively interested in
conversing — free for chat"). The whole outbound stack already supported it —
`parse_show("chat") → Show::Chat`, `build_presence_stanza` emits
`<show>chat</show>`, `client.setPresence(show)` forwards the token to wasm, and
the server models `Chat` as a first-class Show. The only gap was that the
**client never offered it in the manual picker**, so nobody could ever become
"free to chat".

This surfaces `chat` as a sticky manual pick alongside Available / Away /
Do Not Disturb, and ensures it round-trips (pick → `<show>chat</show>` on the
wire → contacts render it → syncs across the user's devices).

## Render decision (scope)

On the **receiving** side an incoming `<show>chat</show>` **folds into
Available** (green/online dot). The wire round-trip is conformant and lossless;
contacts see the peer as online. No new rendered Show value is minted — this
keeps ADR-010 invariant #1 ("RFC 6121 Show values are used verbatim") and the
change confined to the outbound picker path. The fold is made explicit in the
inbound codecs and locked by guard tests.

## Cross-device parity (found during implementation)

Widening the manual-status set means a `chat` pick is published to the Phase 4
cross-device sync node `urn:waddle:status-preference:0` (XEP-0223). Its
server-side payload validator is **strict** and previously rejected
`status='chat'` with `<bad-request/>`, which would have made every chat pick
fail to publish and retry forever. So `chat` is added to the wire type
(`waddle-xmpp-core::ManualStatus`) and the client's `MANUAL_STATUSES`, so a chat
pick syncs across devices exactly like the others. The wasm bridge routes
through `StatusPreference::from_tokens`, so no FFI/UniFFI/Swift surface changed
(wasm-only; `.d.ts` unchanged, `checkXmppClientFfiBindings`/`apple-xmpp-client`
unaffected).

## Changes

- **Picker** (`PresencePicker.vue`): sticky "Free to chat" radio (green dot);
  Reset-to-automatic clears it (generic).
- **Types** (`effective-show.ts`): `ManualStatus` / `EffectiveShow` /
  `BroadcastShow` gain `chat`. A manual chat pick suspends auto-away (no idle
  stamp), like the other picks.
- **Inbound fold** (`wasm-message-codecs.ts`): `mapPresenceShow` /
  `parsePresenceShow` explicitly fold `chat` → available / online.
- **Cross-device sync**: `waddle_status_preference.rs` `ManualStatus::Chat`
  (+ token, error text, docs, Rust tests); `status-preference.ts`
  `MANUAL_STATUSES` gains `chat`.

## Acceptance criteria

- [x] Picker offers a "Free to chat" option that broadcasts `<show>chat</show>`.
- [x] Contacts render the chat state (as Available, per the fold decision).
- [x] Sticky manual pick like the others; "Reset to automatic" clears it.
- [x] Test coverage for the added option.

## Tests

- `effective-show.test.ts` — chat resolves/broadcasts (suspends auto-away).
- `presence-picker.test.ts` — picker offers "Free to chat"; sticky + reset.
- `presence-idle-codec.test.ts` — inbound `chat` fold guards.
- `status-preference.test.ts` — chat round-trips the wire mapping.
- `waddle_status_preference.rs` — Rust round-trip/parse/token tests for `Chat`.
- `waddle_status_preference_pep_sync_ws.rs` — **new** end-to-end WS test:
  server now *accepts* and round-trips a `status='chat'` publish.

## Verification

- `bun test` (chat): 2809 pass, 0 fail.
- `bun run lint` (knip): clean. `tsc --noEmit`: 0 errors.
- `cargo clippy -p waddle-xmpp-core --all-targets -- -D warnings`: clean.
- `cargo test -p waddle-xmpp-core waddle_status_preference`: 23 pass.
- `cargo test -p waddle-server --test waddle_status_preference_pep_sync_ws`: 11 pass.
- Reviewed by three adversarial personas (protocol/XEP, frontend/TS,
  Rust/server) — no real/actionable defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
