### PR TITLE
feat(chat): presence-DND silences the incoming-call ringtone + banner (#1081)

### DIFF
--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -59,6 +59,7 @@ import { isEventUpcomingOrOngoing } from "@/lib/xmpp-client";
 import type { FeedPostInput, StoryPostInput } from "@/lib/xmpp-client";
 import type { ActivityPublication, MoodPublication, TunePublication } from "@/lib/xmpp/pep-types";
 import { setManualActivity } from "@/presence/self-activity";
+import { $ownNotificationsSuppressed } from "@/presence/presence-store";
 import type { VCard4Profile } from "@/lib/xmpp/vcard4-types";
 import { installMessageToolbarLifecycleSuppression } from "@/stores/message-toolbar";
 import {
@@ -535,6 +536,12 @@ onMounted(() => {
       },
     },
     isTabFocused: () => document.visibilityState === "visible" && document.hasFocus(),
+    // Presence Do Not Disturb silences this device's own incoming-call ringtone
+    // + OS banner, reusing the same signal as the message-notification gate
+    // (ADR-010 Phase 5a / #1075, #1081). The in-app IncomingCallToast is
+    // `$callState`-driven, so the call stays visible/answerable — only the
+    // disturbance is suppressed. Read at ring time via `.get()`.
+    isDoNotDisturb: () => $ownNotificationsSuppressed.get(),
   }));
 });
 

--- a/chat/src/shell/audio-alerts.ts
+++ b/chat/src/shell/audio-alerts.ts
@@ -37,12 +37,19 @@ export function createIncomingCallAlertController(options: {
   notifier?: IncomingCallNotifier;
   focusTarget?: IncomingCallFocusTarget;
   isTabFocused?: () => boolean;
+  // Presence Do Not Disturb (effective `<show>dnd</show>`): when true, the
+  // whole incoming-call alert — looping ringtone + OS notification banner — is
+  // silenced, mirroring the message-notification DND gate (ADR-010, #1075/#1081).
+  // The in-app IncomingCallToast is `$callState`-driven and unaffected, so the
+  // call stays visible/answerable; only the disturbance is suppressed.
+  isDoNotDisturb?: () => boolean;
 }): IncomingCallAlertController {
   const active = new Map<string, IncomingCallNotificationHandle | null>();
 
   return {
     start({ peerJid, sid, media }) {
       if (active.has(sid)) return;
+      if (options.isDoNotDisturb?.() === true) return;
       active.set(sid, null);
       void options.player.startLoop(sid);
       if (options.isTabFocused?.() !== false) return;

--- a/chat/tests/incoming-call-alert-dnd.test.ts
+++ b/chat/tests/incoming-call-alert-dnd.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, mock, test } from "bun:test";
+import {
+  createIncomingCallAlertController,
+  type IncomingCallNotifier,
+} from "../src/shell/audio-alerts";
+
+// Presence Do Not Disturb (effective `<show>dnd</show>`) must silence this
+// device's own incoming-call ringtone AND OS notification banner — the whole
+// alert-controller path (ADR-010 / epic #1071, follow-up #1081). The in-app
+// IncomingCallToast renders from `$callState`, not from this controller, so it
+// stays visible; only the disturbance (sound + OS banner) is suppressed.
+
+function makePlayer() {
+  return {
+    startLoop: mock((_key: string) => {}),
+    stop: mock((_key: string) => {}),
+  };
+}
+
+const CALL = { peerJid: "bob@example.com", sid: "call-1", media: { audio: true, video: false } };
+
+describe("incoming-call alert under presence Do Not Disturb", () => {
+  test("does not ring the tone while effective Show is Do Not Disturb", () => {
+    const player = makePlayer();
+    const controller = createIncomingCallAlertController({
+      player,
+      isDoNotDisturb: () => true,
+    });
+
+    controller.start(CALL);
+
+    expect(player.startLoop).not.toHaveBeenCalled();
+  });
+
+  test("does not raise the OS notification banner under DND (tab unfocused)", () => {
+    const player = makePlayer();
+    const notifier: IncomingCallNotifier = {
+      showIncomingCall: mock(() => ({ close: () => {} })),
+    };
+    const controller = createIncomingCallAlertController({
+      player,
+      notifier,
+      isTabFocused: () => false,
+      isDoNotDisturb: () => true,
+    });
+
+    controller.start(CALL);
+
+    expect(notifier.showIncomingCall).not.toHaveBeenCalled();
+  });
+
+  test("rings and banners normally when not in Do Not Disturb", () => {
+    const player = makePlayer();
+    const notifier: IncomingCallNotifier = {
+      showIncomingCall: mock(() => ({ close: () => {} })),
+    };
+    const controller = createIncomingCallAlertController({
+      player,
+      notifier,
+      isTabFocused: () => false,
+      isDoNotDisturb: () => false,
+    });
+
+    controller.start(CALL);
+
+    expect(player.startLoop).toHaveBeenCalledWith("call-1");
+    expect(notifier.showIncomingCall).toHaveBeenCalledTimes(1);
+  });
+
+  test("a DND-suppressed start leaves stop and stopAll as safe no-ops", () => {
+    const player = makePlayer();
+    const controller = createIncomingCallAlertController({
+      player,
+      isDoNotDisturb: () => true,
+    });
+
+    controller.start(CALL);
+    // Nothing was started, so tearing the slot down must not touch the player
+    // and must not throw on an sid that was never registered as active.
+    controller.stop(CALL.sid);
+    controller.stopAll();
+
+    expect(player.stop).not.toHaveBeenCalled();
+  });
+});

--- a/chat/tests/incoming-call-alert-dnd.test.ts
+++ b/chat/tests/incoming-call-alert-dnd.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
   createIncomingCallAlertController,
   type IncomingCallNotifier,
 } from "../src/shell/audio-alerts";
+import {
+  $ownNotificationsSuppressed,
+  pickPresence,
+  resetPresenceMode,
+} from "../src/presence/presence-store";
 
 // Presence Do Not Disturb (effective `<show>dnd</show>`) must silence this
 // device's own incoming-call ringtone AND OS notification banner — the whole
@@ -81,5 +86,32 @@ describe("incoming-call alert under presence Do Not Disturb", () => {
     controller.stopAll();
 
     expect(player.stop).not.toHaveBeenCalled();
+  });
+});
+
+// Integration: prove the real presence-store signal — the exact expression the
+// production caller wires (`ChatReadyShell.vue`: `() => $ownNotificationsSuppressed.get()`)
+// — reaches the controller. Guards the seam between the picker store and the
+// call alert, not just the injected-predicate contract.
+describe("incoming-call alert wired to the presence store", () => {
+  afterEach(() => {
+    // The store is module-global; reset so a picked DND can't leak across tests.
+    resetPresenceMode();
+  });
+
+  test("picking Do Not Disturb suppresses the ring; resetting restores it", () => {
+    const player = makePlayer();
+    const controller = createIncomingCallAlertController({
+      player,
+      isDoNotDisturb: () => $ownNotificationsSuppressed.get(),
+    });
+
+    pickPresence("dnd");
+    controller.start(CALL);
+    expect(player.startLoop).not.toHaveBeenCalled();
+
+    resetPresenceMode();
+    controller.start(CALL);
+    expect(player.startLoop).toHaveBeenCalledWith("call-1");
   });
 });


