### PR TITLE
fix(server): SM decode group-skip no longer leaks a poison session's unacked stanzas into the preceding user's queue

### DIFF
--- a/server/crates/waddle-server/src/sm_persistence/joined_sessions.rs
+++ b/server/crates/waddle-server/src/sm_persistence/joined_sessions.rs
@@ -25,6 +25,13 @@ pub(super) async fn list_all_sessions_with_unacked(
     // row in the same session was undercutting the cold-start
     // perf goal for large queues).
     let mut current_stream_id: Option<String> = None;
+    // Explicit "the current group's session failed to decode" flag.
+    // Inferring this from `out.last().is_none()` is wrong once any
+    // valid session precedes the poison one: `out` is non-empty, so
+    // the poison group's unacked rows would be appended to the
+    // preceding session's queue and replayed on the wrong user's
+    // `<resumed/>` (issue #1157).
+    let mut skipping_current_group = false;
     let mut poison_sessions = 0usize;
     while let Some(row) = rows
         .next()
@@ -65,13 +72,15 @@ pub(super) async fn list_all_sessions_with_unacked(
                     // belonging to the same skipped group and
                     // also dropped.
                     current_stream_id = Some(row_stream_id);
+                    skipping_current_group = true;
                     poison_sessions += 1;
                     continue;
                 }
             };
             current_stream_id = Some(row_stream_id);
+            skipping_current_group = false;
             out.push((session, Vec::new()));
