### PR TITLE
fix(server): gate MUC room MAM archive access on membership (#1093)

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
@@ -48,6 +48,31 @@ pub(super) async fn handle_archive_inbox_upload_iq(
             )];
         }
 
+        // XEP-0313 §5.1: a MUC archive MUST only serve users who have the
+        // right to enter the room at query time. Gate before any archive
+        // read, for every room type (#1093).
+        if !is_personal {
+            match resolve_muc_room_archive_access(state, &target_bare, sender_bare.as_ref()).await {
+                RoomArchiveAccess::Allowed => {}
+                RoomArchiveAccess::Denied => {
+                    return vec![build_iq_error_xml_typed(
+                        id,
+                        None,
+                        None,
+                        forbidden_iq_error("Operation not permitted."),
+                    )];
+                }
+                RoomArchiveAccess::Error => {
+                    return vec![build_iq_error_xml_typed(
+                        id,
+                        None,
+                        None,
+                        internal_server_error_iq_error("Internal server error."),
+                    )];
+                }
+            }
+        }
+
         if is_mam_query_form_request(request_iq) {
             return vec![iq_to_xml(build_query_form_iq(request_iq))];
         }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
@@ -48,11 +48,34 @@ pub(super) async fn handle_archive_inbox_upload_iq(
             )];
         }
 
