### PR TITLE
fix(server): dedupe WASM MAM results by mam_id via shared MamResultCollector (#1179)

### DIFF
--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -483,22 +483,7 @@ impl WasmDriverTask {
                     };
                     let _ = responder.send(result);
                 } else if let Some(pending) = self.pending_mam_queries.remove(&id) {
-                    let PendingMamQuery {
-                        collector,
-                        responder,
-                    } = pending;
-                    let result = if element.attr("type") == Some("result") {
-                        let (rsm, is_complete) = mam::parse_fin_from_iq_result(&element);
-                        Ok(waddle_xmpp_client::MamPage {
-                            query_id: collector.query_id().to_string(),
-                            messages: collector.into_messages(),
-                            rsm,
-                            is_complete,
-                        })
-                    } else {
-                        Err(ClientError::StanzaError(parse_stanza_error(&element)))
-                    };
-                    let _ = responder.send(result);
+                    resolve_pending_mam_query(pending, &element);
                 } else if let Some(pending) = self.pending_inbox_queries.remove(&id) {
                     let result = if element.attr("type") == Some("result") {
                         let fin = waddle_xmpp_client::inbox::parse_inbox_fin(&element)
@@ -676,6 +661,28 @@ fn collect_pending_mam_result(
     }
 }
 
+/// Complete a pending MAM query with the IQ that resolved it: a `<fin/>` IQ
+/// result yields the deduped [`waddle_xmpp_client::MamPage`], anything else a
+/// stanza error.
+fn resolve_pending_mam_query(pending: PendingMamQuery, element: &Element) {
+    let PendingMamQuery {
+        collector,
+        responder,
+    } = pending;
+    let result = if element.attr("type") == Some("result") {
+        let (rsm, is_complete) = mam::parse_fin_from_iq_result(element);
+        Ok(waddle_xmpp_client::MamPage {
+            query_id: collector.query_id().to_string(),
+            messages: collector.into_messages(),
+            rsm,
+            is_complete,
+        })
+    } else {
+        Err(ClientError::StanzaError(parse_stanza_error(element)))
+    };
+    let _ = responder.send(result);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -776,6 +783,107 @@ mod tests {
         );
         assert_eq!(messages[0].mam_id, "mam-0");
         assert_eq!(messages[1].mam_id, "mam-1");
+    }
+
+    #[test]
+    fn mam_collection_drops_results_without_a_query_id() {
+        let mut pending_mam_queries = HashMap::new();
+        let (responder, _rx) = oneshot::channel();
+        pending_mam_queries.insert(
+            "iq-1".to_string(),
+            PendingMamQuery::new("query-1", responder),
+        );
+
+        let mut archived = build_archived("mam-0", "query-1", "hello 0");
+        archived.query_id = None;
+        collect_pending_mam_result(&mut pending_mam_queries, archived);
+
+        let pending = pending_mam_queries
+            .remove("iq-1")
+            .expect("pending query still registered");
+        assert!(
+            pending.collector.into_messages().is_empty(),
+            "a result without a queryid must not be attributed to any pending query"
+        );
+    }
+
+    fn build_fin_iq(iq_id: &str, first: &str, last: &str, count: u32) -> Element {
+        let set = Element::builder("set", waddle_xmpp_core::mam::RSM_NS)
+            .append(
+                Element::builder("first", waddle_xmpp_core::mam::RSM_NS)
+                    .append(first)
+                    .build(),
+            )
+            .append(
+                Element::builder("last", waddle_xmpp_core::mam::RSM_NS)
+                    .append(last)
+                    .build(),
+            )
+            .append(
+                Element::builder("count", waddle_xmpp_core::mam::RSM_NS)
+                    .append(count.to_string())
+                    .build(),
+            )
+            .build();
+
+        let fin = Element::builder("fin", waddle_xmpp_core::mam::MAM_NS)
+            .attr(minidom::rxml::xml_ncname!("complete").to_owned(), "true")
+            .append(set)
+            .build();
+
+        Element::builder("iq", NS_CLIENT)
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), iq_id)
+            .append(fin)
+            .build()
+    }
+
+    #[test]
+    fn fin_iq_result_resolves_pending_query_with_deduped_page() {
+        let mut pending_mam_queries = HashMap::new();
+        let (responder, mut rx) = oneshot::channel();
+        pending_mam_queries.insert(
+            "iq-1".to_string(),
+            PendingMamQuery::new("query-1", responder),
+        );
+
+        collect_pending_mam_result(
+            &mut pending_mam_queries,
+            build_archived("mam-0", "query-1", "hello 0"),
+        );
+        collect_pending_mam_result(
+            &mut pending_mam_queries,
+            build_archived("mam-1", "query-1", "hello 1"),
+        );
+        // XEP-0198 resume replays the unacked tail before the (also replayed)
+        // <fin/> arrives.
+        collect_pending_mam_result(
+            &mut pending_mam_queries,
+            build_archived("mam-1", "query-1", "hello 1"),
+        );
+
+        let pending = pending_mam_queries
+            .remove("iq-1")
+            .expect("pending query still registered");
+        resolve_pending_mam_query(pending, &build_fin_iq("iq-1", "mam-0", "mam-1", 2));
+
+        let page = rx
+            .try_recv()
+            .expect("responder completed")
+            .expect("responder sent a result")
+            .expect("fin result resolves to a page");
+        assert_eq!(page.query_id, "query-1");
+        assert_eq!(
+            page.messages.len(),
+            2,
+            "the page must carry the deduped rows, not the replayed duplicates"
+        );
+        assert_eq!(page.messages[0].mam_id, "mam-0");
+        assert_eq!(page.messages[1].mam_id, "mam-1");
+        assert!(page.is_complete, "<fin complete='true'/> must propagate");
+        assert_eq!(page.rsm.first.as_deref(), Some("mam-0"));
+        assert_eq!(page.rsm.last.as_deref(), Some("mam-1"));
+        assert_eq!(page.rsm.count, Some(2));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -262,14 +262,8 @@ impl WasmDriverTask {
         {
             Ok(()) => match id {
                 Some(id) => {
-                    self.pending_mam_queries.insert(
-                        id,
-                        PendingMamQuery {
-                            query_id,
-                            messages: Vec::new(),
-                            responder,
-                        },
-                    );
+                    self.pending_mam_queries
+                        .insert(id, PendingMamQuery::new(&query_id, responder));
                     true
                 }
                 None => {
@@ -489,18 +483,22 @@ impl WasmDriverTask {
                     };
                     let _ = responder.send(result);
                 } else if let Some(pending) = self.pending_mam_queries.remove(&id) {
+                    let PendingMamQuery {
+                        collector,
+                        responder,
+                    } = pending;
                     let result = if element.attr("type") == Some("result") {
                         let (rsm, is_complete) = mam::parse_fin_from_iq_result(&element);
                         Ok(waddle_xmpp_client::MamPage {
-                            messages: pending.messages,
+                            query_id: collector.query_id().to_string(),
+                            messages: collector.into_messages(),
                             rsm,
-                            query_id: pending.query_id,
                             is_complete,
                         })
                     } else {
                         Err(ClientError::StanzaError(parse_stanza_error(&element)))
                     };
-                    let _ = pending.responder.send(result);
+                    let _ = responder.send(result);
                 } else if let Some(pending) = self.pending_inbox_queries.remove(&id) {
                     let result = if element.attr("type") == Some("result") {
                         let fin = waddle_xmpp_client::inbox::parse_inbox_fin(&element)
@@ -517,15 +515,7 @@ impl WasmDriverTask {
                 None
             }
             ClientEvent::MamResult(archived) => {
-                if let Some(query_id) = archived.query_id.as_deref() {
-                    if let Some((_, pending)) = self
-                        .pending_mam_queries
-                        .iter_mut()
-                        .find(|(_, pending)| pending.query_id == query_id)
-                    {
-                        pending.messages.push(*archived);
-                    }
-                }
+                collect_pending_mam_result(&mut self.pending_mam_queries, *archived);
                 None
             }
             ClientEvent::InboxStreamEntry(entry) => {
@@ -668,6 +658,24 @@ fn cancel_raw_iq_state(
     *deferred_commands = retained;
 }
 
+/// Route a MAM result stanza to the pending query it belongs to, matching on
+/// the XEP-0313 `queryid`. Results without a `queryid`, or for a query that is
+/// no longer pending, are dropped; the pending query's collector weeds out
+/// XEP-0198 resume-replayed duplicates by `mam_id`.
+fn collect_pending_mam_result(
+    pending_mam_queries: &mut HashMap<String, PendingMamQuery>,
+    archived: ArchivedMessage,
+) {
+    if let Some(query_id) = archived.query_id.as_deref() {
+        if let Some((_, pending)) = pending_mam_queries
+            .iter_mut()
+            .find(|(_, pending)| pending.query_id() == query_id)
+        {
+            pending.collect(archived);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -697,6 +705,77 @@ mod tests {
             on_call: None,
             resume_state: None,
         }))
+    }
+
+    fn build_archived(mam_id: &str, query_id: &str, body: &str) -> ArchivedMessage {
+        let stanza_id = waddle_xmpp_core::xep0359::StanzaId::new(
+            mam_id,
+            "room@muc.example.com".parse().expect("valid archive jid"),
+        );
+        ArchivedMessage {
+            mam_id: mam_id.to_string(),
+            query_id: Some(query_id.to_string()),
+            id: None,
+            stanza_id: Some(stanza_id.clone()),
+            origin_id: None,
+            timestamp: None,
+            from: Some("room@muc.example.com/alice".to_string()),
+            to: Some("alice@example.com/res".to_string()),
+            stanza_ids: vec![stanza_id],
+            parent_thread_id: None,
+            message_type: "groupchat".to_string(),
+            body: Some(body.to_string()),
+            thread: None,
+            author_real_jid: None,
+            inner: Element::builder("message", NS_CLIENT).build(),
+            payload: Default::default(),
+        }
+    }
+
+    #[test]
+    fn mam_collection_dedups_replayed_results_and_filters_foreign_query_ids() {
+        let mut pending_mam_queries = HashMap::new();
+        let (responder, _rx) = oneshot::channel();
+        pending_mam_queries.insert(
+            "iq-1".to_string(),
+            PendingMamQuery::new("query-1", responder),
+        );
+
+        // Original delivery.
+        collect_pending_mam_result(
+            &mut pending_mam_queries,
+            build_archived("mam-0", "query-1", "hello 0"),
+        );
+        collect_pending_mam_result(
+            &mut pending_mam_queries,
+            build_archived("mam-1", "query-1", "hello 1"),
+        );
+        // XEP-0198 resume replays the unacked tail: same queryid, same mam_id.
+        collect_pending_mam_result(
+            &mut pending_mam_queries,
+            build_archived("mam-1", "query-1", "hello 1"),
+        );
+        collect_pending_mam_result(
+            &mut pending_mam_queries,
+            build_archived("mam-0", "query-1", "hello 0"),
+        );
+        // A result for another open query must never be collected.
+        collect_pending_mam_result(
+            &mut pending_mam_queries,
+            build_archived("mam-9", "some-other-query", "noise"),
+        );
+
+        let pending = pending_mam_queries
+            .remove("iq-1")
+            .expect("pending query still registered");
+        let messages = pending.collector.into_messages();
+        assert_eq!(
+            messages.len(),
+            2,
+            "replayed results with an already-collected mam_id must be dropped"
+        );
+        assert_eq!(messages[0].mam_id, "mam-0");
+        assert_eq!(messages[1].mam_id, "mam-1");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -18,7 +18,7 @@ use waddle_xmpp_client::discovery::{
     WaddleInboxMarkRead,
 };
 use waddle_xmpp_client::error::parse_stanza_error;
-use waddle_xmpp_client::mam::{self, build_mam_iq, MamIqBuilder};
+use waddle_xmpp_client::mam::{self, build_mam_iq, MamIqBuilder, MamResultCollector};
 use waddle_xmpp_client::mds::{
     build_mds_catchup_iq, build_mds_publish_iq, build_mds_subscribe_iq, parse_mds_catchup_result,
     MdsCatchupEntry, NS_PUBSUB_PUBLISH_OPTIONS_FEATURE,

--- a/server/crates/waddle-xmpp-client-wasm/src/state.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/state.rs
@@ -267,9 +267,28 @@ pub(crate) fn client_driver_event(event: ClientEvent) -> DriverEvent {
 }
 
 pub(crate) struct PendingMamQuery {
-    pub(crate) query_id: String,
-    pub(crate) messages: Vec<ArchivedMessage>,
+    pub(crate) collector: MamResultCollector,
     pub(crate) responder: oneshot::Sender<DriverResult<waddle_xmpp_client::MamPage>>,
+}
+
+impl PendingMamQuery {
+    pub(crate) fn new(
+        query_id: &str,
+        responder: oneshot::Sender<DriverResult<waddle_xmpp_client::MamPage>>,
+    ) -> Self {
+        Self {
+            collector: MamResultCollector::new(query_id),
+            responder,
+        }
+    }
+
+    pub(crate) fn query_id(&self) -> &str {
+        self.collector.query_id()
+    }
+
+    pub(crate) fn collect(&mut self, archived: ArchivedMessage) {
+        self.collector.collect(archived);
+    }
 }
 
 pub(crate) struct PendingInboxQuery {

--- a/server/crates/waddle-xmpp-client/src/mam.rs
+++ b/server/crates/waddle-xmpp-client/src/mam.rs
@@ -13,7 +13,6 @@ use waddle_xmpp_core::mam::{
 };
 use waddle_xmpp_core::xep0359::{OriginId, StanzaId as StableStanzaId, NS_SID as XEP0359_NS};
 
-#[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 use std::collections::HashSet;
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 use std::time::Duration;
@@ -376,19 +375,18 @@ fn parse_archived_author_real_jid(inner: &Element) -> Option<String> {
 
 /// Accumulates MAM results for one query: filters out results belonging to
 /// other queries and drops duplicates by `mam_id` (XEP-0198 §5 leaves weeding
-/// out resume-replayed duplicates to the recipient). Both collection arms of
-/// [`run_mam_query`] delegate to one instance, so the dedup state cannot
+/// out resume-replayed duplicates to the recipient). Every collection path —
+/// both arms of the native [`run_mam_query`] and the WASM driver's pending
+/// query — delegates to one instance per query, so the dedup state cannot
 /// diverge between them.
-#[cfg(all(feature = "native", not(target_arch = "wasm32")))]
-struct MamResultCollector {
+pub struct MamResultCollector {
     query_id: String,
     seen_mam_ids: HashSet<String>,
     messages: Vec<ArchivedMessage>,
 }
 
-#[cfg(all(feature = "native", not(target_arch = "wasm32")))]
 impl MamResultCollector {
-    fn new(query_id: &str) -> Self {
+    pub fn new(query_id: &str) -> Self {
         Self {
             query_id: query_id.to_string(),
             seen_mam_ids: HashSet::new(),
@@ -396,9 +394,13 @@ impl MamResultCollector {
         }
     }
 
+    pub fn query_id(&self) -> &str {
+        &self.query_id
+    }
+
     /// Keep the result if it belongs to this query and its `mam_id` has not
     /// been collected yet; ignore it otherwise.
-    fn collect(&mut self, archived: ArchivedMessage) {
+    pub fn collect(&mut self, archived: ArchivedMessage) {
         if archived.query_id.as_deref() == Some(&self.query_id)
             && self.seen_mam_ids.insert(archived.mam_id.clone())
         {
@@ -406,7 +408,7 @@ impl MamResultCollector {
         }
     }
 
-    fn into_messages(self) -> Vec<ArchivedMessage> {
+    pub fn into_messages(self) -> Vec<ArchivedMessage> {
         self.messages
     }
 }


### PR DESCRIPTION
Fixes #1179.

## Problem

PR #1154 added `MamResultCollector` to dedupe MAM (XEP-0313) page results by `mam_id`, but gated it `#[cfg(all(feature = "native", not(target_arch = "wasm32")))]`. The WASM driver the chat client actually runs still appended every `MamResult` unconditionally, so an XEP-0198 resume that retransmits MAM result stanzas from the unacked window produced duplicate rows in the returned `MamPage` — double-counting catch-up watermarks and perturbing RSM cursor logic on the browser build.

## Changes

- **`waddle-xmpp-client/src/mam.rs`** — un-gated `MamResultCollector` and made it `pub` with a `query_id()` accessor, so the native `run_mam_query` and the WASM driver share one dedupe implementation (XEP-0198 §5 leaves weeding out resume-replayed duplicates to the recipient; XEP-0313 guarantees archive-ID uniqueness, so first-occurrence-wins is safe).
- **`waddle-xmpp-client-wasm/src/state.rs`** — `PendingMamQuery` now embeds a `MamResultCollector` (replacing the raw `query_id` + `Vec<ArchivedMessage>` fields) with `new()` / `query_id()` / `collect()` helpers.
- **`waddle-xmpp-client-wasm/src/driver.rs`** — extracted the `ClientEvent::MamResult` routing into `collect_pending_mam_result` and the `<fin/>` IQ-result assembly into `resolve_pending_mam_query`, both natively testable and both on the production dispatch path.

## Tests (TDD, mirroring the native suite from #1154)

- `mam_collection_dedups_replayed_results_and_filters_foreign_query_ids` — a retransmitted `MamResult` with an already-collected `mam_id` yields a single row; foreign `queryid` results are never collected. Verified RED against the pre-fix append-only behavior.
- `fin_iq_result_resolves_pending_query_with_deduped_page` — the `<fin/>` IQ result resolves the responder with the deduped `MamPage` (query_id, RSM first/last/count, `is_complete`).
- `mam_collection_drops_results_without_a_query_id` — a result without a `queryid` is not attributed to any pending query.

## Verification

- `cargo test -p waddle-xmpp-client-wasm` (125 pass) and `cargo test -p waddle-xmpp-client` (508 pass)
- `cargo clippy -p waddle-xmpp-client -p waddle-xmpp-client-wasm --all-targets -- -D warnings` clean
- `cargo check -p waddle-xmpp-client-wasm --target wasm32-unknown-unknown` clean
- Three adversarial review personas (XEP conformance, Rust correctness, test quality); both actionable findings from round 1 (untested fin assembly, untested no-queryid arm) addressed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