-        } else if out.last().is_none() {
+        } else if skipping_current_group {
             // Same stream_id as a previously-skipped poison
             // session; drop this unacked row too.
             continue;

--- a/server/crates/waddle-server/src/sm_persistence/joined_sessions.rs
+++ b/server/crates/waddle-server/src/sm_persistence/joined_sessions.rs
@@ -53,7 +53,7 @@ pub(super) async fn list_all_sessions_with_unacked(
         };
         let starts_new_group = current_stream_id.as_deref() != Some(row_stream_id.as_str());
         if starts_new_group {
-            // Decode the session columns (0..=14, 15 columns)
+            // Decode the session columns (0..=16, 17 columns)
             // exactly once per stream_id group. On decode
             // failure, skip the entire group's rows so a single
             // poison-pill session can't brick cold startup

--- a/server/crates/waddle-server/src/sm_persistence/tests.rs
+++ b/server/crates/waddle-server/src/sm_persistence/tests.rs
@@ -521,6 +521,59 @@ async fn list_all_sessions_with_unacked_skips_poison_pill_unacked_rows() {
     assert_eq!(beta_unacked.map(Vec::len), Some(0));
 }
 
+/// Regression for #1157: a session row that fails to decode while
+/// its unacked rows decode fine MUST have those rows dropped with
+/// the group — not appended to the preceding valid session's queue,
+/// which would replay one user's stanzas on another user's
+/// `<resumed/>` (XEP-0198 §5 retransmission is per-stream).
+#[tokio::test]
+async fn poison_session_rows_do_not_leak_into_preceding_sessions_queue() {
+    let storage = DatabaseSmPersistence::open(None).await.unwrap();
+    // Valid session "alpha" with one unacked stanza; sorts before
+    // "beta" under the query's ORDER BY stream_id ASC.
+    storage
+        .upsert_session(fixture_session("alpha"))
+        .await
+        .unwrap();
+    storage
+        .append_unacked(fixture_unacked("alpha", 1))
+        .await
+        .unwrap();
+    // Session "beta" with two healthy unacked stanzas, then corrupt
+    // beta's session row so decode_session fails while the unacked
+    // rows still decode.
+    storage
+        .upsert_session(fixture_session("beta"))
+        .await
+        .unwrap();
+    storage
+        .append_unacked(fixture_unacked("beta", 1))
+        .await
+        .unwrap();
+    storage
+        .append_unacked(fixture_unacked("beta", 2))
+        .await
+        .unwrap();
+    storage
+        .execute(
+            "UPDATE sm_sessions SET presence_show = 'bogus' WHERE stream_id = ?",
+            crate::db_params!["beta".to_string()],
+        )
+        .await
+        .expect("corrupt beta session row");
+
+    let grouped = storage.list_all_sessions_with_unacked().await.unwrap();
+    // The poison group is fully dropped...
+    assert_eq!(grouped.len(), 1);
+    let (session, unacked) = &grouped[0];
+    assert_eq!(session.stream_id.as_str(), "alpha");
+    // ...and alpha's queue holds exactly its own stanza — beta's
+    // rows must not have been appended to it.
+    assert_eq!(unacked.len(), 1);
+    assert_eq!(unacked[0].sequence, 1);
+    assert_eq!(unacked[0].stream_id.as_str(), "alpha");
+}
+
 /// Regression for #456: existing Postgres SM tables created before
 /// the driver-aware BIGINT selector must be widened online. The test
 /// exercises both session timestamp fields and unacked receipt

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/persistence_codec.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/persistence_codec.rs
@@ -99,6 +99,24 @@ pub(super) fn persisted_to_detached(
 
     let unacked_stanzas: Vec<DetachedUnackedStanza> = unacked
         .iter()
+        .filter(|row| {
+            // Defense in depth (issue #1157): each row carries the
+            // stream_id it was persisted under. Drop any row whose
+            // stream_id is not the session being hydrated, so a
+            // grouping bug in a storage backend can never replay one
+            // user's stanzas on another user's `<resumed/>`
+            // (XEP-0198 §5 retransmission is per-stream).
+            let matches = row.stream_id == persisted.stream_id;
+            if !matches {
+                tracing::warn!(
+                    session_stream_id = %persisted.stream_id,
+                    row_stream_id = %row.stream_id,
+                    sequence = row.sequence,
+                    "dropping unacked row labeled with a foreign stream_id during hydration"
+                );
+            }
+            matches
+        })
         .map(|row| {
             let element: minidom::Element = match &*row.stanza {
                 crate::Stanza::Message(m) => m.clone().into(),

--- a/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
+++ b/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
@@ -151,6 +151,130 @@ impl SmPersistenceStorage for BlockingFirstAtomicStore {
     }
 }
 
+/// Storage double that mislabels rows: its
+/// `list_all_sessions_with_unacked` attaches a foreign-stream
+/// unacked stanza to every session's queue. Models the class of
+/// grouping bug fixed in #1157 arising again in any backend, so the
+/// registry-side defense can be exercised through the public
+/// restore path.
+struct MislabelingStore {
+    inner: InMemorySmPersistence,
+}
+
+#[async_trait]
+impl SmPersistenceStorage for MislabelingStore {
+    async fn upsert_session(&self, session: PersistedSession) -> Result<(), SmPersistenceError> {
+        self.inner.upsert_session(session).await
+    }
+
+    async fn get_session(
+        &self,
+        stream_id: &SmSessionId,
+    ) -> Result<Option<PersistedSession>, SmPersistenceError> {
+        self.inner.get_session(stream_id).await
+    }
+
+    async fn delete_session(&self, stream_id: &SmSessionId) -> Result<(), SmPersistenceError> {
+        self.inner.delete_session(stream_id).await
+    }
+
+    async fn append_unacked(
+        &self,
+        stanza: PersistedUnackedStanza,
+    ) -> Result<(), SmPersistenceError> {
+        self.inner.append_unacked(stanza).await
+    }
+
+    async fn ack_through(
+        &self,
+        stream_id: &SmSessionId,
+        up_to_sequence: u32,
+    ) -> Result<u64, SmPersistenceError> {
+        self.inner.ack_through(stream_id, up_to_sequence).await
+    }
+
+    async fn list_unacked(
+        &self,
+        stream_id: &SmSessionId,
+    ) -> Result<Vec<PersistedUnackedStanza>, SmPersistenceError> {
+        self.inner.list_unacked(stream_id).await
+    }
+
+    async fn list_expired_sessions(
+        &self,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<Vec<PersistedSession>, SmPersistenceError> {
+        self.inner.list_expired_sessions(now).await
+    }
+
+    async fn list_all_sessions(&self) -> Result<Vec<PersistedSession>, SmPersistenceError> {
+        self.inner.list_all_sessions().await
+    }
+
+    async fn list_all_sessions_with_unacked(
+        &self,
+    ) -> Result<Vec<(PersistedSession, Vec<PersistedUnackedStanza>)>, SmPersistenceError> {
+        let mut groups = self.inner.list_all_sessions_with_unacked().await?;
+        for (_, unacked) in &mut groups {
+            let to: FullJid = "mallory@example.test/phone".parse().expect("valid jid");
+            unacked.push(PersistedUnackedStanza {
+                stream_id: SmSessionId::new("attacker-stream"),
+                sequence: 99,
+                stanza: Box::new(chat_stanza(&to, "leaked secret")),
+                original_receipt_at: chrono::Utc::now(),
+            });
+        }
+        Ok(groups)
+    }
+}
+
+/// Issue #1157 defense in depth: hydration MUST verify each unacked
+/// row's own `stream_id` against the session being restored and drop
+/// mismatched rows, so a grouping bug anywhere in a storage backend
+/// can never replay one user's stanzas on another user's
+/// `<resumed/>` (XEP-0198 §5 retransmission is per-stream).
+#[tokio::test]
+async fn xep0198_restore_drops_unacked_rows_labeled_with_foreign_stream_id() {
+    let persistence: Arc<dyn SmPersistenceStorage> = Arc::new(MislabelingStore {
+        inner: InMemorySmPersistence::new(),
+    });
+    let registry = InMemorySmSessionRegistry::new().with_persistence(Arc::clone(&persistence));
+    let mut session = detached_session("victim-stream", "alice@example.test/laptop");
+    session
+        .unacked_stanzas
+        .push(waddle_xmpp::stream_management::DetachedUnackedStanza {
+            sequence: 12,
+            stanza_xml:
+                "<message xmlns='jabber:client' id='m12'><body>alice's own</body></message>"
+                    .to_string(),
+            original_receipt_at: chrono::Utc::now(),
+        });
+    registry.store_session(session).await.expect("store");
+
+    // Simulate restart: restore through the mislabeling storage.
+    drop(registry);
+    let restored = InMemorySmSessionRegistry::new().with_persistence(Arc::clone(&persistence));
+    restored.restore_from_persistence().await.expect("restore");
+
+    let claimed = restored
+        .claim_session("victim-stream")
+        .await
+        .expect("claim restored")
+        .expect("present");
+    assert_eq!(
+        claimed.unacked_stanzas.len(),
+        1,
+        "the foreign-stream row must be dropped, not queued for replay"
+    );
+    assert_eq!(claimed.unacked_stanzas[0].sequence, 12);
+    assert!(
+        claimed.unacked_stanzas[0]
+            .stanza_xml
+            .contains("alice's own"),
+        "only the session's own stanza survives hydration"
+    );
+}
+
 #[tokio::test]
 async fn xep0198_claimed_session_remains_writable_until_completed() {
     let registry = InMemorySmSessionRegistry::new();


### PR DESCRIPTION
Fixes #1157.

## Problem

`list_all_sessions_with_unacked` groups the `sm_sessions LEFT JOIN sm_unacked` rows per session. When `decode_session` fails for a group, the intended behavior is to drop the whole group — but the guard was `else if out.last().is_none()`, which only holds when the output vector is empty. If a valid session A precedes a poison session B (bad `full_jid`, unknown `presence_show`, invalid `detached_at_ms`) whose unacked rows decode fine, B's rows were appended to **A's** queue and replayed on A's `<resumed/>` — a cross-user data leak (XEP-0198 §5 retransmission must be per-stream).

## What changed

1. **Group-skip fix** (`waddle-server/src/sm_persistence/joined_sessions.rs`): the skip decision is now an explicit `skipping_current_group` flag, set when a group's session row fails to decode and reset when a new group decodes successfully — never inferred from `out` being empty.
2. **Defense in depth** (`waddle-xmpp/.../session_registry/persistence_codec.rs`): `persisted_to_detached` now verifies each unacked row's own `stream_id` against the session being hydrated and drops mismatched rows with a warn, so a grouping bug in *any* storage backend can never replay one user's stanzas on another user's stream. Every legitimate `PersistedUnackedStanza` constructor stamps a self-consistent `stream_id`, so no valid row is dropped.
3. Corrected a stale comment (session column count 15 → 17) in the touched decode block.

## Tests (TDD, red verified before each green)

- `poison_session_rows_do_not_leak_into_preceding_sessions_queue` (waddle-server): valid session `alpha` + poison session `beta` (corrupted `presence_show`, healthy unacked rows) → alpha restores with exactly its own queue, beta fully dropped. Red run reproduced the exact leak (beta's row appended to alpha's queue).
- `xep0198_restore_drops_unacked_rows_labeled_with_foreign_stream_id` (waddle-xmpp): a `MislabelingStore` double attaches a foreign-stream row to every group; after `restore_from_persistence` + `claim_session` only the session's own stanza survives.

## Verification

- Full workspace `cargo test` green; `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.
- Adversarial review by two independent personas (red-team + Rust correctness): fix confirmed sound across all row orderings (poison first/last/consecutive, unreadable stream_id, valid↔poison transitions); correctness reviewer independently re-verified red/green by reverting the fix. No remaining actionable issues in this PR.
- Adjacent low-severity findings filed as follow-ups: #1197 (poison rows retained at rest), #1198 (`list_expired_sessions`/`list_all_sessions` abort on first poison row — latent, no production caller).