### PR DESCRIPTION
## Summary

Closes #1081. Follow-up gap discovered while implementing #1075 (Presence Phase 5a — *DND quiets own notifications*, epic #1071).

Presence **Do Not Disturb** (effective `<show>dnd</show>`) already silences this device's own **message** banners + sounds via the `$ownNotificationsSuppressed` signal (#1075/#1080). The **incoming-call** alert was on a separate, ungated path: `createIncomingCallAlertController.start()` unconditionally rang the looping tone and raised the OS notification banner, so a 1:1 / MUC call still rang and bannered under DND.

## Decision

Presence-DND silences **both** the incoming-call **ringtone** and the **OS notification banner** — the whole alert-controller path. This matches the #1075 message gate (suppresses banners + sounds, leaves visual/unread state) and the literal meaning of "Do Not Disturb". Consistent with ADR-010: *"Presence-DND may suppress own notifications … the client may silence its own banners/sounds."*

The in-app `IncomingCallToast` stays visible — it renders from `$callState`, not from the alert controller — so the user can still see and answer the call; they simply aren't disturbed by sound or an OS banner. Badge/unread paths are untouched.

DND is read **at ring time** (`start()`), mirroring the per-event message gate. A call that is already ringing when DND is toggled on keeps its current alert state (the natural way to stop a ringing call is to reject it); a snapshot-at-ring-time seam keeps the controller pure and parity-matched with the message path.

## Changes

- **`chat/src/shell/audio-alerts.ts`**: add an optional `isDoNotDisturb?: () => boolean` predicate to `createIncomingCallAlertController`; when it returns `true`, `start()` returns early before registering the slot, ringing the tone, or raising the OS notification. Mirrors the message gate's injected `isDoNotDisturb` seam. A suppressed `start` registers nothing, so `stop`/`stopAll` stay safe no-ops.
- **`chat/src/components/chat/ChatReadyShell.vue`**: wire `isDoNotDisturb: () => $ownNotificationsSuppressed.get()` into the controller created in `onMounted`, reusing the same presence-store signal as the message gate.
- **`chat/tests/incoming-call-alert-dnd.test.ts`** (new): ringtone suppressed under DND; OS banner suppressed under DND (tab unfocused); normal ring + banner when not DND (regression guard, fails on an inverted/misplaced gate); `stop`/`stopAll` safe after a suppressed `start`; and an end-to-end test driving the real picker store (`pickPresence("dnd")` suppresses through the exact wired predicate, `resetPresenceMode()` restores).

## Scope / conformance

- No XMPP wire change: this is a purely client-local notification gate keyed off the already-conformant RFC 6121 `<show>dnd</show>` effective Show. No stanza is built/parsed/sent, so the XEP custom test-suite (Rust) hard rule does not apply; TS coverage is the correct layer.
- Distinct from the server-side `urn:waddle:dnd:0` quiet-hours schedule (the **DND schedule**), which is unrelated and unchanged.

## Out of scope

- The service-worker push path (`sw-template.js`) — that is the `urn:waddle:dnd:0` quiet-hours schedule's domain (#317).

## Verification

- `bun run build` (incl. `astro check` typecheck): pass
- `bun run lint` (`knip`): clean
- `bun test`: 2814 pass, 0 fail
- Three adversarial review personas (protocol/XEP conformance, correctness/edge-cases, test quality): no real blockers; the one actionable gap (end-to-end store→controller coverage) was addressed by the added integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
