### PR TITLE
fix(server): RFC 7395 §3.8 WS keepalive — core-owned liveness policy, ping + dead-peer close

### DIFF
--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -134,7 +134,7 @@ pub struct ServerConfig {
     pub extensions: ExtensionConfig,
     /// Operator controls for server-side link-preview enrichment.
     pub link_preview: LinkPreviewConfig,
-    /// RFC 7395 §5.6 WebSocket keepalive knobs (issue #1090), parsed
+    /// RFC 7395 §3.8 WebSocket keepalive knobs (issue #1090), parsed
     /// from `WADDLE_WS_KEEPALIVE_*` by [`ws_keepalive_from_vars`].
     pub ws_keepalive: waddle_xmpp::protocol::KeepaliveConfig,
     /// SpiceDB backend configuration.
@@ -391,7 +391,7 @@ const WS_KEEPALIVE_MAX_INTERVAL_SECS: u64 = 120;
 /// cap on busy rooms.
 const WS_KEEPALIVE_MAX_MISS_LIMIT: u64 = 10;
 
-/// Parse + validate the RFC 7395 §5.6 keepalive knobs (issue #1090):
+/// Parse + validate the RFC 7395 §3.8 keepalive knobs (issue #1090):
 ///
 /// - `WADDLE_WS_KEEPALIVE_INTERVAL_SECS` — probe/tick interval,
 ///   default 45, valid range 1..=120 (see

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -134,6 +134,9 @@ pub struct ServerConfig {
     pub extensions: ExtensionConfig,
     /// Operator controls for server-side link-preview enrichment.
     pub link_preview: LinkPreviewConfig,
+    /// RFC 7395 §5.6 WebSocket keepalive knobs (issue #1090), parsed
+    /// from `WADDLE_WS_KEEPALIVE_*` by [`ws_keepalive_from_vars`].
+    pub ws_keepalive: waddle_xmpp::protocol::KeepaliveConfig,
     /// SpiceDB backend configuration.
     /// Runtime startup requires this to be set.
     pub spicedb: Option<SpiceDbConfig>,
@@ -370,6 +373,73 @@ fn parse_u64_var(
         .unwrap_or(Ok(default))
 }
 
+/// Ceiling for `WADDLE_WS_KEEPALIVE_INTERVAL_SECS`.
+///
+/// On an idle-but-alive connection the probe's pong counts as activity
+/// for the following tick, so the worst-case inter-traffic gap on the
+/// stream is `2 × interval`. The Cilium/Envoy gateway in front resets
+/// idle streams at its ~300s default; capping the interval at 120s
+/// bounds the gap at 240s with a 60s margin. This startup guard
+/// replaces the "raise gateway idleTimeout" defense-in-depth from
+/// issue #1090's original acceptance criteria — a fat-fingered
+/// interval fails fast instead of silently reintroducing the ~304s
+/// reset storm.
+const WS_KEEPALIVE_MAX_INTERVAL_SECS: u64 = 120;
+
+/// Upper bound for `WADDLE_WS_KEEPALIVE_MISS_LIMIT`; beyond this the
+/// dead-peer detection is too slow to beat the XEP-0198 unacked-queue
+/// cap on busy rooms.
+const WS_KEEPALIVE_MAX_MISS_LIMIT: u64 = 10;
+
+/// Parse + validate the RFC 7395 §5.6 keepalive knobs (issue #1090):
+///
+/// - `WADDLE_WS_KEEPALIVE_INTERVAL_SECS` — probe/tick interval,
+///   default 45, valid range 1..=120 (see
+///   [`WS_KEEPALIVE_MAX_INTERVAL_SECS`]).
+/// - `WADDLE_WS_KEEPALIVE_MISS_LIMIT` — consecutive unanswered probes
+///   before the connection is closed, default 2, valid range 1..=10.
+///
+/// Out-of-range values are startup errors, never clamped: a config
+/// that would defeat the keepalive must fail loudly.
+pub fn ws_keepalive_from_vars<I, K, V>(
+    vars: I,
+) -> Result<waddle_xmpp::protocol::KeepaliveConfig, String>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    let vars = vars
+        .into_iter()
+        .map(|(key, value)| (key.as_ref().to_string(), value.as_ref().to_string()))
+        .collect::<std::collections::HashMap<_, _>>();
+    let interval_secs = parse_u64_var(&vars, "WADDLE_WS_KEEPALIVE_INTERVAL_SECS", 45)?;
+    if !(1..=WS_KEEPALIVE_MAX_INTERVAL_SECS).contains(&interval_secs) {
+        return Err(format!(
+            "WADDLE_WS_KEEPALIVE_INTERVAL_SECS='{interval_secs}' must be between 1 and \
+             {WS_KEEPALIVE_MAX_INTERVAL_SECS}: the worst-case inter-traffic gap is twice the \
+             interval and must stay under the gateway's 300s stream-idle timeout"
+        ));
+    }
+    let miss_limit = parse_u64_var(&vars, "WADDLE_WS_KEEPALIVE_MISS_LIMIT", 2)?;
+    if !(1..=WS_KEEPALIVE_MAX_MISS_LIMIT).contains(&miss_limit) {
+        return Err(format!(
+            "WADDLE_WS_KEEPALIVE_MISS_LIMIT='{miss_limit}' must be between 1 and \
+             {WS_KEEPALIVE_MAX_MISS_LIMIT}"
+        ));
+    }
+    Ok(waddle_xmpp::protocol::KeepaliveConfig {
+        interval_ms: interval_secs * 1_000,
+        miss_limit: u32::try_from(miss_limit)
+            .map_err(|_| "WADDLE_WS_KEEPALIVE_MISS_LIMIT out of range".to_string())?,
+    })
+}
+
+/// Env-reading wrapper around [`ws_keepalive_from_vars`].
+pub fn ws_keepalive_from_env() -> Result<waddle_xmpp::protocol::KeepaliveConfig, String> {
+    ws_keepalive_from_vars(std::env::vars())
+}
+
 fn parse_host_patterns_var(
     vars: &std::collections::HashMap<String, String>,
     key: &str,
@@ -417,6 +487,7 @@ impl Default for ServerConfig {
             auth: AuthConfig::default(),
             extensions: ExtensionConfig::default(),
             link_preview: LinkPreviewConfig::default(),
+            ws_keepalive: waddle_xmpp::protocol::KeepaliveConfig::default(),
             spicedb: None,
             occupant_id_secret: test_occupant_id_secret(),
         }
@@ -437,6 +508,7 @@ impl ServerConfig {
         let extensions =
             ExtensionConfig::from_env().map_err(|e| format!("invalid extension config: {e}"))?;
         let link_preview = LinkPreviewConfig::from_env()?;
+        let ws_keepalive = ws_keepalive_from_env()?;
         let spicedb = SpiceDbConfig::from_env()?;
 
         let occupant_id_secret =
@@ -449,6 +521,7 @@ impl ServerConfig {
             auth,
             extensions,
             link_preview,
+            ws_keepalive,
             spicedb,
             occupant_id_secret,
         })
@@ -481,6 +554,7 @@ impl ServerConfig {
             auth: AuthConfig::default(),
             extensions: ExtensionConfig::default(),
             link_preview: LinkPreviewConfig::default(),
+            ws_keepalive: waddle_xmpp::protocol::KeepaliveConfig::default(),
             spicedb: None,
             occupant_id_secret: test_occupant_id_secret(),
         }
@@ -495,6 +569,7 @@ impl ServerConfig {
             auth: AuthConfig::default(),
             extensions: ExtensionConfig::default(),
             link_preview: LinkPreviewConfig::default(),
+            ws_keepalive: waddle_xmpp::protocol::KeepaliveConfig::default(),
             spicedb: None,
             occupant_id_secret: test_occupant_id_secret(),
         }
@@ -504,6 +579,62 @@ impl ServerConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ws_keepalive_defaults_are_45s_2_misses() {
+        let config = ws_keepalive_from_vars(std::iter::empty::<(&str, &str)>()).unwrap();
+        assert_eq!(config.interval_ms, 45_000);
+        assert_eq!(config.miss_limit, 2);
+    }
+
+    #[test]
+    fn ws_keepalive_parses_operator_overrides() {
+        let config = ws_keepalive_from_vars([
+            ("WADDLE_WS_KEEPALIVE_INTERVAL_SECS", "60"),
+            ("WADDLE_WS_KEEPALIVE_MISS_LIMIT", "3"),
+        ])
+        .unwrap();
+        assert_eq!(config.interval_ms, 60_000);
+        assert_eq!(config.miss_limit, 3);
+    }
+
+    #[test]
+    fn ws_keepalive_rejects_intervals_that_defeat_the_gateway_timeout() {
+        // 2×interval must stay under the gateway's 300s stream-idle
+        // timeout; anything above the 120s ceiling fails startup
+        // instead of silently reintroducing the ~304s reset storm.
+        for bad in ["0", "121", "300"] {
+            let err =
+                ws_keepalive_from_vars([("WADDLE_WS_KEEPALIVE_INTERVAL_SECS", bad)]).unwrap_err();
+            assert!(
+                err.contains("WADDLE_WS_KEEPALIVE_INTERVAL_SECS"),
+                "error must name the env var; got: {err}"
+            );
+            assert!(
+                err.contains("300s"),
+                "error must explain the gateway constraint; got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn ws_keepalive_rejects_out_of_range_miss_limits() {
+        for bad in ["0", "11"] {
+            let err =
+                ws_keepalive_from_vars([("WADDLE_WS_KEEPALIVE_MISS_LIMIT", bad)]).unwrap_err();
+            assert!(
+                err.contains("WADDLE_WS_KEEPALIVE_MISS_LIMIT"),
+                "error must name the env var; got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn ws_keepalive_rejects_non_numeric_values() {
+        let err =
+            ws_keepalive_from_vars([("WADDLE_WS_KEEPALIVE_INTERVAL_SECS", "45s")]).unwrap_err();
+        assert!(err.contains("must be a positive integer"));
+    }
 
     #[test]
     fn parse_session_key_rejects_unset() {

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -391,6 +391,53 @@ const WS_KEEPALIVE_MAX_INTERVAL_SECS: u64 = 120;
 /// cap on busy rooms.
 const WS_KEEPALIVE_MAX_MISS_LIMIT: u64 = 10;
 
+/// Typed validation failure for the `WADDLE_WS_KEEPALIVE_*` knobs
+/// (issue #1090).
+///
+/// Per the typed-payloads rule, error results are typed enums; the
+/// `Display` text is the human-facing startup diagnostic surfaced by
+/// [`ServerConfig::from_env`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum WsKeepaliveConfigError {
+    /// The interval would let the worst-case inter-traffic gap
+    /// (`2 × interval`) reach the gateway's ~300s stream-idle timeout.
+    #[error(
+        "WADDLE_WS_KEEPALIVE_INTERVAL_SECS='{value}' must be between 1 and {max}: the \
+         worst-case inter-traffic gap is twice the interval and must stay under the \
+         gateway's 300s stream-idle timeout"
+    )]
+    IntervalOutOfRange { value: u64, max: u64 },
+    /// The miss limit is zero (would close every idle peer instantly)
+    /// or so high that dead peers outlive the unacked-queue cap.
+    #[error("WADDLE_WS_KEEPALIVE_MISS_LIMIT='{value}' must be between 1 and {max}")]
+    MissLimitOutOfRange { value: u64, max: u64 },
+    /// The env var is set but is not a base-10 unsigned integer.
+    #[error("{key}='{value}' must be a positive integer")]
+    NotAnInteger { key: &'static str, value: String },
+}
+
+/// Read a `WADDLE_WS_KEEPALIVE_*` var as `u64`, treating unset/blank
+/// as the default. Sibling of [`parse_u64_var`] with a typed error.
+fn ws_keepalive_u64_var(
+    vars: &std::collections::HashMap<String, String>,
+    key: &'static str,
+    default: u64,
+) -> Result<u64, WsKeepaliveConfigError> {
+    match vars
+        .get(key)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+    {
+        None => Ok(default),
+        Some(raw) => raw
+            .parse::<u64>()
+            .map_err(|_| WsKeepaliveConfigError::NotAnInteger {
+                key,
+                value: raw.to_string(),
+            }),
+    }
+}
+
 /// Parse + validate the RFC 7395 §3.8 keepalive knobs (issue #1090):
 ///
 /// - `WADDLE_WS_KEEPALIVE_INTERVAL_SECS` — probe/tick interval,
@@ -403,7 +450,7 @@ const WS_KEEPALIVE_MAX_MISS_LIMIT: u64 = 10;
 /// that would defeat the keepalive must fail loudly.
 pub fn ws_keepalive_from_vars<I, K, V>(
     vars: I,
-) -> Result<waddle_xmpp::protocol::KeepaliveConfig, String>
+) -> Result<waddle_xmpp::protocol::KeepaliveConfig, WsKeepaliveConfigError>
 where
     I: IntoIterator<Item = (K, V)>,
     K: AsRef<str>,
@@ -413,30 +460,30 @@ where
         .into_iter()
         .map(|(key, value)| (key.as_ref().to_string(), value.as_ref().to_string()))
         .collect::<std::collections::HashMap<_, _>>();
-    let interval_secs = parse_u64_var(&vars, "WADDLE_WS_KEEPALIVE_INTERVAL_SECS", 45)?;
+    let interval_secs = ws_keepalive_u64_var(&vars, "WADDLE_WS_KEEPALIVE_INTERVAL_SECS", 45)?;
     if !(1..=WS_KEEPALIVE_MAX_INTERVAL_SECS).contains(&interval_secs) {
-        return Err(format!(
-            "WADDLE_WS_KEEPALIVE_INTERVAL_SECS='{interval_secs}' must be between 1 and \
-             {WS_KEEPALIVE_MAX_INTERVAL_SECS}: the worst-case inter-traffic gap is twice the \
-             interval and must stay under the gateway's 300s stream-idle timeout"
-        ));
+        return Err(WsKeepaliveConfigError::IntervalOutOfRange {
+            value: interval_secs,
+            max: WS_KEEPALIVE_MAX_INTERVAL_SECS,
+        });
     }
-    let miss_limit = parse_u64_var(&vars, "WADDLE_WS_KEEPALIVE_MISS_LIMIT", 2)?;
+    let miss_limit = ws_keepalive_u64_var(&vars, "WADDLE_WS_KEEPALIVE_MISS_LIMIT", 2)?;
     if !(1..=WS_KEEPALIVE_MAX_MISS_LIMIT).contains(&miss_limit) {
-        return Err(format!(
-            "WADDLE_WS_KEEPALIVE_MISS_LIMIT='{miss_limit}' must be between 1 and \
-             {WS_KEEPALIVE_MAX_MISS_LIMIT}"
-        ));
+        return Err(WsKeepaliveConfigError::MissLimitOutOfRange {
+            value: miss_limit,
+            max: WS_KEEPALIVE_MAX_MISS_LIMIT,
+        });
     }
     Ok(waddle_xmpp::protocol::KeepaliveConfig {
         interval_ms: interval_secs * 1_000,
-        miss_limit: u32::try_from(miss_limit)
-            .map_err(|_| "WADDLE_WS_KEEPALIVE_MISS_LIMIT out of range".to_string())?,
+        // Infallible: miss_limit is range-checked to 1..=10 above.
+        miss_limit: miss_limit as u32,
     })
 }
 
 /// Env-reading wrapper around [`ws_keepalive_from_vars`].
-pub fn ws_keepalive_from_env() -> Result<waddle_xmpp::protocol::KeepaliveConfig, String> {
+pub fn ws_keepalive_from_env(
+) -> Result<waddle_xmpp::protocol::KeepaliveConfig, WsKeepaliveConfigError> {
     ws_keepalive_from_vars(std::env::vars())
 }
 
@@ -508,7 +555,10 @@ impl ServerConfig {
         let extensions =
             ExtensionConfig::from_env().map_err(|e| format!("invalid extension config: {e}"))?;
         let link_preview = LinkPreviewConfig::from_env()?;
-        let ws_keepalive = ws_keepalive_from_env()?;
+        // `ServerConfig::from_env` predates the typed-error rule and
+        // still aggregates `String` diagnostics; render the typed
+        // keepalive error at this boundary.
+        let ws_keepalive = ws_keepalive_from_env().map_err(|error| error.to_string())?;
         let spicedb = SpiceDbConfig::from_env()?;
 
         let occupant_id_secret =
@@ -603,28 +653,37 @@ mod tests {
         // 2×interval must stay under the gateway's 300s stream-idle
         // timeout; anything above the 120s ceiling fails startup
         // instead of silently reintroducing the ~304s reset storm.
-        for bad in ["0", "121", "300"] {
+        for (bad, value) in [("0", 0), ("121", 121), ("300", 300)] {
             let err =
                 ws_keepalive_from_vars([("WADDLE_WS_KEEPALIVE_INTERVAL_SECS", bad)]).unwrap_err();
+            assert_eq!(
+                err,
+                WsKeepaliveConfigError::IntervalOutOfRange { value, max: 120 }
+            );
+            let rendered = err.to_string();
             assert!(
-                err.contains("WADDLE_WS_KEEPALIVE_INTERVAL_SECS"),
-                "error must name the env var; got: {err}"
+                rendered.contains("WADDLE_WS_KEEPALIVE_INTERVAL_SECS"),
+                "diagnostic must name the env var; got: {rendered}"
             );
             assert!(
-                err.contains("300s"),
-                "error must explain the gateway constraint; got: {err}"
+                rendered.contains("300s"),
+                "diagnostic must explain the gateway constraint; got: {rendered}"
             );
         }
     }
 
     #[test]
     fn ws_keepalive_rejects_out_of_range_miss_limits() {
-        for bad in ["0", "11"] {
+        for (bad, value) in [("0", 0), ("11", 11)] {
             let err =
                 ws_keepalive_from_vars([("WADDLE_WS_KEEPALIVE_MISS_LIMIT", bad)]).unwrap_err();
+            assert_eq!(
+                err,
+                WsKeepaliveConfigError::MissLimitOutOfRange { value, max: 10 }
+            );
             assert!(
-                err.contains("WADDLE_WS_KEEPALIVE_MISS_LIMIT"),
-                "error must name the env var; got: {err}"
+                err.to_string().contains("WADDLE_WS_KEEPALIVE_MISS_LIMIT"),
+                "diagnostic must name the env var; got: {err}"
             );
         }
     }
@@ -633,7 +692,14 @@ mod tests {
     fn ws_keepalive_rejects_non_numeric_values() {
         let err =
             ws_keepalive_from_vars([("WADDLE_WS_KEEPALIVE_INTERVAL_SECS", "45s")]).unwrap_err();
-        assert!(err.contains("must be a positive integer"));
+        assert_eq!(
+            err,
+            WsKeepaliveConfigError::NotAnInteger {
+                key: "WADDLE_WS_KEEPALIVE_INTERVAL_SECS",
+                value: "45s".to_string()
+            }
+        );
+        assert!(err.to_string().contains("must be a positive integer"));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -608,6 +608,7 @@ async fn create_websocket_state(
             },
             occupant_id_secret: server_config.occupant_id_secret.clone(),
             link_preview: server_config.link_preview.clone(),
+            ws_keepalive: server_config.ws_keepalive,
             provider_ingress,
             provider_dispatch_tasks,
         },

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -61,10 +61,18 @@
 //!   recipient inbox upsert (channel + thread rows) plus the XEP-0430
 //!   inbox push to the owner's other resources.
 //!
+//! - [`OutboundEvent::SendKeepaliveProbe`] — RFC 7395 §5.6 liveness
+//!   probe; counted into [`InterpretOutcome::keepalive_probes`] for the
+//!   transport adapter to map to a WS `Ping` frame (issue #1090).
+//! - [`OutboundEvent::SetTimer`] / [`OutboundEvent::CancelTimer`] —
+//!   relayed as typed [`TimerCommand`]s in
+//!   [`InterpretOutcome::timer_commands`]; the adapter owns the actual
+//!   clock and feeds `InboundEvent::Tick` back on expiry.
+//!
 //! Stubbed (warn-logged until migration steps land them):
 //! - `AskSfu`, `QueryMam`, `LoadScramCredentials`,
-//!   `ValidateOAuthBearer`, `SetTimer`, `CancelTimer`,
-//!   `RegisterConnection` — wired in later migration steps.
+//!   `ValidateOAuthBearer`, `RegisterConnection` — wired in later
+//!   migration steps.
 
 use crate::auth::Session;
 use crate::permissions::{CheckPermission, Object, ObjectType, Permission, Subject};
@@ -189,7 +197,7 @@ use room_subject::persist_room_subject_event;
 use route_to_connection::route_to_connection;
 use routing::{deliver_peer_to_full, run_headless_recipient_pass};
 
-pub use deps::{Deps, InterpretOutcome};
+pub use deps::{Deps, InterpretOutcome, TimerCommand};
 pub(crate) use groupchat_archive::push_inbox_update;
 pub(crate) use notification_activity_ingest::{
     record_presence_available_activity_on_state, record_presence_unavailable_activity_on_state,
@@ -411,12 +419,16 @@ async fn interpret_with_depth(
                     frames: nested_frames,
                     close: nested_close,
                     feedback: nested_feedback,
+                    keepalive_probes: nested_probes,
+                    timer_commands: nested_timer_commands,
                 } = nested;
                 outcome.frames.extend(nested_frames);
                 if nested_close {
                     outcome.close = true;
                 }
                 outcome.feedback.extend(nested_feedback);
+                outcome.keepalive_probes += nested_probes;
+                outcome.timer_commands.extend(nested_timer_commands);
             }
             OutboundEvent::ProjectInbox {
                 owner,
@@ -606,20 +618,20 @@ async fn interpret_with_depth(
                     "OutboundEvent variant not yet wired in interpreter"
                 );
             }
+            OutboundEvent::SendKeepaliveProbe => {
+                // A liveness probe is a transport control frame, not a
+                // stanza — it never serializes to XML here. The command
+                // rides the outcome back to the transport adapter,
+                // which maps it to its native frame (WS `Ping`).
+                outcome.keepalive_probes += 1;
+            }
             OutboundEvent::SetTimer { id, duration_ms } => {
-                warn!(
-                    variant = "SetTimer",
-                    timer_id = id.0,
-                    duration_ms,
-                    "OutboundEvent variant not yet wired in interpreter"
-                );
+                outcome
+                    .timer_commands
+                    .push(TimerCommand::Set { id, duration_ms });
             }
             OutboundEvent::CancelTimer(id) => {
-                warn!(
-                    variant = "CancelTimer",
-                    timer_id = id.0,
-                    "OutboundEvent variant not yet wired in interpreter"
-                );
+                outcome.timer_commands.push(TimerCommand::Cancel(id));
             }
             OutboundEvent::QueueOfflineDelivery {
                 recipient,

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -61,7 +61,7 @@
 //!   recipient inbox upsert (channel + thread rows) plus the XEP-0430
 //!   inbox push to the owner's other resources.
 //!
-//! - [`OutboundEvent::SendKeepaliveProbe`] — RFC 7395 §5.6 liveness
+//! - [`OutboundEvent::SendKeepaliveProbe`] — RFC 7395 §3.8 liveness
 //!   probe; counted into [`InterpretOutcome::keepalive_probes`] for the
 //!   transport adapter to map to a WS `Ping` frame (issue #1090).
 //! - [`OutboundEvent::SetTimer`] / [`OutboundEvent::CancelTimer`] —

--- a/server/crates/waddle-server/src/server/routes/interpret/deps.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/deps.rs
@@ -1,4 +1,5 @@
 use super::*;
+use waddle_xmpp::protocol::TimerId;
 
 /// Outcome of interpreting a batch of [`OutboundEvent`]s.
 ///
@@ -17,6 +18,29 @@ pub struct InterpretOutcome {
     pub close: bool,
     /// Async-callback completions to feed back to the state machine.
     pub feedback: Vec<InboundEvent>,
+    /// Number of [`OutboundEvent::SendKeepaliveProbe`] effects in the
+    /// batch (RFC 7395 §5.6 / issue #1090). Probes are transport
+    /// control frames with no XML form, so they ride the outcome as a
+    /// count and the adapter maps each to its native frame (WS
+    /// `Ping`). In practice this is 0 or 1 per tick.
+    pub keepalive_probes: u32,
+    /// Timer effects ([`OutboundEvent::SetTimer`] /
+    /// [`OutboundEvent::CancelTimer`]) for the adapter's
+    /// connection-local timer wheel. Only the transport adapter owns a
+    /// clock; the interpreter just relays the typed commands.
+    pub timer_commands: Vec<TimerCommand>,
+}
+
+/// Typed timer instruction relayed from the state machine to the
+/// transport adapter's timer wheel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimerCommand {
+    /// Arm (or re-arm, replacing any existing deadline for `id`) a
+    /// one-shot timer that feeds `InboundEvent::Tick(id)` back into
+    /// the state machine after `duration_ms`.
+    Set { id: TimerId, duration_ms: u64 },
+    /// Disarm the timer for `id`; a no-op when none is pending.
+    Cancel(TimerId),
 }
 
 /// Typed dependency context for the interpreter.

--- a/server/crates/waddle-server/src/server/routes/interpret/deps.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/deps.rs
@@ -19,7 +19,7 @@ pub struct InterpretOutcome {
     /// Async-callback completions to feed back to the state machine.
     pub feedback: Vec<InboundEvent>,
     /// Number of [`OutboundEvent::SendKeepaliveProbe`] effects in the
-    /// batch (RFC 7395 §5.6 / issue #1090). Probes are transport
+    /// batch (RFC 7395 §3.8 / issue #1090). Probes are transport
     /// control frames with no XML form, so they ride the outcome as a
     /// count and the adapter maps each to its native frame (WS
     /// `Ping`). In practice this is 0 or 1 per tick.

--- a/server/crates/waddle-server/src/server/routes/interpret/routing.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/routing.rs
@@ -75,6 +75,11 @@ pub(super) async fn run_headless_recipient_pass(
         frames,
         close,
         feedback,
+        // The transient SM has no transport, so it never receives
+        // TransportReady/Tick and cannot emit keepalive or timer
+        // effects; discarding matches the frames/feedback semantics.
+        keepalive_probes: _,
+        timer_commands: _,
     } = nested;
     debug!(
         bare_jid = %recipient_bare,

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -57,7 +57,7 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
 
     // Track connection state
     let mut conn = WsConnState::new();
-    // RFC 7395 §5.6 keepalive (issue #1090): the liveness policy lives
+    // RFC 7395 §3.8 keepalive (issue #1090): the liveness policy lives
     // in the per-connection sans-io machine, so one must exist from
     // the very first instant — a client that wedges before
     // authenticating is reaped by the same clock. `TransportReady`
@@ -88,7 +88,7 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                     Some(Ok(Message::Text(text))) => {
                         debug!(len = text.len(), "Received XMPP WebSocket message");
                         // Any inbound frame is liveness evidence for the
-                        // RFC 7395 §5.6 keepalive policy (issue #1090).
+                        // RFC 7395 §3.8 keepalive policy (issue #1090).
                         conn.note_transport_activity();
 
                         // Handle XMPP framing (RFC 7395)
@@ -298,7 +298,7 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                 }
             }
 
-            // RFC 7395 §5.6 keepalive clock (issue #1090). Fires only
+            // RFC 7395 §3.8 keepalive clock (issue #1090). Fires only
             // when the state machine armed a timer; the tick is fed
             // back into the machine, whose policy decides: quiet
             // re-arm, probe + re-arm, or close a dead peer. A
@@ -342,10 +342,17 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                     break;
                 }
                 if drive.close {
-                    info!("Keepalive miss limit reached; closing dead connection");
+                    // The policy's Log event (relayed above via interpret)
+                    // carries the reason (miss limit vs negotiation
+                    // deadline); this line adds the connection identity
+                    // for correlation with gateway/Loki reset queries.
+                    info!(
+                        jid = ?conn.phase.bound_jid(),
+                        "Keepalive policy closed the connection"
+                    );
                     let _ = close_ws_connection(
                         &mut ws_sender,
-                        "Failed to send WebSocket close frame after keepalive miss limit",
+                        "Failed to send WebSocket close frame after keepalive close",
                     )
                     .await;
                     break;

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -2,12 +2,15 @@ use super::*;
 use super::{
     cleanup::cleanup_connection_shutdown,
     frame::handle_xmpp_frame,
+    interpret_loop::build_interpret_deps,
     outbound::handle_outbound_stanza,
     registration::{register_bound_connection_after_frame, RegistrationAfterFrame},
+    replay::drive_interpret_loop,
     send::{close_ws_connection, send_ws_message, send_ws_text_frames},
     session_init::build_internal_server_error_stream_error,
     state::WsConnState,
     stream_management::{is_countable_stanza, SmRegistrationFinalization},
+    timers::TransportTimers,
     transport_xml::{build_handled_count_too_high_stream_error, websocket_stream_close_xml},
 };
 use waddle_xmpp::stream_management::SmRequest;
@@ -54,6 +57,23 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
 
     // Track connection state
     let mut conn = WsConnState::new();
+    // RFC 7395 §5.6 keepalive (issue #1090): the liveness policy lives
+    // in the per-connection sans-io machine, so one must exist from
+    // the very first instant — a client that wedges before
+    // authenticating is reaped by the same clock. `TransportReady`
+    // arms the keepalive timer; the machine re-arms it on every tick.
+    conn.init_prebind_state_machine(
+        &domain,
+        &state.deps.protocol.dispatcher,
+        state.deps.ws_keepalive,
+    );
+    let mut timers = TransportTimers::new();
+    if let Some(sm) = conn.state_machine.as_mut() {
+        let events = sm.handle(InboundEvent::TransportReady);
+        let interpret_deps = build_interpret_deps(state.as_ref(), None);
+        let drive = drive_interpret_loop(events, sm, &interpret_deps).await;
+        timers.apply(drive.timer_commands);
+    }
     // Set when our own registry slot was replaced by a newer connection for
     // the same FullJid (detected via outbound_rx closing). In that case the
     // cleanup block below must NOT touch the registry or MUC state — those
@@ -67,6 +87,9 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
                         debug!(len = text.len(), "Received XMPP WebSocket message");
+                        // Any inbound frame is liveness evidence for the
+                        // RFC 7395 §5.6 keepalive policy (issue #1090).
+                        conn.note_transport_activity();
 
                         // Handle XMPP framing (RFC 7395)
                         let mut responses =
@@ -209,9 +232,11 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                         }
                     }
                     Some(Ok(Message::Binary(_))) => {
+                        conn.note_transport_activity();
                         warn!("Received binary WebSocket message (not supported for XMPP)");
                     }
                     Some(Ok(Message::Ping(data))) => {
+                        conn.note_transport_activity();
                         if !send_ws_message(&mut ws_sender, Message::Pong(data), "Failed to send pong")
                             .await
                         {
@@ -219,7 +244,10 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                         }
                     }
                     Some(Ok(Message::Pong(_))) => {
-                        // Ignore pongs
+                        // Liveness evidence for the keepalive policy —
+                        // any payload counts, no probe correlation
+                        // (issue #1090 "any inbound frame = alive").
+                        conn.note_transport_activity();
                     }
                     Some(Ok(Message::Close(_))) => {
                         info!("WebSocket close requested");
@@ -245,6 +273,7 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                             &mut ws_sender,
                             &state,
                             &mut conn,
+                            &mut timers,
                             outbound_stanza,
                         )
                         .await
@@ -266,6 +295,60 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                         superseded = true;
                         break;
                     }
+                }
+            }
+
+            // RFC 7395 §5.6 keepalive clock (issue #1090). Fires only
+            // when the state machine armed a timer; the tick is fed
+            // back into the machine, whose policy decides: quiet
+            // re-arm, probe + re-arm, or close a dead peer. A
+            // keepalive close breaks the loop with a graceful WS close
+            // handshake and rides the normal shutdown fork below — SM
+            // detach-for-resume when negotiated, full cleanup
+            // otherwise.
+            timer_id = timers.next_expired() => {
+                let Some(sm) = conn.state_machine.as_mut() else {
+                    warn!(timer_id = timer_id.0, "Timer fired without a state machine; disarming");
+                    continue;
+                };
+                let events = sm.handle(InboundEvent::Tick(timer_id));
+                let interpret_deps =
+                    build_interpret_deps(state.as_ref(), conn.authenticated_session.as_ref());
+                let drive = drive_interpret_loop(events, sm, &interpret_deps).await;
+                timers.apply(drive.timer_commands);
+                if !drive.frames.is_empty() {
+                    // No tick pathway emits stanzas today; a frame here
+                    // means a new timer consumer forgot to extend this
+                    // arm with the SM-recording write contract.
+                    warn!(
+                        frames = drive.frames.len(),
+                        "Timer tick produced wire frames; dropping"
+                    );
+                }
+                let mut ping_send_failed = false;
+                for _ in 0..drive.keepalive_probes {
+                    if !send_ws_message(
+                        &mut ws_sender,
+                        Message::Ping(axum::body::Bytes::new()),
+                        "Failed to send keepalive ping",
+                    )
+                    .await
+                    {
+                        ping_send_failed = true;
+                        break;
+                    }
+                }
+                if ping_send_failed {
+                    break;
+                }
+                if drive.close {
+                    info!("Keepalive miss limit reached; closing dead connection");
+                    let _ = close_ws_connection(
+                        &mut ws_sender,
+                        "Failed to send WebSocket close frame after keepalive miss limit",
+                    )
+                    .await;
+                    break;
                 }
             }
         }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message.rs
@@ -143,8 +143,10 @@ pub async fn handle_message(
         Stanza::Message(incoming),
     ))));
     let deps = build_interpret_deps(state, authenticated_session);
