### PR TITLE
fix(server): graceful shutdown closes live sessions via <stream:error><system-shutdown/> (#1091)

### DIFF
--- a/server/crates/waddle-ecdysis/src/lib.rs
+++ b/server/crates/waddle-ecdysis/src/lib.rs
@@ -35,4 +35,4 @@ mod shutdown;
 
 pub use listener::ListenerSet;
 pub use restart::{restart, RestartError};
-pub use shutdown::{ConnectionGuard, GracefulShutdown, ShutdownSignal};
+pub use shutdown::{ConnectionGuard, GracefulShutdown, ShutdownHandle, ShutdownSignal};

--- a/server/crates/waddle-ecdysis/src/shutdown.rs
+++ b/server/crates/waddle-ecdysis/src/shutdown.rs
@@ -94,21 +94,40 @@ impl ShutdownHandle {
     ///
     /// Returns `true` if all connections drained, `false` on timeout.
     pub async fn wait_for_connections_drained(&self) -> bool {
+        self.wait_for_connections_drained_for(self.drain_timeout)
+            .await
+    }
+
+    /// Like [`Self::wait_for_connections_drained`], but bounded by an
+    /// explicit `timeout` so callers sharing one overall drain budget
+    /// (e.g. connection drain + Q6 promotion inside a single pod
+    /// termination grace period) can pass the remaining slice.
+    pub async fn wait_for_connections_drained_for(&self, timeout: Duration) -> bool {
         if self.active_connections() == 0 {
             return true;
         }
         tokio::select! {
             _ = self.wait_for_drain() => true,
-            _ = tokio::time::sleep(self.drain_timeout) => false,
+            _ = tokio::time::sleep(timeout) => false,
         }
     }
 
     async fn wait_for_drain(&self) {
         loop {
+            // Register interest BEFORE checking the counter:
+            // `notify_waiters()` (fired by the last guard's drop) wakes
+            // only already-registered waiters and stores no permit, so
+            // check-then-register would lose a wakeup that lands
+            // between the load and the first poll of `notified()` —
+            // stalling the drain until the timeout despite zero
+            // connections remaining.
+            let notified = self.drain_notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
             if self.connection_count.load(Ordering::SeqCst) == 0 {
                 return;
             }
-            self.drain_notify.notified().await;
+            notified.await;
         }
     }
 }
@@ -150,13 +169,6 @@ impl GracefulShutdown {
     /// Get a `CancellationToken` that fires when the accept loop should stop.
     pub fn stop_token(&self) -> CancellationToken {
         self.handle.stop_token()
-    }
-
-    /// Create a `ConnectionGuard` for a new connection.
-    ///
-    /// Increments the counter on creation, decrements on drop.
-    pub fn connection_guard(&self) -> ConnectionGuard {
-        self.handle.connection_guard()
     }
 
     /// Get the current number of active connections.
@@ -210,7 +222,7 @@ impl GracefulShutdown {
             warn!(
                 remaining_connections = self.active_connections(),
                 timeout_secs = self.handle.drain_timeout.as_secs(),
-                "Drain timeout expired, force-exiting"
+                "Drain timeout expired with connections still active"
             );
         }
         drained
@@ -245,7 +257,7 @@ impl GracefulShutdown {
         if !clean {
             error!(
                 remaining_connections = self.active_connections(),
-                "Force-exiting with remaining connections"
+                "Drain phase ended with connections still active"
             );
         }
 
@@ -262,8 +274,8 @@ mod tests {
         let shutdown = GracefulShutdown::new(Duration::from_secs(5));
         let stop_token = shutdown.stop_token();
 
-        let guard1 = shutdown.connection_guard();
-        let guard2 = shutdown.connection_guard();
+        let guard1 = shutdown.handle().connection_guard();
+        let guard2 = shutdown.handle().connection_guard();
         assert_eq!(shutdown.active_connections(), 2);
 
         shutdown.trigger_stop();
@@ -283,7 +295,7 @@ mod tests {
     async fn test_drain_timeout() {
         let shutdown = GracefulShutdown::new(Duration::from_millis(100));
 
-        let _guard = shutdown.connection_guard();
+        let _guard = shutdown.handle().connection_guard();
         assert_eq!(shutdown.active_connections(), 1);
 
         shutdown.trigger_stop();
@@ -299,7 +311,9 @@ mod tests {
 
         assert_eq!(shutdown.active_connections(), 0);
 
-        let mut guards: Vec<_> = (0..10).map(|_| shutdown.connection_guard()).collect();
+        let mut guards: Vec<_> = (0..10)
+            .map(|_| shutdown.handle().connection_guard())
+            .collect();
         assert_eq!(shutdown.active_connections(), 10);
 
         guards.truncate(5);

--- a/server/crates/waddle-ecdysis/src/shutdown.rs
+++ b/server/crates/waddle-ecdysis/src/shutdown.rs
@@ -45,8 +45,13 @@ impl Drop for DropNotifier {
     }
 }
 
-/// Coordinator for graceful shutdown with connection draining.
-pub struct GracefulShutdown {
+/// Cheap-clone view of the shutdown coordinator's connection-tracking
+/// state. Threaded into accept paths (to mint [`ConnectionGuard`]s and
+/// observe the stop token) and drain tasks (to wait for live
+/// connections to finish) without moving the [`GracefulShutdown`]
+/// coordinator itself.
+#[derive(Clone)]
+pub struct ShutdownHandle {
     /// Token cancelled when the server should stop accepting new connections.
     stop_accepting: CancellationToken,
 
@@ -60,27 +65,7 @@ pub struct GracefulShutdown {
     drain_timeout: Duration,
 }
 
-impl GracefulShutdown {
-    /// Create a new shutdown coordinator.
-    pub fn new(drain_timeout: Duration) -> Self {
-        Self {
-            stop_accepting: CancellationToken::new(),
-            connection_count: Arc::new(AtomicUsize::new(0)),
-            drain_notify: Arc::new(tokio::sync::Notify::new()),
-            drain_timeout,
-        }
-    }
-
-    /// Create with drain timeout from `WADDLE_DRAIN_TIMEOUT_SECS` env or default (30s).
-    pub fn from_env() -> Self {
-        let timeout_secs: u64 = std::env::var("WADDLE_DRAIN_TIMEOUT_SECS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(30);
-
-        Self::new(Duration::from_secs(timeout_secs))
-    }
-
+impl ShutdownHandle {
     /// Get a `CancellationToken` that fires when the accept loop should stop.
     pub fn stop_token(&self) -> CancellationToken {
         self.stop_accepting.clone()
@@ -104,6 +89,81 @@ impl GracefulShutdown {
         self.connection_count.load(Ordering::SeqCst)
     }
 
+    /// Wait until every [`ConnectionGuard`] has dropped, bounded by the
+    /// drain timeout.
+    ///
+    /// Returns `true` if all connections drained, `false` on timeout.
+    pub async fn wait_for_connections_drained(&self) -> bool {
+        if self.active_connections() == 0 {
+            return true;
+        }
+        tokio::select! {
+            _ = self.wait_for_drain() => true,
+            _ = tokio::time::sleep(self.drain_timeout) => false,
+        }
+    }
+
+    async fn wait_for_drain(&self) {
+        loop {
+            if self.connection_count.load(Ordering::SeqCst) == 0 {
+                return;
+            }
+            self.drain_notify.notified().await;
+        }
+    }
+}
+
+/// Coordinator for graceful shutdown with connection draining.
+pub struct GracefulShutdown {
+    handle: ShutdownHandle,
+}
+
+impl GracefulShutdown {
+    /// Create a new shutdown coordinator.
+    pub fn new(drain_timeout: Duration) -> Self {
+        Self {
+            handle: ShutdownHandle {
+                stop_accepting: CancellationToken::new(),
+                connection_count: Arc::new(AtomicUsize::new(0)),
+                drain_notify: Arc::new(tokio::sync::Notify::new()),
+                drain_timeout,
+            },
+        }
+    }
+
+    /// Get a cheap-clone [`ShutdownHandle`] sharing this coordinator's
+    /// stop token and connection-tracking state.
+    pub fn handle(&self) -> ShutdownHandle {
+        self.handle.clone()
+    }
+
+    /// Create with drain timeout from `WADDLE_DRAIN_TIMEOUT_SECS` env or default (30s).
+    pub fn from_env() -> Self {
+        let timeout_secs: u64 = std::env::var("WADDLE_DRAIN_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30);
+
+        Self::new(Duration::from_secs(timeout_secs))
+    }
+
+    /// Get a `CancellationToken` that fires when the accept loop should stop.
+    pub fn stop_token(&self) -> CancellationToken {
+        self.handle.stop_token()
+    }
+
+    /// Create a `ConnectionGuard` for a new connection.
+    ///
+    /// Increments the counter on creation, decrements on drop.
+    pub fn connection_guard(&self) -> ConnectionGuard {
+        self.handle.connection_guard()
+    }
+
+    /// Get the current number of active connections.
+    pub fn active_connections(&self) -> usize {
+        self.handle.active_connections()
+    }
+
     /// Wait for a shutdown signal (SIGTERM or SIGQUIT).
     pub async fn wait_for_signal(&self) -> ShutdownSignal {
         let mut sigterm =
@@ -124,7 +184,7 @@ impl GracefulShutdown {
 
     /// Trigger the stop-accepting phase programmatically (for testing).
     pub fn trigger_stop(&self) {
-        self.stop_accepting.cancel();
+        self.handle.stop_accepting.cancel();
     }
 
     /// Run the drain phase: wait for all connections to complete or timeout.
@@ -139,34 +199,21 @@ impl GracefulShutdown {
 
         info!(
             active_connections = active,
-            timeout_secs = self.drain_timeout.as_secs(),
+            timeout_secs = self.handle.drain_timeout.as_secs(),
             "Draining active connections"
         );
 
-        tokio::select! {
-            _ = self.wait_for_drain() => {
-                info!("All connections drained cleanly");
-                true
-            }
-            _ = tokio::time::sleep(self.drain_timeout) => {
-                let remaining = self.active_connections();
-                warn!(
-                    remaining_connections = remaining,
-                    timeout_secs = self.drain_timeout.as_secs(),
-                    "Drain timeout expired, force-exiting"
-                );
-                false
-            }
+        let drained = self.handle.wait_for_connections_drained().await;
+        if drained {
+            info!("All connections drained cleanly");
+        } else {
+            warn!(
+                remaining_connections = self.active_connections(),
+                timeout_secs = self.handle.drain_timeout.as_secs(),
+                "Drain timeout expired, force-exiting"
+            );
         }
-    }
-
-    async fn wait_for_drain(&self) {
-        loop {
-            if self.connection_count.load(Ordering::SeqCst) == 0 {
-                return;
-            }
-            self.drain_notify.notified().await;
-        }
+        drained
     }
 
     /// Run the full shutdown lifecycle.
@@ -192,7 +239,7 @@ impl GracefulShutdown {
         }
 
         info!("Stopping accept loops");
-        self.stop_accepting.cancel();
+        self.handle.stop_accepting.cancel();
 
         let clean = self.drain().await;
         if !clean {
@@ -262,10 +309,43 @@ mod tests {
         assert_eq!(shutdown.active_connections(), 0);
     }
 
+    #[tokio::test]
+    async fn handle_mints_guards_that_count_and_drain() {
+        let shutdown = GracefulShutdown::new(Duration::from_secs(5));
+        let handle = shutdown.handle();
+
+        let guard = handle.connection_guard();
+        assert_eq!(shutdown.active_connections(), 1);
+        assert_eq!(handle.active_connections(), 1);
+
+        shutdown.trigger_stop();
+        assert!(handle.stop_token().is_cancelled());
+
+        let waiter = tokio::spawn({
+            let handle = handle.clone();
+            async move { handle.wait_for_connections_drained().await }
+        });
+        drop(guard);
+        let drained = waiter.await.expect("drain waiter task");
+        assert!(drained);
+        assert_eq!(shutdown.active_connections(), 0);
+    }
+
+    #[tokio::test]
+    async fn handle_wait_for_connections_drained_times_out() {
+        let shutdown = GracefulShutdown::new(Duration::from_millis(50));
+        let handle = shutdown.handle();
+        let _guard = handle.connection_guard();
+
+        let drained = handle.wait_for_connections_drained().await;
+        assert!(!drained);
+        assert_eq!(handle.active_connections(), 1);
+    }
+
     #[test]
     fn test_from_env_default() {
         std::env::remove_var("WADDLE_DRAIN_TIMEOUT_SECS");
         let shutdown = GracefulShutdown::from_env();
-        assert_eq!(shutdown.drain_timeout, Duration::from_secs(30));
+        assert_eq!(shutdown.handle.drain_timeout, Duration::from_secs(30));
     }
 }

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -46,7 +46,10 @@ pub(crate) struct HttpServerDeps {
     pub(crate) pubsub_database_storage: Arc<crate::pubsub::DatabasePubSubStorage>,
     pub(crate) acme_http01_challenge_service: Option<TowerHttp01ChallengeService>,
     pub(crate) listener: tokio::net::TcpListener,
-    pub(crate) stop_token: tokio_util::sync::CancellationToken,
+    /// Ecdysis shutdown view: carries the stop token that gates the
+    /// graceful_shutdown closure and mints per-connection guards in
+    /// the WebSocket accept path (issue #1091).
+    pub(crate) shutdown_handle: waddle_ecdysis::ShutdownHandle,
     /// Q6 graceful-shutdown drain completion signal — fired by the
     /// drain task when it finishes promoting unacked queues. The
     /// HTTP server's graceful_shutdown closure waits on this after
@@ -64,10 +67,11 @@ pub(crate) async fn start_http_server(deps: HttpServerDeps) -> Result<()> {
         pubsub_database_storage,
         acme_http01_challenge_service,
         listener,
-        stop_token,
+        shutdown_handle,
         drain_complete,
     } = deps;
 
+    let stop_token = shutdown_handle.stop_token();
     let app = create_router(RouterDeps {
         state,
         server_config,
@@ -75,7 +79,7 @@ pub(crate) async fn start_http_server(deps: HttpServerDeps) -> Result<()> {
         mam_storage,
         pubsub_database_storage,
         acme_http01_challenge_service,
-        shutdown_stop_token: stop_token.clone(),
+        shutdown_handle,
         drain_complete: drain_complete.clone(),
     })
     .await?;
@@ -126,7 +130,7 @@ pub(crate) struct RouterDeps {
     pub(crate) mam_storage: Arc<dyn MamStorage>,
     pub(crate) pubsub_database_storage: Arc<crate::pubsub::DatabasePubSubStorage>,
     pub(crate) acme_http01_challenge_service: Option<TowerHttp01ChallengeService>,
-    pub(crate) shutdown_stop_token: tokio_util::sync::CancellationToken,
+    pub(crate) shutdown_handle: waddle_ecdysis::ShutdownHandle,
     pub(crate) drain_complete: Arc<tokio::sync::Notify>,
 }
 
@@ -139,9 +143,10 @@ pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
         mam_storage,
         pubsub_database_storage,
         acme_http01_challenge_service,
-        shutdown_stop_token,
+        shutdown_handle,
         drain_complete,
     } = deps;
+    let shutdown_stop_token = shutdown_handle.stop_token();
     // Create auth broker state
     let auth_state = Arc::new(AuthState::new(
         state.clone(),
@@ -156,6 +161,7 @@ pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
         Arc::clone(&auth_state),
         mam_storage,
         pubsub_database_storage,
+        shutdown_handle,
     )
     .await?;
 
@@ -328,6 +334,7 @@ async fn create_websocket_state(
     auth_state: Arc<AuthState>,
     mam_storage: Arc<dyn MamStorage>,
     pubsub_database_storage: Arc<crate::pubsub::DatabasePubSubStorage>,
+    shutdown_handle: waddle_ecdysis::ShutdownHandle,
 ) -> Result<Arc<WebSocketState>> {
     // Create connection registry for WebSocket message routing
     let connection_registry = Arc::new(ConnectionRegistry::new());
@@ -611,6 +618,7 @@ async fn create_websocket_state(
             ws_keepalive: server_config.ws_keepalive,
             provider_ingress,
             provider_dispatch_tasks,
+            shutdown: shutdown_handle,
         },
     });
     deferred_extension_host_tools.set(Arc::new(extension_host_adapter::ExtensionHostAdapter::new(

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -204,7 +204,7 @@ pub async fn start_with_config(
     let http_mam_storage = websocket_mam_storage.clone();
     let http_server_config = server_config.clone();
     let http_xmpp_config = xmpp_config.clone();
-    let http_stop = stop_token.clone();
+    let http_shutdown_handle = shutdown.handle();
     let acme_http01_challenge_service = acme_runtime
         .as_ref()
         .map(|runtime| runtime.http01_challenge_service.clone());
@@ -224,7 +224,7 @@ pub async fn start_with_config(
             pubsub_database_storage: http_pubsub_database_storage,
             acme_http01_challenge_service,
             listener: http_listener,
-            stop_token: http_stop,
+            shutdown_handle: http_shutdown_handle,
             drain_complete: http_drain_complete,
         })
         .await

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -57,6 +57,14 @@ async fn xmpp_websocket_handler(
 /// Size of the outbound message channel buffer
 const OUTBOUND_CHANNEL_SIZE: usize = 256;
 
+/// Budget for writing the system-shutdown stream error + close frames
+/// to one peer during graceful shutdown (issue #1091). Deliberately
+/// much shorter than the generic 60s `SEND_STALL_TIMEOUT`: a peer that
+/// has stopped reading must not hold its connection guard past the
+/// drain window — the notification is best-effort, while the SM detach
+/// that follows the break is what actually preserves the session.
+const SHUTDOWN_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 /// Handle an XMPP WebSocket connection
 async fn handle_xmpp_websocket(
     socket: WebSocket,
@@ -246,22 +254,35 @@ async fn handle_xmpp_websocket(
                     jid = ?conn.phase.bound_jid(),
                     "Graceful shutdown: closing live session with system-shutdown stream error"
                 );
-                if conn.stream_open_sent {
-                    let _ = send_ws_text_frames(
+                let close_peer = async {
+                    if conn.stream_open_sent {
+                        let _ = send_ws_text_frames(
+                            &mut ws_sender,
+                            [
+                                build_system_shutdown_stream_error(),
+                                websocket_stream_close_xml(),
+                            ],
+                            "Failed to send system-shutdown stream error",
+                        )
+                        .await;
+                    }
+                    let _ = close_ws_connection(
                         &mut ws_sender,
-                        [
-                            build_system_shutdown_stream_error(),
-                            websocket_stream_close_xml(),
-                        ],
-                        "Failed to send system-shutdown stream error",
+                        "Failed to send WebSocket close frame after system-shutdown",
                     )
                     .await;
+                };
+                if tokio::time::timeout(SHUTDOWN_CLOSE_TIMEOUT, close_peer)
+                    .await
+                    .is_err()
+                {
+                    warn!(
+                        jid = ?conn.phase.bound_jid(),
+                        timeout_secs = SHUTDOWN_CLOSE_TIMEOUT.as_secs(),
+                        "Graceful shutdown: peer did not accept the close frames in time; \
+                         proceeding to detach without them"
+                    );
                 }
-                let _ = close_ws_connection(
-                    &mut ws_sender,
-                    "Failed to send WebSocket close frame after system-shutdown",
-                )
-                .await;
                 break;
             }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -35,8 +35,15 @@ async fn xmpp_websocket_handler(
     ws: WebSocketUpgrade,
     State(state): State<Arc<WebSocketState>>,
 ) -> Response {
-    // Graceful shutdown has begun (issue #1091): refuse new sessions so
-    // the drain converges. Clients retry against the replacement pod.
+    // Graceful shutdown gate (issue #1091). The guard is minted BEFORE
+    // the stop-token check: the upgrade handshake spans a client
+    // round-trip, so a check-then-mint order would let a connection be
+    // admitted after `wait_for_connections_drained` already observed
+    // zero guards and the Q6 drain concluded — reintroducing the very
+    // unpromoted-queue gap this issue closes. Mint-then-check means
+    // every request either sees the cancelled token (503, guard drops)
+    // or is counted by the drain.
+    let connection_guard = state.deps.shutdown.connection_guard();
     if state.deps.shutdown.stop_token().is_cancelled() {
         info!("Rejecting XMPP WebSocket upgrade: server is draining");
         return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
@@ -44,20 +51,24 @@ async fn xmpp_websocket_handler(
     info!("XMPP WebSocket connection request");
 
     ws.protocols(["xmpp"])
-        .on_upgrade(move |socket| handle_xmpp_websocket(socket, state))
+        .on_upgrade(move |socket| handle_xmpp_websocket(socket, state, connection_guard))
 }
 
 /// Size of the outbound message channel buffer
 const OUTBOUND_CHANNEL_SIZE: usize = 256;
 
 /// Handle an XMPP WebSocket connection
-async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
+async fn handle_xmpp_websocket(
+    socket: WebSocket,
+    state: Arc<WebSocketState>,
+    // Minted in the upgrade handler and held for the connection's whole
+    // lifetime — including the detach/cleanup below — so the ecdysis
+    // drain (issue #1091) only completes once every live session has
+    // been closed AND its SM state handed to the session registry for
+    // Q6 promotion.
+    _connection_guard: waddle_ecdysis::ConnectionGuard,
+) {
     let domain = state.deps.auth_state.xmpp_domain.clone();
-    // Held for the connection's whole lifetime — including the
-    // detach/cleanup below — so the ecdysis drain (issue #1091) only
-    // completes once every live session has been closed AND its SM
-    // state handed to the session registry for Q6 promotion.
-    let _connection_guard = state.deps.shutdown.connection_guard();
     let shutdown_token = state.deps.shutdown.stop_token();
     info!(domain = %domain, "XMPP WebSocket connection established");
 
@@ -218,26 +229,34 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
 
             // Graceful shutdown (issue #1091): SIGTERM cancelled the
             // ecdysis stop token. Close this live session natively —
-            // RFC 6120 §4.9.3.19 <system-shutdown/> stream error, then
+            // RFC 6120 §4.9.3.20 <system-shutdown/> stream error, then
             // the RFC 7395 <close/> frame and the WS close handshake —
             // and break WITHOUT transitioning to Closing: the cleanup
             // fork below must still see a resumable phase so an
             // XEP-0198 session detaches into the SmSessionRegistry,
             // where the shutdown drain promotes its unacked queue (Q6).
+            //
+            // Stream frames are sent only after the server has answered
+            // the client's <open/>: RFC 6120 §4.9.1.2 forbids a stream
+            // error before the response stream header, so a connection
+            // still in the upgrade-to-open gap gets the WS closing
+            // handshake alone.
             _ = shutdown_token.cancelled() => {
                 info!(
                     jid = ?conn.phase.bound_jid(),
                     "Graceful shutdown: closing live session with system-shutdown stream error"
                 );
-                let _ = send_ws_text_frames(
-                    &mut ws_sender,
-                    [
-                        build_system_shutdown_stream_error(),
-                        websocket_stream_close_xml(),
-                    ],
-                    "Failed to send system-shutdown stream error",
-                )
-                .await;
+                if conn.stream_open_sent {
+                    let _ = send_ws_text_frames(
+                        &mut ws_sender,
+                        [
+                            build_system_shutdown_stream_error(),
+                            websocket_stream_close_xml(),
+                        ],
+                        "Failed to send system-shutdown stream error",
+                    )
+                    .await;
+                }
                 let _ = close_ws_connection(
                     &mut ws_sender,
                     "Failed to send WebSocket close frame after system-shutdown",

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -12,8 +12,12 @@ use super::{
     state::WsConnState,
     stream_management::SmRegistrationFinalization,
     timers::TransportTimers,
-    transport_xml::{build_handled_count_too_high_stream_error, websocket_stream_close_xml},
+    transport_xml::{
+        build_handled_count_too_high_stream_error, build_system_shutdown_stream_error,
+        websocket_stream_close_xml,
+    },
 };
+use axum::response::IntoResponse;
 use futures::stream::{SplitSink, SplitStream};
 
 /// Create the WebSocket router
@@ -31,6 +35,12 @@ async fn xmpp_websocket_handler(
     ws: WebSocketUpgrade,
     State(state): State<Arc<WebSocketState>>,
 ) -> Response {
+    // Graceful shutdown has begun (issue #1091): refuse new sessions so
+    // the drain converges. Clients retry against the replacement pod.
+    if state.deps.shutdown.stop_token().is_cancelled() {
+        info!("Rejecting XMPP WebSocket upgrade: server is draining");
+        return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response();
+    }
     info!("XMPP WebSocket connection request");
 
     ws.protocols(["xmpp"])
@@ -43,6 +53,12 @@ const OUTBOUND_CHANNEL_SIZE: usize = 256;
 /// Handle an XMPP WebSocket connection
 async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
     let domain = state.deps.auth_state.xmpp_domain.clone();
+    // Held for the connection's whole lifetime — including the
+    // detach/cleanup below — so the ecdysis drain (issue #1091) only
+    // completes once every live session has been closed AND its SM
+    // state handed to the session registry for Q6 promotion.
+    let _connection_guard = state.deps.shutdown.connection_guard();
+    let shutdown_token = state.deps.shutdown.stop_token();
     info!(domain = %domain, "XMPP WebSocket connection established");
 
     let (mut ws_sender, mut ws_receiver) = socket.split();
@@ -198,6 +214,36 @@ async fn handle_xmpp_websocket(socket: WebSocket, state: Arc<WebSocketState>) {
                         break;
                     }
                 }
+            }
+
+            // Graceful shutdown (issue #1091): SIGTERM cancelled the
+            // ecdysis stop token. Close this live session natively —
+            // RFC 6120 §4.9.3.19 <system-shutdown/> stream error, then
+            // the RFC 7395 <close/> frame and the WS close handshake —
+            // and break WITHOUT transitioning to Closing: the cleanup
+            // fork below must still see a resumable phase so an
+            // XEP-0198 session detaches into the SmSessionRegistry,
+            // where the shutdown drain promotes its unacked queue (Q6).
+            _ = shutdown_token.cancelled() => {
+                info!(
+                    jid = ?conn.phase.bound_jid(),
+                    "Graceful shutdown: closing live session with system-shutdown stream error"
+                );
+                let _ = send_ws_text_frames(
+                    &mut ws_sender,
+                    [
+                        build_system_shutdown_stream_error(),
+                        websocket_stream_close_xml(),
+                    ],
+                    "Failed to send system-shutdown stream error",
+                )
+                .await;
+                let _ = close_ws_connection(
+                    &mut ws_sender,
+                    "Failed to send WebSocket close frame after system-shutdown",
+                )
+                .await;
+                break;
             }
 
             // RFC 7395 §3.8 keepalive clock (issue #1090). Fires only

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -48,6 +48,7 @@ async fn handle_xmpp_frame_impl(
         pending_resume_h,
         suppress_sm_record_next_batch,
         state_machine,
+        stream_open_sent,
         ..
     } = conn;
     let muc_domain = state.deps.service_domains.muc.clone();
@@ -101,6 +102,7 @@ async fn handle_xmpp_frame_impl(
             info!("XMPP stream open requested");
             let open_element = websocket_stream_open_xml(domain);
             let features_element = build_stream_features_for_phase(phase);
+            *stream_open_sent = true;
             vec![open_element, features_element]
         }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -109,6 +109,9 @@ async fn handle_xmpp_frame_impl(
         InboundFrame::Close => {
             info!("XMPP stream close requested");
             *phase = ConnectionPhase::closing(phase.bound_jid().cloned());
+            // The stream is over: no response header remains to hang a
+            // graceful-shutdown <stream:error> on.
+            *stream_open_sent = false;
             vec![websocket_stream_close_xml()]
         }
 
@@ -121,7 +124,7 @@ async fn handle_xmpp_frame_impl(
                 }
                 return vec![sasl_failure_xml("not-authorized")];
             }
-            match mechanism.as_str() {
+            let responses = match mechanism.as_str() {
                 "SCRAM-SHA-256" => {
                     handle_sasl_scram_client_first(&data, domain, state, phase).await
                 }
@@ -132,7 +135,15 @@ async fn handle_xmpp_frame_impl(
                     warn!(mechanism = %other, "Unsupported SASL mechanism");
                     vec![sasl_failure_xml("invalid-mechanism")]
                 }
+            };
+            // RFC 6120 §6.4.6: SASL success restarts the stream. Until
+            // the client's next <open/> is answered, no response header
+            // exists for the new stream, so the graceful-shutdown arm
+            // must not send a <stream:error> (§4.9.1.2).
+            if phase.is_authenticated() {
+                *stream_open_sent = false;
             }
+            responses
         }
 
         InboundFrame::SaslResponse(data) => {
@@ -143,7 +154,15 @@ async fn handle_xmpp_frame_impl(
             let scram = phase
                 .take_scram_pending()
                 .expect("SASL response must have pending SCRAM state");
-            handle_sasl_scram_response(&data, domain, scram, authenticated_session, phase)
+            let responses =
+                handle_sasl_scram_response(&data, domain, scram, authenticated_session, phase);
+            // Same stream-restart rule as the <auth/> arm above: after
+            // SCRAM success no response header exists for the new
+            // stream until the next <open/> is answered.
+            if phase.is_authenticated() {
+                *stream_open_sent = false;
+            }
+            responses
         }
 
         InboundFrame::Stanza(stanza) => {

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -238,6 +238,7 @@ mod tests {
                 occupant_id_secret: deps.occupant_id_secret.clone(),
                 link_preview: deps.link_preview.clone(),
                 ws_keepalive: deps.ws_keepalive,
+                shutdown: deps.shutdown.clone(),
                 provider_ingress: Arc::clone(&deps.provider_ingress),
                 provider_dispatch_tasks: deps.provider_dispatch_tasks.clone(),
             },

--- a/server/crates/waddle-server/src/server/routes/websocket/session_init.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/session_init.rs
@@ -45,13 +45,13 @@ pub(super) fn build_internal_server_error_stream_error(text: &str) -> String {
         .expect("serializing stream error should not fail");
 
     let mut internal = BytesStart::new("internal-server-error");
-    internal.push_attribute(("xmlns", "urn:ietf:params:xml:ns:xmpp-streams"));
+    internal.push_attribute(("xmlns", waddle_xmpp::ns::STREAMS));
     writer
         .write_event(Event::Empty(internal))
         .expect("serializing internal-server-error should not fail");
 
     let mut text_elem = BytesStart::new("text");
-    text_elem.push_attribute(("xmlns", "urn:ietf:params:xml:ns:xmpp-streams"));
+    text_elem.push_attribute(("xmlns", waddle_xmpp::ns::STREAMS));
     text_elem.push_attribute(("xml:lang", "en"));
     writer
         .write_event(Event::Start(text_elem))

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -333,6 +333,12 @@ pub struct ProtocolServices {
 /// value threaded through the frame dispatcher.
 pub(super) struct WsConnState {
     pub(super) phase: ConnectionPhase,
+    /// True once the server has answered the client's RFC 7395 `<open/>`
+    /// with its own `<open/>` response. Gates the graceful-shutdown
+    /// stream error (issue #1091): RFC 6120 §4.9.1.2 forbids sending a
+    /// stream error before the response stream header, so a connection
+    /// still in the upgrade-to-open gap is closed at the WS layer only.
+    pub(super) stream_open_sent: bool,
     /// The authenticated backend Session for this connection, if any.
     /// Populated on SASL success and used for SM resume/detach.
     pub(super) authenticated_session: Option<Session>,
@@ -404,6 +410,7 @@ impl WsConnState {
     pub(super) fn new() -> Self {
         Self {
             phase: ConnectionPhase::new(),
+            stream_open_sent: false,
             authenticated_session: None,
             sm_state: StreamManagementState::new(),
             carbons_enabled: false,

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -184,6 +184,12 @@ pub struct WebSocketDeps {
     /// RFC 7395 §3.8 keepalive knobs (issue #1090), parsed and
     /// validated at startup from `WADDLE_WS_KEEPALIVE_*` env vars.
     pub ws_keepalive: waddle_xmpp::protocol::KeepaliveConfig,
+    /// Ecdysis graceful-shutdown view (issue #1091): the accept path
+    /// mints a [`waddle_ecdysis::ConnectionGuard`] per connection so
+    /// `drain()` tracks real connections, and the per-connection loop
+    /// observes the stop token to close live sessions with
+    /// `<stream:error><system-shutdown/>`.
+    pub shutdown: waddle_ecdysis::ShutdownHandle,
 }
 
 pub struct ProtocolServices {

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -284,6 +284,8 @@ async fn create_test_websocket_state_with_extension_manager(
                 .expect("test secret meets length floor"),
                 link_preview: server_config.link_preview.clone(),
                 ws_keepalive: server_config.ws_keepalive,
+                shutdown: waddle_ecdysis::GracefulShutdown::new(std::time::Duration::from_secs(1))
+                    .handle(),
                 provider_ingress: Arc::new(
                     crate::server::routes::extension_webhooks::ProviderIngressRegistry::default(),
                 ),

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/frame_parsing.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/frame_parsing.rs
@@ -262,6 +262,49 @@ async fn websocket_oauthbearer_authenticates_session_token() {
 }
 
 #[tokio::test]
+async fn websocket_stream_open_sent_tracks_current_stream_instance() {
+    let state = create_test_websocket_state().await;
+    let session = create_test_session(state.as_ref(), "alice").await;
+    let mut conn = WsConnState::new();
+    let open =
+        r#"<open xmlns="urn:ietf:params:xml:ns:xmpp-framing" to="example.com" version="1.0"/>"#;
+    let close = r#"<close xmlns="urn:ietf:params:xml:ns:xmpp-framing"/>"#;
+
+    assert!(!conn.stream_open_sent, "no stream answered yet at upgrade");
+    handle_xmpp_frame(open, "example.com", state.as_ref(), &mut conn).await;
+    assert!(conn.stream_open_sent, "server answered the first <open/>");
+
+    // RFC 6120 §6.4.6: SASL success restarts the stream — the server
+    // has not yet sent a response header for the NEW stream, so a
+    // stream error is illegal in this gap.
+    let payload = BASE64_STANDARD.encode(format!("n,,\x01auth=Bearer {}\x01\x01", session.id));
+    let auth = element_to_xml(
+        Element::builder("auth", waddle_xmpp::ns::SASL)
+            .attr(
+                minidom::rxml::xml_ncname!("mechanism").to_owned(),
+                "OAUTHBEARER",
+            )
+            .append(payload)
+            .build(),
+    );
+    let responses = handle_xmpp_frame(&auth, "example.com", state.as_ref(), &mut conn).await;
+    assert_eq!(responses, vec![sasl_success_xml()]);
+    assert!(
+        !conn.stream_open_sent,
+        "SASL success restarts the stream; no response header exists for the new stream yet"
+    );
+
+    handle_xmpp_frame(open, "example.com", state.as_ref(), &mut conn).await;
+    assert!(conn.stream_open_sent, "restarted stream answered");
+
+    handle_xmpp_frame(close, "example.com", state.as_ref(), &mut conn).await;
+    assert!(
+        !conn.stream_open_sent,
+        "a closed stream has no live response header to error on"
+    );
+}
+
+#[tokio::test]
 async fn websocket_rejects_reauthentication_after_successful_sasl() {
     let state = create_test_websocket_state().await;
     let session = create_test_session(state.as_ref(), "alice").await;

--- a/server/crates/waddle-server/src/server/routes/websocket/transport_xml.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/transport_xml.rs
@@ -184,7 +184,7 @@ pub(super) fn build_handled_count_too_high_stream_error(
     String::from_utf8(writer.into_inner()).expect("quick-xml serializes valid UTF-8")
 }
 
-/// Build the RFC 6120 §4.9.3.19 `<stream:error><system-shutdown/>`
+/// Build the RFC 6120 §4.9.3.20 `<stream:error><system-shutdown/>`
 /// frame sent to every live session when graceful shutdown begins
 /// (issue #1091). Pairs with `websocket_stream_close_xml()` so the
 /// client sees error → close → WS close and reconnects elsewhere.
@@ -261,7 +261,7 @@ mod stream_error_tests {
 
     #[test]
     fn system_shutdown_stream_error_matches_rfc6120_wire_shape() {
-        // RFC 6120 §4.9.3.19: <system-shutdown/> in the
+        // RFC 6120 §4.9.3.20: <system-shutdown/> in the
         // urn:ietf:params:xml:ns:xmpp-streams namespace, wrapped in
         // <stream:error> qualified by the streams prefix namespace.
         assert_eq!(

--- a/server/crates/waddle-server/src/server/routes/websocket/transport_xml.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/transport_xml.rs
@@ -184,6 +184,30 @@ pub(super) fn build_handled_count_too_high_stream_error(
     String::from_utf8(writer.into_inner()).expect("quick-xml serializes valid UTF-8")
 }
 
+/// Build the RFC 6120 §4.9.3.19 `<stream:error><system-shutdown/>`
+/// frame sent to every live session when graceful shutdown begins
+/// (issue #1091). Pairs with `websocket_stream_close_xml()` so the
+/// client sees error → close → WS close and reconnects elsewhere.
+pub(super) fn build_system_shutdown_stream_error() -> String {
+    let mut writer = Writer::new(Vec::new());
+    let mut stream_error = BytesStart::new("stream:error");
+    stream_error.push_attribute(("xmlns:stream", waddle_xmpp::ns::STREAM));
+    writer
+        .write_event(Event::Start(stream_error))
+        .expect("serializing stream error should not fail");
+
+    let mut shutdown = BytesStart::new("system-shutdown");
+    shutdown.push_attribute(("xmlns", "urn:ietf:params:xml:ns:xmpp-streams"));
+    writer
+        .write_event(Event::Empty(shutdown))
+        .expect("serializing system-shutdown should not fail");
+
+    writer
+        .write_event(Event::End(BytesEnd::new("stream:error")))
+        .expect("serializing stream error end should not fail");
+    String::from_utf8(writer.into_inner()).expect("quick-xml serializes valid UTF-8")
+}
+
 pub(super) fn build_stream_features_xml(authenticated: bool) -> String {
     let mut features = Element::builder("features", waddle_xmpp::ns::STREAM);
     if authenticated {
@@ -229,4 +253,22 @@ pub(super) fn sasl_failure_xml(condition: &str) -> String {
             .append(Element::builder(condition, waddle_xmpp::ns::SASL).build())
             .build(),
     )
+}
+
+#[cfg(test)]
+mod stream_error_tests {
+    use super::*;
+
+    #[test]
+    fn system_shutdown_stream_error_matches_rfc6120_wire_shape() {
+        // RFC 6120 §4.9.3.19: <system-shutdown/> in the
+        // urn:ietf:params:xml:ns:xmpp-streams namespace, wrapped in
+        // <stream:error> qualified by the streams prefix namespace.
+        assert_eq!(
+            build_system_shutdown_stream_error(),
+            "<stream:error xmlns:stream=\"http://etherx.jabber.org/streams\">\
+             <system-shutdown xmlns=\"urn:ietf:params:xml:ns:xmpp-streams\"/>\
+             </stream:error>"
+        );
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/transport_xml.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/transport_xml.rs
@@ -149,7 +149,7 @@ pub(super) fn build_handled_count_too_high_stream_error(
         .expect("serializing stream error should not fail");
 
     let mut undefined = BytesStart::new("undefined-condition");
-    undefined.push_attribute(("xmlns", "urn:ietf:params:xml:ns:xmpp-streams"));
+    undefined.push_attribute(("xmlns", waddle_xmpp::ns::STREAMS));
     writer
         .write_event(Event::Empty(undefined))
         .expect("serializing undefined-condition should not fail");
@@ -165,7 +165,7 @@ pub(super) fn build_handled_count_too_high_stream_error(
         .expect("serializing handled-count-too-high should not fail");
 
     let mut text = BytesStart::new("text");
-    text.push_attribute(("xmlns", "urn:ietf:params:xml:ns:xmpp-streams"));
+    text.push_attribute(("xmlns", waddle_xmpp::ns::STREAMS));
     text.push_attribute(("xml:lang", "en"));
     writer
         .write_event(Event::Start(text))
@@ -197,7 +197,7 @@ pub(super) fn build_system_shutdown_stream_error() -> String {
         .expect("serializing stream error should not fail");
 
     let mut shutdown = BytesStart::new("system-shutdown");
-    shutdown.push_attribute(("xmlns", "urn:ietf:params:xml:ns:xmpp-streams"));
+    shutdown.push_attribute(("xmlns", waddle_xmpp::ns::STREAMS));
     writer
         .write_event(Event::Empty(shutdown))
         .expect("serializing system-shutdown should not fail");
@@ -266,9 +266,11 @@ mod stream_error_tests {
         // <stream:error> qualified by the streams prefix namespace.
         assert_eq!(
             build_system_shutdown_stream_error(),
-            "<stream:error xmlns:stream=\"http://etherx.jabber.org/streams\">\
-             <system-shutdown xmlns=\"urn:ietf:params:xml:ns:xmpp-streams\"/>\
-             </stream:error>"
+            concat!(
+                "<stream:error xmlns:stream=\"http://etherx.jabber.org/streams\">",
+                "<system-shutdown xmlns=\"urn:ietf:params:xml:ns:xmpp-streams\"/>",
+                "</stream:error>"
+            )
         );
     }
 }

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -696,9 +696,14 @@ pub(crate) fn spawn_graceful_shutdown_drain(
         // One deadline covers BOTH phases (connection drain + Q6
         // promotion): the pod's terminationGracePeriodSeconds is sized
         // for a single WADDLE_DRAIN_TIMEOUT_SECS budget, so serializing
-        // two full budgets would let SIGKILL truncate Q6 promotion when
-        // one stuck peer burns the whole connection-drain slice.
-        let drain_deadline = std::time::Instant::now() + max_drain_duration_from_env();
+        // two full budgets would let SIGKILL truncate Q6 promotion.
+        // The connection wait gets at most HALF the budget: a single
+        // stuck peer must not consume the whole deadline and starve Q6
+        // promotion for sessions that already detached cleanly — the
+        // stuck session itself falls back to its durable SM row on
+        // next startup either way.
+        let total_budget = max_drain_duration_from_env();
+        let drain_deadline = std::time::Instant::now() + total_budget;
         info!(
             active_connections = websocket_state.deps.shutdown.active_connections(),
             "Graceful shutdown: waiting for live sessions to close and detach"
@@ -706,9 +711,7 @@ pub(crate) fn spawn_graceful_shutdown_drain(
         if !websocket_state
             .deps
             .shutdown
-            .wait_for_connections_drained_for(
-                drain_deadline.saturating_duration_since(std::time::Instant::now()),
-            )
+            .wait_for_connections_drained_for(total_budget / 2)
             .await
         {
             warn!(

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -686,6 +686,30 @@ pub(crate) fn spawn_graceful_shutdown_drain(
         let _notify_guard = NotifyOnDrop(drain_notify);
 
         drain_token.cancelled().await;
+        // Issue #1091: live sessions observe the same stop token, send
+        // <system-shutdown/> and detach into the SmSessionRegistry.
+        // Wait (bounded by the ecdysis drain timeout) for every
+        // connection guard to drop before the Q6 passes below, so live
+        // sessions' unacked queues are in the registry when
+        // drain_all_for_shutdown runs — otherwise the quiet window
+        // could conclude before a slow session finishes detaching.
+        info!(
+            active_connections = websocket_state.deps.shutdown.active_connections(),
+            "Graceful shutdown: waiting for live sessions to close and detach"
+        );
+        if !websocket_state
+            .deps
+            .shutdown
+            .wait_for_connections_drained()
+            .await
+        {
+            warn!(
+                remaining_connections = websocket_state.deps.shutdown.active_connections(),
+                "Graceful shutdown: connection drain timed out; promoting \
+                 whatever detached in time. Remaining sessions keep their \
+                 durable SM rows for next-startup retry."
+            );
+        }
         info!("Graceful shutdown: starting SM session Q6 drain");
         const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
         const QUIET_WINDOW_PASSES: u32 = 8;

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -688,11 +688,17 @@ pub(crate) fn spawn_graceful_shutdown_drain(
         drain_token.cancelled().await;
         // Issue #1091: live sessions observe the same stop token, send
         // <system-shutdown/> and detach into the SmSessionRegistry.
-        // Wait (bounded by the ecdysis drain timeout) for every
-        // connection guard to drop before the Q6 passes below, so live
-        // sessions' unacked queues are in the registry when
-        // drain_all_for_shutdown runs — otherwise the quiet window
+        // Wait for every connection guard to drop before the Q6 passes
+        // below, so live sessions' unacked queues are in the registry
+        // when drain_all_for_shutdown runs — otherwise the quiet window
         // could conclude before a slow session finishes detaching.
+        //
+        // One deadline covers BOTH phases (connection drain + Q6
+        // promotion): the pod's terminationGracePeriodSeconds is sized
+        // for a single WADDLE_DRAIN_TIMEOUT_SECS budget, so serializing
+        // two full budgets would let SIGKILL truncate Q6 promotion when
+        // one stuck peer burns the whole connection-drain slice.
+        let drain_deadline = std::time::Instant::now() + max_drain_duration_from_env();
         info!(
             active_connections = websocket_state.deps.shutdown.active_connections(),
             "Graceful shutdown: waiting for live sessions to close and detach"
@@ -700,7 +706,9 @@ pub(crate) fn spawn_graceful_shutdown_drain(
         if !websocket_state
             .deps
             .shutdown
-            .wait_for_connections_drained()
+            .wait_for_connections_drained_for(
+                drain_deadline.saturating_duration_since(std::time::Instant::now()),
+            )
             .await
         {
             warn!(
@@ -713,7 +721,6 @@ pub(crate) fn spawn_graceful_shutdown_drain(
         info!("Graceful shutdown: starting SM session Q6 drain");
         const POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(250);
         const QUIET_WINDOW_PASSES: u32 = 8;
-        let drain_deadline = std::time::Instant::now() + max_drain_duration_from_env();
         let mut empty_passes = 0u32;
         let mut total_drained = 0usize;
         loop {

--- a/server/crates/waddle-server/src/server/tests.rs
+++ b/server/crates/waddle-server/src/server/tests.rs
@@ -708,7 +708,8 @@ async fn test_app() -> Router {
         mam_storage,
         pubsub_database_storage,
         acme_http01_challenge_service: None,
-        shutdown_stop_token: tokio_util::sync::CancellationToken::new(),
+        shutdown_handle: waddle_ecdysis::GracefulShutdown::new(std::time::Duration::from_secs(1))
+            .handle(),
         drain_complete: std::sync::Arc::new(tokio::sync::Notify::new()),
     })
     .await

--- a/server/crates/waddle-server/tests/graceful_shutdown_ws.rs
+++ b/server/crates/waddle-server/tests/graceful_shutdown_ws.rs
@@ -1,0 +1,222 @@
+//! Graceful shutdown of live WebSocket sessions (issue #1091).
+//!
+//! On SIGTERM the server must natively close every live session:
+//! send `<stream:error><system-shutdown/>` (RFC 6120 §4.9.3.19)
+//! followed by the RFC 7395 `<close/>` frame, detach XEP-0198
+//! sessions so their unacked queues flow through Q6 promotion, and
+//! exit within the drain timeout — no SIGKILL required.
+
+mod ws_common;
+
+use std::time::Duration;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+
+/// SIGTERM with a live authenticated client: the client receives
+/// `system-shutdown` then the framing `<close/>`, and the process
+/// exits well within the drain timeout instead of hanging until
+/// SIGKILL.
+#[tokio::test]
+async fn sigterm_closes_live_session_with_system_shutdown_and_exits() {
+    let mut server = TestServer::start_with_extra_envs(&[], &[("WADDLE_DRAIN_TIMEOUT_SECS", "5")]);
+    let mut client = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "admin",
+        server.fixed_account_password(),
+        "shutdown-test",
+    )
+    .await
+    .expect("connect and auth");
+
+    server.send_sigterm();
+
+    let stream_error = client
+        .recv_matching(|frame| frame.contains("<stream:error"))
+        .await
+        .expect("receive stream error after SIGTERM");
+    assert!(
+        stream_error.contains("system-shutdown"),
+        "stream error must carry RFC 6120 §4.9.3.19 system-shutdown: {stream_error}"
+    );
+    assert!(
+        stream_error.contains("urn:ietf:params:xml:ns:xmpp-streams"),
+        "system-shutdown must be in the xmpp-streams namespace: {stream_error}"
+    );
+
+    let close = client
+        .recv_matching(|frame| frame.contains("<close"))
+        .await
+        .expect("receive RFC 7395 close frame after stream error");
+    assert!(
+        close.contains("urn:ietf:params:xml:ns:xmpp-framing"),
+        "close frame must use the xmpp-framing namespace: {close}"
+    );
+
+    assert!(
+        server.wait_for_exit(Duration::from_secs(20)).await,
+        "server must exit on its own within the drain timeout"
+    );
+}
+
+/// A live XEP-0198 session's unacked stanzas must survive SIGTERM:
+/// the session detaches on shutdown, the drain promotes its unacked
+/// queue (Q6) into durable offline delivery, and the recipient gets
+/// the message after the server restarts — instead of losing it on
+/// every deploy.
+#[tokio::test]
+async fn sigterm_promotes_live_sm_session_unacked_queue_for_next_startup_delivery() {
+    let scratch = std::env::temp_dir().join(format!("waddle-shutdown-q6-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&scratch).expect("create scratch dir");
+    let global_db = format!("sqlite://{}?mode=rwc", scratch.join("global.db").display());
+    let sm_db = format!("sqlite://{}?mode=rwc", scratch.join("sm.db").display());
+    let pending_db = format!("sqlite://{}?mode=rwc", scratch.join("pending.db").display());
+    // MAM must be durable too: the promoted pending_delivery row
+    // references the archived stanza by (by, stanza-id), so redelivery
+    // after restart resolves the payload out of the archive.
+    let mam_db = format!("sqlite://{}?mode=rwc", scratch.join("mam.db").display());
+    let extra_envs: Vec<(&str, &str)> = vec![
+        ("WADDLE_XMPP_SM_DATABASE_URL", sm_db.as_str()),
+        ("WADDLE_XMPP_MAM_DATABASE_URL", mam_db.as_str()),
+        (
+            "WADDLE_XMPP_PENDING_DELIVERY_DATABASE_URL",
+            pending_db.as_str(),
+        ),
+        ("WADDLE_DRAIN_TIMEOUT_SECS", "5"),
+    ];
+
+    // Phase 1: admin holds a live resumable SM session with one
+    // unacked inbound DM when SIGTERM lands.
+    let body_text = "unacked-message-must-survive-shutdown";
+    {
+        let mut server = TestServer::start_persistent_with_extra_envs(
+            &global_db,
+            &[("bob", "bob-shutdown-password-1")],
+            &extra_envs,
+        );
+        let mut admin = WsXmppClient::connect_and_auth(
+            &server.ws_url(),
+            DOMAIN,
+            "admin",
+            server.fixed_account_password(),
+            "shutdown-q6",
+        )
+        .await
+        .expect("connect admin");
+        admin
+            .send(r#"<enable xmlns="urn:xmpp:sm:3" resume="true"/>"#)
+            .await
+            .expect("send SM enable");
+        admin
+            .recv_matching(|frame| frame.contains("<enabled"))
+            .await
+            .expect("SM enabled");
+
+        let mut bob = WsXmppClient::connect_and_auth(
+            &server.ws_url(),
+            DOMAIN,
+            "bob",
+            "bob-shutdown-password-1",
+            "shutdown-bob",
+        )
+        .await
+        .expect("connect bob");
+        let admin_jid = admin.full_jid.clone().expect("admin bound jid");
+        bob.send(&format!(
+            r#"<message to="{admin_jid}" type="chat" id="q6-1"><body xmlns="jabber:client">{body_text}</body></message>"#
+        ))
+        .await
+        .expect("bob sends DM");
+        // The DM reaches admin's live session (now in the unacked
+        // queue — admin never sends <a/>).
+        admin
+            .recv_matching(|frame| frame.contains(body_text))
+            .await
+            .expect("admin receives DM before shutdown");
+
+        server.send_sigterm();
+        admin
+            .recv_matching(|frame| frame.contains("system-shutdown"))
+            .await
+            .expect("admin sees system-shutdown");
+        assert!(
+            server.wait_for_exit(Duration::from_secs(20)).await,
+            "server must exit after promoting unacked queues"
+        );
+    }
+
+    // Phase 2: fresh process on the same databases — the promoted
+    // stanza is delivered as offline mail on initial presence.
+    let server = TestServer::start_persistent_with_extra_envs(
+        &global_db,
+        &[("bob", "bob-shutdown-password-1")],
+        &extra_envs,
+    );
+    let mut admin = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "admin",
+        server.fixed_account_password(),
+        "shutdown-q6-return",
+    )
+    .await
+    .expect("reconnect admin");
+    admin.send("<presence/>").await.expect("initial presence");
+    let delivered = admin
+        .recv_matching(|frame| frame.contains(body_text))
+        .await
+        .expect("promoted unacked DM delivered after restart");
+    assert!(
+        delivered.contains("urn:xmpp:delay"),
+        "offline redelivery must carry an XEP-0203 delay stamp: {delivered}"
+    );
+
+    let _ = std::fs::remove_dir_all(&scratch);
+}
+
+/// SIGTERM with several live clients: every session gets the
+/// system-shutdown stream error, not just one.
+#[tokio::test]
+async fn sigterm_notifies_every_live_session() {
+    let mut server = TestServer::start_with_extra_envs(
+        &[("bob", "bob-shutdown-password-1")],
+        &[("WADDLE_DRAIN_TIMEOUT_SECS", "5")],
+    );
+    let mut admin = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "admin",
+        server.fixed_account_password(),
+        "shutdown-admin",
+    )
+    .await
+    .expect("connect admin");
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        "bob-shutdown-password-1",
+        "shutdown-bob",
+    )
+    .await
+    .expect("connect bob");
+
+    server.send_sigterm();
+
+    for client in [&mut admin, &mut bob] {
+        let stream_error = client
+            .recv_matching(|frame| frame.contains("<stream:error"))
+            .await
+            .expect("each live session receives a stream error");
+        assert!(
+            stream_error.contains("system-shutdown"),
+            "expected system-shutdown, got: {stream_error}"
+        );
+    }
+
+    assert!(
+        server.wait_for_exit(Duration::from_secs(20)).await,
+        "server must exit with multiple clients connected"
+    );
+}

--- a/server/crates/waddle-server/tests/graceful_shutdown_ws.rs
+++ b/server/crates/waddle-server/tests/graceful_shutdown_ws.rs
@@ -1,7 +1,7 @@
 //! Graceful shutdown of live WebSocket sessions (issue #1091).
 //!
 //! On SIGTERM the server must natively close every live session:
-//! send `<stream:error><system-shutdown/>` (RFC 6120 §4.9.3.19)
+//! send `<stream:error><system-shutdown/>` (RFC 6120 §4.9.3.20)
 //! followed by the RFC 7395 `<close/>` frame, detach XEP-0198
 //! sessions so their unacked queues flow through Q6 promotion, and
 //! exit within the drain timeout — no SIGKILL required.
@@ -38,7 +38,7 @@ async fn sigterm_closes_live_session_with_system_shutdown_and_exits() {
         .expect("receive stream error after SIGTERM");
     assert!(
         stream_error.contains("system-shutdown"),
-        "stream error must carry RFC 6120 §4.9.3.19 system-shutdown: {stream_error}"
+        "stream error must carry RFC 6120 §4.9.3.20 system-shutdown: {stream_error}"
     );
     assert!(
         stream_error.contains("urn:ietf:params:xml:ns:xmpp-streams"),
@@ -67,8 +67,10 @@ async fn sigterm_closes_live_session_with_system_shutdown_and_exits() {
 /// every deploy.
 #[tokio::test]
 async fn sigterm_promotes_live_sm_session_unacked_queue_for_next_startup_delivery() {
-    let scratch = std::env::temp_dir().join(format!("waddle-shutdown-q6-{}", uuid::Uuid::new_v4()));
-    std::fs::create_dir_all(&scratch).expect("create scratch dir");
+    // RAII tempdir: cleans up the sqlite files even when an assertion
+    // below panics; the guard outlives both server phases.
+    let scratch_dir = tempfile::tempdir().expect("create scratch dir");
+    let scratch = scratch_dir.path();
     let global_db = format!("sqlite://{}?mode=rwc", scratch.join("global.db").display());
     let sm_db = format!("sqlite://{}?mode=rwc", scratch.join("sm.db").display());
     let pending_db = format!("sqlite://{}?mode=rwc", scratch.join("pending.db").display());
@@ -171,8 +173,6 @@ async fn sigterm_promotes_live_sm_session_unacked_queue_for_next_startup_deliver
         delivered.contains("urn:xmpp:delay"),
         "offline redelivery must carry an XEP-0203 delay stamp: {delivered}"
     );
-
-    let _ = std::fs::remove_dir_all(&scratch);
 }
 
 /// SIGTERM with several live clients: every session gets the

--- a/server/crates/waddle-server/tests/ws_common/mod.rs
+++ b/server/crates/waddle-server/tests/ws_common/mod.rs
@@ -268,16 +268,15 @@ impl TestServer {
     }
 
     /// Send SIGTERM to the server process — the real deploy-time
-    /// graceful-shutdown trigger (issue #1091).
+    /// graceful-shutdown trigger (issue #1091). Sent via the raw
+    /// syscall so the suite has no external `kill` binary dependency.
     #[allow(dead_code)]
     pub fn send_sigterm(&self) {
-        let pid = self.process.id();
-        let status = Command::new("kill")
-            .arg("-TERM")
-            .arg(pid.to_string())
-            .status()
-            .expect("spawn kill -TERM");
-        assert!(status.success(), "kill -TERM {pid} failed: {status}");
+        let pid = self.process.id() as libc::pid_t;
+        // SAFETY: pid is a live child owned by this TestServer (reaped
+        // only in Drop), so the signal cannot hit a recycled pid.
+        let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
+        assert_eq!(rc, 0, "kill(SIGTERM) failed for pid {pid}");
     }
 
     /// Wait for the server process to exit on its own, polling

--- a/server/crates/waddle-server/tests/ws_common/mod.rs
+++ b/server/crates/waddle-server/tests/ws_common/mod.rs
@@ -193,7 +193,11 @@ impl TestServer {
         for (key, value) in extra_envs {
             command.env(*key, *value);
         }
-        command.stdout(Stdio::null()).stderr(Stdio::null());
+        if std::env::var("WADDLE_TEST_SERVER_STDIO").as_deref() == Ok("inherit") {
+            command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+        } else {
+            command.stdout(Stdio::null()).stderr(Stdio::null());
+        }
         let child = command
             .spawn()
             .unwrap_or_else(|e| panic!("Failed to start waddle-server at {bin}: {e}"));
@@ -261,6 +265,34 @@ impl TestServer {
     #[allow(dead_code)]
     pub fn fixed_account_password(&self) -> &str {
         &self.fixed_account_password
+    }
+
+    /// Send SIGTERM to the server process — the real deploy-time
+    /// graceful-shutdown trigger (issue #1091).
+    #[allow(dead_code)]
+    pub fn send_sigterm(&self) {
+        let pid = self.process.id();
+        let status = Command::new("kill")
+            .arg("-TERM")
+            .arg(pid.to_string())
+            .status()
+            .expect("spawn kill -TERM");
+        assert!(status.success(), "kill -TERM {pid} failed: {status}");
+    }
+
+    /// Wait for the server process to exit on its own, polling
+    /// `try_wait`. Returns `true` if it exited within `timeout`.
+    #[allow(dead_code)]
+    pub async fn wait_for_exit(&mut self, timeout: Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        while tokio::time::Instant::now() < deadline {
+            match self.process.try_wait() {
+                Ok(Some(_status)) => return true,
+                Ok(None) => tokio::time::sleep(Duration::from_millis(100)).await,
+                Err(error) => panic!("try_wait on waddle-server: {error}"),
+            }
+        }
+        false
     }
 }
 

--- a/server/crates/waddle-xmpp/src/parser/ns.rs
+++ b/server/crates/waddle-xmpp/src/parser/ns.rs
@@ -14,6 +14,8 @@ pub const BIND: &str = "urn:ietf:params:xml:ns:xmpp-bind";
 pub const SESSION: &str = "urn:ietf:params:xml:ns:xmpp-session";
 /// Stanza error namespace
 pub const STANZAS: &str = "urn:ietf:params:xml:ns:xmpp-stanzas";
+/// Stream error namespace (RFC 6120 §4.9)
+pub const STREAMS: &str = "urn:ietf:params:xml:ns:xmpp-streams";
 /// Stream Management namespace (XEP-0198, version 3)
 pub const SM: &str = "urn:xmpp:sm:3";
 /// Instant Stream Resumption namespace (XEP-0397)


### PR DESCRIPTION
Fixes #1091.

## Problem

On SIGTERM, axum's graceful-shutdown future waits for all connections — including upgraded WebSockets — to finish, but nothing closed live sessions: the per-connection loop never observed the stop token and no `system-shutdown` stream error was sent. With any client connected the process hung until SIGKILL, and live sessions' in-flight unacked stanzas skipped Q6 promotion and were lost on every deploy. The ecdysis `ConnectionGuard`/drain machinery built for this was dead code.

## What changed

**ecdysis (`waddle-ecdysis`)**
- New cheap-clone `ShutdownHandle` view of the coordinator (stop token + guard minting + `active_connections` + bounded `wait_for_connections_drained[_for]`); `GracefulShutdown` now wraps and delegates to it.
- Fixed a pre-existing lost-wakeup race in the drain wait (`Notified::enable()` before the counter check — `notify_waiters()` stores no permit).
- Removed the now-dead `GracefulShutdown::connection_guard` delegator; reworded drain-timeout logs that falsely claimed force-exit.

**Accept path (`connection.rs`)**
- The upgrade handler mints a `ConnectionGuard` **before** checking the stop token (mint-then-check closes the TOCTOU where a handshake in flight could be admitted after the drain concluded) and moves it into the connection task, where it is held through cleanup/detach.
- Upgrades arriving after cancellation are refused with 503.
- New `select!` arm on the stop token: each live session gets `<stream:error><system-shutdown xmlns='urn:ietf:params:xml:ns:xmpp-streams'/></stream:error>` (RFC 6120 §4.9.3.20) + the RFC 7395 `<close/>` frame + the WS closing handshake, then breaks **without** entering `Closing` — so the existing cleanup fork detaches resumable XEP-0198 sessions into the `SmSessionRegistry`.
- Connections still in the upgrade-to-`<open/>` gap get the WS close only (RFC 6120 §4.9.1.2 forbids a stream error before the response stream header); a new `WsConnState::stream_open_sent` flag tracks this.

**Drain ordering (`session_janitors.rs`)**
- The Q6 shutdown drain now waits for every connection guard to drop before its quiet-window passes, so live sessions' unacked queues are in the registry when `drain_all_for_shutdown` runs.
- One shared deadline (`WADDLE_DRAIN_TIMEOUT_SECS`) covers connection drain + Q6 promotion, keeping the total under the pod's 35s `terminationGracePeriodSeconds`.

**Wire shape (`transport_xml.rs`)** — `build_system_shutdown_stream_error()` via quick-xml Writer (no string-concat XML), byte-exact unit test against an independent RFC literal.

## Tests

- `tests/graceful_shutdown_ws.rs` (new, real SIGTERM against the spawned binary):
  - live session receives `system-shutdown` → `<close/>` → WS close, and the process exits on its own within the drain budget;
  - every one of multiple live sessions is notified;
  - a live SM session's unacked DM is detached, Q6-promoted to durable offline delivery, and delivered (with XEP-0203 delay) after restart on persistent DBs.
- ecdysis unit tests for `ShutdownHandle` guard counting/drain/timeout; harness gains `send_sigterm`/`wait_for_exit` and an opt-in `WADDLE_TEST_SERVER_STDIO=inherit` debug knob.

## Review

**Round 4 (Qodo + Codex PR comments):** all seven inline comments resolved and replied to. Four were already fixed in round 3; two new Codex findings fixed in `bb8e04f3`: the connection-drain wait is capped at **half** of `WADDLE_DRAIN_TIMEOUT_SECS` so one stuck peer can't starve Q6 promotion for cleanly-detached sessions, and the shutdown arm's stream-error/close writes are bounded by a 5s `SHUTDOWN_CLOSE_TIMEOUT` (vs. the generic 60s send-stall budget) so a wedged peer can't hold its connection guard past the drain window.

**Round 3 (external code review):** four findings addressed — `stream_open_sent` now tracks the *current stream instance* (reset on SASL success per RFC 6120 §6.4.6 and on inbound `<close/>`, closing the post-SASL re-open gap where a stream error would violate §4.9.1.2; unit-tested through open → SASL success → re-open → close); new shared `waddle_xmpp::ns::STREAMS` constant replaces hardcoded namespace literals in all websocket stream-error builders; the wire test's compact expected literal is now unambiguous via `concat!`; `send_sigterm` uses `libc::kill` directly instead of shelling out to `kill(1)`.

Three adversarial personas (concurrency, XMPP conformance, code quality) reviewed round 1 — all seven findings fixed (lost wakeup, guard TOCTOU, serialized budgets vs. grace period, pre-open stream error, RFC cite, dead delegator, test tempdir). A hostile round-2 verifier confirmed the fixes against tokio/tokio-util sources and found no remaining issues.

`cargo fmt` + `clippy --all-targets --all-features -D warnings` clean; waddle-ecdysis (13), waddle-server lib (1401), and graceful-shutdown/keepalive/carbons integration suites all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
