### PR TITLE
fix(chat): single choreographed MAM catch-up on fresh reconnect — skip lifecycle reload when covered, with failure fallback

### DIFF
--- a/chat/src/channels/mam-paging.ts
+++ b/chat/src/channels/mam-paging.ts
@@ -7,6 +7,7 @@ import type {
   LiveRoomMessage,
 } from "@/lib/xmpp-client";
 import type { TimelineMessage } from "@/lib/chat-ui";
+import type { TimelineLoadResult } from "@/lib/timeline-load-result";
 import { findMessageById } from "@/lib/message-ids";
 import {
   isTopPinnedScrollDirection,
@@ -112,12 +113,12 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
     channelId: string,
     unreadAtLoad = 0,
     metadataSeed: TimelineMessage[] = [],
-  ) {
-    if (!session.value) return;
+  ): Promise<TimelineLoadResult> {
+    if (!session.value) return "aborted";
 
     const requestId = ++messageRequestId;
     const roomJid = roomJidForChannel(channelId);
-    if (!roomJid) return;
+    if (!roomJid) return "aborted";
     initialLatestPagePinned = false;
     isLoadingMessages.value = true;
     isLoadingOlderMessages.value = false;
@@ -170,7 +171,7 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
         (activeSpaceId.value ?? "") !== spaceId ||
         activeChannelId.value !== channelId
       ) {
-        return;
+        return "aborted";
       }
 
       const cursor = cursorFromLatestPage({
@@ -210,18 +211,19 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
         (activeSpaceId.value ?? "") !== spaceId ||
         activeChannelId.value !== channelId
       ) {
-        return;
+        return "loaded";
       }
       initialLatestPagePinned = true;
       const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
       if (newest) persistLastSeen(channelId, newest.id);
+      return "loaded";
     } catch (e) {
-      if (requestId === messageRequestId) {
-        const queuedOnly = appendQueuedMessages([], roomJid);
-        messages.value = queuedOnly;
-        actionError.value = queuedOnly.length > 0 ? "" : normalizeError(e);
-        isLoadingMessages.value = false;
-      }
+      if (requestId !== messageRequestId) return "aborted";
+      const queuedOnly = appendQueuedMessages([], roomJid);
+      messages.value = queuedOnly;
+      actionError.value = queuedOnly.length > 0 ? "" : normalizeError(e);
+      isLoadingMessages.value = false;
+      return "failed";
     }
   }
 

