### PR TITLE
fix(server): dedup MAM page results by mam_id in run_mam_query (#1152)

### DIFF
--- a/server/crates/waddle-xmpp-client/src/mam.rs
+++ b/server/crates/waddle-xmpp-client/src/mam.rs
@@ -374,6 +374,43 @@ fn parse_archived_author_real_jid(inner: &Element) -> Option<String> {
         .map(|jid| bare_jid(jid).to_string())
 }
 
+/// Accumulates MAM results for one query: filters out results belonging to
+/// other queries and drops duplicates by `mam_id` (XEP-0198 §5 leaves weeding
+/// out resume-replayed duplicates to the recipient). Both collection arms of
+/// [`run_mam_query`] delegate to one instance, so the dedup state cannot
+/// diverge between them.
+#[cfg(all(feature = "native", not(target_arch = "wasm32")))]
+struct MamResultCollector {
+    query_id: String,
+    seen_mam_ids: HashSet<String>,
+    messages: Vec<ArchivedMessage>,
+}
+
+#[cfg(all(feature = "native", not(target_arch = "wasm32")))]
+impl MamResultCollector {
+    fn new(query_id: &str) -> Self {
+        Self {
+            query_id: query_id.to_string(),
+            seen_mam_ids: HashSet::new(),
+            messages: Vec::new(),
+        }
+    }
+
+    /// Keep the result if it belongs to this query and its `mam_id` has not
+    /// been collected yet; ignore it otherwise.
+    fn collect(&mut self, archived: ArchivedMessage) {
+        if archived.query_id.as_deref() == Some(&self.query_id)
+            && self.seen_mam_ids.insert(archived.mam_id.clone())
+        {
+            self.messages.push(archived);
+        }
+    }
+
+    fn into_messages(self) -> Vec<ArchivedMessage> {
+        self.messages
+    }
+}
+
 /// Subscribe to the event bus, send the IQ, collect MAM result messages until
 /// the IQ correlation resolves, then assemble and return a [`MamPage`].
 ///
@@ -392,27 +429,16 @@ async fn run_mam_query(
 ) -> ClientResult<MamPage> {
     // Subscribe BEFORE sending so we don't miss any result messages.
     let mut rx = handle.events();
-    let query_id_owned = query_id.to_string();
 
     let query = async {
-        let mut messages: Vec<ArchivedMessage> = Vec::new();
-        // XEP-0198 resume mid-query retransmits unacked results with the same
-        // queryid and mam_id; XEP-0198 §5 leaves weeding out such duplicates
-        // to the recipient.
-        let mut seen_mam_ids: HashSet<String> = HashSet::new();
+        let mut collector = MamResultCollector::new(query_id);
         let mut send_iq_fut = Box::pin(handle.send_iq(iq));
 
         let fin_el = loop {
             tokio::select! {
                 result = &mut send_iq_fut => break result?,
                 event = rx.recv() => match event {
-                    Ok(ClientEvent::MamResult(archived))
-                        if archived.query_id.as_deref() == Some(&query_id_owned) =>
-                    {
-                        if seen_mam_ids.insert(archived.mam_id.clone()) {
-                            messages.push(*archived);
-                        }
-                    }
+                    Ok(ClientEvent::MamResult(archived)) => collector.collect(*archived),
                     Ok(_) => {}
                     Err(broadcast::error::RecvError::Closed) => {
                         return Err(ClientError::Disconnected);
@@ -428,13 +454,7 @@ async fn run_mam_query(
         // before the IQ result resolves the oneshot.
         loop {
             match rx.try_recv() {
-                Ok(ClientEvent::MamResult(archived))
-                    if archived.query_id.as_deref() == Some(&query_id_owned) =>
-                {
-                    if seen_mam_ids.insert(archived.mam_id.clone()) {
-                        messages.push(*archived);
-                    }
-                }
+                Ok(ClientEvent::MamResult(archived)) => collector.collect(*archived),
                 Ok(_) => continue,
                 Err(broadcast::error::TryRecvError::Empty)
                 | Err(broadcast::error::TryRecvError::Closed) => break,
@@ -442,7 +462,7 @@ async fn run_mam_query(
             }
         }
 
-        Ok::<_, ClientError>((fin_el, messages))
+        Ok::<_, ClientError>((fin_el, collector.into_messages()))
     };
 
     let (fin_el, messages) = timeout(Duration::from_secs(30), query)

--- a/server/crates/waddle-xmpp-client/src/mam.rs
+++ b/server/crates/waddle-xmpp-client/src/mam.rs
@@ -14,6 +14,8 @@ use waddle_xmpp_core::mam::{
 use waddle_xmpp_core::xep0359::{OriginId, StanzaId as StableStanzaId, NS_SID as XEP0359_NS};
 
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
+use std::collections::HashSet;
+#[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 use std::time::Duration;
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 use tokio::sync::broadcast;
@@ -394,6 +396,9 @@ async fn run_mam_query(
 
     let query = async {
         let mut messages: Vec<ArchivedMessage> = Vec::new();
+        // XEP-0198 resume mid-query retransmits unacked results with the same
+        // queryid and mam_id; XEP-0313 puts the dedup obligation on us.
+        let mut seen_mam_ids: HashSet<String> = HashSet::new();
         let mut send_iq_fut = Box::pin(handle.send_iq(iq));
 
         let fin_el = loop {
@@ -403,7 +408,9 @@ async fn run_mam_query(
                     Ok(ClientEvent::MamResult(archived))
                         if archived.query_id.as_deref() == Some(&query_id_owned) =>
                     {
-                        messages.push(*archived);
+                        if seen_mam_ids.insert(archived.mam_id.clone()) {
+                            messages.push(*archived);
+                        }
                     }
                     Ok(_) => {}
                     Err(broadcast::error::RecvError::Closed) => {
@@ -423,7 +430,9 @@ async fn run_mam_query(
                 Ok(ClientEvent::MamResult(archived))
                     if archived.query_id.as_deref() == Some(&query_id_owned) =>
                 {
-                    messages.push(*archived);
+                    if seen_mam_ids.insert(archived.mam_id.clone()) {
+                        messages.push(*archived);
+                    }
                 }
                 Ok(_) => continue,
                 Err(broadcast::error::TryRecvError::Empty)

--- a/server/crates/waddle-xmpp-client/src/mam.rs
+++ b/server/crates/waddle-xmpp-client/src/mam.rs
@@ -397,7 +397,8 @@ async fn run_mam_query(
     let query = async {
         let mut messages: Vec<ArchivedMessage> = Vec::new();
         // XEP-0198 resume mid-query retransmits unacked results with the same
-        // queryid and mam_id; XEP-0313 puts the dedup obligation on us.
+        // queryid and mam_id; XEP-0198 §5 leaves weeding out such duplicates
+        // to the recipient.
         let mut seen_mam_ids: HashSet<String> = HashSet::new();
         let mut send_iq_fut = Box::pin(handle.send_iq(iq));
 

--- a/server/crates/waddle-xmpp-client/src/mam/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/mam/tests.rs
@@ -785,6 +785,29 @@ mod query {
         assert_eq!(page.rsm.count, Some(5));
     }
 
+    #[test]
+    fn collector_dedups_replayed_results_and_filters_foreign_query_ids() {
+        let mut collector = super::super::MamResultCollector::new("query-1");
+
+        // Original delivery.
+        collector.collect(build_archived("mam-0", "query-1", "hello 0"));
+        collector.collect(build_archived("mam-1", "query-1", "hello 1"));
+        // XEP-0198 resume replays the unacked tail: same queryid, same mam_id.
+        collector.collect(build_archived("mam-1", "query-1", "hello 1"));
+        collector.collect(build_archived("mam-0", "query-1", "hello 0"));
+        // A result for another open query must never be collected.
+        collector.collect(build_archived("mam-9", "some-other-query", "noise"));
+
+        let messages = collector.into_messages();
+        assert_eq!(
+            messages.len(),
+            2,
+            "replayed results with an already-collected mam_id must be dropped"
+        );
+        assert_eq!(messages[0].mam_id, "mam-0");
+        assert_eq!(messages[1].mam_id, "mam-1");
+    }
+
     #[tokio::test(flavor = "current_thread")]
     async fn fetch_room_history_dedups_replayed_results_by_mam_id() {
         let (handle, mut cmd_rx, evt_tx) = make_handle();

--- a/server/crates/waddle-xmpp-client/src/mam/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/mam/tests.rs
@@ -786,6 +786,74 @@ mod query {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn fetch_room_history_dedups_replayed_results_by_mam_id() {
+        let (handle, mut cmd_rx, evt_tx) = make_handle();
+
+        tokio::spawn(async move {
+            let cmd = cmd_rx.recv().await.expect("driver received cmd");
+            let (stanza, responder) = match cmd {
+                XmppCommand::SendIq { stanza, responder } => (stanza, responder),
+                other => panic!("unexpected command: {other:?}"),
+            };
+
+            let query_id = stanza
+                .get_child("query", MAM_NS)
+                .and_then(|q| q.attr("queryid"))
+                .expect("queryid attribute on <query>")
+                .to_string();
+            let iq_id = stanza.attr("id").expect("id attribute on <iq>").to_string();
+
+            // Original delivery.
+            for i in 0..3u32 {
+                evt_tx
+                    .send(ClientEvent::MamResult(Box::new(build_archived(
+                        &format!("mam-{i}"),
+                        &query_id,
+                        &format!("hello {i}"),
+                    ))))
+                    .expect("broadcast MAM result");
+            }
+
+            // XEP-0198 resume replays the unacked tail: same queryid, same
+            // mam_id, delivered again before the (also replayed) <fin/>.
+            for i in 1..3u32 {
+                evt_tx
+                    .send(ClientEvent::MamResult(Box::new(build_archived(
+                        &format!("mam-{i}"),
+                        &query_id,
+                        &format!("hello {i}"),
+                    ))))
+                    .expect("broadcast replayed MAM result");
+            }
+
+            responder
+                .send(Ok(build_fin_iq(&iq_id, "mam-0", "mam-2", 3)))
+                .expect("responder not dropped");
+        });
+
+        let page = timeout(
+            Duration::from_secs(2),
+            handle.fetch_room_history("room@muc.example.com", 50, None),
+        )
+        .await
+        .expect("run_mam_query must resolve once <fin/> arrives")
+        .expect("fetch_room_history succeeds");
+
+        assert_eq!(
+            page.messages.len(),
+            3,
+            "replayed results with an already-collected mam_id must be dropped"
+        );
+        for (i, msg) in page.messages.iter().enumerate() {
+            assert_eq!(msg.mam_id, format!("mam-{i}"));
+        }
+        assert!(page.is_complete);
+        assert_eq!(page.rsm.first.as_deref(), Some("mam-0"));
+        assert_eq!(page.rsm.last.as_deref(), Some("mam-2"));
+        assert_eq!(page.rsm.count, Some(3));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn fetch_room_history_propagates_send_iq_error() {
         let (handle, mut cmd_rx, _evt_tx) = make_handle();
 


### PR DESCRIPTION
Fixes #1152.

## Problem

`run_mam_query` in `server/crates/waddle-xmpp-client/src/mam.rs` collected `ClientEvent::MamResult` events with a plain `messages.push(...)` in both collection arms — the `tokio::select!` loop and the post-`<fin/>` `try_recv` drain. The `queryid` filter at both sites only screens out *other* queries, not duplicates of this one.

When an XEP-0198 resume happens while a MAM query is open, results the client received but had not yet acked sit in the server's unacked replay window and are retransmitted (correct server behavior per XEP-0198; PR #1151 deliberately rejected a replay exemption as protocol-unsound). The replayed results carry the same `queryid` and the same MAM `id`, so the returned `MamPage` could contain duplicate rows.

## Fix

- Add a per-query `HashSet<String>` of seen `mam_id`s in `run_mam_query`; push a result only on first sight. The same set guards **both** collection arms, so the dedup holds regardless of which `select!` branch consumes a given event.
- First-sight push preserves the server's chronological delivery order, and RSM paging metadata (`first`/`last`/`count`/`complete`) is untouched — it derives from the `<fin/>` element, not the collected set, and `first`/`last` still reference entries present in the deduped page.
- Receive-side only: no stanza construction, ack (`h`) accounting, or any other wire behavior changes.

## Conformance

- XEP-0313 (Business Rules → IDs): archive IDs are unique per item within an archive, and each query targets exactly one archive — so `mam_id` is a sound dedup key per query.
- XEP-0198 §5 explicitly leaves weeding out retransmission duplicates to the recipient; silently dropping the second copy is the sanctioned behavior.

## Review feedback addressed

Both bot reviewers noted the end-to-end test cannot deterministically split deliveries across the two collection arms (`select!` polls ready branches in random order, so this is inherent, not fixable with synchronization). Resolved structurally: the queryid filter + `mam_id` dedup were extracted into a single `MamResultCollector` that both arms delegate to — arm-specific dedup divergence is now impossible by construction — plus a deterministic unit test on the collector.

## Testing (TDD)

- Deterministic unit test `collector_dedups_replayed_results_and_filters_foreign_query_ids` covers the collector directly: replayed `mam_id`s collapse to one entry in first-seen order; foreign-queryid results are dropped.
- End-to-end test `fetch_room_history_dedups_replayed_results_by_mam_id` feeds the query the same `MamResult`s (same `mam_id`, same `queryid`) twice around the `<fin/>` and asserts the page contains each once, in order, with RSM metadata intact. Written red-first: it fails against the pre-fix collector (5 rows instead of 3) and passes with the fix.
- Full `waddle-xmpp-client` suite green (518 tests), `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt` applied.
- Two adversarial review passes (async/correctness + XEP conformance) found no actionable issues; the conformance pass corrected one spec citation in a comment.

## Acceptance criteria

- [x] A `MamPage` never contains two entries with the same `mam_id`, including when results are delivered twice for the same open `queryid`
- [x] Dedup applies in both collection arms of `run_mam_query` (select loop and post-fin drain)
- [x] Unit test: feed the collector the same `MamResult` twice around a `<fin/>` and assert the page contains it once
- [x] RSM paging metadata (`first`/`last`/`complete`) remains derived from the deduped set