-    let (frames, _close) = drive_interpret_loop(events, sm, &deps).await;
-    frames
+    // Stanza dispatch never emits keepalive/timer effects (those come
+    // only from TransportReady/Tick in the connection loop), and
+    // `close` was already ignored on this path — only frames matter.
+    drive_interpret_loop(events, sm, &deps).await.frames
 }
 
 async fn handle_dm_pin_message(

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -85,6 +85,7 @@ mod send;
 mod session_init;
 mod state;
 mod stream_management;
+mod timers;
 mod transport_xml;
 
 pub mod handlers;

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -237,6 +237,7 @@ mod tests {
                 },
                 occupant_id_secret: deps.occupant_id_secret.clone(),
                 link_preview: deps.link_preview.clone(),
+                ws_keepalive: deps.ws_keepalive,
                 provider_ingress: Arc::clone(&deps.provider_ingress),
                 provider_dispatch_tasks: deps.provider_dispatch_tasks.clone(),
             },

--- a/server/crates/waddle-server/src/server/routes/websocket/outbound.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/outbound.rs
@@ -1,7 +1,8 @@
 use super::*;
 use super::{
     interpret_loop::build_interpret_deps, replay::drive_interpret_loop, send::send_ws_message,
-    state::WsConnState, stream_management::is_countable_stanza, transport_xml::stanza_to_xml,
+    state::WsConnState, stream_management::is_countable_stanza, timers::TransportTimers,
+    transport_xml::stanza_to_xml,
 };
 use waddle_xmpp::stream_management::SmRequest;
 
