### PR TITLE
fix(server): gate PEP fan-out on access_model — stop MDS read-state leaking to roster contacts (#1094)

### DIFF
--- a/server/crates/waddle-server/src/pubsub/node.rs
+++ b/server/crates/waddle-server/src/pubsub/node.rs
@@ -77,7 +77,32 @@ impl DatabasePubSubStorage {
         else {
             return Ok(None);
         };
-        Ok(Some(Self::decode_node(&row)?))
+        let mut node = Self::decode_node(&row)?;
+
+        // Lazy backfill (issue #1094): fan-out privacy is derived from
+        // the PERSISTED access_model, so a well-known private node
+        // created before its whitelist default existed (stored as
+        // `presence`) would silently re-enter roster+CAPS fan-out. The
+        // configure-time clamp in `bounded_node_config` only fires on
+        // updates; heal legacy rows here on read so every consumer
+        // (fan-out, authz, items) sees the pinned model. The UPDATE
+        // runs once per stale row — steady state is a pure in-memory
+        // comparison.
+        if NodeConfig::pins_whitelist_access(node_name)
+            && node.config.access_model != AccessModel::Whitelist
+        {
+            self.execute(
+                "UPDATE pubsub_nodes SET access_model = ? WHERE owner_jid = ? AND node_name = ?",
+                crate::db_params![
+                    AccessModel::Whitelist.to_string(),
+                    owner.to_string(),
+                    node_name
+                ],
+            )
+            .await?;
+            node.config.access_model = AccessModel::Whitelist;
+        }
+        Ok(Some(node))
     }
 
     pub(super) async fn delete_node_impl(
@@ -350,10 +375,9 @@ fn bounded_node_config(node_name: &str, config: &NodeConfig) -> NodeConfig {
     // Well-known private PEP nodes (whitelist in `NodeConfig::pep_for_node`:
     // MDS per XEP-0490 §3, DND, story reads, status preference) must stay
     // whitelist: an owner configure-set flipping the access model would
-    // re-enable the #1094 roster fan-out and non-owner item reads. Derived
-    // from the well-known table so new private nodes are pinned without
-    // another list to maintain.
-    if NodeConfig::pep_for_node(node_name).access_model == AccessModel::Whitelist {
+    // re-enable the #1094 roster fan-out and non-owner item reads. Same
+    // predicate as the read-path backfill in `get_node_impl`.
+    if NodeConfig::pins_whitelist_access(node_name) {
         config.access_model = AccessModel::Whitelist;
     }
     config

--- a/server/crates/waddle-server/src/pubsub/node.rs
+++ b/server/crates/waddle-server/src/pubsub/node.rs
@@ -1,5 +1,5 @@
 use jid::BareJid;
-use waddle_xmpp::pubsub::{NodeConfig, PubSubNode};
+use waddle_xmpp::pubsub::{AccessModel, NodeConfig, PubSubNode};
 use waddle_xmpp::XmppError;
 
 use super::{
@@ -346,7 +346,17 @@ fn bounded_node_config(node_name: &str, config: &NodeConfig) -> NodeConfig {
     if is_dm_bookmarks_node(node_name) {
         return config.clone().normalize_waddle_dm_bookmarks();
     }
-    config.clone()
+    let mut config = config.clone();
+    // Well-known private PEP nodes (whitelist in `NodeConfig::pep_for_node`:
+    // MDS per XEP-0490 §3, DND, story reads, status preference) must stay
+    // whitelist: an owner configure-set flipping the access model would
+    // re-enable the #1094 roster fan-out and non-owner item reads. Derived
+    // from the well-known table so new private nodes are pinned without
+    // another list to maintain.
+    if NodeConfig::pep_for_node(node_name).access_model == AccessModel::Whitelist {
+        config.access_model = AccessModel::Whitelist;
+    }
+    config
 }
 
 fn is_bookmarks_node(node_name: &str) -> bool {

--- a/server/crates/waddle-server/src/pubsub/tests.rs
+++ b/server/crates/waddle-server/src/pubsub/tests.rs
@@ -387,6 +387,56 @@ async fn dm_bookmark_node_config_clamps_unbounded_max_items_and_pins_whitelist()
 }
 
 #[tokio::test]
+async fn well_known_private_pep_nodes_pin_whitelist_across_reconfigure() {
+    // Issue #1094: fan-out privacy is derived from the stored
+    // access_model, so every well-known whitelist PEP node must resist
+    // an owner configure-set flipping it open — otherwise one IQ
+    // re-enables the roster fan-out and non-owner item reads the
+    // whitelist default exists to prevent.
+    use waddle_xmpp_core::pubsub::AccessModel;
+    let private_nodes = [
+        waddle_xmpp_core::pubsub::pep::PEP_NODE_MDS_DISPLAYED,
+        waddle_xmpp_core::pubsub::pep::PEP_NODE_WADDLE_DND,
+        waddle_xmpp_core::waddle_story_reads::PEP_NODE_WADDLE_STORY_READS,
+        waddle_xmpp_core::waddle_status_preference::PEP_NODE_WADDLE_STATUS_PREFERENCE,
+    ];
+
+    let storage = DatabasePubSubStorage::open(Some("sqlite::memory:"))
+        .await
+        .expect("storage");
+    let owner = jid("alice@example.com");
+
+    for pep_node in private_nodes {
+        let (node, _) = storage
+            .get_or_create_node(&owner, pep_node)
+            .await
+            .expect("node");
+        assert_eq!(
+            node.config.access_model,
+            AccessModel::Whitelist,
+            "{pep_node} must auto-create whitelist"
+        );
+
+        let mut config = node.config.clone();
+        config.access_model = AccessModel::Open;
+        storage
+            .update_node_config(&owner, pep_node, &config)
+            .await
+            .expect("reconfigure");
+        let node = storage
+            .get_node(&owner, pep_node)
+            .await
+            .expect("node lookup")
+            .expect("node exists");
+        assert_eq!(
+            node.config.access_model,
+            AccessModel::Whitelist,
+            "{pep_node} access_model must be forced back to whitelist"
+        );
+    }
+}
+
+#[tokio::test]
 async fn xep0402_bookmark_node_config_forces_private_durable_fields() {
     let storage = DatabasePubSubStorage::open(Some("sqlite::memory:"))
         .await

--- a/server/crates/waddle-server/src/pubsub/tests.rs
+++ b/server/crates/waddle-server/src/pubsub/tests.rs
@@ -437,6 +437,68 @@ async fn well_known_private_pep_nodes_pin_whitelist_across_reconfigure() {
 }
 
 #[tokio::test]
+async fn legacy_presence_row_on_pinned_private_node_is_backfilled_to_whitelist_on_read() {
+    // Issue #1094 follow-up: fan-out privacy is derived from the
+    // PERSISTED access_model, so a well-known private node created
+    // before its whitelist default existed (persisted as `presence`)
+    // would silently re-enter roster+CAPS fan-out. The read path must
+    // lazily backfill such rows: return whitelist AND rewrite the
+    // stored row so every later reader (fan-out, authz) sees it too.
+    use waddle_xmpp_core::pubsub::AccessModel;
+    let reads_node = waddle_xmpp_core::waddle_story_reads::PEP_NODE_WADDLE_STORY_READS;
+
+    let storage = DatabasePubSubStorage::open(Some("sqlite::memory:"))
+        .await
+        .expect("storage");
+    let owner = jid("alice@example.com");
+    let (_, created) = storage
+        .get_or_create_node(&owner, reads_node)
+        .await
+        .expect("node");
+    assert!(created);
+
+    // Simulate the pre-deploy legacy row: the pin in
+    // update_node_config makes this state unreachable via the public
+    // API, so write it directly.
+    let db = storage.database();
+    let conn = db.guard().await.expect("guard");
+    conn.execute(
+        "UPDATE pubsub_nodes SET access_model = 'presence' WHERE owner_jid = ? AND node_name = ?",
+        crate::db_params![owner.to_string(), reads_node],
+    )
+    .await
+    .expect("write legacy access_model");
+    drop(conn);
+
+    let node = storage
+        .get_node(&owner, reads_node)
+        .await
+        .expect("node lookup")
+        .expect("node exists");
+    assert_eq!(
+        node.config.access_model,
+        AccessModel::Whitelist,
+        "read path must backfill a legacy presence row to whitelist"
+    );
+
+    // The heal must be persisted, not just patched in the returned value.
+    let conn = db.guard().await.expect("guard");
+    let mut rows = conn
+        .query(
+            "SELECT access_model FROM pubsub_nodes WHERE owner_jid = ? AND node_name = ?",
+            crate::db_params![owner.to_string(), reads_node],
+        )
+        .await
+        .expect("row query");
+    let row = rows.next().await.expect("row result").expect("row");
+    let stored: String = row.get(0).expect("access_model column");
+    assert_eq!(
+        stored, "whitelist",
+        "backfill must rewrite the persisted row"
+    );
+}
+
+#[tokio::test]
 async fn xep0402_bookmark_node_config_forces_private_durable_fields() {
     let storage = DatabasePubSubStorage::open(Some("sqlite::memory:"))
         .await

--- a/server/crates/waddle-server/src/pubsub_authz.rs
+++ b/server/crates/waddle-server/src/pubsub_authz.rs
@@ -57,19 +57,46 @@ pub async fn can_subscribe(
     let Some(node_meta) = storage.get_node(target, node).await? else {
         return Ok(false);
     };
-    if is_pep && node == waddle_xmpp::xep::xep0402::PEP_NODE {
-        return Ok(derive_pep_owner(target, entity));
+    Ok(can_subscribe_with_config(
+        &node_meta.config,
+        aff,
+        target,
+        node,
+        entity,
+        is_pep,
+    ))
+}
+
+/// Access-model arm of [`can_subscribe`] against an already-loaded
+/// node config. Callers that hold the config (the publish fan-out gate
+/// fetches it once per publish) use this to avoid a redundant
+/// `get_node` round-trip per entity; `can_subscribe` itself is the
+/// fetching wrapper, so the decision logic cannot diverge between the
+/// subscribe/read gate and the fan-out entitlement.
+pub fn can_subscribe_with_config(
+    node_cfg: &waddle_xmpp::pubsub::NodeConfig,
+    aff: Affiliation,
+    target: &BareJid,
+    node: &str,
+    entity: &BareJid,
+    is_pep: bool,
+) -> bool {
+    if aff.is_outcast() {
+        return false;
     }
-    match node_meta.config.access_model {
-        AccessModel::Open => Ok(true),
-        AccessModel::Whitelist => Ok(matches!(
+    if is_pep && node == waddle_xmpp::xep::xep0402::PEP_NODE {
+        return derive_pep_owner(target, entity);
+    }
+    match node_cfg.access_model {
+        AccessModel::Open => true,
+        AccessModel::Whitelist => matches!(
             aff,
             Affiliation::Owner | Affiliation::Publisher | Affiliation::Member
-        )),
+        ),
         AccessModel::Presence | AccessModel::Roster => {
-            Ok(matches!(aff, Affiliation::Owner) || (is_pep && derive_pep_owner(target, entity)))
+            matches!(aff, Affiliation::Owner) || (is_pep && derive_pep_owner(target, entity))
         }
-        AccessModel::Authorize => Ok(matches!(aff, Affiliation::Owner)),
+        AccessModel::Authorize => matches!(aff, Affiliation::Owner),
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
@@ -181,7 +181,14 @@ pub async fn fan_out_publish(state: &WebSocketState, req: FanOutRequest<'_>) {
 
     for sub in subscribers {
         if is_private_pep_node
-            && !private_node_subscriber_allowed(state, owner, node, &sub.subscriber.to_bare()).await
+            && !private_node_subscriber_allowed(
+                state,
+                owner,
+                node,
+                &node_cfg,
+                &sub.subscriber.to_bare(),
+            )
+            .await
         {
             continue;
         }
@@ -370,24 +377,28 @@ pub async fn fan_out_publish(state: &WebSocketState, req: FanOutRequest<'_>) {
 /// access model suppresses the implicit XEP-0163 §3 roster fan-out,
 /// not deliveries the owner explicitly authorized.
 ///
-/// Delegates to `pubsub_authz::can_subscribe` so the fan-out
-/// entitlement can never diverge from the subscribe/read gate: the
-/// XEP-0402 bookmarks owner-only carve-out and the Authorize arm apply
-/// identically here. This matters because an XEP-0060 §8.8 owner
-/// subscriptions-set writes subscription rows WITHOUT a can_subscribe
-/// check — a row's existence is not authorization. Fails closed on
-/// lookup errors — withholding one event beats leaking to a subscriber
-/// we cannot vet.
+/// Delegates to `pubsub_authz::can_subscribe_with_config` — the same
+/// decision arm as the subscribe/read gate — so the fan-out
+/// entitlement can never diverge from it: the XEP-0402 bookmarks
+/// owner-only carve-out and the Authorize arm apply identically here.
+/// This matters because an XEP-0060 §8.8 owner subscriptions-set
+/// writes subscription rows WITHOUT a can_subscribe check — a row's
+/// existence is not authorization. The node config fetched once at the
+/// top of `fan_out_publish` is reused, so the only per-subscriber
+/// storage hit is the affiliation lookup. Fails closed on lookup
+/// errors — withholding one event beats leaking to a subscriber we
+/// cannot vet.
 async fn private_node_subscriber_allowed(
     state: &WebSocketState,
     owner: &BareJid,
     node: &str,
+    node_cfg: &waddle_xmpp::pubsub::NodeConfig,
     subscriber: &BareJid,
 ) -> bool {
     if subscriber == owner {
         return true;
     }
-    match crate::pubsub_authz::can_subscribe(
+    match crate::pubsub_authz::effective_affiliation(
         &state.deps.protocol.pubsub_storage,
         owner,
         node,
@@ -396,7 +407,14 @@ async fn private_node_subscriber_allowed(
     )
     .await
     {
-        Ok(allowed) => allowed,
+        Ok(affiliation) => crate::pubsub_authz::can_subscribe_with_config(
+            node_cfg,
+            affiliation,
+            owner,
+            node,
+            subscriber,
+            true,
+        ),
         Err(error) => {
             warn!(
                 owner = %owner,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
@@ -32,7 +32,7 @@
 use jid::{BareJid, FullJid, Jid};
 use std::collections::HashSet;
 use tracing::{info, warn};
-use waddle_xmpp::pubsub::{build_pubsub_event, PubSubEvent, PubSubItem};
+use waddle_xmpp::pubsub::{build_pubsub_event, AccessModel, PubSubEvent, PubSubItem};
 use waddle_xmpp::registry::BroadcastOutcome;
 use waddle_xmpp::Stanza;
 use waddle_xmpp_core::build_pubsub_retract_event;
@@ -84,27 +84,6 @@ pub async fn fan_out_publish(state: &WebSocketState, req: FanOutRequest<'_>) {
     let publisher = req.publisher;
     let publisher_full = req.publisher_full;
     let is_pep = req.is_pep;
-    // Private PEP nodes (whitelist-access) carve out of roster + CAPS
-    // fan-out even though the published payload is broadcast at the
-    // pubsub layer. Whitelist `access_model` only gates the items-fetch
-    // path; without this check a contact with `+notify` for the node's
-    // namespace would still receive headline events. New entries here
-    // require an integration test asserting roster contacts do NOT
-    // receive the event (see `xep0402_bookmarks_*` and the
-    // `urn:waddle:story:reads:0` fan-out test).
-    let is_private_bookmarks_node = is_pep && node == waddle_xmpp::xep::xep0402::PEP_NODE;
-    let is_private_story_reads_node =
-        is_pep && node == waddle_xmpp_core::waddle_story_reads::PEP_NODE_WADDLE_STORY_READS;
-    // ADR-010 Phase 4: the synced manual-status node is owner-only. Skip
-    // the §3 roster pass so a contact advertising
-    // `urn:waddle:status-preference:0+notify` never learns the user's
-    // picked mode; the §3.4 owner-self pass still runs so the user's own
-    // resources adopt it live.
-    let is_private_status_preference_node = is_pep
-        && node == waddle_xmpp_core::waddle_status_preference::PEP_NODE_WADDLE_STATUS_PREFERENCE;
-    let is_private_pep_node = is_private_bookmarks_node
-        || is_private_story_reads_node
-        || is_private_status_preference_node;
     let storage = &state.deps.protocol.pubsub_storage;
 
     let node_cfg = match storage.get_node(owner, node).await {
@@ -127,6 +106,24 @@ pub async fn fan_out_publish(state: &WebSocketState, req: FanOutRequest<'_>) {
             return;
         }
     };
+
+    // Private PEP nodes carve out of roster + CAPS fan-out even though
+    // the published payload is broadcast at the pubsub layer. Whitelist
+    // `access_model` only gates the items-fetch path; without this
+    // check a contact with `+notify` for the node's namespace would
+    // still receive headline events (issue #1094: MDS read-state
+    // leaked to the whole roster this way). Derived from the node's
+    // actual `access_model` — NOT a node-name allowlist — so any
+    // whitelist-configured node (XEP-0490 MDS, XEP-0402 bookmarks,
+    // story reads, status preference, DND, DM bookmarks, ...) is
+    // private by construction: the §3 roster pass runs only for
+    // Open/Presence/Roster nodes; Whitelist/Authorize nodes reach the
+    // owner's own resources exclusively (§3.4 owner-self pass).
+    let is_private_pep_node = is_pep
+        && matches!(
+            node_cfg.access_model,
+            AccessModel::Whitelist | AccessModel::Authorize
+        );
 
     let subscribers = match storage.list_deliverable_subscribers(owner, node).await {
         Ok(subs) => subs,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
@@ -32,7 +32,7 @@
 use jid::{BareJid, FullJid, Jid};
 use std::collections::HashSet;
 use tracing::{info, warn};
-use waddle_xmpp::pubsub::{build_pubsub_event, AccessModel, PubSubEvent, PubSubItem};
+use waddle_xmpp::pubsub::{build_pubsub_event, AccessModel, Affiliation, PubSubEvent, PubSubItem};
 use waddle_xmpp::registry::BroadcastOutcome;
 use waddle_xmpp::Stanza;
 use waddle_xmpp_core::build_pubsub_retract_event;
@@ -180,7 +180,16 @@ pub async fn fan_out_publish(state: &WebSocketState, req: FanOutRequest<'_>) {
     }
 
     for sub in subscribers {
-        if is_private_pep_node && sub.subscriber.to_bare() != *owner {
+        if is_private_pep_node
+            && !private_node_subscriber_allowed(
+                state,
+                owner,
+                node,
+                node_cfg.access_model,
+                &sub.subscriber.to_bare(),
+            )
+            .await
+        {
             continue;
         }
 
@@ -357,6 +366,58 @@ pub async fn fan_out_publish(state: &WebSocketState, req: FanOutRequest<'_>) {
         self_caps_delivered = self_metrics.delivered,
         "PubSub publish fan-out complete"
     );
+}
+
+/// Whether an explicit subscriber of a private (Whitelist/Authorize)
+/// PEP node is entitled to event notifications.
+///
+/// XEP-0060 §4.5 + §8.9: on a Whitelist node the owner whitelists an
+/// entity by affiliating it (member/publisher), and that entity's
+/// server-approved subscription MUST then be notified (§7.1) — the
+/// access model suppresses the implicit XEP-0163 §3 roster fan-out,
+/// not deliveries the owner explicitly authorized. Mirrors the
+/// Whitelist arm of `pubsub_authz::can_subscribe`. `Authorize` is
+/// owner-only in this server (see `AccessModel::Authorize`), so
+/// non-owner subscribers are never entitled there. Fails closed on
+/// affiliation-lookup errors — withholding one event beats leaking to
+/// a subscriber we cannot vet.
+async fn private_node_subscriber_allowed(
+    state: &WebSocketState,
+    owner: &BareJid,
+    node: &str,
+    access_model: AccessModel,
+    subscriber: &BareJid,
+) -> bool {
+    if subscriber == owner {
+        return true;
+    }
+    if access_model != AccessModel::Whitelist {
+        return false;
+    }
+    match crate::pubsub_authz::effective_affiliation(
+        &state.deps.protocol.pubsub_storage,
+        owner,
+        node,
+        subscriber,
+        true,
+    )
+    .await
+    {
+        Ok(affiliation) => matches!(
+            affiliation,
+            Affiliation::Owner | Affiliation::Publisher | Affiliation::Member
+        ),
+        Err(error) => {
+            warn!(
+                owner = %owner,
+                node,
+                subscriber = %subscriber,
+                error = %error,
+                "Affiliation lookup failed during private-node fan-out; failing closed"
+            );
+            false
+        }
+    }
 }
 
 pub async fn fan_out_retract(state: &WebSocketState, req: FanOutRetractRequest<'_>) {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/pubsub_fanout.rs
@@ -32,7 +32,7 @@
 use jid::{BareJid, FullJid, Jid};
 use std::collections::HashSet;
 use tracing::{info, warn};
-use waddle_xmpp::pubsub::{build_pubsub_event, AccessModel, Affiliation, PubSubEvent, PubSubItem};
+use waddle_xmpp::pubsub::{build_pubsub_event, AccessModel, PubSubEvent, PubSubItem};
 use waddle_xmpp::registry::BroadcastOutcome;
 use waddle_xmpp::Stanza;
 use waddle_xmpp_core::build_pubsub_retract_event;
@@ -181,14 +181,7 @@ pub async fn fan_out_publish(state: &WebSocketState, req: FanOutRequest<'_>) {
 
     for sub in subscribers {
         if is_private_pep_node
-            && !private_node_subscriber_allowed(
-                state,
-                owner,
-                node,
-                node_cfg.access_model,
-                &sub.subscriber.to_bare(),
-            )
-            .await
+            && !private_node_subscriber_allowed(state, owner, node, &sub.subscriber.to_bare()).await
         {
             continue;
         }
@@ -375,26 +368,26 @@ pub async fn fan_out_publish(state: &WebSocketState, req: FanOutRequest<'_>) {
 /// entity by affiliating it (member/publisher), and that entity's
 /// server-approved subscription MUST then be notified (§7.1) — the
 /// access model suppresses the implicit XEP-0163 §3 roster fan-out,
-/// not deliveries the owner explicitly authorized. Mirrors the
-/// Whitelist arm of `pubsub_authz::can_subscribe`. `Authorize` is
-/// owner-only in this server (see `AccessModel::Authorize`), so
-/// non-owner subscribers are never entitled there. Fails closed on
-/// affiliation-lookup errors — withholding one event beats leaking to
-/// a subscriber we cannot vet.
+/// not deliveries the owner explicitly authorized.
+///
+/// Delegates to `pubsub_authz::can_subscribe` so the fan-out
+/// entitlement can never diverge from the subscribe/read gate: the
+/// XEP-0402 bookmarks owner-only carve-out and the Authorize arm apply
+/// identically here. This matters because an XEP-0060 §8.8 owner
+/// subscriptions-set writes subscription rows WITHOUT a can_subscribe
+/// check — a row's existence is not authorization. Fails closed on
+/// lookup errors — withholding one event beats leaking to a subscriber
+/// we cannot vet.
 async fn private_node_subscriber_allowed(
     state: &WebSocketState,
     owner: &BareJid,
     node: &str,
-    access_model: AccessModel,
     subscriber: &BareJid,
 ) -> bool {
     if subscriber == owner {
         return true;
     }
-    if access_model != AccessModel::Whitelist {
-        return false;
-    }
-    match crate::pubsub_authz::effective_affiliation(
+    match crate::pubsub_authz::can_subscribe(
         &state.deps.protocol.pubsub_storage,
         owner,
         node,
@@ -403,17 +396,14 @@ async fn private_node_subscriber_allowed(
     )
     .await
     {
-        Ok(affiliation) => matches!(
-            affiliation,
-            Affiliation::Owner | Affiliation::Publisher | Affiliation::Member
-        ),
+        Ok(allowed) => allowed,
         Err(error) => {
             warn!(
                 owner = %owner,
                 node,
                 subscriber = %subscriber,
                 error = %error,
-                "Affiliation lookup failed during private-node fan-out; failing closed"
+                "Subscriber authorization lookup failed during private-node fan-out; failing closed"
             );
             false
         }

--- a/server/crates/waddle-server/tests/xep0163_pep_ws.rs
+++ b/server/crates/waddle-server/tests/xep0163_pep_ws.rs
@@ -794,6 +794,110 @@ async fn pep_bookmark_publish_skips_roster_contacts_even_with_matching_caps_noti
 }
 
 #[tokio::test]
+async fn pep_bookmark_member_affiliation_grants_no_event_delivery() {
+    // XEP-0402 bookmarks are owner-only regardless of affiliation: the
+    // `can_subscribe` carve-out denies a member-affiliated non-owner,
+    // and the fan-out entitlement must apply the SAME rule. An owner
+    // subscriptions-set (§8.8) can force a subscription row without a
+    // can_subscribe check, so fan-out must not treat "subscription row
+    // exists + member affiliation" as authorization on this node.
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+    let mut alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        "alice-bookmark-member-1",
+    )
+    .await
+    .expect("alice connect");
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "bob-bookmark-member-1",
+    )
+    .await
+    .expect("bob connect");
+    let alice_bare = format!("alice@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+    let node = "urn:xmpp:bookmarks:1";
+
+    alice
+        .send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("alice presence");
+    bob.send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("bob presence");
+
+    let seed = iq_set_to(
+        &mut alice,
+        "pep-bookmark-member-seed",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{node}"><item id="seed-member@muc.example.com"><conference xmlns="{node}" name="Seed"><extensions><notify xmlns="urn:xmpp:notification-settings:1"><never/></notify></extensions></conference></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(seed.contains(r#"type='result'"#), "seed publish: {seed}");
+
+    // Owner affiliates bob as member (§8.9.4) and force-subscribes him
+    // via the owner subscriptions-set (§8.8), which bypasses
+    // can_subscribe.
+    let aff = iq_set_to(
+        &mut alice,
+        "pep-bookmark-member-aff",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB_OWNER}"><affiliations node="{node}"><affiliation jid="{bob_bare}" affiliation="member"/></affiliations></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(aff.contains(r#"type='result'"#), "affiliations set: {aff}");
+    let subs = iq_set_to(
+        &mut alice,
+        "pep-bookmark-member-subs",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB_OWNER}"><subscriptions node="{node}"><subscription jid="{bob_bare}" subscription="subscribed"/></subscriptions></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        subs.contains(r#"type='result'"#),
+        "owner subscriptions set: {subs}"
+    );
+
+    let pub_resp = iq_set_to(
+        &mut alice,
+        "pep-bookmark-member-pub",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><publish node="{node}"><item id="private-member@muc.example.com"><conference xmlns="{node}" name="Private"><extensions><notify xmlns="urn:xmpp:notification-settings:1"><never/></notify></extensions></conference></item></publish></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type='result'"#), "publish: {pub_resp}");
+
+    let event = wait_for_event_message(&mut bob, node, Duration::from_millis(700)).await;
+    assert!(
+        event.is_none(),
+        "bookmarks are owner-only even for member-affiliated subscribers; leaked: {event:?}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}
+
+#[tokio::test]
 async fn pep_bookmark_open_config_does_not_grant_non_owner_access() {
     let _serial = TEST_SERIAL.lock().await;
     let alice_password = format!("alice-{}", uuid::Uuid::new_v4());

--- a/server/crates/waddle-server/tests/xep0223_story_reads_ws.rs
+++ b/server/crates/waddle-server/tests/xep0223_story_reads_ws.rs
@@ -20,8 +20,92 @@ use ws_common::{TestServer, WsXmppClient};
 const DOMAIN: &str = "localhost";
 const READS_NODE: &str = "urn:waddle:story:reads:0";
 const READS_NS: &str = "urn:waddle:story:reads:0";
+const NS_CAPS: &str = "http://jabber.org/protocol/caps";
+const NS_DISCO_INFO: &str = "http://jabber.org/protocol/disco#info";
 
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+/// Compute the XEP-0115 ver hash for the advertised feature set.
+/// Copied verbatim from `xep0163_pep_ws.rs`.
+fn caps_verification_string(
+    identity_category: &str,
+    identity_type: &str,
+    identity_name: &str,
+    features: &[&str],
+) -> String {
+    use waddle_xmpp::disco::info::{Feature, Identity};
+    use waddle_xmpp::xep::xep0115::compute_caps_hash;
+    let identities = vec![Identity::new(
+        identity_category,
+        identity_type,
+        Some(identity_name),
+    )];
+    let features: Vec<Feature> = features.iter().map(|f| Feature::new(f)).collect();
+    compute_caps_hash(&identities, &features)
+}
+
+/// Send a ping IQ and wait for its result — a deterministic FIFO
+/// anchor proving all prior frames on this connection were processed.
+/// Copied verbatim from `xep0163_pep_ws.rs`.
+async fn ping_anchor(client: &mut WsXmppClient, id: &str) {
+    client
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="get" id="{id}"><ping xmlns="urn:xmpp:ping"/></iq>"#
+        ))
+        .await
+        .expect("send ping");
+    let _ = client
+        .recv_matching(|frame| frame.contains(&format!(r#"id='{id}'"#)) && frame.contains("<iq"))
+        .await
+        .expect("ping result");
+}
+
+/// Establish bob -> alice presence subscription so alice's roster has
+/// bob with `subscription = from` (the XEP-0163 §3 fan-out target).
+/// Adapted from `xep0163_pep_ws.rs`.
+async fn establish_bob_subscribes_to_alice(alice: &mut WsXmppClient, bob: &mut WsXmppClient) {
+    let alice_bare = format!("alice@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+    alice
+        .send(r#"<iq xmlns="jabber:client" type="get" id="roster-init-a"><query xmlns="jabber:iq:roster"/></iq>"#)
+        .await
+        .expect("alice roster get");
+    let _ = alice
+        .recv_matching(|f| f.contains("roster-init-a"))
+        .await
+        .expect("alice roster result");
+    bob.send(r#"<iq xmlns="jabber:client" type="get" id="roster-init-b"><query xmlns="jabber:iq:roster"/></iq>"#)
+        .await
+        .expect("bob roster get");
+    let _ = bob
+        .recv_matching(|f| f.contains("roster-init-b"))
+        .await
+        .expect("bob roster result");
+
+    alice
+        .send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("alice presence");
+    bob.send(&format!(
+        r#"<presence xmlns="jabber:client" type="subscribe" to="{alice_bare}"/>"#
+    ))
+    .await
+    .expect("bob subscribes");
+    let _subscribe = alice
+        .recv_matching(|f| f.contains(r#"type='subscribe'"#))
+        .await
+        .expect("alice receives subscribe");
+    alice
+        .send(&format!(
+            r#"<presence xmlns="jabber:client" type="subscribed" to="{bob_bare}"/>"#
+        ))
+        .await
+        .expect("alice approves");
+    let _subscribed = bob
+        .recv_matching(|f| f.contains(r#"type='subscribed'"#))
+        .await
+        .expect("bob receives approval");
+}
 
 async fn connect_admin() -> (TestServer, WsXmppClient) {
     let server = TestServer::start();
@@ -236,6 +320,89 @@ async fn node_is_private_to_owner() {
     assert!(
         bob_result.contains("forbidden") || bob_result.contains("item-not-found"),
         "expected forbidden or item-not-found, got: {bob_result}"
+    );
+
+    let _ = alice.close().await;
+    let _ = bob.close().await;
+}
+
+#[tokio::test]
+async fn private_pep_does_not_fan_out_to_roster_contact_with_notify_caps() {
+    // Issue #1094 regression guard for the access_model-derived fan-out
+    // gate: story reads must be whitelist-configured at auto-create so
+    // a roster contact (subscription=from) advertising
+    // `urn:waddle:story:reads:0+notify` caps never receives the §3
+    // roster fan-out. Unlike `private_pep_does_not_fan_out_to_roster`
+    // below, this test puts bob on the REAL leak path (roster + caps),
+    // which is presence-driven and needs no pubsub <subscribe/>.
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut alice, mut bob) = connect_two_accounts().await;
+
+    establish_bob_subscribes_to_alice(&mut alice, &mut bob).await;
+
+    let notify_var = format!("{READS_NODE}+notify");
+    let features = [NS_DISCO_INFO, notify_var.as_str()];
+    let caps_node = "https://bob.example/story-reads-caps";
+    let ver = caps_verification_string("client", "pc", "Bob's Client", &features);
+    let bob_full = bob.full_jid.clone().expect("bob full jid");
+    bob.send(&format!(
+        r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{caps_node}" ver="{ver}"/></presence>"#
+    ))
+    .await
+    .expect("bob caps presence");
+    let disco_query = bob
+        .recv_matching(|f| {
+            f.contains("<iq") && f.contains(r#"type='get'"#) && f.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server caps disco to bob");
+    let iq_id = ws_common::extract_attr_after(&disco_query, "<iq", "id").expect("iq id");
+    let feature_xml: String = features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    bob.send(&format!(
+        r#"<iq xmlns="jabber:client" type="result" id="{iq_id}" from="{bob_full}"><query xmlns="{NS_DISCO_INFO}" node="{caps_node}#{ver}"><identity category="client" type="pc" name="Bob's Client"/>{feature_xml}</query></iq>"#
+    ))
+    .await
+    .expect("bob disco reply");
+    ping_anchor(&mut bob, "story-reads-caps-anchor").await;
+
+    let body = reads_body(&[("story-leak", "2026-07-03T10:00:00Z")]);
+    alice
+        .send(&publish_reads_iq("alice-caps-pub", &body))
+        .await
+        .expect("alice publish");
+    let publish_result = alice
+        .recv_matching(|f| f.contains(r#"id='alice-caps-pub'"#))
+        .await
+        .expect("alice publish result");
+    assert!(
+        publish_result.contains(r#"type='result'"#),
+        "publish failed: {publish_result}"
+    );
+
+    // Poll the raw stream (no consuming anchor) for a leaked event.
+    let mut leaked: Option<String> = None;
+    let deadline = std::time::Instant::now() + Duration::from_millis(700);
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match bob.recv_timeout(remaining).await {
+            Ok(frame) => {
+                if frame.contains(READS_NODE) || frame.contains("story-leak") {
+                    leaked = Some(frame);
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    assert!(
+        leaked.is_none(),
+        "story-reads leaked to roster contact with +notify caps: {leaked:?}"
     );
 
     let _ = alice.close().await;

--- a/server/crates/waddle-server/tests/xep0490_mds_ws.rs
+++ b/server/crates/waddle-server/tests/xep0490_mds_ws.rs
@@ -458,6 +458,103 @@ async fn xep0490_other_resource_with_notify_caps_receives_event() {
 }
 
 #[tokio::test]
+async fn xep0490_publish_does_not_fan_out_to_roster_contacts_with_notify_caps() {
+    // Issue #1094: the MDS node is whitelist-access (XEP-0490 §3), so
+    // read-state publishes are private to the account. A roster contact
+    // with subscription=from advertising `urn:xmpp:mds:displayed:0+notify`
+    // MUST NOT receive the §3 roster fan-out — otherwise every message
+    // read leaks last-read stanza-ids to the whole roster.
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+    let mut alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        "mds-roster-alice",
+    )
+    .await
+    .expect("alice connect");
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "mds-roster-bob",
+    )
+    .await
+    .expect("bob connect");
+    let alice_bare = format!("alice@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+    let bob_full = bob.full_jid.clone().expect("bob full jid");
+
+    establish_bob_subscribes_to_alice(&mut alice, &mut bob, &alice_bare, &bob_bare).await;
+
+    // Bob advertises the MDS +notify filter via XEP-0115 caps — the
+    // exact posture of a real MDS-capable client.
+    let features = [NS_DISCO_INFO, MDS_NOTIFY];
+    let caps_node = "https://bob.example/mds-roster-caps";
+    let ver = caps_verification_string("client", "pc", "Bob's Client", &features);
+    bob.send(&format!(
+        r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{caps_node}" ver="{ver}"/></presence>"#
+    ))
+    .await
+    .expect("bob caps presence");
+    let disco_query = bob
+        .recv_matching(|f| {
+            f.contains("<iq") && f.contains(r#"type='get'"#) && f.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server caps disco to bob");
+    let iq_id = extract_iq_id(&disco_query);
+    let feature_xml: String = features
+        .iter()
+        .map(|f| format!(r#"<feature var="{f}"/>"#))
+        .collect();
+    bob.send(&format!(
+        r#"<iq xmlns="jabber:client" type="result" id="{iq_id}" from="{bob_full}"><query xmlns="{NS_DISCO_INFO}" node="{caps_node}#{ver}"><identity category="client" type="pc" name="Bob's Client"/>{feature_xml}</query></iq>"#
+    ))
+    .await
+    .expect("bob disco reply");
+
+    ping_anchor(
+        &mut bob,
+        &format!("mds-roster-anchor-{}", uuid::Uuid::new_v4()),
+    )
+    .await;
+
+    // Alice marks a chat as read.
+    let pub_resp = iq_set_to(
+        &mut alice,
+        "mds-roster-pub",
+        &alice_bare,
+        &mds_publish_xml(
+            "romeo@montague.lit",
+            "0f710f2b-52ed-4d52-b928-784dad74a52b",
+            &alice_bare,
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type='result'"#), "publish: {pub_resp}");
+
+    // No ping anchor here: recv_matching would consume (and hide) a
+    // leaked event. Poll the raw stream like the bookmark privacy test.
+    let event = wait_for_event_message(&mut bob, MDS_NODE, Duration::from_millis(700)).await;
+    assert!(
+        event.is_none(),
+        "whitelist-access MDS node MUST NOT fan out read state to roster contacts: {event:?}"
+    );
+
+    let _ = alice.close().await;
+    let _ = bob.close().await;
+}
+
+#[tokio::test]
 async fn xep0490_muc_stanza_id_by_attribute_round_trips_through_publish_and_catchup() {
     let _serial = TEST_SERIAL.lock().await;
     let server = TestServer::start();
@@ -525,6 +622,56 @@ fn caps_verification_string(
 fn extract_iq_id(frame: &str) -> String {
     use ws_common::extract_attr_after;
     extract_attr_after(frame, "<iq", "id").expect("iq has id attribute")
+}
+
+/// Establish bob -> alice presence subscription so alice's roster
+/// has bob with `subscription = from` (alice's PEP fan-out target).
+/// Copied verbatim from `xep0163_pep_ws.rs`.
+async fn establish_bob_subscribes_to_alice(
+    alice: &mut WsXmppClient,
+    bob: &mut WsXmppClient,
+    alice_bare: &str,
+    bob_bare: &str,
+) {
+    alice
+        .send(r#"<iq xmlns="jabber:client" type="get" id="roster-init-a"><query xmlns="jabber:iq:roster"/></iq>"#)
+        .await
+        .expect("alice roster get");
+    let _ = alice
+        .recv_matching(|f| f.contains("roster-init-a"))
+        .await
+        .expect("alice roster result");
+    bob.send(r#"<iq xmlns="jabber:client" type="get" id="roster-init-b"><query xmlns="jabber:iq:roster"/></iq>"#)
+        .await
+        .expect("bob roster get");
+    let _ = bob
+        .recv_matching(|f| f.contains("roster-init-b"))
+        .await
+        .expect("bob roster result");
+
+    alice
+        .send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("alice presence");
+    bob.send(&format!(
+        r#"<presence xmlns="jabber:client" type="subscribe" to="{alice_bare}"/>"#
+    ))
+    .await
+    .expect("bob subscribes");
+    let _subscribe = alice
+        .recv_matching(|f| f.contains(r#"type='subscribe'"#))
+        .await
+        .expect("alice receives subscribe");
+    alice
+        .send(&format!(
+            r#"<presence xmlns="jabber:client" type="subscribed" to="{bob_bare}"/>"#
+        ))
+        .await
+        .expect("alice approves");
+    let _subscribed = bob
+        .recv_matching(|f| f.contains(r#"type='subscribed'"#))
+        .await
+        .expect("bob receives approval");
 }
 
 async fn ping_anchor(client: &mut WsXmppClient, id: &str) {

--- a/server/crates/waddle-server/tests/xep0490_mds_ws.rs
+++ b/server/crates/waddle-server/tests/xep0490_mds_ws.rs
@@ -30,6 +30,7 @@ const ADMIN: &str = "admin";
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
 const NS_PUBSUB: &str = "http://jabber.org/protocol/pubsub";
+const NS_PUBSUB_OWNER: &str = "http://jabber.org/protocol/pubsub#owner";
 const NS_PUBSUB_EVENT: &str = "http://jabber.org/protocol/pubsub#event";
 const NS_CAPS: &str = "http://jabber.org/protocol/caps";
 const NS_DISCO_INFO: &str = "http://jabber.org/protocol/disco#info";
@@ -548,6 +549,199 @@ async fn xep0490_publish_does_not_fan_out_to_roster_contacts_with_notify_caps() 
     assert!(
         event.is_none(),
         "whitelist-access MDS node MUST NOT fan out read state to roster contacts: {event:?}"
+    );
+
+    let _ = alice.close().await;
+    let _ = bob.close().await;
+}
+
+#[tokio::test]
+async fn xep0490_whitelisted_member_subscriber_still_receives_events() {
+    // XEP-0060 §8.9 + whitelist: the owner CAN whitelist another entity
+    // by setting its affiliation to `member`; that entity may then
+    // subscribe and MUST receive event notifications (§7.1.2.2 — the
+    // node access model gates the roster fan-out, not a server-approved
+    // subscription). Guards the #1094 access_model gate against
+    // over-blocking: private means "no implicit roster fan-out", not
+    // "accept the subscription and never deliver".
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+    let mut alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        "mds-member-alice",
+    )
+    .await
+    .expect("alice connect");
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "mds-member-bob",
+    )
+    .await
+    .expect("bob connect");
+    let alice_bare = format!("alice@{DOMAIN}");
+    let bob_bare = format!("bob@{DOMAIN}");
+
+    alice
+        .send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("alice presence");
+    bob.send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("bob presence");
+
+    // Auto-create the whitelist node with a first publish.
+    let seed = iq_set_to(
+        &mut alice,
+        "mds-member-seed",
+        &alice_bare,
+        &mds_publish_xml(
+            "juliet@capulet.lit",
+            "11111111-1111-1111-1111-111111111111",
+            &alice_bare,
+        ),
+    )
+    .await;
+    assert!(seed.contains(r#"type='result'"#), "seed publish: {seed}");
+
+    // Alice whitelists bob (XEP-0060 §8.9.4 affiliation=member).
+    let aff = iq_set_to(
+        &mut alice,
+        "mds-member-aff",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB_OWNER}"><affiliations node="{MDS_NODE}"><affiliation jid="{bob_bare}" affiliation="member"/></affiliations></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(aff.contains(r#"type='result'"#), "affiliations set: {aff}");
+
+    // Bob subscribes; the whitelist arm of can_subscribe admits members.
+    let sub = iq_set_to(
+        &mut bob,
+        "mds-member-sub",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB}"><subscribe node="{MDS_NODE}" jid="{bob_bare}"/></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(
+        sub.contains(r#"type='result'"#) && sub.contains(r#"subscription='subscribed'"#),
+        "whitelisted member subscribe must be accepted: {sub}"
+    );
+
+    // Alice publishes; bob's approved subscription MUST be notified.
+    let pub_resp = iq_set_to(
+        &mut alice,
+        "mds-member-pub",
+        &alice_bare,
+        &mds_publish_xml(
+            "romeo@montague.lit",
+            "22222222-2222-2222-2222-222222222222",
+            &alice_bare,
+        ),
+    )
+    .await;
+    assert!(pub_resp.contains(r#"type='result'"#), "publish: {pub_resp}");
+
+    let event = wait_for_event_message(&mut bob, MDS_NODE, Duration::from_secs(2))
+        .await
+        .expect("server-approved whitelist member subscriber MUST receive the publish event");
+    assert!(
+        event.contains(r#"id='romeo@montague.lit'"#),
+        "event must carry the published item: {event}"
+    );
+
+    let _ = alice.close().await;
+    let _ = bob.close().await;
+}
+
+#[tokio::test]
+async fn xep0490_open_config_request_does_not_unpin_whitelist() {
+    // XEP-0490 §3 REQUIRES the MDS node to be whitelist-access. An
+    // owner configure-set requesting `access_model=open` must not be
+    // able to unpin that (mirrors the XEP-0402 bookmarks hardening in
+    // `pep_bookmark_open_config_does_not_grant_non_owner_access`):
+    // otherwise one configure IQ re-enables the #1094 roster fan-out
+    // and non-owner reads of the read-state node.
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+    let mut alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "alice",
+        &alice_password,
+        "mds-cfg-alice",
+    )
+    .await
+    .expect("alice connect");
+    let mut bob = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "bob",
+        &bob_password,
+        "mds-cfg-bob",
+    )
+    .await
+    .expect("bob connect");
+    let alice_bare = format!("alice@{DOMAIN}");
+
+    let seed = iq_set_to(
+        &mut alice,
+        "mds-cfg-seed",
+        &alice_bare,
+        &mds_publish_xml(
+            "juliet@capulet.lit",
+            "33333333-3333-3333-3333-333333333333",
+            &alice_bare,
+        ),
+    )
+    .await;
+    assert!(seed.contains(r#"type='result'"#), "seed publish: {seed}");
+
+    let cfg = iq_set_to(
+        &mut alice,
+        "mds-cfg-open",
+        &alice_bare,
+        &format!(
+            r#"<pubsub xmlns="{NS_PUBSUB_OWNER}"><configure node="{MDS_NODE}"><x xmlns="jabber:x:data" type="submit"><field var="pubsub#access_model"><value>open</value></field></x></configure></pubsub>"#
+        ),
+    )
+    .await;
+    assert!(cfg.contains(r#"type='result'"#), "configure: {cfg}");
+
+    // Even after the open-config request, a non-owner read of the
+    // read-state node MUST stay denied.
+    let read = iq_get_to(
+        &mut bob,
+        "mds-cfg-bob-read",
+        &alice_bare,
+        &format!(r#"<pubsub xmlns="{NS_PUBSUB}"><items node="{MDS_NODE}"/></pubsub>"#),
+    )
+    .await;
+    assert!(
+        read.contains(r#"type='error'"#),
+        "MDS items must stay private after an open configure request: {read}"
+    );
+    assert!(
+        !read.contains("juliet@capulet.lit"),
+        "read-state item id (a conversation JID) must not leak: {read}"
     );
 
     let _ = alice.close().await;

--- a/server/crates/waddle-xmpp-core/src/pubsub/node.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/node.rs
@@ -335,8 +335,40 @@ impl NodeConfig {
             config = Self::waddle_dm_bookmarks_defaults();
         } else if node == crate::waddle_status_preference::PEP_NODE_WADDLE_STATUS_PREFERENCE {
             config = Self::waddle_status_preference_defaults();
+        } else if node == crate::waddle_story_reads::PEP_NODE_WADDLE_STORY_READS {
+            config = Self::waddle_story_reads_defaults();
         }
         config
+    }
+
+    /// Defaults for the Waddle story-reads PEP node.
+    ///
+    /// The single `current` item is the user's private story read-state
+    /// (which stories they have seen, and when) — no roster contact may
+    /// read it. The wasm client requests exactly this shape via
+    /// publish-options, but publish-options are not enforced at the
+    /// server's Publish arm, so the auto-create default MUST already be
+    /// `whitelist` + `never`: with the generic `pep_default()`
+    /// (`access_model = presence`) the access_model-derived fan-out
+    /// gate (issue #1094) would let the XEP-0163 §3 roster pass deliver
+    /// read-state to any contact advertising
+    /// `urn:waddle:story:reads:0+notify`.
+    ///
+    /// `notify_retract` / `notify_delete` are `false` because the
+    /// server does not emit those events for this node; read-state
+    /// changes are always republishes of the `current` item.
+    pub fn waddle_story_reads_defaults() -> Self {
+        Self {
+            access_model: AccessModel::Whitelist,
+            publish_model: PublishModel::Publishers,
+            node_type: None,
+            max_items: 1,
+            persist_items: true,
+            deliver_payloads: true,
+            notify_retract: false,
+            notify_delete: false,
+            send_last_published_item: SendLastPublishedItem::Never,
+        }
     }
 
     /// Defaults for the Waddle status-preference PEP node (ADR-010

--- a/server/crates/waddle-xmpp-core/src/pubsub/node.rs
+++ b/server/crates/waddle-xmpp-core/src/pubsub/node.rs
@@ -341,6 +341,21 @@ impl NodeConfig {
         config
     }
 
+    /// Whether a node's access model is pinned to `whitelist` by its
+    /// well-known PEP defaults (issue #1094).
+    ///
+    /// Fan-out privacy is derived from the persisted `access_model`,
+    /// so nodes whose well-known default is `whitelist` must never be
+    /// stored with anything weaker — neither via an owner
+    /// configure-set nor as a legacy row created before the default
+    /// existed. Consumers use this single predicate for both the
+    /// configure-time clamp and the read-time backfill so the pin set
+    /// always tracks the `pep_for_node` table and never becomes a
+    /// second hand-maintained node-name list.
+    pub fn pins_whitelist_access(node: &str) -> bool {
+        Self::pep_for_node(node).access_model == AccessModel::Whitelist
+    }
+
     /// Defaults for the Waddle story-reads PEP node.
     ///
     /// The single `current` item is the user's private story read-state


### PR DESCRIPTION
Fixes #1094.

## Problem

The "private PEP node" carve-out that suppresses the XEP-0163 §3 roster fan-out in `pubsub_fanout.rs` was a hard-coded list of three node names (`urn:xmpp:bookmarks:1`, `urn:waddle:story:reads:0`, `urn:waddle:status-preference:0`). `urn:xmpp:mds:displayed:0` is whitelist-access per XEP-0490 §3 but was **not** on that list, and the client advertises `urn:xmpp:mds:displayed:0+notify` — so every MDS publish (fired on every message read, payload = last-read stanza-id) was delivered as a `type='headline'` event to every available resource of every roster contact, leaking read state.

## Fix

1. **Access-model-derived fan-out gate** (`pubsub_fanout.rs`): the carve-out is now computed from the node's stored `access_model` (already fetched for `deliver_payloads`), and the name list is deleted. `Open`/`Presence`/`Roster` → §3 roster + CAPS fan-out runs as before. `Whitelist`/`Authorize` → the §3 roster pass is skipped; only the §3.4 owner-self pass and authorized explicit subscribers deliver. Any future whitelist node is private by construction. This also newly covers `urn:waddle:dnd:0` and `urn:waddle:dm-bookmarks:0` (both whitelist, never on the old list).
2. **Explicit-subscriber entitlement delegates to `pubsub_authz::can_subscribe`** (`private_node_subscriber_allowed`): an owner-whitelisted `member`'s approved subscription still receives events (XEP-0060 §8.9/§7.1), the XEP-0402 bookmarks owner-only carve-out applies identically to delivery, and a subscription row forced via §8.8 owner subscriptions-set is not treated as authorization. Fails closed on lookup errors.
3. **Story-reads whitelist default** (`NodeConfig::pep_for_node`): `urn:waddle:story:reads:0` was missing from the well-known table, so it auto-created as `presence` (publish-options are not enforced server-side) — under the derived gate it would have re-leaked read state to roster contacts. Added `waddle_story_reads_defaults()` (whitelist, `send_last_published_item=never`, `max_items=1`).
4. **Config pinning** (`bounded_node_config`): every well-known private PEP node (MDS, DND, story-reads, status-preference; derived from `pep_for_node`, no second list) has its `access_model` forced back to whitelist on every reconfigure, so one owner configure-set IQ can no longer reopen roster fan-out or non-owner item reads.
5. **Lazy legacy-row backfill** (`get_node_impl`, code-review follow-up): a well-known private node persisted before its whitelist default existed (stored as `presence`) is healed on read — the row is rewritten to whitelist and the pinned config returned, so fan-out/authz never see the stale model. Uses the same shared `NodeConfig::pins_whitelist_access` predicate as the configure clamp (derived from `pep_for_node`); one UPDATE per stale row, in-memory comparison at steady state.

## Process (TDD + adversarial review)

Every fix landed test-first; each new test was verified RED on the pre-fix code:

- `xep0490_publish_does_not_fan_out_to_roster_contacts_with_notify_caps` — roster contact (`subscription=from`) with MDS `+notify` CAPS receives nothing (reproduced the leak verbatim on main).
- `xep0490_whitelisted_member_subscriber_still_receives_events` — §8.9 member + approved subscription still notified.
- `xep0490_open_config_request_does_not_unpin_whitelist` — open-configure then non-owner read stays denied (leaked conversation JIDs before the pin).
- `private_pep_does_not_fan_out_to_roster_contact_with_notify_caps` (story-reads) — real roster+caps posture, unlike the pre-existing subscription-only test which could not see this leak.
- `pep_bookmark_member_affiliation_grants_no_event_delivery` — member affiliation + §8.8-forced subscription row gets no bookmark events.
- `well_known_private_pep_nodes_pin_whitelist_across_reconfigure` — unit pin for MDS/DND/story-reads/status-preference.
- `legacy_presence_row_on_pinned_private_node_is_backfilled_to_whitelist_on_read` — simulates a pre-deploy `presence` row via raw SQL (unreachable through the public API since the configure pin) and asserts both the returned config and the persisted row heal.

Three rounds of adversarial persona review (XEP conformance vs `./xeps`, correctness/security, test quality) ran until round 3 reported no real actionable issues; rounds 1–2 findings are the fixes 2–4 above. Round 3 also empirically re-verified the newest test RED against the prior commit.

## Acceptance criteria

- [x] MDS (and any whitelist-access node) publishes do not fan out to roster contacts
- [x] Owner's own resources still receive the notification (XEP-0163 §3.4) — pinned by `xep0490_other_resource_with_notify_caps_receives_event`
- [x] Fan-out gating is derived from `access_model`, not a hard-coded node list
- [x] Test asserts roster contacts do NOT receive a whitelist-node event

## Verification

- 100+ integration tests green locally across 14 suites covering every `fan_out_publish` call site (MDS, PEP §3/§3.4/blocking/dedup, bookmarks, story-reads, status-preference, DND, DM-bookmarks, avatar, vCard4, generic PubSub, Spaces, social feed, stories, story reactions) plus 1403 lib tests.
- `cargo fmt` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean.
- CI: all 17 checks green on the head commit, including `nixClippy`, `nixTest`, `nixXmppServerTests`, `nixXmppUnitTests`, `nixXmppXepIntegration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
