### PR TITLE
fix(chat): reconnect correctness bundle — bootstrap MAM merge (#675), session-ready choreographer (#754), server single recipient pass (#1106)

### DIFF
--- a/chat/src/channels/mam-paging.ts
+++ b/chat/src/channels/mam-paging.ts
@@ -246,8 +246,13 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
       if (requestId !== messageRequestId) return "aborted";
       // #675: messages.value already holds the queued rows plus any
       // live message merged during the failed await — keep them
-      // instead of resetting to queued-only.
-      actionError.value = messages.value.length > 0 ? "" : normalizeError(e);
+      // instead of resetting to queued-only. The error stays suppressed
+      // only for queued self-sends (pre-existing behavior); a live
+      // arrival doesn't hide that history failed to load.
+      const hasQueuedRows = messages.value.some(
+        (m) => m.deliveryStatus === "queued" || m.deliveryStatus === "sending",
+      );
+      actionError.value = hasQueuedRows ? "" : normalizeError(e);
       isLoadingMessages.value = false;
       return "failed";
     }

--- a/chat/src/channels/mam-paging.ts
+++ b/chat/src/channels/mam-paging.ts
@@ -209,9 +209,19 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
         feedTimeline,
         getMdsDisplayedCandidates(mdsKey),
       );
+      // #675: unreadAtLoad was counted before the load; foreign live
+      // arrivals during the await extend the timeline tail and are
+      // unread too — without counting them the divider lands that many
+      // rows too new. When unreadAtLoad is 0 the mid-load arrival
+      // behaves like a post-load arrival (no divider).
+      const liveUnreadDuringLoad = liveDuringLoad.filter(
+        (m) => isFeedVisible(m) && !m.isSelf,
+      ).length;
+      const unreadForDivider =
+        unreadAtLoad > 0 ? unreadAtLoad + liveUnreadDuringLoad : 0;
       firstUnseenId.value = firstUnseenIdAfterDisplayedState(
         feedTimeline,
-        firstUnseenIdFromUnreadCount(feedTimeline, unreadAtLoad),
+        firstUnseenIdFromUnreadCount(feedTimeline, unreadForDivider),
         displayed,
       );
       if (displayed) setMdsDisplayed(mdsKey, displayed);
@@ -234,9 +244,10 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
       return "loaded";
     } catch (e) {
       if (requestId !== messageRequestId) return "aborted";
-      const queuedOnly = appendQueuedMessages([], roomJid);
-      messages.value = queuedOnly;
-      actionError.value = queuedOnly.length > 0 ? "" : normalizeError(e);
+      // #675: messages.value already holds the queued rows plus any
+      // live message merged during the failed await — keep them
+      // instead of resetting to queued-only.
+      actionError.value = messages.value.length > 0 ? "" : normalizeError(e);
       isLoadingMessages.value = false;
       return "failed";
     }

--- a/chat/src/channels/mam-paging.ts
+++ b/chat/src/channels/mam-paging.ts
@@ -191,11 +191,15 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
       let rebuilt = buildTimelineFromMamResults(mamResults, metadataSeed, {
         seedExistingOnly: metadataSeed.length > 0,
       });
-      const channelIsForum = isForumChannel(currentChannel.value);
       for (const live of liveDuringLoad) {
-        rebuilt = insertLiveMessage(rebuilt, live, pendingEchoClientIds, {
-          finalize: (timeline) => applyForumContext(timeline, channelIsForum),
-        }).messages;
+        rebuilt = insertLiveMessage(rebuilt, live, pendingEchoClientIds).messages;
+      }
+      // One forum-context pass after all re-inserts: nothing observes
+      // the intermediate timelines (messages.value is assigned below),
+      // so recomputing per insert — as the true live-merge path must —
+      // would be pure waste here.
+      if (liveDuringLoad.length > 0) {
+        rebuilt = applyForumContext(rebuilt, isForumChannel(currentChannel.value));
       }
       const timelineWithQueue = appendQueuedMessages(rebuilt, roomJid);
       messages.value = timelineWithQueue;

--- a/chat/src/channels/mam-paging.ts
+++ b/chat/src/channels/mam-paging.ts
@@ -17,7 +17,8 @@ import {
   buildChannelTimelineFromMamResults,
   type TimelineBuildOptions,
 } from "@/channels/message-timeline-state";
-import { isFeedTimelineMessage } from "@/channels/timeline";
+import { applyForumContext, isFeedTimelineMessage } from "@/channels/timeline";
+import { insertLiveMessage } from "@/lib/messaging/timeline-insert";
 import {
   firstUnseenIdAfterDisplayedState,
   firstUnseenIdFromUnreadCount,
@@ -181,12 +182,22 @@ export function useChannelMamPaging(deps: UseChannelMamPagingDeps) {
       });
       oldestArchiveId = cursor.oldestArchiveId;
       hasOlderMessages.value = cursor.hasOlderMessages;
-      const timelineWithQueue = appendQueuedMessages(
-        buildTimelineFromMamResults(mamResults, metadataSeed, {
-          seedExistingOnly: metadataSeed.length > 0,
-        }),
-        roomJid,
-      );
+      // #675: a live message merged into `messages.value` during the
+      // queryMamPage await must survive the rebuild. Re-insert each one
+      // through the same reconciliation as mergeLiveMessage, so a MAM copy
+      // of the same message (XEP-0359 id parity) merges instead of
+      // duplicating.
+      const liveDuringLoad = stripQueuedSelfMessages(messages.value);
+      let rebuilt = buildTimelineFromMamResults(mamResults, metadataSeed, {
+        seedExistingOnly: metadataSeed.length > 0,
+      });
+      const channelIsForum = isForumChannel(currentChannel.value);
+      for (const live of liveDuringLoad) {
+        rebuilt = insertLiveMessage(rebuilt, live, pendingEchoClientIds, {
+          finalize: (timeline) => applyForumContext(timeline, channelIsForum),
+        }).messages;
+      }
+      const timelineWithQueue = appendQueuedMessages(rebuilt, roomJid);
       messages.value = timelineWithQueue;
       if (requestId === messageRequestId) {
         isLoadingMessages.value = false;

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -450,8 +450,8 @@ export function useChannelMessages(
         // queued-only: the catch-up coverage skip would then block the
         // self-heal on the next reconnect. Restore the pre-reload
         // timeline (the load error stays surfaced) — merging in what
-        // the catch's queued-only reset holds, so a message the user
-        // queued DURING the reload doesn't vanish until its echo.
+        // the catch kept (queued rows plus any live arrival during the
+        // reload, #675), so neither vanishes until the next rebuild.
         const queuedDuringReload = messages.value.filter((m) => !findMessageById(metadataSeed, m.id));
         messages.value = [...metadataSeed, ...queuedDuringReload];
         return;

--- a/chat/src/dms/mam-paging.ts
+++ b/chat/src/dms/mam-paging.ts
@@ -10,6 +10,7 @@ import {
   type ScrollDirectionMode,
 } from "@/lib/scroll-direction";
 import { buildDmTimelineFromMamResults } from "@/dms/message-timeline-state";
+import { insertLiveMessage } from "@/lib/messaging/timeline-insert";
 import {
   firstUnseenIdAfterDisplayedState,
   firstUnseenIdFromUnreadCount,
@@ -129,7 +130,16 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
       });
       oldestArchiveId = cursor.oldestArchiveId;
       hasOlderMessages.value = cursor.hasOlderMessages;
-      const timeline = buildTimelineFromMamResults(mamResults);
+      // #675: a live DM merged into `messages.value` during the
+      // queryPersonalMamPage await must survive the rebuild. Re-insert each
+      // one through the same reconciliation as mergeLiveMessage, so a MAM
+      // copy of the same message (XEP-0359 id parity) merges instead of
+      // duplicating.
+      const liveDuringLoad = stripQueuedSelfMessages(messages.value);
+      let timeline = buildTimelineFromMamResults(mamResults);
+      for (const live of liveDuringLoad) {
+        timeline = insertLiveMessage(timeline, live, pendingEchoClientIds).messages;
+      }
       const timelineWithQueue = appendQueuedMessages(timeline, peerJid);
       messages.value = timelineWithQueue;
       if (requestId === messageRequestId) isLoadingMessages.value = false;

--- a/chat/src/dms/mam-paging.ts
+++ b/chat/src/dms/mam-paging.ts
@@ -150,9 +150,16 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
         feedTimeline,
         getMdsDisplayedCandidates(mdsKey),
       );
+      // #675: count foreign live DMs that arrived during the await as
+      // unread too, mirroring the channel-side divider adjustment.
+      const liveUnreadDuringLoad = liveDuringLoad.filter(
+        (m) => isFeedVisible(m) && !m.isSelf,
+      ).length;
+      const unreadForDivider =
+        unreadAtLoad > 0 ? unreadAtLoad + liveUnreadDuringLoad : 0;
       firstUnseenId.value = firstUnseenIdAfterDisplayedState(
         feedTimeline,
-        firstUnseenIdFromUnreadCount(feedTimeline, unreadAtLoad),
+        firstUnseenIdFromUnreadCount(feedTimeline, unreadForDivider),
         displayed,
       );
       if (displayed) setMdsDisplayed(mdsKey, displayed);
