### PR TITLE
fix(server): reset client XEP-0198 inbound handled counter on fresh SM enable (#1181)

### DIFF
--- a/server/crates/waddle-xmpp-client/src/runtime/sm.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/sm.rs
@@ -95,6 +95,15 @@ impl XmppRuntime {
                 ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked { stanza_id })
             }));
         } else if element.name() == "enabled" {
+            // <enabled/> is only legal as the answer to <enable/>. A
+            // duplicate on a live SM session is a protocol violation
+            // (mirroring unexpected <resumed/>): silently re-running the
+            // XEP-0198 §5 counter reset below would drive the next
+            // <a h/> backwards on the wire.
+            if self.sm_state.enabled {
+                self.handle_sm_protocol_violation(events);
+                return Ok(());
+            }
             let previd = crate::stream_management::SmState::parse_enabled(element);
             let max_resume_seconds = crate::stream_management::SmState::parse_enabled_max(element);
             self.sm_state.previd = previd.clone();

--- a/server/crates/waddle-xmpp-client/src/runtime/sm.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/sm.rs
@@ -100,6 +100,11 @@ impl XmppRuntime {
             self.sm_state.previd = previd.clone();
             self.sm_state.max_resume_seconds = max_resume_seconds;
             self.sm_state.enabled = true;
+            // <enabled/> always establishes a NEW SM session (a resumed
+            // one answers with <resumed/> instead), so the received-
+            // stanza counter restarts from zero here (XEP-0198 §5,
+            // issue #1181).
+            self.sm_state.start_inbound();
             events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::Enabled { previd },
             )));

--- a/server/crates/waddle-xmpp-client/src/runtime/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/tests.rs
@@ -506,6 +506,288 @@ fn runtime_falls_back_to_resource_binding_when_sm_resume_fails() {
 }
 
 #[test]
