### PR TITLE
fix: security bundle — pubsub authz fail-closed, Giphy proxy + global error telemetry, SFU kick/ban eviction, webhook JWT exp (#1158 #1168 #935 #1141)

### DIFF
--- a/chat/src/components/AppShell.vue
+++ b/chat/src/components/AppShell.vue
@@ -6,11 +6,7 @@ import CallAudioSink from "@/components/calls/CallAudioSink.vue";
 import { useChatAppController } from "@/shell/chat-app-controller";
 import { appController } from "@/stores/app-controller";
 
-const props = defineProps<{
-  giphyApiKey?: string;
-}>();
-
-const controller = useChatAppController(props.giphyApiKey ?? "");
+const controller = useChatAppController();
 const { connectionStore } = controller;
 
 // Publish the controller into a module-level ref so per-route Vue

--- a/chat/src/components/calls/CallChatPanel.vue
+++ b/chat/src/components/calls/CallChatPanel.vue
@@ -26,7 +26,6 @@ const props = defineProps<{
   avatarUrlByAuthor: Record<string, string | null>;
   isSending?: boolean;
   disabled?: boolean;
-  giphyApiKey?: string;
   mentionCandidates?: MentionCandidate[];
   slowModeCooldown?: number;
   uploadProgress?: { uploading: boolean; progress: number; filename: string };
@@ -128,7 +127,6 @@ onMounted(() => void nextTick(scrollToBottom));
       :is-forum-channel="false"
       :is-sending="!!isSending"
       :disabled="!!disabled"
-      :giphy-api-key="giphyApiKey ?? ''"
       :mention-candidates="mentionCandidates ?? []"
       :slow-mode-cooldown="slowModeCooldown ?? 0"
       :upload-progress="uploadProgress ?? { uploading: false, progress: 0, filename: '' }"

--- a/chat/src/components/calls/CallExpandedSurface.vue
+++ b/chat/src/components/calls/CallExpandedSurface.vue
@@ -120,7 +120,6 @@ const props = defineProps<{
   callThreadId?: string | null;
   isSending?: boolean;
   disabled?: boolean;
-  giphyApiKey?: string;
   mentionCandidates?: MentionCandidate[];
   slowModeCooldown?: number;
   uploadProgress?: { uploading: boolean; progress: number; filename: string };
@@ -812,7 +811,6 @@ onBeforeUnmount(() => {
               :avatar-url-by-author="avatarUrlByAuthor ?? {}"
               :is-sending="!!isSending"
               :disabled="!!disabled || !callThreadOverride"
-              :giphy-api-key="giphyApiKey ?? ''"
               :mention-candidates="mentionCandidates ?? []"
               :slow-mode-cooldown="slowModeCooldown ?? 0"
               :upload-progress="uploadProgress ?? { uploading: false, progress: 0, filename: '' }"

--- a/chat/src/components/chat/ChatReadyShell.vue
+++ b/chat/src/components/chat/ChatReadyShell.vue
@@ -76,7 +76,6 @@ const controller = props.controller;
 
 const {
   connectionStore,
-  giphyApiKey,
   ui,
   waddles,
   messaging,
@@ -890,7 +889,6 @@ onUnmounted(() => {
               :self-domain="selfDomain"
               :avatar-url-by-author="avatarUrlByAuthor"
               :author-jid-by-nick="authorJidByNick"
-              :giphy-api-key="giphyApiKey"
               :mention-candidates="mentionCandidates"
               :room-hats="authorHatsByNick"
               :room-authority="authorAuthorityByNick"
@@ -1024,7 +1022,6 @@ onUnmounted(() => {
               :room-authority="authorAuthorityByNick"
               :room-presence="threadPanelIsDm ? {} : messaging.roomPresence.value"
               :room-last-seen="threadPanelIsDm ? {} : messaging.roomLastSeen.value"
-              :giphy-api-key="giphyApiKey"
               :mention-candidates="mentionCandidates"
               :slow-mode-cooldown="threadPanelIsDm ? 0 : messaging.slowModeCooldown.value"
               :is-sending="false"
@@ -1069,7 +1066,6 @@ onUnmounted(() => {
               :room-authority="authorAuthorityByNick"
               :room-presence="threadPanelIsDm ? {} : messaging.roomPresence.value"
               :room-last-seen="threadPanelIsDm ? {} : messaging.roomLastSeen.value"
-              :giphy-api-key="giphyApiKey"
               :mention-candidates="mentionCandidates"
               :slow-mode-cooldown="threadPanelIsDm ? 0 : messaging.slowModeCooldown.value"
               :is-sending="activeIsSending"

--- a/chat/src/components/chat/ContentArea.vue
+++ b/chat/src/components/chat/ContentArea.vue
@@ -95,7 +95,6 @@ const props = defineProps<{
   selfDomain?: string;
   avatarUrlByAuthor: Record<string, string | null>;
   authorJidByNick?: Record<string, string>;
-  giphyApiKey: string;
   mentionCandidates: MentionCandidate[];
   roomHats: RoomHats;
   roomAuthority: RoomAuthority;
@@ -873,7 +872,6 @@ function dayDividerLabel(createdAt: string): string {
       :is-forum-channel="isForumChannel"
       :is-sending="isSending"
       :disabled="!canShowComposer"
-      :giphy-api-key="giphyApiKey"
       :mention-candidates="mentionCandidates"
       :slow-mode-cooldown="slowModeCooldown"
       :upload-progress="uploadProgress"
@@ -1089,7 +1087,6 @@ function dayDividerLabel(createdAt: string): string {
       :is-forum-channel="isForumChannel"
       :is-sending="isSending"
       :disabled="!canShowComposer"
-      :giphy-api-key="giphyApiKey"
       :mention-candidates="mentionCandidates"
       :slow-mode-cooldown="slowModeCooldown"
       :upload-progress="uploadProgress"
@@ -1148,7 +1145,6 @@ function dayDividerLabel(createdAt: string): string {
       :avatar-url-by-author="avatarUrlByAuthor"
       :is-sending="isSending"
       :disabled="!canShowComposer"
-      :giphy-api-key="giphyApiKey"
       :mention-candidates="mentionCandidates"
       :slow-mode-cooldown="slowModeCooldown"
       :upload-progress="uploadProgress"

--- a/chat/src/components/chat/GifPicker.vue
+++ b/chat/src/components/chat/GifPicker.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from "vue";
 import { Loader2, Search, SearchX, X } from "lucide-vue-next";
+import {
+  GIF_SEARCH_UNAVAILABLE_MESSAGE,
+  resolveGifPickerResponse,
+  type GifPickerFetchState,
+  type GiphyGif,
+} from "@/lib/gif-picker-fetch";
 
 defineProps<{
   isTopPinned?: boolean;
@@ -16,42 +22,36 @@ onMounted(() => {
   searchInput.value?.focus();
 });
 
-// Trimmed shape returned by the same-origin `/api/giphy` proxy.
-interface GiphyGif {
-  id: string;
-  title: string;
-  images: {
-    fixed_height_small: { url: string };
-    original: { url: string };
-  };
-}
-
 const query = ref("");
 const results = ref<GiphyGif[]>([]);
 const isLoading = ref(false);
 const notConfigured = ref(false);
+const errorMessage = ref<string | null>(null);
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 // Searches go through the same-origin `/api/giphy` proxy so the Giphy
 // key never reaches the browser (see `@/lib/giphy-proxy`). Rating and
 // key handling live server-side; the client only sends `q` + `limit`.
+// Response classification (503 not-configured vs 429/502 error vs ok)
+// lives in `@/lib/gif-picker-fetch` so the latest response always
+// drives the panel and failed fetches never keep stale results.
 async function fetchGifs(searchQuery: string) {
   isLoading.value = true;
   try {
     const params = new URLSearchParams({ limit: "24" });
     const q = searchQuery.trim();
     if (q) params.set("q", q);
-    const res = await fetch(`/api/giphy?${params}`);
-    if (res.status === 503) {
-      notConfigured.value = true;
-      results.value = [];
-      return;
-    }
-    if (res.ok) {
-      notConfigured.value = false;
-      const data = await res.json();
-      results.value = data.data ?? [];
-    }
+    const state = await fetch(`/api/giphy?${params}`).then(
+      resolveGifPickerResponse,
+      (): GifPickerFetchState => ({
+        notConfigured: false,
+        results: [],
+        errorMessage: GIF_SEARCH_UNAVAILABLE_MESSAGE,
+      }),
+    );
+    notConfigured.value = state.notConfigured;
+    results.value = state.results;
+    errorMessage.value = state.errorMessage;
   } finally {
     isLoading.value = false;
   }
@@ -103,6 +103,11 @@ function selectGif(gif: GiphyGif) {
     <!-- Server has no Giphy key configured (proxy answered 503) -->
     <div v-if="notConfigured" class="type-control flex h-24 items-center justify-center px-4 text-center text-muted-foreground">
       GIF search is not configured.
+    </div>
+
+    <!-- Transient proxy failure (429 rate limit / 502 upstream) -->
+    <div v-else-if="errorMessage" class="type-control flex h-24 items-center justify-center px-4 text-center text-muted-foreground">
+      {{ errorMessage }}
     </div>
 
     <!-- Results -->

--- a/chat/src/components/chat/GifPicker.vue
+++ b/chat/src/components/chat/GifPicker.vue
@@ -2,8 +2,7 @@
 import { onMounted, ref, watch } from "vue";
 import { Loader2, Search, SearchX, X } from "lucide-vue-next";
 
-const props = defineProps<{
-  apiKey: string;
+defineProps<{
   isTopPinned?: boolean;
 }>();
 
@@ -17,11 +16,12 @@ onMounted(() => {
   searchInput.value?.focus();
 });
 
+// Trimmed shape returned by the same-origin `/api/giphy` proxy.
 interface GiphyGif {
   id: string;
   title: string;
   images: {
-    fixed_height_small: { url: string; width: string; height: string };
+    fixed_height_small: { url: string };
     original: { url: string };
   };
 }
@@ -29,17 +29,26 @@ interface GiphyGif {
 const query = ref("");
 const results = ref<GiphyGif[]>([]);
 const isLoading = ref(false);
+const notConfigured = ref(false);
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
+// Searches go through the same-origin `/api/giphy` proxy so the Giphy
+// key never reaches the browser (see `@/lib/giphy-proxy`). Rating and
+// key handling live server-side; the client only sends `q` + `limit`.
 async function fetchGifs(searchQuery: string) {
-  if (!props.apiKey) return;
   isLoading.value = true;
   try {
-    const endpoint = searchQuery.trim()
-      ? `https://api.giphy.com/v1/gifs/search?q=${encodeURIComponent(searchQuery)}&api_key=${props.apiKey}&limit=24&rating=g`
-      : `https://api.giphy.com/v1/gifs/trending?api_key=${props.apiKey}&limit=24&rating=g`;
-    const res = await fetch(endpoint);
+    const params = new URLSearchParams({ limit: "24" });
+    const q = searchQuery.trim();
+    if (q) params.set("q", q);
+    const res = await fetch(`/api/giphy?${params}`);
+    if (res.status === 503) {
+      notConfigured.value = true;
+      results.value = [];
+      return;
+    }
     if (res.ok) {
+      notConfigured.value = false;
       const data = await res.json();
       results.value = data.data ?? [];
     }
@@ -91,8 +100,8 @@ function selectGif(gif: GiphyGif) {
       </div>
     </div>
 
-    <!-- No API key -->
-    <div v-if="!apiKey" class="type-control flex h-24 items-center justify-center px-4 text-center text-muted-foreground">
+    <!-- Server has no Giphy key configured (proxy answered 503) -->
+    <div v-if="notConfigured" class="type-control flex h-24 items-center justify-center px-4 text-center text-muted-foreground">
       GIF search is not configured.
     </div>
 

--- a/chat/src/components/chat/MessageComposer.vue
+++ b/chat/src/components/chat/MessageComposer.vue
@@ -35,7 +35,6 @@ const props = defineProps<{
   isForumChannel: boolean;
   isSending: boolean;
   disabled: boolean;
-  giphyApiKey: string;
   mentionCandidates: MentionCandidate[];
   slowModeCooldown: number;
   uploadProgress: { uploading: boolean; progress: number; filename: string };
@@ -443,7 +442,6 @@ watch(isPreparingSend, (preparing) => {
 
     <GifPicker
       v-if="showGifPicker"
-      :api-key="giphyApiKey"
       :is-top-pinned="isTopPinned"
       @select="onGifSelected"
       @close="showGifPicker = false"

--- a/chat/src/components/chat/ThreadPanel.vue
+++ b/chat/src/components/chat/ThreadPanel.vue
@@ -60,7 +60,6 @@ const props = defineProps<{
   roomAuthority: RoomAuthority;
   roomPresence: RoomPresence;
   roomLastSeen: Record<string, number>;
-  giphyApiKey: string;
   mentionCandidates: MentionCandidate[];
   slowModeCooldown: number;
   isSending: boolean;
@@ -420,7 +419,6 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
         :channel-name="`thread in ${channelName}`"
         :is-sending="isSending"
         :disabled="false"
-        :giphy-api-key="giphyApiKey"
         :mention-candidates="mentionCandidates"
         :slow-mode-cooldown="slowModeCooldown"
         :upload-progress="uploadProgress"
@@ -620,7 +618,6 @@ function replyChildHasNestedThread(message: TimelineMessage): boolean {
         :channel-name="`thread in ${channelName}`"
         :is-sending="isSending"
         :disabled="false"
-        :giphy-api-key="giphyApiKey"
         :mention-candidates="mentionCandidates"
         :slow-mode-cooldown="slowModeCooldown"
         :upload-progress="uploadProgress"

--- a/chat/src/env.d.ts
+++ b/chat/src/env.d.ts
@@ -15,7 +15,8 @@ interface ImportMeta {
 
 // `GIPHY_API_KEY` is a Cloudflare Pages secret rather than a `wrangler.jsonc`
 // var, so `wrangler types` can't see it. Augment the generated `Cloudflare.Env`
-// here so layouts can read `env.GIPHY_API_KEY` without an unsafe cast.
+// here so the `/api/giphy` proxy route can read `env.GIPHY_API_KEY` without an
+// unsafe cast. The key stays server-side; it is never passed to any island.
 declare namespace Cloudflare {
   interface Env {
     GIPHY_API_KEY?: string;

--- a/chat/src/layouts/AppLayout.astro
+++ b/chat/src/layouts/AppLayout.astro
@@ -9,7 +9,6 @@ import "@/styles/global.css";
 // time via the router's module-level `currentMatch`; no need for the
 // page to thread an SSR-computed initial match through.
 const serverBaseUrl = env.SERVER_BASE_URL;
-const giphyApiKey = env.GIPHY_API_KEY ?? "";
 ---
 
 <html lang="en">
@@ -71,7 +70,7 @@ const giphyApiKey = env.GIPHY_API_KEY ?? "";
   </head>
   <body class="bg-background text-foreground font-sans antialiased">
     <XmppProvider client:only="vue" transition:persist serverBaseUrl={serverBaseUrl ?? ""} />
-    <AppShell client:only="vue" transition:persist giphyApiKey={giphyApiKey}>
+    <AppShell client:only="vue" transition:persist>
       <slot />
       <div slot="fallback" class="chat-app-shell chat-startup-shell" role="status" aria-live="polite">
         <div class="chat-desktop-shell">

--- a/chat/src/lib/gif-picker-fetch.ts
+++ b/chat/src/lib/gif-picker-fetch.ts
@@ -1,0 +1,49 @@
+/**
+ * Classify a `/api/giphy` proxy response into GifPicker view state.
+ *
+ * The proxy legitimately answers 503 (no key configured), 429 (per-IP
+ * rate limit), and 502 (upstream failure) besides 200 — only the MOST
+ * RECENT response may drive the "not configured" panel, and a failed
+ * fetch must never leave a previous query's results on screen.
+ * Kept as a pure function of the response so the branch matrix is
+ * testable without the SSR harness.
+ */
+
+export interface GiphyGif {
+  id: string;
+  title: string;
+  images: {
+    fixed_height_small: { url: string };
+    original: { url: string };
+  };
+}
+
+export interface GifPickerFetchState {
+  notConfigured: boolean;
+  results: GiphyGif[];
+  errorMessage: string | null;
+}
+
+const RATE_LIMITED_MESSAGE = "Too many GIF searches — try again shortly.";
+export const GIF_SEARCH_UNAVAILABLE_MESSAGE = "GIF search is unavailable right now.";
+
+export async function resolveGifPickerResponse(
+  res: Pick<Response, "ok" | "status" | "json">,
+): Promise<GifPickerFetchState> {
+  if (res.status === 503) {
+    return { notConfigured: true, results: [], errorMessage: null };
+  }
+  if (!res.ok) {
+    return {
+      notConfigured: false,
+      results: [],
+      errorMessage: res.status === 429 ? RATE_LIMITED_MESSAGE : GIF_SEARCH_UNAVAILABLE_MESSAGE,
+    };
+  }
+  try {
+    const payload = (await res.json()) as { data?: GiphyGif[] } | null;
+    return { notConfigured: false, results: payload?.data ?? [], errorMessage: null };
+  } catch {
+    return { notConfigured: false, results: [], errorMessage: GIF_SEARCH_UNAVAILABLE_MESSAGE };
+  }
+}

--- a/chat/src/lib/giphy-proxy.ts
+++ b/chat/src/lib/giphy-proxy.ts
@@ -1,0 +1,106 @@
+/**
+ * Server-side Giphy proxy logic for `/api/giphy`.
+ *
+ * `GIPHY_API_KEY` is a secret: it must never appear in page HTML or in
+ * browser-visible request URLs. The picker therefore calls the
+ * same-origin `/api/giphy` route, and only this Worker-side handler
+ * attaches the key to the upstream Giphy request.
+ *
+ * Kept as a pure function of `(apiKey, params, fetchImpl)` so tests can
+ * drive it without the `cloudflare:workers` runtime.
+ */
+
+const GIPHY_API_ORIGIN = "https://api.giphy.com";
+const DEFAULT_LIMIT = 24;
+const MAX_LIMIT = 50;
+const MAX_QUERY_LENGTH = 100;
+
+interface GiphyProxyGif {
+  id: string;
+  title: string;
+  images: {
+    fixed_height_small: { url: string };
+    original: { url: string };
+  };
+}
+
+export async function handleGiphyProxyRequest(
+  apiKey: string | undefined,
+  params: URLSearchParams,
+  fetchImpl: typeof fetch,
+): Promise<Response> {
+  if (!apiKey) {
+    return jsonError("GIF search is not configured", 503);
+  }
+
+  const query = (params.get("q") ?? "").trim().slice(0, MAX_QUERY_LENGTH);
+  const upstream = new URL(
+    query ? "/v1/gifs/search" : "/v1/gifs/trending",
+    GIPHY_API_ORIGIN,
+  );
+  upstream.searchParams.set("api_key", apiKey);
+  upstream.searchParams.set("limit", String(clampLimit(params.get("limit"))));
+  // Rating is pinned server-side; a client-supplied `rating` is ignored.
+  upstream.searchParams.set("rating", "g");
+  if (query) upstream.searchParams.set("q", query);
+
+  let payload: unknown;
+  try {
+    const response = await fetchImpl(upstream.toString());
+    if (!response.ok) return jsonError("GIF search is unavailable", 502);
+    payload = await response.json();
+  } catch {
+    return jsonError("GIF search is unavailable", 502);
+  }
+
+  return Response.json({ data: trimGiphyPayload(payload) });
+}
+
+function clampLimit(raw: string | null): number {
+  const parsed = Number.parseInt(raw ?? "", 10);
+  if (Number.isNaN(parsed)) return DEFAULT_LIMIT;
+  return Math.min(Math.max(parsed, 1), MAX_LIMIT);
+}
+
+/**
+ * Reduce Giphy's response to exactly the fields the picker renders.
+ * Never echo the upstream body: it carries analytics pingback URLs and
+ * whatever else Giphy adds over time.
+ */
+function trimGiphyPayload(payload: unknown): GiphyProxyGif[] {
+  if (typeof payload !== "object" || payload === null) return [];
+  const data = (payload as { data?: unknown }).data;
+  if (!Array.isArray(data)) return [];
+  const trimmed: GiphyProxyGif[] = [];
+  for (const entry of data) {
+    const gif = trimGiphyEntry(entry);
+    if (gif) trimmed.push(gif);
+  }
+  return trimmed;
+}
+
+function trimGiphyEntry(entry: unknown): GiphyProxyGif | null {
+  if (typeof entry !== "object" || entry === null) return null;
+  const { id, title, images } = entry as {
+    id?: unknown;
+    title?: unknown;
+    images?: { fixed_height_small?: { url?: unknown }; original?: { url?: unknown } };
+  };
+  const preview = images?.fixed_height_small?.url;
+  const original = images?.original?.url;
+  if (typeof id !== "string" || typeof preview !== "string" || typeof original !== "string") {
+    return null;
+  }
+  return {
+    id,
+    title: typeof title === "string" ? title : "",
+    images: {
+      fixed_height_small: { url: preview },
+      original: { url: original },
+    },
+  };
+}
+
+function jsonError(message: string, status: number): Response {
+  return Response.json({ error: message }, { status });
+}

--- a/chat/src/lib/giphy-proxy.ts
+++ b/chat/src/lib/giphy-proxy.ts
@@ -24,13 +24,48 @@ interface GiphyProxyGif {
   };
 }
 
+/**
+ * Fixed-window rate limiter for the proxy route. The route is
+ * unauthenticated (auth lives on the XMPP server), so this per-client
+ * budget is what bounds how fast anonymous traffic can burn the Giphy
+ * key's quota — the Cache-Control below only helps organic repeat
+ * queries in the browser, not adversarial unique-`q` traffic.
+ * In-memory per Worker isolate: best-effort, zero-dependency.
+ */
+export function createGiphyRateLimiter(
+  maxPerWindow: number,
+  windowMs: number,
+): (key: string, nowMs: number) => boolean {
+  const windows = new Map<string, { start: number; count: number }>();
+  return (key, nowMs) => {
+    const entry = windows.get(key);
+    if (!entry || nowMs - entry.start >= windowMs) {
+      // Rolling into a new window: also drop other stale entries so
+      // the map can't grow unboundedly from one-off client keys.
+      if (windows.size > 10_000) {
+        for (const [k, v] of windows) {
+          if (nowMs - v.start >= windowMs) windows.delete(k);
+        }
+      }
+      windows.set(key, { start: nowMs, count: 1 });
+      return true;
+    }
+    entry.count += 1;
+    return entry.count <= maxPerWindow;
+  };
+}
+
 export async function handleGiphyProxyRequest(
   apiKey: string | undefined,
   params: URLSearchParams,
   fetchImpl: typeof fetch,
+  rateGate?: () => boolean,
 ): Promise<Response> {
   if (!apiKey) {
     return jsonError("GIF search is not configured", 503);
+  }
+  if (rateGate && !rateGate()) {
+    return jsonError("Too many GIF searches — try again shortly", 429);
   }
 
   const query = (params.get("q") ?? "").trim().slice(0, MAX_QUERY_LENGTH);
@@ -53,11 +88,10 @@ export async function handleGiphyProxyRequest(
     return jsonError("GIF search is unavailable", 502);
   }
 
-  // Shared-cache the trimmed result: the route is same-origin and
-  // unauthenticated (auth lives on the XMPP server), so a short CDN
-  // TTL is what bounds how fast anonymous traffic can burn the Giphy
-  // key's quota. Responses are identical for identical params —
-  // nothing user-specific is cached.
+  // Response is a pure function of q+limit and nothing user-specific,
+  // so browsers may cache repeat queries briefly. (Cloudflare does not
+  // edge-cache dynamic responses on this header alone — the quota
+  // bound comes from the rate limiter above, not from caching.)
   return Response.json(
     { data: trimGiphyPayload(payload) },
     { headers: { "Cache-Control": "public, max-age=300" } },

--- a/chat/src/lib/giphy-proxy.ts
+++ b/chat/src/lib/giphy-proxy.ts
@@ -53,7 +53,15 @@ export async function handleGiphyProxyRequest(
     return jsonError("GIF search is unavailable", 502);
   }
 
-  return Response.json({ data: trimGiphyPayload(payload) });
+  // Shared-cache the trimmed result: the route is same-origin and
+  // unauthenticated (auth lives on the XMPP server), so a short CDN
+  // TTL is what bounds how fast anonymous traffic can burn the Giphy
+  // key's quota. Responses are identical for identical params —
+  // nothing user-specific is cached.
+  return Response.json(
+    { data: trimGiphyPayload(payload) },
+    { headers: { "Cache-Control": "public, max-age=300" } },
+  );
 }
 
 function clampLimit(raw: string | null): number {

--- a/chat/src/lib/giphy-proxy.ts
+++ b/chat/src/lib/giphy-proxy.ts
@@ -35,17 +35,23 @@ interface GiphyProxyGif {
 export function createGiphyRateLimiter(
   maxPerWindow: number,
   windowMs: number,
+  maxKeys = 10_000,
 ): (key: string, nowMs: number) => boolean {
   const windows = new Map<string, { start: number; count: number }>();
   return (key, nowMs) => {
     const entry = windows.get(key);
     if (!entry || nowMs - entry.start >= windowMs) {
-      // Rolling into a new window: also drop other stale entries so
-      // the map can't grow unboundedly from one-off client keys.
-      if (windows.size > 10_000) {
-        for (const [k, v] of windows) {
-          if (nowMs - v.start >= windowMs) windows.delete(k);
-        }
+      // Hard cap the table by evicting the oldest-inserted keys (Map
+      // preserves insertion order): a flood of fresh keys inside one
+      // window must cost O(1) per request and bounded memory, or the
+      // limiter itself becomes the amplification vector. At cap, an
+      // evicted key regains a fresh budget — bounded memory wins over
+      // per-key strictness.
+      windows.delete(key);
+      while (windows.size >= maxKeys) {
+        const oldest = windows.keys().next().value;
+        if (oldest === undefined) break;
+        windows.delete(oldest);
       }
       windows.set(key, { start: nowMs, count: 1 });
       return true;
@@ -53,6 +59,25 @@ export function createGiphyRateLimiter(
     entry.count += 1;
     return entry.count <= maxPerWindow;
   };
+}
+
+/**
+ * Normalize a client IP into a rate-limit bucket key. IPv6 collapses
+ * to its /64 prefix — a single routed /64 (standard residential/VPS
+ * allocation) holds 2^64 addresses, so keying on the full address
+ * would hand an attacker unlimited fresh budgets. IPv4 and opaque
+ * values pass through unchanged.
+ */
+export function clientRateKey(ip: string): string {
+  if (!ip.includes(":")) return ip;
+  const [head, tail = ""] = ip.split("::", 2);
+  const headGroups = head === "" ? [] : head.split(":");
+  const tailGroups = tail === "" ? [] : tail.split(":");
+  const missing = 8 - headGroups.length - tailGroups.length;
+  const groups = ip.includes("::")
+    ? [...headGroups, ...Array<string>(Math.max(missing, 0)).fill("0"), ...tailGroups]
+    : headGroups;
+  return groups.slice(0, 4).join(":");
 }
 
 export async function handleGiphyProxyRequest(
@@ -65,7 +90,10 @@ export async function handleGiphyProxyRequest(
     return jsonError("GIF search is not configured", 503);
   }
   if (rateGate && !rateGate()) {
-    return jsonError("Too many GIF searches — try again shortly", 429);
+    return Response.json(
+      { error: "Too many GIF searches — try again shortly" },
+      { status: 429, headers: { "Retry-After": "60" } },
+    );
   }
 
   const query = (params.get("q") ?? "").trim().slice(0, MAX_QUERY_LENGTH);

--- a/chat/src/lib/telemetry.ts
+++ b/chat/src/lib/telemetry.ts
@@ -249,21 +249,24 @@ export function initTelemetry(options: InitTelemetryOptions): void {
 // error through the sanitizing `reportError()` path instead.
 
 const GLOBAL_ERROR_DEDUPE_WINDOW_MS = 5_000;
-let globalErrorsInstalled = false;
+// Guard is per-window (not a process-lifetime latch) so a swapped
+// `window` — a fresh test stub, an HMR-recreated document — gets its
+// own listeners instead of a silent no-op.
+let globalErrorsInstalledOn: unknown = null;
 let reportingGlobalError = false;
 let lastGlobalErrorKey = "";
 let lastGlobalErrorAtMs = 0;
 
 /**
- * Install window `error` + `unhandledrejection` capture. Idempotent and
- * a no-op outside the browser. Called once from {@link initTelemetry};
- * `reportError` already no-ops without Faro, so installing before or
- * without a collector is harmless.
+ * Install window `error` + `unhandledrejection` capture. Idempotent
+ * per window instance and a no-op outside the browser. Called once
+ * from {@link initTelemetry}; `reportError` already no-ops without
+ * Faro, so installing before or without a collector is harmless.
  */
 export function installGlobalErrorTelemetry(): void {
-  if (globalErrorsInstalled) return;
   if (typeof window === "undefined" || typeof window.addEventListener !== "function") return;
-  globalErrorsInstalled = true;
+  if (globalErrorsInstalledOn === window) return;
+  globalErrorsInstalledOn = window;
 
   window.addEventListener("error", (event) => {
     handleWindowErrorEvent(event);

--- a/chat/src/lib/telemetry.ts
+++ b/chat/src/lib/telemetry.ts
@@ -62,7 +62,10 @@ export type ErrorKind =
   | "storage.read"
   | "storage.write"
   | "http.fetch"
-  | "upload";
+  | "upload"
+  | "window-error"
+  | "unhandled-rejection"
+  | "vue-render-error";
 
 interface InitTelemetryOptions {
   /** Faro collector URL (from Grafana Cloud Faro app config). */
@@ -235,6 +238,89 @@ export function initTelemetry(options: InitTelemetryOptions): void {
     faro = null;
   }
   installClientHealthTelemetry();
+  installGlobalErrorTelemetry();
+}
+
+// --- Global (window-level) error capture -----------------------------
+//
+// Faro's stock errors instrumentation is deliberately stripped in
+// `getPrivacySafeWebInstrumentations()` because it ships raw messages
+// and stacks. These handlers restore global capture but funnel every
+// error through the sanitizing `reportError()` path instead.
+
+const GLOBAL_ERROR_DEDUPE_WINDOW_MS = 5_000;
+let globalErrorsInstalled = false;
+let reportingGlobalError = false;
+let lastGlobalErrorKey = "";
+let lastGlobalErrorAtMs = 0;
+
+/**
+ * Install window `error` + `unhandledrejection` capture. Idempotent and
+ * a no-op outside the browser. Called once from {@link initTelemetry};
+ * `reportError` already no-ops without Faro, so installing before or
+ * without a collector is harmless.
+ */
+export function installGlobalErrorTelemetry(): void {
+  if (globalErrorsInstalled) return;
+  if (typeof window === "undefined" || typeof window.addEventListener !== "function") return;
+  globalErrorsInstalled = true;
+
+  window.addEventListener("error", (event) => {
+    handleWindowErrorEvent(event);
+  });
+  window.addEventListener("unhandledrejection", (event) => {
+    handleUnhandledRejectionEvent(event);
+  });
+}
+
+/** Exported for tests and for {@link installGlobalErrorTelemetry}. */
+export function handleWindowErrorEvent(event: { error?: unknown; message?: unknown }): void {
+  const error = event.error
+    ?? new Error(typeof event.message === "string" && event.message ? event.message : "window-error");
+  reportGlobalError("window-error", error);
+}
+
+/** Exported for tests and for {@link installGlobalErrorTelemetry}. */
+export function handleUnhandledRejectionEvent(event: { reason?: unknown }): void {
+  reportGlobalError("unhandled-rejection", event.reason ?? new Error("unhandled-rejection"));
+}
+
+/**
+ * Report a Vue render/lifecycle error caught by `app.config.errorHandler`
+ * (installed in `src/vue-app.ts`). Shares the loop guard + flood dedupe
+ * with the window-level handlers.
+ */
+export function reportVueError(error: unknown, componentName?: string, info?: string): void {
+  reportGlobalError("vue-render-error", error, {
+    ...(componentName ? { component: componentName } : {}),
+    ...(info ? { detail: info } : {}),
+  });
+}
+
+function reportGlobalError(
+  kind: ErrorKind,
+  error: unknown,
+  context: Record<string, unknown> = {},
+): void {
+  // Loop guard: an error thrown while reporting (inside Faro or our
+  // sanitizers) would re-enter via the same global handlers forever.
+  if (reportingGlobalError) return;
+  reportingGlobalError = true;
+  try {
+    const message = error instanceof Error ? error.message : String(error);
+    const key = `${kind}:${message}`;
+    const now = Date.now();
+    if (key === lastGlobalErrorKey && now - lastGlobalErrorAtMs < GLOBAL_ERROR_DEDUPE_WINDOW_MS) {
+      return;
+    }
+    lastGlobalErrorKey = key;
+    lastGlobalErrorAtMs = now;
+    reportError(kind, error, { recoverable: false, ...context });
+  } catch {
+    // Never let telemetry take the page down (or recurse).
+  } finally {
+    reportingGlobalError = false;
+  }
 }
 
 function sanitizeFaroTransportItem(item: TransportItem): TransportItem {
@@ -723,7 +809,11 @@ export function __clearSensitiveUrlsForTesting(): void {
 /** For tests only — inject a stub or clear state between test cases. */
 export function __setFaroForTesting(instance: Faro | null): void {
   faro = instance;
-  if (!instance) configuredTrustedSpanOrigins = new Set();
+  if (!instance) {
+    configuredTrustedSpanOrigins = new Set();
+    lastGlobalErrorKey = "";
+    lastGlobalErrorAtMs = 0;
+  }
 }
 
 /** For tests only — exercise the final transport guard without calling Grafana. */

--- a/chat/src/pages/api/giphy.ts
+++ b/chat/src/pages/api/giphy.ts
@@ -1,11 +1,20 @@
 import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
-import { handleGiphyProxyRequest } from "@/lib/giphy-proxy";
+import { createGiphyRateLimiter, handleGiphyProxyRequest } from "@/lib/giphy-proxy";
+
+const RATE_LIMIT_PER_MINUTE = 30;
+
+const allowRequest = createGiphyRateLimiter(RATE_LIMIT_PER_MINUTE, 60_000);
 
 /**
  * Same-origin Giphy proxy. `GIPHY_API_KEY` is a Cloudflare secret and
  * stays server-side; the browser only ever sees `/api/giphy?...` and a
- * trimmed response body. See `@/lib/giphy-proxy` for the handler logic.
+ * trimmed response body. Per-IP rate limited because the route is
+ * unauthenticated. See `@/lib/giphy-proxy` for the handler logic.
  */
-export const GET: APIRoute = ({ url }) =>
-  handleGiphyProxyRequest(env.GIPHY_API_KEY, url.searchParams, fetch);
+export const GET: APIRoute = ({ url, request }) => {
+  const clientKey = request.headers.get("CF-Connecting-IP") ?? "unknown";
+  return handleGiphyProxyRequest(env.GIPHY_API_KEY, url.searchParams, fetch, () =>
+    allowRequest(clientKey, Date.now()),
+  );
+};

--- a/chat/src/pages/api/giphy.ts
+++ b/chat/src/pages/api/giphy.ts
@@ -1,0 +1,11 @@
+import type { APIRoute } from "astro";
+import { env } from "cloudflare:workers";
+import { handleGiphyProxyRequest } from "@/lib/giphy-proxy";
+
+/**
+ * Same-origin Giphy proxy. `GIPHY_API_KEY` is a Cloudflare secret and
+ * stays server-side; the browser only ever sees `/api/giphy?...` and a
+ * trimmed response body. See `@/lib/giphy-proxy` for the handler logic.
+ */
+export const GET: APIRoute = ({ url }) =>
+  handleGiphyProxyRequest(env.GIPHY_API_KEY, url.searchParams, fetch);

--- a/chat/src/pages/api/giphy.ts
+++ b/chat/src/pages/api/giphy.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro";
 import { env } from "cloudflare:workers";
-import { createGiphyRateLimiter, handleGiphyProxyRequest } from "@/lib/giphy-proxy";
+import { clientRateKey, createGiphyRateLimiter, handleGiphyProxyRequest } from "@/lib/giphy-proxy";
 
 const RATE_LIMIT_PER_MINUTE = 30;
 
@@ -13,7 +13,7 @@ const allowRequest = createGiphyRateLimiter(RATE_LIMIT_PER_MINUTE, 60_000);
  * unauthenticated. See `@/lib/giphy-proxy` for the handler logic.
  */
 export const GET: APIRoute = ({ url, request }) => {
-  const clientKey = request.headers.get("CF-Connecting-IP") ?? "unknown";
+  const clientKey = clientRateKey(request.headers.get("CF-Connecting-IP") ?? "unknown");
   return handleGiphyProxyRequest(env.GIPHY_API_KEY, url.searchParams, fetch, () =>
     allowRequest(clientKey, Date.now()),
   );

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -50,7 +50,7 @@ import { useConnectionLifecycle } from "@/shell/controllers/use-connection-lifec
  * coupling), and assembles the controller object AppShell publishes via
  * the `appController` store.
  */
-export function useChatAppController(giphyApiKey: string) {
+export function useChatAppController() {
   const ui = useChatShellState();
   const { mode: scrollDirectionMode } = useScrollDirectionPreference();
   const { isWindowFocused } = useChatWindowVisibility();
@@ -445,7 +445,6 @@ export function useChatAppController(giphyApiKey: string) {
 
   return {
     connectionStore,
-    giphyApiKey,
     ui,
     waddles,
     messaging,

--- a/chat/src/vue-app.ts
+++ b/chat/src/vue-app.ts
@@ -1,5 +1,6 @@
-import type { App } from "vue";
+import type { App, ComponentPublicInstance } from "vue";
 import { QueryClient, VueQueryPlugin } from "@tanstack/vue-query";
+import { reportVueError } from "@/lib/telemetry";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -10,6 +11,23 @@ const queryClient = new QueryClient({
   },
 });
 
+function componentNameOf(instance: ComponentPublicInstance | null): string | undefined {
+  if (!instance) return undefined;
+  const optionsName = instance.$options?.name;
+  if (typeof optionsName === "string" && optionsName) return optionsName;
+  const type = instance.$?.type as { name?: string; __name?: string } | undefined;
+  return type?.name || type?.__name || undefined;
+}
+
 export default (app: App) => {
   app.use(VueQueryPlugin, { queryClient });
+
+  // Every island's App passes through this Astro appEntrypoint, so this
+  // is the single place to catch Vue render/lifecycle errors. Vue's
+  // default handler (console + rethrow-in-dev) is replaced, so keep the
+  // console.error for devtools and funnel a sanitized copy to Faro.
+  app.config.errorHandler = (err, instance, info) => {
+    console.error(err);
+    reportVueError(err, componentNameOf(instance), info);
+  };
 };

--- a/chat/tests/call-activity-dock.test.ts
+++ b/chat/tests/call-activity-dock.test.ts
@@ -4076,7 +4076,6 @@ function contentAreaBaseProps(): Record<string, unknown> {
     selfDomain: "example.com",
     avatarUrlByAuthor: {},
     authorJidByNick: {},
-    giphyApiKey: "",
     mentionCandidates: [],
     roomHats: {},
     roomAuthority: {},

--- a/chat/tests/call-chat-composer.test.ts
+++ b/chat/tests/call-chat-composer.test.ts
@@ -139,7 +139,6 @@ describe("call-chat composer", () => {
         callThreadId: "call-thread-123",
         isSending: false,
         disabled: false,
-        giphyApiKey: "",
         mentionCandidates: [],
         slowModeCooldown: 0,
         uploadProgress: { uploading: false, progress: 0, filename: "" },

--- a/chat/tests/gif-picker-fetch.test.ts
+++ b/chat/tests/gif-picker-fetch.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { resolveGifPickerResponse } from "../src/lib/gif-picker-fetch";
+
+function response(status: number, body?: unknown): Pick<Response, "ok" | "status" | "json"> {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: () => Promise.resolve(body),
+  };
+}
+
+const gif = {
+  id: "g1",
+  title: "penguin",
+  images: {
+    fixed_height_small: { url: "https://media.giphy.com/g1/100.gif" },
+    original: { url: "https://media.giphy.com/g1/full.gif" },
+  },
+};
+
+describe("resolveGifPickerResponse", () => {
+  test("503 means not configured: results cleared, no error message", async () => {
+    const state = await resolveGifPickerResponse(response(503, { error: "GIF search is not configured" }));
+    expect(state).toEqual({ notConfigured: true, results: [], errorMessage: null });
+  });
+
+  test("429 clears results and reports a rate-limit message — NOT the not-configured panel", async () => {
+    const state = await resolveGifPickerResponse(response(429, { error: "Too many GIF searches — try again shortly" }));
+    expect(state.notConfigured).toBe(false);
+    expect(state.results).toEqual([]);
+    expect(state.errorMessage).toBe("Too many GIF searches — try again shortly.");
+  });
+
+  test("502 clears results and reports an unavailable message — NOT the not-configured panel", async () => {
+    const state = await resolveGifPickerResponse(response(502, { error: "GIF search is unavailable" }));
+    expect(state.notConfigured).toBe(false);
+    expect(state.results).toEqual([]);
+    expect(state.errorMessage).toBe("GIF search is unavailable right now.");
+  });
+
+  test("a success after a 503 fully recovers: results set, flags cleared", async () => {
+    const failed = await resolveGifPickerResponse(response(503));
+    expect(failed.notConfigured).toBe(true);
+    const state = await resolveGifPickerResponse(response(200, { data: [gif] }));
+    expect(state).toEqual({ notConfigured: false, results: [gif], errorMessage: null });
+  });
+
+  test("a success payload without data yields empty results, not a crash", async () => {
+    const state = await resolveGifPickerResponse(response(200, {}));
+    expect(state).toEqual({ notConfigured: false, results: [], errorMessage: null });
+  });
+
+  test("an unparseable success body degrades to the unavailable message", async () => {
+    const state = await resolveGifPickerResponse({
+      status: 200,
+      ok: true,
+      json: () => Promise.reject(new Error("bad json")),
+    });
+    expect(state.notConfigured).toBe(false);
+    expect(state.results).toEqual([]);
+    expect(state.errorMessage).toBe("GIF search is unavailable right now.");
+  });
+});

--- a/chat/tests/giphy-proxy-wiring.test.ts
+++ b/chat/tests/giphy-proxy-wiring.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+function read(relative: string): string {
+  return readFileSync(new URL(`../${relative}`, import.meta.url), "utf8");
+}
+
+describe("giphy proxy wiring", () => {
+  test("the API route reads the key server-side and delegates to the pure handler", () => {
+    const source = read("src/pages/api/giphy.ts");
+    expect(source).toContain('from "cloudflare:workers"');
+    expect(source).toContain("GIPHY_API_KEY");
+    expect(source).toContain("handleGiphyProxyRequest");
+  });
+
+  test("GifPicker fetches the same-origin proxy and never talks to Giphy directly", () => {
+    const source = read("src/components/chat/GifPicker.vue");
+    expect(source).toContain("/api/giphy");
+    expect(source).not.toContain("api.giphy.com");
+    expect(source).not.toContain("api_key");
+    expect(source).not.toContain("apiKey");
+  });
+
+  test("the giphyApiKey prop chain is gone", () => {
+    const chain = [
+      "src/layouts/AppLayout.astro",
+      "src/components/AppShell.vue",
+      "src/shell/chat-app-controller.ts",
+      "src/components/chat/ChatReadyShell.vue",
+      "src/components/chat/ContentArea.vue",
+      "src/components/chat/ThreadPanel.vue",
+      "src/components/calls/CallChatPanel.vue",
+      "src/components/calls/CallExpandedSurface.vue",
+      "src/components/chat/MessageComposer.vue",
+    ];
+    for (const relative of chain) {
+      const source = read(relative);
+      expect(source).not.toContain("giphyApiKey");
+      expect(source).not.toContain("giphy-api-key");
+      expect(source).not.toContain("GIPHY_API_KEY");
+    }
+  });
+});

--- a/chat/tests/giphy-proxy.test.ts
+++ b/chat/tests/giphy-proxy.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, test } from "bun:test";
+import { handleGiphyProxyRequest } from "../src/lib/giphy-proxy";
+
+const KEY = "super-secret-giphy-key";
+
+function giphyUpstreamBody() {
+  return {
+    data: [
+      {
+        id: "gif-1",
+        title: "dancing penguin",
+        slug: "dancing-penguin-gif-1",
+        url: "https://giphy.com/gifs/dancing-penguin-gif-1",
+        username: "someuser",
+        analytics: { onload: { url: "https://giphy-analytics.example/pingback" } },
+        images: {
+          fixed_height_small: { url: "https://media.giphy.com/gif-1/100.gif", width: "178", height: "100" },
+          original: { url: "https://media.giphy.com/gif-1/full.gif", width: "480", height: "270" },
+          downsized_large: { url: "https://media.giphy.com/gif-1/large.gif" },
+        },
+      },
+      {
+        id: "gif-2",
+        title: "",
+        images: {
+          fixed_height_small: { url: "https://media.giphy.com/gif-2/100.gif" },
+          original: { url: "https://media.giphy.com/gif-2/full.gif" },
+        },
+      },
+    ],
+    meta: { status: 200, msg: "OK", response_id: "resp-123" },
+    pagination: { total_count: 9999, count: 2, offset: 0 },
+  };
+}
+
+function stubFetch(
+  handler: (url: string) => Response | Promise<Response>,
+): { calls: string[]; fetchImpl: typeof fetch } {
+  const calls: string[] = [];
+  const fetchImpl = (async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    calls.push(url);
+    return handler(url);
+  }) as typeof fetch;
+  return { calls, fetchImpl };
+}
+
+function okUpstream() {
+  return stubFetch(() => Response.json(giphyUpstreamBody()));
+}
+
+describe("handleGiphyProxyRequest", () => {
+  test("search: forwards q with the key upstream and returns a trimmed body without the key", async () => {
+    const { calls, fetchImpl } = okUpstream();
+    const res = await handleGiphyProxyRequest(KEY, new URLSearchParams({ q: "penguin" }), fetchImpl);
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    const upstream = new URL(calls[0]!);
+    expect(upstream.origin).toBe("https://api.giphy.com");
+    expect(upstream.pathname).toBe("/v1/gifs/search");
+    expect(upstream.searchParams.get("api_key")).toBe(KEY);
+    expect(upstream.searchParams.get("q")).toBe("penguin");
+
+    const bodyText = await res.text();
+    expect(bodyText).not.toContain(KEY);
+    const body = JSON.parse(bodyText) as { data: unknown[] };
+    expect(body).toEqual({
+      data: [
+        {
+          id: "gif-1",
+          title: "dancing penguin",
+          images: {
+            fixed_height_small: { url: "https://media.giphy.com/gif-1/100.gif" },
+            original: { url: "https://media.giphy.com/gif-1/full.gif" },
+          },
+        },
+        {
+          id: "gif-2",
+          title: "",
+          images: {
+            fixed_height_small: { url: "https://media.giphy.com/gif-2/100.gif" },
+            original: { url: "https://media.giphy.com/gif-2/full.gif" },
+          },
+        },
+      ],
+    });
+  });
+
+  test("no q hits trending", async () => {
+    const { calls, fetchImpl } = okUpstream();
+    const res = await handleGiphyProxyRequest(KEY, new URLSearchParams(), fetchImpl);
+    expect(res.status).toBe(200);
+    expect(new URL(calls[0]!).pathname).toBe("/v1/gifs/trending");
+    expect(new URL(calls[0]!).searchParams.get("q")).toBeNull();
+  });
+
+  test("clamps limit, pins rating to g, and caps q length", async () => {
+    const { calls, fetchImpl } = okUpstream();
+    const longQuery = "p".repeat(500);
+    await handleGiphyProxyRequest(
+      KEY,
+      new URLSearchParams({ q: longQuery, limit: "500", rating: "r" }),
+      fetchImpl,
+    );
+    const upstream = new URL(calls[0]!);
+    expect(upstream.searchParams.get("limit")).toBe("50");
+    expect(upstream.searchParams.get("rating")).toBe("g");
+    expect(upstream.searchParams.get("q")).toBe("p".repeat(100));
+  });
+
+  test("invalid limit falls back to the default of 24", async () => {
+    const { calls, fetchImpl } = okUpstream();
+    await handleGiphyProxyRequest(KEY, new URLSearchParams({ limit: "banana" }), fetchImpl);
+    expect(new URL(calls[0]!).searchParams.get("limit")).toBe("24");
+  });
+
+  test("upstream non-OK response maps to 502 without leaking the key", async () => {
+    const { fetchImpl } = stubFetch(() => new Response("giphy exploded", { status: 500 }));
+    const res = await handleGiphyProxyRequest(KEY, new URLSearchParams({ q: "x" }), fetchImpl);
+    expect(res.status).toBe(502);
+    expect(await res.text()).not.toContain(KEY);
+  });
+
+  test("upstream fetch rejection maps to 502", async () => {
+    const { fetchImpl } = stubFetch(() => {
+      throw new Error(`connect failed for api_key=${KEY}`);
+    });
+    const res = await handleGiphyProxyRequest(KEY, new URLSearchParams({ q: "x" }), fetchImpl);
+    expect(res.status).toBe(502);
+    expect(await res.text()).not.toContain(KEY);
+  });
+
+  test("unparseable upstream body maps to 502", async () => {
+    const { fetchImpl } = stubFetch(() => new Response("<html>not json</html>", { status: 200 }));
+    const res = await handleGiphyProxyRequest(KEY, new URLSearchParams({ q: "x" }), fetchImpl);
+    expect(res.status).toBe(502);
+  });
+
+  test("missing key maps to 503 without contacting Giphy", async () => {
+    const { calls, fetchImpl } = okUpstream();
+    for (const key of [undefined, ""]) {
+      const res = await handleGiphyProxyRequest(key, new URLSearchParams({ q: "x" }), fetchImpl);
+      expect(res.status).toBe(503);
+    }
+    expect(calls).toHaveLength(0);
+  });
+
+  test("malformed upstream entries are dropped from the trimmed body", async () => {
+    const { fetchImpl } = stubFetch(() =>
+      Response.json({
+        data: [
+          "not-an-object",
+          { id: "no-images" },
+          { id: 42, images: { fixed_height_small: { url: "x" }, original: { url: "y" } } },
+          {
+            id: "good",
+            title: "ok",
+            images: {
+              fixed_height_small: { url: "https://media.giphy.com/good/100.gif" },
+              original: { url: "https://media.giphy.com/good/full.gif" },
+            },
+          },
+        ],
+      }),
+    );
+    const res = await handleGiphyProxyRequest(KEY, new URLSearchParams({ q: "x" }), fetchImpl);
+    const body = (await res.json()) as { data: Array<{ id: string }> };
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0]!.id).toBe("good");
+  });
+});

--- a/chat/tests/giphy-proxy.test.ts
+++ b/chat/tests/giphy-proxy.test.ts
@@ -170,3 +170,23 @@ describe("handleGiphyProxyRequest", () => {
     expect(body.data[0]!.id).toBe("good");
   });
 });
+
+describe("response caching", () => {
+  test("successful responses carry a shared-cache Cache-Control so anonymous hits cannot burn Giphy quota unbounded", async () => {
+    const { fetchImpl } = stubFetch(() => Response.json(giphyUpstreamBody()));
+    const trending = await handleGiphyProxyRequest(KEY, new URLSearchParams(), fetchImpl);
+    expect(trending.headers.get("Cache-Control")).toBe("public, max-age=300");
+
+    const search = await handleGiphyProxyRequest(
+      KEY,
+      new URLSearchParams({ q: "cats" }),
+      fetchImpl,
+    );
+    expect(search.headers.get("Cache-Control")).toBe("public, max-age=300");
+  });
+
+  test("error responses are not cacheable", async () => {
+    const unconfigured = await handleGiphyProxyRequest(undefined, new URLSearchParams(), fetch);
+    expect(unconfigured.headers.get("Cache-Control")).toBeNull();
+  });
+});

--- a/chat/tests/giphy-proxy.test.ts
+++ b/chat/tests/giphy-proxy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { handleGiphyProxyRequest } from "../src/lib/giphy-proxy";
+import { createGiphyRateLimiter, handleGiphyProxyRequest } from "../src/lib/giphy-proxy";
 
 const KEY = "super-secret-giphy-key";
 
@@ -188,5 +188,45 @@ describe("response caching", () => {
   test("error responses are not cacheable", async () => {
     const unconfigured = await handleGiphyProxyRequest(undefined, new URLSearchParams(), fetch);
     expect(unconfigured.headers.get("Cache-Control")).toBeNull();
+  });
+});
+
+describe("rate limiting", () => {
+  test("createGiphyRateLimiter allows up to the per-window budget per key, then blocks, then resets after the window", () => {
+    const allow = createGiphyRateLimiter(3, 60_000);
+    expect(allow("ip-a", 0)).toBe(true);
+    expect(allow("ip-a", 1_000)).toBe(true);
+    expect(allow("ip-a", 2_000)).toBe(true);
+    expect(allow("ip-a", 3_000)).toBe(false);
+    // Independent budgets per key.
+    expect(allow("ip-b", 3_000)).toBe(true);
+    // Window rollover restores the budget.
+    expect(allow("ip-a", 60_001)).toBe(true);
+  });
+
+  test("a denied gate returns 429 without contacting Giphy and without a cache header", async () => {
+    const { calls, fetchImpl } = stubFetch(() => Response.json(giphyUpstreamBody()));
+    const response = await handleGiphyProxyRequest(
+      KEY,
+      new URLSearchParams({ q: "cats" }),
+      fetchImpl,
+      () => false,
+    );
+    expect(response.status).toBe(429);
+    expect(calls.length).toBe(0);
+    expect(response.headers.get("Cache-Control")).toBeNull();
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toBe("Too many GIF searches — try again shortly");
+  });
+
+  test("an allowing gate leaves the happy path untouched", async () => {
+    const { fetchImpl } = stubFetch(() => Response.json(giphyUpstreamBody()));
+    const response = await handleGiphyProxyRequest(
+      KEY,
+      new URLSearchParams({ q: "cats" }),
+      fetchImpl,
+      () => true,
+    );
+    expect(response.status).toBe(200);
   });
 });

--- a/chat/tests/giphy-proxy.test.ts
+++ b/chat/tests/giphy-proxy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createGiphyRateLimiter, handleGiphyProxyRequest } from "../src/lib/giphy-proxy";
+import { clientRateKey, createGiphyRateLimiter, handleGiphyProxyRequest } from "../src/lib/giphy-proxy";
 
 const KEY = "super-secret-giphy-key";
 
@@ -228,5 +228,45 @@ describe("rate limiting", () => {
       () => true,
     );
     expect(response.status).toBe(200);
+  });
+});
+
+describe("rate limiter hardening", () => {
+  test("the key table is hard-capped: oldest keys are evicted instead of scanning/growing under a fresh-key flood", () => {
+    const allow = createGiphyRateLimiter(1, 60_000, 2);
+    expect(allow("k1", 0)).toBe(true);
+    expect(allow("k1", 1)).toBe(false);
+    // Two more unique keys within the same window evict k1 (cap = 2).
+    expect(allow("k2", 2)).toBe(true);
+    expect(allow("k3", 3)).toBe(true);
+    // k1 was evicted, so it gets a fresh budget — bounded memory is
+    // the guarantee; per-key strictness degrades gracefully at cap.
+    expect(allow("k1", 4)).toBe(true);
+    // k3 is still tracked (not evicted by k1's re-insert beyond cap...
+    // k1's re-insert evicts the now-oldest k2).
+    expect(allow("k3", 5)).toBe(false);
+  });
+
+  test("rate keys collapse IPv6 to the /64 prefix so one routed /64 cannot mint unlimited budgets", () => {
+    expect(clientRateKey("2001:db8:1:2:3:4:5:6")).toBe("2001:db8:1:2");
+    expect(clientRateKey("2001:db8:1:2:aaaa:bbbb:cccc:dddd")).toBe("2001:db8:1:2");
+    // Compressed forms expand before truncation.
+    expect(clientRateKey("2001:db8::5")).toBe("2001:db8:0:0");
+    expect(clientRateKey("::1")).toBe("0:0:0:0");
+    // IPv4 stays as-is.
+    expect(clientRateKey("203.0.113.9")).toBe("203.0.113.9");
+    expect(clientRateKey("unknown")).toBe("unknown");
+  });
+
+  test("the 429 advises a retry window", async () => {
+    const { fetchImpl } = stubFetch(() => Response.json(giphyUpstreamBody()));
+    const response = await handleGiphyProxyRequest(
+      KEY,
+      new URLSearchParams(),
+      fetchImpl,
+      () => false,
+    );
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("60");
   });
 });

--- a/chat/tests/global-error-telemetry.test.ts
+++ b/chat/tests/global-error-telemetry.test.ts
@@ -134,6 +134,48 @@ describe("installGlobalErrorTelemetry", () => {
       }
     }
   });
+
+  test("reinstalls listeners when the window instance changes (test window swaps, HMR re-init)", () => {
+    function makeWindowStub() {
+      const listeners = new Map<string, Array<(event: unknown) => void>>();
+      return {
+        listeners,
+        stub: {
+          addEventListener: (type: string, listener: (event: unknown) => void) => {
+            const bucket = listeners.get(type) ?? [];
+            bucket.push(listener);
+            listeners.set(type, bucket);
+          },
+        },
+      };
+    }
+    const first = makeWindowStub();
+    const second = makeWindowStub();
+    const originalWindow = globalThis.window;
+    try {
+      (globalThis as { window: unknown }).window = first.stub;
+      installGlobalErrorTelemetry();
+      expect(first.listeners.get("error")).toHaveLength(1);
+
+      // A different window object (fresh stub, HMR-recreated window)
+      // must get its own listeners — the guard is per-window, not a
+      // process-lifetime latch.
+      (globalThis as { window: unknown }).window = second.stub;
+      installGlobalErrorTelemetry();
+      expect(second.listeners.get("error")).toHaveLength(1);
+      expect(second.listeners.get("unhandledrejection")).toHaveLength(1);
+
+      // Same window again stays idempotent.
+      installGlobalErrorTelemetry();
+      expect(second.listeners.get("error")).toHaveLength(1);
+    } finally {
+      if (originalWindow === undefined) {
+        Reflect.deleteProperty(globalThis, "window");
+      } else {
+        (globalThis as { window: unknown }).window = originalWindow;
+      }
+    }
+  });
 });
 
 describe("vue app errorHandler", () => {

--- a/chat/tests/global-error-telemetry.test.ts
+++ b/chat/tests/global-error-telemetry.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { App } from "vue";
+import { createSSRApp } from "vue";
+import {
+  __setFaroForTesting,
+  handleUnhandledRejectionEvent,
+  handleWindowErrorEvent,
+  installGlobalErrorTelemetry,
+} from "../src/lib/telemetry";
+import configureVueApp from "../src/vue-app";
+
+function createFaroStub() {
+  const errors: Array<{
+    error: Error;
+    options?: { type?: string; context?: Record<string, string> };
+  }> = [];
+  return {
+    errors,
+    api: {
+      pushEvent: () => {},
+      pushMeasurement: () => {},
+      pushError: (
+        error: Error,
+        options?: { type?: string; context?: Record<string, string> },
+      ) => {
+        errors.push({ error, options });
+      },
+    },
+  };
+}
+
+type FaroStub = ReturnType<typeof createFaroStub>;
+
+let stub: FaroStub;
+
+beforeEach(() => {
+  __setFaroForTesting(null);
+  stub = createFaroStub();
+  __setFaroForTesting(stub as unknown as Parameters<typeof __setFaroForTesting>[0]);
+});
+
+afterEach(() => {
+  __setFaroForTesting(null);
+});
+
+describe("handleWindowErrorEvent", () => {
+  test("pushes a sanitized window-error to Faro", () => {
+    handleWindowErrorEvent({
+      error: new Error("stream broke for alice@example.com/desktop"),
+    });
+
+    expect(stub.errors).toHaveLength(1);
+    const pushed = stub.errors[0]!;
+    expect(pushed.options?.type).toBe("window-error");
+    expect(pushed.error.message).toBe("stream broke for :jid");
+    expect(pushed.error.message).not.toContain("alice@example.com");
+  });
+
+  test("falls back to the event message when no Error object is attached", () => {
+    handleWindowErrorEvent({ message: "Script error for bob@example.com" });
+
+    expect(stub.errors).toHaveLength(1);
+    expect(stub.errors[0]!.error.message).toBe("Script error for :jid");
+  });
+
+  test("dedupes an identical error flood into a single push", () => {
+    const boom = new Error("same boom");
+    handleWindowErrorEvent({ error: boom });
+    handleWindowErrorEvent({ error: boom });
+    handleWindowErrorEvent({ error: boom });
+
+    expect(stub.errors).toHaveLength(1);
+  });
+
+  test("distinct errors are each reported", () => {
+    handleWindowErrorEvent({ error: new Error("first boom") });
+    handleWindowErrorEvent({ error: new Error("second boom") });
+
+    expect(stub.errors).toHaveLength(2);
+  });
+});
+
+describe("handleUnhandledRejectionEvent", () => {
+  test("pushes a sanitized unhandled-rejection to Faro", () => {
+    handleUnhandledRejectionEvent({
+      reason: new Error("fetch failed: https://x.example/ws?session_id=abc123&api_key=topsecret"),
+    });
+
+    expect(stub.errors).toHaveLength(1);
+    const pushed = stub.errors[0]!;
+    expect(pushed.options?.type).toBe("unhandled-rejection");
+    expect(pushed.error.message).not.toContain("topsecret");
+    expect(pushed.error.message).not.toContain("abc123");
+  });
+
+  test("stringifies non-Error rejection reasons", () => {
+    handleUnhandledRejectionEvent({ reason: "plain string reason" });
+
+    expect(stub.errors).toHaveLength(1);
+    expect(stub.errors[0]!.error.message).toBe("plain string reason");
+  });
+});
+
+describe("installGlobalErrorTelemetry", () => {
+  test("registers window error and unhandledrejection listeners exactly once", () => {
+    const listeners = new Map<string, Array<(event: unknown) => void>>();
+    const windowStub = {
+      addEventListener: (type: string, listener: (event: unknown) => void) => {
+        const bucket = listeners.get(type) ?? [];
+        bucket.push(listener);
+        listeners.set(type, bucket);
+      },
+    };
+    const originalWindow = globalThis.window;
+    (globalThis as { window: unknown }).window = windowStub;
+    try {
+      installGlobalErrorTelemetry();
+      installGlobalErrorTelemetry();
+
+      expect(listeners.get("error")).toHaveLength(1);
+      expect(listeners.get("unhandledrejection")).toHaveLength(1);
+
+      listeners.get("error")![0]!({ error: new Error("listener boom for carol@example.com") });
+      listeners.get("unhandledrejection")![0]!({ reason: new Error("rejection boom") });
+
+      expect(stub.errors).toHaveLength(2);
+      expect(stub.errors[0]!.error.message).toBe("listener boom for :jid");
+      expect(stub.errors[1]!.options?.type).toBe("unhandled-rejection");
+    } finally {
+      if (originalWindow === undefined) {
+        Reflect.deleteProperty(globalThis, "window");
+      } else {
+        (globalThis as { window: unknown }).window = originalWindow;
+      }
+    }
+  });
+});
+
+describe("vue app errorHandler", () => {
+  function appWithHandler(): App {
+    const app = createSSRApp({ render: () => null });
+    configureVueApp(app);
+    return app;
+  }
+
+  test("funnels render errors through sanitized reportError", () => {
+    const app = appWithHandler();
+    expect(app.config.errorHandler).toBeInstanceOf(Function);
+
+    app.config.errorHandler!(
+      new Error("render exploded for dave@example.com/phone"),
+      null,
+      "render function",
+    );
+
+    expect(stub.errors).toHaveLength(1);
+    const pushed = stub.errors[0]!;
+    expect(pushed.options?.type).toBe("vue-render-error");
+    expect(pushed.error.message).toBe("render exploded for :jid");
+    expect(pushed.options?.context?.detail).toBe("render function");
+  });
+
+  test("includes the component name when the instance exposes one", () => {
+    const app = appWithHandler();
+    const instance = { $options: { name: "GifPicker" } };
+
+    app.config.errorHandler!(
+      new Error("boom"),
+      instance as never,
+      "render function",
+    );
+
+    expect(stub.errors).toHaveLength(1);
+    expect(stub.errors[0]!.options?.context?.component).toBe("GifPicker");
+  });
+});

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -3803,6 +3803,21 @@ async fn run_kick(
         }
     };
 
+    // The kick is durably applied in the room actor at this point:
+    // broadcast the 307 presences and run the SFU eviction BEFORE the
+    // fallible affiliation-revocation ask below, so an actor-
+    // infrastructure failure there can't strand an applied kick with
+    // no occupant notification and a live call session (#935 review).
+    for (recipient, presence) in applied.presence_updates {
+        let _ = connections
+            .send_to(&recipient, Stanza::Presence(presence))
+            .await;
+    }
+    // Membership-scoped visibility (#935): a kick (307) ends the
+    // occupant's room membership, so their live SFU call
+    // participation ends with it.
+    evict_moderation_removals(sfu, &args.channel_jid, &applied.removed_by_moderation);
+
     if revoke_members_only_member {
         sync_private_kick_affiliation_revocation(
             state,
@@ -3815,16 +3830,6 @@ async fn run_kick(
         )
         .await?;
     }
-
-    for (recipient, presence) in applied.presence_updates {
-        let _ = connections
-            .send_to(&recipient, Stanza::Presence(presence))
-            .await;
-    }
-    // Membership-scoped visibility (#935): a kick (307) ends the
-    // occupant's room membership, so their live SFU call
-    // participation ends with it.
-    evict_moderation_removals(sfu, &args.channel_jid, &applied.removed_by_moderation);
 
     Ok(ChannelsKickResult {
         occupant_jid: args.occupant_jid.clone(),

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -347,6 +347,7 @@ pub async fn register(
     app_state: Arc<AppState>,
     connection_registry: Arc<ConnectionRegistry>,
     sm_session_registry: Arc<InMemorySmSessionRegistry>,
+    sfu: Option<Arc<dyn waddle_sfu::SfuService>>,
 ) {
     {
         let state = Arc::clone(&app_state);
@@ -407,6 +408,7 @@ pub async fn register(
     {
         let state = Arc::clone(&app_state);
         let connections = Arc::clone(&connection_registry);
+        let sfu = sfu.clone();
         registry
             .register(
                 NODE_SET_AFFILIATION,
@@ -414,7 +416,8 @@ pub async fn register(
                 move |ctx| {
                     let state = Arc::clone(&state);
                     let connections = Arc::clone(&connections);
-                    async move { handle_set_affiliation(ctx, state, connections).await }
+                    let sfu = sfu.clone();
+                    async move { handle_set_affiliation(ctx, state, connections, sfu).await }
                 },
             )
             .await;
@@ -422,11 +425,13 @@ pub async fn register(
     {
         let state = Arc::clone(&app_state);
         let connections = Arc::clone(&connection_registry);
+        let sfu = sfu.clone();
         registry
             .register(NODE_KICK, "Admin · Kick occupant", move |ctx| {
                 let state = Arc::clone(&state);
                 let connections = Arc::clone(&connections);
-                async move { handle_kick(ctx, state, connections).await }
+                let sfu = sfu.clone();
+                async move { handle_kick(ctx, state, connections, sfu).await }
             })
             .await;
     }
@@ -681,6 +686,7 @@ async fn handle_set_affiliation(
     ctx: CommandContext,
     state: Arc<AppState>,
     connections: Arc<ConnectionRegistry>,
+    sfu: Option<Arc<dyn waddle_sfu::SfuService>>,
 ) -> CommandResult {
     let caller_bare = match caller_or_forbidden(&ctx, &state).await {
         Ok(caller) => caller,
@@ -690,7 +696,7 @@ async fn handle_set_affiliation(
         Ok(args) => args,
         Err(error) => return *bad_request(error),
     };
-    match run_set_affiliation(&state, &connections, &caller_bare, &args).await {
+    match run_set_affiliation(&state, &connections, &caller_bare, &args, sfu.as_ref()).await {
         Ok(result) => CommandResult::Completed {
             form: Some(build_set_affiliation_form(&result)),
             notes: vec![],
@@ -703,6 +709,7 @@ async fn handle_kick(
     ctx: CommandContext,
     state: Arc<AppState>,
     connections: Arc<ConnectionRegistry>,
+    sfu: Option<Arc<dyn waddle_sfu::SfuService>>,
 ) -> CommandResult {
     let caller_bare = match caller_or_forbidden(&ctx, &state).await {
         Ok(bare) => bare,
@@ -730,7 +737,7 @@ async fn handle_kick(
         Ok(args) => args,
         Err(error) => return *bad_request(error),
     };
-    match run_kick(&state, &connections, &caller_full, &args).await {
+    match run_kick(&state, &connections, &caller_full, &args, sfu.as_ref()).await {
         Ok(result) => CommandResult::Completed {
             form: Some(build_kick_form(&result)),
             notes: vec![],
@@ -3501,6 +3508,7 @@ async fn run_set_affiliation(
     connections: &ConnectionRegistry,
     caller_bare: &BareJid,
     args: &ChannelsSetAffiliationArgs,
+    sfu: Option<&Arc<dyn waddle_sfu::SfuService>>,
 ) -> Result<ChannelsSetAffiliationResult, AdminErr> {
     let channel_id = waddle_xmpp::parse_managed_room_jid(&args.channel_jid)
         .ok_or_else(|| bad_request("channel_jid must be a managed MUC room JID"))?;
@@ -3553,7 +3561,7 @@ async fn run_set_affiliation(
         next_affiliation,
     )
     .await?;
-    let updates = match actor
+    let applied = match actor
         .ask(ApplyAffiliationChange {
             actor: Some(caller_bare.clone()),
             jid: args.member_jid.clone(),
@@ -3561,7 +3569,7 @@ async fn run_set_affiliation(
         })
         .await
     {
-        Ok(updates) => updates,
+        Ok(applied) => applied,
         Err(kameo::error::SendError::HandlerError(
             waddle_xmpp::muc::room_actor::AdminApplyError::CannotRemoveLastOwner,
         )) => {
@@ -3587,7 +3595,12 @@ async fn run_set_affiliation(
             return Err(send_err("room actor ApplyAffiliationChange")(error));
         }
     };
-    broadcast_presence_updates(connections, updates).await;
+    broadcast_presence_updates(connections, applied.presence_updates).await;
+    // Membership-scoped visibility (#935): an admin-V2 ban (Outcast)
+    // ends the occupant's room membership, so their live SFU call
+    // participation ends with it. Fire-and-forget inside the SFU
+    // layer; the moderation result is never blocked on LiveKit.
+    evict_moderation_removals(sfu, &args.channel_jid, &applied.removed_by_moderation);
     Ok(ChannelsSetAffiliationResult {
         member_jid: args.member_jid.clone(),
         affiliation: args.affiliation,
@@ -3611,8 +3624,8 @@ async fn sync_private_kick_affiliation_revocation(
         })
         .await
     {
-        Ok(affiliation_updates) => {
-            broadcast_presence_updates(connections, affiliation_updates).await;
+        Ok(applied) => {
+            broadcast_presence_updates(connections, applied.presence_updates).await;
             Ok(())
         }
         Err(error) => {
@@ -3633,6 +3646,7 @@ async fn run_kick(
     connections: &ConnectionRegistry,
     caller_full: &FullJid,
     args: &ChannelsKickArgs,
+    sfu: Option<&Arc<dyn waddle_sfu::SfuService>>,
 ) -> Result<ChannelsKickResult, AdminErr> {
     // XEP-0045 §9.1.1 — kicking an occupant is a role-change to "none";
     // the service MUST send `<presence type='unavailable'>` carrying
@@ -3725,7 +3739,7 @@ async fn run_kick(
         role: Some(Role::None),
         reason: args.reason.clone(),
     }];
-    let updates = match actor
+    let applied = match actor
         .ask(ApplyAdminItems {
             sender_jid: caller_full.clone(),
             // Community-owner admin V2 callers are not necessarily
@@ -3741,7 +3755,7 @@ async fn run_kick(
         })
         .await
     {
-        Ok(updates) => updates,
+        Ok(applied) => applied,
         Err(kameo::error::SendError::HandlerError(
             waddle_xmpp::muc::room_actor::AdminApplyError::OccupantNotFound(_),
         )) if revoke_members_only_member => {
@@ -3802,15 +3816,36 @@ async fn run_kick(
         .await?;
     }
 
-    for (recipient, presence) in updates {
+    for (recipient, presence) in applied.presence_updates {
         let _ = connections
             .send_to(&recipient, Stanza::Presence(presence))
             .await;
     }
+    // Membership-scoped visibility (#935): a kick (307) ends the
+    // occupant's room membership, so their live SFU call
+    // participation ends with it.
+    evict_moderation_removals(sfu, &args.channel_jid, &applied.removed_by_moderation);
 
     Ok(ChannelsKickResult {
         occupant_jid: args.occupant_jid.clone(),
     })
+}
+
+/// Evict every session involuntarily removed by moderation (kick 307
+/// / ban 301) from the room's SFU call, when an SFU is configured.
+fn evict_moderation_removals(
+    sfu: Option<&Arc<dyn waddle_sfu::SfuService>>,
+    room_jid: &BareJid,
+    removed: &[FullJid],
+) {
+    let Some(sfu) = sfu else {
+        return;
+    };
+    for jid in removed {
+        crate::server::routes::websocket::muc_call_sfu::unregister_participant_via_sfu(
+            sfu, room_jid, jid,
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -4160,5 +4195,146 @@ mod tests {
     fn mint_channel_localpart_fallback() {
         assert!(mint_channel_localpart("???").starts_with("channel-"));
         assert!(mint_channel_localpart("Hello World").starts_with("hello-world-"));
+    }
+}
+
+#[cfg(test)]
+mod sfu_eviction_tests {
+    use super::*;
+    use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
+    use crate::server::routes::websocket::tests::RecordingSfu;
+    use crate::server::AppState;
+    use waddle_xmpp::muc::room_actor::JoinWithAffiliation;
+    use waddle_xmpp::muc::RoomConfig;
+
+    async fn fresh_state() -> AppState {
+        let db_pool = DatabasePool::new(DatabaseConfig::default(), PoolConfig)
+            .await
+            .expect("db pool");
+        MigrationRunner::global()
+            .run(db_pool.global())
+            .await
+            .expect("migrations");
+        AppState::new(Arc::new(db_pool))
+    }
+
+    async fn room_with_bob(state: &AppState, room_jid: &BareJid) -> FullJid {
+        let actor = state
+            .room_registry
+            .ask(GetOrCreateRoom {
+                room_jid: room_jid.clone(),
+                waddle_id: "test-waddle".to_string(),
+                channel_id: room_jid.node().expect("localpart").to_string(),
+                config: RoomConfig {
+                    members_only: false,
+                    ..RoomConfig::default()
+                },
+            })
+            .await
+            .expect("room actor");
+        let bob: FullJid = "bob@localhost/web".parse().expect("bob jid");
+        actor
+            .ask(JoinWithAffiliation {
+                sender_jid: bob.clone(),
+                nick: "bob".to_string(),
+                effective_affiliation: Affiliation::Member,
+                local_domain: "localhost".to_string(),
+                admission_revision: 0,
+            })
+            .await
+            .expect("bob joins");
+        bob
+    }
+
+    #[tokio::test]
+    async fn admin_v2_kick_evicts_target_sessions_from_room_call() {
+        let state = fresh_state().await;
+        let connections = ConnectionRegistry::new();
+        let room_jid: BareJid = "kick-evict-chan@muc.localhost".parse().expect("room jid");
+        let bob = room_with_bob(&state, &room_jid).await;
+
+        let recorder = Arc::new(RecordingSfu::default());
+        let sfu: Arc<dyn waddle_sfu::SfuService> = recorder.clone();
+        let caller: FullJid = "owner@localhost/admin".parse().expect("caller jid");
+        run_kick(
+            &state,
+            &connections,
+            &caller,
+            &ChannelsKickArgs {
+                channel_jid: room_jid.clone(),
+                occupant_jid: bob.to_bare(),
+                reason: None,
+            },
+            Some(&sfu),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("kick succeeds"));
+
+        let evicted = recorder.snapshot();
+        assert_eq!(evicted.len(), 1, "kicked session evicted: {evicted:?}");
+        assert_eq!(evicted[0].0.as_str(), "kick-evict-chan@muc.localhost");
+        assert_eq!(evicted[0].1.as_livekit_identity(), "bob@localhost/web");
+    }
+
+    #[tokio::test]
+    async fn admin_v2_ban_evicts_target_sessions_from_room_call() {
+        let state = fresh_state().await;
+        let connections = ConnectionRegistry::new();
+        let room_jid: BareJid = "ban-evict-chan@muc.localhost".parse().expect("room jid");
+        let bob = room_with_bob(&state, &room_jid).await;
+
+        let recorder = Arc::new(RecordingSfu::default());
+        let sfu: Arc<dyn waddle_sfu::SfuService> = recorder.clone();
+        let caller: BareJid = "owner@localhost".parse().expect("caller jid");
+        run_set_affiliation(
+            &state,
+            &connections,
+            &caller,
+            &ChannelsSetAffiliationArgs {
+                channel_jid: room_jid.clone(),
+                member_jid: bob.to_bare(),
+                affiliation: WireAffiliation::Outcast,
+                reason: None,
+            },
+            Some(&sfu),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("ban succeeds"));
+
+        let evicted = recorder.snapshot();
+        assert_eq!(evicted.len(), 1, "banned session evicted: {evicted:?}");
+        assert_eq!(evicted[0].0.as_str(), "ban-evict-chan@muc.localhost");
+        assert_eq!(evicted[0].1.as_livekit_identity(), "bob@localhost/web");
+    }
+
+    #[tokio::test]
+    async fn admin_v2_member_promotion_does_not_evict() {
+        let state = fresh_state().await;
+        let connections = ConnectionRegistry::new();
+        let room_jid: BareJid = "promote-chan@muc.localhost".parse().expect("room jid");
+        let bob = room_with_bob(&state, &room_jid).await;
+
+        let recorder = Arc::new(RecordingSfu::default());
+        let sfu: Arc<dyn waddle_sfu::SfuService> = recorder.clone();
+        let caller: BareJid = "owner@localhost".parse().expect("caller jid");
+        run_set_affiliation(
+            &state,
+            &connections,
+            &caller,
+            &ChannelsSetAffiliationArgs {
+                channel_jid: room_jid.clone(),
+                member_jid: bob.to_bare(),
+                affiliation: WireAffiliation::Admin,
+                reason: None,
+            },
+            Some(&sfu),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("promotion succeeds"));
+
+        assert!(
+            recorder.snapshot().is_empty(),
+            "an affiliation change that keeps the occupant must not evict"
+        );
     }
 }

--- a/server/crates/waddle-server/src/pubsub/node.rs
+++ b/server/crates/waddle-server/src/pubsub/node.rs
@@ -1,4 +1,5 @@
 use jid::BareJid;
+use tracing::error;
 use waddle_xmpp::pubsub::{AccessModel, NodeConfig, PubSubNode};
 use waddle_xmpp::XmppError;
 
@@ -344,12 +345,40 @@ impl DatabasePubSubStorage {
         let created_at = chrono::DateTime::from_timestamp_millis(created_at_ms)
             .ok_or_else(|| XmppError::internal("invalid PubSub created_at_ms".to_string()))?;
 
+        let access_model = access_model_raw.parse().map_err(|()| {
+            error!(
+                node = %node_name,
+                owner = %owner,
+                raw = %access_model_raw,
+                "unknown persisted PubSub access_model; failing node load closed"
+            );
+            XmppError::internal("invalid PubSub access_model".to_string())
+        })?;
+        let publish_model = publish_model_raw.parse().map_err(|()| {
+            error!(
+                node = %node_name,
+                owner = %owner,
+                raw = %publish_model_raw,
+                "unknown persisted PubSub publish_model; failing node load closed"
+            );
+            XmppError::internal("invalid PubSub publish_model".to_string())
+        })?;
+        let send_last_published_item = send_last_raw.parse().map_err(|()| {
+            error!(
+                node = %node_name,
+                owner = %owner,
+                raw = %send_last_raw,
+                "unknown persisted PubSub send_last_published_item; failing node load closed"
+            );
+            XmppError::internal("invalid PubSub send_last_published_item".to_string())
+        })?;
+
         Ok(PubSubNode {
             node_name,
             owner,
             config: NodeConfig {
-                access_model: access_model_raw.parse().unwrap_or_default(),
-                publish_model: publish_model_raw.parse().unwrap_or_default(),
+                access_model,
+                publish_model,
                 node_type,
                 max_items: u32::try_from(max_items)
                     .map_err(|error| XmppError::internal(error.to_string()))?,
@@ -357,7 +386,7 @@ impl DatabasePubSubStorage {
                 deliver_payloads,
                 notify_retract,
                 notify_delete,
-                send_last_published_item: send_last_raw.parse().unwrap_or_default(),
+                send_last_published_item,
             },
             created_at,
         })

--- a/server/crates/waddle-server/src/pubsub/tests.rs
+++ b/server/crates/waddle-server/src/pubsub/tests.rs
@@ -499,6 +499,100 @@ async fn legacy_presence_row_on_pinned_private_node_is_backfilled_to_whitelist_o
 }
 
 #[tokio::test]
+async fn unknown_stored_access_model_fails_node_load_closed() {
+    // Issue #1158: an unrecognized persisted access_model must fail the
+    // node load, not silently default to Presence (fail-open).
+    let storage = DatabasePubSubStorage::open(Some("sqlite::memory:"))
+        .await
+        .expect("storage");
+    let owner = jid("alice@example.com");
+    let node_name = "urn:test:fail-closed-access";
+    storage
+        .get_or_create_node(&owner, node_name)
+        .await
+        .expect("node");
+
+    let db = storage.database();
+    let conn = db.guard().await.expect("guard");
+    conn.execute(
+        "UPDATE pubsub_nodes SET access_model = 'bogus' WHERE owner_jid = ? AND node_name = ?",
+        crate::db_params![owner.to_string(), node_name],
+    )
+    .await
+    .expect("write bogus access_model");
+    drop(conn);
+
+    let result = storage.get_node(&owner, node_name).await;
+    assert!(
+        result.is_err(),
+        "unknown stored access_model must fail node load, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn unknown_stored_publish_model_fails_node_load_closed() {
+    // Issue #1158: an unrecognized persisted publish_model must fail the
+    // node load, not silently default to Open (fail-open).
+    let storage = DatabasePubSubStorage::open(Some("sqlite::memory:"))
+        .await
+        .expect("storage");
+    let owner = jid("alice@example.com");
+    let node_name = "urn:test:fail-closed-publish";
+    storage
+        .get_or_create_node(&owner, node_name)
+        .await
+        .expect("node");
+
+    let db = storage.database();
+    let conn = db.guard().await.expect("guard");
+    conn.execute(
+        "UPDATE pubsub_nodes SET publish_model = 'bogus' WHERE owner_jid = ? AND node_name = ?",
+        crate::db_params![owner.to_string(), node_name],
+    )
+    .await
+    .expect("write bogus publish_model");
+    drop(conn);
+
+    let result = storage.get_node(&owner, node_name).await;
+    assert!(
+        result.is_err(),
+        "unknown stored publish_model must fail node load, got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn unknown_stored_send_last_published_item_fails_node_load_closed() {
+    // Issue #1158: an unrecognized persisted send_last_published_item must
+    // fail the node load, not silently default to OnSubAndPresence.
+    let storage = DatabasePubSubStorage::open(Some("sqlite::memory:"))
+        .await
+        .expect("storage");
+    let owner = jid("alice@example.com");
+    let node_name = "urn:test:fail-closed-send-last";
+    storage
+        .get_or_create_node(&owner, node_name)
+        .await
+        .expect("node");
+
+    let db = storage.database();
+    let conn = db.guard().await.expect("guard");
+    conn.execute(
+        "UPDATE pubsub_nodes SET send_last_published_item = 'bogus' \
+         WHERE owner_jid = ? AND node_name = ?",
+        crate::db_params![owner.to_string(), node_name],
+    )
+    .await
+    .expect("write bogus send_last_published_item");
+    drop(conn);
+
+    let result = storage.get_node(&owner, node_name).await;
+    assert!(
+        result.is_err(),
+        "unknown stored send_last_published_item must fail node load, got {result:?}"
+    );
+}
+
+#[tokio::test]
 async fn xep0402_bookmark_node_config_forces_private_durable_fields() {
     let storage = DatabasePubSubStorage::open(Some("sqlite::memory:"))
         .await

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -486,6 +486,7 @@ async fn create_websocket_state(
         Arc::clone(&state),
         Arc::clone(&connection_registry),
         Arc::clone(&sm_session_registry),
+        sfu_service.clone(),
     )
     .await;
     if let Err(error) = bootstrap_fresh_xmpp_topology(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_admin.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_admin.rs
@@ -393,7 +393,7 @@ pub(super) async fn handle_muc_admin_iq(
             }
         }
     }
-    let updates = match room_actor
+    let applied = match room_actor
         .ask(ApplyAdminItems {
             sender_jid: sender_jid.clone(),
             sender_affiliation: context.affiliation,
@@ -402,7 +402,7 @@ pub(super) async fn handle_muc_admin_iq(
         })
         .await
     {
-        Ok(updates) => updates,
+        Ok(applied) => applied,
         Err(kameo::error::SendError::HandlerError(
             waddle_xmpp::muc::room_actor::AdminApplyError::CannotRemoveLastOwner,
         )) => {
@@ -550,13 +550,24 @@ pub(super) async fn handle_muc_admin_iq(
             )];
         }
     };
-    for (recipient, presence) in updates {
+    for (recipient, presence) in applied.presence_updates {
         let _ = state
             .deps
             .protocol
             .connection_registry
             .send_to(&recipient, Stanza::Presence(presence))
             .await;
+    }
+    // Membership-scoped visibility (#935): a kick (307) or ban (301)
+    // ends the occupant's room membership, so their live SFU call
+    // participation must end with it. Presence loss never reaches
+    // this handler, and eviction failure is fire-and-forget inside
+    // the SFU layer — the moderation IQ result below is never
+    // blocked on LiveKit.
+    for removed in &applied.removed_by_moderation {
+        super::super::super::muc_call_sfu::unregister_participant_from_room(
+            state, &room_jid, removed,
+        );
     }
     vec![iq_to_xml(build_admin_set_result(
         iq.id(),

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -75,7 +75,7 @@ mod frame_backstop;
 pub(crate) mod interpret_loop;
 pub(crate) mod link_preview_refs;
 pub(crate) mod link_preview_telemetry;
-mod muc_call_sfu;
+pub(crate) mod muc_call_sfu;
 mod outbound;
 mod parse_errors;
 mod registration;

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -41,6 +41,17 @@ pub(crate) fn unregister_participant_from_room(
     let Some(sfu) = state.deps.protocol.sfu.as_ref() else {
         return;
     };
+    unregister_participant_via_sfu(sfu, room_jid, jid);
+}
+
+/// SFU-handle variant of [`unregister_participant_from_room`] for
+/// callers that don't hold a `WebSocketState` (the admin V2 command
+/// handlers receive the SFU as an explicit dependency).
+pub(crate) fn unregister_participant_via_sfu(
+    sfu: &std::sync::Arc<dyn waddle_sfu::SfuService>,
+    room_jid: &BareJid,
+    jid: &FullJid,
+) {
     let Ok(call_id) = CallId::new(room_jid.to_string()) else {
         // Room JID couldn't round-trip into a CallId, which means it
         // could never have been used to mint a join token either —
@@ -77,96 +88,10 @@ pub(crate) fn note_participant_left_from_webhook(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::server::routes::websocket::tests::create_test_websocket_state;
-    use std::sync::{Arc, Mutex};
-    use waddle_sfu::{
-        CallState, JoinToken, Jti, MediaCapabilities, SfuError, SfuService, TurnCredential,
-        TurnHost, WebsocketUrl,
+    use crate::server::routes::websocket::tests::{
+        create_test_websocket_state, create_test_websocket_state_with_sfu, RecordingSfu,
     };
-
-    /// Recording fake: captures `(call_id, identity)` separately for
-    /// each teardown dispatch — `unregister_call_participant` (the
-    /// admin-evict path) into `calls`, `note_participant_left` (the
-    /// webhook-bridge local-only path) into `note_calls`. Splitting
-    /// the vecs lets tests assert which trait method was actually
-    /// invoked, mirroring how `waddle-sfu`'s `RecordingAdmin` splits
-    /// `remove_calls` from `delete_calls`. The other trait methods
-    /// are unimplemented because the production code path under
-    /// test only touches the two dispatch surfaces.
-    #[derive(Default)]
-    struct RecordingSfu {
-        calls: Mutex<Vec<(CallId, Identity)>>,
-        note_calls: Mutex<Vec<(CallId, Identity)>>,
-    }
-
-    impl RecordingSfu {
-        fn snapshot(&self) -> Vec<(CallId, Identity)> {
-            self.calls.lock().expect("recording lock").clone()
-        }
-    }
-
-    impl SfuService for RecordingSfu {
-        fn issue_join_token(
-            &self,
-            _: &CallId,
-            _: &Identity,
-            _: MediaCapabilities,
-        ) -> Result<JoinToken, SfuError> {
-            unimplemented!("not exercised by these tests")
-        }
-
-        fn issue_turn_credentials(&self, _: &Identity) -> Result<TurnCredential, SfuError> {
-            unimplemented!("not exercised by these tests")
-        }
-
-        fn register_call_participant(&self, _: &CallId, _: &Identity) {}
-
-        fn has_call_participant(&self, _: &CallId, _: &Identity) -> bool {
-            false
-        }
-
-        fn unregister_call_participant(&self, call_id: &CallId, identity: &Identity) -> CallState {
-            self.calls
-                .lock()
-                .expect("recording lock")
-                .push((call_id.clone(), identity.clone()));
-            CallState::Ended
-        }
-
-        fn note_participant_left(&self, call_id: &CallId, identity: &Identity) {
-            // Recorded into `note_calls`, NOT `calls`: the two trait
-            // methods imply different downstream effects (admin
-            // RemoveParticipant vs. local-only bookkeeping) and the
-            // tests need to distinguish them. Keeping the dispatch
-            // record separated mirrors how `waddle-sfu`'s
-            // `RecordingAdmin` separates `remove_calls` from
-            // `delete_calls` for the same reason.
-            self.note_calls
-                .lock()
-                .expect("recording lock")
-                .push((call_id.clone(), identity.clone()));
-        }
-
-        fn is_revoked(&self, _: &Jti) -> bool {
-            false
-        }
-
-        fn ws_url(&self) -> &WebsocketUrl {
-            unimplemented!("not exercised by these tests")
-        }
-
-        fn turn_host(&self) -> &TurnHost {
-            unimplemented!("not exercised by these tests")
-        }
-
-        fn webhook_secret(&self) -> &waddle_sfu::ApiSecret {
-            unimplemented!("not exercised by these tests")
-        }
-
-        fn participants_for_call(&self, _: &CallId) -> Vec<Identity> {
-            Vec::new()
-        }
-    }
+    use std::sync::Arc;
 
     #[tokio::test]
     async fn unregister_is_no_op_when_no_sfu_is_configured() {
@@ -181,75 +106,10 @@ mod tests {
         unregister_participant_from_room(&state, &room, &alice);
     }
 
-    /// Build a test state with a pluggable `SfuService`. The canonical
-    /// fixture (`create_test_websocket_state`) sets `sfu: None` so
-    /// non-call tests don't exercise SFU code paths; this helper
-    /// rebuilds the protocol services with the SFU slot filled.
-    async fn state_with_sfu(sfu: Arc<RecordingSfu>) -> Arc<WebSocketState> {
-        let base = create_test_websocket_state().await;
-        // `Arc::clone` + restamp the field by constructing a new
-        // WebSocketState wrapping the same deps. The `ProtocolServices`
-        // is owned by an `Arc<WebSocketState>`, so we have to clone
-        // each field — they're all `Arc`-shareable except the
-        // SFU slot we want to fill.
-        let deps = &base.deps;
-        Arc::new(WebSocketState {
-            deps: super::super::state::WebSocketDeps {
-                app_state: Arc::clone(&deps.app_state),
-                auth_state: Arc::clone(&deps.auth_state),
-                service_domains: deps.service_domains.clone(),
-                protocol: super::super::state::ProtocolServices {
-                    connection_registry: Arc::clone(&deps.protocol.connection_registry),
-                    user_registry: deps.protocol.user_registry.clone(),
-                    room_registry: deps.protocol.room_registry.clone(),
-                    mam_storage: Arc::clone(&deps.protocol.mam_storage),
-                    inbox_storage: Arc::clone(&deps.protocol.inbox_storage),
-                    threads_storage: Arc::clone(&deps.protocol.threads_storage),
-                    blocking_storage: Arc::clone(&deps.protocol.blocking_storage),
-                    pending_delivery_storage: Arc::clone(&deps.protocol.pending_delivery_storage),
-                    command_registry: Arc::clone(&deps.protocol.command_registry),
-                    extension_manager: Arc::clone(&deps.protocol.extension_manager),
-                    dispatcher: Arc::clone(&deps.protocol.dispatcher),
-                    pubsub_storage: Arc::clone(&deps.protocol.pubsub_storage),
-                    push_store: Arc::clone(&deps.protocol.push_store),
-                    push_service: Arc::clone(&deps.protocol.push_service),
-                    notification_outbox: Arc::clone(&deps.protocol.notification_outbox),
-                    notification_settings_projection: Arc::clone(
-                        &deps.protocol.notification_settings_projection,
-                    ),
-                    dnd_projection: Arc::clone(&deps.protocol.dnd_projection),
-                    dnd_reader: Arc::clone(&deps.protocol.dnd_reader),
-                    notification_activity: Arc::clone(&deps.protocol.notification_activity),
-                    isr_token_store: Arc::clone(&deps.protocol.isr_token_store),
-                    sm_session_registry: Arc::clone(&deps.protocol.sm_session_registry),
-                    resumable_sessions: Arc::clone(&deps.protocol.resumable_sessions),
-                    caps_resolver: Arc::clone(&deps.protocol.caps_resolver),
-                    avatar_source_locks: Arc::clone(&deps.protocol.avatar_source_locks),
-                    profile_publish_tracker: deps.protocol.profile_publish_tracker.clone(),
-                    pep_feed_bridge: Arc::clone(&deps.protocol.pep_feed_bridge),
-                    call_threads: Arc::clone(&deps.protocol.call_threads),
-                    dm_call_threads: Arc::clone(&deps.protocol.dm_call_threads),
-                    dm_pin_store: Arc::clone(&deps.protocol.dm_pin_store),
-                    dm_call_thread_projections: Arc::clone(
-                        &deps.protocol.dm_call_thread_projections,
-                    ),
-                    pending_dm_call_offers: Arc::clone(&deps.protocol.pending_dm_call_offers),
-                    sfu: Some(sfu),
-                },
-                occupant_id_secret: deps.occupant_id_secret.clone(),
-                link_preview: deps.link_preview.clone(),
-                ws_keepalive: deps.ws_keepalive,
-                shutdown: deps.shutdown.clone(),
-                provider_ingress: Arc::clone(&deps.provider_ingress),
-                provider_dispatch_tasks: deps.provider_dispatch_tasks.clone(),
-            },
-        })
-    }
-
     #[tokio::test]
     async fn unregister_records_call_id_and_identity_on_the_sfu() {
         let recorder = Arc::new(RecordingSfu::default());
-        let state = state_with_sfu(Arc::clone(&recorder)).await;
+        let state = create_test_websocket_state_with_sfu(recorder.clone()).await;
         let room: BareJid = "room@muc.example.com".parse().unwrap();
         let alice: FullJid = "alice@example.com/web".parse().unwrap();
 
@@ -271,7 +131,7 @@ mod tests {
         // through the second call rather than short-circuiting,
         // since silently skipping would mask bugs in the SFU layer.
         let recorder = Arc::new(RecordingSfu::default());
-        let state = state_with_sfu(Arc::clone(&recorder)).await;
+        let state = create_test_websocket_state_with_sfu(recorder.clone()).await;
         let room: BareJid = "room@muc.example.com".parse().unwrap();
         let alice: FullJid = "alice@example.com/web".parse().unwrap();
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -94,6 +94,108 @@ pub(crate) async fn register_test_connection(
     );
 }
 
+/// Build a test [`WebSocketState`] with an arbitrary [`SfuService`]
+/// plugged into the protocol services — used with [`RecordingSfu`] to
+/// assert which SFU teardown surface a handler actually invoked.
+pub(crate) async fn create_test_websocket_state_with_sfu(
+    sfu: Arc<dyn waddle_sfu::SfuService>,
+) -> Arc<WebSocketState> {
+    create_test_websocket_state_with_extension_manager(empty_extension_manager().await, Some(sfu))
+        .await
+}
+
+/// Recording fake: captures `(call_id, identity)` separately for each
+/// teardown dispatch — `unregister_call_participant` (the admin-evict
+/// path) into `calls`, `note_participant_left` (the webhook-bridge
+/// local-only path) into `note_calls`. Splitting the vecs lets tests
+/// assert which trait method was actually invoked, mirroring how
+/// `waddle-sfu`'s `RecordingAdmin` splits `remove_calls` from
+/// `delete_calls`. The other trait methods are unimplemented because
+/// the production code paths under test only touch the teardown
+/// surfaces.
+#[derive(Default)]
+pub(crate) struct RecordingSfu {
+    calls: std::sync::Mutex<Vec<(waddle_sfu::CallId, waddle_sfu::Identity)>>,
+    note_calls: std::sync::Mutex<Vec<(waddle_sfu::CallId, waddle_sfu::Identity)>>,
+}
+
+impl RecordingSfu {
+    pub(crate) fn snapshot(&self) -> Vec<(waddle_sfu::CallId, waddle_sfu::Identity)> {
+        self.calls.lock().expect("recording lock").clone()
+    }
+
+    pub(crate) fn note_snapshot(&self) -> Vec<(waddle_sfu::CallId, waddle_sfu::Identity)> {
+        self.note_calls.lock().expect("recording lock").clone()
+    }
+}
+
+impl waddle_sfu::SfuService for RecordingSfu {
+    fn issue_join_token(
+        &self,
+        _: &waddle_sfu::CallId,
+        _: &waddle_sfu::Identity,
+        _: waddle_sfu::MediaCapabilities,
+    ) -> Result<waddle_sfu::JoinToken, waddle_sfu::SfuError> {
+        unimplemented!("not exercised by these tests")
+    }
+
+    fn issue_turn_credentials(
+        &self,
+        _: &waddle_sfu::Identity,
+    ) -> Result<waddle_sfu::TurnCredential, waddle_sfu::SfuError> {
+        unimplemented!("not exercised by these tests")
+    }
+
+    fn register_call_participant(&self, _: &waddle_sfu::CallId, _: &waddle_sfu::Identity) {}
+
+    fn has_call_participant(&self, _: &waddle_sfu::CallId, _: &waddle_sfu::Identity) -> bool {
+        false
+    }
+
+    fn unregister_call_participant(
+        &self,
+        call_id: &waddle_sfu::CallId,
+        identity: &waddle_sfu::Identity,
+    ) -> waddle_sfu::CallState {
+        self.calls
+            .lock()
+            .expect("recording lock")
+            .push((call_id.clone(), identity.clone()));
+        waddle_sfu::CallState::Ended
+    }
+
+    fn note_participant_left(&self, call_id: &waddle_sfu::CallId, identity: &waddle_sfu::Identity) {
+        // Recorded into `note_calls`, NOT `calls`: the two trait
+        // methods imply different downstream effects (admin
+        // RemoveParticipant vs. local-only bookkeeping) and tests
+        // need to distinguish them.
+        self.note_calls
+            .lock()
+            .expect("recording lock")
+            .push((call_id.clone(), identity.clone()));
+    }
+
+    fn is_revoked(&self, _: &waddle_sfu::Jti) -> bool {
+        false
+    }
+
+    fn ws_url(&self) -> &waddle_sfu::WebsocketUrl {
+        unimplemented!("not exercised by these tests")
+    }
+
+    fn turn_host(&self) -> &waddle_sfu::TurnHost {
+        unimplemented!("not exercised by these tests")
+    }
+
+    fn webhook_secret(&self) -> &waddle_sfu::ApiSecret {
+        unimplemented!("not exercised by these tests")
+    }
+
+    fn participants_for_call(&self, _: &waddle_sfu::CallId) -> Vec<waddle_sfu::Identity> {
+        Vec::new()
+    }
+}
+
 /// A self-contained [`waddle_sfu::LiveKitSfu`] for tests. Mints real
 /// JWTs locally (no network), so the XEP-0166 Jingle handler can
 /// rewrite the Waddle LiveKit transport exactly as it does in

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -2713,6 +2713,7 @@ async fn admin_channels_delete_retracts_duplicate_space_bookmarks() {
         std::sync::Arc::clone(&state.deps.app_state),
         std::sync::Arc::clone(&state.deps.protocol.connection_registry),
         std::sync::Arc::clone(&state.deps.protocol.sm_session_registry),
+        None,
     )
     .await;
 
@@ -2842,6 +2843,7 @@ async fn admin_channels_update_retracts_duplicate_space_bookmarks() {
         std::sync::Arc::clone(&state.deps.app_state),
         std::sync::Arc::clone(&state.deps.protocol.connection_registry),
         std::sync::Arc::clone(&state.deps.protocol.sm_session_registry),
+        None,
     )
     .await;
 
@@ -2991,6 +2993,7 @@ async fn admin_channels_create_space_bookmark_grants_space_members_channel_view(
         std::sync::Arc::clone(&state.deps.app_state),
         std::sync::Arc::clone(&state.deps.protocol.connection_registry),
         std::sync::Arc::clone(&state.deps.protocol.sm_session_registry),
+        None,
     )
     .await;
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -4219,3 +4219,177 @@ async fn handle_muc_leave_records_notification_activity_and_clears_show() {
         after_leave.presence_show,
     );
 }
+
+// --- Issue #935: involuntary MUC removal must evict SFU call participants ---
+
+fn build_admin_set_iq_xml(room_jid: &BareJid, id: &str, item: Element) -> String {
+    element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN)
+                    .append(item)
+                    .build(),
+            )
+            .build(),
+    )
+}
+
+async fn join_alice_owner_and_bob(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+) -> (Session, FullJid, FullJid) {
+    let alice_session = create_test_server_owner_session(state, "alice").await;
+    let bob_session = create_test_session(state, "bob").await;
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob_jid: FullJid = "bob@example.com/web".parse().expect("bob jid");
+    handle_muc_join(
+        state,
+        "example.com",
+        room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(alice_session.clone()),
+    )
+    .await;
+    let _ = handle_muc_join(
+        state,
+        "example.com",
+        room_jid,
+        &bob_jid,
+        "bob",
+        None,
+        &Some(bob_session),
+    )
+    .await;
+    (alice_session, alice_jid, bob_jid)
+}
+
+#[tokio::test]
+async fn muc_admin_kick_evicts_target_sessions_from_room_call() {
+    let recorder = Arc::new(crate::server::routes::websocket::tests::RecordingSfu::default());
+    let state = create_test_websocket_state_with_sfu(recorder.clone()).await;
+    let room_jid: BareJid = "kick-evicts@muc.example.com".parse().expect("room jid");
+    let (alice_session, alice_jid, _bob_jid) =
+        join_alice_owner_and_bob(state.as_ref(), &room_jid).await;
+    let ready = ready_phase(&alice_jid);
+
+    let kick_iq = build_admin_set_iq_xml(
+        &room_jid,
+        "kick-bob",
+        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+            .attr(minidom::rxml::xml_ncname!("nick").to_owned(), "bob")
+            .attr(minidom::rxml::xml_ncname!("role").to_owned(), "none")
+            .build(),
+    );
+    let responses = handle_iq(
+        &kick_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(alice_session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "kick response: {responses:?}");
+    assert!(responses[0].contains("type='result'"), "{responses:?}");
+
+    let evicted = recorder.snapshot();
+    assert_eq!(
+        evicted.len(),
+        1,
+        "exactly the kicked occupant's session is evicted: {evicted:?}"
+    );
+    assert_eq!(evicted[0].0.as_str(), "kick-evicts@muc.example.com");
+    assert_eq!(evicted[0].1.as_livekit_identity(), "bob@example.com/web");
+    assert!(
+        recorder.note_snapshot().is_empty(),
+        "moderation must use the full admin-evict path, not webhook bookkeeping"
+    );
+}
+
+#[tokio::test]
+async fn muc_admin_ban_evicts_target_sessions_from_room_call() {
+    let recorder = Arc::new(crate::server::routes::websocket::tests::RecordingSfu::default());
+    let state = create_test_websocket_state_with_sfu(recorder.clone()).await;
+    let room_jid: BareJid = "ban-evicts@muc.example.com".parse().expect("room jid");
+    let (alice_session, alice_jid, _bob_jid) =
+        join_alice_owner_and_bob(state.as_ref(), &room_jid).await;
+    let ready = ready_phase(&alice_jid);
+
+    let ban_iq = build_admin_set_iq_xml(
+        &room_jid,
+        "ban-bob",
+        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+            .attr(
+                minidom::rxml::xml_ncname!("jid").to_owned(),
+                "bob@example.com",
+            )
+            .attr(
+                minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                "outcast",
+            )
+            .build(),
+    );
+    let responses = handle_iq(
+        &ban_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(alice_session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "ban response: {responses:?}");
+    assert!(responses[0].contains("type='result'"), "{responses:?}");
+
+    let evicted = recorder.snapshot();
+    assert_eq!(
+        evicted.len(),
+        1,
+        "exactly the banned occupant's session is evicted: {evicted:?}"
+    );
+    assert_eq!(evicted[0].0.as_str(), "ban-evicts@muc.example.com");
+    assert_eq!(evicted[0].1.as_livekit_identity(), "bob@example.com/web");
+}
+
+#[tokio::test]
+async fn muc_admin_role_demotion_does_not_evict_from_room_call() {
+    let recorder = Arc::new(crate::server::routes::websocket::tests::RecordingSfu::default());
+    let state = create_test_websocket_state_with_sfu(recorder.clone()).await;
+    let room_jid: BareJid = "demote-keeps@muc.example.com".parse().expect("room jid");
+    let (alice_session, alice_jid, _bob_jid) =
+        join_alice_owner_and_bob(state.as_ref(), &room_jid).await;
+    let ready = ready_phase(&alice_jid);
+
+    let demote_iq = build_admin_set_iq_xml(
+        &room_jid,
+        "demote-bob",
+        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+            .attr(minidom::rxml::xml_ncname!("nick").to_owned(), "bob")
+            .attr(minidom::rxml::xml_ncname!("role").to_owned(), "visitor")
+            .build(),
+    );
+    let responses = handle_iq(
+        &demote_iq,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(alice_session),
+        &ready,
+    )
+    .await;
+    assert_eq!(responses.len(), 1, "demote response: {responses:?}");
+    assert!(responses[0].contains("type='result'"), "{responses:?}");
+
+    assert!(
+        recorder.snapshot().is_empty(),
+        "a role change that keeps the occupant must not end their call session"
+    );
+}

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -2600,3 +2600,59 @@ async fn sm_resume_replay_stamps_xep0203_delay_with_original_receipt_time() {
         "iq replay must not gain a delay element"
     );
 }
+
+#[tokio::test]
+async fn sm_detach_on_transport_drop_does_not_evict_sfu_call_session() {
+    // #935 decided behavior: presence loss must never end a healthy
+    // LiveKit session — an SM-resumable transport drop keeps the MUC
+    // occupant slot, and the SFU participant must survive with it.
+    // Only involuntary moderation (kick 307 / ban 301) or terminal
+    // session death may tear the call down.
+    let recorder = std::sync::Arc::new(super::RecordingSfu::default());
+    let state = super::create_test_websocket_state_with_sfu(recorder.clone()).await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "detach-keeps-call@muc.example.com".parse().expect("room");
+    let jid: FullJid = "alice@example.com/web".parse().expect("jid");
+
+    let _ = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &jid,
+        "alice",
+        None,
+        &Some(owner_session),
+    )
+    .await;
+    let (tx, mut rx) = mpsc::channel::<OutboundStanza>(4);
+    let owner = state
+        .deps
+        .protocol
+        .connection_registry
+        .register(jid.clone(), tx);
+
+    let mut conn = WsConnState::new();
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    conn.registry_owner = Some(owner);
+    conn.sm_state
+        .enable("stream-detach-call".to_string(), true, Some(300));
+
+    cleanup_connection_shutdown(state.as_ref(), &mut rx, &mut conn, false).await;
+
+    assert!(
+        recorder.snapshot().is_empty(),
+        "resumable SM detach must not evict the SFU participant"
+    );
+    assert!(
+        recorder.note_snapshot().is_empty(),
+        "resumable SM detach must not touch SFU bookkeeping either"
+    );
+    assert!(
+        snapshot_room(state.as_ref(), &room_jid)
+            .await
+            .room
+            .find_nick_by_real_jid(&jid)
+            .is_some(),
+        "occupant slot survives the detach"
+    );
+}

--- a/server/crates/waddle-sfu/src/webhook.rs
+++ b/server/crates/waddle-sfu/src/webhook.rs
@@ -84,10 +84,11 @@ pub fn verify_webhook_signature(
     let token = strip_bearer(raw).ok_or(WebhookVerifyError::MalformedAuthorization)?;
 
     let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
-    // LiveKit's webhook JWT omits `aud` / `iss` requirements; we only
-    // care about signature + lifetime. Disabling required claims keeps
-    // the verifier resilient to LK adding optional claims later.
-    validation.required_spec_claims.clear();
+    // LiveKit's webhook JWT omits `aud` / `iss`, so those stay
+    // unrequired — but `exp` must be present: `validate_exp` only
+    // checks the claim when it exists, and a signed token without
+    // `exp` would otherwise verify forever (unbounded replay window).
+    validation.required_spec_claims = std::collections::HashSet::from(["exp".to_owned()]);
     validation.validate_exp = true;
     validation.validate_nbf = true;
     // `leeway` is in seconds; allow a small clock-skew window so a
@@ -263,22 +264,29 @@ mod tests {
             .expect("fixture secret meets length minimum")
     }
 
-    fn sign_for_body(secret: &ApiSecret, body: &[u8]) -> String {
+    fn body_sha256_claim(body: &[u8]) -> String {
         let mut hasher = Sha256::new();
         hasher.update(body);
         let digest = hasher.finalize();
-        let sha256 = Base64Standard.encode(digest);
-        let claims = json!({
-            "sha256": sha256,
-            "exp": (chrono::Utc::now() + chrono::Duration::seconds(60)).timestamp(),
-            "iat": chrono::Utc::now().timestamp(),
-        });
+        Base64Standard.encode(digest)
+    }
+
+    fn sign_claims(secret: &ApiSecret, claims: &serde_json::Value) -> String {
         encode(
             &Header::default(),
-            &claims,
+            claims,
             &EncodingKey::from_secret(secret.as_bytes()),
         )
         .expect("encode test JWT")
+    }
+
+    fn sign_for_body(secret: &ApiSecret, body: &[u8]) -> String {
+        let claims = json!({
+            "sha256": body_sha256_claim(body),
+            "exp": (chrono::Utc::now() + chrono::Duration::seconds(60)).timestamp(),
+            "iat": chrono::Utc::now().timestamp(),
+        });
+        sign_claims(secret, &claims)
     }
 
     #[test]
@@ -336,6 +344,47 @@ mod tests {
             serde_json::to_vec(&json!({"event": "room_finished", "room": {"name": "b"}})).unwrap();
         let err = verify_webhook_signature(&secret, Some(&auth), &tampered).unwrap_err();
         assert!(matches!(err, WebhookVerifyError::BodyHashMismatch));
+    }
+
+    #[test]
+    fn rejects_a_jwt_without_an_exp_claim() {
+        let secret = fixture_secret();
+        let body =
+            serde_json::to_vec(&json!({"event": "room_finished", "room": {"name": "x"}})).unwrap();
+        let claims = json!({
+            "sha256": body_sha256_claim(&body),
+            "iat": chrono::Utc::now().timestamp(),
+        });
+        let auth = format!("Bearer {}", sign_claims(&secret, &claims));
+        let err = verify_webhook_signature(&secret, Some(&auth), &body).unwrap_err();
+        assert!(
+            matches!(
+                &err,
+                WebhookVerifyError::Jwt(jwt)
+                    if matches!(
+                        jwt.kind(),
+                        jsonwebtoken::errors::ErrorKind::MissingRequiredClaim(claim)
+                            if claim == "exp"
+                    )
+            ),
+            "expected missing-exp rejection, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_an_expired_jwt() {
+        let secret = fixture_secret();
+        let body =
+            serde_json::to_vec(&json!({"event": "room_finished", "room": {"name": "x"}})).unwrap();
+        let claims = json!({
+            "sha256": body_sha256_claim(&body),
+            // Older than the 30s clock-skew leeway, so it must bounce.
+            "exp": (chrono::Utc::now() - chrono::Duration::seconds(120)).timestamp(),
+            "iat": (chrono::Utc::now() - chrono::Duration::seconds(180)).timestamp(),
+        });
+        let auth = format!("Bearer {}", sign_claims(&secret, &claims));
+        let err = verify_webhook_signature(&secret, Some(&auth), &body).unwrap_err();
+        assert!(matches!(err, WebhookVerifyError::Jwt(_)));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
@@ -392,6 +392,13 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                 .map(|entry| (entry.jid, entry.affiliation))
                 .collect();
             let current_owner_count = self.room.get_jids_by_affiliation(Affiliation::Owner).len();
+            // Pre-validation simulates the mutation loop step by step
+            // against an evolving affiliation map. It must reject
+            // every set the loop below would reject — the loop
+            // mutates the room (bans remove occupants) as it goes, so
+            // a mid-loop error would leave a partially-applied batch
+            // whose removals and 301 presences are silently dropped
+            // (#935 review). Erroring here keeps the set atomic.
             for item in &msg.items {
                 let Some(target_jid) = item.jid.as_ref() else {
                     continue;
@@ -399,7 +406,10 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                 let Some(new_affiliation) = item.affiliation else {
                     continue;
                 };
-                let target_current_affiliation = self.room.get_affiliation(target_jid);
+                let target_current_affiliation = final_affiliations
+                    .get(target_jid)
+                    .copied()
+                    .unwrap_or(Affiliation::None);
                 let can_modify = match new_affiliation {
                     Affiliation::Owner | Affiliation::Admin => {
                         msg.sender_affiliation == Affiliation::Owner
@@ -425,6 +435,20 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                     && new_affiliation != Affiliation::Owner
                 {
                     return Err(AdminApplyError::CannotAdminModifyOwner);
+                }
+                // Mirror of apply_affiliation_change's per-step
+                // last-owner guard: demoting the sole owner at this
+                // point in the sequence would fail mid-loop.
+                if new_affiliation != Affiliation::Owner
+                    && target_current_affiliation == Affiliation::Owner
+                {
+                    let sole_owner = final_affiliations
+                        .iter()
+                        .filter(|(_, affiliation)| **affiliation == Affiliation::Owner)
+                        .all(|(jid, _)| jid == target_jid);
+                    if sole_owner {
+                        return Err(AdminApplyError::CannotRemoveLastOwner);
+                    }
                 }
                 if new_affiliation == Affiliation::None {
                     final_affiliations.remove(target_jid);

--- a/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
@@ -73,7 +73,7 @@ fn apply_affiliation_change(
     new_affiliation: Affiliation,
     actor: Option<&BareJid>,
     reason: Option<&str>,
-) -> Result<Vec<(FullJid, Presence)>, AdminApplyError> {
+) -> Result<AdminItemsApplied, AdminApplyError> {
     if new_affiliation != Affiliation::Owner {
         let target_current_affiliation = room.get_affiliation(&target_jid);
         if target_current_affiliation == Affiliation::Owner {
@@ -86,16 +86,17 @@ fn apply_affiliation_change(
 
     let change = room.set_affiliation(target_jid.clone(), new_affiliation);
     if change.is_none() {
-        return Ok(Vec::new());
+        return Ok(AdminItemsApplied::default());
     }
 
     let affected_occupants = occupants_for_bare(room, &target_jid);
     if affected_occupants.is_empty() {
-        return Ok(Vec::new());
+        return Ok(AdminItemsApplied::default());
     }
 
     if new_affiliation == Affiliation::Outcast {
         let mut updates = Vec::new();
+        let mut removed_by_moderation = Vec::new();
         for occupant in &affected_occupants {
             let from_room_jid = room
                 .room_jid
@@ -120,11 +121,15 @@ fn apply_affiliation_change(
                 );
                 (recipient, presence)
             }));
+            removed_by_moderation.extend(removed_sessions);
         }
         for occupant in affected_occupants {
             room.remove_occupant(&occupant.nick);
         }
-        return Ok(updates);
+        return Ok(AdminItemsApplied {
+            presence_updates: updates,
+            removed_by_moderation,
+        });
     }
 
     if room.config.members_only && new_affiliation < Affiliation::Member {
@@ -141,7 +146,13 @@ fn apply_affiliation_change(
         for occupant in affected_occupants {
             room.remove_occupant(&occupant.nick);
         }
-        return Ok(updates);
+        // Status-321 removals (affiliation loss in a members-only
+        // room) are deliberately NOT marked for SFU eviction — issue
+        // #935 scoped eviction to kick (307) and ban (301) only.
+        return Ok(AdminItemsApplied {
+            presence_updates: updates,
+            removed_by_moderation: Vec::new(),
+        });
     }
 
     let mut updates = Vec::new();
@@ -170,7 +181,10 @@ fn apply_affiliation_change(
             (recipient, presence)
         }));
     }
-    Ok(updates)
+    Ok(AdminItemsApplied {
+        presence_updates: updates,
+        removed_by_moderation: Vec::new(),
+    })
 }
 
 fn enforce_members_only(
@@ -259,8 +273,23 @@ pub struct ApplyAdminItems {
     pub items: Vec<AdminItem>,
 }
 
+/// Outcome of a moderation action that may involuntarily remove
+/// occupants.
+///
+/// `removed_by_moderation` carries the full JID of every session
+/// removed by a kick (XEP-0045 §8.2, status 307) or ban (§9.1, status
+/// 301). Callers owning an SFU handle must end these sessions' call
+/// participation — Membership-scoped visibility says a call is only
+/// joinable (and stayable) by current occupants. Voluntary leaves and
+/// presence loss never appear here.
+#[derive(Default)]
+pub struct AdminItemsApplied {
+    pub presence_updates: Vec<(FullJid, Presence)>,
+    pub removed_by_moderation: Vec<FullJid>,
+}
+
 impl kameo::message::Message<ApplyAdminItems> for RoomActor {
-    type Reply = Result<Vec<(FullJid, Presence)>, AdminApplyError>;
+    type Reply = Result<AdminItemsApplied, AdminApplyError>;
 
     async fn handle(
         &mut self,
@@ -268,6 +297,7 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let mut presence_updates: Vec<(FullJid, Presence)> = Vec::new();
+        let mut removed_by_moderation: Vec<FullJid> = Vec::new();
         let mut occupants_to_kick: Vec<String> = Vec::new();
         if is_role_change_query(&msg.items) {
             for item in &msg.items {
@@ -334,6 +364,7 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                         );
                         presence_updates.push((recipient, presence));
                     }
+                    removed_by_moderation.extend(target_sessions.iter().cloned());
                     occupants_to_kick.push(target_nick);
                 } else {
                     if let Some(occ) = self.room.occupants.get_mut(&target_nick) {
@@ -443,7 +474,7 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                     return Err(AdminApplyError::CannotAdminModifyOwner);
                 }
                 let actor = msg.sender_jid.to_bare();
-                let updates = apply_affiliation_change(
+                let applied = apply_affiliation_change(
                     &mut self.room,
                     &self.occupant_id_secret,
                     target_jid,
@@ -454,13 +485,17 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                 if target_current_affiliation != new_affiliation {
                     self.admission_revision = self.admission_revision.saturating_add(1);
                 }
-                presence_updates.extend(updates);
+                presence_updates.extend(applied.presence_updates);
+                removed_by_moderation.extend(applied.removed_by_moderation);
             }
         }
         for nick in occupants_to_kick {
             self.room.remove_occupant(&nick);
         }
-        Ok(presence_updates)
+        Ok(AdminItemsApplied {
+            presence_updates,
+            removed_by_moderation,
+        })
     }
 }
 
@@ -471,7 +506,7 @@ pub struct ApplyAffiliationChange {
 }
 
 impl kameo::message::Message<ApplyAffiliationChange> for RoomActor {
-    type Reply = Result<Vec<(FullJid, Presence)>, AdminApplyError>;
+    type Reply = Result<AdminItemsApplied, AdminApplyError>;
 
     async fn handle(
         &mut self,

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -2488,3 +2488,146 @@ async fn non_removing_admin_changes_report_no_moderation_removals() {
         "a role change that keeps the occupant must not evict their call session"
     );
 }
+
+#[tokio::test]
+async fn admin_set_error_after_ban_item_must_not_partially_apply() {
+    // #935 review finding: [ban X, demote sole owner A, promote C]
+    // passed the batch pre-validation (final state has owner C) but
+    // the mutation loop's per-step last-owner check erred AFTER the
+    // ban of X already mutated the room — X's removal and 301
+    // presences (and the SFU eviction contract built on them) were
+    // silently dropped. The set must be atomic: rejected before any
+    // mutation.
+    let actor = spawn_room_actor().await;
+    let owner_bare: BareJid = "owner@example.com".parse().expect("owner jid");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: test_full_jid("victim"),
+            nick: "victim".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("victim joins");
+    actor
+        .ask(ChangeAffiliation {
+            jid: owner_bare.clone(),
+            affiliation: Affiliation::Owner,
+        })
+        .await
+        .expect("set owner");
+
+    let result = actor
+        .ask(ApplyAdminItems {
+            sender_jid: test_full_jid("owner"),
+            sender_affiliation: Affiliation::Owner,
+            sender_role: Role::Moderator,
+            items: vec![
+                AdminItem {
+                    jid: Some("victim@example.com".parse().expect("bare")),
+                    nick: None,
+                    affiliation: Some(Affiliation::Outcast),
+                    role: None,
+                    reason: None,
+                },
+                AdminItem {
+                    jid: Some(owner_bare.clone()),
+                    nick: None,
+                    affiliation: Some(Affiliation::Member),
+                    role: None,
+                    reason: None,
+                },
+                AdminItem {
+                    jid: Some("successor@example.com".parse().expect("bare")),
+                    nick: None,
+                    affiliation: Some(Affiliation::Owner),
+                    role: None,
+                    reason: None,
+                },
+            ],
+        })
+        .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(SendError::HandlerError(
+                AdminApplyError::CannotRemoveLastOwner
+            ))
+        ),
+        "order-sensitive batch is rejected up front"
+    );
+    let occupant = actor
+        .ask(GetOccupantByNick {
+            nick: "victim".to_string(),
+        })
+        .await
+        .expect("ask")
+        .expect("victim must still be an occupant — no partial application");
+    assert_eq!(occupant.affiliation, Affiliation::Member);
+}
+
+#[tokio::test]
+async fn admin_set_with_owner_grant_before_demotion_applies_fully() {
+    // Order-valid counterpart of the atomicity test: promoting the
+    // successor BEFORE demoting the sole owner is accepted, and a ban
+    // in the same set still surfaces its removed sessions.
+    let actor = spawn_room_actor().await;
+    let owner_bare: BareJid = "owner@example.com".parse().expect("owner jid");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: test_full_jid("victim"),
+            nick: "victim".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("victim joins");
+    actor
+        .ask(ChangeAffiliation {
+            jid: owner_bare.clone(),
+            affiliation: Affiliation::Owner,
+        })
+        .await
+        .expect("set owner");
+
+    let applied = actor
+        .ask(ApplyAdminItems {
+            sender_jid: test_full_jid("owner"),
+            sender_affiliation: Affiliation::Owner,
+            sender_role: Role::Moderator,
+            items: vec![
+                AdminItem {
+                    jid: Some("successor@example.com".parse().expect("bare")),
+                    nick: None,
+                    affiliation: Some(Affiliation::Owner),
+                    role: None,
+                    reason: None,
+                },
+                AdminItem {
+                    jid: Some(owner_bare.clone()),
+                    nick: None,
+                    affiliation: Some(Affiliation::Member),
+                    role: None,
+                    reason: None,
+                },
+                AdminItem {
+                    jid: Some("victim@example.com".parse().expect("bare")),
+                    nick: None,
+                    affiliation: Some(Affiliation::Outcast),
+                    role: None,
+                    reason: None,
+                },
+            ],
+        })
+        .await
+        .expect("order-valid batch applies");
+
+    assert_eq!(
+        applied.removed_by_moderation,
+        vec![test_full_jid("victim")],
+        "the ban in the batch surfaces its removed session"
+    );
+}

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -387,6 +387,7 @@ async fn membership_revocation_in_members_only_room_ejects_occupant_with_status_
         })
         .await
         .expect("apply");
+    let updates = updates.presence_updates;
     assert_eq!(updates.len(), 1, "only Alice should receive her removal");
     assert_eq!(updates[0].0, alice);
     assert_eq!(updates[0].1.type_, PresenceType::Unavailable);
@@ -917,12 +918,18 @@ async fn role_none_kick_notifies_same_nick_sibling_sessions() {
         .await
         .expect("kick succeeds");
 
-    assert!(updates.iter().any(|(recipient, presence)| {
-        recipient == &alice_laptop && presence_has_status(presence, "307")
-    }));
-    assert!(updates.iter().any(|(recipient, presence)| {
-        recipient == &alice_phone && presence_has_status(presence, "307")
-    }));
+    assert!(updates
+        .presence_updates
+        .iter()
+        .any(|(recipient, presence)| {
+            recipient == &alice_laptop && presence_has_status(presence, "307")
+        }));
+    assert!(updates
+        .presence_updates
+        .iter()
+        .any(|(recipient, presence)| {
+            recipient == &alice_phone && presence_has_status(presence, "307")
+        }));
     assert_eq!(actor.ask(OccupantCount).await.expect("count"), 0);
 }
 
@@ -967,12 +974,18 @@ async fn members_only_revocation_removes_every_nick_for_bare_jid() {
         .await
         .expect("revocation succeeds");
 
-    assert!(updates.iter().any(|(recipient, presence)| {
-        recipient == &alice_laptop && presence_has_status(presence, "321")
-    }));
-    assert!(updates.iter().any(|(recipient, presence)| {
-        recipient == &alice_phone && presence_has_status(presence, "321")
-    }));
+    assert!(updates
+        .presence_updates
+        .iter()
+        .any(|(recipient, presence)| {
+            recipient == &alice_laptop && presence_has_status(presence, "321")
+        }));
+    assert!(updates
+        .presence_updates
+        .iter()
+        .any(|(recipient, presence)| {
+            recipient == &alice_phone && presence_has_status(presence, "321")
+        }));
     assert_eq!(actor.ask(OccupantCount).await.expect("count"), 0);
 }
 
@@ -2322,5 +2335,156 @@ async fn leaving_one_active_same_nick_session_preserves_sibling_active_muji_stat
             .as_ref()
             .is_some_and(|muji| muji.is_active()),
         "late join replay preserves the remaining active sibling"
+    );
+}
+
+#[tokio::test]
+async fn kick_reports_every_removed_session_for_sfu_eviction() {
+    let actor = spawn_room_actor().await;
+
+    // Alice is in the room from two devices under one nick; both
+    // sessions must be surfaced when she is kicked (issue #935).
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: test_full_jid_resource("alice", "desktop"),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("join alice desktop");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: test_full_jid_resource("alice", "mobile"),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("join alice mobile");
+
+    let applied = actor
+        .ask(ApplyAdminItems {
+            sender_jid: test_full_jid("mod"),
+            sender_affiliation: Affiliation::Admin,
+            sender_role: Role::Moderator,
+            items: vec![AdminItem {
+                jid: None,
+                nick: Some("alice".to_string()),
+                affiliation: None,
+                role: Some(Role::None),
+                reason: None,
+            }],
+        })
+        .await
+        .expect("kick alice");
+
+    let mut removed = applied.removed_by_moderation.clone();
+    removed.sort_by_key(std::string::ToString::to_string);
+    assert_eq!(
+        removed,
+        vec![
+            test_full_jid_resource("alice", "desktop"),
+            test_full_jid_resource("alice", "mobile"),
+        ],
+        "kick (XEP-0045 status 307) must surface all removed sessions"
+    );
+    assert!(
+        !applied.presence_updates.is_empty(),
+        "kick still fans out unavailable presence"
+    );
+}
+
+#[tokio::test]
+async fn ban_reports_every_removed_session_for_sfu_eviction() {
+    let actor = spawn_room_actor().await;
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: test_full_jid_resource("alice", "desktop"),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("join alice desktop");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: test_full_jid_resource("alice", "mobile"),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("join alice mobile");
+
+    let applied = actor
+        .ask(ApplyAdminItems {
+            sender_jid: test_full_jid("mod"),
+            sender_affiliation: Affiliation::Admin,
+            sender_role: Role::Moderator,
+            items: vec![AdminItem {
+                jid: Some("alice@example.com".parse().expect("bare jid")),
+                nick: None,
+                affiliation: Some(Affiliation::Outcast),
+                role: None,
+                reason: None,
+            }],
+        })
+        .await
+        .expect("ban alice");
+
+    let mut removed = applied.removed_by_moderation.clone();
+    removed.sort_by_key(std::string::ToString::to_string);
+    assert_eq!(
+        removed,
+        vec![
+            test_full_jid_resource("alice", "desktop"),
+            test_full_jid_resource("alice", "mobile"),
+        ],
+        "ban (XEP-0045 status 301) must surface all removed sessions"
+    );
+}
+
+#[tokio::test]
+async fn non_removing_admin_changes_report_no_moderation_removals() {
+    let actor = spawn_room_actor().await;
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: test_full_jid("alice"),
+            nick: "alice".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("join alice");
+
+    // A plain role demotion (still an occupant afterwards) must NOT
+    // mark the session for SFU eviction.
+    let applied = actor
+        .ask(ApplyAdminItems {
+            sender_jid: test_full_jid("mod"),
+            sender_affiliation: Affiliation::Admin,
+            sender_role: Role::Moderator,
+            items: vec![AdminItem {
+                jid: None,
+                nick: Some("alice".to_string()),
+                affiliation: None,
+                role: Some(Role::Visitor),
+                reason: None,
+            }],
+        })
+        .await
+        .expect("demote alice");
+
+    assert!(
+        applied.removed_by_moderation.is_empty(),
+        "a role change that keeps the occupant must not evict their call session"
     );
 }


### PR DESCRIPTION
Bundle of four security/reliability fixes — **#1158**, **#1168**, **#935**, **#1141** — each implemented test-first (strict red→green per behavior) and hardened through two adversarial review rounds (app-sec, Rust/distributed-systems, repo-standards personas).

## #1158 — pubsub `access_model`/`publish_model` decode fails closed (server)

The two authorization-load-bearing columns (plus the same-shaped `send_last_published_item`) decoded with `parse().unwrap_or_default()`: an unrecognized stored value silently became the most-open setting (`Presence` / `Open`) with no log — fail-open on exactly the fields gating who can read/publish a node.

- `decode_node` now fails closed with a typed `XmppError::internal` and a structured `tracing::error!` naming the node, owner, and offending raw value — mirroring the sibling `node_type` column's existing pattern.
- Verified no bypass: both row-reading queries route through `decode_node`, fan-out/authz callers propagate the error (never default), and `get_or_create_node` propagates rather than shadowing a corrupt row with a fresh open-default node.
- Tests: unknown stored value per column via raw `UPDATE` fixtures → node load returns `Err`; valid-value round-trips already covered by the existing suite.

## #1168 — Giphy key server-side proxy + global JS error telemetry (chat)

`GIPHY_API_KEY` (a documented secret) was passed as a prop into a `client:only` island — serialized into page HTML and sent in browser fetch URLs. Separately, Faro's global-error instrumentation was stripped with nothing replacing it, so uncaught render errors produced zero telemetry.

- New `/api/giphy` APIRoute (this repo's first Astro endpoint) with a pure, testable core `handleGiphyProxyRequest(apiKey, params, fetchImpl, rateGate?)`: key injected server-side only; `q` trimmed + capped (100 chars); `limit` clamped 1–50; `rating` pinned to `g` (client value ignored); response trimmed to exactly the fields the picker renders (no upstream analytics/pingback echo); 502 on upstream failure, 503 when unconfigured; key never appears in any response.
- The route is unauthenticated (auth lives on the XMPP server), so anonymous quota burn is bounded by a fixed-window **rate limiter** (30/min, keyed on `CF-Connecting-IP` collapsed to the IPv6 /64 prefix so one routed /64 can't mint 2^64 budgets; in-memory per isolate with a hard 10k-key cap and O(1) oldest-key eviction so a fresh-key flood can't turn the limiter itself into an amplification vector). Denied requests get a 429 with `Retry-After: 60` and never contact Giphy. Review round 2 established `Cache-Control` alone is inert as a bound on Cloudflare; successful responses still carry `Cache-Control: public, max-age=300` for organic browser repeat queries.
- `GifPicker` fetches the proxy; the nine-file `giphyApiKey` prop chain (AppLayout → AppShell → controller → ChatReadyShell → ContentArea → ThreadPanel → CallChatPanel → CallExpandedSurface → MessageComposer) is deleted outright (breaking-by-default, knip-clean).
- Global error capture: `window` `error` + `unhandledrejection` listeners and the Vue `appEntrypoint` `errorHandler` all funnel through the existing sanitizing `reportError()` (JID/session/api-key redaction), with a re-entrancy guard and a short same-error flood dedupe.
- Tests: 17 proxy behaviors (core trimming/clamping/error paths, caching, rate-limit budget/rollover/per-key isolation, cap eviction, IPv6 /64 keying, 429 semantics), 3 source-text wiring guards (no `api.giphy.com`/`api_key` in the picker, no `giphyApiKey` anywhere), 9 telemetry-handler behaviors (sanitization asserted with independent literals).

## #935 — evict SFU call participants on involuntary MUC removal (server)

A user kicked (XEP-0045 §8.2, status 307) or banned (§9.1, status 301) mid-call kept hearing and speaking in the channel's LiveKit call until they left voluntarily. `RoomActor` admin replies are now a typed `AdminItemsApplied { presence_updates, removed_by_moderation }`, and both moderation surfaces evict the removed sessions:

- **MUC admin IQ path** (`muc_admin.rs`) via the existing `muc_call_sfu::unregister_participant_from_room`.
- **Admin V2** `channels:kick` / `channels:set-affiliation(outcast)` via an explicit `Option<Arc<dyn SfuService>>` threaded through `channels::register` (no `AppState` growth).
- **Presence loss never evicts**: a resumable SM detach keeps the occupant slot and never reaches the eviction paths (regression test); role/affiliation changes that keep the occupant never evict; status-321 members-only removals are deliberately out of scope per the issue's decided behavior. Eviction is fire-and-forget inside the SFU layer — moderation results never block on LiveKit.
- **Review hardening (round 2):**
  - *Batch atomicity* — a multi-item admin set like `[ban X, demote sole owner, promote successor]` previously passed the order-insensitive pre-check, banned X, then errored mid-loop — dropping X's 301 presences and the eviction. Pre-validation now simulates the mutation loop step-by-step (same can-modify / admin-vs-owner / last-owner checks against an evolving map), so failing sets are rejected before any mutation; order-valid sets still apply fully.
  - *`run_kick` ordering* — 307 broadcast + SFU eviction now run before the fallible members-only affiliation-revocation ask, so an actor failure there can't strand an applied kick unnotified and un-evicted.
- Tests: room-actor kick/ban/negative-control triples for `removed_by_moderation` (multi-session occupants), kick/ban eviction through the real admin IQ handler with a `RecordingSfu` (promoted to a shared fixture, replacing a 60-line hand-cloned state builder), admin-V2 `run_kick`/`run_set_affiliation` eviction + promotion negative control (mutation-tested: disabling the evict call fails the test), SM-detach non-eviction, and the two batch-atomicity tests.

## #1141 — SFU webhook JWT requires `exp` (server)

`required_spec_claims.clear()` meant a signed webhook JWT with no `exp` verified forever — a captured delivery was replayable after a pod restart or once the 1024-entry dedupe LRU rolled.

- `required_spec_claims = {"exp"}` with `validate_exp`/`validate_nbf` kept on and the 30s leeway; `aud`/`iss` stay unrequired (LiveKit doesn't send them). Algorithm remains pinned to HS256 (no alg-confusion surface). Replay window is now bounded by token lifetime.
- Tests: missing-`exp` rejected with `MissingRequiredClaim("exp")`, expired token rejected, legitimate `exp`-bearing tokens still verify.

## Verification

- server: `cargo test -p waddle-server -p waddle-xmpp -p waddle-sfu` green (only pre-existing flake #1188 flickered once; passes in isolation), `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt` applied.
- chat: `bun run build` clean, `bun test` **3217 pass / 0 fail**, `bun run lint` (knip) exit 0.
- Review rounds: three adversarial personas on the full diff (2 real findings → fixed), round 2 on the fixes (1 finding: inert cache bound → rate limiter), round 3 on the limiter (2 findings: prune amplification → hard cap; full-IPv6 keying → /64 buckets), round 4 on the hardening → **no real findings**, loop converged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