@@ -9,6 +10,7 @@ pub(super) async fn handle_outbound_stanza<S, E>(
     sender: &mut S,
     state: &Arc<WebSocketState>,
     conn: &mut WsConnState,
+    timers: &mut TransportTimers,
     outbound_stanza: OutboundStanza,
 ) -> bool
 where
@@ -130,12 +132,29 @@ where
             )));
             let interpret_deps =
                 build_interpret_deps(state.as_ref(), conn.authenticated_session.as_ref());
-            let (frames, close) = drive_interpret_loop(events, sm, &interpret_deps).await;
+            let drive = drive_interpret_loop(events, sm, &interpret_deps).await;
+            // Timer/keepalive effects can't arise from a StanzaFromPeer
+            // dispatch today (only TransportReady/Tick produce them),
+            // but honour them anyway so a future policy change can't
+            // silently drop effects on this path.
+            timers.apply(drive.timer_commands);
+            for _ in 0..drive.keepalive_probes {
+                if !send_ws_message(
+                    sender,
+                    Message::Ping(axum::body::Bytes::new()),
+                    "Failed to send keepalive ping",
+                )
+                .await
+                {
+                    return false;
+                }
+            }
+            let close = drive.close;
             // Always best-effort flush the accumulated frames first, even if
             // `close=true`, so a final error stanza or stream-close frame is
             // visible before transport teardown.
             let mut request_ack_after = false;
