### PR TITLE
fix(server): stop the XEP-0198 unacked-queue eviction storm — chunked batches, per-threshold <r/>, mid-batch ack drain (#1089)

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
@@ -209,6 +209,16 @@ where
                         "Dropping oversized inbound frame during mid-batch drain"
                     );
                 } else if let Some(h) = parse_sm_ack_h(text.as_str()) {
+                    // Applied ahead of any frames already parked in
+                    // `deferred_inbound`. Safe ONLY because ack
+                    // application is order-independent here: `h` is
+                    // cumulative/monotone, and `delete_acked_through`
+                    // removes rows keyed sequence <= h — outbound
+                    // stanzas a deferred frame produces later get
+                    // sequences > h and are untouched. If ack handling
+                    // ever grows a side effect that is not keyed on
+                    // sequence <= h, it must move to the deferred
+                    // queue instead of running inline.
                     apply_sm_ack(state, &mut conn.sm_state, h).await;
                 } else {
                     conn.deferred_inbound.push_back(text);

--- a/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
@@ -1,0 +1,205 @@
+//! Chunked XEP-0198-aware batch writer (issue #1089).
+//!
+//! Writing a large response batch used to record every countable
+//! frame into the 1000-cap unacked queue before anything reached the
+//! socket, emit one coalesced `<r/>` after the whole batch, and give
+//! inbound `<a/>` acks no chance to drain the queue mid-batch. A MAM
+//! history sync or fan-out burst pinned the queue at capacity and
+//! evicted one stanza per subsequent send — permanently breaking
+//! `<resume/>` for the stream.
+//!
+//! This writer records and writes frame by frame and follows every
+//! `ack_threshold`th countable stanza with an `<r/>` (XEP-0198 §4
+//! permits requesting acks at any time).
+
+use super::send::send_ws_message;
+use super::state::WsConnState;
+use super::stream_management::{apply_sm_ack, is_countable_stanza, is_mam_result_message};
+use super::*;
+use futures::FutureExt as _;
+use waddle_xmpp::stream_management::SmRequest;
+
+/// Outcome of writing a response batch.
+#[must_use = "a closed transport must break the connection loop"]
+pub(super) enum BatchWriteOutcome {
+    /// Every frame was written; the connection loop continues.
+    Continue,
+    /// The transport went away mid-batch (send failure). The caller
+    /// must break the connection loop; the SM unacked queue already
+    /// holds every countable frame of the batch for resume replay.
+    TransportClosed,
+}
+
+/// Write a response batch to the WebSocket, recording countable
+/// stanzas into the XEP-0198 unacked queue one frame at a time and
+/// interleaving an `<r/>` ack request after every `ack_threshold`th
+/// countable stanza.
+///
+/// `record` is `false` only for SM resume replay batches, whose
+/// stanzas already sit in the restored unacked queue with their
+/// original sequence numbers.
+pub(super) async fn write_response_batch<S, SE, R, RE>(
+    sender: &mut S,
+    reader: &mut R,
+    state: &WebSocketState,
+    conn: &mut WsConnState,
+    frames: Vec<String>,
+    record: bool,
+) -> BatchWriteOutcome
+where
+    S: Sink<Message, Error = SE> + Unpin,
+    SE: std::fmt::Display,
+    R: futures::Stream<Item = Result<Message, RE>> + Unpin,
+    RE: std::fmt::Display,
+{
+    let mut frames = frames.into_iter();
+    while let Some(frame) = frames.next() {
+        let request_ack = record_frame_for_replay(conn, &frame, record);
+        if !send_ws_message(
+            sender,
+            Message::Text(frame.into()),
+            "Failed to send WebSocket message",
+        )
+        .await
+        {
+            // This frame is already recorded; the rest of the batch
+            // must be too, or the resume replay window silently loses
+            // the tail of the batch.
+            record_remaining_for_replay(conn, frames, record);
+            return BatchWriteOutcome::TransportClosed;
+        }
+        if request_ack {
+            if !send_ws_message(
+                sender,
+                Message::Text(SmRequest::to_xml().into()),
+                "Failed to send SM <r/> request",
+            )
+            .await
+            {
+                record_remaining_for_replay(conn, frames, record);
+                return BatchWriteOutcome::TransportClosed;
+            }
+            // Give already-arrived inbound frames a chance to land:
+            // `<a/>` acks shrink the unacked queue mid-flood instead
+            // of waiting for the whole batch to finish.
+            if matches!(
+                drain_ready_inbound(sender, reader, state, conn).await,
+                DrainSignal::TransportClosed
+            ) {
+                record_remaining_for_replay(conn, frames, record);
+                return BatchWriteOutcome::TransportClosed;
+            }
+        }
+    }
+    BatchWriteOutcome::Continue
+}
+
+/// Record one outbound frame into the XEP-0198 bookkeeping, returning
+/// whether the `<r/>` cadence fired. XEP-0313 MAM result messages
+/// advance the wire counter but stay out of the replay queue — resume
+/// must not duplicate archive results, and a history sync must not
+/// evict live stanzas (issue #1089).
+fn record_frame_for_replay(conn: &mut WsConnState, frame: &str, record: bool) -> bool {
+    if !record || !conn.sm_state.enabled || !is_countable_stanza(frame) {
+        return false;
+    }
+    if is_mam_result_message(frame) {
+        conn.sm_state.record_outbound_replay_exempt().request_ack
+    } else {
+        conn.sm_state.record_outbound(frame.to_string()).request_ack
+    }
+}
+
+/// The transport died mid-batch: record every not-yet-written
+/// countable frame so the resume replay window covers the entire
+/// batch. There is no wire to follow up on, so the cadence signal is
+/// moot (mirrors the detach-drain contract in `replay.rs`).
+fn record_remaining_for_replay(
+    conn: &mut WsConnState,
+    frames: impl Iterator<Item = String>,
+    record: bool,
+) {
+    for frame in frames {
+        let _ = record_frame_for_replay(conn, &frame, record);
+    }
+}
+
+/// Result of a non-blocking inbound drain pass.
+enum DrainSignal {
+    /// Socket has no more buffered frames right now; keep writing.
+    Idle,
+    /// Peer closed (WS close frame, stream end, or read error). The
+    /// batch must stop and the connection loop must exit.
+    TransportClosed,
+}
+
+/// Non-blockingly pull every already-buffered inbound frame off the
+/// socket. `<a/>` acks are applied immediately (they are what keeps
+/// the unacked queue from evicting mid-flood); every other text frame
+/// is deferred, in arrival order, for the main frame dispatcher.
+/// Pings are answered inline so a mid-flood client keepalive isn't
+/// starved; pongs/binary only count as liveness evidence.
+async fn drain_ready_inbound<S, SE, R, RE>(
+    sender: &mut S,
+    reader: &mut R,
+    state: &WebSocketState,
+    conn: &mut WsConnState,
+) -> DrainSignal
+where
+    S: Sink<Message, Error = SE> + Unpin,
+    SE: std::fmt::Display,
+    R: futures::Stream<Item = Result<Message, RE>> + Unpin,
+    RE: std::fmt::Display,
+{
+    loop {
+        let Some(next) = reader.next().now_or_never() else {
+            // Nothing buffered right now — back to writing.
+            return DrainSignal::Idle;
+        };
+        match next {
+            Some(Ok(Message::Text(text))) => {
+                conn.note_transport_activity();
+                if let Some(h) = parse_sm_ack_h(text.as_str()) {
+                    apply_sm_ack(state, &mut conn.sm_state, h).await;
+                } else {
+                    conn.deferred_inbound.push_back(text);
+                }
+            }
+            Some(Ok(Message::Ping(data))) => {
+                conn.note_transport_activity();
+                if !send_ws_message(sender, Message::Pong(data), "Failed to send pong").await {
+                    return DrainSignal::TransportClosed;
+                }
+            }
+            Some(Ok(Message::Pong(_))) | Some(Ok(Message::Binary(_))) => {
+                conn.note_transport_activity();
+            }
+            Some(Ok(Message::Close(_))) => {
+                info!("WebSocket close requested during outbound batch");
+                return DrainSignal::TransportClosed;
+            }
+            Some(Err(error)) => {
+                error!(error = %error, "WebSocket error during outbound batch drain");
+                return DrainSignal::TransportClosed;
+            }
+            None => {
+                debug!("WebSocket stream ended during outbound batch drain");
+                return DrainSignal::TransportClosed;
+            }
+        }
+    }
+}
+
+/// Parse a frame as an XEP-0198 `<a h='N'/>` nonza, returning `h`.
+/// Anything else — including oversized frames, which the main
+/// dispatcher's `MAX_FRAME_SIZE` backstop must see and drop — returns
+/// `None` and is left for the main frame dispatcher.
+fn parse_sm_ack_h(frame: &str) -> Option<u32> {
+    if frame.len() > MAX_FRAME_SIZE || !SmStanza::is_client_nonza_candidate(frame) {
+        return None;
+    }
+    match SmStanza::parse(frame) {
+        Some(SmStanza::Ack(ack)) => Some(ack.h),
+        _ => None,
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
@@ -62,8 +62,11 @@ pub(super) enum BatchWriteOutcome {
 /// in order, so an ack behind parked frames cannot be consumed until
 /// the connection loop processes the backlog. At the cap, behavior
 /// degrades exactly to the pre-#1089 semantics (no mid-batch ack
-/// draining: the queue may evict and mark a replay gap), and the only
-/// affected stream is the one whose own client is flooding it.
+/// draining: the queue may evict and mark a replay gap), and only
+/// this connection's own stream is affected. Note a well-behaved
+/// client can reach the cap during a very large batch — e.g. one
+/// XEP-0184 receipt or XEP-0085 chat state per delivered message —
+/// so this is a graceful-degradation bound, not a misbehavior gate.
 const DEFERRED_INBOUND_CAP: usize = 64;
 
 /// Write a response batch to the WebSocket, recording countable

--- a/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
@@ -197,7 +197,18 @@ where
         match next {
             Some(Ok(Message::Text(text))) => {
                 conn.note_transport_activity();
-                if let Some(h) = parse_sm_ack_h(text.as_str()) {
+                if text.len() > MAX_FRAME_SIZE {
+                    // The main dispatcher's MAX_FRAME_SIZE backstop
+                    // would drop this frame anyway; dropping it here
+                    // keeps up to 64 near-1MiB frames from being
+                    // retained in `deferred_inbound` until the loop
+                    // gets around to processing the backlog.
+                    warn!(
+                        len = text.len(),
+                        max = MAX_FRAME_SIZE,
+                        "Dropping oversized inbound frame during mid-batch drain"
+                    );
+                } else if let Some(h) = parse_sm_ack_h(text.as_str()) {
                     apply_sm_ack(state, &mut conn.sm_state, h).await;
                 } else {
                     conn.deferred_inbound.push_back(text);
@@ -229,11 +240,12 @@ where
 }
 
 /// Parse a frame as an XEP-0198 `<a h='N'/>` nonza, returning `h`.
-/// Anything else — including oversized frames, which the main
-/// dispatcher's `MAX_FRAME_SIZE` backstop must see and drop — returns
-/// `None` and is left for the main frame dispatcher.
+/// Anything else returns `None` and is left for the main frame
+/// dispatcher. Oversized frames never reach this — the drain drops
+/// them before parsing, mirroring the dispatcher's `MAX_FRAME_SIZE`
+/// backstop.
 fn parse_sm_ack_h(frame: &str) -> Option<u32> {
-    if frame.len() > MAX_FRAME_SIZE || !SmStanza::is_client_nonza_candidate(frame) {
+    if !SmStanza::is_client_nonza_candidate(frame) {
         return None;
     }
     match SmStanza::parse(frame) {

--- a/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
@@ -14,10 +14,30 @@
 
 use super::send::send_ws_message;
 use super::state::WsConnState;
-use super::stream_management::{apply_sm_ack, is_countable_stanza, is_mam_result_message};
+use super::stream_management::{apply_sm_ack, is_countable_stanza, is_mam_response_frame};
 use super::*;
 use futures::FutureExt as _;
 use waddle_xmpp::stream_management::SmRequest;
+
+/// How the writer records countable frames into XEP-0198 bookkeeping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BatchSmPolicy {
+    /// Record countable frames; XEP-0313 MAM response frames
+    /// (`<result/>` carriers and the closing `<fin/>` IQ) are
+    /// replay-exempt. ONLY legal for the requester's own connection
+    /// batch, where MAM responses are server-generated — the MAM
+    /// shape is spoofable, so relayed peer content must never get
+    /// this policy.
+    RecordWithMamExemption,
+    /// Record every countable frame. Used for peer-relayed content
+    /// (recipient-pass output), where a forged `{urn:xmpp:mam:2}`
+    /// child must not opt a message out of the reliability layer.
+    RecordAll,
+    /// Record nothing. Only for SM resume replay batches, whose
+    /// stanzas already sit in the restored unacked queue with their
+    /// original sequence numbers.
+    ReplaySuppressed,
+}
 
 /// Outcome of writing a response batch.
 #[must_use = "a closed transport must break the connection loop"]
@@ -26,25 +46,37 @@ pub(super) enum BatchWriteOutcome {
     Continue,
     /// The transport went away mid-batch (send failure). The caller
     /// must break the connection loop; the SM unacked queue already
-    /// holds every countable frame of the batch for resume replay.
+    /// holds every replayable countable frame of the batch.
     TransportClosed,
 }
+
+/// Upper bound on frames the mid-batch drain may park in
+/// [`WsConnState::deferred_inbound`]. Once reached the drain stops
+/// reading, so a flooding client hits TCP backpressure again instead
+/// of converting its send rate into unbounded server heap. `<a/>`
+/// acks are consumed (never parked), so ack draining keeps working on
+/// later passes even at the cap.
+const DEFERRED_INBOUND_CAP: usize = 64;
 
 /// Write a response batch to the WebSocket, recording countable
 /// stanzas into the XEP-0198 unacked queue one frame at a time and
 /// interleaving an `<r/>` ack request after every `ack_threshold`th
 /// countable stanza.
 ///
-/// `record` is `false` only for SM resume replay batches, whose
-/// stanzas already sit in the restored unacked queue with their
-/// original sequence numbers.
+/// XEP-0198 counter discipline for replay-exempt frames: the client
+/// counts a stanza in `h` only when it actually receives it, so an
+/// exempt frame — which can never be re-delivered by replay — must
+/// advance `outbound_count` only after its write succeeded. Queued
+/// (non-exempt) frames are recorded before the write: if the send
+/// fails they replay on resume, and the counters re-converge when
+/// the client receives them.
 pub(super) async fn write_response_batch<S, SE, R, RE>(
     sender: &mut S,
     reader: &mut R,
     state: &WebSocketState,
     conn: &mut WsConnState,
     frames: Vec<String>,
-    record: bool,
+    policy: BatchSmPolicy,
 ) -> BatchWriteOutcome
 where
     S: Sink<Message, Error = SE> + Unpin,
@@ -54,7 +86,18 @@ where
 {
     let mut frames = frames.into_iter();
     while let Some(frame) = frames.next() {
-        let request_ack = record_frame_for_replay(conn, &frame, record);
+        let class = if conn.sm_state.enabled {
+            classify_frame(&frame, policy)
+        } else {
+            FrameSmClass::Untracked
+        };
+        // Queued frames are recorded pre-send (resume replays them if
+        // the send fails). Replay-exempt frames must not be counted
+        // until the write succeeds — see the function doc.
+        let mut request_ack = match class {
+            FrameSmClass::Queue => conn.sm_state.record_outbound(frame.clone()).request_ack,
+            FrameSmClass::ReplayExempt | FrameSmClass::Untracked => false,
+        };
         if !send_ws_message(
             sender,
             Message::Text(frame.into()),
@@ -62,11 +105,11 @@ where
         )
         .await
         {
-            // This frame is already recorded; the rest of the batch
-            // must be too, or the resume replay window silently loses
-            // the tail of the batch.
-            record_remaining_for_replay(conn, frames, record);
+            record_remaining_for_replay(conn, frames, policy);
             return BatchWriteOutcome::TransportClosed;
+        }
+        if matches!(class, FrameSmClass::ReplayExempt) {
+            request_ack = conn.sm_state.record_outbound_replay_exempt().request_ack;
         }
         if request_ack {
             if !send_ws_message(
@@ -76,7 +119,7 @@ where
             )
             .await
             {
-                record_remaining_for_replay(conn, frames, record);
+                record_remaining_for_replay(conn, frames, policy);
                 return BatchWriteOutcome::TransportClosed;
             }
             // Give already-arrived inbound frames a chance to land:
@@ -86,7 +129,7 @@ where
                 drain_ready_inbound(sender, reader, state, conn).await,
                 DrainSignal::TransportClosed
             ) {
-                record_remaining_for_replay(conn, frames, record);
+                record_remaining_for_replay(conn, frames, policy);
                 return BatchWriteOutcome::TransportClosed;
             }
         }
@@ -94,33 +137,50 @@ where
     BatchWriteOutcome::Continue
 }
 
-/// Record one outbound frame into the XEP-0198 bookkeeping, returning
-/// whether the `<r/>` cadence fired. XEP-0313 MAM result messages
-/// advance the wire counter but stay out of the replay queue — resume
-/// must not duplicate archive results, and a history sync must not
-/// evict live stanzas (issue #1089).
-fn record_frame_for_replay(conn: &mut WsConnState, frame: &str, record: bool) -> bool {
-    if !record || !conn.sm_state.enabled || !is_countable_stanza(frame) {
-        return false;
+/// XEP-0198 handling class of one outbound frame under a policy.
+#[derive(Debug, Clone, Copy)]
+enum FrameSmClass {
+    /// Countable; recorded into the unacked replay queue.
+    Queue,
+    /// Countable MAM response frame; counts toward `h` only once
+    /// actually written, never enters the replay queue.
+    ReplayExempt,
+    /// Not countable (nonza / stream frame), or recording suppressed.
+    Untracked,
+}
+
+fn classify_frame(frame: &str, policy: BatchSmPolicy) -> FrameSmClass {
+    if matches!(policy, BatchSmPolicy::ReplaySuppressed) || !is_countable_stanza(frame) {
+        return FrameSmClass::Untracked;
     }
-    if is_mam_result_message(frame) {
-        conn.sm_state.record_outbound_replay_exempt().request_ack
-    } else {
-        conn.sm_state.record_outbound(frame.to_string()).request_ack
+    if matches!(policy, BatchSmPolicy::RecordWithMamExemption) && is_mam_response_frame(frame) {
+        return FrameSmClass::ReplayExempt;
     }
+    FrameSmClass::Queue
 }
 
 /// The transport died mid-batch: record every not-yet-written
-/// countable frame so the resume replay window covers the entire
-/// batch. There is no wire to follow up on, so the cadence signal is
-/// moot (mirrors the detach-drain contract in `replay.rs`).
-fn record_remaining_for_replay(
+/// replayable frame so the resume replay window covers the rest of
+/// the batch. Replay-exempt frames are dropped entirely — they were
+/// never written, so counting them would permanently desync
+/// `outbound_count` from the client's `h`; the client re-runs its
+/// archive query instead. The cadence signal is moot (no wire), which
+/// mirrors the detach-drain contract in `replay.rs`.
+///
+/// Also used by the connection loop's shutdown path for responses to
+/// frames the drain had deferred before the transport went away.
+pub(super) fn record_remaining_for_replay(
     conn: &mut WsConnState,
     frames: impl Iterator<Item = String>,
-    record: bool,
+    policy: BatchSmPolicy,
 ) {
+    if !conn.sm_state.enabled {
+        return;
+    }
     for frame in frames {
-        let _ = record_frame_for_replay(conn, &frame, record);
+        if matches!(classify_frame(&frame, policy), FrameSmClass::Queue) {
+            let _ = conn.sm_state.record_outbound(frame);
+        }
     }
 }
 
@@ -133,12 +193,14 @@ enum DrainSignal {
     TransportClosed,
 }
 
-/// Non-blockingly pull every already-buffered inbound frame off the
+/// Non-blockingly pull already-buffered inbound frames off the
 /// socket. `<a/>` acks are applied immediately (they are what keeps
 /// the unacked queue from evicting mid-flood); every other text frame
-/// is deferred, in arrival order, for the main frame dispatcher.
-/// Pings are answered inline so a mid-flood client keepalive isn't
-/// starved; pongs/binary only count as liveness evidence.
+/// is deferred, in arrival order, for the main frame dispatcher — up
+/// to [`DEFERRED_INBOUND_CAP`], past which the drain stops reading so
+/// TCP backpressure throttles a flooding client. Pings are answered
+/// inline so a mid-flood client keepalive isn't starved;
+/// pongs/binary only count as liveness evidence.
 async fn drain_ready_inbound<S, SE, R, RE>(
     sender: &mut S,
     reader: &mut R,
@@ -152,6 +214,9 @@ where
     RE: std::fmt::Display,
 {
     loop {
+        if conn.deferred_inbound.len() >= DEFERRED_INBOUND_CAP {
+            return DrainSignal::Idle;
+        }
         let Some(next) = reader.next().now_or_never() else {
             // Nothing buffered right now — back to writing.
             return DrainSignal::Idle;

--- a/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/batch_write.rs
@@ -14,25 +14,28 @@
 
 use super::send::send_ws_message;
 use super::state::WsConnState;
-use super::stream_management::{apply_sm_ack, is_countable_stanza, is_mam_response_frame};
+use super::stream_management::{apply_sm_ack, is_countable_stanza};
 use super::*;
 use futures::FutureExt as _;
 use waddle_xmpp::stream_management::SmRequest;
 
 /// How the writer records countable frames into XEP-0198 bookkeeping.
+///
+/// Note there is deliberately NO replay exemption for XEP-0313 MAM
+/// result frames (issue #1089 asked for one; adversarial review
+/// killed it): the client's `h` counts every stanza it receives, and
+/// a frame that is counted but can never be re-delivered by resume
+/// replay permanently desyncs `outbound_count` from `h` the moment a
+/// written frame is lost in flight — un-ackable queue entries and
+/// duplicate replays forever after. Recording MAM results like any
+/// other stanza keeps the counters convergent; a replayed result is
+/// protocol-harmless (XEP-0313 §6.1: clients MUST ignore results they
+/// did not request), and queue pressure from archive floods is solved
+/// by this writer's chunking + mid-batch ack draining instead.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum BatchSmPolicy {
-    /// Record countable frames; XEP-0313 MAM response frames
-    /// (`<result/>` carriers and the closing `<fin/>` IQ) are
-    /// replay-exempt. ONLY legal for the requester's own connection
-    /// batch, where MAM responses are server-generated — the MAM
-    /// shape is spoofable, so relayed peer content must never get
-    /// this policy.
-    RecordWithMamExemption,
-    /// Record every countable frame. Used for peer-relayed content
-    /// (recipient-pass output), where a forged `{urn:xmpp:mam:2}`
-    /// child must not opt a message out of the reliability layer.
-    RecordAll,
+    /// Record every countable frame into the unacked replay queue.
+    Record,
     /// Record nothing. Only for SM resume replay batches, whose
     /// stanzas already sit in the restored unacked queue with their
     /// original sequence numbers.
@@ -54,8 +57,13 @@ pub(super) enum BatchWriteOutcome {
 /// [`WsConnState::deferred_inbound`]. Once reached the drain stops
 /// reading, so a flooding client hits TCP backpressure again instead
 /// of converting its send rate into unbounded server heap. `<a/>`
-/// acks are consumed (never parked), so ack draining keeps working on
-/// later passes even at the cap.
+/// acks are consumed (never parked), acks only stop draining once 64
+/// non-ack frames are already parked ahead of them — reads must stay
+/// in order, so an ack behind parked frames cannot be consumed until
+/// the connection loop processes the backlog. At the cap, behavior
+/// degrades exactly to the pre-#1089 semantics (no mid-batch ack
+/// draining: the queue may evict and mark a replay gap), and the only
+/// affected stream is the one whose own client is flooding it.
 const DEFERRED_INBOUND_CAP: usize = 64;
 
 /// Write a response batch to the WebSocket, recording countable
@@ -63,11 +71,7 @@ const DEFERRED_INBOUND_CAP: usize = 64;
 /// interleaving an `<r/>` ack request after every `ack_threshold`th
 /// countable stanza.
 ///
-/// XEP-0198 counter discipline for replay-exempt frames: the client
-/// counts a stanza in `h` only when it actually receives it, so an
-/// exempt frame — which can never be re-delivered by replay — must
-/// advance `outbound_count` only after its write succeeded. Queued
-/// (non-exempt) frames are recorded before the write: if the send
+/// Frames are recorded just before their own write: if the send
 /// fails they replay on resume, and the counters re-converge when
 /// the client receives them.
 pub(super) async fn write_response_batch<S, SE, R, RE>(
@@ -86,17 +90,10 @@ where
 {
     let mut frames = frames.into_iter();
     while let Some(frame) = frames.next() {
-        let class = if conn.sm_state.enabled {
-            classify_frame(&frame, policy)
+        let request_ack = if should_record(conn, &frame, policy) {
+            conn.sm_state.record_outbound(frame.clone()).request_ack
         } else {
-            FrameSmClass::Untracked
-        };
-        // Queued frames are recorded pre-send (resume replays them if
-        // the send fails). Replay-exempt frames must not be counted
-        // until the write succeeds — see the function doc.
-        let mut request_ack = match class {
-            FrameSmClass::Queue => conn.sm_state.record_outbound(frame.clone()).request_ack,
-            FrameSmClass::ReplayExempt | FrameSmClass::Untracked => false,
+            false
         };
         if !send_ws_message(
             sender,
@@ -107,9 +104,6 @@ where
         {
             record_remaining_for_replay(conn, frames, policy);
             return BatchWriteOutcome::TransportClosed;
-        }
-        if matches!(class, FrameSmClass::ReplayExempt) {
-            request_ack = conn.sm_state.record_outbound_replay_exempt().request_ack;
         }
         if request_ack {
             if !send_ws_message(
@@ -137,35 +131,14 @@ where
     BatchWriteOutcome::Continue
 }
 
-/// XEP-0198 handling class of one outbound frame under a policy.
-#[derive(Debug, Clone, Copy)]
-enum FrameSmClass {
-    /// Countable; recorded into the unacked replay queue.
-    Queue,
-    /// Countable MAM response frame; counts toward `h` only once
-    /// actually written, never enters the replay queue.
-    ReplayExempt,
-    /// Not countable (nonza / stream frame), or recording suppressed.
-    Untracked,
-}
-
-fn classify_frame(frame: &str, policy: BatchSmPolicy) -> FrameSmClass {
-    if matches!(policy, BatchSmPolicy::ReplaySuppressed) || !is_countable_stanza(frame) {
-        return FrameSmClass::Untracked;
-    }
-    if matches!(policy, BatchSmPolicy::RecordWithMamExemption) && is_mam_response_frame(frame) {
-        return FrameSmClass::ReplayExempt;
-    }
-    FrameSmClass::Queue
+fn should_record(conn: &WsConnState, frame: &str, policy: BatchSmPolicy) -> bool {
+    conn.sm_state.enabled && matches!(policy, BatchSmPolicy::Record) && is_countable_stanza(frame)
 }
 
 /// The transport died mid-batch: record every not-yet-written
-/// replayable frame so the resume replay window covers the rest of
-/// the batch. Replay-exempt frames are dropped entirely — they were
-/// never written, so counting them would permanently desync
-/// `outbound_count` from the client's `h`; the client re-runs its
-/// archive query instead. The cadence signal is moot (no wire), which
-/// mirrors the detach-drain contract in `replay.rs`.
+/// countable frame so the resume replay window covers the rest of
+/// the batch. The cadence signal is moot (no wire), which mirrors the
+/// detach-drain contract in `replay.rs`.
 ///
 /// Also used by the connection loop's shutdown path for responses to
 /// frames the drain had deferred before the transport went away.
@@ -174,11 +147,8 @@ pub(super) fn record_remaining_for_replay(
     frames: impl Iterator<Item = String>,
     policy: BatchSmPolicy,
 ) {
-    if !conn.sm_state.enabled {
-        return;
-    }
     for frame in frames {
-        if matches!(classify_frame(&frame, policy), FrameSmClass::Queue) {
+        if should_record(conn, &frame, policy) {
             let _ = conn.sm_state.record_outbound(frame);
         }
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -387,11 +387,7 @@ async fn handle_inbound_text(
         conn.suppress_sm_record_next_batch = false;
         BatchSmPolicy::ReplaySuppressed
     } else {
-        // These responses answer the client's own frames on its own
-        // connection — MAM responses in here are server-generated, so
-        // the replay exemption is safe. Peer-relayed content (which
-        // could spoof the MAM shape) never flows through this batch.
-        BatchSmPolicy::RecordWithMamExemption
+        BatchSmPolicy::Record
     };
     match write_response_batch(
         ws_sender,
@@ -437,7 +433,7 @@ async fn process_deferred_inbound_after_transport_loss(
             conn.suppress_sm_record_next_batch = false;
             BatchSmPolicy::ReplaySuppressed
         } else {
-            BatchSmPolicy::RecordWithMamExemption
+            BatchSmPolicy::Record
         };
         batch_write::record_remaining_for_replay(conn, responses.into_iter(), policy);
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -1,6 +1,6 @@
 use super::*;
 use super::{
-    batch_write::{write_response_batch, BatchWriteOutcome},
+    batch_write::{write_response_batch, BatchSmPolicy, BatchWriteOutcome},
     cleanup::cleanup_connection_shutdown,
     frame::handle_xmpp_frame,
     interpret_loop::build_interpret_deps,
@@ -83,29 +83,39 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
 
     loop {
         // Frames the mid-batch ack drain (issue #1089) pulled off the
-        // socket ahead of the dispatcher. They must be processed in
-        // arrival order BEFORE the socket is polled again, or a frame
-        // the client sent mid-flood would be reordered behind frames
-        // it sent afterwards.
-        if let Some(text) = conn.deferred_inbound.pop_front() {
-            if !handle_inbound_text(
-                &text,
-                &domain,
-                &state,
-                &mut conn,
-                &mut pending_tx,
-                &mut ws_sender,
-                &mut ws_receiver,
-            )
-            .await
-            {
-                break;
-            }
-            continue;
-        }
+        // socket ahead of the dispatcher must be processed in arrival
+        // order BEFORE the socket is polled again — so the socket arm
+        // below is gated on the queue being empty, and an
+        // always-ready arm processes one deferred frame per
+        // iteration. Deferred processing stays a select arm (not a
+        // pre-select loop) so the outbound channel and the keepalive
+        // timer keep getting polled between deferred frames — a
+        // client streaming frames mid-flood must not be able to
+        // starve routed stanzas or dead-peer detection.
+        let deferred_pending = !conn.deferred_inbound.is_empty();
         tokio::select! {
+            // Process one drain-deferred inbound frame.
+            _ = std::future::ready(()), if deferred_pending => {
+                let Some(text) = conn.deferred_inbound.pop_front() else {
+                    continue;
+                };
+                if !handle_inbound_text(
+                    &text,
+                    &domain,
+                    &state,
+                    &mut conn,
+                    &mut pending_tx,
+                    &mut ws_sender,
+                    &mut ws_receiver,
+                )
+                .await
+                {
+                    break;
+                }
+            }
+
             // Handle inbound WebSocket messages from the client
-            msg = ws_receiver.next() => {
+            msg = ws_receiver.next(), if !deferred_pending => {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
                         if !handle_inbound_text(
@@ -253,6 +263,15 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
         }
     }
 
+    // Frames the mid-batch ack drain had already pulled off the
+    // socket when the transport went away (issue #1089). The old loop
+    // would have processed them before ever seeing the close, so
+    // their inbound side effects (routing to peers, inbound_count)
+    // must still happen. There is no wire to answer on: responses to
+    // the departed client are recorded for XEP-0198 resume replay
+    // instead of being written.
+    process_deferred_inbound_after_transport_loss(&domain, state.as_ref(), &mut conn).await;
+
     // Connection is ending. Decide between two paths:
     //   A. Fully clean up (unregister + remove MUC occupants) — the default
     //      for non-SM sessions and for SM sessions that didn't negotiate
@@ -364,11 +383,15 @@ async fn handle_inbound_text(
     // the queue. Re-recording them would bump `outbound_count` past
     // reality and push duplicate queue entries, breaking subsequent
     // acks and a second resume.
-    let record = if conn.suppress_sm_record_next_batch {
+    let policy = if conn.suppress_sm_record_next_batch {
         conn.suppress_sm_record_next_batch = false;
-        false
+        BatchSmPolicy::ReplaySuppressed
     } else {
-        true
+        // These responses answer the client's own frames on its own
+        // connection — MAM responses in here are server-generated, so
+        // the replay exemption is safe. Peer-relayed content (which
+        // could spoof the MAM shape) never flows through this batch.
+        BatchSmPolicy::RecordWithMamExemption
     };
     match write_response_batch(
         ws_sender,
@@ -376,7 +399,7 @@ async fn handle_inbound_text(
         state.as_ref(),
         conn,
         responses,
-        record,
+        policy,
     )
     .await
     {
@@ -393,6 +416,31 @@ async fn handle_inbound_text(
         return false;
     }
     true
+}
+
+/// Process inbound frames the mid-batch drain deferred before the
+/// transport was lost. Runs after the connection loop breaks, before
+/// shutdown cleanup: side effects (peer routing, `inbound_count`)
+/// still happen; responses cannot be written, so replayable countable
+/// ones are recorded into the unacked queue for a future resume.
+/// Registration is skipped — a dead transport must not (re)register
+/// itself.
+async fn process_deferred_inbound_after_transport_loss(
+    domain: &str,
+    state: &WebSocketState,
+    conn: &mut WsConnState,
+) {
+    while let Some(text) = conn.deferred_inbound.pop_front() {
+        let responses = handle_xmpp_frame(&text, domain, state, conn).await;
+        conn.sync_state_machine_phase();
+        let policy = if conn.suppress_sm_record_next_batch {
+            conn.suppress_sm_record_next_batch = false;
+            BatchSmPolicy::ReplaySuppressed
+        } else {
+            BatchSmPolicy::RecordWithMamExemption
+        };
+        batch_write::record_remaining_for_replay(conn, responses.into_iter(), policy);
+    }
 }
 
 fn ensure_websocket_stream_close_for_closing_phase(

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -1,5 +1,6 @@
 use super::*;
 use super::{
+    batch_write::{write_response_batch, BatchWriteOutcome},
     cleanup::cleanup_connection_shutdown,
     frame::handle_xmpp_frame,
     interpret_loop::build_interpret_deps,
@@ -9,11 +10,11 @@ use super::{
     send::{close_ws_connection, send_ws_message, send_ws_text_frames},
     session_init::build_internal_server_error_stream_error,
     state::WsConnState,
-    stream_management::{is_countable_stanza, SmRegistrationFinalization},
+    stream_management::SmRegistrationFinalization,
     timers::TransportTimers,
     transport_xml::{build_handled_count_too_high_stream_error, websocket_stream_close_xml},
 };
-use waddle_xmpp::stream_management::SmRequest;
+use futures::stream::{SplitSink, SplitStream};
 
 /// Create the WebSocket router
 pub fn router(state: Arc<WebSocketState>) -> Router {
@@ -81,153 +82,43 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
     let mut superseded = false;
 
     loop {
+        // Frames the mid-batch ack drain (issue #1089) pulled off the
+        // socket ahead of the dispatcher. They must be processed in
+        // arrival order BEFORE the socket is polled again, or a frame
+        // the client sent mid-flood would be reordered behind frames
+        // it sent afterwards.
+        if let Some(text) = conn.deferred_inbound.pop_front() {
+            if !handle_inbound_text(
+                &text,
+                &domain,
+                &state,
+                &mut conn,
+                &mut pending_tx,
+                &mut ws_sender,
+                &mut ws_receiver,
+            )
+            .await
+            {
+                break;
+            }
+            continue;
+        }
         tokio::select! {
             // Handle inbound WebSocket messages from the client
             msg = ws_receiver.next() => {
                 match msg {
                     Some(Ok(Message::Text(text))) => {
-                        debug!(len = text.len(), "Received XMPP WebSocket message");
-                        // Any inbound frame is liveness evidence for the
-                        // RFC 7395 §3.8 keepalive policy (issue #1090).
-                        conn.note_transport_activity();
-
-                        // Handle XMPP framing (RFC 7395)
-                        let mut responses =
-                            handle_xmpp_frame(text.as_str(), &domain, state.as_ref(), &mut conn)
-                                .await;
-
-                        // Mirror any phase transition `handle_xmpp_frame`
-                        // performed (most importantly Ready → Closing on
-                        // SASL failure / stream error) into the per-
-                        // connection state machine. Without this, late
-                        // `PeerStanza` dispatches from the outbound
-                        // channel would still go through the recipient
-                        // pipeline even though the legacy phase tracker
-                        // has marked the connection Closing.
-                        conn.sync_state_machine_phase();
-
-                        // Register the connection after successful authentication
-                        // and resource binding. This keeps the transport loop
-                        // focused on WebSocket I/O while the registration module
-                        // owns registry publication and post-registration SM
-                        // finalization.
-                        match register_bound_connection_after_frame(
-                            state.as_ref(),
+                        if !handle_inbound_text(
+                            text.as_str(),
                             &domain,
+                            &state,
                             &mut conn,
                             &mut pending_tx,
-                        )
-                        .await
-                        {
-                            RegistrationAfterFrame::Unchanged => {}
-                            RegistrationAfterFrame::SessionInitializationFailed => {
-                                let stream_error = build_internal_server_error_stream_error(
-                                    "Session initialization failed; please reconnect.",
-                                );
-                                let _ = send_ws_text_frames(
-                                    &mut ws_sender,
-                                    [stream_error, websocket_stream_close_xml()],
-                                    "Failed to send session-init stream error",
-                                )
-                                .await;
-                                let _ = close_ws_connection(
-                                    &mut ws_sender,
-                                    "Failed to send WebSocket close frame after session-init error",
-                                )
-                                .await;
-                                break;
-                            }
-                            RegistrationAfterFrame::Registered(sm_finalization) => {
-                                match sm_finalization {
-                                    SmRegistrationFinalization::KeepExistingResponses => {}
-                                    SmRegistrationFinalization::ReplaceWithResumed {
-                                        resumed,
-                                        replay_after_h,
-                                    } => {
-                                        responses = vec![resumed.to_xml()];
-                                        responses.extend(
-                                            conn.sm_state.get_stanzas_to_resend(replay_after_h),
-                                        );
-                                    }
-                                    SmRegistrationFinalization::ReplaceWithFailed(failed) => {
-                                        responses = vec![failed.to_xml()];
-                                    }
-                                    SmRegistrationFinalization::ReplaceWithHandledCountTooHigh {
-                                        acknowledged,
-                                        send_count,
-                                    } => {
-                                        responses = vec![
-                                            build_handled_count_too_high_stream_error(
-                                                acknowledged,
-                                                send_count,
-                                            ),
-                                            websocket_stream_close_xml(),
-                                        ];
-                                    }
-                                }
-                            }
-                        }
-
-                        ensure_websocket_stream_close_for_closing_phase(&conn, &mut responses);
-
-                        // Record outbound stanzas for XEP-0198 replay BEFORE
-                        // writing them to the socket. If SM is enabled and
-                        // the stanza is countable, push it into the unacked
-                        // queue; a future resume will replay this exact XML.
-                        //
-                        // Exception: when `handle_sm_resume` just ran, the
-                        // responses ARE the replay of the restored unacked
-                        // queue — those stanzas already have their original
-                        // sequence numbers and are still in the queue.
-                        // Re-recording them would bump `outbound_count` past
-                        // reality and push duplicate queue entries, breaking
-                        // subsequent acks and a second resume.
-                        let mut request_ack_after = false;
-                        if conn.suppress_sm_record_next_batch {
-                            conn.suppress_sm_record_next_batch = false;
-                        } else if conn.sm_state.enabled {
-                            for frame in &responses {
-                                if is_countable_stanza(frame) {
-                                    let result = conn.sm_state.record_outbound(frame.clone());
-                                    request_ack_after |= result.request_ack;
-                                }
-                            }
-                        }
-
-                        if !send_ws_text_frames(
                             &mut ws_sender,
-                            responses,
-                            "Failed to send WebSocket message",
+                            &mut ws_receiver,
                         )
                         .await
                         {
-                            break;
-                        }
-                        // SM cadence (XEP-0198 §4): once the unacked
-                        // outbound stanza count since the last `<r/>`
-                        // hits the threshold, follow the batch with an
-                        // `<r/>` so the wasm client sends back `<a
-                        // h='N'/>`. Without this, the unacked queue
-                        // grows monotonically until the 1000-cap
-                        // triggers eviction and resume is permanently
-                        // broken for the stream.
-                        if request_ack_after
-                            && !send_ws_message(
-                                &mut ws_sender,
-                                Message::Text(SmRequest::to_xml().into()),
-                                "Failed to send SM <r/> request",
-                            )
-                            .await
-                        {
-                            break;
-                        }
-
-                        if matches!(conn.phase, ConnectionPhase::Closing { .. }) {
-                            let _ = close_ws_connection(
-                                &mut ws_sender,
-                                "Failed to send WebSocket close frame after XMPP stream close",
-                            )
-                            .await;
                             break;
                         }
                     }
@@ -271,6 +162,7 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                     Some(outbound_stanza) => {
                         if !handle_outbound_stanza(
                             &mut ws_sender,
+                            &mut ws_receiver,
                             &state,
                             &mut conn,
                             &mut timers,
@@ -377,6 +269,130 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
     cleanup_connection_shutdown(state.as_ref(), &mut outbound_rx, &mut conn, superseded).await;
 
     info!("XMPP WebSocket connection closed");
+}
+
+/// Handle one inbound XMPP text frame end to end: framing, phase
+/// mirroring, post-frame registration, and the chunked XEP-0198-aware
+/// response write. Extracted from the connection loop's Text arm so
+/// frames deferred by the mid-batch ack drain (issue #1089) go
+/// through the exact same path as frames read off the socket.
+///
+/// Returns `false` when the connection loop must break.
+async fn handle_inbound_text(
+    text: &str,
+    domain: &str,
+    state: &Arc<WebSocketState>,
+    conn: &mut WsConnState,
+    pending_tx: &mut Option<mpsc::Sender<OutboundStanza>>,
+    ws_sender: &mut SplitSink<WebSocket, Message>,
+    ws_receiver: &mut SplitStream<WebSocket>,
+) -> bool {
+    debug!(len = text.len(), "Received XMPP WebSocket message");
+    // Any inbound frame is liveness evidence for the
+    // RFC 7395 §3.8 keepalive policy (issue #1090).
+    conn.note_transport_activity();
+
+    // Handle XMPP framing (RFC 7395)
+    let mut responses = handle_xmpp_frame(text, domain, state.as_ref(), conn).await;
+
+    // Mirror any phase transition `handle_xmpp_frame` performed (most
+    // importantly Ready → Closing on SASL failure / stream error)
+    // into the per-connection state machine. Without this, late
+    // `PeerStanza` dispatches from the outbound channel would still
+    // go through the recipient pipeline even though the legacy phase
+    // tracker has marked the connection Closing.
+    conn.sync_state_machine_phase();
+
+    // Register the connection after successful authentication and
+    // resource binding. This keeps the transport loop focused on
+    // WebSocket I/O while the registration module owns registry
+    // publication and post-registration SM finalization.
+    match register_bound_connection_after_frame(state.as_ref(), domain, conn, pending_tx).await {
+        RegistrationAfterFrame::Unchanged => {}
+        RegistrationAfterFrame::SessionInitializationFailed => {
+            let stream_error = build_internal_server_error_stream_error(
+                "Session initialization failed; please reconnect.",
+            );
+            let _ = send_ws_text_frames(
+                ws_sender,
+                [stream_error, websocket_stream_close_xml()],
+                "Failed to send session-init stream error",
+            )
+            .await;
+            let _ = close_ws_connection(
+                ws_sender,
+                "Failed to send WebSocket close frame after session-init error",
+            )
+            .await;
+            return false;
+        }
+        RegistrationAfterFrame::Registered(sm_finalization) => match sm_finalization {
+            SmRegistrationFinalization::KeepExistingResponses => {}
+            SmRegistrationFinalization::ReplaceWithResumed {
+                resumed,
+                replay_after_h,
+            } => {
+                responses = vec![resumed.to_xml()];
+                responses.extend(conn.sm_state.get_stanzas_to_resend(replay_after_h));
+            }
+            SmRegistrationFinalization::ReplaceWithFailed(failed) => {
+                responses = vec![failed.to_xml()];
+            }
+            SmRegistrationFinalization::ReplaceWithHandledCountTooHigh {
+                acknowledged,
+                send_count,
+            } => {
+                responses = vec![
+                    build_handled_count_too_high_stream_error(acknowledged, send_count),
+                    websocket_stream_close_xml(),
+                ];
+            }
+        },
+    }
+
+    ensure_websocket_stream_close_for_closing_phase(conn, &mut responses);
+
+    // Write the batch through the chunked XEP-0198-aware writer
+    // (issue #1089): each countable stanza is recorded just before
+    // its own write, an `<r/>` follows every `ack_threshold`th one,
+    // and already-arrived inbound frames are drained after each `<r/>`
+    // so `<a/>` acks shrink the unacked queue mid-flood.
+    //
+    // Exception: when `handle_sm_resume` just ran, the responses ARE
+    // the replay of the restored unacked queue — those stanzas
+    // already have their original sequence numbers and are still in
+    // the queue. Re-recording them would bump `outbound_count` past
+    // reality and push duplicate queue entries, breaking subsequent
+    // acks and a second resume.
+    let record = if conn.suppress_sm_record_next_batch {
+        conn.suppress_sm_record_next_batch = false;
+        false
+    } else {
+        true
+    };
+    match write_response_batch(
+        ws_sender,
+        ws_receiver,
+        state.as_ref(),
+        conn,
+        responses,
+        record,
+    )
+    .await
+    {
+        BatchWriteOutcome::Continue => {}
+        BatchWriteOutcome::TransportClosed => return false,
+    }
+
+    if matches!(conn.phase, ConnectionPhase::Closing { .. }) {
+        let _ = close_ws_connection(
+            ws_sender,
+            "Failed to send WebSocket close frame after XMPP stream close",
+        )
+        .await;
+        return false;
+    }
+    true
 }
 
 fn ensure_websocket_stream_close_for_closing_phase(

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -270,7 +270,16 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
     // must still happen. There is no wire to answer on: responses to
     // the departed client are recorded for XEP-0198 resume replay
     // instead of being written.
-    process_deferred_inbound_after_transport_loss(&domain, state.as_ref(), &mut conn).await;
+    //
+    // Skipped when superseded: the registry slot, MUC occupancy, and
+    // SM continuity now belong to the replacement session, and
+    // running handlers from the stale session here could still emit
+    // side effects (routing, inbound_count) against state the
+    // newcomer owns — the same reason the cleanup block below
+    // short-circuits.
+    if !superseded {
+        process_deferred_inbound_after_transport_loss(&domain, state.as_ref(), &mut conn).await;
+    }
 
     // Connection is ending. Decide between two paths:
     //   A. Fully clean up (unregister + remove MUC occupants) — the default

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -67,6 +67,7 @@ use crate::server::AppState;
 use waddle_xmpp::auth::ScramServer;
 use waddle_xmpp::pubsub::PubSubStorage;
 
+mod batch_write;
 mod cleanup;
 mod connection;
 mod frame;

--- a/server/crates/waddle-server/src/server/routes/websocket/outbound.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/outbound.rs
@@ -1,6 +1,6 @@
 use super::*;
 use super::{
-    batch_write::{write_response_batch, BatchWriteOutcome},
+    batch_write::{write_response_batch, BatchSmPolicy, BatchWriteOutcome},
     interpret_loop::build_interpret_deps,
     replay::drive_interpret_loop,
     send::send_ws_message,
@@ -168,8 +168,19 @@ where
             // already-arrived inbound `<a/>` acks after each `<r/>` so
             // a recipient-pass burst (carbons + receipts + archive
             // side-effects) can't pin the unacked queue at capacity.
-            match write_response_batch(sender, reader, state.as_ref(), conn, drive.frames, true)
-                .await
+            //
+            // RecordAll: this is peer-relayed content — a forged
+            // `{urn:xmpp:mam:2}` child must not opt a message out of
+            // the reliability layer, so no MAM replay exemption here.
+            match write_response_batch(
+                sender,
+                reader,
+                state.as_ref(),
+                conn,
+                drive.frames,
+                BatchSmPolicy::RecordAll,
+            )
+            .await
             {
                 BatchWriteOutcome::Continue => {}
                 BatchWriteOutcome::TransportClosed => return false,

--- a/server/crates/waddle-server/src/server/routes/websocket/outbound.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/outbound.rs
@@ -168,17 +168,13 @@ where
             // already-arrived inbound `<a/>` acks after each `<r/>` so
             // a recipient-pass burst (carbons + receipts + archive
             // side-effects) can't pin the unacked queue at capacity.
-            //
-            // RecordAll: this is peer-relayed content — a forged
-            // `{urn:xmpp:mam:2}` child must not opt a message out of
-            // the reliability layer, so no MAM replay exemption here.
             match write_response_batch(
                 sender,
                 reader,
                 state.as_ref(),
                 conn,
                 drive.frames,
-                BatchSmPolicy::RecordAll,
+                BatchSmPolicy::Record,
             )
             .await
             {

--- a/server/crates/waddle-server/src/server/routes/websocket/outbound.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/outbound.rs
@@ -1,21 +1,29 @@
 use super::*;
 use super::{
-    interpret_loop::build_interpret_deps, replay::drive_interpret_loop, send::send_ws_message,
-    state::WsConnState, stream_management::is_countable_stanza, timers::TransportTimers,
+    batch_write::{write_response_batch, BatchWriteOutcome},
+    interpret_loop::build_interpret_deps,
+    replay::drive_interpret_loop,
+    send::send_ws_message,
+    state::WsConnState,
+    stream_management::is_countable_stanza,
+    timers::TransportTimers,
     transport_xml::stanza_to_xml,
 };
 use waddle_xmpp::stream_management::SmRequest;
 
-pub(super) async fn handle_outbound_stanza<S, E>(
+pub(super) async fn handle_outbound_stanza<S, SE, R, RE>(
     sender: &mut S,
+    reader: &mut R,
     state: &Arc<WebSocketState>,
     conn: &mut WsConnState,
     timers: &mut TransportTimers,
     outbound_stanza: OutboundStanza,
 ) -> bool
 where
-    S: Sink<Message, Error = E> + Unpin,
-    E: std::fmt::Display,
+    S: Sink<Message, Error = SE> + Unpin,
+    SE: std::fmt::Display,
+    R: futures::Stream<Item = Result<Message, RE>> + Unpin,
+    RE: std::fmt::Display,
 {
     debug!(kind = ?outbound_stanza.kind, "Received outbound stanza from registry");
     match outbound_stanza.kind {
@@ -153,36 +161,18 @@ where
             // Always best-effort flush the accumulated frames first, even if
             // `close=true`, so a final error stanza or stream-close frame is
             // visible before transport teardown.
-            let mut request_ack_after = false;
-            for xml in drive.frames {
-                if conn.sm_state.enabled && is_countable_stanza(&xml) {
-                    let result = conn.sm_state.record_outbound(xml.clone());
-                    request_ack_after |= result.request_ack;
-                }
-                if !send_ws_message(
-                    sender,
-                    Message::Text(xml.into()),
-                    "Failed to send recipient-pass frame",
-                )
-                .await
-                {
-                    return false;
-                }
-            }
-            // Emit one `<r/>` per batch once threshold has been
-            // reached — see DirectFrame branch comment above. Coalescing
-            // per-batch (rather than per-frame) keeps wire traffic tight
-            // when the recipient pass produces many countable stanzas at
-            // once (carbons + receipts + archive side-effects).
-            if request_ack_after
-                && !send_ws_message(
-                    sender,
-                    Message::Text(SmRequest::to_xml().into()),
-                    "Failed to send SM <r/> request",
-                )
+            //
+            // The chunked writer (issue #1089) records each countable
+            // frame just before its own write, follows every
+            // `ack_threshold`th one with an `<r/>`, and drains
+            // already-arrived inbound `<a/>` acks after each `<r/>` so
+            // a recipient-pass burst (carbons + receipts + archive
+            // side-effects) can't pin the unacked queue at capacity.
+            match write_response_batch(sender, reader, state.as_ref(), conn, drive.frames, true)
                 .await
             {
-                return false;
+                BatchWriteOutcome::Continue => {}
+                BatchWriteOutcome::TransportClosed => return false,
             }
             if close {
                 info!("PeerStanza dispatch requested transport close");

--- a/server/crates/waddle-server/src/server/routes/websocket/replay.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/replay.rs
@@ -1,6 +1,7 @@
 use super::*;
 use super::{
-    interpret_loop::build_interpret_deps, stream_management::is_countable_stanza,
+    interpret_loop::build_interpret_deps,
+    stream_management::{is_countable_stanza, is_mam_result_message},
     transport_xml::stanza_to_xml,
 };
 
@@ -123,7 +124,17 @@ async fn record_drained_xml(
     // Drain path: we're recording into the unacked queue for replay
     // on the next resume, NOT writing to a live wire. The SM cadence
     // signal is moot — there is no socket to follow up with `<r/>`.
-    let _ = sm_state.record_outbound_with_receipt_at(xml.clone(), original_receipt_at);
+    //
+    // XEP-0313 MAM result messages advance the wire counter but stay
+    // out of the replay window (issue #1089): a resume must not
+    // duplicate archive results the client can re-query, so they are
+    // neither queued locally nor stored on the detached session.
+    let mam_result = is_mam_result_message(&xml);
+    if mam_result {
+        let _ = sm_state.record_outbound_replay_exempt();
+    } else {
+        let _ = sm_state.record_outbound_with_receipt_at(xml.clone(), original_receipt_at);
+    }
     let sequence = sm_state.outbound_count;
     if let Some(row_id) = pending_row_id.as_ref() {
         if let Err(error) = state
@@ -154,6 +165,9 @@ async fn record_drained_xml(
                 );
             }
         }
+    }
+    if mam_result {
+        return;
     }
     if let Some(stream_id) = detached_stream_id {
         if let Err(error) = state

--- a/server/crates/waddle-server/src/server/routes/websocket/replay.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/replay.rs
@@ -1,7 +1,6 @@
 use super::*;
 use super::{
-    interpret_loop::build_interpret_deps,
-    stream_management::{is_countable_stanza, is_mam_result_message},
+    interpret_loop::build_interpret_deps, stream_management::is_countable_stanza,
     transport_xml::stanza_to_xml,
 };
 
@@ -125,16 +124,15 @@ async fn record_drained_xml(
     // on the next resume, NOT writing to a live wire. The SM cadence
     // signal is moot — there is no socket to follow up with `<r/>`.
     //
-    // XEP-0313 MAM result messages advance the wire counter but stay
-    // out of the replay window (issue #1089): a resume must not
-    // duplicate archive results the client can re-query, so they are
-    // neither queued locally nor stored on the detached session.
-    let mam_result = is_mam_result_message(&xml);
-    if mam_result {
-        let _ = sm_state.record_outbound_replay_exempt();
-    } else {
-        let _ = sm_state.record_outbound_with_receipt_at(xml.clone(), original_receipt_at);
-    }
+    // No MAM replay exemption here (issue #1089 review): nothing on
+    // this path was ever written to a wire, so the client's `h` can
+    // never include it — counting without queueing would permanently
+    // desync `outbound_count` from `h`. Recording everything keeps
+    // the counters convergent (the resume delivers the stanza, the
+    // client counts it). Server-generated MAM responses also cannot
+    // reach this path: they are produced synchronously on the
+    // requester's own connection, never routed via the registry.
+    let _ = sm_state.record_outbound_with_receipt_at(xml.clone(), original_receipt_at);
     let sequence = sm_state.outbound_count;
     if let Some(row_id) = pending_row_id.as_ref() {
         if let Err(error) = state
@@ -165,9 +163,6 @@ async fn record_drained_xml(
                 );
             }
         }
-    }
-    if mam_result {
-        return;
     }
     if let Some(stream_id) = detached_stream_id {
         if let Err(error) = state

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -361,6 +361,12 @@ pub(super) struct WsConnState {
     /// and duplicate queue entries. The main loop resets the flag to
     /// `false` after skipping the record step.
     pub(super) suppress_sm_record_next_batch: bool,
+    /// Inbound text frames pulled off the socket by the mid-batch ack
+    /// drain (issue #1089) that were NOT `<a/>` acks. The batch writer
+    /// may only consume acks out of order; everything else must reach
+    /// the main frame dispatcher in arrival order, so the connection
+    /// loop processes this queue before polling the socket again.
+    pub(super) deferred_inbound: std::collections::VecDeque<axum::extract::ws::Utf8Bytes>,
     /// Per-connection sans-I/O state machine.
     ///
     /// Initialized in the `Unauthenticated` phase at WS upgrade by
@@ -405,6 +411,7 @@ impl WsConnState {
             pending_resume_h: None,
             registry_owner: None,
             suppress_sm_record_next_batch: false,
+            deferred_inbound: std::collections::VecDeque::new(),
             state_machine: None,
             keepalive_config: waddle_xmpp::protocol::KeepaliveConfig::default(),
         }

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -11,22 +11,19 @@ pub(super) use registration::{
 /// handled/sent counters. Only `<iq>`, `<message>`, `<presence>` qualify;
 /// stream headers, SASL frames, and SM control nonzas do not.
 ///
-/// Matches on the element name rather than a string-prefix: a substring
-/// match like `starts_with("<message")` would also accept future nonzas
-/// such as `<messages>` or `<presences>`.
+/// Frames at this layer sit past the serialization boundary (they are
+/// the exact bytes about to hit — or replay onto — the wire), so the
+/// XEP-0198 decision re-enters the typed domain here: the frame is
+/// parsed into a [`minidom::Element`] and classified on the resolved
+/// element name, never on string prefixes (a substring match like
+/// `starts_with("<message")` would also accept nonzas such as
+/// `<messages>`). Anything that does not parse is by definition not a
+/// stanza this server produced and does not count.
 pub(super) fn is_countable_stanza(frame: &str) -> bool {
-    let trimmed = frame.trim_start();
-    let Some(after_lt) = trimmed.strip_prefix('<') else {
+    let Ok(element) = Element::from_str(frame.trim_start()) else {
         return false;
     };
-    let name_end = after_lt
-        .find(|c: char| c.is_whitespace() || c == '>' || c == '/')
-        .unwrap_or(after_lt.len());
-    let element_name = &after_lt[..name_end];
-    let local_name = element_name
-        .rsplit_once(':')
-        .map_or(element_name, |(_, local)| local);
-    matches!(local_name, "iq" | "message" | "presence")
+    matches!(element.name(), "iq" | "message" | "presence")
 }
 
 pub(super) fn sm_show_from_name(value: &str) -> Option<xmpp_parsers::presence::Show> {

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -29,6 +29,31 @@ pub(super) fn is_countable_stanza(frame: &str) -> bool {
     matches!(local_name, "iq" | "message" | "presence")
 }
 
+/// Returns true if the frame is a XEP-0313 MAM `<result/>` carrier
+/// message. Such messages count toward the XEP-0198 wire counter (the
+/// client's `h` includes them) but are exempt from the unacked replay
+/// queue: replaying archive results after a resume would duplicate
+/// data the client already holds, and during a large history sync
+/// they are what pins the queue at capacity and drives the eviction
+/// storm that permanently breaks resume (issue #1089).
+///
+/// Detection is structural (parse + direct child lookup), not a
+/// substring match — a live message quoting the namespace in its body
+/// must not be exempted from replay. The cheap `contains` gate keeps
+/// the parse off the hot path for the overwhelmingly common non-MAM
+/// frame.
+pub(super) fn is_mam_result_message(frame: &str) -> bool {
+    use std::str::FromStr as _;
+
+    if !frame.contains(waddle_xmpp_core::mam::MAM_NS) {
+        return false;
+    }
+    let Ok(element) = Element::from_str(frame) else {
+        return false;
+    };
+    element.name() == "message" && element.has_child("result", waddle_xmpp_core::mam::MAM_NS)
+}
+
 pub(super) fn sm_show_from_name(value: &str) -> Option<xmpp_parsers::presence::Show> {
     match value {
         "away" => Some(xmpp_parsers::presence::Show::Away),
@@ -102,62 +127,75 @@ pub(super) async fn handle_sm_stanza(
         SmStanza::Enable(enable) => handle_sm_enable(enable, state, ctx.sm_state, ctx.phase),
         SmStanza::Request => vec![SmAck::new(ctx.sm_state.get_inbound_count()).to_xml()],
         SmStanza::Ack(ack) => {
-            ctx.sm_state.acknowledge(ack.h);
-            // Locked Q7b SM-ack lifecycle (issue #209): range-delete
-            // every `pending_delivery` row claimed by this XEP-0198
-            // session whose recorded outbound counter is <= `ack.h`.
-            // This is what actually frees the row from the durable
-            // queue — the flush path no longer deletes on push.
-            //
-            // Session id is the XEP-0198 stream_id (NOT the resource
-            // JID — Qodo review on PR #358: distinct SM sessions on
-            // the same resource share the same JID, so keying by JID
-            // would let one session's ack delete another's claimed
-            // rows). The flush function reads the same stream_id from
-            // the connection's `ConnectionEntry` so claim and delete
-            // agree on the key.
-            // Greptile review on PR #358: this MUST run inline so it
-            // executes after any preceding `record_pushed_at` for the
-            // same connection. Spawning would let a quick ack arrive
-            // and run delete_acked_through against a row whose
-            // outbound_sequence is still NULL (because the
-            // record_pushed_at task hadn't completed), silently
-            // skipping the delete.
-            if let Some(stream_id) = ctx.sm_state.stream_id.clone() {
-                let session_id = waddle_xmpp::pending_delivery::SmSessionId::new(stream_id);
-                let h = ack.h;
-                match state
-                    .deps
-                    .protocol
-                    .pending_delivery_storage
-                    .delete_acked_through(&session_id, h)
-                    .await
-                {
-                    Ok(removed) if removed > 0 => {
-                        debug!(
-                            session = %session_id,
-                            h,
-                            removed,
-                            "pending_delivery rows cleared by SM ack"
-                        );
-                    }
-                    Ok(_) => {}
-                    Err(error) => {
-                        warn!(
-                            session = %session_id,
-                            h,
-                            error = %error,
-                            "pending_delivery delete_acked_through failed; rows \
-                             will be retried on next session via release_claim"
-                        );
-                    }
-                }
-            }
+            apply_sm_ack(state, ctx.sm_state, ack.h).await;
             vec![]
         }
         SmStanza::Resume(resume) => handle_sm_resume(resume, state, ctx).await,
         // Server-origin nonzas should never arrive from a client. Ignore.
         SmStanza::Enabled(_) | SmStanza::Resumed(_) | SmStanza::Failed(_) => vec![],
+    }
+}
+
+/// Apply a client `<a h='N'/>` ack: advance the SM counters, drop the
+/// acked prefix of the unacked queue, and range-delete every
+/// `pending_delivery` row this XEP-0198 session claimed whose
+/// recorded outbound counter is <= `h`.
+///
+/// Locked Q7b SM-ack lifecycle (issue #209): the range-delete is what
+/// actually frees rows from the durable queue — the flush path no
+/// longer deletes on push.
+///
+/// Session id is the XEP-0198 stream_id (NOT the resource JID — Qodo
+/// review on PR #358: distinct SM sessions on the same resource share
+/// the same JID, so keying by JID would let one session's ack delete
+/// another's claimed rows). The flush function reads the same
+/// stream_id from the connection's `ConnectionEntry` so claim and
+/// delete agree on the key.
+///
+/// Greptile review on PR #358: this MUST run inline so it executes
+/// after any preceding `record_pushed_at` for the same connection.
+/// Spawning would let a quick ack arrive and run delete_acked_through
+/// against a row whose outbound_sequence is still NULL (because the
+/// record_pushed_at task hadn't completed), silently skipping the
+/// delete.
+///
+/// Shared by the `<a/>` frame handler and the mid-batch drain in
+/// [`super::batch_write`] (issue #1089) so both paths honour the same
+/// ack lifecycle.
+pub(super) async fn apply_sm_ack(
+    state: &WebSocketState,
+    sm_state: &mut StreamManagementState,
+    h: u32,
+) {
+    sm_state.acknowledge(h);
+    if let Some(stream_id) = sm_state.stream_id.clone() {
+        let session_id = waddle_xmpp::pending_delivery::SmSessionId::new(stream_id);
+        match state
+            .deps
+            .protocol
+            .pending_delivery_storage
+            .delete_acked_through(&session_id, h)
+            .await
+        {
+            Ok(removed) if removed > 0 => {
+                debug!(
+                    session = %session_id,
+                    h,
+                    removed,
+                    "pending_delivery rows cleared by SM ack"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                warn!(
+                    session = %session_id,
+                    h,
+                    error = %error,
+                    "pending_delivery delete_acked_through failed; rows \
+                     will be retried on next session via release_claim"
+                );
+            }
+        }
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -29,48 +29,6 @@ pub(super) fn is_countable_stanza(frame: &str) -> bool {
     matches!(local_name, "iq" | "message" | "presence")
 }
 
-/// Returns true if the frame is part of a XEP-0313 MAM query response
-/// — a `<result/>` carrier message or the closing `<fin/>` IQ.
-///
-/// Both are replay-exempt in the XEP-0198 unacked queue (issue #1089)
-/// on the requester's own response batch: replaying archive results
-/// after a resume would duplicate data the client can re-query, and
-/// during a large history sync they are what pins the queue at
-/// capacity and drives the eviction storm. The `<fin/>` must be
-/// exempt WITH the results: replaying a `fin complete='true'` whose
-/// results were not replayed would falsely tell the client the page
-/// arrived in full and stop it from re-querying — a permanent archive
-/// hole. With both exempt, an interrupted query stays visibly
-/// unanswered on the resumed stream and the client re-runs it.
-///
-/// Callers MUST only apply this exemption to server-generated MAM
-/// responses (the requester's own connection batch). The shape is
-/// spoofable: a relayed peer message carrying a forged
-/// `{urn:xmpp:mam:2}result` child must NOT be able to opt itself out
-/// of the reliability layer, so the peer-relay paths record
-/// everything.
-///
-/// Detection is structural (parse + direct child lookup), not a
-/// substring match — a live message quoting the namespace in its body
-/// must not be exempted from replay. The cheap `contains` gate keeps
-/// the parse off the hot path for the overwhelmingly common non-MAM
-/// frame.
-pub(super) fn is_mam_response_frame(frame: &str) -> bool {
-    use std::str::FromStr as _;
-
-    if !frame.contains(waddle_xmpp_core::mam::MAM_NS) {
-        return false;
-    }
-    let Ok(element) = Element::from_str(frame) else {
-        return false;
-    };
-    match element.name() {
-        "message" => element.has_child("result", waddle_xmpp_core::mam::MAM_NS),
-        "iq" => element.has_child("fin", waddle_xmpp_core::mam::MAM_NS),
-        _ => false,
-    }
-}
-
 pub(super) fn sm_show_from_name(value: &str) -> Option<xmpp_parsers::presence::Show> {
     match value {
         "away" => Some(xmpp_parsers::presence::Show::Away),

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -29,20 +29,33 @@ pub(super) fn is_countable_stanza(frame: &str) -> bool {
     matches!(local_name, "iq" | "message" | "presence")
 }
 
-/// Returns true if the frame is a XEP-0313 MAM `<result/>` carrier
-/// message. Such messages count toward the XEP-0198 wire counter (the
-/// client's `h` includes them) but are exempt from the unacked replay
-/// queue: replaying archive results after a resume would duplicate
-/// data the client already holds, and during a large history sync
-/// they are what pins the queue at capacity and drives the eviction
-/// storm that permanently breaks resume (issue #1089).
+/// Returns true if the frame is part of a XEP-0313 MAM query response
+/// — a `<result/>` carrier message or the closing `<fin/>` IQ.
+///
+/// Both are replay-exempt in the XEP-0198 unacked queue (issue #1089)
+/// on the requester's own response batch: replaying archive results
+/// after a resume would duplicate data the client can re-query, and
+/// during a large history sync they are what pins the queue at
+/// capacity and drives the eviction storm. The `<fin/>` must be
+/// exempt WITH the results: replaying a `fin complete='true'` whose
+/// results were not replayed would falsely tell the client the page
+/// arrived in full and stop it from re-querying — a permanent archive
+/// hole. With both exempt, an interrupted query stays visibly
+/// unanswered on the resumed stream and the client re-runs it.
+///
+/// Callers MUST only apply this exemption to server-generated MAM
+/// responses (the requester's own connection batch). The shape is
+/// spoofable: a relayed peer message carrying a forged
+/// `{urn:xmpp:mam:2}result` child must NOT be able to opt itself out
+/// of the reliability layer, so the peer-relay paths record
+/// everything.
 ///
 /// Detection is structural (parse + direct child lookup), not a
 /// substring match — a live message quoting the namespace in its body
 /// must not be exempted from replay. The cheap `contains` gate keeps
 /// the parse off the hot path for the overwhelmingly common non-MAM
 /// frame.
-pub(super) fn is_mam_result_message(frame: &str) -> bool {
+pub(super) fn is_mam_response_frame(frame: &str) -> bool {
     use std::str::FromStr as _;
 
     if !frame.contains(waddle_xmpp_core::mam::MAM_NS) {
@@ -51,7 +64,11 @@ pub(super) fn is_mam_result_message(frame: &str) -> bool {
     let Ok(element) = Element::from_str(frame) else {
         return false;
     };
-    element.name() == "message" && element.has_child("result", waddle_xmpp_core::mam::MAM_NS)
+    match element.name() {
+        "message" => element.has_child("result", waddle_xmpp_core::mam::MAM_NS),
+        "iq" => element.has_child("fin", waddle_xmpp_core::mam::MAM_NS),
+        _ => false,
+    }
 }
 
 pub(super) fn sm_show_from_name(value: &str) -> Option<xmpp_parsers::presence::Show> {

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -37,6 +37,7 @@ use waddle_xmpp::Affiliation;
 use xmpp_parsers::iq::{Iq, IqPayload};
 use xmpp_parsers::message::MessageType as XmppMessageType;
 
+mod batch_write;
 mod broadcast;
 mod disco_trace;
 mod dispatch;

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
@@ -5,6 +5,7 @@
 //! countable stanza with an `<r/>`, and drains already-arrived inbound
 //! frames after each `<r/>` so `<a/>` acks shrink the queue mid-flood.
 
+use super::super::transport_xml::element_to_xml;
 use super::super::{
     batch_write::{write_response_batch, BatchSmPolicy, BatchWriteOutcome},
     state::WsConnState,
@@ -17,6 +18,7 @@ use std::task::{Context, Poll};
 use waddle_xmpp::stream_management::{SmAck, SmRequest, StreamManagementState};
 
 use axum::extract::ws::Message;
+use xmpp_parsers::minidom::Element;
 
 /// Reader driven by a script: `Some(msg)` yields the message,
 /// `None` yields one `Poll::Pending` (— "nothing more buffered right
@@ -88,8 +90,16 @@ fn reader_with(frames: Vec<Message>) -> impl Stream<Item = Result<Message, Infal
     stream::iter(frames.into_iter().map(Ok)).chain(stream::pending())
 }
 
+fn message_with_id(id: &str) -> String {
+    element_to_xml(
+        Element::builder("message", "jabber:client")
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+            .build(),
+    )
+}
+
 fn countable_message(i: usize) -> String {
-    format!("<message xmlns='jabber:client' id='m{i}'/>")
+    message_with_id(&format!("m{i}"))
 }
 
 /// XEP-0198 §4: the server may request acks at any time. A large
@@ -214,13 +224,22 @@ async fn drained_non_ack_frames_are_deferred_in_arrival_order() {
     conn.sm_state = StreamManagementState::with_config(100, 5);
     conn.sm_state.enable("defer".to_string(), true, Some(300));
 
-    let chat = "<message xmlns='jabber:client' id='live-1'><body>hi</body></message>";
-    let client_r = "<r xmlns='urn:xmpp:sm:3'/>";
+    let chat = element_to_xml(
+        Element::builder("message", "jabber:client")
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), "live-1")
+            .append(
+                Element::builder("body", "jabber:client")
+                    .append("hi")
+                    .build(),
+            )
+            .build(),
+    );
+    let client_r = SmRequest::to_xml();
     let mut sink = CollectSink::default();
     let mut reader = ScriptedReader::new(vec![
-        Some(Message::Text(chat.into())),
+        Some(Message::Text(chat.clone().into())),
         Some(ack_frame(5)),
-        Some(Message::Text(client_r.into())),
+        Some(Message::Text(client_r.clone().into())),
         None,
     ]);
     let frames: Vec<String> = (1..=5).map(countable_message).collect();
@@ -246,7 +265,7 @@ async fn drained_non_ack_frames_are_deferred_in_arrival_order() {
         .iter()
         .map(|t| t.to_string())
         .collect();
-    assert_eq!(deferred, vec![chat.to_string(), client_r.to_string()]);
+    assert_eq!(deferred, vec![chat, client_r]);
 }
 
 /// Deliberate design decision (issue #1089 adversarial review): MAM
@@ -269,12 +288,17 @@ async fn mam_results_are_recorded_like_any_stanza_for_counter_convergence() {
     let live = countable_message(1);
     let mut frames = vec![live.clone()];
     frames.extend((1..=3).map(mam_result_frame));
-    frames.push(
-        "<iq xmlns='jabber:client' type='result' id='q1'>\
-           <fin xmlns='urn:xmpp:mam:2' complete='true'/>\
-         </iq>"
-            .to_string(),
-    );
+    frames.push(element_to_xml(
+        Element::builder("iq", "jabber:client")
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), "q1")
+            .append(
+                Element::builder("fin", "urn:xmpp:mam:2")
+                    .attr(minidom::rxml::xml_ncname!("complete").to_owned(), "true")
+                    .build(),
+            )
+            .build(),
+    ));
 
     let mut sink = CollectSink::default();
     let mut reader = ScriptedReader::new(vec![]);
@@ -373,13 +397,67 @@ async fn resume_replay_batch_is_written_without_recording_or_ack_requests() {
 }
 
 fn mam_result_frame(i: usize) -> String {
-    format!(
-        "<message xmlns='jabber:client' to='u@example.com/r'>\
-           <result xmlns='urn:xmpp:mam:2' queryid='q1' id='{i}'>\
-             <forwarded xmlns='urn:xmpp:forward:0'/>\
-           </result>\
-         </message>"
+    element_to_xml(
+        Element::builder("message", "jabber:client")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                "u@example.com/r",
+            )
+            .append(
+                Element::builder("result", "urn:xmpp:mam:2")
+                    .attr(minidom::rxml::xml_ncname!("queryid").to_owned(), "q1")
+                    .attr(minidom::rxml::xml_ncname!("id").to_owned(), i.to_string())
+                    .append(Element::builder("forwarded", "urn:xmpp:forward:0").build())
+                    .build(),
+            )
+            .build(),
     )
+}
+
+/// Oversized inbound frames are dropped by the drain immediately —
+/// the main dispatcher's MAX_FRAME_SIZE backstop would discard them
+/// anyway, so parking them would only retain up to 64 near-1MiB
+/// payloads in `deferred_inbound` until the loop chews through the
+/// backlog. Well-sized frames around them are still drained normally.
+#[tokio::test]
+async fn drain_drops_oversized_frames_instead_of_parking_them() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    conn.sm_state = StreamManagementState::with_config(100, 5);
+    conn.sm_state
+        .enable("oversize".to_string(), true, Some(300));
+
+    let oversized = "a".repeat(waddle_xmpp::protocol::frame::MAX_FRAME_SIZE + 1);
+    let kept = message_with_id("kept-1");
+    let mut reader = ScriptedReader::new(vec![
+        Some(Message::Text(oversized.into())),
+        Some(ack_frame(5)),
+        Some(Message::Text(kept.clone().into())),
+        None,
+    ]);
+    let mut sink = CollectSink::default();
+    let frames: Vec<String> = (1..=5).map(countable_message).collect();
+
+    let outcome = write_response_batch(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        frames,
+        BatchSmPolicy::Record,
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::Continue));
+    // The ack behind the oversized frame was still applied...
+    assert_eq!(conn.sm_state.last_acked, 5);
+    // ...and only the well-sized frame was parked.
+    let deferred: Vec<String> = conn
+        .deferred_inbound
+        .iter()
+        .map(|t| t.to_string())
+        .collect();
+    assert_eq!(deferred, vec![kept]);
 }
 
 /// The drain parks non-ack frames in `deferred_inbound` — but only up
@@ -394,11 +472,7 @@ async fn drain_stops_parking_deferred_frames_at_the_cap() {
 
     // 200 buffered non-ack frames, far more than the cap.
     let script: Vec<Option<Message>> = (0..200)
-        .map(|i| {
-            Some(Message::Text(
-                format!("<message xmlns='jabber:client' id='flood-{i}'/>").into(),
-            ))
-        })
+        .map(|i| Some(Message::Text(message_with_id(&format!("flood-{i}")).into())))
         .collect();
     let mut reader = ScriptedReader::new(script);
     let mut sink = CollectSink::default();

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
@@ -6,7 +6,7 @@
 //! frames after each `<r/>` so `<a/>` acks shrink the queue mid-flood.
 
 use super::super::{
-    batch_write::{write_response_batch, BatchWriteOutcome},
+    batch_write::{write_response_batch, BatchSmPolicy, BatchWriteOutcome},
     state::WsConnState,
 };
 use super::create_test_websocket_state;
@@ -114,7 +114,7 @@ async fn write_response_batch_requests_ack_every_threshold_not_once_per_batch() 
         state.as_ref(),
         &mut conn,
         frames,
-        true,
+        BatchSmPolicy::RecordWithMamExemption,
     )
     .await;
 
@@ -181,7 +181,7 @@ async fn write_response_batch_drains_acks_between_chunks_so_nothing_evicts() {
         state.as_ref(),
         &mut conn,
         frames,
-        true,
+        BatchSmPolicy::RecordWithMamExemption,
     )
     .await;
 
@@ -231,7 +231,7 @@ async fn drained_non_ack_frames_are_deferred_in_arrival_order() {
         state.as_ref(),
         &mut conn,
         frames,
-        true,
+        BatchSmPolicy::RecordWithMamExemption,
     )
     .await;
 
@@ -285,7 +285,7 @@ async fn mam_result_messages_count_toward_h_but_stay_out_of_replay_window() {
         state.as_ref(),
         &mut conn,
         frames,
-        true,
+        BatchSmPolicy::RecordWithMamExemption,
     )
     .await;
 
@@ -332,7 +332,7 @@ async fn transport_close_mid_batch_still_records_unwritten_frames_for_replay() {
         state.as_ref(),
         &mut conn,
         frames,
-        true,
+        BatchSmPolicy::RecordWithMamExemption,
     )
     .await;
 
@@ -370,7 +370,7 @@ async fn resume_replay_batch_is_written_without_recording_or_ack_requests() {
         state.as_ref(),
         &mut conn,
         frames,
-        false,
+        BatchSmPolicy::ReplaySuppressed,
     )
     .await;
 
@@ -380,6 +380,181 @@ async fn resume_replay_batch_is_written_without_recording_or_ack_requests() {
     let texts = sink_texts(&sink);
     assert_eq!(texts.len(), 12, "all frames written, no <r/> interleaved");
     assert!(!texts.iter().any(|t| *t == SmRequest::to_xml()));
+}
+
+fn mam_result_frame(i: usize) -> String {
+    format!(
+        "<message xmlns='jabber:client' to='u@example.com/r'>\
+           <result xmlns='urn:xmpp:mam:2' queryid='q1' id='{i}'>\
+             <forwarded xmlns='urn:xmpp:forward:0'/>\
+           </result>\
+         </message>"
+    )
+}
+
+/// The MAM `<fin/>` IQ is replay-exempt together with its results: a
+/// replayed `fin complete='true'` whose results were not replayed
+/// would falsely assert the page arrived in full and the client would
+/// never re-query — a permanent archive hole. Exempt, the query stays
+/// visibly unanswered on the resumed stream and the client retries.
+#[tokio::test]
+async fn mam_fin_iq_is_replay_exempt_alongside_its_results() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    conn.sm_state = StreamManagementState::with_config(100, 5);
+    conn.sm_state.enable("fin".to_string(), true, Some(300));
+
+    let fin = "<iq xmlns='jabber:client' type='result' id='q1'>\
+                 <fin xmlns='urn:xmpp:mam:2' complete='true'/>\
+               </iq>";
+    let frames = vec![mam_result_frame(1), mam_result_frame(2), fin.to_string()];
+
+    let mut sink = CollectSink::default();
+    let mut reader = ScriptedReader::new(vec![]);
+    let outcome = write_response_batch(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        frames,
+        BatchSmPolicy::RecordWithMamExemption,
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::Continue));
+    assert_eq!(conn.sm_state.outbound_count, 3, "all written, all counted");
+    assert_eq!(
+        conn.sm_state.queue_len(),
+        0,
+        "nothing enters the replay window"
+    );
+}
+
+/// XEP-0198 counter discipline (issue #1089 review): the client only
+/// counts stanzas it actually receives, and a replay-exempt frame can
+/// never be re-delivered by resume — so an exempt frame that never
+/// reached the wire must NOT advance `outbound_count`. Otherwise the
+/// server's counter permanently outruns the client's `h`: the newest
+/// queue entries become un-ackable and every subsequent resume
+/// replays stanzas the client already has.
+#[tokio::test]
+async fn unwritten_exempt_frames_in_a_dead_batch_tail_are_not_counted() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    conn.sm_state = StreamManagementState::with_config(100, 5);
+    conn.sm_state.enable("tail".to_string(), true, Some(300));
+
+    // Frames 1..=5 live (trigger the first <r/> + drain), 6..=12 MAM
+    // results. The drain after frame 5 sees a Close: the tail (6..12)
+    // is never written.
+    let mut frames: Vec<String> = (1..=5).map(countable_message).collect();
+    frames.extend((6..=12).map(mam_result_frame));
+
+    let mut sink = CollectSink::default();
+    let mut reader = ScriptedReader::new(vec![Some(Message::Close(None))]);
+    let outcome = write_response_batch(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        frames,
+        BatchSmPolicy::RecordWithMamExemption,
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::TransportClosed));
+    assert_eq!(
+        conn.sm_state.outbound_count, 5,
+        "unwritten exempt tail frames must not advance the wire counter"
+    );
+    assert_eq!(
+        conn.sm_state.queue_len(),
+        5,
+        "only the written live frames queue"
+    );
+}
+
+/// The MAM exemption is origin-gated: the structural shape is
+/// spoofable, so peer-relayed content (RecordAll policy) must record
+/// a MAM-shaped message into the replay window like any other stanza
+/// — otherwise a sender could craft `<message><result
+/// xmlns='urn:xmpp:mam:2'/>…` to opt its messages out of the
+/// reliability layer and have them silently dropped on resume.
+#[tokio::test]
+async fn peer_path_records_mam_shaped_frames_into_replay_window() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    conn.sm_state = StreamManagementState::with_config(100, 5);
+    conn.sm_state.enable("spoof".to_string(), true, Some(300));
+
+    let spoofed = "<message xmlns='jabber:client' to='victim@example.com/r'>\
+                     <body>hi</body>\
+                     <result xmlns='urn:xmpp:mam:2' queryid='x' id='1'/>\
+                   </message>";
+
+    let mut sink = CollectSink::default();
+    let mut reader = ScriptedReader::new(vec![]);
+    let outcome = write_response_batch(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        vec![spoofed.to_string()],
+        BatchSmPolicy::RecordAll,
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::Continue));
+    assert_eq!(
+        conn.sm_state.queue_len(),
+        1,
+        "spoof-shaped frame stays replayable"
+    );
+    assert_eq!(
+        conn.sm_state.get_stanzas_to_resend(0),
+        vec![spoofed.to_string()]
+    );
+}
+
+/// The drain parks non-ack frames in `deferred_inbound` — but only up
+/// to a cap, past which it stops reading so a flooding client hits
+/// TCP backpressure instead of growing server heap without bound.
+#[tokio::test]
+async fn drain_stops_parking_deferred_frames_at_the_cap() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    conn.sm_state = StreamManagementState::with_config(10_000, 5);
+    conn.sm_state.enable("cap".to_string(), true, Some(300));
+
+    // 200 buffered non-ack frames, far more than the cap.
+    let script: Vec<Option<Message>> = (0..200)
+        .map(|i| {
+            Some(Message::Text(
+                format!("<message xmlns='jabber:client' id='flood-{i}'/>").into(),
+            ))
+        })
+        .collect();
+    let mut reader = ScriptedReader::new(script);
+    let mut sink = CollectSink::default();
+    // 10 countable frames → two <r/> drains.
+    let frames: Vec<String> = (1..=10).map(countable_message).collect();
+
+    let outcome = write_response_batch(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        frames,
+        BatchSmPolicy::RecordWithMamExemption,
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::Continue));
+    assert_eq!(
+        conn.deferred_inbound.len(),
+        64,
+        "deferred queue must stop growing at the cap"
+    );
 }
 
 fn sm_evicted_total() -> u64 {

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
@@ -1,0 +1,392 @@
+//! Tests for the chunked XEP-0198-aware batch writer (issue #1089).
+//!
+//! The writer is what stops the unacked-queue eviction storm: it
+//! records + writes frame by frame, follows every `ack_threshold`th
+//! countable stanza with an `<r/>`, and drains already-arrived inbound
+//! frames after each `<r/>` so `<a/>` acks shrink the queue mid-flood.
+
+use super::super::{
+    batch_write::{write_response_batch, BatchWriteOutcome},
+    state::WsConnState,
+};
+use super::create_test_websocket_state;
+use futures::{stream, Sink, Stream, StreamExt as _};
+use std::convert::Infallible;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use waddle_xmpp::stream_management::{SmAck, SmRequest, StreamManagementState};
+
+use axum::extract::ws::Message;
+
+/// Reader driven by a script: `Some(msg)` yields the message,
+/// `None` yields one `Poll::Pending` (— "nothing more buffered right
+/// now"). Exhausted scripts stay Pending forever, like a live socket.
+struct ScriptedReader {
+    script: std::collections::VecDeque<Option<Message>>,
+}
+
+impl ScriptedReader {
+    fn new(script: Vec<Option<Message>>) -> Self {
+        Self {
+            script: script.into_iter().collect(),
+        }
+    }
+}
+
+impl Stream for ScriptedReader {
+    type Item = Result<Message, Infallible>;
+
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.script.pop_front() {
+            Some(Some(message)) => Poll::Ready(Some(Ok(message))),
+            Some(None) | None => Poll::Pending,
+        }
+    }
+}
+
+fn ack_frame(h: u32) -> Message {
+    Message::Text(SmAck::new(h).to_xml().into())
+}
+
+/// Sink that records every message written to it.
+#[derive(Default)]
+struct CollectSink {
+    sent: Vec<Message>,
+}
+
+impl Sink<Message> for CollectSink {
+    type Error = Infallible;
+
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+    fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+        self.sent.push(item);
+        Ok(())
+    }
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+fn sink_texts(sink: &CollectSink) -> Vec<String> {
+    sink.sent
+        .iter()
+        .filter_map(|m| match m {
+            Message::Text(t) => Some(t.to_string()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Reader with the given frames already buffered, then Pending forever
+/// (like a live socket with nothing more to read — NOT end-of-stream).
+fn reader_with(frames: Vec<Message>) -> impl Stream<Item = Result<Message, Infallible>> + Unpin {
+    stream::iter(frames.into_iter().map(Ok)).chain(stream::pending())
+}
+
+fn countable_message(i: usize) -> String {
+    format!("<message xmlns='jabber:client' id='m{i}'/>")
+}
+
+/// XEP-0198 §4: the server may request acks at any time. A large
+/// response batch must be followed by an `<r/>` every `ack_threshold`
+/// countable stanzas — not by a single coalesced `<r/>` after the
+/// whole batch (which is what let a MAM flood pin the unacked queue
+/// at capacity before the client ever got a chance to ack).
+#[tokio::test]
+async fn write_response_batch_requests_ack_every_threshold_not_once_per_batch() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    // Default ack_threshold is 5.
+    conn.sm_state.enable("chunk".to_string(), true, Some(300));
+
+    let mut sink = CollectSink::default();
+    let mut reader = reader_with(vec![]);
+    let frames: Vec<String> = (1..=12).map(countable_message).collect();
+
+    let outcome = write_response_batch(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        frames,
+        true,
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::Continue));
+    let texts = sink_texts(&sink);
+    let r_xml = SmRequest::to_xml();
+    // 12 stanzas + 2 interleaved <r/> (after the 5th and 10th).
+    assert_eq!(texts.len(), 14, "wire: {texts:?}");
+    assert_eq!(texts[5], r_xml, "<r/> must follow the 5th countable stanza");
+    assert_eq!(
+        texts[11], r_xml,
+        "<r/> must follow the 10th countable stanza"
+    );
+    assert_eq!(
+        texts.iter().filter(|t| **t == r_xml).count(),
+        2,
+        "no coalesced trailing <r/>, no per-frame spam"
+    );
+    // Stanzas stay in order around the interleaved requests.
+    assert_eq!(texts[0], countable_message(1));
+    assert_eq!(texts[4], countable_message(5));
+    assert_eq!(texts[6], countable_message(6));
+    assert_eq!(texts[13], countable_message(12));
+    assert_eq!(conn.sm_state.outbound_count, 12);
+    assert_eq!(conn.sm_state.queue_len(), 12);
+}
+
+/// Issue #1089 acceptance: inbound `<a/>` acks are processed between
+/// chunks of a large outbound batch, so a healthy client's acks drain
+/// the unacked queue mid-flood and `waddle_sm_unacked_evicted_total`
+/// stays flat — instead of the whole batch being recorded up front
+/// and evicting one stanza per send once the cap is hit.
+///
+/// The scripted reader releases exactly one ack per drain window
+/// (each followed by a Pending), so this only passes if the writer
+/// drains after EVERY `<r/>`, not just once at the end.
+#[tokio::test]
+async fn write_response_batch_drains_acks_between_chunks_so_nothing_evicts() {
+    let _metrics_guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+    let evicted_before = sm_evicted_total();
+
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    // Queue cap 10 with 50 countable frames: without mid-batch ack
+    // draining this MUST evict (50 > 10); with draining it never does.
+    conn.sm_state = StreamManagementState::with_config(10, 5);
+    conn.sm_state.enable("drain".to_string(), true, Some(300));
+
+    let mut sink = CollectSink::default();
+    // One ack per <r/> window: after the k-th <r/> the client has
+    // acked through h = 5k. Nine <r/>s fire for 50 frames (45th is
+    // the last threshold multiple before the batch ends).
+    let mut script: Vec<Option<Message>> = Vec::new();
+    for k in 1..=9 {
+        script.push(Some(ack_frame(5 * k)));
+        script.push(None); // drain window ends: socket has nothing more
+    }
+    let mut reader = ScriptedReader::new(script);
+    let frames: Vec<String> = (1..=50).map(countable_message).collect();
+
+    let outcome = write_response_batch(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        frames,
+        true,
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::Continue));
+    assert_eq!(
+        sm_evicted_total() - evicted_before,
+        0,
+        "healthy acking client must not evict anything from the replay window"
+    );
+    assert_eq!(
+        conn.sm_state.replay_gap_through(),
+        None,
+        "no eviction means no replay gap — resume stays possible"
+    );
+    assert_eq!(conn.sm_state.last_acked, 45, "all scripted acks applied");
+    assert_eq!(
+        conn.sm_state.queue_len(),
+        5,
+        "only the final unacked chunk (46..=50) remains queued"
+    );
+}
+
+/// Frames drained mid-batch that are NOT `<a/>` acks must reach the
+/// main dispatcher in arrival order — the drain may consume acks out
+/// of band, but must never reorder or drop anything else.
+#[tokio::test]
+async fn drained_non_ack_frames_are_deferred_in_arrival_order() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    conn.sm_state = StreamManagementState::with_config(100, 5);
+    conn.sm_state.enable("defer".to_string(), true, Some(300));
+
+    let chat = "<message xmlns='jabber:client' id='live-1'><body>hi</body></message>";
+    let client_r = "<r xmlns='urn:xmpp:sm:3'/>";
+    let mut sink = CollectSink::default();
+    let mut reader = ScriptedReader::new(vec![
+        Some(Message::Text(chat.into())),
+        Some(ack_frame(5)),
+        Some(Message::Text(client_r.into())),
+        None,
+    ]);
+    let frames: Vec<String> = (1..=5).map(countable_message).collect();
+
+    let outcome = write_response_batch(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        frames,
+        true,
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::Continue));
+    // The interleaved ack was applied out of band...
+    assert_eq!(conn.sm_state.last_acked, 5);
+    assert_eq!(conn.sm_state.queue_len(), 0);
+    // ...while the live message and the client's own <r/> are queued
+    // for the main dispatcher, in arrival order.
+    let deferred: Vec<String> = conn
+        .deferred_inbound
+        .iter()
+        .map(|t| t.to_string())
+        .collect();
+    assert_eq!(deferred, vec![chat.to_string(), client_r.to_string()]);
+}
+
+/// Issue #1089 acceptance: XEP-0313 MAM result messages count toward
+/// the wire counter (the client's `h` includes them) but must not be
+/// double-counted into the replay window — a resume must not replay
+/// archive results, and a history sync must not evict live stanzas.
+#[tokio::test]
+async fn mam_result_messages_count_toward_h_but_stay_out_of_replay_window() {
+    let _metrics_guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+    let evicted_before = sm_evicted_total();
+
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    // Queue cap 3: a 20-result MAM page would evict live stanzas if
+    // results were queued for replay.
+    conn.sm_state = StreamManagementState::with_config(3, 5);
+    conn.sm_state.enable("mam".to_string(), true, Some(300));
+
+    let live = countable_message(1);
+    let mut frames = vec![live.clone()];
+    frames.extend((1..=20).map(|i| {
+        format!(
+            "<message xmlns='jabber:client' to='u@example.com/r'>\
+               <result xmlns='urn:xmpp:mam:2' queryid='q1' id='{i}'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'/>\
+               </result>\
+             </message>"
+        )
+    }));
+
+    let mut sink = CollectSink::default();
+    let mut reader = ScriptedReader::new(vec![]);
+    let outcome = write_response_batch(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        frames,
+        true,
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::Continue));
+    // All 21 stanzas counted on the wire (h agreement with client)...
+    assert_eq!(conn.sm_state.outbound_count, 21);
+    // ...but only the live message occupies the replay window.
+    assert_eq!(conn.sm_state.queue_len(), 1);
+    let replay = conn.sm_state.get_stanzas_to_resend(0);
+    assert_eq!(replay, vec![live]);
+    assert_eq!(
+        sm_evicted_total() - evicted_before,
+        0,
+        "MAM flood must not evict live stanzas from the replay window"
+    );
+    assert_eq!(conn.sm_state.replay_gap_through(), None);
+    // Cadence still fires over exempt stanzas: 21 countable frames at
+    // threshold 5 → four <r/> requests on the wire.
+    let r_xml = SmRequest::to_xml();
+    assert_eq!(sink_texts(&sink).iter().filter(|t| **t == r_xml).count(), 4);
+}
+
+/// If the peer closes (or the socket dies) mid-batch, every countable
+/// frame not yet written must still be recorded into the unacked
+/// queue — the batch is no longer recorded up front, so an early exit
+/// that skipped recording would silently drop the tail of the batch
+/// from the resume replay window.
+#[tokio::test]
+async fn transport_close_mid_batch_still_records_unwritten_frames_for_replay() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    conn.sm_state = StreamManagementState::with_config(100, 5);
+    conn.sm_state
+        .enable("close-mid".to_string(), true, Some(300));
+
+    let mut sink = CollectSink::default();
+    // The drain after the first <r/> (frame 5) sees a Close frame.
+    let mut reader = ScriptedReader::new(vec![Some(Message::Close(None))]);
+    let frames: Vec<String> = (1..=12).map(countable_message).collect();
+
+    let outcome = write_response_batch(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        frames,
+        true,
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::TransportClosed));
+    // Frames 1..=5 were written; 6..=12 were not — but ALL 12 must be
+    // in the replay window so a resume delivers the tail.
+    assert_eq!(conn.sm_state.outbound_count, 12);
+    assert_eq!(conn.sm_state.queue_len(), 12);
+    let replay = conn.sm_state.get_stanzas_to_resend(0);
+    assert_eq!(replay.len(), 12);
+    assert_eq!(replay[11], countable_message(12));
+    // Only 5 stanzas + 1 <r/> actually hit the wire.
+    assert_eq!(sink_texts(&sink).len(), 6);
+}
+
+/// `record=false` is the SM resume replay batch: those stanzas
+/// already sit in the restored unacked queue under their original
+/// sequence numbers. Re-recording would double-count `outbound_count`
+/// and duplicate queue entries; emitting `<r/>` is the enabled-path's
+/// job once new traffic flows.
+#[tokio::test]
+async fn resume_replay_batch_is_written_without_recording_or_ack_requests() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    conn.sm_state = StreamManagementState::with_config(100, 5);
+    conn.sm_state.enable("replay".to_string(), true, Some(300));
+
+    let mut sink = CollectSink::default();
+    let mut reader = ScriptedReader::new(vec![]);
+    let frames: Vec<String> = (1..=12).map(countable_message).collect();
+
+    let outcome = write_response_batch(
+        &mut sink,
+        &mut reader,
+        state.as_ref(),
+        &mut conn,
+        frames,
+        false,
+    )
+    .await;
+
+    assert!(matches!(outcome, BatchWriteOutcome::Continue));
+    assert_eq!(conn.sm_state.outbound_count, 0);
+    assert_eq!(conn.sm_state.queue_len(), 0);
+    let texts = sink_texts(&sink);
+    assert_eq!(texts.len(), 12, "all frames written, no <r/> interleaved");
+    assert!(!texts.iter().any(|t| *t == SmRequest::to_xml()));
+}
+
+fn sm_evicted_total() -> u64 {
+    waddle_xmpp::prometheus::render_metrics()
+        .lines()
+        .find(|line| line.starts_with("waddle_sm_unacked_evicted_total "))
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(0)
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
@@ -114,7 +114,7 @@ async fn write_response_batch_requests_ack_every_threshold_not_once_per_batch() 
         state.as_ref(),
         &mut conn,
         frames,
-        BatchSmPolicy::RecordWithMamExemption,
+        BatchSmPolicy::Record,
     )
     .await;
 
@@ -181,7 +181,7 @@ async fn write_response_batch_drains_acks_between_chunks_so_nothing_evicts() {
         state.as_ref(),
         &mut conn,
         frames,
-        BatchSmPolicy::RecordWithMamExemption,
+        BatchSmPolicy::Record,
     )
     .await;
 
@@ -231,7 +231,7 @@ async fn drained_non_ack_frames_are_deferred_in_arrival_order() {
         state.as_ref(),
         &mut conn,
         frames,
-        BatchSmPolicy::RecordWithMamExemption,
+        BatchSmPolicy::Record,
     )
     .await;
 
@@ -249,33 +249,32 @@ async fn drained_non_ack_frames_are_deferred_in_arrival_order() {
     assert_eq!(deferred, vec![chat.to_string(), client_r.to_string()]);
 }
 
-/// Issue #1089 acceptance: XEP-0313 MAM result messages count toward
-/// the wire counter (the client's `h` includes them) but must not be
-/// double-counted into the replay window — a resume must not replay
-/// archive results, and a history sync must not evict live stanzas.
+/// Deliberate design decision (issue #1089 adversarial review): MAM
+/// result messages are recorded into the replay window like ANY other
+/// stanza. An exemption ("count toward h, never replay") permanently
+/// desyncs `outbound_count` from the client's `h` the moment a
+/// written result is lost in flight — XEP-0198 offers no legal way to
+/// count a stanza the client will never receive. A replayed result is
+/// harmless (XEP-0313 §6.1: clients MUST ignore results they did not
+/// request); queue pressure from archive floods is handled by the
+/// chunked writer's mid-batch ack draining instead. This also means a
+/// message spoofing the MAM shape gets no special treatment anywhere.
 #[tokio::test]
-async fn mam_result_messages_count_toward_h_but_stay_out_of_replay_window() {
-    let _metrics_guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
-    let evicted_before = sm_evicted_total();
-
+async fn mam_results_are_recorded_like_any_stanza_for_counter_convergence() {
     let state = create_test_websocket_state().await;
     let mut conn = WsConnState::new();
-    // Queue cap 3: a 20-result MAM page would evict live stanzas if
-    // results were queued for replay.
-    conn.sm_state = StreamManagementState::with_config(3, 5);
+    conn.sm_state = StreamManagementState::with_config(100, 5);
     conn.sm_state.enable("mam".to_string(), true, Some(300));
 
     let live = countable_message(1);
     let mut frames = vec![live.clone()];
-    frames.extend((1..=20).map(|i| {
-        format!(
-            "<message xmlns='jabber:client' to='u@example.com/r'>\
-               <result xmlns='urn:xmpp:mam:2' queryid='q1' id='{i}'>\
-                 <forwarded xmlns='urn:xmpp:forward:0'/>\
-               </result>\
-             </message>"
-        )
-    }));
+    frames.extend((1..=3).map(mam_result_frame));
+    frames.push(
+        "<iq xmlns='jabber:client' type='result' id='q1'>\
+           <fin xmlns='urn:xmpp:mam:2' complete='true'/>\
+         </iq>"
+            .to_string(),
+    );
 
     let mut sink = CollectSink::default();
     let mut reader = ScriptedReader::new(vec![]);
@@ -285,27 +284,18 @@ async fn mam_result_messages_count_toward_h_but_stay_out_of_replay_window() {
         state.as_ref(),
         &mut conn,
         frames,
-        BatchSmPolicy::RecordWithMamExemption,
+        BatchSmPolicy::Record,
     )
     .await;
 
     assert!(matches!(outcome, BatchWriteOutcome::Continue));
-    // All 21 stanzas counted on the wire (h agreement with client)...
-    assert_eq!(conn.sm_state.outbound_count, 21);
-    // ...but only the live message occupies the replay window.
-    assert_eq!(conn.sm_state.queue_len(), 1);
+    // Live message + 3 results + fin: all counted AND all replayable,
+    // so the server can always retransmit what the client's h lacks.
+    assert_eq!(conn.sm_state.outbound_count, 5);
+    assert_eq!(conn.sm_state.queue_len(), 5);
     let replay = conn.sm_state.get_stanzas_to_resend(0);
-    assert_eq!(replay, vec![live]);
-    assert_eq!(
-        sm_evicted_total() - evicted_before,
-        0,
-        "MAM flood must not evict live stanzas from the replay window"
-    );
-    assert_eq!(conn.sm_state.replay_gap_through(), None);
-    // Cadence still fires over exempt stanzas: 21 countable frames at
-    // threshold 5 → four <r/> requests on the wire.
-    let r_xml = SmRequest::to_xml();
-    assert_eq!(sink_texts(&sink).iter().filter(|t| **t == r_xml).count(), 4);
+    assert_eq!(replay.len(), 5);
+    assert_eq!(replay[0], live);
 }
 
 /// If the peer closes (or the socket dies) mid-batch, every countable
@@ -332,7 +322,7 @@ async fn transport_close_mid_batch_still_records_unwritten_frames_for_replay() {
         state.as_ref(),
         &mut conn,
         frames,
-        BatchSmPolicy::RecordWithMamExemption,
+        BatchSmPolicy::Record,
     )
     .await;
 
@@ -392,130 +382,6 @@ fn mam_result_frame(i: usize) -> String {
     )
 }
 
-/// The MAM `<fin/>` IQ is replay-exempt together with its results: a
-/// replayed `fin complete='true'` whose results were not replayed
-/// would falsely assert the page arrived in full and the client would
-/// never re-query — a permanent archive hole. Exempt, the query stays
-/// visibly unanswered on the resumed stream and the client retries.
-#[tokio::test]
-async fn mam_fin_iq_is_replay_exempt_alongside_its_results() {
-    let state = create_test_websocket_state().await;
-    let mut conn = WsConnState::new();
-    conn.sm_state = StreamManagementState::with_config(100, 5);
-    conn.sm_state.enable("fin".to_string(), true, Some(300));
-
-    let fin = "<iq xmlns='jabber:client' type='result' id='q1'>\
-                 <fin xmlns='urn:xmpp:mam:2' complete='true'/>\
-               </iq>";
-    let frames = vec![mam_result_frame(1), mam_result_frame(2), fin.to_string()];
-
-    let mut sink = CollectSink::default();
-    let mut reader = ScriptedReader::new(vec![]);
-    let outcome = write_response_batch(
-        &mut sink,
-        &mut reader,
-        state.as_ref(),
-        &mut conn,
-        frames,
-        BatchSmPolicy::RecordWithMamExemption,
-    )
-    .await;
-
-    assert!(matches!(outcome, BatchWriteOutcome::Continue));
-    assert_eq!(conn.sm_state.outbound_count, 3, "all written, all counted");
-    assert_eq!(
-        conn.sm_state.queue_len(),
-        0,
-        "nothing enters the replay window"
-    );
-}
-
-/// XEP-0198 counter discipline (issue #1089 review): the client only
-/// counts stanzas it actually receives, and a replay-exempt frame can
-/// never be re-delivered by resume — so an exempt frame that never
-/// reached the wire must NOT advance `outbound_count`. Otherwise the
-/// server's counter permanently outruns the client's `h`: the newest
-/// queue entries become un-ackable and every subsequent resume
-/// replays stanzas the client already has.
-#[tokio::test]
-async fn unwritten_exempt_frames_in_a_dead_batch_tail_are_not_counted() {
-    let state = create_test_websocket_state().await;
-    let mut conn = WsConnState::new();
-    conn.sm_state = StreamManagementState::with_config(100, 5);
-    conn.sm_state.enable("tail".to_string(), true, Some(300));
-
-    // Frames 1..=5 live (trigger the first <r/> + drain), 6..=12 MAM
-    // results. The drain after frame 5 sees a Close: the tail (6..12)
-    // is never written.
-    let mut frames: Vec<String> = (1..=5).map(countable_message).collect();
-    frames.extend((6..=12).map(mam_result_frame));
-
-    let mut sink = CollectSink::default();
-    let mut reader = ScriptedReader::new(vec![Some(Message::Close(None))]);
-    let outcome = write_response_batch(
-        &mut sink,
-        &mut reader,
-        state.as_ref(),
-        &mut conn,
-        frames,
-        BatchSmPolicy::RecordWithMamExemption,
-    )
-    .await;
-
-    assert!(matches!(outcome, BatchWriteOutcome::TransportClosed));
-    assert_eq!(
-        conn.sm_state.outbound_count, 5,
-        "unwritten exempt tail frames must not advance the wire counter"
-    );
-    assert_eq!(
-        conn.sm_state.queue_len(),
-        5,
-        "only the written live frames queue"
-    );
-}
-
-/// The MAM exemption is origin-gated: the structural shape is
-/// spoofable, so peer-relayed content (RecordAll policy) must record
-/// a MAM-shaped message into the replay window like any other stanza
-/// — otherwise a sender could craft `<message><result
-/// xmlns='urn:xmpp:mam:2'/>…` to opt its messages out of the
-/// reliability layer and have them silently dropped on resume.
-#[tokio::test]
-async fn peer_path_records_mam_shaped_frames_into_replay_window() {
-    let state = create_test_websocket_state().await;
-    let mut conn = WsConnState::new();
-    conn.sm_state = StreamManagementState::with_config(100, 5);
-    conn.sm_state.enable("spoof".to_string(), true, Some(300));
-
-    let spoofed = "<message xmlns='jabber:client' to='victim@example.com/r'>\
-                     <body>hi</body>\
-                     <result xmlns='urn:xmpp:mam:2' queryid='x' id='1'/>\
-                   </message>";
-
-    let mut sink = CollectSink::default();
-    let mut reader = ScriptedReader::new(vec![]);
-    let outcome = write_response_batch(
-        &mut sink,
-        &mut reader,
-        state.as_ref(),
-        &mut conn,
-        vec![spoofed.to_string()],
-        BatchSmPolicy::RecordAll,
-    )
-    .await;
-
-    assert!(matches!(outcome, BatchWriteOutcome::Continue));
-    assert_eq!(
-        conn.sm_state.queue_len(),
-        1,
-        "spoof-shaped frame stays replayable"
-    );
-    assert_eq!(
-        conn.sm_state.get_stanzas_to_resend(0),
-        vec![spoofed.to_string()]
-    );
-}
-
 /// The drain parks non-ack frames in `deferred_inbound` — but only up
 /// to a cap, past which it stops reading so a flooding client hits
 /// TCP backpressure instead of growing server heap without bound.
@@ -545,7 +411,7 @@ async fn drain_stops_parking_deferred_frames_at_the_cap() {
         state.as_ref(),
         &mut conn,
         frames,
-        BatchSmPolicy::RecordWithMamExemption,
+        BatchSmPolicy::Record,
     )
     .await;
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -100,55 +100,6 @@ fn is_countable_stanza_matches_element_name_not_prefix() {
     assert!(!is_countable_stanza(""));
 }
 
-/// The MAM `<fin/>` IQ must be replay-exempt alongside the results it
-/// closes: replaying a `<fin complete='true'/>` after a resume that
-/// did NOT replay the (exempt) results would tell the client the page
-/// arrived in full and stop it from re-querying — a permanent archive
-/// hole. Exempting the fin leaves the query visibly unanswered on the
-/// resumed stream, so the client re-runs it.
-#[test]
-fn is_mam_response_frame_covers_result_carriers_and_fin_iq() {
-    use super::super::stream_management::is_mam_response_frame;
-
-    // Result carrier message qualifies.
-    assert!(is_mam_response_frame(
-        "<message xmlns='jabber:client' to='u@example.com/r'>\
-           <result xmlns='urn:xmpp:mam:2' queryid='q1' id='42'>\
-             <forwarded xmlns='urn:xmpp:forward:0'/>\
-           </result>\
-         </message>"
-    ));
-    // A live message that merely mentions the namespace in a body is
-    // NOT a MAM result — detection must be structural, not substring.
-    assert!(!is_mam_response_frame(
-        "<message xmlns='jabber:client'><body>urn:xmpp:mam:2 &lt;result</body></message>"
-    ));
-    // A result child in the wrong namespace does not qualify.
-    assert!(!is_mam_response_frame(
-        "<message xmlns='jabber:client'><result xmlns='urn:example:0' id='1'/></message>"
-    ));
-    // The closing fin IQ qualifies.
-    assert!(is_mam_response_frame(
-        "<iq xmlns='jabber:client' type='result' id='q1'>\
-           <fin xmlns='urn:xmpp:mam:2' complete='true'/>\
-         </iq>"
-    ));
-    // A fin in the wrong namespace does not.
-    assert!(!is_mam_response_frame(
-        "<iq xmlns='jabber:client' type='result' id='q1'>\
-           <fin xmlns='urn:example:0'/>\
-         </iq>"
-    ));
-    // Ordinary IQ results and live messages do not.
-    assert!(!is_mam_response_frame(
-        "<iq xmlns='jabber:client' type='result' id='p1'/>"
-    ));
-    assert!(!is_mam_response_frame(
-        "<message xmlns='jabber:client'><body>hi</body></message>"
-    ));
-    assert!(!is_mam_response_frame("not-xml"));
-}
-
 #[tokio::test]
 async fn handle_xmpp_frame_drops_oversized_sm_nonza_before_parse() {
     let state = create_test_websocket_state().await;

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -100,6 +100,44 @@ fn is_countable_stanza_matches_element_name_not_prefix() {
     assert!(!is_countable_stanza(""));
 }
 
+/// XEP-0313 MAM `<result/>` messages count toward the XEP-0198 wire
+/// counter but must never enter the replay window (issue #1089):
+/// replaying archive results after a resume duplicates data the
+/// client already has, and a large history sync would otherwise pin
+/// the unacked queue at capacity and evict live stanzas.
+#[test]
+fn is_mam_result_message_detects_only_mam_result_carriers() {
+    use super::super::stream_management::is_mam_result_message;
+
+    // A serialized MAM result carrier message.
+    assert!(is_mam_result_message(
+        "<message xmlns='jabber:client' to='u@example.com/r'>\
+           <result xmlns='urn:xmpp:mam:2' queryid='q1' id='42'>\
+             <forwarded xmlns='urn:xmpp:forward:0'/>\
+           </result>\
+         </message>"
+    ));
+
+    // A live message that merely mentions the namespace in a body is
+    // NOT a MAM result — detection must be structural, not substring.
+    assert!(!is_mam_result_message(
+        "<message xmlns='jabber:client'><body>urn:xmpp:mam:2 &lt;result</body></message>"
+    ));
+    // A result child in the wrong namespace does not qualify.
+    assert!(!is_mam_result_message(
+        "<message xmlns='jabber:client'><result xmlns='urn:example:0' id='1'/></message>"
+    ));
+    // Non-message stanzas never qualify, even with a MAM child.
+    assert!(!is_mam_result_message(
+        "<iq xmlns='jabber:client' type='result' id='q1'>\
+           <fin xmlns='urn:xmpp:mam:2'/>\
+         </iq>"
+    ));
+    // Malformed XML must not panic or match.
+    assert!(!is_mam_result_message("not-xml"));
+    assert!(!is_mam_result_message(""));
+}
+
 #[tokio::test]
 async fn handle_xmpp_frame_drops_oversized_sm_nonza_before_parse() {
     let state = create_test_websocket_state().await;

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -100,42 +100,53 @@ fn is_countable_stanza_matches_element_name_not_prefix() {
     assert!(!is_countable_stanza(""));
 }
 
-/// XEP-0313 MAM `<result/>` messages count toward the XEP-0198 wire
-/// counter but must never enter the replay window (issue #1089):
-/// replaying archive results after a resume duplicates data the
-/// client already has, and a large history sync would otherwise pin
-/// the unacked queue at capacity and evict live stanzas.
+/// The MAM `<fin/>` IQ must be replay-exempt alongside the results it
+/// closes: replaying a `<fin complete='true'/>` after a resume that
+/// did NOT replay the (exempt) results would tell the client the page
+/// arrived in full and stop it from re-querying — a permanent archive
+/// hole. Exempting the fin leaves the query visibly unanswered on the
+/// resumed stream, so the client re-runs it.
 #[test]
-fn is_mam_result_message_detects_only_mam_result_carriers() {
-    use super::super::stream_management::is_mam_result_message;
+fn is_mam_response_frame_covers_result_carriers_and_fin_iq() {
+    use super::super::stream_management::is_mam_response_frame;
 
-    // A serialized MAM result carrier message.
-    assert!(is_mam_result_message(
+    // Result carrier message qualifies.
+    assert!(is_mam_response_frame(
         "<message xmlns='jabber:client' to='u@example.com/r'>\
            <result xmlns='urn:xmpp:mam:2' queryid='q1' id='42'>\
              <forwarded xmlns='urn:xmpp:forward:0'/>\
            </result>\
          </message>"
     ));
-
     // A live message that merely mentions the namespace in a body is
     // NOT a MAM result — detection must be structural, not substring.
-    assert!(!is_mam_result_message(
+    assert!(!is_mam_response_frame(
         "<message xmlns='jabber:client'><body>urn:xmpp:mam:2 &lt;result</body></message>"
     ));
     // A result child in the wrong namespace does not qualify.
-    assert!(!is_mam_result_message(
+    assert!(!is_mam_response_frame(
         "<message xmlns='jabber:client'><result xmlns='urn:example:0' id='1'/></message>"
     ));
-    // Non-message stanzas never qualify, even with a MAM child.
-    assert!(!is_mam_result_message(
+    // The closing fin IQ qualifies.
+    assert!(is_mam_response_frame(
         "<iq xmlns='jabber:client' type='result' id='q1'>\
-           <fin xmlns='urn:xmpp:mam:2'/>\
+           <fin xmlns='urn:xmpp:mam:2' complete='true'/>\
          </iq>"
     ));
-    // Malformed XML must not panic or match.
-    assert!(!is_mam_result_message("not-xml"));
-    assert!(!is_mam_result_message(""));
+    // A fin in the wrong namespace does not.
+    assert!(!is_mam_response_frame(
+        "<iq xmlns='jabber:client' type='result' id='q1'>\
+           <fin xmlns='urn:example:0'/>\
+         </iq>"
+    ));
+    // Ordinary IQ results and live messages do not.
+    assert!(!is_mam_response_frame(
+        "<iq xmlns='jabber:client' type='result' id='p1'/>"
+    ));
+    assert!(!is_mam_response_frame(
+        "<message xmlns='jabber:client'><body>hi</body></message>"
+    ));
+    assert!(!is_mam_response_frame("not-xml"));
 }
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp/src/stream_management/state.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/state.rs
@@ -193,22 +193,6 @@ impl StreamManagementState {
         self.ack_request_cadence()
     }
 
-    /// Record an outbound stanza that counts toward the XEP-0198 wire
-    /// counter but is exempt from the replay window.
-    ///
-    /// Used for XEP-0313 MAM `<result/>` messages (issue #1089): the
-    /// client's `h` includes them, so `outbound_count` must advance in
-    /// lockstep — but replaying archive results after a resume would
-    /// duplicate data the client already holds, and during a large
-    /// history sync they are what pins the unacked queue at capacity
-    /// and drives the eviction storm that permanently breaks resume.
-    /// Skipping the queue means a resume simply never replays them;
-    /// `get_unacked_after` returns only the stored sequences.
-    pub fn record_outbound_replay_exempt(&mut self) -> RecordOutboundResult {
-        self.outbound_count = self.outbound_count.wrapping_add(1);
-        self.ack_request_cadence()
-    }
-
     /// Cadence: once `ack_threshold` stanzas have flowed since the
     /// last `<r/>` (or the stream was enabled / resumed), tell the
     /// caller to follow this stanza with an `<r/>`. The wasm
@@ -576,48 +560,6 @@ mod tests {
         assert!(!state.record_outbound("<m id='5'/>".to_string()).request_ack);
         // Push 6 — three more since the last request, next request fires.
         assert!(state.record_outbound("<m id='6'/>".to_string()).request_ack);
-    }
-
-    /// XEP-0313 §6 MAM result messages are countable stanzas on the
-    /// wire (the client's `h` includes them), but replaying them after
-    /// a XEP-0198 resume would duplicate archive results the client
-    /// already received — and during a large history sync they are
-    /// exactly what floods the unacked queue into its eviction storm
-    /// (issue #1089). The replay-exempt record keeps the outbound
-    /// counter and `<r/>` cadence in agreement with the client while
-    /// keeping the stanza out of the replay window.
-    #[test]
-    fn record_outbound_replay_exempt_counts_but_never_enters_replay_window() {
-        let mut state = StreamManagementState::with_config(1000, 3);
-        state.enable("mam-exempt".to_string(), true, Some(300));
-
-        // Two queued stanzas, then one replay-exempt (MAM result).
-        assert!(!state.record_outbound("<m id='1'/>".to_string()).request_ack);
-        assert!(!state.record_outbound("<m id='2'/>".to_string()).request_ack);
-        // Exempt stanza still advances the wire counter — and, being
-        // the third countable stanza since enable, trips the cadence.
-        assert!(state.record_outbound_replay_exempt().request_ack);
-
-        assert_eq!(state.outbound_count, 3, "exempt stanza must count toward h");
-        assert_eq!(
-            state.queue_len(),
-            2,
-            "exempt stanza must not enter the unacked replay queue"
-        );
-        // Replay after client h=0 must contain only the queued pair.
-        let resend = state.get_stanzas_to_resend(0);
-        assert_eq!(resend, vec!["<m id='1'/>", "<m id='2'/>"]);
-        // No eviction/gap bookkeeping was touched.
-        assert_eq!(state.replay_gap_through(), None);
-        assert!(state.can_resume_from(0));
-    }
-
-    #[test]
-    fn record_outbound_replay_exempt_does_not_request_ack_when_sm_disabled() {
-        let mut state = StreamManagementState::with_config(1000, 1);
-        // NOTE: `enable` deliberately NOT called.
-        assert!(!state.record_outbound_replay_exempt().request_ack);
-        assert_eq!(state.queue_len(), 0);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/stream_management/state.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/state.rs
@@ -190,13 +190,33 @@ impl StreamManagementState {
                 );
             }
         }
-        // Cadence: once `ack_threshold` stanzas have flowed since the
-        // last `<r/>` (or the stream was enabled / resumed), tell the
-        // caller to follow this stanza with an `<r/>`. The wasm
-        // client only sends `<a h='N'/>` in response to an explicit
-        // request, so without this signal the unacked queue grows
-        // unbounded and eventually starts evicting — breaking SM
-        // resume forever for that stream.
+        self.ack_request_cadence()
+    }
+
+    /// Record an outbound stanza that counts toward the XEP-0198 wire
+    /// counter but is exempt from the replay window.
+    ///
+    /// Used for XEP-0313 MAM `<result/>` messages (issue #1089): the
+    /// client's `h` includes them, so `outbound_count` must advance in
+    /// lockstep — but replaying archive results after a resume would
+    /// duplicate data the client already holds, and during a large
+    /// history sync they are what pins the unacked queue at capacity
+    /// and drives the eviction storm that permanently breaks resume.
+    /// Skipping the queue means a resume simply never replays them;
+    /// `get_unacked_after` returns only the stored sequences.
+    pub fn record_outbound_replay_exempt(&mut self) -> RecordOutboundResult {
+        self.outbound_count = self.outbound_count.wrapping_add(1);
+        self.ack_request_cadence()
+    }
+
+    /// Cadence: once `ack_threshold` stanzas have flowed since the
+    /// last `<r/>` (or the stream was enabled / resumed), tell the
+    /// caller to follow this stanza with an `<r/>`. The wasm
+    /// client only sends `<a h='N'/>` in response to an explicit
+    /// request, so without this signal the unacked queue grows
+    /// unbounded and eventually starts evicting — breaking SM
+    /// resume forever for that stream.
+    fn ack_request_cadence(&mut self) -> RecordOutboundResult {
         let request_ack = self.enabled
             && self
                 .outbound_count
@@ -556,6 +576,48 @@ mod tests {
         assert!(!state.record_outbound("<m id='5'/>".to_string()).request_ack);
         // Push 6 — three more since the last request, next request fires.
         assert!(state.record_outbound("<m id='6'/>".to_string()).request_ack);
+    }
+
+    /// XEP-0313 §6 MAM result messages are countable stanzas on the
+    /// wire (the client's `h` includes them), but replaying them after
+    /// a XEP-0198 resume would duplicate archive results the client
+    /// already received — and during a large history sync they are
+    /// exactly what floods the unacked queue into its eviction storm
+    /// (issue #1089). The replay-exempt record keeps the outbound
+    /// counter and `<r/>` cadence in agreement with the client while
+    /// keeping the stanza out of the replay window.
+    #[test]
+    fn record_outbound_replay_exempt_counts_but_never_enters_replay_window() {
+        let mut state = StreamManagementState::with_config(1000, 3);
+        state.enable("mam-exempt".to_string(), true, Some(300));
+
+        // Two queued stanzas, then one replay-exempt (MAM result).
+        assert!(!state.record_outbound("<m id='1'/>".to_string()).request_ack);
+        assert!(!state.record_outbound("<m id='2'/>".to_string()).request_ack);
+        // Exempt stanza still advances the wire counter — and, being
+        // the third countable stanza since enable, trips the cadence.
+        assert!(state.record_outbound_replay_exempt().request_ack);
+
+        assert_eq!(state.outbound_count, 3, "exempt stanza must count toward h");
+        assert_eq!(
+            state.queue_len(),
+            2,
+            "exempt stanza must not enter the unacked replay queue"
+        );
+        // Replay after client h=0 must contain only the queued pair.
+        let resend = state.get_stanzas_to_resend(0);
+        assert_eq!(resend, vec!["<m id='1'/>", "<m id='2'/>"]);
+        // No eviction/gap bookkeeping was touched.
+        assert_eq!(state.replay_gap_through(), None);
+        assert!(state.can_resume_from(0));
+    }
+
+    #[test]
+    fn record_outbound_replay_exempt_does_not_request_ack_when_sm_disabled() {
+        let mut state = StreamManagementState::with_config(1000, 1);
+        // NOTE: `enable` deliberately NOT called.
+        assert!(!state.record_outbound_replay_exempt().request_ack);
+        assert_eq!(state.queue_len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1089.

## Problem

The XEP-0198 unacked queue flooded before anything hit the socket: every countable frame in an outbound batch was recorded into the 1000-cap queue up front, one coalesced `<r/>` was emitted after the whole batch, and inbound `<a/>` acks could not drain mid-batch. A large fan-out or MAM history sync pinned the queue at capacity and evicted one stanza per subsequent send, permanently breaking `<resume/>` for the stream (~39k evictions, ~18/s bursts at `queue_len=1000` observed in production).

## What changed

**`batch_write.rs` (new)** — chunked XEP-0198-aware batch writer, now used by the main-loop response path (`connection.rs`) and the PeerStanza recipient-pass path (`outbound.rs`):

- Records each countable stanza just before its own write and emits `<r/>` after every `ack_threshold`th countable stanza (XEP-0198 §4 allows requesting acks at any time) — instead of one coalesced `<r/>` per arbitrarily-large batch.
- After each `<r/>`, non-blockingly drains already-buffered inbound frames: `<a/>` acks are applied immediately via the shared `apply_sm_ack` (same Q7b `pending_delivery` range-delete lifecycle as the frame handler), so the queue shrinks mid-flood; all other frames are parked in `conn.deferred_inbound` in arrival order.
- If the transport dies mid-batch, the unwritten tail is still recorded so the resume replay window covers the whole batch.
- `BatchSmPolicy::ReplaySuppressed` carries the old `suppress_sm_record_next_batch` semantics for resume replay batches.

**`connection.rs`** — the Text select-arm is extracted into `handle_inbound_text`, and deferred frames are processed by a dedicated select arm (socket arm gated on the queue being empty) so ordering is preserved without starving the outbound channel or the RFC 7395 keepalive timers. On transport loss, leftover deferred frames still get their inbound side effects (peer routing, `inbound_count`); responses that can no longer be written are recorded for resume replay.

**Flood safety** — `deferred_inbound` is capped (64): at the cap the drain stops reading and TCP backpressure throttles the client. At the cap, behavior degrades exactly to pre-#1089 semantics (queue may evict, replay gap marked, resume correctly rejected), affecting only the flooding client's own stream.

## Deliberate deviation from the issue: no MAM replay exemption

The issue asked to exempt XEP-0313 MAM result messages from the replay window. Three adversarial review rounds proved every variant of that exemption unsound: XEP-0198's `h` counts stanzas the client actually received, and a frame that is counted but can never be re-delivered by resume replay permanently desyncs `outbound_count` from `h` the moment it is lost in flight (written ≠ received) — leaving an un-ackable queue tail, duplicate replays on every subsequent resume, and lagging `pending_delivery` range-deletes. A sound variant would require renumbering counters/queue/pending-row sequence bindings at resume time.

Instead, MAM results are recorded like any other stanza. This is protocol-harmless — XEP-0313 §6.1 requires clients to ignore results they did not request — and the eviction storm itself is fully solved by chunking + mid-batch ack draining (regression test pins evictions at zero under a 50-stanza flood through a 10-cap queue). This also avoids a spoofable structural MAM classifier (a relayed message forging a `{urn:xmpp:mam:2}result` child must not be able to opt itself out of the reliability layer) and a false-`<fin complete='true'/>` archive hole on resume.

## Acceptance criteria

- [x] Inbound `<a/>` acks are processed between chunks of a large outbound batch (`write_response_batch_drains_acks_between_chunks_so_nothing_evicts` — scripted reader releases one ack per drain window, so it only passes if draining happens after every `<r/>`)
- [x] `<r/>` requested at most every `ack_threshold` countable stanzas, not once per batch (`write_response_batch_requests_ack_every_threshold_not_once_per_batch`)
- [x] A non-acking or stalled client can no longer drive unbounded eviction: healthy clients' acks now land mid-flood; genuinely dead peers are killed by the 60s send-stall budget and the RFC 7395 keepalive policy; a reading-but-never-acking client damages only its own stream's replay window (pre-existing capped-queue semantics, surfaced by `waddle_sm_unacked_evicted_total` and a rejected resume rather than silent loss)
- [x] `waddle_sm_unacked_evicted_total` stays flat under a large fan-out to a healthy client (same regression test, metric delta asserted = 0)
- [x] MAM result messages are not double-counted into the replay window — each is counted exactly once and replay preserves counter agreement (`mam_results_are_recorded_like_any_stanza_for_counter_convergence`); the "exempt from replay" reading of this criterion was rejected as protocol-unsound (see above)

## Review

Three adversarial reviewer passes (XEP-0198/0313 conformance, async/concurrency, behavior-regression vs main) ran over three rounds; all findings were fixed or led to the exemption removal above. Final round returned no real issues.

Post-review follow-ups (`76d4857b`):

- Writer tests now build every stanza via `minidom::Element` builders serialized with `element_to_xml` — no `format!`-constructed XML.
- `is_countable_stanza` parses the frame into a `minidom::Element` and classifies on the resolved element name (typed XML decision at the serialization boundary) instead of string prefix sniffing; behavior pinned by the existing classifier test.
- The mid-batch drain drops frames larger than `MAX_FRAME_SIZE` immediately instead of retaining up to 64 near-1MiB payloads in `deferred_inbound` (the dispatcher backstop would discard them anyway); pinned by a dedicated test.
- `process_deferred_inbound_after_transport_loss` is skipped when the session was superseded by a replacement — the registry slot, MUC occupancy, and SM continuity belong to the newcomer, mirroring the cleanup short-circuit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
