### PR TITLE
fix: security/reliability bundle — shared-file & feed XSS + CSP, MAM fail-fast, poison-pill retry hardening (#1156 #1146 #1122)

### DIFF
--- a/chat/public/_headers
+++ b/chat/public/_headers
@@ -1,0 +1,11 @@
+# Headers for statically-served assets (Cloudflare Workers static assets).
+# All other HTML is rendered by the worker and gets its CSP from
+# src/middleware.ts; offline.html is the only static HTML document (served by
+# the service worker when the network is down). It has inline <style> only —
+# no scripts.
+# Both spellings: assets html_handling serves the canonical page at /offline
+# (redirecting /offline.html), while the service worker caches /offline.html.
+/offline.html
+  Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'
+/offline
+  Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'; img-src 'self'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'

--- a/chat/src/channels/message-attachments.ts
+++ b/chat/src/channels/message-attachments.ts
@@ -13,6 +13,7 @@ import {
   encryptedAttachmentKey,
   hasEncryptedAttachmentMetadata,
 } from "@/lib/xmpp/encrypted-attachments";
+import { safeAttachmentUrl } from "@/lib/attachment-url";
 
 type ReadonlyRef<T> = Readonly<Ref<T>>;
 // Internal gallery entry metadata. `sourceId` tracks the same attachment object
@@ -188,8 +189,12 @@ export function useMessageAttachments(message: ReadonlyRef<TimelineMessage>) {
     decryptedAttachmentUrls.value = next;
   }
 
+  // Single choke point for every render sink (img/video/audio/iframe/anchor/
+  // lightbox): wire-provided URLs pass the scheme allowlist or resolve to null
+  // so the attachment renders inert. Decrypted attachments resolve to a
+  // locally-minted blob: URL, which the allowlist keeps working.
   function resolvedAttachmentUrl(file: TimelineSharedFile): string | null {
-    if (!hasEncryptedAttachmentMetadata(file)) return file.url;
+    if (!hasEncryptedAttachmentMetadata(file)) return safeAttachmentUrl(file.url);
     return decryptedAttachmentUrls.value[attachmentKey(file)] ?? null;
   }
 
@@ -203,7 +208,7 @@ export function useMessageAttachments(message: ReadonlyRef<TimelineMessage>) {
 
   async function ensureAttachmentReady(file: TimelineSharedFile, persist = false): Promise<string | null> {
     if (disposed) return null;
-    if (!hasEncryptedAttachmentMetadata(file)) return file.url;
+    if (!hasEncryptedAttachmentMetadata(file)) return safeAttachmentUrl(file.url);
     if (typeof window === "undefined" || typeof URL === "undefined") return null;
     const key = attachmentKey(file);
     const existing = decryptedAttachmentUrls.value[key];

--- a/chat/src/components/chat/MessageBody.vue
+++ b/chat/src/components/chat/MessageBody.vue
@@ -714,9 +714,11 @@ watch(
               </div>
             </div>
           </button>
+          <!-- href resolves via the attachment scheme allowlist; a disallowed
+               scheme drops the attribute so the card renders inert. -->
           <a
             v-else
-            :href="file.url"
+            :href="resolvedAttachmentUrl(file) ?? undefined"
             target="_blank"
             rel="noopener noreferrer"
             class="chat-file-card inline-flex items-center gap-3 bg-muted rounded-lg p-3 hover:bg-muted/80 transition-all duration-200"
@@ -745,7 +747,7 @@ watch(
         >
           <a
             v-if="!file.encrypted || resolvedAttachmentUrl(file)"
-            :href="resolvedAttachmentUrl(file) || file.url || '#'"
+            :href="resolvedAttachmentUrl(file) ?? undefined"
             target="_blank"
             rel="noopener noreferrer"
             class="type-caption inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-foreground hover:bg-muted"

--- a/chat/src/components/community/FeedPane.vue
+++ b/chat/src/components/community/FeedPane.vue
@@ -25,6 +25,7 @@ import type { ActivityPublication, MoodPublication, TunePublication } from "@/li
 import type { VCard4Profile } from "@/lib/xmpp/vcard4-types";
 import type { FeedEntry, FeedPostInput, FeedSourceKind, Story, StoryPostInput, StoryReactionSummary } from "@/lib/xmpp-client";
 import { jidLocalpart } from "@/lib/xmpp/jid";
+import { safeExternalUrl } from "@/lib/chat-ui";
 
 const SOURCE_ICONS = {
   mood: Smile,
@@ -453,8 +454,8 @@ function selectStoryReaction(emoji: string) {
               {{ item.entry.body }}
             </p>
             <a
-              v-if="item.entry.link"
-              :href="item.entry.link"
+              v-if="safeExternalUrl(item.entry.link)"
+              :href="safeExternalUrl(item.entry.link)"
               target="_blank"
               rel="noopener noreferrer"
               class="type-caption inline-flex items-center gap-1 text-primary underline-offset-2 hover:underline"

--- a/chat/src/components/ui/ImageLightbox.vue
+++ b/chat/src/components/ui/ImageLightbox.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, watch } from "vue";
 import { X, ChevronLeft, ChevronRight, Download } from "lucide-vue-next";
+import { safeAttachmentUrl } from "@/lib/attachment-url";
 
 interface LightboxImage {
   url: string;
@@ -21,6 +22,10 @@ const emit = defineEmits<{
 }>();
 
 const current = computed(() => props.images[props.index] ?? null);
+// Callers already resolve gallery entries through the attachment scheme
+// allowlist; re-checking here keeps the lightbox safe against any future
+// caller that forgets to.
+const currentUrl = computed(() => safeAttachmentUrl(current.value?.url));
 const hasPrev = computed(() => props.index > 0);
 const hasNext = computed(() => props.index < props.images.length - 1);
 
@@ -70,7 +75,8 @@ onBeforeUnmount(() => {
 
       <div class="z-sticky absolute top-3 right-3 flex items-center gap-1">
         <a
-          :href="current.url"
+          v-if="currentUrl"
+          :href="currentUrl"
           :download="current.name ?? ''"
           target="_blank"
           rel="noopener noreferrer"
@@ -115,7 +121,8 @@ onBeforeUnmount(() => {
 
       <div class="chat-lightbox-frame relative flex flex-col items-center justify-center" @click.stop>
         <img
-          :src="current.url"
+          v-if="currentUrl"
+          :src="currentUrl"
           :alt="current.name ?? 'Image'"
           class="chat-lightbox-image object-contain rounded-lg shadow-2xl animate-slide-up"
         />

--- a/chat/src/lib/attachment-url.ts
+++ b/chat/src/lib/attachment-url.ts
@@ -1,9 +1,13 @@
 // Scheme allowlist for shared-file attachment URLs (XEP-0447 sources and
 // friends). Attachment URLs arrive over the wire (and out of MAM history)
 // fully attacker-controlled, so anything bound into `href`/`src` MUST pass
-// through here first. `blob:` is allowed because decrypted attachments are
-// locally-minted object URLs; everything else (`javascript:`, `data:`,
-// `vbscript:`, unparseable garbage) is rejected.
+// through here first. `blob:` is allowed so this guard can also re-validate
+// already-resolved local object URLs (e.g. the decrypted-attachment and
+// lightbox paths pass a locally-minted `blob:` URL back through it); a
+// remote-supplied `blob:` string is harmless since object URLs are
+// origin- and agent-scoped and cannot reference another session's blob.
+// Everything else (`javascript:`, `data:`, `vbscript:`, unparseable
+// garbage) is rejected.
 const ALLOWED_ATTACHMENT_PROTOCOLS = new Set(["http:", "https:", "blob:"]);
 
 export function safeAttachmentUrl(value: string | null | undefined): string | null {

--- a/chat/src/lib/attachment-url.ts
+++ b/chat/src/lib/attachment-url.ts
@@ -1,14 +1,16 @@
 // Scheme allowlist for shared-file attachment URLs (XEP-0447 sources and
 // friends). Attachment URLs arrive over the wire (and out of MAM history)
 // fully attacker-controlled, so anything bound into `href`/`src` MUST pass
-// through here first. `blob:` is allowed so this guard can also re-validate
-// already-resolved local object URLs (e.g. the decrypted-attachment and
-// lightbox paths pass a locally-minted `blob:` URL back through it); a
-// remote-supplied `blob:` string is harmless since object URLs are
-// origin- and agent-scoped and cannot reference another session's blob.
-// Everything else (`javascript:`, `data:`, `vbscript:`, unparseable
-// garbage) is rejected.
-const ALLOWED_ATTACHMENT_PROTOCOLS = new Set(["http:", "https:", "blob:"]);
+// through here first. Only `https:` remote URLs are allowed: plain `http:`
+// is rejected so a "safe" attachment can never be a mixed-content fetch the
+// app's CSP would block anyway (the CSP fetch directives are https-only).
+// `blob:` is allowed so this guard can also re-validate already-resolved
+// local object URLs (e.g. the decrypted-attachment and lightbox paths pass
+// a locally-minted `blob:` URL back through it); a remote-supplied `blob:`
+// string is harmless since object URLs are origin- and agent-scoped and
+// cannot reference another session's blob. Everything else (`http:`,
+// `javascript:`, `data:`, `vbscript:`, unparseable garbage) is rejected.
+const ALLOWED_ATTACHMENT_PROTOCOLS = new Set(["https:", "blob:"]);
 
 export function safeAttachmentUrl(value: string | null | undefined): string | null {
   const trimmed = value?.trim();

--- a/chat/src/lib/attachment-url.ts
+++ b/chat/src/lib/attachment-url.ts
@@ -1,0 +1,18 @@
+// Scheme allowlist for shared-file attachment URLs (XEP-0447 sources and
+// friends). Attachment URLs arrive over the wire (and out of MAM history)
+// fully attacker-controlled, so anything bound into `href`/`src` MUST pass
+// through here first. `blob:` is allowed because decrypted attachments are
+// locally-minted object URLs; everything else (`javascript:`, `data:`,
+// `vbscript:`, unparseable garbage) is rejected.
+const ALLOWED_ATTACHMENT_PROTOCOLS = new Set(["http:", "https:", "blob:"]);
+
+export function safeAttachmentUrl(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    return ALLOWED_ATTACHMENT_PROTOCOLS.has(url.protocol) ? trimmed : null;
+  } catch {
+    return null;
+  }
+}

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -649,7 +649,7 @@ function githubEventPresentation(
   };
 }
 
-function safeExternalUrl(value: string | undefined): string | undefined {
+export function safeExternalUrl(value: string | undefined): string | undefined {
   const trimmed = value?.trim();
   if (!trimmed) return undefined;
   try {

--- a/chat/src/middleware.ts
+++ b/chat/src/middleware.ts
@@ -1,0 +1,87 @@
+import { defineMiddleware } from "astro:middleware";
+
+// Baseline Content-Security-Policy for every server-rendered HTML document.
+//
+// Why a middleware header and not Astro's built-in `security.csp`: the app
+// uses `<ClientRouter />` (view transitions) and Shiki client-side syntax
+// highlighting, both explicitly unsupported by Astro's CSP implementation
+// (its auto-generated style hashes would make browsers ignore the
+// `'unsafe-inline'` that Shiki's inline styles and Vue SSR style bindings
+// require).
+//
+// Inline `<script>` bodies (the theme-restore `is:inline` script and Astro's
+// island/view-transition bootstrap) are hashed per response, so `script-src`
+// never needs `'unsafe-inline'`.
+const INLINE_SCRIPT_PATTERN = /<script\b(?![^>]*\bsrc\s*=)[^>]*>([\s\S]*?)<\/script>/gi;
+
+function contentSecurityPolicy(inlineScriptHashes: readonly string[]): string {
+  const scriptSources = ["'self'", "'wasm-unsafe-eval'", ...inlineScriptHashes.map((hash) => `'${hash}'`)];
+  return [
+    "default-src 'self'",
+    // 'wasm-unsafe-eval' for the XMPP client WASM module; hashes cover the
+    // inline theme-restore and Astro bootstrap scripts.
+    `script-src ${scriptSources.join(" ")}`,
+    // Shiki highlights code blocks with style attributes and Vue binds
+    // :style at SSR time; CSP cannot hash style attributes, so inline
+    // styles stay allowed. Scripts remain locked down above.
+    "style-src 'self' 'unsafe-inline'",
+    // Attachments/avatars/GIFs come from arbitrary https upload hosts,
+    // decrypted attachments from blob: object URLs, virtual-background
+    // custom images from data: URLs.
+    "img-src 'self' https: data: blob:",
+    // Inline audio/video attachments (https) and decrypted blob: media.
+    "media-src 'self' https: blob:",
+    "font-src 'self' data:",
+    // XMPP WebSocket + HTTP (SERVER_BASE_URL), LiveKit SFU WebSocket, Faro
+    // collector, HLS/link-preview/attachment fetches. Hosts are
+    // deployment-specific (worker env / server-provided), so scheme-level
+    // https:/wss: is the tightest static policy that cannot break calls.
+    "connect-src 'self' https: wss: blob:",
+    // Service worker ('self') plus blob: workers minted by hls.js, LiveKit
+    // track processors, and the noise-suppression AudioWorklet pipeline.
+    "worker-src 'self' blob:",
+    // PDF attachment iframes (https or decrypted blob:) and allowlisted
+    // player embeds (see player-embed-allowlist.ts).
+    "frame-src 'self' https: blob:",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "manifest-src 'self'",
+  ].join("; ");
+}
+
+async function sha256Source(text: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text));
+  const bytes = new Uint8Array(digest);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return `sha256-${btoa(binary)}`;
+}
+
+async function inlineScriptHashes(html: string): Promise<string[]> {
+  const hashes = new Set<string>();
+  for (const match of html.matchAll(INLINE_SCRIPT_PATTERN)) {
+    const body = match[1];
+    if (body) hashes.add(await sha256Source(body));
+  }
+  return [...hashes];
+}
+
+export const onRequest = defineMiddleware(async (_context, next) => {
+  const response = await next();
+  // The Vite dev server relies on its own inline/eval tooling; enforce the
+  // policy only on production builds (`build` + deploy, `preview`).
+  if (import.meta.env.DEV) return response;
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("text/html")) return response;
+
+  const html = await response.text();
+  const headers = new Headers(response.headers);
+  headers.set("Content-Security-Policy", contentSecurityPolicy(await inlineScriptHashes(html)));
+  return new Response(html, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+});

--- a/chat/tests/attachment-url.test.ts
+++ b/chat/tests/attachment-url.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+import { safeAttachmentUrl } from "../src/lib/attachment-url";
+
+describe("safeAttachmentUrl", () => {
+  test("allows https URLs", () => {
+    expect(safeAttachmentUrl("https://files.example.com/a/report.pdf"))
+      .toBe("https://files.example.com/a/report.pdf");
+  });
+
+  test("allows http URLs", () => {
+    expect(safeAttachmentUrl("http://files.example.com/pic.png"))
+      .toBe("http://files.example.com/pic.png");
+  });
+
+  test("allows locally-minted blob URLs (decrypted attachments)", () => {
+    expect(safeAttachmentUrl("blob:https://waddle.chat/6f2c1a2e-1111-4111-8111-aaaaaaaaaaaa"))
+      .toBe("blob:https://waddle.chat/6f2c1a2e-1111-4111-8111-aaaaaaaaaaaa");
+  });
+
+  test("trims surrounding whitespace from an allowed URL", () => {
+    expect(safeAttachmentUrl("  https://files.example.com/a.png \n"))
+      .toBe("https://files.example.com/a.png");
+  });
+
+  test("rejects javascript: URLs", () => {
+    expect(safeAttachmentUrl("javascript:alert(1)")).toBeNull();
+  });
+
+  test("rejects javascript: URLs regardless of case or leading whitespace", () => {
+    expect(safeAttachmentUrl(" JaVaScRiPt:alert(1)")).toBeNull();
+  });
+
+  test("rejects data: URLs", () => {
+    expect(safeAttachmentUrl("data:text/html,<script>alert(1)</script>")).toBeNull();
+  });
+
+  test("rejects vbscript: URLs", () => {
+    expect(safeAttachmentUrl("vbscript:msgbox(1)")).toBeNull();
+  });
+
+  test("rejects file: URLs", () => {
+    expect(safeAttachmentUrl("file:///etc/passwd")).toBeNull();
+  });
+
+  test("rejects unparseable values", () => {
+    expect(safeAttachmentUrl("not a url")).toBeNull();
+  });
+
+  test("rejects null, undefined, and empty values", () => {
+    expect(safeAttachmentUrl(null)).toBeNull();
+    expect(safeAttachmentUrl(undefined)).toBeNull();
+    expect(safeAttachmentUrl("")).toBeNull();
+    expect(safeAttachmentUrl("   ")).toBeNull();
+  });
+});

--- a/chat/tests/attachment-url.test.ts
+++ b/chat/tests/attachment-url.test.ts
@@ -7,9 +7,8 @@ describe("safeAttachmentUrl", () => {
       .toBe("https://files.example.com/a/report.pdf");
   });
 
-  test("allows http URLs", () => {
-    expect(safeAttachmentUrl("http://files.example.com/pic.png"))
-      .toBe("http://files.example.com/pic.png");
+  test("rejects plain http URLs (mixed content; CSP fetch directives are https-only)", () => {
+    expect(safeAttachmentUrl("http://files.example.com/pic.png")).toBeNull();
   });
 
   test("allows locally-minted blob URLs (decrypted attachments)", () => {

--- a/chat/tests/feed-pane-link-sanitization.test.ts
+++ b/chat/tests/feed-pane-link-sanitization.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import type { FeedEntry } from "@/lib/xmpp/feed-types";
+import { renderVueComponent } from "./helpers/render-vue-sfc";
+
+/**
+ * Regression for the shared-file XSS class (#1156) in the social-feed
+ * surface: `urn:xmpp:pubsub-social-feed:0` entries are member-postable,
+ * so `entry.link` is attacker-controlled and must not reach an anchor
+ * `href` without the http/https allowlist (`safeExternalUrl`).
+ */
+function renderFeed(entries: FeedEntry[]): Promise<string> {
+  return renderVueComponent(
+    "../src/components/community/FeedPane.vue",
+    {
+      entries,
+      stories: [],
+      isLoading: false,
+      isStoriesLoading: false,
+      isPosting: false,
+      isStoryPosting: false,
+      error: null,
+      storiesError: null,
+      canPost: false,
+      selfJid: "self@waddle.chat",
+    },
+    import.meta.url,
+  );
+}
+
+function entry(link: string): FeedEntry {
+  return { id: "e1", body: "hello", author: "mallory@waddle.chat", publishedMs: 1, link };
+}
+
+describe("FeedPane entry link sanitization", () => {
+  test("javascript: link renders no anchor href", async () => {
+    const html = await renderFeed([entry("javascript:alert(document.cookie)")]);
+    expect(html).not.toContain("javascript:");
+    expect(html).not.toContain('href="javascript');
+  });
+
+  test("data:text/html link renders no anchor href", async () => {
+    const html = await renderFeed([entry("data:text/html,<script>alert(1)</script>")]);
+    expect(html).not.toContain("data:text/html");
+  });
+
+  test("https link is preserved as the anchor href", async () => {
+    const html = await renderFeed([entry("https://example.com/post")]);
+    expect(html).toContain('href="https://example.com/post"');
+  });
+});

--- a/chat/tests/message-body-attachment-url-sanitization.test.ts
+++ b/chat/tests/message-body-attachment-url-sanitization.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { createSSRApp, h } from "vue";
+import { parse, compileScript } from "vue/compiler-sfc";
+import { renderToString } from "vue/server-renderer";
+import ts from "typescript";
+import type { TimelineMessage, TimelineSharedFile } from "../src/lib/chat-ui";
+
+describe("MessageBody attachment URL sanitization", () => {
+  test("a javascript: downloadable attachment renders inert — no javascript: href anywhere", async () => {
+    const html = await renderMessageBody({
+      message: messageWithSharedFiles([
+        {
+          url: "javascript:alert(1)",
+          name: "totally-a-file.bin",
+          mediaType: "application/octet-stream",
+          disposition: "attachment",
+        },
+      ]),
+    });
+
+    expect(html).not.toContain("javascript:");
+    // The file card still renders (inert, without a link target).
+    expect(html).toContain("totally-a-file.bin");
+    expect(html).not.toContain('href="javascript:alert(1)"');
+  });
+
+  test("a javascript: downloadable attachment in compact mode renders inert", async () => {
+    const html = await renderMessageBody({
+      message: messageWithSharedFiles([
+        {
+          url: "javascript:alert(1)",
+          name: "totally-a-file.bin",
+          mediaType: "application/octet-stream",
+          disposition: "attachment",
+        },
+      ]),
+      compact: true,
+    });
+
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain("totally-a-file.bin");
+  });
+
+  test("a data:text/html PDF attachment never reaches the iframe src", async () => {
+    const html = await renderMessageBody({
+      message: messageWithSharedFiles([
+        {
+          url: "data:text/html,<script>alert(1)</script>",
+          name: "evil.pdf",
+          mediaType: "application/pdf",
+          disposition: "inline",
+        },
+      ]),
+    });
+
+    expect(html).not.toContain("data:text/html");
+    expect(html).not.toContain("<iframe");
+  });
+
+  test("javascript: inline image, video, and audio attachments render no media src", async () => {
+    const html = await renderMessageBody({
+      message: messageWithSharedFiles([
+        { url: "javascript:alert('img')", mediaType: "image/png", disposition: "inline" },
+        { url: "javascript:alert('vid')", mediaType: "video/mp4", disposition: "inline" },
+        { url: "javascript:alert('aud')", mediaType: "audio/mpeg", disposition: "inline" },
+      ]),
+    });
+
+    expect(html).not.toContain("javascript:");
+    expect(html).not.toContain("<img");
+    expect(html).not.toContain("<video");
+    expect(html).not.toContain("<audio");
+  });
+
+  test("a javascript: sticker renders no image", async () => {
+    const html = await renderMessageBody({
+      message: {
+        ...messageWithSharedFiles([
+          { url: "javascript:alert(1)", mediaType: "image/png", disposition: "inline" },
+        ]),
+        isSticker: true,
+        body: "sticker alt",
+      },
+    });
+
+    expect(html).not.toContain("javascript:");
+    expect(html).not.toContain("<img");
+  });
+
+  test("control: a normal https downloadable attachment keeps its href", async () => {
+    const html = await renderMessageBody({
+      message: messageWithSharedFiles([
+        {
+          url: "https://files.example.com/report.bin",
+          name: "report.bin",
+          mediaType: "application/octet-stream",
+          disposition: "attachment",
+        },
+      ]),
+    });
+
+    expect(html).toContain('href="https://files.example.com/report.bin"');
+    expect(html).toContain("report.bin");
+  });
+
+  test("control: a normal https inline image keeps its src", async () => {
+    const html = await renderMessageBody({
+      message: messageWithSharedFiles([
+        {
+          url: "https://files.example.com/photo.png",
+          name: "photo.png",
+          mediaType: "image/png",
+          disposition: "inline",
+        },
+      ]),
+    });
+
+    expect(html).toContain('src="https://files.example.com/photo.png"');
+  });
+});
+
+function messageWithSharedFiles(sharedFiles: TimelineSharedFile[]): TimelineMessage {
+  return {
+    id: "m1",
+    author: "Alice",
+    body: "",
+    createdAt: "2026-06-02T12:00:00.000Z",
+    createdAtSource: "fallback",
+    isSelf: false,
+    sharedFiles,
+  };
+}
+
+async function renderMessageBody(props: { message: TimelineMessage; compact?: boolean }) {
+  const component = await loadMessageBodyComponent();
+  return renderToString(createSSRApp({ render: () => h(component, props) }));
+}
+
+async function loadMessageBodyComponent() {
+  const filename = new URL("../src/components/chat/MessageBody.vue", import.meta.url);
+  const source = readFileSync(filename, "utf8");
+  const { descriptor } = parse(source, { filename: filename.pathname });
+  const script = compileScript(descriptor, {
+    id: "message-body-attachment-url-sanitization-test",
+    inlineTemplate: true,
+  });
+
+  const tempDir = mkdtempSync(join(tmpdir(), "waddle-message-body-attachments-"));
+  try {
+    const compiled = [
+      rewriteImports(script.content.replace("export default", "const __sfc__ ="), filename, tempDir),
+      "export default __sfc__;",
+    ].join("\n");
+    const js = ts.transpileModule(compiled, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        verbatimModuleSyntax: false,
+      },
+    }).outputText;
+    const modulePath = join(tempDir, "MessageBody.mjs");
+    writeFileSync(modulePath, js);
+    const component = await import(pathToFileURL(modulePath).href);
+    return component.default;
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function rewriteImports(code: string, importer: URL, tempDir: string): string {
+  return code.replace(/from\s+["']([^"']+)["']/g, (_match, specifier: string) =>
+    `from ${JSON.stringify(resolveModuleSpecifier(specifier, importer, tempDir))}`);
+}
+
+function resolveModuleSpecifier(specifier: string, importer: URL, tempDir: string): string {
+  if (specifier.startsWith("@/")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(`../src/${specifier.slice(2)}`, import.meta.url).pathname), tempDir);
+  }
+  if (specifier.startsWith(".")) {
+    return moduleUrlForPath(resolveSourcePath(new URL(specifier, importer).pathname), tempDir);
+  }
+  return import.meta.resolve(specifier);
+}
+
+function resolveSourcePath(basePath: string): string {
+  const candidates = [
+    basePath,
+    `${basePath}.ts`,
+    `${basePath}.tsx`,
+    `${basePath}.js`,
+    `${basePath}.mjs`,
+    `${basePath}.vue`,
+    `${basePath}.json`,
+    `${basePath}/index.ts`,
+  ];
+  const resolved = candidates.find((candidate) => existsSync(candidate));
+  if (!resolved) throw new Error(`Unable to resolve test SFC import: ${basePath}`);
+  return resolved;
+}
+
+function moduleUrlForPath(resolvedPath: string, tempDir: string): string {
+  if (!resolvedPath.endsWith(".vue")) return pathToFileURL(resolvedPath).href;
+  const stubPath = join(tempDir, `${resolvedPath.replace(/[^a-z0-9]/gi, "_")}.mjs`);
+  writeFileSync(stubPath, [
+    `import { h } from ${JSON.stringify(import.meta.resolve("vue"))};`,
+    "export default { name: 'MessageBodyChildStub', setup(_, { slots }) { return () => h('span', { 'data-vue-stub': 'true' }, slots.default?.()); } };",
+  ].join("\n"));
+  return pathToFileURL(stubPath).href;
+}

--- a/server/crates/waddle-server/src/pending_delivery.rs
+++ b/server/crates/waddle-server/src/pending_delivery.rs
@@ -52,8 +52,8 @@ mod flush;
 
 pub use database::DatabasePendingDeliveryStorage;
 pub use flush::{
-    flush_for_resource, ArchiveResolver, FlushContext, FlushOutcome, MamArchiveResolver,
-    NullArchiveResolver,
+    flush_for_resource, ArchiveResolveError, ArchiveResolver, FlushContext, FlushOutcome,
+    MamArchiveResolver, NullArchiveResolver,
 };
 
 #[cfg(test)]

--- a/server/crates/waddle-server/src/pending_delivery/database.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database.rs
@@ -394,6 +394,17 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
             crate::db_params![session.as_str().to_string(), recipient.to_string()],
         )
         .await?;
+        // Return ONLY the rows this claim just tagged, identified by
+        // `outbound_sequence IS NULL`. A row already pushed on this same
+        // session in an earlier flush keeps `flushed_in_session = session`
+        // AND a non-NULL `outbound_sequence` (the UPDATE above only touched
+        // IS NULL rows), so filtering on the null sequence excludes it.
+        // Without this, a re-flush of the same SM session (issue #1122:
+        // `reset_offline_flush` re-opens the once-per-connection CAS after a
+        // transient MAM error defers rows mid-batch) would re-select and
+        // re-push an already-pushed-but-unacked row, duplicating delivery
+        // and overwriting its `outbound_sequence`. This matches the
+        // in-memory backend, which only returns freshly-claimed rows.
         let mut rows = self
             .query(
                 "SELECT row_id, recipient_jid, original_receipt_at, payload_kind, \
@@ -401,6 +412,7 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
                         flushed_in_session, outbound_sequence \
                  FROM pending_delivery \
                  WHERE recipient_jid = ? AND flushed_in_session = ? \
+                   AND outbound_sequence IS NULL \
                  ORDER BY row_id ASC",
                 crate::db_params![recipient.to_string(), session.as_str().to_string()],
             )

--- a/server/crates/waddle-server/src/pending_delivery/flush.rs
+++ b/server/crates/waddle-server/src/pending_delivery/flush.rs
@@ -398,23 +398,28 @@ impl ArchiveResolver for MamArchiveResolver {
             // Definitive miss: no archive row for this id. Poison
             // pill — the caller deletes the pending row.
             Ok(None) => return Ok(None),
-            // Permanent row-content corruption: the production lookup
-            // surfaces a bad timestamp/JID column
-            // (decode_sqlite_message_row / decode_postgres_message_row)
-            // as `Serialization`, and an unusable stored id as
-            // `InvalidQuery`. Retrying can never succeed, so these are
-            // genuine poison pills — `Ok(None)` deletes the row and
-            // fires the loud corruption counter instead of retrying
-            // forever under the "no mail lost" transient counter.
+            // Permanent, retry-can-never-succeed conditions — genuine
+            // poison pills. `Ok(None)` deletes the row and fires the
+            // loud corruption counter instead of retrying forever under
+            // the "no mail lost" transient counter:
+            //   - `Serialization`: bad timestamp/JID column, surfaced by
+            //     decode_sqlite_message_row / decode_postgres_message_row.
+            //   - `InvalidQuery`: an unusable stored id.
+            //   - `NotFound`: a definitive miss. The lookup returns
+            //     `Ok(None)` for a genuine miss today, so this is
+            //     unreachable here, but classifying it as a poison pill
+            //     (not transient) keeps a future refactor that surfaces
+            //     `NotFound` from wedging the row in an immortal retry.
             Err(
                 error @ (waddle_xmpp::mam::storage::MamStorageError::Serialization(_)
-                | waddle_xmpp::mam::storage::MamStorageError::InvalidQuery(_)),
+                | waddle_xmpp::mam::storage::MamStorageError::InvalidQuery(_)
+                | waddle_xmpp::mam::storage::MamStorageError::NotFound(_)),
             ) => {
                 warn!(
                     error = %error,
                     archive_jid = %archive_bare,
                     stanza_id = %stanza_id,
-                    "MAM row decode failed permanently during flush; treating as poison pill"
+                    "MAM lookup resolved to a permanent miss during flush; treating as poison pill"
                 );
                 return Ok(None);
             }
@@ -422,10 +427,7 @@ impl ArchiveResolver for MamArchiveResolver {
             // typed error so the caller RELEASES the row (and the
             // rest of the claimed batch) for retry instead of
             // destroying queued mail during a MAM outage.
-            Err(
-                error @ (waddle_xmpp::mam::storage::MamStorageError::Database(_)
-                | waddle_xmpp::mam::storage::MamStorageError::NotFound(_)),
-            ) => {
+            Err(error @ waddle_xmpp::mam::storage::MamStorageError::Database(_)) => {
                 warn!(
                     error = %error,
                     archive_jid = %archive_bare,

--- a/server/crates/waddle-server/src/pending_delivery/flush.rs
+++ b/server/crates/waddle-server/src/pending_delivery/flush.rs
@@ -13,8 +13,15 @@ pub struct FlushOutcome {
     /// the row is deleted so the flush loop never wedges on it.
     pub unresolved: u32,
     /// Number of rows whose MAM lookup failed *transiently* (issue
-    /// #1122). These rows are NOT deleted — the claim is released so
-    /// the next flush retries once MAM storage recovers.
+    /// #1122), plus every later row in the same claimed batch: the
+    /// first transient failure is batch-fatal (see the Err arm in
+    /// [`flush_for_resource`]) so FIFO order is preserved and a MAM
+    /// outage isn't hammered once per remaining row. These rows are
+    /// NOT deleted — their claims are released, and the presence
+    /// handler resets the connection's offline-flush CAS when this
+    /// counter is non-zero so the client's next presence update
+    /// re-attempts the flush (another recovering resource can also
+    /// pick the rows up).
     pub deferred_transient: u32,
     /// Number of rows dropped because the recipient blocked the sender
     /// AFTER the row was inserted (XEP-0191 §2 step 4 flush-time
@@ -129,7 +136,8 @@ where
         return outcome;
     }
 
-    for row in claimed {
+    let mut rows = claimed.into_iter();
+    while let Some(row) = rows.next() {
         let payload = match materialize(&row, archive_resolver).await {
             Ok(Some(payload)) => payload,
             Ok(None) => {
@@ -157,27 +165,39 @@ where
                 // Issue #1122: the MAM lookup ERRORED — a transient
                 // storage failure, not a missing row. Deleting here
                 // would let a momentary MAM outage destroy queued
-                // offline mail. Release the claim instead so the next
-                // flush (this session's next presence transition, or
-                // another recovering resource) retries the lookup.
+                // offline mail. The failure is BATCH-FATAL:
+                // pending_delivery is FIFO (XEP-0160 §3 order of
+                // receipt), so delivering later rows while releasing
+                // this one would reorder the recipient's offline
+                // mail, and a hard MAM outage would otherwise cost
+                // one failing lookup per remaining archived row,
+                // awaited inline in the presence handler. Release
+                // this row and every remaining claimed row, then
+                // abort the flush. Retry fires on the client's next
+                // presence update — `maybe_flush_pending_delivery`
+                // resets the connection's offline-flush CAS when
+                // `deferred_transient > 0` — or via another
+                // recovering resource.
                 outcome.deferred_transient += 1;
                 waddle_xmpp::prometheus::increment_pending_delivery_archive_lookup_transient_failure();
                 warn!(
                     row_id = %row.id,
                     error = %error,
                     "pending_delivery archive lookup failed transiently; \
-                     releasing row for retry on the next flush"
+                     aborting flush batch and releasing this row and all \
+                     remaining claimed rows for retry"
                 );
-                if let Err(release_error) = storage.release_row(&row.id).await {
-                    warn!(
-                        row_id = %row.id,
-                        error = %release_error,
-                        "pending_delivery release_row (transient archive \
-                         failure) also failed; claim-expiry janitor will \
-                         release it once the session expires"
-                    );
+                release_row_or_warn(storage, &row.id, "transient archive failure").await;
+                for deferred in rows.by_ref() {
+                    outcome.deferred_transient += 1;
+                    release_row_or_warn(
+                        storage,
+                        &deferred.id,
+                        "transient archive failure (batch abort)",
+                    )
+                    .await;
                 }
-                continue;
+                break;
             }
         };
         // XEP-0191 §2 step 4 flush-time block re-evaluation
@@ -288,6 +308,25 @@ where
     outcome
 }
 
+/// Release a row's flush claim, downgrading a release failure to a
+/// warning: the claim-expiry janitor will release the row once the
+/// claiming session expires.
+async fn release_row_or_warn(
+    storage: &Arc<dyn PendingDeliveryStorage>,
+    row_id: &PendingRowId,
+    context: &'static str,
+) {
+    if let Err(error) = storage.release_row(row_id).await {
+        warn!(
+            row_id = %row_id,
+            error = %error,
+            context,
+            "pending_delivery release_row failed; claim-expiry janitor \
+             will release it once the session expires"
+        );
+    }
+}
+
 /// Resolves Archived `PendingRow` references against MAM.
 ///
 /// Production wiring uses [`MamArchiveResolver`] over a real
@@ -307,9 +346,12 @@ pub trait ArchiveResolver: Send + Sync {
     ///   unparseable preserved XML). The caller treats this as a
     ///   poison pill and deletes the `pending_delivery` row.
     /// - `Err(_)` — *transient* lookup failure (MAM storage outage).
-    ///   The caller releases the row's claim so the next flush
-    ///   retries; the queued message is never destroyed by a
-    ///   momentary outage.
+    ///   Batch-fatal for the caller: it releases this row's claim AND
+    ///   every remaining claimed row, then aborts the flush so FIFO
+    ///   order is preserved; the queued messages are never destroyed
+    ///   by a momentary outage. Permanent decode failures
+    ///   (`Serialization` / `InvalidQuery` row corruption) must be
+    ///   reported as `Ok(None)`, never as `Err(_)`.
     async fn resolve(
         &self,
         stanza_id: &StanzaId,
@@ -323,8 +365,12 @@ pub trait ArchiveResolver: Send + Sync {
 #[derive(Debug, thiserror::Error)]
 pub enum ArchiveResolveError {
     /// The MAM storage lookup itself failed (DB outage, timeout, …).
+    /// Carries only *retryable* storage errors: permanent decode
+    /// failures (`MamStorageError::Serialization` / `InvalidQuery`)
+    /// are mapped to `Ok(None)` poison pills by
+    /// [`MamArchiveResolver::resolve`] and never reach this variant.
     #[error("MAM storage lookup failed: {0}")]
-    Storage(#[from] waddle_xmpp::mam::storage::MamStorageError),
+    Storage(waddle_xmpp::mam::storage::MamStorageError),
 }
 
 /// MAM-backed resolver for production use.
@@ -352,10 +398,34 @@ impl ArchiveResolver for MamArchiveResolver {
             // Definitive miss: no archive row for this id. Poison
             // pill — the caller deletes the pending row.
             Ok(None) => return Ok(None),
+            // Permanent row-content corruption: the production lookup
+            // surfaces a bad timestamp/JID column
+            // (decode_sqlite_message_row / decode_postgres_message_row)
+            // as `Serialization`, and an unusable stored id as
+            // `InvalidQuery`. Retrying can never succeed, so these are
+            // genuine poison pills — `Ok(None)` deletes the row and
+            // fires the loud corruption counter instead of retrying
+            // forever under the "no mail lost" transient counter.
+            Err(
+                error @ (waddle_xmpp::mam::storage::MamStorageError::Serialization(_)
+                | waddle_xmpp::mam::storage::MamStorageError::InvalidQuery(_)),
+            ) => {
+                warn!(
+                    error = %error,
+                    archive_jid = %archive_bare,
+                    stanza_id = %stanza_id,
+                    "MAM row decode failed permanently during flush; treating as poison pill"
+                );
+                return Ok(None);
+            }
             // Transient storage failure (issue #1122): propagate the
-            // typed error so the caller RELEASES the row for retry
-            // instead of destroying queued mail during a MAM outage.
-            Err(error) => {
+            // typed error so the caller RELEASES the row (and the
+            // rest of the claimed batch) for retry instead of
+            // destroying queued mail during a MAM outage.
+            Err(
+                error @ (waddle_xmpp::mam::storage::MamStorageError::Database(_)
+                | waddle_xmpp::mam::storage::MamStorageError::NotFound(_)),
+            ) => {
                 warn!(
                     error = %error,
                     archive_jid = %archive_bare,

--- a/server/crates/waddle-server/src/pending_delivery/flush.rs
+++ b/server/crates/waddle-server/src/pending_delivery/flush.rs
@@ -7,10 +7,15 @@ pub struct FlushOutcome {
     pub claimed: u32,
     /// Number of replayed stanzas successfully pushed to the resource.
     pub pushed: u32,
-    /// Number of rows the resolver could not materialize (Archived row
-    /// whose MAM lookup is not available — happens when MAM storage is
-    /// unwired in the test fixture, never in production).
+    /// Number of rows the resolver definitively could not materialize
+    /// (Archived row whose MAM lookup returned no row, or whose
+    /// preserved wire XML is unparseable). These are poison pills:
+    /// the row is deleted so the flush loop never wedges on it.
     pub unresolved: u32,
+    /// Number of rows whose MAM lookup failed *transiently* (issue
+    /// #1122). These rows are NOT deleted — the claim is released so
+    /// the next flush retries once MAM storage recovers.
+    pub deferred_transient: u32,
     /// Number of rows dropped because the recipient blocked the sender
     /// AFTER the row was inserted (XEP-0191 §2 step 4 flush-time
     /// re-evaluation, issue #209 PR #360). Blocked rows are deleted
@@ -125,23 +130,55 @@ where
     }
 
     for row in claimed {
-        let Some(payload) = materialize(&row, archive_resolver).await else {
-            // Archived row whose MAM lookup failed — the original
-            // stanza is unrecoverable. Drop the row instead of
-            // releasing it so we don't loop forever on a poison pill.
-            // The message is permanently lost from the recipient's
-            // perspective; we surface it loudly so production logs
-            // can flag MAM corruption / unexpected tombstones.
-            outcome.unresolved += 1;
-            waddle_xmpp::prometheus::increment_pending_delivery_unresolved_poison_pill();
-            if let Err(error) = storage.delete_row(&row.id).await {
+        let payload = match materialize(&row, archive_resolver).await {
+            Ok(Some(payload)) => payload,
+            Ok(None) => {
+                // Archived row whose MAM lookup definitively found
+                // nothing usable (row missing, tombstoned, or its
+                // preserved XML is unparseable) — the original stanza
+                // is unrecoverable. Drop the row instead of releasing
+                // it so we don't loop forever on a poison pill. The
+                // message is permanently lost from the recipient's
+                // perspective; we surface it loudly so production
+                // logs can flag MAM corruption / unexpected
+                // tombstones.
+                outcome.unresolved += 1;
+                waddle_xmpp::prometheus::increment_pending_delivery_unresolved_poison_pill();
+                if let Err(error) = storage.delete_row(&row.id).await {
+                    warn!(
+                        row_id = %row.id,
+                        error = %error,
+                        "pending_delivery delete_row (unresolved poison pill) failed"
+                    );
+                }
+                continue;
+            }
+            Err(error) => {
+                // Issue #1122: the MAM lookup ERRORED — a transient
+                // storage failure, not a missing row. Deleting here
+                // would let a momentary MAM outage destroy queued
+                // offline mail. Release the claim instead so the next
+                // flush (this session's next presence transition, or
+                // another recovering resource) retries the lookup.
+                outcome.deferred_transient += 1;
+                waddle_xmpp::prometheus::increment_pending_delivery_archive_lookup_transient_failure();
                 warn!(
                     row_id = %row.id,
                     error = %error,
-                    "pending_delivery delete_row (unresolved poison pill) failed"
+                    "pending_delivery archive lookup failed transiently; \
+                     releasing row for retry on the next flush"
                 );
+                if let Err(release_error) = storage.release_row(&row.id).await {
+                    warn!(
+                        row_id = %row.id,
+                        error = %release_error,
+                        "pending_delivery release_row (transient archive \
+                         failure) also failed; claim-expiry janitor will \
+                         release it once the session expires"
+                    );
+                }
+                continue;
             }
-            continue;
         };
         // XEP-0191 §2 step 4 flush-time block re-evaluation
         // (issue #209 PR #360): if the recipient blocked the sender
@@ -261,10 +298,33 @@ pub trait ArchiveResolver: Send + Sync {
     /// Read the archived stanza by canonical XEP-0359 [`StanzaId`]
     /// (`{ id, by }`). Returns the typed
     /// [`xmpp_parsers::message::Message`] reconstructed from the MAM
-    /// row; returns `None` on miss or any non-fatal lookup failure
-    /// (the caller treats this as a poison pill and drops the
-    /// `pending_delivery` row).
-    async fn resolve(&self, stanza_id: &StanzaId) -> Option<xmpp_parsers::message::Message>;
+    /// row.
+    ///
+    /// The three outcomes are semantically distinct (issue #1122):
+    ///
+    /// - `Ok(Some(message))` — resolved; the caller replays it.
+    /// - `Ok(None)` — definitive miss (no archive row, tombstone, or
+    ///   unparseable preserved XML). The caller treats this as a
+    ///   poison pill and deletes the `pending_delivery` row.
+    /// - `Err(_)` — *transient* lookup failure (MAM storage outage).
+    ///   The caller releases the row's claim so the next flush
+    ///   retries; the queued message is never destroyed by a
+    ///   momentary outage.
+    async fn resolve(
+        &self,
+        stanza_id: &StanzaId,
+    ) -> Result<Option<xmpp_parsers::message::Message>, ArchiveResolveError>;
+}
+
+/// Transient failure resolving an Archived `pending_delivery` row
+/// against MAM (issue #1122). Distinct from a genuine miss
+/// (`Ok(None)`): the flush loop releases the row for retry instead of
+/// poison-pill-deleting it.
+#[derive(Debug, thiserror::Error)]
+pub enum ArchiveResolveError {
+    /// The MAM storage lookup itself failed (DB outage, timeout, …).
+    #[error("MAM storage lookup failed: {0}")]
+    Storage(#[from] waddle_xmpp::mam::storage::MamStorageError),
 }
 
 /// MAM-backed resolver for production use.
@@ -274,7 +334,10 @@ pub struct MamArchiveResolver {
 
 #[async_trait::async_trait]
 impl ArchiveResolver for MamArchiveResolver {
-    async fn resolve(&self, stanza_id: &StanzaId) -> Option<xmpp_parsers::message::Message> {
+    async fn resolve(
+        &self,
+        stanza_id: &StanzaId,
+    ) -> Result<Option<xmpp_parsers::message::Message>, ArchiveResolveError> {
         // MAM lookup keys on the archive's *bare* JID — XEP-0313 §5
         // archives are per-user / per-room (BareJid), and the canonical
         // `StanzaId.by` Jid carries that information (the MAM writer
@@ -286,24 +349,37 @@ impl ArchiveResolver for MamArchiveResolver {
             .await
         {
             Ok(Some(archived)) => archived,
-            Ok(None) => return None,
+            // Definitive miss: no archive row for this id. Poison
+            // pill — the caller deletes the pending row.
+            Ok(None) => return Ok(None),
+            // Transient storage failure (issue #1122): propagate the
+            // typed error so the caller RELEASES the row for retry
+            // instead of destroying queued mail during a MAM outage.
             Err(error) => {
                 warn!(
                     error = %error,
                     archive_jid = %archive_bare,
                     stanza_id = %stanza_id,
-                    "MAM lookup failed during flush"
+                    "MAM lookup failed transiently during flush"
                 );
-                return None;
+                return Err(ArchiveResolveError::Storage(error));
             }
         };
         // Parse the preserved wire XML back into a typed Message. The
         // archived row includes server-stamped <stanza-id> by recipient
         // bare, so the parsed Message already carries the XEP-0359
         // identifier required by locked Q5c.
-        let stanza_xml = archived.stanza_xml.as_deref()?;
-        let element: xmpp_parsers::minidom::Element = stanza_xml.parse().ok()?;
-        xmpp_parsers::message::Message::try_from(element).ok()
+        //
+        // An absent or unparseable `stanza_xml` is row corruption, not
+        // a transient condition — retrying can never succeed, so these
+        // stay `Ok(None)` poison pills.
+        let Some(stanza_xml) = archived.stanza_xml.as_deref() else {
+            return Ok(None);
+        };
+        let Ok(element) = stanza_xml.parse::<xmpp_parsers::minidom::Element>() else {
+            return Ok(None);
+        };
+        Ok(xmpp_parsers::message::Message::try_from(element).ok())
     }
 }
 
@@ -313,21 +389,27 @@ pub struct NullArchiveResolver;
 
 #[async_trait::async_trait]
 impl ArchiveResolver for NullArchiveResolver {
-    async fn resolve(&self, _stanza_id: &StanzaId) -> Option<xmpp_parsers::message::Message> {
-        None
+    async fn resolve(
+        &self,
+        _stanza_id: &StanzaId,
+    ) -> Result<Option<xmpp_parsers::message::Message>, ArchiveResolveError> {
+        Ok(None)
     }
 }
 
-async fn materialize<R>(row: &PendingRow, resolver: &R) -> Option<MaterializedPayload>
+async fn materialize<R>(
+    row: &PendingRow,
+    resolver: &R,
+) -> Result<Option<MaterializedPayload>, ArchiveResolveError>
 where
     R: ArchiveResolver + ?Sized,
 {
     match &row.payload {
-        PendingPayload::Transient(_) => MaterializedPayload::from_transient(row),
-        PendingPayload::Archived(stanza_id) => {
-            let archived = resolver.resolve(stanza_id).await?;
-            Some(MaterializedPayload::Archived(Box::new(archived)))
-        }
+        PendingPayload::Transient(_) => Ok(MaterializedPayload::from_transient(row)),
+        PendingPayload::Archived(stanza_id) => Ok(resolver
+            .resolve(stanza_id)
+            .await?
+            .map(|archived| MaterializedPayload::Archived(Box::new(archived)))),
     }
 }
 

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -1642,3 +1642,395 @@ async fn db_storage_postgres_handles_i32_overflow_receipt_ms() {
     let deleted = storage.delete_row(&row_id).await.expect("cleanup");
     assert_eq!(deleted, 1, "test row must be deleted by id");
 }
+
+// ── Issue #1122: transient MAM failure vs genuine tombstone miss ────
+//
+// The archive resolver must distinguish a transient MAM storage
+// error (release the row so the next flush retries) from a genuine
+// miss / unparseable row (poison pill: delete). Collapsing both into
+// "unresolved" meant a momentary MAM outage permanently destroyed
+// queued offline mail.
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use waddle_xmpp::mam::storage::{InMemoryMamStorage, MamStorage, MamStorageError};
+use waddle_xmpp_core::mam::ArchivedMessage;
+
+/// MAM storage wrapper that fails `get_message_by_archive_or_stanza_id`
+/// with a transient `Database` error for the first
+/// `failures_remaining` lookups, then delegates to the inner
+/// in-memory storage. Every other operation delegates unconditionally.
+struct LookupOutageMamStorage {
+    inner: InMemoryMamStorage,
+    failures_remaining: AtomicU32,
+}
+
+impl LookupOutageMamStorage {
+    fn new(inner: InMemoryMamStorage, failures: u32) -> Self {
+        Self {
+            inner,
+            failures_remaining: AtomicU32::new(failures),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl MamStorage for LookupOutageMamStorage {
+    async fn store_message(
+        &self,
+        archive_jid: &BareJid,
+        message: &ArchivedMessage,
+    ) -> Result<String, MamStorageError> {
+        self.inner.store_message(archive_jid, message).await
+    }
+    async fn query_messages(
+        &self,
+        archive_jid: &BareJid,
+        query: &waddle_xmpp_core::mam::MamQuery,
+    ) -> Result<waddle_xmpp_core::mam::MamResult, MamStorageError> {
+        self.inner.query_messages(archive_jid, query).await
+    }
+    async fn get_message(
+        &self,
+        archive_id: &str,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        self.inner.get_message(archive_id).await
+    }
+    async fn replace_with_tombstone(
+        &self,
+        archive_id: &str,
+        tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+    ) -> Result<bool, MamStorageError> {
+        self.inner
+            .replace_with_tombstone(archive_id, tombstone)
+            .await
+    }
+    async fn get_message_by_stanza_id(
+        &self,
+        archive_jid: &BareJid,
+        stanza_id: &str,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        self.inner
+            .get_message_by_stanza_id(archive_jid, stanza_id)
+            .await
+    }
+    async fn get_message_by_message_id(
+        &self,
+        archive_jid: &BareJid,
+        message_id: &str,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        self.inner
+            .get_message_by_message_id(archive_jid, message_id)
+            .await
+    }
+    async fn get_message_by_archive_or_stanza_id(
+        &self,
+        archive_jid: &BareJid,
+        stanza_id: &str,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        let remaining = self.failures_remaining.load(Ordering::Acquire);
+        if remaining > 0 {
+            self.failures_remaining
+                .store(remaining - 1, Ordering::Release);
+            return Err(MamStorageError::Database(
+                "simulated transient MAM outage".to_string(),
+            ));
+        }
+        self.inner
+            .get_message_by_archive_or_stanza_id(archive_jid, stanza_id)
+            .await
+    }
+    async fn count_messages(&self, room_jid: &BareJid) -> Result<u32, MamStorageError> {
+        self.inner.count_messages(room_jid).await
+    }
+    async fn delete_before(
+        &self,
+        room_jid: &BareJid,
+        before: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, MamStorageError> {
+        self.inner.delete_before(room_jid, before).await
+    }
+}
+
+/// Seed the given MAM storage with an archived copy of a chat message
+/// addressed to `recipient`, retrievable by `archive_id` via
+/// `get_message_by_archive_or_stanza_id`. `stanza_xml` overrides the
+/// preserved wire XML (pass `None` to leave the column empty, or
+/// garbage to simulate a corrupt row).
+async fn seed_archived_message(
+    mam: &dyn MamStorage,
+    recipient: &str,
+    archive_id: &str,
+    stanza_xml: Option<String>,
+) {
+    let recipient_bare = bare(recipient);
+    let mut archived = ArchivedMessage::for_test(
+        "bob@elsewhere/x".parse::<jid::Jid>().expect("jid"),
+        jid::Jid::from(recipient_bare.clone()),
+    );
+    archived.id = archive_id.to_string();
+    archived.stanza_id = Some(StanzaId::new(
+        archive_id,
+        jid::Jid::from(recipient_bare.clone()),
+    ));
+    archived.stanza_xml = stanza_xml;
+    mam.store_message(&recipient_bare, &archived)
+        .await
+        .expect("seed archived message");
+}
+
+fn valid_archived_stanza_xml(recipient: &str, body: &str) -> String {
+    transient_message_xml(recipient, body)
+}
+
+#[tokio::test]
+async fn flush_archived_row_transient_resolver_error_releases_row_for_retry() {
+    // Issue #1122 core repro: MAM lookup errors (outage), the row
+    // must be RELEASED for the next flush — not poison-pill-deleted.
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    storage
+        .insert(archived_row("alice@example.com", "archive-1"))
+        .await
+        .unwrap();
+
+    // MAM storage that always fails the lookup.
+    let mam: Arc<dyn MamStorage> = Arc::new(LookupOutageMamStorage::new(
+        InMemoryMamStorage::new(),
+        u32::MAX,
+    ));
+    let resolver = MamArchiveResolver { mam_storage: mam };
+
+    let registry = ConnectionRegistry::new();
+    let resource = full("alice@example.com/web");
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    registry.register(resource.clone(), tx);
+    let sm_session = SmSessionId::new("sm-stream-mam-outage");
+
+    let outcome = flush_for_resource(
+        &storage,
+        &registry,
+        &bare("alice@example.com"),
+        &resource,
+        FlushContext {
+            server_domain: "example.com",
+            sm_session: Some(&sm_session),
+            blocking_storage: None,
+            archive_resolver: &resolver,
+        },
+    )
+    .await;
+
+    assert_eq!(outcome.claimed, 1);
+    assert_eq!(outcome.pushed, 0);
+    assert_eq!(
+        outcome.unresolved, 0,
+        "transient MAM error must NOT count as an unresolved poison pill"
+    );
+    assert_eq!(
+        outcome.deferred_transient, 1,
+        "transient MAM error must be counted as a deferred row"
+    );
+    assert!(rx.try_recv().is_err(), "nothing pushed during the outage");
+
+    // The row survives AND its claim is released so the next flush
+    // (or another recovering resource) can re-claim it.
+    let rows = storage.list(&bare("alice@example.com")).await.unwrap();
+    assert_eq!(rows.len(), 1, "row must not be deleted on transient error");
+    assert!(
+        rows[0].flushed_in_session.is_none(),
+        "row must be released for re-claim on the next flush"
+    );
+}
+
+#[tokio::test]
+async fn flush_archived_row_genuine_mam_miss_is_poison_pill_deleted() {
+    // Genuine tombstone miss (`Ok(None)` from MAM): the original
+    // stanza is unrecoverable — keep the poison-pill delete so the
+    // flush loop never wedges on the row.
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    storage
+        .insert(archived_row("alice@example.com", "archive-missing"))
+        .await
+        .unwrap();
+
+    let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new()); // empty archive
+    let resolver = MamArchiveResolver { mam_storage: mam };
+
+    let registry = ConnectionRegistry::new();
+    let resource = full("alice@example.com/web");
+    let (tx, _rx) = tokio::sync::mpsc::channel(8);
+    registry.register(resource.clone(), tx);
+    let sm_session = SmSessionId::new("sm-stream-mam-miss");
+
+    let outcome = flush_for_resource(
+        &storage,
+        &registry,
+        &bare("alice@example.com"),
+        &resource,
+        FlushContext {
+            server_domain: "example.com",
+            sm_session: Some(&sm_session),
+            blocking_storage: None,
+            archive_resolver: &resolver,
+        },
+    )
+    .await;
+
+    assert_eq!(outcome.unresolved, 1);
+    assert_eq!(outcome.deferred_transient, 0);
+    assert_eq!(
+        storage.count(&bare("alice@example.com")).await.unwrap(),
+        0,
+        "genuine miss is a poison pill: row deleted"
+    );
+}
+
+#[tokio::test]
+async fn flush_archived_row_unparseable_stanza_xml_is_poison_pill() {
+    // Corrupt archive rows (garbage / absent stanza_xml) are
+    // unrecoverable — poison-pill delete, never retry-loop.
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    storage
+        .insert(archived_row("alice@example.com", "archive-garbage"))
+        .await
+        .unwrap();
+    storage
+        .insert(archived_row("alice@example.com", "archive-no-xml"))
+        .await
+        .unwrap();
+
+    let mam_inner = InMemoryMamStorage::new();
+    seed_archived_message(
+        &mam_inner,
+        "alice@example.com",
+        "archive-garbage",
+        Some("<<<definitely-not-xml".to_string()),
+    )
+    .await;
+    seed_archived_message(&mam_inner, "alice@example.com", "archive-no-xml", None).await;
+    let mam: Arc<dyn MamStorage> = Arc::new(mam_inner);
+    let resolver = MamArchiveResolver { mam_storage: mam };
+
+    let registry = ConnectionRegistry::new();
+    let resource = full("alice@example.com/web");
+    let (tx, _rx) = tokio::sync::mpsc::channel(8);
+    registry.register(resource.clone(), tx);
+    let sm_session = SmSessionId::new("sm-stream-mam-corrupt");
+
+    let outcome = flush_for_resource(
+        &storage,
+        &registry,
+        &bare("alice@example.com"),
+        &resource,
+        FlushContext {
+            server_domain: "example.com",
+            sm_session: Some(&sm_session),
+            blocking_storage: None,
+            archive_resolver: &resolver,
+        },
+    )
+    .await;
+
+    assert_eq!(outcome.unresolved, 2);
+    assert_eq!(outcome.deferred_transient, 0);
+    assert_eq!(
+        storage.count(&bare("alice@example.com")).await.unwrap(),
+        0,
+        "unparseable rows are poison pills: deleted, not retried"
+    );
+}
+
+#[tokio::test]
+async fn flush_brief_mam_outage_preserves_offline_message() {
+    // End-to-end issue #1122 guarantee: a MAM outage during one flush
+    // loses no mail — the next flush re-claims the released row,
+    // resolves it, and delivers it via the normal SM-ack lifecycle.
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    storage
+        .insert(archived_row("alice@example.com", "archive-1"))
+        .await
+        .unwrap();
+
+    let mam_inner = InMemoryMamStorage::new();
+    seed_archived_message(
+        &mam_inner,
+        "alice@example.com",
+        "archive-1",
+        Some(valid_archived_stanza_xml(
+            "alice@example.com",
+            "survived-the-outage",
+        )),
+    )
+    .await;
+    // Fail exactly the first lookup, then recover.
+    let mam: Arc<dyn MamStorage> = Arc::new(LookupOutageMamStorage::new(mam_inner, 1));
+    let resolver = MamArchiveResolver { mam_storage: mam };
+
+    let registry = ConnectionRegistry::new();
+    let resource = full("alice@example.com/web");
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    registry.register(resource.clone(), tx);
+    let sm_session = SmSessionId::new("sm-stream-brief-outage");
+
+    // Flush #1: outage — nothing delivered, nothing lost.
+    let first = flush_for_resource(
+        &storage,
+        &registry,
+        &bare("alice@example.com"),
+        &resource,
+        FlushContext {
+            server_domain: "example.com",
+            sm_session: Some(&sm_session),
+            blocking_storage: None,
+            archive_resolver: &resolver,
+        },
+    )
+    .await;
+    assert_eq!(first.deferred_transient, 1);
+    assert_eq!(first.pushed, 0);
+    assert_eq!(storage.count(&bare("alice@example.com")).await.unwrap(), 1);
+
+    // Flush #2: MAM is back — the released row is re-claimed and
+    // delivered.
+    let second = flush_for_resource(
+        &storage,
+        &registry,
+        &bare("alice@example.com"),
+        &resource,
+        FlushContext {
+            server_domain: "example.com",
+            sm_session: Some(&sm_session),
+            blocking_storage: None,
+            archive_resolver: &resolver,
+        },
+    )
+    .await;
+    assert_eq!(second.claimed, 1);
+    assert_eq!(second.pushed, 1);
+    assert_eq!(second.deferred_transient, 0);
+    assert_eq!(second.unresolved, 0);
+
+    let pushed = rx.try_recv().expect("replay stanza delivered");
+    match &pushed.stanza {
+        waddle_xmpp::Stanza::Message(m) => {
+            assert_eq!(
+                m.bodies.get("").map(|b| b.as_str()),
+                Some("survived-the-outage")
+            );
+        }
+        other => panic!("expected Message replay, got {other:?}"),
+    }
+
+    // Locked Q7b: after delivery the row stays claimed by the SM
+    // session; only the normal SM-ack path removes it.
+    let rows = storage.list(&bare("alice@example.com")).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].flushed_in_session.as_ref(), Some(&sm_session));
+    storage
+        .delete_acked_through(&sm_session, u32::MAX)
+        .await
+        .unwrap();
+}

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -520,7 +520,10 @@ async fn db_storage_reclaim_excludes_already_pushed_rows_for_same_session() {
     let pushed_id = pushed.id.clone();
     let deferred = transient_row("carol@example.com", "deferred-second");
     let deferred_id = deferred.id.clone();
-    assert_eq!(storage.insert(pushed).await.unwrap(), InsertOutcome::Inserted);
+    assert_eq!(
+        storage.insert(pushed).await.unwrap(),
+        InsertOutcome::Inserted
+    );
     assert_eq!(
         storage.insert(deferred).await.unwrap(),
         InsertOutcome::Inserted

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -502,6 +502,65 @@ async fn db_storage_lists_only_unoutboxed_unclaimed_archived_rows() {
 }
 
 #[tokio::test]
+async fn db_storage_reclaim_excludes_already_pushed_rows_for_same_session() {
+    // Regression (issue #1122 review, P1): after a transient MAM error
+    // defers rows mid-batch and `reset_offline_flush` re-opens the CAS, the
+    // NEXT flush re-claims the same SM session. `claim_for_session` must
+    // return only the freshly-claimed (deferred) rows, never a row already
+    // pushed on this session and still awaiting its SM ack — re-pushing it
+    // would duplicate delivery and overwrite its outbound_sequence. Exercises
+    // the real SQL backend (the in-memory backend already had this property,
+    // which is why the earlier flush tests missed it).
+    let storage = DatabasePendingDeliveryStorage::open(None, QuotaPolicy::Unlimited)
+        .await
+        .expect("open in-memory storage");
+    let session = SmSessionId::new("resumed-session");
+
+    let pushed = transient_row("carol@example.com", "pushed-first");
+    let pushed_id = pushed.id.clone();
+    let deferred = transient_row("carol@example.com", "deferred-second");
+    let deferred_id = deferred.id.clone();
+    assert_eq!(storage.insert(pushed).await.unwrap(), InsertOutcome::Inserted);
+    assert_eq!(
+        storage.insert(deferred).await.unwrap(),
+        InsertOutcome::Inserted
+    );
+
+    // First flush claims both rows FIFO.
+    let first = storage
+        .claim_for_session(&bare("carol@example.com"), &session)
+        .await
+        .expect("first claim");
+    assert_eq!(first.len(), 2, "both rows claimed on first flush");
+
+    // Row one is pushed (SM sequence stamped); row two is released back for
+    // retry, exactly as the transient-error batch abort does.
+    assert_eq!(storage.record_pushed_at(&pushed_id, 1).await.unwrap(), 1);
+    assert_eq!(storage.release_row(&deferred_id).await.unwrap(), 1);
+
+    // Re-flush of the SAME session must re-claim ONLY the deferred row.
+    let second = storage
+        .claim_for_session(&bare("carol@example.com"), &session)
+        .await
+        .expect("second claim");
+    assert_eq!(second.len(), 1, "only the deferred row is re-claimed");
+    assert_eq!(second[0].id, deferred_id);
+
+    // The already-pushed row keeps its outbound_sequence (not re-claimed,
+    // not cleared), so the pending SM ack still deletes exactly it.
+    let rows = storage
+        .list(&bare("carol@example.com"))
+        .await
+        .expect("list rows");
+    let pushed_row = rows
+        .iter()
+        .find(|r| r.id == pushed_id)
+        .expect("pushed row still present");
+    assert_eq!(pushed_row.outbound_sequence, Some(1));
+    assert_eq!(pushed_row.flushed_in_session.as_ref(), Some(&session));
+}
+
+#[tokio::test]
 async fn db_storage_archived_full_jid_by_round_trips_as_bare() {
     // Regression: `StanzaId.by` is a `jid::Jid`, so a future call site
     // could legitimately construct one with a resource. The

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -1656,19 +1656,34 @@ use waddle_xmpp::mam::storage::{InMemoryMamStorage, MamStorage, MamStorageError}
 use waddle_xmpp_core::mam::ArchivedMessage;
 
 /// MAM storage wrapper that fails `get_message_by_archive_or_stanza_id`
-/// with a transient `Database` error for the first
-/// `failures_remaining` lookups, then delegates to the inner
+/// with a configurable error (default: transient `Database`) for the
+/// first `failures_remaining` lookups, then delegates to the inner
 /// in-memory storage. Every other operation delegates unconditionally.
 struct LookupOutageMamStorage {
     inner: InMemoryMamStorage,
     failures_remaining: AtomicU32,
+    make_error: fn() -> MamStorageError,
 }
 
 impl LookupOutageMamStorage {
     fn new(inner: InMemoryMamStorage, failures: u32) -> Self {
+        Self::with_error(inner, failures, || {
+            MamStorageError::Database("simulated transient MAM outage".to_string())
+        })
+    }
+
+    /// Like [`Self::new`] but failing lookups return the error produced
+    /// by `make_error` (e.g. `Serialization` to simulate a corrupt
+    /// archive row whose column decode fails on every attempt).
+    fn with_error(
+        inner: InMemoryMamStorage,
+        failures: u32,
+        make_error: fn() -> MamStorageError,
+    ) -> Self {
         Self {
             inner,
             failures_remaining: AtomicU32::new(failures),
+            make_error,
         }
     }
 }
@@ -1731,9 +1746,7 @@ impl MamStorage for LookupOutageMamStorage {
         if remaining > 0 {
             self.failures_remaining
                 .store(remaining - 1, Ordering::Release);
-            return Err(MamStorageError::Database(
-                "simulated transient MAM outage".to_string(),
-            ));
+            return Err((self.make_error)());
         }
         self.inner
             .get_message_by_archive_or_stanza_id(archive_jid, stanza_id)
@@ -2033,4 +2046,319 @@ async fn flush_brief_mam_outage_preserves_offline_message() {
         .delete_acked_through(&sm_session, u32::MAX)
         .await
         .unwrap();
+}
+
+// ── Adversarial review R1 (#1122 follow-up): transient MAM failure is
+// batch-fatal. pending_delivery is FIFO (XEP-0160 §3 order of
+// receipt): releasing a failing Archived row while delivering later
+// rows would break delivery order, and a hard MAM outage would mean
+// one failing lookup per archived row awaited inline in the presence
+// handler. The first Err aborts the flush and releases everything
+// still undelivered.
+
+fn body_of(stanza: &waddle_xmpp::Stanza) -> String {
+    match stanza {
+        waddle_xmpp::Stanza::Message(m) => m
+            .bodies
+            .get("")
+            .map(|b| b.as_str().to_string())
+            .unwrap_or_default(),
+        other => panic!("expected Message replay, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn flush_transient_error_aborts_batch_releases_remaining_rows_and_preserves_fifo() {
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    storage
+        .insert(transient_row("alice@example.com", "first"))
+        .await
+        .unwrap();
+    storage
+        .insert(archived_row("alice@example.com", "archive-mid"))
+        .await
+        .unwrap();
+    storage
+        .insert(transient_row("alice@example.com", "third"))
+        .await
+        .unwrap();
+
+    let mam_inner = InMemoryMamStorage::new();
+    seed_archived_message(
+        &mam_inner,
+        "alice@example.com",
+        "archive-mid",
+        Some(valid_archived_stanza_xml("alice@example.com", "second")),
+    )
+    .await;
+    // Fail exactly the first lookup (the "archive-mid" row), then recover.
+    let mam: Arc<dyn MamStorage> = Arc::new(LookupOutageMamStorage::new(mam_inner, 1));
+    let resolver = MamArchiveResolver { mam_storage: mam };
+
+    let registry = ConnectionRegistry::new();
+    let resource = full("alice@example.com/web");
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    registry.register(resource.clone(), tx);
+    let sm_session = SmSessionId::new("sm-stream-batch-abort");
+
+    let first = flush_for_resource(
+        &storage,
+        &registry,
+        &bare("alice@example.com"),
+        &resource,
+        FlushContext {
+            server_domain: "example.com",
+            sm_session: Some(&sm_session),
+            blocking_storage: None,
+            archive_resolver: &resolver,
+        },
+    )
+    .await;
+
+    assert_eq!(first.claimed, 3);
+    assert_eq!(
+        first.pushed, 1,
+        "row delivered before the failure stays delivered"
+    );
+    assert_eq!(
+        first.unresolved, 0,
+        "transient failure must never poison-pill"
+    );
+    assert_eq!(
+        first.deferred_transient, 2,
+        "failing row AND all later claimed rows are deferred"
+    );
+    assert_eq!(
+        body_of(&rx.try_recv().expect("first row delivered").stanza),
+        "first"
+    );
+    assert!(
+        rx.try_recv().is_err(),
+        "batch aborted: no row after the failure is delivered in this flush"
+    );
+
+    // Nothing deleted; the failing row and its successors are released
+    // (re-claimable), the delivered row stays claimed for the SM ack.
+    let rows = storage.list(&bare("alice@example.com")).await.unwrap();
+    assert_eq!(rows.len(), 3, "no row deleted on transient failure");
+    let released = rows
+        .iter()
+        .filter(|r| r.flushed_in_session.is_none())
+        .count();
+    assert_eq!(released, 2, "failing + subsequent rows released for retry");
+
+    // Retry flush with MAM recovered: FIFO preserved — "second" is
+    // delivered before "third".
+    let second = flush_for_resource(
+        &storage,
+        &registry,
+        &bare("alice@example.com"),
+        &resource,
+        FlushContext {
+            server_domain: "example.com",
+            sm_session: Some(&sm_session),
+            blocking_storage: None,
+            archive_resolver: &resolver,
+        },
+    )
+    .await;
+    assert_eq!(second.claimed, 2);
+    assert_eq!(second.pushed, 2);
+    assert_eq!(second.deferred_transient, 0);
+    assert_eq!(second.unresolved, 0);
+    assert_eq!(
+        body_of(
+            &rx.try_recv()
+                .expect("archived row delivered on retry")
+                .stanza
+        ),
+        "second"
+    );
+    assert_eq!(
+        body_of(&rx.try_recv().expect("later row delivered on retry").stanza),
+        "third"
+    );
+}
+
+// ── Adversarial review R3 (#1122 follow-up): decode corruption is
+// permanent, not transient. The production lookup surfaces row-content
+// corruption (decode_sqlite_message_row / decode_postgres_message_row
+// on a bad timestamp/JID column) as MamStorageError::Serialization;
+// retrying can never succeed, so it must take the loud poison-pill
+// path — not the "no mail lost" transient counter.
+
+#[tokio::test]
+async fn flush_archived_row_serialization_error_is_poison_pill_not_transient() {
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    storage
+        .insert(archived_row("alice@example.com", "archive-corrupt"))
+        .await
+        .unwrap();
+
+    let mam: Arc<dyn MamStorage> = Arc::new(LookupOutageMamStorage::with_error(
+        InMemoryMamStorage::new(),
+        u32::MAX,
+        || MamStorageError::Serialization("bad timestamp column".to_string()),
+    ));
+    let resolver = MamArchiveResolver { mam_storage: mam };
+
+    let registry = ConnectionRegistry::new();
+    let resource = full("alice@example.com/web");
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    registry.register(resource.clone(), tx);
+    let sm_session = SmSessionId::new("sm-stream-corrupt-decode");
+
+    let outcome = flush_for_resource(
+        &storage,
+        &registry,
+        &bare("alice@example.com"),
+        &resource,
+        FlushContext {
+            server_domain: "example.com",
+            sm_session: Some(&sm_session),
+            blocking_storage: None,
+            archive_resolver: &resolver,
+        },
+    )
+    .await;
+
+    assert_eq!(outcome.unresolved, 1, "decode corruption is a poison pill");
+    assert_eq!(
+        outcome.deferred_transient, 0,
+        "decode corruption must NOT count as transient"
+    );
+    assert!(rx.try_recv().is_err(), "nothing deliverable");
+    assert_eq!(
+        storage.count(&bare("alice@example.com")).await.unwrap(),
+        0,
+        "corrupt row deleted, never released-and-retried forever"
+    );
+}
+
+#[tokio::test]
+async fn archive_resolver_maps_invalid_query_to_permanent_miss() {
+    // InvalidQuery, like Serialization, cannot succeed on retry — the
+    // resolver reports a definitive miss (poison pill), not Err.
+    let mam: Arc<dyn MamStorage> = Arc::new(LookupOutageMamStorage::with_error(
+        InMemoryMamStorage::new(),
+        u32::MAX,
+        || MamStorageError::InvalidQuery("unusable stored id".to_string()),
+    ));
+    let resolver = MamArchiveResolver { mam_storage: mam };
+    let recipient = bare("alice@example.com");
+    let stanza_id = StanzaId::new("archive-bad-query", jid::Jid::from(recipient));
+    let resolved = resolver
+        .resolve(&stanza_id)
+        .await
+        .expect("permanent decode failure must be Ok(None), not a retryable Err");
+    assert!(resolved.is_none());
+}
+
+// ── Adversarial review R2 (#1122 follow-up): deferred rows must be
+// retryable within a live session. `claim_offline_flush()` is a
+// once-per-connection CAS, so after a transient MAM blip the presence
+// handler resets it (when `deferred_transient > 0`) and the client's
+// next presence update re-attempts the flush.
+
+#[tokio::test]
+async fn reset_offline_flush_reopens_the_once_per_session_cas() {
+    let registry = ConnectionRegistry::new();
+    let resource = full("alice@example.com/web");
+    let (tx, _rx) = tokio::sync::mpsc::channel(8);
+    registry.register(resource.clone(), tx);
+    let entry = registry.get_entry(&resource).expect("registered entry");
+
+    assert!(entry.claim_offline_flush(), "first claim wins");
+    assert!(!entry.claim_offline_flush(), "CAS: second claim loses");
+    entry.reset_offline_flush();
+    assert!(
+        entry.claim_offline_flush(),
+        "reset re-opens the CAS for the next presence update"
+    );
+    assert!(!entry.claim_offline_flush(), "and it is again once-only");
+}
+
+#[tokio::test]
+async fn transient_deferral_plus_cas_reset_delivers_on_next_presence_flush() {
+    // Mirrors `maybe_flush_pending_delivery`: claim the CAS, flush
+    // (MAM outage → deferral), reset the CAS because
+    // `deferred_transient > 0`, then the next presence update's claim
+    // succeeds and the retry flush delivers.
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    storage
+        .insert(archived_row("alice@example.com", "archive-1"))
+        .await
+        .unwrap();
+
+    let mam_inner = InMemoryMamStorage::new();
+    seed_archived_message(
+        &mam_inner,
+        "alice@example.com",
+        "archive-1",
+        Some(valid_archived_stanza_xml(
+            "alice@example.com",
+            "after-the-blip",
+        )),
+    )
+    .await;
+    // Fail exactly the first lookup, then recover.
+    let mam: Arc<dyn MamStorage> = Arc::new(LookupOutageMamStorage::new(mam_inner, 1));
+    let resolver = MamArchiveResolver { mam_storage: mam };
+
+    let registry = ConnectionRegistry::new();
+    let resource = full("alice@example.com/web");
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    registry.register(resource.clone(), tx);
+    let entry = registry.get_entry(&resource).expect("registered entry");
+    let sm_session = SmSessionId::new("sm-stream-cas-reset");
+
+    assert!(
+        entry.claim_offline_flush(),
+        "fresh session claims the flush"
+    );
+    let first = flush_for_resource(
+        &storage,
+        &registry,
+        &bare("alice@example.com"),
+        &resource,
+        FlushContext {
+            server_domain: "example.com",
+            sm_session: Some(&sm_session),
+            blocking_storage: None,
+            archive_resolver: &resolver,
+        },
+    )
+    .await;
+    assert_eq!(first.deferred_transient, 1);
+    assert_eq!(first.pushed, 0);
+
+    // The presence handler's contract: deferral re-opens the CAS.
+    entry.reset_offline_flush();
+    assert!(
+        entry.claim_offline_flush(),
+        "next presence update re-claims after a deferral"
+    );
+
+    let second = flush_for_resource(
+        &storage,
+        &registry,
+        &bare("alice@example.com"),
+        &resource,
+        FlushContext {
+            server_domain: "example.com",
+            sm_session: Some(&sm_session),
+            blocking_storage: None,
+            archive_resolver: &resolver,
+        },
+    )
+    .await;
+    assert_eq!(second.pushed, 1);
+    assert_eq!(second.deferred_transient, 0);
+    assert_eq!(
+        body_of(&rx.try_recv().expect("delivered on retry").stanza),
+        "after-the-blip"
+    );
 }

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -110,6 +110,12 @@ pub(crate) async fn start_http_server(deps: HttpServerDeps) -> Result<()> {
 pub(crate) async fn create_websocket_mam_storage(
     database_url: Option<String>,
 ) -> Result<Arc<dyn MamStorage>> {
+    if !cfg!(test) {
+        ensure_mam_database_is_durable(
+            database_url.as_deref(),
+            env_flag("WADDLE_XMPP_MAM_ALLOW_IN_MEMORY"),
+        )?;
+    }
     let storage = match database_url.as_deref() {
         Some(database_url) => SqlxMamStorage::open(database_url).await,
         None => SqlxMamStorage::open_in_memory().await,
@@ -825,6 +831,32 @@ async fn create_pending_delivery_storage(
         .await
         .expect("open pending_delivery storage"),
     )
+}
+
+/// Fail-fast guard for XEP-0313 MAM storage durability. A missing or
+/// in-memory database URL is only acceptable for dev/test runs that
+/// explicitly opt in via `WADDLE_XMPP_MAM_ALLOW_IN_MEMORY`.
+pub(crate) fn ensure_mam_database_is_durable(
+    database_url: Option<&str>,
+    allow_in_memory: bool,
+) -> Result<()> {
+    if database_url.is_some_and(|url| !sqlite_url_is_in_memory(url)) {
+        return Ok(());
+    }
+    if allow_in_memory {
+        warn!(
+            "WADDLE_XMPP_MAM_ALLOW_IN_MEMORY is set; the XEP-0313 MAM archive \
+             is using in-memory SQLite and will NOT survive restart. \
+             Use only in tests."
+        );
+        return Ok(());
+    }
+    anyhow::bail!(
+        "XEP-0313 MAM archive requires durable storage. Set \
+         WADDLE_XMPP_MAM_DATABASE_URL (or the WADDLE_DATABASE_URL fallback) \
+         to a durable SQLite/Postgres DSN, or set \
+         WADDLE_XMPP_MAM_ALLOW_IN_MEMORY=true only for tests."
+    );
 }
 
 fn ensure_push_service_global_database_is_durable() -> Result<()> {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
@@ -145,6 +145,7 @@ async fn maybe_flush_pending_delivery(state: &WebSocketState, sender_jid: &FullJ
             claimed = outcome.claimed,
             pushed = outcome.pushed,
             unresolved = outcome.unresolved,
+            deferred_transient = outcome.deferred_transient,
             "XEP-0160 pending_delivery flush completed"
         );
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
@@ -98,7 +98,10 @@ pub(super) async fn handle_regular_presence_update(
 /// `ConnectionEntry::claim_offline_flush()` is a CAS that returns
 /// `true` exactly once per fresh session — repeated presence updates
 /// (priority transitions, status text changes) do not re-flush an
-/// already-drained queue.
+/// already-drained queue. Exception (issue #1122 follow-up): when the
+/// flush defers rows on a transient MAM failure
+/// (`deferred_transient > 0`), the CAS is reset so the next presence
+/// update retries instead of stranding the rows until reconnect.
 async fn maybe_flush_pending_delivery(state: &WebSocketState, sender_jid: &FullJid) {
     let entry = match state
         .deps
@@ -139,6 +142,19 @@ async fn maybe_flush_pending_delivery(state: &WebSocketState, sender_jid: &FullJ
         },
     )
     .await;
+    if outcome.deferred_transient > 0 {
+        // Issue #1122 follow-up (R2): the flush hit a transient MAM
+        // failure and released the failing row plus the rest of the
+        // batch. `claim_offline_flush` is a once-per-connection CAS,
+        // so without a reset those rows would wait for a full
+        // reconnect — potentially forever on a long-lived session.
+        // Re-open the CAS so this client's next presence update
+        // re-attempts the flush (rate-limited by presence traffic —
+        // no hot retry loop). Safe: this runs on the same connection
+        // task that won the claim above, so no concurrent claimant
+        // can race the reset.
+        entry.reset_offline_flush();
+    }
     if outcome.claimed > 0 {
         debug!(
             jid = %sender_jid,

--- a/server/crates/waddle-server/src/server/tests.rs
+++ b/server/crates/waddle-server/src/server/tests.rs
@@ -402,6 +402,58 @@ fn push_service_durability_guard_rejects_sqlite_memory_urls() {
     ));
 }
 
+#[test]
+fn mam_storage_guard_rejects_missing_database_url() {
+    let error = http::ensure_mam_database_is_durable(None, false)
+        .expect_err("missing MAM database URL must fail-fast");
+    let message = format!("{error:?}");
+    assert!(
+        message.contains("WADDLE_XMPP_MAM_DATABASE_URL"),
+        "error should name the primary env var: {message}"
+    );
+    assert!(
+        message.contains("WADDLE_DATABASE_URL"),
+        "error should name the fallback env var: {message}"
+    );
+    assert!(
+        message.contains("WADDLE_XMPP_MAM_ALLOW_IN_MEMORY"),
+        "error should name the test-only escape hatch: {message}"
+    );
+}
+
+#[test]
+fn mam_storage_guard_rejects_in_memory_sqlite_urls() {
+    for database_url in [
+        "sqlite::memory:",
+        "sqlite::memory:?cache=shared",
+        "sqlite://?mode=memory",
+        ":memory:",
+    ] {
+        let error = http::ensure_mam_database_is_durable(Some(database_url), false)
+            .expect_err("in-memory MAM database URL must fail-fast");
+        let message = format!("{error:?}");
+        assert!(
+            message.contains("WADDLE_XMPP_MAM_DATABASE_URL"),
+            "error for {database_url} should name the env var: {message}"
+        );
+    }
+}
+
+#[test]
+fn mam_storage_guard_accepts_durable_urls_and_allow_flag() {
+    http::ensure_mam_database_is_durable(Some("sqlite:///var/lib/waddle/mam.db"), false)
+        .expect("durable sqlite URL must pass");
+    http::ensure_mam_database_is_durable(
+        Some("postgres://postgres:postgres@localhost/waddle"),
+        false,
+    )
+    .expect("postgres URL must pass");
+    http::ensure_mam_database_is_durable(None, true)
+        .expect("allow flag must permit missing URL for tests");
+    http::ensure_mam_database_is_durable(Some("sqlite::memory:"), true)
+        .expect("allow flag must permit in-memory URL for tests");
+}
+
 #[tokio::test]
 async fn test_health_endpoint() {
     let app = test_app().await;

--- a/server/crates/waddle-ws-test-support/src/lib.rs
+++ b/server/crates/waddle-ws-test-support/src/lib.rs
@@ -187,6 +187,7 @@ impl TestServer {
             .env("WADDLE_DB_DRIVER", "sqlite")
             .env("WADDLE_DATABASE_URL", &database_url)
             .env("WADDLE_XMPP_PUSH_SERVICE_ALLOW_IN_MEMORY", "true")
+            .env("WADDLE_XMPP_MAM_ALLOW_IN_MEMORY", "true")
             .env(
                 "WADDLE_XMPP_MAM_DATABASE_URL",
                 mam_database_url.as_deref().unwrap_or("sqlite::memory:"),

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -52,6 +52,12 @@ static PENDING_DELIVERY_AGED_OUT: AtomicU64 = AtomicU64::new(0);
 // materialize a row's MAM payload and dropped it. Should be ~0 on a
 // healthy deployment; non-zero signals MAM corruption.
 static PENDING_DELIVERY_UNRESOLVED_POISON_PILL: AtomicU64 = AtomicU64::new(0);
+// `pending_delivery_archive_lookup_transient_failure`: flush hit a
+// transient MAM storage error resolving an Archived row and RELEASED
+// the row for retry instead of dropping it (issue #1122). Distinct
+// from the poison-pill counter: this one signals MAM storage
+// availability problems, not archive corruption, and no mail is lost.
+static PENDING_DELIVERY_ARCHIVE_LOOKUP_TRANSIENT_FAILURE: AtomicU64 = AtomicU64::new(0);
 // `sm_promotion_storage_failed`: Q6 promotion encountered a
 // pending_delivery insert error and preserved the durable SM row for
 // retry (issue #209 PR #346 + finding #14 dead-letter cap).
@@ -361,6 +367,10 @@ pub fn increment_pending_delivery_unresolved_poison_pill() {
     PENDING_DELIVERY_UNRESOLVED_POISON_PILL.fetch_add(1, Ordering::Relaxed);
 }
 
+pub fn increment_pending_delivery_archive_lookup_transient_failure() {
+    PENDING_DELIVERY_ARCHIVE_LOOKUP_TRANSIENT_FAILURE.fetch_add(1, Ordering::Relaxed);
+}
+
 pub fn add_sm_promotion_storage_failed(n: u64) {
     SM_PROMOTION_STORAGE_FAILED.fetch_add(n, Ordering::Relaxed);
 }
@@ -501,6 +511,7 @@ pub fn reset_metrics_for_test() {
     PENDING_DELIVERY_ORPHAN_CLAIMS_RELEASED.store(0, Ordering::Release);
     PENDING_DELIVERY_AGED_OUT.store(0, Ordering::Release);
     PENDING_DELIVERY_UNRESOLVED_POISON_PILL.store(0, Ordering::Release);
+    PENDING_DELIVERY_ARCHIVE_LOOKUP_TRANSIENT_FAILURE.store(0, Ordering::Release);
     SM_PROMOTION_STORAGE_FAILED.store(0, Ordering::Release);
     SM_PROMOTION_NOT_PROMOTABLE.store(0, Ordering::Release);
     SM_PROMOTION_BLOCKLIST_FAILED.store(0, Ordering::Release);
@@ -536,6 +547,8 @@ pub fn render_metrics() -> String {
     let pending_orphan_released = PENDING_DELIVERY_ORPHAN_CLAIMS_RELEASED.load(Ordering::Relaxed);
     let pending_aged_out = PENDING_DELIVERY_AGED_OUT.load(Ordering::Relaxed);
     let pending_poison_pill = PENDING_DELIVERY_UNRESOLVED_POISON_PILL.load(Ordering::Relaxed);
+    let pending_archive_lookup_transient =
+        PENDING_DELIVERY_ARCHIVE_LOOKUP_TRANSIENT_FAILURE.load(Ordering::Relaxed);
     let sm_promotion_storage_failed = SM_PROMOTION_STORAGE_FAILED.load(Ordering::Relaxed);
     let sm_promotion_not_promotable = SM_PROMOTION_NOT_PROMOTABLE.load(Ordering::Relaxed);
     let sm_promotion_blocklist_failed = SM_PROMOTION_BLOCKLIST_FAILED.load(Ordering::Relaxed);
@@ -590,6 +603,9 @@ pub fn render_metrics() -> String {
             "# HELP waddle_pending_delivery_unresolved_poison_pill_total Pending_delivery flushes that dropped a row because its MAM payload could not be resolved (corruption signal).\n",
             "# TYPE waddle_pending_delivery_unresolved_poison_pill_total counter\n",
             "waddle_pending_delivery_unresolved_poison_pill_total {pending_poison_pill}\n",
+            "# HELP waddle_pending_delivery_archive_lookup_transient_failure_total Pending_delivery flushes that hit a transient MAM storage error resolving an Archived row and released the row for retry instead of dropping it (issue #1122). Signals MAM storage availability problems, not corruption; no mail is lost.\n",
+            "# TYPE waddle_pending_delivery_archive_lookup_transient_failure_total counter\n",
+            "waddle_pending_delivery_archive_lookup_transient_failure_total {pending_archive_lookup_transient}\n",
             "# HELP waddle_sm_promotion_storage_failed_total Q6 promotion encountered a transient pending_delivery insert error; durable SM row preserved for retry.\n",
             "# TYPE waddle_sm_promotion_storage_failed_total counter\n",
             "waddle_sm_promotion_storage_failed_total {sm_promotion_storage_failed}\n",
@@ -641,6 +657,7 @@ pub fn render_metrics() -> String {
         pending_orphan_released = pending_orphan_released,
         pending_aged_out = pending_aged_out,
         pending_poison_pill = pending_poison_pill,
+        pending_archive_lookup_transient = pending_archive_lookup_transient,
         sm_promotion_storage_failed = sm_promotion_storage_failed,
         sm_promotion_not_promotable = sm_promotion_not_promotable,
         sm_promotion_blocklist_failed = sm_promotion_blocklist_failed,
@@ -767,6 +784,7 @@ mod tests {
         add_pending_delivery_orphan_claims_released(7);
         add_pending_delivery_aged_out(3);
         increment_pending_delivery_unresolved_poison_pill();
+        increment_pending_delivery_archive_lookup_transient_failure();
         add_sm_promotion_storage_failed(2);
         increment_sm_promotion_not_promotable();
         increment_sm_promotion_blocklist_failed();
@@ -781,6 +799,7 @@ mod tests {
             "waddle_pending_delivery_orphan_claims_released_total",
             "waddle_pending_delivery_aged_out_total",
             "waddle_pending_delivery_unresolved_poison_pill_total",
+            "waddle_pending_delivery_archive_lookup_transient_failure_total",
             "waddle_sm_promotion_storage_failed_total",
             "waddle_sm_promotion_not_promotable_total",
             "waddle_sm_promotion_blocklist_failed_total",
@@ -800,6 +819,9 @@ mod tests {
         assert!(rendered.contains("waddle_pending_delivery_quota_exceeded_total 1"));
         assert!(rendered.contains("waddle_pending_delivery_orphan_claims_released_total 7"));
         assert!(rendered.contains("waddle_pending_delivery_aged_out_total 3"));
+        assert!(
+            rendered.contains("waddle_pending_delivery_archive_lookup_transient_failure_total 1")
+        );
         assert!(rendered.contains("waddle_sm_promotion_storage_failed_total 2"));
         assert!(rendered.contains("waddle_sm_promotion_not_promotable_total 1"));
         assert!(rendered.contains("waddle_sm_resume_window_clamped_total 1"));

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -53,10 +53,14 @@ static PENDING_DELIVERY_AGED_OUT: AtomicU64 = AtomicU64::new(0);
 // healthy deployment; non-zero signals MAM corruption.
 static PENDING_DELIVERY_UNRESOLVED_POISON_PILL: AtomicU64 = AtomicU64::new(0);
 // `pending_delivery_archive_lookup_transient_failure`: flush hit a
-// transient MAM storage error resolving an Archived row and RELEASED
-// the row for retry instead of dropping it (issue #1122). Distinct
-// from the poison-pill counter: this one signals MAM storage
+// transient MAM storage error (Database outage — permanent decode
+// corruption takes the poison-pill path instead) resolving an
+// Archived row. The failure is batch-fatal: the failing row and every
+// remaining claimed row are RELEASED (FIFO preserved) and the flush
+// aborts; the client's next presence update retries (issue #1122).
+// Distinct from the poison-pill counter: this one signals MAM storage
 // availability problems, not archive corruption, and no mail is lost.
+// Incremented once per aborted flush, not once per released row.
 static PENDING_DELIVERY_ARCHIVE_LOOKUP_TRANSIENT_FAILURE: AtomicU64 = AtomicU64::new(0);
 // `sm_promotion_storage_failed`: Q6 promotion encountered a
 // pending_delivery insert error and preserved the durable SM row for
@@ -603,7 +607,7 @@ pub fn render_metrics() -> String {
             "# HELP waddle_pending_delivery_unresolved_poison_pill_total Pending_delivery flushes that dropped a row because its MAM payload could not be resolved (corruption signal).\n",
             "# TYPE waddle_pending_delivery_unresolved_poison_pill_total counter\n",
             "waddle_pending_delivery_unresolved_poison_pill_total {pending_poison_pill}\n",
-            "# HELP waddle_pending_delivery_archive_lookup_transient_failure_total Pending_delivery flushes that hit a transient MAM storage error resolving an Archived row and released the row for retry instead of dropping it (issue #1122). Signals MAM storage availability problems, not corruption; no mail is lost.\n",
+            "# HELP waddle_pending_delivery_archive_lookup_transient_failure_total Pending_delivery flushes aborted by a transient MAM storage error resolving an Archived row: the failing row and the rest of the claimed batch are released (FIFO preserved) and the client's next presence update retries (issue #1122). Signals MAM storage availability problems, not corruption; no mail is lost.\n",
             "# TYPE waddle_pending_delivery_archive_lookup_transient_failure_total counter\n",
             "waddle_pending_delivery_archive_lookup_transient_failure_total {pending_archive_lookup_transient}\n",
             "# HELP waddle_sm_promotion_storage_failed_total Q6 promotion encountered a transient pending_delivery insert error; durable SM row preserved for retry.\n",

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/outbound.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/outbound.rs
@@ -207,6 +207,19 @@ impl ConnectionEntry {
             .is_ok()
     }
 
+    /// Re-open the offline-flush CAS after a flush that deferred rows
+    /// on a transient MAM failure (issue #1122 follow-up). Without
+    /// this, [`Self::claim_offline_flush`] — once per connection —
+    /// would strand the released `pending_delivery` rows until a full
+    /// reconnect, potentially forever on a long-lived session. The
+    /// client's next presence update then re-claims and re-attempts
+    /// the flush, naturally rate-limited by presence traffic. Runs on
+    /// the same connection task that claimed the flush, so there is
+    /// no concurrent claimant to race with.
+    pub fn reset_offline_flush(&self) {
+        self.offline_flushed.store(false, Ordering::Release);
+    }
+
     /// Publish the XEP-0198 SM session id for this connection.
     /// Called by the websocket main loop after `<enable/>` (fresh
     /// SM session) and after `<resume/>` (continuation onto a


### PR DESCRIPTION
Bundle of three security/reliability fixes: **#1156**, **#1146**, **#1122**. Each was implemented test-first and hardened through adversarial review rounds.

> The CNPG R2 backups (**#1159**) originally bundled here were split into their own PR (#1200) so the `hitl` secret/restore path can be reviewed and rolled out independently.

## #1156 — shared-file attachment stored XSS + baseline CSP (chat)

Shared-file attachment URLs were rendered into `href`/`src` with no scheme validation, so a `javascript:`/`data:text/html` URL in a file-sharing stanza persisted via MAM and executed on click. The reference-link/extension-annotation paths already sanitized; the shared-file path bypassed both.

- New `safeAttachmentUrl` allowlist (`http`/`https`/`blob`) gates `resolvedAttachmentUrl` and `ensureAttachmentReady` — a single choke point covering the sticker/gallery image, inline video/audio, PDF iframe, image lightbox, and the download affordance. `MessageBody` download anchor and compact chip drop `href` on a disallowed scheme (inert render); `ImageLightbox` re-gates as defense in depth.
- Baseline **CSP**: new Astro middleware sets a per-response `Content-Security-Policy` on server-rendered HTML — `script-src 'self' 'wasm-unsafe-eval'` plus per-page inline-script hashes (no `unsafe-inline`), `object-src 'none'`, `frame-ancestors 'none'`; `public/_headers` covers the static offline page. Host-permissive `connect-src`/`img-src`/`media-src` are deliberate (deployment-specific XMPP wss / LiveKit / Faro / upload hosts) and justified inline.
- Review follow-up: the **same XSS class was still open in the social feed** — `FeedPane` bound the member-postable `urn:xmpp:pubsub-social-feed:0` `entry.link` straight into an anchor. Now routed through `safeExternalUrl` (http/https), anchor dropped on a bad scheme.
- Tests: `safeAttachmentUrl` unit suite + SSR-render regressions (attachment and feed `javascript:`/`data:` links render inert; `https` controls preserved).

## #1146 — missing MAM database URL fails fast (server)

An absent MAM DB URL silently fell back to volatile single-connection in-memory SQLite — a dropped env var in production was indistinguishable from a healthy config until data loss.

- New `ensure_mam_database_is_durable` guard runs before MAM storage opens: a missing URL or an in-memory sqlite DSN aborts startup with an error naming `WADDLE_XMPP_MAM_DATABASE_URL`, the `WADDLE_DATABASE_URL` fallback, and the `WADDLE_XMPP_MAM_ALLOW_IN_MEMORY` test-only escape hatch (mirrors the existing push-service durability guard).
- `cfg!(test)` bypass keeps unit tests on the in-memory path; the ws-test-support harness sets the allow-flag for spawned server binaries.
- Tests: rejects missing URL, rejects every in-memory sqlite spelling, accepts durable sqlite/postgres and the allow-flag.

## #1122 — transient MAM lookup errors no longer delete offline mail (server)

The pending-delivery archive resolver collapsed `Err(_)` (transient DB/storage failure) into `None` (genuine tombstone miss); the flush loop then poison-pill-deleted the queued offline message — a momentary MAM outage destroyed mail.

- `ArchiveResolver::resolve` now returns `Result<Option<Message>, ArchiveResolveError>` (typed, thiserror). Flush is a three-way match: `Ok(Some)` replays, `Ok(None)` keeps the poison-pill delete + counter, `Err` releases the row for retry and bumps a new `waddle_pending_delivery_archive_lookup_transient_failure_total`.
- Review hardening (three follow-up findings):
  - **FIFO / no hammering** — a transient error is batch-fatal: release the failing row *and every remaining claimed row*, then abort the batch, preserving XEP-0160 §3 order of receipt and avoiding one-failed-lookup-per-row stalling the presence handler.
  - **In-session retry** — released rows were otherwise stranded until a full reconnect (`claim_offline_flush` is a once-per-connection CAS). Added `ConnectionEntry::reset_offline_flush`, called when `deferred_transient > 0`, so the client's next presence update retries (rate-limited by presence traffic, same connection task — no race).
  - **Corruption is a poison pill, not transient** — `MamStorageError::Serialization`/`InvalidQuery`/`NotFound` (definitive/permanent conditions) map to `Ok(None)` (delete + loud corruption counter); only `Database` (which every sqlx error, incl. pool timeouts, maps to) stays transient. `#[from]` dropped so no blanket conversion bypasses the classification.
- Tests: transient-release, genuine-miss delete, unparseable-XML poison pill, FIFO-preserving batch abort, CAS-reset re-delivery, serialization-error poison pill, and a fail-once outage delivering on the next flush with zero loss.

## Verification

- chat: `bun run build` clean, `bun test` **3188 pass / 0 fail**, `bun run lint` (knip) exit 0.
- server: `cargo test -p waddle-server` (lib + all integration binaries) green, `cargo test -p waddle-server pending_delivery` **43 pass**, `cargo clippy --workspace --all-targets -- -D warnings` clean.
- Adversarial review personas (app-sec, Rust/distributed-systems, repo-standards) + a second round on the fixes themselves; all real findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
