### PR TITLE
fix(chat): dedupe id-less live stanzas against their MAM copy via synthesized-id content match

### DIFF
--- a/chat/src/channels/message-timeline-state.ts
+++ b/chat/src/channels/message-timeline-state.ts
@@ -18,6 +18,7 @@ import { compareTimelineMessages } from "@/lib/timeline-timestamps";
 import { assignCorrectionFields, type CorrectionPayload } from "@/lib/messaging/correction";
 import { retractTimelineMessage } from "@/lib/messaging/retraction";
 import { mergeRetractionTombstone } from "@/lib/messaging/timeline-insert";
+import { adoptArchiveIdentity, findSynthesizedIdMergeTarget } from "@/lib/messaging/synthesized-id-merge";
 
 function mergeReplyToMetadata(
   existing: TimelineMessage["replyTo"],
@@ -323,19 +324,27 @@ export function buildChannelTimelineFromMamResults(params: {
     byId.add(message);
   }
   const timeline = options.seedExistingOnly ? [] : [...existing];
+  // #1182: rows whose primary id had to be fabricated (id-less live
+  // stanzas) can only reconcile by content. Each is consumable once so
+  // two identical archive hits can't both collapse into it.
+  const synthesizedRows = existing.filter((message) => message.synthesizedId);
   for (const raw of regularMessages) {
     const mapped = mapLiveRoomMessageToTimeline(session, raw, (id) => byId.get(id));
     const tm = mapped.isRetracted
       ? retractTimelineMessage(mapped, mapped.retractionId)
       : mapped;
-    const existingMessage = [tm.id, ...(tm.wireIds ?? [])]
+    const idMatch = [tm.id, ...(tm.wireIds ?? [])]
       .map((id) => byId.get(id))
       .find((message): message is TimelineMessage => !!message);
+    const synthesizedMatch = idMatch ? undefined : findSynthesizedIdMergeTarget(synthesizedRows, tm);
+    if (synthesizedMatch) synthesizedRows.splice(synthesizedRows.indexOf(synthesizedMatch), 1);
+    const existingMessage = idMatch ?? synthesizedMatch;
     if (existingMessage) {
       const mergedBase = options.seedExistingOnly
         ? mergeMissingThreadMetadata(tm, existingMessage)
         : mergeMissingThreadMetadata(existingMessage, tm);
-      const merged = mergeRetractionTombstone(mergedBase, tm);
+      let merged = mergeRetractionTombstone(mergedBase, tm);
+      if (synthesizedMatch) merged = adoptArchiveIdentity(merged, tm);
       if (options.seedExistingOnly) {
         byId.add(merged);
         timeline.push(merged);

--- a/chat/src/channels/timeline.ts
+++ b/chat/src/channels/timeline.ts
@@ -27,6 +27,7 @@ export function mapLiveRoomMessageToTimeline(
   if (msg.isRetracted) tm.isRetracted = true;
   if (msg.retractionId) tm.retractionId = msg.retractionId;
   if (msg.authorRealJid) tm.authorRealJid = msg.authorRealJid;
+  if (msg.synthesizedId) tm.synthesizedId = true;
   if (msg.wireIds && msg.wireIds.length > 0) tm.wireIds = msg.wireIds;
   if (msg.mentions && msg.mentions.length > 0) tm.mentions = msg.mentions;
   if (msg.sharedFiles && msg.sharedFiles.length > 0) tm.sharedFiles = msg.sharedFiles;

--- a/chat/src/dms/message-timeline-state.ts
+++ b/chat/src/dms/message-timeline-state.ts
@@ -13,6 +13,7 @@ import { compareTimelineMessages } from "@/lib/timeline-timestamps";
 import { assignCorrectionFields, type CorrectionPayload } from "@/lib/messaging/correction";
 import { retractTimelineMessage } from "@/lib/messaging/retraction";
 import { type ArchiveMergeHooks, mergeRetractionTombstone } from "@/lib/messaging/timeline-insert";
+import { adoptArchiveIdentity, findSynthesizedIdMergeTarget } from "@/lib/messaging/synthesized-id-merge";
 
 export function fromLiveDmMessage(
   session: WaddleSession,
@@ -35,6 +36,7 @@ export function fromLiveDmMessage(
   if (msg.displayedMarkerRequested) tm.displayedMarkerRequested = true;
   if (msg.isRetracted) tm.isRetracted = true;
   if (msg.retractionId) tm.retractionId = msg.retractionId;
+  if (msg.synthesizedId) tm.synthesizedId = true;
   if (msg.wireIds?.length) tm.wireIds = msg.wireIds;
   if (msg.mentions?.length) tm.mentions = msg.mentions;
   if (msg.markup?.length) tm.markup = msg.markup;
@@ -193,6 +195,10 @@ export function buildDmTimelineFromMamResults(params: {
   const byId = new MessageIdIndex<TimelineMessage>();
   for (const message of existing) byId.add(message);
   const timeline = [...existing];
+  // #1182: rows whose primary id had to be fabricated (id-less live
+  // stanzas) can only reconcile by content. Each is consumable once so
+  // two identical archive hits can't both collapse into it.
+  const synthesizedRows = existing.filter((message) => message.synthesizedId);
   for (const raw of regular) {
     const tm = fromLiveDmMessage(session, raw, (id) => byId.get(id));
     // Look up via every wire alias, not just the primary id — when
@@ -201,11 +207,15 @@ export function buildDmTimelineFromMamResults(params: {
     // (on `tm.id` only) would miss the existing row and insert a
     // duplicate. Channel side has done this for a while; this is the
     // matching DM-side fix (Bug 5 in PR1).
-    const existingMessage = [tm.id, ...(tm.wireIds ?? [])]
+    const idMatch = [tm.id, ...(tm.wireIds ?? [])]
       .map((id) => byId.get(id))
       .find((message): message is TimelineMessage => !!message);
+    const synthesizedMatch = idMatch ? undefined : findSynthesizedIdMergeTarget(synthesizedRows, tm);
+    if (synthesizedMatch) synthesizedRows.splice(synthesizedRows.indexOf(synthesizedMatch), 1);
+    const existingMessage = idMatch ?? synthesizedMatch;
     if (existingMessage) {
-      const merged = mergeRetractionTombstone(existingMessage, tm, dmArchiveMergeHooks);
+      let merged = mergeRetractionTombstone(existingMessage, tm, dmArchiveMergeHooks);
+      if (synthesizedMatch) merged = adoptArchiveIdentity(merged, tm);
       if (merged !== existingMessage) {
         const index = timeline.indexOf(existingMessage);
         if (index !== -1) timeline[index] = merged;

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -196,6 +196,10 @@ export interface ExtensionAnnotation {
 
 export interface TimelineMessage {
   id: string;
+  /** #1182: `id` is a fabricated UUID — the live stanza carried no wire
+   * identity at all, so only content-based reconciliation can match it
+   * to its MAM copy. Cleared once the row adopts a real identity. */
+  synthesizedId?: true;
   /** Equivalent wire-level ids (XEP-0359 stanza/origin ids, echoed ids). */
   wireIds?: string[];
   /** XEP-0308 correction target: original sender message id/origin-id. */

--- a/chat/src/lib/messaging/synthesized-id-merge.ts
+++ b/chat/src/lib/messaging/synthesized-id-merge.ts
@@ -1,0 +1,82 @@
+import type { TimelineMessage } from "@/lib/chat-ui";
+import { mergeMessageIds } from "@/lib/message-ids";
+import { barePeerJid } from "@/lib/xmpp-client";
+
+// #1182: a live stanza with no wire identity (no client id, no XEP-0359
+// stanza-id/origin-id) is keyed on a fabricated UUID (`synthesizedId`).
+// Its MAM copy carries the real archive UID, so id/alias lookups can
+// never match the two — content-based reconciliation is the only bridge.
+// The fabricated UUID never went on the wire, so nothing else (reactions,
+// retractions, corrections) can reference it; adopting the archive
+// identity is always safe.
+
+/**
+ * Bound on live-receipt-time vs archive-stamp divergence. Generous enough
+ * for clock skew, tight enough that a user repeating the same message
+ * later doesn't collapse into the earlier row.
+ */
+const SYNTHESIZED_MATCH_WINDOW_MS = 5 * 60_000;
+
+/**
+ * Same-author check that works for both pipelines: MUC rows compare the
+ * room-occupant JID (the MAM copy may add a real JID the live copy never
+ * saw); DM rows compare the bare sender JID.
+ */
+function sameAuthor(a: TimelineMessage, b: TimelineMessage): boolean {
+  if (a.authorOccupantJid || b.authorOccupantJid) {
+    return a.authorOccupantJid === b.authorOccupantJid;
+  }
+  return a.author === b.author
+    && barePeerJid(a.authorJid ?? "") === barePeerJid(b.authorJid ?? "");
+}
+
+function withinMatchWindow(a: TimelineMessage, b: TimelineMessage): boolean {
+  const delta = Math.abs(Date.parse(a.createdAt) - Date.parse(b.createdAt));
+  return Number.isFinite(delta) && delta <= SYNTHESIZED_MATCH_WINDOW_MS;
+}
+
+/**
+ * Finds the row an identity-less arrival reconciles into: same author,
+ * same body, timestamps within the match window — and exactly one side
+ * synthesized, so two genuinely distinct id-less messages with equal
+ * bodies can never collapse into each other.
+ */
+export function findSynthesizedIdMergeTarget(
+  candidates: readonly TimelineMessage[],
+  incoming: TimelineMessage,
+): TimelineMessage | undefined {
+  if (!incoming.body) return undefined;
+  return candidates.find((existing) =>
+    !existing.synthesizedId !== !incoming.synthesizedId
+    && existing.body === incoming.body
+    && sameAuthor(existing, incoming)
+    && withinMatchWindow(existing, incoming)
+  );
+}
+
+const ADOPTED_IDENTITY_FIELDS = [
+  "replyableId",
+  "stanzaId",
+  "stanzaIdBy",
+  "reactionTargetId",
+  "correctionTargetId",
+] as const;
+
+/**
+ * Replaces a reconciled row's fabricated identity with the archive copy's
+ * real one: the archive primary id wins (the UUID is demoted to a wire
+ * alias), the archive-derived id fields the id-less live stanza could
+ * never provide are adopted, and the `synthesizedId` flag is cleared.
+ */
+export function adoptArchiveIdentity(
+  row: TimelineMessage,
+  archiveRow: TimelineMessage,
+): TimelineMessage {
+  const adopted = mergeMessageIds(row, archiveRow.id, archiveRow.wireIds);
+  delete adopted.synthesizedId;
+  for (const field of ADOPTED_IDENTITY_FIELDS) {
+    const value = archiveRow[field];
+    if (adopted[field] === undefined && value !== undefined) adopted[field] = value;
+  }
+  return adopted;
+}

--- a/chat/src/lib/messaging/synthesized-id-merge.ts
+++ b/chat/src/lib/messaging/synthesized-id-merge.ts
@@ -18,6 +18,15 @@ import { barePeerJid } from "@/lib/xmpp-client";
 const SYNTHESIZED_MATCH_WINDOW_MS = 5 * 60_000;
 
 /**
+ * How far the real (archive) stamp may *lead* the synthesized receipt
+ * stamp. The archive records the same message the client already
+ * received, so it can only lead by clock skew — a same-content row
+ * stamped later than this is a distinct message sent while we were
+ * offline and must never be swallowed.
+ */
+const REAL_STAMP_AHEAD_TOLERANCE_MS = 90_000;
+
+/**
  * Same-author check that works for both pipelines: MUC rows compare the
  * room-occupant JID (the MAM copy may add a real JID the live copy never
  * saw); DM rows compare the bare sender JID.
@@ -30,9 +39,17 @@ function sameAuthor(a: TimelineMessage, b: TimelineMessage): boolean {
     && barePeerJid(a.authorJid ?? "") === barePeerJid(b.authorJid ?? "");
 }
 
-function withinMatchWindow(a: TimelineMessage, b: TimelineMessage): boolean {
-  const delta = Math.abs(Date.parse(a.createdAt) - Date.parse(b.createdAt));
-  return Number.isFinite(delta) && delta <= SYNTHESIZED_MATCH_WINDOW_MS;
+/**
+ * Asymmetric stamp check: the real side may trail the synthesized
+ * receipt by the full window (slow delivery, skew) but only lead it by
+ * the skew tolerance (see `REAL_STAMP_AHEAD_TOLERANCE_MS`).
+ */
+function stampsReconcilable(synthesized: TimelineMessage, real: TimelineMessage): boolean {
+  const synthesizedStamp = Date.parse(synthesized.createdAt);
+  const realStamp = Date.parse(real.createdAt);
+  if (!Number.isFinite(synthesizedStamp) || !Number.isFinite(realStamp)) return false;
+  return realStamp - synthesizedStamp <= REAL_STAMP_AHEAD_TOLERANCE_MS
+    && synthesizedStamp - realStamp <= SYNTHESIZED_MATCH_WINDOW_MS;
 }
 
 /**
@@ -62,7 +79,9 @@ export function findSynthesizedIdMergeTarget(
     !existing.synthesizedId !== !incoming.synthesizedId
     && contentKey(existing) === incomingKey
     && sameAuthor(existing, incoming)
-    && withinMatchWindow(existing, incoming)
+    && (incoming.synthesizedId
+      ? stampsReconcilable(incoming, existing)
+      : stampsReconcilable(existing, incoming))
   );
 }
 

--- a/chat/src/lib/messaging/synthesized-id-merge.ts
+++ b/chat/src/lib/messaging/synthesized-id-merge.ts
@@ -53,14 +53,18 @@ function stampsReconcilable(synthesized: TimelineMessage, real: TimelineMessage)
 }
 
 /**
- * The comparable content of a row: its body, or — for body-less file
- * messages — its attachment URLs. Empty for rows with neither (e.g.
- * retraction tombstones), which therefore never content-match.
+ * The comparable content of a row: body AND attachment URLs together, in
+ * a fixed composite shape so a caption shared by two different file
+ * shares can't match, and a body that spells out the file section can't
+ * collide with a genuine file-only key. Empty for rows with neither
+ * (e.g. retraction tombstones), which therefore never content-match.
  */
 function contentKey(message: TimelineMessage): string {
-  if (message.body) return message.body;
   const urls = (message.sharedFiles ?? []).map((file) => file.url);
-  return urls.length ? `files:${urls.join("\n")}` : "";
+  if (!message.body && !urls.length) return "";
+  // Newline-delimited sections: URLs cannot contain raw newlines, so a
+  // body can never forge the files-section boundary.
+  return `body:${message.body}\nfiles:${urls.join("\n")}`;
 }
 
 /**

--- a/chat/src/lib/messaging/synthesized-id-merge.ts
+++ b/chat/src/lib/messaging/synthesized-id-merge.ts
@@ -36,19 +36,31 @@ function withinMatchWindow(a: TimelineMessage, b: TimelineMessage): boolean {
 }
 
 /**
+ * The comparable content of a row: its body, or — for body-less file
+ * messages — its attachment URLs. Empty for rows with neither (e.g.
+ * retraction tombstones), which therefore never content-match.
+ */
+function contentKey(message: TimelineMessage): string {
+  if (message.body) return message.body;
+  const urls = (message.sharedFiles ?? []).map((file) => file.url);
+  return urls.length ? `files:${urls.join("\n")}` : "";
+}
+
+/**
  * Finds the row an identity-less arrival reconciles into: same author,
- * same body, timestamps within the match window — and exactly one side
+ * same content, timestamps within the match window — and exactly one side
  * synthesized, so two genuinely distinct id-less messages with equal
- * bodies can never collapse into each other.
+ * content can never collapse into each other.
  */
 export function findSynthesizedIdMergeTarget(
   candidates: readonly TimelineMessage[],
   incoming: TimelineMessage,
 ): TimelineMessage | undefined {
-  if (!incoming.body) return undefined;
+  const incomingKey = contentKey(incoming);
+  if (!incomingKey) return undefined;
   return candidates.find((existing) =>
     !existing.synthesizedId !== !incoming.synthesizedId
-    && existing.body === incoming.body
+    && contentKey(existing) === incomingKey
     && sameAuthor(existing, incoming)
     && withinMatchWindow(existing, incoming)
   );

--- a/chat/src/lib/messaging/timeline-insert.ts
+++ b/chat/src/lib/messaging/timeline-insert.ts
@@ -3,6 +3,7 @@ import { mergeMessageIds } from "@/lib/message-ids";
 import { compareTimelineMessages, pickAuthoritativeTimestamp } from "@/lib/timeline-timestamps";
 import { retractTimelineMessage } from "@/lib/messaging/retraction";
 import { consumeReconciledEchoIds, findLiveMergeTarget } from "@/lib/messaging/self-echo";
+import { findSynthesizedIdMergeTarget } from "@/lib/messaging/synthesized-id-merge";
 
 // Timeline insertion mechanics shared by the channel and DM pipelines:
 // ordering, id-based dedupe, in-place merge of duplicate arrivals, and
@@ -31,7 +32,11 @@ export interface LiveInsertResult {
  * prior "sending" / "failed" optimistic state).
  */
 function mergedLiveRow(existing: TimelineMessage, incoming: TimelineMessage): TimelineMessage {
-  const mergedIds = mergeMessageIds(existing, incoming.id, incoming.wireIds);
+  // #1182: a fabricated primary id must never displace a real one — keep
+  // the existing row's identity and demote the incoming UUID to an alias.
+  const mergedIds = incoming.synthesizedId
+    ? mergeMessageIds(existing, existing.id, [incoming.id, ...(incoming.wireIds ?? [])])
+    : mergeMessageIds(existing, incoming.id, incoming.wireIds);
   const authoritativeTimestamp = pickAuthoritativeTimestamp(
     { createdAt: existing.createdAt, createdAtSource: existing.createdAtSource },
     { createdAt: incoming.createdAt, createdAtSource: incoming.createdAtSource },
@@ -48,6 +53,8 @@ function mergedLiveRow(existing: TimelineMessage, incoming: TimelineMessage): Ti
   }
   if (mergedIds.wireIds?.length) updated.wireIds = mergedIds.wireIds;
   else delete updated.wireIds;
+  // #1182: the reconciled row is only still identity-less if both sides were.
+  if (!(existing.synthesizedId && incoming.synthesizedId)) delete updated.synthesizedId;
   if (existing.isSelf && incoming.isSelf) {
     updated.deliveryStatus = "delivered";
   }
@@ -67,7 +74,10 @@ export function insertLiveMessage(
   policy: LiveInsertPolicy = {},
 ): LiveInsertResult {
   const finalize = policy.finalize ?? ((timeline: TimelineMessage[]) => timeline);
-  const existing = findLiveMergeTarget(messages, msg, pendingEchoClientIds);
+  // #1182: an id-less (re)delivery has no wire ids to overlap the row a
+  // MAM reload already seeded — fall back to content reconciliation.
+  const existing = findLiveMergeTarget(messages, msg, pendingEchoClientIds)
+    ?? findSynthesizedIdMergeTarget(messages, msg);
   if (existing) {
     const merged = messages
       .map((m) => (m.id === existing.id ? mergedLiveRow(m, msg) : m))

--- a/chat/src/lib/messaging/timeline-insert.ts
+++ b/chat/src/lib/messaging/timeline-insert.ts
@@ -75,9 +75,12 @@ export function insertLiveMessage(
 ): LiveInsertResult {
   const finalize = policy.finalize ?? ((timeline: TimelineMessage[]) => timeline);
   // #1182: an id-less (re)delivery has no wire ids to overlap the row a
-  // MAM reload already seeded — fall back to content reconciliation.
+  // MAM reload already seeded — fall back to content reconciliation. Only
+  // for a synthesized *incoming*: an id-carrying arrival is a distinct
+  // message (an id-less original can never be redelivered with an id) and
+  // must not be swallowed by an earlier same-body synthesized row.
   const existing = findLiveMergeTarget(messages, msg, pendingEchoClientIds)
-    ?? findSynthesizedIdMergeTarget(messages, msg);
+    ?? (msg.synthesizedId ? findSynthesizedIdMergeTarget(messages, msg) : undefined);
   if (existing) {
     const merged = messages
       .map((m) => (m.id === existing.id ? mergedLiveRow(m, msg) : m))

--- a/chat/src/lib/messaging/timeline-insert.ts
+++ b/chat/src/lib/messaging/timeline-insert.ts
@@ -74,13 +74,16 @@ export function insertLiveMessage(
   policy: LiveInsertPolicy = {},
 ): LiveInsertResult {
   const finalize = policy.finalize ?? ((timeline: TimelineMessage[]) => timeline);
-  // #1182: an id-less (re)delivery has no wire ids to overlap the row a
-  // MAM reload already seeded — fall back to content reconciliation. Only
-  // for a synthesized *incoming*: an id-carrying arrival is a distinct
-  // message (an id-less original can never be redelivered with an id) and
-  // must not be swallowed by an earlier same-body synthesized row.
+  // #1182: content reconciliation bridges the fabricated-UUID gap in two
+  // shapes only: a synthesized incoming (id-less redelivery onto a
+  // MAM-seeded row) and an archive-decoded incoming (reconnect catch-up
+  // emits archive rows through this path — #1190 skips the lifecycle
+  // reload, so this is the only chance to reconcile the id-less
+  // original). A genuinely new id-carrying *live* arrival is a distinct
+  // message and must not be swallowed by a same-body synthesized row.
+  const contentMatchable = msg.synthesizedId || msg.createdAtSource === "archive";
   const existing = findLiveMergeTarget(messages, msg, pendingEchoClientIds)
-    ?? (msg.synthesizedId ? findSynthesizedIdMergeTarget(messages, msg) : undefined);
+    ?? (contentMatchable ? findSynthesizedIdMergeTarget(messages, msg) : undefined);
   if (existing) {
     const merged = messages
       .map((m) => (m.id === existing.id ? mergedLiveRow(m, msg) : m))

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -151,6 +151,10 @@ export interface LiveRoomMessage {
   id: string;
   /** XEP-0313 archive UID from the MAM result envelope, when known. */
   archiveId?: string;
+  /** #1182: `id` is a fabricated UUID — the live stanza carried no wire
+   * identity at all (no client id, no XEP-0359 stanza-id/origin-id), so
+   * only content-based reconciliation can match it to its MAM copy. */
+  synthesizedId?: true;
   wireIds?: string[];
   /** XEP-0308 correction target: original sender message id/origin-id. */
   correctionTargetId?: string;
@@ -237,6 +241,8 @@ export interface LiveDmMessage {
   id: string;
   /** XEP-0313 archive UID from the MAM result envelope, when known. */
   archiveId?: string;
+  /** #1182: `id` is a fabricated UUID — see `LiveRoomMessage.synthesizedId`. */
+  synthesizedId?: true;
   wireIds?: string[];
   /** XEP-0308 correction target: original sender message id/origin-id. */
   correctionTargetId?: string;

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -660,7 +660,12 @@ export function dmMessageFromArchived(
   const extensionAnnotations = extensionAnnotationsFromWasm(message.extension_envelope);
   const callThread = isSupportedDmCallThread(message.call_thread) ? message.call_thread : undefined;
   const callThreadEnded = message.call_thread_ended;
-  const dmWireIds = [message.id, message.origin_id]
+  // #1182: the user-server-injected XEP-0359 stanza-id is a real wire
+  // identity — the MAM copy is keyed on it (XEP-0313 servers use it as the
+  // archive UID) — so fold it into the aliases like the room path does
+  // with `stampedByRoom`. This both dedupes exactly and keeps such rows
+  // out of the synthesized-id content-match pool.
+  const dmWireIds = [message.id, message.origin_id, ownStanzaId?.id]
     .filter((value): value is string => !!value && value !== dmPrimaryId);
   // Alias a DM call-thread anchor by its sid so a same-session MAM backfill
   // collapses onto the synthesized live anchor (see `dm-call-anchor.ts`)

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -441,12 +441,14 @@ export function roomMessageFromArchived(
   const roomPrimaryId = message.id ?? stampedByRoom ?? message.mam_id;
   const roomWireIds = [message.id, message.origin_id, stampedByRoom]
     .filter((value): value is string => !!value && value !== roomPrimaryId);
-  // #1182: on the live path `mam_id` is fabricated by the dispatcher, so a
-  // stanza with no wire identity at all ends up keyed on a random UUID that
-  // the MAM copy can never match. Flag it for content-based reconciliation
-  // and don't let the fabricated UUID masquerade as an archive UID.
+  // #1182: on the live path `mam_id` is fabricated by the dispatcher
+  // (`message.id ?? randomUUID`), so a stanza with no wire identity at all
+  // ends up keyed on a random UUID that the MAM copy can never match. Flag
+  // it for content-based reconciliation and don't let the fabricated UUID
+  // masquerade as an archive UID. `!message.id` is essential: a client-id-
+  // only stanza also satisfies `primary === mam_id` but has a real identity.
   const synthesizedPrimary =
-    source === "live" && roomPrimaryId === message.mam_id && roomWireIds.length === 0;
+    source === "live" && !message.id && roomPrimaryId === message.mam_id && roomWireIds.length === 0;
   if (activeRetractionTarget) {
     return {
       id: roomPrimaryId,
@@ -677,8 +679,9 @@ export function dmMessageFromArchived(
   // #1182: see `roomMessageFromArchived` — a live stanza with no wire
   // identity is keyed on a dispatcher-fabricated UUID; flag it for
   // content-based reconciliation instead of claiming an archive UID.
+  // `!message.id` is essential (client-id-only also has primary === mam_id).
   const synthesizedPrimary =
-    source === "live" && dmPrimaryId === message.mam_id && dmWireIds.length === 0;
+    source === "live" && !message.id && dmPrimaryId === message.mam_id && dmWireIds.length === 0;
   const { linkPreviews: associatedLinkPreviews, sharedFiles: associatedSharedFiles } =
     associateDirectVideoPreviews(
       linkPreviews.map((preview) => linkPreviewFromWasm(preview, decodeOptions)),

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -441,6 +441,12 @@ export function roomMessageFromArchived(
   const roomPrimaryId = message.id ?? stampedByRoom ?? message.mam_id;
   const roomWireIds = [message.id, message.origin_id, stampedByRoom]
     .filter((value): value is string => !!value && value !== roomPrimaryId);
+  // #1182: on the live path `mam_id` is fabricated by the dispatcher, so a
+  // stanza with no wire identity at all ends up keyed on a random UUID that
+  // the MAM copy can never match. Flag it for content-based reconciliation
+  // and don't let the fabricated UUID masquerade as an archive UID.
+  const synthesizedPrimary =
+    source === "live" && roomPrimaryId === message.mam_id && roomWireIds.length === 0;
   if (activeRetractionTarget) {
     return {
       id: roomPrimaryId,
@@ -538,7 +544,7 @@ export function roomMessageFromArchived(
     );
   const base: LiveRoomMessage = {
     id: roomPrimaryId,
-    archiveId: message.mam_id,
+    ...(synthesizedPrimary ? { synthesizedId: true } : { archiveId: message.mam_id }),
     fromJid,
     roomJid,
     nick,
@@ -668,6 +674,11 @@ export function dmMessageFromArchived(
   // anyway, but the codec stays symmetric with the room path so a stray
   // foreign-server archive row can't manifest a bodyless DM ghost either.
   if (!message.body && !message.subject && !callThread && !sharedFiles.length && !linkPreviews.length && !extensionAnnotations.length && !message.is_retracted) return null;
+  // #1182: see `roomMessageFromArchived` — a live stanza with no wire
+  // identity is keyed on a dispatcher-fabricated UUID; flag it for
+  // content-based reconciliation instead of claiming an archive UID.
+  const synthesizedPrimary =
+    source === "live" && dmPrimaryId === message.mam_id && dmWireIds.length === 0;
   const { linkPreviews: associatedLinkPreviews, sharedFiles: associatedSharedFiles } =
     associateDirectVideoPreviews(
       linkPreviews.map((preview) => linkPreviewFromWasm(preview, decodeOptions)),
@@ -675,7 +686,7 @@ export function dmMessageFromArchived(
     );
   const base: LiveDmMessage = {
     id: dmPrimaryId,
-    archiveId: message.mam_id,
+    ...(synthesizedPrimary ? { synthesizedId: true } : { archiveId: message.mam_id }),
     peerJid,
     fromJid,
     nick,

--- a/chat/tests/idless-live-mam-dedupe.test.ts
+++ b/chat/tests/idless-live-mam-dedupe.test.ts
@@ -1,0 +1,268 @@
+// #1182: live stanzas lacking any wire identity (client id, XEP-0359
+// stanza-id/origin-id) get a fabricated UUID as their primary id and can
+// never dedupe against their MAM copy. These tests pin the codec marking
+// (`synthesizedId`) and the content-based reconciliation fallback at both
+// merge directions.
+
+import { describe, expect, test } from "bun:test";
+
+import { dmMessageFromArchived, roomMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
+import { buildChannelTimelineFromMamResults } from "../src/channels/message-timeline-state";
+import { buildDmTimelineFromMamResults, fromLiveDmMessage } from "../src/dms/message-timeline-state";
+import { mapLiveRoomMessageToTimeline } from "../src/channels/timeline";
+import { insertLiveMessage } from "../src/lib/messaging/timeline-insert";
+import type { WasmArchivedMessage } from "../src/lib/xmpp/wasm-types";
+import type { WaddleSession } from "../src/lib/server-auth";
+
+const session: WaddleSession = {
+  session_id: "tok",
+  user_id: "alice-id",
+  username: "alice",
+  avatar_url: null,
+  xmpp_localpart: "alice",
+  jid: "alice@example.com/desktop",
+  xmpp_websocket_url: "wss://example.com/ws",
+  is_expired: false,
+  expires_at: null,
+};
+
+const baseArchivedRoom: WasmArchivedMessage = {
+  mam_id: "fabricated-uuid-1",
+  message_type: "groupchat",
+  from: "room@conf.example.com/bob",
+  to: "alice@example.com",
+  body: "hello",
+  reaction_emojis: [],
+  is_muc: true,
+  markup_spans: [],
+  mention_uris: [],
+  references: [],
+  is_sticker: false,
+  shared_files: [],
+};
+
+const baseArchivedDm: WasmArchivedMessage = {
+  mam_id: "fabricated-uuid-2",
+  message_type: "chat",
+  from: "bob@example.com",
+  to: "alice@example.com",
+  body: "hello",
+  reaction_emojis: [],
+  is_muc: false,
+  markup_spans: [],
+  mention_uris: [],
+  references: [],
+  is_sticker: false,
+  shared_files: [],
+};
+
+describe("codec synthesized-primary-id marking (#1182)", () => {
+  test("live MUC stanza with no wire identity is flagged and gets no archiveId", () => {
+    const result = roomMessageFromArchived(baseArchivedRoom, "live");
+    expect(result?.id).toBe("fabricated-uuid-1");
+    expect(result?.synthesizedId).toBe(true);
+    expect(result?.archiveId).toBeUndefined();
+  });
+
+  test("live MUC stanza with a room-stamped stanza-id is not flagged", () => {
+    const result = roomMessageFromArchived(
+      {
+        ...baseArchivedRoom,
+        stanza_id: "room-stamped-1",
+        stanza_id_by: "room@conf.example.com",
+      },
+      "live",
+    );
+    expect(result?.id).toBe("room-stamped-1");
+    expect(result?.synthesizedId).toBeUndefined();
+  });
+
+  test("live DM stanza with no wire identity is flagged and gets no archiveId", () => {
+    const result = dmMessageFromArchived(baseArchivedDm, "alice@example.com", "live");
+    expect(result?.id).toBe("fabricated-uuid-2");
+    expect(result?.synthesizedId).toBe(true);
+    expect(result?.archiveId).toBeUndefined();
+  });
+
+  test("live DM stanza with an origin-id is not flagged", () => {
+    const result = dmMessageFromArchived(
+      { ...baseArchivedDm, origin_id: "origin-1" },
+      "alice@example.com",
+      "live",
+    );
+    expect(result?.id).toBe("origin-1");
+    expect(result?.synthesizedId).toBeUndefined();
+  });
+
+  test("archive MUC row is never flagged and keeps its archiveId", () => {
+    const result = roomMessageFromArchived({ ...baseArchivedRoom, mam_id: "mam-1" });
+    expect(result?.synthesizedId).toBeUndefined();
+    expect(result?.archiveId).toBe("mam-1");
+  });
+});
+
+describe("channel MAM merge reconciles synthesized live rows (#1182)", () => {
+  const liveIdless = (overrides: Partial<WasmArchivedMessage> = {}) =>
+    roomMessageFromArchived(
+      { ...baseArchivedRoom, timestamp: "2026-07-01T10:00:00.000Z", ...overrides },
+      "live",
+    )!;
+  const mamCopy = (overrides: Partial<WasmArchivedMessage> = {}) =>
+    roomMessageFromArchived({
+      ...baseArchivedRoom,
+      mam_id: "archive-uid-1",
+      stanza_id: "archive-uid-1",
+      stanza_id_by: "room@conf.example.com",
+      timestamp: "2026-07-01T10:00:01.000Z",
+      ...overrides,
+    })!;
+
+  test("MAM copy merges into the synthesized live row instead of duplicating", () => {
+    const existing = [mapLiveRoomMessageToTimeline(session, liveIdless())];
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [mamCopy()],
+      existing,
+    });
+    expect(timeline).toHaveLength(1);
+    const row = timeline[0]!;
+    expect(row.id).toBe("archive-uid-1");
+    expect(row.wireIds).toContain(existing[0]!.id);
+    expect(row.synthesizedId).toBeUndefined();
+    expect(row.replyableId).toBe("archive-uid-1");
+  });
+
+  test("a different-body MAM row still appends", () => {
+    const existing = [mapLiveRoomMessageToTimeline(session, liveIdless())];
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [mamCopy({ body: "something else" })],
+      existing,
+    });
+    expect(timeline).toHaveLength(2);
+  });
+
+  test("a same-body MAM row outside the timestamp window still appends", () => {
+    const existing = [mapLiveRoomMessageToTimeline(session, liveIdless())];
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [mamCopy({ timestamp: "2026-07-01T11:00:00.000Z" })],
+      existing,
+    });
+    expect(timeline).toHaveLength(2);
+  });
+
+  test("two identical MAM rows only consume the synthesized row once", () => {
+    const existing = [mapLiveRoomMessageToTimeline(session, liveIdless())];
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [
+        mamCopy(),
+        mamCopy({ mam_id: "archive-uid-2", stanza_id: "archive-uid-2" }),
+      ],
+      existing,
+    });
+    expect(timeline).toHaveLength(2);
+    expect(timeline.map((m) => m.id).sort()).toEqual(["archive-uid-1", "archive-uid-2"]);
+  });
+
+  test("a same-body MAM row from a different occupant still appends", () => {
+    const existing = [mapLiveRoomMessageToTimeline(session, liveIdless())];
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [mamCopy({ from: "room@conf.example.com/carol" })],
+      existing,
+    });
+    expect(timeline).toHaveLength(2);
+  });
+});
+
+describe("DM MAM merge reconciles synthesized live rows (#1182)", () => {
+  const liveIdlessDm = () =>
+    dmMessageFromArchived(
+      { ...baseArchivedDm, timestamp: "2026-07-01T10:00:00.000Z" },
+      "alice@example.com",
+      "live",
+    )!;
+  const mamDmCopy = (overrides: Partial<WasmArchivedMessage> = {}) =>
+    dmMessageFromArchived(
+      {
+        ...baseArchivedDm,
+        mam_id: "dm-archive-uid-1",
+        timestamp: "2026-07-01T10:00:01.000Z",
+        ...overrides,
+      },
+      "alice@example.com",
+    )!;
+
+  test("MAM copy merges into the synthesized live DM row instead of duplicating", () => {
+    const existing = [fromLiveDmMessage(session, liveIdlessDm())];
+    const timeline = buildDmTimelineFromMamResults({
+      session,
+      mamResults: [mamDmCopy()],
+      existing,
+    });
+    expect(timeline).toHaveLength(1);
+    const row = timeline[0]!;
+    expect(row.id).toBe("dm-archive-uid-1");
+    expect(row.wireIds).toContain(existing[0]!.id);
+    expect(row.synthesizedId).toBeUndefined();
+  });
+
+  test("a same-body MAM row from the other conversation side still appends", () => {
+    const existing = [fromLiveDmMessage(session, liveIdlessDm())];
+    const timeline = buildDmTimelineFromMamResults({
+      session,
+      mamResults: [
+        mamDmCopy({ from: "alice@example.com", to: "bob@example.com", id: "self-1" }),
+      ],
+      existing,
+    });
+    expect(timeline).toHaveLength(2);
+  });
+});
+
+describe("live insert reconciles id-less redelivery onto MAM-seeded rows (#1182)", () => {
+  const mamSeededRow = () =>
+    mapLiveRoomMessageToTimeline(
+      session,
+      roomMessageFromArchived({
+        ...baseArchivedRoom,
+        mam_id: "archive-uid-1",
+        stanza_id: "archive-uid-1",
+        stanza_id_by: "room@conf.example.com",
+        timestamp: "2026-07-01T10:00:01.000Z",
+      })!,
+    );
+  // The dispatcher fabricates a fresh UUID per id-less delivery — mirror
+  // that so two rows never share the fabricated primary id.
+  const idlessLiveRow = (fabricatedId = crypto.randomUUID()) =>
+    mapLiveRoomMessageToTimeline(
+      session,
+      roomMessageFromArchived(
+        { ...baseArchivedRoom, mam_id: fabricatedId, timestamp: "2026-07-01T10:00:00.000Z" },
+        "live",
+      )!,
+    );
+
+  test("id-less live redelivery merges into the archive-keyed row", () => {
+    const result = insertLiveMessage([mamSeededRow()], idlessLiveRow(), new Set());
+    expect(result.appended).toBe(false);
+    expect(result.messages).toHaveLength(1);
+    const row = result.messages[0]!;
+    expect(row.id).toBe("archive-uid-1");
+    expect(row.synthesizedId).toBeUndefined();
+  });
+
+  test("two distinct id-less live messages with equal bodies never merge", () => {
+    const first = insertLiveMessage([], idlessLiveRow(), new Set());
+    const second = insertLiveMessage(first.messages, idlessLiveRow(), new Set());
+    expect(second.appended).toBe(true);
+    expect(second.messages).toHaveLength(2);
+  });
+});

--- a/chat/tests/idless-live-mam-dedupe.test.ts
+++ b/chat/tests/idless-live-mam-dedupe.test.ts
@@ -387,3 +387,83 @@ describe("file-only id-less messages reconcile by attachment URLs (#1182)", () =
     expect(timeline).toHaveLength(2);
   });
 });
+
+describe("DM server-stamped stanza-id is a real wire identity (#1182)", () => {
+  test("live DM with only a stanza-id is not flagged and carries it as an alias", () => {
+    const result = dmMessageFromArchived(
+      {
+        ...baseArchivedDm,
+        stanza_id: "srv-stamped-1",
+        stanza_id_by: "example.com",
+        mam_id: "fabricated-uuid-9",
+      },
+      "alice@example.com",
+      "live",
+    );
+    expect(result?.synthesizedId).toBeUndefined();
+    expect(result?.wireIds).toContain("srv-stamped-1");
+  });
+
+  test("MAM copy keyed on the stanza-id dedupes exactly against the live row", () => {
+    const existing = [
+      fromLiveDmMessage(
+        session,
+        dmMessageFromArchived(
+          {
+            ...baseArchivedDm,
+            stanza_id: "srv-stamped-2",
+            stanza_id_by: "example.com",
+            mam_id: "fabricated-uuid-10",
+            timestamp: "2026-07-01T10:00:00.000Z",
+          },
+          "alice@example.com",
+          "live",
+        )!,
+      ),
+    ];
+    const timeline = buildDmTimelineFromMamResults({
+      session,
+      mamResults: [
+        dmMessageFromArchived(
+          { ...baseArchivedDm, mam_id: "srv-stamped-2", timestamp: "2026-07-01T10:00:00.000Z" },
+          "alice@example.com",
+        )!,
+      ],
+      existing,
+    });
+    expect(timeline).toHaveLength(1);
+  });
+});
+
+describe("seedExistingOnly keeps the consumed synthesized row's UUID as alias (#1182)", () => {
+  test("lifecycle-reload merge preserves the fabricated id so persisted last-seen still resolves", () => {
+    const fabricated = crypto.randomUUID();
+    const existing = [
+      mapLiveRoomMessageToTimeline(
+        session,
+        roomMessageFromArchived(
+          { ...baseArchivedRoom, mam_id: fabricated, timestamp: "2026-07-01T10:00:00.000Z" },
+          "live",
+        )!,
+      ),
+    ];
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [
+        roomMessageFromArchived({
+          ...baseArchivedRoom,
+          mam_id: "archive-uid-9",
+          stanza_id: "archive-uid-9",
+          stanza_id_by: "room@conf.example.com",
+          timestamp: "2026-07-01T10:00:01.000Z",
+        })!,
+      ],
+      existing,
+      options: { seedExistingOnly: true },
+    });
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]!.id).toBe("archive-uid-9");
+    expect(timeline[0]!.wireIds).toContain(fabricated);
+  });
+});

--- a/chat/tests/idless-live-mam-dedupe.test.ts
+++ b/chat/tests/idless-live-mam-dedupe.test.ts
@@ -467,3 +467,31 @@ describe("seedExistingOnly keeps the consumed synthesized row's UUID as alias (#
     expect(timeline[0]!.wireIds).toContain(fabricated);
   });
 });
+
+describe("reconnect catch-up (archive-sourced live emit) reconciles synthesized rows (#1182)", () => {
+  test("an archive-decoded catch-up arrival merges into the synthesized live row", () => {
+    const synthesized = mapLiveRoomMessageToTimeline(
+      session,
+      roomMessageFromArchived(
+        { ...baseArchivedRoom, mam_id: crypto.randomUUID(), timestamp: "2026-07-01T10:00:00.000Z" },
+        "live",
+      )!,
+    );
+    // client-mam catch-up decodes with the default "archive" source and
+    // emits through the live pipeline (insertLiveMessage).
+    const catchupCopy = mapLiveRoomMessageToTimeline(
+      session,
+      roomMessageFromArchived({
+        ...baseArchivedRoom,
+        mam_id: "archive-uid-11",
+        stanza_id: "archive-uid-11",
+        stanza_id_by: "room@conf.example.com",
+        timestamp: "2026-07-01T10:00:01.000Z",
+      })!,
+    );
+    const result = insertLiveMessage([synthesized], catchupCopy, new Set());
+    expect(result.appended).toBe(false);
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]!.synthesizedId).toBeUndefined();
+  });
+});

--- a/chat/tests/idless-live-mam-dedupe.test.ts
+++ b/chat/tests/idless-live-mam-dedupe.test.ts
@@ -495,3 +495,31 @@ describe("reconnect catch-up (archive-sourced live emit) reconciles synthesized 
     expect(result.messages[0]!.synthesizedId).toBeUndefined();
   });
 });
+
+describe("archive stamps well after the synthesized receipt are distinct messages (#1182)", () => {
+  test("a same-content archive arrival stamped 3 minutes later appends instead of merging", () => {
+    // A's synthesized row was received at 10:00:00; an archive copy of A
+    // can only lead that stamp by clock skew. A same-content row stamped
+    // 10:03:00 is a distinct message sent while we were offline.
+    const synthesized = mapLiveRoomMessageToTimeline(
+      session,
+      roomMessageFromArchived(
+        { ...baseArchivedRoom, mam_id: crypto.randomUUID(), timestamp: "2026-07-01T10:00:00.000Z" },
+        "live",
+      )!,
+    );
+    const laterDistinct = mapLiveRoomMessageToTimeline(
+      session,
+      roomMessageFromArchived({
+        ...baseArchivedRoom,
+        mam_id: "archive-uid-12",
+        stanza_id: "archive-uid-12",
+        stanza_id_by: "room@conf.example.com",
+        timestamp: "2026-07-01T10:03:00.000Z",
+      })!,
+    );
+    const result = insertLiveMessage([synthesized], laterDistinct, new Set());
+    expect(result.appended).toBe(true);
+    expect(result.messages).toHaveLength(2);
+  });
+});

--- a/chat/tests/idless-live-mam-dedupe.test.ts
+++ b/chat/tests/idless-live-mam-dedupe.test.ts
@@ -266,3 +266,124 @@ describe("live insert reconciles id-less redelivery onto MAM-seeded rows (#1182)
     expect(second.messages).toHaveLength(2);
   });
 });
+
+describe("client-id-only live stanzas are real identities, not synthesized (#1182)", () => {
+  // The dispatcher reshapes live stanzas with `mam_id: message.id ?? uuid`,
+  // so a client-id-only stanza also has primary === mam_id — it must still
+  // NOT be flagged: the client id is a real wire identity.
+  test("live MUC stanza with only a client id is not flagged", () => {
+    const result = roomMessageFromArchived(
+      { ...baseArchivedRoom, id: "client-1", mam_id: "client-1" },
+      "live",
+    );
+    expect(result?.id).toBe("client-1");
+    expect(result?.synthesizedId).toBeUndefined();
+  });
+
+  test("live DM stanza with only a client id is not flagged", () => {
+    const result = dmMessageFromArchived(
+      { ...baseArchivedDm, id: "client-2", mam_id: "client-2" },
+      "alice@example.com",
+      "live",
+    );
+    expect(result?.id).toBe("client-2");
+    expect(result?.synthesizedId).toBeUndefined();
+  });
+});
+
+describe("live insert only content-matches when the incoming row is synthesized (#1182)", () => {
+  test("an id-carrying same-body live arrival never merges into a synthesized row", () => {
+    const synthesized = mapLiveRoomMessageToTimeline(
+      session,
+      roomMessageFromArchived(
+        { ...baseArchivedRoom, mam_id: crypto.randomUUID(), timestamp: "2026-07-01T10:00:00.000Z" },
+        "live",
+      )!,
+    );
+    const withClientId = mapLiveRoomMessageToTimeline(
+      session,
+      roomMessageFromArchived(
+        { ...baseArchivedRoom, id: "client-9", mam_id: "client-9", timestamp: "2026-07-01T10:00:30.000Z" },
+        "live",
+      )!,
+    );
+    const result = insertLiveMessage([synthesized], withClientId, new Set());
+    expect(result.appended).toBe(true);
+    expect(result.messages).toHaveLength(2);
+  });
+});
+
+describe("file-only id-less messages reconcile by attachment URLs (#1182)", () => {
+  const file = { url: "https://files.example.com/pic.png", disposition: "inline" };
+
+  test("MAM copy of a body-less file message merges into the synthesized live row", () => {
+    const existing = [
+      mapLiveRoomMessageToTimeline(
+        session,
+        roomMessageFromArchived(
+          {
+            ...baseArchivedRoom,
+            body: undefined,
+            shared_files: [file],
+            mam_id: crypto.randomUUID(),
+            timestamp: "2026-07-01T10:00:00.000Z",
+          },
+          "live",
+        )!,
+      ),
+    ];
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [
+        roomMessageFromArchived({
+          ...baseArchivedRoom,
+          body: undefined,
+          shared_files: [file],
+          mam_id: "archive-uid-7",
+          stanza_id: "archive-uid-7",
+          stanza_id_by: "room@conf.example.com",
+          timestamp: "2026-07-01T10:00:01.000Z",
+        })!,
+      ],
+      existing,
+    });
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]!.id).toBe("archive-uid-7");
+  });
+
+  test("a body-less file message with a different attachment still appends", () => {
+    const existing = [
+      mapLiveRoomMessageToTimeline(
+        session,
+        roomMessageFromArchived(
+          {
+            ...baseArchivedRoom,
+            body: undefined,
+            shared_files: [file],
+            mam_id: crypto.randomUUID(),
+            timestamp: "2026-07-01T10:00:00.000Z",
+          },
+          "live",
+        )!,
+      ),
+    ];
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [
+        roomMessageFromArchived({
+          ...baseArchivedRoom,
+          body: undefined,
+          shared_files: [{ url: "https://files.example.com/other.png", disposition: "inline" }],
+          mam_id: "archive-uid-8",
+          stanza_id: "archive-uid-8",
+          stanza_id_by: "room@conf.example.com",
+          timestamp: "2026-07-01T10:00:01.000Z",
+        })!,
+      ],
+      existing,
+    });
+    expect(timeline).toHaveLength(2);
+  });
+});

--- a/chat/tests/idless-live-mam-dedupe.test.ts
+++ b/chat/tests/idless-live-mam-dedupe.test.ts
@@ -523,3 +523,90 @@ describe("archive stamps well after the synthesized receipt are distinct message
     expect(result.messages).toHaveLength(2);
   });
 });
+
+describe("content key covers caption + attachments together (#1182 review)", () => {
+  const withFile = (url: string, overrides: Partial<WasmArchivedMessage> = {}): WasmArchivedMessage => ({
+    ...baseArchivedRoom,
+    body: "look",
+    shared_files: [{ url, disposition: "inline" }],
+    timestamp: "2026-07-01T10:00:00.000Z",
+    ...overrides,
+  });
+
+  test("same caption but different attachment does not merge", () => {
+    const existing = [
+      mapLiveRoomMessageToTimeline(
+        session,
+        roomMessageFromArchived(withFile("https://files.example.com/a.png", { mam_id: crypto.randomUUID() }), "live")!,
+      ),
+    ];
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [
+        roomMessageFromArchived(withFile("https://files.example.com/b.png", {
+          mam_id: "archive-uid-13",
+          stanza_id: "archive-uid-13",
+          stanza_id_by: "room@conf.example.com",
+          timestamp: "2026-07-01T10:00:01.000Z",
+        }))!,
+      ],
+      existing,
+    });
+    expect(timeline).toHaveLength(2);
+  });
+
+  test("same caption and same attachment merges", () => {
+    const existing = [
+      mapLiveRoomMessageToTimeline(
+        session,
+        roomMessageFromArchived(withFile("https://files.example.com/a.png", { mam_id: crypto.randomUUID() }), "live")!,
+      ),
+    ];
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [
+        roomMessageFromArchived(withFile("https://files.example.com/a.png", {
+          mam_id: "archive-uid-14",
+          stanza_id: "archive-uid-14",
+          stanza_id_by: "room@conf.example.com",
+          timestamp: "2026-07-01T10:00:01.000Z",
+        }))!,
+      ],
+      existing,
+    });
+    expect(timeline).toHaveLength(1);
+    expect(timeline[0]!.id).toBe("archive-uid-14");
+  });
+
+  test("a body that spells a file key never collides with a file-only message", () => {
+    const bodySpoof = mapLiveRoomMessageToTimeline(
+      session,
+      roomMessageFromArchived(
+        {
+          ...baseArchivedRoom,
+          body: "files:https://files.example.com/pic.png",
+          mam_id: crypto.randomUUID(),
+          timestamp: "2026-07-01T10:00:00.000Z",
+        },
+        "live",
+      )!,
+    );
+    const fileOnly = mapLiveRoomMessageToTimeline(
+      session,
+      roomMessageFromArchived({
+        ...baseArchivedRoom,
+        body: undefined,
+        shared_files: [{ url: "https://files.example.com/pic.png", disposition: "inline" }],
+        mam_id: "archive-uid-15",
+        stanza_id: "archive-uid-15",
+        stanza_id_by: "room@conf.example.com",
+        timestamp: "2026-07-01T10:00:01.000Z",
+      })!,
+    );
+    const result = insertLiveMessage([bodySpoof], fileOnly, new Set());
+    expect(result.appended).toBe(true);
+    expect(result.messages).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Fixes #1182.

## Problem

The live dispatcher reshapes inbound stanzas with `mam_id = message.id ?? crypto.randomUUID()` before handing them to the archive codecs. For a live stanza carrying **no wire identity at all** (no client `id`, no XEP-0359 stanza-id/origin-id), the codec's primary-id fallback chain bottoms out on that fabricated UUID with zero `wireIds` overlap against the real archive UID the MAM copy carries. When the same message later arrives via MAM (bootstrap, catch-up, reconnect reload), neither `MessageIdIndex` nor `insertLiveMessage` can match the two copies → duplicate timeline row. This was the residual duplicate surface that survives #1106 and #1179.

## What changed

1. **Codecs** (`wasm-message-codecs.ts`): when the live entry point had to key a row on the fabricated UUID (`source === "live" && !message.id && primary === mam_id && wireIds empty`), the row is marked `synthesizedId: true` and the fabricated UUID is not stamped as `archiveId`. The `!message.id` guard matters: a client-id-only stanza also satisfies `primary === mam_id` but has a real identity.
2. **DM stanza-id alias** (`wasm-message-codecs.ts`): the user-server-injected XEP-0359 stanza-id is now folded into `dmWireIds` (mirroring the room path's `stampedByRoom`), so stanza-id-only live DMs dedupe **exactly** against their MAM copy and never enter the content-match pool.
3. **Shared fallback** (`lib/messaging/synthesized-id-merge.ts`, new): content-based merge-target lookup — same author (occupant JID for MUC, bare JID + nick for DM), same content key (body, or attachment URLs for body-less file messages), timestamps within an asymmetric window (the real side may trail the synthesized receipt by 5 minutes but only lead it by a 90-second skew tolerance — the archive copy of an already-received message can only lead by clock skew, so a same-content row stamped later is a distinct message sent while offline) — gated so **exactly one side** carries `synthesizedId`, so two genuinely distinct id-less messages with equal content never collapse. `adoptArchiveIdentity` then rewrites the reconciled row to the archive copy's real identity (real primary id, fabricated UUID demoted to a wire alias, `replyableId`/`stanzaId`/etc. adopted, flag cleared).
4. **MAM merge direction**: `buildChannelTimelineFromMamResults` / `buildDmTimelineFromMamResults` fall back to the content match when the id/alias lookup misses, consuming each synthesized row at most once per batch. Seed mode (`seedExistingOnly`) retains the consumed row's UUID as an alias (pinned by test) so persisted last-seen ids keep resolving.
5. **Live direction**: `insertLiveMessage` gets the same fallback, gated on the incoming row being **synthesized or archive-decoded** — reconnect catch-up (#1190 skips the lifecycle reload) emits archive rows through this path, and it is the only chance to reconcile the id-less original. A genuinely new id-carrying live arrival never content-matches. In `mergedLiveRow` a fabricated primary never displaces a real one.

## Adversarial review rounds

Three persona reviewers (correctness, chaos/edge-case, standards) + three verification rounds, repeated until clean. Real findings fixed in follow-up commits: the client-id-only false-flag gate bug (found independently by all three), the un-gated live-insert fallback direction, the DM stanza-id alias gap, and body-less file-message coverage. Confirmed non-issues: seed-mode alias retention (already guaranteed by `mergeMissingThreadMetadata`, now pinned), `MessageIdIndex` staleness after identity adoption (fabricated UUIDs never occur in wire data).

## Known residual gaps (documented, not regressions)

- A distinct same-content message from the same author can still be mistaken for the id-less original inside the asymmetric window (inherent ambiguity of content matching; bounded by author + window + XOR gates + the 90s lead tolerance). A client clock trailing the server by more than ~90s degrades to a duplicate (the strictly safer failure mode), never a swallowed message.
- An XEP-0198-replayed id-less stanza (both copies synthesized, fresh UUIDs) still duplicates until MAM catch-up reconciles it — pre-existing behavior.
- Live-path reaction/retraction control-row codec returns still stamp the fabricated `mam_id` as `archiveId` — pre-existing, no live-path consumer reads it.

## Scope

Client-local dedupe heuristic only — no wire-shape changes (XEP-0313/XEP-0359 handling unchanged). TDD throughout: 24 dedicated tests in `chat/tests/idless-live-mam-dedupe.test.ts`; full chat suite (3150 tests), `tsc --noEmit`, and `knip` green.