+        // Resolve the managed-channel row once. Both the XEP-0313 §5.1
+        // archive gate and the group-DM visibility boundary need it;
+        // sharing the lookup avoids a duplicate DB round-trip per query.
+        let managed_channel = match get_managed_channel_for_room(state, &target_bare).await {
+            Ok(channel) => channel,
+            Err(error) => {
+                warn!(error = %error, target = %target_bare, "Failed to resolve managed channel for MAM query");
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    None,
+                    None,
+                    internal_server_error_iq_error("Internal server error."),
+                )];
+            }
+        };
+
         // XEP-0313 §5.1: a MUC archive MUST only serve users who have the
         // right to enter the room at query time. Gate before any archive
         // read, for every room type (#1093).
         if !is_personal {
-            match resolve_muc_room_archive_access(state, &target_bare, sender_bare.as_ref()).await {
+            match resolve_muc_room_archive_access(
+                state,
+                &target_bare,
+                sender_bare.as_ref(),
+                managed_channel.as_ref(),
+            )
+            .await
+            {
                 RoomArchiveAccess::Allowed => {}
                 RoomArchiveAccess::Denied => {
                     return vec![build_iq_error_xml_typed(
@@ -98,8 +121,13 @@ pub(super) async fn handle_archive_inbox_upload_iq(
             }
         };
 
-        let visibility =
-            group_dm_archive_visibility(state, &target_bare, sender_bare.as_ref()).await;
+        let visibility = group_dm_archive_visibility(
+            state,
+            &target_bare,
+            sender_bare.as_ref(),
+            managed_channel.as_ref(),
+        )
+        .await;
         let visibility_boundary = match visibility {
             GroupDmArchiveVisibility::NotGroupDm | GroupDmArchiveVisibility::Full => None,
             GroupDmArchiveVisibility::Restricted(boundary) => Some(boundary),
@@ -373,26 +401,21 @@ async fn group_dm_archive_visibility(
     state: &WebSocketState,
     room_jid: &BareJid,
     sender_bare: Option<&BareJid>,
+    channel: Option<&XmppChannelRecord>,
 ) -> GroupDmArchiveVisibility {
     let Some(sender_bare) = sender_bare else {
         return GroupDmArchiveVisibility::Denied;
     };
-    let Some(channel_id) = waddle_xmpp::parse_managed_room_jid(room_jid) else {
-        return GroupDmArchiveVisibility::NotGroupDm;
-    };
-    let channel = get_xmpp_channel(
-        state.deps.app_state.db_pool.global_actor().clone(),
-        &channel_id,
-    )
-    .await
-    .ok()
-    .flatten();
+    // The managed-channel row was resolved once by the caller and shared
+    // with the archive gate; a `None` row means the room is unmanaged and
+    // therefore not a group DM.
     let Some(channel) = channel else {
         return GroupDmArchiveVisibility::NotGroupDm;
     };
     if channel.channel_type != waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM {
         return GroupDmArchiveVisibility::NotGroupDm;
     }
+    let channel_id = channel.id.as_str();
 
     let allowed = state
         .deps
@@ -401,7 +424,7 @@ async fn group_dm_archive_visibility(
         .ask(CheckPermission {
             subject: Subject::user(sender_bare.to_string()),
             permission: Permission::Member,
-            object: Object::new(ObjectType::Channel, &channel_id),
+            object: Object::new(ObjectType::Channel, channel_id),
         })
         .await
         .map(|response| response.allowed);

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -206,8 +206,9 @@ use super::super::{
     is_muc_room_jid, stanza_to_xml, WebSocketState,
 };
 use super::presence::{
-    get_managed_channel_for_room, send_current_presence_from_user_to_jid,
-    send_unavailable_presence_from_user_to_jid,
+    get_managed_channel_for_room, resolve_muc_room_archive_access,
+    send_current_presence_from_user_to_jid, send_unavailable_presence_from_user_to_jid,
+    RoomArchiveAccess,
 };
 use crate::auth::{local_account_exists, Session};
 use crate::db::actor::{DbExecute, DbQuery, DbQueryOne, GetDatabase};

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence.rs
@@ -41,7 +41,10 @@ mod subscription;
 
 #[cfg(test)]
 pub use muc::parse_room_jid_context;
-pub use muc::{get_managed_channel_for_room, handle_muc_join, handle_muc_leave};
+pub use muc::{
+    get_managed_channel_for_room, handle_muc_join, handle_muc_leave,
+    resolve_muc_room_archive_access, RoomArchiveAccess,
+};
 use probe::handle_presence_probe;
 use regular::handle_regular_presence_update;
 pub use subscription::broadcast_unavailable_for_expired_detached_session;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -111,12 +111,27 @@ async fn handle_muc_join_unlocked(
                 .as_ref()
                 .map(|snapshot| snapshot.room.config.members_only)
                 .unwrap_or(channel.members_only);
+            let Ok(session_bare) = session.user_jid.parse::<BareJid>() else {
+                return vec![build_muc_presence_error_xml(
+                    room_jid,
+                    &nick,
+                    sender_jid,
+                    StanzaError::new(
+                        ErrorType::Wait,
+                        DefinedCondition::InternalServerError,
+                        "en",
+                        "Failed to resolve managed-channel affiliation.",
+                    ),
+                )];
+            };
             match resolve_managed_channel_affiliation(
                 state,
-                &session.user_jid,
+                &session_bare,
                 room_jid,
                 &channel.id,
                 admission_members_only,
+                // Join admission repairs a stale Space→channel projection.
+                true,
             )
             .await
             {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -3,7 +3,10 @@ use super::*;
 mod access;
 mod xml;
 
-pub use access::{get_managed_channel_for_room, parse_room_jid_context};
+pub use access::{
+    get_managed_channel_for_room, parse_room_jid_context, resolve_muc_room_archive_access,
+    RoomArchiveAccess,
+};
 
 use access::{resolve_managed_channel_affiliation, server_permission_allowed};
 use waddle_xmpp::muc::room_actor::GetSnapshot;
@@ -110,7 +113,7 @@ async fn handle_muc_join_unlocked(
                 .unwrap_or(channel.members_only);
             match resolve_managed_channel_affiliation(
                 state,
-                session,
+                &session.user_jid,
                 room_jid,
                 &channel.id,
                 admission_members_only,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
@@ -70,26 +70,19 @@ pub enum RoomArchiveAccess {
 /// rooms require at least Member affiliation, open rooms admit any
 /// non-outcast. An unmanaged room without a live actor has no admission
 /// data, so it fails closed.
+///
+/// `channel` is the managed-channel row for `room_jid` (or `None` for an
+/// unmanaged room), resolved once by the caller and shared with
+/// `group_dm_archive_visibility` so a single MAM query does not fetch the
+/// same row twice.
 pub async fn resolve_muc_room_archive_access(
     state: &WebSocketState,
     room_jid: &BareJid,
     requester: Option<&BareJid>,
+    channel: Option<&XmppChannelRecord>,
 ) -> RoomArchiveAccess {
     let Some(requester) = requester else {
         return RoomArchiveAccess::Denied;
-    };
-
-    let channel = match get_managed_channel_for_room(state, room_jid).await {
-        Ok(channel) => channel,
-        Err(error) => {
-            warn!(
-                room = %room_jid,
-                requester = %requester,
-                error = %error,
-                "Failed to resolve managed channel for MAM access gate"
-            );
-            return RoomArchiveAccess::Error;
-        }
     };
 
     let snapshot = match get_room_actor(state, room_jid).await {
@@ -144,7 +137,22 @@ pub async fn resolve_muc_room_archive_access(
     // persisted channel row and are unaffected.
     match snapshot {
         Some(snapshot) if snapshot.room.can_user_join(requester) => RoomArchiveAccess::Allowed,
-        _ => RoomArchiveAccess::Denied,
+        Some(_) => {
+            debug!(
+                room = %room_jid,
+                requester = %requester,
+                "MAM archive denied: requester may not enter unmanaged room"
+            );
+            RoomArchiveAccess::Denied
+        }
+        None => {
+            debug!(
+                room = %room_jid,
+                requester = %requester,
+                "MAM archive denied: no live actor for unmanaged room (fail-closed)"
+            );
+            RoomArchiveAccess::Denied
+        }
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
@@ -5,13 +5,13 @@ use crate::permissions::{
 
 pub(super) async fn resolve_managed_channel_affiliation(
     state: &WebSocketState,
-    session: &Session,
+    user_jid: &str,
     room_jid: &BareJid,
     channel_id: &str,
     members_only: bool,
 ) -> Result<Option<Affiliation>, ()> {
     let object = Object::new(ObjectType::Channel, channel_id);
-    let subject = Subject::user(&session.user_jid);
+    let subject = Subject::user(user_jid);
     if let Some(affiliation) =
         direct_channel_affiliation(state, object.clone(), subject.clone()).await?
     {
@@ -44,6 +44,87 @@ pub(super) async fn resolve_managed_channel_affiliation(
         return Ok(read_access_affiliation(members_only));
     }
     Ok(None)
+}
+
+/// XEP-0313 §5.1 archive-access decision for a MUC room MAM query.
+pub enum RoomArchiveAccess {
+    Allowed,
+    Denied,
+    Error,
+}
+
+/// XEP-0313 §5.1: "A MUC archive MUST check that the user requesting the
+/// archive has the right to enter it at the time of the query and only
+/// allow access if so." The decision mirrors join admission: members-only
+/// rooms require at least Member affiliation, open rooms admit any
+/// non-outcast. An unmanaged room without a live actor has no admission
+/// data, so it fails closed.
+pub async fn resolve_muc_room_archive_access(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    requester: Option<&BareJid>,
+) -> RoomArchiveAccess {
+    let Some(requester) = requester else {
+        return RoomArchiveAccess::Denied;
+    };
+
+    let channel = match get_managed_channel_for_room(state, room_jid).await {
+        Ok(channel) => channel,
+        Err(error) => {
+            warn!(
+                room = %room_jid,
+                requester = %requester,
+                error = %error,
+                "Failed to resolve managed channel for MAM access gate"
+            );
+            return RoomArchiveAccess::Error;
+        }
+    };
+
+    let snapshot = match get_room_actor(state, room_jid).await {
+        Some(actor) => match actor.ask(GetSnapshot).await {
+            Ok(snapshot) => Some(snapshot),
+            Err(error) => {
+                warn!(
+                    room = %room_jid,
+                    requester = %requester,
+                    error = ?error,
+                    "Failed to snapshot room for MAM access gate"
+                );
+                return RoomArchiveAccess::Error;
+            }
+        },
+        None => None,
+    };
+
+    if let Some(channel) = channel {
+        // Same precedence as join admission: a live actor's config wins
+        // over a stale channel row.
+        let members_only = snapshot
+            .as_ref()
+            .map(|snapshot| snapshot.room.config.members_only)
+            .unwrap_or(channel.members_only);
+        return match resolve_managed_channel_affiliation(
+            state,
+            requester.to_string().as_str(),
+            room_jid,
+            &channel.id,
+            members_only,
+        )
+        .await
+        {
+            Ok(Some(Affiliation::Outcast)) => RoomArchiveAccess::Denied,
+            Ok(Some(_)) => RoomArchiveAccess::Allowed,
+            Ok(None) if members_only => RoomArchiveAccess::Denied,
+            Ok(None) => RoomArchiveAccess::Allowed,
+            Err(()) => RoomArchiveAccess::Error,
+        };
+    }
+
+    match snapshot {
+        Some(snapshot) if snapshot.room.can_user_join(requester) => RoomArchiveAccess::Allowed,
+        _ => RoomArchiveAccess::Denied,
+    }
 }
 
 async fn direct_channel_affiliation(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
@@ -121,6 +121,14 @@ pub async fn resolve_muc_room_archive_access(
         };
     }
 
+    // Unmanaged room (instant room, no channel row). Admission data lives
+    // only in the live actor's in-memory affiliation list and config; both
+    // are lost when the room is evicted. If no actor is live we cannot
+    // authorize the request, so we deliberately fail closed rather than
+    // fail open: an instant room reconfigured members-only before eviction
+    // would otherwise leak its archive to non-members (the #1093 bypass).
+    // Managed channels — the norm in Waddle — always resolve above via the
+    // persisted channel row and are unaffected.
     match snapshot {
         Some(snapshot) if snapshot.room.can_user_join(requester) => RoomArchiveAccess::Allowed,
         _ => RoomArchiveAccess::Denied,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/access.rs
@@ -5,13 +5,14 @@ use crate::permissions::{
 
 pub(super) async fn resolve_managed_channel_affiliation(
     state: &WebSocketState,
-    user_jid: &str,
+    user_jid: &BareJid,
     room_jid: &BareJid,
     channel_id: &str,
     members_only: bool,
+    allow_repairs: bool,
 ) -> Result<Option<Affiliation>, ()> {
     let object = Object::new(ObjectType::Channel, channel_id);
-    let subject = Subject::user(user_jid);
+    let subject = Subject::user(user_jid.to_string());
     if let Some(affiliation) =
         direct_channel_affiliation(state, object.clone(), subject.clone()).await?
     {
@@ -39,9 +40,19 @@ pub(super) async fn resolve_managed_channel_affiliation(
         return Ok(read_access_affiliation(members_only));
     }
 
-    restore_space_parent_tuples_for_room(state, room_jid, channel_id).await?;
-    if check_channel_permission(state, object, subject, Permission::Read).await? {
-        return Ok(read_access_affiliation(members_only));
+    // The parent-tuple repair below issues `WriteTuple`/`DeleteTuple`
+    // effects. Join admission opts in (`allow_repairs = true`) so a stale
+    // Space→channel projection self-heals on the way into the room. The
+    // read-only MAM archive gate opts out: an archive query must not
+    // mutate the permission graph. A member whose Space-inherited read
+    // access hinges on a broken parent tuple is denied here until their
+    // next join repairs it; explicit channel affiliations (resolved by
+    // `direct_channel_affiliation` above) are unaffected.
+    if allow_repairs {
+        restore_space_parent_tuples_for_room(state, room_jid, channel_id).await?;
+        if check_channel_permission(state, object, subject, Permission::Read).await? {
+            return Ok(read_access_affiliation(members_only));
+        }
     }
     Ok(None)
 }
@@ -106,10 +117,12 @@ pub async fn resolve_muc_room_archive_access(
             .unwrap_or(channel.members_only);
         return match resolve_managed_channel_affiliation(
             state,
-            requester.to_string().as_str(),
+            requester,
             room_jid,
             &channel.id,
             members_only,
+            // Read-only archive gate: never mutate the permission graph.
+            false,
         )
         .await
         {

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -4511,3 +4511,270 @@ async fn dm_call_session_initiate_forwards_to_peer_not_feature_not_implemented()
         "peer must receive the forwarded Jingle session-initiate; got: {xml}"
     );
 }
+
+// =========================================================================
+// XEP-0313 §5.1 MUC archive access gate (#1093)
+// =========================================================================
+
+fn mam_room_query_frame(id: &str, room_jid: &str) -> String {
+    let query =
+        xmpp_parsers::minidom::Element::builder("query", waddle_xmpp_core::mam::MAM_NS).build();
+    iq_set_frame(id, room_jid, query)
+}
+
+async fn upsert_test_channel(state: &WebSocketState, id: &str, members_only: bool) {
+    crate::server::xmpp_state::upsert_xmpp_channel(
+        state.deps.app_state.db_pool.global_actor().clone(),
+        &crate::server::xmpp_state::XmppChannelUpsert {
+            id: id.to_string(),
+            name: id.to_string(),
+            description: None,
+            channel_type: "channel".to_string(),
+            position: 0,
+            is_default: false,
+            pin_permission: waddle_xmpp::muc::PinPermission::Anyone,
+            members_only,
+            public_room: !members_only,
+        },
+    )
+    .await
+    .expect("channel upsert");
+}
+
+#[tokio::test]
+async fn mam_members_only_channel_query_returns_forbidden_for_non_member() {
+    let state = create_test_websocket_state().await;
+    upsert_test_channel(state.as_ref(), "secret-ops", true).await;
+
+    let mallory: FullJid = "mallory@example.com/web".parse().expect("jid");
+    let session = Session::new("mallory@example.com", "mallory", "mallory");
+
+    let responses = handle_iq(
+        &mam_room_query_frame("mam-gate-1", "secret-ops@muc.example.com"),
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&mallory),
+    )
+    .await;
+
+    assert_eq!(
+        responses.len(),
+        1,
+        "non-member MAM query must yield exactly one error frame: {responses:?}"
+    );
+    assert!(
+        responses[0].contains("<forbidden"),
+        "non-member MAM query on a members-only channel must be forbidden: {responses:?}"
+    );
+}
+
+#[tokio::test]
+async fn mam_members_only_channel_query_succeeds_for_channel_member() {
+    let state = create_test_websocket_state().await;
+    upsert_test_channel(state.as_ref(), "secret-ops", true).await;
+
+    let alice: FullJid = "alice@example.com/web".parse().expect("jid");
+    let session = Session::new("alice@example.com", "alice", "alice");
+    state
+        .deps
+        .app_state
+        .permission_actor
+        .ask(WriteTuple {
+            tuple: Tuple::new(
+                Object::new(ObjectType::Channel, "secret-ops"),
+                Relation::new("member"),
+                Subject::user(&session.user_jid),
+            ),
+        })
+        .await
+        .expect("channel member tuple");
+
+    let responses = handle_iq(
+        &mam_room_query_frame("mam-gate-2", "secret-ops@muc.example.com"),
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&alice),
+    )
+    .await;
+
+    let fin = responses.last().expect("member MAM query must respond");
+    assert!(
+        fin.contains("<fin") && fin.contains("type='result'"),
+        "channel member MAM query must return a result fin: {responses:?}"
+    );
+}
+
+#[tokio::test]
+async fn mam_public_channel_query_succeeds_for_non_member() {
+    let state = create_test_websocket_state().await;
+    upsert_test_channel(state.as_ref(), "town-square", false).await;
+
+    let mallory: FullJid = "mallory@example.com/web".parse().expect("jid");
+    let session = Session::new("mallory@example.com", "mallory", "mallory");
+
+    let responses = handle_iq(
+        &mam_room_query_frame("mam-gate-3", "town-square@muc.example.com"),
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&mallory),
+    )
+    .await;
+
+    let fin = responses
+        .last()
+        .expect("public-room MAM query must respond");
+    assert!(
+        fin.contains("<fin") && fin.contains("type='result'"),
+        "public channel MAM query must stay open to non-members: {responses:?}"
+    );
+}
+
+/// Spawn an unmanaged members-only room actor with `member_jid` given
+/// Member affiliation via the same join message the presence path uses.
+async fn create_members_only_room_with_member(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    member_jid: &FullJid,
+) {
+    let config = waddle_xmpp::muc::RoomConfig {
+        name: "war-room".to_string(),
+        members_only: true,
+        ..Default::default()
+    };
+    let actor = get_or_create_room_actor(
+        state,
+        room_jid,
+        config,
+        "default".to_string(),
+        "default".to_string(),
+    )
+    .await
+    .expect("room actor");
+    actor
+        .ask(waddle_xmpp::muc::room_actor::JoinWithAffiliation {
+            sender_jid: member_jid.clone(),
+            nick: "member".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("member join");
+}
+
+#[tokio::test]
+async fn mam_members_only_unmanaged_room_query_returns_forbidden_for_non_member() {
+    let state = create_test_websocket_state().await;
+    let room_jid: BareJid = "war-room@muc.example.com".parse().expect("room jid");
+    let member: FullJid = "alice@example.com/web".parse().expect("jid");
+    create_members_only_room_with_member(state.as_ref(), &room_jid, &member).await;
+
+    let mallory: FullJid = "mallory@example.com/web".parse().expect("jid");
+    let session = Session::new("mallory@example.com", "mallory", "mallory");
+
+    let responses = handle_iq(
+        &mam_room_query_frame("mam-gate-4", "war-room@muc.example.com"),
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&mallory),
+    )
+    .await;
+
+    assert_eq!(
+        responses.len(),
+        1,
+        "expected one error frame: {responses:?}"
+    );
+    assert!(
+        responses[0].contains("<forbidden"),
+        "non-member MAM query on a members-only unmanaged room must be forbidden: {responses:?}"
+    );
+}
+
+#[tokio::test]
+async fn mam_members_only_unmanaged_room_query_succeeds_for_member() {
+    let state = create_test_websocket_state().await;
+    let room_jid: BareJid = "war-room@muc.example.com".parse().expect("room jid");
+    let member: FullJid = "alice@example.com/web".parse().expect("jid");
+    create_members_only_room_with_member(state.as_ref(), &room_jid, &member).await;
+
+    let session = Session::new("alice@example.com", "alice", "alice");
+    let responses = handle_iq(
+        &mam_room_query_frame("mam-gate-5", "war-room@muc.example.com"),
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&member),
+    )
+    .await;
+
+    let fin = responses.last().expect("member MAM query must respond");
+    assert!(
+        fin.contains("<fin") && fin.contains("type='result'"),
+        "room member MAM query must return a result fin: {responses:?}"
+    );
+}
+
+#[tokio::test]
+async fn mam_room_query_without_bound_session_returns_forbidden() {
+    let state = create_test_websocket_state().await;
+    upsert_test_channel(state.as_ref(), "town-square", false).await;
+
+    let responses = handle_iq(
+        &mam_room_query_frame("mam-gate-6", "town-square@muc.example.com"),
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &None,
+        &ConnectionPhase::Unauthenticated,
+    )
+    .await;
+
+    assert_eq!(
+        responses.len(),
+        1,
+        "expected one error frame: {responses:?}"
+    );
+    assert!(
+        responses[0].contains("<forbidden"),
+        "room MAM query without a bound session must be forbidden: {responses:?}"
+    );
+}
+
+#[tokio::test]
+async fn mam_unmanaged_room_without_live_actor_fails_closed() {
+    let state = create_test_websocket_state().await;
+
+    let mallory: FullJid = "mallory@example.com/web".parse().expect("jid");
+    let session = Session::new("mallory@example.com", "mallory", "mallory");
+
+    let responses = handle_iq(
+        &mam_room_query_frame("mam-gate-7", "ghost-room@muc.example.com"),
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&mallory),
+    )
+    .await;
+
+    assert_eq!(
+        responses.len(),
+        1,
+        "expected one error frame: {responses:?}"
+    );
+    assert!(
+        responses[0].contains("<forbidden"),
+        "an unmanaged room with no live actor has no admission data; the \
+         archive gate must fail closed: {responses:?}"
+    );
+}

--- a/server/crates/waddle-server/tests/xep0313_mam_integration.rs
+++ b/server/crates/waddle-server/tests/xep0313_mam_integration.rs
@@ -986,3 +986,160 @@ async fn xep_0313_with_filter_does_not_match_domain_prefix_collision() {
     );
     assert_eq!(exact_result.messages[0].from, legit_from);
 }
+
+// =========================================================================
+// XEP-0313 §5.1 MUC archive access gate (#1093)
+// =========================================================================
+
+/// Join (creating an instant room), set the given members-only state via
+/// the XEP-0045 §10.2 owner-config form, and archive one message.
+async fn create_room_with_message(client: &mut WsXmppClient, room: &str, members_only: bool) {
+    client
+        .send(&format!(
+            r#"<presence to="{room}/{USERNAME}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
+        ))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|f| f.contains("<subject"))
+        .await
+        .expect("join responses");
+
+    let cfg_id = format!("cfg-{}", uuid::Uuid::new_v4());
+    let members_only_value = if members_only { "1" } else { "0" };
+    client
+        .send(&format!(
+            r#"<iq type="set" id="{cfg_id}" to="{room}"><query xmlns="http://jabber.org/protocol/muc#owner"><x xmlns="jabber:x:data" type="submit"><field var="FORM_TYPE" type="hidden"><value>http://jabber.org/protocol/muc#roomconfig</value></field><field var="muc#roomconfig_membersonly"><value>{members_only_value}</value></field></x></query></iq>"#
+        ))
+        .await
+        .expect("send owner config");
+    let cfg_response = client
+        .recv_matching(|f| f.contains("<iq") && f.contains(&cfg_id))
+        .await
+        .expect("owner config response");
+    assert!(
+        cfg_response.contains("result"),
+        "owner config must be accepted: {cfg_response}"
+    );
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}"><body>archive gate probe</body></message>"#
+        ))
+        .await
+        .expect("send message");
+    client
+        .recv_matching(|f| f.contains("archive gate probe"))
+        .await
+        .expect("echo");
+}
+
+/// XEP-0313 §5.1: "In a members-only chat room, only owners, admins or
+/// members can query a room archive." A non-member MUST get <forbidden/>
+/// before any archive read; the owner keeps full access.
+#[tokio::test]
+async fn xep_0313_members_only_room_archive_requires_membership() {
+    let _guard = TEST_SERIAL.lock().await;
+    let mallory_pass = format!("mallory-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("mallory", &mallory_pass)]);
+    let admin_pass = server.fixed_account_password().to_string();
+    let mut admin = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        USERNAME,
+        &admin_pass,
+        &format!("test-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("admin connect");
+
+    let room = format!("members-only-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    create_room_with_message(&mut admin, &room, true).await;
+
+    // Owner (member+) retains archive access.
+    let owner_q = format!("q-owner-{}", uuid::Uuid::new_v4());
+    let owner_frames = query_mam(&mut admin, &mam_query_xml(&owner_q, &room, Some(10)))
+        .await
+        .expect("owner MAM query");
+    assert!(
+        owner_frames
+            .iter()
+            .any(|f| f.contains("archive gate probe")),
+        "room owner must still read the members-only archive: {owner_frames:?}"
+    );
+
+    // Non-member is forbidden.
+    let mut mallory = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "mallory",
+        &mallory_pass,
+        &format!("test-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("mallory connect");
+    let mallory_q = format!("q-mallory-{}", uuid::Uuid::new_v4());
+    mallory
+        .send(&mam_query_xml(&mallory_q, &room, Some(10)))
+        .await
+        .expect("send non-member MAM query");
+    let denial = mallory
+        .recv_matching(|f| f.contains(&mallory_q))
+        .await
+        .expect("non-member MAM reply");
+    assert!(
+        denial.contains("<forbidden"),
+        "non-member MAM query on a members-only room must be forbidden: {denial}"
+    );
+    assert!(
+        !denial.contains("archive gate probe"),
+        "forbidden reply must not leak archived content: {denial}"
+    );
+
+    let _ = mallory.close().await;
+    let _ = admin.close().await;
+}
+
+/// XEP-0313 §5.1: "In the case of open MUC rooms, the MUC archives can
+/// generally be accessed by any users (including those who have never
+/// entered the room) who do not have an affiliation of 'outcast'."
+#[tokio::test]
+async fn xep_0313_open_room_archive_accessible_to_non_member() {
+    let _guard = TEST_SERIAL.lock().await;
+    let mallory_pass = format!("mallory-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[("mallory", &mallory_pass)]);
+    let admin_pass = server.fixed_account_password().to_string();
+    let mut admin = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        USERNAME,
+        &admin_pass,
+        &format!("test-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("admin connect");
+
+    let room = format!("open-room-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    create_room_with_message(&mut admin, &room, false).await;
+
+    let mut mallory = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        "mallory",
+        &mallory_pass,
+        &format!("test-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("mallory connect");
+    let mallory_q = format!("q-open-{}", uuid::Uuid::new_v4());
+    let frames = query_mam(&mut mallory, &mam_query_xml(&mallory_q, &room, Some(10)))
+        .await
+        .expect("open-room MAM query by non-member");
+    assert!(
+        frames.iter().any(|f| f.contains("archive gate probe")),
+        "open-room archive must stay readable for non-outcast non-members: {frames:?}"
+    );
+
+    let _ = mallory.close().await;
+    let _ = admin.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0313_mam_integration.rs
+++ b/server/crates/waddle-server/tests/xep0313_mam_integration.rs
@@ -9,6 +9,7 @@ use tokio::sync::Mutex;
 use waddle_xmpp::mam::{ArchivedMessage, MamQuery, MamStorage, MamStorageError, SqlxMamStorage};
 use ws_common::{disco_info_query, TestServer, WsXmppClient};
 use xmpp_parsers::message::MessageType;
+use xmpp_parsers::minidom::Element;
 
 const DOMAIN: &str = "localhost";
 const USERNAME: &str = "admin";
@@ -991,15 +992,49 @@ async fn xep_0313_with_filter_does_not_match_domain_prefix_collision() {
 // XEP-0313 §5.1 MUC archive access gate (#1093)
 // =========================================================================
 
+const NS_CLIENT: &str = "jabber:client";
+const NS_MUC: &str = "http://jabber.org/protocol/muc";
+const NS_MUC_OWNER: &str = "http://jabber.org/protocol/muc#owner";
+const NS_XDATA: &str = "jabber:x:data";
+const MUC_ROOMCONFIG_FORM: &str = "http://jabber.org/protocol/muc#roomconfig";
+const ARCHIVE_PROBE_BODY: &str = "archive gate probe";
+
+/// Serialize a `minidom::Element` to a wire frame. The XML-generation
+/// hard rule bans `format!`-built stanzas even in tests, so stanzas are
+/// composed with typed `minidom` builders and serialized here.
+fn element_to_xml(element: Element) -> String {
+    let mut bytes = Vec::new();
+    element.write_to(&mut bytes).expect("serialize XML");
+    String::from_utf8(bytes).expect("XML serialization is UTF-8")
+}
+
+fn attr_name(name: &'static str) -> &'static minidom::rxml::NcNameStr {
+    name.try_into().expect("valid ncname")
+}
+
+fn data_form_field(var: &str, field_type: Option<&str>, value: &str) -> Element {
+    let mut builder =
+        Element::builder("field", NS_XDATA).attr(attr_name("var").to_owned(), var.to_owned());
+    if let Some(field_type) = field_type {
+        builder = builder.attr(attr_name("type").to_owned(), field_type.to_owned());
+    }
+    builder
+        .append(
+            Element::builder("value", NS_XDATA)
+                .append(value.to_owned())
+                .build(),
+        )
+        .build()
+}
+
 /// Join (creating an instant room), set the given members-only state via
 /// the XEP-0045 §10.2 owner-config form, and archive one message.
 async fn create_room_with_message(client: &mut WsXmppClient, room: &str, members_only: bool) {
-    client
-        .send(&format!(
-            r#"<presence to="{room}/{USERNAME}"><x xmlns="http://jabber.org/protocol/muc"/></presence>"#
-        ))
-        .await
-        .expect("send join");
+    let join = Element::builder("presence", NS_CLIENT)
+        .attr(attr_name("to").to_owned(), format!("{room}/{USERNAME}"))
+        .append(Element::builder("x", NS_MUC).build())
+        .build();
+    client.send(&element_to_xml(join)).await.expect("send join");
     client
         .recv_until(|f| f.contains("<subject"))
         .await
@@ -1007,10 +1042,27 @@ async fn create_room_with_message(client: &mut WsXmppClient, room: &str, members
 
     let cfg_id = format!("cfg-{}", uuid::Uuid::new_v4());
     let members_only_value = if members_only { "1" } else { "0" };
-    client
-        .send(&format!(
-            r#"<iq type="set" id="{cfg_id}" to="{room}"><query xmlns="http://jabber.org/protocol/muc#owner"><x xmlns="jabber:x:data" type="submit"><field var="FORM_TYPE" type="hidden"><value>http://jabber.org/protocol/muc#roomconfig</value></field><field var="muc#roomconfig_membersonly"><value>{members_only_value}</value></field></x></query></iq>"#
+    let form = Element::builder("x", NS_XDATA)
+        .attr(attr_name("type").to_owned(), "submit")
+        .append(data_form_field(
+            "FORM_TYPE",
+            Some("hidden"),
+            MUC_ROOMCONFIG_FORM,
         ))
+        .append(data_form_field(
+            "muc#roomconfig_membersonly",
+            None,
+            members_only_value,
+        ))
+        .build();
+    let owner_config = Element::builder("iq", NS_CLIENT)
+        .attr(attr_name("type").to_owned(), "set")
+        .attr(attr_name("id").to_owned(), cfg_id.clone())
+        .attr(attr_name("to").to_owned(), room.to_owned())
+        .append(Element::builder("query", NS_MUC_OWNER).append(form).build())
+        .build();
+    client
+        .send(&element_to_xml(owner_config))
         .await
         .expect("send owner config");
     let cfg_response = client
@@ -1022,14 +1074,21 @@ async fn create_room_with_message(client: &mut WsXmppClient, room: &str, members
         "owner config must be accepted: {cfg_response}"
     );
 
+    let message = Element::builder("message", NS_CLIENT)
+        .attr(attr_name("type").to_owned(), "groupchat")
+        .attr(attr_name("to").to_owned(), room.to_owned())
+        .append(
+            Element::builder("body", NS_CLIENT)
+                .append(ARCHIVE_PROBE_BODY)
+                .build(),
+        )
+        .build();
     client
-        .send(&format!(
-            r#"<message type="groupchat" to="{room}"><body>archive gate probe</body></message>"#
-        ))
+        .send(&element_to_xml(message))
         .await
         .expect("send message");
     client
-        .recv_matching(|f| f.contains("archive gate probe"))
+        .recv_matching(|f| f.contains(ARCHIVE_PROBE_BODY))
         .await
         .expect("echo");
 }


### PR DESCRIPTION
Fixes #1093 — access-control bypass in the MAM IQ handler.

## Problem

`handle_archive_inbox_upload_iq` admitted room-archive queries whenever the target was on the MUC domain (`is_muc_room_jid`, a bare domain match), and the membership gate ran **only** for group-DM channels. Every other room — including members-only/private managed channels — got full archive access. Any authenticated user who knew or enumerated a room JID could page its entire history.

XEP-0313 §5.1: *"A MUC archive MUST check that the user requesting the archive has the right to enter it at the time of the query and only allow access if so. In a members-only chat room, only owners, admins or members can query a room archive."*

## Fix

Gate every non-personal MAM query on the same admission logic the join path uses, before any archive read, returning `<forbidden/>`:

- **`resolve_muc_room_archive_access`** (`presence/muc/access.rs`) — the XEP-0313 §5.1 decision:
  - **Managed channel**: `members_only` taken from the live room snapshot, falling back to the channel row (identical precedence to join admission). Resolves affiliation via `resolve_managed_channel_affiliation`; outcast → forbidden, members-only without affiliation → forbidden, open channel → allowed for any non-outcast.
  - **Unmanaged room with a live actor**: `MucRoom::can_user_join` (members-only requires Member+, open rooms exclude outcasts).
  - **Unmanaged room with no live actor** / **unbound requester**: fail closed. An evicted instant room has no persistent config or affiliation data, so we cannot authorize it; failing open would re-leak an instant room reconfigured members-only before eviction. Managed channels (the norm) are unaffected.
- **`archive_inbox_upload.rs`** — the gate runs before the form-request branch and before `query_messages`/`count_messages`, for all room types. The fulltext (`urn:xmpp:fulltext:0`) variant is a field inside the same `urn:xmpp:mam:2` query, so it flows through the same gated path. Personal (`to=self`) queries skip the gate. The existing group-DM per-member visibility boundary is unchanged and still runs after the gate for members.
- `resolve_managed_channel_affiliation` now takes `user_jid: &str` instead of `&Session` so both the join and archive paths share it.

## Tests

- **Unit** (`websocket/tests/iq.rs`, via the `handle_iq` seam): members-only managed channel forbidden for non-member / allowed for member; public channel allowed for non-member; unmanaged live members-only room forbidden for non-member / allowed for member; unbound session forbidden; unmanaged room with no live actor fails closed. Each fails if the gate is removed.
- **Integration** (`tests/xep0313_mam_integration.rs`): members-only room forbids a non-member (and the `<forbidden/>` reply leaks no archived content) while the owner retains access; open room stays readable by a non-member.

## Review

Two adversarial reviewers (security + correctness) audited the diff. Security: no exploitable bypass survives — gate precedes every read, `is_personal` is server-JID-derived and not spoofable, outcast/precedence handling matches join admission. Correctness: no regressions — group-DM members are `Allowed` so the visibility boundary still runs; no spurious room-actor creation; tests are behavioral, not tautological. The one raised finding (evicted open instant rooms become archive-inaccessible) is a deliberate, documented fail-safe tradeoff, not a leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