+fn runtime_fresh_sm_session_ack_counts_only_current_session_inbound_stanzas() {
+    // Issue #1181: a failed resume followed by a fresh bind + <enable/>
+    // starts a NEW XEP-0198 session. XEP-0198 §5 zeroes both counters at
+    // session start, so the h reported to the new stream must not carry
+    // the previous session's received-stanza count (7 here).
+    let mut config = config();
+    config.session.stream_management.resume_state =
+        Some(SmResumeState::new("old-sm-id", 7, 12).unwrap());
+    let mut runtime = XmppRuntime::new(config).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    let failed_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("failed", crate::stream_management::NS_SM).build(),
+        )))
+        .unwrap();
+    let bind_id = failed_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::ResourceBindingRequested(request)) => {
+                Some(request.stanza_id.clone())
+            }
+            _ => None,
+        })
+        .expect("bind requested after failed resume");
+    let ready_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            bind_result(&bind_id),
+        )))
+        .unwrap();
+    let enable = ready_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )) if element.name() == "enable" && element.ns() == crate::stream_management::NS_SM => {
+                Some(element.clone())
+            }
+            _ => None,
+        })
+        .expect("fresh stream management enable");
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            enable,
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("enabled", crate::stream_management::NS_SM)
+                .attr(minidom::rxml::xml_ncname!("resume").to_owned(), "true")
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "new-sm-id")
+                .build(),
+        )))
+        .unwrap();
+
+    for id in ["inbound-1", "inbound-2"] {
+        runtime
+            .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+                Element::builder("message", crate::NS_CLIENT)
+                    .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+                    .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+                    .build(),
+            )))
+            .unwrap();
+    }
+
+    let ack_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("r", crate::stream_management::NS_SM).build(),
+        )))
+        .unwrap();
+
+    let ack = ack_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )) if element.name() == "a" && element.ns() == crate::stream_management::NS_SM => {
+                Some(element.clone())
+            }
+            _ => None,
+        })
+        .expect("ack in response to <r/>");
+    assert_eq!(
+        ack.attr("h"),
+        Some("2"),
+        "fresh SM session must count only stanzas received on the new session, \
+         not carry the previous session's inbound count"
+    );
+}
+
+#[test]
+fn runtime_resume_after_fresh_sm_session_reports_only_current_session_inbound() {
+    // Issue #1181 prod loop: failed resume → fresh enable → detach →
+    // resume. The h in the next <resume/> is what the server compares
+    // against its per-session send count; a carried-over count gets the
+    // resume rejected with handled-count-too-high.
+    let mut first_config = config();
+    first_config.session.stream_management.resume_state =
+        Some(SmResumeState::new("old-sm-id", 7, 12).unwrap());
+    let mut runtime = XmppRuntime::new(first_config).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+    let failed_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("failed", crate::stream_management::NS_SM).build(),
+        )))
+        .unwrap();
+    let bind_id = failed_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::ResourceBindingRequested(request)) => {
+                Some(request.stanza_id.clone())
+            }
+            _ => None,
+        })
+        .expect("bind requested after failed resume");
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            bind_result(&bind_id),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            SmState::build_enable(true),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("enabled", crate::stream_management::NS_SM)
+                .attr(minidom::rxml::xml_ncname!("resume").to_owned(), "true")
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "new-sm-id")
+                .build(),
+        )))
+        .unwrap();
+    for id in ["inbound-1", "inbound-2"] {
+        runtime
+            .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+                Element::builder("message", crate::NS_CLIENT)
+                    .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+                    .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+                    .build(),
+            )))
+            .unwrap();
+    }
+
+    // Transport drops; the snapshot carries the session into a new runtime.
+    let resume_state = runtime.resume_state().expect("resume state");
+    let mut next_config = config();
+    next_config.session.stream_management.resume_state = Some(resume_state);
+    let mut next_runtime = XmppRuntime::new(next_config).unwrap();
+    drive_to_authenticated_stream(&mut next_runtime);
+    let events = next_runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+
+    let resume = events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )) if element.name() == "resume" && element.ns() == crate::stream_management::NS_SM => {
+                Some(element.clone())
+            }
+            _ => None,
+        })
+        .expect("resume element");
+    assert_eq!(resume.attr("previd"), Some("new-sm-id"));
+    assert_eq!(
+        resume.attr("h"),
+        Some("2"),
+        "resume h must never exceed what the server sent on the new session"
+    );
+}
+
+#[test]
+fn runtime_resume_h_stays_consistent_across_repeated_resume_cycles() {
+    // Issue #1181 conformance cycle: enable → receive → detach → resume →
+    // receive → detach → resume. Each <resume/> h must equal exactly the
+    // stanzas received across the SAME SM session (successful resumes
+    // continue the session; the counter carries forward, never inflates).
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            SmState::build_enable(true),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("enabled", crate::stream_management::NS_SM)
+                .attr(minidom::rxml::xml_ncname!("resume").to_owned(), "true")
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "sm-1")
+                .build(),
+        )))
+        .unwrap();
+    for id in ["a-1", "a-2", "a-3"] {
+        runtime
+            .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+                Element::builder("message", crate::NS_CLIENT)
+                    .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+                    .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+                    .build(),
+            )))
+            .unwrap();
+    }
+
+    // First detach → resume.
+    let resume_state = runtime.resume_state().expect("first resume state");
+    let mut second_config = config();
+    second_config.session.stream_management.resume_state = Some(resume_state);
+    let mut second = XmppRuntime::new(second_config).unwrap();
+    drive_to_authenticated_stream(&mut second);
+    let events = second
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+    let first_resume = events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )) if element.name() == "resume" => Some(element.clone()),
+            _ => None,
+        })
+        .expect("first resume element");
+    assert_eq!(first_resume.attr("h"), Some("3"));
+    second
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("resumed", crate::stream_management::NS_SM)
+                .attr(minidom::rxml::xml_ncname!("previd").to_owned(), "sm-1")
+                .attr(minidom::rxml::xml_ncname!("h").to_owned(), "0")
+                .build(),
+        )))
+        .unwrap();
+    for id in ["b-1", "b-2"] {
+        second
+            .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+                Element::builder("message", crate::NS_CLIENT)
+                    .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+                    .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+                    .build(),
+            )))
+            .unwrap();
+    }
+
+    // Second detach → resume: the counter continues the same session.
+    let resume_state = second.resume_state().expect("second resume state");
+    let mut third_config = config();
+    third_config.session.stream_management.resume_state = Some(resume_state);
+    let mut third = XmppRuntime::new(third_config).unwrap();
+    drive_to_authenticated_stream(&mut third);
+    let events = third
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+    let second_resume = events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )) if element.name() == "resume" => Some(element.clone()),
+            _ => None,
+        })
+        .expect("second resume element");
+    assert_eq!(second_resume.attr("previd"), Some("sm-1"));
+    assert_eq!(second_resume.attr("h"), Some("5"));
+}
+
+#[test]
 fn runtime_requests_default_resume_window_when_enabling_stream_management() {
     let mut runtime = XmppRuntime::new(config()).unwrap();
     drive_to_authenticated_stream(&mut runtime);

--- a/server/crates/waddle-xmpp-client/src/runtime/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/tests.rs
@@ -693,12 +693,106 @@ fn runtime_resume_after_fresh_sm_session_reports_only_current_session_inbound() 
 }
 
 #[test]