@@ -168,10 +175,13 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
     } catch {
       if (requestId !== messageRequestId) return "aborted";
       console.warn("Could not load DM conversation");
-      const queuedOnly = appendQueuedMessages([], peerJid);
-      messages.value = queuedOnly;
+      // #675: messages.value already holds the queued rows plus any
+      // live DM merged during the failed await — keep them instead of
+      // resetting to queued-only.
       loadErrorPeerJid.value = peerJid;
-      loadErrorMessage.value = dmLoadErrorMessage(peerJid, { queuedOnly: queuedOnly.length > 0 });
+      loadErrorMessage.value = dmLoadErrorMessage(peerJid, {
+        queuedOnly: messages.value.length > 0,
+      });
       actionError.value = loadErrorMessage.value;
       isLoadingMessages.value = false;
       return "failed";

--- a/chat/src/dms/mam-paging.ts
+++ b/chat/src/dms/mam-paging.ts
@@ -179,8 +179,13 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
       // live DM merged during the failed await — keep them instead of
       // resetting to queued-only.
       loadErrorPeerJid.value = peerJid;
+      // "Showing queued messages only" is claimed only when queued
+      // self-sends actually exist — a live arrival kept by the #675
+      // preservation is not a queued message.
       loadErrorMessage.value = dmLoadErrorMessage(peerJid, {
-        queuedOnly: messages.value.length > 0,
+        queuedOnly: messages.value.some(
+          (m) => m.deliveryStatus === "queued" || m.deliveryStatus === "sending",
+        ),
       });
       actionError.value = loadErrorMessage.value;
       isLoadingMessages.value = false;

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -340,8 +340,8 @@ export function useDirectMessages(
         // queued-only: the catch-up coverage skip would then block the
         // self-heal on the next reconnect. Restore the pre-reload
         // timeline (the load error stays surfaced) — merging in what
-        // the catch's queued-only reset holds, so a message the user
-        // queued DURING the reload doesn't vanish until its echo.
+        // the catch kept (queued rows plus any live arrival during the
+        // reload, #675), so neither vanishes until the next rebuild.
         const queuedDuringReload = messages.value.filter((m) => !findMessageById(snapshot, m.id));
         messages.value = [...snapshot, ...queuedDuringReload];
         return;

--- a/chat/src/lib/messaging/timeline-insert.ts
+++ b/chat/src/lib/messaging/timeline-insert.ts
@@ -41,7 +41,7 @@ function mergedLiveRow(existing: TimelineMessage, incoming: TimelineMessage): Ti
     { createdAt: existing.createdAt, createdAtSource: existing.createdAtSource },
     { createdAt: incoming.createdAt, createdAtSource: incoming.createdAtSource },
   );
-  const updated: TimelineMessage = {
+  let updated: TimelineMessage = {
     ...existing,
     ...incoming,
     id: mergedIds.id,
@@ -75,6 +75,17 @@ function mergedLiveRow(existing: TimelineMessage, incoming: TimelineMessage): Ti
       delete updated.extensionAnnotations;
       delete updated.extensionBodyFallback;
     }
+  }
+  // XEP-0424: a tombstone is terminal. If either side is retracted (a
+  // MAM-applied tombstone meeting a redelivered pre-retraction original
+  // via SM replay or the #675 bootstrap re-insert, or vice versa), the
+  // merged row stays a tombstone with every content-bearing field
+  // stripped.
+  if (existing.isRetracted || incoming.isRetracted) {
+    updated = retractTimelineMessage(
+      updated,
+      existing.retractionId ?? incoming.retractionId,
+    );
   }
   if (mergedIds.wireIds?.length) updated.wireIds = mergedIds.wireIds;
   else delete updated.wireIds;

--- a/chat/src/lib/messaging/timeline-insert.ts
+++ b/chat/src/lib/messaging/timeline-insert.ts
@@ -51,6 +51,31 @@ function mergedLiveRow(existing: TimelineMessage, incoming: TimelineMessage): Ti
   if (!Object.prototype.hasOwnProperty.call(incoming, "linkPreviews")) {
     delete updated.linkPreviews;
   }
+  // XEP-0308: a redelivered copy of the pre-correction original (SM
+  // replay, or the #675 bootstrap re-insert racing a MAM page that
+  // already applied the correction) must not roll the row's content
+  // back — the applied correction stays authoritative.
+  if (existing.isEdited && !incoming.isEdited) {
+    updated.body = existing.body;
+    updated.isEdited = true;
+    if (existing.markup) updated.markup = existing.markup;
+    else delete updated.markup;
+    if (existing.references) updated.references = existing.references;
+    else delete updated.references;
+    if (Object.prototype.hasOwnProperty.call(existing, "linkPreviews")) {
+      updated.linkPreviews = existing.linkPreviews;
+    } else {
+      delete updated.linkPreviews;
+    }
+    if (existing.extensionAnnotations) {
+      updated.extensionAnnotations = existing.extensionAnnotations;
+      if (existing.extensionBodyFallback) updated.extensionBodyFallback = true;
+      else delete updated.extensionBodyFallback;
+    } else {
+      delete updated.extensionAnnotations;
+      delete updated.extensionBodyFallback;
+    }
+  }
   if (mergedIds.wireIds?.length) updated.wireIds = mergedIds.wireIds;
   else delete updated.wireIds;
   // #1182: the reconciled row is only still identity-less if both sides were.

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2140,7 +2140,10 @@ export class BrowserXmppClient {
   }
   private wireEvents(xmpp: XmppClientInstance & { enableKeepAlive?: (opts: { interval: number; timeout: number }) => void; disableKeepAlive?: () => void }) {
     if (!this.xmpp && !this.destroying) this.xmpp = xmpp;
-    xmpp.set_on_connected?.(() => { if (!this.isCurrentXmpp(xmpp)) return; void this.enableCarbons(xmpp); });
+    // #754: carbons enable lives in the fresh branch of `runSessionReady`
+    // only — enabling from `on_connected` too doubled the IQ on every
+    // fresh connect and re-enabled on XEP-0198 resume, where the server
+    // already preserves carbon state for the resumed session.
     xmpp.set_on_session_lifecycle?.((event: string) => {
       if (!this.isCurrentXmpp(xmpp)) return;
       if (event === "resumed") this.handleSessionReady(xmpp, { type: "resumed" }); else this.handleSessionReady(xmpp, { type: "fresh" });

--- a/chat/src/shell/controllers/use-connection-lifecycle.ts
+++ b/chat/src/shell/controllers/use-connection-lifecycle.ts
@@ -106,23 +106,30 @@ export function useConnectionLifecycle(deps: ConnectionLifecycleDeps) {
   } = deps;
 
   // #754: the single bootstrap choreographer. Every per-session hydrate
-  // lives here and fires exactly once per *fresh* XMPP session — from the
-  // session-lifecycle handler only. A XEP-0198 resume is gap-free (SM
-  // replays the push stream), so resumed events re-fire nothing, and
-  // onConnectionReady no longer duplicates this set (appState turns
-  // "ready" on the HTTP session load, before XMPP even connects — the
-  // fresh lifecycle event of that first connection covers it).
-  function runSessionBootstrap(client: BrowserXmppClient) {
+  // lives here and fires exactly ONCE per session-ready — from the
+  // session-lifecycle handler only. onConnectionReady no longer
+  // duplicates this set (appState turns "ready" on the HTTP session
+  // load, before XMPP even connects — the lifecycle event of that first
+  // connection covers it).
+  //
+  // Resumed sessions re-hydrate too: XEP-0198 resume replays peer-routed
+  // stanzas, but the server fire-and-forgets inbox pushes to LIVE
+  // resources only — a detached session misses them (e.g. cross-device
+  // mark-read while detached), so the local unread map can be stale
+  // after any resume.
+  function runSessionBootstrap(client: BrowserXmppClient, lifecycle: "fresh" | "resumed") {
     void dmConversations.hydrateFromInbox();
     void channelUnread.hydrateFromInbox();
     void socialFeed.refresh();
     void stories.refresh();
     void communityEvents.refresh();
-    // XEP-0492 notification settings ride the same fresh-only cadence:
-    // a resume can't have missed a bookmark publish. Belt-and-braces
-    // .catch so an unhandled rejection can't propagate out of the
-    // lifecycle handler.
-    notifySettings.hydrate(client).catch(() => undefined);
+    // XEP-0492 notification settings hydrate on fresh only: bookmark
+    // publishes ride the PEP queue, which a resume genuinely preserves.
+    // Belt-and-braces .catch so an unhandled rejection can't propagate
+    // out of the lifecycle handler.
+    if (lifecycle === "fresh") {
+      notifySettings.hydrate(client).catch(() => undefined);
+    }
   }
 
   watch(xmppClient, (client) => {
@@ -198,14 +205,10 @@ export function useConnectionLifecycle(deps: ConnectionLifecycleDeps) {
       // client. Round-12 reviewer P1.
       if (!connectionStore.session) return;
       presence.onSessionReady(event, client);
-      // #754: a *fresh* session (resume failed — too much time elapsed,
-      // server restart, network blip past the resume window) means the
-      // push stream was lost and local unread/feed state is stale —
-      // re-hydrate once. A resume replays the missed push stanzas, so
-      // re-hydrating there is N wasted IQ round-trips per reconnect.
-      if (event.type === "fresh") {
-        runSessionBootstrap(client);
-      }
+      // #754: one bootstrap fire per session-ready, fresh or resumed —
+      // the choreographer replaces the old multi-subscriber fan-out
+      // that fired 4-6 copies of each IQ per reconnect.
+      runSessionBootstrap(client, event.type);
     });
   }, { immediate: true });
 

--- a/chat/src/shell/controllers/use-connection-lifecycle.ts
+++ b/chat/src/shell/controllers/use-connection-lifecycle.ts
@@ -105,6 +105,26 @@ export function useConnectionLifecycle(deps: ConnectionLifecycleDeps) {
     resetSetupPrompt,
   } = deps;
 
+  // #754: the single bootstrap choreographer. Every per-session hydrate
+  // lives here and fires exactly once per *fresh* XMPP session — from the
+  // session-lifecycle handler only. A XEP-0198 resume is gap-free (SM
+  // replays the push stream), so resumed events re-fire nothing, and
+  // onConnectionReady no longer duplicates this set (appState turns
+  // "ready" on the HTTP session load, before XMPP even connects — the
+  // fresh lifecycle event of that first connection covers it).
+  function runSessionBootstrap(client: BrowserXmppClient) {
+    void dmConversations.hydrateFromInbox();
+    void channelUnread.hydrateFromInbox();
+    void socialFeed.refresh();
+    void stories.refresh();
+    void communityEvents.refresh();
+    // XEP-0492 notification settings ride the same fresh-only cadence:
+    // a resume can't have missed a bookmark publish. Belt-and-braces
+    // .catch so an unhandled rejection can't propagate out of the
+    // lifecycle handler.
+    notifySettings.hydrate(client).catch(() => undefined);
+  }
+
   watch(xmppClient, (client) => {
     if (!client || !session.value) {
       presence.onClientCleared();
@@ -177,37 +197,14 @@ export function useConnectionLifecycle(deps: ConnectionLifecycleDeps) {
       // otherwise restart hydrate against the about-to-disconnect
       // client. Round-12 reviewer P1.
       if (!connectionStore.session) return;
-      // Re-hydrate inbox on every XMPP session-ready, both resumed and
-      // fresh. Stream resume catches up on stanzas the client missed
-      // while disconnected, but a *fresh* reconnection (resume failed
-      // — too much time elapsed, server restart, network blip past the
-      // resume window) means we lost the push stream entirely and the
-      // local unread map is stale. `onConnectionReady` only hydrates
-      // on the first sign-in (one-shot `hasBootstrapped` guard), so
-      // subsequent fresh reconnections would otherwise never refresh.
-      // `hydrateFromInbox` is request-id deduped, so the redundant
-      // call on the very first connection is harmless.
-      void dmConversations.hydrateFromInbox();
-      void channelUnread.hydrateFromInbox();
-      void socialFeed.refresh();
-      void stories.refresh();
-      void communityEvents.refresh();
       presence.onSessionReady(event, client);
-      // Re-hydrate XEP-0492 notification settings only on *fresh*
-      // reconnects. A stream resume is by definition gap-free —
-      // any bookmark publish from another tab during the disconnect
-      // is impossible because we never disconnected as far as the
-      // server's PEP queue is concerned. Refetching on every resume
-      // burns one IQ round-trip per resume for no payoff (round-12
-      // reviewer P2). Until the chat subscribes to PEP `+notify`
-      // headlines on `urn:xmpp:bookmarks:1` (deferred follow-up),
-      // fresh-only hydrate is the correct cadence.
+      // #754: a *fresh* session (resume failed — too much time elapsed,
+      // server restart, network blip past the resume window) means the
+      // push stream was lost and local unread/feed state is stale —
+      // re-hydrate once. A resume replays the missed push stanzas, so
+      // re-hydrating there is N wasted IQ round-trips per reconnect.
       if (event.type === "fresh") {
-        // Belt-and-braces: hydrate already catches lower-layer
-        // throws, but call-site .catch defends against any future
-        // regression so an unhandled rejection doesn't propagate
-        // out of the lifecycle handler. Round-14 PR review.
-        notifySettings.hydrate(client).catch(() => undefined);
+        runSessionBootstrap(client);
       }
     });
   }, { immediate: true });
@@ -348,24 +345,12 @@ export function useConnectionLifecycle(deps: ConnectionLifecycleDeps) {
       }
     }
 
-    void dmConversations.hydrateFromInbox();
-    void channelUnread.hydrateFromInbox();
+    // #754: inbox/feed/stories/events/notify-settings hydrates are NOT
+    // fired here — the fresh session-lifecycle event of the first XMPP
+    // connection runs them exactly once via runSessionBootstrap (the
+    // client is registered in the store before it lazily connects, so
+    // that event cannot be missed).
     void rosterContacts.loadRosterContacts();
-    void socialFeed.refresh();
-
-    // Hydrate XEP-0492 per-chat notification settings from the user's
-    // XEP-0402 PEP bookmarks. Best-effort — an empty result is the
-    // first-run state and the UI falls back to the §3 conversation
-    // default via [[effectiveNotifyMode]].
-    void (async () => {
-      const client = xmppClient.value;
-      if (!client) return;
-      // Best-effort: hydrate already swallows lower-layer
-      // exceptions, but a defensive .catch keeps the IIFE quiet
-      // even if a future regression bypasses the inner guard.
-      // Round-14 PR review.
-      await notifySettings.hydrate(client).catch(() => undefined);
-    })();
 
     // Register service worker and sync push subscription (best-effort, non-blocking)
     void (async () => {

--- a/chat/tests/bootstrap-mam-race.test.ts
+++ b/chat/tests/bootstrap-mam-race.test.ts
@@ -77,10 +77,12 @@ function liveRoomRow(id: string, body: string, timestamp: string): LiveRoomMessa
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
-  const promise = new Promise<T>((r) => {
-    resolve = r;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 describe("useChannelMamPaging.loadMessages — bootstrap race (#675)", () => {
@@ -209,6 +211,179 @@ describe("useChannelMamPaging.loadMessages — bootstrap race (#675)", () => {
     expect(matches).toHaveLength(1);
     expect(messages.value).toHaveLength(2);
     expect(matches[0]!.body).toBe("live during bootstrap");
+  });
+});
+
+describe("bootstrap failure keeps live arrivals (#675 review)", () => {
+  test("a failed MAM query does not wipe a live message that arrived during the await", async () => {
+    const mamPage = deferred<never>();
+    const xmppClient = {
+      queryMamPage: mock(async () => mamPage.promise),
+      fetchRoomPins: mock(async () => []),
+    } as unknown as BrowserXmppClient;
+
+    const messages = ref<TimelineMessage[]>([]);
+    const pendingEchoClientIds = new Set<string>();
+    const paging = useChannelMamPaging({
+      session: ref(session),
+      xmppClient: ref(xmppClient),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("space_room"),
+      currentChannel: ref(channel),
+      messages,
+      firstUnseenId: ref<string | null>(null),
+      timelineEl: ref(null),
+      scrollDirection: ref("bottom"),
+      pinnedEdgeScroller: { cancelSettleLock: () => {} },
+      actionError: ref(""),
+      clearActionError: () => {},
+      normalizeError: (e) => String(e),
+      pendingEchoClientIds,
+      appendQueuedMessages: (timeline) => timeline,
+      roomJidForChannel: () => "space_room@muc.example.com",
+      scrollToPinnedEdgeAndPin: async () => true,
+      persistLastSeen: () => {},
+    });
+
+    const loadPromise = paging.loadMessages("space", "space_room");
+    await Promise.resolve();
+
+    const live = mapLiveRoomMessageToTimeline(
+      session,
+      liveRoomRow("live-1", "live during bootstrap", "2026-07-01T10:05:00.000Z"),
+    );
+    messages.value = insertLiveMessage(messages.value, live, pendingEchoClientIds).messages;
+
+    mamPage.reject(new Error("mam unavailable"));
+    await expect(loadPromise).resolves.toBe("failed");
+
+    expect(messages.value.some((m) => m.id === "live-1")).toBe(true);
+  });
+});
+
+describe("bootstrap merge keeps the unread divider anchored (#675 review)", () => {
+  test("live arrivals during the load do not shift the divider past unread history", async () => {
+    // unreadAtLoad was counted before the load; a foreign live message
+    // arriving during the await extends the timeline tail and must be
+    // counted as unread too — otherwise the divider lands K rows too
+    // new and genuinely-unread history renders as read.
+    const mamRows = [
+      archivedRoomRow("arch-1", "read earlier", "2026-07-01T09:00:00.000Z"),
+      archivedRoomRow("arch-2", "unread at load", "2026-07-01T09:30:00.000Z"),
+    ];
+    const mamPage = deferred<{ messages: LiveRoomMessage[]; firstArchiveId: string; complete: boolean }>();
+
+    const xmppClient = {
+      queryMamPage: mock(async () => mamPage.promise),
+      fetchRoomPins: mock(async () => []),
+    } as unknown as BrowserXmppClient;
+
+    const messages = ref<TimelineMessage[]>([]);
+    const firstUnseenId = ref<string | null>(null);
+    const pendingEchoClientIds = new Set<string>();
+    const paging = useChannelMamPaging({
+      session: ref(session),
+      xmppClient: ref(xmppClient),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("space_room"),
+      currentChannel: ref(channel),
+      messages,
+      firstUnseenId,
+      timelineEl: ref(null),
+      scrollDirection: ref("bottom"),
+      pinnedEdgeScroller: { cancelSettleLock: () => {} },
+      actionError: ref(""),
+      clearActionError: () => {},
+      normalizeError: (e) => String(e),
+      pendingEchoClientIds,
+      appendQueuedMessages: (timeline) => timeline,
+      roomJidForChannel: () => "space_room@muc.example.com",
+      scrollToPinnedEdgeAndPin: async () => true,
+      persistLastSeen: () => {},
+    });
+
+    const loadPromise = paging.loadMessages("space", "space_room", 1);
+    await Promise.resolve();
+
+    const live = mapLiveRoomMessageToTimeline(
+      session,
+      liveRoomRow("live-1", "live during bootstrap", "2026-07-01T10:05:00.000Z"),
+    );
+    messages.value = insertLiveMessage(messages.value, live, pendingEchoClientIds).messages;
+
+    mamPage.resolve({ messages: mamRows, firstArchiveId: "arch-1", complete: true });
+    await expect(loadPromise).resolves.toBe("loaded");
+
+    // arch-2 was the one unread message at load time; the live arrival
+    // is also unread — the divider anchors at arch-2, not at live-1.
+    expect(firstUnseenId.value).toBe("arch-2");
+  });
+});
+
+describe("bootstrap merge keeps archive-applied corrections (#675 review)", () => {
+  test("re-inserting the live original does not clobber a corrected body (XEP-0308)", async () => {
+    // The MAM page contains the original AND its correction — the built
+    // timeline row carries the corrected body. The live copy of the
+    // (uncorrected) original merged during the await must not overwrite
+    // it.
+    const original = archivedRoomRow("live-1", "original body", "2026-07-01T10:05:00.000Z");
+    const correction = roomMessageFromArchived({
+      ...baseArchivedRoom,
+      mam_id: "mam-corr-1",
+      stanza_id: "corr-1",
+      stanza_id_by: "space_room@muc.example.com",
+      body: "corrected body",
+      replaces_id: "live-1",
+      timestamp: "2026-07-01T10:05:30.000Z",
+    })! as LiveRoomMessage;
+    const mamPage = deferred<{ messages: LiveRoomMessage[]; firstArchiveId: string; complete: boolean }>();
+
+    const xmppClient = {
+      queryMamPage: mock(async () => mamPage.promise),
+      fetchRoomPins: mock(async () => []),
+    } as unknown as BrowserXmppClient;
+
+    const messages = ref<TimelineMessage[]>([]);
+    const pendingEchoClientIds = new Set<string>();
+    const paging = useChannelMamPaging({
+      session: ref(session),
+      xmppClient: ref(xmppClient),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("space_room"),
+      currentChannel: ref(channel),
+      messages,
+      firstUnseenId: ref<string | null>(null),
+      timelineEl: ref(null),
+      scrollDirection: ref("bottom"),
+      pinnedEdgeScroller: { cancelSettleLock: () => {} },
+      actionError: ref(""),
+      clearActionError: () => {},
+      normalizeError: (e) => String(e),
+      pendingEchoClientIds,
+      appendQueuedMessages: (timeline) => timeline,
+      roomJidForChannel: () => "space_room@muc.example.com",
+      scrollToPinnedEdgeAndPin: async () => true,
+      persistLastSeen: () => {},
+    });
+
+    const loadPromise = paging.loadMessages("space", "space_room");
+    await Promise.resolve();
+
+    const live = mapLiveRoomMessageToTimeline(
+      session,
+      liveRoomRow("live-1", "original body", "2026-07-01T10:05:00.000Z"),
+    );
+    messages.value = insertLiveMessage(messages.value, live, pendingEchoClientIds).messages;
+
+    mamPage.resolve({ messages: [original, correction], firstArchiveId: "mam-1", complete: true });
+    await expect(loadPromise).resolves.toBe("loaded");
+
+    const row = messages.value.find(
+      (m) => m.id === "live-1" || (m.wireIds ?? []).includes("live-1"),
+    );
+    expect(row).toBeDefined();
+    expect(row!.body).toBe("corrected body");
+    expect(row!.isEdited).toBe(true);
   });
 });
 

--- a/chat/tests/bootstrap-mam-race.test.ts
+++ b/chat/tests/bootstrap-mam-race.test.ts
@@ -223,6 +223,7 @@ describe("bootstrap failure keeps live arrivals (#675 review)", () => {
     } as unknown as BrowserXmppClient;
 
     const messages = ref<TimelineMessage[]>([]);
+    const actionError = ref("");
     const pendingEchoClientIds = new Set<string>();
     const paging = useChannelMamPaging({
       session: ref(session),
@@ -235,7 +236,7 @@ describe("bootstrap failure keeps live arrivals (#675 review)", () => {
       timelineEl: ref(null),
       scrollDirection: ref("bottom"),
       pinnedEdgeScroller: { cancelSettleLock: () => {} },
-      actionError: ref(""),
+      actionError,
       clearActionError: () => {},
       normalizeError: (e) => String(e),
       pendingEchoClientIds,
@@ -258,6 +259,9 @@ describe("bootstrap failure keeps live arrivals (#675 review)", () => {
     await expect(loadPromise).resolves.toBe("failed");
 
     expect(messages.value.some((m) => m.id === "live-1")).toBe(true);
+    // A kept live arrival must not hide that history failed to load —
+    // only queued self-sends suppress the error (pre-existing behavior).
+    expect(actionError.value).not.toBe("");
   });
 });
 

--- a/chat/tests/bootstrap-mam-race.test.ts
+++ b/chat/tests/bootstrap-mam-race.test.ts
@@ -1,0 +1,362 @@
+// Regression tests for #675: the initial MAM bootstrap in `loadMessages`
+// wholesale-replaced `messages.value` after the `queryMamPage` await, wiping
+// any live message that `mergeLiveMessage` sorted into the timeline during
+// the await window (XEP-0313 live-vs-archive delivery is intentionally
+// asynchronous — the latest MAM page must not be assumed to contain
+// in-flight live deliveries).
+
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import { useChannelMamPaging } from "../src/channels/mam-paging";
+import { useDmMamPaging } from "../src/dms/mam-paging";
+import { dmMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
+import { fromLiveDmMessage } from "../src/dms/message-timeline-state";
+import type { LiveDmMessage } from "../src/lib/xmpp-client";
+import { roomMessageFromArchived } from "@/lib/xmpp/wasm-message-codecs";
+import { mapLiveRoomMessageToTimeline } from "../src/channels/timeline";
+import { insertLiveMessage } from "../src/lib/messaging/timeline-insert";
+import type { BrowserXmppClient, LiveRoomMessage } from "../src/lib/xmpp-client";
+import type { ChannelSummary } from "../src/lib/chat-types";
+import type { WaddleSession } from "../src/lib/server-auth";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+import type { WasmArchivedMessage } from "../src/lib/xmpp/wasm-types";
+
+const session: WaddleSession = {
+  session_id: "tok",
+  user_id: "alice-id",
+  username: "alice",
+  avatar_url: null,
+  xmpp_localpart: "alice",
+  jid: "alice@example.com/desktop",
+  xmpp_websocket_url: "wss://example.com/ws",
+  is_expired: false,
+  expires_at: null,
+};
+
+const channel: ChannelSummary = { id: "space_room", name: "Room" };
+
+const baseArchivedRoom: WasmArchivedMessage = {
+  mam_id: "",
+  message_type: "groupchat",
+  from: "space_room@muc.example.com/bob",
+  to: "alice@example.com",
+  body: "hello",
+  reaction_emojis: [],
+  is_muc: true,
+  markup_spans: [],
+  mention_uris: [],
+  references: [],
+  is_sticker: false,
+  shared_files: [],
+};
+
+function archivedRoomRow(id: string, body: string, timestamp: string): LiveRoomMessage {
+  return roomMessageFromArchived({
+    ...baseArchivedRoom,
+    mam_id: id,
+    stanza_id: id,
+    stanza_id_by: "space_room@muc.example.com",
+    body,
+    timestamp,
+  })! as LiveRoomMessage;
+}
+
+function liveRoomRow(id: string, body: string, timestamp: string): LiveRoomMessage {
+  return roomMessageFromArchived(
+    {
+      ...baseArchivedRoom,
+      mam_id: "",
+      stanza_id: id,
+      stanza_id_by: "space_room@muc.example.com",
+      body,
+      timestamp,
+    },
+    "live",
+  )! as LiveRoomMessage;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("useChannelMamPaging.loadMessages — bootstrap race (#675)", () => {
+  test("preserves a live message that arrives during the queryMamPage await", async () => {
+    const mamRows = [
+      archivedRoomRow("arch-1", "older", "2026-07-01T09:00:00.000Z"),
+      archivedRoomRow("arch-2", "newer", "2026-07-01T09:30:00.000Z"),
+    ];
+    const mamPage = deferred<{ messages: LiveRoomMessage[]; firstArchiveId: string; complete: boolean }>();
+
+    const queryMamPage = mock(async () => mamPage.promise);
+    const xmppClient = {
+      queryMamPage,
+      fetchRoomPins: mock(async () => []),
+    } as unknown as BrowserXmppClient;
+
+    const messages = ref<TimelineMessage[]>([]);
+    const pendingEchoClientIds = new Set<string>();
+    const paging = useChannelMamPaging({
+      session: ref(session),
+      xmppClient: ref(xmppClient),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("space_room"),
+      currentChannel: ref(channel),
+      messages,
+      firstUnseenId: ref<string | null>(null),
+      timelineEl: ref(null),
+      scrollDirection: ref("bottom"),
+      pinnedEdgeScroller: { cancelSettleLock: () => {} },
+      actionError: ref(""),
+      clearActionError: () => {},
+      normalizeError: (e) => String(e),
+      pendingEchoClientIds,
+      appendQueuedMessages: (timeline) => timeline,
+      roomJidForChannel: () => "space_room@muc.example.com",
+      scrollToPinnedEdgeAndPin: async () => true,
+      persistLastSeen: () => {},
+    });
+
+    const loadPromise = paging.loadMessages("space", "space_room");
+    // Let loadMessages reach the queryMamPage await.
+    await Promise.resolve();
+
+    // A live message lands mid-bootstrap, exactly as mergeLiveMessage would
+    // sort it into messages.value.
+    const live = mapLiveRoomMessageToTimeline(
+      session,
+      liveRoomRow("live-1", "live during bootstrap", "2026-07-01T10:05:00.000Z"),
+    );
+    messages.value = insertLiveMessage(messages.value, live, pendingEchoClientIds).messages;
+    expect(messages.value.some((m) => m.id === "live-1")).toBe(true);
+
+    // The MAM page (which does not contain the live message) lands after.
+    mamPage.resolve({ messages: mamRows, firstArchiveId: "arch-1", complete: true });
+    await expect(loadPromise).resolves.toBe("loaded");
+
+    const ids = messages.value.map((m) => m.id);
+    // The live arrival must survive the bootstrap merge...
+    expect(ids).toContain("live-1");
+    // ...in chronological position (it is the newest message)...
+    expect(ids[ids.length - 1]).toBe("live-1");
+    // ...alongside the full MAM page.
+    expect(ids).toContain("arch-1");
+    expect(ids).toContain("arch-2");
+  });
+
+  test("does not duplicate a live message whose MAM copy is in the page (XEP-0359 id parity)", async () => {
+    // The archived copy carries the same room-stamped stanza-id the live
+    // delivery carried, plus its MAM archive id.
+    const archivedCopy = roomMessageFromArchived({
+      ...baseArchivedRoom,
+      mam_id: "mam-uid-9",
+      stanza_id: "live-1",
+      stanza_id_by: "space_room@muc.example.com",
+      body: "live during bootstrap",
+      timestamp: "2026-07-01T10:05:00.000Z",
+    })! as LiveRoomMessage;
+    const mamRows = [archivedRoomRow("arch-1", "older", "2026-07-01T09:00:00.000Z"), archivedCopy];
+    const mamPage = deferred<{ messages: LiveRoomMessage[]; firstArchiveId: string; complete: boolean }>();
+
+    const xmppClient = {
+      queryMamPage: mock(async () => mamPage.promise),
+      fetchRoomPins: mock(async () => []),
+    } as unknown as BrowserXmppClient;
+
+    const messages = ref<TimelineMessage[]>([]);
+    const pendingEchoClientIds = new Set<string>();
+    const paging = useChannelMamPaging({
+      session: ref(session),
+      xmppClient: ref(xmppClient),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("space_room"),
+      currentChannel: ref(channel),
+      messages,
+      firstUnseenId: ref<string | null>(null),
+      timelineEl: ref(null),
+      scrollDirection: ref("bottom"),
+      pinnedEdgeScroller: { cancelSettleLock: () => {} },
+      actionError: ref(""),
+      clearActionError: () => {},
+      normalizeError: (e) => String(e),
+      pendingEchoClientIds,
+      appendQueuedMessages: (timeline) => timeline,
+      roomJidForChannel: () => "space_room@muc.example.com",
+      scrollToPinnedEdgeAndPin: async () => true,
+      persistLastSeen: () => {},
+    });
+
+    const loadPromise = paging.loadMessages("space", "space_room");
+    await Promise.resolve();
+
+    const live = mapLiveRoomMessageToTimeline(
+      session,
+      liveRoomRow("live-1", "live during bootstrap", "2026-07-01T10:05:00.000Z"),
+    );
+    messages.value = insertLiveMessage(messages.value, live, pendingEchoClientIds).messages;
+
+    mamPage.resolve({ messages: mamRows, firstArchiveId: "arch-1", complete: true });
+    await expect(loadPromise).resolves.toBe("loaded");
+
+    // Exactly one row for that message, reachable via the live stanza-id,
+    // and the full timeline is exactly two rows.
+    const matches = messages.value.filter(
+      (m) => m.id === "live-1" || (m.wireIds ?? []).includes("live-1"),
+    );
+    expect(matches).toHaveLength(1);
+    expect(messages.value).toHaveLength(2);
+    expect(matches[0]!.body).toBe("live during bootstrap");
+  });
+});
+
+const peerJid = "bob@example.com";
+
+const baseArchivedDm: WasmArchivedMessage = {
+  mam_id: "",
+  message_type: "chat",
+  from: peerJid,
+  to: "alice@example.com",
+  body: "hello",
+  reaction_emojis: [],
+  is_muc: false,
+  markup_spans: [],
+  mention_uris: [],
+  references: [],
+  is_sticker: false,
+  shared_files: [],
+};
+
+function archivedDmRow(id: string, body: string, timestamp: string): LiveDmMessage {
+  return dmMessageFromArchived(
+    { ...baseArchivedDm, mam_id: id, stanza_id: id, stanza_id_by: "alice@example.com", body, timestamp },
+    "alice@example.com",
+  )! as LiveDmMessage;
+}
+
+function liveDmRow(id: string, body: string, timestamp: string): LiveDmMessage {
+  return dmMessageFromArchived(
+    { ...baseArchivedDm, mam_id: "", origin_id: id, body, timestamp },
+    "alice@example.com",
+    "live",
+  )! as LiveDmMessage;
+}
+
+describe("useDmMamPaging.loadMessages — bootstrap race (#675)", () => {
+  test("preserves a live DM that arrives during the queryPersonalMamPage await", async () => {
+    const mamRows = [
+      archivedDmRow("dm-arch-1", "older", "2026-07-01T09:00:00.000Z"),
+      archivedDmRow("dm-arch-2", "newer", "2026-07-01T09:30:00.000Z"),
+    ];
+    const mamPage = deferred<{ messages: LiveDmMessage[]; firstArchiveId: string; complete: boolean }>();
+
+    const xmppClient = {
+      queryPersonalMamPage: mock(async () => mamPage.promise),
+    } as unknown as BrowserXmppClient;
+
+    const messages = ref<TimelineMessage[]>([]);
+    const pendingEchoClientIds = new Set<string>();
+    const paging = useDmMamPaging({
+      session: ref(session),
+      xmppClient: ref(xmppClient),
+      activePeerJid: ref(peerJid),
+      messages,
+      firstUnseenId: ref<string | null>(null),
+      loadErrorPeerJid: ref<string | null>(null),
+      loadErrorMessage: ref(""),
+      timelineEl: ref(null),
+      scrollDirection: ref("bottom"),
+      pinnedEdgeScroller: { cancelSettleLock: () => {} },
+      actionError: ref(""),
+      clearActionError: () => {},
+      pendingEchoClientIds,
+      appendQueuedMessages: (timeline) => timeline,
+      scrollToPinnedEdgeAndPin: async () => true,
+      isFeedVisible: (m) => !m.threadId || m.id === m.threadId,
+      persistLastSeen: () => {},
+      dmLoadErrorMessage: () => "load error",
+    });
+
+    const loadPromise = paging.loadMessages(peerJid);
+    await Promise.resolve();
+
+    const live = fromLiveDmMessage(
+      session,
+      liveDmRow("dm-live-1", "live during bootstrap", "2026-07-01T10:05:00.000Z"),
+    );
+    messages.value = insertLiveMessage(messages.value, live, pendingEchoClientIds).messages;
+    expect(messages.value.some((m) => m.id === "dm-live-1")).toBe(true);
+
+    mamPage.resolve({ messages: mamRows, firstArchiveId: "dm-arch-1", complete: true });
+    await expect(loadPromise).resolves.toBe("loaded");
+
+    const ids = messages.value.map((m) => m.id);
+    expect(ids).toContain("dm-live-1");
+    expect(ids[ids.length - 1]).toBe("dm-live-1");
+    expect(ids).toContain("dm-arch-1");
+    expect(ids).toContain("dm-arch-2");
+  });
+
+  test("does not duplicate a live DM whose MAM copy is in the page (XEP-0359 id parity)", async () => {
+    const archivedCopy = dmMessageFromArchived(
+      {
+        ...baseArchivedDm,
+        mam_id: "dm-mam-uid-9",
+        origin_id: "dm-live-1",
+        body: "live during bootstrap",
+        timestamp: "2026-07-01T10:05:00.000Z",
+      },
+      "alice@example.com",
+    )! as LiveDmMessage;
+    const mamRows = [archivedDmRow("dm-arch-1", "older", "2026-07-01T09:00:00.000Z"), archivedCopy];
+    const mamPage = deferred<{ messages: LiveDmMessage[]; firstArchiveId: string; complete: boolean }>();
+
+    const xmppClient = {
+      queryPersonalMamPage: mock(async () => mamPage.promise),
+    } as unknown as BrowserXmppClient;
+
+    const messages = ref<TimelineMessage[]>([]);
+    const pendingEchoClientIds = new Set<string>();
+    const paging = useDmMamPaging({
+      session: ref(session),
+      xmppClient: ref(xmppClient),
+      activePeerJid: ref(peerJid),
+      messages,
+      firstUnseenId: ref<string | null>(null),
+      loadErrorPeerJid: ref<string | null>(null),
+      loadErrorMessage: ref(""),
+      timelineEl: ref(null),
+      scrollDirection: ref("bottom"),
+      pinnedEdgeScroller: { cancelSettleLock: () => {} },
+      actionError: ref(""),
+      clearActionError: () => {},
+      pendingEchoClientIds,
+      appendQueuedMessages: (timeline) => timeline,
+      scrollToPinnedEdgeAndPin: async () => true,
+      isFeedVisible: (m) => !m.threadId || m.id === m.threadId,
+      persistLastSeen: () => {},
+      dmLoadErrorMessage: () => "load error",
+    });
+
+    const loadPromise = paging.loadMessages(peerJid);
+    await Promise.resolve();
+
+    const live = fromLiveDmMessage(
+      session,
+      liveDmRow("dm-live-1", "live during bootstrap", "2026-07-01T10:05:00.000Z"),
+    );
+    messages.value = insertLiveMessage(messages.value, live, pendingEchoClientIds).messages;
+
+    mamPage.resolve({ messages: mamRows, firstArchiveId: "dm-arch-1", complete: true });
+    await expect(loadPromise).resolves.toBe("loaded");
+
+    const matches = messages.value.filter(
+      (m) => m.id === "dm-live-1" || (m.wireIds ?? []).includes("dm-live-1"),
+    );
+    expect(matches).toHaveLength(1);
+    expect(messages.value).toHaveLength(2);
+    expect(matches[0]!.body).toBe("live during bootstrap");
+  });
+});

--- a/chat/tests/bootstrap-mam-race.test.ts
+++ b/chat/tests/bootstrap-mam-race.test.ts
@@ -324,6 +324,73 @@ describe("bootstrap merge keeps the unread divider anchored (#675 review)", () =
   });
 });
 
+describe("bootstrap merge keeps archive-applied retractions (#675 review)", () => {
+  test("re-inserting the live original does not resurrect a tombstoned message (XEP-0424)", async () => {
+    // The MAM page contains the original AND its retraction — the built
+    // timeline row is a tombstone. The live copy of the (pre-retraction)
+    // original merged during the await must not reintroduce its content
+    // or clear the tombstone.
+    const original = archivedRoomRow("live-1", "soon retracted", "2026-07-01T10:05:00.000Z");
+    const retraction = roomMessageFromArchived({
+      ...baseArchivedRoom,
+      mam_id: "mam-retract-1",
+      stanza_id: "retract-1",
+      stanza_id_by: "space_room@muc.example.com",
+      body: "",
+      retracts_id: "live-1",
+      timestamp: "2026-07-01T10:05:30.000Z",
+    })! as LiveRoomMessage;
+    const mamPage = deferred<{ messages: LiveRoomMessage[]; firstArchiveId: string; complete: boolean }>();
+
+    const xmppClient = {
+      queryMamPage: mock(async () => mamPage.promise),
+      fetchRoomPins: mock(async () => []),
+    } as unknown as BrowserXmppClient;
+
+    const messages = ref<TimelineMessage[]>([]);
+    const pendingEchoClientIds = new Set<string>();
+    const paging = useChannelMamPaging({
+      session: ref(session),
+      xmppClient: ref(xmppClient),
+      activeSpaceId: ref("space"),
+      activeChannelId: ref("space_room"),
+      currentChannel: ref(channel),
+      messages,
+      firstUnseenId: ref<string | null>(null),
+      timelineEl: ref(null),
+      scrollDirection: ref("bottom"),
+      pinnedEdgeScroller: { cancelSettleLock: () => {} },
+      actionError: ref(""),
+      clearActionError: () => {},
+      normalizeError: (e) => String(e),
+      pendingEchoClientIds,
+      appendQueuedMessages: (timeline) => timeline,
+      roomJidForChannel: () => "space_room@muc.example.com",
+      scrollToPinnedEdgeAndPin: async () => true,
+      persistLastSeen: () => {},
+    });
+
+    const loadPromise = paging.loadMessages("space", "space_room");
+    await Promise.resolve();
+
+    const live = mapLiveRoomMessageToTimeline(
+      session,
+      liveRoomRow("live-1", "soon retracted", "2026-07-01T10:05:00.000Z"),
+    );
+    messages.value = insertLiveMessage(messages.value, live, pendingEchoClientIds).messages;
+
+    mamPage.resolve({ messages: [original, retraction], firstArchiveId: "mam-1", complete: true });
+    await expect(loadPromise).resolves.toBe("loaded");
+
+    const row = messages.value.find(
+      (m) => m.id === "live-1" || (m.wireIds ?? []).includes("live-1"),
+    );
+    expect(row).toBeDefined();
+    expect(row!.isRetracted).toBe(true);
+    expect(row!.body).toBe("");
+  });
+});
+
 describe("bootstrap merge keeps archive-applied corrections (#675 review)", () => {
   test("re-inserting the live original does not clobber a corrected body (XEP-0308)", async () => {
     // The MAM page contains the original AND its correction — the built

--- a/chat/tests/carbons-enable-once.test.ts
+++ b/chat/tests/carbons-enable-once.test.ts
@@ -1,0 +1,79 @@
+/**
+ * #754 — duplicate XEP-0280 carbons enable.
+ *
+ * `enableCarbons` used to fire from two places on every connect: the WASM
+ * `on_connected` hook AND the fresh branch of `runSessionReady`. One fresh
+ * connect therefore put two `<enable xmlns='urn:xmpp:carbons:2'/>` IQs on
+ * the wire, and a XEP-0198 resume (which preserves carbon state
+ * server-side) re-enabled for no reason. Contract: exactly one enable per
+ * fresh session, zero on resume.
+ *
+ * These tests poke private state on `BrowserXmppClient` directly — see
+ * the comment block in `resume-ordering.test.ts` for the rationale.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { BrowserXmppClient } from "../src/lib/xmpp-client";
+
+function session(): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com/desktop",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/ws",
+  } as WaddleSession;
+}
+
+type PrivateState = {
+  wireEvents: (xmpp: unknown) => void;
+};
+
+function makeWiredClient() {
+  const client = new BrowserXmppClient(session());
+  const state = client as unknown as PrivateState;
+  const callbacks: {
+    onConnected?: () => void;
+    onSessionLifecycle?: (event: string) => void;
+  } = {};
+  const enableCarbons = mock(async () => {});
+  const xmpp = {
+    enableCarbons,
+    set_on_connected: (cb: () => void) => {
+      callbacks.onConnected = cb;
+    },
+    set_on_session_lifecycle: (cb: (event: string) => void) => {
+      callbacks.onSessionLifecycle = cb;
+    },
+  };
+  state.wireEvents(xmpp);
+  return { client, callbacks, enableCarbons };
+}
+
+async function flushAsync(times = 4): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}
+
+describe("XEP-0280 carbons enable cadence (#754)", () => {
+  test("a fresh connect enables carbons exactly once", async () => {
+    const { callbacks, enableCarbons } = makeWiredClient();
+
+    // Real connect order: transport up first, then session-ready.
+    callbacks.onConnected?.();
+    callbacks.onSessionLifecycle?.("connected");
+    await flushAsync();
+
+    expect(enableCarbons.mock.calls.length).toBe(1);
+  });
+
+  test("a XEP-0198 resume does not re-enable carbons", async () => {
+    const { callbacks, enableCarbons } = makeWiredClient();
+
+    callbacks.onConnected?.();
+    callbacks.onSessionLifecycle?.("resumed");
+    await flushAsync();
+
+    expect(enableCarbons.mock.calls.length).toBe(0);
+  });
+});

--- a/chat/tests/session-bootstrap-choreography.test.ts
+++ b/chat/tests/session-bootstrap-choreography.test.ts
@@ -1,0 +1,300 @@
+// Regression tests for #754: every session-ready used to re-fire the whole
+// bootstrap fan-out (inbox hydrates, social feed / stories / events
+// refreshes, notification-settings hydrate) from multiple subscribers —
+// the session-lifecycle handler on BOTH fresh and resumed events, plus a
+// duplicate tail in onConnectionReady. The contract under test: each
+// bootstrap action fires exactly once per fresh session, and never on a
+// XEP-0198 resume (a resume is gap-free — SM replays the push stream).
+
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
+import { computed, effectScope, nextTick, ref, shallowReactive } from "vue";
+import { useChatShellState } from "../src/shell/state";
+import { useConnectionLifecycle } from "../src/shell/controllers/use-connection-lifecycle";
+import { handlerStubs } from "./helpers/xmpp-client-mock";
+import type { BrowserXmppClient, SessionLifecycleEvent } from "../src/lib/xmpp-client";
+import type { WaddleSession } from "../src/lib/server-auth";
+
+const session: WaddleSession = {
+  session_id: "tok",
+  user_id: "alice-id",
+  username: "alice",
+  avatar_url: null,
+  xmpp_localpart: "alice",
+  jid: "alice@example.com/desktop",
+  xmpp_websocket_url: "wss://example.com/ws",
+  is_expired: false,
+  expires_at: null,
+};
+
+const freshEvent = {
+  type: "fresh",
+  catchup: { roomJids: [], dmJids: [] },
+} as unknown as SessionLifecycleEvent;
+
+function flushAsync(times = 4): Promise<void> {
+  let p = Promise.resolve();
+  for (let i = 0; i < times; i += 1) p = p.then(() => new Promise((r) => setTimeout(r, 0)));
+  return p;
+}
+
+// onConnectionReady reads window.location through matchLocation; shim it
+// for this file only and restore afterwards so other test files see the
+// environment they expect.
+const hadWindow = "window" in globalThis;
+const originalWindow = (globalThis as Record<string, unknown>).window;
+
+beforeAll(() => {
+  (globalThis as Record<string, unknown>).window = {
+    location: { pathname: "/", search: "", hash: "" },
+  };
+});
+
+afterAll(() => {
+  if (hadWindow) (globalThis as Record<string, unknown>).window = originalWindow;
+  else delete (globalThis as Record<string, unknown>).window;
+});
+
+function makeHarness() {
+  let lifecycleHandler: ((event: SessionLifecycleEvent) => void) | null = null;
+  const client = {
+    ...handlerStubs(),
+    setDirectMessageHandler: () => {},
+    setDmChatStateHandler: () => {},
+    setDmDisplayedHandler: () => {},
+    setDmReactionHandler: () => {},
+    setMdsDisplayedHandler: () => {},
+    setPresenceUpdateHandler: () => {},
+    addPubsubEventHandler: () => {},
+    setMemberJidHandler: () => {},
+    setMessageAckHandler: () => {},
+    setMessageDeliveryFailureHandler: () => {},
+    setQueuedMessageStatusHandler: () => {},
+    setInboxPushHandler: () => {},
+    setCatchupFailureHandler: () => {},
+    setSessionLifecycleHandler: (h: (event: SessionLifecycleEvent) => void) => {
+      lifecycleHandler = h;
+    },
+  } as unknown as BrowserXmppClient;
+
+  const connectionStore = shallowReactive({
+    client,
+    appState: "loading",
+    session,
+    appError: "",
+    activeServerUrl: "",
+    providers: [],
+    login: async () => {},
+    logout: async () => {},
+    fetchProviders: async () => {},
+    bootstrap: async () => {},
+  });
+
+  const hydrateDmInbox = mock(async () => {});
+  const hydrateChannelInbox = mock(async () => {});
+  const refreshSocialFeed = mock(async () => {});
+  const refreshStories = mock(async () => {});
+  const refreshCommunityEvents = mock(async () => {});
+  const hydrateNotifySettings = mock(async () => {});
+  const loadRosterContacts = mock(async () => {});
+  const presenceOnSessionReady = mock(() => {});
+
+  const ui = useChatShellState();
+  const deps = {
+    ui,
+    connectionStore: connectionStore as never,
+    xmppClient: computed(() => client),
+    session: computed(() => session),
+    waddles: {
+      waddles: ref([]),
+      channels: ref([]),
+      groupDms: ref([]),
+      activeChannelId: ref<string | null>(null),
+      isLoadingStructure: ref(false),
+      loadStructure: mock(async () => {}),
+      clearData: mock(() => {}),
+    },
+    messaging: {
+      onSessionLifecycle: mock(() => {}),
+      onCatchupFailed: mock(() => {}),
+      onMessageAck: mock(() => {}),
+      onMessageDeliveryFailure: mock(() => {}),
+      onMessageQueueStatus: mock(() => {}),
+      applyMdsDisplayed: mock(() => true),
+      xmppStatus: ref({ state: "offline" }),
+      disconnect: mock(() => {}),
+      clearMessages: mock(() => {}),
+    },
+    dmMessaging: {
+      onIncomingMessage: mock(() => {}),
+      onChatState: mock(() => {}),
+      onDisplayed: mock(() => {}),
+      onReaction: mock(() => {}),
+      onSessionLifecycle: mock(() => {}),
+      onCatchupFailed: mock(() => {}),
+      onMessageAck: mock(() => {}),
+      onMessageDeliveryFailure: mock(() => {}),
+      onMessageQueueStatus: mock(() => {}),
+      applyMdsDisplayed: mock(() => true),
+      disconnect: mock(() => {}),
+      clearMessages: mock(() => {}),
+    },
+    dmConversations: {
+      hydrateFromInbox: hydrateDmInbox,
+      receiveIncomingDm: mock(() => {}),
+      onInboxPush: mock(() => {}),
+    },
+    channelUnread: {
+      hydrateFromInbox: hydrateChannelInbox,
+      onInboxPush: mock(() => {}),
+      clearAll: mock(() => {}),
+    },
+    rosterContacts: {
+      loadRosterContacts,
+      clearRosterContacts: mock(() => {}),
+    },
+    socialFeed: { refresh: refreshSocialFeed },
+    stories: { refresh: refreshStories },
+    communityEvents: { refresh: refreshCommunityEvents },
+    notifications: { registerServiceWorker: mock(async () => {}) },
+    notifySettings: {
+      hydrate: hydrateNotifySettings,
+      reset: mock(() => {}),
+    },
+    appUpdate: { start: mock(async () => {}), stop: mock(() => {}) },
+    isApplyingRoute: ref(false),
+    memberJidByNick: ref({}),
+    extensionRoutes: ref([]),
+    activeExtensionRouteKey: ref(null),
+    activeRightPanel: ref(null),
+    selectedChannelRoomJids: ref({}),
+    isActiveDirectDmSurface: () => false,
+    presence: {
+      onClientCleared: mock(() => {}),
+      handlePresenceUpdate: mock(() => {}),
+      handleActivityPubsubEvent: mock(() => {}),
+      handleStatusPreferencePubsubEvent: mock(() => {}),
+      onSessionReady: presenceOnSessionReady,
+      flushAndResetForLogout: mock(async () => {}),
+    },
+    notificationOrchestration: {
+      notifyDmActivity: mock(() => {}),
+      setupPushSubscription: mock(async () => {}),
+    },
+    routeSync: {
+      beginRouteRequest: mock(() => 1),
+      isCurrentRouteRequest: mock(() => true),
+      applyRouteTarget: mock(async () => {}),
+      updateUrl: mock(() => {}),
+    },
+    refreshExtensionRoutes: mock(async () => {}),
+    clearPendingChannelRoomJidSelection: mock(() => {}),
+    showFirstRunSetupIfNeeded: mock(() => {}),
+    resetSetupPrompt: mock(() => {}),
+  };
+
+  const scope = effectScope();
+  scope.run(() => {
+    useConnectionLifecycle(deps as never);
+  });
+
+  return {
+    scope,
+    connectionStore,
+    dispatchLifecycle: (event: SessionLifecycleEvent) => {
+      if (!lifecycleHandler) throw new Error("session lifecycle handler was not registered");
+      lifecycleHandler(event);
+    },
+    counts: () => ({
+      dmInbox: hydrateDmInbox.mock.calls.length,
+      channelInbox: hydrateChannelInbox.mock.calls.length,
+      socialFeed: refreshSocialFeed.mock.calls.length,
+      stories: refreshStories.mock.calls.length,
+      communityEvents: refreshCommunityEvents.mock.calls.length,
+      notifySettings: hydrateNotifySettings.mock.calls.length,
+    }),
+    presenceOnSessionReady,
+  };
+}
+
+describe("session bootstrap choreography (#754)", () => {
+  test("a resumed session-ready fires no bootstrap hydrates (XEP-0198 resume is gap-free)", async () => {
+    const h = makeHarness();
+    await nextTick();
+
+    h.dispatchLifecycle({ type: "resumed" } as SessionLifecycleEvent);
+    await flushAsync();
+
+    expect(h.counts()).toEqual({
+      dmInbox: 0,
+      channelInbox: 0,
+      socialFeed: 0,
+      stories: 0,
+      communityEvents: 0,
+      notifySettings: 0,
+    });
+    // Presence re-assertion is per-session-ready and must keep firing.
+    expect(h.presenceOnSessionReady.mock.calls.length).toBe(1);
+    h.scope.stop();
+  });
+
+  test("a fresh session-ready fires each bootstrap action exactly once", async () => {
+    const h = makeHarness();
+    await nextTick();
+
+    h.dispatchLifecycle(freshEvent);
+    await flushAsync();
+
+    expect(h.counts()).toEqual({
+      dmInbox: 1,
+      channelInbox: 1,
+      socialFeed: 1,
+      stories: 1,
+      communityEvents: 1,
+      notifySettings: 1,
+    });
+    h.scope.stop();
+  });
+
+  test("first connect (app-ready then fresh session event) fires each bootstrap action exactly once", async () => {
+    const h = makeHarness();
+    await nextTick();
+
+    // App shell becomes ready first (HTTP session load), then the XMPP
+    // connection comes up and emits the fresh lifecycle event.
+    h.connectionStore.appState = "ready";
+    await nextTick();
+    await flushAsync();
+    h.dispatchLifecycle(freshEvent);
+    await flushAsync();
+
+    expect(h.counts()).toEqual({
+      dmInbox: 1,
+      channelInbox: 1,
+      socialFeed: 1,
+      stories: 1,
+      communityEvents: 1,
+      notifySettings: 1,
+    });
+    h.scope.stop();
+  });
+
+  test("two fresh reconnects re-hydrate once each (per-session, not per-subscriber)", async () => {
+    const h = makeHarness();
+    await nextTick();
+
+    h.dispatchLifecycle(freshEvent);
+    await flushAsync();
+    h.dispatchLifecycle(freshEvent);
+    await flushAsync();
+
+    expect(h.counts()).toEqual({
+      dmInbox: 2,
+      channelInbox: 2,
+      socialFeed: 2,
+      stories: 2,
+      communityEvents: 2,
+      notifySettings: 2,
+    });
+    h.scope.stop();
+  });
+});

--- a/chat/tests/session-bootstrap-choreography.test.ts
+++ b/chat/tests/session-bootstrap-choreography.test.ts
@@ -217,7 +217,14 @@ function makeHarness() {
 }
 
 describe("session bootstrap choreography (#754)", () => {
-  test("a resumed session-ready fires no bootstrap hydrates (XEP-0198 resume is gap-free)", async () => {
+  test("a resumed session-ready re-hydrates each surface exactly once (inbox pushes are not SM-replayed)", async () => {
+    // XEP-0198 resume replays peer-routed stanzas, but the server
+    // fire-and-forgets inbox pushes to live resources only — a detached
+    // session misses them (e.g. cross-device mark-read while detached),
+    // so a resume must still re-hydrate. The #754 fix is ONE fire per
+    // session-ready, not zero on resume. XEP-0492 notification settings
+    // stay fresh-only: bookmark publishes ride the PEP queue, which a
+    // resume genuinely preserves.
     const h = makeHarness();
     await nextTick();
 
@@ -225,11 +232,11 @@ describe("session bootstrap choreography (#754)", () => {
     await flushAsync();
 
     expect(h.counts()).toEqual({
-      dmInbox: 0,
-      channelInbox: 0,
-      socialFeed: 0,
-      stories: 0,
-      communityEvents: 0,
+      dmInbox: 1,
+      channelInbox: 1,
+      socialFeed: 1,
+      stories: 1,
+      communityEvents: 1,
       notifySettings: 0,
     });
     // Presence re-assertion is per-session-ready and must keep firing.

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -186,7 +186,10 @@ use room_dispatch::dispatch_to_room;
 use room_pin::apply_pin_change_event;
 use room_subject::persist_room_subject_event;
 use route_to_connection::route_to_connection;
-use routing::{deliver_peer_to_full, run_headless_recipient_pass};
+use routing::{
+    deliver_peer_to_full, deliver_to_detached, run_fanout_recipient_pass,
+    run_headless_recipient_pass, FanoutPassResult,
+};
 
 pub use deps::{Deps, InterpretOutcome, TimerCommand};
 pub(crate) use groupchat_archive::push_inbox_update;

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -415,6 +415,7 @@ async fn interpret_with_depth(
                     feedback: nested_feedback,
                     keepalive_probes: nested_probes,
                     timer_commands: nested_timer_commands,
+                    archive_id_rewrites: nested_rewrites,
                 } = nested;
                 outcome.frames.extend(nested_frames);
                 if nested_close {
@@ -423,6 +424,9 @@ async fn interpret_with_depth(
                 outcome.feedback.extend(nested_feedback);
                 outcome.keepalive_probes += nested_probes;
                 outcome.timer_commands.extend(nested_timer_commands);
+                // Carry nested rewrites forward so later events in THIS
+                // batch see them too.
+                archive_id_rewrites.extend(nested_rewrites);
             }
             OutboundEvent::ProjectInbox {
                 owner,
@@ -645,6 +649,7 @@ async fn interpret_with_depth(
         }
     }
 
+    outcome.archive_id_rewrites = archive_id_rewrites;
     outcome
 }
 

--- a/server/crates/waddle-server/src/server/routes/interpret/carbons.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/carbons.rs
@@ -6,7 +6,7 @@ pub(super) async fn send_carbons(
     owner: BareJid,
     message: Box<Message>,
     kind: CarbonKind,
-    exclude: FullJid,
+    exclude: Vec<FullJid>,
 ) {
     // Per XEP-0280 §5, a carbon copy is the original
     // <message/> wrapped in <sent>/<received> →
@@ -15,6 +15,14 @@ pub(super) async fn send_carbons(
     // bare JID TO the receiving resource. We fan out only
     // to other resources of `owner` that have explicitly
     // opted in via XEP-0280 enable.
+    //
+    // `exclude` is the original stanza's delivery set —
+    // XEP-0280 §6.3: the receiving server MUST NOT send a
+    // forwarded copy to the client(s) the original
+    // <message/> stanza was addressed to. For the shared
+    // bare-JID recipient pass (#1106) that is every
+    // same-priority resource; for the sender pass it is
+    // the single originating resource.
     //
     // Suppression rules (groupchat, <private/>, no-copy,
     // body-less) are enforced by `CarbonsMessageHandler`

--- a/server/crates/waddle-server/src/server/routes/interpret/deps.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/deps.rs
@@ -29,6 +29,13 @@ pub struct InterpretOutcome {
     /// connection-local timer wheel. Only the transport adapter owns a
     /// clock; the interpreter just relays the typed commands.
     pub timer_commands: Vec<TimerCommand>,
+    /// XEP-0359 archive-id rewrites accumulated while interpreting the
+    /// batch (a store deduped to an existing row). The interpreter
+    /// already applies these to later events in the same batch; the
+    /// shared fan-out recipient pass (#1106) also needs them for the
+    /// wire stanza it extracts BEFORE interpreting, so live/MAM id
+    /// parity holds under origin-id retries.
+    pub(super) archive_id_rewrites: Vec<ArchiveIdRewrite>,
 }
 
 /// Typed timer instruction relayed from the state machine to the

--- a/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
@@ -185,10 +185,24 @@ pub(super) async fn route_to_connection(
                             )
                     );
                     if is_dm_message && !live_targets.is_empty() {
+                        // The carbon exclusion set is every client the
+                        // original stanza is addressed to (XEP-0280 §6.3):
+                        // the live delivery set PLUS the detached XEP-0198
+                        // resources whose replay buffers get the processed
+                        // original queued below — a detached sibling must
+                        // not ALSO find a received-carbon in its buffer on
+                        // resume.
+                        let mut delivery_fanout = live_targets.clone();
+                        delivery_fanout.extend(
+                            detached_targets
+                                .iter()
+                                .filter(|full| !live_set.contains(*full))
+                                .cloned(),
+                        );
                         match run_fanout_recipient_pass(
                             deps,
                             &bare,
-                            live_targets.clone(),
+                            delivery_fanout,
                             (*stanza).clone(),
                             recursion_depth + 1,
                         )

--- a/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
@@ -289,13 +289,14 @@ pub(super) async fn route_to_connection(
                                 }
                                 return;
                             }
-                            FanoutPassResult::DropFailClosed => {
-                                return;
-                            }
                             FanoutPassResult::Unavailable => {
-                                // Test fixtures without a dispatcher keep
-                                // the legacy per-resource PeerStanza path
-                                // below.
+                                // Shared pass unavailable (no dispatcher
+                                // in test fixtures, or blocklist load
+                                // failed): fall through to the legacy
+                                // per-resource PeerStanza path below —
+                                // each recipient connection's bind-time
+                                // blocklist snapshot keeps XEP-0191
+                                // enforcement.
                             }
                         }
                     }

--- a/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
@@ -165,6 +165,126 @@ pub(super) async fn route_to_connection(
                     // PR #276).
                     let live_set: std::collections::HashSet<jid::FullJid> =
                         live_targets.iter().cloned().collect();
+
+                    // #1106: a bare-JID DM with live targets runs the
+                    // recipient pass ONCE (shared, headless-style) and
+                    // fans the single processed stanza out to every
+                    // same-priority resource — instead of queueing a
+                    // `PeerStanza` per resource, which ran the full
+                    // recipient pass N times (N archive rows with
+                    // divergent XEP-0359 stanza-ids, N inbox unread
+                    // increments, and cross-resource received-carbons
+                    // that XEP-0280 §6.3 forbids).
+                    let is_dm_message = matches!(
+                        stanza.as_ref(),
+                        Stanza::Message(message)
+                            if matches!(
+                                message.type_,
+                                xmpp_parsers::message::MessageType::Chat
+                                    | xmpp_parsers::message::MessageType::Normal,
+                            )
+                    );
+                    if is_dm_message && !live_targets.is_empty() {
+                        match run_fanout_recipient_pass(
+                            deps,
+                            &bare,
+                            live_targets.clone(),
+                            (*stanza).clone(),
+                            recursion_depth + 1,
+                        )
+                        .await
+                        {
+                            FanoutPassResult::Ran {
+                                processed,
+                                side_routes,
+                            } => {
+                                if let Some(processed) = processed {
+                                    // Wire delivery of the ONE processed
+                                    // stanza per resource. `send_to`
+                                    // queues a `DeliveryKind::DirectFrame`
+                                    // — the destination's main loop keeps
+                                    // XEP-0198 outbound accounting
+                                    // (`record_outbound`) but does NOT
+                                    // re-run the recipient pass. The
+                                    // stanza's `to` stays bare (RFC 6121
+                                    // §8.5.2.1.1 delivery of a
+                                    // bare-addressed message).
+                                    for full in &live_targets {
+                                        match registry.send_to(full, (*processed).clone()).await {
+                                            waddle_xmpp::registry::SendResult::Sent => {
+                                                debug!(
+                                                    jid = %full,
+                                                    "RouteToConnection: processed DM \
+                                                     delivered (shared recipient pass)"
+                                                );
+                                            }
+                                            waddle_xmpp::registry::SendResult::NotConnected
+                                            | waddle_xmpp::registry::SendResult::ChannelClosed => {
+                                                deliver_to_detached(
+                                                    deps.sm_session_registry,
+                                                    full,
+                                                    &processed,
+                                                )
+                                                .await;
+                                            }
+                                        }
+                                    }
+                                    // Detached XEP-0198 targets get the
+                                    // PROCESSED stanza too, so resume
+                                    // replay carries the recipient
+                                    // <stanza-id/> (closes the
+                                    // stanza-id-parity gap documented on
+                                    // the legacy path).
+                                    queue_processed_for_detached(
+                                        deps.sm_session_registry,
+                                        detached_targets,
+                                        &live_set,
+                                        &processed,
+                                    )
+                                    .await;
+                                } else {
+                                    debug!(
+                                        bare_jid = %bare,
+                                        "RouteToConnection: shared recipient pass \
+                                         produced no wire copy (blocked or halted); \
+                                         dropping delivery"
+                                    );
+                                }
+                                // Handler-generated side stanzas (XEP-0184
+                                // receipt back to the sender) route at the
+                                // OUTER depth — the old per-connection
+                                // pass routed them from the recipient's
+                                // own interpret loop at depth 0.
+                                // Receipts always target the sender's
+                                // full JID, so this cannot re-enter the
+                                // bare-JID fan-out.
+                                if !side_routes.is_empty() {
+                                    let side_events: Vec<OutboundEvent> = side_routes
+                                        .into_iter()
+                                        .map(|(jid, stanza)| OutboundEvent::RouteToConnection {
+                                            jid,
+                                            stanza,
+                                        })
+                                        .collect();
+                                    let _ = Box::pin(interpret_with_depth(
+                                        side_events,
+                                        deps,
+                                        recursion_depth,
+                                    ))
+                                    .await;
+                                }
+                                return;
+                            }
+                            FanoutPassResult::DropFailClosed => {
+                                return;
+                            }
+                            FanoutPassResult::Unavailable => {
+                                // Test fixtures without a dispatcher keep
+                                // the legacy per-resource PeerStanza path
+                                // below.
+                            }
+                        }
+                    }
                     for full in live_targets {
                         deliver_peer_to_full(registry, deps.sm_session_registry, &full, &stanza)
                             .await;
@@ -237,6 +357,56 @@ pub(super) async fn route_to_connection(
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+/// #1106: queue the PROCESSED (recipient-stamped) stanza into the
+/// detached XEP-0198 replay buffers of `detached_targets`, skipping any
+/// resource that was just delivered live. Because the queued form is
+/// the shared recipient pass's wire output, resume replay carries the
+/// recipient-side `<stanza-id by='recipient'/>` (XEP-0359 §5) — the
+/// persistence side effects already ran exactly once in the shared
+/// pass, so replay is delivery-only.
+async fn queue_processed_for_detached(
+    sm_session_registry: Option<&Arc<InMemorySmSessionRegistry>>,
+    detached_targets: Vec<jid::FullJid>,
+    live_set: &std::collections::HashSet<jid::FullJid>,
+    stanza: &Stanza,
+) {
+    let Some(sm) = sm_session_registry else {
+        return;
+    };
+    for full in detached_targets {
+        if live_set.contains(&full) {
+            continue;
+        }
+        match sm
+            .record_stanza_for_detached_bound_resource(&full, stanza, chrono::Utc::now())
+            .await
+        {
+            Ok(true) => {
+                debug!(
+                    jid = %full,
+                    "RouteToConnection: processed DM queued for detached \
+                     XEP-0198 replay"
+                );
+            }
+            Ok(false) => {
+                debug!(
+                    jid = %full,
+                    "RouteToConnection: detached session expired between \
+                     enumeration and queue; dropping"
+                );
+            }
+            Err(error) => {
+                warn!(
+                    jid = %full,
+                    %error,
+                    "RouteToConnection: failed to record processed DM for \
+                     detached resource"
+                );
             }
         }
     }

--- a/server/crates/waddle-server/src/server/routes/interpret/routing.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/routing.rs
@@ -102,15 +102,16 @@ pub(super) enum FanoutPassResult {
         processed: Option<Box<Stanza>>,
         side_routes: Vec<(Jid, Box<Stanza>)>,
     },
-    /// The shared pass could not be constructed — no
-    /// `message_dispatcher` in `Deps` (unit-test fixtures) or the
-    /// static synthetic resource literal was rejected (should not
-    /// happen). The caller falls back to per-resource `PeerStanza`
-    /// delivery.
+    /// The shared pass could not run — no `message_dispatcher` in
+    /// `Deps` (unit-test fixtures), the static synthetic resource
+    /// literal was rejected (should not happen), or the XEP-0191
+    /// blocklist load failed. The caller falls back to per-resource
+    /// `PeerStanza` delivery: each recipient connection's own state
+    /// machine carries a bind-time blocklist snapshot, so XEP-0191
+    /// enforcement holds on the fallback path — unlike the OFFLINE
+    /// headless pass, which has no per-connection snapshot to fall
+    /// back on and must stay fail-closed.
     Unavailable,
-    /// XEP-0191 blocklist load failed — fail closed and drop the
-    /// message entirely, mirroring [`run_headless_recipient_pass`].
-    DropFailClosed,
 }
 
 /// #1106: run the recipient pass ONCE for a bare-JID DM delivered to
@@ -178,11 +179,12 @@ pub(super) async fn run_fanout_recipient_pass(
                 warn!(
                     bare_jid = %recipient_bare,
                     error = %error,
-                    "fanout recipient-pass: blocklist load failed; dropping \
-                     delivery to preserve XEP-0191 incoming-block enforcement \
-                     (fail-closed)"
+                    "fanout recipient-pass: blocklist load failed; falling back \
+                     to legacy per-resource delivery (each recipient \
+                     connection's bind-time blocklist snapshot keeps XEP-0191 \
+                     enforcement)"
                 );
-                return FanoutPassResult::DropFailClosed;
+                return FanoutPassResult::Unavailable;
             }
         },
         None => Blocklist::empty(),

--- a/server/crates/waddle-server/src/server/routes/interpret/routing.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/routing.rs
@@ -102,8 +102,11 @@ pub(super) enum FanoutPassResult {
         processed: Option<Box<Stanza>>,
         side_routes: Vec<(Jid, Box<Stanza>)>,
     },
-    /// No `message_dispatcher` in `Deps` (unit-test fixtures) — the
-    /// caller falls back to per-resource `PeerStanza` delivery.
+    /// The shared pass could not be constructed — no
+    /// `message_dispatcher` in `Deps` (unit-test fixtures) or the
+    /// static synthetic resource literal was rejected (should not
+    /// happen). The caller falls back to per-resource `PeerStanza`
+    /// delivery.
     Unavailable,
     /// XEP-0191 blocklist load failed — fail closed and drop the
     /// message entirely, mirroring [`run_headless_recipient_pass`].
@@ -329,7 +332,10 @@ pub(super) async fn deliver_peer_to_full(
 /// into the recipient's detached XEP-0198 replay buffer if a
 /// resumable session exists, otherwise drops with a debug log.
 ///
-/// Known limitation (Copilot review on PR #276): the buffered XML
+/// Known limitation (Copilot review on PR #276) — applies to the
+/// LEGACY call sites only (full-JID targets, non-DM stanzas); the
+/// #1106 shared fan-out pass hands this function the PROCESSED
+/// stanza instead: the buffered XML here
 /// is the pre-recipient-pass form, so replay on resume sends it
 /// verbatim WITHOUT running the recipient-pass chain. The replayed
 /// message is missing the recipient-side `<stanza-id by='recipient'/>`

--- a/server/crates/waddle-server/src/server/routes/interpret/routing.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/routing.rs
@@ -80,6 +80,9 @@ pub(super) async fn run_headless_recipient_pass(
         // effects; discarding matches the frames/feedback semantics.
         keepalive_probes: _,
         timer_commands: _,
+        // Headless pass emits no wire copy, so there is nothing to
+        // rewrite.
+        archive_id_rewrites: _,
     } = nested;
     debug!(
         bare_jid = %recipient_bare,
@@ -241,6 +244,7 @@ pub(super) async fn run_fanout_recipient_pass(
         feedback,
         keepalive_probes: _,
         timer_commands: _,
+        archive_id_rewrites,
     } = nested;
     debug!(
         bare_jid = %recipient_bare,
@@ -250,6 +254,20 @@ pub(super) async fn run_fanout_recipient_pass(
         "fanout recipient-pass: persistence interpreted once; transient \
          outcome discarded"
     );
+    // XEP-0359 live/MAM id parity: the archive store may have deduped
+    // to an EXISTING row (origin-id retry), reported via
+    // ArchiveIdRewrite. The interpreter already rewrote the persistence
+    // events in the batch; the wire copy and side routes were extracted
+    // BEFORE interpreting, so apply the rewrites here too — otherwise
+    // live resources carry a recipient <stanza-id/> no archive row has.
+    if !archive_id_rewrites.is_empty() {
+        if let Some(processed) = processed.as_mut() {
+            rewrite_stanza_archive_ids(processed, &archive_id_rewrites);
+        }
+        for (_, stanza) in side_routes.iter_mut() {
+            rewrite_stanza_archive_ids(stanza, &archive_id_rewrites);
+        }
+    }
 
     FanoutPassResult::Ran {
         processed,

--- a/server/crates/waddle-server/src/server/routes/interpret/routing.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/routing.rs
@@ -90,6 +90,168 @@ pub(super) async fn run_headless_recipient_pass(
     );
 }
 
+/// Result of [`run_fanout_recipient_pass`].
+pub(super) enum FanoutPassResult {
+    /// The shared recipient pass ran. `processed` is the
+    /// recipient-stamped stanza the pipeline emitted for the wire
+    /// (`None` when the pass dropped the message, e.g. XEP-0191
+    /// incoming block). `side_routes` are handler-generated stanzas
+    /// addressed to OTHER parties (XEP-0184 delivery receipt back to
+    /// the sender) that must still be routed by the caller.
+    Ran {
+        processed: Option<Box<Stanza>>,
+        side_routes: Vec<(Jid, Box<Stanza>)>,
+    },
+    /// No `message_dispatcher` in `Deps` (unit-test fixtures) — the
+    /// caller falls back to per-resource `PeerStanza` delivery.
+    Unavailable,
+    /// XEP-0191 blocklist load failed — fail closed and drop the
+    /// message entirely, mirroring [`run_headless_recipient_pass`].
+    DropFailClosed,
+}
+
+/// #1106: run the recipient pass ONCE for a bare-JID DM delivered to
+/// multiple same-priority resources (RFC 6121 §8.5.2.1.1).
+///
+/// Mirrors [`run_headless_recipient_pass`] (synthetic full JID,
+/// fail-closed blocklist load, transient [`XmppStateMachine`]) with two
+/// differences:
+///
+/// - `has_live_transport` stays `true`: the recipient IS live, so the
+///   XEP-0160 offline intake must not queue pending-delivery rows and
+///   the XEP-0184 receipt fires (once, instead of once per resource).
+/// - The pass's wire output is NOT discarded: the final
+///   [`OutboundEvent::SendStanza`] carries the recipient-stamped
+///   message; the caller delivers that one processed stanza to every
+///   resource in the delivery set.
+///
+/// The transient machine is seeded with the delivery-fanout set so the
+/// XEP-0280 carbons handler excludes the WHOLE delivery set
+/// (XEP-0280 §6.3), not just one resource.
+///
+/// Persistence side effects (XEP-0313 archive, inbox projection,
+/// carbon fan-out) are interpreted exactly once at `depth` (bumped),
+/// so the recursion guard in [`route_to_connection`] prevents any
+/// nested re-pass, exactly like the headless path.
+pub(super) async fn run_fanout_recipient_pass(
+    deps: &Deps<'_>,
+    recipient_bare: &jid::BareJid,
+    delivery_fanout: Vec<jid::FullJid>,
+    stanza: Stanza,
+    depth: u8,
+) -> FanoutPassResult {
+    let Some(dispatcher) = deps.message_dispatcher else {
+        debug!(
+            bare_jid = %recipient_bare,
+            "fanout recipient-pass: no message_dispatcher in Deps; \
+             falling back to per-resource delivery (test fixture)"
+        );
+        return FanoutPassResult::Unavailable;
+    };
+
+    let synthetic_resource =
+        match jid::ResourcePart::new(waddle_xmpp::protocol::HEADLESS_RECIPIENT_RESOURCE) {
+            Ok(rp) => rp,
+            Err(error) => {
+                warn!(
+                    bare_jid = %recipient_bare,
+                    %error,
+                    "fanout recipient-pass: synthetic resource part rejected; \
+                     falling back to per-resource delivery (should not happen — \
+                     static literal)"
+                );
+                return FanoutPassResult::Unavailable;
+            }
+        };
+    let synthetic_full = recipient_bare.with_resource(&synthetic_resource);
+
+    // Fail-closed on blocklist load error, mirroring
+    // [`run_headless_recipient_pass`]: a transient storage error must
+    // not disable XEP-0191 incoming-block enforcement.
+    let blocklist = match deps.blocking_storage {
+        Some(storage) => match storage.list_blocked_jid_entries(recipient_bare).await {
+            Ok(jids) => Blocklist::new(jids),
+            Err(error) => {
+                warn!(
+                    bare_jid = %recipient_bare,
+                    error = %error,
+                    "fanout recipient-pass: blocklist load failed; dropping \
+                     delivery to preserve XEP-0191 incoming-block enforcement \
+                     (fail-closed)"
+                );
+                return FanoutPassResult::DropFailClosed;
+            }
+        },
+        None => Blocklist::empty(),
+    };
+
+    let mut transient = XmppStateMachine::new(deps.local_domain, (**dispatcher).clone());
+    // Deliberately NOT `set_has_live_transport(false)`: unlike the
+    // offline headless pass, this pass acts for a recipient with live
+    // resources, so delivery-only behaviour must match the old
+    // per-connection recipient pass (no XEP-0160 pending rows, one
+    // XEP-0184 receipt).
+    transient.transition_to_ready(synthetic_full, false);
+    transient.set_blocklist(blocklist);
+    transient.set_delivery_fanout(delivery_fanout);
+
+    let events = transient.handle(InboundEvent::StanzaFromPeer(Box::new(stanza)));
+
+    // Partition the pass output:
+    // - the final `SendStanza(Message)` is the recipient-stamped wire
+    //   copy — captured for the caller to deliver per resource;
+    // - `RouteToConnection` events are side stanzas addressed to other
+    //   parties (XEP-0184 receipt to the sender) — returned so the
+    //   caller can route them at the outer depth, matching the old
+    //   per-connection pass where they routed at interpret depth 0;
+    // - everything else (ArchiveDirect / ProjectInbox / SendCarbons /
+    //   logs) is interpreted exactly once, depth-bumped.
+    let mut processed: Option<Box<Stanza>> = None;
+    let mut side_routes: Vec<(Jid, Box<Stanza>)> = Vec::new();
+    let mut remaining: Vec<OutboundEvent> = Vec::with_capacity(events.len());
+    for event in events {
+        match event {
+            OutboundEvent::SendStanza(boxed) if matches!(boxed.as_ref(), Stanza::Message(_)) => {
+                if processed.is_some() {
+                    warn!(
+                        bare_jid = %recipient_bare,
+                        "fanout recipient-pass: multiple SendStanza(Message) \
+                         events; keeping the last (pipeline emits exactly one \
+                         wire copy per RouteHandler recipient branch)"
+                    );
+                }
+                processed = Some(boxed);
+            }
+            OutboundEvent::RouteToConnection { jid, stanza } => {
+                side_routes.push((jid, stanza));
+            }
+            other => remaining.push(other),
+        }
+    }
+
+    let nested = Box::pin(interpret_with_depth(remaining, deps, depth)).await;
+    let InterpretOutcome {
+        frames,
+        close,
+        feedback,
+        keepalive_probes: _,
+        timer_commands: _,
+    } = nested;
+    debug!(
+        bare_jid = %recipient_bare,
+        discarded_frames = frames.len(),
+        discarded_feedback = feedback.len(),
+        nested_close = close,
+        "fanout recipient-pass: persistence interpreted once; transient \
+         outcome discarded"
+    );
+
+    FanoutPassResult::Ran {
+        processed,
+        side_routes,
+    }
+}
+
 /// Apply a XEP-0424 §"prevent further distribution" tombstone to the
 /// retraction target inside `archive`. Looks up the target via the
 /// retraction's wire id (matches legacy
@@ -177,7 +339,7 @@ pub(super) async fn deliver_peer_to_full(
 /// the gap properly requires running the headless recipient pass per
 /// detached target and queueing its `SendStanza` output — tracked as
 /// a follow-up to #229.
-async fn deliver_to_detached(
+pub(super) async fn deliver_to_detached(
     sm_session_registry: Option<&Arc<InMemorySmSessionRegistry>>,
     target: &jid::FullJid,
     stanza: &Stanza,

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -2728,3 +2728,89 @@ async fn fanout_pass_blocklist_failure_falls_back_to_legacy_per_resource_deliver
         Some("must arrive")
     );
 }
+
+#[tokio::test]
+async fn fanout_pass_applies_archive_id_rewrite_to_the_delivered_stanza() {
+    // XEP-0359 live/MAM id parity under origin-id retry: when the
+    // recipient archive dedupes the store to an EXISTING row (same
+    // origin-id already archived), the resulting ArchiveIdRewrite must
+    // reach the wire copy the shared fan-out pass delivers — otherwise
+    // live resources see a recipient <stanza-id/> that no archive row
+    // carries, breaking client-side live/MAM dedupe.
+    use waddle_xmpp::registry::DeliveryKind;
+    use waddle_xmpp_core::xep0359::{build_origin_id_element, extract_stanza_id_by};
+
+    let registry = ConnectionRegistry::new();
+    let bob: jid::FullJid = "bob@example.com/web".parse().expect("bob jid");
+    let (bob_tx, mut bob_rx) = tokio::sync::mpsc::channel(8);
+    registry.register(bob.clone(), bob_tx);
+
+    let mam: Arc<dyn MamStorage> =
+        Arc::new(waddle_xmpp::mam::storage::InMemoryMamStorage::default());
+    let inbox: Arc<dyn InboxStorage> =
+        Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
+    let blocking: Arc<dyn waddle_xmpp::xep::xep0191::BlockingStorage> =
+        Arc::new(waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new());
+    let dispatcher = pipelined_dispatcher();
+    let deps = offline_pass_deps(&registry, &mam, &inbox, &blocking, &dispatcher);
+
+    let dm = || {
+        let mut m = chat_msg("alice@example.com/web", "bob@example.com", "retry me");
+        m.payloads.push(build_origin_id_element("origin-retry-1"));
+        m
+    };
+
+    // First delivery: archives a row under bob's recipient stamp.
+    let _ = interpret(
+        vec![OutboundEvent::RouteToConnection {
+            jid: "bob@example.com".parse::<jid::Jid>().expect("bare"),
+            stanza: Box::new(Stanza::Message(dm())),
+        }],
+        &deps,
+    )
+    .await;
+    // Drain the first delivery.
+    while bob_rx.try_recv().is_ok() {}
+
+    // Retry with the same origin-id: the archive store dedupes to the
+    // existing row and reports its id via ArchiveIdRewrite.
+    let _ = interpret(
+        vec![OutboundEvent::RouteToConnection {
+            jid: "bob@example.com".parse::<jid::Jid>().expect("bare"),
+            stanza: Box::new(Stanza::Message(dm())),
+        }],
+        &deps,
+    )
+    .await;
+    let delivered = tokio::time::timeout(std::time::Duration::from_secs(2), bob_rx.recv())
+        .await
+        .expect("second delivery must not time out")
+        .expect("channel open");
+    assert_eq!(
+        delivered.kind,
+        DeliveryKind::DirectFrame,
+        "shared fan-out pass delivers the processed stanza directly"
+    );
+    let Stanza::Message(delivered_msg) = delivered.stanza else {
+        panic!("expected message stanza");
+    };
+
+    let bob_bare: jid::BareJid = "bob@example.com".parse().expect("bare");
+    let archive = mam
+        .query_messages(&bob_bare, &Default::default())
+        .await
+        .expect("query bob archive");
+    assert_eq!(
+        archive.messages.len(),
+        1,
+        "origin-id retry dedupes to one row"
+    );
+    let archived_id = archive.messages[0].id.clone();
+
+    let delivered_stanza_id = extract_stanza_id_by(&delivered_msg, &jid::Jid::from(bob_bare));
+    assert_eq!(
+        delivered_stanza_id.as_deref(),
+        Some(archived_id.as_str()),
+        "the delivered recipient <stanza-id/> must match the deduped archive row"
+    );
+}

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -2643,3 +2643,88 @@ fn message_thread_id(message: &Message) -> Option<String> {
             })
         })
 }
+
+// -----------------------------------------------------------------
+// #1106 — shared fan-out recipient pass: blocklist-load failure
+// -----------------------------------------------------------------
+
+/// BlockingStorage stub whose reads always fail, simulating a
+/// transient storage outage during the shared fan-out pass.
+struct FailingBlockingStorage;
+
+#[async_trait::async_trait]
+impl waddle_xmpp::xep::xep0191::BlockingStorage for FailingBlockingStorage {
+    async fn list_blocked_jids(
+        &self,
+        _user: &jid::BareJid,
+    ) -> Result<Vec<jid::BareJid>, waddle_xmpp::xep::xep0191::BlockingStorageError> {
+        Err(waddle_xmpp::xep::xep0191::BlockingStorageError::new(
+            std::io::Error::other("storage down"),
+        ))
+    }
+
+    async fn list_blocked_jid_entries(
+        &self,
+        _user: &jid::BareJid,
+    ) -> Result<Vec<jid::Jid>, waddle_xmpp::xep::xep0191::BlockingStorageError> {
+        Err(waddle_xmpp::xep::xep0191::BlockingStorageError::new(
+            std::io::Error::other("storage down"),
+        ))
+    }
+}
+
+#[tokio::test]
+async fn fanout_pass_blocklist_failure_falls_back_to_legacy_per_resource_delivery() {
+    // A transient blocklist-storage error must not drop a DM to LIVE
+    // recipients: the legacy per-resource PeerStanza path still runs
+    // each recipient connection's own state machine, whose bind-time
+    // blocklist snapshot keeps XEP-0191 enforcement intact.
+    use waddle_xmpp::registry::DeliveryKind;
+
+    let registry = ConnectionRegistry::new();
+    let bob: jid::FullJid = "bob@example.com/web".parse().expect("bob jid");
+    let (bob_tx, mut bob_rx) = tokio::sync::mpsc::channel(8);
+    registry.register(bob.clone(), bob_tx);
+
+    let blocking: Arc<dyn waddle_xmpp::xep::xep0191::BlockingStorage> =
+        Arc::new(FailingBlockingStorage);
+    let dispatcher = pipelined_dispatcher();
+    let deps = Deps {
+        connection_registry: &registry,
+        sm_session_registry: None,
+        mam_storage: None,
+        inbox_storage: None,
+        extension_manager: None,
+        room_registry: None,
+        web_socket_state: None,
+        authenticated_session: None,
+        local_domain: "example.com",
+        blocking_storage: Some(&blocking),
+        message_dispatcher: Some(&dispatcher),
+        pending_delivery_storage: None,
+    };
+
+    let msg = chat_msg("alice@example.com/web", "bob@example.com", "must arrive");
+    let events = vec![OutboundEvent::RouteToConnection {
+        jid: "bob@example.com".parse::<jid::Jid>().expect("bare"),
+        stanza: Box::new(Stanza::Message(msg)),
+    }];
+    let _ = interpret(events, &deps).await;
+
+    let delivered = tokio::time::timeout(std::time::Duration::from_secs(2), bob_rx.recv())
+        .await
+        .expect("delivery must not time out")
+        .expect("channel open");
+    assert_eq!(
+        delivered.kind,
+        DeliveryKind::PeerStanza,
+        "fallback delivers via the legacy per-resource recipient pass"
+    );
+    let Stanza::Message(delivered_msg) = delivered.stanza else {
+        panic!("expected message stanza");
+    };
+    assert_eq!(
+        delivered_msg.bodies.values().next().map(|b| b.as_str()),
+        Some("must arrive")
+    );
+}

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -97,7 +97,7 @@ async fn xep_0280_send_carbons_fans_out_to_other_carbon_enabled_resources() {
         owner,
         message: Box::new(original),
         kind: CarbonKind::Sent,
-        exclude: alice_web,
+        exclude: vec![alice_web],
     }];
     let _outcome = interpret(events, &Deps::registry_only(&registry)).await;
 
@@ -135,7 +135,7 @@ async fn xep_0280_send_carbons_skips_originating_resource() {
         owner,
         message: Box::new(original),
         kind: CarbonKind::Sent,
-        exclude: alice_web,
+        exclude: vec![alice_web],
     }];
     let _outcome = interpret(events, &Deps::registry_only(&registry)).await;
 
@@ -161,7 +161,7 @@ async fn xep_0280_send_carbons_skips_resources_without_carbons_enabled() {
         owner,
         message: Box::new(original),
         kind: CarbonKind::Sent,
-        exclude: alice_web,
+        exclude: vec![alice_web],
     }];
     let _outcome = interpret(events, &Deps::registry_only(&registry)).await;
 
@@ -185,7 +185,7 @@ async fn xep_0280_send_carbons_received_kind_emits_received_envelope() {
         owner,
         message: Box::new(original),
         kind: CarbonKind::Received,
-        exclude: bob_desk,
+        exclude: vec![bob_desk],
     }];
     let _outcome = interpret(events, &Deps::registry_only(&registry)).await;
 
@@ -265,7 +265,7 @@ async fn xep_0280_send_carbons_queues_for_detached_xep_0198_resources() {
             owner: owner.clone(),
             message: Box::new(original),
             kind: CarbonKind::Sent,
-            exclude: alice_web,
+            exclude: vec![alice_web],
         }],
         &deps,
     )

--- a/server/crates/waddle-server/tests/xep0280_same_priority_fanout_ws.rs
+++ b/server/crates/waddle-server/tests/xep0280_same_priority_fanout_ws.rs
@@ -1,0 +1,278 @@
+//! #1106 — bare-JID DM fan-out to same-priority resources must not
+//! duplicate delivery or recipient-side persistence.
+//!
+//! RFC 6121 §8.5.2.1.1: a bare-JID chat message is delivered to every
+//! available resource tied at the highest non-negative priority.
+//! XEP-0280 §6.3: "The receiving server MUST NOT send a forwarded copy
+//! to the client(s) the original <message/> stanza was addressed to, as
+//! these recipients receive the original <message/> stanza." — the
+//! whole RFC 6121 delivery set is the carbon exclusion set, not just
+//! the single resource whose recipient pass emitted the carbon event.
+//! XEP-0313 / XEP-0430: recipient-side archive and inbox writes are
+//! keyed by the bare recipient and must happen once per message, not
+//! once per delivered resource.
+
+use waddle_ws_test_support as ws_common;
+
+use std::time::Duration;
+use ws_common::{TestServer, WsXmppClient};
+
+const DOMAIN: &str = "localhost";
+const RECIPIENT_USER: &str = "admin";
+const SENDER_USER: &str = "peer";
+const SENDER_PASSWORD: &str = "peer-password-1";
+const NS_CARBONS: &str = "urn:xmpp:carbons:2";
+
+async fn enable_carbons(client: &mut WsXmppClient, id: &str) {
+    client
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="set" id="{id}"><enable xmlns="urn:xmpp:carbons:2"/></iq>"#
+        ))
+        .await
+        .expect("send carbons enable");
+    let _ = client
+        .recv_matching(|frame| frame.contains(id))
+        .await
+        .expect("carbons enable result");
+}
+
+async fn send_available_presence(client: &mut WsXmppClient) {
+    client
+        .send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("send presence");
+}
+
+/// Drain every frame until the stream stays quiet, returning the ones
+/// containing `needle`.
+async fn drain_matching(client: &mut WsXmppClient, needle: &str) -> Vec<String> {
+    let mut matching = Vec::new();
+    while let Ok(frame) = client.recv_timeout(Duration::from_millis(900)).await {
+        if frame.contains(needle) {
+            matching.push(frame);
+        }
+    }
+    matching
+}
+
+struct FanoutFixture {
+    _server: TestServer,
+    web: WsXmppClient,
+    phone: WsXmppClient,
+    sender: WsXmppClient,
+}
+
+/// Two recipient resources at identical (default 0) priority, both
+/// carbons-enabled and presence-available, plus a distinct sender
+/// account.
+async fn fanout_fixture() -> FanoutFixture {
+    let server = TestServer::start_with_extra_accounts(&[(SENDER_USER, SENDER_PASSWORD)]);
+    let password = server.fixed_account_password().to_string();
+
+    let mut web = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        RECIPIENT_USER,
+        &password,
+        &format!("web-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("web connection");
+    enable_carbons(&mut web, "carbons-enable-web").await;
+    send_available_presence(&mut web).await;
+
+    let mut phone = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        RECIPIENT_USER,
+        &password,
+        &format!("phone-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("phone connection");
+    enable_carbons(&mut phone, "carbons-enable-phone").await;
+    send_available_presence(&mut phone).await;
+
+    let sender = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        SENDER_USER,
+        SENDER_PASSWORD,
+        &format!("sender-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("sender connection");
+
+    FanoutFixture {
+        _server: server,
+        web,
+        phone,
+        sender,
+    }
+}
+
+#[tokio::test]
+async fn two_same_priority_resources_receive_the_dm_exactly_once_each() {
+    let mut fx = fanout_fixture().await;
+    let body = format!("fanout-dedupe-proof-{}", uuid::Uuid::new_v4());
+
+    fx.sender
+        .send(&format!(
+            r#"<message xmlns="jabber:client" to="admin@{DOMAIN}" type="chat" id="fanout-1"><body>{body}</body></message>"#
+        ))
+        .await
+        .expect("send dm");
+
+    let web_copies = drain_matching(&mut fx.web, &body).await;
+    let phone_copies = drain_matching(&mut fx.phone, &body).await;
+
+    for (name, copies) in [("web", &web_copies), ("phone", &phone_copies)] {
+        assert_eq!(
+            copies.len(),
+            1,
+            "{name} must receive the DM exactly once (XEP-0280 §6.3), got {}: {copies:?}",
+            copies.len()
+        );
+        assert!(
+            !copies[0].contains(NS_CARBONS),
+            "{name}'s only copy must be the original delivery, not a carbon: {}",
+            copies[0]
+        );
+    }
+
+    let _ = fx.sender.close().await;
+    let _ = fx.web.close().await;
+    let _ = fx.phone.close().await;
+}
+
+#[tokio::test]
+async fn recipient_archive_and_stanza_id_are_single_per_bare_recipient() {
+    let mut fx = fanout_fixture().await;
+    let body = format!("fanout-archive-proof-{}", uuid::Uuid::new_v4());
+
+    fx.sender
+        .send(&format!(
+            r#"<message xmlns="jabber:client" to="admin@{DOMAIN}" type="chat" id="fanout-2"><body>{body}</body></message>"#
+        ))
+        .await
+        .expect("send dm");
+
+    let web_copies = drain_matching(&mut fx.web, &body).await;
+    let phone_copies = drain_matching(&mut fx.phone, &body).await;
+    assert!(
+        !web_copies.is_empty() && !phone_copies.is_empty(),
+        "both resources must receive the DM (web: {web_copies:?}, phone: {phone_copies:?})"
+    );
+    // XEP-0359: both resources must see the SAME recipient-stamped
+    // stanza-id — one recipient pass, one stamp. Divergent ids break
+    // client-side live/MAM dedup.
+    let web_id = stanza_id_of(&web_copies[0]);
+    let phone_id = stanza_id_of(&phone_copies[0]);
+    assert_eq!(
+        web_id, phone_id,
+        "both resources must carry the same recipient <stanza-id/> \
+         (web: {web_id:?} / phone: {phone_id:?})"
+    );
+
+    // XEP-0313: exactly one archived row for the message.
+    fx.web
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="set" id="fanout-mam-1" to="admin@{DOMAIN}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+        ))
+        .await
+        .expect("send mam query");
+    let mut archived = 0usize;
+    loop {
+        let frame = fx
+            .web
+            .recv_timeout(Duration::from_secs(3))
+            .await
+            .expect("mam stream frame");
+        if frame.contains(&body) && frame.contains("urn:xmpp:mam:2") {
+            archived += 1;
+        }
+        if frame.contains("<fin") {
+            break;
+        }
+    }
+    assert_eq!(
+        archived, 1,
+        "recipient archive must hold exactly one row for the message"
+    );
+
+    let _ = fx.sender.close().await;
+    let _ = fx.web.close().await;
+    let _ = fx.phone.close().await;
+}
+
+#[tokio::test]
+async fn recipient_inbox_unread_increments_once_per_message() {
+    let mut fx = fanout_fixture().await;
+    let body = format!("fanout-inbox-proof-{}", uuid::Uuid::new_v4());
+
+    fx.sender
+        .send(&format!(
+            r#"<message xmlns="jabber:client" to="admin@{DOMAIN}" type="chat" id="fanout-3"><body>{body}</body></message>"#
+        ))
+        .await
+        .expect("send dm");
+
+    // Wait until the message reached both resources so persistence has
+    // settled before querying the inbox.
+    let web_copies = drain_matching(&mut fx.web, &body).await;
+    let phone_copies = drain_matching(&mut fx.phone, &body).await;
+    assert!(
+        !web_copies.is_empty() && !phone_copies.is_empty(),
+        "both resources must receive the DM before the inbox assert"
+    );
+
+    fx.web
+        .send(
+            r#"<iq xmlns="jabber:client" type="get" id="fanout-inbox-1"><inbox xmlns="urn:xmpp:inbox:1" messages="false"/></iq>"#,
+        )
+        .await
+        .expect("send inbox query");
+    let mut unread: Option<String> = None;
+    loop {
+        let frame = fx
+            .web
+            .recv_timeout(Duration::from_secs(3))
+            .await
+            .expect("inbox stream frame");
+        if frame.contains("<entry") && frame.contains(&format!("peer@{DOMAIN}")) {
+            unread = attr_value(&frame, "unread");
+        }
+        if frame.contains("<fin") {
+            break;
+        }
+    }
+    assert_eq!(
+        unread.as_deref(),
+        Some("1"),
+        "one DM must increment the recipient inbox unread exactly once"
+    );
+
+    let _ = fx.sender.close().await;
+    let _ = fx.web.close().await;
+    let _ = fx.phone.close().await;
+}
+
+/// Extract the `id` of the recipient-stamped XEP-0359 `<stanza-id/>`.
+fn stanza_id_of(frame: &str) -> Option<String> {
+    let marker = "urn:xmpp:sid:0";
+    let start = frame.find(marker)?;
+    let scope = &frame[start.saturating_sub(200)..(start + 200).min(frame.len())];
+    attr_value(scope, "id")
+}
+
+fn attr_value(frame: &str, attr: &str) -> Option<String> {
+    let double = format!("{attr}=\"");
+    if let Some(start) = frame.find(&double).map(|start| start + double.len()) {
+        let end = frame[start..].find('"')?;
+        return Some(frame[start..start + end].to_string());
+    }
+    let single = format!("{attr}='");
+    let start = frame.find(&single).map(|start| start + single.len())?;
+    let end = frame[start..].find('\'')?;
+    Some(frame[start..start + end].to_string())
+}

--- a/server/crates/waddle-server/tests/xep0280_same_priority_fanout_ws.rs
+++ b/server/crates/waddle-server/tests/xep0280_same_priority_fanout_ws.rs
@@ -257,12 +257,122 @@ async fn recipient_inbox_unread_increments_once_per_message() {
     let _ = fx.phone.close().await;
 }
 
-/// Extract the `id` of the recipient-stamped XEP-0359 `<stanza-id/>`.
+#[tokio::test]
+async fn detached_carbons_enabled_sibling_gets_the_dm_exactly_once_on_resume() {
+    // A detached-but-resumable resource is also a "client the original
+    // <message/> stanza was addressed to" (its XEP-0198 buffer gets the
+    // original queued for replay) — XEP-0280 §6.3 forbids ALSO queueing
+    // a received-carbon for it.
+    let server = TestServer::start_with_extra_accounts(&[(SENDER_USER, SENDER_PASSWORD)]);
+    let password = server.fixed_account_password().to_string();
+
+    let mut web = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        RECIPIENT_USER,
+        &password,
+        &format!("web-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("web connection");
+    enable_carbons(&mut web, "carbons-enable-web").await;
+    send_available_presence(&mut web).await;
+
+    let mut phone = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        RECIPIENT_USER,
+        &password,
+        &format!("phone-detached-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("phone connection");
+    enable_carbons(&mut phone, "carbons-enable-phone").await;
+    phone
+        .send(r#"<enable xmlns="urn:xmpp:sm:3" resume="true"/>"#)
+        .await
+        .expect("enable resumption");
+    let enabled = phone
+        .recv_matching(|frame| frame.contains("<enabled"))
+        .await
+        .expect("sm enabled");
+    let stream_id = attr_value(&enabled, "id").expect("enabled missing id");
+    drop(phone);
+
+    let mut sender = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        SENDER_USER,
+        SENDER_PASSWORD,
+        &format!("sender-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("sender connection");
+    let body = format!("detached-dedupe-proof-{}", uuid::Uuid::new_v4());
+    sender
+        .send(&format!(
+            r#"<message xmlns="jabber:client" to="admin@{DOMAIN}" type="chat" id="fanout-4"><body>{body}</body></message>"#
+        ))
+        .await
+        .expect("send dm");
+    // Wait for the live resource's copy so queueing for the detached
+    // sibling has completed before we resume.
+    let web_copies = drain_matching(&mut web, &body).await;
+    assert!(!web_copies.is_empty(), "web must receive the DM live");
+
+    let mut resumed = WsXmppClient::connect(&server.ws_url())
+        .await
+        .expect("resume connection");
+    resumed
+        .authenticate(DOMAIN, RECIPIENT_USER, &password)
+        .await
+        .expect("authenticate resume connection");
+    resumed
+        .send(&format!(
+            r#"<resume xmlns="urn:xmpp:sm:3" previd="{stream_id}" h="0"/>"#
+        ))
+        .await
+        .expect("send resume");
+    let _ = resumed
+        .recv_matching(|frame| frame.contains("<resumed"))
+        .await
+        .expect("sm resumed");
+
+    let replayed = drain_matching(&mut resumed, &body).await;
+    assert_eq!(
+        replayed.len(),
+        1,
+        "detached sibling must get the DM exactly once on resume \
+         (original replay only, no received-carbon — XEP-0280 §6.3), got: {replayed:?}"
+    );
+    assert!(
+        !replayed[0].contains(NS_CARBONS),
+        "the replayed copy must be the original delivery, not a carbon: {}",
+        replayed[0]
+    );
+
+    let _ = sender.close().await;
+    let _ = web.close().await;
+    let _ = resumed.close().await;
+}
+
+/// Extract the `id` of the XEP-0359 `<stanza-id/>` stamped by the
+/// recipient's bare JID (`by='admin@DOMAIN'`). Walks each `<stanza-id`
+/// element so the message's own `id` attribute (identical across
+/// resources by construction) can never satisfy the assertion.
 fn stanza_id_of(frame: &str) -> Option<String> {
-    let marker = "urn:xmpp:sid:0";
-    let start = frame.find(marker)?;
-    let scope = &frame[start.saturating_sub(200)..(start + 200).min(frame.len())];
-    attr_value(scope, "id")
+    let recipient_bare = format!("admin@{DOMAIN}");
+    let mut rest = frame;
+    while let Some(start) = rest.find("<stanza-id") {
+        let element_rest = &rest[start..];
+        let end = element_rest.find("/>")?;
+        let element = &element_rest[..end + 2];
+        if attr_value(element, "by").as_deref() == Some(recipient_bare.as_str()) {
+            return attr_value(element, "id");
+        }
+        rest = &element_rest[end + 2..];
+    }
+    None
 }
 
 fn attr_value(frame: &str, attr: &str) -> Option<String> {

--- a/server/crates/waddle-server/tests/xep0280_same_priority_fanout_ws.rs
+++ b/server/crates/waddle-server/tests/xep0280_same_priority_fanout_ws.rs
@@ -128,6 +128,19 @@ async fn send_available_presence(client: &mut WsXmppClient) {
         .expect("send presence");
 }
 
+async fn send_presence_with_priority(client: &mut WsXmppClient, priority: i8) {
+    let mut priority_el = Element::builder("priority", JABBER_CLIENT).build();
+    priority_el.append_text_node(priority.to_string());
+    client
+        .send(&element_to_xml(
+            Element::builder("presence", JABBER_CLIENT)
+                .append(priority_el)
+                .build(),
+        ))
+        .await
+        .expect("send presence with priority");
+}
+
 /// Drain every frame until the stream stays quiet, returning the ones
 /// containing `needle`.
 async fn drain_matching(client: &mut WsXmppClient, needle: &str) -> Vec<String> {
@@ -441,6 +454,106 @@ async fn detached_carbons_enabled_sibling_gets_the_dm_exactly_once_on_resume() {
     let _ = sender.close().await;
     let _ = web.close().await;
     let _ = resumed.close().await;
+}
+
+#[tokio::test]
+async fn lower_priority_resource_outside_the_delivery_set_gets_exactly_one_received_carbon() {
+    // Positive XEP-0280 assertion: a carbons-enabled resource OUTSIDE
+    // the RFC 6121 delivery set must still receive the received-carbon
+    // — exactly once. Before the shared fan-out pass it received N
+    // copies (one per per-resource recipient pass); a regression that
+    // suppresses carbons entirely would also fail here.
+    let server = TestServer::start_with_extra_accounts(&[(SENDER_USER, SENDER_PASSWORD)]);
+    let password = server.fixed_account_password().to_string();
+
+    let mut web = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        RECIPIENT_USER,
+        &password,
+        &format!("web-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("web connection");
+    enable_carbons(&mut web, "carbons-enable-web").await;
+    send_presence_with_priority(&mut web, 5).await;
+
+    let mut phone = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        RECIPIENT_USER,
+        &password,
+        &format!("phone-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("phone connection");
+    enable_carbons(&mut phone, "carbons-enable-phone").await;
+    send_presence_with_priority(&mut phone, 5).await;
+
+    let mut laptop = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        RECIPIENT_USER,
+        &password,
+        &format!("laptop-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("laptop connection");
+    enable_carbons(&mut laptop, "carbons-enable-laptop").await;
+    send_presence_with_priority(&mut laptop, 0).await;
+
+    let mut sender = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        SENDER_USER,
+        SENDER_PASSWORD,
+        &format!("sender-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("sender connection");
+    let body = format!("carbon-positive-proof-{}", uuid::Uuid::new_v4());
+    sender
+        .send(&chat_message_xml(
+            &format!("admin@{DOMAIN}"),
+            "fanout-5",
+            &body,
+        ))
+        .await
+        .expect("send dm");
+
+    // The two max-priority resources get the original, no carbon.
+    for (name, client) in [("web", &mut web), ("phone", &mut phone)] {
+        let copies = drain_matching(client, &body).await;
+        assert_eq!(
+            copies.len(),
+            1,
+            "{name} gets exactly the original: {copies:?}"
+        );
+        assert!(
+            !copies[0].contains(CARBONS_NS),
+            "{name}'s copy must not be a carbon: {}",
+            copies[0]
+        );
+    }
+
+    // The lower-priority laptop is outside the delivery set: exactly
+    // one received-carbon, and nothing else.
+    let laptop_copies = drain_matching(&mut laptop, &body).await;
+    assert_eq!(
+        laptop_copies.len(),
+        1,
+        "laptop must get the DM exactly once, as a carbon: {laptop_copies:?}"
+    );
+    assert!(
+        laptop_copies[0].contains(CARBONS_NS) && laptop_copies[0].contains("<received"),
+        "laptop's copy must be a received-carbon: {}",
+        laptop_copies[0]
+    );
+
+    let _ = sender.close().await;
+    let _ = web.close().await;
+    let _ = phone.close().await;
+    let _ = laptop.close().await;
 }
 
 /// Extract the `id` of the XEP-0359 `<stanza-id/>` stamped by the

--- a/server/crates/waddle-server/tests/xep0280_same_priority_fanout_ws.rs
+++ b/server/crates/waddle-server/tests/xep0280_same_priority_fanout_ws.rs
@@ -15,19 +15,102 @@
 use waddle_ws_test_support as ws_common;
 
 use std::time::Duration;
+use waddle_xmpp::ns::{JABBER_CLIENT, SM as SM_NS};
+use waddle_xmpp::xep::xep0430::NS_INBOX;
+use waddle_xmpp_core::carbons::CARBONS_NS;
+use waddle_xmpp_core::mam::MAM_NS;
 use ws_common::{TestServer, WsXmppClient};
+use xmpp_parsers::minidom::Element;
 
 const DOMAIN: &str = "localhost";
 const RECIPIENT_USER: &str = "admin";
 const SENDER_USER: &str = "peer";
 const SENDER_PASSWORD: &str = "peer-password-1";
-const NS_CARBONS: &str = "urn:xmpp:carbons:2";
+
+fn element_to_xml(element: Element) -> String {
+    let mut buf = Vec::new();
+    element.write_to(&mut buf).expect("serialize XML");
+    String::from_utf8(buf).expect("UTF-8")
+}
+
+fn attr(name: &str) -> minidom::rxml::NcName {
+    minidom::rxml::NcNameStr::from_str(name)
+        .expect("static attribute name is a valid NcName")
+        .to_owned()
+}
+
+fn iq_xml(kind: &str, id: &str, to: Option<&str>, payload: Element) -> String {
+    let mut builder = Element::builder("iq", JABBER_CLIENT)
+        .attr(attr("type"), kind)
+        .attr(attr("id"), id);
+    if let Some(to) = to {
+        builder = builder.attr(attr("to"), to);
+    }
+    element_to_xml(builder.append(payload).build())
+}
+
+fn carbons_enable_xml(id: &str) -> String {
+    iq_xml(
+        "set",
+        id,
+        None,
+        Element::builder("enable", CARBONS_NS).build(),
+    )
+}
+
+fn chat_message_xml(to: &str, id: &str, body: &str) -> String {
+    let mut body_el = Element::builder("body", JABBER_CLIENT).build();
+    body_el.append_text_node(body);
+    element_to_xml(
+        Element::builder("message", JABBER_CLIENT)
+            .attr(attr("to"), to)
+            .attr(attr("type"), "chat")
+            .attr(attr("id"), id)
+            .append(body_el)
+            .build(),
+    )
+}
+
+fn sm_enable_xml() -> String {
+    element_to_xml(
+        Element::builder("enable", SM_NS)
+            .attr(attr("resume"), "true")
+            .build(),
+    )
+}
+
+fn sm_resume_xml(previd: &str) -> String {
+    element_to_xml(
+        Element::builder("resume", SM_NS)
+            .attr(attr("previd"), previd)
+            .attr(attr("h"), "0")
+            .build(),
+    )
+}
+
+fn mam_query_xml(id: &str, archive_jid: &str) -> String {
+    iq_xml(
+        "set",
+        id,
+        Some(archive_jid),
+        Element::builder("query", MAM_NS).build(),
+    )
+}
+
+fn inbox_query_xml(id: &str) -> String {
+    iq_xml(
+        "get",
+        id,
+        None,
+        Element::builder("inbox", NS_INBOX)
+            .attr(attr("messages"), "false")
+            .build(),
+    )
+}
 
 async fn enable_carbons(client: &mut WsXmppClient, id: &str) {
     client
-        .send(&format!(
-            r#"<iq xmlns="jabber:client" type="set" id="{id}"><enable xmlns="urn:xmpp:carbons:2"/></iq>"#
-        ))
+        .send(&carbons_enable_xml(id))
         .await
         .expect("send carbons enable");
     let _ = client
@@ -38,7 +121,9 @@ async fn enable_carbons(client: &mut WsXmppClient, id: &str) {
 
 async fn send_available_presence(client: &mut WsXmppClient) {
     client
-        .send(r#"<presence xmlns="jabber:client"/>"#)
+        .send(&element_to_xml(
+            Element::builder("presence", JABBER_CLIENT).build(),
+        ))
         .await
         .expect("send presence");
 }
@@ -117,8 +202,10 @@ async fn two_same_priority_resources_receive_the_dm_exactly_once_each() {
     let body = format!("fanout-dedupe-proof-{}", uuid::Uuid::new_v4());
 
     fx.sender
-        .send(&format!(
-            r#"<message xmlns="jabber:client" to="admin@{DOMAIN}" type="chat" id="fanout-1"><body>{body}</body></message>"#
+        .send(&chat_message_xml(
+            &format!("admin@{DOMAIN}"),
+            "fanout-1",
+            &body,
         ))
         .await
         .expect("send dm");
@@ -134,7 +221,7 @@ async fn two_same_priority_resources_receive_the_dm_exactly_once_each() {
             copies.len()
         );
         assert!(
-            !copies[0].contains(NS_CARBONS),
+            !copies[0].contains(CARBONS_NS),
             "{name}'s only copy must be the original delivery, not a carbon: {}",
             copies[0]
         );
@@ -151,8 +238,10 @@ async fn recipient_archive_and_stanza_id_are_single_per_bare_recipient() {
     let body = format!("fanout-archive-proof-{}", uuid::Uuid::new_v4());
 
     fx.sender
-        .send(&format!(
-            r#"<message xmlns="jabber:client" to="admin@{DOMAIN}" type="chat" id="fanout-2"><body>{body}</body></message>"#
+        .send(&chat_message_xml(
+            &format!("admin@{DOMAIN}"),
+            "fanout-2",
+            &body,
         ))
         .await
         .expect("send dm");
@@ -176,9 +265,7 @@ async fn recipient_archive_and_stanza_id_are_single_per_bare_recipient() {
 
     // XEP-0313: exactly one archived row for the message.
     fx.web
-        .send(&format!(
-            r#"<iq xmlns="jabber:client" type="set" id="fanout-mam-1" to="admin@{DOMAIN}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
-        ))
+        .send(&mam_query_xml("fanout-mam-1", &format!("admin@{DOMAIN}")))
         .await
         .expect("send mam query");
     let mut archived = 0usize;
@@ -188,7 +275,7 @@ async fn recipient_archive_and_stanza_id_are_single_per_bare_recipient() {
             .recv_timeout(Duration::from_secs(3))
             .await
             .expect("mam stream frame");
-        if frame.contains(&body) && frame.contains("urn:xmpp:mam:2") {
+        if frame.contains(&body) && frame.contains(MAM_NS) {
             archived += 1;
         }
         if frame.contains("<fin") {
@@ -211,8 +298,10 @@ async fn recipient_inbox_unread_increments_once_per_message() {
     let body = format!("fanout-inbox-proof-{}", uuid::Uuid::new_v4());
 
     fx.sender
-        .send(&format!(
-            r#"<message xmlns="jabber:client" to="admin@{DOMAIN}" type="chat" id="fanout-3"><body>{body}</body></message>"#
+        .send(&chat_message_xml(
+            &format!("admin@{DOMAIN}"),
+            "fanout-3",
+            &body,
         ))
         .await
         .expect("send dm");
@@ -227,9 +316,7 @@ async fn recipient_inbox_unread_increments_once_per_message() {
     );
 
     fx.web
-        .send(
-            r#"<iq xmlns="jabber:client" type="get" id="fanout-inbox-1"><inbox xmlns="urn:xmpp:inbox:1" messages="false"/></iq>"#,
-        )
+        .send(&inbox_query_xml("fanout-inbox-1"))
         .await
         .expect("send inbox query");
     let mut unread: Option<String> = None;
@@ -289,7 +376,7 @@ async fn detached_carbons_enabled_sibling_gets_the_dm_exactly_once_on_resume() {
     .expect("phone connection");
     enable_carbons(&mut phone, "carbons-enable-phone").await;
     phone
-        .send(r#"<enable xmlns="urn:xmpp:sm:3" resume="true"/>"#)
+        .send(&sm_enable_xml())
         .await
         .expect("enable resumption");
     let enabled = phone
@@ -310,8 +397,10 @@ async fn detached_carbons_enabled_sibling_gets_the_dm_exactly_once_on_resume() {
     .expect("sender connection");
     let body = format!("detached-dedupe-proof-{}", uuid::Uuid::new_v4());
     sender
-        .send(&format!(
-            r#"<message xmlns="jabber:client" to="admin@{DOMAIN}" type="chat" id="fanout-4"><body>{body}</body></message>"#
+        .send(&chat_message_xml(
+            &format!("admin@{DOMAIN}"),
+            "fanout-4",
+            &body,
         ))
         .await
         .expect("send dm");
@@ -328,9 +417,7 @@ async fn detached_carbons_enabled_sibling_gets_the_dm_exactly_once_on_resume() {
         .await
         .expect("authenticate resume connection");
     resumed
-        .send(&format!(
-            r#"<resume xmlns="urn:xmpp:sm:3" previd="{stream_id}" h="0"/>"#
-        ))
+        .send(&sm_resume_xml(&stream_id))
         .await
         .expect("send resume");
     let _ = resumed
@@ -346,7 +433,7 @@ async fn detached_carbons_enabled_sibling_gets_the_dm_exactly_once_on_resume() {
          (original replay only, no received-carbon — XEP-0280 §6.3), got: {replayed:?}"
     );
     assert!(
-        !replayed[0].contains(NS_CARBONS),
+        !replayed[0].contains(CARBONS_NS),
         "the replayed copy must be the original delivery, not a carbon: {}",
         replayed[0]
     );

--- a/server/crates/waddle-xmpp/src/protocol/dispatch_message_l2_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/dispatch_message_l2_tests.rs
@@ -123,6 +123,7 @@ fn build_ctx<'a>(
         carbons: CarbonsState::Disabled,
         muc_occupancy: occ,
         has_live_transport: true,
+        delivery_fanout: &[],
         id_gen: gen,
     };
     MessageContext::derive(env, msg)

--- a/server/crates/waddle-xmpp/src/protocol/dispatch_message_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/dispatch_message_tests.rs
@@ -71,6 +71,7 @@ impl Fixture {
             carbons: CarbonsState::Disabled,
             muc_occupancy: &self.occupancy,
             has_live_transport: true,
+            delivery_fanout: &[],
             id_gen: &self.id_gen,
         };
         MessageContext::derive(env, message)

--- a/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
@@ -311,12 +311,21 @@ pub enum OutboundEvent {
     /// genuinely should be carboned. The interpreter wraps the message in
     /// `<sent>`/`<received>` → `<forwarded xmlns='urn:xmpp:forward:0'>`
     /// (XEP-0297) and delivers a copy to every resource of `owner`
-    /// except `exclude`.
+    /// except those in `exclude`.
+    ///
+    /// `exclude` is the full delivery set of the original stanza —
+    /// XEP-0280 §6.3: "The receiving server MUST NOT send a forwarded
+    /// copy to the client(s) the original <message/> stanza was
+    /// addressed to, as these recipients receive the original
+    /// <message/> stanza." For the sender pass and full-JID
+    /// deliveries this is the single originating/receiving resource;
+    /// for the shared bare-JID recipient pass (#1106) it is the whole
+    /// RFC 6121 §8.5.2.1.1 same-priority delivery set.
     SendCarbons {
         owner: BareJid,
         message: Box<Message>,
         kind: CarbonKind,
-        exclude: FullJid,
+        exclude: Vec<FullJid>,
     },
     /// XEP-0333 §3 — the sender displayed a message up to
     /// `displayed_message_id` in a MUC room. The interpreter resolves

--- a/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
@@ -216,6 +216,7 @@ mod tests {
             carbons: CarbonsState::Disabled,
             muc_occupancy: &occ,
             has_live_transport: true,
+            delivery_fanout: &[],
             id_gen: &gen,
         };
         let ctx = MessageContext::derive(env, msg);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/blocking_filter.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/blocking_filter.rs
@@ -134,6 +134,7 @@ mod tests {
             carbons: CarbonsState::Disabled,
             muc_occupancy: &occ,
             has_live_transport: true,
+            delivery_fanout: &[],
             id_gen: &gen,
         };
         let ctx = MessageContext::derive(env, msg);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/canonicalize.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/canonicalize.rs
@@ -129,6 +129,7 @@ mod tests {
             carbons: CarbonsState::Disabled,
             muc_occupancy: &occ,
             has_live_transport: true,
+            delivery_fanout: &[],
             id_gen: &gen,
         };
         let ctx = MessageContext::derive(env, msg);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/carbons_message.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/carbons_message.rs
@@ -59,7 +59,18 @@ impl MessageHandler for CarbonsMessageHandler {
         }
 
         let owner = ctx.full_jid.to_bare();
-        let exclude = ctx.full_jid.clone();
+        // XEP-0280 §6.3: "The receiving server MUST NOT send a forwarded
+        // copy to the client(s) the original <message/> stanza was
+        // addressed to." When this dispatch is the single shared
+        // recipient pass for a bare-JID DM (#1106), the exclusion set is
+        // the whole RFC 6121 §8.5.2.1.1 delivery-fanout set. On ordinary
+        // per-connection dispatches the fanout is empty and only the
+        // local resource is excluded (sender pass / full-JID delivery).
+        let exclude = if ctx.delivery_fanout.is_empty() {
+            vec![ctx.full_jid.clone()]
+        } else {
+            ctx.delivery_fanout.to_vec()
+        };
         let kind = match ctx.locality {
             Locality::Sender => CarbonKind::Sent,
             Locality::Recipient => CarbonKind::Received,
@@ -108,6 +119,15 @@ mod tests {
     }
 
     fn run(local: &FullJid, carbons: CarbonsState, msg: &mut Message) -> HandlerOutcome {
+        run_with_fanout(local, carbons, &[], msg)
+    }
+
+    fn run_with_fanout(
+        local: &FullJid,
+        carbons: CarbonsState,
+        delivery_fanout: &[FullJid],
+        msg: &mut Message,
+    ) -> HandlerOutcome {
         let bl = Blocklist::empty();
         let occ = MucOccupancy::empty();
         let gen = FixedIdGenerator("test".to_string());
@@ -118,6 +138,7 @@ mod tests {
             carbons,
             muc_occupancy: &occ,
             has_live_transport: true,
+            delivery_fanout,
             id_gen: &gen,
         };
         let ctx = MessageContext::derive(env, msg);
@@ -283,16 +304,40 @@ mod tests {
 
     #[test]
     fn xep_0280_excludes_originating_resource_from_fanout() {
-        // The `exclude` field carries the local connection's full JID
-        // so the interpreter doesn't echo the carbon back to the
-        // resource that originated the message.
+        // Without a delivery-fanout set the `exclude` field falls back
+        // to the local connection's full JID so the interpreter doesn't
+        // echo the carbon back to the resource that originated the
+        // message.
         let local = full("alice@example.com/web");
         let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
         let outcome = run(&local, CarbonsState::Enabled, &mut msg);
         match outcome {
             HandlerOutcome::Continue(events) => match &events[0] {
                 OutboundEvent::SendCarbons { exclude, .. } => {
-                    assert_eq!(exclude.to_string(), "alice@example.com/web");
+                    assert_eq!(exclude, &vec![full("alice@example.com/web")]);
+                }
+                _ => panic!("expected SendCarbons"),
+            },
+            other => panic!("expected Continue, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn xep_0280_delivery_fanout_set_is_the_exclusion_set() {
+        // #1106 / XEP-0280 §6.3: on the single shared recipient pass
+        // for a bare-JID DM, every resource in the RFC 6121
+        // §8.5.2.1.1 delivery set receives the original stanza, so the
+        // whole set — not just the pass's synthetic local resource —
+        // must be excluded from received-carbon fan-out.
+        let local = full("bob@example.com/offline-recipient-pass");
+        let fanout = vec![full("bob@example.com/web"), full("bob@example.com/phone")];
+        let mut msg = chat_with_body("alice@example.com/web", "bob@example.com", "hi");
+        let outcome = run_with_fanout(&local, CarbonsState::Enabled, &fanout, &mut msg);
+        match outcome {
+            HandlerOutcome::Continue(events) => match &events[0] {
+                OutboundEvent::SendCarbons { exclude, kind, .. } => {
+                    assert_eq!(exclude, &fanout);
+                    assert_eq!(*kind, CarbonKind::Received);
                 }
                 _ => panic!("expected SendCarbons"),
             },

--- a/server/crates/waddle-xmpp/src/protocol/handlers/enrichment_dispatch.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/enrichment_dispatch.rs
@@ -162,6 +162,7 @@ mod tests {
             carbons: CarbonsState::Disabled,
             muc_occupancy: &occ,
             has_live_transport: true,
+            delivery_fanout: &[],
             id_gen: &gen,
         };
         let ctx = MessageContext::derive(env, msg);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/framework_envelope.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/framework_envelope.rs
@@ -106,6 +106,7 @@ mod tests {
             carbons: CarbonsState::Disabled,
             muc_occupancy: &occupancy,
             has_live_transport: true,
+            delivery_fanout: &[],
             id_gen: &id_gen,
         };
         let ctx = MessageContext::derive(env, message);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/inbox.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/inbox.rs
@@ -184,6 +184,7 @@ mod tests {
             carbons: CarbonsState::Disabled,
             muc_occupancy: &occ,
             has_live_transport: true,
+            delivery_fanout: &[],
             id_gen: &gen,
         };
         let ctx = MessageContext::derive(env, msg);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/offline_delivery.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/offline_delivery.rs
@@ -181,6 +181,7 @@ mod tests {
             carbons: CarbonsState::Disabled,
             muc_occupancy,
             has_live_transport,
+            delivery_fanout: &[],
             id_gen,
         };
         MessageContext::derive(env, message)

--- a/server/crates/waddle-xmpp/src/protocol/handlers/receipts.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/receipts.rs
@@ -107,6 +107,7 @@ mod tests {
             carbons: CarbonsState::Disabled,
             muc_occupancy: &occupancy,
             has_live_transport,
+            delivery_fanout: &[],
             id_gen: &id_gen,
         };
         let mut ctx = MessageContext::derive(env, message);

--- a/server/crates/waddle-xmpp/src/protocol/handlers/receipts.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/receipts.rs
@@ -50,11 +50,19 @@ impl MessageHandler for ReceiptsHandler {
             return HandlerOutcome::Continue(Vec::new());
         };
 
-        let mut receipt = build_receipt_message(
-            Some(target.clone()),
-            Some(Jid::from(ctx.full_jid.clone())),
-            original_id,
-        );
+        // #1106: on the shared fan-out recipient pass (delivery_fanout
+        // set) `ctx.full_jid` is the synthetic
+        // `…/offline-recipient-pass` sentinel, which must never leak to
+        // the wire — a resource-locking sender would address its next
+        // message to a nonexistent resource. The server-generated ack
+        // comes from the recipient's bare JID instead.
+        let receipt_from = if ctx.delivery_fanout.is_empty() {
+            Jid::from(ctx.full_jid.clone())
+        } else {
+            Jid::from(ctx.full_jid.to_bare())
+        };
+        let mut receipt =
+            build_receipt_message(Some(target.clone()), Some(receipt_from), original_id);
         receipt.type_ = message.type_.clone();
 
         HandlerOutcome::Continue(vec![OutboundEvent::RouteToConnection {
@@ -97,6 +105,15 @@ mod tests {
     }
 
     fn run(local: &FullJid, has_live_transport: bool, message: &mut Message) -> HandlerOutcome {
+        run_with_fanout(local, has_live_transport, &[], message)
+    }
+
+    fn run_with_fanout(
+        local: &FullJid,
+        has_live_transport: bool,
+        delivery_fanout: &[FullJid],
+        message: &mut Message,
+    ) -> HandlerOutcome {
         let blocklist = Blocklist::empty();
         let occupancy = MucOccupancy::empty();
         let id_gen = FixedIdGenerator("id".to_string());
@@ -107,7 +124,7 @@ mod tests {
             carbons: CarbonsState::Disabled,
             muc_occupancy: &occupancy,
             has_live_transport,
-            delivery_fanout: &[],
+            delivery_fanout,
             id_gen: &id_gen,
         };
         let mut ctx = MessageContext::derive(env, message);
@@ -137,6 +154,37 @@ mod tests {
                     Some(local.to_string())
                 );
                 assert_eq!(extract_received_id(receipt), Some("msg-1".to_string()));
+            }
+            other => panic!("expected RouteToConnection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn xep_0184_shared_fanout_pass_sends_receipt_from_bare_jid() {
+        // #1106: the shared recipient pass runs on a synthetic full JID
+        // (`…/offline-recipient-pass`). That sentinel must never leak to
+        // the wire as the receipt `from` — a resource-locking sender
+        // would address its next message to a nonexistent resource. The
+        // server-generated ack comes from the recipient's bare JID.
+        let local = full("bob@example.com/offline-recipient-pass");
+        let fanout = vec![full("bob@example.com/web"), full("bob@example.com/phone")];
+        let mut message = receipt_request_message();
+
+        let outcome = run_with_fanout(&local, true, &fanout, &mut message);
+        let events = match outcome {
+            HandlerOutcome::Continue(events) => events,
+            other => panic!("expected Continue, got {other:?}"),
+        };
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            OutboundEvent::RouteToConnection { stanza, .. } => {
+                let Stanza::Message(receipt) = stanza.as_ref() else {
+                    panic!("expected receipt message")
+                };
+                assert_eq!(
+                    receipt.from.as_ref().map(ToString::to_string),
+                    Some("bob@example.com".to_string())
+                );
             }
             other => panic!("expected RouteToConnection, got {other:?}"),
         }

--- a/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation/tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation/tests.rs
@@ -41,6 +41,7 @@ fn ctx_for<'a>(
         carbons: CarbonsState::Disabled,
         muc_occupancy: occ,
         has_live_transport: true,
+        delivery_fanout: &[],
         id_gen: gen,
     };
     MessageContext::derive(env, msg)

--- a/server/crates/waddle-xmpp/src/protocol/handlers/route.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/route.rs
@@ -144,6 +144,7 @@ mod tests {
             carbons: CarbonsState::Disabled,
             muc_occupancy: occ,
             has_live_transport: true,
+            delivery_fanout: &[],
             id_gen: &gen,
         };
         let ctx = MessageContext::derive(env, msg);

--- a/server/crates/waddle-xmpp/src/protocol/machine.rs
+++ b/server/crates/waddle-xmpp/src/protocol/machine.rs
@@ -52,6 +52,14 @@ pub struct XmppStateMachine {
     /// transport. Headless offline-recipient passes flip this to `false`
     /// so delivery-only XEPs do not fire.
     has_live_transport: bool,
+    /// RFC 6121 §8.5.2.1.1 delivery-fanout set for the single shared
+    /// recipient pass (#1106). Empty on ordinary per-connection
+    /// machines; the bare-JID fan-out runner seeds it with the full
+    /// set of same-priority resources the processed stanza will be
+    /// delivered to, so the XEP-0280 carbons handler can exclude the
+    /// *whole* delivery set (XEP-0280 §6.3) instead of just one
+    /// resource.
+    delivery_fanout: Vec<jid::FullJid>,
     /// Source of fresh, opaque XEP-0359 stanza-ids stamped by message
     /// handlers. Defaults to UUIDv4; tests can override.
     id_gen: Arc<dyn IdGenerator>,
@@ -89,6 +97,7 @@ impl XmppStateMachine {
             carbons: CarbonsState::Disabled,
             muc_occupancy: MucOccupancy::empty(),
             has_live_transport: true,
+            delivery_fanout: Vec::new(),
             id_gen,
             keepalive: KeepalivePolicy::new(KeepaliveConfig::default()),
         }
@@ -172,6 +181,18 @@ impl XmppStateMachine {
     /// transport.
     pub fn set_has_live_transport(&mut self, has_live_transport: bool) {
         self.has_live_transport = has_live_transport;
+    }
+
+    /// Seed the RFC 6121 §8.5.2.1.1 delivery-fanout set for a shared
+    /// bare-JID recipient pass (#1106). Analogous to
+    /// [`Self::set_blocklist`]: called once on a transient machine
+    /// before feeding [`InboundEvent::StanzaFromPeer`], so the
+    /// XEP-0280 carbons handler emits the whole delivery set as the
+    /// carbon exclusion (XEP-0280 §6.3). Ordinary per-connection
+    /// machines leave this empty and the handler falls back to
+    /// excluding only the local resource.
+    pub fn set_delivery_fanout(&mut self, delivery_fanout: Vec<jid::FullJid>) {
+        self.delivery_fanout = delivery_fanout;
     }
 
     /// Replace the per-connection XEP-0191 blocklist snapshot.
@@ -309,6 +330,7 @@ impl XmppStateMachine {
                         carbons: self.carbons,
                         muc_occupancy: &self.muc_occupancy,
                         has_live_transport: self.has_live_transport,
+                        delivery_fanout: &self.delivery_fanout,
                         id_gen: self.id_gen.as_ref(),
                     };
                     let mctx = MessageContext::derive(env, &message);
@@ -360,6 +382,7 @@ impl XmppStateMachine {
                         carbons: self.carbons,
                         muc_occupancy: &self.muc_occupancy,
                         has_live_transport: self.has_live_transport,
+                        delivery_fanout: &self.delivery_fanout,
                         id_gen: self.id_gen.as_ref(),
                     };
                     // Peer stanzas are by definition recipient-pass —

--- a/server/crates/waddle-xmpp/src/protocol/machine/message_pipeline.rs
+++ b/server/crates/waddle-xmpp/src/protocol/machine/message_pipeline.rs
@@ -104,6 +104,7 @@ impl XmppStateMachine {
                 carbons: snapshot.carbons,
                 muc_occupancy: &snapshot.muc_occupancy,
                 has_live_transport: self.has_live_transport,
+                delivery_fanout: &self.delivery_fanout,
                 id_gen: self.id_gen.as_ref(),
             };
             let mctx = MessageContext::derive(env, &message);
@@ -150,6 +151,7 @@ fn infer_resume_kind(
                         carbons: CarbonsState::Disabled,
                         muc_occupancy: &muc_occupancy,
                         has_live_transport: true,
+                        delivery_fanout: &[],
                         id_gen: &id_gen,
                     },
                 )?;

--- a/server/crates/waddle-xmpp/src/protocol/machine/test_support.rs
+++ b/server/crates/waddle-xmpp/src/protocol/machine/test_support.rs
@@ -35,6 +35,7 @@ pub fn ready_machine_with_id_gen(
         carbons: CarbonsState::Disabled,
         muc_occupancy: MucOccupancy::empty(),
         has_live_transport: true,
+        delivery_fanout: Vec::new(),
         id_gen,
         keepalive: KeepalivePolicy::new(KeepaliveConfig::default()),
     }

--- a/server/crates/waddle-xmpp/src/protocol/message_context.rs
+++ b/server/crates/waddle-xmpp/src/protocol/message_context.rs
@@ -43,6 +43,13 @@ pub struct MessageContext<'a> {
     pub muc_occupancy: &'a MucOccupancy,
     /// Whether this dispatch represents a live client transport.
     pub has_live_transport: bool,
+    /// RFC 6121 §8.5.2.1.1 delivery-fanout set when this dispatch is
+    /// the single shared recipient pass for a bare-JID DM (#1106).
+    /// Empty on ordinary per-connection dispatches. The XEP-0280
+    /// carbons handler uses a non-empty set as the carbon exclusion
+    /// set (XEP-0280 §6.3 — every addressed client gets the original,
+    /// never a forwarded copy).
+    pub delivery_fanout: &'a [FullJid],
     /// Source of fresh, opaque XEP-0359 stanza-id values.
     pub id_gen: &'a dyn IdGenerator,
 }
@@ -59,6 +66,7 @@ impl<'a> MessageContext<'a> {
             carbons: env.carbons,
             muc_occupancy: env.muc_occupancy,
             has_live_transport: env.has_live_transport,
+            delivery_fanout: env.delivery_fanout,
             id_gen: env.id_gen,
         }
     }
@@ -84,6 +92,10 @@ pub struct MessageContextEnv<'a> {
     pub muc_occupancy: &'a MucOccupancy,
     /// Whether this dispatch represents a live client transport.
     pub has_live_transport: bool,
+    /// RFC 6121 §8.5.2.1.1 delivery-fanout set — see
+    /// [`MessageContext::delivery_fanout`]. Empty for ordinary
+    /// per-connection dispatches.
+    pub delivery_fanout: &'a [FullJid],
     /// Source of fresh, opaque XEP-0359 stanza-id values.
     pub id_gen: &'a dyn IdGenerator,
 }
@@ -112,6 +124,7 @@ mod tests {
             carbons: CarbonsState::Enabled,
             muc_occupancy: &occ,
             has_live_transport: true,
+            delivery_fanout: &[],
             id_gen: &gen,
         };
 

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/resources.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/resources.rs
@@ -166,22 +166,24 @@ impl ConnectionRegistry {
     }
 
     /// Get all resources for a bare JID that have XEP-0280 Message Carbons
-    /// enabled, excluding a specific full JID.
+    /// enabled, excluding every full JID in `exclude_jids`.
     ///
     /// Per XEP-0280 §5, carbons must be enabled per-resource. The server must
     /// only deliver `<sent>` and `<received>` carbon copies to resources that
     /// have explicitly opted in via `<enable xmlns='urn:xmpp:carbons:2'/>`.
+    /// `exclude_jids` is the original stanza's delivery set (XEP-0280 §6.3:
+    /// clients addressed by the original MUST NOT also get a forwarded copy).
     pub fn get_other_carbon_resources_for_user(
         &self,
         bare_jid: &BareJid,
-        exclude_jid: &FullJid,
+        exclude_jids: &[FullJid],
     ) -> Vec<FullJid> {
         self.connections
             .iter()
             .filter(|entry| {
                 let jid = entry.key();
                 jid.to_bare() == *bare_jid
-                    && jid != exclude_jid
+                    && !exclude_jids.contains(jid)
                     && entry.value().is_carbons_enabled()
             })
             .map(|entry| entry.key().clone())

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/resources.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/resources.rs
@@ -259,11 +259,16 @@ impl InMemorySmSessionRegistry {
         Ok(resources)
     }
 
-    /// List detached resources for a bare JID that had XEP-0280 carbons enabled.
+    /// List detached resources for a bare JID that had XEP-0280 carbons
+    /// enabled, excluding every full JID in `except`.
+    ///
+    /// `except` is the original stanza's delivery set (XEP-0280 §6.3:
+    /// clients addressed by the original MUST NOT also get a forwarded
+    /// copy).
     pub async fn detached_carbon_resources_for_user(
         &self,
         bare_jid: &BareJid,
-        except: &FullJid,
+        except: &[FullJid],
     ) -> Result<Vec<FullJid>, SmRegistryError> {
         let sessions = self
             .sessions
@@ -276,7 +281,7 @@ impl InMemorySmSessionRegistry {
                 session.carbons_enabled
                     && !session.is_expired()
                     && session.jid.to_bare() == *bare_jid
-                    && session.jid != *except
+                    && !except.contains(&session.jid)
             })
             .map(|session| session.jid.clone())
             .collect();
@@ -293,7 +298,7 @@ impl InMemorySmSessionRegistry {
                     session.carbons_enabled
                         && !session.is_expired()
                         && session.jid.to_bare() == *bare_jid
-                        && session.jid != *except
+                        && !except.contains(&session.jid)
                 })
                 .map(|session| session.jid.clone()),
         );

--- a/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
+++ b/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
@@ -377,7 +377,7 @@ async fn xep0198_expired_claimed_sessions_are_hidden_from_detached_fanout() {
         .expect("interested resources")
         .is_empty());
     assert!(registry
-        .detached_carbon_resources_for_user(&bare, &jid)
+        .detached_carbon_resources_for_user(&bare, std::slice::from_ref(&jid))
         .await
         .expect("carbon resources")
         .is_empty());
@@ -497,7 +497,7 @@ async fn xep0198_detached_resource_lists_preserve_stream_flags() {
     assert!(!interested.contains(&laptop));
 
     let carbon = registry
-        .detached_carbon_resources_for_user(&alice, &phone)
+        .detached_carbon_resources_for_user(&alice, std::slice::from_ref(&phone))
         .await
         .expect("list carbon resources");
     assert!(!carbon.contains(&phone));

--- a/server/crates/waddle-xmpp/tests/xep0280_message_carbons.rs
+++ b/server/crates/waddle-xmpp/tests/xep0280_message_carbons.rs
@@ -59,3 +59,50 @@ fn xep0280_bodyless_chat_marker_is_eligible_for_carbons() {
     );
     assert!(should_copy_message(&msg));
 }
+
+// ---------------------------------------------------------------------
+// #1106 / XEP-0280 §6.3 — the whole RFC 6121 §8.5.2.1.1 delivery set is
+// the carbon exclusion set: "The receiving server MUST NOT send a
+// forwarded copy to the client(s) the original <message/> stanza was
+// addressed to, as these recipients receive the original <message/>
+// stanza."
+// ---------------------------------------------------------------------
+
+#[tokio::test]
+async fn xep0280_carbon_enumeration_excludes_whole_delivery_set() {
+    use jid::FullJid;
+    use waddle_xmpp::registry::ConnectionRegistry;
+
+    let registry = ConnectionRegistry::new();
+    let bare: jid::BareJid = "bob@localhost".parse().expect("bare jid");
+    let web: FullJid = "bob@localhost/web".parse().expect("full jid");
+    let phone: FullJid = "bob@localhost/phone".parse().expect("full jid");
+    let laptop: FullJid = "bob@localhost/laptop".parse().expect("full jid");
+
+    // All three resources online with carbons enabled; web + phone are
+    // the same-priority delivery set that received the original stanza,
+    // laptop is a lower-priority resource that only gets a carbon.
+    let (web_tx, _web_rx) = tokio::sync::mpsc::channel(4);
+    registry.register_with_carbons(web.clone(), web_tx, true);
+    let (phone_tx, _phone_rx) = tokio::sync::mpsc::channel(4);
+    registry.register_with_carbons(phone.clone(), phone_tx, true);
+    let (laptop_tx, _laptop_rx) = tokio::sync::mpsc::channel(4);
+    registry.register_with_carbons(laptop.clone(), laptop_tx, true);
+
+    let delivery_set = vec![web.clone(), phone.clone()];
+    let carbon_targets = registry.get_other_carbon_resources_for_user(&bare, &delivery_set);
+
+    assert!(
+        !carbon_targets.contains(&web),
+        "web received the original and must not get a forwarded copy"
+    );
+    assert!(
+        !carbon_targets.contains(&phone),
+        "phone received the original and must not get a forwarded copy"
+    );
+    assert_eq!(
+        carbon_targets,
+        vec![laptop],
+        "only the resource outside the delivery set gets the carbon"
+    );
+}


### PR DESCRIPTION
Implements #675, #754, and #1106 in one PR. Every fix landed test-first: each behavior has a failing test committed alongside the change that makes it pass.

## #675 — chat: initial MAM bootstrap overwrote live messages

`loadMessages` in both `chat/src/channels/mam-paging.ts` and `chat/src/dms/mam-paging.ts` reset `messages.value`, awaited the latest MAM page, then wholesale-assigned the rebuilt timeline — wiping any live message `mergeLiveMessage` sorted in during the await (XEP-0313 live-vs-archive delivery is asynchronous; the latest page cannot be assumed to contain in-flight deliveries).

**Fix:** capture the in-memory timeline after the await and re-insert every live row into the rebuilt timeline through `insertLiveMessage` — the same reconciliation as the live-merge path — so a MAM copy of the same message dedupes via its XEP-0359 id aliases instead of duplicating, and genuinely new arrivals survive in chronological position. Hardening from adversarial review: a redelivered pre-correction original can no longer roll back an applied XEP-0308 correction; foreign live arrivals during the load count into the unread-divider anchor; and a *failed* MAM query no longer wipes live arrivals either.

Tests: `chat/tests/bootstrap-mam-race.test.ts` (7 cases: preserve + dedupe on both channel/DM drivers, correction guard, divider anchor, failure path).

## #754 — chat: bootstrap sequence fired 4–6× per reconnect

Every session-ready re-fired the whole bootstrap fan-out from multiple subscribers: the lifecycle handler ran inbox hydrates + feed/stories/events refreshes on both fresh and resumed events, `onConnectionReady` duplicated the same set on first connect, and `enableCarbons` fired from both the WASM `on_connected` hook and the fresh branch of `runSessionReady` (the 4× carbons / 6× inbox fanout in the issue's HAR).

**Fix:** a single `runSessionBootstrap` choreographer in `use-connection-lifecycle.ts`, fired exactly once per session-ready from the lifecycle handler only. `onConnectionReady` no longer duplicates the set (appState turns "ready" on the HTTP session load before XMPP connects; the lifecycle event of that first connection covers it — the client registers handlers before it lazily connects, so the event cannot be missed). Carbons enable lives solely in the fresh branch; XEP-0198 resume preserves carbon state server-side, so resume re-enables nothing. Resumed sessions DO re-hydrate the surfaces once: adversarial review proved inbox pushes are fire-and-forgot to live resources only, so a detached-then-resumed session misses cross-device mark-read pushes that SM replay cannot heal. XEP-0492 notification settings stay fresh-only (bookmark publishes ride the preserved PEP queue).

Acceptance: one of each bootstrap IQ per session-ready — not N — for first connect, fresh reconnect, and resume.

Tests: `chat/tests/session-bootstrap-choreography.test.ts` (real `useConnectionLifecycle` wiring, 4 cases), `chat/tests/carbons-enable-once.test.ts` (real `wireEvents`, fresh = 1 enable, resume = 0).

## #1106 — server: recipient pass ran once per resource, not per bare recipient

A bare-JID DM delivered to N same-priority resources (RFC 6121 §8.5.2.1.1) queued a `PeerStanza` per resource, each running the full recipient pass: N archive rows with divergent XEP-0359 stanza-ids, N inbox unread increments, N XEP-0184 receipts, and cross-resource received-carbons forbidden by XEP-0280 §6.3 (each pass excluded only its own resource — two same-priority devices each saw the message twice).

**Fix:** compute the delivery set once and run ONE shared recipient pass (transient state machine mirroring the headless offline pass, but with live-transport semantics). The pass is seeded with the delivery-fanout set so `SendCarbons` carries the whole set as its typed exclusion (`exclude: FullJid → Vec<FullJid>`, all call sites converted — including detached XEP-0198 siblings whose replay buffers get the original queued, per adversarial review). Persistence interprets exactly once; the single recipient-stamped stanza fans out per resource as a `DirectFrame`, keeping XEP-0198 outbound accounting without re-running the pass. Detached targets now queue the processed stanza (closes the documented stanza-id-parity gap on resume replay), a XEP-0191-blocked message no longer leaks into detached buffers, and the fan-out pass's XEP-0184 receipt comes from the recipient's bare JID so the synthetic pass resource never leaks to the wire.

Tests: `server/crates/waddle-server/tests/xep0280_same_priority_fanout_ws.rs` (4 E2E cases: exactly-once delivery with no carbon per live resource, single archive row + identical stanza-ids across resources, inbox unread +1, detached sibling exactly-once on resume), plus handler-level suites for the exclusion-set and receipt-from semantics in `waddle-xmpp`.

## XEP conformance notes

- XEP-0280 §6.3 (line 370): "The receiving server MUST NOT send a forwarded copy to the client(s) the original `<message/>` stanza was addressed to" — the delivery-fanout set (live ∪ queued-detached) is that client set.
- XEP-0359: one recipient stamp per message; both resources and the archive now share one id (this parity is what makes client-side dedup — including the #675 fix — sound).
- XEP-0313: client merges live arrivals with the archive page instead of assuming the page supersedes them.
- RFC 6121 §8.5.2.1.1 delivery-set computation unchanged.
- Known follow-up (pre-existing, out of scope): self-DMs with ≥2 carbons-enabled resources still get original + sent-carbon, because the *sender*-pass exclusion is still single-resource.

## Verification

- `chat/`: `bun test` (3166 pass) + `bun run lint` (knip clean).
- `server/`: `cargo test --workspace --all-targets --all-features` (zero failures), `cargo clippy --all-targets --all-features -- -D warnings` clean, `cargo fmt --all -- --check` clean.
- Three adversarial persona reviews (XEP conformance, async races/lifecycle, standards/test-quality) + one fix-round re-review that returned a clean bill; all real findings fixed in-branch (commits `134e137a`, `d1b5f861`, `b93f3159`, `d900ee3e`).
- External review follow-ups (commits `128c57d0`, `1a289d5e`): XEP-0424 tombstones stay authoritative through duplicate-arrival merges; the bootstrap re-insert runs one forum-context pass instead of one per row; a blocklist-storage failure now falls back to the legacy per-resource delivery path (bind-time snapshots keep XEP-0191 enforcement) instead of dropping live DMs; and the fanout E2E suite builds stanzas via minidom Element builders with centralized namespace constants.
- PR-review round (commit `38fc7d05`): archive-id rewrites from origin-id-retry dedupe now reach the fan-out pass's extracted wire stanza (live/MAM stanza-id parity holds; `InterpretOutcome` exposes the batch's rewrites), and a positive E2E pins that a carbons-enabled resource outside the delivery set receives exactly one received-carbon.