--- a/chat/src/channels/mam-paging.ts
+++ b/chat/src/channels/mam-paging.ts
@@ -206,11 +206,15 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
       if (displayed) setMdsDisplayed(mdsKey, displayed);
       const pinned = await scrollToPinnedEdgeAndPin();
       if (
-        !pinned ||
         requestId !== messageRequestId ||
         (activeSpaceId.value ?? "") !== spaceId ||
         activeChannelId.value !== channelId
       ) {
+        // Superseded during the pin step: the timeline was rebuilt, but
+        // a newer request owns it now — callers must not react.
+        return "aborted";
+      }
+      if (!pinned) {
         return "loaded";
       }
       initialLatestPagePinned = true;

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -446,8 +446,11 @@ export function useChannelMessages(
         // A failed reload must not leave the timeline wiped to
         // queued-only: the catch-up coverage skip would then block the
         // self-heal on the next reconnect. Restore the pre-reload
-        // timeline; the load error stays surfaced.
-        messages.value = metadataSeed;
+        // timeline (the load error stays surfaced) — merging in what
+        // the catch's queued-only reset holds, so a message the user
+        // queued DURING the reload doesn't vanish until its echo.
+        const queuedDuringReload = messages.value.filter((m) => !findMessageById(metadataSeed, m.id));
+        messages.value = [...metadataSeed, ...queuedDuringReload];
         return;
       }
       if (preserved.length === 0) return;

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -4,6 +4,7 @@ import type { ChannelSummary } from "@/lib/chat-types";
 import type { WaddleSession } from "@/lib/server-auth";
 import {
   BrowserXmppClient,
+  bareJidKey,
   barePeerJid,
   type RoomActivityEvent,
   type SessionLifecycleEvent,
@@ -395,8 +396,11 @@ export function useChannelMessages(
     // MAM fetch racing the catch-up's merges for messages.value. The
     // catch-up path (cursor paging + live-merge) fully closes the gap,
     // so skip the rebuild — same choreography as a resumed session.
+    // Coverage keys are server-emitted (RFC 7622-lowercased) JIDs while
+    // the directory-derived room JID may differ in case — compare via
+    // bareJidKey or the skip silently fails open back into the race.
     const roomJid = roomJidForChannel(channelId);
-    if (roomJid && event.catchup.roomJids.includes(roomJid)) return;
+    if (roomJid && event.catchup.roomJids.some((jid) => bareJidKey(jid) === bareJidKey(roomJid))) return;
     const metadataSeed = messages.value;
     const preserved = messages.value.filter(
       (m) =>

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -6,6 +6,7 @@ import {
   BrowserXmppClient,
   bareJidKey,
   barePeerJid,
+  type CatchupConversationFailure,
   type RoomActivityEvent,
   type SessionLifecycleEvent,
   type RoomAuthority,
@@ -378,29 +379,53 @@ export function useChannelMessages(
 
   /**
    * On a fresh XMPP session (resume failed or first connect after a drop),
-   * refetch MAM to close any message gap for the current channel. Local
-   * optimistic sends (sending/failed) are preserved across the reload so
-   * the UI doesn't drop unsent entries the user can still retry.
-   * Resumed sessions never call this — the server replays everything.
+   * refetch MAM to close any message gap for the current channel — unless
+   * the client's own reconnect catch-up covers this room (#1180): a
+   * wholesale reload would then be a second concurrent MAM fetch racing
+   * the catch-up's merges for messages.value. The catch-up path (cursor
+   * paging + live-merge) fully closes the gap, same choreography as a
+   * resumed session. Resumed sessions never call this — the server
+   * replays everything.
    */
   function onSessionLifecycle(event: SessionLifecycleEvent) {
     if (event.type !== "fresh") return;
+    const channelId = activeChannelId.value;
+    if (!channelId) return;
+    // Coverage keys are server-emitted (RFC 7622-lowercased) JIDs while
+    // the directory-derived room JID may differ in case — compare via
+    // bareJidKey or the skip silently fails open back into the race.
+    const roomJid = roomJidForChannel(channelId);
+    if (roomJid && event.catchup.roomJids.some((jid) => bareJidKey(jid) === bareJidKey(roomJid))) return;
+    refetchTimelineToCloseGap();
+  }
+
+  /**
+   * Fallback for a covered-but-failed reconnect catch-up (#1180): the
+   * lifecycle skip above trusted the catch-up to close this room's gap;
+   * when it fails, run the wholesale reload it suppressed — serialized
+   * after the failed attempt, so the two fetches can no longer race.
+   */
+  function onCatchupFailed(failure: CatchupConversationFailure) {
+    if (failure.kind !== "room") return;
+    const channelId = activeChannelId.value;
+    if (!channelId) return;
+    const roomJid = roomJidForChannel(channelId);
+    if (!roomJid || bareJidKey(roomJid) !== bareJidKey(failure.key)) return;
+    refetchTimelineToCloseGap();
+  }
+
+  /**
+   * Wholesale MAM refetch of the active channel. Local optimistic sends
+   * (queued/sending/failed) are preserved across the reload so the UI
+   * doesn't drop unsent entries the user can still retry.
+   */
+  function refetchTimelineToCloseGap() {
     const spaceId = activeSpaceId.value;
     const channelId = activeChannelId.value;
     if (!channelId) return;
     // Only catch up if we had already loaded this channel; otherwise the
     // standard loadMessages call on channel-select handles it.
     if (messages.value.length === 0) return;
-    // #1180: when the client's reconnect catch-up is about to page this
-    // room itself, a wholesale reload here would be a second concurrent
-    // MAM fetch racing the catch-up's merges for messages.value. The
-    // catch-up path (cursor paging + live-merge) fully closes the gap,
-    // so skip the rebuild — same choreography as a resumed session.
-    // Coverage keys are server-emitted (RFC 7622-lowercased) JIDs while
-    // the directory-derived room JID may differ in case — compare via
-    // bareJidKey or the skip silently fails open back into the race.
-    const roomJid = roomJidForChannel(channelId);
-    if (roomJid && event.catchup.roomJids.some((jid) => bareJidKey(jid) === bareJidKey(roomJid))) return;
     const metadataSeed = messages.value;
     const preserved = messages.value.filter(
       (m) =>
@@ -742,5 +767,6 @@ export function useChannelMessages(
     onMessageAck,
     onMessageDeliveryFailure,
     onSessionLifecycle,
+    onCatchupFailed,
   };
 }

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -390,6 +390,13 @@ export function useChannelMessages(
     // Only catch up if we had already loaded this channel; otherwise the
     // standard loadMessages call on channel-select handles it.
     if (messages.value.length === 0) return;
+    // #1180: when the client's reconnect catch-up is about to page this
+    // room itself, a wholesale reload here would be a second concurrent
+    // MAM fetch racing the catch-up's merges for messages.value. The
+    // catch-up path (cursor paging + live-merge) fully closes the gap,
+    // so skip the rebuild — same choreography as a resumed session.
+    const roomJid = roomJidForChannel(channelId);
+    if (roomJid && event.catchup.roomJids.includes(roomJid)) return;
     const metadataSeed = messages.value;
     const preserved = messages.value.filter(
       (m) =>

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -437,6 +437,9 @@ export function useChannelMessages(
     );
     void (async () => {
       const result = await loadMessages(spaceId ?? "", channelId, 0, metadataSeed);
+      // "aborted": a newer request (same or switched conversation) owns
+      // the timeline now — reacting would push stale rows onto it.
+      if (result === "aborted") return;
       if (
         (activeSpaceId.value ?? "") !== (spaceId ?? "") ||
         activeChannelId.value !== channelId

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -436,13 +436,21 @@ export function useChannelMessages(
         ),
     );
     void (async () => {
-      await loadMessages(spaceId ?? "", channelId, 0, metadataSeed);
+      const result = await loadMessages(spaceId ?? "", channelId, 0, metadataSeed);
       if (
-        preserved.length === 0 ||
         (activeSpaceId.value ?? "") !== (spaceId ?? "") ||
         activeChannelId.value !== channelId
       )
         return;
+      if (result === "failed") {
+        // A failed reload must not leave the timeline wiped to
+        // queued-only: the catch-up coverage skip would then block the
+        // self-heal on the next reconnect. Restore the pre-reload
+        // timeline; the load error stays surfaced.
+        messages.value = metadataSeed;
+        return;
+      }
+      if (preserved.length === 0) return;
       const toAppend = preserved.filter((m) => !findMessageById(messages.value, m.id));
       if (toAppend.length > 0) messages.value = [...messages.value, ...toAppend];
     })();
@@ -569,7 +577,7 @@ export function useChannelMessages(
     metadataSeed: TimelineMessage[] = [],
   ) {
     messageSearch.reset();
-    await paging.loadMessages(spaceId, channelId, unreadAtLoad, metadataSeed);
+    return paging.loadMessages(spaceId, channelId, unreadAtLoad, metadataSeed);
   }
 
   async function selectChannel(channelId: string) {

--- a/chat/src/dms/mam-paging.ts
+++ b/chat/src/dms/mam-paging.ts
@@ -147,7 +147,10 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
       );
       if (displayed) setMdsDisplayed(mdsKey, displayed);
       const pinned = await scrollToPinnedEdgeAndPin();
-      if (!pinned || requestId !== messageRequestId || activePeerJid.value !== peerJid) return "loaded";
+      // Superseded during the pin step: the timeline was rebuilt, but a
+      // newer request owns it now — callers must not react.
+      if (requestId !== messageRequestId || activePeerJid.value !== peerJid) return "aborted";
+      if (!pinned) return "loaded";
       initialLatestPagePinned = true;
       const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
       if (newest) persistLastSeen(peerJid, newest.id);

--- a/chat/src/dms/mam-paging.ts
+++ b/chat/src/dms/mam-paging.ts
@@ -3,6 +3,7 @@ import type { BrowserXmppClient, LiveDmMessage } from "@/lib/xmpp-client";
 import { barePeerJid } from "@/lib/xmpp-client";
 import type { WaddleSession } from "@/lib/server-auth";
 import type { TimelineMessage } from "@/lib/chat-ui";
+import type { TimelineLoadResult } from "@/lib/timeline-load-result";
 import { findMessageById } from "@/lib/message-ids";
 import {
   isTopPinnedScrollDirection,
@@ -93,8 +94,8 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
     });
   }
 
-  async function loadMessages(peerJid: string, unreadAtLoad = 0) {
-    if (!session.value) return;
+  async function loadMessages(peerJid: string, unreadAtLoad = 0): Promise<TimelineLoadResult> {
+    if (!session.value) return "aborted";
     const requestId = ++messageRequestId;
     initialLatestPagePinned = false;
     isLoadingMessages.value = true;
@@ -118,7 +119,7 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
         : xmppClient.value
           ? await xmppClient.value.queryPersonalMam(peerJid, PAGE_SIZE)
           : [];
-      if (requestId !== messageRequestId || activePeerJid.value !== peerJid) return;
+      if (requestId !== messageRequestId || activePeerJid.value !== peerJid) return "aborted";
       loadErrorPeerJid.value = null;
       loadErrorMessage.value = "";
       const cursor = cursorFromLatestPage({
@@ -146,20 +147,21 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
       );
       if (displayed) setMdsDisplayed(mdsKey, displayed);
       const pinned = await scrollToPinnedEdgeAndPin();
-      if (!pinned || requestId !== messageRequestId || activePeerJid.value !== peerJid) return;
+      if (!pinned || requestId !== messageRequestId || activePeerJid.value !== peerJid) return "loaded";
       initialLatestPagePinned = true;
       const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
       if (newest) persistLastSeen(peerJid, newest.id);
+      return "loaded";
     } catch {
-      if (requestId === messageRequestId) {
-        console.warn("Could not load DM conversation");
-        const queuedOnly = appendQueuedMessages([], peerJid);
-        messages.value = queuedOnly;
-        loadErrorPeerJid.value = peerJid;
-        loadErrorMessage.value = dmLoadErrorMessage(peerJid, { queuedOnly: queuedOnly.length > 0 });
-        actionError.value = loadErrorMessage.value;
-        isLoadingMessages.value = false;
-      }
+      if (requestId !== messageRequestId) return "aborted";
+      console.warn("Could not load DM conversation");
+      const queuedOnly = appendQueuedMessages([], peerJid);
+      messages.value = queuedOnly;
+      loadErrorPeerJid.value = peerJid;
+      loadErrorMessage.value = dmLoadErrorMessage(peerJid, { queuedOnly: queuedOnly.length > 0 });
+      actionError.value = loadErrorMessage.value;
+      isLoadingMessages.value = false;
+      return "failed";
     }
   }
 

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -8,7 +8,7 @@ import type {
   LiveDmMessage,
   SessionLifecycleEvent,
 } from "@/lib/xmpp-client";
-import { barePeerJid, jidLocalpart } from "@/lib/xmpp-client";
+import { bareJidKey, barePeerJid, jidLocalpart } from "@/lib/xmpp-client";
 import type { WaddleSession } from "@/lib/server-auth";
 import {
   displayedStateCanAdvance,
@@ -301,7 +301,7 @@ export function useDirectMessages(
     // itself — a wholesale reload here would race its merges for
     // messages.value. Skip the rebuild; cursor paging + live-merge
     // closes the gap, same choreography as a resumed session.
-    if (event.catchup.dmJids.includes(barePeerJid(peerJid))) return;
+    if (event.catchup.dmJids.some((jid) => bareJidKey(jid) === bareJidKey(peerJid))) return;
     const preserved = messages.value.filter(
       (m) =>
         m.isSelf && (

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -336,8 +336,11 @@ export function useDirectMessages(
         // A failed reload must not leave the timeline wiped to
         // queued-only: the catch-up coverage skip would then block the
         // self-heal on the next reconnect. Restore the pre-reload
-        // timeline; the load error stays surfaced.
-        messages.value = snapshot;
+        // timeline (the load error stays surfaced) — merging in what
+        // the catch's queued-only reset holds, so a message the user
+        // queued DURING the reload doesn't vanish until its echo.
+        const queuedDuringReload = messages.value.filter((m) => !findMessageById(snapshot, m.id));
+        messages.value = [...snapshot, ...queuedDuringReload];
         return;
       }
       if (preserved.length === 0) return;

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -287,7 +287,7 @@ export function useDirectMessages(
   // clears stale results.
   async function loadMessages(peerJid: string, unreadAtLoad = 0) {
     messageSearch.reset();
-    await paging.loadMessages(peerJid, unreadAtLoad);
+    return paging.loadMessages(peerJid, unreadAtLoad);
   }
 
   /** On a fresh session (SM resume failed), re-fetch MAM to close any gap
@@ -320,7 +320,8 @@ export function useDirectMessages(
     const peerJid = activePeerJid.value;
     if (!peerJid) return;
     if (messages.value.length === 0) return;
-    const preserved = messages.value.filter(
+    const snapshot = messages.value;
+    const preserved = snapshot.filter(
       (m) =>
         m.isSelf && (
           m.deliveryStatus === "queued"
@@ -329,8 +330,17 @@ export function useDirectMessages(
         ),
     );
     void (async () => {
-      await loadMessages(peerJid);
-      if (preserved.length === 0 || activePeerJid.value !== peerJid) return;
+      const result = await loadMessages(peerJid);
+      if (activePeerJid.value !== peerJid) return;
+      if (result === "failed") {
+        // A failed reload must not leave the timeline wiped to
+        // queued-only: the catch-up coverage skip would then block the
+        // self-heal on the next reconnect. Restore the pre-reload
+        // timeline; the load error stays surfaced.
+        messages.value = snapshot;
+        return;
+      }
+      if (preserved.length === 0) return;
       const toAppend = preserved.filter((m) => !findMessageById(messages.value, m.id));
       if (toAppend.length > 0) messages.value = [...messages.value, ...toAppend];
     })();

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -331,6 +331,9 @@ export function useDirectMessages(
     );
     void (async () => {
       const result = await loadMessages(peerJid);
+      // "aborted": a newer request (same or switched conversation) owns
+      // the timeline now — reacting would push stale rows onto it.
+      if (result === "aborted") return;
       if (activePeerJid.value !== peerJid) return;
       if (result === "failed") {
         // A failed reload must not leave the timeline wiped to

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -9,6 +9,7 @@ import type {
   SessionLifecycleEvent,
 } from "@/lib/xmpp-client";
 import { bareJidKey, barePeerJid, jidLocalpart } from "@/lib/xmpp-client";
+import type { CatchupConversationFailure } from "@/lib/xmpp-client";
 import type { WaddleSession } from "@/lib/server-auth";
 import {
   displayedStateCanAdvance,
@@ -290,18 +291,35 @@ export function useDirectMessages(
   }
 
   /** On a fresh session (SM resume failed), re-fetch MAM to close any gap
-   *  for the currently-open conversation. Local optimistic sends are
-   *  preserved across the reload so the user keeps retry affordances. */
+   *  for the currently-open conversation — unless the client's reconnect
+   *  catch-up covers this peer (#1180): a wholesale reload would then
+   *  race the catch-up's merges for messages.value. Cursor paging +
+   *  live-merge closes the gap, same choreography as a resumed session. */
   function onSessionLifecycle(event: SessionLifecycleEvent) {
     if (event.type !== "fresh") return;
     const peerJid = activePeerJid.value;
     if (!peerJid) return;
-    if (messages.value.length === 0) return;
-    // #1180: the reconnect catch-up is about to page this conversation
-    // itself — a wholesale reload here would race its merges for
-    // messages.value. Skip the rebuild; cursor paging + live-merge
-    // closes the gap, same choreography as a resumed session.
     if (event.catchup.dmJids.some((jid) => bareJidKey(jid) === bareJidKey(peerJid))) return;
+    refetchTimelineToCloseGap();
+  }
+
+  /** Fallback for a covered-but-failed reconnect catch-up (#1180): run
+   *  the wholesale reload the lifecycle skip suppressed — serialized
+   *  after the failed attempt, so the two fetches can no longer race. */
+  function onCatchupFailed(failure: CatchupConversationFailure) {
+    if (failure.kind !== "dm") return;
+    const peerJid = activePeerJid.value;
+    if (!peerJid || bareJidKey(peerJid) !== bareJidKey(failure.key)) return;
+    refetchTimelineToCloseGap();
+  }
+
+  /** Wholesale MAM refetch of the active conversation. Local optimistic
+   *  sends are preserved across the reload so the user keeps retry
+   *  affordances. */
+  function refetchTimelineToCloseGap() {
+    const peerJid = activePeerJid.value;
+    if (!peerJid) return;
+    if (messages.value.length === 0) return;
     const preserved = messages.value.filter(
       (m) =>
         m.isSelf && (
@@ -460,6 +478,7 @@ export function useDirectMessages(
     onMessageAck,
     onMessageDeliveryFailure,
     onSessionLifecycle,
+    onCatchupFailed,
     scrollToPinnedEdge,
     isPinnedAtEdge: pinnedEdgeScroller.isPinnedAtEdge,
     latestRemoteMessageId,

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -297,6 +297,11 @@ export function useDirectMessages(
     const peerJid = activePeerJid.value;
     if (!peerJid) return;
     if (messages.value.length === 0) return;
+    // #1180: the reconnect catch-up is about to page this conversation
+    // itself — a wholesale reload here would race its merges for
+    // messages.value. Skip the rebuild; cursor paging + live-merge
+    // closes the gap, same choreography as a resumed session.
+    if (event.catchup.dmJids.includes(barePeerJid(peerJid))) return;
     const preserved = messages.value.filter(
       (m) =>
         m.isSelf && (

--- a/chat/src/lib/timeline-load-result.ts
+++ b/chat/src/lib/timeline-load-result.ts
@@ -3,7 +3,7 @@
  *
  * - "loaded": the timeline was rebuilt from a fetched MAM page.
  * - "aborted": a newer request or a conversation switch superseded this
- *   call before it touched the timeline — do not react to it.
+ *   call — the timeline now belongs to that newer owner; do not react.
  * - "failed": the fetch errored and the catch reset the timeline to
  *   queued-only. Callers that reloaded an existing timeline (#1180
  *   catch-up fallback) must restore their pre-reload snapshot.

--- a/chat/src/lib/timeline-load-result.ts
+++ b/chat/src/lib/timeline-load-result.ts
@@ -1,0 +1,11 @@
+/**
+ * Outcome of a wholesale timeline `loadMessages` call.
+ *
+ * - "loaded": the timeline was rebuilt from a fetched MAM page.
+ * - "aborted": a newer request or a conversation switch superseded this
+ *   call before it touched the timeline — do not react to it.
+ * - "failed": the fetch errored and the catch reset the timeline to
+ *   queued-only. Callers that reloaded an existing timeline (#1180
+ *   catch-up fallback) must restore their pre-reload snapshot.
+ */
+export type TimelineLoadResult = "loaded" | "aborted" | "failed";

--- a/chat/src/lib/xmpp/client-events.ts
+++ b/chat/src/lib/xmpp/client-events.ts
@@ -60,6 +60,15 @@ export type PubsubEvent = WasmPubsubEvent;
 
 type CatchupOutcome = "completed" | "aborted" | "failed";
 
+/**
+ * Reconnect catch-up failed for one conversation (#1180): the fresh
+ * lifecycle event reported this conversation as covered, so its
+ * consumer skipped the wholesale MAM reload — this event is the
+ * fallback signal to run that reload after the failed attempt
+ * (serialized, so the two fetches can no longer race).
+ */
+export type CatchupConversationFailure = { kind: "dm" | "room"; key: string };
+
 export type CatchupHookInfo = {
   conversations: number;
   processedConversations: number;
@@ -105,6 +114,7 @@ export type ClientEvents = {
   messageDeliveryFailure: [messageId: string];
   queuedMessageStatus: [messageId: string, status: "queued" | "sending"];
   sessionLifecycle: [event: SessionLifecycleEvent];
+  catchupFailure: [failure: CatchupConversationFailure];
   // Observe-only telemetry hooks (multi-listener, error-isolated via
   // `emitSafe`). Includes the background-tab RESULT_CODE_HUNG health
   // hooks (see docs/planning/hung-tab-investigation.md); the client

--- a/chat/src/lib/xmpp/client-mam.ts
+++ b/chat/src/lib/xmpp/client-mam.ts
@@ -444,7 +444,21 @@ export class MamPager {
           // sessions never skipped a reload — the stream is gap-free —
           // so a failure there must not trigger a spurious reload.
           if (lifecycle === "fresh") {
-            this.deps.events.emitSafe("catchupFailure", { kind: entry.kind, key: entry.key });
+            // Plain `emit` with local isolation, not `emitSafe`: a throw
+            // must neither propagate (it would reject the resume barrier
+            // and abort the remaining entries) nor be mislabeled as a
+            // telemetry-hook failure — this handler is the reload
+            // fallback, so surface a failure on the typed error channel.
+            try {
+              this.deps.events.emit("catchupFailure", { kind: entry.kind, key: entry.key });
+            } catch (handlerError) {
+              this.deps.emitError({
+                kind: "history",
+                recoverable: true,
+                detail: `Reconnect catch-up fallback handler failed for ${entry.key}`,
+                cause: handlerError,
+              });
+            }
           }
         }
       }

--- a/chat/src/lib/xmpp/client-mam.ts
+++ b/chat/src/lib/xmpp/client-mam.ts
@@ -436,8 +436,10 @@ export class MamPager {
           });
           // #1180: the fresh lifecycle event promised this conversation
           // was covered, so its consumer skipped the wholesale reload.
-          // Signal the failure so that reload can run as the fallback —
-          // after the failed attempt, never concurrently with it.
+          // Signal the failure so that reload can run as the fallback.
+          // Serialization is per-conversation: the fallback fires after
+          // THIS conversation's attempt failed (other entries may still
+          // be paging their own conversations concurrently).
           this.deps.events.emitSafe("catchupFailure", { kind: entry.kind, key: entry.key });
         }
       }

--- a/chat/src/lib/xmpp/client-mam.ts
+++ b/chat/src/lib/xmpp/client-mam.ts
@@ -434,6 +434,11 @@ export class MamPager {
             detail: `Reconnect catch-up failed for ${entry.key}`,
             cause: error,
           });
+          // #1180: the fresh lifecycle event promised this conversation
+          // was covered, so its consumer skipped the wholesale reload.
+          // Signal the failure so that reload can run as the fallback —
+          // after the failed attempt, never concurrently with it.
+          this.deps.events.emitSafe("catchupFailure", { kind: entry.kind, key: entry.key });
         }
       }
     } finally {

--- a/chat/src/lib/xmpp/client-mam.ts
+++ b/chat/src/lib/xmpp/client-mam.ts
@@ -395,6 +395,7 @@ export class MamPager {
   async runReconnectCatchup(
     xmpp: MamWasmClient,
     entries: ReadonlyArray<ReconnectCatchupEntry>,
+    lifecycle: "fresh" | "resumed",
   ) {
     const sessionJid = this.deps.sessionJid();
     // Observe-only: measure how much work a single catch-up did and how
@@ -434,13 +435,17 @@ export class MamPager {
             detail: `Reconnect catch-up failed for ${entry.key}`,
             cause: error,
           });
-          // #1180: the fresh lifecycle event promised this conversation
+          // #1180: the FRESH lifecycle event promised this conversation
           // was covered, so its consumer skipped the wholesale reload.
           // Signal the failure so that reload can run as the fallback.
           // Serialization is per-conversation: the fallback fires after
           // THIS conversation's attempt failed (other entries may still
-          // be paging their own conversations concurrently).
-          this.deps.events.emitSafe("catchupFailure", { kind: entry.kind, key: entry.key });
+          // be paging their own conversations concurrently). Resumed
+          // sessions never skipped a reload — the stream is gap-free —
+          // so a failure there must not trigger a spurious reload.
+          if (lifecycle === "fresh") {
+            this.deps.events.emitSafe("catchupFailure", { kind: entry.kind, key: entry.key });
+          }
         }
       }
     } finally {

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1912,7 +1912,7 @@ export class BrowserXmppClient {
     // `handleSessionReady` (synchronous WASM callback) can never
     // observe `pendingDuringResume` set without `resumeBarrier`
     // also set.
-    const catchupPromise = this.runReconnectCatchup(xmpp, catchupEntries);
+    const catchupPromise = this.runReconnectCatchup(xmpp, catchupEntries, lifecycle.type);
     const barrierPromise = catchupPromise.finally(() => this.completeResumeBarrier(xmpp));
     this.pendingDuringResume = [];
     this.resumeBarrier = { xmpp, promise: barrierPromise };
@@ -2134,8 +2134,9 @@ export class BrowserXmppClient {
   private runReconnectCatchup(
     xmpp: XmppClientInstance,
     entries: Array<{ kind: "dm" | "room"; key: string; after?: string; since?: string; seenIds?: string[] }>,
+    lifecycle: SessionLifecycleEvent["type"],
   ) {
-    return this.mam.runReconnectCatchup(xmpp, entries);
+    return this.mam.runReconnectCatchup(xmpp, entries, lifecycle);
   }
   private wireEvents(xmpp: XmppClientInstance & { enableKeepAlive?: (opts: { interval: number; timeout: number }) => void; disableKeepAlive?: () => void }) {
     if (!this.xmpp && !this.destroying) this.xmpp = xmpp;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -32,6 +32,7 @@ import {
 import { barePeerJid, fullJidIdentityKey, jidDomain, jidLocalpart, roomBareJidFor } from "./jid";
 import { TypedEventBus } from "./client-events";
 import type {
+  CatchupConversationFailure,
   CatchupHookInfo,
   ClientEvents,
   MdsDisplayedEntry,
@@ -610,6 +611,7 @@ export class BrowserXmppClient {
   setMessageDeliveryFailureHandler(h: (messageId: string) => void) { this.events.set("messageDeliveryFailure", h); }
   setQueuedMessageStatusHandler(h: (messageId: string, status: "queued" | "sending") => void) { this.events.set("queuedMessageStatus", h); }
   setSessionLifecycleHandler(h: (event: SessionLifecycleEvent) => void) { this.events.set("sessionLifecycle", h); }
+  setCatchupFailureHandler(h: (failure: CatchupConversationFailure) => void) { this.events.set("catchupFailure", h); }
 
   onMessageAcked(hook: (id: string, meta: { kind: "room" | "dm"; latencyMs: number }) => void) { this.events.on("messageAcked", hook); }
   onMessageDeliveryFailed(hook: (id: string, meta: { kind: "room" | "dm" }) => void) { this.events.on("messageDeliveryFailed", hook); }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1844,11 +1844,14 @@ export class BrowserXmppClient {
   private async doSelfPing() { if (!this.xmpp?.send_raw_iq || !this.currentRoom) return; try { await this.xmpp.send_raw_iq(`<iq type="get" id="${crypto.randomUUID()}" to="${this.currentRoom}/${this.session.username}"><ping xmlns="urn:xmpp:ping"/></iq>`); } catch { this.events.emit("roomDisconnect"); } }
   private handleMessageAck(id: string) { this.outboundQueue.handleAck(id); }
   private handleMessageFailed(id: string) { this.outboundQueue.handleFailed(id); }
-  private handleSessionReady(xmpp: XmppClientInstance, lifecycle: SessionLifecycleEvent) {
+  // `lifecycle` is the bare kind here — the emitted
+  // `SessionLifecycleEvent` is built inside `runSessionReady`, where
+  // the fresh variant gains its reconnect catch-up coverage (#1180).
+  private handleSessionReady(xmpp: XmppClientInstance, lifecycle: { type: SessionLifecycleEvent["type"] }) {
     void this.runSessionReady(xmpp, lifecycle);
   }
 
-  private async runSessionReady(xmpp: XmppClientInstance, lifecycle: SessionLifecycleEvent) {
+  private async runSessionReady(xmpp: XmppClientInstance, lifecycle: { type: SessionLifecycleEvent["type"] }) {
     if (this.xmpp !== xmpp) return;
     this.connected = true; this.reconnect.resetAttempts();
     this.emitStatus({ state: "online", detail: this.outboundQueue.persistedCount() > 0 ? lifecycle.type === "fresh" ? "Reconnected — replaying queued messages" : "Connection resumed — replaying queued messages" : lifecycle.type === "fresh" ? "Connection ready" : "Connection resumed" });
@@ -1879,8 +1882,24 @@ export class BrowserXmppClient {
     if (roomsToJoin.size > 0) {
       void this.fanOutAutoJoin([...roomsToJoin]);
     }
-    this.emitSessionLifecycle(lifecycle);
+    // #1180: consume the catch-up cursors BEFORE emitting the
+    // lifecycle event so the fresh event can report which
+    // conversations `runReconnectCatchup` is about to page. Timeline
+    // consumers skip their own wholesale MAM reload for covered
+    // conversations — otherwise two concurrent fetches race to write
+    // the timeline and the rebuild clobbers the catch-up's merges.
     const catchupEntries = this.catchup.onSessionStarted();
+    this.emitSessionLifecycle(
+      lifecycle.type === "fresh"
+        ? {
+          type: "fresh",
+          catchup: {
+            dmJids: catchupEntries.filter((e) => e.kind === "dm").map((e) => e.key),
+            roomJids: catchupEntries.filter((e) => e.kind === "room").map((e) => e.key),
+          },
+        }
+        : { type: "resumed" },
+    );
     if (catchupEntries.length === 0) {
       this.flushAfterSessionReady(xmpp);
       this.fulfillOnceConnected();

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -1,5 +1,5 @@
 export { BrowserXmppClient } from "./client";
-export type { PubsubEvent } from "./client-events";
+export type { CatchupConversationFailure, PubsubEvent } from "./client-events";
 export type {
   DmBookmarkItem,
   NotifyMode,

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -26,6 +26,7 @@ export type {
   WasmAdminSpacesListResult,
 } from "./wasm-types";
 export {
+  bareJidKey,
   barePeerJid,
   jidDomain,
   jidDomainOrEmpty,

--- a/chat/src/lib/xmpp/jid.ts
+++ b/chat/src/lib/xmpp/jid.ts
@@ -39,6 +39,15 @@ export function fullJidIdentityKey(fullJid?: string | null): string {
   return `${bare}/${resource}`;
 }
 
+/**
+ * Comparison key for bare-JID equality across sources: server-emitted
+ * JIDs are RFC 7622-lowercased while directory/UI-derived JIDs may
+ * carry the original case, so byte comparison silently misses.
+ */
+export function bareJidKey(jid: string): string {
+  return barePeerJid(jid).trim().toLowerCase();
+}
+
 export function parseManagedRoomBareJid(
   roomJid: string,
 ): { channelId: string } | null {

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -18,7 +18,7 @@ export interface XmppStatusSnapshot {
  * covered must NOT fire their own MAM reload — two concurrent fetches
  * for the same conversation race on the timeline (#1180).
  */
-export type SessionCatchupCoverage = {
+type SessionCatchupCoverage = {
   dmJids: readonly string[];
   roomJids: readonly string[];
 };

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -12,12 +12,27 @@ export interface XmppStatusSnapshot {
 }
 
 /**
+ * Conversations the client's own reconnect catch-up will page via
+ * XEP-0313 after this session-ready (bare JIDs, keyed the same way as
+ * `ReconnectCatchup` cursors). Consumers whose active conversation is
+ * covered must NOT fire their own MAM reload — two concurrent fetches
+ * for the same conversation race on the timeline (#1180).
+ */
+export type SessionCatchupCoverage = {
+  dmJids: readonly string[];
+  roomJids: readonly string[];
+};
+
+/**
  * XEP-0198 Stream Management session lifecycle:
  * - "resumed": the prior stream was resumed server-side, no gap.
  * - "fresh": a new session was bound (either first connect, or resume failed).
- *   Consumers may re-fetch MAM to close any gap.
+ *   Consumers may re-fetch MAM to close any gap — unless `catchup`
+ *   already covers the conversation.
  */
-export type SessionLifecycleEvent = { type: "resumed" } | { type: "fresh" };
+export type SessionLifecycleEvent =
+  | { type: "resumed" }
+  | { type: "fresh"; catchup: SessionCatchupCoverage };
 
 export type MamPageParam =
   | { type: "latest"; start?: string }

--- a/chat/src/shell/controllers/use-connection-lifecycle.ts
+++ b/chat/src/shell/controllers/use-connection-lifecycle.ts
@@ -161,6 +161,13 @@ export function useConnectionLifecycle(deps: ConnectionLifecycleDeps) {
       dmConversations.onInboxPush(entry);
       channelUnread.onInboxPush(entry);
     });
+    // #1180: the fresh lifecycle event's coverage made the composables
+    // skip their MAM reload; a covered-but-failed catch-up hands the
+    // reload back to them here, after the failed attempt.
+    client.setCatchupFailureHandler((failure) => {
+      messaging.onCatchupFailed(failure);
+      dmMessaging.onCatchupFailed(failure);
+    });
     client.setSessionLifecycleHandler((event) => {
       messaging.onSessionLifecycle(event);
       dmMessaging.onSessionLifecycle(event);

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -166,6 +166,58 @@ describe("client send readiness", () => {
     }
   });
 
+  test("failed catch-up fallback reload keeps messages queued during the reload", async () => {
+    // #1180: the fallback restores the pre-reload snapshot when its own
+    // reload fails — but a message the user queued DURING that reload
+    // lives only in the outbound store + the catch's queued-only reset.
+    // The restore must merge it in, not clobber it away until echo.
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "dm",
+      id: "queued-mid-reload",
+      createdAt: new Date().toISOString(),
+      peerJid: "bob@example.com",
+      body: "sent while the reload was in flight",
+    });
+    const client = {
+      queryPersonalMamPage: mock(async () => {
+        throw new Error("remote-server-timeout");
+      }),
+    } as unknown as BrowserXmppClient;
+    const actionError = ref("");
+    const originalConsoleWarn = console.warn;
+    console.warn = mock(() => undefined) as typeof console.warn;
+    try {
+      const dm = useDirectMessages(
+        ref<WaddleSession | null>(session()),
+        ref<BrowserXmppClient | null>(client),
+        ref("bob@example.com"),
+        String,
+        actionError,
+        () => {
+          actionError.value = "";
+        },
+      );
+      dm.messages.value = [
+        {
+          id: "dm-old",
+          author: "bob",
+          body: "earlier",
+          createdAt: "2024-01-01T00:00:00Z",
+          isSelf: false,
+        },
+      ];
+
+      dm.onCatchupFailed({ kind: "dm", key: "bob@example.com" });
+      await settleReconnectCatchup(6);
+
+      const ids = dm.messages.value.map((m) => m.id);
+      expect(ids).toContain("dm-old");
+      expect(ids).toContain("queued-mid-reload");
+    } finally {
+      console.warn = originalConsoleWarn;
+    }
+  });
+
   test("DM load failures keep queued messages visible with a retryable warning", async () => {
     enqueueQueuedMessage("alice@example.com", {
       kind: "dm",

--- a/chat/tests/session-lifecycle-catchup-coverage.test.ts
+++ b/chat/tests/session-lifecycle-catchup-coverage.test.ts
@@ -1,0 +1,89 @@
+/**
+ * #1180 — fresh-reconnect double-MAM race.
+ *
+ * On a fresh session-ready the client runs its own reconnect catch-up
+ * (cursor paging merged via live-merge). The `sessionLifecycle` event
+ * it emits must carry which conversations that catch-up covers, so
+ * timeline consumers can skip their wholesale MAM reload for a covered
+ * conversation instead of racing the catch-up's merges.
+ *
+ * These tests poke private state on `BrowserXmppClient` directly — see
+ * the comment block in `resume-ordering.test.ts` for the rationale.
+ */
+import { describe, expect, test } from "bun:test";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { BrowserXmppClient } from "../src/lib/xmpp-client";
+import type { SessionLifecycleEvent } from "../src/lib/xmpp/types";
+import type { ReconnectCatchup } from "../src/lib/xmpp/reconnect-catchup";
+
+function session(): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com/desktop",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/ws",
+  } as WaddleSession;
+}
+
+type PrivateState = {
+  xmpp: unknown;
+  catchup: ReconnectCatchup;
+  runSessionReady: (
+    xmpp: unknown,
+    lifecycle: { type: "resumed" | "fresh" },
+  ) => Promise<void>;
+};
+
+function makeClient() {
+  const client = new BrowserXmppClient(session());
+  const state = client as unknown as PrivateState;
+  const xmpp = {};
+  state.xmpp = xmpp;
+  const received: SessionLifecycleEvent[] = [];
+  client.setSessionLifecycleHandler((event) => received.push(event));
+  return { client, state, xmpp, received };
+}
+
+describe("#1180 fresh lifecycle carries reconnect catch-up coverage", () => {
+  test("fresh session-ready reports the conversations the catch-up will page", async () => {
+    const { state, xmpp, received } = makeClient();
+    // Arm the tracker: the first session-started is initial login
+    // (nothing to catch up on); cursors recorded before the *next*
+    // session-started are what the catch-up covers.
+    state.catchup.onSessionStarted();
+    state.catchup.recordDmSeen("bob@example.com", "2026-07-01T10:00:00.000Z");
+    state.catchup.recordRoomSeen("c1@muc.example.com", "2026-07-01T10:00:01.000Z");
+
+    await state.runSessionReady(xmpp, { type: "fresh" });
+
+    expect(received).toEqual([
+      {
+        type: "fresh",
+        catchup: {
+          dmJids: ["bob@example.com"],
+          roomJids: ["c1@muc.example.com"],
+        },
+      },
+    ]);
+  });
+
+  test("fresh session-ready with nothing to catch up on reports empty coverage", async () => {
+    const { state, xmpp, received } = makeClient();
+
+    await state.runSessionReady(xmpp, { type: "fresh" });
+
+    expect(received).toEqual([
+      { type: "fresh", catchup: { dmJids: [], roomJids: [] } },
+    ]);
+  });
+
+  test("resumed session-ready carries no coverage field", async () => {
+    const { state, xmpp, received } = makeClient();
+    state.catchup.onSessionStarted();
+    state.catchup.recordDmSeen("bob@example.com", "2026-07-01T10:00:00.000Z");
+
+    await state.runSessionReady(xmpp, { type: "resumed" });
+
+    expect(received).toEqual([{ type: "resumed" }]);
+  });
+});

--- a/chat/tests/session-lifecycle-catchup-coverage.test.ts
+++ b/chat/tests/session-lifecycle-catchup-coverage.test.ts
@@ -146,6 +146,29 @@ describe("#1180 fresh lifecycle carries reconnect catch-up coverage", () => {
     ]);
   });
 
+  test("a failed catch-up on a RESUMED session emits no catchupFailure", async () => {
+    // Resumed sessions never skipped a reload (the fresh-only lifecycle
+    // path is the only skipper), so there is nothing to fall back to —
+    // emitting here would trigger a spurious wholesale reload for a
+    // gap-free stream.
+    const { client, state, received } = makeClient();
+    const xmpp = {
+      fetch_room_history_page: () => {
+        throw new Error("boom");
+      },
+    };
+    state.xmpp = xmpp;
+    state.catchup.onSessionStarted();
+    state.catchup.recordRoomSeen("c1@muc.example.com", "2026-07-01T10:00:01.000Z");
+    const failures: Array<{ kind: "dm" | "room"; key: string }> = [];
+    client.setCatchupFailureHandler((failure) => failures.push(failure));
+
+    await state.runSessionReady(xmpp, { type: "resumed" });
+
+    expect(failures).toEqual([]);
+    expect(received).toEqual([{ type: "resumed" }]);
+  });
+
   test("resumed session-ready carries no coverage field", async () => {
     const { state, xmpp, received } = makeClient();
     state.catchup.onSessionStarted();

--- a/chat/tests/session-lifecycle-catchup-coverage.test.ts
+++ b/chat/tests/session-lifecycle-catchup-coverage.test.ts
@@ -100,6 +100,33 @@ describe("#1180 fresh lifecycle carries reconnect catch-up coverage", () => {
     ]);
   });
 
+  test("an entry aborted by disconnect emits no catchupFailure", async () => {
+    // The fallback reload must never fire against a dead handle: when
+    // the connection dropped mid-catch-up, the NEXT session-ready owns
+    // recovery (its coverage/catch-up run starts over).
+    const { client, state, received } = makeClient();
+    const xmpp = {
+      fetch_room_history_page: () => {
+        // Simulate the connection dropping mid-fetch: a new handle
+        // takes over before the error propagates.
+        state.xmpp = { tag: "successor" };
+        throw new Error("socket closed");
+      },
+    };
+    state.xmpp = xmpp;
+    state.catchup.onSessionStarted();
+    state.catchup.recordRoomSeen("c1@muc.example.com", "2026-07-01T10:00:01.000Z");
+    const failures: Array<{ kind: "dm" | "room"; key: string }> = [];
+    client.setCatchupFailureHandler((failure) => failures.push(failure));
+
+    await state.runSessionReady(xmpp, { type: "fresh" });
+
+    expect(failures).toEqual([]);
+    expect(received).toEqual([
+      { type: "fresh", catchup: { dmJids: [], roomJids: ["c1@muc.example.com"] } },
+    ]);
+  });
+
   test("a successful catch-up emits no catchupFailure", async () => {
     const { client, state, received } = makeClient();
     const xmpp = {

--- a/chat/tests/session-lifecycle-catchup-coverage.test.ts
+++ b/chat/tests/session-lifecycle-catchup-coverage.test.ts
@@ -146,6 +146,33 @@ describe("#1180 fresh lifecycle carries reconnect catch-up coverage", () => {
     ]);
   });
 
+  test("a throwing catchupFailure handler surfaces as an error event, not an unhandled rejection", async () => {
+    // The fallback handler is business-critical: if it throws, the
+    // failure must land on the typed error channel (visible, correctly
+    // attributed) while the session-ready flow still completes.
+    const { client, state } = makeClient();
+    const xmpp = {
+      fetch_room_history_page: () => {
+        throw new Error("boom");
+      },
+    };
+    state.xmpp = xmpp;
+    state.catchup.onSessionStarted();
+    state.catchup.recordRoomSeen("c1@muc.example.com", "2026-07-01T10:00:01.000Z");
+    client.setCatchupFailureHandler(() => {
+      throw new Error("handler broke");
+    });
+    const errors: Array<{ detail?: string }> = [];
+    client.onError((event) => errors.push(event));
+
+    // Must resolve — a throwing handler must not reject the barrier.
+    await state.runSessionReady(xmpp, { type: "fresh" });
+
+    expect(
+      errors.some((e) => e.detail?.includes("catch-up fallback handler failed")),
+    ).toBe(true);
+  });
+
   test("a failed catch-up on a RESUMED session emits no catchupFailure", async () => {
     // Resumed sessions never skipped a reload (the fresh-only lifecycle
     // path is the only skipper), so there is nothing to fall back to —

--- a/chat/tests/session-lifecycle-catchup-coverage.test.ts
+++ b/chat/tests/session-lifecycle-catchup-coverage.test.ts
@@ -77,6 +77,48 @@ describe("#1180 fresh lifecycle carries reconnect catch-up coverage", () => {
     ]);
   });
 
+  test("a failed per-conversation catch-up emits catchupFailure with the entry key", async () => {
+    const { client, state, received } = makeClient();
+    const xmpp = {
+      fetch_room_history_page: () => {
+        throw new Error("boom");
+      },
+    };
+    state.xmpp = xmpp;
+    state.catchup.onSessionStarted();
+    state.catchup.recordRoomSeen("c1@muc.example.com", "2026-07-01T10:00:01.000Z");
+    const failures: Array<{ kind: "dm" | "room"; key: string }> = [];
+    client.setCatchupFailureHandler((failure) => failures.push(failure));
+
+    await state.runSessionReady(xmpp, { type: "fresh" });
+
+    expect(failures).toEqual([{ kind: "room", key: "c1@muc.example.com" }]);
+    // The lifecycle event still reported coverage — the failure signal
+    // is the consumer's cue to run the reload it skipped.
+    expect(received).toEqual([
+      { type: "fresh", catchup: { dmJids: [], roomJids: ["c1@muc.example.com"] } },
+    ]);
+  });
+
+  test("a successful catch-up emits no catchupFailure", async () => {
+    const { client, state, received } = makeClient();
+    const xmpp = {
+      fetch_room_history_page: async () => ({ messages: [], complete: true }),
+    };
+    state.xmpp = xmpp;
+    state.catchup.onSessionStarted();
+    state.catchup.recordRoomSeen("c1@muc.example.com", "2026-07-01T10:00:01.000Z");
+    const failures: Array<{ kind: "dm" | "room"; key: string }> = [];
+    client.setCatchupFailureHandler((failure) => failures.push(failure));
+
+    await state.runSessionReady(xmpp, { type: "fresh" });
+
+    expect(failures).toEqual([]);
+    expect(received).toEqual([
+      { type: "fresh", catchup: { dmJids: [], roomJids: ["c1@muc.example.com"] } },
+    ]);
+  });
+
   test("resumed session-ready carries no coverage field", async () => {
     const { state, xmpp, received } = makeClient();
     state.catchup.onSessionStarted();

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -143,6 +143,32 @@ describe("XEP-0198 delivery status (group chat)", () => {
 });
 
 describe("XEP-0198 session lifecycle catch-up (group chat)", () => {
+  test("fresh session skips the MAM reload when reconnect catch-up covers the room", async () => {
+    const client = makeRoomClient();
+    const { messaging } = makeRoomMessaging(client);
+
+    const existing = [
+      {
+        id: "seen-1",
+        author: "bob",
+        body: "hi",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+    ];
+    messaging.messages.value = existing;
+
+    messaging.onSessionLifecycle({
+      type: "fresh",
+      catchup: { dmJids: [], roomJids: ["c1@muc.example.com"] },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const clientAny = client as unknown as { value: { queryMam: ReturnType<typeof mock> } };
+    expect(clientAny.value.queryMam).not.toHaveBeenCalled();
+    expect(messaging.messages.value).toEqual(existing);
+  });
+
   test("fresh session re-fetches MAM when messages were already loaded", async () => {
     const client = makeRoomClient();
     const { messaging } = makeRoomMessaging(client);
@@ -157,7 +183,7 @@ describe("XEP-0198 session lifecycle catch-up (group chat)", () => {
       },
     ];
 
-    messaging.onSessionLifecycle({ type: "fresh" });
+    messaging.onSessionLifecycle({ type: "fresh", catchup: { dmJids: [], roomJids: [] } });
 
     // Wait for microtasks so loadMessages can fire.
     await new Promise((r) => setTimeout(r, 0));
@@ -226,7 +252,7 @@ describe("XEP-0198 session lifecycle catch-up (group chat)", () => {
       },
     ];
 
-    messaging.onSessionLifecycle({ type: "fresh" });
+    messaging.onSessionLifecycle({ type: "fresh", catchup: { dmJids: [], roomJids: [] } });
     await new Promise((r) => setTimeout(r, 0));
     await new Promise((r) => setTimeout(r, 0));
     await nextTick();
@@ -250,7 +276,7 @@ describe("XEP-0198 session lifecycle catch-up (group chat)", () => {
     const client = makeRoomClient();
     const { messaging } = makeRoomMessaging(client);
 
-    messaging.onSessionLifecycle({ type: "fresh" });
+    messaging.onSessionLifecycle({ type: "fresh", catchup: { dmJids: [], roomJids: [] } });
     await new Promise((r) => setTimeout(r, 0));
 
     const clientAny = client as unknown as { value: { queryMam: ReturnType<typeof mock> } };
@@ -467,7 +493,7 @@ describe("XEP-0198 delivery status (DM)", () => {
       },
     ];
 
-    dm.onSessionLifecycle({ type: "fresh" });
+    dm.onSessionLifecycle({ type: "fresh", catchup: { dmJids: [], roomJids: [] } });
     await new Promise((r) => setTimeout(r, 0));
 
     const clientAny = client as unknown as {
@@ -804,7 +830,7 @@ describe("XEP-0198 delivery status (DM)", () => {
       },
     ];
 
-    dm.onSessionLifecycle({ type: "fresh" });
+    dm.onSessionLifecycle({ type: "fresh", catchup: { dmJids: [], roomJids: [] } });
     // Wait two ticks: one for microtask, one for loadMessages async path.
     await new Promise((r) => setTimeout(r, 0));
     await new Promise((r) => setTimeout(r, 0));
@@ -849,7 +875,7 @@ describe("XEP-0198 self-echo reconciliation (group chat)", () => {
       },
     ];
 
-    messaging.onSessionLifecycle({ type: "fresh" });
+    messaging.onSessionLifecycle({ type: "fresh", catchup: { dmJids: [], roomJids: [] } });
     await new Promise((r) => setTimeout(r, 0));
     await new Promise((r) => setTimeout(r, 0));
     await nextTick();
@@ -904,7 +930,7 @@ describe("XEP-0198 self-echo reconciliation (group chat)", () => {
     await messaging.sendMessage("hello room");
     expect(messaging.messages.value[0]?.deliveryStatus).toBe("sending");
 
-    messaging.onSessionLifecycle({ type: "fresh" });
+    messaging.onSessionLifecycle({ type: "fresh", catchup: { dmJids: [], roomJids: [] } });
     await new Promise((r) => setTimeout(r, 0));
     await new Promise((r) => setTimeout(r, 0));
     await nextTick();
@@ -943,7 +969,7 @@ test("fresh DM session self-echo reconciles preserved sending entries", async ()
   await dm.sendMessage("hello dm");
   expect(dm.messages.value[0]?.deliveryStatus).toBe("sending");
 
-  dm.onSessionLifecycle({ type: "fresh" });
+  dm.onSessionLifecycle({ type: "fresh", catchup: { dmJids: [], roomJids: [] } });
   await new Promise((r) => setTimeout(r, 0));
   await new Promise((r) => setTimeout(r, 0));
   await nextTick();

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -479,6 +479,34 @@ describe("XEP-0198 delivery status (DM)", () => {
     expect(dm.messages.value[0].deliveryStatus).toBe("delivered");
   });
 
+  test("fresh DM session skips the MAM reload when reconnect catch-up covers the peer", async () => {
+    const client = makeDmClient();
+    const { dm } = makeDmMessaging(client);
+
+    const existing = [
+      {
+        id: "dm-old",
+        author: "bob",
+        body: "earlier",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+    ];
+    dm.messages.value = existing;
+
+    dm.onSessionLifecycle({
+      type: "fresh",
+      catchup: { dmJids: ["bob@example.com"], roomJids: [] },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const clientAny = client as unknown as {
+      value: { queryPersonalMam: ReturnType<typeof mock> };
+    };
+    expect(clientAny.value.queryPersonalMam).not.toHaveBeenCalled();
+    expect(dm.messages.value).toEqual(existing);
+  });
+
   test("fresh DM session re-fetches personal MAM when messages were loaded", async () => {
     const client = makeDmClient();
     const { dm } = makeDmMessaging(client);

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -661,6 +661,55 @@ describe("XEP-0198 delivery status (DM)", () => {
     expect(dm.messages.value).toEqual(existing);
   });
 
+  test("a superseded fallback reload does not append stale rows onto the newer load", async () => {
+    // The fallback reload can be superseded by a user-triggered reload
+    // of the SAME conversation. The superseded call reports "aborted"
+    // and the fallback must not react — the newer request owns the
+    // timeline now.
+    const resolvers: Array<(value: LiveDmMessage[]) => void> = [];
+    const queryPersonalMam = mock(
+      () => new Promise<LiveDmMessage[]>((resolve) => resolvers.push(resolve)),
+    );
+    const client = ref({ queryPersonalMam } as never) as never;
+    const { dm } = makeDmMessaging(client);
+
+    dm.messages.value = [
+      {
+        id: "dm-old",
+        author: "bob",
+        body: "earlier",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+      {
+        id: "failed-1",
+        author: "alice",
+        body: "unsent",
+        createdAt: "2024-01-01T00:01:00Z",
+        isSelf: true,
+        deliveryStatus: "failed",
+      },
+    ];
+
+    dm.onCatchupFailed({ kind: "dm", key: "bob@example.com" });
+    await new Promise((r) => setTimeout(r, 0));
+    void dm.loadMessages("bob@example.com");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(resolvers).toHaveLength(2);
+
+    // Newer request completes first and owns the timeline.
+    resolvers[1]([]);
+    await new Promise((r) => setTimeout(r, 0));
+    const ownedByNewer = [...dm.messages.value];
+
+    // The superseded fallback reload now resolves → "aborted".
+    resolvers[0]([]);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(dm.messages.value).toEqual(ownedByNewer);
+  });
+
   test("catch-up failure for a different DM peer does not reload", async () => {
     const client = makeDmClient();
     const { dm } = makeDmMessaging(client);

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -169,6 +169,33 @@ describe("XEP-0198 session lifecycle catch-up (group chat)", () => {
     expect(messaging.messages.value).toEqual(existing);
   });
 
+  test("catch-up coverage matches room JIDs case-insensitively", async () => {
+    // Cursor keys are server-emitted JIDs (RFC 7622 lowercased); the
+    // directory-derived room JID can differ in case. The skip must
+    // still fire or the double-MAM race silently returns.
+    const client = makeRoomClient();
+    const { messaging } = makeRoomMessaging(client);
+
+    messaging.messages.value = [
+      {
+        id: "seen-1",
+        author: "bob",
+        body: "hi",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+    ];
+
+    messaging.onSessionLifecycle({
+      type: "fresh",
+      catchup: { dmJids: [], roomJids: ["C1@MUC.Example.com"] },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const clientAny = client as unknown as { value: { queryMam: ReturnType<typeof mock> } };
+    expect(clientAny.value.queryMam).not.toHaveBeenCalled();
+  });
+
   test("fresh session re-fetches MAM when messages were already loaded", async () => {
     const client = makeRoomClient();
     const { messaging } = makeRoomMessaging(client);

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -196,6 +196,52 @@ describe("XEP-0198 session lifecycle catch-up (group chat)", () => {
     expect(clientAny.value.queryMam).not.toHaveBeenCalled();
   });
 
+  test("catch-up failure for the active room falls back to the wholesale reload", async () => {
+    // The coverage-based skip trusts the catch-up to close the gap; when
+    // that catch-up fails for this room the reload is the safety net —
+    // serialized after the failed attempt, so the #1180 race can't recur.
+    const client = makeRoomClient();
+    const { messaging } = makeRoomMessaging(client);
+
+    messaging.messages.value = [
+      {
+        id: "seen-1",
+        author: "bob",
+        body: "hi",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+    ];
+
+    messaging.onCatchupFailed({ kind: "room", key: "C1@muc.example.com" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const clientAny = client as unknown as { value: { queryMam: ReturnType<typeof mock> } };
+    expect(clientAny.value.queryMam).toHaveBeenCalledWith("w1", "c1", 100);
+  });
+
+  test("catch-up failure for a different room does not reload", async () => {
+    const client = makeRoomClient();
+    const { messaging } = makeRoomMessaging(client);
+
+    messaging.messages.value = [
+      {
+        id: "seen-1",
+        author: "bob",
+        body: "hi",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+    ];
+
+    messaging.onCatchupFailed({ kind: "room", key: "other@muc.example.com" });
+    messaging.onCatchupFailed({ kind: "dm", key: "c1@muc.example.com" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const clientAny = client as unknown as { value: { queryMam: ReturnType<typeof mock> } };
+    expect(clientAny.value.queryMam).not.toHaveBeenCalled();
+  });
+
   test("fresh session re-fetches MAM when messages were already loaded", async () => {
     const client = makeRoomClient();
     const { messaging } = makeRoomMessaging(client);
@@ -532,6 +578,53 @@ describe("XEP-0198 delivery status (DM)", () => {
     };
     expect(clientAny.value.queryPersonalMam).not.toHaveBeenCalled();
     expect(dm.messages.value).toEqual(existing);
+  });
+
+  test("catch-up failure for the active DM peer falls back to the wholesale reload", async () => {
+    const client = makeDmClient();
+    const { dm } = makeDmMessaging(client);
+
+    dm.messages.value = [
+      {
+        id: "dm-old",
+        author: "bob",
+        body: "earlier",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+    ];
+
+    dm.onCatchupFailed({ kind: "dm", key: "Bob@example.com" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const clientAny = client as unknown as {
+      value: { queryPersonalMam: ReturnType<typeof mock> };
+    };
+    expect(clientAny.value.queryPersonalMam).toHaveBeenCalledWith("bob@example.com", 100);
+  });
+
+  test("catch-up failure for a different DM peer does not reload", async () => {
+    const client = makeDmClient();
+    const { dm } = makeDmMessaging(client);
+
+    dm.messages.value = [
+      {
+        id: "dm-old",
+        author: "bob",
+        body: "earlier",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+    ];
+
+    dm.onCatchupFailed({ kind: "dm", key: "carol@example.com" });
+    dm.onCatchupFailed({ kind: "room", key: "bob@example.com" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const clientAny = client as unknown as {
+      value: { queryPersonalMam: ReturnType<typeof mock> };
+    };
+    expect(clientAny.value.queryPersonalMam).not.toHaveBeenCalled();
   });
 
   test("fresh DM session re-fetches personal MAM when messages were loaded", async () => {

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -220,6 +220,36 @@ describe("XEP-0198 session lifecycle catch-up (group chat)", () => {
     expect(clientAny.value.queryMam).toHaveBeenCalledWith("w1", "c1", 100);
   });
 
+  test("a failed fallback reload restores the pre-reload timeline instead of wiping it", async () => {
+    // If the reload the fallback fires ALSO fails, loadMessages' catch
+    // wipes the timeline to queued-only — and the covered-skip would
+    // then block the self-heal on the next reconnect. The fallback must
+    // put the pre-reload timeline back.
+    const queryMam = mock(async () => {
+      throw new Error("mam down");
+    });
+    const client = ref({ ...handlerStubs(), queryMam } as never) as never;
+    const { messaging } = makeRoomMessaging(client);
+
+    const existing = [
+      {
+        id: "seen-1",
+        author: "bob",
+        body: "hi",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+    ];
+    messaging.messages.value = existing;
+
+    messaging.onCatchupFailed({ kind: "room", key: "c1@muc.example.com" });
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(queryMam).toHaveBeenCalled();
+    expect(messaging.messages.value).toEqual(existing);
+  });
+
   test("catch-up failure for a different room does not reload", async () => {
     const client = makeRoomClient();
     const { messaging } = makeRoomMessaging(client);
@@ -569,7 +599,9 @@ describe("XEP-0198 delivery status (DM)", () => {
 
     dm.onSessionLifecycle({
       type: "fresh",
-      catchup: { dmJids: ["bob@example.com"], roomJids: [] },
+      // Case differs from the active peer JID on purpose: coverage
+      // matching must be case-insensitive (RFC 7622-lowercased keys).
+      catchup: { dmJids: ["Bob@Example.com"], roomJids: [] },
     });
     await new Promise((r) => setTimeout(r, 0));
 
@@ -601,6 +633,32 @@ describe("XEP-0198 delivery status (DM)", () => {
       value: { queryPersonalMam: ReturnType<typeof mock> };
     };
     expect(clientAny.value.queryPersonalMam).toHaveBeenCalledWith("bob@example.com", 100);
+  });
+
+  test("a failed DM fallback reload restores the pre-reload timeline instead of wiping it", async () => {
+    const queryPersonalMam = mock(async () => {
+      throw new Error("mam down");
+    });
+    const client = ref({ queryPersonalMam } as never) as never;
+    const { dm } = makeDmMessaging(client);
+
+    const existing = [
+      {
+        id: "dm-old",
+        author: "bob",
+        body: "earlier",
+        createdAt: "2024-01-01T00:00:00Z",
+        isSelf: false,
+      },
+    ];
+    dm.messages.value = existing;
+
+    dm.onCatchupFailed({ kind: "dm", key: "bob@example.com" });
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(queryPersonalMam).toHaveBeenCalled();
+    expect(dm.messages.value).toEqual(existing);
   });
 
   test("catch-up failure for a different DM peer does not reload", async () => {

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { WaddleSession } from "../src/lib/server-auth";
-import { BrowserXmppClient } from "../src/lib/xmpp-client";
+import { BrowserXmppClient, type SessionLifecycleEvent } from "../src/lib/xmpp-client";
 import {
   __clearSensitiveUrlsForTesting,
   __scrubMissingFetchSpanUrlForTesting,
@@ -569,7 +569,7 @@ describe("BrowserXmppClient telemetry hooks", () => {
       xmpp: unknown;
       wireEvents: (xmpp: unknown) => void;
       emitStatus: (snap: { state: string; detail?: string }) => void;
-      emitSessionLifecycle: (evt: { type: "fresh" | "resumed" }) => void;
+      emitSessionLifecycle: (evt: SessionLifecycleEvent) => void;
       events: { emitSafe: (event: string, ...args: unknown[]) => void };
     };
     const handlers = new Map<string, Array<(msg: unknown) => void>>();


### PR DESCRIPTION
Fixes #1180.

## Problem

On a fresh (resume-failed) reconnect, `runSessionReady` fired two independent MAM fetches for the same open conversation concurrently:

1. `emitSessionLifecycle` → `onSessionLifecycle` → `loadMessages` — wholesale timeline rebuild from a latest MAM page.
2. `runReconnectCatchup` — cursor-based `after`/`since` paging merged through the live-merge path.

They raced to write `messages.value`: the wholesale assignment was built from a pre-await seed and discarded rows the catch-up merged in the meantime → missing messages after failed-resume reconnects (~369/week fall to the fresh path per server logs).

## Fix — single choreographed catch-up per session-ready

**Coverage-based skip.** `runSessionReady` now consumes `ReconnectCatchup.onSessionStarted()` *before* emitting the lifecycle event, and the `fresh` `SessionLifecycleEvent` carries `catchup: { dmJids, roomJids }` — the conversations the client's own catch-up is about to page. The channel/DM composables skip their wholesale MAM reload when their active conversation is covered (case-insensitive bare-JID match via the new `bareJidKey`, since cursor keys are server-emitted RFC 7622-lowercased JIDs while directory-derived JIDs may differ in case). A fresh+covered reconnect now behaves exactly like the well-tested resumed path: existing timeline + cursor catch-up via live-merge. Uncovered conversations keep today's reload — the catch-up won't touch them, so no race.

**Failure fallback.** Coverage is a promise, not a result: if the catch-up fails for one conversation, a new `catchupFailure` event ({kind, key}) hands the suppressed reload back to the composable — after the failed attempt, so the two fetches still can't race for the same conversation. Emitted only on *fresh* session-ready (resumed sessions never skipped a reload — a failure there must not trigger a spurious reload; Codex review). Aborts (connection dropped mid-catch-up) deliberately do not emit: the next session-ready owns recovery.

**Failed-fallback restore.** `loadMessages` (channels + DMs) now returns `"loaded" | "aborted" | "failed"`. If the fallback reload *itself* fails, the composable restores the pre-reload timeline instead of leaving the catch's queued-only wipe (which the covered-skip would otherwise make sticky across reconnects), merging in any message the user queued during the reload so it doesn't vanish until its server echo. Supersession — including during the post-load pin step — reports `"aborted"`, and the fallback explicitly does not react to it, so a superseded reload can never push stale rows onto the newer request's timeline (Qodo review).

## Wire behavior / XEP boundary

No wire change. Both surviving paths remain XEP-0313 (MAM) + XEP-0059 (RSM) conformant; XEP-0198 resend obligations (outbound queue) are untouched. This is pure client choreography of when each query fires.

## Review notes (3 adversarial rounds, all findings resolved or accepted)

- Accepted trade-off: on a covered fresh reconnect the "New messages" divider / MDS recompute of the old wholesale reload no longer runs — identical to today's resumed-session choreography; unread counts still re-hydrate via `hydrateFromInbox()`.
- Out of scope (pre-existing): switching to a covered conversation mid-catch-up still fires channel-select `loadMessages` (#675's seed-clobber shape); #675/#1165 remain open.
- `bareJidKey` uses `toLowerCase()`, matching `fullJidIdentityKey`/`channel-room.ts` conventions; exotic Unicode divergence from RFC 7622 casefold can only fail open to the pre-fix behavior, never mismatch two distinct conversations.

## Tests

- `tests/sm-delivery.test.ts`: covered-room/peer skip, case-insensitive coverage match, uncovered reload unchanged, fallback reload on `catchupFailure` (match + non-match), failed-fallback timeline restore (channels + DMs).
- `tests/session-lifecycle-catchup-coverage.test.ts` (new): fresh event carries entry keys; empty coverage; resumed unchanged; `catchupFailure` emitted with the entry key on per-entry failure, not on success, not on disconnect-abort.
- `tests/client-send-readiness.test.ts`: mid-reload queued send survives a failed fallback restore.
- Review-round additions: no `catchupFailure` on resumed sessions; superseded fallback reload does not mutate the newer request's timeline.
- Full chat suite: 3125 pass; `tsc --noEmit` clean; `knip` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