+fn runtime_rejects_duplicate_enabled_on_live_sm_session() {
+    // A stray/duplicate <enabled/> mid-session must be a protocol
+    // violation (mirroring unexpected <resumed/>), NOT a silent
+    // re-establish: re-running the XEP-0198 §5 counter reset on a live
+    // session would drive the client's next <a h/> backwards on the
+    // wire (issue #1181 adversarial review).
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+    let bind_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+    let bind_id = bind_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::ResourceBindingRequested(request)) => {
+                Some(request.stanza_id.clone())
+            }
+            _ => None,
+        })
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            bind_result(&bind_id),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            SmState::build_enable(true),
+        )))
+        .unwrap();
+    let enabled = Element::builder("enabled", crate::stream_management::NS_SM)
+        .attr(minidom::rxml::xml_ncname!("resume").to_owned(), "true")
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), "sm-1")
+        .build();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            enabled.clone(),
+        )))
+        .unwrap();
+    for id in ["live-1", "live-2", "live-3"] {
+        runtime
+            .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+                Element::builder("message", crate::NS_CLIENT)
+                    .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+                    .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+                    .build(),
+            )))
+            .unwrap();
+    }
+
+    let duplicate_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            enabled,
+        )))
+        .unwrap();
+
+    assert!(
+        duplicate_events.iter().any(|event| matches!(
+            event,
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element)
+            )) if element.name() == "error"
+                && element
+                    .get_child("bad-request", "urn:ietf:params:xml:ns:xmpp-streams")
+                    .is_some()
+        )),
+        "duplicate <enabled/> on a live SM session must be answered with a \
+         stream error, not silently re-establish the session"
+    );
+}
+
+#[test]
 fn runtime_resume_h_stays_consistent_across_repeated_resume_cycles() {
     // Issue #1181 conformance cycle: enable → receive → detach → resume →
     // receive → detach → resume. Each <resume/> h must equal exactly the
     // stanzas received across the SAME SM session (successful resumes
     // continue the session; the counter carries forward, never inflates).
     let mut runtime = XmppRuntime::new(config()).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+    let bind_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+    let bind_id = bind_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::ResourceBindingRequested(request)) => {
+                Some(request.stanza_id.clone())
+            }
+            _ => None,
+        })
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            bind_result(&bind_id),
+        )))
+        .unwrap();
     runtime
         .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
             SmState::build_enable(true),

--- a/server/crates/waddle-xmpp-client/src/stream_management.rs
+++ b/server/crates/waddle-xmpp-client/src/stream_management.rs
@@ -189,6 +189,19 @@ impl SmState {
         });
     }
 