-            for xml in frames {
+            for xml in drive.frames {
                 if conn.sm_state.enabled && is_countable_stanza(&xml) {
                     let result = conn.sm_state.record_outbound(xml.clone());
                     request_ack_after |= result.request_ack;

--- a/server/crates/waddle-server/src/server/routes/websocket/replay.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/replay.rs
@@ -177,7 +177,7 @@ pub(super) struct DriveOutcome {
     pub(super) frames: Vec<String>,
     /// Set when any round emitted [`OutboundEvent::CloseTransport`].
     pub(super) close: bool,
-    /// RFC 7395 §5.6 liveness probes to send as WS `Ping` frames
+    /// RFC 7395 §3.8 liveness probes to send as WS `Ping` frames
     /// (issue #1090).
     pub(super) keepalive_probes: u32,
     /// Timer effects for the connection-local timer wheel.

--- a/server/crates/waddle-server/src/server/routes/websocket/replay.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/replay.rs
@@ -66,9 +66,12 @@ pub(super) async fn drain_outbound_into_replay(
                 let events = sm.handle(InboundEvent::StanzaFromPeer(Box::new(
                     outbound_stanza.stanza,
                 )));
-                let (frames, _close) = drive_interpret_loop(events, sm, &deps).await;
+                // Detach drain: there is no live socket, so `close`,
+                // keepalive probes, and timer commands are all moot —
+                // only the frames matter, recorded for resume replay.
+                let drive = drive_interpret_loop(events, sm, &deps).await;
                 let mut row_id_for_first = pending_row_id.clone();
-                for xml in frames {
+                for xml in drive.frames {
                     let row_for_this = row_id_for_first.take();
                     record_drained_xml(
                         state,
@@ -165,34 +168,50 @@ async fn record_drained_xml(
     }
 }
 
+/// Accumulated result of [`drive_interpret_loop`]: everything the
+/// transport adapter must act on after the state machine + interpreter
+/// finished a dispatch, across all feedback rounds.
+#[derive(Debug, Default)]
+pub(super) struct DriveOutcome {
+    /// Serialized wire frames to write, in order.
+    pub(super) frames: Vec<String>,
+    /// Set when any round emitted [`OutboundEvent::CloseTransport`].
+    pub(super) close: bool,
+    /// RFC 7395 §5.6 liveness probes to send as WS `Ping` frames
+    /// (issue #1090).
+    pub(super) keepalive_probes: u32,
+    /// Timer effects for the connection-local timer wheel.
+    pub(super) timer_commands: Vec<crate::server::routes::interpret::TimerCommand>,
+}
+
 /// Drive the interpret-loop that resolves an initial batch of
 /// [`OutboundEvent`]s and any callback-feedback rounds the dispatcher
 /// chain produces (e.g. `LookupArchivedMessage` -> `ArchivedMessageLoaded`
 /// -> resumed pipeline events).
 ///
-/// Returns the accumulated wire frames (already serialized via
-/// [`crate::server::routes::interpret::interpret`]) and a `close`
-/// flag set when any round emitted [`OutboundEvent::CloseTransport`].
-/// The state machine `sm` is borrowed mutably so feedback events can
-/// be re-fed via `sm.handle(...)` and produce the next-round
-/// `OutboundEvent` batch.
+/// Returns the accumulated [`DriveOutcome`] (frames already serialized
+/// via [`crate::server::routes::interpret::interpret`]). The state
+/// machine `sm` is borrowed mutably so feedback events can be re-fed
+/// via `sm.handle(...)` and produce the next-round `OutboundEvent`
+/// batch.
 pub(super) async fn drive_interpret_loop(
     initial_events: Vec<OutboundEvent>,
     sm: &mut XmppStateMachine,
     deps: &crate::server::routes::interpret::Deps<'_>,
-) -> (Vec<String>, bool) {
-    let mut all_frames = Vec::new();
-    let mut close = false;
+) -> DriveOutcome {
+    let mut drive = DriveOutcome::default();
     let mut events_to_run = initial_events;
     // Each iteration: resolve the current batch, append its frames,
     // honour `close`, and if the batch produced callback-feedback,
     // feed it back through the SM to get the next batch.
     while !events_to_run.is_empty() {
         let outcome = crate::server::routes::interpret::interpret(events_to_run, deps).await;
-        all_frames.extend(outcome.frames);
+        drive.frames.extend(outcome.frames);
         if outcome.close {
-            close = true;
+            drive.close = true;
         }
+        drive.keepalive_probes += outcome.keepalive_probes;
+        drive.timer_commands.extend(outcome.timer_commands);
         if outcome.feedback.is_empty() {
             break;
         }
@@ -202,5 +221,5 @@ pub(super) async fn drive_interpret_loop(
         }
         events_to_run = next_events;
     }
-    (all_frames, close)
+    drive
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/send.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/send.rs
@@ -1,5 +1,20 @@
 use super::*;
 
+/// Upper bound for a single WebSocket send (including the flush that
+/// `SinkExt::send` forces through to the socket).
+///
+/// A peer whose TCP path has black-holed (NAT expiry, network
+/// partition — no RST/FIN) stops draining its receive window; once the
+/// kernel send buffer fills, an unbounded `send().await` parks the
+/// connection task inside a `select!` arm body, and the RFC 7395
+/// keepalive timer arm (issue #1090) is never polled again — dead-peer
+/// detection would silently degrade to the ~15-minute kernel TCP
+/// timeout exactly when a busy outbound stream meets a dead peer. A
+/// healthy client drains a single frame in milliseconds; 60s of
+/// undrained buffer means the path is gone. Stalled sends report
+/// failure, which every caller already treats as fatal teardown.
+const SEND_STALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
 pub(super) async fn send_ws_text_frames<S, E, I>(
     sender: &mut S,
     frames: I,
@@ -29,10 +44,18 @@ where
     S: Sink<Message, Error = E> + Unpin,
     E: std::fmt::Display,
 {
-    match sender.send(message).await {
-        Ok(()) => true,
-        Err(error) => {
+    match tokio::time::timeout(SEND_STALL_TIMEOUT, sender.send(message)).await {
+        Ok(Ok(())) => true,
+        Ok(Err(error)) => {
             error!(error = %error, "{failure_message}");
+            false
+        }
+        Err(_elapsed) => {
+            error!(
+                stall_timeout_secs = SEND_STALL_TIMEOUT.as_secs(),
+                "WebSocket send stalled past the write budget (peer not draining); \
+                 treating connection as dead: {failure_message}"
+            );
             false
         }
     }
@@ -43,10 +66,17 @@ where
     S: Sink<Message, Error = E> + Unpin,
     E: std::fmt::Display,
 {
-    match sender.close().await {
-        Ok(()) => true,
-        Err(error) => {
+    match tokio::time::timeout(SEND_STALL_TIMEOUT, sender.close()).await {
+        Ok(Ok(())) => true,
+        Ok(Err(error)) => {
             error!(error = %error, "{failure_message}");
+            false
+        }
+        Err(_elapsed) => {
+            error!(
+                stall_timeout_secs = SEND_STALL_TIMEOUT.as_secs(),
+                "WebSocket close stalled past the write budget: {failure_message}"
+            );
             false
         }
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -181,6 +181,9 @@ pub struct WebSocketDeps {
     /// graceful shutdown so in-flight deliveries can finish updating the
     /// ledger before runtime teardown.
     pub provider_dispatch_tasks: crate::server::routes::extension_webhooks::ProviderDispatchTracker,
+    /// RFC 7395 §5.6 keepalive knobs (issue #1090), parsed and
+    /// validated at startup from `WADDLE_WS_KEEPALIVE_*` env vars.
+    pub ws_keepalive: waddle_xmpp::protocol::KeepaliveConfig,
 }
 
 pub struct ProtocolServices {
@@ -358,20 +361,31 @@ pub(super) struct WsConnState {
     /// and duplicate queue entries. The main loop resets the flag to
     /// `false` after skipping the record step.
     pub(super) suppress_sm_record_next_batch: bool,
-    /// Per-connection sans-I/O state machine for the message
-    /// pipeline (issue #229 PR11). `None` until `transition_to_ready`
-    /// is called on bind — see [`Self::ensure_state_machine`].
+    /// Per-connection sans-I/O state machine.
     ///
-    /// When `Some`, the per-connection main loop dispatches
-    /// [`OutboundStanza`] entries on their [`DeliveryKind`]:
-    /// `PeerStanza` values feed [`InboundEvent::StanzaFromPeer`]
-    /// into this state machine and the resulting outbound events are
-    /// resolved via [`crate::server::routes::interpret::interpret`]
-    /// before any wire write. `DirectFrame` values bypass the state
-    /// machine entirely and write straight to the wire.
+    /// Initialized in the `Unauthenticated` phase at WS upgrade by
+    /// [`Self::init_prebind_state_machine`] so the RFC 7395 §5.6
+    /// keepalive policy (issue #1090) covers the connection from its
+    /// very first instant — a client that wedges before authenticating
+    /// is reaped by the same liveness clock. Replaced at bind /
+    /// SM-resume by [`Self::ensure_state_machine`] with a `Ready`
+    /// machine carrying the bound user's session snapshot.
+    ///
+    /// The per-connection main loop dispatches [`OutboundStanza`]
+    /// entries on their [`DeliveryKind`]: `PeerStanza` values feed
+    /// [`InboundEvent::StanzaFromPeer`] into this state machine and
+    /// the resulting outbound events are resolved via
+    /// [`crate::server::routes::interpret::interpret`] before any wire
+    /// write (an `Unauthenticated` machine drops them with a WARN, as
+    /// the previous `None` guard did). `DirectFrame` values bypass the
+    /// state machine entirely and write straight to the wire.
     ///
     /// [`InboundEvent::StanzaFromPeer`]: waddle_xmpp::protocol::InboundEvent::StanzaFromPeer
     pub(super) state_machine: Option<XmppStateMachine>,
+    /// Deployment keepalive knobs, retained so the bind-time machine
+    /// replacement in [`Self::ensure_state_machine`] re-seeds the
+    /// policy with the same configuration the pre-bind machine used.
+    pub(super) keepalive_config: waddle_xmpp::protocol::KeepaliveConfig,
 }
 
 impl WsConnState {
@@ -392,6 +406,35 @@ impl WsConnState {
             registry_owner: None,
             suppress_sm_record_next_batch: false,
             state_machine: None,
+            keepalive_config: waddle_xmpp::protocol::KeepaliveConfig::default(),
+        }
+    }
+
+    /// Initialize the per-connection [`XmppStateMachine`] in the
+    /// `Unauthenticated` phase at WS upgrade, seeding the RFC 7395
+    /// §5.6 keepalive policy (issue #1090) with the deployment
+    /// config. Called exactly once, before the connection loop's
+    /// first `select!`; the caller then feeds
+    /// `InboundEvent::TransportReady` to arm the keepalive clock.
+    pub(super) fn init_prebind_state_machine(
+        &mut self,
+        domain: &str,
+        dispatcher: &Arc<StanzaDispatcher>,
+        keepalive: waddle_xmpp::protocol::KeepaliveConfig,
+    ) {
+        self.keepalive_config = keepalive;
+        let mut sm = XmppStateMachine::new(domain.to_string(), (**dispatcher).clone());
+        sm.set_keepalive_config(keepalive);
+        self.state_machine = Some(sm);
+    }
+
+    /// Feed transport-level liveness evidence (any inbound WS frame —
+    /// text, ping, pong, or binary) into the keepalive policy. The
+    /// `KeepaliveAck` event never produces outbound effects.
+    pub(super) fn note_transport_activity(&mut self) {
+        if let Some(sm) = self.state_machine.as_mut() {
+            let events = sm.handle(InboundEvent::KeepaliveAck);
+            debug_assert!(events.is_empty(), "KeepaliveAck must be effect-free");
         }
     }
 
@@ -427,6 +470,7 @@ impl WsConnState {
         blocklist: Blocklist,
     ) {
         let mut sm = XmppStateMachine::new(domain.to_string(), (**dispatcher).clone());
+        sm.set_keepalive_config(self.keepalive_config);
         sm.transition_to_ready(full_jid, resumed);
         sm.set_blocklist(blocklist);
         self.state_machine = Some(sm);

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -181,7 +181,7 @@ pub struct WebSocketDeps {
     /// graceful shutdown so in-flight deliveries can finish updating the
     /// ledger before runtime teardown.
     pub provider_dispatch_tasks: crate::server::routes::extension_webhooks::ProviderDispatchTracker,
-    /// RFC 7395 §5.6 keepalive knobs (issue #1090), parsed and
+    /// RFC 7395 §3.8 keepalive knobs (issue #1090), parsed and
     /// validated at startup from `WADDLE_WS_KEEPALIVE_*` env vars.
     pub ws_keepalive: waddle_xmpp::protocol::KeepaliveConfig,
 }
@@ -364,7 +364,7 @@ pub(super) struct WsConnState {
     /// Per-connection sans-I/O state machine.
     ///
     /// Initialized in the `Unauthenticated` phase at WS upgrade by
-    /// [`Self::init_prebind_state_machine`] so the RFC 7395 §5.6
+    /// [`Self::init_prebind_state_machine`] so the RFC 7395 §3.8
     /// keepalive policy (issue #1090) covers the connection from its
     /// very first instant — a client that wedges before authenticating
     /// is reaped by the same liveness clock. Replaced at bind /
@@ -411,11 +411,13 @@ impl WsConnState {
     }
 
     /// Initialize the per-connection [`XmppStateMachine`] in the
-    /// `Unauthenticated` phase at WS upgrade, seeding the RFC 7395
-    /// §5.6 keepalive policy (issue #1090) with the deployment
-    /// config. Called exactly once, before the connection loop's
-    /// first `select!`; the caller then feeds
-    /// `InboundEvent::TransportReady` to arm the keepalive clock.
+    /// `Unauthenticated` phase, seeding the RFC 7395 §3.8 keepalive
+    /// policy (issue #1090) with the deployment config. Called at WS
+    /// upgrade, before the connection loop's first `select!` (the
+    /// caller then feeds `InboundEvent::TransportReady` to arm the
+    /// keepalive clock), and again by the failed-SM-resume reset so
+    /// the machine — and with it the keepalive tick chain — is never
+    /// absent mid-connection.
     pub(super) fn init_prebind_state_machine(
         &mut self,
         domain: &str,

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management/registration.rs
@@ -184,7 +184,20 @@ fn reset_registered_resume_attempt(
         .unregister_if_owner(jid, owner);
     conn.registry_owner = None;
     conn.phase = ConnectionPhase::authenticated(jid);
-    conn.state_machine = None;
+    // Replace (never null) the per-connection state machine: the
+    // connection loop's keepalive timer arm feeds `Tick` into
+    // `conn.state_machine`, and the policy re-arms the adapter's timer
+    // wheel on every tick. Dropping the machine to `None` here would
+    // let the next tick hit the loop's no-machine guard, which cannot
+    // re-arm — permanently disarming dead-peer detection (issue #1090)
+    // for whatever remains of this connection. A fresh pre-bind
+    // machine restores the session-free semantics this reset wants
+    // (an `Unauthenticated` machine drops peer stanzas with a WARN,
+    // matching the old `None` guard) while keeping the keepalive
+    // clock chain unbroken.
+    let domain = state.deps.auth_state.xmpp_domain.clone();
+    let keepalive = conn.keepalive_config;
+    conn.init_prebind_state_machine(&domain, &state.deps.protocol.dispatcher, keepalive);
     conn.sm_state = StreamManagementState::new();
     conn.blocklist_interested = false;
     conn.suppress_sm_record_next_batch = false;

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -282,6 +282,7 @@ async fn create_test_websocket_state_with_extension_manager(
                 )
                 .expect("test secret meets length floor"),
                 link_preview: server_config.link_preview.clone(),
+                ws_keepalive: server_config.ws_keepalive,
                 provider_ingress: Arc::new(
                     crate::server::routes::extension_webhooks::ProviderIngressRegistry::default(),
                 ),

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/dispatch.rs
@@ -52,7 +52,8 @@ async fn drive_interpret_loop_resolves_send_stanza_into_wire_frames() {
 
     let initial_events = vec![OutboundEvent::SendStanza(Box::new(Stanza::Message(msg)))];
     let deps = build_interpret_deps(state.as_ref(), None);
-    let (frames, close) = drive_interpret_loop(initial_events, sm, &deps).await;
+    let drive = drive_interpret_loop(initial_events, sm, &deps).await;
+    let (frames, close) = (drive.frames, drive.close);
 
     assert!(!close, "SendStanza alone never requests transport close");
     assert_eq!(frames.len(), 1, "single SendStanza -> single wire frame");
@@ -105,7 +106,7 @@ async fn drive_interpret_loop_runs_recipient_pass_for_peer_message() {
         peer_msg,
     ))));
     let deps = build_interpret_deps(state.as_ref(), None);
-    let (frames, _close) = drive_interpret_loop(events, sm, &deps).await;
+    let frames = drive_interpret_loop(events, sm, &deps).await.frames;
 
     // Recipient pass terminates with at least one SendStanza
     // carrying bob's stamp.

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/send.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/send.rs
@@ -93,3 +93,51 @@ async fn close_ws_connection_closes_sink() {
     assert!(closed);
     assert!(sink.closed);
 }
+
+/// A sink whose peer never drains: `poll_ready` pends forever, the
+/// shape of a black-holed TCP path with a full send buffer.
+struct StalledSink;
+
+impl Sink<Message> for StalledSink {
+    type Error = &'static str;
+
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Pending
+    }
+
+    fn start_send(self: Pin<&mut Self>, _item: Message) -> Result<(), Self::Error> {
+        unreachable!("poll_ready never completes")
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Pending
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Pending
+    }
+}
+
+/// Issue #1090 write-stall budget: a send that cannot make progress
+/// must report failure within the 60s budget instead of parking the
+/// connection task forever (which would freeze the keepalive clock —
+/// the adversarial-review finding the budget exists to close). Paused
+/// tokio time auto-advances past the timeout, so this pins the bound
+/// without a real 60s wait.
+#[tokio::test(start_paused = true)]
+async fn send_ws_message_fails_when_the_sink_stalls_past_the_budget() {
+    let mut sink = StalledSink;
+
+    let sent = send_ws_message(&mut sink, Message::Text("<ping/>".into()), "expected stall").await;
+
+    assert!(!sent, "a stalled send must report failure, not hang");
+}
+
+#[tokio::test(start_paused = true)]
+async fn close_ws_connection_fails_when_the_sink_stalls_past_the_budget() {
+    let mut sink = StalledSink;
+
+    let closed = close_ws_connection(&mut sink, "expected stall").await;
+
+    assert!(!closed, "a stalled close must report failure, not hang");
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/timers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/timers.rs
@@ -1,0 +1,151 @@
+//! Connection-local timer wheel for state-machine-owned timers.
+//!
+//! The sans-io core emits typed timer effects
+//! ([`OutboundEvent::SetTimer`] / [`OutboundEvent::CancelTimer`],
+//! relayed as [`TimerCommand`]s by the interpreter); this wheel is the
+//! transport adapter's clock that realizes them. The connection loop
+//! selects on [`TransportTimers::next_expired`] and feeds each fired
+//! id back into the machine as `InboundEvent::Tick(id)`.
+//!
+//! Timers are one-shot: a fired id is popped and stays disarmed until
+//! the machine re-arms it (the RFC 7395 keepalive policy re-arms on
+//! every tick). Arming an already-armed id replaces its deadline.
+//!
+//! [`OutboundEvent::SetTimer`]: waddle_xmpp::protocol::OutboundEvent::SetTimer
+//! [`OutboundEvent::CancelTimer`]: waddle_xmpp::protocol::OutboundEvent::CancelTimer
+
+use crate::server::routes::interpret::TimerCommand;
+use std::time::Duration;
+use tokio::time::Instant;
+use waddle_xmpp::protocol::TimerId;
+
+/// The adapter-owned realization of the state machine's timers.
+///
+/// Sized for a handful of concurrent timers per connection (today:
+/// exactly one, the keepalive clock), hence a `Vec` rather than a heap.
+#[derive(Debug, Default)]
+pub(super) struct TransportTimers {
+    deadlines: Vec<(TimerId, Instant)>,
+}
+
+impl TransportTimers {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Apply a batch of interpreter-relayed timer commands.
+    pub(super) fn apply(&mut self, commands: impl IntoIterator<Item = TimerCommand>) {
+        for command in commands {
+            match command {
+                TimerCommand::Set { id, duration_ms } => {
+                    self.set(id, Duration::from_millis(duration_ms));
+                }
+                TimerCommand::Cancel(id) => self.cancel(id),
+            }
+        }
+    }
+
+    fn set(&mut self, id: TimerId, after: Duration) {
+        let deadline = Instant::now() + after;
+        if let Some(slot) = self.deadlines.iter_mut().find(|(armed, _)| *armed == id) {
+            slot.1 = deadline;
+        } else {
+            self.deadlines.push((id, deadline));
+        }
+    }
+
+    fn cancel(&mut self, id: TimerId) {
+        self.deadlines.retain(|(armed, _)| *armed != id);
+    }
+
+    /// Sleep until the earliest armed timer expires, pop it, and return
+    /// its id. Pends forever when nothing is armed.
+    ///
+    /// Cancellation-safe for `tokio::select!`: state is only mutated
+    /// after the sleep completes, so a dropped future leaves every
+    /// deadline armed.
+    pub(super) async fn next_expired(&mut self) -> TimerId {
+        let Some((id, deadline)) = self
+            .deadlines
+            .iter()
+            .min_by_key(|(_, deadline)| *deadline)
+            .copied()
+        else {
+            return std::future::pending().await;
+        };
+        tokio::time::sleep_until(deadline).await;
+        self.cancel(id);
+        id
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const A: TimerId = TimerId(1);
+    const B: TimerId = TimerId(2);
+
+    #[tokio::test(start_paused = true)]
+    async fn fires_in_deadline_order_and_pops() {
+        let mut timers = TransportTimers::new();
+        timers.apply([
+            TimerCommand::Set {
+                id: B,
+                duration_ms: 200,
+            },
+            TimerCommand::Set {
+                id: A,
+                duration_ms: 100,
+            },
+        ]);
+        assert_eq!(timers.next_expired().await, A);
+        assert_eq!(timers.next_expired().await, B);
+        // Both popped: nothing armed → pending forever.
+        let idle = tokio::time::timeout(Duration::from_secs(3600), timers.next_expired()).await;
+        assert!(idle.is_err(), "empty wheel must pend");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn rearm_replaces_the_deadline() {
+        let mut timers = TransportTimers::new();
+        timers.apply([TimerCommand::Set {
+            id: A,
+            duration_ms: 100,
+        }]);
+        timers.apply([TimerCommand::Set {
+            id: A,
+            duration_ms: 500,
+        }]);
+        let fired = tokio::time::timeout(Duration::from_millis(300), timers.next_expired()).await;
+        assert!(fired.is_err(), "old deadline must be replaced");
+        assert_eq!(timers.next_expired().await, A);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cancel_disarms() {
+        let mut timers = TransportTimers::new();
+        timers.apply([TimerCommand::Set {
+            id: A,
+            duration_ms: 100,
+        }]);
+        timers.apply([TimerCommand::Cancel(A)]);
+        let idle = tokio::time::timeout(Duration::from_secs(3600), timers.next_expired()).await;
+        assert!(idle.is_err(), "cancelled timer must not fire");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dropped_wait_leaves_timers_armed() {
+        let mut timers = TransportTimers::new();
+        timers.apply([TimerCommand::Set {
+            id: A,
+            duration_ms: 200,
+        }]);
+        // Poll-and-drop before expiry (select! losing the race).
+        let premature =
+            tokio::time::timeout(Duration::from_millis(50), timers.next_expired()).await;
+        assert!(premature.is_err());
+        // The deadline survives the dropped future.
+        assert_eq!(timers.next_expired().await, A);
+    }
+}

--- a/server/crates/waddle-server/tests/rfc7395_keepalive_ws.rs
+++ b/server/crates/waddle-server/tests/rfc7395_keepalive_ws.rs
@@ -146,7 +146,7 @@ async fn unauthenticated_socket_is_reaped_despite_auto_pongs() {
 
     // Poll continuously so every server ping is auto-ponged — this is
     // the "wedged app, live network stack" shape. Expect the server to
-    // close ~4-5s in (negotiation limit 3 ticks + close tick at 1s).
+    // close ~3-4s in (negotiation limit tick 3 at the 1s interval).
     let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
     let mut closed = false;
     while tokio::time::Instant::now() < deadline {

--- a/server/crates/waddle-server/tests/rfc7395_keepalive_ws.rs
+++ b/server/crates/waddle-server/tests/rfc7395_keepalive_ws.rs
@@ -1,4 +1,4 @@
-//! RFC 7395 §5.6 keepalive over a real WebSocket (issue #1090).
+//! RFC 7395 §3.8 keepalive over a real WebSocket (issue #1090).
 //!
 //! End-to-end conformance: the server sends `Ping` frames on an
 //! inbound-idle interval, an idle-but-responsive client survives
@@ -127,6 +127,48 @@ async fn silent_peer_is_closed_after_miss_limit() {
     assert!(
         closed,
         "server must close a silent peer after the miss limit"
+    );
+}
+
+/// Locked design decision on #1090: "timer runs from WS upgrade so
+/// wedged pre-bind connections get reaped too." A socket that upgrades
+/// but never authenticates keeps auto-ponging at the WS layer
+/// (tokio-tungstenite here, the browser network process in real
+/// clients), so probe answers alone must not keep it alive — the
+/// negotiation deadline (NEGOTIATION_TICK_LIMIT ticks) closes it.
+#[tokio::test]
+async fn unauthenticated_socket_is_reaped_despite_auto_pongs() {
+    let server = keepalive_server("1", "2");
+    // Connect the raw WebSocket only — no SASL, no bind.
+    let mut client = WsXmppClient::connect(&server.ws_url())
+        .await
+        .expect("raw websocket connect");
+
+    // Poll continuously so every server ping is auto-ponged — this is
+    // the "wedged app, live network stack" shape. Expect the server to
+    // close ~4-5s in (negotiation limit 3 ticks + close tick at 1s).
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+    let mut closed = false;
+    while tokio::time::Instant::now() < deadline {
+        match client.recv_raw_timeout(Duration::from_secs(15)).await {
+            Ok(Some(tungstenite::Message::Close(_))) | Ok(None) => {
+                closed = true;
+                break;
+            }
+            Ok(Some(_)) => {}
+            Err(e) => {
+                assert!(
+                    e.contains("WebSocket error"),
+                    "expected close/EOF/error, got timeout: {e}"
+                );
+                closed = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        closed,
+        "an unauthenticated auto-ponging socket must be reaped by the negotiation deadline"
     );
 }
 

--- a/server/crates/waddle-server/tests/rfc7395_keepalive_ws.rs
+++ b/server/crates/waddle-server/tests/rfc7395_keepalive_ws.rs
@@ -14,11 +14,32 @@ mod ws_common;
 
 use std::time::Duration;
 
+use futures::StreamExt;
 use tokio_tungstenite::tungstenite;
 use ws_common::{TestServer, WsXmppClient};
 
 const DOMAIN: &str = "localhost";
 const USERNAME: &str = "admin";
+
+/// Receive one raw WebSocket frame — control frames included.
+///
+/// This suite observes server-initiated `Ping` frames, which the
+/// harness's `recv_timeout` deliberately treats as errors. Polling the
+/// stream also lets tokio-tungstenite flush its automatic `Pong`
+/// replies, so a client driven by this helper behaves like a healthy
+/// browser. `Ok(None)` means the stream ended. Local to this suite (on
+/// the harness it would be dead code in every other test binary).
+async fn recv_raw_timeout(
+    client: &mut WsXmppClient,
+    dur: Duration,
+) -> Result<Option<tungstenite::Message>, String> {
+    match tokio::time::timeout(dur, client.ws.next()).await {
+        Ok(Some(Ok(message))) => Ok(Some(message)),
+        Ok(Some(Err(e))) => Err(format!("WebSocket error: {e}")),
+        Ok(None) => Ok(None),
+        Err(_) => Err("Timeout waiting for raw frame".to_string()),
+    }
+}
 
 fn keepalive_server(interval_secs: &str, miss_limit: &str) -> TestServer {
     TestServer::start_with_extra_envs(
@@ -58,7 +79,7 @@ async fn idle_session_receives_pings_and_survives() {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(12);
     let mut pings = 0u32;
     while tokio::time::Instant::now() < deadline && pings < 3 {
-        match client.recv_raw_timeout(Duration::from_secs(12)).await {
+        match recv_raw_timeout(&mut client, Duration::from_secs(12)).await {
             Ok(Some(tungstenite::Message::Ping(_))) => pings += 1,
             Ok(Some(_)) => {} // unrelated frame (SM nudges, etc.)
             Ok(None) => panic!("server closed an idle-but-responsive connection"),
@@ -106,7 +127,7 @@ async fn silent_peer_is_closed_after_miss_limit() {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
     let mut closed = false;
     while tokio::time::Instant::now() < deadline {
-        match client.recv_raw_timeout(Duration::from_secs(10)).await {
+        match recv_raw_timeout(&mut client, Duration::from_secs(10)).await {
             Ok(Some(tungstenite::Message::Close(_))) | Ok(None) => {
                 closed = true;
                 break;
@@ -150,7 +171,7 @@ async fn unauthenticated_socket_is_reaped_despite_auto_pongs() {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
     let mut closed = false;
     while tokio::time::Instant::now() < deadline {
-        match client.recv_raw_timeout(Duration::from_secs(15)).await {
+        match recv_raw_timeout(&mut client, Duration::from_secs(15)).await {
             Ok(Some(tungstenite::Message::Close(_))) | Ok(None) => {
                 closed = true;
                 break;

--- a/server/crates/waddle-server/tests/rfc7395_keepalive_ws.rs
+++ b/server/crates/waddle-server/tests/rfc7395_keepalive_ws.rs
@@ -1,0 +1,177 @@
+//! RFC 7395 §5.6 keepalive over a real WebSocket (issue #1090).
+//!
+//! End-to-end conformance: the server sends `Ping` frames on an
+//! inbound-idle interval, an idle-but-responsive client survives
+//! indefinitely, a silent (dead) peer is closed after the miss limit
+//! with a graceful close handshake, and a keepalive close takes the
+//! XEP-0198 detach-for-resume path.
+//!
+//! The interval is shrunk to the 1s config floor via
+//! `WADDLE_WS_KEEPALIVE_INTERVAL_SECS`; the pure policy timing lives in
+//! the clock-free suite at `waddle-xmpp/tests/rfc7395_keepalive.rs`.
+
+mod ws_common;
+
+use std::time::Duration;
+
+use tokio_tungstenite::tungstenite;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const USERNAME: &str = "admin";
+
+fn keepalive_server(interval_secs: &str, miss_limit: &str) -> TestServer {
+    TestServer::start_with_extra_envs(
+        &[],
+        &[
+            ("WADDLE_WS_KEEPALIVE_INTERVAL_SECS", interval_secs),
+            ("WADDLE_WS_KEEPALIVE_MISS_LIMIT", miss_limit),
+        ],
+    )
+}
+
+async fn connect(server: &TestServer, resource: &str) -> WsXmppClient {
+    let password = server.fixed_account_password().to_string();
+    WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        USERNAME,
+        &password,
+        &format!("{resource}-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("websocket connection")
+}
+
+/// AC: "Server sends WS ping frames on an idle interval" + "Idle
+/// sessions survive past the current 5-minute window". With a 1s
+/// interval, 12s of idling spans 12 intervals — the scaled equivalent
+/// of far more than 5 minutes at the production 45s interval. The
+/// client only polls (tokio-tungstenite auto-pongs, like a browser);
+/// it must observe repeated server pings and remain fully functional
+/// afterwards.
+#[tokio::test]
+async fn idle_session_receives_pings_and_survives() {
+    let server = keepalive_server("1", "2");
+    let mut client = connect(&server, "keepalive-idle").await;
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(12);
+    let mut pings = 0u32;
+    while tokio::time::Instant::now() < deadline && pings < 3 {
+        match client.recv_raw_timeout(Duration::from_secs(12)).await {
+            Ok(Some(tungstenite::Message::Ping(_))) => pings += 1,
+            Ok(Some(_)) => {} // unrelated frame (SM nudges, etc.)
+            Ok(None) => panic!("server closed an idle-but-responsive connection"),
+            Err(e) => panic!("keepalive ping never arrived: {e}"),
+        }
+    }
+    assert!(
+        pings >= 3,
+        "expected repeated server-initiated pings on an idle connection; saw {pings}"
+    );
+
+    // The session must still be fully functional after many idle
+    // intervals: an XMPP ping IQ round-trips.
+    client
+        .send(r#"<iq type="get" id="post-idle-ping"><ping xmlns="urn:xmpp:ping"/></iq>"#)
+        .await
+        .expect("send xmpp ping after idling");
+    let reply = client
+        .recv_matching(|frame| frame.contains("post-idle-ping"))
+        .await
+        .expect("xmpp ping reply after idling");
+    assert!(
+        reply.contains(r#"type="result""#) || reply.contains("type='result'"),
+        "idle-surviving session must answer IQs: {reply}"
+    );
+}
+
+/// AC: consecutive unanswered probes close the connection. A client
+/// that stops polling never flushes tokio-tungstenite's auto-pongs —
+/// from the server's perspective it is a dead peer. With interval=1s
+/// and miss_limit=1 the close lands ~3s after the last inbound frame;
+/// the client must then find a graceful `Close` (or clean EOF), not a
+/// hung socket.
+#[tokio::test]
+async fn silent_peer_is_closed_after_miss_limit() {
+    let server = keepalive_server("1", "1");
+    let mut client = connect(&server, "keepalive-dead").await;
+
+    // Go dark: no polling, so no pongs leave this side.
+    tokio::time::sleep(Duration::from_secs(6)).await;
+
+    // Resume polling: buffered pings may surface first, then the
+    // server's close must arrive. A live server would emit nothing but
+    // pings here, so a bounded loop distinguishes closed from hung.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+    let mut closed = false;
+    while tokio::time::Instant::now() < deadline {
+        match client.recv_raw_timeout(Duration::from_secs(10)).await {
+            Ok(Some(tungstenite::Message::Close(_))) | Ok(None) => {
+                closed = true;
+                break;
+            }
+            Ok(Some(_)) => {}
+            // A reset after the server tore down also proves closure,
+            // but the graceful path should have delivered Close first.
+            Err(e) => {
+                assert!(
+                    e.contains("WebSocket error"),
+                    "expected close/EOF/error, got timeout: {e}"
+                );
+                closed = true;
+                break;
+            }
+        }
+    }
+    assert!(
+        closed,
+        "server must close a silent peer after the miss limit"
+    );
+}
+
+/// The keepalive close must ride the XEP-0198 detach-for-resume path:
+/// a client whose network stalled (missed pongs → server closed) can
+/// come back and `<resume/>` its stream instead of losing the session.
+#[tokio::test]
+async fn keepalive_close_detaches_for_sm_resume() {
+    let server = keepalive_server("1", "1");
+    let mut client = connect(&server, "keepalive-resume").await;
+
+    client
+        .send(r#"<enable xmlns="urn:xmpp:sm:3" resume="true"/>"#)
+        .await
+        .expect("enable stream management");
+    let enabled = client
+        .recv_matching(|frame| frame.contains("<enabled"))
+        .await
+        .expect("stream management enabled");
+    let stream_id = ws_common::extract_attr_after(&enabled, "<enabled", "id")
+        .unwrap_or_else(|| panic!("enabled missing id: {enabled}"));
+
+    // Go dark until the keepalive reaps the connection (~3s at 1s/1
+    // miss; generous margin for CI).
+    tokio::time::sleep(Duration::from_secs(6)).await;
+
+    let mut resumed = WsXmppClient::connect(&server.ws_url())
+        .await
+        .expect("reconnect after keepalive close");
+    resumed
+        .authenticate(DOMAIN, USERNAME, server.fixed_account_password())
+        .await
+        .expect("re-authenticate after keepalive close");
+    resumed
+        .send(&format!(
+            r#"<resume xmlns="urn:xmpp:sm:3" previd="{stream_id}" h="0"/>"#
+        ))
+        .await
+        .expect("send resume");
+    let resumption = resumed
+        .recv_matching(|frame| frame.contains("<resumed") || frame.contains("<failed"))
+        .await
+        .expect("resume reply");
+    assert!(
+        resumption.contains("<resumed"),
+        "keepalive close must detach for resume, not fully clean up: {resumption}"
+    );
+}

--- a/server/crates/waddle-server/tests/ws_common/mod.rs
+++ b/server/crates/waddle-server/tests/ws_common/mod.rs
@@ -463,6 +463,30 @@ impl WsXmppClient {
         }
     }
 
+    /// Receive one raw WebSocket frame — control frames included.
+    ///
+    /// The RFC 7395 keepalive suite uses this to observe
+    /// server-initiated `Ping` frames, which [`Self::recv_timeout`]
+    /// deliberately treats as errors. Polling the stream also lets
+    /// tokio-tungstenite flush its automatic `Pong` replies, so a
+    /// client that keeps calling this behaves like a healthy browser.
+    /// `Ok(None)` means the stream ended.
+    ///
+    /// `#[allow(dead_code)]` matches the established pattern on this
+    /// harness (each integration test compiles as its own crate).
+    #[allow(dead_code)]
+    pub async fn recv_raw_timeout(
+        &mut self,
+        dur: Duration,
+    ) -> Result<Option<tungstenite::Message>, String> {
+        match timeout(dur, self.ws.next()).await {
+            Ok(Some(Ok(message))) => Ok(Some(message)),
+            Ok(Some(Err(e))) => Err(format!("WebSocket error: {e}")),
+            Ok(None) => Ok(None),
+            Err(_) => Err("Timeout waiting for raw frame".to_string()),
+        }
+    }
+
     /// Receive frames until one matches the predicate. Returns all collected frames.
     #[allow(dead_code)]
     pub async fn recv_until<F: Fn(&str) -> bool>(

--- a/server/crates/waddle-server/tests/ws_common/mod.rs
+++ b/server/crates/waddle-server/tests/ws_common/mod.rs
@@ -279,7 +279,13 @@ impl Drop for TestServer {
 
 /// A WebSocket XMPP client for integration tests.
 pub struct WsXmppClient {
-    ws: tokio_tungstenite::WebSocketStream<
+    /// `pub(crate)` so suites with frame-level needs (the RFC 7395
+    /// keepalive tests observe raw `Ping`/`Close` control frames,
+    /// which [`Self::recv_timeout`] deliberately treats as errors)
+    /// can poll the stream directly with their own local helpers —
+    /// keeping this shared harness free of per-suite methods that
+    /// would be dead code in every other test binary.
+    pub(crate) ws: tokio_tungstenite::WebSocketStream<
         tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
     >,
     pub full_jid: Option<String>,
@@ -460,30 +466,6 @@ impl WsXmppClient {
             Ok(Some(Err(e))) => Err(format!("WebSocket error: {e}")),
             Ok(None) => Err("WebSocket stream ended".to_string()),
             Err(_) => Err("Timeout waiting for message".to_string()),
-        }
-    }
-
-    /// Receive one raw WebSocket frame — control frames included.
-    ///
-    /// The RFC 7395 keepalive suite uses this to observe
-    /// server-initiated `Ping` frames, which [`Self::recv_timeout`]
-    /// deliberately treats as errors. Polling the stream also lets
-    /// tokio-tungstenite flush its automatic `Pong` replies, so a
-    /// client that keeps calling this behaves like a healthy browser.
-    /// `Ok(None)` means the stream ended.
-    ///
-    /// `#[allow(dead_code)]` matches the established pattern on this
-    /// harness (each integration test compiles as its own crate).
-    #[allow(dead_code)]
-    pub async fn recv_raw_timeout(
-        &mut self,
-        dur: Duration,
-    ) -> Result<Option<tungstenite::Message>, String> {
-        match timeout(dur, self.ws.next()).await {
-            Ok(Some(Ok(message))) => Ok(Some(message)),
-            Ok(Some(Err(e))) => Err(format!("WebSocket error: {e}")),
-            Ok(None) => Ok(None),
-            Err(_) => Err("Timeout waiting for raw frame".to_string()),
         }
     }
 

--- a/server/crates/waddle-xmpp/src/protocol/event.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event.rs
@@ -120,19 +120,21 @@ pub enum InboundEvent {
     StanzaFromPeer(Box<Stanza>),
     /// The transport reports it is up and ready to carry frames (WS
     /// upgrade complete). Fed exactly once, before any client frame —
-    /// arms the RFC 7395 §5.6 keepalive clock so even a connection
+    /// arms the RFC 7395 §3.8 keepalive clock so even a connection
     /// that never authenticates is reaped by the liveness policy.
     TransportReady,
     /// The transport reports it has been closed.
     TransportClosed,
     /// A timer previously armed via [`OutboundEvent::SetTimer`] fired.
     Tick(TimerId),
-    /// Transport-level liveness evidence that does not surface as a
-    /// parsed frame — a WS pong (any payload) or a client-initiated WS
-    /// ping. Under the issue #1090 policy *any* inbound frame proves
-    /// the peer alive; the WebSocket adapter feeds this for control
-    /// frames while [`InboundEvent::FrameReceived`] covers text frames
-    /// on the state-machine path.
+    /// Transport-level liveness evidence. Under the issue #1090 policy
+    /// *any* inbound frame proves the peer alive, so the WebSocket
+    /// adapter feeds this for **every** received frame — text, binary,
+    /// client-initiated ping, and pong (any payload) — because most
+    /// frames are dispatched on the legacy path and never reach the
+    /// machine as [`InboundEvent::FrameReceived`]. `FrameReceived`
+    /// also marks the peer alive for the frames that *do* take the
+    /// machine path; the double-mark is idempotent.
     KeepaliveAck,
 
     // -------------------------------------------------------------------

--- a/server/crates/waddle-xmpp/src/protocol/event.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event.rs
@@ -100,8 +100,10 @@ pub struct CallbackId(pub u64);
 
 /// Opaque identifier for a state-machine-owned timer.
 ///
-/// Later migration steps use this for SCRAM timeouts and
-/// XEP-0198 stream-management keep-alives.
+/// The RFC 7395 keepalive clock reserves
+/// [`crate::protocol::keepalive::KEEPALIVE_TIMER`]; later migration
+/// steps allocate distinct ids for SCRAM timeouts and XEP-0198 ack
+/// deadlines.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TimerId(pub u64);
 
@@ -116,8 +118,22 @@ pub enum InboundEvent {
     ///
     /// Boxed to keep `InboundEvent` small (see `InboundFrame::Stanza`).
     StanzaFromPeer(Box<Stanza>),
+    /// The transport reports it is up and ready to carry frames (WS
+    /// upgrade complete). Fed exactly once, before any client frame —
+    /// arms the RFC 7395 §5.6 keepalive clock so even a connection
+    /// that never authenticates is reaped by the liveness policy.
+    TransportReady,
     /// The transport reports it has been closed.
     TransportClosed,
+    /// A timer previously armed via [`OutboundEvent::SetTimer`] fired.
+    Tick(TimerId),
+    /// Transport-level liveness evidence that does not surface as a
+    /// parsed frame — a WS pong (any payload) or a client-initiated WS
+    /// ping. Under the issue #1090 policy *any* inbound frame proves
+    /// the peer alive; the WebSocket adapter feeds this for control
+    /// frames while [`InboundEvent::FrameReceived`] covers text frames
+    /// on the state-machine path.
+    KeepaliveAck,
 
     // -------------------------------------------------------------------
     // Async callback completions (matched to a previously emitted

--- a/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
@@ -28,7 +28,7 @@ pub enum OutboundEvent {
     /// Write a typed stanza to the transport. The interpreter serializes
     /// the stanza to its XML wire form at the I/O boundary.
     SendStanza(Box<Stanza>),
-    /// Send a transport-native liveness probe (RFC 7395 §5.6 / issue
+    /// Send a transport-native liveness probe (RFC 7395 §3.8 / issue
     /// #1090). The probe is a transport control frame with no stanza
     /// semantics, so the *adapter* — not the interpreter's XML path —
     /// maps it to its native mechanism: a WebSocket `Ping` frame with

--- a/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
@@ -28,6 +28,15 @@ pub enum OutboundEvent {
     /// Write a typed stanza to the transport. The interpreter serializes
     /// the stanza to its XML wire form at the I/O boundary.
     SendStanza(Box<Stanza>),
+    /// Send a transport-native liveness probe (RFC 7395 §5.6 / issue
+    /// #1090). The probe is a transport control frame with no stanza
+    /// semantics, so the *adapter* — not the interpreter's XML path —
+    /// maps it to its native mechanism: a WebSocket `Ping` frame with
+    /// an empty payload today; a future TCP transport would map it to
+    /// whitespace keepalive or XEP-0199. Emitted by
+    /// [`crate::protocol::keepalive::KeepalivePolicy`] on an
+    /// inbound-idle tick.
+    SendKeepaliveProbe,
     /// Close the transport gracefully.
     CloseTransport,
 

--- a/server/crates/waddle-xmpp/src/protocol/keepalive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/keepalive.rs
@@ -90,6 +90,13 @@ impl Default for KeepaliveConfig {
 /// remove that bound. Three ticks is 135s at the default 45s interval
 /// (and 360s at the 120s config ceiling) — orders of magnitude above a
 /// normal sub-second SASL + bind negotiation.
+///
+/// The budget is tick-based, so it scales with the configured
+/// interval: at the 1s config floor a client has only ~3s of wall
+/// clock to authenticate (inbound frames do NOT extend it — auto-pongs
+/// are indistinguishable from progress at this layer). Ample for any
+/// real SASL exchange, but worth knowing when tuning the interval far
+/// below the default.
 pub const NEGOTIATION_TICK_LIMIT: u32 = 3;
 
 /// Per-connection keepalive policy state.
@@ -157,9 +164,9 @@ impl KeepalivePolicy {
     /// resource); pre-`Ready` connections are additionally bounded by
     /// [`NEGOTIATION_TICK_LIMIT`].
     ///
-    /// - Still negotiating past the tick limit → close, even if the
-    ///   peer answers probes (auto-pong proves nothing about session
-    ///   progress).
+    /// - Still negotiating when the tick limit is reached → close,
+    ///   even if the peer answers probes (auto-pong proves nothing
+    ///   about session progress).
     /// - Evidence since the last tick → quiet re-arm.
     /// - Silence → probe and re-arm, until `miss_limit` probes have
     ///   gone unanswered, then close the transport.
@@ -168,15 +175,14 @@ impl KeepalivePolicy {
             self.negotiation_ticks = 0;
         } else {
             self.negotiation_ticks += 1;
-            if self.negotiation_ticks > NEGOTIATION_TICK_LIMIT {
+            if self.negotiation_ticks >= NEGOTIATION_TICK_LIMIT {
                 return vec![
                     OutboundEvent::Log {
                         level: Level::INFO,
                         message: format!(
                             "Keepalive: session still negotiating after {} ticks \
                              (interval {}ms); closing stalled pre-bind connection",
-                            self.negotiation_ticks - 1,
-                            self.config.interval_ms
+                            self.negotiation_ticks, self.config.interval_ms
                         ),
                     },
                     OutboundEvent::CloseTransport,
@@ -377,17 +383,16 @@ mod tests {
         // The peer's WS stack answers every probe (mark_alive), but the
         // session never reaches Ready — liveness must not grant
         // immortality to a socket that makes no session progress.
-        for _ in 0..NEGOTIATION_TICK_LIMIT {
+        for _ in 0..NEGOTIATION_TICK_LIMIT - 1 {
             p.mark_alive();
             let events = p.on_tick(false);
             assert!(!has_close(&events), "still within negotiation budget");
         }
+        // The limit tick itself closes: 3 ticks = 135s at defaults,
+        // exactly as the NEGOTIATION_TICK_LIMIT docs state.
         p.mark_alive();
         let events = p.on_tick(false);
-        assert!(
-            has_close(&events),
-            "negotiation limit exhausted: {events:?}"
-        );
+        assert!(has_close(&events), "negotiation limit reached: {events:?}");
         assert!(
             !events
                 .iter()
@@ -400,7 +405,7 @@ mod tests {
     fn reaching_ready_resets_the_negotiation_budget() {
         let mut p = KeepalivePolicy::new(cfg(45_000, 2));
         p.on_transport_ready();
-        for _ in 0..NEGOTIATION_TICK_LIMIT {
+        for _ in 0..NEGOTIATION_TICK_LIMIT - 1 {
             p.mark_alive();
             assert!(!has_close(&p.on_tick(false)));
         }
@@ -415,9 +420,12 @@ mod tests {
     }
 
     #[test]
-    fn silent_negotiating_peer_still_dies_by_miss_limit_first() {
-        // A pre-bind peer that also stops ponging hits the ordinary
-        // dead-peer close (miss limit) before the negotiation limit.
+    fn silent_negotiating_peer_is_probed_then_closed_at_the_limit() {
+        // A pre-bind peer that also stops ponging: grace tick, one
+        // unanswered probe, then the third tick closes it — the miss
+        // limit's earliest possible close is also the third tick, and
+        // the negotiation check runs first, so the negotiation deadline
+        // is the operative bound for silent pre-bind peers.
         let mut p = KeepalivePolicy::new(cfg(45_000, 1));
         p.on_transport_ready();
         assert!(!has_probe(&p.on_tick(false))); // grace

--- a/server/crates/waddle-xmpp/src/protocol/keepalive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/keepalive.rs
@@ -1,7 +1,10 @@
-//! RFC 7395 §5.6 transport keepalive policy (issue #1090).
+//! RFC 7395 §3.8 transport keepalive policy (issue #1090).
 //!
-//! The XMPP-over-WebSocket subprotocol prescribes WebSocket ping/pong
-//! frames as the keepalive mechanism. This module owns the *policy* —
+//! RFC 7395 §3.8 ("Pings and Keepalives") sanctions WebSocket ping/pong
+//! control frames as the keepalive mechanism for the XMPP subprotocol
+//! (alongside XEP-0199 and XEP-0198); Waddle uses WS ping/pong because
+//! it needs no stanza semantics and browsers answer it automatically at
+//! the protocol layer. This module owns the *policy* —
 //! when to probe, when to give up — as pure, clock-free state driven by
 //! [`InboundEvent::Tick`](super::InboundEvent::Tick) and liveness
 //! evidence. The transport adapter owns the *mechanism*: it maps
@@ -73,6 +76,22 @@ impl Default for KeepaliveConfig {
     }
 }
 
+/// Ticks a connection may spend outside the `Ready` phase before it is
+/// closed regardless of pong answers.
+///
+/// Every RFC 6455 stack auto-pongs below the application (browsers
+/// answer from the network process even for a frozen tab), so "answers
+/// probes" proves only that the TCP path and WS stack are alive — not
+/// that the client is making session progress. Without this bound, an
+/// unauthenticated socket would be held forever: the server's own
+/// pings keep the gateway's idle timer happy and the auto-pongs keep
+/// the miss counter at zero. Ironically, before issue #1090 the
+/// gateway's ~300s reset reaped such sockets; the keepalive must not
+/// remove that bound. Three ticks is 135s at the default 45s interval
+/// (and 360s at the 120s config ceiling) — orders of magnitude above a
+/// normal sub-second SASL + bind negotiation.
+pub const NEGOTIATION_TICK_LIMIT: u32 = 3;
+
 /// Per-connection keepalive policy state.
 ///
 /// Owned by [`XmppStateMachine`](super::XmppStateMachine); driven
@@ -96,6 +115,8 @@ pub struct KeepalivePolicy {
     alive_since_tick: bool,
     /// Probes sent without any intervening inbound evidence.
     consecutive_misses: u32,
+    /// Ticks observed while the session was not yet `Ready`.
+    negotiation_ticks: u32,
 }
 
 impl KeepalivePolicy {
@@ -108,6 +129,7 @@ impl KeepalivePolicy {
             config,
             alive_since_tick: true,
             consecutive_misses: 0,
+            negotiation_ticks: 0,
         }
     }
 
@@ -117,6 +139,7 @@ impl KeepalivePolicy {
     pub fn on_transport_ready(&mut self) -> Vec<OutboundEvent> {
         self.alive_since_tick = true;
         self.consecutive_misses = 0;
+        self.negotiation_ticks = 0;
         vec![OutboundEvent::SetTimer {
             id: KEEPALIVE_TIMER,
             duration_ms: self.config.interval_ms,
@@ -129,12 +152,37 @@ impl KeepalivePolicy {
         self.consecutive_misses = 0;
     }
 
-    /// Evaluate the policy on a keepalive tick.
+    /// Evaluate the policy on a keepalive tick. `session_ready` is
+    /// whether the machine has reached the `Ready` phase (bound
+    /// resource); pre-`Ready` connections are additionally bounded by
+    /// [`NEGOTIATION_TICK_LIMIT`].
     ///
+    /// - Still negotiating past the tick limit → close, even if the
+    ///   peer answers probes (auto-pong proves nothing about session
+    ///   progress).
     /// - Evidence since the last tick → quiet re-arm.
     /// - Silence → probe and re-arm, until `miss_limit` probes have
     ///   gone unanswered, then close the transport.
-    pub fn on_tick(&mut self) -> Vec<OutboundEvent> {
+    pub fn on_tick(&mut self, session_ready: bool) -> Vec<OutboundEvent> {
+        if session_ready {
+            self.negotiation_ticks = 0;
+        } else {
+            self.negotiation_ticks += 1;
+            if self.negotiation_ticks > NEGOTIATION_TICK_LIMIT {
+                return vec![
+                    OutboundEvent::Log {
+                        level: Level::INFO,
+                        message: format!(
+                            "Keepalive: session still negotiating after {} ticks \
+                             (interval {}ms); closing stalled pre-bind connection",
+                            self.negotiation_ticks - 1,
+                            self.config.interval_ms
+                        ),
+                    },
+                    OutboundEvent::CloseTransport,
+                ];
+            }
+        }
         let rearm = OutboundEvent::SetTimer {
             id: KEEPALIVE_TIMER,
             duration_ms: self.config.interval_ms,
@@ -165,12 +213,17 @@ impl KeepalivePolicy {
 ///
 /// Free function so [`XmppStateMachine::handle`] stays a thin match:
 /// unknown ids are logged (a cancelled-then-fired race is benign), the
-/// keepalive id runs the policy.
+/// keepalive id runs the policy. `session_ready` mirrors whether the
+/// machine's phase is `Ready`.
 ///
 /// [`XmppStateMachine::handle`]: super::XmppStateMachine::handle
-pub(super) fn dispatch_tick(policy: &mut KeepalivePolicy, id: TimerId) -> Vec<OutboundEvent> {
+pub(super) fn dispatch_tick(
+    policy: &mut KeepalivePolicy,
+    id: TimerId,
+    session_ready: bool,
+) -> Vec<OutboundEvent> {
     if id == KEEPALIVE_TIMER {
-        policy.on_tick()
+        policy.on_tick(session_ready)
     } else {
         vec![OutboundEvent::Log {
             level: Level::WARN,
@@ -227,7 +280,7 @@ mod tests {
         p.on_transport_ready();
         for _ in 0..10 {
             p.mark_alive();
-            let events = p.on_tick();
+            let events = p.on_tick(true);
             assert!(!has_probe(&events), "active peer got probed: {events:?}");
             assert!(!has_close(&events));
             assert_rearm(&events, 45_000);
@@ -239,16 +292,16 @@ mod tests {
         let mut p = KeepalivePolicy::new(cfg(45_000, 2));
         p.on_transport_ready();
         // Tick 1: initial alive grace clears quietly.
-        assert!(!has_probe(&p.on_tick()));
+        assert!(!has_probe(&p.on_tick(true)));
         // Tick 2: silence → probe. Peer pongs.
-        let events = p.on_tick();
+        let events = p.on_tick(true);
         assert!(has_probe(&events));
         assert_rearm(&events, 45_000);
         p.mark_alive();
         // Tick 3: pong counted as evidence → quiet.
-        assert!(!has_probe(&p.on_tick()));
+        assert!(!has_probe(&p.on_tick(true)));
         // Tick 4: silence again → probe. Worst-case wire gap is 2·interval.
-        assert!(has_probe(&p.on_tick()));
+        assert!(has_probe(&p.on_tick(true)));
     }
 
     #[test]
@@ -256,15 +309,15 @@ mod tests {
         let mut p = KeepalivePolicy::new(cfg(45_000, 2));
         p.on_transport_ready();
         // Tick 1: initial grace.
-        assert!(!has_probe(&p.on_tick()));
+        assert!(!has_probe(&p.on_tick(true)));
         // Ticks 2..=3: two probes, never answered.
         for _ in 0..2 {
-            let events = p.on_tick();
+            let events = p.on_tick(true);
             assert!(has_probe(&events));
             assert!(!has_close(&events));
         }
         // Tick 4: miss limit reached → close, no further probe or re-arm.
-        let events = p.on_tick();
+        let events = p.on_tick(true);
         assert!(has_close(&events));
         assert!(!has_probe(&events));
         assert!(
@@ -279,31 +332,31 @@ mod tests {
     fn late_evidence_resets_the_miss_counter() {
         let mut p = KeepalivePolicy::new(cfg(45_000, 2));
         p.on_transport_ready();
-        p.on_tick(); // grace
-        assert!(has_probe(&p.on_tick())); // miss 1
-        assert!(has_probe(&p.on_tick())); // miss 2
+        p.on_tick(true); // grace
+        assert!(has_probe(&p.on_tick(true))); // miss 1
+        assert!(has_probe(&p.on_tick(true))); // miss 2
         p.mark_alive(); // peer answers just in time
-        assert!(!has_probe(&p.on_tick())); // quiet tick
-                                           // The full miss budget is available again.
-        assert!(has_probe(&p.on_tick()));
-        assert!(has_probe(&p.on_tick()));
-        assert!(has_close(&p.on_tick()));
+        assert!(!has_probe(&p.on_tick(true))); // quiet tick
+                                               // The full miss budget is available again.
+        assert!(has_probe(&p.on_tick(true)));
+        assert!(has_probe(&p.on_tick(true)));
+        assert!(has_close(&p.on_tick(true)));
     }
 
     #[test]
     fn miss_limit_one_closes_on_second_silent_tick() {
         let mut p = KeepalivePolicy::new(cfg(1_000, 1));
         p.on_transport_ready();
-        p.on_tick(); // grace
-        assert!(has_probe(&p.on_tick()));
-        assert!(has_close(&p.on_tick()));
+        p.on_tick(true); // grace
+        assert!(has_probe(&p.on_tick(true)));
+        assert!(has_close(&p.on_tick(true)));
     }
 
     #[test]
     fn unknown_timer_id_is_logged_not_actioned() {
         let mut p = KeepalivePolicy::new(cfg(45_000, 2));
         p.on_transport_ready();
-        let events = dispatch_tick(&mut p, TimerId(999));
+        let events = dispatch_tick(&mut p, TimerId(999), true);
         assert_eq!(events.len(), 1);
         assert!(matches!(events[0], OutboundEvent::Log { .. }));
         assert!(!has_probe(&events) && !has_close(&events));
@@ -313,7 +366,62 @@ mod tests {
     fn keepalive_tick_routes_through_dispatch() {
         let mut p = KeepalivePolicy::new(cfg(45_000, 2));
         p.on_transport_ready();
-        dispatch_tick(&mut p, KEEPALIVE_TIMER); // grace
-        assert!(has_probe(&dispatch_tick(&mut p, KEEPALIVE_TIMER)));
+        dispatch_tick(&mut p, KEEPALIVE_TIMER, true); // grace
+        assert!(has_probe(&dispatch_tick(&mut p, KEEPALIVE_TIMER, true)));
+    }
+
+    #[test]
+    fn auto_ponging_but_never_binding_peer_is_closed_at_the_negotiation_limit() {
+        let mut p = KeepalivePolicy::new(cfg(45_000, 2));
+        p.on_transport_ready();
+        // The peer's WS stack answers every probe (mark_alive), but the
+        // session never reaches Ready — liveness must not grant
+        // immortality to a socket that makes no session progress.
+        for _ in 0..NEGOTIATION_TICK_LIMIT {
+            p.mark_alive();
+            let events = p.on_tick(false);
+            assert!(!has_close(&events), "still within negotiation budget");
+        }
+        p.mark_alive();
+        let events = p.on_tick(false);
+        assert!(
+            has_close(&events),
+            "negotiation limit exhausted: {events:?}"
+        );
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, OutboundEvent::SetTimer { .. })),
+            "negotiation close must not re-arm: {events:?}"
+        );
+    }
+
+    #[test]
+    fn reaching_ready_resets_the_negotiation_budget() {
+        let mut p = KeepalivePolicy::new(cfg(45_000, 2));
+        p.on_transport_ready();
+        for _ in 0..NEGOTIATION_TICK_LIMIT {
+            p.mark_alive();
+            assert!(!has_close(&p.on_tick(false)));
+        }
+        // Session binds just in time; ready ticks clear the counter and
+        // ordinary keepalive behavior takes over indefinitely.
+        for _ in 0..10 {
+            p.mark_alive();
+            let events = p.on_tick(true);
+            assert!(!has_close(&events));
+            assert_rearm(&events, 45_000);
+        }
+    }
+
+    #[test]
+    fn silent_negotiating_peer_still_dies_by_miss_limit_first() {
+        // A pre-bind peer that also stops ponging hits the ordinary
+        // dead-peer close (miss limit) before the negotiation limit.
+        let mut p = KeepalivePolicy::new(cfg(45_000, 1));
+        p.on_transport_ready();
+        assert!(!has_probe(&p.on_tick(false))); // grace
+        assert!(has_probe(&p.on_tick(false))); // probe, unanswered
+        assert!(has_close(&p.on_tick(false)));
     }
 }

--- a/server/crates/waddle-xmpp/src/protocol/keepalive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/keepalive.rs
@@ -1,0 +1,319 @@
+//! RFC 7395 §5.6 transport keepalive policy (issue #1090).
+//!
+//! The XMPP-over-WebSocket subprotocol prescribes WebSocket ping/pong
+//! frames as the keepalive mechanism. This module owns the *policy* —
+//! when to probe, when to give up — as pure, clock-free state driven by
+//! [`InboundEvent::Tick`](super::InboundEvent::Tick) and liveness
+//! evidence. The transport adapter owns the *mechanism*: it maps
+//! [`OutboundEvent::SendKeepaliveProbe`] to its native probe frame (a
+//! WS `Ping` today; a future TCP transport would map it to whitespace
+//! keepalive or XEP-0199) and feeds ticks and
+//! [`InboundEvent::KeepaliveAck`](super::InboundEvent::KeepaliveAck)
+//! evidence back in.
+//!
+//! # Probe basis: inbound idle
+//!
+//! Probes fire on *inbound* silence, not outbound. A dead client on a
+//! busy MUC stream never sends anything while the server happily keeps
+//! writing; an outbound-idle basis would never detect its death and the
+//! XEP-0198 unacked queue would grow until the queue-cap eviction
+//! permanently breaks resume. Outbound stanzas independently keep the
+//! gateway's bidirectional stream-idle timer happy, so inbound-idle
+//! covers both goals with one clock.
+//!
+//! # Liveness evidence: any inbound frame
+//!
+//! A peer that sends *anything* — a stanza, a client-initiated ping, a
+//! pong with any payload — is alive, which is the only fact the close
+//! policy needs. There is deliberately no RFC 6455 pong-payload
+//! correlation: it would add state and a false-positive class
+//! (payload-mangling intermediaries) for zero liveness value.
+//!
+//! # Timing
+//!
+//! With interval `I` and miss limit `M`:
+//!
+//! - An idle-but-alive peer sees a probe at most every `2·I` (its pong
+//!   counts as activity for the following tick), so the worst-case
+//!   inter-traffic gap on the stream is `2·I` — the deployment config
+//!   ceiling keeps that under the gateway's 300s idle timeout.
+//! - A dead peer is closed after `M` unanswered probes: between
+//!   `(M + 1)·I` and `(M + 2)·I` after its last inbound frame.
+
+use super::event::{OutboundEvent, TimerId};
+use tracing::Level;
+
+/// The reserved [`TimerId`] for the transport keepalive clock.
+///
+/// Timer ids are per-connection; other state-machine timers (SCRAM
+/// timeouts, SM ack deadlines) must allocate distinct ids.
+pub const KEEPALIVE_TIMER: TimerId = TimerId(1);
+
+/// Deployment-tunable keepalive knobs.
+///
+/// Validated at server startup (`waddle-server` `config.rs`): the
+/// interval ceiling guarantees `2·interval` stays under the gateway's
+/// stream-idle timeout, replacing the "raise gateway idleTimeout"
+/// defense-in-depth from issue #1090's original acceptance criteria.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KeepaliveConfig {
+    /// Tick interval in milliseconds.
+    pub interval_ms: u64,
+    /// Consecutive unanswered probes tolerated before the connection
+    /// is closed.
+    pub miss_limit: u32,
+}
+
+impl Default for KeepaliveConfig {
+    fn default() -> Self {
+        Self {
+            interval_ms: 45_000,
+            miss_limit: 2,
+        }
+    }
+}
+
+/// Per-connection keepalive policy state.
+///
+/// Owned by [`XmppStateMachine`](super::XmppStateMachine); driven
+/// exclusively through the machine's [`handle`] entry point:
+///
+/// - [`InboundEvent::TransportReady`] → [`Self::on_transport_ready`]
+///   arms the timer.
+/// - [`InboundEvent::Tick`]`(`[`KEEPALIVE_TIMER`]`)` →
+///   [`Self::on_tick`] evaluates the policy and re-arms.
+/// - [`InboundEvent::KeepaliveAck`] (and any machine-visible inbound
+///   client frame) → [`Self::mark_alive`].
+///
+/// [`InboundEvent::TransportReady`]: super::InboundEvent::TransportReady
+/// [`InboundEvent::Tick`]: super::InboundEvent::Tick
+/// [`InboundEvent::KeepaliveAck`]: super::InboundEvent::KeepaliveAck
+/// [`handle`]: super::XmppStateMachine::handle
+#[derive(Debug)]
+pub struct KeepalivePolicy {
+    config: KeepaliveConfig,
+    /// Whether any inbound evidence arrived since the last tick.
+    alive_since_tick: bool,
+    /// Probes sent without any intervening inbound evidence.
+    consecutive_misses: u32,
+}
+
+impl KeepalivePolicy {
+    /// A fresh policy starts `alive`: the transport just proved
+    /// liveness by connecting (or, for the bind-time machine
+    /// replacement in the WebSocket adapter, by binding), so the first
+    /// quiet interval passes without a probe.
+    pub fn new(config: KeepaliveConfig) -> Self {
+        Self {
+            config,
+            alive_since_tick: true,
+            consecutive_misses: 0,
+        }
+    }
+
+    /// Arm the keepalive clock. Emitted-once when the transport
+    /// reports readiness (WS upgrade), *before* authentication — a
+    /// connection that wedges pre-bind is reaped by the same policy.
+    pub fn on_transport_ready(&mut self) -> Vec<OutboundEvent> {
+        self.alive_since_tick = true;
+        self.consecutive_misses = 0;
+        vec![OutboundEvent::SetTimer {
+            id: KEEPALIVE_TIMER,
+            duration_ms: self.config.interval_ms,
+        }]
+    }
+
+    /// Record inbound liveness evidence.
+    pub fn mark_alive(&mut self) {
+        self.alive_since_tick = true;
+        self.consecutive_misses = 0;
+    }
+
+    /// Evaluate the policy on a keepalive tick.
+    ///
+    /// - Evidence since the last tick → quiet re-arm.
+    /// - Silence → probe and re-arm, until `miss_limit` probes have
+    ///   gone unanswered, then close the transport.
+    pub fn on_tick(&mut self) -> Vec<OutboundEvent> {
+        let rearm = OutboundEvent::SetTimer {
+            id: KEEPALIVE_TIMER,
+            duration_ms: self.config.interval_ms,
+        };
+        if self.alive_since_tick {
+            self.alive_since_tick = false;
+            return vec![rearm];
+        }
+        if self.consecutive_misses >= self.config.miss_limit {
+            return vec![
+                OutboundEvent::Log {
+                    level: Level::INFO,
+                    message: format!(
+                        "Keepalive: {} unanswered probes (interval {}ms); closing transport \
+                         for dead peer",
+                        self.consecutive_misses, self.config.interval_ms
+                    ),
+                },
+                OutboundEvent::CloseTransport,
+            ];
+        }
+        self.consecutive_misses += 1;
+        vec![OutboundEvent::SendKeepaliveProbe, rearm]
+    }
+}
+
+/// Dispatch a [`Tick`](InboundEvent::Tick) by timer id.
+///
+/// Free function so [`XmppStateMachine::handle`] stays a thin match:
+/// unknown ids are logged (a cancelled-then-fired race is benign), the
+/// keepalive id runs the policy.
+///
+/// [`XmppStateMachine::handle`]: super::XmppStateMachine::handle
+pub(super) fn dispatch_tick(policy: &mut KeepalivePolicy, id: TimerId) -> Vec<OutboundEvent> {
+    if id == KEEPALIVE_TIMER {
+        policy.on_tick()
+    } else {
+        vec![OutboundEvent::Log {
+            level: Level::WARN,
+            message: format!("Tick for unknown timer id {id:?}; ignoring"),
+        }]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg(interval_ms: u64, miss_limit: u32) -> KeepaliveConfig {
+        KeepaliveConfig {
+            interval_ms,
+            miss_limit,
+        }
+    }
+
+    fn assert_rearm(events: &[OutboundEvent], interval_ms: u64) {
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                OutboundEvent::SetTimer { id, duration_ms }
+                    if *id == KEEPALIVE_TIMER && *duration_ms == interval_ms
+            )),
+            "expected keepalive re-arm in {events:?}"
+        );
+    }
+
+    fn has_probe(events: &[OutboundEvent]) -> bool {
+        events
+            .iter()
+            .any(|e| matches!(e, OutboundEvent::SendKeepaliveProbe))
+    }
+
+    fn has_close(events: &[OutboundEvent]) -> bool {
+        events
+            .iter()
+            .any(|e| matches!(e, OutboundEvent::CloseTransport))
+    }
+
+    #[test]
+    fn transport_ready_arms_the_timer() {
+        let mut p = KeepalivePolicy::new(cfg(45_000, 2));
+        let events = p.on_transport_ready();
+        assert_eq!(events.len(), 1);
+        assert_rearm(&events, 45_000);
+    }
+
+    #[test]
+    fn active_peer_is_never_probed() {
+        let mut p = KeepalivePolicy::new(cfg(45_000, 2));
+        p.on_transport_ready();
+        for _ in 0..10 {
+            p.mark_alive();
+            let events = p.on_tick();
+            assert!(!has_probe(&events), "active peer got probed: {events:?}");
+            assert!(!has_close(&events));
+            assert_rearm(&events, 45_000);
+        }
+    }
+
+    #[test]
+    fn idle_alive_peer_is_probed_every_other_tick() {
+        let mut p = KeepalivePolicy::new(cfg(45_000, 2));
+        p.on_transport_ready();
+        // Tick 1: initial alive grace clears quietly.
+        assert!(!has_probe(&p.on_tick()));
+        // Tick 2: silence → probe. Peer pongs.
+        let events = p.on_tick();
+        assert!(has_probe(&events));
+        assert_rearm(&events, 45_000);
+        p.mark_alive();
+        // Tick 3: pong counted as evidence → quiet.
+        assert!(!has_probe(&p.on_tick()));
+        // Tick 4: silence again → probe. Worst-case wire gap is 2·interval.
+        assert!(has_probe(&p.on_tick()));
+    }
+
+    #[test]
+    fn dead_peer_closes_after_miss_limit_unanswered_probes() {
+        let mut p = KeepalivePolicy::new(cfg(45_000, 2));
+        p.on_transport_ready();
+        // Tick 1: initial grace.
+        assert!(!has_probe(&p.on_tick()));
+        // Ticks 2..=3: two probes, never answered.
+        for _ in 0..2 {
+            let events = p.on_tick();
+            assert!(has_probe(&events));
+            assert!(!has_close(&events));
+        }
+        // Tick 4: miss limit reached → close, no further probe or re-arm.
+        let events = p.on_tick();
+        assert!(has_close(&events));
+        assert!(!has_probe(&events));
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, OutboundEvent::SetTimer { .. })),
+            "closing tick must not re-arm: {events:?}"
+        );
+    }
+
+    #[test]
+    fn late_evidence_resets_the_miss_counter() {
+        let mut p = KeepalivePolicy::new(cfg(45_000, 2));
+        p.on_transport_ready();
+        p.on_tick(); // grace
+        assert!(has_probe(&p.on_tick())); // miss 1
+        assert!(has_probe(&p.on_tick())); // miss 2
+        p.mark_alive(); // peer answers just in time
+        assert!(!has_probe(&p.on_tick())); // quiet tick
+                                           // The full miss budget is available again.
+        assert!(has_probe(&p.on_tick()));
+        assert!(has_probe(&p.on_tick()));
+        assert!(has_close(&p.on_tick()));
+    }
+
+    #[test]
+    fn miss_limit_one_closes_on_second_silent_tick() {
+        let mut p = KeepalivePolicy::new(cfg(1_000, 1));
+        p.on_transport_ready();
+        p.on_tick(); // grace
+        assert!(has_probe(&p.on_tick()));
+        assert!(has_close(&p.on_tick()));
+    }
+
+    #[test]
+    fn unknown_timer_id_is_logged_not_actioned() {
+        let mut p = KeepalivePolicy::new(cfg(45_000, 2));
+        p.on_transport_ready();
+        let events = dispatch_tick(&mut p, TimerId(999));
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0], OutboundEvent::Log { .. }));
+        assert!(!has_probe(&events) && !has_close(&events));
+    }
+
+    #[test]
+    fn keepalive_tick_routes_through_dispatch() {
+        let mut p = KeepalivePolicy::new(cfg(45_000, 2));
+        p.on_transport_ready();
+        dispatch_tick(&mut p, KEEPALIVE_TIMER); // grace
+        assert!(has_probe(&dispatch_tick(&mut p, KEEPALIVE_TIMER)));
+    }
+}

--- a/server/crates/waddle-xmpp/src/protocol/machine.rs
+++ b/server/crates/waddle-xmpp/src/protocol/machine.rs
@@ -16,6 +16,7 @@ use super::dispatch::StanzaDispatcher;
 use super::event::{CallbackId, InboundEvent, OutboundEvent, StanzaContext};
 use super::frame::InboundFrame;
 use super::id_gen::{IdGenerator, UuidV4Generator};
+use super::keepalive::{dispatch_tick, KeepaliveConfig, KeepalivePolicy};
 use super::message_context::{MessageContext, MessageContextEnv};
 use super::phase::ConnectionPhase;
 use super::session_state::{Blocklist, CarbonsState, MucOccupancy};
@@ -54,6 +55,12 @@ pub struct XmppStateMachine {
     /// Source of fresh, opaque XEP-0359 stanza-ids stamped by message
     /// handlers. Defaults to UUIDv4; tests can override.
     id_gen: Arc<dyn IdGenerator>,
+    /// RFC 7395 §5.6 transport keepalive policy (issue #1090). Driven
+    /// by [`InboundEvent::TransportReady`] / [`InboundEvent::Tick`] /
+    /// [`InboundEvent::KeepaliveAck`]; emits
+    /// [`OutboundEvent::SendKeepaliveProbe`] and, after the miss
+    /// limit, [`OutboundEvent::CloseTransport`].
+    keepalive: KeepalivePolicy,
 }
 
 impl XmppStateMachine {
@@ -83,7 +90,18 @@ impl XmppStateMachine {
             muc_occupancy: MucOccupancy::empty(),
             has_live_transport: true,
             id_gen,
+            keepalive: KeepalivePolicy::new(KeepaliveConfig::default()),
         }
+    }
+
+    /// Replace the keepalive policy with one built from a
+    /// deployment-supplied [`KeepaliveConfig`]. Called by the transport
+    /// adapter immediately after construction (both the pre-bind
+    /// machine created at WS upgrade and the bind-time replacement in
+    /// `ensure_state_machine`), before any event is fed. Mirrors the
+    /// [`Self::set_blocklist`] seeding pattern.
+    pub fn set_keepalive_config(&mut self, config: KeepaliveConfig) {
+        self.keepalive = KeepalivePolicy::new(config);
     }
 
     /// Allocate a fresh [`CallbackId`] for an outbound async delegation.
@@ -180,9 +198,23 @@ impl XmppStateMachine {
     /// This is the only public entry point during normal operation.
     pub fn handle(&mut self, event: InboundEvent) -> Vec<OutboundEvent> {
         match event {
-            InboundEvent::FrameReceived(frame) => self.on_frame(frame),
+            InboundEvent::FrameReceived(frame) => {
+                // Any client-origin frame is liveness evidence for the
+                // RFC 7395 keepalive policy. Peer-routed stanzas
+                // (`StanzaFromPeer`) deliberately are NOT — they are
+                // outbound-direction traffic and say nothing about
+                // whether *this* peer is alive.
+                self.keepalive.mark_alive();
+                self.on_frame(frame)
+            }
             InboundEvent::StanzaFromPeer(stanza) => self.on_peer_stanza(*stanza),
+            InboundEvent::TransportReady => self.keepalive.on_transport_ready(),
             InboundEvent::TransportClosed => self.on_closed(),
+            InboundEvent::Tick(id) => dispatch_tick(&mut self.keepalive, id),
+            InboundEvent::KeepaliveAck => {
+                self.keepalive.mark_alive();
+                Vec::new()
+            }
             InboundEvent::EnrichmentComplete { id, message } => {
                 self.on_enrichment_complete(id, *message)
             }

--- a/server/crates/waddle-xmpp/src/protocol/machine.rs
+++ b/server/crates/waddle-xmpp/src/protocol/machine.rs
@@ -55,7 +55,7 @@ pub struct XmppStateMachine {
     /// Source of fresh, opaque XEP-0359 stanza-ids stamped by message
     /// handlers. Defaults to UUIDv4; tests can override.
     id_gen: Arc<dyn IdGenerator>,
-    /// RFC 7395 §5.6 transport keepalive policy (issue #1090). Driven
+    /// RFC 7395 §3.8 transport keepalive policy (issue #1090). Driven
     /// by [`InboundEvent::TransportReady`] / [`InboundEvent::Tick`] /
     /// [`InboundEvent::KeepaliveAck`]; emits
     /// [`OutboundEvent::SendKeepaliveProbe`] and, after the miss
@@ -210,7 +210,10 @@ impl XmppStateMachine {
             InboundEvent::StanzaFromPeer(stanza) => self.on_peer_stanza(*stanza),
             InboundEvent::TransportReady => self.keepalive.on_transport_ready(),
             InboundEvent::TransportClosed => self.on_closed(),
-            InboundEvent::Tick(id) => dispatch_tick(&mut self.keepalive, id),
+            InboundEvent::Tick(id) => {
+                let session_ready = matches!(self.phase, ConnectionPhase::Ready { .. });
+                dispatch_tick(&mut self.keepalive, id, session_ready)
+            }
             InboundEvent::KeepaliveAck => {
                 self.keepalive.mark_alive();
                 Vec::new()

--- a/server/crates/waddle-xmpp/src/protocol/machine/test_support.rs
+++ b/server/crates/waddle-xmpp/src/protocol/machine/test_support.rs
@@ -36,5 +36,6 @@ pub fn ready_machine_with_id_gen(
         muc_occupancy: MucOccupancy::empty(),
         has_live_transport: true,
         id_gen,
+        keepalive: KeepalivePolicy::new(KeepaliveConfig::default()),
     }
 }

--- a/server/crates/waddle-xmpp/src/protocol/mod.rs
+++ b/server/crates/waddle-xmpp/src/protocol/mod.rs
@@ -29,6 +29,7 @@ pub mod event;
 pub mod frame;
 pub mod handlers;
 pub mod id_gen;
+pub mod keepalive;
 pub mod machine;
 pub mod message_context;
 pub mod phase;
@@ -56,6 +57,7 @@ pub use event::{
 };
 pub use frame::InboundFrame;
 pub use id_gen::{CounterIdGenerator, FixedIdGenerator, IdGenerator, UuidV4Generator};
+pub use keepalive::{KeepaliveConfig, KEEPALIVE_TIMER};
 pub use machine::XmppStateMachine;
 pub use message_context::{MessageContext, MessageContextEnv};
 pub use phase::{ConnectionPhase, ScramPendingState};

--- a/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/wire_trace_l4_tests.rs
@@ -356,6 +356,7 @@ fn outbound_variant_name(event: &OutboundEvent) -> &'static str {
         OutboundEvent::LoadScramCredentials { .. } => "LoadScramCredentials",
         OutboundEvent::ValidateOAuthBearer { .. } => "ValidateOAuthBearer",
         OutboundEvent::LookupArchivedMessage { .. } => "LookupArchivedMessage",
+        OutboundEvent::SendKeepaliveProbe => "SendKeepaliveProbe",
         OutboundEvent::SetTimer { .. } => "SetTimer",
         OutboundEvent::CancelTimer(_) => "CancelTimer",
         OutboundEvent::QueueOfflineDelivery { .. } => "QueueOfflineDelivery",

--- a/server/crates/waddle-xmpp/tests/rfc7395_keepalive.rs
+++ b/server/crates/waddle-xmpp/tests/rfc7395_keepalive.rs
@@ -1,0 +1,155 @@
+//! RFC 7395 §5.6 keepalive — dedicated conformance suite (issue #1090).
+//!
+//! Exercises the liveness policy through the public
+//! [`XmppStateMachine::handle`] entry point exactly as the WebSocket
+//! transport adapter drives it: `TransportReady` at upgrade, `Tick`
+//! from the adapter's timer wheel, `KeepaliveAck` for transport-level
+//! evidence (pong / client ping), `FrameReceived` for client frames.
+//! Everything here is pure and clock-free — no sockets, no tokio time.
+
+use waddle_xmpp::protocol::{
+    InboundEvent, InboundFrame, KeepaliveConfig, OutboundEvent, StanzaDispatcher, TimerId,
+    XmppStateMachine, KEEPALIVE_TIMER,
+};
+
+fn machine(interval_ms: u64, miss_limit: u32) -> XmppStateMachine {
+    let mut sm = XmppStateMachine::new("example.com", StanzaDispatcher::new());
+    sm.set_keepalive_config(KeepaliveConfig {
+        interval_ms,
+        miss_limit,
+    });
+    sm
+}
+
+fn tick(sm: &mut XmppStateMachine) -> Vec<OutboundEvent> {
+    sm.handle(InboundEvent::Tick(KEEPALIVE_TIMER))
+}
+
+fn has_probe(events: &[OutboundEvent]) -> bool {
+    events
+        .iter()
+        .any(|e| matches!(e, OutboundEvent::SendKeepaliveProbe))
+}
+
+fn has_close(events: &[OutboundEvent]) -> bool {
+    events
+        .iter()
+        .any(|e| matches!(e, OutboundEvent::CloseTransport))
+}
+
+fn has_rearm(events: &[OutboundEvent], interval_ms: u64) -> bool {
+    events.iter().any(|e| {
+        matches!(
+            e,
+            OutboundEvent::SetTimer { id, duration_ms }
+                if *id == KEEPALIVE_TIMER && *duration_ms == interval_ms
+        )
+    })
+}
+
+#[test]
+fn transport_ready_arms_the_keepalive_clock() {
+    let mut sm = machine(45_000, 2);
+    let events = sm.handle(InboundEvent::TransportReady);
+    assert!(
+        has_rearm(&events, 45_000),
+        "TransportReady must arm the keepalive timer: {events:?}"
+    );
+    assert!(!has_probe(&events) && !has_close(&events));
+}
+
+#[test]
+fn every_tick_rearms_until_close() {
+    let mut sm = machine(45_000, 2);
+    sm.handle(InboundEvent::TransportReady);
+    // Grace tick + two probing ticks all re-arm; the closing tick must not.
+    for _ in 0..3 {
+        assert!(has_rearm(&tick(&mut sm), 45_000));
+    }
+    let closing = tick(&mut sm);
+    assert!(has_close(&closing));
+    assert!(!has_rearm(&closing, 45_000), "close must not re-arm");
+}
+
+#[test]
+fn idle_connection_probes_and_pong_keeps_it_alive_forever() {
+    let mut sm = machine(45_000, 2);
+    sm.handle(InboundEvent::TransportReady);
+    tick(&mut sm); // initial grace
+    for _ in 0..20 {
+        let events = tick(&mut sm);
+        assert!(has_probe(&events), "silent tick must probe");
+        assert!(!has_close(&events), "answered probes must never close");
+        // The adapter feeds the client's pong as KeepaliveAck.
+        assert!(sm.handle(InboundEvent::KeepaliveAck).is_empty());
+        // Pong counted as evidence → the next tick is quiet.
+        let quiet = tick(&mut sm);
+        assert!(!has_probe(&quiet) && !has_close(&quiet));
+    }
+}
+
+#[test]
+fn dead_peer_is_closed_after_miss_limit_probes() {
+    let mut sm = machine(45_000, 2);
+    sm.handle(InboundEvent::TransportReady);
+    tick(&mut sm); // grace
+    assert!(has_probe(&tick(&mut sm))); // probe 1, unanswered
+    assert!(has_probe(&tick(&mut sm))); // probe 2, unanswered
+    let events = tick(&mut sm);
+    assert!(
+        has_close(&events),
+        "miss limit exhausted must close: {events:?}"
+    );
+    assert!(!has_probe(&events));
+}
+
+#[test]
+fn client_frames_count_as_liveness_evidence() {
+    let mut sm = machine(45_000, 2);
+    sm.handle(InboundEvent::TransportReady);
+    tick(&mut sm); // grace
+    tick(&mut sm); // probe 1
+                   // A parsed client frame (stream open) arrives — the machine path
+                   // marks alive without a separate KeepaliveAck.
+    sm.handle(InboundEvent::FrameReceived(InboundFrame::Open));
+    let events = tick(&mut sm);
+    assert!(
+        !has_probe(&events) && !has_close(&events),
+        "frame evidence must reset the policy: {events:?}"
+    );
+}
+
+#[test]
+fn evidence_resets_the_full_miss_budget() {
+    let mut sm = machine(45_000, 1);
+    sm.handle(InboundEvent::TransportReady);
+    tick(&mut sm); // grace
+    assert!(has_probe(&tick(&mut sm))); // probe (budget exhausted)
+    sm.handle(InboundEvent::KeepaliveAck);
+    assert!(!has_probe(&tick(&mut sm))); // quiet
+    assert!(has_probe(&tick(&mut sm))); // full budget again
+    assert!(has_close(&tick(&mut sm)));
+}
+
+#[test]
+fn unknown_timer_ids_are_ignored_by_the_policy() {
+    let mut sm = machine(45_000, 2);
+    sm.handle(InboundEvent::TransportReady);
+    tick(&mut sm); // grace
+    for _ in 0..10 {
+        let events = sm.handle(InboundEvent::Tick(TimerId(999)));
+        assert!(
+            !has_probe(&events) && !has_close(&events),
+            "foreign timer must not drive the keepalive policy: {events:?}"
+        );
+    }
+    // The keepalive clock still behaves normally afterwards.
+    assert!(has_probe(&tick(&mut sm)));
+}
+
+#[test]
+fn keepalive_ack_is_effect_free() {
+    let mut sm = machine(45_000, 2);
+    sm.handle(InboundEvent::TransportReady);
+    assert!(sm.handle(InboundEvent::KeepaliveAck).is_empty());
+}

--- a/server/crates/waddle-xmpp/tests/rfc7395_keepalive.rs
+++ b/server/crates/waddle-xmpp/tests/rfc7395_keepalive.rs
@@ -1,4 +1,4 @@
-//! RFC 7395 §5.6 keepalive — dedicated conformance suite (issue #1090).
+//! RFC 7395 §3.8 keepalive — dedicated conformance suite (issue #1090).
 //!
 //! Exercises the liveness policy through the public
 //! [`XmppStateMachine::handle`] entry point exactly as the WebSocket
@@ -7,17 +7,28 @@
 //! evidence (pong / client ping), `FrameReceived` for client frames.
 //! Everything here is pure and clock-free — no sockets, no tokio time.
 
+use std::str::FromStr;
 use waddle_xmpp::protocol::{
     InboundEvent, InboundFrame, KeepaliveConfig, OutboundEvent, StanzaDispatcher, TimerId,
     XmppStateMachine, KEEPALIVE_TIMER,
 };
 
-fn machine(interval_ms: u64, miss_limit: u32) -> XmppStateMachine {
+/// A machine still in stream negotiation (pre-bind), as at WS upgrade.
+fn negotiating_machine(interval_ms: u64, miss_limit: u32) -> XmppStateMachine {
     let mut sm = XmppStateMachine::new("example.com", StanzaDispatcher::new());
     sm.set_keepalive_config(KeepaliveConfig {
         interval_ms,
         miss_limit,
     });
+    sm
+}
+
+/// A machine with a bound session (`Ready`), as after bind — the
+/// steady-state the keepalive spends its life in.
+fn machine(interval_ms: u64, miss_limit: u32) -> XmppStateMachine {
+    let mut sm = negotiating_machine(interval_ms, miss_limit);
+    let jid = jid::FullJid::from_str("alice@example.com/web").expect("static test jid");
+    sm.transition_to_ready(jid, false);
     sm
 }
 
@@ -152,4 +163,50 @@ fn keepalive_ack_is_effect_free() {
     let mut sm = machine(45_000, 2);
     sm.handle(InboundEvent::TransportReady);
     assert!(sm.handle(InboundEvent::KeepaliveAck).is_empty());
+}
+
+#[test]
+fn auto_ponging_socket_that_never_binds_is_reaped() {
+    // Every RFC 6455 stack auto-pongs below the application, so a
+    // wedged-but-TCP-alive pre-auth socket answers every probe. The
+    // negotiation deadline must reap it anyway — otherwise the
+    // keepalive would hold unauthenticated sockets forever (the
+    // gateway's idle reset used to bound them; issue #1090 must not
+    // remove that bound).
+    let mut sm = negotiating_machine(45_000, 2);
+    sm.handle(InboundEvent::TransportReady);
+    let mut closed_at = None;
+    for round in 1..=10 {
+        sm.handle(InboundEvent::KeepaliveAck); // auto-pong
+        if has_close(&tick(&mut sm)) {
+            closed_at = Some(round);
+            break;
+        }
+    }
+    assert_eq!(
+        closed_at,
+        Some(4),
+        "pre-bind socket must close on the tick after NEGOTIATION_TICK_LIMIT"
+    );
+}
+
+#[test]
+fn binding_before_the_negotiation_deadline_grants_normal_keepalive() {
+    let mut sm = negotiating_machine(45_000, 2);
+    sm.handle(InboundEvent::TransportReady);
+    // Two negotiating ticks pass while the client authenticates.
+    sm.handle(InboundEvent::KeepaliveAck);
+    assert!(!has_close(&tick(&mut sm)));
+    sm.handle(InboundEvent::KeepaliveAck);
+    assert!(!has_close(&tick(&mut sm)));
+    // Bind lands (the adapter replaces the machine at bind; phase
+    // transition models the same outcome for the policy).
+    let jid = jid::FullJid::from_str("alice@example.com/web").expect("static test jid");
+    sm.transition_to_ready(jid, false);
+    // A responsive bound session now lives indefinitely.
+    for _ in 0..10 {
+        sm.handle(InboundEvent::KeepaliveAck);
+        let events = tick(&mut sm);
+        assert!(!has_close(&events), "bound responsive session must live");
+    }
 }

--- a/server/crates/waddle-xmpp/tests/rfc7395_keepalive.rs
+++ b/server/crates/waddle-xmpp/tests/rfc7395_keepalive.rs
@@ -185,8 +185,9 @@ fn auto_ponging_socket_that_never_binds_is_reaped() {
     }
     assert_eq!(
         closed_at,
-        Some(4),
-        "pre-bind socket must close on the tick after NEGOTIATION_TICK_LIMIT"
+        Some(3),
+        "pre-bind socket must close on the NEGOTIATION_TICK_LIMIT tick itself \
+         (3 ticks = 135s at the default 45s interval)"
     );
 }
 


### PR DESCRIPTION
Fixes #1090.

## Problem

The WebSocket connection loop never initiated any traffic on a clock — the only server-initiated write was the count-gated XEP-0198 `<r/>`. The Cilium/Envoy gateway's default ~300s stream-idle timeout therefore reset every quiet session (~1,293 `Connection reset without closing handshake` errors in 48h, paired at ~304s), feeding reconnect + SM-resume churn. Dead peers were also invisible: WS Pongs were swallowed, so a client whose network vanished kept accumulating unacked stanzas until the XEP-0198 queue-cap eviction permanently broke resume.

## What this does

RFC 7395 §3.8 ("Pings and Keepalives") sanctions WS ping/pong as the keepalive mechanism for the XMPP subprotocol. This PR implements it with the liveness **policy in the sans-io core** and the **mechanism in the transport adapter** — wiring the previously-stubbed timer machinery in the process. (Design locked in a /grill-me session; decisions recorded on #1090.)

### Core (`waddle-xmpp`)
- New `protocol::keepalive` module: `KeepalivePolicy` + `KeepaliveConfig` + reserved `KEEPALIVE_TIMER` id. Pure, clock-free, unit-testable.
- New events: `InboundEvent::TransportReady` (arms the clock at WS upgrade), `InboundEvent::Tick(TimerId)`, `InboundEvent::KeepaliveAck` (transport-level liveness evidence), `OutboundEvent::SendKeepaliveProbe` (transport-agnostic: a future TCP transport would map it to whitespace keepalive or XEP-0199).
- **Inbound-idle policy**: on each tick — evidence since the last tick → quiet re-arm; silence → probe + re-arm; `miss_limit` unanswered probes → `CloseTransport`. Inbound basis (not outbound) so a dead client on a busy MUC stream is still detected before the unacked-queue eviction. "Any inbound frame = alive" — no RFC 6455 pong-payload correlation, no extra state.

### Interpreter (`waddle-server`)
- `SetTimer`/`CancelTimer` are now wired (previously warn-logged as "not yet wired"): relayed as typed `TimerCommand`s in `InterpretOutcome::timer_commands`. `SendKeepaliveProbe` rides `InterpretOutcome::keepalive_probes` — a probe is a transport control frame with no XML form, so the adapter (not the XML path) realizes it.
- `drive_interpret_loop` returns a `DriveOutcome` struct instead of a growing tuple.

### Adapter (WebSocket route)
- New `TransportTimers` wheel (cancellation-safe, one-shot, re-arm-replaces) + a third `select!` arm feeding `Tick` into the machine.
- Probe → `Message::Ping` (empty payload). Previously-swallowed `Pong`, client `Ping`, and `Binary` frames now feed `KeepaliveAck`.
- The per-connection state machine now exists **from WS upgrade** (`Unauthenticated` phase) instead of from bind, so a connection that wedges pre-auth is reaped by the same policy. The bind-time machine replacement re-seeds the policy from the retained config.
- A keepalive close sends a graceful WS Close frame and rides the existing shutdown fork: **SM detach-for-resume** when negotiated, full cleanup otherwise — a client waking from a dropped network resumes instead of losing its session.

### Config
- `WADDLE_WS_KEEPALIVE_INTERVAL_SECS` (default 45) and `WADDLE_WS_KEEPALIVE_MISS_LIMIT` (default 2, range 1..=10).
- **Startup fails** (never clamps) if the interval exceeds 120s: an idle-but-alive peer's pong counts as evidence for the following tick, so the worst-case inter-traffic gap is `2×interval`, which must stay under the gateway's 300s default with margin. This guard replaces the original "raise gateway idleTimeout" acceptance criterion (AC edited on #1090 with justification) — a fat-fingered config fails loudly instead of silently reintroducing the reset storm, without touching the fragile HITL Cilium deploy path.

### Timing (defaults: 45s / 2 misses)
- Idle-but-alive peer: probed every ~90s, survives indefinitely.
- Dead peer: closed 135–180s after its last inbound frame.
- Still-negotiating socket: closed after 3 ticks (135s) regardless of pongs.

## Hardening from the adversarial-review round

Three persona reviewers (tokio-concurrency, XMPP conformance, production reliability) ran against the initial implementation; every substantiated finding is fixed in this PR:

1. **Write-stall budget (60s per WS send)** — a black-holed peer with a full TCP send buffer parks the connection task on `send().await` inside a `select!` arm body, which freezes the keepalive clock in exactly the busy-stream-to-dead-client case. All writes flow through the `send.rs` helpers, which now bound each send; a stalled flush fails and tears the connection down.
2. **Negotiation deadline (`NEGOTIATION_TICK_LIMIT` = 3 ticks)** — every RFC 6455 stack auto-pongs below the application (browsers answer from the network process even for a frozen tab), so probe answers prove nothing about session progress. Without this bound the keepalive would hold unauthenticated sockets forever — ironically defeating the gateway idle reaper that previously bounded them. A machine still outside `Ready` after 3 ticks is closed despite pongs.
3. **Failed-SM-resume reset kept the tick chain** — `reset_registered_resume_attempt` used to null the state machine while the timer wheel was still armed; the next tick would hit the no-machine guard and permanently disarm keepalive for that connection. It now re-initializes a pre-bind machine, so the machine (and with it the keepalive) is never absent mid-connection.
4. **Citation corrections** — the issue text cited a nonexistent "RFC 7395 §5.6" and called ping/pong "prescribed"; all code/docs now cite §3.8 accurately (it's a MAY, alongside XEP-0199/0198).

Flagged pre-existing (not fixed here, follow-up material): axum 0.8 auto-responds to client Pings, and `connection.rs` *also* answers them manually — every client Ping gets two Pongs. Legal per RFC 6455 §5.5.3, untouched by this PR.

## Bot-review round (Qodo / Greptile / Codex)

All three flagged the same negotiation-deadline off-by-one (`>` closed on tick 4, not the documented tick 3, and the log's `- 1` masked it) — fixed to `>=` with tests updated at all three layers. Qodo's two rule findings are implemented as well:
- `ws_keepalive_from_vars`/`from_env` (Rule 424485) now return a typed `WsKeepaliveConfigError` (`thiserror`: `IntervalOutOfRange` / `MissLimitOutOfRange` / `NotAnInteger`) instead of `Result<_, String>`; `ServerConfig::from_env` renders it into its legacy `String` aggregate at the boundary, and the config tests assert on typed variants plus the human-facing `Display` text.
- The `#[allow(dead_code)]` on the harness's `recv_raw_timeout` (Rule 426954) is **removed**, not justified: the helper moved into its sole consumer (`tests/rfc7395_keepalive_ws.rs`) over a `pub(crate)` stream field — narrowing visibility / wiring into the exercised path instead of suppressing, per the repo's clippy rule. No new suppressions remain in the diff.

## Conformance notes
- XEP-0198 explicitly defers stream liveness to transport-level keepalives ("use XEP-0199, whitespace pings, or TCP keepalives"; pings were removed from SM itself). RFC 7395 §3.8 sanctions WS ping/pong for this binding (alongside XEP-0199) — whitespace keepalive is unavailable over RFC 7395 framing.
- No wire-visible XMPP change: probes are WS control frames; XMPP stanzas, SM counting, and resume semantics are untouched.

## Tests
- `waddle-xmpp/src/protocol/keepalive.rs` — clock-free policy unit tests (probe cadence, miss budget reset, close, unknown timer ids).
- `waddle-xmpp/tests/rfc7395_keepalive.rs` — dedicated RFC 7395 suite through the public `XmppStateMachine::handle` entry point, driven exactly as the adapter drives it.
- `waddle-server` — `TransportTimers` wheel tests (paused-clock: ordering, re-arm, cancel, cancellation-safety) and `ws_keepalive_from_vars` validation tests (defaults, overrides, ceiling, rejects).
- `waddle-server/tests/rfc7395_keepalive_ws.rs` — live-socket integration at the 1s config floor: idle session receives repeated pings and stays fully functional (scaled equivalent of surviving far past the 5-minute window), a silent peer is closed after the miss limit with a graceful Close, an unauthenticated auto-ponging socket is reaped by the negotiation deadline, and a keepalive close detaches for XEP-0198 `<resume/>`.

## Verification
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, full unit + integration suites green locally; CI nix gates monitored on this PR.
- Post-deploy: re-run the audit's Loki query for `Connection reset without closing handshake` and record before/after on #1090 before closing (final AC item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
