### PR TITLE
fix(server): stamp XEP-0203 delay on XEP-0198 resume replay (#1178)

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -447,7 +447,22 @@ async fn handle_inbound_text(
                 replay_after_h,
             } => {
                 responses = vec![resumed.to_xml()];
-                responses.extend(conn.sm_state.get_stanzas_to_resend(replay_after_h));
+                // Issue #1178: like the pre-registration resume path,
+                // replayed stanzas carry a XEP-0203 <delay/> with their
+                // original receipt time (XEP-0198 §5).
+                let server_domain = state.deps.auth_state.xmpp_domain.as_str();
+                responses.extend(
+                    conn.sm_state
+                        .get_stanzas_to_resend(replay_after_h)
+                        .into_iter()
+                        .map(|entry| {
+                            waddle_xmpp::stream_management::stamp_replay_delay(
+                                &entry.stanza_xml,
+                                server_domain,
+                                entry.original_receipt_at,
+                            )
+                        }),
+                );
             }
             SmRegistrationFinalization::ReplaceWithFailed(failed) => {
                 responses = vec![failed.to_xml()];

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -449,7 +449,7 @@ async fn handle_inbound_text(
                 responses = vec![resumed.to_xml()];
                 // Issue #1178: like the pre-registration resume path,
                 // replayed stanzas carry a XEP-0203 <delay/> with their
-                // original receipt time (XEP-0198 §5).
+                // original receipt time.
                 let server_domain = state.deps.auth_state.xmpp_domain.as_str();
                 responses.extend(
                     conn.sm_state

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -379,7 +379,8 @@ async fn handle_sm_resume(resume: SmResume, state: &WebSocketState, ctx: SmCtx<'
 
     // Issue #1178: stamp each replayed stanza with a XEP-0203 <delay/>
     // carrying its original receipt time, so clients sort it at its true
-    // timeline position instead of the drain time (XEP-0198 §5).
+    // timeline position instead of the drain time (XEP-0198 Acks-section
+    // redelivery stamping, applied to the <resumed/> replay by analogy).
     let server_domain = state.deps.auth_state.xmpp_domain.as_str();
     let replay: Vec<String> = sm_state
         .get_stanzas_to_resend(resume.h)

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -221,7 +221,7 @@ fn handle_sm_enable(
 }
 
 async fn handle_sm_resume(resume: SmResume, state: &WebSocketState, ctx: SmCtx<'_>) -> Vec<String> {
-    use waddle_xmpp::stream_management::{SmFailed, SmResumed};
+    use waddle_xmpp::stream_management::{stamp_replay_delay, SmFailed, SmResumed};
 
     let SmCtx {
         phase,
@@ -377,9 +377,16 @@ async fn handle_sm_resume(resume: SmResume, state: &WebSocketState, ctx: SmCtx<'
     // the main loop must NOT push them through `record_outbound` again.
     *suppress_sm_record_next_batch = true;
 
+    // Issue #1178: stamp each replayed stanza with a XEP-0203 <delay/>
+    // carrying its original receipt time, so clients sort it at its true
+    // timeline position instead of the drain time (XEP-0198 §5).
+    let server_domain = state.deps.auth_state.xmpp_domain.as_str();
     let replay: Vec<String> = sm_state
         .get_stanzas_to_resend(resume.h)
         .into_iter()
+        .map(|entry| {
+            stamp_replay_delay(&entry.stanza_xml, server_domain, entry.original_receipt_at)
+        })
         .collect();
     info!(
         stream_id = %resume.previd,

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/batch_write.rs
@@ -319,7 +319,7 @@ async fn mam_results_are_recorded_like_any_stanza_for_counter_convergence() {
     assert_eq!(conn.sm_state.queue_len(), 5);
     let replay = conn.sm_state.get_stanzas_to_resend(0);
     assert_eq!(replay.len(), 5);
-    assert_eq!(replay[0], live);
+    assert_eq!(replay[0].stanza_xml, live);
 }
 
 /// If the peer closes (or the socket dies) mid-batch, every countable
@@ -357,7 +357,7 @@ async fn transport_close_mid_batch_still_records_unwritten_frames_for_replay() {
     assert_eq!(conn.sm_state.queue_len(), 12);
     let replay = conn.sm_state.get_stanzas_to_resend(0);
     assert_eq!(replay.len(), 12);
-    assert_eq!(replay[11], countable_message(12));
+    assert_eq!(replay[11].stanza_xml, countable_message(12));
     // Only 5 stanzas + 1 <r/> actually hit the wire.
     assert_eq!(sink_texts(&sink).len(), 6);
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/dispatch.rs
@@ -177,7 +177,7 @@ async fn drain_outbound_dispatches_direct_frame_into_unacked_unchanged() {
     let queue = conn.sm_state.get_stanzas_to_resend(0);
     assert_eq!(queue.len(), 1, "DirectFrame recorded once");
     assert_eq!(
-        queue[0], expected_xml,
+        queue[0].stanza_xml, expected_xml,
         "DirectFrame is recorded byte-for-byte (no recipient pipeline rewrite)"
     );
 }
@@ -239,7 +239,11 @@ async fn drain_outbound_dispatches_peer_stanza_through_recipient_pass() {
         !queue.is_empty(),
         "PeerStanza drain MUST record at least the recipient-pass wire frame"
     );
-    let combined: String = queue.join("\n");
+    let combined: String = queue
+        .iter()
+        .map(|entry| entry.stanza_xml.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
     assert!(
         combined.contains("by='bob@example.com'"),
         "drained PeerStanza replay must carry bob's recipient-side stanza-id; got: {combined}"

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/registration.rs
@@ -228,10 +228,9 @@ async fn register_bound_connection_after_frame_completes_pending_resume_claim() 
     );
     assert!(conn.pending_resume_stream_id.is_none());
     assert!(conn.pending_resume_h.is_none());
-    assert_eq!(
-        conn.sm_state.get_stanzas_to_resend(9),
-        vec!["<message id='m10'/>".to_string()]
-    );
+    let replay = conn.sm_state.get_stanzas_to_resend(9);
+    assert_eq!(replay.len(), 1);
+    assert_eq!(replay[0].stanza_xml, "<message id='m10'/>");
     assert!(state
         .deps
         .protocol

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -2401,3 +2401,103 @@ async fn sm_janitor_helper_drains_expired_and_cleans_muc() {
         "MUC occupant must be gone after janitor sweep"
     );
 }
+
+#[tokio::test]
+async fn sm_resume_replay_stamps_xep0203_delay_with_original_receipt_time() {
+    // Issue #1178: stanzas replayed after <resumed/> must carry a
+    // XEP-0203 <delay/> whose stamp is the ORIGINAL server receipt
+    // time — otherwise clients timestamp them at drain time and sort
+    // them to the bottom of the timeline.
+    use chrono::{TimeZone, Utc};
+    use waddle_xmpp::stream_management::{DetachedSession, DetachedUnackedStanza};
+
+    let state = create_test_websocket_state().await;
+    let domain = state.deps.auth_state.xmpp_domain.clone();
+    let session = create_test_session(state.as_ref(), "bob").await;
+    let payload = BASE64_STANDARD.encode(format!("n,,\x01auth=Bearer {}\x01\x01", session.id));
+    let auth_frame = element_to_xml(
+        Element::builder("auth", waddle_xmpp::ns::SASL)
+            .attr(
+                minidom::rxml::xml_ncname!("mechanism").to_owned(),
+                "OAUTHBEARER",
+            )
+            .append(payload)
+            .build(),
+    );
+    let mut conn = WsConnState::new();
+    let auth_responses = handle_xmpp_frame(&auth_frame, &domain, state.as_ref(), &mut conn).await;
+    assert_eq!(auth_responses, vec![sasl_success_xml()]);
+
+    let original_receipt = Utc.with_ymd_and_hms(2026, 7, 1, 9, 15, 30).unwrap();
+    let detached_jid: FullJid = format!("bob@{domain}/web").parse().expect("jid");
+    state
+        .deps
+        .protocol
+        .sm_session_registry
+        .store_session(DetachedSession {
+            stream_id: "stream-replay-delay".to_string(),
+            user_id: format!("bob@{domain}"),
+            jid: detached_jid.clone(),
+            inbound_count: 1,
+            outbound_count: 2,
+            last_acked: 0,
+            replay_gap_through: None,
+            unacked_stanzas: vec![
+                DetachedUnackedStanza {
+                    sequence: 1,
+                    stanza_xml: format!(
+                        "<message xmlns='jabber:client' from='alice@{domain}/a' \
+                         to='bob@{domain}/web' type='chat' id='replayed-1'>\
+                         <body>while you were away</body></message>"
+                    ),
+                    original_receipt_at: original_receipt,
+                },
+                DetachedUnackedStanza {
+                    sequence: 2,
+                    stanza_xml: format!(
+                        "<iq xmlns='jabber:client' from='{domain}' to='bob@{domain}/web' \
+                         type='result' id='replayed-iq'/>"
+                    ),
+                    original_receipt_at: original_receipt,
+                },
+            ],
+            max_resume_time: Some(300),
+            detached_at: std::time::Instant::now(),
+            carbons_enabled: false,
+            roster_interested: false,
+            blocklist_interested: false,
+            presence_available: false,
+            presence_show: None,
+            presence_status: None,
+            presence_priority: 0,
+        })
+        .await
+        .expect("store");
+
+    let resume_frame = resume_frame_xml("stream-replay-delay", 0);
+    let responses = handle_xmpp_frame(&resume_frame, &domain, state.as_ref(), &mut conn).await;
+
+    assert_eq!(responses.len(), 3, "<resumed/> + 2 replayed stanzas");
+    let resumed = Element::from_str(&responses[0]).expect("xml");
+    assert_eq!(resumed.name(), "resumed");
+
+    // The replayed <message/> carries the server's delay stamp with the
+    // original receipt time, not the resume time.
+    let replayed_message = Element::from_str(&responses[1]).expect("replayed message xml");
+    assert_eq!(replayed_message.name(), "message");
+    let delay = replayed_message
+        .children()
+        .find(|child| child.name() == "delay" && child.ns() == "urn:xmpp:delay")
+        .expect("replayed message must carry a XEP-0203 delay");
+    assert_eq!(delay.attr("from"), Some(domain.as_str()));
+    assert_eq!(delay.attr("stamp"), Some("2026-07-01T09:15:30Z"));
+
+    // The replayed <iq/> stays unstamped — XEP-0203 covers message and
+    // presence only.
+    let replayed_iq = Element::from_str(&responses[2]).expect("replayed iq xml");
+    assert_eq!(replayed_iq.name(), "iq");
+    assert!(
+        !replayed_iq.children().any(|child| child.name() == "delay"),
+        "iq replay must not gain a delay element"
+    );
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -2430,6 +2430,36 @@ async fn sm_resume_replay_stamps_xep0203_delay_with_original_receipt_time() {
 
     let original_receipt = Utc.with_ymd_and_hms(2026, 7, 1, 9, 15, 30).unwrap();
     let detached_jid: FullJid = format!("bob@{domain}/web").parse().expect("jid");
+    let queued_message_xml = {
+        let mut message =
+            xmpp_parsers::message::Message::new(Some(jid::Jid::from(detached_jid.clone())));
+        message.from = Some(
+            format!("alice@{domain}/a")
+                .parse::<jid::Jid>()
+                .expect("jid"),
+        );
+        message.type_ = xmpp_parsers::message::MessageType::Chat;
+        message.id = Some(xmpp_parsers::message::Id("replayed-1".to_string()));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "while you were away".to_string(),
+        );
+        stanza_to_xml(&Stanza::Message(message))
+    };
+    let queued_iq_xml = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(
+                minidom::rxml::xml_ncname!("from").to_owned(),
+                domain.as_str(),
+            )
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                detached_jid.to_string(),
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), "replayed-iq")
+            .build(),
+    );
     state
         .deps
         .protocol
@@ -2445,19 +2475,12 @@ async fn sm_resume_replay_stamps_xep0203_delay_with_original_receipt_time() {
             unacked_stanzas: vec![
                 DetachedUnackedStanza {
                     sequence: 1,
-                    stanza_xml: format!(
-                        "<message xmlns='jabber:client' from='alice@{domain}/a' \
-                         to='bob@{domain}/web' type='chat' id='replayed-1'>\
-                         <body>while you were away</body></message>"
-                    ),
+                    stanza_xml: queued_message_xml,
                     original_receipt_at: original_receipt,
                 },
                 DetachedUnackedStanza {
                     sequence: 2,
-                    stanza_xml: format!(
-                        "<iq xmlns='jabber:client' from='{domain}' to='bob@{domain}/web' \
-                         type='result' id='replayed-iq'/>"
-                    ),
+                    stanza_xml: queued_iq_xml,
                     original_receipt_at: original_receipt,
                 },
             ],

--- a/server/crates/waddle-server/src/sm_promotion.rs
+++ b/server/crates/waddle-server/src/sm_promotion.rs
@@ -114,6 +114,26 @@ pub async fn promote_session_unacked(
     summary
 }
 
+/// Extract the stamp of a `<delay/>` this server itself added to the
+/// stanza on a prior replay hop, if one is present.
+fn self_stamp_time(
+    message: &xmpp_parsers::message::Message,
+    server_domain: &str,
+) -> Option<DateTime<Utc>> {
+    message
+        .payloads
+        .iter()
+        .filter(|payload| {
+            waddle_xmpp::xep::xep0203::is_delay_element(payload)
+                && payload.attr("from") == Some(server_domain)
+        })
+        .find_map(|payload| {
+            waddle_xmpp::xep::xep0203::parse_delay_element(payload)
+                .ok()
+                .map(|info| info.stamp)
+        })
+}
+
 struct PromotionContext<'a> {
     online: &'a OnlineResources,
     blocklist: &'a Blocklist,
@@ -128,11 +148,23 @@ struct PromotionContext<'a> {
 async fn promote_one(
     message: xmpp_parsers::message::Message,
     sequence: u32,
-    ctx: PromotionContext<'_>,
+    mut ctx: PromotionContext<'_>,
 ) -> PromotedOutcome {
     if waddle_xmpp_core::mam::is_mam_query_response_message(&message) {
         waddle_xmpp::prometheus::increment_sm_promotion_not_promotable();
         return PromotedOutcome::NotPromotable;
+    }
+
+    // Multi-hop Q6 chain (issue #1178): a stanza this promoter already
+    // redelivered once carries our own `<delay/>` with the TRUE
+    // original receipt time, while the queue entry's receipt time is
+    // the (later) redelivery time. Prefer the self-stamp so the
+    // promoted `pending_delivery` row — and therefore every later
+    // flush of an Archived row, which rehydrates from MAM without any
+    // self-stamp — keeps the original time instead of drifting one
+    // hop later on each expiry.
+    if let Some(stamp) = self_stamp_time(&message, ctx.server_domain) {
+        ctx.original_receipt_fallback = stamp;
     }
 
     let routing: DmRouting = classify_dm_intake(&message, ctx.online, ctx.blocklist);

--- a/server/crates/waddle-server/src/sm_promotion/tests.rs
+++ b/server/crates/waddle-server/src/sm_promotion/tests.rs
@@ -720,3 +720,59 @@ async fn storage_failure_records_storage_failed_not_dropped() {
         "has_storage_failure() must be true so caller skips confirm_drained"
     );
 }
+
+#[tokio::test]
+async fn promotion_prefers_existing_self_stamp_time_over_queue_receipt_time() {
+    // Multi-hop Q6 chain (issue #1178 round-3 review): a message
+    // received at T0 was Q6-redelivered with an accurate
+    // <delay from='example.com' stamp='T0'/> and recorded into the
+    // destination's unacked queue at redelivery time T1. When THAT
+    // session also expires, the promoted pending_delivery row must
+    // carry T0 — the self-stamp on the in-flight stanza — not the
+    // queue's T1, or the eventual flush stamps the redelivery time
+    // (Archived rows rehydrate from MAM, which has no self-stamp, so
+    // the row time is what ends up on the wire).
+    use chrono::TimeZone;
+
+    let t0 = Utc.with_ymd_and_hms(2026, 7, 1, 10, 0, 0).unwrap();
+    let mut m =
+        xmpp_parsers::message::Message::new(Some("alice@example.com".parse::<jid::Jid>().unwrap()));
+    m.from = Some("bob@elsewhere/x".parse::<jid::Jid>().unwrap());
+    m.type_ = xmpp_parsers::message::MessageType::Chat;
+    m.bodies
+        .insert(xmpp_parsers::message::Lang::new(), "second hop".to_string());
+    waddle_xmpp::xep::xep0203::add_delay_stamp(&mut m, t0, "example.com");
+    let element: xmpp_parsers::minidom::Element = m.into();
+    let mut buf = Vec::new();
+    element.write_to(&mut buf).unwrap();
+    let xml = String::from_utf8(buf).unwrap();
+
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+    // detached_session_with_unacked stamps original_receipt_at with
+    // Utc::now() — the (later) redelivery-time T1.
+    let session = detached_session_with_unacked(
+        "stream-second-hop",
+        full("alice@example.com/laptop"),
+        vec![xml],
+    );
+
+    let summary = promote_session_unacked(
+        &session,
+        &registry,
+        &storage,
+        &Blocklist::empty(),
+        "example.com",
+    )
+    .await;
+
+    assert_eq!(summary.queued, 1);
+    let rows = storage.list(&bare("alice@example.com")).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].original_receipt_at, t0,
+        "promoted row must carry the self-stamp's original time, \
+         not the unacked queue's redelivery-time receipt"
+    );
+}

--- a/server/crates/waddle-xmpp/src/pending_delivery/flush.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/flush.rs
@@ -129,8 +129,10 @@ pub fn build_replay_stanza(
     // Legitimate upstream `<delay/>` elements (e.g. ones a different
     // server in a federated chain stamped, or a forwarded-message
     // delay from a stored stanza) are preserved unchanged so the
-    // recipient sees the full delivery history per XEP-0203 §5
-    // ("multiple delay elements MAY appear").
+    // recipient sees the full delivery history. XEP-0203 §2 has each
+    // delaying entity add one and only one <delay/>; this server adds
+    // only its own, and stacking alongside foreign delays matches
+    // common ecosystem practice (MUC history + MAM).
     message.payloads.retain(|payload| {
         !(payload.name() == "delay"
             && payload.ns() == NS_DELAY

--- a/server/crates/waddle-xmpp/src/pending_delivery/flush.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/flush.rs
@@ -10,7 +10,7 @@
 //! - **XEP-0203 §4.1** — `<delay xmlns='urn:xmpp:delay' from='SERVER'
 //!   stamp='ORIGINAL_RECEIPT_ISO8601'>Offline Storage</delay>`. The
 //!   stamp is the original (failed) receipt time, NOT the flush time
-//!   (XEP-0198 §5 line 364 + locked Q6c).
+//!   (XEP-0198 Acks section, xep-0198.xml line 364, + locked Q6c).
 //! - **XEP-0359 §3.1** — for `Archived` rows the server-stamped
 //!   `<stanza-id by='RECIPIENT_BARE'/>` is preserved (it was added at
 //!   archive time and lives in MAM); for `Transient` rows no
@@ -101,7 +101,7 @@ impl ReplayReason {
 ///
 /// `original_receipt_at` is the server-side receipt time of the
 /// original stanza (before it was queued for offline delivery). This
-/// is what XEP-0203 §4.2 + XEP-0198 §5 line 364 require on the
+/// is what XEP-0203 §4.2 + XEP-0198's Acks section (xep-0198.xml line 364) require on the
 /// `<delay/>` stamp.
 ///
 /// `reason` selects the optional human-readable description carried
@@ -120,11 +120,14 @@ pub fn build_replay_stanza(
     reason: ReplayReason,
 ) -> Message {
     let mut message = *payload.into_message();
-    // Strip ONLY any pre-existing `<delay/>` whose `from` attribute
-    // matches our own server domain — that would be a stamp this
-    // server itself added on a prior path (round-trip via MAM, replay
-    // through a transient pass, etc.) and re-emitting it would result
-    // in two `<delay from='our-domain'/>` siblings.
+    // If the stanza already carries a `<delay/>` this server stamped on
+    // a prior hop, keep it and add nothing: that stamp records the true
+    // original time, which can be EARLIER than the caller's
+    // `original_receipt_at` (a Q6 SM-expiry redelivery is recorded into
+    // the destination's unacked queue at redelivery time, so a second
+    // Q6 pass would otherwise overwrite the accurate stamp — and
+    // persist the corruption into `pending_delivery`). This also keeps
+    // exactly one `<delay from='our-domain'/>` on re-flush round-trips.
     //
     // Legitimate upstream `<delay/>` elements (e.g. ones a different
     // server in a federated chain stamped, or a forwarded-message
@@ -133,16 +136,18 @@ pub fn build_replay_stanza(
     // delaying entity add one and only one <delay/>; this server adds
     // only its own, and stacking alongside foreign delays matches
     // common ecosystem practice (MUC history + MAM).
-    message.payloads.retain(|payload| {
-        !(payload.name() == "delay"
+    let already_self_stamped = message.payloads.iter().any(|payload| {
+        payload.name() == "delay"
             && payload.ns() == NS_DELAY
-            && payload.attr("from") == Some(server_domain))
+            && payload.attr("from") == Some(server_domain)
     });
-    message.payloads.push(build_offline_delay(
-        server_domain,
-        original_receipt_at,
-        reason.description(),
-    ));
+    if !already_self_stamped {
+        message.payloads.push(build_offline_delay(
+            server_domain,
+            original_receipt_at,
+            reason.description(),
+        ));
+    }
     message
 }
 
@@ -319,11 +324,9 @@ mod tests {
     }
 
     #[test]
-    fn replay_stanza_strips_only_self_stamped_delay_to_avoid_double_stamping() {
-        // Pre-existing delay stamped by THIS server should be replaced
-        // by the freshly-built one (avoid two `<delay from='example.com'/>`
-        // siblings). Round-trip safety: if a stanza somehow ends up
-        // re-flushed, we don't want two of the server's own stamps.
+    fn replay_stanza_keeps_single_self_stamp_when_reflushed() {
+        // Round-trip safety: if a stanza somehow ends up re-flushed, we
+        // don't want two of the server's own stamps.
         let mut row = transient_row("alice@example.com", "hi");
         if let PendingPayload::Transient(msg) = &mut row.payload {
             msg.payloads
@@ -352,8 +355,41 @@ mod tests {
     }
 
     #[test]
+    fn replay_stanza_preserves_earlier_self_stamp_from_prior_hop() {
+        // Multi-hop Q6 chain (issue #1178 round-2 review): a message
+        // received at T0 is Q6-redelivered to a live resource with an
+        // accurate `<delay stamp='T0'/>`, recorded into THAT resource's
+        // unacked queue at redelivery time T1, and that session also
+        // expires. The second Q6 pass calls this builder with
+        // `original_receipt_at = T1`; replacing the T0 self-stamp with
+        // T1 would corrupt the timeline AND persist the corruption into
+        // `pending_delivery`. The existing self-stamp records the true
+        // original time and must survive.
+        let t0 = Utc.with_ymd_and_hms(2026, 5, 1, 10, 0, 0).unwrap();
+        let t1_redelivery = fixed_receipt(); // 12:30, later than T0
+        let mut row = transient_row("alice@example.com", "hi");
+        if let PendingPayload::Transient(msg) = &mut row.payload {
+            msg.payloads
+                .push(build_offline_delay("example.com", t0, None));
+        }
+        let payload = MaterializedPayload::from_transient(&row).unwrap();
+        let replayed = build_replay_stanza(
+            payload,
+            "example.com",
+            t1_redelivery,
+            ReplayReason::SmRedelivery,
+        );
+        let delay = delay_element(&replayed).expect("delay present");
+        assert_eq!(
+            delay.attr("stamp"),
+            Some("2026-05-01T10:00:00Z"),
+            "the earlier accurate self-stamp survives the second hop"
+        );
+    }
+
+    #[test]
     fn replay_stanza_preserves_upstream_delay_metadata() {
-        // XEP-0203 §5 allows multiple `<delay/>` elements, e.g. when a
+        // Delays stamped by other entities are preserved, e.g. when a
         // stanza traverses multiple servers in a federated chain. Our
         // offline-delay stamping must NOT strip delays stamped by
         // other entities.

--- a/server/crates/waddle-xmpp/src/stream_management/mod.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/mod.rs
@@ -25,6 +25,7 @@
 //! - `UnackedQueue` - Queue of unacknowledged outbound stanzas
 
 pub mod persistence;
+mod replay;
 mod session_registry;
 mod stanzas;
 #[cfg(test)]
@@ -32,6 +33,7 @@ mod stanzas_tests;
 mod state;
 mod unacked_queue;
 
+pub use replay::{stamp_replay_delay, ReplayStanza};
 pub use session_registry::{
     DetachedSession, DetachedUnackedStanza, InMemorySmSessionRegistry, SmClaimCompletion,
     SmRegistryError, SmSessionRegistry,

--- a/server/crates/waddle-xmpp/src/stream_management/replay.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/replay.rs
@@ -24,6 +24,17 @@ use crate::xep::NS_DELAY;
 /// One entry of the `<resumed/>` replay set: the queued wire XML plus
 /// the server-side receipt time of the original stanza, so the caller
 /// can stamp the XEP-0203 `<delay/>` with the true send time.
+///
+/// `stanza_xml` is deliberately the raw wire form, not a typed
+/// [`minidom::Element`]: the unacked queue is XEP-0198's retransmission
+/// log — a byte-preserving record of the frames that already hit the
+/// socket (see [`super::UnackedStanza`] / [`super::DetachedUnackedStanza`],
+/// which model the same domain). Replay entries are the literal
+/// write-to-wire frames, i.e. the I/O boundary where the typed-payloads
+/// rule permits `String`. Keeping the bytes also lets
+/// [`stamp_replay_delay`] fall back to verbatim (unstamped) replay when
+/// an entry does not re-parse, instead of dropping an unacked stanza —
+/// XEP-0198's no-loss guarantee outranks the stamp.
 #[derive(Debug, Clone)]
 pub struct ReplayStanza {
     /// The wire XML captured when the stanza was first sent.
@@ -61,7 +72,10 @@ pub fn stamp_replay_delay(
         // arm should be unreachable; if it ever fires, the stanza
         // replays unstamped and the #1178 out-of-order symptom returns
         // for it — make that observable instead of silent.
-        warn!("SM replay stanza is not a well-formed element; replaying unstamped");
+        warn!(
+            stanza_prefix = %stanza_xml.chars().take(120).collect::<String>(),
+            "SM replay stanza is not a well-formed element; replaying unstamped"
+        );
         return stanza_xml.to_string();
     };
 

--- a/server/crates/waddle-xmpp/src/stream_management/replay.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/replay.rs
@@ -1,0 +1,82 @@
+//! XEP-0203 delay stamping for XEP-0198 `<resumed/>` replay (issue
+//! #1178).
+//!
+//! Unacked stanzas are queued as the exact wire XML captured at record
+//! time. Replaying them verbatim loses the original send time — clients
+//! fall back to drain-time timestamps and sort the stanzas to the tail
+//! of the timeline. XEP-0198 §5 says resent stanzas should carry a
+//! XEP-0203 `<delay/>` with the original timestamp; this module is the
+//! pure builder that applies that stamp at the serialization boundary.
+
+use chrono::{DateTime, Utc};
+use minidom::Element;
+use std::str::FromStr;
+
+use crate::parser::element_to_string;
+use crate::xep::xep0203::{build_delay_element, DelayInfo};
+use crate::xep::NS_DELAY;
+
+/// One entry of the `<resumed/>` replay set: the queued wire XML plus
+/// the server-side receipt time of the original stanza, so the caller
+/// can stamp the XEP-0203 `<delay/>` with the true send time.
+#[derive(Debug, Clone)]
+pub struct ReplayStanza {
+    /// The wire XML captured when the stanza was first sent.
+    pub stanza_xml: String,
+    /// Server-side receipt time of the original stanza.
+    pub original_receipt_at: DateTime<Utc>,
+}
+
+/// Stamp a queued replay stanza with a XEP-0203 `<delay/>` carrying
+/// the original server-side receipt time.
+///
+/// Mirrors the offline-flush builder
+/// [`crate::pending_delivery::flush::build_replay_stanza`] but operates
+/// on the unacked queue's wire-XML form: the queue sits past the
+/// serialization boundary, so the stanza re-enters the typed domain
+/// here as a [`minidom::Element`], is annotated, and is serialized
+/// back. No reason text is attached — like
+/// [`crate::pending_delivery::flush::ReplayReason::SmRedelivery`], the
+/// stanza was never persisted offline; only the timestamp is late.
+pub fn stamp_replay_delay(
+    stanza_xml: &str,
+    server_domain: &str,
+    original_receipt_at: DateTime<Utc>,
+) -> String {
+    let Ok(mut element) = Element::from_str(stanza_xml.trim_start()) else {
+        return stanza_xml.to_string();
+    };
+
+    // XEP-0203 §3 defines delay annotations for message and presence
+    // stanzas only; anything else (notably <iq/>) replays verbatim.
+    if !matches!(element.name(), "message" | "presence") {
+        return stanza_xml.to_string();
+    }
+
+    // Strip ONLY delays this server itself stamped on an earlier path
+    // (offline flush before the stanza entered the SM queue) so the
+    // replay never carries two `<delay from='our-domain'/>` siblings.
+    // Upstream delays are re-appended unchanged — XEP-0203 §5 allows
+    // multiple delay elements and they are the recipient's delivery
+    // history.
+    let mut preserved = Vec::new();
+    while let Some(delay) = element.remove_child("delay", NS_DELAY) {
+        if delay.attr("from") != Some(server_domain) {
+            preserved.push(delay);
+        }
+    }
+    for delay in preserved {
+        element.append_child(delay);
+    }
+
+    element.append_child(build_delay_element(&DelayInfo {
+        from: Some(server_domain.to_string()),
+        stamp: original_receipt_at,
+        reason: None,
+    }));
+
+    match element_to_string(&element) {
+        Ok(stamped) => stamped,
+        Err(_) => stanza_xml.to_string(),
+    }
+}

--- a/server/crates/waddle-xmpp/src/stream_management/replay.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/replay.rs
@@ -4,13 +4,18 @@
 //! Unacked stanzas are queued as the exact wire XML captured at record
 //! time. Replaying them verbatim loses the original send time — clients
 //! fall back to drain-time timestamps and sort the stanzas to the tail
-//! of the timeline. XEP-0198 §5 says resent stanzas should carry a
-//! XEP-0203 `<delay/>` with the original timestamp; this module is the
-//! pure builder that applies that stamp at the serialization boundary.
+//! of the timeline. XEP-0198's Acks section requires a XEP-0203
+//! `<delay/>` with the original timestamp when unacknowledged stanzas
+//! are redelivered after a failed session; we apply the same stamping
+//! to the `<resumed/>` replay (the spec is silent there, but the
+//! rationale — preserving the original send date for the recipient —
+//! is identical). This module is the pure builder that applies that
+//! stamp at the serialization boundary.
 
 use chrono::{DateTime, Utc};
 use minidom::Element;
 use std::str::FromStr;
+use tracing::warn;
 
 use crate::parser::element_to_string;
 use crate::xep::xep0203::{build_delay_element, DelayInfo};
@@ -38,37 +43,49 @@ pub struct ReplayStanza {
 /// back. No reason text is attached — like
 /// [`crate::pending_delivery::flush::ReplayReason::SmRedelivery`], the
 /// stanza was never persisted offline; only the timestamp is late.
+///
+/// If the stanza already carries a `<delay/>` this server stamped on an
+/// earlier path it is returned unchanged: that stamp records the true
+/// original time, which can be EARLIER than the queue's
+/// `original_receipt_at`. A Q6 SM-expiry redelivery, for example, is
+/// recorded into the destination's unacked queue at redelivery time —
+/// overwriting its flush-stamped delay would shift the message to the
+/// redelivery time, the exact corruption this module exists to prevent.
 pub fn stamp_replay_delay(
     stanza_xml: &str,
     server_domain: &str,
     original_receipt_at: DateTime<Utc>,
 ) -> String {
     let Ok(mut element) = Element::from_str(stanza_xml.trim_start()) else {
+        // Queue entries are produced by our own serializers, so this
+        // arm should be unreachable; if it ever fires, the stanza
+        // replays unstamped and the #1178 out-of-order symptom returns
+        // for it — make that observable instead of silent.
+        warn!("SM replay stanza is not a well-formed element; replaying unstamped");
         return stanza_xml.to_string();
     };
 
-    // XEP-0203 §3 defines delay annotations for message and presence
+    // XEP-0203 §2 defines delay annotations for message and presence
     // stanzas only; anything else (notably <iq/>) replays verbatim.
     if !matches!(element.name(), "message" | "presence") {
         return stanza_xml.to_string();
     }
 
-    // Strip ONLY delays this server itself stamped on an earlier path
-    // (offline flush before the stanza entered the SM queue) so the
-    // replay never carries two `<delay from='our-domain'/>` siblings.
-    // Upstream delays are re-appended unchanged — XEP-0203 §5 allows
-    // multiple delay elements and they are the recipient's delivery
-    // history.
-    let mut preserved = Vec::new();
-    while let Some(delay) = element.remove_child("delay", NS_DELAY) {
-        if delay.attr("from") != Some(server_domain) {
-            preserved.push(delay);
-        }
-    }
-    for delay in preserved {
-        element.append_child(delay);
+    let already_self_stamped = element.children().any(|child| {
+        child.name() == "delay"
+            && child.ns() == NS_DELAY
+            && child.attr("from") == Some(server_domain)
+    });
+    if already_self_stamped {
+        return stanza_xml.to_string();
     }
 
+    // Delays stamped by OTHER entities (an upstream server in a
+    // federated chain, a MUC service) are left in place: they are the
+    // recipient's delivery history. XEP-0203 §2 has each delaying
+    // entity add one and only one <delay/>, and this server adds only
+    // its own; stacking alongside foreign delays matches the offline
+    // flush path and common ecosystem practice (MUC history + MAM).
     element.append_child(build_delay_element(&DelayInfo {
         from: Some(server_domain.to_string()),
         stamp: original_receipt_at,
@@ -77,6 +94,9 @@ pub fn stamp_replay_delay(
 
     match element_to_string(&element) {
         Ok(stamped) => stamped,
-        Err(_) => stanza_xml.to_string(),
+        Err(error) => {
+            warn!(%error, "failed to serialize delay-stamped SM replay; replaying unstamped");
+            stanza_xml.to_string()
+        }
     }
 }

--- a/server/crates/waddle-xmpp/src/stream_management/state.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/state.rs
@@ -239,8 +239,9 @@ impl StreamManagementState {
     /// Get stanzas that need to be resent after resumption.
     ///
     /// `client_h` is the last sequence number the client acknowledged receiving.
-    /// Returns stanzas with sequence > client_h.
-    pub fn get_stanzas_to_resend(&self, client_h: u32) -> Vec<String> {
+    /// Returns stanzas with sequence > client_h, each paired with its
+    /// original receipt time for the XEP-0203 replay stamp.
+    pub fn get_stanzas_to_resend(&self, client_h: u32) -> Vec<super::ReplayStanza> {
         self.unacked_queue.get_unacked_after(client_h)
     }
 
@@ -431,7 +432,9 @@ mod tests {
         // for clients that still need it.
         let resend = state.get_stanzas_to_resend(0);
         assert_eq!(resend.len(), 3, "evicted seq=1 must be absent from replay");
-        assert!(!resend.iter().any(|xml| xml.contains("id='1'")));
+        assert!(!resend
+            .iter()
+            .any(|replay| replay.stanza_xml.contains("id='1'")));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/stream_management/unacked_queue.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/unacked_queue.rs
@@ -150,12 +150,17 @@ impl UnackedQueue {
     /// Get all stanzas with sequence > h that need to be resent.
     ///
     /// This is used during stream resumption when the client reports
-    /// which stanza it last received.
-    pub fn get_unacked_after(&self, h: u32) -> Vec<String> {
+    /// which stanza it last received. Each entry carries the original
+    /// receipt time so the resume path can stamp the XEP-0203
+    /// `<delay/>` with the true send time (issue #1178).
+    pub fn get_unacked_after(&self, h: u32) -> Vec<super::ReplayStanza> {
         self.stanzas
             .iter()
             .filter(|s| sequence_gt(s.sequence, h))
-            .map(|s| s.stanza_xml.clone())
+            .map(|s| super::ReplayStanza {
+                stanza_xml: s.stanza_xml.clone(),
+                original_receipt_at: s.original_receipt_at,
+            })
             .collect()
     }
 
@@ -293,8 +298,8 @@ mod tests {
         // Get stanzas after h=2 (should be 3 and 4)
         let unacked = queue.get_unacked_after(2);
         assert_eq!(unacked.len(), 2);
-        assert_eq!(unacked[0], "<msg3/>");
-        assert_eq!(unacked[1], "<msg4/>");
+        assert_eq!(unacked[0].stanza_xml, "<msg3/>");
+        assert_eq!(unacked[1].stanza_xml, "<msg4/>");
 
         // Get stanzas after h=0 (all of them)
         let unacked = queue.get_unacked_after(0);

--- a/server/crates/waddle-xmpp/tests/xep0198_resume_replay_delay.rs
+++ b/server/crates/waddle-xmpp/tests/xep0198_resume_replay_delay.rs
@@ -10,15 +10,30 @@
 //! (failed) delivery timestamp, as per XEP-0203"); we apply the same
 //! stamping to the `<resumed/>` replay by analogy.
 
-use chrono::{TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
+use jid::Jid;
 use minidom::Element;
 use std::str::FromStr;
+use waddle_xmpp::parser::{element_to_string, message_to_string};
 use waddle_xmpp::stream_management::{stamp_replay_delay, StreamManagementState};
+use waddle_xmpp::xep::xep0203::{build_delay_element, DelayInfo};
+use waddle_xmpp::xep::NS_DELAY;
+use xmpp_parsers::message::{Id, Lang, Message, MessageType};
 
-const NS_DELAY: &str = "urn:xmpp:delay";
-
-fn fixed_receipt() -> chrono::DateTime<Utc> {
+fn fixed_receipt() -> DateTime<Utc> {
     Utc.with_ymd_and_hms(2026, 7, 1, 9, 15, 30).unwrap()
+}
+
+/// Serialize a typed chat `<message/>` fixture (bob → alice) with the
+/// given id, body, and any pre-attached `<delay/>` payloads.
+fn chat_message_xml(id: &str, body: &str, delays: Vec<Element>) -> String {
+    let mut message = Message::new(Some("alice@example.com".parse::<Jid>().expect("jid")));
+    message.from = Some("bob@example.com/x".parse::<Jid>().expect("jid"));
+    message.type_ = MessageType::Chat;
+    message.id = Some(Id(id.to_string()));
+    message.bodies.insert(Lang::new(), body.to_string());
+    message.payloads.extend(delays);
+    message_to_string(&message).expect("serialize message fixture")
 }
 
 fn delay_children(xml: &str) -> Vec<Element> {
@@ -32,11 +47,9 @@ fn delay_children(xml: &str) -> Vec<Element> {
 
 #[test]
 fn replayed_message_carries_delay_with_original_receipt_stamp() {
-    let original =
-        "<message xmlns='jabber:client' from='bob@example.com/x' to='alice@example.com' \
-         type='chat' id='m1'><body>hi</body></message>";
+    let original = chat_message_xml("m1", "hi", Vec::new());
 
-    let stamped = stamp_replay_delay(original, "example.com", fixed_receipt());
+    let stamped = stamp_replay_delay(&original, "example.com", fixed_receipt());
 
     let delays = delay_children(&stamped);
     assert_eq!(delays.len(), 1, "exactly one delay element on replay");
@@ -54,11 +67,22 @@ fn replayed_message_carries_delay_with_original_receipt_stamp() {
 fn replayed_iq_is_not_stamped() {
     // XEP-0203 §2 defines delay annotations for message and presence
     // stanzas; a replayed <iq/> must go out byte-identical.
-    let original = "<iq xmlns='jabber:client' from='example.com' to='alice@example.com/r' \
-                    type='result' id='q1'/>";
+    let original = element_to_string(
+        &Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(minidom::rxml::xml_ncname!("from").to_owned(), "example.com")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                "alice@example.com/r",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), "q1")
+            .build(),
+    )
+    .expect("serialize iq fixture");
 
-    let stamped = stamp_replay_delay(original, "example.com", fixed_receipt());
+    let stamped = stamp_replay_delay(&original, "example.com", fixed_receipt());
 
+    assert_eq!(stamped, original, "iq replays byte-identical");
     assert!(delay_children(&stamped).is_empty(), "iq gains no delay");
 }
 
@@ -72,14 +96,19 @@ fn replay_preserves_existing_self_stamped_delay_and_upstream_delay() {
     // MUST be kept as-is (no second self-stamp, no overwrite with the
     // later queue receipt). Delays from other entities are the
     // recipient's delivery history and stay untouched.
-    let original = "<message xmlns='jabber:client' from='bob@example.com/x' \
-         to='alice@example.com' type='chat' id='m2'><body>hi</body>\
-         <delay xmlns='urn:xmpp:delay' from='example.com' \
-         stamp='2026-06-30T08:00:00Z'>Offline Storage</delay>\
-         <delay xmlns='urn:xmpp:delay' from='upstream.example.org' \
-         stamp='2026-06-30T07:59:00Z'>Forwarded by upstream</delay></message>";
+    let self_stamp = build_delay_element(&DelayInfo {
+        from: Some("example.com".to_string()),
+        stamp: Utc.with_ymd_and_hms(2026, 6, 30, 8, 0, 0).unwrap(),
+        reason: Some("Offline Storage".to_string()),
+    });
+    let upstream_delay = build_delay_element(&DelayInfo {
+        from: Some("upstream.example.org".to_string()),
+        stamp: Utc.with_ymd_and_hms(2026, 6, 30, 7, 59, 0).unwrap(),
+        reason: Some("Forwarded by upstream".to_string()),
+    });
+    let original = chat_message_xml("m2", "hi", vec![self_stamp, upstream_delay]);
 
-    let stamped = stamp_replay_delay(original, "example.com", fixed_receipt());
+    let stamped = stamp_replay_delay(&original, "example.com", fixed_receipt());
 
     let delays = delay_children(&stamped);
     let self_stamped: Vec<_> = delays
@@ -116,9 +145,8 @@ fn first_send_is_recorded_unstamped_and_gains_delay_only_at_replay() {
     let mut state = StreamManagementState::new();
     state.enable("stream-first-send".to_string(), true, Some(300));
 
-    let wire = "<message xmlns='jabber:client' from='bob@example.com/x' to='alice@example.com' \
-         type='chat' id='live-1'><body>live</body></message>";
-    let _ = state.record_outbound_with_receipt_at(wire.to_string(), fixed_receipt());
+    let wire = chat_message_xml("live-1", "live", Vec::new());
+    let _ = state.record_outbound_with_receipt_at(wire.clone(), fixed_receipt());
 
     let replay = state.get_stanzas_to_resend(0);
     assert_eq!(replay.len(), 1);
@@ -147,19 +175,15 @@ fn resend_set_carries_each_stanzas_original_receipt_time() {
 
     let first_receipt = Utc.with_ymd_and_hms(2026, 7, 1, 9, 0, 0).unwrap();
     let second_receipt = Utc.with_ymd_and_hms(2026, 7, 1, 9, 5, 0).unwrap();
-    let _ = state.record_outbound_with_receipt_at(
-        "<message xmlns='jabber:client' id='a'/>".to_string(),
-        first_receipt,
-    );
-    let _ = state.record_outbound_with_receipt_at(
-        "<message xmlns='jabber:client' id='b'/>".to_string(),
-        second_receipt,
-    );
+    let first_xml = chat_message_xml("a", "first", Vec::new());
+    let second_xml = chat_message_xml("b", "second", Vec::new());
+    let _ = state.record_outbound_with_receipt_at(first_xml.clone(), first_receipt);
+    let _ = state.record_outbound_with_receipt_at(second_xml.clone(), second_receipt);
 
     let replay = state.get_stanzas_to_resend(0);
     assert_eq!(replay.len(), 2);
     assert_eq!(replay[0].original_receipt_at, first_receipt);
-    assert!(replay[0].stanza_xml.contains("id='a'"));
+    assert_eq!(replay[0].stanza_xml, first_xml);
     assert_eq!(replay[1].original_receipt_at, second_receipt);
-    assert!(replay[1].stanza_xml.contains("id='b'"));
+    assert_eq!(replay[1].stanza_xml, second_xml);
 }

--- a/server/crates/waddle-xmpp/tests/xep0198_resume_replay_delay.rs
+++ b/server/crates/waddle-xmpp/tests/xep0198_resume_replay_delay.rs
@@ -1,12 +1,14 @@
-//! XEP-0198 §5/§6 + XEP-0203 — delay stamping on `<resumed/>` replay
+//! XEP-0198 + XEP-0203 — delay stamping on `<resumed/>` replay
 //! (issue #1178).
 //!
 //! When a stream resumes, unacked stanzas replayed from the queue MUST
 //! carry a `<delay xmlns='urn:xmpp:delay'/>` whose `stamp` is the
 //! server-side receipt time of the original stanza — not the replay
 //! time — so clients sort them at their true timeline position instead
-//! of the drain time (XEP-0198 §5 "add a delay element with the
-//! original (failed) delivery timestamp, as per XEP-0203").
+//! of the drain time. XEP-0198's Acks section requires this delay for
+//! failed-session redelivery ("add a delay element with the original
+//! (failed) delivery timestamp, as per XEP-0203"); we apply the same
+//! stamping to the `<resumed/>` replay by analogy.
 
 use chrono::{TimeZone, Utc};
 use minidom::Element;
@@ -61,15 +63,19 @@ fn replayed_iq_is_not_stamped() {
 }
 
 #[test]
-fn replay_replaces_self_stamped_delay_but_preserves_upstream_delay() {
-    // A queued stanza can already carry delays: one this server itself
-    // stamped on an earlier path (offline flush before the SM queue),
-    // and one from an upstream entity. Re-stamping must replace only
-    // our own (no two <delay from='example.com'/> siblings) and keep
-    // the upstream delivery history per XEP-0203 §5.
+fn replay_preserves_existing_self_stamped_delay_and_upstream_delay() {
+    // A queued stanza can already carry a delay this server itself
+    // stamped on an earlier path — the offline flush, or a Q6
+    // SM-expiry redelivery whose queue receipt time is the REDELIVERY
+    // time, not the original send time. In that case the existing
+    // self-stamp is the only accurate record of the original time and
+    // MUST be kept as-is (no second self-stamp, no overwrite with the
+    // later queue receipt). Delays from other entities are the
+    // recipient's delivery history and stay untouched.
     let original = "<message xmlns='jabber:client' from='bob@example.com/x' \
          to='alice@example.com' type='chat' id='m2'><body>hi</body>\
-         <delay xmlns='urn:xmpp:delay' from='example.com' stamp='2026-06-30T08:00:00Z'/>\
+         <delay xmlns='urn:xmpp:delay' from='example.com' \
+         stamp='2026-06-30T08:00:00Z'>Offline Storage</delay>\
          <delay xmlns='urn:xmpp:delay' from='upstream.example.org' \
          stamp='2026-06-30T07:59:00Z'>Forwarded by upstream</delay></message>";
 
@@ -83,8 +89,14 @@ fn replay_replaces_self_stamped_delay_but_preserves_upstream_delay() {
     assert_eq!(self_stamped.len(), 1, "exactly one self-stamped delay");
     assert_eq!(
         self_stamped[0].attr("stamp"),
-        Some("2026-07-01T09:15:30Z"),
-        "self-stamped delay carries the queue receipt time"
+        Some("2026-06-30T08:00:00Z"),
+        "the earlier accurate self-stamp is kept, not overwritten with \
+         the (possibly later) queue receipt time"
+    );
+    assert_eq!(
+        self_stamped[0].text(),
+        "Offline Storage",
+        "the original delay's reason text survives replay"
     );
     assert!(
         delays

--- a/server/crates/waddle-xmpp/tests/xep0198_resume_replay_delay.rs
+++ b/server/crates/waddle-xmpp/tests/xep0198_resume_replay_delay.rs
@@ -1,0 +1,153 @@
+//! XEP-0198 §5/§6 + XEP-0203 — delay stamping on `<resumed/>` replay
+//! (issue #1178).
+//!
+//! When a stream resumes, unacked stanzas replayed from the queue MUST
+//! carry a `<delay xmlns='urn:xmpp:delay'/>` whose `stamp` is the
+//! server-side receipt time of the original stanza — not the replay
+//! time — so clients sort them at their true timeline position instead
+//! of the drain time (XEP-0198 §5 "add a delay element with the
+//! original (failed) delivery timestamp, as per XEP-0203").
+
+use chrono::{TimeZone, Utc};
+use minidom::Element;
+use std::str::FromStr;
+use waddle_xmpp::stream_management::{stamp_replay_delay, StreamManagementState};
+
+const NS_DELAY: &str = "urn:xmpp:delay";
+
+fn fixed_receipt() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 7, 1, 9, 15, 30).unwrap()
+}
+
+fn delay_children(xml: &str) -> Vec<Element> {
+    let element = Element::from_str(xml).expect("stamped replay stays well-formed XML");
+    element
+        .children()
+        .filter(|child| child.name() == "delay" && child.ns() == NS_DELAY)
+        .cloned()
+        .collect()
+}
+
+#[test]
+fn replayed_message_carries_delay_with_original_receipt_stamp() {
+    let original =
+        "<message xmlns='jabber:client' from='bob@example.com/x' to='alice@example.com' \
+         type='chat' id='m1'><body>hi</body></message>";
+
+    let stamped = stamp_replay_delay(original, "example.com", fixed_receipt());
+
+    let delays = delay_children(&stamped);
+    assert_eq!(delays.len(), 1, "exactly one delay element on replay");
+    assert_eq!(delays[0].attr("from"), Some("example.com"));
+    // XEP-0082 §3.2 canonical UTC form with the `Z` suffix, matching
+    // the original receipt time — never the replay time.
+    assert_eq!(delays[0].attr("stamp"), Some("2026-07-01T09:15:30Z"));
+    assert!(
+        delays[0].text().is_empty(),
+        "SM resume replay carries no offline-storage reason text"
+    );
+}
+
+#[test]
+fn replayed_iq_is_not_stamped() {
+    // XEP-0203 §3 defines delay annotations for message and presence
+    // stanzas; a replayed <iq/> must go out byte-identical.
+    let original = "<iq xmlns='jabber:client' from='example.com' to='alice@example.com/r' \
+                    type='result' id='q1'/>";
+
+    let stamped = stamp_replay_delay(original, "example.com", fixed_receipt());
+
+    assert!(delay_children(&stamped).is_empty(), "iq gains no delay");
+}
+
+#[test]
+fn replay_replaces_self_stamped_delay_but_preserves_upstream_delay() {
+    // A queued stanza can already carry delays: one this server itself
+    // stamped on an earlier path (offline flush before the SM queue),
+    // and one from an upstream entity. Re-stamping must replace only
+    // our own (no two <delay from='example.com'/> siblings) and keep
+    // the upstream delivery history per XEP-0203 §5.
+    let original = "<message xmlns='jabber:client' from='bob@example.com/x' \
+         to='alice@example.com' type='chat' id='m2'><body>hi</body>\
+         <delay xmlns='urn:xmpp:delay' from='example.com' stamp='2026-06-30T08:00:00Z'/>\
+         <delay xmlns='urn:xmpp:delay' from='upstream.example.org' \
+         stamp='2026-06-30T07:59:00Z'>Forwarded by upstream</delay></message>";
+
+    let stamped = stamp_replay_delay(original, "example.com", fixed_receipt());
+
+    let delays = delay_children(&stamped);
+    let self_stamped: Vec<_> = delays
+        .iter()
+        .filter(|delay| delay.attr("from") == Some("example.com"))
+        .collect();
+    assert_eq!(self_stamped.len(), 1, "exactly one self-stamped delay");
+    assert_eq!(
+        self_stamped[0].attr("stamp"),
+        Some("2026-07-01T09:15:30Z"),
+        "self-stamped delay carries the queue receipt time"
+    );
+    assert!(
+        delays
+            .iter()
+            .any(|delay| delay.attr("from") == Some("upstream.example.org")),
+        "upstream delay metadata preserved"
+    );
+}
+
+#[test]
+fn first_send_is_recorded_unstamped_and_gains_delay_only_at_replay() {
+    // The unacked queue must hold the stanza byte-for-byte as it was
+    // first written to the wire — the XEP-0203 stamp is applied only
+    // when the stanza is replayed after <resumed/>. Stamping at record
+    // time would leak a delay element onto the FIRST delivery, telling
+    // the recipient a live message was delayed.
+    let mut state = StreamManagementState::new();
+    state.enable("stream-first-send".to_string(), true, Some(300));
+
+    let wire = "<message xmlns='jabber:client' from='bob@example.com/x' to='alice@example.com' \
+         type='chat' id='live-1'><body>live</body></message>";
+    let _ = state.record_outbound_with_receipt_at(wire.to_string(), fixed_receipt());
+
+    let replay = state.get_stanzas_to_resend(0);
+    assert_eq!(replay.len(), 1);
+    assert_eq!(
+        replay[0].stanza_xml, wire,
+        "queue preserves the first-send bytes — no delay on first delivery"
+    );
+    assert!(delay_children(&replay[0].stanza_xml).is_empty());
+
+    let stamped = stamp_replay_delay(
+        &replay[0].stanza_xml,
+        "example.com",
+        replay[0].original_receipt_at,
+    );
+    assert_eq!(delay_children(&stamped).len(), 1, "delay appears at replay");
+}
+
+#[test]
+fn resend_set_carries_each_stanzas_original_receipt_time() {
+    // The queue records `original_receipt_at` per stanza; the resume
+    // replay set must surface it alongside the XML so the caller can
+    // stamp the XEP-0203 delay with the true send time — not the
+    // resume time.
+    let mut state = StreamManagementState::new();
+    state.enable("stream-1178".to_string(), true, Some(300));
+
+    let first_receipt = Utc.with_ymd_and_hms(2026, 7, 1, 9, 0, 0).unwrap();
+    let second_receipt = Utc.with_ymd_and_hms(2026, 7, 1, 9, 5, 0).unwrap();
+    let _ = state.record_outbound_with_receipt_at(
+        "<message xmlns='jabber:client' id='a'/>".to_string(),
+        first_receipt,
+    );
+    let _ = state.record_outbound_with_receipt_at(
+        "<message xmlns='jabber:client' id='b'/>".to_string(),
+        second_receipt,
+    );
+
+    let replay = state.get_stanzas_to_resend(0);
+    assert_eq!(replay.len(), 2);
+    assert_eq!(replay[0].original_receipt_at, first_receipt);
+    assert!(replay[0].stanza_xml.contains("id='a'"));
+    assert_eq!(replay[1].original_receipt_at, second_receipt);
+    assert!(replay[1].stanza_xml.contains("id='b'"));
+}

--- a/server/crates/waddle-xmpp/tests/xep0198_resume_replay_delay.rs
+++ b/server/crates/waddle-xmpp/tests/xep0198_resume_replay_delay.rs
@@ -52,7 +52,7 @@ fn replayed_message_carries_delay_with_original_receipt_stamp() {
 
 #[test]
 fn replayed_iq_is_not_stamped() {
-    // XEP-0203 §3 defines delay annotations for message and presence
+    // XEP-0203 §2 defines delay annotations for message and presence
     // stanzas; a replayed <iq/> must go out byte-identical.
     let original = "<iq xmlns='jabber:client' from='example.com' to='alice@example.com/r' \
                     type='result' id='q1'/>";


### PR DESCRIPTION
Fixes #1178.

## Problem

After a successful XEP-0198 `<resume/>`, unacked stanzas were replayed as the raw XML captured at record time — no `<delay/>`. Clients decoded them with `fallback` timestamp authority (`createdAt = Date.now()` at drain time) and sorted them to the bottom of the timeline. This was the primary out-of-order mechanism on the resume-success path (~3,260 resumes/week in prod, up to 40 stanzas per resume).

## What changed

**`waddle-xmpp/stream_management`**
- `get_stanzas_to_resend` / `UnackedQueue::get_unacked_after` now return typed `ReplayStanza { stanza_xml, original_receipt_at }` entries instead of bare `String`s (the queue already tracked per-stanza receipt times for the Q6 promotion path).
- New `stream_management/replay.rs`: pure `stamp_replay_delay(xml, server_domain, original_receipt_at)` builder. Parses the queued frame back into a `minidom::Element` (the queue sits past the serialization boundary), appends `<delay xmlns='urn:xmpp:delay' from='DOMAIN' stamp='ORIGINAL_ISO8601'/>` via the typed `xep0203` builder, and re-serializes. Message/presence only — `<iq/>` replays verbatim (XEP-0203 §2). No reason text (mirrors `ReplayReason::SmRedelivery`). Parse/serialize failures replay unstamped with a `warn!`.
- If the stanza already carries this server's own `<delay/>` (offline-flush stamp, Q6 SM-expiry redelivery), it is returned **unchanged**: that stamp records the true original time, which can be earlier than the queue's receipt time. Overwriting it would re-introduce the exact corruption this PR fixes.

**`waddle-server` websocket**
- Both replay paths stamp: the pre-registration `handle_sm_resume` response and the post-registration `ReplaceWithResumed` finalization, using `auth_state.xmpp_domain`.

**`waddle-xmpp/pending_delivery` (round-2 review finding)**
- `build_replay_stanza` gets the same preserve-if-self-stamped semantics, so a multi-hop Q6 chain (receive T0 → SM expiry → live redelivery recorded at T1 → second SM expiry) no longer overwrites the accurate T0 stamp on Transient payloads. Single-hop flush behaviour unchanged.
- Corrected stale/incorrect XEP citations (the delay-on-redelivery guidance lives in XEP-0198's Acks section; XEP-0203 §2 is the one-delay-per-entity rule).

**`waddle-server` Q6 promotion (round-3 review finding)**
- `promote_one` now reads the `<delay from='DOMAIN'/>` stamp a prior hop attached and uses it as the promoted `pending_delivery` row's `original_receipt_at`. Without this, MAM-archived payloads (which rehydrate from the archive without any self-stamp) flushed with the redelivery time after a second expiry. T0 now survives any number of expiry hops for both Archived and Transient payloads.

## Tests

- New dedicated suite `waddle-xmpp/tests/xep0198_resume_replay_delay.rs` (5 tests): stamp with original receipt time on replayed messages, absence on first send, `<iq/>` passthrough, preservation of an existing accurate self-stamp + upstream delays, per-stanza receipt times through `get_stanzas_to_resend`.
- End-to-end websocket test (`tests/stream_management.rs`): full `<resume/>` → `<resumed/>` + replay, asserting the message carries `<delay from=DOMAIN stamp=ORIGINAL>` and the iq stays unstamped.
- Flush test pinning multi-hop Q6 stamp preservation; promotion test pinning the row `original_receipt_at` override.

## Verification

- `cargo test --workspace` green; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.
- One unrelated pre-existing flaky test surfaced during verification (`caps_repeated_advert_while_resolution_pending_sends_one_query`, fails ~1/3 on main too) — filed as #1188.
- Four adversarial review rounds (XEP conformance, Rust correctness, client impact, then focused re-reviews of each fix) — every real finding fixed in follow-up commits; round 4 reported no real issues. Client-side decode path traced end-to-end (`delay` authority beats `fallback`/`queued`, `archive` still wins).
- Follow-up noted for the future s2s intake: it must strip `from='our-domain'` delays like the c2s intake does, or a remote server could backdate messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)