+    /// Start a fresh inbound SM sequence after receiving `<enabled/>`.
+    ///
+    /// XEP-0198 §5: the received-stanza counter is "set to zero and
+    /// started after receiving either `<enable/>` or `<enabled/>`".
+    /// Without this reset, a failed resume followed by a fresh
+    /// `<enable/>` carries the previous session's inbound count into
+    /// the new session's `h`, compounding per reconnect cycle until
+    /// the server rejects `<resume/>` with handled-count-too-high
+    /// (issue #1181).
+    pub fn start_inbound(&mut self) {
+        self.inbound_count = 0;
+    }
+
     /// Start a fresh outbound SM sequence after sending `<enable/>`.
     pub fn start_outbound(&mut self) {
         self.outbound_count = 0;


### PR DESCRIPTION
Fixes #1181.

## Root cause

The client (`waddle-xmpp-client`, the crate the WASM client wraps) never reset its XEP-0198 received-stanza counter when a **new** SM session was enabled:

- `SmState::start_outbound()` (called when `<enable/>` is sent) resets `outbound_count`, `server_h`, and the outbound queue — but not `inbound_count`.
- Both `<a h='N'/>` acks and `<resume h='N'/>` send the raw `inbound_count`.

So every failed-resume → fresh-bind → `<enable/>` cycle carried the entire previous session's received-stanza count into the new session's `h`, while the server's per-session `outbound_count` restarted at zero. This compounds per reconnect cycle — exactly the prod signature (`client_h=4251` vs `send_count=1130`, ratios 1.7–3.8×, 75 rejections/week).

XEP-0198 §5: *"The counter for the received stanzas ('h') is set to zero and started after receiving either `<enable/>` or `<enabled/>`."*

## Server-side audit (issue scope item 1)

Audited every outbound serialization path against `outbound_count`; no server asymmetry found:

- The chunked batch writer (`batch_write.rs`) records each countable frame just before its own write; the `ReplaySuppressed` batch only ever contains `<resumed/>` + verbatim replays already in the restored unacked queue — the issue's `suppress_sm_record_next_batch` hypothesis does not hold.
- `outbound.rs` (DirectFrame + PeerStanza) and the detached fan-out (`replay.rs`) all record before write.
- Per-connection server SM state is freshly zeroed per transport; failed registered resume attempts reset it explicitly.

## Fix

`SmState` gains `start_inbound()` (zeroes `inbound_count`); the `<enabled/>` handler in `runtime/sm.rs` calls it. `<enabled/>` always establishes a NEW session (a resumed one answers `<resumed/>`), so this is the exact spec point. One-line behavioral change; no FFI/wire-shape change — the WASM publish workflow already triggers on `server/crates/waddle-xmpp-client/**`.

## Hardening (from adversarial review)

The `<enabled/>` branch was unguarded: a stray duplicate `<enabled/>` mid-session would re-run the §5 counter reset on a live session and drive the client's next `<a h/>` backwards on the wire. It is now a protocol violation (stream error + close), mirroring unexpected `<resumed/>`. The guard keys on `sm_state.enabled` only — never on the `<enable/>` `MessageSent` echo — so transport event ordering cannot false-positive a legitimate first `<enabled/>`. A second adversarial pass verified every reconnect/re-enable path clears `enabled` before a new `<enabled/>` can arrive, and that the violation path preserves `previd`/counters for a clean follow-up resume.

## Tests (TDD, red → green; issue scope item 2)

1. `runtime_fresh_sm_session_ack_counts_only_current_session_inbound_stanzas` — failed resume → fresh `<enable/>`/`<enabled/>` → 2 inbound stanzas → `<r/>` must be answered with `h='2'` (was `h='9'`: 7 carried + 2 new).
2. `runtime_resume_after_fresh_sm_session_reports_only_current_session_inbound` — the prod loop: after the fresh session detaches, the next `<resume/>` carries `h='2'`, never the inherited count.
3. `runtime_rejects_duplicate_enabled_on_live_sm_session` — duplicate `<enabled/>` on a live session is answered with a stream error, not a silent counter reset.
4. `runtime_resume_h_stays_consistent_across_repeated_resume_cycles` — enable → receive → detach → resume → receive → detach → resume; each `<resume h/>` equals exactly the stanzas received on the same SM session (`client_h <= send_count` invariant across the double cycle).

Tests 1–3 verified RED without their respective fixes and GREEN with them. Full workspace: `cargo test --workspace` green (one known caps flake #1188, passes on rerun), `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt` applied.

Related: #1099 (live `<a h/>` validation — the early-warning companion, unchanged here), reconnect cluster #1178/#1179/#1180.
