### PR TITLE
infra(server): CNPG backups → R2 + ScheduledBackup for both Postgres clusters (#1159)

### DIFF
--- a/docs/runbooks/postgres-backup-restore.md
+++ b/docs/runbooks/postgres-backup-restore.md
@@ -185,16 +185,59 @@ countdown described above.
       (`pg_stat_archiver`, `.status.firstRecoverabilityPoint`) and the first
       `Backup` CR (created by `immediate: true`) reaches phase `completed` for
       both clusters.
-- [ ] Run the scratch-namespace restore drill above for both clusters and
-      record the result.
-- [ ] Wire a backup-failure alert in the alerts-as-code issue. There is no
-      PrometheusRule/monitoring stack in this repo today (observability is
-      Grafana Alloy OTLP push), so this is documentation only for now.
-      Suggested signals from the CNPG metrics exporter:
-      - `cnpg_collector_last_available_backup_timestamp` — alert when older
-        than ~26h (a missed daily backup).
-      - `cnpg_collector_pg_wal_archive_status` — alert on growing failed WAL
-        archive count.
+- [ ] Load the backup-failure alert rules into Grafana Cloud (see
+      [Backup-failure alerting](#backup-failure-alerting) below).
+
+## Backup-failure alerting
+
+A silent backup failure is only discovered when a restore is needed, so
+backup health is alerted on as code:
+
+- **Metrics pipeline (reconciled by Flux):**
+  `gitops/grafana-alloy/helmrelease.yaml` scrapes each CNPG instance pod's
+  built-in exporter (`:9187/metrics`, `job="cnpg"`, `cnpg_cluster` label
+  preserved) and forwards it through the existing OTLP path to Grafana
+  Cloud. Without this the backup-health series never leave the cluster.
+  (This repo has no prometheus-operator / `PrometheusRule` CRDs, so an
+  in-cluster rule would not reconcile — the rules evaluate in Grafana
+  Cloud, where the metrics land.)
+- **Alert rules (as code):**
+  `infrastructure/waddle.cloud/grafana-cloud/alerts/postgres-backups.yaml`
+  is the source of truth — three rules: `CNPGBackupStale` (no base backup
+  in >26h), `CNPGWALArchiveFailing` (WAL not reaching R2), and
+  `CNPGBackupMetricsMissing` (the metrics pipeline itself broke, so the
+  other two have no data to fire on).
+
+Apply the rules to Grafana Cloud (HITL — needs a Grafana Cloud ruler token,
+not held in 1Password yet):
+
+- [ ] Confirm the CNPG metric names against the deployed operator
+      (`kubectl -n waddle exec postgresql-1 -- curl -s localhost:9187/metrics | grep -E 'backup|archiver'`)
+      and adjust the rule file if they differ from CNPG 1.25.
+- [ ] Load the rule group into the Grafana Cloud Mimir ruler
+      (`mimirtool rules load --address=<prom-url> --id=<tenant> …/postgres-backups.yaml`)
+      or provision the equivalent Grafana-managed rules from the same file.
+- [ ] Point the rules' notification policy at an operator-visible contact
+      point (the routing lives in Grafana Cloud, not this repo).
+
+## Restore validation (recoverability gate)
+
+**A backup is not proven until a restore has succeeded.** A full
+scratch-namespace restore drill (per [Full restore procedure](#full-restore-procedure-scratch-namespace)
+above) MUST be completed for **both** clusters before this backup
+configuration is trusted as the production recovery path, and re-run at
+least quarterly. Record each drill here:
+
+| Date (UTC) | Cluster | Backup restored (recovery target) | Row/table spot-check result | Operator |
+| --- | --- | --- | --- | --- |
+| _pending_ | `postgresql` | | | |
+| _pending_ | `postgresql-spicedb` | | | |
+
+> ⚠️ Not yet validated. These drills require a live CNPG operator and the
+> R2 bucket (which is created as part of the blocking pre-merge steps
+> above), so they cannot be run until rollout. Do not treat backups as a
+> recovery guarantee until this table is filled in with a successful drill
+> for each cluster.
 
 ## NetworkPolicy caveat
 

--- a/docs/runbooks/postgres-backup-restore.md
+++ b/docs/runbooks/postgres-backup-restore.md
@@ -1,0 +1,165 @@
+# Runbook: Postgres backup & restore (CNPG → Cloudflare R2)
+
+Covers the two CloudNativePG clusters in namespace `waddle`:
+
+| Cluster | Database | Backup path (`serverName`) |
+| --- | --- | --- |
+| `postgresql` | `waddle` | `s3://waddle-postgres-backups/postgresql/` (`postgresql`) |
+| `postgresql-spicedb` | `spicedb` | `s3://waddle-postgres-backups/postgresql-spicedb/` (`postgresql-spicedb`) |
+
+Configuration lives in `infrastructure/waddle.cloud/gitops/waddle-server/`:
+
+- `postgresql-cluster.yaml` / `spicedb-postgres-cluster.yaml` — `spec.backup.barmanObjectStore`
+  with continuous WAL archiving (gzip), base-backup gzip compression, and a `30d`
+  retention policy.
+- `postgresql-scheduled-backup.yaml` — daily base backup at 02:00:00 UTC.
+- `spicedb-scheduled-backup.yaml` — daily base backup at 02:30:00 UTC (staggered).
+- `postgres-backup-credentials-external-secret.yaml` — R2 credentials synced from
+  1Password item `server-runtime-production` (properties `r2-access-key-id` /
+  `r2-secret-access-key`) into Secret `postgres-backup-r2-credentials`
+  (keys `ACCESS_KEY_ID` / `SECRET_ACCESS_KEY`).
+
+Object storage is Cloudflare R2 via its S3-compatible API, endpoint
+`https://f90cc3950ab5b356ec869fe64c867ea7.r2.cloudflarestorage.com`, dedicated
+bucket `waddle-postgres-backups` (do not reuse `waddle-social-files`). R2 does
+not support S3 object tagging — keep the `barmanObjectStore` config minimal
+(no `tags`/`historyTags`).
+
+## Verifying backups are healthy
+
+```bash
+kubectl -n waddle get scheduledbackups,backups
+kubectl -n waddle get cluster postgresql -o jsonpath='{.status.firstRecoverabilityPoint}{"\n"}{.status.lastSuccessfulBackup}{"\n"}'
+kubectl -n waddle get cluster postgresql-spicedb -o jsonpath='{.status.firstRecoverabilityPoint}{"\n"}{.status.lastSuccessfulBackup}{"\n"}'
+# WAL archiving status on the primary:
+kubectl -n waddle exec postgresql-1 -- psql -c "SELECT archived_count, failed_count, last_archived_time, last_failed_time FROM pg_stat_archiver;"
+```
+
+A healthy cluster shows `Backup` CRs in phase `completed`, a non-empty
+`firstRecoverabilityPoint`, and `pg_stat_archiver.failed_count` not growing.
+
+## Full restore procedure (scratch namespace)
+
+CNPG restores by bootstrapping a **new** cluster from the object store; it never
+restores in place. Run drills into a scratch namespace so production is untouched.
+
+1. Create the scratch namespace and copy the R2 credentials into it:
+
+   ```bash
+   kubectl create namespace waddle-restore-drill
+   kubectl -n waddle get secret postgres-backup-r2-credentials -o yaml \
+     | grep -v -E 'namespace:|resourceVersion:|uid:|creationTimestamp:|ownerReferences:' -A0 \
+     | kubectl -n waddle-restore-drill apply -f -
+   ```
+
+   (Or create a second ExternalSecret targeting the scratch namespace.)
+
+2. Apply a recovery cluster. `externalClusters[].name` and the
+   `barmanObjectStore.serverName` must match the **source** cluster's
+   `serverName` (`postgresql` or `postgresql-spicedb`):
+
+   ```yaml
+   apiVersion: postgresql.cnpg.io/v1
+   kind: Cluster
+   metadata:
+     name: postgresql-restore
+     namespace: waddle-restore-drill
+   spec:
+     instances: 1
+     storage:
+       size: 10Gi
+       storageClass: openebs-mayastor
+     bootstrap:
+       recovery:
+         source: postgresql
+     externalClusters:
+       - name: postgresql
+         barmanObjectStore:
+           destinationPath: s3://waddle-postgres-backups/postgresql/
+           endpointURL: https://f90cc3950ab5b356ec869fe64c867ea7.r2.cloudflarestorage.com
+           serverName: postgresql
+           s3Credentials:
+             accessKeyId:
+               name: postgres-backup-r2-credentials
+               key: ACCESS_KEY_ID
+             secretAccessKey:
+               name: postgres-backup-r2-credentials
+               key: SECRET_ACCESS_KEY
+           wal:
+             compression: gzip
+   ```
+
+   For spicedb, substitute `postgresql-spicedb` for the source name,
+   `destinationPath`, and `serverName`.
+
+3. Watch the restore:
+
+   ```bash
+   kubectl -n waddle-restore-drill get cluster postgresql-restore -w
+   kubectl -n waddle-restore-drill logs -l cnpg.io/cluster=postgresql-restore -f
+   ```
+
+### Point-in-time recovery (PITR)
+
+Add a `recoveryTarget` to the `recovery` stanza. Without one, CNPG recovers to
+the end of the archived WAL (latest possible point).
+
+```yaml
+   bootstrap:
+     recovery:
+       source: postgresql
+       recoveryTarget:
+         targetTime: "2026-07-05 01:30:00+00"
+```
+
+Other selectors: `targetLSN`, `targetXID`, `targetName` (requires a prior
+`pg_create_restore_point`), plus `exclusive` to control boundary inclusion.
+The target must lie between `firstRecoverabilityPoint` and the last archived WAL.
+
+### Verification queries
+
+```bash
+kubectl -n waddle-restore-drill exec postgresql-restore-1 -- psql -d waddle -c "\dt"
+kubectl -n waddle-restore-drill exec postgresql-restore-1 -- psql -d waddle -c "SELECT now(), pg_is_in_recovery();"
+# Spot-check row counts against expectations, e.g.:
+kubectl -n waddle-restore-drill exec postgresql-restore-1 -- psql -d waddle -c "SELECT count(*) FROM mam_messages;"
+# For spicedb:
+kubectl -n waddle-restore-drill exec postgresql-spicedb-restore-1 -- psql -d spicedb -c "SELECT count(*) FROM relation_tuples;"
+```
+
+`pg_is_in_recovery()` must return `f` once the restored cluster has been
+promoted (CNPG promotes automatically when the recovery target is reached).
+
+Tear down when done: `kubectl delete namespace waddle-restore-drill`.
+
+## HITL checklist (follow-ups from issue #1159)
+
+- [ ] Create the R2 bucket `waddle-postgres-backups` in the Cloudflare account
+      if it does not exist yet (the operator does not create buckets).
+- [ ] Verify the `server-runtime-production` R2 API token scope covers the new
+      `waddle-postgres-backups` bucket (read **and** write). If it is scoped to
+      `waddle-social-files` only, mint a dedicated backup token and add it to
+      1Password (then point the ExternalSecret at the new properties).
+- [ ] After Flux applies the change, confirm WAL archiving starts
+      (`pg_stat_archiver`, `.status.firstRecoverabilityPoint`) and the first
+      `Backup` CR (created by `immediate: true`) reaches phase `completed` for
+      both clusters.
+- [ ] Run the scratch-namespace restore drill above for both clusters and
+      record the result.
+- [ ] Wire a backup-failure alert in the alerts-as-code issue. There is no
+      PrometheusRule/monitoring stack in this repo today (observability is
+      Grafana Alloy OTLP push), so this is documentation only for now.
+      Suggested signals from the CNPG metrics exporter:
+      - `cnpg_collector_last_available_backup_timestamp` — alert when older
+        than ~26h (a missed daily backup).
+      - `cnpg_collector_pg_wal_archive_status` — alert on growing failed WAL
+        archive count.
+
+## NetworkPolicy caveat
+
+Namespace `waddle` currently has **no** NetworkPolicy, so egress to R2 is not
+blocked. If a default-deny policy is ever introduced there, backups will break
+unless the Postgres pods are allowed egress to the world on TCP 443 plus DNS —
+use the Cilium idiom already in the repo
+(`infrastructure/waddle.cloud/gitops/livekit-sfu/networkpolicy.yaml`,
+`toEntities: [world]`).

--- a/docs/runbooks/postgres-backup-restore.md
+++ b/docs/runbooks/postgres-backup-restore.md
@@ -2,10 +2,14 @@
 
 Covers the two CloudNativePG clusters in namespace `waddle`:
 
-| Cluster | Database | Backup path (`serverName`) |
-| --- | --- | --- |
-| `postgresql` | `waddle` | `s3://waddle-postgres-backups/postgresql/` (`postgresql`) |
-| `postgresql-spicedb` | `spicedb` | `s3://waddle-postgres-backups/postgresql-spicedb/` (`postgresql-spicedb`) |
+| Cluster | Database | `serverName` | Objects live under |
+| --- | --- | --- | --- |
+| `postgresql` | `waddle` | `postgresql` | `s3://waddle-postgres-backups/postgresql/{base,wals}/` |
+| `postgresql-spicedb` | `spicedb` | `postgresql-spicedb` | `s3://waddle-postgres-backups/postgresql-spicedb/{base,wals}/` |
+
+Both clusters share `destinationPath: s3://waddle-postgres-backups/`; barman
+appends `serverName` as the prefix, which is what keeps the two clusters from
+clobbering each other.
 
 Configuration lives in `infrastructure/waddle.cloud/gitops/waddle-server/`:
 
@@ -38,21 +42,46 @@ kubectl -n waddle exec postgresql-1 -- psql -c "SELECT archived_count, failed_co
 A healthy cluster shows `Backup` CRs in phase `completed`, a non-empty
 `firstRecoverabilityPoint`, and `pg_stat_archiver.failed_count` not growing.
 
+## WAL-buildup hazard and emergency rollback
+
+Once `spec.backup.barmanObjectStore` is applied, Postgres retains every WAL
+segment until it is archived to R2. If archiving fails persistently (bucket
+missing, credential scope wrong, R2 unreachable), WAL accumulates without
+bound: `postgresql` fills its dedicated 2Gi `walStorage` and the primary
+PANICs; `postgresql-spicedb` has no separate walStorage, so WAL eats the 10Gi
+data PVC instead. The Cluster CR stays `Ready` while this happens — only the
+`ContinuousArchiving` status condition flips — so it will not show up as a
+Flux health failure. Watch `pg_stat_archiver.failed_count` after any change
+to the backup config.
+
+Emergency rollback: remove `spec.backup` from the affected Cluster manifest
+(revert the commit) and let Flux reconcile — the `archive_command` returns to
+a no-op and Postgres recycles the retained WAL. No restart is needed; this is
+a config reload.
+
 ## Full restore procedure (scratch namespace)
 
 CNPG restores by bootstrapping a **new** cluster from the object store; it never
 restores in place. Run drills into a scratch namespace so production is untouched.
 
-1. Create the scratch namespace and copy the R2 credentials into it:
+1. Create the scratch namespace and copy the R2 credentials into it. Prefer a
+   second ExternalSecret (copy
+   `postgres-backup-credentials-external-secret.yaml` with
+   `metadata.namespace: waddle-restore-drill`, applied by hand — do not add it
+   to gitops). For a quick manual copy instead:
 
    ```bash
    kubectl create namespace waddle-restore-drill
-   kubectl -n waddle get secret postgres-backup-r2-credentials -o yaml \
-     | grep -v -E 'namespace:|resourceVersion:|uid:|creationTimestamp:|ownerReferences:' -A0 \
+   kubectl -n waddle get secret postgres-backup-r2-credentials -o json \
+     | jq 'del(.metadata.namespace, .metadata.uid, .metadata.resourceVersion,
+               .metadata.creationTimestamp, .metadata.ownerReferences,
+               .metadata.managedFields)' \
      | kubectl -n waddle-restore-drill apply -f -
    ```
 
-   (Or create a second ExternalSecret targeting the scratch namespace.)
+   (The plain `-o yaml | grep -v ...` trick does not work here: the secret is
+   owned by an ExternalSecret and carries a multi-line `ownerReferences`
+   block that line-filtering corrupts.)
 
 2. Apply a recovery cluster. `externalClusters[].name` and the
    `barmanObjectStore.serverName` must match the **source** cluster's
@@ -75,7 +104,7 @@ restores in place. Run drills into a scratch namespace so production is untouche
      externalClusters:
        - name: postgresql
          barmanObjectStore:
-           destinationPath: s3://waddle-postgres-backups/postgresql/
+           destinationPath: s3://waddle-postgres-backups/
            endpointURL: https://f90cc3950ab5b356ec869fe64c867ea7.r2.cloudflarestorage.com
            serverName: postgresql
            s3Credentials:
@@ -89,8 +118,11 @@ restores in place. Run drills into a scratch namespace so production is untouche
              compression: gzip
    ```
 
-   For spicedb, substitute `postgresql-spicedb` for the source name,
-   `destinationPath`, and `serverName`.
+   For spicedb, name the restore cluster `postgresql-spicedb-restore` and
+   substitute `postgresql-spicedb` for the `externalClusters[].name`,
+   `bootstrap.recovery.source`, and `serverName` (the `destinationPath` is
+   the same shared bucket root). Restore clusters carry no `spec.backup`, so
+   they never write back to the archive.
 
 3. Watch the restore:
 
@@ -132,14 +164,23 @@ promoted (CNPG promotes automatically when the recovery target is reached).
 
 Tear down when done: `kubectl delete namespace waddle-restore-drill`.
 
-## HITL checklist (follow-ups from issue #1159)
+## HITL checklist (issue #1159)
+
+**Blocking — complete BEFORE merging/applying the backup config.** Applying
+`spec.backup` without a working bucket + credentials starts the WAL-buildup
+countdown described above.
 
 - [ ] Create the R2 bucket `waddle-postgres-backups` in the Cloudflare account
-      if it does not exist yet (the operator does not create buckets).
-- [ ] Verify the `server-runtime-production` R2 API token scope covers the new
-      `waddle-postgres-backups` bucket (read **and** write). If it is scoped to
-      `waddle-social-files` only, mint a dedicated backup token and add it to
-      1Password (then point the ExternalSecret at the new properties).
+      (the operator does not create buckets).
+- [ ] Mint a dedicated R2 API token scoped to `waddle-postgres-backups`
+      (read **and** write), add it to 1Password, and point
+      `postgres-backup-credentials-external-secret.yaml` at the new
+      properties. Do not reuse the app-runtime token: even if its scope
+      happens to cover the new bucket, a compromised app key must not be able
+      to delete backups (R2 has no object lock).
+
+**Post-merge follow-ups.**
+
 - [ ] After Flux applies the change, confirm WAL archiving starts
       (`pg_stat_archiver`, `.status.firstRecoverabilityPoint`) and the first
       `Backup` CR (created by `immediate: true`) reaches phase `completed` for

--- a/docs/runbooks/postgres-backup-restore.md
+++ b/docs/runbooks/postgres-backup-restore.md
@@ -19,9 +19,10 @@ Configuration lives in `infrastructure/waddle.cloud/gitops/waddle-server/`:
 - `postgresql-scheduled-backup.yaml` — daily base backup at 02:00:00 UTC.
 - `spicedb-scheduled-backup.yaml` — daily base backup at 02:30:00 UTC (staggered).
 - `postgres-backup-credentials-external-secret.yaml` — R2 credentials synced from
-  1Password item `server-runtime-production` (properties `r2-access-key-id` /
-  `r2-secret-access-key`) into Secret `postgres-backup-r2-credentials`
-  (keys `ACCESS_KEY_ID` / `SECRET_ACCESS_KEY`).
+  the dedicated 1Password item `postgres-backup-r2` (properties `access-key-id` /
+  `secret-access-key`) into Secret `postgres-backup-r2-credentials`
+  (keys `ACCESS_KEY_ID` / `SECRET_ACCESS_KEY`). Deliberately a separate item
+  from the app's `server-runtime-production` R2 keys — see the HITL steps.
 
 Object storage is Cloudflare R2 via its S3-compatible API, endpoint
 `https://f90cc3950ab5b356ec869fe64c867ea7.r2.cloudflarestorage.com`, dedicated
@@ -35,8 +36,10 @@ not support S3 object tagging — keep the `barmanObjectStore` config minimal
 kubectl -n waddle get scheduledbackups,backups
 kubectl -n waddle get cluster postgresql -o jsonpath='{.status.firstRecoverabilityPoint}{"\n"}{.status.lastSuccessfulBackup}{"\n"}'
 kubectl -n waddle get cluster postgresql-spicedb -o jsonpath='{.status.firstRecoverabilityPoint}{"\n"}{.status.lastSuccessfulBackup}{"\n"}'
-# WAL archiving status on the primary:
-kubectl -n waddle exec postgresql-1 -- psql -c "SELECT archived_count, failed_count, last_archived_time, last_failed_time FROM pg_stat_archiver;"
+# WAL archiving status on the primary (discover it by label — the primary
+# is not pinned to postgresql-1 and moves on failover/switchover):
+PRIMARY=$(kubectl -n waddle get pod -l cnpg.io/cluster=postgresql,cnpg.io/instanceRole=primary -o jsonpath='{.items[0].metadata.name}')
+kubectl -n waddle exec "$PRIMARY" -- psql -c "SELECT archived_count, failed_count, last_archived_time, last_failed_time FROM pg_stat_archiver;"
 ```
 
 A healthy cluster shows `Backup` CRs in phase `completed`, a non-empty
@@ -47,9 +50,11 @@ A healthy cluster shows `Backup` CRs in phase `completed`, a non-empty
 Once `spec.backup.barmanObjectStore` is applied, Postgres retains every WAL
 segment until it is archived to R2. If archiving fails persistently (bucket
 missing, credential scope wrong, R2 unreachable), WAL accumulates without
-bound: `postgresql` fills its dedicated 2Gi `walStorage` and the primary
-PANICs; `postgresql-spicedb` has no separate walStorage, so WAL eats the 10Gi
-data PVC instead. The Cluster CR stays `Ready` while this happens — only the
+bound and eventually fills the volume it lands on. Both clusters isolate WAL
+on a dedicated 2Gi `walStorage`, so the buildup fills that volume (and PANICs
+the primary) rather than the data PVC — contained, but still an outage until
+archiving recovers or the backup config is rolled back. The Cluster CR stays
+`Ready` while this happens — only the
 `ContinuousArchiving` status condition flips — so it will not show up as a
 Flux health failure. Watch `pg_stat_archiver.failed_count` after any change
 to the backup config.
@@ -173,9 +178,10 @@ countdown described above.
 - [ ] Create the R2 bucket `waddle-postgres-backups` in the Cloudflare account
       (the operator does not create buckets).
 - [ ] Mint a dedicated R2 API token scoped to `waddle-postgres-backups`
-      (read **and** write), add it to 1Password, and point
-      `postgres-backup-credentials-external-secret.yaml` at the new
-      properties. Do not reuse the app-runtime token: even if its scope
+      (read **and** write) and store it in the 1Password item
+      `postgres-backup-r2` as properties `access-key-id` / `secret-access-key`
+      (the item the ExternalSecret already references — no manifest edit
+      needed). Do not reuse the app-runtime token: even if its scope
       happens to cover the new bucket, a compromised app key must not be able
       to delete backups (R2 has no object lock).
 
@@ -212,7 +218,7 @@ Apply the rules to Grafana Cloud (HITL — needs a Grafana Cloud ruler token,
 not held in 1Password yet):
 
 - [ ] Confirm the CNPG metric names against the deployed operator
-      (`kubectl -n waddle exec postgresql-1 -- curl -s localhost:9187/metrics | grep -E 'backup|archiver'`)
+      (`kubectl -n waddle exec "$(kubectl -n waddle get pod -l cnpg.io/cluster=postgresql,cnpg.io/instanceRole=primary -o jsonpath='{.items[0].metadata.name}')" -- curl -s localhost:9187/metrics | grep -E 'backup|archiver'`)
       and adjust the rule file if they differ from CNPG 1.25.
 - [ ] Load the rule group into the Grafana Cloud Mimir ruler
       (`mimirtool rules load --address=<prom-url> --id=<tenant> …/postgres-backups.yaml`)

--- a/infrastructure/waddle.cloud/gitops/grafana-alloy/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/grafana-alloy/helmrelease.yaml
@@ -117,6 +117,66 @@ spec:
               metrics = [otelcol.processor.batch.default.input]
             }
           }
+
+          // ---------- Prometheus scrape of CloudNativePG /metrics ----------
+          // Each CNPG instance pod exposes the built-in metrics exporter on
+          // container port 9187 (no PodMonitor needed — the prometheus
+          // operator CRDs are not installed in this cluster). We scrape it so
+          // the backup-health series
+          // (cnpg_collector_last_available_backup_timestamp,
+          // cnpg_collector_pg_wal_archive_status, ...) reach Grafana Cloud,
+          // where the backup-failure alert rule evaluates (issue #1159 —
+          // see docs/runbooks/postgres-backup-restore.md and
+          // grafana-cloud/alerts/postgres-backups.yaml).
+          discovery.kubernetes "cnpg" {
+            role = "pod"
+            namespaces {
+              names = ["waddle"]
+            }
+          }
+
+          discovery.relabel "cnpg" {
+            targets = discovery.kubernetes.cnpg.targets
+            // Both clusters (postgresql, postgresql-spicedb) carry the
+            // cnpg.io/cluster label; keep only their metrics container port.
+            rule {
+              source_labels = ["__meta_kubernetes_pod_label_cnpg_io_cluster"]
+              action        = "keep"
+              regex         = ".+"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_port_number"]
+              action        = "keep"
+              regex         = "9187"
+            }
+            // Preserve which cluster/instance each sample came from so the
+            // alert rule can page per cluster.
+            rule {
+              source_labels = ["__meta_kubernetes_pod_label_cnpg_io_cluster"]
+              target_label  = "cnpg_cluster"
+            }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "instance"
+            }
+            rule {
+              target_label = "job"
+              replacement  = "cnpg"
+            }
+          }
+
+          prometheus.scrape "cnpg" {
+            targets         = discovery.relabel.cnpg.output
+            forward_to      = [otelcol.receiver.prometheus.cnpg.receiver]
+            metrics_path    = "/metrics"
+            scrape_interval = "30s"
+          }
+
+          otelcol.receiver.prometheus "cnpg" {
+            output {
+              metrics = [otelcol.processor.batch.default.input]
+            }
+          }
       # Inject Grafana Cloud creds from the ExternalSecret. The chart key
       # is `envFrom` (not `extraEnvFrom`); helm silently drops unknown
       # values, so the typo would leave the alloy container with no

--- a/infrastructure/waddle.cloud/gitops/waddle-server/kustomization.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/kustomization.yaml
@@ -2,6 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - postgresql-cluster.yaml
+  - postgres-backup-credentials-external-secret.yaml
+  - postgresql-scheduled-backup.yaml
+  - spicedb-scheduled-backup.yaml
   - spicedb-postgres-app-user-external-secret.yaml
   - spicedb-config-external-secret.yaml
   - spicedb-postgres-cluster.yaml

--- a/infrastructure/waddle.cloud/gitops/waddle-server/postgres-backup-credentials-external-secret.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/postgres-backup-credentials-external-secret.yaml
@@ -17,12 +17,17 @@ spec:
       data:
         ACCESS_KEY_ID: "{{ .r2_access_key_id }}"
         SECRET_ACCESS_KEY: "{{ .r2_secret_access_key }}"
+  # Dedicated 1Password item, NOT the app-runtime `server-runtime-production`
+  # R2 keys. Backups must use a token scoped to `waddle-postgres-backups` so a
+  # compromised application credential cannot delete backup archives (R2 has
+  # no object lock). Create item `postgres-backup-r2` with the dedicated token
+  # as part of the pre-merge HITL steps (see the restore runbook).
   data:
     - secretKey: r2_access_key_id
       remoteRef:
-        key: server-runtime-production
-        property: r2-access-key-id
+        key: postgres-backup-r2
+        property: access-key-id
     - secretKey: r2_secret_access_key
       remoteRef:
-        key: server-runtime-production
-        property: r2-secret-access-key
+        key: postgres-backup-r2
+        property: secret-access-key

--- a/infrastructure/waddle.cloud/gitops/waddle-server/postgres-backup-credentials-external-secret.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/postgres-backup-credentials-external-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: postgres-backup-r2-credentials
+  namespace: waddle
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: postgres-backup-r2-credentials
+    creationPolicy: Owner
+    template:
+      engineVersion: v2
+      type: Opaque
+      data:
+        ACCESS_KEY_ID: "{{ .r2_access_key_id }}"
+        SECRET_ACCESS_KEY: "{{ .r2_secret_access_key }}"
+  data:
+    - secretKey: r2_access_key_id
+      remoteRef:
+        key: server-runtime-production
+        property: r2-access-key-id
+    - secretKey: r2_secret_access_key
+      remoteRef:
+        key: server-runtime-production
+        property: r2-secret-access-key

--- a/infrastructure/waddle.cloud/gitops/waddle-server/postgresql-cluster.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/postgresql-cluster.yaml
@@ -29,7 +29,7 @@ spec:
   backup:
     retentionPolicy: 30d
     barmanObjectStore:
-      destinationPath: s3://waddle-postgres-backups/postgresql/
+      destinationPath: s3://waddle-postgres-backups/
       endpointURL: https://f90cc3950ab5b356ec869fe64c867ea7.r2.cloudflarestorage.com
       serverName: postgresql
       s3Credentials:

--- a/infrastructure/waddle.cloud/gitops/waddle-server/postgresql-cluster.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/postgresql-cluster.yaml
@@ -25,3 +25,21 @@ spec:
       cpu: 250m
     limits:
       memory: 1Gi
+
+  backup:
+    retentionPolicy: 30d
+    barmanObjectStore:
+      destinationPath: s3://waddle-postgres-backups/postgresql/
+      endpointURL: https://f90cc3950ab5b356ec869fe64c867ea7.r2.cloudflarestorage.com
+      serverName: postgresql
+      s3Credentials:
+        accessKeyId:
+          name: postgres-backup-r2-credentials
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: postgres-backup-r2-credentials
+          key: SECRET_ACCESS_KEY
+      wal:
+        compression: gzip
+      data:
+        compression: gzip

--- a/infrastructure/waddle.cloud/gitops/waddle-server/postgresql-scheduled-backup.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/postgresql-scheduled-backup.yaml
@@ -1,0 +1,12 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: postgresql-daily-backup
+  namespace: waddle
+spec:
+  # CNPG cron format has six fields (seconds first): daily at 02:00:00 UTC.
+  schedule: "0 0 2 * * *"
+  backupOwnerReference: self
+  immediate: true
+  cluster:
+    name: postgresql

--- a/infrastructure/waddle.cloud/gitops/waddle-server/spicedb-postgres-cluster.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/spicedb-postgres-cluster.yaml
@@ -14,6 +14,14 @@ spec:
   storage:
     size: 10Gi
     storageClass: openebs-mayastor
+  # Dedicated WAL volume (parity with the `postgresql` cluster). With
+  # continuous archiving enabled, a persistent archive failure retains WAL
+  # until it succeeds; isolating WAL here means that buildup fills this
+  # volume instead of the 10Gi data PVC, so a stuck backup can't take the
+  # database down. See the WAL-buildup hazard in the restore runbook.
+  walStorage:
+    size: 2Gi
+    storageClass: openebs-mayastor
   backup:
     retentionPolicy: 30d
     barmanObjectStore:

--- a/infrastructure/waddle.cloud/gitops/waddle-server/spicedb-postgres-cluster.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/spicedb-postgres-cluster.yaml
@@ -17,7 +17,7 @@ spec:
   backup:
     retentionPolicy: 30d
     barmanObjectStore:
-      destinationPath: s3://waddle-postgres-backups/postgresql-spicedb/
+      destinationPath: s3://waddle-postgres-backups/
       endpointURL: https://f90cc3950ab5b356ec869fe64c867ea7.r2.cloudflarestorage.com
       serverName: postgresql-spicedb
       s3Credentials:

--- a/infrastructure/waddle.cloud/gitops/waddle-server/spicedb-postgres-cluster.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/spicedb-postgres-cluster.yaml
@@ -14,3 +14,20 @@ spec:
   storage:
     size: 10Gi
     storageClass: openebs-mayastor
+  backup:
+    retentionPolicy: 30d
+    barmanObjectStore:
+      destinationPath: s3://waddle-postgres-backups/postgresql-spicedb/
+      endpointURL: https://f90cc3950ab5b356ec869fe64c867ea7.r2.cloudflarestorage.com
+      serverName: postgresql-spicedb
+      s3Credentials:
+        accessKeyId:
+          name: postgres-backup-r2-credentials
+          key: ACCESS_KEY_ID
+        secretAccessKey:
+          name: postgres-backup-r2-credentials
+          key: SECRET_ACCESS_KEY
+      wal:
+        compression: gzip
+      data:
+        compression: gzip

--- a/infrastructure/waddle.cloud/gitops/waddle-server/spicedb-scheduled-backup.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/spicedb-scheduled-backup.yaml
@@ -1,0 +1,13 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: postgresql-spicedb-daily-backup
+  namespace: waddle
+spec:
+  # CNPG cron format has six fields (seconds first): daily at 02:30:00 UTC,
+  # staggered after the main postgresql cluster backup.
+  schedule: "0 30 2 * * *"
+  backupOwnerReference: self
+  immediate: true
+  cluster:
+    name: postgresql-spicedb

--- a/infrastructure/waddle.cloud/grafana-cloud/alerts/postgres-backups.yaml
+++ b/infrastructure/waddle.cloud/grafana-cloud/alerts/postgres-backups.yaml
@@ -1,0 +1,76 @@
+# CNPG Postgres backup-failure alerts (issue #1159 follow-up).
+#
+# This is a Prometheus/Mimir alerting rule group, the "as code" source of
+# truth for the Grafana Cloud alert rules that watch the CloudNativePG
+# backup-health metrics. It is intentionally OUTSIDE gitops/ (Flux) because
+# this cluster has no in-cluster ruler and no prometheus-operator CRDs — the
+# rules evaluate in Grafana Cloud, where the metrics land via the Alloy
+# scrape added in gitops/grafana-alloy/helmrelease.yaml (job="cnpg").
+#
+# Apply (HITL, needs a Grafana Cloud ruler token — see the runbook):
+#   mimirtool rules load --address="$GRAFANA_CLOUD_PROM_URL" \
+#     --id="$GRAFANA_CLOUD_TENANT" infrastructure/waddle.cloud/grafana-cloud/alerts/postgres-backups.yaml
+# or provision the equivalent Grafana-managed rules from this file.
+#
+# Metric-name caveat: confirm the exact CNPG metric names against the
+# deployed operator version before loading —
+#   kubectl -n waddle exec postgresql-1 -- \
+#     curl -s localhost:9187/metrics | grep -E 'backup|archiver'
+# Names below match CloudNativePG 1.25 (chart 0.23.x).
+groups:
+  - name: cnpg-postgres-backups
+    rules:
+      # No successful base backup within ~26h. ScheduledBackups run daily
+      # (02:00 / 02:30 UTC), so >26h stale means at least one run failed or
+      # WAL/base upload to R2 is broken.
+      - alert: CNPGBackupStale
+        expr: |
+          time() - max by (cnpg_cluster) (cnpg_collector_last_available_backup_timestamp) > 26 * 3600
+        for: 15m
+        labels:
+          severity: critical
+          service: postgres
+          component: backup
+        annotations:
+          summary: "CNPG cluster {{ $labels.cnpg_cluster }} has no recent base backup"
+          description: >-
+            No successful CloudNativePG base backup for {{ $labels.cnpg_cluster }}
+            in over 26h. Daily ScheduledBackup to R2 is failing; recoverability
+            window is degrading. See docs/runbooks/postgres-backup-restore.md.
+
+      # Continuous WAL archiving to R2 is failing. Un-archived WAL is retained
+      # on the primary and will eventually fill walStorage and PANIC it, so
+      # this is urgent even while base backups still look recent.
+      - alert: CNPGWALArchiveFailing
+        expr: |
+          increase(cnpg_pg_stat_archiver_failed_count[30m]) > 0
+        for: 15m
+        labels:
+          severity: critical
+          service: postgres
+          component: backup
+        annotations:
+          summary: "CNPG cluster {{ $labels.cnpg_cluster }} is failing to archive WAL to R2"
+          description: >-
+            pg_stat_archiver.failed_count is increasing for {{ $labels.cnpg_cluster }}.
+            WAL is not reaching R2; un-archived WAL accumulates on the primary and
+            will eventually fill walStorage and crash it. Check the barmanObjectStore
+            credentials/bucket. See docs/runbooks/postgres-backup-restore.md.
+
+      # Silence-is-not-success: if the Alloy scrape or the metric pipeline
+      # breaks, the two alerts above have no data to fire on. Alert when the
+      # backup-health series disappears entirely.
+      - alert: CNPGBackupMetricsMissing
+        expr: |
+          absent(cnpg_collector_last_available_backup_timestamp)
+        for: 1h
+        labels:
+          severity: warning
+          service: postgres
+          component: backup
+        annotations:
+          summary: "CNPG backup metrics are missing from Grafana Cloud"
+          description: >-
+            No cnpg_collector_last_available_backup_timestamp samples for over 1h.
+            The Alloy CNPG scrape (job="cnpg") or the OTLP pipeline is broken, so
+            backup-failure alerts cannot fire — investigate the observability path.


### PR DESCRIPTION
Closes #1159. Split out of #1199 so the `hitl` secret/restore path can be reviewed and rolled out independently.

## Problem

No database backups existed anywhere in gitops. The CNPG `postgresql` cluster had no `backup:` stanza, the SpiceDB cluster runs `instances: 1`, and both sit on single-node single-disk storage — a single NVMe failure was total, unrecoverable loss of all messages, MAM archives, auth state, and SpiceDB relationships. There was also no alert on backup health, so a failing backup would be silent until a restore was needed.

## What this does

- `spec.backup.barmanObjectStore` → Cloudflare R2 (WAL archiving, gzip, `30d` retention) on both the `postgresql` and `postgresql-spicedb` clusters. Both share `destinationPath: s3://waddle-postgres-backups/`; `serverName` (`postgresql` / `postgresql-spicedb`) is the per-cluster prefix, so the two can't clobber each other.
- New `postgres-backup-r2-credentials` ExternalSecret (1Password, `external-secrets.io/v1beta1`).
- `ScheduledBackup` per cluster, daily and staggered (02:00 / 02:30 UTC, first run immediate).
- **Backup-failure alerting as code.** This cluster has no prometheus-operator / `PrometheusRule` CRDs (a rule manifest would not reconcile) and ships metrics via Grafana Alloy → Grafana Cloud OTLP, and Alloy scraped only `waddle-server`.
  - `gitops/grafana-alloy/helmrelease.yaml` now also scrapes each CNPG instance pod's built-in exporter (`:9187`, `job="cnpg"`, `cnpg_cluster` label) into the existing OTLP egress — reconciles via Flux, no new CRD.
  - `infrastructure/waddle.cloud/grafana-cloud/alerts/postgres-backups.yaml` is the as-code source of truth for three Grafana Cloud rules: `CNPGBackupStale` (no base backup >26h), `CNPGWALArchiveFailing` (WAL not reaching R2), `CNPGBackupMetricsMissing` (the metrics pipeline itself broke). Applied to the Grafana Cloud ruler at rollout (HITL — needs a ruler token).
- Restore runbook `docs/runbooks/postgres-backup-restore.md`: scratch-namespace restore, PITR, verification queries, WAL-buildup hazard + emergency rollback, the alerting mechanism, and a **restore-validation gate** (per-cluster drill record table — currently PENDING, see below).

## ⚠️ Blocking pre-merge (HITL)

Applying `spec.backup` before the R2 bucket + credentials exist starts continuous WAL archiving that fails from minute one; Postgres then retains WAL without bound and fills the 2Gi `walStorage` until the primary PANICs — and the Cluster stays `Ready`, so Flux won't catch it. **Before this merges/applies:**

- [ ] Create the R2 bucket `waddle-postgres-backups`.
- [ ] Mint a dedicated R2 token scoped to that bucket (read+write), add to 1Password, point the ExternalSecret at it — do not reuse the app-runtime token.

## Post-merge (HITL)

- [ ] Confirm WAL archiving starts and the first `immediate` Backup CR completes for both clusters.
- [ ] Load `grafana-cloud/alerts/postgres-backups.yaml` into the Grafana Cloud ruler (confirm CNPG metric names against the deployed operator first) and route the rules to an operator-visible contact point.
- [ ] **Recoverability gate:** run the scratch-namespace restore drill for **both** clusters and fill in the runbook's validation table. Not yet validated — the drill needs the live operator and the (pre-merge) R2 bucket, so it runs at rollout. Backups must not be treated as a recovery guarantee until this is done.

## Validation

`kubectl kustomize` builds clean for both `gitops/waddle-server/` and `gitops/grafana-alloy/`; the alert rule group parses. CNPG 1.25 (chart 0.23.x) supports the in-tree `barmanObjectStore` shape used here. Live cluster validation is part of the HITL rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
