### PR TITLE
feat(server): ADR-0017 Phase 2 — owned libp2p swarm behind the clustering flag (node discovery only)

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -7679,6 +7679,7 @@ dependencies = [
  "jsonwebtoken",
  "kameo",
  "libc",
+ "libp2p",
  "lru 0.18.0",
  "minidom",
  "object_store",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -180,6 +180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
 name = "askama"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,7 +233,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
 dependencies = [
- "asn1-rs-derive",
+ "asn1-rs-derive 0.5.1",
  "asn1-rs-impl",
  "displaydoc",
  "nom",
@@ -238,10 +244,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive 0.6.0",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "asn1-rs-derive"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -407,6 +441,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -420,6 +467,18 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64",
+ "http",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "autocfg"
@@ -590,10 +649,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base256emoji"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
+dependencies = [
+ "const-str 0.4.3",
+ "match-lookup",
+]
+
+[[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
 
 [[package]]
 name = "base64"
@@ -663,6 +744,15 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -818,6 +908,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbor4ii"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "472931dd4dfcc785075b09be910147f9c6258883fc4591d0dac6116392b2daa6"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +942,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -850,6 +960,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -885,6 +1008,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.6",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1056,6 +1180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-fnv1a-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b13ea120a812beba79e34316b3942a857c86ec1593cb34f27bb28272ce2cca"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1218,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-str"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
+
+[[package]]
+name = "const-str"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18f12cc9948ed9604230cdddc7c86e270f9401ccbe3c2e98a4378c5e7632212f"
+dependencies = [
+ "const-str-proc-macro",
+]
+
+[[package]]
+name = "const-str-proc-macro"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7e7913ec01ed98b697e62f8d3fd63c86dc6cccaf983c7eebc64d0e563b0ad9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "const_format"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1271,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1327,6 +1493,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1434,6 +1615,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1489,6 +1697,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "data-encoding-macro"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
+dependencies = [
+ "data-encoding",
+ "syn",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,7 +1769,21 @@ version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs 0.7.2",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -1683,6 +1925,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +1954,30 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2 0.10.9",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1760,6 +2032,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1822,6 +2106,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+dependencies = [
+ "getrandom 0.3.4",
+ "libm",
+ "rand 0.9.4",
+ "siphasher",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,6 +2152,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1980,6 +2282,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-bounded"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91f328e7fb845fc832912fb6a34f40cf6d1888c92f974d1893a54e97b5ff542e"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,6 +2381,12 @@ name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -2367,6 +2685,53 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.4",
+ "ring",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.4",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "hkdf"
@@ -2705,6 +3070,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "if-watch"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
+dependencies = [
+ "async-io",
+ "core-foundation 0.9.4",
+ "fnv",
+ "futures",
+ "if-addrs",
+ "ipnet",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
+ "rtnetlink",
+ "system-configuration",
+ "tokio",
+ "windows",
+]
+
+[[package]]
+name = "igd-next"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516893339c97f6011282d5825ac94fc1c7aad5cad26bdc2d0cee068c0bf97f97"
+dependencies = [
+ "async-trait",
+ "attohttpc",
+ "bytes",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rand 0.9.4",
+ "tokio",
+ "url",
+ "xmltree",
+]
+
+[[package]]
 name = "image"
 version = "0.25.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,6 +3197,19 @@ name = "io-lifetimes"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.3",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "ipnet"
@@ -2945,10 +3377,17 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1dfd134d7a2c6ec05ee696dcbf3f7a034bdb97ecc623e981014652dcd124d77"
 dependencies = [
+ "const-fnv1a-hash",
+ "const-str 1.1.0",
  "downcast-rs",
  "dyn-clone",
+ "either",
  "futures",
  "kameo_macros",
+ "libp2p",
+ "libp2p-identity",
+ "linkme",
+ "rmp-serde",
  "serde",
  "tokio",
  "tracing",
@@ -3024,6 +3463,344 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libp2p"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce71348bf5838e46449ae240631117b487073d5f347c06d434caddcb91dceb5a"
+dependencies = [
+ "bytes",
+ "either",
+ "futures",
+ "futures-timer",
+ "getrandom 0.2.17",
+ "libp2p-allow-block-list",
+ "libp2p-connection-limits",
+ "libp2p-core",
+ "libp2p-dns",
+ "libp2p-identity",
+ "libp2p-kad",
+ "libp2p-mdns",
+ "libp2p-metrics",
+ "libp2p-noise",
+ "libp2p-quic",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "libp2p-tcp",
+ "libp2p-upnp",
+ "libp2p-yamux",
+ "multiaddr",
+ "pin-project",
+ "rw-stream-sink",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "libp2p-allow-block-list"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16ccf824ee859ca83df301e1c0205270206223fd4b1f2e512a693e1912a8f4a"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+]
+
+[[package]]
+name = "libp2p-connection-limits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18b8b607cf3bfa2f8c57db9c7d8569a315d5cc0a282e6bfd5ebfc0a9840b2a0"
+dependencies = [
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+]
+
+[[package]]
+name = "libp2p-core"
+version = "0.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249128cd37a2199aff30a7675dffa51caf073b51aa612d2f544b19932b9aebca"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "libp2p-identity",
+ "multiaddr",
+ "multihash",
+ "multistream-select",
+ "parking_lot",
+ "pin-project",
+ "quick-protobuf",
+ "rand 0.8.6",
+ "rw-stream-sink",
+ "thiserror 2.0.18",
+ "tracing",
+ "unsigned-varint 0.8.0",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b770c1c8476736ca98c578cba4b505104ff8e842c2876b528925f9766379f9a"
+dependencies = [
+ "async-trait",
+ "futures",
+ "hickory-resolver",
+ "libp2p-core",
+ "libp2p-identity",
+ "parking_lot",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-identity"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
+dependencies = [
+ "bs58",
+ "ed25519-dalek",
+ "hkdf 0.12.4",
+ "multihash",
+ "prost 0.14.3",
+ "rand 0.8.6",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-kad"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d3fd632a5872ec804d37e7413ceea20588f69d027a0fa3c46f82574f4dee60"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "fnv",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand 0.8.6",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tracing",
+ "uint",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-mdns"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66872d0f1ffcded2788683f76931be1c52e27f343edb93bc6d0bcd8887be443"
+dependencies = [
+ "futures",
+ "hickory-proto",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.6",
+ "smallvec",
+ "socket2 0.5.10",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-metrics"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805a555148522cb3414493a5153451910cb1a146c53ffbf4385708349baf62b7"
+dependencies = [
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-kad",
+ "libp2p-swarm",
+ "pin-project",
+ "prometheus-client",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-noise"
+version = "0.46.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc73eacbe6462a0eb92a6527cac6e63f02026e5407f8831bde8293f19217bfbf"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "multiaddr",
+ "multihash",
+ "quick-protobuf",
+ "rand 0.8.6",
+ "snow",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "tracing",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "libp2p-quic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcc597d70bf7f6f30cbe07081802c836184e48416e89e9ce73a0ba2c56a319e"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-tls",
+ "quinn",
+ "quinn-proto",
+ "rand 0.8.6",
+ "ring",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-request-response"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f1cca83488b90102abac7b67d5c36fc65bc02ed47620228af7ed002e6a1478"
+dependencies = [
+ "async-trait",
+ "cbor4ii",
+ "futures",
+ "futures-bounded",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand 0.8.6",
+ "serde",
+ "smallvec",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-swarm"
+version = "0.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce88c6c4bf746c8482480345ea3edfd08301f49e026889d1cbccfa1808a9ed9e"
+dependencies = [
+ "either",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "hashlink 0.10.0",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm-derive",
+ "multistream-select",
+ "rand 0.8.6",
+ "smallvec",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "libp2p-swarm-derive"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
+dependencies = [
+ "heck",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "libp2p-tcp"
+version = "0.44.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb6585b9309699f58704ec9ab0bb102eca7a3777170fa91a8678d73ca9cafa93"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "if-watch",
+ "libc",
+ "libp2p-core",
+ "socket2 0.6.3",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-tls"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ff65a82e35375cbc31ebb99cacbbf28cb6c4fefe26bf13756ddcf708d40080"
+dependencies = [
+ "futures",
+ "futures-rustls",
+ "libp2p-core",
+ "libp2p-identity",
+ "rcgen",
+ "ring",
+ "rustls",
+ "rustls-webpki",
+ "thiserror 2.0.18",
+ "x509-parser 0.17.0",
+ "yasna",
+]
+
+[[package]]
+name = "libp2p-upnp"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4757e65fe69399c1a243bbb90ec1ae5a2114b907467bf09f3575e899815bb8d3"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "igd-next",
+ "libp2p-core",
+ "libp2p-swarm",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "libp2p-yamux"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f15df094914eb4af272acf9adaa9e287baa269943f32ea348ba29cfb9bfc60d8"
+dependencies = [
+ "either",
+ "futures",
+ "libp2p-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "yamux 0.12.1",
+ "yamux 0.13.10",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3052,6 +3829,26 @@ version = "0.1.0"
 dependencies = [
  "sha2 0.11.0",
  "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3125,6 +3922,17 @@ name = "macro-string"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "match-lookup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3268,6 +4076,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3278,10 +4103,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "multiaddr"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6351f60b488e04c1d21bc69e56b89cb3f5e8f5d22557d6e8031bdfd79b6961"
+dependencies = [
+ "arrayref",
+ "byteorder",
+ "data-encoding",
+ "libp2p-identity",
+ "multibase",
+ "multihash",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.8.0",
+ "url",
+]
+
+[[package]]
+name = "multibase"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
+dependencies = [
+ "base-x",
+ "base256emoji",
+ "base45",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
+dependencies = [
+ "unsigned-varint 0.8.0",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "multistream-select"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "pin-project",
+ "smallvec",
+ "unsigned-varint 0.7.2",
+]
 
 [[package]]
 name = "native-tls"
@@ -3299,6 +4179,72 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
+dependencies = [
+ "bitflags",
+ "libc",
+ "log",
+ "netlink-packet-core",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -3500,7 +4446,16 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs 0.7.2",
 ]
 
 [[package]]
@@ -3519,6 +4474,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3725,6 +4684,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathdiff"
@@ -3946,6 +4911,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4070,6 +5046,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf41c1a7c32ed72abe5082fb19505b969095c12da9f5732a4bc9878757fd087c"
+dependencies = [
+ "dtoa",
+ "itoa",
+ "parking_lot",
+ "prometheus-client-derive-encode",
+]
+
+[[package]]
+name = "prometheus-client-derive-encode"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4189,6 +5188,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quick-protobuf"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "quick-protobuf-codec"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "quick-protobuf",
+ "thiserror 1.0.69",
+ "unsigned-varint 0.8.0",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4215,6 +5236,7 @@ checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
 dependencies = [
  "bytes",
  "cfg_aliases",
+ "futures-io",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
@@ -4235,6 +5257,7 @@ checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
+ "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
  "rand 0.9.4",
@@ -4311,7 +5334,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -4550,6 +5573,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4571,6 +5600,25 @@ dependencies = [
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
 ]
 
 [[package]]
@@ -4605,6 +5653,24 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rtnetlink"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-proto",
+ "netlink-sys",
+ "nix",
+ "thiserror 1.0.69",
+ "tokio",
 ]
 
 [[package]]
@@ -4731,7 +5797,7 @@ dependencies = [
  "tokio-util",
  "tower-service",
  "webpki-roots 1.0.7",
- "x509-parser",
+ "x509-parser 0.16.0",
 ]
 
 [[package]]
@@ -4771,7 +5837,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -4809,6 +5875,17 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rw-stream-sink"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+dependencies = [
+ "futures",
+ "pin-project",
+ "static_assertions",
+]
 
 [[package]]
 name = "rxml"
@@ -4936,7 +6013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5225,6 +6302,23 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "snow"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "ring",
+ "rustc_version",
+ "sha2 0.10.9",
+ "subtle",
+]
 
 [[package]]
 name = "socket2"
@@ -5557,6 +6651,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-interface"
 version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5571,6 +6686,12 @@ dependencies = [
  "windows-sys 0.59.0",
  "winx",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "target-lexicon"
@@ -6194,6 +7315,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6387,6 +7520,18 @@ dependencies = [
  "crypto-common 0.1.6",
  "subtle",
 ]
+
+[[package]]
+name = "unsigned-varint"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "untrusted"
@@ -7425,6 +8570,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "wiggle"
 version = "44.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7515,6 +8666,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7525,6 +8697,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -7554,6 +8737,27 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"
@@ -7664,6 +8868,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -8072,20 +9285,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
- "asn1-rs",
+ "asn1-rs 0.6.2",
  "data-encoding",
- "der-parser",
+ "der-parser 9.0.0",
  "lazy_static",
  "nom",
- "oid-registry",
+ "oid-registry 0.7.1",
  "rusticata-macros",
  "thiserror 1.0.69",
  "time",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4569f339c0c402346d4a75a9e39cf8dad310e287eef1ff56d4c68e5067f53460"
+dependencies = [
+ "asn1-rs 0.7.2",
+ "data-encoding",
+ "der-parser 10.0.0",
+ "lazy_static",
+ "nom",
+ "oid-registry 0.8.1",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
 ]
 
 [[package]]
@@ -8145,6 +9402,37 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink 0.11.0",
+]
+
+[[package]]
+name = "yamux"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "pin-project",
+ "rand 0.8.6",
+ "static_assertions",
+]
+
+[[package]]
+name = "yamux"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1991f6690292030e31b0144d73f5e8368936c58e45e7068254f7138b23b00672"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot",
+ "pin-project",
+ "rand 0.9.4",
+ "static_assertions",
+ "web-time",
 ]
 
 [[package]]

--- a/server/crates/waddle-server/Cargo.toml
+++ b/server/crates/waddle-server/Cargo.toml
@@ -134,6 +134,15 @@ tempfile = "3.27"
 waddle-xmpp = { path = "../waddle-xmpp", features = ["test-utils"] }
 waddle-xmpp-core = { path = "../waddle-xmpp-core", features = ["test-utils"] }
 
+[features]
+# ADR-0017 Phase 2: the owned libp2p swarm subsystem (node discovery only).
+# OFF by default so the standard production build links zero libp2p and is
+# byte-for-byte identical to the single-replica path. Enabling it turns on
+# kameo's `remote` feature (which pulls libp2p) and compiles the
+# `crate::clustering` swarm/codec/relay modules. A clustering-built binary is
+# still inert unless the runtime `clustering.enabled` config is also set.
+clustering = ["kameo/remote"]
+
 [[bin]]
 name = "waddle-server"
 path = "src/main.rs"

--- a/server/crates/waddle-server/Cargo.toml
+++ b/server/crates/waddle-server/Cargo.toml
@@ -25,6 +25,20 @@ sqlx = { workspace = true }
 # Actor Framework
 kameo = { workspace = true }
 
+# ADR-0017 Phase 2: owned libp2p swarm subsystem (behind the `clustering`
+# feature). Version-pinned to match kameo 0.20's libp2p (0.56) so the whole
+# dependency graph unifies on one libp2p and `kameo::remote::Behaviour`
+# composes into our owned `NetworkBehaviour`. Optional — a default build links
+# no libp2p at all.
+libp2p = { version = "0.56", default-features = false, features = [
+    "tokio",
+    "tcp",
+    "quic",
+    "noise",
+    "yamux",
+    "macros",
+], optional = true }
+
 # XMPP Server
 waddle-xmpp = { path = "../waddle-xmpp" }
 waddle-xmpp-core = { path = "../waddle-xmpp-core" }
@@ -141,7 +155,7 @@ waddle-xmpp-core = { path = "../waddle-xmpp-core", features = ["test-utils"] }
 # kameo's `remote` feature (which pulls libp2p) and compiles the
 # `crate::clustering` swarm/codec/relay modules. A clustering-built binary is
 # still inert unless the runtime `clustering.enabled` config is also set.
-clustering = ["kameo/remote"]
+clustering = ["kameo/remote", "dep:libp2p"]
 
 [[bin]]
 name = "waddle-server"

--- a/server/crates/waddle-server/src/clustering/allowlist.rs
+++ b/server/crates/waddle-server/src/clustering/allowlist.rs
@@ -145,8 +145,12 @@ pub struct AllowlistDiff {
 /// Compute the changes needed to move the swarm's allowed set from `current`
 /// to `next`.
 pub fn diff_allowlist(current: &HashSet<PeerId>, next: &HashSet<PeerId>) -> AllowlistDiff {
-    let added = next.difference(current).copied().collect();
-    let removed = current.difference(next).copied().collect();
+    let mut added: Vec<PeerId> = next.difference(current).copied().collect();
+    let mut removed: Vec<PeerId> = current.difference(next).copied().collect();
+    // `HashSet` iteration order is non-deterministic; sort so the diff (and
+    // anything logging or asserting on it) is stable across runs.
+    added.sort_unstable();
+    removed.sort_unstable();
     AllowlistDiff { added, removed }
 }
 
@@ -167,6 +171,16 @@ mod tests {
         let diff = diff_allowlist(&current, &next);
         assert_eq!(diff.added, vec![c]);
         assert_eq!(diff.removed, vec![a]);
+    }
+
+    #[test]
+    fn diff_output_is_deterministically_ordered() {
+        let peers: Vec<PeerId> = (0..8).map(|_| peer()).collect();
+        let next: HashSet<PeerId> = peers.iter().copied().collect();
+        let diff = diff_allowlist(&HashSet::new(), &next);
+        let mut expected = peers;
+        expected.sort_unstable();
+        assert_eq!(diff.added, expected);
     }
 
     #[test]

--- a/server/crates/waddle-server/src/clustering/allowlist.rs
+++ b/server/crates/waddle-server/src/clustering/allowlist.rs
@@ -14,6 +14,20 @@
 //! on this table). The runtime never inserts or deletes allowlist rows; it
 //! only reads them. Tests seed rows directly, playing the enrollment
 //! authority's part.
+//!
+//! Two operational rules fall out of enforcement being symmetric (each side
+//! checks the **remote** peer against its own copy of the same table):
+//! - **Every node's PeerId must be enrolled** — including the dialer. A ↔ B
+//!   connects only if both A and B are on the list. In practice enrollment
+//!   means enrolling the PeerIds derived from the pre-enrolled keypair pool;
+//!   ephemeral identities (empty pool) mint a fresh PeerId per process that
+//!   can never be pre-enrolled, so ephemeral-identity nodes **cannot form a
+//!   cluster** — that fallback only serves single-node spikes and tests.
+//! - **The containment bound is approximate**: worst case is ~2× the refresh
+//!   interval plus query latency (single-flight refresh + skipped ticks), and
+//!   a Postgres outage freezes revocation at the last-known set for the
+//!   outage's duration — the deliberate fail-closed trade-off (never fail
+//!   open, never mass-revoke on a transient error).
 
 use crate::db::{Database, DatabaseError};
 use async_trait::async_trait;
@@ -27,6 +41,15 @@ pub enum AllowlistError {
     /// The backing database returned an error.
     #[error("clustering peer-allowlist database error: {0}")]
     Database(#[from] DatabaseError),
+    /// The table has rows but not one parsed as a valid PeerId. Distinguished
+    /// from a genuinely empty table (deny-all) so a systematic
+    /// encoding/driver regression fails the refresh — keeping the last-known
+    /// set — instead of silently mass-revoking the whole cluster.
+    #[error(
+        "clustering peer-allowlist has {rows} rows but none parsed as a PeerId; \
+         refusing to apply an empty set from a populated table"
+    )]
+    AllRowsInvalid { rows: usize },
 }
 
 /// Read-only view of the enrolled peer set. A trait so a dedicated
@@ -36,6 +59,12 @@ pub enum AllowlistError {
 pub trait AllowlistStore: Send + Sync {
     /// Create the backing table if it does not exist (idempotent; inserts
     /// nothing — enrollment stays with the pipeline authority).
+    ///
+    /// Phase-4 note: `CREATE TABLE IF NOT EXISTS` still requires `CREATE` on
+    /// the schema even when the table already exists (Postgres checks the ACL
+    /// before the existence short-circuit), so when the SELECT-only runtime
+    /// grants land, the pipeline must provision this table and this call must
+    /// be dropped or gated — otherwise startup fails on the hardened role.
     async fn ensure_schema(&self) -> Result<(), AllowlistError>;
 
     /// The currently enrolled peer IDs. Rows that fail to parse as a libp2p
@@ -78,7 +107,9 @@ impl AllowlistStore for PostgresAllowlistStore {
             .query("SELECT peer_id FROM clustering_peer_allowlist", ())
             .await?;
         let mut peers = HashSet::new();
+        let mut total_rows = 0usize;
         while let Some(row) = rows.next().await? {
+            total_rows += 1;
             let raw: String = row.get(0)?;
             match PeerId::from_str(&raw) {
                 Ok(peer) => {
@@ -92,6 +123,12 @@ impl AllowlistStore for PostgresAllowlistStore {
                     );
                 }
             }
+        }
+        // A populated table where *nothing* parsed is a systematic failure,
+        // not an enrollment decision: fail the read (the refresh keeps the
+        // last-known set) rather than mass-revoke every peer.
+        if peers.is_empty() && total_rows > 0 {
+            return Err(AllowlistError::AllRowsInvalid { rows: total_rows });
         }
         Ok(peers)
     }
@@ -144,6 +181,7 @@ mod tests {
     // part — the runtime itself never writes this table).
     #[tokio::test]
     async fn enrolled_peers_reads_rows_and_skips_invalid() {
+        let _guard = crate::clustering::allowlist_table_lock().lock().await;
         let Ok(url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
             return;
         };
@@ -173,5 +211,45 @@ mod tests {
         let peers = store.enrolled_peers().await.expect("read enrolled");
         assert_eq!(peers.len(), 2);
         assert!(peers.contains(&a) && peers.contains(&b));
+    }
+
+    // A populated table where nothing parses must fail the read (the refresh
+    // keeps the last-known set) rather than yield an empty set that would
+    // mass-revoke the whole cluster.
+    #[tokio::test]
+    async fn all_rows_invalid_is_an_error_not_an_empty_set() {
+        let _guard = crate::clustering::allowlist_table_lock().lock().await;
+        let Ok(url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = Database::from_config(
+            "clustering-allowlist-test-invalid",
+            &DatabaseConfig::new(DatabaseDriver::Postgres, url),
+        )
+        .await
+        .expect("open test postgres");
+        let store = PostgresAllowlistStore::new(db.clone());
+        store.ensure_schema().await.expect("ensure schema");
+
+        let conn = db.guard().await.expect("guard");
+        conn.execute("DELETE FROM clustering_peer_allowlist", ())
+            .await
+            .expect("clean table");
+        conn.execute(
+            "INSERT INTO clustering_peer_allowlist (peer_id) VALUES (?)",
+            crate::db_params!["definitely-not-a-peer-id".to_string()],
+        )
+        .await
+        .expect("seed invalid row");
+
+        let err = store.enrolled_peers().await.expect_err("read must fail");
+        assert!(matches!(err, AllowlistError::AllRowsInvalid { rows: 1 }));
+
+        // A genuinely empty table is still Ok(empty) — deny-all, not an error.
+        conn.execute("DELETE FROM clustering_peer_allowlist", ())
+            .await
+            .expect("empty table");
+        let peers = store.enrolled_peers().await.expect("empty read succeeds");
+        assert!(peers.is_empty());
     }
 }

--- a/server/crates/waddle-server/src/clustering/allowlist.rs
+++ b/server/crates/waddle-server/src/clustering/allowlist.rs
@@ -1,0 +1,177 @@
+//! Peer allowlist for the clustering swarm (ADR-0017 element 3).
+//!
+//! The cluster maintains an allowlist of **enrolled peer IDs** in Postgres.
+//! Connections from peers not on the list are rejected at the swarm behaviour
+//! layer (`libp2p::allow_block_list` composed into `WaddleBehaviour`) —
+//! completing the Noise handshake is necessary but never sufficient. A
+//! periodic refresh diffs the enrolled set and **actively closes live
+//! connections** whose peer ID is no longer enrolled, bounding a revoked
+//! peer's swarm access to one refresh interval.
+//!
+//! Enrollment authority is separate from the runtime by design: rows are
+//! provisioned only by the deployment pipeline (an admin-role migration/Helm
+//! hook job — Phase 4 ships the grants making the runtime role `SELECT`-only
+//! on this table). The runtime never inserts or deletes allowlist rows; it
+//! only reads them. Tests seed rows directly, playing the enrollment
+//! authority's part.
+
+use crate::db::{Database, DatabaseError};
+use async_trait::async_trait;
+use libp2p::PeerId;
+use std::collections::HashSet;
+use std::str::FromStr;
+
+/// Allowlist read failures.
+#[derive(Debug, thiserror::Error)]
+pub enum AllowlistError {
+    /// The backing database returned an error.
+    #[error("clustering peer-allowlist database error: {0}")]
+    Database(#[from] DatabaseError),
+}
+
+/// Read-only view of the enrolled peer set. A trait so a dedicated
+/// control-plane pool implementation (Phase 3) or a test double can
+/// substitute without touching callers.
+#[async_trait]
+pub trait AllowlistStore: Send + Sync {
+    /// Create the backing table if it does not exist (idempotent; inserts
+    /// nothing — enrollment stays with the pipeline authority).
+    async fn ensure_schema(&self) -> Result<(), AllowlistError>;
+
+    /// The currently enrolled peer IDs. Rows that fail to parse as a libp2p
+    /// `PeerId` are skipped with a warning (a malformed enrollment must not
+    /// take down the reader).
+    async fn enrolled_peers(&self) -> Result<HashSet<PeerId>, AllowlistError>;
+}
+
+/// Postgres implementation.
+pub struct PostgresAllowlistStore {
+    db: Database,
+}
+
+impl PostgresAllowlistStore {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl AllowlistStore for PostgresAllowlistStore {
+    async fn ensure_schema(&self) -> Result<(), AllowlistError> {
+        let conn = self.db.guard().await?;
+        conn.execute(
+            r#"
+            CREATE TABLE IF NOT EXISTS clustering_peer_allowlist (
+                peer_id     TEXT PRIMARY KEY,
+                enrolled_at TIMESTAMPTZ NOT NULL DEFAULT now()
+            )
+            "#,
+            (),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn enrolled_peers(&self) -> Result<HashSet<PeerId>, AllowlistError> {
+        let conn = self.db.guard().await?;
+        let mut rows = conn
+            .query("SELECT peer_id FROM clustering_peer_allowlist", ())
+            .await?;
+        let mut peers = HashSet::new();
+        while let Some(row) = rows.next().await? {
+            let raw: String = row.get(0)?;
+            match PeerId::from_str(&raw) {
+                Ok(peer) => {
+                    peers.insert(peer);
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        peer_id = %raw,
+                        %error,
+                        "clustering allowlist row is not a valid PeerId; skipping"
+                    );
+                }
+            }
+        }
+        Ok(peers)
+    }
+}
+
+/// The difference between two enrolled sets: peers to newly allow and peers
+/// to revoke (disallow + close live connections).
+#[derive(Debug, PartialEq, Eq)]
+pub struct AllowlistDiff {
+    pub added: Vec<PeerId>,
+    pub removed: Vec<PeerId>,
+}
+
+/// Compute the changes needed to move the swarm's allowed set from `current`
+/// to `next`.
+pub fn diff_allowlist(current: &HashSet<PeerId>, next: &HashSet<PeerId>) -> AllowlistDiff {
+    let added = next.difference(current).copied().collect();
+    let removed = current.difference(next).copied().collect();
+    AllowlistDiff { added, removed }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{DatabaseConfig, DatabaseDriver};
+
+    fn peer() -> PeerId {
+        PeerId::random()
+    }
+
+    #[test]
+    fn diff_reports_added_and_removed() {
+        let (a, b, c) = (peer(), peer(), peer());
+        let current: HashSet<PeerId> = [a, b].into_iter().collect();
+        let next: HashSet<PeerId> = [b, c].into_iter().collect();
+        let diff = diff_allowlist(&current, &next);
+        assert_eq!(diff.added, vec![c]);
+        assert_eq!(diff.removed, vec![a]);
+    }
+
+    #[test]
+    fn diff_of_identical_sets_is_empty() {
+        let set: HashSet<PeerId> = [peer(), peer()].into_iter().collect();
+        let diff = diff_allowlist(&set, &set.clone());
+        assert!(diff.added.is_empty());
+        assert!(diff.removed.is_empty());
+    }
+
+    // Postgres-gated: seeds rows directly (playing the enrollment pipeline's
+    // part — the runtime itself never writes this table).
+    #[tokio::test]
+    async fn enrolled_peers_reads_rows_and_skips_invalid() {
+        let Ok(url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
+            return;
+        };
+        let db = Database::from_config(
+            "clustering-allowlist-test",
+            &DatabaseConfig::new(DatabaseDriver::Postgres, url),
+        )
+        .await
+        .expect("open test postgres");
+        let store = PostgresAllowlistStore::new(db.clone());
+        store.ensure_schema().await.expect("ensure schema");
+
+        let conn = db.guard().await.expect("guard");
+        conn.execute("DELETE FROM clustering_peer_allowlist", ())
+            .await
+            .expect("clean table");
+        let (a, b) = (peer(), peer());
+        for enrolled in [a.to_string(), b.to_string(), "not-a-peer-id".to_string()] {
+            conn.execute(
+                "INSERT INTO clustering_peer_allowlist (peer_id) VALUES (?)",
+                crate::db_params![enrolled],
+            )
+            .await
+            .expect("enroll row");
+        }
+
+        let peers = store.enrolled_peers().await.expect("read enrolled");
+        assert_eq!(peers.len(), 2);
+        assert!(peers.contains(&a) && peers.contains(&b));
+    }
+}

--- a/server/crates/waddle-server/src/clustering/behaviour.rs
+++ b/server/crates/waddle-server/src/clustering/behaviour.rs
@@ -1,0 +1,36 @@
+//! The owned libp2p `NetworkBehaviour` for the clustering swarm.
+//!
+//! We compose `kameo::remote::Behaviour` into a behaviour we build and drive
+//! ourselves, rather than using `kameo::remote::bootstrap()` (an mDNS
+//! development helper). This is what lets us own the transports, the event
+//! loop, peer dialing, and — in later slices — the allowlist and per-peer
+//! relay actors.
+
+use kameo::remote;
+use libp2p::swarm::NetworkBehaviour;
+use libp2p::PeerId;
+
+/// Waddle's composed swarm behaviour.
+///
+/// Phase 2 carries only kameo's remote behaviour (messaging + kademlia
+/// registry). The `derive(NetworkBehaviour)` macro generates the
+/// [`WaddleBehaviourEvent`] enum (one `Kameo(remote::Event)` variant) and the
+/// combined connection handler.
+// `derive(NetworkBehaviour)` auto-generates the out-event enum named after the
+// struct — `WaddleBehaviourEvent` — with one `Kameo(remote::Event)` variant.
+#[derive(NetworkBehaviour)]
+pub struct WaddleBehaviour {
+    /// kameo remote actors: request-response messaging plus the kademlia-based
+    /// registry (demoted to node discovery only this phase).
+    pub kameo: remote::Behaviour,
+}
+
+impl WaddleBehaviour {
+    /// Build the behaviour for `local_peer_id` with the given kameo messaging
+    /// limits (request timeout, concurrent-stream cap, envelope size maxima).
+    pub fn new(local_peer_id: PeerId, messaging_config: remote::messaging::Config) -> Self {
+        Self {
+            kameo: remote::Behaviour::new(local_peer_id, messaging_config),
+        }
+    }
+}

--- a/server/crates/waddle-server/src/clustering/behaviour.rs
+++ b/server/crates/waddle-server/src/clustering/behaviour.rs
@@ -3,23 +3,27 @@
 //! We compose `kameo::remote::Behaviour` into a behaviour we build and drive
 //! ourselves, rather than using `kameo::remote::bootstrap()` (an mDNS
 //! development helper). This is what lets us own the transports, the event
-//! loop, peer dialing, and — in later slices — the allowlist and per-peer
-//! relay actors.
+//! loop, peer dialing, the peer allowlist, and — in a later slice — the
+//! per-peer relay actors.
 
 use kameo::remote;
+use libp2p::allow_block_list::{self, AllowedPeers};
 use libp2p::swarm::NetworkBehaviour;
 use libp2p::PeerId;
+use std::collections::HashSet;
 
-/// Waddle's composed swarm behaviour.
-///
-/// Phase 2 carries only kameo's remote behaviour (messaging + kademlia
-/// registry). The `derive(NetworkBehaviour)` macro generates the
-/// [`WaddleBehaviourEvent`] enum (one `Kameo(remote::Event)` variant) and the
-/// combined connection handler.
 // `derive(NetworkBehaviour)` auto-generates the out-event enum named after the
-// struct — `WaddleBehaviourEvent` — with one `Kameo(remote::Event)` variant.
+// struct — `WaddleBehaviourEvent` — with one variant per field.
 #[derive(NetworkBehaviour)]
 pub struct WaddleBehaviour {
+    /// Peer authorization (ADR element 3): connections from peers not on the
+    /// enrolled allowlist are denied at establishment, and `disallow_peer`
+    /// closes live connections — completing the Noise handshake is necessary
+    /// but never sufficient. Composed FIRST so its deny verdict is reached
+    /// before any other behaviour handles the connection (denial by any
+    /// composed behaviour denies the connection regardless of order; the
+    /// position is for clarity).
+    pub allowed: allow_block_list::Behaviour<AllowedPeers>,
     /// kameo remote actors: request-response messaging plus the kademlia-based
     /// registry (demoted to node discovery only this phase).
     pub kameo: remote::Behaviour,
@@ -27,9 +31,18 @@ pub struct WaddleBehaviour {
 
 impl WaddleBehaviour {
     /// Build the behaviour for `local_peer_id` with the given kameo messaging
-    /// limits (request timeout, concurrent-stream cap, envelope size maxima).
-    pub fn new(local_peer_id: PeerId, messaging_config: remote::messaging::Config) -> Self {
+    /// limits and the initially enrolled peer set.
+    pub fn new(
+        local_peer_id: PeerId,
+        messaging_config: remote::messaging::Config,
+        enrolled: &HashSet<PeerId>,
+    ) -> Self {
+        let mut allowed = allow_block_list::Behaviour::<AllowedPeers>::default();
+        for peer in enrolled {
+            allowed.allow_peer(*peer);
+        }
         Self {
+            allowed,
             kameo: remote::Behaviour::new(local_peer_id, messaging_config),
         }
     }

--- a/server/crates/waddle-server/src/clustering/codec.rs
+++ b/server/crates/waddle-server/src/clustering/codec.rs
@@ -131,8 +131,15 @@ fn enforce_bounds(xml: &str) -> Result<(), RemoteCodecError> {
                 check_attribute_cap(&start)?;
             }
             Ok(quick_xml::events::Event::Empty(start)) => {
-                // Self-closing elements don't change depth but still carry
-                // attributes.
+                // A self-closing element opens no lasting scope but still
+                // occupies one nesting level of its own — count it against
+                // the cap so the parsed tree's depth invariant is exact
+                // (a leaf under MAX open elements must not slip through).
+                if depth + 1 > MAX_REMOTE_XML_DEPTH {
+                    return Err(RemoteCodecError::TooDeep {
+                        max: MAX_REMOTE_XML_DEPTH,
+                    });
+                }
                 check_attribute_cap(&start)?;
             }
             Ok(quick_xml::events::Event::End(_)) => {
@@ -283,6 +290,33 @@ mod tests {
         }
         let err = decode_element(&xml).expect_err("depth cap enforced");
         assert!(matches!(err, RemoteCodecError::TooDeep { .. }));
+    }
+
+    #[test]
+    fn self_closing_leaf_counts_against_the_depth_cap() {
+        // A self-closing element under MAX open elements is one level deeper
+        // than the cap and must be rejected; the same leaf one level higher
+        // must pass. (Open/close pairs at exactly MAX are the control.)
+        let build = |open_depth: usize, with_leaf: bool| {
+            let mut xml = String::from("<a xmlns='jabber:client'>");
+            for _ in 1..open_depth {
+                xml.push_str("<a>");
+            }
+            if with_leaf {
+                xml.push_str("<leaf/>");
+            }
+            for _ in 0..open_depth {
+                xml.push_str("</a>");
+            }
+            xml
+        };
+        let err = decode_element(&build(MAX_REMOTE_XML_DEPTH, true))
+            .expect_err("leaf under MAX opens exceeds the cap");
+        assert!(matches!(err, RemoteCodecError::TooDeep { .. }));
+        decode_element(&build(MAX_REMOTE_XML_DEPTH - 1, true))
+            .expect("leaf at exactly MAX depth is allowed");
+        decode_element(&build(MAX_REMOTE_XML_DEPTH, false))
+            .expect("MAX open/close pairs without the leaf are allowed");
     }
 
     #[test]

--- a/server/crates/waddle-server/src/clustering/codec.rs
+++ b/server/crates/waddle-server/src/clustering/codec.rs
@@ -210,6 +210,13 @@ impl<'de> Deserialize<'de> for RemoteElement {
     }
 }
 
+// NB on the XML-generation hard rule: several tests below assemble XML with
+// `format!`/`push_str`. That is deliberate and necessary — they produce
+// ADVERSARIAL payloads (nesting bombs, attribute bombs, oversized and
+// malformed documents) that typed builders cannot emit by construction;
+// builder-only XML is exactly the property the production encode path keeps.
+// The rule protects wire/production XML, which never goes through these
+// helpers.
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/server/crates/waddle-server/src/clustering/codec.rs
+++ b/server/crates/waddle-server/src/clustering/codec.rs
@@ -1,0 +1,339 @@
+//! Remote XML-text codec for the clustering transport (ADR-0017 element 3).
+//!
+//! Neither `xmpp-parsers` 0.22 nor `minidom` 0.18 implements serde, so every
+//! remote payload crossing the kameo boundary carries its stanza as XML text
+//! inside a serde-friendly newtype. Serialization goes through
+//! `Stanza::to_element()` (which applies the `ensure_thread_element` fixup, so
+//! RFC 6121 `<thread/>` survives the wire) and `element_to_string`.
+//!
+//! Deserialization is **bounded before tree construction**: minidom's parser
+//! is recursive, so a small, deeply-nested payload from a compromised peer
+//! could otherwise overflow the stack and crash the node — forfeiting its
+//! claims. A non-recursive `quick-xml` pre-scan enforces a byte cap, a nesting
+//! depth cap, and a per-element attribute/namespace-declaration cap first; a
+//! payload failing any bound (or failing the re-parse) is a **typed error the
+//! caller NACKs to the sender** — never a silent drop — and counts in the drop
+//! metrics.
+
+use super::metrics;
+use serde::de::Error as _;
+use serde::ser::Error as _;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use waddle_xmpp::Stanza;
+
+/// Byte cap on a single serialized stanza/element payload. Well below kameo's
+/// request-size maximum so the codec bound, not the transport cap, is the
+/// binding limit for one stanza.
+pub const MAX_REMOTE_XML_BYTES: usize = 256 * 1024;
+
+/// Nesting-depth cap enforced before minidom's recursive parse. Real XMPP
+/// stanzas rarely exceed ~10 levels; 32 leaves generous headroom.
+pub const MAX_REMOTE_XML_DEPTH: usize = 32;
+
+/// Cap on attributes (including `xmlns` declarations) per element.
+pub const MAX_REMOTE_XML_ATTRIBUTES: usize = 64;
+
+/// Typed decode/encode failures at the remote codec boundary. The receiving
+/// handler converts these into a NACK to the sender; they are never a silent
+/// drop.
+#[derive(Debug, thiserror::Error)]
+pub enum RemoteCodecError {
+    /// The stanza could not be serialized to XML text.
+    #[error("remote codec failed to serialize stanza: {0}")]
+    Serialize(String),
+    /// The payload exceeds the byte cap.
+    #[error("remote XML payload of {bytes} bytes exceeds the {max}-byte cap")]
+    TooLarge { bytes: usize, max: usize },
+    /// The payload nests deeper than the pre-parse depth cap.
+    #[error("remote XML payload exceeds nesting depth cap of {max}")]
+    TooDeep { max: usize },
+    /// An element carries more attributes/namespace declarations than allowed.
+    #[error("remote XML element exceeds the {max}-attribute cap")]
+    TooManyAttributes { max: usize },
+    /// The payload is not well-formed XML (pre-scan or minidom parse failed).
+    #[error("remote XML payload failed to re-parse: {0}")]
+    Malformed(String),
+    /// The top-level element is not a message/presence/iq stanza.
+    #[error("remote payload element '{name}' is not an XMPP stanza")]
+    NotAStanza { name: String },
+}
+
+impl RemoteCodecError {
+    /// Stable low-cardinality label for the drop metrics.
+    fn reason(&self) -> &'static str {
+        match self {
+            RemoteCodecError::Serialize(_) => "serialize",
+            RemoteCodecError::TooLarge { .. } => "too_large",
+            RemoteCodecError::TooDeep { .. } => "too_deep",
+            RemoteCodecError::TooManyAttributes { .. } => "too_many_attributes",
+            RemoteCodecError::Malformed(_) => "malformed",
+            RemoteCodecError::NotAStanza { .. } => "not_a_stanza",
+        }
+    }
+}
+
+/// Encode a stanza as wire XML text (thread-preserving).
+pub fn encode_stanza(stanza: &Stanza) -> Result<String, RemoteCodecError> {
+    waddle_xmpp::parser::element_to_string(&stanza.to_element())
+        .map_err(|error| RemoteCodecError::Serialize(error.to_string()))
+}
+
+/// Decode wire XML text into a typed stanza, enforcing all bounds first.
+pub fn decode_stanza(xml: &str) -> Result<Stanza, RemoteCodecError> {
+    let element = decode_element(xml)?;
+    match element.name() {
+        "message" => xmpp_parsers::message::Message::try_from(element)
+            .map(Stanza::Message)
+            .map_err(|error| RemoteCodecError::Malformed(error.to_string())),
+        "presence" => xmpp_parsers::presence::Presence::try_from(element)
+            .map(Stanza::Presence)
+            .map_err(|error| RemoteCodecError::Malformed(error.to_string())),
+        "iq" => xmpp_parsers::iq::Iq::try_from(element)
+            .map(|iq| Stanza::Iq(Box::new(iq)))
+            .map_err(|error| RemoteCodecError::Malformed(error.to_string())),
+        other => Err(RemoteCodecError::NotAStanza {
+            name: other.to_string(),
+        }),
+    }
+}
+
+/// Decode wire XML text into a minidom `Element`, enforcing the byte, depth,
+/// and attribute caps with a non-recursive pre-scan **before** handing the
+/// text to minidom's recursive parser.
+pub fn decode_element(xml: &str) -> Result<minidom::Element, RemoteCodecError> {
+    enforce_bounds(xml)?;
+    xml.parse::<minidom::Element>()
+        .map_err(|error: minidom::Error| RemoteCodecError::Malformed(error.to_string()))
+}
+
+/// Non-recursive bounds scan over the XML text.
+fn enforce_bounds(xml: &str) -> Result<(), RemoteCodecError> {
+    if xml.len() > MAX_REMOTE_XML_BYTES {
+        return Err(RemoteCodecError::TooLarge {
+            bytes: xml.len(),
+            max: MAX_REMOTE_XML_BYTES,
+        });
+    }
+
+    let mut reader = quick_xml::Reader::from_str(xml);
+    let mut depth: usize = 0;
+    loop {
+        match reader.read_event() {
+            Ok(quick_xml::events::Event::Start(start)) => {
+                depth += 1;
+                if depth > MAX_REMOTE_XML_DEPTH {
+                    return Err(RemoteCodecError::TooDeep {
+                        max: MAX_REMOTE_XML_DEPTH,
+                    });
+                }
+                check_attribute_cap(&start)?;
+            }
+            Ok(quick_xml::events::Event::Empty(start)) => {
+                // Self-closing elements don't change depth but still carry
+                // attributes.
+                check_attribute_cap(&start)?;
+            }
+            Ok(quick_xml::events::Event::End(_)) => {
+                depth = depth.saturating_sub(1);
+            }
+            Ok(quick_xml::events::Event::Eof) => return Ok(()),
+            Ok(_) => {}
+            Err(error) => return Err(RemoteCodecError::Malformed(error.to_string())),
+        }
+    }
+}
+
+/// Count one element's attributes (namespace declarations included) against
+/// the cap; a malformed attribute list is a malformed payload.
+fn check_attribute_cap(start: &quick_xml::events::BytesStart<'_>) -> Result<(), RemoteCodecError> {
+    let mut count = 0usize;
+    for attribute in start.attributes() {
+        attribute.map_err(|error| RemoteCodecError::Malformed(error.to_string()))?;
+        count += 1;
+        if count > MAX_REMOTE_XML_ATTRIBUTES {
+            return Err(RemoteCodecError::TooManyAttributes {
+                max: MAX_REMOTE_XML_ATTRIBUTES,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// A `Stanza` carried across the kameo remote boundary as bounded XML text.
+#[derive(Debug, Clone)]
+pub struct RemoteStanza(pub Stanza);
+
+impl Serialize for RemoteStanza {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let xml = encode_stanza(&self.0).map_err(S::Error::custom)?;
+        serializer.serialize_str(&xml)
+    }
+}
+
+impl<'de> Deserialize<'de> for RemoteStanza {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let xml = String::deserialize(deserializer)?;
+        decode_stanza(&xml).map(RemoteStanza).map_err(|error| {
+            metrics::record_remote_codec_drop(error.reason());
+            D::Error::custom(error)
+        })
+    }
+}
+
+/// An arbitrary XML `Element` carried across the kameo remote boundary as
+/// bounded XML text.
+#[derive(Debug, Clone)]
+pub struct RemoteElement(pub minidom::Element);
+
+impl Serialize for RemoteElement {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let xml = waddle_xmpp::parser::element_to_string(&self.0).map_err(S::Error::custom)?;
+        serializer.serialize_str(&xml)
+    }
+}
+
+impl<'de> Deserialize<'de> for RemoteElement {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let xml = String::deserialize(deserializer)?;
+        decode_element(&xml).map(RemoteElement).map_err(|error| {
+            metrics::record_remote_codec_drop(error.reason());
+            D::Error::custom(error)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn message_with_thread() -> Stanza {
+        let mut message = xmpp_parsers::message::Message::new(Some(
+            jid::Jid::from_str("romeo@example.net").expect("valid jid"),
+        ));
+        message.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "wherefore art thou".to_string(),
+        );
+        message.thread = Some(xmpp_parsers::message::Thread {
+            id: "e0ffe42b28561960c6b12b944a092794b9683a38".to_string(),
+            parent: None,
+        });
+        Stanza::Message(message)
+    }
+
+    #[test]
+    fn stanza_round_trips_preserving_thread() {
+        let stanza = message_with_thread();
+        let xml = encode_stanza(&stanza).expect("encode");
+        assert!(xml.contains("<thread"), "thread element on the wire: {xml}");
+        let decoded = decode_stanza(&xml).expect("decode");
+        match decoded {
+            Stanza::Message(message) => {
+                let thread = message.thread.expect("thread survives round-trip");
+                assert_eq!(thread.id, "e0ffe42b28561960c6b12b944a092794b9683a38");
+            }
+            other => panic!("expected message, got {}", other.name()),
+        }
+    }
+
+    #[test]
+    fn iq_and_presence_round_trip() {
+        let iq = Stanza::Iq(Box::new(xmpp_parsers::iq::Iq::from_get(
+            "ping-1",
+            xmpp_parsers::ping::Ping,
+        )));
+        let decoded = decode_stanza(&encode_stanza(&iq).expect("encode iq")).expect("decode iq");
+        assert_eq!(decoded.name(), "iq");
+
+        let presence = Stanza::Presence(xmpp_parsers::presence::Presence::new(
+            xmpp_parsers::presence::Type::None,
+        ));
+        let decoded = decode_stanza(&encode_stanza(&presence).expect("encode presence"))
+            .expect("decode presence");
+        assert_eq!(decoded.name(), "presence");
+    }
+
+    #[test]
+    fn deeply_nested_payload_is_a_typed_error_not_a_crash() {
+        // 4096 nested elements: must be rejected by the pre-scan depth cap,
+        // never handed to minidom's recursive parser.
+        let depth = 4096;
+        let mut xml = String::new();
+        for _ in 0..depth {
+            xml.push_str("<a xmlns='jabber:client'>");
+        }
+        for _ in 0..depth {
+            xml.push_str("</a>");
+        }
+        let err = decode_element(&xml).expect_err("depth cap enforced");
+        assert!(matches!(err, RemoteCodecError::TooDeep { .. }));
+    }
+
+    #[test]
+    fn attribute_bomb_is_a_typed_error() {
+        let mut xml = String::from("<message xmlns='jabber:client'");
+        for index in 0..(MAX_REMOTE_XML_ATTRIBUTES + 8) {
+            xml.push_str(&format!(" a{index}='v'"));
+        }
+        xml.push_str("/>");
+        let err = decode_element(&xml).expect_err("attribute cap enforced");
+        assert!(matches!(err, RemoteCodecError::TooManyAttributes { .. }));
+    }
+
+    #[test]
+    fn oversized_payload_is_a_typed_error() {
+        let body = "x".repeat(MAX_REMOTE_XML_BYTES + 1);
+        let xml = format!("<message xmlns='jabber:client'><body>{body}</body></message>");
+        let err = decode_element(&xml).expect_err("byte cap enforced");
+        assert!(matches!(err, RemoteCodecError::TooLarge { .. }));
+    }
+
+    #[test]
+    fn malformed_and_non_stanza_payloads_are_typed_errors() {
+        assert!(matches!(
+            decode_element("<unclosed"),
+            Err(RemoteCodecError::Malformed(_))
+        ));
+        assert!(matches!(
+            decode_stanza("<stream xmlns='jabber:client'/>"),
+            Err(RemoteCodecError::NotAStanza { .. })
+        ));
+    }
+
+    #[test]
+    fn serde_wrappers_round_trip_through_json() {
+        // Exercise the Serialize/Deserialize impls the kameo transport uses
+        // (rmp-serde in production; JSON here exercises the same code path).
+        let wrapped = RemoteStanza(message_with_thread());
+        let json = serde_json::to_string(&wrapped).expect("serialize");
+        let back: RemoteStanza = serde_json::from_str(&json).expect("deserialize");
+        match back.0 {
+            Stanza::Message(message) => assert!(message.thread.is_some()),
+            other => panic!("expected message, got {}", other.name()),
+        }
+
+        let element = RemoteElement(
+            "<x xmlns='urn:example'><y/></x>"
+                .parse::<minidom::Element>()
+                .expect("parse element"),
+        );
+        let json = serde_json::to_string(&element).expect("serialize element");
+        let back: RemoteElement = serde_json::from_str(&json).expect("deserialize element");
+        assert_eq!(back.0.name(), "x");
+    }
+
+    #[test]
+    fn serde_rejects_a_bounds_violating_payload() {
+        let mut xml = String::new();
+        for _ in 0..64 {
+            xml.push_str("<a xmlns='urn:example'>");
+        }
+        for _ in 0..64 {
+            xml.push_str("</a>");
+        }
+        let json = serde_json::to_string(&xml).expect("wrap as json string");
+        let result: Result<RemoteElement, _> = serde_json::from_str(&json);
+        assert!(result.is_err(), "bounds enforced through the serde path");
+    }
+}

--- a/server/crates/waddle-server/src/clustering/codec.rs
+++ b/server/crates/waddle-server/src/clustering/codec.rs
@@ -6,10 +6,12 @@
 //! `Stanza::to_element()` (which applies the `ensure_thread_element` fixup, so
 //! RFC 6121 `<thread/>` survives the wire) and `element_to_string`.
 //!
-//! Deserialization is **bounded before tree construction**: minidom's parser
-//! is recursive, so a small, deeply-nested payload from a compromised peer
-//! could otherwise overflow the stack and crash the node — forfeiting its
-//! claims. A non-recursive `quick-xml` pre-scan enforces a byte cap, a nesting
+//! Deserialization is **bounded before tree construction**. (minidom 0.18's
+//! own parse is an explicit-stack tree builder, so the parse itself cannot
+//! overflow — but the recursion in nested `Element` `Drop`/`Clone` glue and
+//! in `xmpp_parsers::*::try_from` is what the depth cap bounds, so the
+//! pre-scan stays load-bearing; do not remove it because the parser looks
+//! safe.) A non-recursive `quick-xml` pre-scan enforces a byte cap, a nesting
 //! depth cap, and a per-element attribute/namespace-declaration cap first; a
 //! payload failing any bound (or failing the re-parse) is a **typed error the
 //! caller NACKs to the sender** — never a silent drop — and counts in the drop
@@ -165,7 +167,10 @@ pub struct RemoteStanza(pub Stanza);
 
 impl Serialize for RemoteStanza {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let xml = encode_stanza(&self.0).map_err(S::Error::custom)?;
+        let xml = encode_stanza(&self.0).map_err(|error| {
+            metrics::record_remote_codec_drop(error.reason());
+            S::Error::custom(error)
+        })?;
         serializer.serialize_str(&xml)
     }
 }
@@ -187,7 +192,10 @@ pub struct RemoteElement(pub minidom::Element);
 
 impl Serialize for RemoteElement {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let xml = waddle_xmpp::parser::element_to_string(&self.0).map_err(S::Error::custom)?;
+        let xml = waddle_xmpp::parser::element_to_string(&self.0).map_err(|error| {
+            metrics::record_remote_codec_drop("serialize");
+            S::Error::custom(error)
+        })?;
         serializer.serialize_str(&xml)
     }
 }

--- a/server/crates/waddle-server/src/clustering/dns.rs
+++ b/server/crates/waddle-server/src/clustering/dns.rs
@@ -11,28 +11,29 @@ use libp2p::multiaddr::Protocol;
 use libp2p::Multiaddr;
 use std::net::IpAddr;
 
-/// Resolve the headless-Service DNS name to a deduplicated set of dialable TCP
-/// multiaddrs. Returns an empty vec (never an error) when resolution fails, so
+/// Resolve every bootstrap seed's DNS name to a deduplicated set of dialable
+/// TCP multiaddrs. A seed that fails to resolve is skipped (never an error) —
 /// the caller's dial loop simply retries on its next tick.
-pub async fn resolve_bootstrap_peers(bootstrap: &ClusteringBootstrapConfig) -> Vec<Multiaddr> {
-    let host_port = format!("{}:{}", bootstrap.dns_name, bootstrap.port);
-    let resolved = match tokio::net::lookup_host(&host_port).await {
-        Ok(addrs) => addrs,
-        Err(error) => {
-            tracing::debug!(
-                dns = %bootstrap.dns_name,
-                %error,
-                "clustering bootstrap DNS resolution failed; will retry"
-            );
-            return Vec::new();
-        }
-    };
-
+pub async fn resolve_bootstrap_peers(seeds: &[ClusteringBootstrapConfig]) -> Vec<Multiaddr> {
     let mut peers: Vec<Multiaddr> = Vec::new();
-    for sockaddr in resolved {
-        let multiaddr = tcp_multiaddr(sockaddr.ip(), bootstrap.port);
-        if !peers.contains(&multiaddr) {
-            peers.push(multiaddr);
+    for seed in seeds {
+        let host_port = format!("{}:{}", seed.dns_name, seed.port);
+        let resolved = match tokio::net::lookup_host(&host_port).await {
+            Ok(addrs) => addrs,
+            Err(error) => {
+                tracing::debug!(
+                    dns = %seed.dns_name,
+                    %error,
+                    "clustering bootstrap DNS resolution failed; will retry"
+                );
+                continue;
+            }
+        };
+        for sockaddr in resolved {
+            let multiaddr = tcp_multiaddr(sockaddr.ip(), seed.port);
+            if !peers.contains(&multiaddr) {
+                peers.push(multiaddr);
+            }
         }
     }
     peers

--- a/server/crates/waddle-server/src/clustering/dns.rs
+++ b/server/crates/waddle-server/src/clustering/dns.rs
@@ -17,7 +17,12 @@ use std::net::IpAddr;
 pub async fn resolve_bootstrap_peers(seeds: &[ClusteringBootstrapConfig]) -> Vec<Multiaddr> {
     let mut peers: Vec<Multiaddr> = Vec::new();
     for seed in seeds {
-        let host_port = format!("{}:{}", seed.dns_name, seed.port);
+        // IPv6 literals are stored unbracketed and must be re-bracketed for
+        // the `host:port` lookup form (`[::1]:7900`).
+        let host_port = match seed.dns_name.parse::<IpAddr>() {
+            Ok(IpAddr::V6(v6)) => format!("[{v6}]:{}", seed.port),
+            _ => format!("{}:{}", seed.dns_name, seed.port),
+        };
         let resolved = match tokio::net::lookup_host(&host_port).await {
             Ok(addrs) => addrs,
             Err(error) => {
@@ -63,5 +68,18 @@ mod tests {
     fn builds_ipv6_tcp_multiaddr() {
         let ma = tcp_multiaddr(IpAddr::V6(Ipv6Addr::LOCALHOST), 7900);
         assert_eq!(ma.to_string(), "/ip6/::1/tcp/7900");
+    }
+
+    // An IPv6-literal seed (stored unbracketed by the config parser) must be
+    // re-bracketed for lookup; an IP literal resolves without touching DNS.
+    #[tokio::test]
+    async fn resolves_ipv6_literal_seed() {
+        let peers = resolve_bootstrap_peers(&[ClusteringBootstrapConfig {
+            dns_name: "::1".to_string(),
+            port: 7900,
+        }])
+        .await;
+        assert_eq!(peers.len(), 1);
+        assert_eq!(peers[0].to_string(), "/ip6/::1/tcp/7900");
     }
 }

--- a/server/crates/waddle-server/src/clustering/dns.rs
+++ b/server/crates/waddle-server/src/clustering/dns.rs
@@ -1,0 +1,66 @@
+//! Headless-Service peer discovery for the clustering swarm.
+//!
+//! A Kubernetes headless Service resolves to the A/AAAA records of every ready
+//! pod. We resolve the configured DNS name to socket addresses and turn each
+//! into a dialable TCP multiaddr; libp2p learns each peer's `PeerId` after the
+//! Noise handshake, so we never need to know peer IDs ahead of time (kademlia
+//! carries node discovery only — ADR element 6).
+
+use crate::config::ClusteringBootstrapConfig;
+use libp2p::multiaddr::Protocol;
+use libp2p::Multiaddr;
+use std::net::IpAddr;
+
+/// Resolve the headless-Service DNS name to a deduplicated set of dialable TCP
+/// multiaddrs. Returns an empty vec (never an error) when resolution fails, so
+/// the caller's dial loop simply retries on its next tick.
+pub async fn resolve_bootstrap_peers(bootstrap: &ClusteringBootstrapConfig) -> Vec<Multiaddr> {
+    let host_port = format!("{}:{}", bootstrap.dns_name, bootstrap.port);
+    let resolved = match tokio::net::lookup_host(&host_port).await {
+        Ok(addrs) => addrs,
+        Err(error) => {
+            tracing::debug!(
+                dns = %bootstrap.dns_name,
+                %error,
+                "clustering bootstrap DNS resolution failed; will retry"
+            );
+            return Vec::new();
+        }
+    };
+
+    let mut peers: Vec<Multiaddr> = Vec::new();
+    for sockaddr in resolved {
+        let multiaddr = tcp_multiaddr(sockaddr.ip(), bootstrap.port);
+        if !peers.contains(&multiaddr) {
+            peers.push(multiaddr);
+        }
+    }
+    peers
+}
+
+/// Build a dialable `/ip{4,6}/…/tcp/<port>` multiaddr for a resolved peer IP.
+fn tcp_multiaddr(ip: IpAddr, port: u16) -> Multiaddr {
+    let ip_proto = match ip {
+        IpAddr::V4(v4) => Protocol::Ip4(v4),
+        IpAddr::V6(v6) => Protocol::Ip6(v6),
+    };
+    Multiaddr::empty().with(ip_proto).with(Protocol::Tcp(port))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    #[test]
+    fn builds_ipv4_tcp_multiaddr() {
+        let ma = tcp_multiaddr(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 5)), 7900);
+        assert_eq!(ma.to_string(), "/ip4/10.0.0.5/tcp/7900");
+    }
+
+    #[test]
+    fn builds_ipv6_tcp_multiaddr() {
+        let ma = tcp_multiaddr(IpAddr::V6(Ipv6Addr::LOCALHOST), 7900);
+        assert_eq!(ma.to_string(), "/ip6/::1/tcp/7900");
+    }
+}

--- a/server/crates/waddle-server/src/clustering/identity.rs
+++ b/server/crates/waddle-server/src/clustering/identity.rs
@@ -1,17 +1,81 @@
 //! Per-node libp2p identity for the clustering swarm.
 //!
-//! Phase 2 Slice 1 uses an **ephemeral** ed25519 keypair generated at
-//! startup — sufficient for the node-discovery spike, where a fresh `PeerId`
-//! per process is harmless. Slice 2 replaces this with a keypair leased from a
-//! pre-enrolled pool via a Postgres CAS (ADR element 3), giving a stable,
-//! revocable, per-pod identity (and a fallible acquisition path).
+//! Two paths:
+//! - **Leased pool identity** (production shape, ADR element 3): the node
+//!   leases one slot of the pre-enrolled keypair pool via a Postgres CAS and
+//!   uses that slot's keypair, giving a stable, revocable, per-pod identity
+//!   with at most one live holder per keypair.
+//! - **Ephemeral** fallback: when no pool is configured, a fresh ed25519
+//!   keypair is generated per process — fine for the discovery spike and
+//!   tests, but not a stable identity.
 
-use libp2p::identity::Keypair;
+use base64::Engine;
+use libp2p::identity::{ed25519, Keypair};
 
-/// Produce the node's libp2p keypair.
-///
-/// Currently generates a fresh ed25519 keypair each start. Slice 2 turns this
-/// into a fallible pool-lease acquisition.
-pub fn node_keypair() -> Keypair {
+/// Length of an ed25519 secret key seed in bytes.
+const ED25519_SECRET_LEN: usize = 32;
+
+/// Generate a fresh ephemeral ed25519 keypair (no pool configured).
+pub fn ephemeral_keypair() -> Keypair {
     Keypair::generate_ed25519()
+}
+
+/// Decode one enrolled keypair-pool entry (base64-encoded 32-byte ed25519
+/// secret key) into a libp2p `Keypair`.
+pub fn keypair_from_pool_entry(entry: &str) -> Result<Keypair, IdentityError> {
+    let raw = base64::engine::general_purpose::STANDARD
+        .decode(entry.trim())
+        .map_err(|error| IdentityError::Decode(error.to_string()))?;
+    let mut seed: [u8; ED25519_SECRET_LEN] = raw.as_slice().try_into().map_err(|_| {
+        IdentityError::Decode(format!(
+            "expected a {ED25519_SECRET_LEN}-byte ed25519 secret, got {} bytes",
+            raw.len()
+        ))
+    })?;
+    // `try_from_bytes` zeroizes the input slice, so `seed` is cleared after.
+    let secret = ed25519::SecretKey::try_from_bytes(&mut seed)
+        .map_err(|error| IdentityError::Decode(error.to_string()))?;
+    Ok(Keypair::from(ed25519::Keypair::from(secret)))
+}
+
+/// Failures decoding an enrolled keypair-pool entry.
+#[derive(Debug, thiserror::Error)]
+pub enum IdentityError {
+    #[error("failed to decode enrolled keypair pool entry: {0}")]
+    Decode(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_a_generated_ed25519_seed() {
+        // Take a real ed25519 secret, base64 it, and confirm decode yields the
+        // same PeerId.
+        let original = ed25519::Keypair::generate();
+        let seed = original.secret().as_ref().to_vec();
+        let b64 = base64::engine::general_purpose::STANDARD.encode(&seed);
+
+        let decoded = keypair_from_pool_entry(&b64).expect("decodes");
+        let expected = Keypair::from(original).public().to_peer_id();
+        assert_eq!(decoded.public().to_peer_id(), expected);
+    }
+
+    #[test]
+    fn rejects_wrong_length_seed() {
+        let b64 = base64::engine::general_purpose::STANDARD.encode([0u8; 16]);
+        assert!(matches!(
+            keypair_from_pool_entry(&b64),
+            Err(IdentityError::Decode(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_non_base64() {
+        assert!(matches!(
+            keypair_from_pool_entry("not valid base64!!!"),
+            Err(IdentityError::Decode(_))
+        ));
+    }
 }

--- a/server/crates/waddle-server/src/clustering/identity.rs
+++ b/server/crates/waddle-server/src/clustering/identity.rs
@@ -11,6 +11,7 @@
 
 use base64::Engine;
 use libp2p::identity::{ed25519, Keypair};
+use zeroize::Zeroize;
 
 /// Length of an ed25519 secret key seed in bytes.
 const ED25519_SECRET_LEN: usize = 32;
@@ -23,15 +24,21 @@ pub fn ephemeral_keypair() -> Keypair {
 /// Decode one enrolled keypair-pool entry (base64-encoded 32-byte ed25519
 /// secret key) into a libp2p `Keypair`.
 pub fn keypair_from_pool_entry(entry: &str) -> Result<Keypair, IdentityError> {
-    let raw = base64::engine::general_purpose::STANDARD
+    let mut raw = base64::engine::general_purpose::STANDARD
         .decode(entry.trim())
         .map_err(|error| IdentityError::Decode(error.to_string()))?;
-    let mut seed: [u8; ED25519_SECRET_LEN] = raw.as_slice().try_into().map_err(|_| {
-        IdentityError::Decode(format!(
-            "expected a {ED25519_SECRET_LEN}-byte ed25519 secret, got {} bytes",
-            raw.len()
-        ))
-    })?;
+    // `try_into` copies into `seed`, so the decode buffer still holds the
+    // secret — clear it on both paths rather than leave key material in heap
+    // memory until drop.
+    let seed: Result<[u8; ED25519_SECRET_LEN], _> = raw.as_slice().try_into();
+    let Ok(mut seed) = seed else {
+        let got = raw.len();
+        raw.zeroize();
+        return Err(IdentityError::Decode(format!(
+            "expected a {ED25519_SECRET_LEN}-byte ed25519 secret, got {got} bytes"
+        )));
+    };
+    raw.zeroize();
     // `try_from_bytes` zeroizes the input slice, so `seed` is cleared after.
     let secret = ed25519::SecretKey::try_from_bytes(&mut seed)
         .map_err(|error| IdentityError::Decode(error.to_string()))?;

--- a/server/crates/waddle-server/src/clustering/identity.rs
+++ b/server/crates/waddle-server/src/clustering/identity.rs
@@ -1,0 +1,17 @@
+//! Per-node libp2p identity for the clustering swarm.
+//!
+//! Phase 2 Slice 1 uses an **ephemeral** ed25519 keypair generated at
+//! startup — sufficient for the node-discovery spike, where a fresh `PeerId`
+//! per process is harmless. Slice 2 replaces this with a keypair leased from a
+//! pre-enrolled pool via a Postgres CAS (ADR element 3), giving a stable,
+//! revocable, per-pod identity (and a fallible acquisition path).
+
+use libp2p::identity::Keypair;
+
+/// Produce the node's libp2p keypair.
+///
+/// Currently generates a fresh ed25519 keypair each start. Slice 2 turns this
+/// into a fallible pool-lease acquisition.
+pub fn node_keypair() -> Keypair {
+    Keypair::generate_ed25519()
+}

--- a/server/crates/waddle-server/src/clustering/lease.rs
+++ b/server/crates/waddle-server/src/clustering/lease.rs
@@ -16,17 +16,20 @@
 //! lands with the Phase 3 ownership control plane; Phase 2's only control-plane
 //! traffic is this slot heartbeat.
 
+use super::NodeId;
 use crate::db::{Database, DatabaseError};
 use async_trait::async_trait;
 use std::time::Duration;
 
 /// Per-process leaseholder identity. `node_id`/`node_epoch` are freshly
 /// generated on every process start and never reused, so a restarted pod never
-/// looks like its former self holding a slot.
+/// looks like its former self holding a slot. Both are typed values
+/// (typed-payloads rule); serialization to TEXT happens only at the SQL
+/// parameter boundary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LeaseIdentity {
-    pub node_id: String,
-    pub node_epoch: String,
+    pub node_id: NodeId,
+    pub node_epoch: uuid::Uuid,
 }
 
 /// A successfully leased keypair-pool slot (index into the enrolled pool).
@@ -126,10 +129,11 @@ impl PostgresKeypairSlotLease {
                    OR clustering_keypair_slots.expired
                    OR clustering_keypair_slots.heartbeat < now() - (? || ' milliseconds')::interval
                 "#,
+                // Storage boundary: typed identity serializes to TEXT here.
                 crate::db_params![
                     i64::from(slot_index),
-                    identity.node_id.clone(),
-                    identity.node_epoch.clone(),
+                    identity.node_id.as_str().to_string(),
+                    identity.node_epoch.to_string(),
                     lease_ttl.as_millis().to_string(),
                 ],
             )
@@ -170,7 +174,7 @@ impl KeypairSlotLease for PostgresKeypairSlotLease {
         // Scan slots, starting at an offset derived from this node's id so
         // concurrently-starting pods don't all contend on slot 0 first. The
         // CAS guarantees correctness regardless of scan order.
-        let start = (stable_offset(&identity.node_id) % pool_size) as u32;
+        let start = (stable_offset(identity.node_id.as_str()) % pool_size) as u32;
         let pool = pool_size as u32;
         for step in 0..pool {
             let slot_index = (start + step) % pool;
@@ -206,8 +210,8 @@ impl KeypairSlotLease for PostgresKeypairSlotLease {
                 "#,
                 crate::db_params![
                     i64::from(slot.slot_index),
-                    identity.node_id.clone(),
-                    identity.node_epoch.clone(),
+                    identity.node_id.as_str().to_string(),
+                    identity.node_epoch.to_string(),
                     lease_ttl.as_millis().to_string(),
                 ],
             )
@@ -232,8 +236,8 @@ impl KeypairSlotLease for PostgresKeypairSlotLease {
             "#,
             crate::db_params![
                 i64::from(slot.slot_index),
-                identity.node_id.clone(),
-                identity.node_epoch.clone(),
+                identity.node_id.as_str().to_string(),
+                identity.node_epoch.to_string(),
             ],
         )
         .await?;
@@ -272,8 +276,8 @@ mod tests {
 
     fn ident() -> LeaseIdentity {
         LeaseIdentity {
-            node_id: uuid::Uuid::new_v4().to_string(),
-            node_epoch: uuid::Uuid::new_v4().to_string(),
+            node_id: NodeId::generate(),
+            node_epoch: uuid::Uuid::new_v4(),
         }
     }
 

--- a/server/crates/waddle-server/src/clustering/lease.rs
+++ b/server/crates/waddle-server/src/clustering/lease.rs
@@ -1,0 +1,372 @@
+//! Keypair-slot Postgres CAS lease (ADR-0017 element 3/4).
+//!
+//! A pod leases exactly one slot of the pre-enrolled keypair pool via a
+//! server-time (`now()`) compare-and-set, so at most one live node ever holds
+//! a given slot — and therefore no two swarm members share a libp2p `PeerId`.
+//! The lease is heartbeat-renewed; a renewal that finds its slot stolen or
+//! expired is **fencing loss** and the node must stop using that identity.
+//!
+//! Postgres-only: the control plane has no SQLite equivalent (`now()`-based
+//! row CAS), and clustering requires Postgres. The store goes through the
+//! portable `Database` (which rewrites `?`→`$n` for Postgres and leaves
+//! `now()`/interval SQL intact); it is only ever invoked on a Postgres
+//! deployment.
+//!
+//! The dedicated control-plane connection pool the ADR prescribes (element 4/12)
+//! lands with the Phase 3 ownership control plane; Phase 2's only control-plane
+//! traffic is this slot heartbeat.
+
+use crate::db::{Database, DatabaseError};
+use async_trait::async_trait;
+use std::time::Duration;
+
+/// Per-process leaseholder identity. `node_id`/`node_epoch` are freshly
+/// generated on every process start and never reused, so a restarted pod never
+/// looks like its former self holding a slot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeaseIdentity {
+    pub node_id: String,
+    pub node_epoch: String,
+}
+
+/// A successfully leased keypair-pool slot (index into the enrolled pool).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LeasedSlot {
+    pub slot_index: u32,
+}
+
+/// Keypair-slot lease failures.
+#[derive(Debug, thiserror::Error)]
+pub enum LeaseError {
+    /// The backing database returned an error.
+    #[error("clustering keypair-slot lease database error: {0}")]
+    Database(#[from] DatabaseError),
+    /// Every pool slot is currently held by a live node.
+    #[error(
+        "no free clustering keypair-slot could be leased: all {pool_size} enrolled pool slots \
+         are held by live nodes (scale-up beyond the enrolled pool needs a pipeline enrollment run)"
+    )]
+    NoFreeSlot { pool_size: usize },
+    /// A heartbeat renewal found the slot no longer held by this node
+    /// (stolen after lease expiry, or epoch superseded).
+    #[error("clustering keypair-slot {slot_index} lease lost (fencing): slot no longer held by this node")]
+    FencingLoss { slot_index: u32 },
+    /// `acquire` was called with an empty pool — a configuration error the
+    /// caller should have screened out.
+    #[error("clustering keypair-slot lease requested with an empty keypair pool")]
+    EmptyPool,
+}
+
+/// The keypair-slot lease store. A trait so a dedicated control-plane pool
+/// implementation (Phase 3) or a test double can substitute without touching
+/// callers.
+#[async_trait]
+pub trait KeypairSlotLease: Send + Sync {
+    /// Create the backing table if it does not exist.
+    async fn ensure_schema(&self) -> Result<(), LeaseError>;
+
+    /// Lease any free or expired slot in `[0, pool_size)`. Returns the leased
+    /// slot, or [`LeaseError::NoFreeSlot`] if all are held by live nodes.
+    async fn acquire(
+        &self,
+        identity: &LeaseIdentity,
+        pool_size: usize,
+        lease_ttl: Duration,
+    ) -> Result<LeasedSlot, LeaseError>;
+
+    /// Renew the lease on a held slot. Returns [`LeaseError::FencingLoss`] when
+    /// the freshness-gated CAS affects zero rows (lease lapsed or stolen).
+    async fn heartbeat(
+        &self,
+        identity: &LeaseIdentity,
+        slot: LeasedSlot,
+        lease_ttl: Duration,
+    ) -> Result<(), LeaseError>;
+
+    /// Release a held slot on graceful drain (epoch-gated, best-effort).
+    async fn release(&self, identity: &LeaseIdentity, slot: LeasedSlot) -> Result<(), LeaseError>;
+}
+
+/// Postgres implementation using `now()`-based row CAS.
+pub struct PostgresKeypairSlotLease {
+    db: Database,
+}
+
+impl PostgresKeypairSlotLease {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+
+    /// Try to claim one specific slot. Returns `true` on success (row inserted
+    /// or a stale/free row stolen), `false` if the slot is held fresh.
+    async fn try_acquire_slot(
+        &self,
+        identity: &LeaseIdentity,
+        slot_index: u32,
+        lease_ttl: Duration,
+    ) -> Result<bool, LeaseError> {
+        let conn = self.db.guard().await?;
+        // Upsert CAS: insert a fresh hold, or steal an existing row only when
+        // it is unheld, already expired, or its heartbeat has aged past the
+        // TTL. A held-and-fresh slot fails the ON CONFLICT WHERE and affects
+        // zero rows. Postgres row-locks the conflicting row, so two racing
+        // acquirers of the same slot serialize and exactly one wins.
+        let affected = conn
+            .execute(
+                r#"
+                INSERT INTO clustering_keypair_slots
+                    (slot_index, holder_node, holder_epoch, heartbeat, expired)
+                VALUES (?, ?, ?, now(), false)
+                ON CONFLICT (slot_index) DO UPDATE SET
+                    holder_node = EXCLUDED.holder_node,
+                    holder_epoch = EXCLUDED.holder_epoch,
+                    heartbeat = now(),
+                    expired = false
+                WHERE clustering_keypair_slots.holder_node IS NULL
+                   OR clustering_keypair_slots.expired
+                   OR clustering_keypair_slots.heartbeat < now() - (? || ' seconds')::interval
+                "#,
+                crate::db_params![
+                    i64::from(slot_index),
+                    identity.node_id.clone(),
+                    identity.node_epoch.clone(),
+                    lease_ttl.as_secs().to_string(),
+                ],
+            )
+            .await?;
+        Ok(affected == 1)
+    }
+}
+
+#[async_trait]
+impl KeypairSlotLease for PostgresKeypairSlotLease {
+    async fn ensure_schema(&self) -> Result<(), LeaseError> {
+        let conn = self.db.guard().await?;
+        conn.execute(
+            r#"
+            CREATE TABLE IF NOT EXISTS clustering_keypair_slots (
+                slot_index   INTEGER PRIMARY KEY,
+                holder_node  TEXT,
+                holder_epoch TEXT,
+                heartbeat    TIMESTAMPTZ NOT NULL DEFAULT now(),
+                expired      BOOLEAN NOT NULL DEFAULT TRUE
+            )
+            "#,
+            (),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn acquire(
+        &self,
+        identity: &LeaseIdentity,
+        pool_size: usize,
+        lease_ttl: Duration,
+    ) -> Result<LeasedSlot, LeaseError> {
+        if pool_size == 0 {
+            return Err(LeaseError::EmptyPool);
+        }
+        // Scan slots, starting at an offset derived from this node's id so
+        // concurrently-starting pods don't all contend on slot 0 first. The
+        // CAS guarantees correctness regardless of scan order.
+        let start = (stable_offset(&identity.node_id) % pool_size) as u32;
+        let pool = pool_size as u32;
+        for step in 0..pool {
+            let slot_index = (start + step) % pool;
+            if self
+                .try_acquire_slot(identity, slot_index, lease_ttl)
+                .await?
+            {
+                return Ok(LeasedSlot { slot_index });
+            }
+        }
+        Err(LeaseError::NoFreeSlot { pool_size })
+    }
+
+    async fn heartbeat(
+        &self,
+        identity: &LeaseIdentity,
+        slot: LeasedSlot,
+        lease_ttl: Duration,
+    ) -> Result<(), LeaseError> {
+        let conn = self.db.guard().await?;
+        // Freshness-gated renewal CAS (ADR element 4): renew only while we
+        // still hold the slot under our epoch and the lease has not lapsed.
+        let affected = conn
+            .execute(
+                r#"
+                UPDATE clustering_keypair_slots
+                SET heartbeat = now()
+                WHERE slot_index = ?
+                  AND holder_node = ?
+                  AND holder_epoch = ?
+                  AND NOT expired
+                  AND heartbeat >= now() - (? || ' seconds')::interval
+                "#,
+                crate::db_params![
+                    i64::from(slot.slot_index),
+                    identity.node_id.clone(),
+                    identity.node_epoch.clone(),
+                    lease_ttl.as_secs().to_string(),
+                ],
+            )
+            .await?;
+        if affected == 0 {
+            return Err(LeaseError::FencingLoss {
+                slot_index: slot.slot_index,
+            });
+        }
+        Ok(())
+    }
+
+    async fn release(&self, identity: &LeaseIdentity, slot: LeasedSlot) -> Result<(), LeaseError> {
+        let conn = self.db.guard().await?;
+        // Epoch-gated release: mark the slot free+expired so a replacement can
+        // acquire it immediately, but only if we still own it.
+        conn.execute(
+            r#"
+            UPDATE clustering_keypair_slots
+            SET holder_node = NULL, holder_epoch = NULL, expired = true
+            WHERE slot_index = ? AND holder_node = ? AND holder_epoch = ?
+            "#,
+            crate::db_params![
+                i64::from(slot.slot_index),
+                identity.node_id.clone(),
+                identity.node_epoch.clone(),
+            ],
+        )
+        .await?;
+        Ok(())
+    }
+}
+
+/// A cheap, stable, non-cryptographic offset from a node id, so pods spread
+/// their initial slot scan instead of all starting at 0.
+fn stable_offset(node_id: &str) -> usize {
+    // FNV-1a over the bytes — deterministic and dependency-free.
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in node_id.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash as usize
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{DatabaseConfig, DatabaseDriver};
+    use std::sync::OnceLock;
+    use std::time::Duration;
+
+    // These tests share one `clustering_keypair_slots` table, so serialize
+    // them and wipe the table at each start. They are skipped unless
+    // `WADDLE_TEST_POSTGRES_URL` points at a Postgres (the control-plane CAS
+    // has no SQLite equivalent). CI runs them under the clustering feature +
+    // the Nix-spawned Postgres.
+    fn serial_lock() -> &'static tokio::sync::Mutex<()> {
+        static LOCK: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+    }
+
+    fn ident() -> LeaseIdentity {
+        LeaseIdentity {
+            node_id: uuid::Uuid::new_v4().to_string(),
+            node_epoch: uuid::Uuid::new_v4().to_string(),
+        }
+    }
+
+    async fn clean_store() -> Option<PostgresKeypairSlotLease> {
+        let url = std::env::var("WADDLE_TEST_POSTGRES_URL").ok()?;
+        let db = Database::from_config(
+            "clustering-lease-test",
+            &DatabaseConfig::new(DatabaseDriver::Postgres, url),
+        )
+        .await
+        .expect("open test postgres");
+        let store = PostgresKeypairSlotLease::new(db);
+        store.ensure_schema().await.expect("ensure schema");
+        store
+            .db
+            .guard()
+            .await
+            .expect("guard")
+            .execute("DELETE FROM clustering_keypair_slots", ())
+            .await
+            .expect("clean slots");
+        Some(store)
+    }
+
+    const TTL: Duration = Duration::from_secs(30);
+
+    #[tokio::test]
+    async fn two_nodes_lease_distinct_slots() {
+        let _guard = serial_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let (a, b) = (ident(), ident());
+        let slot_a = store.acquire(&a, 2, TTL).await.expect("a acquires");
+        let slot_b = store.acquire(&b, 2, TTL).await.expect("b acquires");
+        assert_ne!(slot_a.slot_index, slot_b.slot_index);
+    }
+
+    #[tokio::test]
+    async fn single_slot_pool_admits_exactly_one() {
+        let _guard = serial_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let (a, b) = (ident(), ident());
+        store.acquire(&a, 1, TTL).await.expect("a acquires slot 0");
+        let err = store.acquire(&b, 1, TTL).await.expect_err("b is refused");
+        assert!(matches!(err, LeaseError::NoFreeSlot { pool_size: 1 }));
+    }
+
+    #[tokio::test]
+    async fn heartbeat_renews_and_release_frees() {
+        let _guard = serial_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let (a, b) = (ident(), ident());
+        let slot = store.acquire(&a, 1, TTL).await.expect("a acquires");
+        store.heartbeat(&a, slot, TTL).await.expect("a renews");
+        // While A holds it, B cannot take it.
+        assert!(store.acquire(&b, 1, TTL).await.is_err());
+        // After A releases, B acquires immediately.
+        store.release(&a, slot).await.expect("a releases");
+        let slot_b = store.acquire(&b, 1, TTL).await.expect("b acquires freed");
+        assert_eq!(slot_b.slot_index, slot.slot_index);
+    }
+
+    #[tokio::test]
+    async fn expired_slot_is_stolen_and_old_holder_fences() {
+        let _guard = serial_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let (a, b) = (ident(), ident());
+        let short_ttl = Duration::from_secs(1);
+        let slot = store.acquire(&a, 1, short_ttl).await.expect("a acquires");
+        // Let the lease lapse, then B steals the expired slot.
+        tokio::time::sleep(Duration::from_millis(1_200)).await;
+        let slot_b = store
+            .acquire(&b, 1, short_ttl)
+            .await
+            .expect("b steals expired slot");
+        assert_eq!(slot_b.slot_index, slot.slot_index);
+        // A's renewal now fails — fencing loss.
+        let err = store
+            .heartbeat(&a, slot, short_ttl)
+            .await
+            .expect_err("a fences");
+        assert!(matches!(err, LeaseError::FencingLoss { .. }));
+    }
+
+    #[test]
+    fn stable_offset_is_deterministic() {
+        assert_eq!(stable_offset("node-a"), stable_offset("node-a"));
+    }
+}

--- a/server/crates/waddle-server/src/clustering/lease.rs
+++ b/server/crates/waddle-server/src/clustering/lease.rs
@@ -124,13 +124,13 @@ impl PostgresKeypairSlotLease {
                     expired = false
                 WHERE clustering_keypair_slots.holder_node IS NULL
                    OR clustering_keypair_slots.expired
-                   OR clustering_keypair_slots.heartbeat < now() - (? || ' seconds')::interval
+                   OR clustering_keypair_slots.heartbeat < now() - (? || ' milliseconds')::interval
                 "#,
                 crate::db_params![
                     i64::from(slot_index),
                     identity.node_id.clone(),
                     identity.node_epoch.clone(),
-                    lease_ttl.as_secs().to_string(),
+                    lease_ttl.as_millis().to_string(),
                 ],
             )
             .await?;
@@ -202,13 +202,13 @@ impl KeypairSlotLease for PostgresKeypairSlotLease {
                   AND holder_node = ?
                   AND holder_epoch = ?
                   AND NOT expired
-                  AND heartbeat >= now() - (? || ' seconds')::interval
+                  AND heartbeat >= now() - (? || ' milliseconds')::interval
                 "#,
                 crate::db_params![
                     i64::from(slot.slot_index),
                     identity.node_id.clone(),
                     identity.node_epoch.clone(),
-                    lease_ttl.as_secs().to_string(),
+                    lease_ttl.as_millis().to_string(),
                 ],
             )
             .await?;
@@ -363,6 +363,30 @@ mod tests {
             .await
             .expect_err("a fences");
         assert!(matches!(err, LeaseError::FencingLoss { .. }));
+    }
+
+    #[tokio::test]
+    async fn sub_second_ttl_uses_millisecond_precision() {
+        let _guard = serial_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let (a, b) = (ident(), ident());
+        // A 300ms TTL must NOT floor to '0 seconds' (which would make every
+        // slot instantly stealable and every renewal fence).
+        let ttl = Duration::from_millis(300);
+        let slot = store.acquire(&a, 1, ttl).await.expect("a acquires");
+        // Immediately renewable within the sub-second window, and the fresh
+        // slot is not stealable by B.
+        store
+            .heartbeat(&a, slot, ttl)
+            .await
+            .expect("a renews in-window");
+        assert!(store.acquire(&b, 1, ttl).await.is_err());
+        // After the window lapses, B steals it.
+        tokio::time::sleep(Duration::from_millis(450)).await;
+        let slot_b = store.acquire(&b, 1, ttl).await.expect("b steals expired");
+        assert_eq!(slot_b.slot_index, slot.slot_index);
     }
 
     #[test]

--- a/server/crates/waddle-server/src/clustering/metrics.rs
+++ b/server/crates/waddle-server/src/clustering/metrics.rs
@@ -71,6 +71,22 @@ pub fn record_allowlist_size(count: i64) {
     .record(count, &[]);
 }
 
+/// Count a remote-codec decode rejection (bounds violation or re-parse
+/// failure). `reason` is a stable low-cardinality label
+/// (`too_large`/`too_deep`/`too_many_attributes`/`malformed`/`not_a_stanza`/
+/// `serialize`).
+pub fn record_remote_codec_drop(reason: &'static str) {
+    static C: OnceLock<Counter<u64>> = OnceLock::new();
+    C.get_or_init(|| {
+        meter()
+            .u64_counter("waddle.clustering.remote_codec_drops")
+            .with_description("Remote payloads rejected by the XML codec (NACKed, never silent)")
+            .with_unit("payload")
+            .build()
+    })
+    .add(1, &[opentelemetry::KeyValue::new("reason", reason)]);
+}
+
 /// Count peers revoked by an allowlist refresh (live connections closed).
 pub fn record_peers_revoked(count: u64) {
     static C: OnceLock<Counter<u64>> = OnceLock::new();

--- a/server/crates/waddle-server/src/clustering/metrics.rs
+++ b/server/crates/waddle-server/src/clustering/metrics.rs
@@ -1,0 +1,59 @@
+//! Observability for the clustering swarm subsystem (ADR-0017 Phase 2).
+//!
+//! Uses the global OpenTelemetry meter provider (initialized by the host in
+//! `telemetry.rs`), mirroring `waddle_xmpp::metrics`. Three instruments this
+//! phase:
+//! - a connected-peer gauge (authoritative from swarm connection events),
+//! - a kademlia routing-table-size gauge (observed from kameo registry
+//!   `RoutingUpdated` events — the `kademlia` field itself is private in kameo
+//!   0.20, so this is the peer set we have seen enter the routing table), and
+//! - a bootstrap-dial retry counter.
+
+use opentelemetry::metrics::{Counter, Gauge, Meter};
+use std::sync::OnceLock;
+
+static METER: OnceLock<Meter> = OnceLock::new();
+
+fn meter() -> &'static Meter {
+    METER.get_or_init(|| opentelemetry::global::meter("waddle-clustering"))
+}
+
+/// Set the current number of connected swarm peers.
+pub fn record_connected_peers(count: i64) {
+    static G: OnceLock<Gauge<i64>> = OnceLock::new();
+    G.get_or_init(|| {
+        meter()
+            .i64_gauge("waddle.clustering.connected_peers")
+            .with_description("Current number of connected clustering swarm peers")
+            .with_unit("peer")
+            .build()
+    })
+    .record(count, &[]);
+}
+
+/// Set the current size of the (observed) kademlia routing table.
+pub fn record_routing_table_size(count: i64) {
+    static G: OnceLock<Gauge<i64>> = OnceLock::new();
+    G.get_or_init(|| {
+        meter()
+            .i64_gauge("waddle.clustering.routing_table_size")
+            .with_description("Observed kademlia routing-table peer count")
+            .with_unit("peer")
+            .build()
+    })
+    .record(count, &[]);
+}
+
+/// Increment the bootstrap-dial retry counter (one per dial attempt to a
+/// headless-DNS-resolved seed peer).
+pub fn record_bootstrap_dial() {
+    static C: OnceLock<Counter<u64>> = OnceLock::new();
+    C.get_or_init(|| {
+        meter()
+            .u64_counter("waddle.clustering.bootstrap_dials")
+            .with_description("Total bootstrap dial attempts to headless-DNS peers")
+            .with_unit("dial")
+            .build()
+    })
+    .add(1, &[]);
+}

--- a/server/crates/waddle-server/src/clustering/metrics.rs
+++ b/server/crates/waddle-server/src/clustering/metrics.rs
@@ -57,3 +57,29 @@ pub fn record_bootstrap_dial() {
     })
     .add(1, &[]);
 }
+
+/// Set the current number of enrolled allowlist peers.
+pub fn record_allowlist_size(count: i64) {
+    static G: OnceLock<Gauge<i64>> = OnceLock::new();
+    G.get_or_init(|| {
+        meter()
+            .i64_gauge("waddle.clustering.allowlist_size")
+            .with_description("Currently enrolled clustering peer-allowlist entries")
+            .with_unit("peer")
+            .build()
+    })
+    .record(count, &[]);
+}
+
+/// Count peers revoked by an allowlist refresh (live connections closed).
+pub fn record_peers_revoked(count: u64) {
+    static C: OnceLock<Counter<u64>> = OnceLock::new();
+    C.get_or_init(|| {
+        meter()
+            .u64_counter("waddle.clustering.peers_revoked")
+            .with_description("Peers revoked by allowlist refresh (live connections closed)")
+            .with_unit("peer")
+            .build()
+    })
+    .add(count, &[]);
+}

--- a/server/crates/waddle-server/src/clustering/metrics.rs
+++ b/server/crates/waddle-server/src/clustering/metrics.rs
@@ -87,6 +87,20 @@ pub fn record_remote_codec_drop(reason: &'static str) {
     .add(1, &[opentelemetry::KeyValue::new("reason", reason)]);
 }
 
+/// Count a supervised relay-actor respawn (unexpected stop + mandatory
+/// same-name re-registration).
+pub fn record_relay_respawn() {
+    static C: OnceLock<Counter<u64>> = OnceLock::new();
+    C.get_or_init(|| {
+        meter()
+            .u64_counter("waddle.clustering.relay_respawns")
+            .with_description("Supervised relay-actor respawns with same-name re-registration")
+            .with_unit("respawn")
+            .build()
+    })
+    .add(1, &[]);
+}
+
 /// Count peers revoked by an allowlist refresh (live connections closed).
 pub fn record_peers_revoked(count: u64) {
     static C: OnceLock<Counter<u64>> = OnceLock::new();

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -15,8 +15,11 @@ use crate::config::ClusteringConfig;
 use crate::db::{Database, DatabaseDriver};
 use tokio_util::sync::CancellationToken;
 
+/// Peer-allowlist store. Public: the multi-process cluster harness
+/// provisions the control-plane schema through the same `ensure_schema`
+/// path production uses, never a diverging inline DDL copy.
 #[cfg(feature = "clustering")]
-mod allowlist;
+pub mod allowlist;
 #[cfg(feature = "clustering")]
 mod behaviour;
 /// Remote XML-text serde codec for stanzas/elements crossing the kameo
@@ -28,8 +31,10 @@ pub mod codec;
 mod dns;
 #[cfg(feature = "clustering")]
 mod identity;
+/// Keypair-slot lease store. Public for the same reason as [`allowlist`]:
+/// the harness provisions schema via the production path.
 #[cfg(feature = "clustering")]
-mod lease;
+pub mod lease;
 #[cfg(feature = "clustering")]
 mod metrics;
 /// Per-node supervised relay actor + client handle. Public: the multi-process

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -19,6 +19,11 @@ use tokio_util::sync::CancellationToken;
 mod allowlist;
 #[cfg(feature = "clustering")]
 mod behaviour;
+/// Remote XML-text serde codec for stanzas/elements crossing the kameo
+/// boundary. Public: the Slice 5 relay actors' message types embed these
+/// wrappers, and downstream phases (cross-node routing) build on them.
+#[cfg(feature = "clustering")]
+pub mod codec;
 #[cfg(feature = "clustering")]
 mod dns;
 #[cfg(feature = "clustering")]
@@ -29,6 +34,16 @@ mod lease;
 mod metrics;
 #[cfg(feature = "clustering")]
 mod swarm;
+
+/// Serializes tests that touch the shared `clustering_peer_allowlist` table
+/// (the allowlist store tests and the swarm bring-up smoke test, which loads
+/// the allowlist at startup) so a concurrently seeded row cannot leak between
+/// them.
+#[cfg(all(test, feature = "clustering"))]
+pub(crate) fn allowlist_table_lock() -> &'static tokio::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<tokio::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| tokio::sync::Mutex::new(()))
+}
 
 /// Startup failures for the clustering subsystem. The human-facing `Display`
 /// text is surfaced as the server-startup diagnostic.

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -37,8 +37,12 @@ mod metrics;
 /// builds on the relay message set.
 #[cfg(feature = "clustering")]
 pub mod relay;
+/// Owned swarm bring-up. Public so the multi-process cluster harness can run
+/// a swarm inside the test process (kameo's `init_global` is a process
+/// singleton, so multi-node behaviour is only testable across processes —
+/// the harness process joins the swarm as a real node).
 #[cfg(feature = "clustering")]
-mod swarm;
+pub mod swarm;
 
 /// Serializes tests that touch the shared `clustering_peer_allowlist` table
 /// (the allowlist store tests and the swarm bring-up smoke test, which loads

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -44,6 +44,39 @@ pub mod relay;
 #[cfg(feature = "clustering")]
 pub mod swarm;
 
+/// A node's per-process clustering identity: freshly generated on every
+/// start, never reused across restarts. Names the node's keypair-slot lease
+/// and its single kademlia relay registration, and travels on remote actor
+/// message types (typed per the typed-payloads rule — never a bare `String`).
+#[cfg(feature = "clustering")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct NodeId(String);
+
+#[cfg(feature = "clustering")]
+impl NodeId {
+    /// Mint a fresh per-process node id.
+    pub fn generate() -> Self {
+        Self(uuid::Uuid::new_v4().to_string())
+    }
+
+    /// Wrap an id received out-of-band (e.g. a harness node-id file).
+    pub fn new(raw: String) -> Self {
+        Self(raw)
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(feature = "clustering")]
+impl std::fmt::Display for NodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 /// Serializes tests that touch the shared `clustering_peer_allowlist` table
 /// (the allowlist store tests and the swarm bring-up smoke test, which loads
 /// the allowlist at startup) so a concurrently seeded row cannot leak between

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -51,12 +51,21 @@ pub fn start_if_enabled(
     if !config.enabled {
         return Ok(());
     }
-    if driver != DatabaseDriver::Postgres {
-        return Err(ClusteringError::RequiresPostgres { driver });
+
+    // Root-cause-first: a binary built without the `clustering` feature can
+    // never cluster regardless of driver, so that is the more fundamental
+    // failure and is reported before the Postgres prerequisite.
+    #[cfg(not(feature = "clustering"))]
+    {
+        let _ = driver;
+        Err(ClusteringError::FeatureNotCompiled)
     }
 
     #[cfg(feature = "clustering")]
     {
+        if driver != DatabaseDriver::Postgres {
+            return Err(ClusteringError::RequiresPostgres { driver });
+        }
         tracing::info!(
             listen_addrs = ?config.listen_addrs,
             request_timeout_ms = config.messaging.request_timeout.as_millis() as u64,
@@ -65,9 +74,5 @@ pub fn start_if_enabled(
         // Slices 1–5 wire the owned swarm event loop, keypair-slot lease,
         // peer allowlist, remote codec, and supervised relay actors here.
         Ok(())
-    }
-    #[cfg(not(feature = "clustering"))]
-    {
-        Err(ClusteringError::FeatureNotCompiled)
     }
 }

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -32,6 +32,11 @@ mod identity;
 mod lease;
 #[cfg(feature = "clustering")]
 mod metrics;
+/// Per-node supervised relay actor + client handle. Public: the multi-process
+/// cluster harness drives `RelayHandle` cross-node, and Phase 4's routing
+/// builds on the relay message set.
+#[cfg(feature = "clustering")]
+pub mod relay;
 #[cfg(feature = "clustering")]
 mod swarm;
 
@@ -104,11 +109,12 @@ pub async fn start_if_enabled(
             return Err(ClusteringError::RequiresPostgres { driver });
         }
         // The swarm leases its keypair-pool slot from `db` (Postgres control
-        // plane) before binding. Slices 3–5 add the peer allowlist, remote
-        // codec, and supervised relay actors on top.
-        let local_peer_id = swarm::spawn(config, db, stop_token.clone()).await?;
+        // plane) before binding, enforces the peer allowlist at the behaviour
+        // layer, and registers its supervised relay actor in kademlia.
+        let handle = swarm::spawn(config, db, stop_token.clone()).await?;
         tracing::info!(
-            %local_peer_id,
+            local_peer_id = %handle.local_peer_id,
+            node_id = %handle.node_id,
             listen_addrs = ?config.listen_addrs,
             request_timeout_ms = config.messaging.request_timeout.as_millis() as u64,
             "ADR-0017 Phase 2: clustering swarm started (node discovery only)"

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -16,6 +16,8 @@ use crate::db::{Database, DatabaseDriver};
 use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "clustering")]
+mod allowlist;
+#[cfg(feature = "clustering")]
 mod behaviour;
 #[cfg(feature = "clustering")]
 mod dns;

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -12,7 +12,7 @@
 //! the subsystem is exercised only by the multi-process test harness.
 
 use crate::config::ClusteringConfig;
-use crate::db::DatabaseDriver;
+use crate::db::{Database, DatabaseDriver};
 use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "clustering")]
@@ -21,6 +21,8 @@ mod behaviour;
 mod dns;
 #[cfg(feature = "clustering")]
 mod identity;
+#[cfg(feature = "clustering")]
+mod lease;
 #[cfg(feature = "clustering")]
 mod metrics;
 #[cfg(feature = "clustering")]
@@ -59,21 +61,23 @@ pub enum ClusteringError {
 /// the default single-replica path, unchanged. When enabled it validates the
 /// Postgres control-plane prerequisite and, on a `clustering`-feature build,
 /// brings up the owned libp2p swarm (later slices).
-pub fn start_if_enabled(
+pub async fn start_if_enabled(
     config: &ClusteringConfig,
-    driver: DatabaseDriver,
+    db: &Database,
     stop_token: &CancellationToken,
 ) -> Result<(), ClusteringError> {
     if !config.enabled {
         return Ok(());
     }
 
+    let driver = db.driver();
+
     // Root-cause-first: a binary built without the `clustering` feature can
     // never cluster regardless of driver, so that is the more fundamental
     // failure and is reported before the Postgres prerequisite.
     #[cfg(not(feature = "clustering"))]
     {
-        let _ = (driver, stop_token);
+        let _ = (db, stop_token, driver);
         Err(ClusteringError::FeatureNotCompiled)
     }
 
@@ -82,9 +86,10 @@ pub fn start_if_enabled(
         if driver != DatabaseDriver::Postgres {
             return Err(ClusteringError::RequiresPostgres { driver });
         }
-        // Slices 2–5 wire the keypair-slot lease, peer allowlist, remote codec,
-        // and supervised relay actors on top of this swarm.
-        let local_peer_id = swarm::spawn(config, stop_token.clone())?;
+        // The swarm leases its keypair-pool slot from `db` (Postgres control
+        // plane) before binding. Slices 3–5 add the peer allowlist, remote
+        // codec, and supervised relay actors on top.
+        let local_peer_id = swarm::spawn(config, db, stop_token.clone()).await?;
         tracing::info!(
             %local_peer_id,
             listen_addrs = ?config.listen_addrs,

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -1,0 +1,73 @@
+//! ADR-0017 Phase 2 — owned libp2p swarm subsystem (node discovery only).
+//!
+//! Strictly additive and flag-gated. With `clustering.enabled` false (the
+//! default) none of this runs and server behaviour is byte-for-byte identical
+//! to the single-replica path. The subsystem is additionally gated behind the
+//! `clustering` Cargo feature, which pulls in `kameo/remote` + libp2p; a
+//! default build links no libp2p at all.
+//!
+//! This phase is **discovery only**: kademlia resolves peers, but no stanza is
+//! routed cross-node (that is Phase 4). `replicaCount > 1` and
+//! `clustering.enabled` stay hard-locked in the Helm chart until Phase 4, so
+//! the subsystem is exercised only by the multi-process test harness.
+
+use crate::config::ClusteringConfig;
+use crate::db::DatabaseDriver;
+use tokio_util::sync::CancellationToken;
+
+/// Startup failures for the clustering subsystem. The human-facing `Display`
+/// text is surfaced as the server-startup diagnostic.
+#[derive(Debug, thiserror::Error)]
+pub enum ClusteringError {
+    /// Clustering was requested on a non-Postgres deployment. The cross-node
+    /// control plane (leases, allowlist, ownership claims) is Postgres-only;
+    /// SQLite gets single-writer exclusivity for free and never clusters.
+    #[error(
+        "clustering.enabled=true requires the Postgres database driver \
+         (the cross-node control plane has no SQLite equivalent); found {driver:?}"
+    )]
+    RequiresPostgres { driver: DatabaseDriver },
+
+    /// Clustering was requested at runtime but the binary was built without the
+    /// `clustering` Cargo feature, so the swarm subsystem is not compiled in.
+    #[error(
+        "clustering.enabled=true but this binary was built without the \
+         `clustering` cargo feature; rebuild with `--features clustering`"
+    )]
+    FeatureNotCompiled,
+}
+
+/// Conditionally start the clustering swarm subsystem.
+///
+/// Returns `Ok(())` immediately, doing nothing, when clustering is disabled —
+/// the default single-replica path, unchanged. When enabled it validates the
+/// Postgres control-plane prerequisite and, on a `clustering`-feature build,
+/// brings up the owned libp2p swarm (later slices).
+pub fn start_if_enabled(
+    config: &ClusteringConfig,
+    driver: DatabaseDriver,
+    _stop_token: &CancellationToken,
+) -> Result<(), ClusteringError> {
+    if !config.enabled {
+        return Ok(());
+    }
+    if driver != DatabaseDriver::Postgres {
+        return Err(ClusteringError::RequiresPostgres { driver });
+    }
+
+    #[cfg(feature = "clustering")]
+    {
+        tracing::info!(
+            listen_addrs = ?config.listen_addrs,
+            request_timeout_ms = config.messaging.request_timeout.as_millis() as u64,
+            "ADR-0017 Phase 2: clustering enabled — owned libp2p swarm (discovery only)"
+        );
+        // Slices 1–5 wire the owned swarm event loop, keypair-slot lease,
+        // peer allowlist, remote codec, and supervised relay actors here.
+        Ok(())
+    }
+    #[cfg(not(feature = "clustering"))]
+    {
+        Err(ClusteringError::FeatureNotCompiled)
+    }
+}

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -119,6 +119,21 @@ pub enum ClusteringError {
     Swarm(#[from] swarm::SwarmError),
 }
 
+/// Derive the clustering subsystem's own cancellation scope from the
+/// process-wide shutdown token.
+///
+/// `CancellationToken::child_token` gives us both directions we need: parent
+/// cancellation (process shutdown) still propagates into the child, so
+/// server-wide shutdown always tears clustering down; but cancelling the
+/// child does NOT cancel the parent, so a clustering-internal self-fence
+/// (keypair-slot fencing loss, or a lease-renewal deadline blown while
+/// partitioned from Postgres — see `swarm::run_heartbeat`) only stops
+/// clustering. It must never drain axum, WebSocket admission, or ACME.
+#[cfg(feature = "clustering")]
+fn clustering_scope_token(parent: &CancellationToken) -> CancellationToken {
+    parent.child_token()
+}
+
 /// Conditionally start the clustering swarm subsystem.
 ///
 /// Returns `Ok(())` immediately, doing nothing, when clustering is disabled —
@@ -150,10 +165,14 @@ pub async fn start_if_enabled(
         if driver != DatabaseDriver::Postgres {
             return Err(ClusteringError::RequiresPostgres { driver });
         }
+        // Every clustering task (swarm event loop, lease heartbeat, relay
+        // supervisor, allowlist/DNS timers) is driven off this child, never
+        // the raw process-wide `stop_token` — see `clustering_scope_token`.
+        let clustering_stop = clustering_scope_token(stop_token);
         // The swarm leases its keypair-pool slot from `db` (Postgres control
         // plane) before binding, enforces the peer allowlist at the behaviour
         // layer, and registers its supervised relay actor in kademlia.
-        let handle = swarm::spawn(config, db, stop_token.clone()).await?;
+        let handle = swarm::spawn(config, db, clustering_stop).await?;
         tracing::info!(
             local_peer_id = %handle.local_peer_id,
             node_id = %handle.node_id,
@@ -162,5 +181,34 @@ pub async fn start_if_enabled(
             "ADR-0017 Phase 2: clustering swarm started (node discovery only)"
         );
         Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "clustering"))]
+mod tests {
+    use super::*;
+
+    // Regression coverage for the cancellation-scope invariant: a
+    // clustering self-fence must not take down the whole process, but
+    // process shutdown must still take down clustering.
+    #[test]
+    fn clustering_scope_cancels_independently_of_parent() {
+        let parent = CancellationToken::new();
+        let child = clustering_scope_token(&parent);
+
+        child.cancel();
+
+        assert!(child.is_cancelled());
+        assert!(!parent.is_cancelled());
+    }
+
+    #[test]
+    fn parent_cancellation_still_tears_down_clustering_scope() {
+        let parent = CancellationToken::new();
+        let child = clustering_scope_token(&parent);
+
+        parent.cancel();
+
+        assert!(child.is_cancelled());
     }
 }

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -15,6 +15,17 @@ use crate::config::ClusteringConfig;
 use crate::db::DatabaseDriver;
 use tokio_util::sync::CancellationToken;
 
+#[cfg(feature = "clustering")]
+mod behaviour;
+#[cfg(feature = "clustering")]
+mod dns;
+#[cfg(feature = "clustering")]
+mod identity;
+#[cfg(feature = "clustering")]
+mod metrics;
+#[cfg(feature = "clustering")]
+mod swarm;
+
 /// Startup failures for the clustering subsystem. The human-facing `Display`
 /// text is surfaced as the server-startup diagnostic.
 #[derive(Debug, thiserror::Error)]
@@ -35,6 +46,11 @@ pub enum ClusteringError {
          `clustering` cargo feature; rebuild with `--features clustering`"
     )]
     FeatureNotCompiled,
+
+    /// The owned libp2p swarm failed to build or start.
+    #[cfg(feature = "clustering")]
+    #[error(transparent)]
+    Swarm(#[from] swarm::SwarmError),
 }
 
 /// Conditionally start the clustering swarm subsystem.
@@ -46,7 +62,7 @@ pub enum ClusteringError {
 pub fn start_if_enabled(
     config: &ClusteringConfig,
     driver: DatabaseDriver,
-    _stop_token: &CancellationToken,
+    stop_token: &CancellationToken,
 ) -> Result<(), ClusteringError> {
     if !config.enabled {
         return Ok(());
@@ -57,7 +73,7 @@ pub fn start_if_enabled(
     // failure and is reported before the Postgres prerequisite.
     #[cfg(not(feature = "clustering"))]
     {
-        let _ = driver;
+        let _ = (driver, stop_token);
         Err(ClusteringError::FeatureNotCompiled)
     }
 
@@ -66,13 +82,15 @@ pub fn start_if_enabled(
         if driver != DatabaseDriver::Postgres {
             return Err(ClusteringError::RequiresPostgres { driver });
         }
+        // Slices 2–5 wire the keypair-slot lease, peer allowlist, remote codec,
+        // and supervised relay actors on top of this swarm.
+        let local_peer_id = swarm::spawn(config, stop_token.clone())?;
         tracing::info!(
+            %local_peer_id,
             listen_addrs = ?config.listen_addrs,
             request_timeout_ms = config.messaging.request_timeout.as_millis() as u64,
-            "ADR-0017 Phase 2: clustering enabled — owned libp2p swarm (discovery only)"
+            "ADR-0017 Phase 2: clustering swarm started (node discovery only)"
         );
-        // Slices 1–5 wire the owned swarm event loop, keypair-slot lease,
-        // peer allowlist, remote codec, and supervised relay actors here.
         Ok(())
     }
 }

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -238,7 +238,12 @@ pub fn spawn_supervised(node_id: NodeId, fault_injection: bool, stop_token: Canc
                 Err(error) => {
                     tracing::warn!(%name, %error, "clustering relay registration failed; retrying");
                     actor_ref.kill();
-                    tokio::time::sleep(RESPAWN_BACKOFF).await;
+                    // Cancellation-aware backoff: graceful shutdown must not
+                    // wait out the retry delay.
+                    tokio::select! {
+                        _ = stop_token.cancelled() => return,
+                        _ = tokio::time::sleep(RESPAWN_BACKOFF) => {}
+                    }
                     continue;
                 }
             }
@@ -267,9 +272,13 @@ pub fn spawn_supervised(node_id: NodeId, fault_injection: bool, stop_token: Canc
                     _ = actor_ref.wait_for_shutdown() => {
                         // Unexpected stop/panic: kameo has already
                         // unregistered the name. Respawn and re-register
-                        // under the SAME name after a short backoff.
+                        // under the SAME name after a short backoff (which a
+                        // graceful shutdown must not wait out).
                         respawns += 1;
-                        tokio::time::sleep(RESPAWN_BACKOFF).await;
+                        tokio::select! {
+                            _ = stop_token.cancelled() => return,
+                            _ = tokio::time::sleep(RESPAWN_BACKOFF) => {}
+                        }
                         break;
                     }
                     _ = reregister.tick() => {

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -21,6 +21,7 @@
 
 use super::codec::RemoteStanza;
 use super::metrics;
+use super::NodeId;
 use kameo::actor::{ActorRef, RemoteActorRef, Spawn};
 use kameo::error::RemoteSendError;
 use kameo::message::{Context, Message};
@@ -31,7 +32,7 @@ use tokio_util::sync::CancellationToken;
 
 /// The kademlia registration name for a node's relay actor — the node's ONLY
 /// kademlia name (O(1) registrations per node, never per entity).
-pub fn relay_name(node_id: &str) -> String {
+pub fn relay_name(node_id: &NodeId) -> String {
     format!("waddle-relay/{node_id}")
 }
 
@@ -69,13 +70,13 @@ const LOOKUP_BACKOFF: [Duration; 3] = [
 #[derive(Actor, RemoteActor)]
 #[remote_actor(id = "waddle.clustering.relay-actor.v1")]
 pub struct RelayActor {
-    node_id: String,
+    node_id: NodeId,
     /// When false (production), the fault-injection messages are inert acks.
     fault_injection: bool,
 }
 
 impl RelayActor {
-    pub fn new(node_id: String, fault_injection: bool) -> Self {
+    pub fn new(node_id: NodeId, fault_injection: bool) -> Self {
         Self {
             node_id,
             fault_injection,
@@ -90,7 +91,7 @@ pub struct RelayPing;
 /// Reply to [`RelayPing`].
 #[derive(Debug, Clone, Serialize, Deserialize, Reply)]
 pub struct RelayPong {
-    pub node_id: String,
+    pub node_id: NodeId,
 }
 
 #[kameo::remote_message("waddle.clustering.relay.ping.v1")]
@@ -119,7 +120,7 @@ pub struct RelayEchoStanza {
 /// Reply to [`RelayEchoStanza`].
 #[derive(Debug, Clone, Serialize, Deserialize, Reply)]
 pub struct RelayEchoReply {
-    pub node_id: String,
+    pub node_id: NodeId,
     pub stanza: RemoteStanza,
 }
 
@@ -211,7 +212,7 @@ impl Message<RelaySleep> for RelayActor {
 /// **re-register under the same name** on every respawn (kameo auto-registers
 /// removal on actor stop, so re-registration is mandatory, not optional).
 /// Stops cleanly when `stop_token` fires.
-pub fn spawn_supervised(node_id: String, fault_injection: bool, stop_token: CancellationToken) {
+pub fn spawn_supervised(node_id: NodeId, fault_injection: bool, stop_token: CancellationToken) {
     tokio::spawn(async move {
         let name = relay_name(&node_id);
         let mut respawns: u64 = 0;
@@ -286,9 +287,17 @@ pub fn spawn_supervised(node_id: String, fault_injection: bool, stop_token: Canc
 /// when the transport reports the cached ref dead
 /// (`ActorNotRunning`/`UnknownActor`/`BadActorType` — e.g. after a supervised
 /// respawn minted a new `ActorId` under the same name).
+///
+/// Every ask carries the ADR element-5 receiver-side timeouts
+/// (`mailbox_timeout`/`reply_timeout`), defaulting to the compiled
+/// [`ClusteringMessagingConfig`](crate::config::ClusteringMessagingConfig)
+/// defaults; callers with a runtime config apply it via
+/// [`Self::with_ask_timeouts`].
 pub struct RelayHandle {
-    node_id: String,
+    node_id: NodeId,
     cached: Option<RemoteActorRef<RelayActor>>,
+    mailbox_timeout: Duration,
+    reply_timeout: Duration,
 }
 
 /// Failures asking a remote relay.
@@ -296,18 +305,30 @@ pub struct RelayHandle {
 pub enum RelayAskError {
     /// The relay name did not resolve in kademlia within the backoff budget.
     #[error("relay for node '{node_id}' not found in the swarm registry")]
-    NotFound { node_id: String },
+    NotFound { node_id: NodeId },
     /// The ask failed at the transport/handler layer.
     #[error("relay ask failed: {0}")]
     Send(String),
 }
 
 impl RelayHandle {
-    pub fn new(node_id: String) -> Self {
+    pub fn new(node_id: NodeId) -> Self {
+        let defaults = crate::config::ClusteringMessagingConfig::default();
         Self {
             node_id,
             cached: None,
+            mailbox_timeout: defaults.mailbox_timeout,
+            reply_timeout: defaults.reply_timeout,
         }
+    }
+
+    /// Apply the deployment's configured receiver-side ask timeouts (ADR
+    /// element 5: both must sit under the transport `request_timeout`, which
+    /// config parsing already validates).
+    pub fn with_ask_timeouts(mut self, mailbox_timeout: Duration, reply_timeout: Duration) -> Self {
+        self.mailbox_timeout = mailbox_timeout;
+        self.reply_timeout = reply_timeout;
+        self
     }
 
     /// Resolve the relay ref, using the cache when warm and a bounded-backoff
@@ -347,7 +368,12 @@ impl RelayHandle {
     /// re-resolve via kademlia, then retry the ask exactly once.
     pub async fn ping(&mut self) -> Result<RelayPong, RelayAskError> {
         let remote_ref = self.resolve().await?;
-        match remote_ref.ask(&RelayPing).await {
+        match remote_ref
+            .ask(&RelayPing)
+            .mailbox_timeout(self.mailbox_timeout)
+            .reply_timeout(self.reply_timeout)
+            .await
+        {
             Ok(pong) => Ok(pong),
             Err(error) if is_stale_ref_error(&error) => {
                 tracing::debug!(
@@ -359,6 +385,8 @@ impl RelayHandle {
                 let remote_ref = self.resolve().await?;
                 remote_ref
                     .ask(&RelayPing)
+                    .mailbox_timeout(self.mailbox_timeout)
+                    .reply_timeout(self.reply_timeout)
                     .await
                     .map_err(|error| RelayAskError::Send(error.to_string()))
             }
@@ -371,7 +399,12 @@ impl RelayHandle {
     /// whether the *request* went out; callers assert recovery separately.
     pub async fn crash(&mut self) -> Result<(), RelayAskError> {
         let remote_ref = self.resolve().await?;
-        match remote_ref.ask(&RelayCrash).await {
+        match remote_ref
+            .ask(&RelayCrash)
+            .mailbox_timeout(self.mailbox_timeout)
+            .reply_timeout(self.reply_timeout)
+            .await
+        {
             // A dead-before-reply error is the expected outcome of a crash.
             Ok(_) | Err(_) => Ok(()),
         }
@@ -384,6 +417,8 @@ impl RelayHandle {
         let remote_ref = self.resolve().await?;
         remote_ref
             .ask(&RelaySleep { millis })
+            .mailbox_timeout(self.mailbox_timeout)
+            .reply_timeout(self.reply_timeout)
             .await
             .map_err(|error| RelayAskError::Send(error.to_string()))
     }
@@ -396,13 +431,20 @@ impl RelayHandle {
     ) -> Result<RelayEchoReply, RelayAskError> {
         let message = RelayEchoStanza { stanza };
         let remote_ref = self.resolve().await?;
-        match remote_ref.ask(&message).await {
+        match remote_ref
+            .ask(&message)
+            .mailbox_timeout(self.mailbox_timeout)
+            .reply_timeout(self.reply_timeout)
+            .await
+        {
             Ok(reply) => Ok(reply),
             Err(error) if is_stale_ref_error(&error) => {
                 self.cached = None;
                 let remote_ref = self.resolve().await?;
                 remote_ref
                     .ask(&message)
+                    .mailbox_timeout(self.mailbox_timeout)
+                    .reply_timeout(self.reply_timeout)
                     .await
                     .map_err(|error| RelayAskError::Send(error.to_string()))
             }
@@ -430,8 +472,12 @@ mod tests {
 
     #[test]
     fn relay_name_is_node_scoped() {
-        assert_eq!(relay_name("node-1"), "waddle-relay/node-1");
-        assert_ne!(relay_name("node-1"), relay_name("node-2"));
+        let (a, b) = (
+            NodeId::new("node-1".to_string()),
+            NodeId::new("node-2".to_string()),
+        );
+        assert_eq!(relay_name(&a), "waddle-relay/node-1");
+        assert_ne!(relay_name(&a), relay_name(&b));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -244,6 +244,10 @@ pub fn spawn_supervised(node_id: NodeId, fault_injection: bool, stop_token: Canc
             }
 
             let mut reregister = tokio::time::interval(REREGISTER_INTERVAL);
+            // Delayed ticks must not burst-catch-up (re-registration is
+            // idempotent but each burst tick is a wasted DHT write) — same
+            // policy as the swarm event-loop timers.
+            reregister.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             // Skip the immediate first tick — we just registered above.
             reregister.tick().await;
 

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -285,8 +285,8 @@ pub fn spawn_supervised(node_id: NodeId, fault_injection: bool, stop_token: Canc
 /// A client handle to some node's relay, caching the resolved
 /// `RemoteActorRef` and refreshing it via bounded-backoff kademlia re-lookup
 /// when the transport reports the cached ref dead
-/// (`ActorNotRunning`/`UnknownActor`/`BadActorType` — e.g. after a supervised
-/// respawn minted a new `ActorId` under the same name).
+/// (`ActorNotRunning`/`ActorStopped`/`UnknownActor`/`BadActorType` — e.g.
+/// after a supervised respawn minted a new `ActorId` under the same name).
 ///
 /// Every ask carries the ADR element-5 receiver-side timeouts
 /// (`mailbox_timeout`/`reply_timeout`), defaulting to the compiled

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -1,0 +1,313 @@
+//! Per-node relay actor for the clustering swarm (ADR-0017 elements 5/6).
+//!
+//! Each node registers exactly **one** name in kademlia: its relay actor,
+//! keyed by the node's per-instance `node_id`. Kademlia carries node
+//! discovery only — entity→node resolution is Phase 3's Postgres claims
+//! table, and per-entity DHT registration is ruled out by kameo 0.20's
+//! hardcoded `MemoryStore` limits.
+//!
+//! The relay is **supervised**: kameo auto-unregisters an actor that stops or
+//! panics (removing this node from the routing fabric while its Postgres
+//! heartbeat stays fresh — a steady-state, cluster-wide degradation with no
+//! self-healing path), so an owning task respawns it and **re-registers it
+//! under the same name**. Sender-side `ActorNotRunning`/`UnknownActor`/
+//! `BadActorType` errors trigger a bounded-backoff kademlia re-lookup — the
+//! transport-layer refresh path, distinct from Phase 3's `NotOwner`
+//! claims-refresh path.
+//!
+//! Phase 2 is **discovery only**: the relay's message set proves the
+//! cross-node ask round-trip and the XML codec on the wire (spike exit
+//! criteria); it is not wired into the stanza delivery path (Phase 4).
+
+use super::codec::RemoteStanza;
+use super::metrics;
+use kameo::actor::{ActorRef, RemoteActorRef, Spawn};
+use kameo::error::RemoteSendError;
+use kameo::message::{Context, Message};
+use kameo::{Actor, RemoteActor, Reply};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+/// The kademlia registration name for a node's relay actor — the node's ONLY
+/// kademlia name (O(1) registrations per node, never per entity).
+pub fn relay_name(node_id: &str) -> String {
+    format!("waddle-relay/{node_id}")
+}
+
+/// Backoff between supervised respawn/re-registration attempts.
+const RESPAWN_BACKOFF: Duration = Duration::from_secs(1);
+
+/// Bounded backoff schedule for sender-side relay re-lookup.
+const LOOKUP_BACKOFF: [Duration; 3] = [
+    Duration::from_millis(100),
+    Duration::from_millis(400),
+    Duration::from_millis(1_600),
+];
+
+/// The per-node relay actor. Phase 2 carries only the liveness/codec-proof
+/// message set; the ordered per-peer relay channel semantics (sequencing, gap
+/// detection, sticky failover) land with cross-node routing in Phase 4.
+#[derive(Actor, RemoteActor)]
+pub struct RelayActor {
+    node_id: String,
+}
+
+impl RelayActor {
+    pub fn new(node_id: String) -> Self {
+        Self { node_id }
+    }
+}
+
+/// Liveness probe: which node answers this relay name?
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayPing;
+
+/// Reply to [`RelayPing`].
+#[derive(Debug, Clone, Serialize, Deserialize, Reply)]
+pub struct RelayPong {
+    pub node_id: String,
+}
+
+#[kameo::remote_message("waddle.clustering.relay.ping.v1")]
+impl Message<RelayPing> for RelayActor {
+    type Reply = RelayPong;
+
+    async fn handle(
+        &mut self,
+        _msg: RelayPing,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> RelayPong {
+        RelayPong {
+            node_id: self.node_id.clone(),
+        }
+    }
+}
+
+/// Codec proof: carry a stanza across the wire and echo it back, exercising
+/// the bounded XML codec's decode on the receiver and re-encode on the reply
+/// path in one round-trip.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayEchoStanza {
+    pub stanza: RemoteStanza,
+}
+
+/// Reply to [`RelayEchoStanza`].
+#[derive(Debug, Clone, Serialize, Deserialize, Reply)]
+pub struct RelayEchoReply {
+    pub node_id: String,
+    pub stanza: RemoteStanza,
+}
+
+#[kameo::remote_message("waddle.clustering.relay.echo_stanza.v1")]
+impl Message<RelayEchoStanza> for RelayActor {
+    type Reply = RelayEchoReply;
+
+    async fn handle(
+        &mut self,
+        msg: RelayEchoStanza,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> RelayEchoReply {
+        RelayEchoReply {
+            node_id: self.node_id.clone(),
+            stanza: msg.stanza,
+        }
+    }
+}
+
+/// Spawn the node's relay actor under supervision: register it in kademlia
+/// under [`relay_name`], respawn it if it ever stops unexpectedly, and
+/// **re-register under the same name** on every respawn (kameo auto-registers
+/// removal on actor stop, so re-registration is mandatory, not optional).
+/// Stops cleanly when `stop_token` fires.
+pub fn spawn_supervised(node_id: String, stop_token: CancellationToken) {
+    tokio::spawn(async move {
+        let name = relay_name(&node_id);
+        let mut respawns: u64 = 0;
+        loop {
+            if stop_token.is_cancelled() {
+                break;
+            }
+            let actor_ref: ActorRef<RelayActor> =
+                RelayActor::spawn(RelayActor::new(node_id.clone()));
+            match actor_ref.register(name.clone()).await {
+                Ok(()) => {
+                    if respawns > 0 {
+                        metrics::record_relay_respawn();
+                        tracing::warn!(
+                            %name,
+                            respawns,
+                            "clustering relay actor respawned and re-registered under the same name"
+                        );
+                    } else {
+                        tracing::info!(%name, "clustering relay actor registered");
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(%name, %error, "clustering relay registration failed; retrying");
+                    actor_ref.kill();
+                    tokio::time::sleep(RESPAWN_BACKOFF).await;
+                    continue;
+                }
+            }
+
+            tokio::select! {
+                _ = stop_token.cancelled() => {
+                    // Graceful stop: unregister the name proactively so peers
+                    // stop resolving a dead relay, then stop the actor.
+                    let _ = kameo::remote::unregister(name.clone()).await;
+                    let _ = actor_ref.stop_gracefully().await;
+                    break;
+                }
+                _ = actor_ref.wait_for_shutdown() => {
+                    // Unexpected stop/panic: kameo has already unregistered
+                    // the name. Respawn and re-register under the SAME name
+                    // after a short backoff.
+                    respawns += 1;
+                    tokio::time::sleep(RESPAWN_BACKOFF).await;
+                }
+            }
+        }
+    });
+}
+
+/// A client handle to some node's relay, caching the resolved
+/// `RemoteActorRef` and refreshing it via bounded-backoff kademlia re-lookup
+/// when the transport reports the cached ref dead
+/// (`ActorNotRunning`/`UnknownActor`/`BadActorType` — e.g. after a supervised
+/// respawn minted a new `ActorId` under the same name).
+pub struct RelayHandle {
+    node_id: String,
+    cached: Option<RemoteActorRef<RelayActor>>,
+}
+
+/// Failures asking a remote relay.
+#[derive(Debug, thiserror::Error)]
+pub enum RelayAskError {
+    /// The relay name did not resolve in kademlia within the backoff budget.
+    #[error("relay for node '{node_id}' not found in the swarm registry")]
+    NotFound { node_id: String },
+    /// The ask failed at the transport/handler layer.
+    #[error("relay ask failed: {0}")]
+    Send(String),
+}
+
+impl RelayHandle {
+    pub fn new(node_id: String) -> Self {
+        Self {
+            node_id,
+            cached: None,
+        }
+    }
+
+    /// Resolve the relay ref, using the cache when warm and a bounded-backoff
+    /// kademlia lookup when cold.
+    async fn resolve(&mut self) -> Result<RemoteActorRef<RelayActor>, RelayAskError> {
+        if let Some(cached) = &self.cached {
+            return Ok(cached.clone());
+        }
+        let name = relay_name(&self.node_id);
+        for backoff in LOOKUP_BACKOFF {
+            match RemoteActorRef::<RelayActor>::lookup(name.clone()).await {
+                Ok(Some(remote_ref)) => {
+                    self.cached = Some(remote_ref.clone());
+                    return Ok(remote_ref);
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::debug!(%name, %error, "clustering relay lookup error; backing off");
+                }
+            }
+            tokio::time::sleep(backoff).await;
+        }
+        Err(RelayAskError::NotFound {
+            node_id: self.node_id.clone(),
+        })
+    }
+
+    /// Ping the relay, refreshing a stale cached ref once: transport-layer
+    /// errors that mean "this ActorId is gone" invalidate the cache and
+    /// re-resolve via kademlia, then retry the ask exactly once.
+    pub async fn ping(&mut self) -> Result<RelayPong, RelayAskError> {
+        let remote_ref = self.resolve().await?;
+        match remote_ref.ask(&RelayPing).await {
+            Ok(pong) => Ok(pong),
+            Err(error) if is_stale_ref_error(&error) => {
+                tracing::debug!(
+                    node_id = %self.node_id,
+                    %error,
+                    "clustering relay ref stale; re-resolving via kademlia"
+                );
+                self.cached = None;
+                let remote_ref = self.resolve().await?;
+                remote_ref
+                    .ask(&RelayPing)
+                    .await
+                    .map_err(|error| RelayAskError::Send(error.to_string()))
+            }
+            Err(error) => Err(RelayAskError::Send(error.to_string())),
+        }
+    }
+
+    /// Round-trip a stanza through the relay (codec proof), with the same
+    /// stale-ref refresh-and-retry-once behaviour as [`Self::ping`].
+    pub async fn echo_stanza(
+        &mut self,
+        stanza: RemoteStanza,
+    ) -> Result<RelayEchoReply, RelayAskError> {
+        let message = RelayEchoStanza { stanza };
+        let remote_ref = self.resolve().await?;
+        match remote_ref.ask(&message).await {
+            Ok(reply) => Ok(reply),
+            Err(error) if is_stale_ref_error(&error) => {
+                self.cached = None;
+                let remote_ref = self.resolve().await?;
+                remote_ref
+                    .ask(&message)
+                    .await
+                    .map_err(|error| RelayAskError::Send(error.to_string()))
+            }
+            Err(error) => Err(RelayAskError::Send(error.to_string())),
+        }
+    }
+}
+
+/// Transport-layer errors meaning the cached `RemoteActorRef` no longer names
+/// a live actor — the explicit re-lookup trigger (ADR element 6). Distinct
+/// from handler/timeout errors, which say nothing about registration state.
+fn is_stale_ref_error<E>(error: &RemoteSendError<E>) -> bool {
+    matches!(
+        error,
+        RemoteSendError::ActorNotRunning
+            | RemoteSendError::ActorStopped
+            | RemoteSendError::UnknownActor { .. }
+            | RemoteSendError::BadActorType
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn relay_name_is_node_scoped() {
+        assert_eq!(relay_name("node-1"), "waddle-relay/node-1");
+        assert_ne!(relay_name("node-1"), relay_name("node-2"));
+    }
+
+    #[test]
+    fn stale_ref_errors_trigger_relookup_and_others_do_not() {
+        assert!(is_stale_ref_error::<std::convert::Infallible>(
+            &RemoteSendError::ActorNotRunning
+        ));
+        assert!(is_stale_ref_error::<std::convert::Infallible>(
+            &RemoteSendError::BadActorType
+        ));
+        assert!(!is_stale_ref_error::<std::convert::Infallible>(
+            &RemoteSendError::ReplyTimeout
+        ));
+        assert!(!is_stale_ref_error::<std::convert::Infallible>(
+            &RemoteSendError::MailboxFull
+        ));
+    }
+}

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -222,7 +222,28 @@ pub fn spawn_supervised(node_id: NodeId, fault_injection: bool, stop_token: Canc
             }
             let actor_ref: ActorRef<RelayActor> =
                 RelayActor::spawn(RelayActor::new(node_id.clone(), fault_injection));
-            match actor_ref.register(name.clone()).await {
+            // Race registration against cancellation instead of plain
+            // `.await`: kameo's swarm-command reply future panics
+            // (`.expect(..)` on a dropped oneshot sender) if the event loop
+            // observes this SAME stop token, drops `Swarm<WaddleBehaviour>`,
+            // and the pending register command's reply is abandoned as a
+            // result. `biased` is load-bearing: the event loop drops the
+            // swarm only AFTER observing this token, so polling the
+            // cancellation arm first guarantees `register` is never polled
+            // against an already-closed swarm command channel (an unbiased
+            // select could poll `register` first, whose very first poll
+            // sends the command and panics on the dropped reply).
+            // Cancellation landing mid-register simply drops the in-flight
+            // future (no panic on drop, only on a completed poll).
+            let register_result = tokio::select! {
+                biased;
+                _ = stop_token.cancelled() => {
+                    actor_ref.kill();
+                    return;
+                }
+                result = actor_ref.register(name.clone()) => result,
+            };
+            match register_result {
                 Ok(()) => {
                     if respawns > 0 {
                         metrics::record_relay_respawn();
@@ -284,9 +305,28 @@ pub fn spawn_supervised(node_id: NodeId, fault_injection: bool, stop_token: Canc
                     _ = reregister.tick() => {
                         // Same-name refresh so a registration that predated
                         // our first peer connection becomes discoverable
-                        // (see REREGISTER_INTERVAL).
-                        if let Err(error) = actor_ref.register(name.clone()).await {
-                            tracing::debug!(%name, %error, "clustering relay periodic re-registration failed");
+                        // (see REREGISTER_INTERVAL). Guarded against the same
+                        // cancellation race as the post-(re)spawn
+                        // registration above: the `biased` inner `select!`
+                        // polls the cancellation arm first, so `register` is
+                        // never polled once cancellation is visible — and the
+                        // event loop drops the swarm only after observing the
+                        // same token, so a closed swarm command channel can
+                        // never panic here (`is_cancelled()` merely
+                        // short-circuits the common case). Falling through to
+                        // the outer loop after a lost race is sufficient: the
+                        // next iteration's `stop_token.cancelled()` arm fires
+                        // immediately.
+                        if !stop_token.is_cancelled() {
+                            tokio::select! {
+                                biased;
+                                _ = stop_token.cancelled() => {}
+                                result = actor_ref.register(name.clone()) => {
+                                    if let Err(error) = result {
+                                        tracing::debug!(%name, %error, "clustering relay periodic re-registration failed");
+                                    }
+                                }
+                            }
                         }
                     }
                 }
@@ -306,6 +346,18 @@ pub fn spawn_supervised(node_id: NodeId, fault_injection: bool, stop_token: Canc
 /// [`ClusteringMessagingConfig`](crate::config::ClusteringMessagingConfig)
 /// defaults; callers with a runtime config apply it via
 /// [`Self::with_ask_timeouts`].
+///
+/// `resolve`/`ping`/`crash`/`sleep`/`echo_stanza` all await kameo swarm-
+/// command replies and share the same theoretical panic-on-drop hazard as
+/// `spawn_supervised`'s `register` calls (see there) if awaited concurrently
+/// with the local swarm being torn down. Unlike `spawn_supervised`, this
+/// handle owns no cancellation token to race against: today every caller
+/// (the swarm bring-up smoke test, and the Phase 4 cross-node callers this
+/// type is built for) either runs before local shutdown starts or targets a
+/// different node's swarm entirely, so there is no concrete call site racing
+/// this process's own teardown. Threading a token through here becomes
+/// necessary the moment a caller awaits these methods from a task that also
+/// watches this node's clustering stop token.
 pub struct RelayHandle {
     node_id: NodeId,
     cached: Option<RemoteActorRef<RelayActor>>,

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -10,10 +10,10 @@
 //! panics (removing this node from the routing fabric while its Postgres
 //! heartbeat stays fresh — a steady-state, cluster-wide degradation with no
 //! self-healing path), so an owning task respawns it and **re-registers it
-//! under the same name**. Sender-side `ActorNotRunning`/`UnknownActor`/
-//! `BadActorType` errors trigger a bounded-backoff kademlia re-lookup — the
-//! transport-layer refresh path, distinct from Phase 3's `NotOwner`
-//! claims-refresh path.
+//! under the same name**. Sender-side stale-ref errors (`ActorNotRunning`/
+//! `ActorStopped`/`UnknownActor`/`BadActorType`) trigger a bounded-backoff
+//! kademlia re-lookup — the transport-layer refresh path, distinct from
+//! Phase 3's `NotOwner` claims-refresh path.
 //!
 //! Phase 2 is **discovery only**: the relay's message set proves the
 //! cross-node ask round-trip and the XML codec on the wire (spike exit
@@ -306,9 +306,71 @@ pub enum RelayAskError {
     /// The relay name did not resolve in kademlia within the backoff budget.
     #[error("relay for node '{node_id}' not found in the swarm registry")]
     NotFound { node_id: NodeId },
-    /// The ask failed at the transport/handler layer.
-    #[error("relay ask failed: {0}")]
-    Send(String),
+    /// The ask failed at the transport/handler layer. `failure` is the typed,
+    /// matchable classification; `message` is the rendered kameo error, kept
+    /// for human-facing diagnostics only.
+    #[error("relay ask failed ({failure:?}): {message}")]
+    Send {
+        failure: RelaySendFailure,
+        message: String,
+    },
+}
+
+/// Typed classification of a failed relay ask. kameo's [`RemoteSendError`]
+/// is generic over each message's handler-error type, so this enum is the
+/// stable shape callers can match on (typed-payloads rule).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelaySendFailure {
+    /// The cached `ActorId` is dead or wrong — the stale-ref re-lookup set.
+    StaleRef,
+    /// The receiver's mailbox refused the message (full / enqueue timeout).
+    MailboxFull,
+    /// The reply budget elapsed before the handler answered.
+    ReplyTimeout,
+    /// The handler itself returned an error.
+    Handler,
+    /// Message/reply (de)serialization failed at either end, or the peer
+    /// does not know this message type (protocol mismatch).
+    Codec,
+    /// Transport-level failure: dialing, network timeout, closed connection,
+    /// unsupported protocols, IO, or an unbootstrapped swarm.
+    Transport,
+}
+
+fn classify<E>(error: &RemoteSendError<E>) -> RelaySendFailure {
+    match error {
+        RemoteSendError::ActorNotRunning
+        | RemoteSendError::ActorStopped
+        | RemoteSendError::UnknownActor { .. }
+        | RemoteSendError::BadActorType => RelaySendFailure::StaleRef,
+        RemoteSendError::MailboxFull => RelaySendFailure::MailboxFull,
+        RemoteSendError::ReplyTimeout => RelaySendFailure::ReplyTimeout,
+        RemoteSendError::HandlerError(_) => RelaySendFailure::Handler,
+        RemoteSendError::UnknownMessage { .. }
+        | RemoteSendError::SerializeMessage(_)
+        | RemoteSendError::DeserializeMessage(_)
+        | RemoteSendError::SerializeReply(_)
+        | RemoteSendError::SerializeHandlerError(_)
+        | RemoteSendError::DeserializeHandlerError(_) => RelaySendFailure::Codec,
+        RemoteSendError::SwarmNotBootstrapped
+        | RemoteSendError::DialFailure
+        | RemoteSendError::NetworkTimeout
+        | RemoteSendError::ConnectionClosed
+        | RemoteSendError::UnsupportedProtocols
+        | RemoteSendError::Io(_) => RelaySendFailure::Transport,
+    }
+}
+
+/// Wrap a kameo send error as a [`RelayAskError`], preserving the typed
+/// classification alongside the rendered diagnostic.
+fn send_error<E>(error: RemoteSendError<E>) -> RelayAskError
+where
+    RemoteSendError<E>: std::fmt::Display,
+{
+    RelayAskError::Send {
+        failure: classify(&error),
+        message: error.to_string(),
+    }
 }
 
 impl RelayHandle {
@@ -388,9 +450,9 @@ impl RelayHandle {
                     .mailbox_timeout(self.mailbox_timeout)
                     .reply_timeout(self.reply_timeout)
                     .await
-                    .map_err(|error| RelayAskError::Send(error.to_string()))
+                    .map_err(send_error)
             }
-            Err(error) => Err(RelayAskError::Send(error.to_string())),
+            Err(error) => Err(send_error(error)),
         }
     }
 
@@ -420,7 +482,7 @@ impl RelayHandle {
             .mailbox_timeout(self.mailbox_timeout)
             .reply_timeout(self.reply_timeout)
             .await
-            .map_err(|error| RelayAskError::Send(error.to_string()))
+            .map_err(send_error)
     }
 
     /// Round-trip a stanza through the relay (codec proof), with the same
@@ -446,9 +508,9 @@ impl RelayHandle {
                     .mailbox_timeout(self.mailbox_timeout)
                     .reply_timeout(self.reply_timeout)
                     .await
-                    .map_err(|error| RelayAskError::Send(error.to_string()))
+                    .map_err(send_error)
             }
-            Err(error) => Err(RelayAskError::Send(error.to_string())),
+            Err(error) => Err(send_error(error)),
         }
     }
 }
@@ -457,13 +519,7 @@ impl RelayHandle {
 /// a live actor — the explicit re-lookup trigger (ADR element 6). Distinct
 /// from handler/timeout errors, which say nothing about registration state.
 fn is_stale_ref_error<E>(error: &RemoteSendError<E>) -> bool {
-    matches!(
-        error,
-        RemoteSendError::ActorNotRunning
-            | RemoteSendError::ActorStopped
-            | RemoteSendError::UnknownActor { .. }
-            | RemoteSendError::BadActorType
-    )
+    classify(error) == RelaySendFailure::StaleRef
 }
 
 #[cfg(test)]
@@ -494,5 +550,26 @@ mod tests {
         assert!(!is_stale_ref_error::<std::convert::Infallible>(
             &RemoteSendError::MailboxFull
         ));
+    }
+
+    #[test]
+    fn ask_failures_classify_into_typed_kinds() {
+        use std::convert::Infallible;
+        for (error, expected) in [
+            (RemoteSendError::ActorStopped, RelaySendFailure::StaleRef),
+            (RemoteSendError::MailboxFull, RelaySendFailure::MailboxFull),
+            (
+                RemoteSendError::ReplyTimeout,
+                RelaySendFailure::ReplyTimeout,
+            ),
+            (
+                RemoteSendError::SerializeMessage(String::new()),
+                RelaySendFailure::Codec,
+            ),
+            (RemoteSendError::DialFailure, RelaySendFailure::Transport),
+            (RemoteSendError::NetworkTimeout, RelaySendFailure::Transport),
+        ] {
+            assert_eq!(classify::<Infallible>(&error), expected, "{error:?}");
+        }
     }
 }

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -38,6 +38,18 @@ pub fn relay_name(node_id: &str) -> String {
 /// Backoff between supervised respawn/re-registration attempts.
 const RESPAWN_BACKOFF: Duration = Duration::from_secs(1);
 
+/// Periodic same-name re-registration cadence. A registration performed
+/// before the node's first peer connection stores its provider record only
+/// locally (nobody can discover it), and kademlia's own republish is 30
+/// minutes out — so the supervisor re-registers on this cadence (same-peer
+/// metadata overwrite is permitted), bounding how long a freshly
+/// (re)started node stays undiscoverable to roughly one interval after its
+/// first peer connection.
+const REREGISTER_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Upper bound on a fault-injected relay sleep.
+const MAX_FAULT_SLEEP_MS: u64 = 60_000;
+
 /// Bounded backoff schedule for sender-side relay re-lookup.
 const LOOKUP_BACKOFF: [Duration; 3] = [
     Duration::from_millis(100),
@@ -46,16 +58,28 @@ const LOOKUP_BACKOFF: [Duration; 3] = [
 ];
 
 /// The per-node relay actor. Phase 2 carries only the liveness/codec-proof
-/// message set; the ordered per-peer relay channel semantics (sequencing, gap
-/// detection, sticky failover) land with cross-node routing in Phase 4.
+/// message set plus harness fault-injection; the ordered per-peer relay
+/// channel semantics (sequencing, gap detection, sticky failover) land with
+/// cross-node routing in Phase 4.
+// The id is pinned via the derive's attribute (the default would be
+// `module_path!()::RelayActor`, which silently changes on a module move and
+// breaks mixed-build rolling deploys). The derive must stay — a manual
+// `impl RemoteActor` skips the linkme `REMOTE_ACTORS` registration the swarm
+// uses to validate registry records, silently breaking lookups.
 #[derive(Actor, RemoteActor)]
+#[remote_actor(id = "waddle.clustering.relay-actor.v1")]
 pub struct RelayActor {
     node_id: String,
+    /// When false (production), the fault-injection messages are inert acks.
+    fault_injection: bool,
 }
 
 impl RelayActor {
-    pub fn new(node_id: String) -> Self {
-        Self { node_id }
+    pub fn new(node_id: String, fault_injection: bool) -> Self {
+        Self {
+            node_id,
+            fault_injection,
+        }
     }
 }
 
@@ -115,12 +139,79 @@ impl Message<RelayEchoStanza> for RelayActor {
     }
 }
 
+/// Harness fault injection: crash the relay actor (simulating an unexpected
+/// stop, so the supervised respawn + same-name re-registration and the
+/// sender-side stale-ref recovery can be asserted cross-node). Inert unless
+/// the node runs with `WADDLE_CLUSTERING_FAULT_INJECTION=true`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayCrash;
+
+/// Harness fault injection: hold the relay's mailbox for `millis`
+/// (single-threaded per-actor), so a receiver handler exceeding the sender's
+/// transport `request_timeout` can be provoked. Inert unless fault injection
+/// is enabled.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelaySleep {
+    pub millis: u64,
+}
+
+/// Reply to the fault-injection messages: whether the fault was applied
+/// (false = fault injection disabled on this node).
+#[derive(Debug, Clone, Serialize, Deserialize, Reply)]
+pub struct RelayFaultAck {
+    pub applied: bool,
+}
+
+#[kameo::remote_message("waddle.clustering.relay.crash.v1")]
+impl Message<RelayCrash> for RelayActor {
+    type Reply = RelayFaultAck;
+
+    async fn handle(
+        &mut self,
+        _msg: RelayCrash,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> RelayFaultAck {
+        if self.fault_injection {
+            // Kill this actor: an unexpected stop from the supervisor's point
+            // of view (kameo auto-unregisters, the supervisor respawns and
+            // re-registers). The reply may or may not make it out first —
+            // harness callers tolerate an error on this ask.
+            ctx.actor_ref().kill();
+            RelayFaultAck { applied: true }
+        } else {
+            RelayFaultAck { applied: false }
+        }
+    }
+}
+
+#[kameo::remote_message("waddle.clustering.relay.sleep.v1")]
+impl Message<RelaySleep> for RelayActor {
+    type Reply = RelayFaultAck;
+
+    async fn handle(
+        &mut self,
+        msg: RelaySleep,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> RelayFaultAck {
+        if self.fault_injection {
+            // Clamped so even the harness (or a compromised harness peer)
+            // cannot wedge the relay's single-threaded mailbox indefinitely —
+            // a wedged-but-live actor has no respawn path.
+            let millis = msg.millis.min(MAX_FAULT_SLEEP_MS);
+            tokio::time::sleep(Duration::from_millis(millis)).await;
+            RelayFaultAck { applied: true }
+        } else {
+            RelayFaultAck { applied: false }
+        }
+    }
+}
+
 /// Spawn the node's relay actor under supervision: register it in kademlia
 /// under [`relay_name`], respawn it if it ever stops unexpectedly, and
 /// **re-register under the same name** on every respawn (kameo auto-registers
 /// removal on actor stop, so re-registration is mandatory, not optional).
 /// Stops cleanly when `stop_token` fires.
-pub fn spawn_supervised(node_id: String, stop_token: CancellationToken) {
+pub fn spawn_supervised(node_id: String, fault_injection: bool, stop_token: CancellationToken) {
     tokio::spawn(async move {
         let name = relay_name(&node_id);
         let mut respawns: u64 = 0;
@@ -129,7 +220,7 @@ pub fn spawn_supervised(node_id: String, stop_token: CancellationToken) {
                 break;
             }
             let actor_ref: ActorRef<RelayActor> =
-                RelayActor::spawn(RelayActor::new(node_id.clone()));
+                RelayActor::spawn(RelayActor::new(node_id.clone(), fault_injection));
             match actor_ref.register(name.clone()).await {
                 Ok(()) => {
                     if respawns > 0 {
@@ -151,20 +242,39 @@ pub fn spawn_supervised(node_id: String, stop_token: CancellationToken) {
                 }
             }
 
-            tokio::select! {
-                _ = stop_token.cancelled() => {
-                    // Graceful stop: unregister the name proactively so peers
-                    // stop resolving a dead relay, then stop the actor.
-                    let _ = kameo::remote::unregister(name.clone()).await;
-                    let _ = actor_ref.stop_gracefully().await;
-                    break;
-                }
-                _ = actor_ref.wait_for_shutdown() => {
-                    // Unexpected stop/panic: kameo has already unregistered
-                    // the name. Respawn and re-register under the SAME name
-                    // after a short backoff.
-                    respawns += 1;
-                    tokio::time::sleep(RESPAWN_BACKOFF).await;
+            let mut reregister = tokio::time::interval(REREGISTER_INTERVAL);
+            // Skip the immediate first tick — we just registered above.
+            reregister.tick().await;
+
+            loop {
+                tokio::select! {
+                    _ = stop_token.cancelled() => {
+                        // Graceful stop: stopping the actor triggers kameo's
+                        // own (panic-free, fire-and-forget) unregistration.
+                        // Deliberately NOT `remote::unregister(..).await`
+                        // here: that future panics if the swarm's command
+                        // channel is dropped first, which this shutdown
+                        // races by construction (the event loop stops on the
+                        // same token).
+                        let _ = actor_ref.stop_gracefully().await;
+                        return;
+                    }
+                    _ = actor_ref.wait_for_shutdown() => {
+                        // Unexpected stop/panic: kameo has already
+                        // unregistered the name. Respawn and re-register
+                        // under the SAME name after a short backoff.
+                        respawns += 1;
+                        tokio::time::sleep(RESPAWN_BACKOFF).await;
+                        break;
+                    }
+                    _ = reregister.tick() => {
+                        // Same-name refresh so a registration that predated
+                        // our first peer connection becomes discoverable
+                        // (see REREGISTER_INTERVAL).
+                        if let Err(error) = actor_ref.register(name.clone()).await {
+                            tracing::debug!(%name, %error, "clustering relay periodic re-registration failed");
+                        }
+                    }
                 }
             }
         }
@@ -207,7 +317,8 @@ impl RelayHandle {
             return Ok(cached.clone());
         }
         let name = relay_name(&self.node_id);
-        for backoff in LOOKUP_BACKOFF {
+        let mut backoffs = LOOKUP_BACKOFF.iter();
+        loop {
             match RemoteActorRef::<RelayActor>::lookup(name.clone()).await {
                 Ok(Some(remote_ref)) => {
                     self.cached = Some(remote_ref.clone());
@@ -218,11 +329,17 @@ impl RelayHandle {
                     tracing::debug!(%name, %error, "clustering relay lookup error; backing off");
                 }
             }
-            tokio::time::sleep(backoff).await;
+            // Back off between attempts only — no trailing sleep after the
+            // final miss.
+            match backoffs.next() {
+                Some(backoff) => tokio::time::sleep(*backoff).await,
+                None => {
+                    return Err(RelayAskError::NotFound {
+                        node_id: self.node_id.clone(),
+                    })
+                }
+            }
         }
-        Err(RelayAskError::NotFound {
-            node_id: self.node_id.clone(),
-        })
     }
 
     /// Ping the relay, refreshing a stale cached ref once: transport-layer
@@ -247,6 +364,28 @@ impl RelayHandle {
             }
             Err(error) => Err(RelayAskError::Send(error.to_string())),
         }
+    }
+
+    /// Harness: ask the relay to crash (fault injection). The ask may fail —
+    /// the actor can die before the reply leaves — so the result only says
+    /// whether the *request* went out; callers assert recovery separately.
+    pub async fn crash(&mut self) -> Result<(), RelayAskError> {
+        let remote_ref = self.resolve().await?;
+        match remote_ref.ask(&RelayCrash).await {
+            // A dead-before-reply error is the expected outcome of a crash.
+            Ok(_) | Err(_) => Ok(()),
+        }
+    }
+
+    /// Harness: ask the relay to sleep for `millis` inside its handler,
+    /// WITHOUT the stale-ref retry (the point is to observe the sender-side
+    /// transport timeout, not to recover from it).
+    pub async fn sleep(&mut self, millis: u64) -> Result<RelayFaultAck, RelayAskError> {
+        let remote_ref = self.resolve().await?;
+        remote_ref
+            .ask(&RelaySleep { millis })
+            .await
+            .map_err(|error| RelayAskError::Send(error.to_string()))
     }
 
     /// Round-trip a stanza through the relay (codec proof), with the same

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -457,8 +457,11 @@ impl RelayHandle {
     }
 
     /// Harness: ask the relay to crash (fault injection). The ask may fail —
-    /// the actor can die before the reply leaves — so the result only says
-    /// whether the *request* went out; callers assert recovery separately.
+    /// the actor can die before the reply leaves — so only the failure
+    /// classes plausible for a mid-ask death are tolerated; anything else
+    /// (codec mismatch, full mailbox, handler error) means the crash request
+    /// never plausibly reached the relay and is propagated so callers don't
+    /// pass vacuously. Callers assert recovery separately.
     pub async fn crash(&mut self) -> Result<(), RelayAskError> {
         let remote_ref = self.resolve().await?;
         match remote_ref
@@ -467,8 +470,17 @@ impl RelayHandle {
             .reply_timeout(self.reply_timeout)
             .await
         {
-            // A dead-before-reply error is the expected outcome of a crash.
-            Ok(_) | Err(_) => Ok(()),
+            Ok(_) => Ok(()),
+            // Dead-before-reply presents as a stale ref, a reply that never
+            // arrives, or a torn connection — all expected outcomes here.
+            Err(error) => match classify(&error) {
+                RelaySendFailure::StaleRef
+                | RelaySendFailure::ReplyTimeout
+                | RelaySendFailure::Transport => Ok(()),
+                RelaySendFailure::MailboxFull
+                | RelaySendFailure::Handler
+                | RelaySendFailure::Codec => Err(send_error(error)),
+            },
         }
     }
 

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -198,6 +198,12 @@ pub async fn spawn(
     // The node's single kademlia registration: its supervised relay actor.
     // Must start after the event loop is polling (registration flows through
     // the swarm command channel serviced by the loop).
+    if config.fault_injection {
+        tracing::warn!(
+            "clustering fault injection is ENABLED: any enrolled peer can crash this node's \
+             relay or stall its mailbox — test harnesses only, never production"
+        );
+    }
     relay::spawn_supervised(node_id.clone(), config.fault_injection, stop_token);
 
     let handle = SwarmHandle {

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -7,6 +7,7 @@
 //! run the event loop until the shared shutdown token fires. No stanza is
 //! routed cross-node.
 
+use super::allowlist::{diff_allowlist, AllowlistError, AllowlistStore, PostgresAllowlistStore};
 use super::behaviour::{WaddleBehaviour, WaddleBehaviourEvent};
 use super::lease::{
     KeypairSlotLease, LeaseError, LeaseIdentity, LeasedSlot, PostgresKeypairSlotLease,
@@ -35,6 +36,11 @@ const BOOTSTRAP_DIAL_INTERVAL: Duration = Duration::from_secs(15);
 /// back to the event loop for dialing.
 const DIAL_CHANNEL_CAPACITY: usize = 64;
 
+/// Buffer for enrolled-peer sets flowing from the off-loop allowlist reader
+/// back to the event loop. Single-flight refreshes mean at most one set is
+/// ever in flight; a small buffer keeps the sender from awaiting.
+const ALLOWLIST_CHANNEL_CAPACITY: usize = 4;
+
 /// Failures while building or starting the swarm. Human-facing `Display` text
 /// is surfaced at server startup.
 #[derive(Debug, thiserror::Error)]
@@ -60,6 +66,9 @@ pub enum SwarmError {
     /// A leased pool slot's keypair could not be decoded.
     #[error(transparent)]
     Identity(#[from] identity::IdentityError),
+    /// The peer allowlist could not be read at startup.
+    #[error(transparent)]
+    Allowlist(#[from] AllowlistError),
 }
 
 /// Build the swarm, install the global `ActorSwarm`, start listening, and
@@ -93,6 +102,20 @@ pub async fn spawn(
     let keypair = node_keypair(config, db, &stop_token).await?;
     let local_peer_id = keypair.public().to_peer_id();
 
+    // Peer authorization (ADR element 3): load the enrolled peer set before
+    // the swarm accepts anything. An empty allowlist is deny-all — correct for
+    // a first node with no peers, but worth a loud note.
+    let allowlist: Arc<dyn AllowlistStore> = Arc::new(PostgresAllowlistStore::new(db.clone()));
+    allowlist.ensure_schema().await?;
+    let enrolled = allowlist.enrolled_peers().await?;
+    metrics::record_allowlist_size(enrolled.len() as i64);
+    if enrolled.is_empty() {
+        tracing::warn!(
+            "clustering peer allowlist is empty: all peer connections will be rejected until \
+             peers are enrolled (deny-all)"
+        );
+    }
+
     let messaging_config = remote::messaging::Config::default()
         .with_request_timeout(config.messaging.request_timeout)
         .with_max_concurrent_streams(config.messaging.max_concurrent_streams)
@@ -112,7 +135,9 @@ pub async fn spawn(
         // `TryIntoBehaviour<B> for B` form, whose error is `Infallible`). The
         // fallible form requires exactly `Box<dyn Error + Send + Sync>`, so an
         // `Ok::<_, Infallible>` wrapper would be misread as the behaviour type.
-        .with_behaviour(|key| WaddleBehaviour::new(key.public().to_peer_id(), messaging_config))
+        .with_behaviour(|key| {
+            WaddleBehaviour::new(key.public().to_peer_id(), messaging_config, &enrolled)
+        })
         .map_err(|never: Infallible| -> SwarmError { match never {} })?
         .build();
 
@@ -136,9 +161,27 @@ pub async fn spawn(
     }
 
     let bootstrap = config.bootstrap.clone();
-    tokio::spawn(run_event_loop(swarm, bootstrap, stop_token));
+    tokio::spawn(run_event_loop(
+        swarm,
+        bootstrap,
+        AllowlistRefresh {
+            store: allowlist,
+            current: enrolled,
+            interval: config.allowlist_refresh_interval,
+        },
+        stop_token,
+    ));
 
     Ok(local_peer_id)
+}
+
+/// State for the periodic allowlist refresh driven by the event loop.
+struct AllowlistRefresh {
+    store: Arc<dyn AllowlistStore>,
+    /// The enrolled set as currently applied to the swarm's allowed-peers
+    /// behaviour.
+    current: HashSet<PeerId>,
+    interval: Duration,
 }
 
 /// Resolve this node's libp2p keypair: lease a pool slot (and start its
@@ -231,11 +274,13 @@ async fn run_heartbeat(
     }
 }
 
-/// Drive the swarm until `stop_token` fires: dial seed peers on a timer, feed
-/// swarm events to the handler, and stop cleanly on shutdown.
+/// Drive the swarm until `stop_token` fires: dial seed peers on a timer,
+/// refresh the peer allowlist on a timer (revoking removed peers), feed swarm
+/// events to the handler, and stop cleanly on shutdown.
 async fn run_event_loop(
     mut swarm: Swarm<WaddleBehaviour>,
     bootstrap: Option<ClusteringBootstrapConfig>,
+    mut allowlist: AllowlistRefresh,
     stop_token: CancellationToken,
 ) {
     // Peers we currently hold a connection to (authoritative from connection
@@ -247,6 +292,8 @@ async fn run_event_loop(
     // happens right away rather than after a full interval.
     let mut dial_timer = tokio::time::interval(BOOTSTRAP_DIAL_INTERVAL);
     dial_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    let mut allowlist_timer = tokio::time::interval(allowlist.interval);
+    allowlist_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     // DNS resolution runs in a spawned task and hands resolved multiaddrs back
     // over this channel, so a slow lookup never stalls swarm polling (which
@@ -261,6 +308,13 @@ async fn run_event_loop(
     // process-wide. At most one resolver runs at a time; ticks are skipped
     // while one is in flight and resume once it returns.
     let dns_in_flight = Arc::new(AtomicBool::new(false));
+
+    // Allowlist refreshes follow the same off-loop + single-flight shape: the
+    // DB read runs in a spawned task and the fresh enrolled set comes back
+    // over a channel, so a slow query never stalls swarm polling.
+    let (allowlist_tx, mut allowlist_rx) =
+        tokio::sync::mpsc::channel::<HashSet<PeerId>>(ALLOWLIST_CHANNEL_CAPACITY);
+    let allowlist_in_flight = Arc::new(AtomicBool::new(false));
 
     loop {
         tokio::select! {
@@ -285,6 +339,30 @@ async fn run_event_loop(
                     }
                 }
             }
+            _ = allowlist_timer.tick() => {
+                if !allowlist_in_flight.swap(true, Ordering::AcqRel) {
+                    let store = Arc::clone(&allowlist.store);
+                    let allowlist_tx = allowlist_tx.clone();
+                    let in_flight = Arc::clone(&allowlist_in_flight);
+                    tokio::spawn(async move {
+                        match store.enrolled_peers().await {
+                            Ok(enrolled) => {
+                                let _ = allowlist_tx.send(enrolled).await;
+                            }
+                            Err(error) => {
+                                // Keep the last-known set on a read failure —
+                                // never fail open, never mass-revoke on a
+                                // transient DB error.
+                                tracing::warn!(%error, "clustering allowlist refresh failed; keeping current set");
+                            }
+                        }
+                        in_flight.store(false, Ordering::Release);
+                    });
+                }
+            }
+            Some(enrolled) = allowlist_rx.recv() => {
+                apply_allowlist(&mut swarm, &mut allowlist, enrolled);
+            }
             Some(addr) = dial_rx.recv() => {
                 metrics::record_bootstrap_dial();
                 if let Err(error) = swarm.dial(addr.clone()) {
@@ -296,6 +374,39 @@ async fn run_event_loop(
             }
         }
     }
+}
+
+/// Apply a freshly read enrolled set to the swarm's allowed-peers behaviour:
+/// newly enrolled peers become dialable/acceptable, and removed peers are
+/// revoked — `disallow_peer` also closes their live connections, so a revoked
+/// peer's swarm access ends within one refresh interval (ADR element 3).
+fn apply_allowlist(
+    swarm: &mut Swarm<WaddleBehaviour>,
+    allowlist: &mut AllowlistRefresh,
+    enrolled: HashSet<PeerId>,
+) {
+    let diff = diff_allowlist(&allowlist.current, &enrolled);
+    if diff.added.is_empty() && diff.removed.is_empty() {
+        return;
+    }
+    for peer in &diff.added {
+        swarm.behaviour_mut().allowed.allow_peer(*peer);
+    }
+    for peer in &diff.removed {
+        swarm.behaviour_mut().allowed.disallow_peer(*peer);
+        tracing::warn!(peer_id = %peer, "clustering peer revoked: closing live connections");
+    }
+    if !diff.removed.is_empty() {
+        metrics::record_peers_revoked(diff.removed.len() as u64);
+    }
+    metrics::record_allowlist_size(enrolled.len() as i64);
+    tracing::info!(
+        added = diff.added.len(),
+        revoked = diff.removed.len(),
+        enrolled = enrolled.len(),
+        "clustering peer allowlist refreshed"
+    );
+    allowlist.current = enrolled;
 }
 
 /// Record a newly connected peer, updating the connected-peer gauge on the
@@ -389,8 +500,8 @@ mod tests {
     use crate::config::ClusteringConfig;
     use crate::db::{DatabaseConfig, DatabaseDriver};
 
-    // An in-memory SQLite handle for tests that take the ephemeral-identity
-    // path (empty keypair pool), where the DB is never touched.
+    // An in-memory SQLite handle for tests that fail before any DB touch
+    // (listen-addr parsing precedes allowlist and lease access).
     async fn scratch_db() -> Database {
         Database::from_config(
             "clustering-swarm-test",
@@ -402,19 +513,29 @@ mod tests {
 
     // kameo's `init_global` is a process singleton, so exactly ONE test per
     // test binary may successfully bring up the swarm. This smoke test
-    // exercises the whole bring-up: keypair generation, transport init (tcp +
-    // quic + Noise + yamux), the global `ActorSwarm` install, and `listen_on`
-    // binding an ephemeral port — then drives the event loop briefly and shuts
-    // it down on the token.
+    // exercises the whole bring-up: keypair generation, allowlist load
+    // (deny-all empty set), transport init (tcp + quic + Noise + yamux), the
+    // global `ActorSwarm` install, and `listen_on` binding an ephemeral port —
+    // then drives the event loop briefly and shuts it down on the token.
+    // Postgres-gated: allowlist enforcement is unconditional and its store is
+    // Postgres-only (as clustering itself is).
     #[tokio::test]
     async fn swarm_spawn_brings_up_and_shuts_down() {
+        let Ok(url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
+            return;
+        };
         let config = ClusteringConfig {
             enabled: true,
             listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".to_string()],
             bootstrap: None,
             ..ClusteringConfig::default()
         };
-        let db = scratch_db().await;
+        let db = Database::from_config(
+            "clustering-swarm-test",
+            &DatabaseConfig::new(DatabaseDriver::Postgres, url),
+        )
+        .await
+        .expect("open test postgres");
         let stop = CancellationToken::new();
 
         let peer_id = spawn(&config, &db, stop.clone())
@@ -437,6 +558,8 @@ mod tests {
             bootstrap: None,
             ..ClusteringConfig::default()
         };
+        // Listen-addr validation fails before any DB access, so a SQLite
+        // scratch handle is fine here.
         let db = scratch_db().await;
         let err = spawn(&config, &db, CancellationToken::new())
             .await

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -643,6 +643,24 @@ fn handle_swarm_event(
         SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
             tracing::debug!(?peer_id, %error, "clustering outgoing connection error");
         }
+        // A failing or closed listener silently degrades the node (peers can
+        // no longer dial it) — surface it loudly rather than letting it fall
+        // through the wildcard.
+        SwarmEvent::ListenerError { listener_id, error } => {
+            tracing::warn!(?listener_id, %error, "clustering swarm listener error");
+        }
+        SwarmEvent::ListenerClosed {
+            listener_id,
+            addresses,
+            reason,
+        } => {
+            tracing::warn!(
+                ?listener_id,
+                ?addresses,
+                ?reason,
+                "clustering swarm listener closed"
+            );
+        }
         _ => {}
     }
 }

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -132,6 +132,16 @@ pub async fn spawn(
             "clustering peer allowlist is empty: all peer connections will be rejected until \
              peers are enrolled (deny-all)"
         );
+    } else if !enrolled.contains(&local_peer_id) {
+        // Enrollment is symmetric and cluster-wide: a node absent from the
+        // shared table is rejected by every peer, which otherwise presents
+        // only as silent dial failures on the other nodes. Not fatal —
+        // enrollment can land moments after boot and the refresh picks it up.
+        tracing::warn!(
+            %local_peer_id,
+            "clustering: this node's PeerId is not in the peer allowlist — every enrolled \
+             peer will reject its connections until it is enrolled"
+        );
     }
 
     let messaging_config = remote::messaging::Config::default()

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -21,16 +21,12 @@ use kameo::remote::{self, registry};
 use libp2p::identity::Keypair;
 use libp2p::swarm::SwarmEvent;
 use libp2p::{noise, tcp, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
-
-/// How often the event loop re-resolves the headless-DNS name and dials any
-/// seed peers, to pick up pod churn (rolling restarts, scale changes).
-const BOOTSTRAP_DIAL_INTERVAL: Duration = Duration::from_secs(15);
 
 /// Buffer for resolved-peer multiaddrs flowing from the off-loop DNS resolver
 /// back to the event loop for dialing.
@@ -40,6 +36,11 @@ const DIAL_CHANNEL_CAPACITY: usize = 64;
 /// back to the event loop. Single-flight refreshes mean at most one set is
 /// ever in flight; a small buffer keeps the sender from awaiting.
 const ALLOWLIST_CHANNEL_CAPACITY: usize = 4;
+
+/// Idle timeout for swarm connections: a cluster mesh wants long-lived peer
+/// connections, and libp2p's ~10s default would close them between discovery
+/// traffic and force a re-dial per interaction.
+const IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(300);
 
 /// Failures while building or starting the swarm. Human-facing `Display` text
 /// is surfaced at server startup.
@@ -69,6 +70,9 @@ pub enum SwarmError {
     /// The peer allowlist could not be read at startup.
     #[error(transparent)]
     Allowlist(#[from] AllowlistError),
+    /// The configured node-id file could not be written.
+    #[error("failed to write clustering node-id file '{path}': {reason}")]
+    NodeIdFile { path: String, reason: String },
 }
 
 /// Identity of a running swarm: the libp2p `PeerId` plus the per-process
@@ -153,6 +157,10 @@ pub async fn spawn(
             WaddleBehaviour::new(key.public().to_peer_id(), messaging_config, &enrolled)
         })
         .map_err(|never: Infallible| -> SwarmError { match never {} })?
+        // A cluster mesh wants long-lived peer connections; libp2p's default
+        // ~10s idle timeout would close them between discovery traffic and
+        // force a re-dial per interaction.
+        .with_swarm_config(|config| config.with_idle_connection_timeout(IDLE_CONNECTION_TIMEOUT))
         .build();
 
     // Install the process-global kameo `ActorSwarm` so `RemoteActorRef`
@@ -174,10 +182,11 @@ pub async fn spawn(
             })?;
     }
 
-    let bootstrap = config.bootstrap.clone();
+    let bootstrap_peers = config.bootstrap_peers.clone();
     tokio::spawn(run_event_loop(
         swarm,
-        bootstrap,
+        bootstrap_peers,
+        config.dial_interval,
         AllowlistRefresh {
             store: allowlist,
             current: enrolled,
@@ -189,12 +198,24 @@ pub async fn spawn(
     // The node's single kademlia registration: its supervised relay actor.
     // Must start after the event loop is polling (registration flows through
     // the swarm command channel serviced by the loop).
-    relay::spawn_supervised(node_id.clone(), stop_token);
+    relay::spawn_supervised(node_id.clone(), config.fault_injection, stop_token);
 
-    Ok(SwarmHandle {
+    let handle = SwarmHandle {
         local_peer_id,
         node_id,
-    })
+    };
+
+    // Publish the node identity for the multi-process harness (mirrors the
+    // WADDLE_HTTP_PORT_FILE convention).
+    if let Some(path) = &config.node_id_file {
+        let contents = format!("{} {}\n", handle.node_id, handle.local_peer_id);
+        std::fs::write(path, contents).map_err(|error| SwarmError::NodeIdFile {
+            path: path.display().to_string(),
+            reason: error.to_string(),
+        })?;
+    }
+
+    Ok(handle)
 }
 
 /// State for the periodic allowlist refresh driven by the event loop.
@@ -305,18 +326,24 @@ async fn run_heartbeat(
 /// events to the handler, and stop cleanly on shutdown.
 async fn run_event_loop(
     mut swarm: Swarm<WaddleBehaviour>,
-    bootstrap: Option<ClusteringBootstrapConfig>,
+    bootstrap_peers: Vec<ClusteringBootstrapConfig>,
+    dial_interval: Duration,
     mut allowlist: AllowlistRefresh,
     stop_token: CancellationToken,
 ) {
     // Peers we currently hold a connection to (authoritative from connection
-    // events) and peers observed to enter the kademlia routing table.
+    // events), peers observed to enter the kademlia routing table, and the
+    // remote address of every live connection (so the bootstrap dial loop can
+    // skip endpoints it is already connected to instead of churning a fresh
+    // connection every interval that the duplicate-PeerId defense then
+    // closes).
     let mut connected: HashSet<PeerId> = HashSet::new();
     let mut routing_peers: HashSet<PeerId> = HashSet::new();
+    let mut conn_addrs: HashMap<libp2p::swarm::ConnectionId, Multiaddr> = HashMap::new();
 
     // `interval` fires its first tick immediately, so the first dial round
     // happens right away rather than after a full interval.
-    let mut dial_timer = tokio::time::interval(BOOTSTRAP_DIAL_INTERVAL);
+    let mut dial_timer = tokio::time::interval(dial_interval);
     dial_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
     let mut allowlist_timer = tokio::time::interval(allowlist.interval);
     allowlist_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
@@ -349,20 +376,20 @@ async fn run_event_loop(
                 break;
             }
             _ = dial_timer.tick() => {
-                if let Some(ref bootstrap) = bootstrap {
-                    if !dns_in_flight.swap(true, Ordering::AcqRel) {
-                        let bootstrap = bootstrap.clone();
-                        let dial_tx = dial_tx.clone();
-                        let in_flight = Arc::clone(&dns_in_flight);
-                        tokio::spawn(async move {
-                            for addr in dns::resolve_bootstrap_peers(&bootstrap).await {
-                                if dial_tx.send(addr).await.is_err() {
-                                    break;
-                                }
+                if !bootstrap_peers.is_empty()
+                    && !dns_in_flight.swap(true, Ordering::AcqRel)
+                {
+                    let seeds = bootstrap_peers.clone();
+                    let dial_tx = dial_tx.clone();
+                    let in_flight = Arc::clone(&dns_in_flight);
+                    tokio::spawn(async move {
+                        for addr in dns::resolve_bootstrap_peers(&seeds).await {
+                            if dial_tx.send(addr).await.is_err() {
+                                break;
                             }
-                            in_flight.store(false, Ordering::Release);
-                        });
-                    }
+                        }
+                        in_flight.store(false, Ordering::Release);
+                    });
                 }
             }
             _ = allowlist_timer.tick() => {
@@ -390,13 +417,25 @@ async fn run_event_loop(
                 apply_allowlist(&mut swarm, &mut allowlist, enrolled);
             }
             Some(addr) = dial_rx.recv() => {
+                // Skip endpoints we already hold a connection to: redialing a
+                // connected peer every interval would just mint a duplicate
+                // connection for the duplicate-PeerId defense to close.
+                if conn_addrs.values().any(|connected_addr| *connected_addr == addr) {
+                    continue;
+                }
                 metrics::record_bootstrap_dial();
                 if let Err(error) = swarm.dial(addr.clone()) {
                     tracing::debug!(%addr, %error, "clustering bootstrap dial failed");
                 }
             }
             event = swarm.select_next_some() => {
-                handle_swarm_event(&mut swarm, event, &mut connected, &mut routing_peers);
+                handle_swarm_event(
+                    &mut swarm,
+                    event,
+                    &mut connected,
+                    &mut routing_peers,
+                    &mut conn_addrs,
+                );
             }
         }
     }
@@ -469,6 +508,7 @@ fn handle_swarm_event(
     event: SwarmEvent<WaddleBehaviourEvent>,
     connected: &mut HashSet<PeerId>,
     routing_peers: &mut HashSet<PeerId>,
+    conn_addrs: &mut HashMap<libp2p::swarm::ConnectionId, Multiaddr>,
 ) {
     match event {
         SwarmEvent::NewListenAddr { address, .. } => {
@@ -477,8 +517,19 @@ fn handle_swarm_event(
         SwarmEvent::ConnectionEstablished {
             peer_id,
             connection_id,
+            endpoint,
             ..
         } => {
+            conn_addrs.insert(connection_id, endpoint.get_remote_address().clone());
+            // Feed outbound (dialed) addresses to the behaviours: kademlia
+            // only inserts a peer into its routing table once it knows a
+            // dialable address for it. kameo's mDNS dev-bootstrap does this on
+            // every discovery; our owned dialing must do it explicitly or the
+            // routing table stays empty and every lookup fails. Inbound remote
+            // addresses are ephemeral ports, never dialable — skip those.
+            if endpoint.is_dialer() {
+                swarm.add_peer_address(peer_id, endpoint.get_remote_address().clone());
+            }
             // Duplicate-PeerId defense-in-depth (ADR element 3): the
             // keypair-slot lease already guarantees a unique PeerId per live
             // node, so a second concurrent connection to an already-connected
@@ -493,13 +544,17 @@ fn handle_swarm_event(
                 track_peer_connected(peer_id, connected);
             }
         }
-        // Only drop the peer when its last connection closes (num_established 0).
         SwarmEvent::ConnectionClosed {
             peer_id,
-            num_established: 0,
+            connection_id,
+            num_established,
             ..
         } => {
-            track_peer_disconnected(peer_id, connected);
+            conn_addrs.remove(&connection_id);
+            // Only drop the peer when its last connection closes.
+            if num_established == 0 {
+                track_peer_disconnected(peer_id, connected);
+            }
         }
         SwarmEvent::Behaviour(WaddleBehaviourEvent::Kameo(remote::Event::Registry(
             registry::Event::RoutingUpdated {
@@ -565,7 +620,7 @@ mod tests {
         let config = ClusteringConfig {
             enabled: true,
             listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".to_string()],
-            bootstrap: None,
+            bootstrap_peers: Vec::new(),
             ..ClusteringConfig::default()
         };
         let db = Database::from_config(
@@ -622,7 +677,7 @@ mod tests {
         let config = ClusteringConfig {
             enabled: true,
             listen_addrs: vec!["not-a-multiaddr".to_string()],
-            bootstrap: None,
+            bootstrap_peers: Vec::new(),
             ..ClusteringConfig::default()
         };
         // Listen-addr validation fails before any DB access, so a SQLite

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -16,6 +16,8 @@ use kameo::remote::{self, registry};
 use libp2p::swarm::SwarmEvent;
 use libp2p::{noise, tcp, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder};
 use std::collections::HashSet;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
@@ -146,6 +148,14 @@ async fn run_event_loop(
     // hold `dial_tx` for the loop's lifetime, so `recv()` never closes.
     let (dial_tx, mut dial_rx) = tokio::sync::mpsc::channel::<Multiaddr>(DIAL_CHANNEL_CAPACITY);
 
+    // Single-flight guard for the DNS resolver. `tokio::net::lookup_host` runs
+    // an uncancellable `getaddrinfo` on the blocking pool; without this, a DNS
+    // outage would spawn a new stuck task every interval and eventually
+    // saturate the blocking pool, starving unrelated `spawn_blocking` work
+    // process-wide. At most one resolver runs at a time; ticks are skipped
+    // while one is in flight and resume once it returns.
+    let dns_in_flight = Arc::new(AtomicBool::new(false));
+
     loop {
         tokio::select! {
             _ = stop_token.cancelled() => {
@@ -154,15 +164,19 @@ async fn run_event_loop(
             }
             _ = dial_timer.tick() => {
                 if let Some(ref bootstrap) = bootstrap {
-                    let bootstrap = bootstrap.clone();
-                    let dial_tx = dial_tx.clone();
-                    tokio::spawn(async move {
-                        for addr in dns::resolve_bootstrap_peers(&bootstrap).await {
-                            if dial_tx.send(addr).await.is_err() {
-                                break;
+                    if !dns_in_flight.swap(true, Ordering::AcqRel) {
+                        let bootstrap = bootstrap.clone();
+                        let dial_tx = dial_tx.clone();
+                        let in_flight = Arc::clone(&dns_in_flight);
+                        tokio::spawn(async move {
+                            for addr in dns::resolve_bootstrap_peers(&bootstrap).await {
+                                if dial_tx.send(addr).await.is_err() {
+                                    break;
+                                }
                             }
-                        }
-                    });
+                            in_flight.store(false, Ordering::Release);
+                        });
+                    }
                 }
             }
             Some(addr) = dial_rx.recv() => {

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -257,10 +257,9 @@ async fn node_keypair(
 
     let lease = PostgresKeypairSlotLease::new(db.clone());
     lease.ensure_schema().await?;
-    // Storage boundary: the lease persists the id as TEXT.
     let node = LeaseIdentity {
-        node_id: node_id.as_str().to_string(),
-        node_epoch: uuid::Uuid::new_v4().to_string(),
+        node_id: node_id.clone(),
+        node_epoch: uuid::Uuid::new_v4(),
     };
     let pool_size = config.keypair_pool.len();
     let slot = lease
@@ -665,9 +664,22 @@ mod tests {
         // short-circuits asks whose target peer is the local node, so this
         // exercises registration, kademlia lookup, payload serde, and the
         // handler without a second process; the true cross-node round-trip is
-        // a Slice 6 harness case). Registration is async — poll briefly.
+        // a Slice 6 harness case). Registration is async — retry until the
+        // relay is discoverable so a slow CI runner cannot flake the test.
         let mut relay_handle = relay::RelayHandle::new(handle.node_id.clone());
-        let pong = relay_handle.ping().await.expect("relay answers ping");
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
+        let pong = loop {
+            match relay_handle.ping().await {
+                Ok(pong) => break pong,
+                Err(error) => {
+                    assert!(
+                        tokio::time::Instant::now() < deadline,
+                        "relay never answered ping: {error}"
+                    );
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        };
         assert_eq!(pong.node_id, handle.node_id);
 
         // Codec proof over the ask path: a thread-carrying message survives

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -12,7 +12,7 @@ use super::behaviour::{WaddleBehaviour, WaddleBehaviourEvent};
 use super::lease::{
     KeypairSlotLease, LeaseError, LeaseIdentity, LeasedSlot, PostgresKeypairSlotLease,
 };
-use super::{dns, identity, metrics};
+use super::{dns, identity, metrics, relay};
 use crate::config::{ClusteringBootstrapConfig, ClusteringConfig};
 use crate::db::Database;
 use core::convert::Infallible;
@@ -71,8 +71,17 @@ pub enum SwarmError {
     Allowlist(#[from] AllowlistError),
 }
 
-/// Build the swarm, install the global `ActorSwarm`, start listening, and
-/// spawn the event loop on `stop_token`. Returns the local `PeerId`.
+/// Identity of a running swarm: the libp2p `PeerId` plus the per-process
+/// `node_id` that names this node's keypair-slot lease and relay registration.
+#[derive(Debug, Clone)]
+pub struct SwarmHandle {
+    pub local_peer_id: PeerId,
+    pub node_id: String,
+}
+
+/// Build the swarm, install the global `ActorSwarm`, start listening, spawn
+/// the event loop and the supervised relay on `stop_token`, and return the
+/// node's swarm identity.
 ///
 /// When a keypair pool is configured the node leases one pool slot from the
 /// Postgres control plane and uses that keypair (and heartbeats it); otherwise
@@ -81,7 +90,7 @@ pub async fn spawn(
     config: &ClusteringConfig,
     db: &Database,
     stop_token: CancellationToken,
-) -> Result<PeerId, SwarmError> {
+) -> Result<SwarmHandle, SwarmError> {
     // Parse and validate the listen multiaddrs first, before building any
     // transport or touching the process-global `ActorSwarm` — fail fast on bad
     // config.
@@ -99,7 +108,12 @@ pub async fn spawn(
         })
         .collect::<Result<Vec<Multiaddr>, SwarmError>>()?;
 
-    let keypair = node_keypair(config, db, &stop_token).await?;
+    // One per-process node id: freshly generated every start, never reused
+    // across restarts. Names this node's keypair-slot lease and its single
+    // kademlia relay registration.
+    let node_id = uuid::Uuid::new_v4().to_string();
+
+    let keypair = node_keypair(config, db, &node_id, &stop_token).await?;
     let local_peer_id = keypair.public().to_peer_id();
 
     // Peer authorization (ADR element 3): load the enrolled peer set before
@@ -169,10 +183,18 @@ pub async fn spawn(
             current: enrolled,
             interval: config.allowlist_refresh_interval,
         },
-        stop_token,
+        stop_token.clone(),
     ));
 
-    Ok(local_peer_id)
+    // The node's single kademlia registration: its supervised relay actor.
+    // Must start after the event loop is polling (registration flows through
+    // the swarm command channel serviced by the loop).
+    relay::spawn_supervised(node_id.clone(), stop_token);
+
+    Ok(SwarmHandle {
+        local_peer_id,
+        node_id,
+    })
 }
 
 /// State for the periodic allowlist refresh driven by the event loop.
@@ -190,6 +212,7 @@ struct AllowlistRefresh {
 async fn node_keypair(
     config: &ClusteringConfig,
     db: &Database,
+    node_id: &str,
     stop_token: &CancellationToken,
 ) -> Result<Keypair, SwarmError> {
     if config.keypair_pool.is_empty() {
@@ -206,7 +229,7 @@ async fn node_keypair(
     let lease = PostgresKeypairSlotLease::new(db.clone());
     lease.ensure_schema().await?;
     let node = LeaseIdentity {
-        node_id: uuid::Uuid::new_v4().to_string(),
+        node_id: node_id.to_string(),
         node_epoch: uuid::Uuid::new_v4().to_string(),
     };
     let pool_size = config.keypair_pool.len();
@@ -553,14 +576,43 @@ mod tests {
         .expect("open test postgres");
         let stop = CancellationToken::new();
 
-        let peer_id = spawn(&config, &db, stop.clone())
+        let handle = spawn(&config, &db, stop.clone())
             .await
             .expect("swarm brings up cleanly");
-        assert!(!peer_id.to_string().is_empty());
+        assert!(!handle.local_peer_id.to_string().is_empty());
 
-        // Let the event loop run a beat so a NewListenAddr is processed, then
-        // signal shutdown; the loop must stop on the token.
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        // Relay round-trip through the remote registry + ask path (kameo
+        // short-circuits asks whose target peer is the local node, so this
+        // exercises registration, kademlia lookup, payload serde, and the
+        // handler without a second process; the true cross-node round-trip is
+        // a Slice 6 harness case). Registration is async — poll briefly.
+        let mut relay_handle = relay::RelayHandle::new(handle.node_id.clone());
+        let pong = relay_handle.ping().await.expect("relay answers ping");
+        assert_eq!(pong.node_id, handle.node_id);
+
+        // Codec proof over the ask path: a thread-carrying message survives
+        // the RemoteStanza round-trip.
+        let mut message = xmpp_parsers::message::Message::new(None::<jid::Jid>);
+        message.thread = Some(xmpp_parsers::message::Thread {
+            id: "relay-echo-thread".to_string(),
+            parent: None,
+        });
+        let echoed = relay_handle
+            .echo_stanza(super::super::codec::RemoteStanza(
+                waddle_xmpp::Stanza::Message(message),
+            ))
+            .await
+            .expect("relay echoes stanza");
+        match echoed.stanza.0 {
+            waddle_xmpp::Stanza::Message(message) => {
+                assert_eq!(
+                    message.thread.expect("thread survives").id,
+                    "relay-echo-thread"
+                );
+            }
+            other => panic!("expected message, got {}", other.name()),
+        }
+
         stop.cancel();
         tokio::time::sleep(Duration::from_millis(50)).await;
     }

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -1,0 +1,277 @@
+//! The owned libp2p swarm: build, listen, dial, and drive the event loop.
+//!
+//! Node discovery only this phase. We build a swarm we own (tcp + quic,
+//! Noise, yamux), install the process-global kameo `ActorSwarm` so remote
+//! actor lookups resolve (used by the relay actors in a later slice), listen
+//! on the configured multiaddrs, dial headless-DNS-resolved seed peers, and
+//! run the event loop until the shared shutdown token fires. No stanza is
+//! routed cross-node.
+
+use super::behaviour::{WaddleBehaviour, WaddleBehaviourEvent};
+use super::{dns, identity, metrics};
+use crate::config::{ClusteringBootstrapConfig, ClusteringConfig};
+use core::convert::Infallible;
+use futures::StreamExt;
+use kameo::remote::{self, registry};
+use libp2p::swarm::SwarmEvent;
+use libp2p::{noise, tcp, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder};
+use std::collections::HashSet;
+use std::time::Duration;
+use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
+
+/// How often the event loop re-resolves the headless-DNS name and dials any
+/// seed peers, to pick up pod churn (rolling restarts, scale changes).
+const BOOTSTRAP_DIAL_INTERVAL: Duration = Duration::from_secs(15);
+
+/// Buffer for resolved-peer multiaddrs flowing from the off-loop DNS resolver
+/// back to the event loop for dialing.
+const DIAL_CHANNEL_CAPACITY: usize = 64;
+
+/// Failures while building or starting the swarm. Human-facing `Display` text
+/// is surfaced at server startup.
+#[derive(Debug, thiserror::Error)]
+pub enum SwarmError {
+    /// A transport (TCP/Noise/yamux) failed to initialize.
+    #[error("clustering swarm transport init failed: {0}")]
+    Transport(String),
+    /// The process-global kameo `ActorSwarm` was already initialized — only
+    /// one swarm may exist per process (kameo `init_global` is a singleton).
+    #[error(
+        "clustering swarm already bootstrapped in this process (kameo init_global is a singleton)"
+    )]
+    AlreadyBootstrapped,
+    /// A configured listen multiaddr could not be parsed.
+    #[error("clustering listen address '{addr}' is not a valid multiaddr: {reason}")]
+    ListenAddrInvalid { addr: String, reason: String },
+    /// `listen_on` was rejected by the transport for a parsed multiaddr.
+    #[error("clustering swarm failed to listen on '{addr}': {reason}")]
+    Listen { addr: String, reason: String },
+}
+
+/// Build the swarm, install the global `ActorSwarm`, start listening, and
+/// spawn the event loop on `stop_token`. Returns the local `PeerId`.
+pub fn spawn(
+    config: &ClusteringConfig,
+    stop_token: CancellationToken,
+) -> Result<PeerId, SwarmError> {
+    // Parse and validate the listen multiaddrs first, before building any
+    // transport or touching the process-global `ActorSwarm` — fail fast on bad
+    // config.
+    let listen_addrs = config
+        .listen_addrs
+        .iter()
+        .map(|addr| {
+            addr.parse::<Multiaddr>()
+                .map_err(
+                    |error: libp2p::multiaddr::Error| SwarmError::ListenAddrInvalid {
+                        addr: addr.clone(),
+                        reason: error.to_string(),
+                    },
+                )
+        })
+        .collect::<Result<Vec<Multiaddr>, SwarmError>>()?;
+
+    let keypair = identity::node_keypair();
+    let local_peer_id = keypair.public().to_peer_id();
+
+    let messaging_config = remote::messaging::Config::default()
+        .with_request_timeout(config.messaging.request_timeout)
+        .with_max_concurrent_streams(config.messaging.max_concurrent_streams)
+        .with_request_size_maximum(config.messaging.max_request_bytes)
+        .with_response_size_maximum(config.messaging.max_response_bytes);
+
+    let mut swarm = SwarmBuilder::with_existing_identity(keypair)
+        .with_tokio()
+        .with_tcp(
+            tcp::Config::default(),
+            noise::Config::new,
+            yamux::Config::default,
+        )
+        .map_err(|error| SwarmError::Transport(error.to_string()))?
+        .with_quic()
+        // Infallible construction: return the behaviour directly (libp2p's
+        // `TryIntoBehaviour<B> for B` form, whose error is `Infallible`). The
+        // fallible form requires exactly `Box<dyn Error + Send + Sync>`, so an
+        // `Ok::<_, Infallible>` wrapper would be misread as the behaviour type.
+        .with_behaviour(|key| WaddleBehaviour::new(key.public().to_peer_id(), messaging_config))
+        .map_err(|never: Infallible| match never {})?
+        .build();
+
+    // Install the process-global kameo `ActorSwarm` so `RemoteActorRef`
+    // lookups resolve against this swarm (used by the relay actors in a later
+    // slice). One swarm per process by construction.
+    swarm
+        .behaviour()
+        .kameo
+        .try_init_global()
+        .map_err(|_| SwarmError::AlreadyBootstrapped)?;
+
+    for multiaddr in listen_addrs {
+        let display = multiaddr.to_string();
+        swarm
+            .listen_on(multiaddr)
+            .map_err(|error| SwarmError::Listen {
+                addr: display,
+                reason: error.to_string(),
+            })?;
+    }
+
+    let bootstrap = config.bootstrap.clone();
+    tokio::spawn(run_event_loop(swarm, bootstrap, stop_token));
+
+    Ok(local_peer_id)
+}
+
+/// Drive the swarm until `stop_token` fires: dial seed peers on a timer, feed
+/// swarm events to the handler, and stop cleanly on shutdown.
+async fn run_event_loop(
+    mut swarm: Swarm<WaddleBehaviour>,
+    bootstrap: Option<ClusteringBootstrapConfig>,
+    stop_token: CancellationToken,
+) {
+    // Peers we currently hold a connection to (authoritative from connection
+    // events) and peers observed to enter the kademlia routing table.
+    let mut connected: HashSet<PeerId> = HashSet::new();
+    let mut routing_peers: HashSet<PeerId> = HashSet::new();
+
+    // `interval` fires its first tick immediately, so the first dial round
+    // happens right away rather than after a full interval.
+    let mut dial_timer = tokio::time::interval(BOOTSTRAP_DIAL_INTERVAL);
+    dial_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    // DNS resolution runs in a spawned task and hands resolved multiaddrs back
+    // over this channel, so a slow lookup never stalls swarm polling (which
+    // must keep running to service handshakes, keepalives, and kademlia). We
+    // hold `dial_tx` for the loop's lifetime, so `recv()` never closes.
+    let (dial_tx, mut dial_rx) = tokio::sync::mpsc::channel::<Multiaddr>(DIAL_CHANNEL_CAPACITY);
+
+    loop {
+        tokio::select! {
+            _ = stop_token.cancelled() => {
+                tracing::info!("clustering swarm event loop stopping (shutdown)");
+                break;
+            }
+            _ = dial_timer.tick() => {
+                if let Some(ref bootstrap) = bootstrap {
+                    let bootstrap = bootstrap.clone();
+                    let dial_tx = dial_tx.clone();
+                    tokio::spawn(async move {
+                        for addr in dns::resolve_bootstrap_peers(&bootstrap).await {
+                            if dial_tx.send(addr).await.is_err() {
+                                break;
+                            }
+                        }
+                    });
+                }
+            }
+            Some(addr) = dial_rx.recv() => {
+                metrics::record_bootstrap_dial();
+                if let Err(error) = swarm.dial(addr.clone()) {
+                    tracing::debug!(%addr, %error, "clustering bootstrap dial failed");
+                }
+            }
+            event = swarm.select_next_some() => {
+                handle_swarm_event(event, &mut connected, &mut routing_peers);
+            }
+        }
+    }
+}
+
+/// Update local peer bookkeeping and metrics from a single swarm event.
+fn handle_swarm_event(
+    event: SwarmEvent<WaddleBehaviourEvent>,
+    connected: &mut HashSet<PeerId>,
+    routing_peers: &mut HashSet<PeerId>,
+) {
+    match event {
+        SwarmEvent::NewListenAddr { address, .. } => {
+            tracing::info!(%address, "clustering swarm listening");
+        }
+        SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+            if connected.insert(peer_id) {
+                metrics::record_connected_peers(connected.len() as i64);
+                tracing::debug!(%peer_id, "clustering peer connected");
+            }
+        }
+        SwarmEvent::ConnectionClosed {
+            peer_id,
+            num_established,
+            ..
+        } => {
+            // Only drop the peer when its last connection closes.
+            if num_established == 0 && connected.remove(&peer_id) {
+                metrics::record_connected_peers(connected.len() as i64);
+                tracing::debug!(%peer_id, "clustering peer disconnected");
+            }
+        }
+        SwarmEvent::Behaviour(WaddleBehaviourEvent::Kameo(remote::Event::Registry(
+            registry::Event::RoutingUpdated {
+                peer,
+                is_new_peer,
+                old_peer,
+                ..
+            },
+        ))) => {
+            let mut changed = false;
+            if is_new_peer {
+                changed |= routing_peers.insert(peer);
+            }
+            if let Some(evicted) = old_peer {
+                changed |= routing_peers.remove(&evicted);
+            }
+            if changed {
+                metrics::record_routing_table_size(routing_peers.len() as i64);
+                tracing::debug!(%peer, "clustering kademlia routing table updated");
+            }
+        }
+        SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {
+            tracing::debug!(?peer_id, %error, "clustering outgoing connection error");
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ClusteringConfig;
+
+    // kameo's `init_global` is a process singleton, so exactly ONE test per
+    // test binary may successfully bring up the swarm. This smoke test
+    // exercises the whole bring-up: keypair generation, transport init (tcp +
+    // quic + Noise + yamux), the global `ActorSwarm` install, and `listen_on`
+    // binding an ephemeral port — then drives the event loop briefly and shuts
+    // it down on the token.
+    #[tokio::test]
+    async fn swarm_spawn_brings_up_and_shuts_down() {
+        let config = ClusteringConfig {
+            enabled: true,
+            listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".to_string()],
+            bootstrap: None,
+            ..ClusteringConfig::default()
+        };
+        let stop = CancellationToken::new();
+
+        let peer_id = spawn(&config, stop.clone()).expect("swarm brings up cleanly");
+        assert!(!peer_id.to_string().is_empty());
+
+        // Let the event loop run a beat so a NewListenAddr is processed, then
+        // signal shutdown; the loop must stop on the token.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        stop.cancel();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    #[tokio::test]
+    async fn spawn_rejects_invalid_listen_multiaddr() {
+        let config = ClusteringConfig {
+            enabled: true,
+            listen_addrs: vec!["not-a-multiaddr".to_string()],
+            bootstrap: None,
+            ..ClusteringConfig::default()
+        };
+        let err = spawn(&config, CancellationToken::new()).expect_err("invalid addr rejected");
+        assert!(matches!(err, SwarmError::ListenAddrInvalid { .. }));
+    }
+}

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -305,14 +305,16 @@ async fn node_keypair(
 /// Renew the keypair-slot lease on a timer until shutdown; release the slot on
 /// graceful stop, and self-fence (cancel the swarm) on fencing loss so a
 /// superseded identity stops serving.
-async fn run_heartbeat(
-    lease: PostgresKeypairSlotLease,
+async fn run_heartbeat<L>(
+    lease: L,
     node: LeaseIdentity,
     slot: LeasedSlot,
     interval: Duration,
     lease_ttl: Duration,
     stop_token: CancellationToken,
-) {
+) where
+    L: KeypairSlotLease + Send + Sync + 'static,
+{
     let mut timer = tokio::time::interval(interval);
     timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
@@ -378,7 +380,13 @@ async fn run_event_loop(
     // happens right away rather than after a full interval.
     let mut dial_timer = tokio::time::interval(dial_interval);
     dial_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
-    let mut allowlist_timer = tokio::time::interval(allowlist.interval);
+    // The startup path already loaded the enrolled set synchronously before
+    // this loop started, so the first periodic refresh is deferred one full
+    // interval (`interval_at`) instead of immediately re-reading the table.
+    let mut allowlist_timer = tokio::time::interval_at(
+        tokio::time::Instant::now() + allowlist.interval,
+        allowlist.interval,
+    );
     allowlist_timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     // DNS resolution runs in a spawned task and hands resolved multiaddrs back

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -117,7 +117,49 @@ pub async fn spawn(
     // kademlia relay registration.
     let node_id = NodeId::generate();
 
-    let keypair = node_keypair(config, db, &node_id, &stop_token).await?;
+    let (keypair, pending_lease) = node_keypair(config, db, &node_id).await?;
+
+    // Everything fallible after the slot lease runs in `bring_up`; only once
+    // it all succeeds does the slot's heartbeat start. A failure releases the
+    // slot immediately instead of leaving it held until lease-TTL expiry —
+    // repeated crash-restarts (each with a fresh node_id) would otherwise
+    // chew through the pool one slot per attempt and starve replacements
+    // with NoFreeSlot.
+    match bring_up(config, db, node_id, keypair, listen_addrs, &stop_token).await {
+        Ok(handle) => {
+            if let Some(pending) = pending_lease {
+                tokio::spawn(run_heartbeat(
+                    pending.lease,
+                    pending.node,
+                    pending.slot,
+                    config.lease.heartbeat_interval,
+                    config.lease.lease_ttl,
+                    stop_token.clone(),
+                ));
+            }
+            Ok(handle)
+        }
+        Err(error) => {
+            if let Some(pending) = pending_lease {
+                pending.release_best_effort("swarm bring-up failed").await;
+            }
+            Err(error)
+        }
+    }
+}
+
+/// The fallible remainder of swarm bring-up after the keypair-slot lease:
+/// allowlist load, transport/behaviour build, global `ActorSwarm` install,
+/// listeners, event loop, supervised relay, and the node-id file. Split out
+/// of [`spawn`] so a failure anywhere in it releases the leased slot.
+async fn bring_up(
+    config: &ClusteringConfig,
+    db: &Database,
+    node_id: NodeId,
+    keypair: Keypair,
+    listen_addrs: Vec<Multiaddr>,
+    stop_token: &CancellationToken,
+) -> Result<SwarmHandle, SwarmError> {
     let local_peer_id = keypair.public().to_peer_id();
 
     // Peer authorization (ADR element 3): load the enrolled peer set before
@@ -214,7 +256,7 @@ pub async fn spawn(
              relay or stall its mailbox — test harnesses only, never production"
         );
     }
-    relay::spawn_supervised(node_id.clone(), config.fault_injection, stop_token);
+    relay::spawn_supervised(node_id.clone(), config.fault_injection, stop_token.clone());
 
     let handle = SwarmHandle {
         local_peer_id,
@@ -245,15 +287,40 @@ struct AllowlistRefresh {
     interval: Duration,
 }
 
-/// Resolve this node's libp2p keypair: lease a pool slot (and start its
-/// heartbeat) when a keypair pool is configured, else generate an ephemeral
-/// identity.
+/// A leased keypair slot whose heartbeat has not started yet: held across
+/// the rest of swarm bring-up so a failure there releases the slot
+/// immediately instead of leaving it blocked until lease-TTL expiry.
+struct PendingLease {
+    lease: PostgresKeypairSlotLease,
+    node: LeaseIdentity,
+    slot: LeasedSlot,
+}
+
+impl PendingLease {
+    /// Best-effort release: without it a failed bring-up holds the slot
+    /// hostage until TTL expiry while this node crash-loops onto fresh
+    /// slots, transiently shrinking the pool for every other node.
+    async fn release_best_effort(self, context: &'static str) {
+        if let Err(error) = self.lease.release(&self.node, self.slot).await {
+            tracing::warn!(
+                %error,
+                slot = self.slot.slot_index,
+                context,
+                "failed to release keypair slot"
+            );
+        }
+    }
+}
+
+/// Resolve this node's libp2p keypair: lease a pool slot when a keypair pool
+/// is configured (returned as a [`PendingLease`] — the caller starts its
+/// heartbeat only after the rest of bring-up succeeds, or releases it), else
+/// generate an ephemeral identity.
 async fn node_keypair(
     config: &ClusteringConfig,
     db: &Database,
     node_id: &NodeId,
-    stop_token: &CancellationToken,
-) -> Result<Keypair, SwarmError> {
+) -> Result<(Keypair, Option<PendingLease>), SwarmError> {
     if config.keypair_pool.is_empty() {
         tracing::warn!(
             "clustering: no keypair pool configured — using an ephemeral per-process identity. \
@@ -262,7 +329,7 @@ async fn node_keypair(
              configure WADDLE_CLUSTERING_KEYPAIR_POOL and enroll every node's PeerId for any \
              multi-node deployment"
         );
-        return Ok(identity::ephemeral_keypair());
+        return Ok((identity::ephemeral_keypair(), None));
     }
 
     let lease = PostgresKeypairSlotLease::new(db.clone());
@@ -277,39 +344,23 @@ async fn node_keypair(
         .await?;
     // `acquire` only ever returns an in-range slot, so this index is valid.
     let entry = &config.keypair_pool[slot.slot_index as usize];
+    let pending = PendingLease { lease, node, slot };
     let keypair = match identity::keypair_from_pool_entry(entry) {
         Ok(keypair) => keypair,
         Err(error) => {
-            // Best-effort release: without it a malformed pool entry holds
-            // the slot hostage until lease-TTL expiry while this node
-            // crash-loops onto fresh slots, transiently shrinking the pool
-            // for every other node.
-            if let Err(release_error) = lease.release(&node, slot).await {
-                tracing::warn!(
-                    %release_error,
-                    slot = slot.slot_index,
-                    "failed to release keypair slot after decode failure"
-                );
-            }
+            pending
+                .release_best_effort("keypair pool entry decode failed")
+                .await;
             return Err(error.into());
         }
     };
     tracing::info!(
-        slot = slot.slot_index,
+        slot = pending.slot.slot_index,
         pool_size,
         "clustering: leased keypair-pool slot for node identity"
     );
 
-    tokio::spawn(run_heartbeat(
-        lease,
-        node,
-        slot,
-        config.lease.heartbeat_interval,
-        config.lease.lease_ttl,
-        stop_token.clone(),
-    ));
-
-    Ok(keypair)
+    Ok((keypair, Some(pending)))
 }
 
 /// Renew the keypair-slot lease on a timer until shutdown; release the slot on

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -376,7 +376,10 @@ async fn run_heartbeat<L>(
 ) where
     L: KeypairSlotLease + Send + Sync + 'static,
 {
-    let mut timer = tokio::time::interval(interval);
+    // The slot was acquired (heartbeat stamped) moments ago, so the first
+    // renewal is deferred one full interval (`interval_at`) — same pattern
+    // as the allowlist refresh timer.
+    let mut timer = tokio::time::interval_at(tokio::time::Instant::now() + interval, interval);
     timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     loop {

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -87,6 +87,13 @@ pub struct SwarmHandle {
 /// the event loop and the supervised relay on `stop_token`, and return the
 /// node's swarm identity.
 ///
+/// `stop_token` is expected to be the clustering-scoped child token minted by
+/// `clustering::clustering_scope_token` (a child of the process-wide shutdown
+/// token): every task spawned here derives its own token from this same
+/// value, so a clustering-internal self-fence (lease fencing loss or a blown
+/// renewal deadline) cancels only this scope, while process shutdown still
+/// propagates in and tears clustering down.
+///
 /// When a keypair pool is configured the node leases one pool slot from the
 /// Postgres control plane and uses that keypair (and heartbeats it); otherwise
 /// it falls back to an ephemeral per-process identity.
@@ -132,6 +139,7 @@ pub async fn spawn(
                     pending.lease,
                     pending.node,
                     pending.slot,
+                    pending.acquired_at,
                     config.lease.heartbeat_interval,
                     config.lease.lease_ttl,
                     stop_token.clone(),
@@ -294,6 +302,11 @@ struct PendingLease {
     lease: PostgresKeypairSlotLease,
     node: LeaseIdentity,
     slot: LeasedSlot,
+    /// When the slot was acquired: the heartbeat's initial "last successful
+    /// renewal" instant, so the lease-deadline self-fence measures
+    /// from the real acquire time rather than from whenever `bring_up`
+    /// happens to finish and the heartbeat task is spawned.
+    acquired_at: tokio::time::Instant,
 }
 
 impl PendingLease {
@@ -342,9 +355,17 @@ async fn node_keypair(
     let slot = lease
         .acquire(&node, pool_size, config.lease.lease_ttl)
         .await?;
+    // The acquire itself counts as the first successful renewal for the
+    // lease-deadline self-fence.
+    let acquired_at = tokio::time::Instant::now();
     // `acquire` only ever returns an in-range slot, so this index is valid.
     let entry = &config.keypair_pool[slot.slot_index as usize];
-    let pending = PendingLease { lease, node, slot };
+    let pending = PendingLease {
+        lease,
+        node,
+        slot,
+        acquired_at,
+    };
     let keypair = match identity::keypair_from_pool_entry(entry) {
         Ok(keypair) => keypair,
         Err(error) => {
@@ -364,12 +385,32 @@ async fn node_keypair(
 }
 
 /// Renew the keypair-slot lease on a timer until shutdown; release the slot on
-/// graceful stop, and self-fence (cancel the swarm) on fencing loss so a
-/// superseded identity stops serving.
+/// graceful stop, and self-fence — cancel `stop_token` (the clustering scope,
+/// never the process-wide token; see `clustering::clustering_scope_token`) —
+/// on either a definitive fencing loss (CAS miss: another node already holds
+/// the slot) or once `lease_ttl` has elapsed since the last successful renewal
+/// without one landing (a node partitioned from Postgres but still alive on
+/// libp2p, which would otherwise keep using a PeerId that another node may
+/// legitimately have re-derived after stealing the now-expired slot).
+///
+/// Renewals are single-flight and a hung renewal is polled to completion
+/// rather than timeout-dropped: abandoning an in-flight sqlx future mid-poll
+/// makes the pool spawn an unbounded background `ping()` against the same
+/// dead socket to vet the connection, so dropping one renewal per tick during
+/// a sustained partition would wedge the entire shared pool (the server's hot
+/// path) within `max_connections` ticks. Instead the deadline arm below is
+/// the sole fencing trigger for a hang, and the one in-flight renewal is
+/// dropped at most once per process — on fence or shutdown. Worst case on the
+/// shutdown-mid-hang path is two abandoned connections (the dropped renewal
+/// plus a timed-out release), still a one-time bounded cost, never per-tick.
+/// The deadline is authoritative by construction (`biased` orders it ahead of
+/// renewal completion): a renewal landing in the same poll as the deadline
+/// loses the tie and the node fences conservatively.
 async fn run_heartbeat<L>(
     lease: L,
     node: LeaseIdentity,
     slot: LeasedSlot,
+    acquired_at: tokio::time::Instant,
     interval: Duration,
     lease_ttl: Duration,
     stop_token: CancellationToken,
@@ -382,25 +423,58 @@ async fn run_heartbeat<L>(
     let mut timer = tokio::time::interval_at(tokio::time::Instant::now() + interval, interval);
     timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
-    loop {
+    // Last instant a renewal (or the initial acquire) definitely succeeded.
+    // Only ever moves forward on `Ok`; a failed or hung renewal does not
+    // reset it, so retries do not silently extend the deadline.
+    let mut last_success = acquired_at;
+
+    'fenced: loop {
+        // Phase 1: wait for the next renewal to be due. The deadline arm
+        // fires here when every attempt has been failing fast (quick DB
+        // errors between ticks).
         tokio::select! {
+            biased;
             _ = stop_token.cancelled() => {
-                if let Err(error) = lease.release(&node, slot).await {
-                    tracing::warn!(%error, slot = slot.slot_index, "clustering keypair-slot release failed on shutdown");
-                }
-                break;
+                release_slot_bounded(&lease, &node, slot, interval).await;
+                return;
             }
-            _ = timer.tick() => {
-                match lease.heartbeat(&node, slot, lease_ttl).await {
-                    Ok(()) => {}
+            _ = tokio::time::sleep_until(last_success + lease_ttl) => {
+                break 'fenced;
+            }
+            _ = timer.tick() => {}
+        }
+
+        // Phase 2: drive exactly one renewal to completion, racing only the
+        // deadline and shutdown. A hung renewal parks here (single-flight —
+        // no new attempt piles up behind it) until it resolves or the
+        // deadline arm fences.
+        let renewal = std::pin::pin!(lease.heartbeat(&node, slot, lease_ttl));
+        tokio::select! {
+            biased;
+            _ = stop_token.cancelled() => {
+                // Dropping the hung renewal here is the shutdown-path
+                // exception to the never-drop rule: one abandoned
+                // connection, once.
+                release_slot_bounded(&lease, &node, slot, interval).await;
+                return;
+            }
+            _ = tokio::time::sleep_until(last_success + lease_ttl) => {
+                break 'fenced;
+            }
+            result = renewal => {
+                match result {
+                    Ok(()) => {
+                        last_success = tokio::time::Instant::now();
+                    }
                     Err(LeaseError::FencingLoss { slot_index }) => {
                         tracing::error!(
                             slot = slot_index,
-                            "clustering keypair-slot lease lost (fencing) — self-fencing swarm"
+                            "clustering keypair-slot lease lost (fencing) — self-fencing clustering scope"
                         );
-                        // The identity is no longer ours; stop the swarm.
+                        // The identity is no longer ours; stop clustering,
+                        // not the whole process.
                         stop_token.cancel();
-                        break;
+                        return;
                     }
                     Err(error) => {
                         tracing::warn!(%error, slot = slot.slot_index, "clustering keypair-slot heartbeat error; will retry next tick");
@@ -409,11 +483,46 @@ async fn run_heartbeat<L>(
             }
         }
     }
+
+    tracing::error!(
+        slot = slot.slot_index,
+        lease_ttl_ms = u64::try_from(lease_ttl.as_millis()).unwrap_or(u64::MAX),
+        "clustering keypair-slot lease deadline exceeded without successful renewal — self-fencing clustering scope"
+    );
+    stop_token.cancel();
 }
 
-/// Drive the swarm until `stop_token` fires: dial seed peers on a timer,
-/// refresh the peer allowlist on a timer (revoking removed peers), feed swarm
-/// events to the handler, and stop cleanly on shutdown.
+/// Best-effort, time-bounded slot release on shutdown: a hung release must
+/// not stall clustering teardown indefinitely (the slot frees itself via TTL
+/// expiry anyway). Dropping a hung release abandons at most one connection,
+/// once, at shutdown.
+async fn release_slot_bounded<L>(
+    lease: &L,
+    node: &LeaseIdentity,
+    slot: LeasedSlot,
+    budget: Duration,
+) where
+    L: KeypairSlotLease + Send + Sync,
+{
+    match tokio::time::timeout(budget, lease.release(node, slot)).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => {
+            tracing::warn!(%error, slot = slot.slot_index, "clustering keypair-slot release failed on shutdown");
+        }
+        Err(_) => {
+            tracing::warn!(
+                slot = slot.slot_index,
+                "clustering keypair-slot release timed out on shutdown; slot frees via TTL expiry"
+            );
+        }
+    }
+}
+
+/// Drive the swarm until `stop_token` (the clustering scope, a child of the
+/// process shutdown token) fires: dial seed peers on a timer, refresh the
+/// peer allowlist on a timer (revoking removed peers), feed swarm events to
+/// the handler, and stop cleanly on shutdown — whether that shutdown is the
+/// whole process draining or just this node self-fencing its lease.
 async fn run_event_loop(
     mut swarm: Swarm<WaddleBehaviour>,
     bootstrap_peers: Vec<ClusteringBootstrapConfig>,
@@ -859,5 +968,310 @@ mod tests {
             .await
             .expect_err("invalid addr rejected");
         assert!(matches!(err, SwarmError::ListenAddrInvalid { .. }));
+    }
+
+    // A `KeypairSlotLease` double that always fails renewal with a generic
+    // (non-fencing) database error, so `run_heartbeat` never sees
+    // `LeaseError::FencingLoss` and the only self-fence path exercised is the
+    // lease-deadline check.
+    struct PartitionedLease {
+        release_called: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl KeypairSlotLease for PartitionedLease {
+        async fn ensure_schema(&self) -> Result<(), LeaseError> {
+            Ok(())
+        }
+
+        async fn acquire(
+            &self,
+            _identity: &LeaseIdentity,
+            _pool_size: usize,
+            _lease_ttl: Duration,
+        ) -> Result<LeasedSlot, LeaseError> {
+            Ok(LeasedSlot { slot_index: 0 })
+        }
+
+        async fn heartbeat(
+            &self,
+            _identity: &LeaseIdentity,
+            _slot: LeasedSlot,
+            _lease_ttl: Duration,
+        ) -> Result<(), LeaseError> {
+            Err(LeaseError::Database(crate::db::DatabaseError::QueryFailed(
+                "simulated Postgres partition".to_string(),
+            )))
+        }
+
+        async fn release(
+            &self,
+            _identity: &LeaseIdentity,
+            _slot: LeasedSlot,
+        ) -> Result<(), LeaseError> {
+            self.release_called.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    // A node that can no longer renew its lease (e.g. partitioned from
+    // Postgres, still alive on libp2p) must self-fence once `lease_ttl` has
+    // elapsed since the last successful renewal — never retry forever, which
+    // would let another node's legitimate steal-and-reuse of the same slot
+    // produce two live nodes sharing one PeerId indefinitely.
+    #[tokio::test(start_paused = true)]
+    async fn heartbeat_self_fences_once_lease_deadline_blown_without_postgres() {
+        let interval = Duration::from_millis(50);
+        let lease_ttl = Duration::from_millis(200);
+        let release_called = Arc::new(AtomicBool::new(false));
+        let lease = PartitionedLease {
+            release_called: Arc::clone(&release_called),
+        };
+        let node = LeaseIdentity {
+            node_id: NodeId::generate(),
+            node_epoch: uuid::Uuid::new_v4(),
+        };
+        let slot = LeasedSlot { slot_index: 0 };
+        let stop_token = CancellationToken::new();
+        let acquired_at = tokio::time::Instant::now();
+
+        tokio::spawn(run_heartbeat(
+            lease,
+            node,
+            slot,
+            acquired_at,
+            interval,
+            lease_ttl,
+            stop_token.clone(),
+        ));
+
+        // A few failing renewals inside the TTL window must not self-fence.
+        tokio::time::advance(interval * 3).await;
+        tokio::task::yield_now().await;
+        assert!(
+            !stop_token.is_cancelled(),
+            "must not self-fence before the lease deadline elapses"
+        );
+
+        // Once the deadline is blown, the next failing tick self-fences the
+        // clustering scope (not a graceful release — the slot may already be
+        // held by whoever legitimately stole it).
+        tokio::time::advance(lease_ttl).await;
+        tokio::task::yield_now().await;
+        assert!(
+            stop_token.is_cancelled(),
+            "must self-fence once the lease deadline is exceeded"
+        );
+        assert!(
+            !release_called.load(Ordering::SeqCst),
+            "deadline self-fence is not a graceful release"
+        );
+    }
+
+    // A `KeypairSlotLease` double whose renewal HANGS forever (a black-holed
+    // connection stuck in TCP retransmission), rather than erroring — the
+    // failure mode a timeout-free `Err`-only deadline check can never see.
+    struct HangingLease {
+        release_called: Arc<AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl KeypairSlotLease for HangingLease {
+        async fn ensure_schema(&self) -> Result<(), LeaseError> {
+            Ok(())
+        }
+
+        async fn acquire(
+            &self,
+            _identity: &LeaseIdentity,
+            _pool_size: usize,
+            _lease_ttl: Duration,
+        ) -> Result<LeasedSlot, LeaseError> {
+            Ok(LeasedSlot { slot_index: 0 })
+        }
+
+        async fn heartbeat(
+            &self,
+            _identity: &LeaseIdentity,
+            _slot: LeasedSlot,
+            _lease_ttl: Duration,
+        ) -> Result<(), LeaseError> {
+            std::future::pending().await
+        }
+
+        async fn release(
+            &self,
+            _identity: &LeaseIdentity,
+            _slot: LeasedSlot,
+        ) -> Result<(), LeaseError> {
+            self.release_called.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    // A renewal that never resolves must still self-fence at the deadline:
+    // the deadline select arm, not an `Err` from the renewal, is the fencing
+    // trigger, so a hang cannot suppress it.
+    #[tokio::test(start_paused = true)]
+    async fn heartbeat_self_fences_when_renewal_hangs() {
+        let interval = Duration::from_millis(50);
+        let lease_ttl = Duration::from_millis(200);
+        let release_called = Arc::new(AtomicBool::new(false));
+        let lease = HangingLease {
+            release_called: Arc::clone(&release_called),
+        };
+        let node = LeaseIdentity {
+            node_id: NodeId::generate(),
+            node_epoch: uuid::Uuid::new_v4(),
+        };
+        let slot = LeasedSlot { slot_index: 0 };
+        let stop_token = CancellationToken::new();
+        let acquired_at = tokio::time::Instant::now();
+
+        tokio::spawn(run_heartbeat(
+            lease,
+            node,
+            slot,
+            acquired_at,
+            interval,
+            lease_ttl,
+            stop_token.clone(),
+        ));
+
+        // The first tick starts a renewal that hangs; inside the TTL window
+        // that must not fence.
+        tokio::time::advance(interval * 3).await;
+        tokio::task::yield_now().await;
+        assert!(
+            !stop_token.is_cancelled(),
+            "a hung renewal must not self-fence before the lease deadline"
+        );
+
+        // The deadline arm fires at `acquired_at + lease_ttl` even though the
+        // renewal never produced an `Err`.
+        tokio::time::advance(lease_ttl).await;
+        tokio::task::yield_now().await;
+        assert!(
+            stop_token.is_cancelled(),
+            "a hung renewal must self-fence once the lease deadline is exceeded"
+        );
+        assert!(
+            !release_called.load(Ordering::SeqCst),
+            "deadline self-fence is not a graceful release"
+        );
+    }
+
+    // A `KeypairSlotLease` double whose first renewal succeeds and every
+    // later one hangs, so `last_success` moves off `acquired_at` — pinning
+    // that the deadline is measured from the last SUCCESSFUL renewal, not
+    // from acquisition.
+    struct SucceedsOnceThenHangsLease {
+        renewals: Arc<std::sync::atomic::AtomicU32>,
+    }
+
+    #[async_trait::async_trait]
+    impl KeypairSlotLease for SucceedsOnceThenHangsLease {
+        async fn ensure_schema(&self) -> Result<(), LeaseError> {
+            Ok(())
+        }
+
+        async fn acquire(
+            &self,
+            _identity: &LeaseIdentity,
+            _pool_size: usize,
+            _lease_ttl: Duration,
+        ) -> Result<LeasedSlot, LeaseError> {
+            Ok(LeasedSlot { slot_index: 0 })
+        }
+
+        async fn heartbeat(
+            &self,
+            _identity: &LeaseIdentity,
+            _slot: LeasedSlot,
+            _lease_ttl: Duration,
+        ) -> Result<(), LeaseError> {
+            if self.renewals.fetch_add(1, Ordering::SeqCst) == 0 {
+                Ok(())
+            } else {
+                std::future::pending().await
+            }
+        }
+
+        async fn release(
+            &self,
+            _identity: &LeaseIdentity,
+            _slot: LeasedSlot,
+        ) -> Result<(), LeaseError> {
+            Ok(())
+        }
+    }
+
+    // Advance paused time in sub-interval steps, yielding between steps so
+    // the heartbeat task actually runs at each timer firing. A single coarse
+    // `advance` past several deadlines fires all their wakers before the task
+    // is polled once, and the biased deadline arm then wins over a tick that
+    // "happened" earlier — correct fencing behavior for a starved runtime,
+    // but not the scheduling the test means to simulate.
+    async fn advance_in_steps(total: Duration, step: Duration) {
+        let mut advanced = Duration::ZERO;
+        while advanced < total {
+            tokio::time::advance(step).await;
+            tokio::task::yield_now().await;
+            advanced += step;
+        }
+    }
+
+    // The deadline restarts from each successful renewal: after one success
+    // at ~1 interval, a subsequent hang must fence at `success + lease_ttl`,
+    // strictly LATER than `acquired_at + lease_ttl` — a regression to
+    // measuring from acquisition fences early and fails the mid-window
+    // assertion.
+    #[tokio::test(start_paused = true)]
+    async fn heartbeat_deadline_measures_from_last_successful_renewal() {
+        let interval = Duration::from_millis(50);
+        let lease_ttl = Duration::from_millis(200);
+        let step = Duration::from_millis(10);
+        let lease = SucceedsOnceThenHangsLease {
+            renewals: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        };
+        let node = LeaseIdentity {
+            node_id: NodeId::generate(),
+            node_epoch: uuid::Uuid::new_v4(),
+        };
+        let slot = LeasedSlot { slot_index: 0 };
+        let stop_token = CancellationToken::new();
+        let acquired_at = tokio::time::Instant::now();
+
+        tokio::spawn(run_heartbeat(
+            lease,
+            node,
+            slot,
+            acquired_at,
+            interval,
+            lease_ttl,
+            stop_token.clone(),
+        ));
+        // First poll at t=0 so the renewal timer is based at acquisition.
+        tokio::task::yield_now().await;
+
+        // t=60ms: the first renewal (tick at 50ms) succeeded, resetting the
+        // deadline to ~t=250-260ms; every later renewal hangs.
+        advance_in_steps(Duration::from_millis(60), step).await;
+        assert!(!stop_token.is_cancelled());
+
+        // t=220ms: past `acquired_at + lease_ttl` (200ms) but inside the
+        // renewed window — measuring from acquisition would fence here.
+        advance_in_steps(Duration::from_millis(160), step).await;
+        assert!(
+            !stop_token.is_cancelled(),
+            "deadline must restart from the successful renewal, not acquisition"
+        );
+
+        // t=280ms: past the renewed deadline — the hang must fence now.
+        advance_in_steps(Duration::from_millis(60), step).await;
+        assert!(
+            stop_token.is_cancelled(),
+            "a hang after a successful renewal must fence at success + lease_ttl"
+        );
     }
 }

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -8,11 +8,16 @@
 //! routed cross-node.
 
 use super::behaviour::{WaddleBehaviour, WaddleBehaviourEvent};
+use super::lease::{
+    KeypairSlotLease, LeaseError, LeaseIdentity, LeasedSlot, PostgresKeypairSlotLease,
+};
 use super::{dns, identity, metrics};
 use crate::config::{ClusteringBootstrapConfig, ClusteringConfig};
+use crate::db::Database;
 use core::convert::Infallible;
 use futures::StreamExt;
 use kameo::remote::{self, registry};
+use libp2p::identity::Keypair;
 use libp2p::swarm::SwarmEvent;
 use libp2p::{noise, tcp, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder};
 use std::collections::HashSet;
@@ -49,12 +54,23 @@ pub enum SwarmError {
     /// `listen_on` was rejected by the transport for a parsed multiaddr.
     #[error("clustering swarm failed to listen on '{addr}': {reason}")]
     Listen { addr: String, reason: String },
+    /// The keypair-slot lease could not be acquired or its schema set up.
+    #[error(transparent)]
+    Lease(#[from] LeaseError),
+    /// A leased pool slot's keypair could not be decoded.
+    #[error(transparent)]
+    Identity(#[from] identity::IdentityError),
 }
 
 /// Build the swarm, install the global `ActorSwarm`, start listening, and
 /// spawn the event loop on `stop_token`. Returns the local `PeerId`.
-pub fn spawn(
+///
+/// When a keypair pool is configured the node leases one pool slot from the
+/// Postgres control plane and uses that keypair (and heartbeats it); otherwise
+/// it falls back to an ephemeral per-process identity.
+pub async fn spawn(
     config: &ClusteringConfig,
+    db: &Database,
     stop_token: CancellationToken,
 ) -> Result<PeerId, SwarmError> {
     // Parse and validate the listen multiaddrs first, before building any
@@ -74,7 +90,7 @@ pub fn spawn(
         })
         .collect::<Result<Vec<Multiaddr>, SwarmError>>()?;
 
-    let keypair = identity::node_keypair();
+    let keypair = node_keypair(config, db, &stop_token).await?;
     let local_peer_id = keypair.public().to_peer_id();
 
     let messaging_config = remote::messaging::Config::default()
@@ -97,7 +113,7 @@ pub fn spawn(
         // fallible form requires exactly `Box<dyn Error + Send + Sync>`, so an
         // `Ok::<_, Infallible>` wrapper would be misread as the behaviour type.
         .with_behaviour(|key| WaddleBehaviour::new(key.public().to_peer_id(), messaging_config))
-        .map_err(|never: Infallible| match never {})?
+        .map_err(|never: Infallible| -> SwarmError { match never {} })?
         .build();
 
     // Install the process-global kameo `ActorSwarm` so `RemoteActorRef`
@@ -123,6 +139,96 @@ pub fn spawn(
     tokio::spawn(run_event_loop(swarm, bootstrap, stop_token));
 
     Ok(local_peer_id)
+}
+
+/// Resolve this node's libp2p keypair: lease a pool slot (and start its
+/// heartbeat) when a keypair pool is configured, else generate an ephemeral
+/// identity.
+async fn node_keypair(
+    config: &ClusteringConfig,
+    db: &Database,
+    stop_token: &CancellationToken,
+) -> Result<Keypair, SwarmError> {
+    if config.keypair_pool.is_empty() {
+        tracing::warn!(
+            "clustering: no keypair pool configured — using an ephemeral per-process identity \
+             (no stable or revocable PeerId; configure WADDLE_CLUSTERING_KEYPAIR_POOL for production)"
+        );
+        return Ok(identity::ephemeral_keypair());
+    }
+
+    let lease = PostgresKeypairSlotLease::new(db.clone());
+    lease.ensure_schema().await?;
+    let node = LeaseIdentity {
+        node_id: uuid::Uuid::new_v4().to_string(),
+        node_epoch: uuid::Uuid::new_v4().to_string(),
+    };
+    let pool_size = config.keypair_pool.len();
+    let slot = lease
+        .acquire(&node, pool_size, config.lease.lease_ttl)
+        .await?;
+    // `acquire` only ever returns an in-range slot, so this index is valid.
+    let entry = &config.keypair_pool[slot.slot_index as usize];
+    let keypair = identity::keypair_from_pool_entry(entry)?;
+    tracing::info!(
+        slot = slot.slot_index,
+        pool_size,
+        "clustering: leased keypair-pool slot for node identity"
+    );
+
+    tokio::spawn(run_heartbeat(
+        lease,
+        node,
+        slot,
+        config.lease.heartbeat_interval,
+        config.lease.lease_ttl,
+        stop_token.clone(),
+    ));
+
+    Ok(keypair)
+}
+
+/// Renew the keypair-slot lease on a timer until shutdown; release the slot on
+/// graceful stop, and self-fence (cancel the swarm) on fencing loss so a
+/// superseded identity stops serving.
+async fn run_heartbeat(
+    lease: PostgresKeypairSlotLease,
+    node: LeaseIdentity,
+    slot: LeasedSlot,
+    interval: Duration,
+    lease_ttl: Duration,
+    stop_token: CancellationToken,
+) {
+    let mut timer = tokio::time::interval(interval);
+    timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = stop_token.cancelled() => {
+                if let Err(error) = lease.release(&node, slot).await {
+                    tracing::warn!(%error, slot = slot.slot_index, "clustering keypair-slot release failed on shutdown");
+                }
+                break;
+            }
+            _ = timer.tick() => {
+                match lease.heartbeat(&node, slot, lease_ttl).await {
+                    Ok(()) => {}
+                    Err(LeaseError::FencingLoss { slot_index }) => {
+                        tracing::error!(
+                            slot = slot_index,
+                            "clustering keypair-slot lease lost (fencing) — self-fencing swarm"
+                        );
+                        // The identity is no longer ours; stop the swarm.
+                        stop_token.cancel();
+                        break;
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, slot = slot.slot_index, "clustering keypair-slot heartbeat error; will retry next tick");
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Drive the swarm until `stop_token` fires: dial seed peers on a timer, feed
@@ -186,7 +292,7 @@ async fn run_event_loop(
                 }
             }
             event = swarm.select_next_some() => {
-                handle_swarm_event(event, &mut connected, &mut routing_peers);
+                handle_swarm_event(&mut swarm, event, &mut connected, &mut routing_peers);
             }
         }
     }
@@ -210,8 +316,11 @@ fn track_peer_disconnected(peer_id: PeerId, connected: &mut HashSet<PeerId>) {
     }
 }
 
-/// Update local peer bookkeeping and metrics from a single swarm event.
+/// Update local peer bookkeeping and metrics from a single swarm event. Takes
+/// `&mut swarm` so it can close duplicate connections (duplicate-PeerId
+/// defense-in-depth, ADR element 3).
 fn handle_swarm_event(
+    swarm: &mut Swarm<WaddleBehaviour>,
     event: SwarmEvent<WaddleBehaviourEvent>,
     connected: &mut HashSet<PeerId>,
     routing_peers: &mut HashSet<PeerId>,
@@ -220,8 +329,24 @@ fn handle_swarm_event(
         SwarmEvent::NewListenAddr { address, .. } => {
             tracing::info!(%address, "clustering swarm listening");
         }
-        SwarmEvent::ConnectionEstablished { peer_id, .. } => {
-            track_peer_connected(peer_id, connected);
+        SwarmEvent::ConnectionEstablished {
+            peer_id,
+            connection_id,
+            ..
+        } => {
+            // Duplicate-PeerId defense-in-depth (ADR element 3): the
+            // keypair-slot lease already guarantees a unique PeerId per live
+            // node, so a second concurrent connection to an already-connected
+            // peer is unexpected — keep the first, reject the new one.
+            if connected.contains(&peer_id) {
+                tracing::warn!(
+                    %peer_id,
+                    "clustering: rejecting duplicate connection to already-connected peer"
+                );
+                swarm.close_connection(connection_id);
+            } else {
+                track_peer_connected(peer_id, connected);
+            }
         }
         // Only drop the peer when its last connection closes (num_established 0).
         SwarmEvent::ConnectionClosed {
@@ -262,6 +387,18 @@ fn handle_swarm_event(
 mod tests {
     use super::*;
     use crate::config::ClusteringConfig;
+    use crate::db::{DatabaseConfig, DatabaseDriver};
+
+    // An in-memory SQLite handle for tests that take the ephemeral-identity
+    // path (empty keypair pool), where the DB is never touched.
+    async fn scratch_db() -> Database {
+        Database::from_config(
+            "clustering-swarm-test",
+            &DatabaseConfig::new(DatabaseDriver::Sqlite, "sqlite::memory:".to_string()),
+        )
+        .await
+        .expect("open scratch sqlite")
+    }
 
     // kameo's `init_global` is a process singleton, so exactly ONE test per
     // test binary may successfully bring up the swarm. This smoke test
@@ -277,9 +414,12 @@ mod tests {
             bootstrap: None,
             ..ClusteringConfig::default()
         };
+        let db = scratch_db().await;
         let stop = CancellationToken::new();
 
-        let peer_id = spawn(&config, stop.clone()).expect("swarm brings up cleanly");
+        let peer_id = spawn(&config, &db, stop.clone())
+            .await
+            .expect("swarm brings up cleanly");
         assert!(!peer_id.to_string().is_empty());
 
         // Let the event loop run a beat so a NewListenAddr is processed, then
@@ -297,7 +437,10 @@ mod tests {
             bootstrap: None,
             ..ClusteringConfig::default()
         };
-        let err = spawn(&config, CancellationToken::new()).expect_err("invalid addr rejected");
+        let db = scratch_db().await;
+        let err = spawn(&config, &db, CancellationToken::new())
+            .await
+            .expect_err("invalid addr rejected");
         assert!(matches!(err, SwarmError::ListenAddrInvalid { .. }));
     }
 }

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -192,6 +192,24 @@ async fn run_event_loop(
     }
 }
 
+/// Record a newly connected peer, updating the connected-peer gauge on the
+/// first connection to that peer.
+fn track_peer_connected(peer_id: PeerId, connected: &mut HashSet<PeerId>) {
+    if connected.insert(peer_id) {
+        metrics::record_connected_peers(connected.len() as i64);
+        tracing::debug!(%peer_id, "clustering peer connected");
+    }
+}
+
+/// Record a peer whose last connection closed, updating the connected-peer
+/// gauge if it was tracked.
+fn track_peer_disconnected(peer_id: PeerId, connected: &mut HashSet<PeerId>) {
+    if connected.remove(&peer_id) {
+        metrics::record_connected_peers(connected.len() as i64);
+        tracing::debug!(%peer_id, "clustering peer disconnected");
+    }
+}
+
 /// Update local peer bookkeeping and metrics from a single swarm event.
 fn handle_swarm_event(
     event: SwarmEvent<WaddleBehaviourEvent>,
@@ -203,21 +221,15 @@ fn handle_swarm_event(
             tracing::info!(%address, "clustering swarm listening");
         }
         SwarmEvent::ConnectionEstablished { peer_id, .. } => {
-            if connected.insert(peer_id) {
-                metrics::record_connected_peers(connected.len() as i64);
-                tracing::debug!(%peer_id, "clustering peer connected");
-            }
+            track_peer_connected(peer_id, connected);
         }
+        // Only drop the peer when its last connection closes (num_established 0).
         SwarmEvent::ConnectionClosed {
             peer_id,
-            num_established,
+            num_established: 0,
             ..
         } => {
-            // Only drop the peer when its last connection closes.
-            if num_established == 0 && connected.remove(&peer_id) {
-                metrics::record_connected_peers(connected.len() as i64);
-                tracing::debug!(%peer_id, "clustering peer disconnected");
-            }
+            track_peer_disconnected(peer_id, connected);
         }
         SwarmEvent::Behaviour(WaddleBehaviourEvent::Kameo(remote::Event::Registry(
             registry::Event::RoutingUpdated {

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -12,7 +12,7 @@ use super::behaviour::{WaddleBehaviour, WaddleBehaviourEvent};
 use super::lease::{
     KeypairSlotLease, LeaseError, LeaseIdentity, LeasedSlot, PostgresKeypairSlotLease,
 };
-use super::{dns, identity, metrics, relay};
+use super::{dns, identity, metrics, relay, NodeId};
 use crate::config::{ClusteringBootstrapConfig, ClusteringConfig};
 use crate::db::Database;
 use core::convert::Infallible;
@@ -80,7 +80,7 @@ pub enum SwarmError {
 #[derive(Debug, Clone)]
 pub struct SwarmHandle {
     pub local_peer_id: PeerId,
-    pub node_id: String,
+    pub node_id: NodeId,
 }
 
 /// Build the swarm, install the global `ActorSwarm`, start listening, spawn
@@ -115,7 +115,7 @@ pub async fn spawn(
     // One per-process node id: freshly generated every start, never reused
     // across restarts. Names this node's keypair-slot lease and its single
     // kademlia relay registration.
-    let node_id = uuid::Uuid::new_v4().to_string();
+    let node_id = NodeId::generate();
 
     let keypair = node_keypair(config, db, &node_id, &stop_token).await?;
     let local_peer_id = keypair.public().to_peer_id();
@@ -209,10 +209,12 @@ pub async fn spawn(
     // WADDLE_HTTP_PORT_FILE convention).
     if let Some(path) = &config.node_id_file {
         let contents = format!("{} {}\n", handle.node_id, handle.local_peer_id);
-        std::fs::write(path, contents).map_err(|error| SwarmError::NodeIdFile {
-            path: path.display().to_string(),
-            reason: error.to_string(),
-        })?;
+        tokio::fs::write(path, contents)
+            .await
+            .map_err(|error| SwarmError::NodeIdFile {
+                path: path.display().to_string(),
+                reason: error.to_string(),
+            })?;
     }
 
     Ok(handle)
@@ -233,7 +235,7 @@ struct AllowlistRefresh {
 async fn node_keypair(
     config: &ClusteringConfig,
     db: &Database,
-    node_id: &str,
+    node_id: &NodeId,
     stop_token: &CancellationToken,
 ) -> Result<Keypair, SwarmError> {
     if config.keypair_pool.is_empty() {
@@ -249,8 +251,9 @@ async fn node_keypair(
 
     let lease = PostgresKeypairSlotLease::new(db.clone());
     lease.ensure_schema().await?;
+    // Storage boundary: the lease persists the id as TEXT.
     let node = LeaseIdentity {
-        node_id: node_id.to_string(),
+        node_id: node_id.as_str().to_string(),
         node_epoch: uuid::Uuid::new_v4().to_string(),
     };
     let pool_size = config.keypair_pool.len();
@@ -259,7 +262,23 @@ async fn node_keypair(
         .await?;
     // `acquire` only ever returns an in-range slot, so this index is valid.
     let entry = &config.keypair_pool[slot.slot_index as usize];
-    let keypair = identity::keypair_from_pool_entry(entry)?;
+    let keypair = match identity::keypair_from_pool_entry(entry) {
+        Ok(keypair) => keypair,
+        Err(error) => {
+            // Best-effort release: without it a malformed pool entry holds
+            // the slot hostage until lease-TTL expiry while this node
+            // crash-loops onto fresh slots, transiently shrinking the pool
+            // for every other node.
+            if let Err(release_error) = lease.release(&node, slot).await {
+                tracing::warn!(
+                    %release_error,
+                    slot = slot.slot_index,
+                    "failed to release keypair slot after decode failure"
+                );
+            }
+            return Err(error.into());
+        }
+    };
     tracing::info!(
         slot = slot.slot_index,
         pool_size,

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -194,8 +194,11 @@ async fn node_keypair(
 ) -> Result<Keypair, SwarmError> {
     if config.keypair_pool.is_empty() {
         tracing::warn!(
-            "clustering: no keypair pool configured — using an ephemeral per-process identity \
-             (no stable or revocable PeerId; configure WADDLE_CLUSTERING_KEYPAIR_POOL for production)"
+            "clustering: no keypair pool configured — using an ephemeral per-process identity. \
+             An ephemeral PeerId can never be pre-enrolled on the peer allowlist, so this node \
+             CANNOT join or form a cluster (allowlist enforcement is symmetric and unconditional); \
+             configure WADDLE_CLUSTERING_KEYPAIR_POOL and enroll every node's PeerId for any \
+             multi-node deployment"
         );
         return Ok(identity::ephemeral_keypair());
     }
@@ -399,6 +402,14 @@ fn apply_allowlist(
     if !diff.removed.is_empty() {
         metrics::record_peers_revoked(diff.removed.len() as u64);
     }
+    if enrolled.is_empty() {
+        // Reachable only via a genuinely emptied table (an all-rows-invalid
+        // read fails the refresh instead) — i.e. a deliberate full-cluster
+        // revocation by the enrollment authority. Say so loudly.
+        tracing::warn!(
+            "clustering peer allowlist is now empty: deny-all — every peer connection revoked"
+        );
+    }
     metrics::record_allowlist_size(enrolled.len() as i64);
     tracing::info!(
         added = diff.added.len(),
@@ -521,6 +532,10 @@ mod tests {
     // Postgres-only (as clustering itself is).
     #[tokio::test]
     async fn swarm_spawn_brings_up_and_shuts_down() {
+        // Hold the shared table lock so a concurrently seeded (possibly
+        // invalid) allowlist row from the allowlist tests cannot fail this
+        // startup load.
+        let _guard = crate::clustering::allowlist_table_lock().lock().await;
         let Ok(url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
             return;
         };

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -365,13 +365,13 @@ async fn run_event_loop(
     let mut routing_peers: HashSet<PeerId> = HashSet::new();
     let mut conn_addrs: HashMap<libp2p::swarm::ConnectionId, Multiaddr> = HashMap::new();
     // Which peer answered at each dialed address, learned from outbound
-    // establishments and never expired (bounded by the seed set; a same-port
-    // replacement pod overwrites its entry on the next outbound dial). Lets
-    // the dial loop skip a seed whose owner is connected *inbound-only* —
-    // `conn_addrs` alone cannot, because an inbound connection's remote
-    // address is an ephemeral source port that never matches the seed addr,
-    // so every interval would churn a duplicate connection for the
-    // duplicate-PeerId defense to close.
+    // establishments and pruned when the owner's last connection closes (so
+    // the map stays bounded by connected peers under pod churn, and a fully
+    // disconnected peer stays redialable). Lets the dial loop skip a seed
+    // whose owner is connected *inbound-only* — `conn_addrs` alone cannot,
+    // because an inbound connection's remote address is an ephemeral source
+    // port that never matches the seed addr, so every interval would churn a
+    // duplicate connection for the duplicate-PeerId defense to close.
     let mut addr_owners: HashMap<Multiaddr, PeerId> = HashMap::new();
 
     // `interval` fires its first tick immediately, so the first dial round
@@ -615,9 +615,14 @@ fn handle_swarm_event(
             ..
         } => {
             conn_addrs.remove(&connection_id);
-            // Only drop the peer when its last connection closes.
+            // Only drop the peer when its last connection closes. Its
+            // addr-ownership entries go with it: a fully disconnected peer
+            // must be redialable (the skip would be wrong), and pruning here
+            // keeps the map bounded by *connected* peers under pod churn
+            // instead of accumulating every address ever dialed.
             if num_established == 0 {
                 track_peer_disconnected(peer_id, connected);
+                addr_owners.retain(|_, owner| *owner != peer_id);
             }
         }
         SwarmEvent::Behaviour(WaddleBehaviourEvent::Kameo(remote::Event::Registry(

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -364,6 +364,15 @@ async fn run_event_loop(
     let mut connected: HashSet<PeerId> = HashSet::new();
     let mut routing_peers: HashSet<PeerId> = HashSet::new();
     let mut conn_addrs: HashMap<libp2p::swarm::ConnectionId, Multiaddr> = HashMap::new();
+    // Which peer answered at each dialed address, learned from outbound
+    // establishments and never expired (bounded by the seed set; a same-port
+    // replacement pod overwrites its entry on the next outbound dial). Lets
+    // the dial loop skip a seed whose owner is connected *inbound-only* —
+    // `conn_addrs` alone cannot, because an inbound connection's remote
+    // address is an ephemeral source port that never matches the seed addr,
+    // so every interval would churn a duplicate connection for the
+    // duplicate-PeerId defense to close.
+    let mut addr_owners: HashMap<Multiaddr, PeerId> = HashMap::new();
 
     // `interval` fires its first tick immediately, so the first dial round
     // happens right away rather than after a full interval.
@@ -443,8 +452,17 @@ async fn run_event_loop(
             Some(addr) = dial_rx.recv() => {
                 // Skip endpoints we already hold a connection to: redialing a
                 // connected peer every interval would just mint a duplicate
-                // connection for the duplicate-PeerId defense to close.
+                // connection for the duplicate-PeerId defense to close. Two
+                // checks: an outbound connection's remote address matches the
+                // seed addr directly; an inbound-only peer is recognized via
+                // the addr's last known owner.
                 if conn_addrs.values().any(|connected_addr| *connected_addr == addr) {
+                    continue;
+                }
+                if addr_owners
+                    .get(&addr)
+                    .is_some_and(|owner| connected.contains(owner))
+                {
                     continue;
                 }
                 metrics::record_bootstrap_dial();
@@ -459,6 +477,7 @@ async fn run_event_loop(
                     &mut connected,
                     &mut routing_peers,
                     &mut conn_addrs,
+                    &mut addr_owners,
                 );
             }
         }
@@ -533,6 +552,7 @@ fn handle_swarm_event(
     connected: &mut HashSet<PeerId>,
     routing_peers: &mut HashSet<PeerId>,
     conn_addrs: &mut HashMap<libp2p::swarm::ConnectionId, Multiaddr>,
+    addr_owners: &mut HashMap<Multiaddr, PeerId>,
 ) {
     match event {
         SwarmEvent::NewListenAddr { address, .. } => {
@@ -553,6 +573,10 @@ fn handle_swarm_event(
             // addresses are ephemeral ports, never dialable — skip those.
             if endpoint.is_dialer() {
                 swarm.add_peer_address(peer_id, endpoint.get_remote_address().clone());
+                // Remember who owns this dialable address so the dial loop
+                // can skip it while the peer stays connected (even if only
+                // through an inbound connection).
+                addr_owners.insert(endpoint.get_remote_address().clone(), peer_id);
             }
             // Duplicate-PeerId defense-in-depth (ADR element 3): the
             // keypair-slot lease already guarantees a unique PeerId per live

--- a/server/crates/waddle-server/src/clustering/swarm.rs
+++ b/server/crates/waddle-server/src/clustering/swarm.rs
@@ -402,6 +402,24 @@ async fn run_event_loop(
         tokio::sync::mpsc::channel::<HashSet<PeerId>>(ALLOWLIST_CHANNEL_CAPACITY);
     let allowlist_in_flight = Arc::new(AtomicBool::new(false));
 
+    // Resets its single-flight flag on drop, so a panic in a guarded task can
+    // never permanently wedge that background operation (for the allowlist
+    // that would mean this node stops applying peer revocations).
+    struct InFlightGuard(Arc<AtomicBool>);
+
+    impl InFlightGuard {
+        /// Claim the flag; `None` while a prior task is still in flight.
+        fn try_claim(flag: &Arc<AtomicBool>) -> Option<Self> {
+            (!flag.swap(true, Ordering::AcqRel)).then(|| Self(Arc::clone(flag)))
+        }
+    }
+
+    impl Drop for InFlightGuard {
+        fn drop(&mut self) {
+            self.0.store(false, Ordering::Release);
+        }
+    }
+
     loop {
         tokio::select! {
             _ = stop_token.cancelled() => {
@@ -409,28 +427,27 @@ async fn run_event_loop(
                 break;
             }
             _ = dial_timer.tick() => {
-                if !bootstrap_peers.is_empty()
-                    && !dns_in_flight.swap(true, Ordering::AcqRel)
-                {
-                    let seeds = bootstrap_peers.clone();
-                    let dial_tx = dial_tx.clone();
-                    let in_flight = Arc::clone(&dns_in_flight);
-                    tokio::spawn(async move {
-                        for addr in dns::resolve_bootstrap_peers(&seeds).await {
-                            if dial_tx.send(addr).await.is_err() {
-                                break;
+                if !bootstrap_peers.is_empty() {
+                    if let Some(guard) = InFlightGuard::try_claim(&dns_in_flight) {
+                        let seeds = bootstrap_peers.clone();
+                        let dial_tx = dial_tx.clone();
+                        tokio::spawn(async move {
+                            let _guard = guard;
+                            for addr in dns::resolve_bootstrap_peers(&seeds).await {
+                                if dial_tx.send(addr).await.is_err() {
+                                    break;
+                                }
                             }
-                        }
-                        in_flight.store(false, Ordering::Release);
-                    });
+                        });
+                    }
                 }
             }
             _ = allowlist_timer.tick() => {
-                if !allowlist_in_flight.swap(true, Ordering::AcqRel) {
+                if let Some(guard) = InFlightGuard::try_claim(&allowlist_in_flight) {
                     let store = Arc::clone(&allowlist.store);
                     let allowlist_tx = allowlist_tx.clone();
-                    let in_flight = Arc::clone(&allowlist_in_flight);
                     tokio::spawn(async move {
+                        let _guard = guard;
                         match store.enrolled_peers().await {
                             Ok(enrolled) => {
                                 let _ = allowlist_tx.send(enrolled).await;
@@ -442,7 +459,6 @@ async fn run_event_loop(
                                 tracing::warn!(%error, "clustering allowlist refresh failed; keeping current set");
                             }
                         }
-                        in_flight.store(false, Ordering::Release);
                     });
                 }
             }

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -133,7 +133,7 @@ impl SpiceDbConfig {
 /// [`crate::clustering`]. This struct carries no libp2p types (multiaddrs are
 /// strings, parsed inside the feature-gated swarm module) so it compiles into
 /// every build.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ClusteringConfig {
     pub enabled: bool,
     /// libp2p listen multiaddrs for the swarm transport. Default: one
@@ -176,6 +176,34 @@ pub struct ClusteringConfig {
     /// (`WADDLE_CLUSTERING_NODE_ID_FILE`) so the harness can resolve this
     /// node's relay name — mirrors the `WADDLE_HTTP_PORT_FILE` convention.
     pub node_id_file: Option<std::path::PathBuf>,
+}
+
+/// Manual `Debug`: `keypair_pool` holds base64-encoded ed25519 secret-key
+/// seeds, and `ClusteringConfig` is embedded in `ServerConfig`, so a derived
+/// impl would print raw private key material into any `{:?}` sink (panic
+/// handlers, error logs, `--nocapture` test output). The pool is redacted to
+/// a count; every other field formats as the derive would.
+impl std::fmt::Debug for ClusteringConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClusteringConfig")
+            .field("enabled", &self.enabled)
+            .field("listen_addrs", &self.listen_addrs)
+            .field("bootstrap_peers", &self.bootstrap_peers)
+            .field("messaging", &self.messaging)
+            .field(
+                "keypair_pool",
+                &format_args!("[{} keys redacted]", self.keypair_pool.len()),
+            )
+            .field("lease", &self.lease)
+            .field(
+                "allowlist_refresh_interval",
+                &self.allowlist_refresh_interval,
+            )
+            .field("dial_interval", &self.dial_interval)
+            .field("fault_injection", &self.fault_injection)
+            .field("node_id_file", &self.node_id_file)
+            .finish()
+    }
 }
 
 /// Timing for the keypair-slot lease heartbeat and expiry (ADR element 4
@@ -1132,6 +1160,23 @@ mod tests {
         assert_eq!(config.keypair_pool, vec!["keyA", "keyB", "keyC"]);
         assert_eq!(config.lease.heartbeat_interval.as_millis(), 5000);
         assert_eq!(config.lease.lease_ttl.as_millis(), 20000);
+    }
+
+    #[test]
+    fn clustering_debug_redacts_keypair_pool_secrets() {
+        let config = ClusteringConfig {
+            keypair_pool: vec![
+                "c2VjcmV0LXNlZWQtQQ==".to_string(),
+                "c2VjcmV0LXNlZWQtQg==".to_string(),
+            ],
+            ..ClusteringConfig::default()
+        };
+        let rendered = format!("{config:?}");
+        assert!(
+            !rendered.contains("c2VjcmV0"),
+            "Debug output leaked keypair seed material: {rendered}"
+        );
+        assert!(rendered.contains("[2 keys redacted]"), "{rendered}");
     }
 
     #[test]

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -146,6 +146,33 @@ pub struct ClusteringConfig {
     /// kameo `messaging::Config` limits and the ADR element-5 timeout
     /// hierarchy.
     pub messaging: ClusteringMessagingConfig,
+    /// Pre-enrolled per-pod keypair pool: base64-encoded 32-byte ed25519 secret
+    /// keys (`WADDLE_CLUSTERING_KEYPAIR_POOL`, comma-separated). At startup a
+    /// pod leases exactly one pool slot via a Postgres CAS and uses that
+    /// keypair as its libp2p identity (ADR element 3). Empty (the default)
+    /// falls back to an ephemeral per-process keypair — fine for the discovery
+    /// spike and tests, but no stable/revocable identity.
+    pub keypair_pool: Vec<String>,
+    /// Keypair-slot lease timing (heartbeat interval + lease TTL).
+    pub lease: ClusteringLeaseConfig,
+}
+
+/// Timing for the keypair-slot lease heartbeat and expiry (ADR element 4
+/// shape). `lease_ttl` must exceed `heartbeat_interval` with margin so a
+/// briefly-delayed renewal does not lose the slot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusteringLeaseConfig {
+    pub heartbeat_interval: Duration,
+    pub lease_ttl: Duration,
+}
+
+impl Default for ClusteringLeaseConfig {
+    fn default() -> Self {
+        Self {
+            heartbeat_interval: Duration::from_secs(10),
+            lease_ttl: Duration::from_secs(30),
+        }
+    }
 }
 
 /// Headless-Service peer discovery inputs for the swarm.
@@ -198,6 +225,8 @@ impl Default for ClusteringConfig {
             listen_addrs: vec!["/ip4/0.0.0.0/tcp/0".to_string()],
             bootstrap: None,
             messaging: ClusteringMessagingConfig::default(),
+            keypair_pool: Vec::new(),
+            lease: ClusteringLeaseConfig::default(),
         }
     }
 }
@@ -324,6 +353,46 @@ impl ClusteringConfig {
             );
         }
 
+        let keypair_pool = match vars
+            .get("WADDLE_CLUSTERING_KEYPAIR_POOL")
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+        {
+            None => Vec::new(),
+            Some(raw) => raw
+                .split(',')
+                .map(|entry| entry.trim().to_string())
+                .filter(|entry| !entry.is_empty())
+                .collect(),
+        };
+
+        let lease_defaults = ClusteringLeaseConfig::default();
+        let heartbeat_interval = Duration::from_millis(parse_u64_var(
+            &vars,
+            "WADDLE_CLUSTERING_HEARTBEAT_INTERVAL_MS",
+            millis_u64(lease_defaults.heartbeat_interval),
+        )?);
+        let lease_ttl = Duration::from_millis(parse_u64_var(
+            &vars,
+            "WADDLE_CLUSTERING_LEASE_TTL_MS",
+            millis_u64(lease_defaults.lease_ttl),
+        )?);
+        if heartbeat_interval.is_zero() {
+            return Err(
+                "WADDLE_CLUSTERING_HEARTBEAT_INTERVAL_MS must be greater than 0".to_string(),
+            );
+        }
+        // TTL must survive at least one missed renewal plus margin, else a
+        // single delayed heartbeat forfeits the slot.
+        if lease_ttl < heartbeat_interval * 2 {
+            return Err(format!(
+                "WADDLE_CLUSTERING_LEASE_TTL_MS ({}) must be at least 2x \
+                 WADDLE_CLUSTERING_HEARTBEAT_INTERVAL_MS ({})",
+                lease_ttl.as_millis(),
+                heartbeat_interval.as_millis()
+            ));
+        }
+
         Ok(Self {
             enabled,
             listen_addrs,
@@ -335,6 +404,11 @@ impl ClusteringConfig {
                 max_concurrent_streams,
                 max_request_bytes,
                 max_response_bytes,
+            },
+            keypair_pool,
+            lease: ClusteringLeaseConfig {
+                heartbeat_interval,
+                lease_ttl,
             },
         })
     }
@@ -962,6 +1036,43 @@ mod tests {
         let err =
             ClusteringConfig::from_vars([("WADDLE_CLUSTERING_ENABLED", "maybe")]).unwrap_err();
         assert!(err.contains("WADDLE_CLUSTERING_ENABLED"));
+    }
+
+    #[test]
+    fn clustering_parses_keypair_pool_and_lease_timing() {
+        let config = ClusteringConfig::from_vars([
+            ("WADDLE_CLUSTERING_KEYPAIR_POOL", " keyA , keyB ,keyC"),
+            ("WADDLE_CLUSTERING_HEARTBEAT_INTERVAL_MS", "5000"),
+            ("WADDLE_CLUSTERING_LEASE_TTL_MS", "20000"),
+        ])
+        .unwrap();
+        assert_eq!(config.keypair_pool, vec!["keyA", "keyB", "keyC"]);
+        assert_eq!(config.lease.heartbeat_interval.as_millis(), 5000);
+        assert_eq!(config.lease.lease_ttl.as_millis(), 20000);
+    }
+
+    #[test]
+    fn clustering_defaults_have_empty_pool_and_valid_lease() {
+        let config = ClusteringConfig::from_vars(std::iter::empty::<(&str, &str)>()).unwrap();
+        assert!(config.keypair_pool.is_empty());
+        assert_eq!(config.lease, ClusteringLeaseConfig::default());
+    }
+
+    #[test]
+    fn clustering_rejects_lease_ttl_below_two_heartbeats() {
+        let err = ClusteringConfig::from_vars([
+            ("WADDLE_CLUSTERING_HEARTBEAT_INTERVAL_MS", "10000"),
+            ("WADDLE_CLUSTERING_LEASE_TTL_MS", "15000"),
+        ])
+        .unwrap_err();
+        assert!(err.contains("WADDLE_CLUSTERING_LEASE_TTL_MS"));
+    }
+
+    #[test]
+    fn clustering_rejects_zero_heartbeat_interval() {
+        let err = ClusteringConfig::from_vars([("WADDLE_CLUSTERING_HEARTBEAT_INTERVAL_MS", "0")])
+            .unwrap_err();
+        assert!(err.contains("WADDLE_CLUSTERING_HEARTBEAT_INTERVAL_MS"));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -209,8 +209,11 @@ pub struct ClusteringBootstrapConfig {
 ///
 /// Invariants enforced at parse time: `reply_timeout <= request_timeout` and
 /// `mailbox_timeout <= request_timeout`. `request_timeout` is the sender-side
-/// libp2p transport cap (`with_request_timeout`) and is the binding bound; any
-/// `reply_timeout` above it is dead configuration.
+/// libp2p transport cap (`with_request_timeout`, applied at swarm build) and
+/// is the binding bound; any `reply_timeout` above it is dead configuration.
+/// `mailbox_timeout`/`reply_timeout` are per-ask parameters, applied by every
+/// relay ask (`clustering::relay::RelayHandle`); Phase 4's delivery asks
+/// inherit the same wiring.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClusteringMessagingConfig {
     pub request_timeout: Duration,

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -499,11 +499,28 @@ impl ClusteringConfig {
             .filter(|value| !value.is_empty())
         {
             None => Vec::new(),
-            Some(raw) => raw
-                .split(',')
-                .map(|entry| entry.trim().to_string())
-                .filter(|entry| !entry.is_empty())
-                .collect(),
+            Some(raw) => {
+                let entries: Vec<String> = raw
+                    .split(',')
+                    .map(|entry| entry.trim().to_string())
+                    .filter(|entry| !entry.is_empty())
+                    .collect();
+                // Two slots holding the same keypair would let two live nodes
+                // share a PeerId — exactly what the slot lease exists to
+                // prevent. The entries are secrets, so the error names slot
+                // positions, never values.
+                let mut seen = std::collections::HashMap::new();
+                for (index, entry) in entries.iter().enumerate() {
+                    if let Some(first) = seen.insert(entry.as_str(), index) {
+                        return Err(format!(
+                            "WADDLE_CLUSTERING_KEYPAIR_POOL entries at positions {first} and \
+                             {index} are identical: duplicate keypairs would let two live \
+                             nodes share a PeerId"
+                        ));
+                    }
+                }
+                entries
+            }
         };
 
         let lease_defaults = ClusteringLeaseConfig::default();
@@ -1311,6 +1328,21 @@ mod tests {
             "Debug output leaked keypair seed material: {rendered}"
         );
         assert!(rendered.contains("[2 keys redacted]"), "{rendered}");
+    }
+
+    #[test]
+    fn clustering_rejects_duplicate_keypair_pool_entries() {
+        let err = ClusteringConfig::from_vars([(
+            "WADDLE_CLUSTERING_KEYPAIR_POOL",
+            "c2VjcmV0QQ==, c2VjcmV0Qg==, c2VjcmV0QQ==",
+        )])
+        .unwrap_err();
+        assert!(err.contains("positions 0 and 2"), "{err}");
+        // The entries are secrets — the diagnostic must not echo them.
+        assert!(
+            !err.contains("c2VjcmV0"),
+            "error leaked pool material: {err}"
+        );
     }
 
     #[test]

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -238,8 +238,10 @@ pub struct ClusteringBootstrapConfig {
 
 /// kameo `messaging::Config` limits plus the ADR element-5 timeout hierarchy.
 ///
-/// Invariants enforced at parse time: `reply_timeout <= request_timeout` and
-/// `mailbox_timeout <= request_timeout`. `request_timeout` is the sender-side
+/// Invariants enforced at parse time: `reply_timeout <= request_timeout`,
+/// `mailbox_timeout <= request_timeout`, and — because the mailbox and reply
+/// phases run sequentially on the receiver — `mailbox_timeout + reply_timeout
+/// <= request_timeout`. `request_timeout` is the sender-side
 /// libp2p transport cap (`with_request_timeout`, applied at swarm build) and
 /// is the binding bound; any `reply_timeout` above it is dead configuration.
 /// `mailbox_timeout`/`reply_timeout` are per-ask parameters, applied by every
@@ -451,6 +453,22 @@ impl ClusteringConfig {
                 "WADDLE_CLUSTERING_MAILBOX_TIMEOUT_MS ({}) must be <= \
                  WADDLE_CLUSTERING_REQUEST_TIMEOUT_MS ({})",
                 mailbox_timeout.as_millis(),
+                request_timeout.as_millis()
+            ));
+        }
+        // The mailbox and reply phases of an ask are sequential on the
+        // receiver, so their combined worst case must also fit under the
+        // sender-side transport cap — otherwise the tail of the reply budget
+        // is dead configuration the transport timeout always preempts.
+        if mailbox_timeout + reply_timeout > request_timeout {
+            return Err(format!(
+                "WADDLE_CLUSTERING_MAILBOX_TIMEOUT_MS ({}) + \
+                 WADDLE_CLUSTERING_REPLY_TIMEOUT_MS ({}) must be <= \
+                 WADDLE_CLUSTERING_REQUEST_TIMEOUT_MS ({}): the phases are \
+                 sequential, so any combined budget above the transport cap \
+                 can never be observed",
+                mailbox_timeout.as_millis(),
+                reply_timeout.as_millis(),
                 request_timeout.as_millis()
             ));
         }
@@ -1202,6 +1220,22 @@ mod tests {
         ])
         .unwrap_err();
         assert!(err.contains("WADDLE_CLUSTERING_MAILBOX_TIMEOUT_MS"));
+    }
+
+    #[test]
+    fn clustering_rejects_combined_mailbox_plus_reply_above_request_timeout() {
+        // Each timeout individually fits under the transport cap, but the
+        // mailbox and reply phases are sequential, so their sum exceeding the
+        // cap makes the reply budget's tail unreachable.
+        let err = ClusteringConfig::from_vars([
+            ("WADDLE_CLUSTERING_REQUEST_TIMEOUT_MS", "10000"),
+            ("WADDLE_CLUSTERING_REPLY_TIMEOUT_MS", "8000"),
+            ("WADDLE_CLUSTERING_MAILBOX_TIMEOUT_MS", "8000"),
+        ])
+        .unwrap_err();
+        assert!(err.contains("WADDLE_CLUSTERING_MAILBOX_TIMEOUT_MS"));
+        assert!(err.contains("WADDLE_CLUSTERING_REPLY_TIMEOUT_MS"));
+        assert!(err.contains("sequential"));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -139,10 +139,13 @@ pub struct ClusteringConfig {
     /// libp2p listen multiaddrs for the swarm transport. Default: one
     /// ephemeral TCP address (`/ip4/0.0.0.0/tcp/0`).
     pub listen_addrs: Vec<String>,
-    /// Kubernetes headless-Service peer discovery. `None` = cold start with no
-    /// bootstrap peers (kademlia bootstrap retries continuously; an empty peer
-    /// set is tolerated, avoiding cold-start deadlock).
-    pub bootstrap: Option<ClusteringBootstrapConfig>,
+    /// Peer discovery seeds (`WADDLE_CLUSTERING_BOOTSTRAP_PEERS`, comma-
+    /// separated `host:port`). In production this is a single entry — the
+    /// Kubernetes headless Service name, which resolves to every ready pod;
+    /// the multi-process harness lists one loopback entry per node. Empty =
+    /// cold start with no bootstrap peers (dialing retries continuously; an
+    /// empty peer set is tolerated, avoiding cold-start deadlock).
+    pub bootstrap_peers: Vec<ClusteringBootstrapConfig>,
     /// kameo `messaging::Config` limits and the ADR element-5 timeout
     /// hierarchy.
     pub messaging: ClusteringMessagingConfig,
@@ -160,6 +163,19 @@ pub struct ClusteringConfig {
     /// (`WADDLE_CLUSTERING_ALLOWLIST_REFRESH_MS`). This interval is the
     /// containment bound for a revoked peer (ADR element 3).
     pub allowlist_refresh_interval: Duration,
+    /// How often the swarm re-resolves the headless-DNS bootstrap name and
+    /// dials seed peers, picking up pod churn
+    /// (`WADDLE_CLUSTERING_DIAL_INTERVAL_MS`).
+    pub dial_interval: Duration,
+    /// Enable the relay's fault-injection message set (crash/sleep) for the
+    /// multi-process cluster harness (`WADDLE_CLUSTERING_FAULT_INJECTION`).
+    /// Never enable in production: it lets any enrolled peer stop this node's
+    /// relay or hold its mailbox.
+    pub fault_injection: bool,
+    /// Write `"<node_id> <peer_id>\n"` to this path once the swarm is up
+    /// (`WADDLE_CLUSTERING_NODE_ID_FILE`) so the harness can resolve this
+    /// node's relay name — mirrors the `WADDLE_HTTP_PORT_FILE` convention.
+    pub node_id_file: Option<std::path::PathBuf>,
 }
 
 /// Timing for the keypair-slot lease heartbeat and expiry (ADR element 4
@@ -180,12 +196,12 @@ impl Default for ClusteringLeaseConfig {
     }
 }
 
-/// Headless-Service peer discovery inputs for the swarm.
+/// One peer-discovery seed: a DNS name (A/AAAA-resolved to one or more peer
+/// IPs — the headless Service resolves to every ready pod) plus the TCP port
+/// those peers listen on for the swarm transport.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClusteringBootstrapConfig {
-    /// Headless Service DNS name resolved (A/AAAA) to peer addresses.
     pub dns_name: String,
-    /// TCP port peers listen on for the swarm transport.
     pub port: u16,
 }
 
@@ -228,11 +244,14 @@ impl Default for ClusteringConfig {
         Self {
             enabled: false,
             listen_addrs: vec!["/ip4/0.0.0.0/tcp/0".to_string()],
-            bootstrap: None,
+            bootstrap_peers: Vec::new(),
             messaging: ClusteringMessagingConfig::default(),
             keypair_pool: Vec::new(),
             lease: ClusteringLeaseConfig::default(),
             allowlist_refresh_interval: Duration::from_secs(30),
+            dial_interval: Duration::from_secs(15),
+            fault_injection: false,
+            node_id_file: None,
         }
     }
 }
@@ -278,21 +297,43 @@ impl ClusteringConfig {
             }
         };
 
-        let bootstrap = match vars
-            .get("WADDLE_CLUSTERING_BOOTSTRAP_DNS")
-            .map(|value| value.trim().to_string())
+        let bootstrap_peers = match vars
+            .get("WADDLE_CLUSTERING_BOOTSTRAP_PEERS")
+            .map(|value| value.trim())
             .filter(|value| !value.is_empty())
         {
-            None => None,
-            Some(dns_name) => {
-                let port = parse_u64_var(&vars, "WADDLE_CLUSTERING_BOOTSTRAP_PORT", 7900)?;
-                let port = u16::try_from(port).ok().filter(|value| *value != 0).ok_or_else(|| {
-                    format!(
-                        "WADDLE_CLUSTERING_BOOTSTRAP_PORT='{port}' must be a valid TCP port (1-65535)"
-                    )
-                })?;
-                Some(ClusteringBootstrapConfig { dns_name, port })
-            }
+            None => Vec::new(),
+            Some(raw) => raw
+                .split(',')
+                .map(str::trim)
+                .filter(|entry| !entry.is_empty())
+                .map(|entry| {
+                    let (dns_name, port) = entry.rsplit_once(':').ok_or_else(|| {
+                        format!(
+                            "WADDLE_CLUSTERING_BOOTSTRAP_PEERS entry '{entry}' must be host:port"
+                        )
+                    })?;
+                    let port = port
+                        .parse::<u16>()
+                        .ok()
+                        .filter(|value| *value != 0)
+                        .ok_or_else(|| {
+                            format!(
+                                "WADDLE_CLUSTERING_BOOTSTRAP_PEERS entry '{entry}' has an \
+                                 invalid TCP port (1-65535)"
+                            )
+                        })?;
+                    if dns_name.is_empty() {
+                        return Err(format!(
+                            "WADDLE_CLUSTERING_BOOTSTRAP_PEERS entry '{entry}' has an empty host"
+                        ));
+                    }
+                    Ok(ClusteringBootstrapConfig {
+                        dns_name: dns_name.to_string(),
+                        port,
+                    })
+                })
+                .collect::<Result<Vec<_>, String>>()?,
         };
 
         let messaging_defaults = ClusteringMessagingConfig::default();
@@ -409,11 +450,25 @@ impl ClusteringConfig {
                 "WADDLE_CLUSTERING_ALLOWLIST_REFRESH_MS must be greater than 0".to_string(),
             );
         }
+        let dial_interval = Duration::from_millis(parse_u64_var(
+            &vars,
+            "WADDLE_CLUSTERING_DIAL_INTERVAL_MS",
+            millis_u64(Self::default().dial_interval),
+        )?);
+        if dial_interval.is_zero() {
+            return Err("WADDLE_CLUSTERING_DIAL_INTERVAL_MS must be greater than 0".to_string());
+        }
+        let fault_injection = parse_bool_var(&vars, "WADDLE_CLUSTERING_FAULT_INJECTION", false)?;
+        let node_id_file = vars
+            .get("WADDLE_CLUSTERING_NODE_ID_FILE")
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+            .map(std::path::PathBuf::from);
 
         Ok(Self {
             enabled,
             listen_addrs,
-            bootstrap,
+            bootstrap_peers,
             messaging: ClusteringMessagingConfig {
                 request_timeout,
                 reply_timeout,
@@ -428,6 +483,9 @@ impl ClusteringConfig {
                 lease_ttl,
             },
             allowlist_refresh_interval,
+            dial_interval,
+            fault_injection,
+            node_id_file,
         })
     }
 }
@@ -958,7 +1016,7 @@ mod tests {
         let config = ClusteringConfig::from_vars(std::iter::empty::<(&str, &str)>()).unwrap();
         assert!(!config.enabled);
         assert_eq!(config.listen_addrs, vec!["/ip4/0.0.0.0/tcp/0".to_string()]);
-        assert!(config.bootstrap.is_none());
+        assert!(config.bootstrap_peers.is_empty());
         assert_eq!(config.messaging, ClusteringMessagingConfig::default());
         // Byte-for-byte-identical guarantee: the whole struct equals Default.
         assert_eq!(config, ClusteringConfig::default());
@@ -985,36 +1043,40 @@ mod tests {
     }
 
     #[test]
-    fn clustering_parses_bootstrap_dns_and_port() {
+    fn clustering_parses_bootstrap_peer_list() {
         let config = ClusteringConfig::from_vars([
             ("WADDLE_CLUSTERING_ENABLED", "1"),
-            ("WADDLE_CLUSTERING_BOOTSTRAP_DNS", "waddle-server-swarm"),
-            ("WADDLE_CLUSTERING_BOOTSTRAP_PORT", "7900"),
+            (
+                "WADDLE_CLUSTERING_BOOTSTRAP_PEERS",
+                "waddle-server-swarm:7900, localhost:7901",
+            ),
         ])
         .unwrap();
-        let bootstrap = config.bootstrap.expect("bootstrap parsed");
-        assert_eq!(bootstrap.dns_name, "waddle-server-swarm");
-        assert_eq!(bootstrap.port, 7900);
+        assert_eq!(
+            config.bootstrap_peers,
+            vec![
+                ClusteringBootstrapConfig {
+                    dns_name: "waddle-server-swarm".to_string(),
+                    port: 7900,
+                },
+                ClusteringBootstrapConfig {
+                    dns_name: "localhost".to_string(),
+                    port: 7901,
+                },
+            ]
+        );
     }
 
     #[test]
-    fn clustering_bootstrap_defaults_port_when_dns_set() {
-        let config = ClusteringConfig::from_vars([(
-            "WADDLE_CLUSTERING_BOOTSTRAP_DNS",
-            "waddle-server-swarm",
-        )])
-        .unwrap();
-        assert_eq!(config.bootstrap.expect("bootstrap parsed").port, 7900);
-    }
-
-    #[test]
-    fn clustering_rejects_zero_bootstrap_port() {
-        let err = ClusteringConfig::from_vars([
-            ("WADDLE_CLUSTERING_BOOTSTRAP_DNS", "swarm"),
-            ("WADDLE_CLUSTERING_BOOTSTRAP_PORT", "0"),
-        ])
-        .unwrap_err();
-        assert!(err.contains("WADDLE_CLUSTERING_BOOTSTRAP_PORT"));
+    fn clustering_rejects_malformed_bootstrap_entries() {
+        for bad in ["no-port", "host:0", ":7900", "host:notaport"] {
+            let err = ClusteringConfig::from_vars([("WADDLE_CLUSTERING_BOOTSTRAP_PEERS", bad)])
+                .unwrap_err();
+            assert!(
+                err.contains("WADDLE_CLUSTERING_BOOTSTRAP_PEERS"),
+                "entry '{bad}' must be rejected: {err}"
+            );
+        }
     }
 
     #[test]
@@ -1096,6 +1158,31 @@ mod tests {
         let err = ClusteringConfig::from_vars([("WADDLE_CLUSTERING_ALLOWLIST_REFRESH_MS", "0")])
             .unwrap_err();
         assert!(err.contains("WADDLE_CLUSTERING_ALLOWLIST_REFRESH_MS"));
+    }
+
+    #[test]
+    fn clustering_parses_harness_knobs() {
+        let config = ClusteringConfig::from_vars([
+            ("WADDLE_CLUSTERING_DIAL_INTERVAL_MS", "2000"),
+            ("WADDLE_CLUSTERING_FAULT_INJECTION", "true"),
+            ("WADDLE_CLUSTERING_NODE_ID_FILE", "/tmp/node-id"),
+        ])
+        .unwrap();
+        assert_eq!(config.dial_interval.as_millis(), 2000);
+        assert!(config.fault_injection);
+        assert_eq!(
+            config.node_id_file,
+            Some(std::path::PathBuf::from("/tmp/node-id"))
+        );
+
+        let defaults = ClusteringConfig::from_vars(std::iter::empty::<(&str, &str)>()).unwrap();
+        assert_eq!(defaults.dial_interval.as_secs(), 15);
+        assert!(!defaults.fault_injection);
+        assert!(defaults.node_id_file.is_none());
+
+        let err =
+            ClusteringConfig::from_vars([("WADDLE_CLUSTERING_DIAL_INTERVAL_MS", "0")]).unwrap_err();
+        assert!(err.contains("WADDLE_CLUSTERING_DIAL_INTERVAL_MS"));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -439,6 +439,16 @@ impl ClusteringConfig {
         // transport cap; a `reply_timeout` above it is dead configuration (the
         // sender always observes `OutboundFailure(Timeout)` at the cap), and
         // the receiver-side `mailbox_timeout` must also fit under the cap.
+        // All three must be non-zero: a zero anywhere times out every ask
+        // instantly, and an all-zero triple would otherwise satisfy every
+        // ordering check below.
+        if request_timeout.is_zero() || reply_timeout.is_zero() || mailbox_timeout.is_zero() {
+            return Err(
+                "WADDLE_CLUSTERING_REQUEST_TIMEOUT_MS, WADDLE_CLUSTERING_REPLY_TIMEOUT_MS, \
+                 and WADDLE_CLUSTERING_MAILBOX_TIMEOUT_MS must all be greater than 0"
+                    .to_string(),
+            );
+        }
         if reply_timeout > request_timeout {
             return Err(format!(
                 "WADDLE_CLUSTERING_REPLY_TIMEOUT_MS ({}) must be <= \
@@ -1220,6 +1230,27 @@ mod tests {
         ])
         .unwrap_err();
         assert!(err.contains("WADDLE_CLUSTERING_MAILBOX_TIMEOUT_MS"));
+    }
+
+    #[test]
+    fn clustering_rejects_zero_timeouts() {
+        // An all-zero triple satisfies every ordering check (0 <= 0), so the
+        // non-zero guard must catch it — and each individually-zero value.
+        for vars in [
+            vec![
+                ("WADDLE_CLUSTERING_REQUEST_TIMEOUT_MS", "0"),
+                ("WADDLE_CLUSTERING_REPLY_TIMEOUT_MS", "0"),
+                ("WADDLE_CLUSTERING_MAILBOX_TIMEOUT_MS", "0"),
+            ],
+            vec![("WADDLE_CLUSTERING_REPLY_TIMEOUT_MS", "0")],
+            vec![("WADDLE_CLUSTERING_MAILBOX_TIMEOUT_MS", "0")],
+        ] {
+            let err = ClusteringConfig::from_vars(vars.clone()).unwrap_err();
+            assert!(
+                err.contains("must all be greater than 0"),
+                "{vars:?}: {err}"
+            );
+        }
     }
 
     #[test]

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -124,6 +124,228 @@ impl SpiceDbConfig {
     }
 }
 
+/// ADR-0017 Phase 2 clustering (owned libp2p swarm) configuration.
+///
+/// Parsed from `WADDLE_CLUSTERING_*`. With `enabled` false (the default) the
+/// swarm subsystem never starts and server behaviour is byte-for-byte
+/// identical to the single-replica path. Clustering additionally requires the
+/// `clustering` build feature and the Postgres control plane; see
+/// [`crate::clustering`]. This struct carries no libp2p types (multiaddrs are
+/// strings, parsed inside the feature-gated swarm module) so it compiles into
+/// every build.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusteringConfig {
+    pub enabled: bool,
+    /// libp2p listen multiaddrs for the swarm transport. Default: one
+    /// ephemeral TCP address (`/ip4/0.0.0.0/tcp/0`).
+    pub listen_addrs: Vec<String>,
+    /// Kubernetes headless-Service peer discovery. `None` = cold start with no
+    /// bootstrap peers (kademlia bootstrap retries continuously; an empty peer
+    /// set is tolerated, avoiding cold-start deadlock).
+    pub bootstrap: Option<ClusteringBootstrapConfig>,
+    /// kameo `messaging::Config` limits and the ADR element-5 timeout
+    /// hierarchy.
+    pub messaging: ClusteringMessagingConfig,
+}
+
+/// Headless-Service peer discovery inputs for the swarm.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusteringBootstrapConfig {
+    /// Headless Service DNS name resolved (A/AAAA) to peer addresses.
+    pub dns_name: String,
+    /// TCP port peers listen on for the swarm transport.
+    pub port: u16,
+}
+
+/// kameo `messaging::Config` limits plus the ADR element-5 timeout hierarchy.
+///
+/// Invariants enforced at parse time: `reply_timeout <= request_timeout` and
+/// `mailbox_timeout <= request_timeout`. `request_timeout` is the sender-side
+/// libp2p transport cap (`with_request_timeout`) and is the binding bound; any
+/// `reply_timeout` above it is dead configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClusteringMessagingConfig {
+    pub request_timeout: Duration,
+    pub reply_timeout: Duration,
+    pub mailbox_timeout: Duration,
+    /// Cap on concurrent asks per peer connection (kameo default 100).
+    pub max_concurrent_streams: usize,
+    /// Max serialized request envelope bytes (kameo default 1 MiB).
+    pub max_request_bytes: u64,
+    /// Max serialized response envelope bytes (kameo default 10 MiB).
+    pub max_response_bytes: u64,
+}
+
+impl Default for ClusteringMessagingConfig {
+    fn default() -> Self {
+        Self {
+            // Sized above the worst-case fenced-write / resume-handshake budget
+            // (the 10s kameo default is too low per ADR element 5).
+            request_timeout: Duration::from_secs(30),
+            reply_timeout: Duration::from_secs(20),
+            mailbox_timeout: Duration::from_secs(5),
+            max_concurrent_streams: 256,
+            max_request_bytes: 1024 * 1024,
+            max_response_bytes: 10 * 1024 * 1024,
+        }
+    }
+}
+
+impl Default for ClusteringConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            listen_addrs: vec!["/ip4/0.0.0.0/tcp/0".to_string()],
+            bootstrap: None,
+            messaging: ClusteringMessagingConfig::default(),
+        }
+    }
+}
+
+impl ClusteringConfig {
+    pub fn from_env() -> Result<Self, String> {
+        Self::from_vars(std::env::vars())
+    }
+
+    pub fn from_vars<I, K, V>(vars: I) -> Result<Self, String>
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        let vars = vars
+            .into_iter()
+            .map(|(key, value)| (key.as_ref().to_string(), value.as_ref().to_string()))
+            .collect::<std::collections::HashMap<_, _>>();
+
+        let defaults = Self::default();
+        let enabled = parse_bool_var(&vars, "WADDLE_CLUSTERING_ENABLED", false)?;
+
+        let listen_addrs = match vars
+            .get("WADDLE_CLUSTERING_LISTEN_ADDRS")
+            .map(|value| value.trim())
+            .filter(|value| !value.is_empty())
+        {
+            None => defaults.listen_addrs,
+            Some(raw) => {
+                let addrs: Vec<String> = raw
+                    .split(',')
+                    .map(|entry| entry.trim().to_string())
+                    .filter(|entry| !entry.is_empty())
+                    .collect();
+                if addrs.is_empty() {
+                    return Err(
+                        "WADDLE_CLUSTERING_LISTEN_ADDRS must contain at least one multiaddr"
+                            .to_string(),
+                    );
+                }
+                addrs
+            }
+        };
+
+        let bootstrap = match vars
+            .get("WADDLE_CLUSTERING_BOOTSTRAP_DNS")
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty())
+        {
+            None => None,
+            Some(dns_name) => {
+                let port = parse_u64_var(&vars, "WADDLE_CLUSTERING_BOOTSTRAP_PORT", 7900)?;
+                let port = u16::try_from(port).ok().filter(|value| *value != 0).ok_or_else(|| {
+                    format!(
+                        "WADDLE_CLUSTERING_BOOTSTRAP_PORT='{port}' must be a valid TCP port (1-65535)"
+                    )
+                })?;
+                Some(ClusteringBootstrapConfig { dns_name, port })
+            }
+        };
+
+        let messaging_defaults = ClusteringMessagingConfig::default();
+        let request_timeout = Duration::from_millis(parse_u64_var(
+            &vars,
+            "WADDLE_CLUSTERING_REQUEST_TIMEOUT_MS",
+            millis_u64(messaging_defaults.request_timeout),
+        )?);
+        let reply_timeout = Duration::from_millis(parse_u64_var(
+            &vars,
+            "WADDLE_CLUSTERING_REPLY_TIMEOUT_MS",
+            millis_u64(messaging_defaults.reply_timeout),
+        )?);
+        let mailbox_timeout = Duration::from_millis(parse_u64_var(
+            &vars,
+            "WADDLE_CLUSTERING_MAILBOX_TIMEOUT_MS",
+            millis_u64(messaging_defaults.mailbox_timeout),
+        )?);
+        let max_concurrent_streams = parse_usize_var(
+            &vars,
+            "WADDLE_CLUSTERING_MAX_CONCURRENT_STREAMS",
+            messaging_defaults.max_concurrent_streams,
+        )?;
+        let max_request_bytes = parse_u64_var(
+            &vars,
+            "WADDLE_CLUSTERING_MAX_REQUEST_BYTES",
+            messaging_defaults.max_request_bytes,
+        )?;
+        let max_response_bytes = parse_u64_var(
+            &vars,
+            "WADDLE_CLUSTERING_MAX_RESPONSE_BYTES",
+            messaging_defaults.max_response_bytes,
+        )?;
+
+        // ADR element-5 timeout hierarchy. `request_timeout` is the sender-side
+        // transport cap; a `reply_timeout` above it is dead configuration (the
+        // sender always observes `OutboundFailure(Timeout)` at the cap), and
+        // the receiver-side `mailbox_timeout` must also fit under the cap.
+        if reply_timeout > request_timeout {
+            return Err(format!(
+                "WADDLE_CLUSTERING_REPLY_TIMEOUT_MS ({}) must be <= \
+                 WADDLE_CLUSTERING_REQUEST_TIMEOUT_MS ({}): a reply timeout above the \
+                 transport request timeout is dead configuration",
+                reply_timeout.as_millis(),
+                request_timeout.as_millis()
+            ));
+        }
+        if mailbox_timeout > request_timeout {
+            return Err(format!(
+                "WADDLE_CLUSTERING_MAILBOX_TIMEOUT_MS ({}) must be <= \
+                 WADDLE_CLUSTERING_REQUEST_TIMEOUT_MS ({})",
+                mailbox_timeout.as_millis(),
+                request_timeout.as_millis()
+            ));
+        }
+        if max_concurrent_streams == 0 {
+            return Err("WADDLE_CLUSTERING_MAX_CONCURRENT_STREAMS must be at least 1".to_string());
+        }
+        if max_request_bytes == 0 || max_response_bytes == 0 {
+            return Err(
+                "WADDLE_CLUSTERING_MAX_REQUEST_BYTES and WADDLE_CLUSTERING_MAX_RESPONSE_BYTES \
+                 must both be non-zero"
+                    .to_string(),
+            );
+        }
+
+        Ok(Self {
+            enabled,
+            listen_addrs,
+            bootstrap,
+            messaging: ClusteringMessagingConfig {
+                request_timeout,
+                reply_timeout,
+                mailbox_timeout,
+                max_concurrent_streams,
+                max_request_bytes,
+                max_response_bytes,
+            },
+        })
+    }
+}
+
+/// Milliseconds of a `Duration` as `u64`, saturating (used only to derive
+/// env-var defaults from the compiled-in `Duration` defaults).
+fn millis_u64(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
 #[derive(Debug, Clone)]
 pub struct ServerConfig {
     pub mode: ServerMode,
@@ -146,6 +368,9 @@ pub struct ServerConfig {
     /// every stamping site reads the same key. Required at startup;
     /// see [`parse_occupant_id_secret`] for the validation rules.
     pub occupant_id_secret: OccupantIdSecret,
+    /// ADR-0017 Phase 2 clustering (owned libp2p swarm) configuration. With
+    /// `enabled` false (the default) the swarm subsystem never starts.
+    pub clustering: ClusteringConfig,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -537,6 +762,7 @@ impl Default for ServerConfig {
             ws_keepalive: waddle_xmpp::protocol::KeepaliveConfig::default(),
             spicedb: None,
             occupant_id_secret: test_occupant_id_secret(),
+            clustering: ClusteringConfig::default(),
         }
     }
 }
@@ -564,6 +790,8 @@ impl ServerConfig {
         let occupant_id_secret =
             parse_occupant_id_secret(std::env::var("WADDLE_OCCUPANT_ID_SECRET").ok().as_deref())?;
 
+        let clustering = ClusteringConfig::from_env()?;
+
         Ok(Self {
             mode,
             base_url,
@@ -574,6 +802,7 @@ impl ServerConfig {
             ws_keepalive,
             spicedb,
             occupant_id_secret,
+            clustering,
         })
     }
 
@@ -607,6 +836,7 @@ impl ServerConfig {
             ws_keepalive: waddle_xmpp::protocol::KeepaliveConfig::default(),
             spicedb: None,
             occupant_id_secret: test_occupant_id_secret(),
+            clustering: ClusteringConfig::default(),
         }
     }
 
@@ -622,6 +852,7 @@ impl ServerConfig {
             ws_keepalive: waddle_xmpp::protocol::KeepaliveConfig::default(),
             spicedb: None,
             occupant_id_secret: test_occupant_id_secret(),
+            clustering: ClusteringConfig::default(),
         }
     }
 }
@@ -629,6 +860,109 @@ impl ServerConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn clustering_defaults_are_disabled() {
+        let config = ClusteringConfig::from_vars(std::iter::empty::<(&str, &str)>()).unwrap();
+        assert!(!config.enabled);
+        assert_eq!(config.listen_addrs, vec!["/ip4/0.0.0.0/tcp/0".to_string()]);
+        assert!(config.bootstrap.is_none());
+        assert_eq!(config.messaging, ClusteringMessagingConfig::default());
+        // Byte-for-byte-identical guarantee: the whole struct equals Default.
+        assert_eq!(config, ClusteringConfig::default());
+    }
+
+    #[test]
+    fn clustering_parses_enabled_and_listen_addrs() {
+        let config = ClusteringConfig::from_vars([
+            ("WADDLE_CLUSTERING_ENABLED", "true"),
+            (
+                "WADDLE_CLUSTERING_LISTEN_ADDRS",
+                "/ip4/0.0.0.0/tcp/7900, /ip4/0.0.0.0/udp/7900/quic-v1",
+            ),
+        ])
+        .unwrap();
+        assert!(config.enabled);
+        assert_eq!(
+            config.listen_addrs,
+            vec![
+                "/ip4/0.0.0.0/tcp/7900".to_string(),
+                "/ip4/0.0.0.0/udp/7900/quic-v1".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn clustering_parses_bootstrap_dns_and_port() {
+        let config = ClusteringConfig::from_vars([
+            ("WADDLE_CLUSTERING_ENABLED", "1"),
+            ("WADDLE_CLUSTERING_BOOTSTRAP_DNS", "waddle-server-swarm"),
+            ("WADDLE_CLUSTERING_BOOTSTRAP_PORT", "7900"),
+        ])
+        .unwrap();
+        let bootstrap = config.bootstrap.expect("bootstrap parsed");
+        assert_eq!(bootstrap.dns_name, "waddle-server-swarm");
+        assert_eq!(bootstrap.port, 7900);
+    }
+
+    #[test]
+    fn clustering_bootstrap_defaults_port_when_dns_set() {
+        let config = ClusteringConfig::from_vars([(
+            "WADDLE_CLUSTERING_BOOTSTRAP_DNS",
+            "waddle-server-swarm",
+        )])
+        .unwrap();
+        assert_eq!(config.bootstrap.expect("bootstrap parsed").port, 7900);
+    }
+
+    #[test]
+    fn clustering_rejects_zero_bootstrap_port() {
+        let err = ClusteringConfig::from_vars([
+            ("WADDLE_CLUSTERING_BOOTSTRAP_DNS", "swarm"),
+            ("WADDLE_CLUSTERING_BOOTSTRAP_PORT", "0"),
+        ])
+        .unwrap_err();
+        assert!(err.contains("WADDLE_CLUSTERING_BOOTSTRAP_PORT"));
+    }
+
+    #[test]
+    fn clustering_rejects_reply_timeout_above_request_timeout() {
+        // reply_timeout > request_timeout is dead configuration per ADR
+        // element 5 (the sender caps out at the transport request_timeout).
+        let err = ClusteringConfig::from_vars([
+            ("WADDLE_CLUSTERING_REQUEST_TIMEOUT_MS", "10000"),
+            ("WADDLE_CLUSTERING_REPLY_TIMEOUT_MS", "20000"),
+        ])
+        .unwrap_err();
+        assert!(err.contains("must be <="));
+    }
+
+    #[test]
+    fn clustering_rejects_mailbox_timeout_above_request_timeout() {
+        let err = ClusteringConfig::from_vars([
+            ("WADDLE_CLUSTERING_REQUEST_TIMEOUT_MS", "10000"),
+            // Keep reply under the request cap so the mailbox check is the one
+            // that trips (otherwise the reply-timeout invariant fires first).
+            ("WADDLE_CLUSTERING_REPLY_TIMEOUT_MS", "5000"),
+            ("WADDLE_CLUSTERING_MAILBOX_TIMEOUT_MS", "20000"),
+        ])
+        .unwrap_err();
+        assert!(err.contains("WADDLE_CLUSTERING_MAILBOX_TIMEOUT_MS"));
+    }
+
+    #[test]
+    fn clustering_rejects_zero_concurrent_streams() {
+        let err = ClusteringConfig::from_vars([("WADDLE_CLUSTERING_MAX_CONCURRENT_STREAMS", "0")])
+            .unwrap_err();
+        assert!(err.contains("MAX_CONCURRENT_STREAMS"));
+    }
+
+    #[test]
+    fn clustering_rejects_non_boolean_enabled() {
+        let err =
+            ClusteringConfig::from_vars([("WADDLE_CLUSTERING_ENABLED", "maybe")]).unwrap_err();
+        assert!(err.contains("WADDLE_CLUSTERING_ENABLED"));
+    }
 
     #[test]
     fn ws_keepalive_defaults_are_45s_2_misses() {

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -140,7 +140,8 @@ pub struct ClusteringConfig {
     /// ephemeral TCP address (`/ip4/0.0.0.0/tcp/0`).
     pub listen_addrs: Vec<String>,
     /// Peer discovery seeds (`WADDLE_CLUSTERING_BOOTSTRAP_PEERS`, comma-
-    /// separated `host:port`). In production this is a single entry — the
+    /// separated `host:port`; bracket IPv6 literals as `[::1]:7900`). In
+    /// production this is a single entry — the
     /// Kubernetes headless Service name, which resolves to every ready pod;
     /// the multi-process harness lists one loopback entry per node. Empty =
     /// cold start with no bootstrap peers (dialing retries continuously; an
@@ -224,9 +225,11 @@ impl Default for ClusteringLeaseConfig {
     }
 }
 
-/// One peer-discovery seed: a DNS name (A/AAAA-resolved to one or more peer
-/// IPs — the headless Service resolves to every ready pod) plus the TCP port
-/// those peers listen on for the swarm transport.
+/// One peer-discovery seed: a DNS name or IP literal (A/AAAA-resolved to one
+/// or more peer IPs — the headless Service resolves to every ready pod) plus
+/// the TCP port those peers listen on for the swarm transport. IPv6 literals
+/// are stored unbracketed (`::1`); the resolver re-brackets them for the
+/// `host:port` lookup form.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClusteringBootstrapConfig {
     pub dns_name: String,
@@ -339,11 +342,42 @@ impl ClusteringConfig {
                 .map(str::trim)
                 .filter(|entry| !entry.is_empty())
                 .map(|entry| {
-                    let (dns_name, port) = entry.rsplit_once(':').ok_or_else(|| {
-                        format!(
-                            "WADDLE_CLUSTERING_BOOTSTRAP_PEERS entry '{entry}' must be host:port"
-                        )
-                    })?;
+                    // IPv6 literals must be bracketed (`[::1]:7900`): the
+                    // resolver takes `host:port` strings, and an unbracketed
+                    // IPv6 host is ambiguous with the port separator — it
+                    // would parse "successfully" here and then never resolve,
+                    // retrying forever. Fail fast instead. Brackets are
+                    // stripped for storage; the resolver re-adds them.
+                    let (dns_name, port) = if let Some(rest) = entry.strip_prefix('[') {
+                        let (host, port) = rest.split_once("]:").ok_or_else(|| {
+                            format!(
+                                "WADDLE_CLUSTERING_BOOTSTRAP_PEERS entry '{entry}' must be \
+                                 [ipv6]:port"
+                            )
+                        })?;
+                        if host.parse::<std::net::Ipv6Addr>().is_err() {
+                            return Err(format!(
+                                "WADDLE_CLUSTERING_BOOTSTRAP_PEERS entry '{entry}' has an \
+                                 invalid bracketed IPv6 literal"
+                            ));
+                        }
+                        (host, port)
+                    } else {
+                        let (host, port) = entry.rsplit_once(':').ok_or_else(|| {
+                            format!(
+                                "WADDLE_CLUSTERING_BOOTSTRAP_PEERS entry '{entry}' must be \
+                                 host:port"
+                            )
+                        })?;
+                        if host.contains(':') {
+                            return Err(format!(
+                                "WADDLE_CLUSTERING_BOOTSTRAP_PEERS entry '{entry}': IPv6 \
+                                 literals must be bracketed, e.g. [::1]:7900 — the \
+                                 unbracketed form never resolves"
+                            ));
+                        }
+                        (host, port)
+                    };
                     let port = port
                         .parse::<u16>()
                         .ok()
@@ -1100,7 +1134,20 @@ mod tests {
 
     #[test]
     fn clustering_rejects_malformed_bootstrap_entries() {
-        for bad in ["no-port", "host:0", ":7900", "host:notaport"] {
+        for bad in [
+            "no-port",
+            "host:0",
+            ":7900",
+            "host:notaport",
+            // Unbracketed IPv6: rsplit would "parse" it and then it never
+            // resolves — must fail fast at config time.
+            "::1:7900",
+            "fe80::1:7900",
+            // Bracketed but broken.
+            "[::1]",
+            "[::1]:0",
+            "[not-ipv6]:7900",
+        ] {
             let err = ClusteringConfig::from_vars([("WADDLE_CLUSTERING_BOOTSTRAP_PEERS", bad)])
                 .unwrap_err();
             assert!(
@@ -1108,6 +1155,28 @@ mod tests {
                 "entry '{bad}' must be rejected: {err}"
             );
         }
+    }
+
+    #[test]
+    fn clustering_parses_bracketed_ipv6_bootstrap_entries() {
+        let config = ClusteringConfig::from_vars([(
+            "WADDLE_CLUSTERING_BOOTSTRAP_PEERS",
+            "[::1]:7900, [fe80::1]:7901",
+        )])
+        .unwrap();
+        assert_eq!(
+            config.bootstrap_peers,
+            vec![
+                ClusteringBootstrapConfig {
+                    dns_name: "::1".to_string(),
+                    port: 7900,
+                },
+                ClusteringBootstrapConfig {
+                    dns_name: "fe80::1".to_string(),
+                    port: 7901,
+                },
+            ]
+        );
     }
 
     #[test]

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -155,6 +155,11 @@ pub struct ClusteringConfig {
     pub keypair_pool: Vec<String>,
     /// Keypair-slot lease timing (heartbeat interval + lease TTL).
     pub lease: ClusteringLeaseConfig,
+    /// How often the swarm re-reads the peer allowlist and revokes live
+    /// connections whose PeerId is no longer enrolled
+    /// (`WADDLE_CLUSTERING_ALLOWLIST_REFRESH_MS`). This interval is the
+    /// containment bound for a revoked peer (ADR element 3).
+    pub allowlist_refresh_interval: Duration,
 }
 
 /// Timing for the keypair-slot lease heartbeat and expiry (ADR element 4
@@ -227,6 +232,7 @@ impl Default for ClusteringConfig {
             messaging: ClusteringMessagingConfig::default(),
             keypair_pool: Vec::new(),
             lease: ClusteringLeaseConfig::default(),
+            allowlist_refresh_interval: Duration::from_secs(30),
         }
     }
 }
@@ -393,6 +399,17 @@ impl ClusteringConfig {
             ));
         }
 
+        let allowlist_refresh_interval = Duration::from_millis(parse_u64_var(
+            &vars,
+            "WADDLE_CLUSTERING_ALLOWLIST_REFRESH_MS",
+            millis_u64(Self::default().allowlist_refresh_interval),
+        )?);
+        if allowlist_refresh_interval.is_zero() {
+            return Err(
+                "WADDLE_CLUSTERING_ALLOWLIST_REFRESH_MS must be greater than 0".to_string(),
+            );
+        }
+
         Ok(Self {
             enabled,
             listen_addrs,
@@ -410,6 +427,7 @@ impl ClusteringConfig {
                 heartbeat_interval,
                 lease_ttl,
             },
+            allowlist_refresh_interval,
         })
     }
 }
@@ -1066,6 +1084,18 @@ mod tests {
         ])
         .unwrap_err();
         assert!(err.contains("WADDLE_CLUSTERING_LEASE_TTL_MS"));
+    }
+
+    #[test]
+    fn clustering_parses_allowlist_refresh_and_rejects_zero() {
+        let config =
+            ClusteringConfig::from_vars([("WADDLE_CLUSTERING_ALLOWLIST_REFRESH_MS", "5000")])
+                .unwrap();
+        assert_eq!(config.allowlist_refresh_interval.as_millis(), 5000);
+
+        let err = ClusteringConfig::from_vars([("WADDLE_CLUSTERING_ALLOWLIST_REFRESH_MS", "0")])
+            .unwrap_err();
+        assert!(err.contains("WADDLE_CLUSTERING_ALLOWLIST_REFRESH_MS"));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/lib.rs
+++ b/server/crates/waddle-server/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod admin;
 pub mod auth;
 pub mod channel_space_links;
+pub mod clustering;
 pub mod config;
 pub mod db;
 pub mod dnd_projection;

--- a/server/crates/waddle-server/src/permissions/actor.rs
+++ b/server/crates/waddle-server/src/permissions/actor.rs
@@ -18,7 +18,12 @@ enum PermissionActorBackend {
     SpiceDb(Box<SpiceDbPermissionBackend>),
     Local {
         tuple_store: TupleStore,
-        checker: PermissionChecker,
+        // Boxed to keep the enum's `Local` variant small: enabling the
+        // `clustering` feature unifies the dependency graph on libp2p's
+        // (larger) transitive crypto crates, which grows `PermissionChecker`
+        // enough to trip `clippy::large_enum_variant` on this two-variant enum
+        // (`SpiceDb` is already boxed for the same reason).
+        checker: Box<PermissionChecker>,
     },
 }
 
@@ -114,7 +119,7 @@ impl PermissionActor {
         Self {
             backend: PermissionActorBackend::Local {
                 tuple_store,
-                checker,
+                checker: Box::new(checker),
             },
         }
     }

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -175,6 +175,16 @@ pub async fn start_with_config(
     room_registry_gauge::spawn(room_registry_handle.clone(), stop_token.clone());
     let room_registry = room_registry_handle.actor_ref().clone();
 
+    // ADR-0017 Phase 2: conditionally start the owned libp2p swarm subsystem
+    // (node discovery only), gated behind `clustering.enabled` + the
+    // `clustering` build feature + the Postgres control plane. A no-op when
+    // disabled — the default single-replica path is byte-for-byte unchanged.
+    crate::clustering::start_if_enabled(
+        &server_config.clustering,
+        db_pool.global().driver(),
+        &stop_token,
+    )?;
+
     // Create HTTP state (shares db_pool via Arc)
     let blob_storage = crate::storage::build_blob_storage()
         .map_err(|e| anyhow::anyhow!("Failed to initialize blob storage: {}", e))?;

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -179,11 +179,8 @@ pub async fn start_with_config(
     // (node discovery only), gated behind `clustering.enabled` + the
     // `clustering` build feature + the Postgres control plane. A no-op when
     // disabled — the default single-replica path is byte-for-byte unchanged.
-    crate::clustering::start_if_enabled(
-        &server_config.clustering,
-        db_pool.global().driver(),
-        &stop_token,
-    )?;
+    crate::clustering::start_if_enabled(&server_config.clustering, db_pool.global(), &stop_token)
+        .await?;
 
     // Create HTTP state (shares db_pool via Arc)
     let blob_storage = crate::storage::build_blob_storage()

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -33,7 +33,9 @@ use base64::Engine;
 use libp2p::identity::ed25519;
 use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
+use waddle_server::clustering::allowlist::{AllowlistStore, PostgresAllowlistStore};
 use waddle_server::clustering::codec::RemoteStanza;
+use waddle_server::clustering::lease::{KeypairSlotLease, PostgresKeypairSlotLease};
 use waddle_server::clustering::relay::RelayHandle;
 use waddle_server::clustering::swarm;
 use waddle_server::clustering::NodeId;
@@ -80,16 +82,17 @@ async fn open_control_db(url: &str) -> Database {
 
 /// Reset the clustering control-plane tables and enroll every pool PeerId.
 async fn reset_and_enroll(db: &Database, pool: &EnrolledPool) {
+    // Provision the schema through the production `ensure_schema` path — an
+    // inline DDL copy here could silently diverge as the schema evolves.
+    PostgresKeypairSlotLease::new(db.clone())
+        .ensure_schema()
+        .await
+        .expect("lease schema");
+    PostgresAllowlistStore::new(db.clone())
+        .ensure_schema()
+        .await
+        .expect("allowlist schema");
     let conn = db.guard().await.expect("guard");
-    for ddl in [
-        "CREATE TABLE IF NOT EXISTS clustering_peer_allowlist (\
-             peer_id TEXT PRIMARY KEY, enrolled_at TIMESTAMPTZ NOT NULL DEFAULT now())",
-        "CREATE TABLE IF NOT EXISTS clustering_keypair_slots (\
-             slot_index INTEGER PRIMARY KEY, holder_node TEXT, holder_epoch TEXT, \
-             heartbeat TIMESTAMPTZ NOT NULL DEFAULT now(), expired BOOLEAN NOT NULL DEFAULT TRUE)",
-    ] {
-        conn.execute(ddl, ()).await.expect("ensure schema");
-    }
     conn.execute("DELETE FROM clustering_keypair_slots", ())
         .await
         .expect("clean slots");

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -10,15 +10,21 @@
 //!   wire (thread-preserving stanza echo);
 //! - integrity under concurrent large + small payloads (libp2p per-substream
 //!   flow control interleaves them; per-pair *sequencing* is Phase 4);
-//! - an ask whose receiver handler exceeds the sender's transport
-//!   `request_timeout` fails **sender-side** — the transport cap, not
-//!   `reply_timeout`, is the binding bound;
+//! - the receiver-applied ask budgets fail a slow handler with the typed
+//!   `ReplyTimeout` classification inside the reply budget, and — with those
+//!   budgets deliberately inflated past both the handler and the transport
+//!   cap, so the receiver cannot proactively reply in time — the sender's
+//!   libp2p `request_timeout` fails the ask with the typed `Transport`
+//!   classification at ≈ the cap, proving the transport cap is the binding
+//!   bound;
 //! - relay crash → supervised respawn + same-name re-registration, recovered
 //!   by the sender's stale-ref kademlia re-lookup;
 //! - revoked-peer-with-live-connection: containment within the allowlist
 //!   refresh interval, and recovery after re-enrollment;
-//! - node churn: a restarted node (fresh node_id + relay name) is
-//!   re-discovered via kademlia through the surviving mesh.
+//! - node churn: a sequential rolling restart of BOTH original bootstrap
+//!   peers (at most one node down at any instant) — each replacement (fresh
+//!   node_id + relay name) is re-discovered via kademlia, and both
+//!   replacements stay reachable once no original peer survives.
 //!
 //! Gated on the `clustering` feature and `WADDLE_TEST_POSTGRES_URL` (skips
 //! cleanly otherwise). Deferred to Phase 3 (needs heartbeat fencing + the
@@ -36,7 +42,7 @@ use tokio_util::sync::CancellationToken;
 use waddle_server::clustering::allowlist::{AllowlistStore, PostgresAllowlistStore};
 use waddle_server::clustering::codec::RemoteStanza;
 use waddle_server::clustering::lease::{KeypairSlotLease, PostgresKeypairSlotLease};
-use waddle_server::clustering::relay::RelayHandle;
+use waddle_server::clustering::relay::{RelayAskError, RelayHandle, RelaySendFailure};
 use waddle_server::clustering::swarm;
 use waddle_server::clustering::NodeId;
 use waddle_server::config::{ClusteringBootstrapConfig, ClusteringConfig, ClusteringLeaseConfig};
@@ -269,7 +275,7 @@ async fn cluster_exit_criteria_end_to_end() {
     // loopback seed per node.
     let port_a = free_tcp_port();
     let port_b = free_tcp_port();
-    let (server_a, node_a, peer_a) =
+    let (mut server_a, node_a, peer_a) =
         spawn_cluster_server(&postgres_url, &pool.pool_env, port_a, &[port_b]).await;
     let (server_b, node_b, _peer_b) =
         spawn_cluster_server(&postgres_url, &pool.pool_env, port_b, &[port_a]).await;
@@ -372,19 +378,80 @@ async fn cluster_exit_criteria_end_to_end() {
         result.expect("concurrent echo task");
     }
 
-    // --- Exit criterion: an ask whose receiver handler exceeds every
-    // configured timeout (reply 1.5s, transport cap 2s) fails SENDER-side
-    // within the budget — never by waiting out the 5s handler.
+    // --- Exit criterion (part 1): the receiver-applied ask budgets. A 5s
+    // handler exceeds relay_a's receiver-side reply budget (1.5s): the
+    // receiver's local ask times out first and sends a ReplyTimeout error
+    // frame back over the wire — the sender observes the typed ReplyTimeout
+    // classification within the reply budget, never by waiting out the
+    // handler. (With the validated config invariant mailbox + reply <=
+    // request, the receiver ALWAYS replies before the transport cap, so this
+    // path can never exercise `request_timeout` — that is part 2 below.)
     let started = Instant::now();
     let result = relay_a.sleep(5_000).await;
     let elapsed = started.elapsed();
+    let error = match result {
+        Ok(_) => panic!("5s receiver handler must fail the ask, but it succeeded"),
+        Err(error) => error,
+    };
     assert!(
-        result.is_err(),
-        "5s receiver handler must fail sender-side within the 2s transport cap"
+        matches!(
+            error,
+            RelayAskError::Send {
+                failure: RelaySendFailure::ReplyTimeout,
+                ..
+            }
+        ),
+        "expected the typed ReplyTimeout classification, got: {error}"
     );
     assert!(
         elapsed < Duration::from_secs(4),
-        "failure must occur within the ~2s timeout budget, not after the 5s handler (took {elapsed:?})"
+        "ReplyTimeout must fire within the ~1.5s reply budget, not after the 5s handler (took {elapsed:?})"
+    );
+
+    // --- Exit criterion (part 2): the transport cap is the binding bound.
+    // A dedicated handle grants the receiver ask budgets (10s mailbox/reply)
+    // above BOTH the 5s handler and the sender's 2s transport
+    // `request_timeout`, so the receiver cannot proactively reply — neither a
+    // ReplyTimeout frame (budget outlives the handler) nor the success reply
+    // (handler outlives the transport window) can arrive in time. The only
+    // bound that can fire is the sender-side libp2p request_response
+    // `request_timeout`, surfacing as the typed Transport classification at
+    // ≈ the cap. Production config validation forbids this inversion
+    // (mailbox + reply <= request), which is exactly why part 1 alone could
+    // never prove the transport cap; the per-ask builder lets the harness
+    // construct it deliberately. Aimed at B so A's relay is idle for the
+    // crash scenario next.
+    let mut relay_b_slow = RelayHandle::new(NodeId::new(node_b.clone()))
+        .with_ask_timeouts(Duration::from_secs(10), Duration::from_secs(10));
+    ping_until(&mut relay_b_slow, &node_b, Duration::from_secs(30))
+        .await
+        .expect("warm-up ping resolves B before timing the transport cap");
+    let started = Instant::now();
+    let result = relay_b_slow.sleep(5_000).await;
+    let elapsed = started.elapsed();
+    let error = match result {
+        Ok(_) => panic!(
+            "5s receiver handler must fail sender-side at the 2s transport cap, but it succeeded"
+        ),
+        Err(error) => error,
+    };
+    assert!(
+        matches!(
+            error,
+            RelayAskError::Send {
+                failure: RelaySendFailure::Transport,
+                ..
+            }
+        ),
+        "expected the typed Transport classification (sender-side request_timeout), got: {error}"
+    );
+    assert!(
+        elapsed >= Duration::from_millis(1_500),
+        "transport-cap failure fired suspiciously early — not the 2s request_timeout (took {elapsed:?})"
+    );
+    assert!(
+        elapsed < Duration::from_secs(4),
+        "transport-cap failure must fire at ~2s, not after the 5s handler (took {elapsed:?})"
     );
 
     // --- Exit criterion: relay crash → supervised respawn + same-name
@@ -429,11 +496,14 @@ async fn cluster_exit_criteria_end_to_end() {
         .await
         .expect("re-enrolled peer reachable again");
 
-    // --- Exit criterion: re-discovery after churn. Kill B and replace it
-    // with a fresh process on the SAME swarm port (exactly what a replacement
-    // pod behind the same headless Service looks like): new node_id, new
-    // relay name, new leased slot. The mesh's periodic re-dial reconnects and
-    // the newcomer's periodic re-registration makes its relay resolvable.
+    // --- Exit criterion: re-discovery through a rolling restart of BOTH
+    // bootstrap peers, sequential, at most one node down at any instant.
+    //
+    // Leg 1: hard-kill B (SIGKILL — an unclean pod death) and replace it with
+    // a fresh process on the SAME swarm port (exactly what a replacement pod
+    // behind the same headless Service looks like): new node_id, new relay
+    // name, new leased slot. The mesh's periodic re-dial reconnects and the
+    // newcomer's periodic re-registration makes its relay resolvable.
     drop(server_b);
     let (server_b2, node_b2, _peer_b2) =
         spawn_cluster_server(&postgres_url, &pool.pool_env, port_b, &[port_a]).await;
@@ -443,10 +513,35 @@ async fn cluster_exit_criteria_end_to_end() {
         .await
         .expect("restarted node re-discovered via kademlia");
 
+    // Leg 2: with B's replacement verified live, cycle A too — the graceful
+    // path this time (SIGTERM is what a real rolling restart sends), which
+    // drains: the keypair slot is released for the replacement and the relay
+    // proactively unregisters. After this NO original bootstrap peer
+    // survives, so the test process must reach both replacements via the
+    // periodic re-dial + kademlia re-discovery alone.
+    server_a.send_sigterm();
+    assert!(
+        server_a.wait_for_exit(Duration::from_secs(30)).await,
+        "node A did not exit after SIGTERM"
+    );
+    drop(server_a);
+    let (server_a2, node_a2, _peer_a2) =
+        spawn_cluster_server(&postgres_url, &pool.pool_env, port_a, &[port_b]).await;
+    assert_ne!(node_a2, node_a, "restarted node must mint a fresh node_id");
+    let mut relay_a2 = RelayHandle::new(NodeId::new(node_a2.clone()));
+    ping_until(&mut relay_a2, &node_a2, Duration::from_secs(45))
+        .await
+        .expect("A's replacement re-discovered via kademlia after the full rolling restart");
+    // Full cross-node discovery holds with zero original peers left: B's
+    // replacement must still answer alongside A's.
+    ping_until(&mut relay_b2, &node_b2, Duration::from_secs(30))
+        .await
+        .expect("B's replacement still reachable after the full rolling restart");
+
     // --- Shutdown.
     stop.cancel();
     drop(server_b2);
-    drop(server_a);
+    drop(server_a2);
 }
 
 /// DEFERRED (Phase 3): lone-survivor at N=2 keeps serving while a node

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -106,6 +106,15 @@ async fn reset_and_enroll(db: &Database, pool: &EnrolledPool) {
     }
 }
 
+/// Reserve an ephemeral TCP port by binding and immediately releasing it.
+///
+/// Inherently best-effort (bind/release TOCTOU): another process could grab
+/// the port before the spawned server binds it. The window is unavoidable
+/// here — the mesh needs pre-agreed ports (A's seed list names B's port and
+/// vice versa), so neither server can pick its own port at bind time. The
+/// kernel avoids immediately reissuing a just-released ephemeral port, and a
+/// lost race fails loudly (the server's swarm listen bind errors and the
+/// node-id file never appears) rather than corrupting the test.
 fn free_tcp_port() -> u16 {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
     let port = listener.local_addr().expect("local addr").port();
@@ -118,68 +127,83 @@ fn free_tcp_port() -> u16 {
 /// `bootstrap_ports` element (the harness expression of the headless
 /// Service resolving to every pod). Returns the server handle plus its
 /// published (node_id, peer_id).
-fn spawn_cluster_server(
+///
+/// `TestServer::start_with_extra_envs` and the node-id-file poll both block
+/// (process spawn + sleep polling), so the whole bring-up runs on the tokio
+/// blocking pool instead of stalling a worker thread.
+async fn spawn_cluster_server(
     postgres_url: &str,
     pool_env: &str,
     swarm_port: u16,
     bootstrap_ports: &[u16],
 ) -> (TestServer, String, String) {
-    let node_id_file = std::env::temp_dir().join(format!(
-        "waddle-clustering-e2e-node-{}",
-        uuid::Uuid::new_v4()
-    ));
-    let listen = format!("/ip4/127.0.0.1/tcp/{swarm_port}");
-    let node_id_file_str = node_id_file.display().to_string();
-    let bootstrap_peers = bootstrap_ports
-        .iter()
-        .map(|port| format!("localhost:{port}"))
-        .collect::<Vec<_>>()
-        .join(",");
+    let postgres_url = postgres_url.to_string();
+    let pool_env = pool_env.to_string();
+    let bootstrap_ports = bootstrap_ports.to_vec();
+    tokio::task::spawn_blocking(move || {
+        let node_id_file = std::env::temp_dir().join(format!(
+            "waddle-clustering-e2e-node-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let listen = format!("/ip4/127.0.0.1/tcp/{swarm_port}");
+        let node_id_file_str = node_id_file.display().to_string();
+        let bootstrap_peers = bootstrap_ports
+            .iter()
+            .map(|port| format!("localhost:{port}"))
+            .collect::<Vec<_>>()
+            .join(",");
 
-    let mut envs: Vec<(&str, &str)> = vec![
-        ("WADDLE_DB_DRIVER", "postgres"),
-        ("WADDLE_DATABASE_URL", postgres_url),
-        // NB: the fixed test account stays enabled (TestServer's default) —
-        // disabling it flips the permission backend onto the SpiceDB path and
-        // fails startup. Its seeding is delete-then-recreate, safe for the
-        // sequential startups this harness performs.
-        ("WADDLE_CLUSTERING_ENABLED", "true"),
-        ("WADDLE_CLUSTERING_LISTEN_ADDRS", &listen),
-        ("WADDLE_CLUSTERING_KEYPAIR_POOL", pool_env),
-        ("WADDLE_CLUSTERING_NODE_ID_FILE", &node_id_file_str),
-        ("WADDLE_CLUSTERING_FAULT_INJECTION", "true"),
-        // Tight intervals so revocation/re-dial assertions run fast.
-        ("WADDLE_CLUSTERING_ALLOWLIST_REFRESH_MS", "1000"),
-        ("WADDLE_CLUSTERING_DIAL_INTERVAL_MS", "1000"),
-        ("WADDLE_CLUSTERING_HEARTBEAT_INTERVAL_MS", "1000"),
-        ("WADDLE_CLUSTERING_LEASE_TTL_MS", "10000"),
-    ];
-    if !bootstrap_peers.is_empty() {
-        envs.push(("WADDLE_CLUSTERING_BOOTSTRAP_PEERS", &bootstrap_peers));
-    }
-
-    let server = TestServer::start_with_extra_envs(&[], &envs);
-
-    // The node-id file is written during clustering bring-up, which precedes
-    // HTTP readiness — but poll defensively anyway.
-    let deadline = Instant::now() + Duration::from_secs(30);
-    let contents = loop {
-        if let Ok(contents) = std::fs::read_to_string(&node_id_file) {
-            if contents.trim().split(' ').count() == 2 {
-                break contents;
-            }
+        let mut envs: Vec<(&str, &str)> = vec![
+            ("WADDLE_DB_DRIVER", "postgres"),
+            ("WADDLE_DATABASE_URL", &postgres_url),
+            // NB: the fixed test account stays enabled (TestServer's default) —
+            // disabling it flips the permission backend onto the SpiceDB path and
+            // fails startup. Its seeding is delete-then-recreate, safe for the
+            // sequential startups this harness performs.
+            ("WADDLE_CLUSTERING_ENABLED", "true"),
+            ("WADDLE_CLUSTERING_LISTEN_ADDRS", &listen),
+            ("WADDLE_CLUSTERING_KEYPAIR_POOL", &pool_env),
+            ("WADDLE_CLUSTERING_NODE_ID_FILE", &node_id_file_str),
+            ("WADDLE_CLUSTERING_FAULT_INJECTION", "true"),
+            // Tight intervals so revocation/re-dial assertions run fast.
+            ("WADDLE_CLUSTERING_ALLOWLIST_REFRESH_MS", "1000"),
+            ("WADDLE_CLUSTERING_DIAL_INTERVAL_MS", "1000"),
+            ("WADDLE_CLUSTERING_HEARTBEAT_INTERVAL_MS", "1000"),
+            ("WADDLE_CLUSTERING_LEASE_TTL_MS", "10000"),
+        ];
+        if !bootstrap_peers.is_empty() {
+            envs.push(("WADDLE_CLUSTERING_BOOTSTRAP_PEERS", &bootstrap_peers));
         }
-        assert!(
-            Instant::now() < deadline,
-            "server did not publish its node-id file"
-        );
-        std::thread::sleep(Duration::from_millis(100));
-    };
-    let mut parts = contents.trim().split(' ');
-    let node_id = parts.next().expect("node id").to_string();
-    let peer_id = parts.next().expect("peer id").to_string();
-    let _ = std::fs::remove_file(&node_id_file);
-    (server, node_id, peer_id)
+
+        let server = TestServer::start_with_extra_envs(&[], &envs);
+
+        // The node-id file is written during clustering bring-up, which
+        // precedes HTTP readiness — but poll defensively anyway.
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let contents = loop {
+            if let Ok(contents) = std::fs::read_to_string(&node_id_file) {
+                if contents.trim().split(' ').count() == 2 {
+                    break contents;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "server did not publish its node-id file"
+            );
+            std::thread::sleep(Duration::from_millis(100));
+        };
+        let mut parts = contents.trim().split(' ');
+        let node_id = parts.next().expect("node id").to_string();
+        let peer_id = parts.next().expect("peer id").to_string();
+        let _ = std::fs::remove_file(&node_id_file);
+        (server, node_id, peer_id)
+    })
+    .await
+    .unwrap_or_else(|join_error| match join_error.try_into_panic() {
+        // Re-raise the inner panic so assertion messages surface verbatim.
+        Ok(payload) => std::panic::resume_unwind(payload),
+        Err(join_error) => panic!("cluster server bring-up task failed: {join_error}"),
+    })
 }
 
 /// Ping a relay with retries until `deadline` (discovery through kademlia can
@@ -243,9 +267,9 @@ async fn cluster_exit_criteria_end_to_end() {
     let port_a = free_tcp_port();
     let port_b = free_tcp_port();
     let (server_a, node_a, peer_a) =
-        spawn_cluster_server(&postgres_url, &pool.pool_env, port_a, &[port_b]);
+        spawn_cluster_server(&postgres_url, &pool.pool_env, port_a, &[port_b]).await;
     let (server_b, node_b, _peer_b) =
-        spawn_cluster_server(&postgres_url, &pool.pool_env, port_b, &[port_a]);
+        spawn_cluster_server(&postgres_url, &pool.pool_env, port_b, &[port_a]).await;
 
     // --- The test process joins as node C.
     let stop = CancellationToken::new();
@@ -406,7 +430,7 @@ async fn cluster_exit_criteria_end_to_end() {
     // the newcomer's periodic re-registration makes its relay resolvable.
     drop(server_b);
     let (server_b2, node_b2, _peer_b2) =
-        spawn_cluster_server(&postgres_url, &pool.pool_env, port_b, &[port_a]);
+        spawn_cluster_server(&postgres_url, &pool.pool_env, port_b, &[port_a]).await;
     assert_ne!(node_b2, node_b, "restarted node must mint a fresh node_id");
     let mut relay_b2 = RelayHandle::new(NodeId::new(node_b2.clone()));
     ping_until(&mut relay_b2, &node_b2, Duration::from_secs(45))

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -293,11 +293,14 @@ async fn cluster_exit_criteria_end_to_end() {
         },
         allowlist_refresh_interval: Duration::from_secs(1),
         dial_interval: Duration::from_secs(1),
-        // The binding transport cap for the timeout criterion below.
+        // The binding transport cap for the timeout criterion below. This
+        // literal bypasses env parsing, so it must uphold the same element-5
+        // invariant the parser enforces: mailbox + reply <= request
+        // (0.5s + 1.5s <= 2s).
         messaging: waddle_server::config::ClusteringMessagingConfig {
             request_timeout: Duration::from_secs(2),
-            reply_timeout: Duration::from_secs(2),
-            mailbox_timeout: Duration::from_secs(1),
+            reply_timeout: Duration::from_millis(1_500),
+            mailbox_timeout: Duration::from_millis(500),
             ..waddle_server::config::ClusteringMessagingConfig::default()
         },
         fault_injection: false,
@@ -366,19 +369,19 @@ async fn cluster_exit_criteria_end_to_end() {
         result.expect("concurrent echo task");
     }
 
-    // --- Exit criterion: an ask whose receiver handler exceeds the sender's
-    // transport request_timeout (2s here) fails SENDER-side — the transport
-    // cap, not reply_timeout, is the binding bound.
+    // --- Exit criterion: an ask whose receiver handler exceeds every
+    // configured timeout (reply 1.5s, transport cap 2s) fails SENDER-side
+    // within the budget — never by waiting out the 5s handler.
     let started = Instant::now();
     let result = relay_a.sleep(5_000).await;
     let elapsed = started.elapsed();
     assert!(
         result.is_err(),
-        "5s receiver handler must fail a 2s request_timeout sender-side"
+        "5s receiver handler must fail sender-side within the 2s transport cap"
     );
     assert!(
         elapsed < Duration::from_secs(4),
-        "failure must occur at the ~2s transport cap, not after the 5s handler (took {elapsed:?})"
+        "failure must occur within the ~2s timeout budget, not after the 5s handler (took {elapsed:?})"
     );
 
     // --- Exit criterion: relay crash → supervised respawn + same-name

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -36,6 +36,7 @@ use tokio_util::sync::CancellationToken;
 use waddle_server::clustering::codec::RemoteStanza;
 use waddle_server::clustering::relay::RelayHandle;
 use waddle_server::clustering::swarm;
+use waddle_server::clustering::NodeId;
 use waddle_server::config::{ClusteringBootstrapConfig, ClusteringConfig, ClusteringLeaseConfig};
 use waddle_server::db::{Database, DatabaseConfig, DatabaseDriver};
 use waddle_ws_test_support::TestServer;
@@ -192,7 +193,7 @@ async fn ping_until(
     let mut last_error = String::new();
     while Instant::now() < until {
         match handle.ping().await {
-            Ok(pong) if pong.node_id == expected_node => return Ok(()),
+            Ok(pong) if pong.node_id.as_str() == expected_node => return Ok(()),
             Ok(pong) => return Err(format!("wrong node answered: {}", pong.node_id)),
             Err(error) => last_error = error.to_string(),
         }
@@ -281,16 +282,21 @@ async fn cluster_exit_criteria_end_to_end() {
     let handle = swarm::spawn(&config, &db, stop.clone())
         .await
         .expect("test-process swarm joins the mesh");
-    assert!(!handle.node_id.is_empty());
+    assert!(!handle.node_id.as_str().is_empty());
 
     // --- Exit criterion: cross-node ask round-trip (real network, two other
     // processes), including discovery of B through the mesh (the test only
     // bootstraps toward A).
-    let mut relay_a = RelayHandle::new(node_a.clone());
+    // Exercise the configured receiver-side ask timeouts (ADR element 5)
+    // through the handle's wiring, not just config validation.
+    let mut relay_a = RelayHandle::new(NodeId::new(node_a.clone())).with_ask_timeouts(
+        config.messaging.mailbox_timeout,
+        config.messaging.reply_timeout,
+    );
     ping_until(&mut relay_a, &node_a, Duration::from_secs(30))
         .await
         .expect("cross-node ping to A");
-    let mut relay_b = RelayHandle::new(node_b.clone());
+    let mut relay_b = RelayHandle::new(NodeId::new(node_b.clone()));
     ping_until(&mut relay_b, &node_b, Duration::from_secs(30))
         .await
         .expect("cross-node ping to B");
@@ -317,7 +323,7 @@ async fn cluster_exit_criteria_end_to_end() {
         let size = if index % 2 == 0 { 100 * 1024 } else { 16 };
         let thread_id = format!("mix-{index}");
         join_set.spawn(async move {
-            let mut relay = RelayHandle::new(node);
+            let mut relay = RelayHandle::new(NodeId::new(node));
             let reply = relay
                 .echo_stanza(thread_message(&thread_id, size))
                 .await
@@ -402,7 +408,7 @@ async fn cluster_exit_criteria_end_to_end() {
     let (server_b2, node_b2, _peer_b2) =
         spawn_cluster_server(&postgres_url, &pool.pool_env, port_b, &[port_a]);
     assert_ne!(node_b2, node_b, "restarted node must mint a fresh node_id");
-    let mut relay_b2 = RelayHandle::new(node_b2.clone());
+    let mut relay_b2 = RelayHandle::new(NodeId::new(node_b2.clone()));
     ping_until(&mut relay_b2, &node_b2, Duration::from_secs(45))
         .await
         .expect("restarted node re-discovered via kademlia");

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -1,0 +1,436 @@
+//! ADR-0017 Phase 2 Slice 6 — multi-process cluster harness.
+//!
+//! kameo's `init_global` is a process singleton, so multi-node behaviour is
+//! only testable across processes: this harness spawns two real
+//! `waddle-server` processes (clustering enabled, shared Postgres control
+//! plane) and joins the swarm from the test process as a third node, then
+//! asserts the Phase 2 spike exit criteria over the real network:
+//!
+//! - cross-node relay ask round-trip (ping) and the bounded XML codec on the
+//!   wire (thread-preserving stanza echo);
+//! - integrity under concurrent large + small payloads (libp2p per-substream
+//!   flow control interleaves them; per-pair *sequencing* is Phase 4);
+//! - an ask whose receiver handler exceeds the sender's transport
+//!   `request_timeout` fails **sender-side** — the transport cap, not
+//!   `reply_timeout`, is the binding bound;
+//! - relay crash → supervised respawn + same-name re-registration, recovered
+//!   by the sender's stale-ref kademlia re-lookup;
+//! - revoked-peer-with-live-connection: containment within the allowlist
+//!   refresh interval, and recovery after re-enrollment;
+//! - node churn: a restarted node (fresh node_id + relay name) is
+//!   re-discovered via kademlia through the surviving mesh.
+//!
+//! Gated on the `clustering` feature and `WADDLE_TEST_POSTGRES_URL` (skips
+//! cleanly otherwise). Deferred to Phase 3 (needs heartbeat fencing + the
+//! durable queue): lone-survivor at N=2 keeps serving; a single dead link of
+//! three degrades to the durable fallback without fencing either endpoint.
+//! Deferred as a manual go/no-go measurement (dominated by kademlia's
+//! hardcoded 1h record TTL): the dead publisher's record-visibility window.
+
+#![cfg(feature = "clustering")]
+
+use base64::Engine;
+use libp2p::identity::ed25519;
+use std::time::{Duration, Instant};
+use tokio_util::sync::CancellationToken;
+use waddle_server::clustering::codec::RemoteStanza;
+use waddle_server::clustering::relay::RelayHandle;
+use waddle_server::clustering::swarm;
+use waddle_server::config::{ClusteringBootstrapConfig, ClusteringConfig, ClusteringLeaseConfig};
+use waddle_server::db::{Database, DatabaseConfig, DatabaseDriver};
+use waddle_ws_test_support::TestServer;
+
+const POOL_SIZE: usize = 4;
+
+struct EnrolledPool {
+    /// base64-encoded 32-byte ed25519 seeds (the WADDLE_CLUSTERING_KEYPAIR_POOL value).
+    pool_env: String,
+    /// PeerIds derived from every pool slot (all enrolled).
+    peer_ids: Vec<libp2p::PeerId>,
+}
+
+fn generate_pool() -> EnrolledPool {
+    let mut seeds = Vec::new();
+    let mut peer_ids = Vec::new();
+    for _ in 0..POOL_SIZE {
+        let keypair = ed25519::Keypair::generate();
+        let seed = keypair.secret().as_ref().to_vec();
+        peer_ids.push(
+            libp2p::identity::Keypair::from(keypair)
+                .public()
+                .to_peer_id(),
+        );
+        seeds.push(base64::engine::general_purpose::STANDARD.encode(seed));
+    }
+    EnrolledPool {
+        pool_env: seeds.join(","),
+        peer_ids,
+    }
+}
+
+async fn open_control_db(url: &str) -> Database {
+    Database::from_config(
+        "clustering-e2e-harness",
+        &DatabaseConfig::new(DatabaseDriver::Postgres, url.to_string()),
+    )
+    .await
+    .expect("open harness postgres")
+}
+
+/// Reset the clustering control-plane tables and enroll every pool PeerId.
+async fn reset_and_enroll(db: &Database, pool: &EnrolledPool) {
+    let conn = db.guard().await.expect("guard");
+    for ddl in [
+        "CREATE TABLE IF NOT EXISTS clustering_peer_allowlist (\
+             peer_id TEXT PRIMARY KEY, enrolled_at TIMESTAMPTZ NOT NULL DEFAULT now())",
+        "CREATE TABLE IF NOT EXISTS clustering_keypair_slots (\
+             slot_index INTEGER PRIMARY KEY, holder_node TEXT, holder_epoch TEXT, \
+             heartbeat TIMESTAMPTZ NOT NULL DEFAULT now(), expired BOOLEAN NOT NULL DEFAULT TRUE)",
+    ] {
+        conn.execute(ddl, ()).await.expect("ensure schema");
+    }
+    conn.execute("DELETE FROM clustering_keypair_slots", ())
+        .await
+        .expect("clean slots");
+    conn.execute("DELETE FROM clustering_peer_allowlist", ())
+        .await
+        .expect("clean allowlist");
+    for peer in &pool.peer_ids {
+        conn.execute(
+            "INSERT INTO clustering_peer_allowlist (peer_id) VALUES (?)",
+            waddle_server::db_params![peer.to_string()],
+        )
+        .await
+        .expect("enroll peer");
+    }
+}
+
+fn free_tcp_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    port
+}
+
+/// Spawn a clustering-enabled waddle-server on a fixed swarm port, wired to
+/// the shared Postgres and seeded with one loopback bootstrap entry per
+/// `bootstrap_ports` element (the harness expression of the headless
+/// Service resolving to every pod). Returns the server handle plus its
+/// published (node_id, peer_id).
+fn spawn_cluster_server(
+    postgres_url: &str,
+    pool_env: &str,
+    swarm_port: u16,
+    bootstrap_ports: &[u16],
+) -> (TestServer, String, String) {
+    let node_id_file = std::env::temp_dir().join(format!(
+        "waddle-clustering-e2e-node-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let listen = format!("/ip4/127.0.0.1/tcp/{swarm_port}");
+    let node_id_file_str = node_id_file.display().to_string();
+    let bootstrap_peers = bootstrap_ports
+        .iter()
+        .map(|port| format!("localhost:{port}"))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let mut envs: Vec<(&str, &str)> = vec![
+        ("WADDLE_DB_DRIVER", "postgres"),
+        ("WADDLE_DATABASE_URL", postgres_url),
+        // NB: the fixed test account stays enabled (TestServer's default) —
+        // disabling it flips the permission backend onto the SpiceDB path and
+        // fails startup. Its seeding is delete-then-recreate, safe for the
+        // sequential startups this harness performs.
+        ("WADDLE_CLUSTERING_ENABLED", "true"),
+        ("WADDLE_CLUSTERING_LISTEN_ADDRS", &listen),
+        ("WADDLE_CLUSTERING_KEYPAIR_POOL", pool_env),
+        ("WADDLE_CLUSTERING_NODE_ID_FILE", &node_id_file_str),
+        ("WADDLE_CLUSTERING_FAULT_INJECTION", "true"),
+        // Tight intervals so revocation/re-dial assertions run fast.
+        ("WADDLE_CLUSTERING_ALLOWLIST_REFRESH_MS", "1000"),
+        ("WADDLE_CLUSTERING_DIAL_INTERVAL_MS", "1000"),
+        ("WADDLE_CLUSTERING_HEARTBEAT_INTERVAL_MS", "1000"),
+        ("WADDLE_CLUSTERING_LEASE_TTL_MS", "10000"),
+    ];
+    if !bootstrap_peers.is_empty() {
+        envs.push(("WADDLE_CLUSTERING_BOOTSTRAP_PEERS", &bootstrap_peers));
+    }
+
+    let server = TestServer::start_with_extra_envs(&[], &envs);
+
+    // The node-id file is written during clustering bring-up, which precedes
+    // HTTP readiness — but poll defensively anyway.
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let contents = loop {
+        if let Ok(contents) = std::fs::read_to_string(&node_id_file) {
+            if contents.trim().split(' ').count() == 2 {
+                break contents;
+            }
+        }
+        assert!(
+            Instant::now() < deadline,
+            "server did not publish its node-id file"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    };
+    let mut parts = contents.trim().split(' ');
+    let node_id = parts.next().expect("node id").to_string();
+    let peer_id = parts.next().expect("peer id").to_string();
+    let _ = std::fs::remove_file(&node_id_file);
+    (server, node_id, peer_id)
+}
+
+/// Ping a relay with retries until `deadline` (discovery through kademlia can
+/// take a few dial/refresh rounds).
+async fn ping_until(
+    handle: &mut RelayHandle,
+    expected_node: &str,
+    deadline: Duration,
+) -> Result<(), String> {
+    let until = Instant::now() + deadline;
+    let mut last_error = String::new();
+    while Instant::now() < until {
+        match handle.ping().await {
+            Ok(pong) if pong.node_id == expected_node => return Ok(()),
+            Ok(pong) => return Err(format!("wrong node answered: {}", pong.node_id)),
+            Err(error) => last_error = error.to_string(),
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    Err(format!("relay ping never succeeded: {last_error}"))
+}
+
+fn thread_message(id: &str, body_size: usize) -> RemoteStanza {
+    let mut message = xmpp_parsers::message::Message::new(None::<jid::Jid>);
+    message.thread = Some(xmpp_parsers::message::Thread {
+        id: id.to_string(),
+        parent: None,
+    });
+    message
+        .bodies
+        .insert(xmpp_parsers::message::Lang::new(), "x".repeat(body_size));
+    RemoteStanza(waddle_xmpp::Stanza::Message(message))
+}
+
+/// The whole Phase 2 exit-criteria suite runs as ONE test: the test process
+/// hosts a single swarm (kameo `init_global` is a process singleton), and the
+/// scenario steps build on each other.
+#[tokio::test(flavor = "multi_thread")]
+async fn cluster_exit_criteria_end_to_end() {
+    let Ok(postgres_url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
+        eprintln!("skipping: WADDLE_TEST_POSTGRES_URL not set");
+        return;
+    };
+
+    // Surface the test-process swarm's own tracing (lookups, connections,
+    // relay registration) when debugging with --nocapture.
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("waddle_server::clustering=debug,libp2p_kad=debug")
+        .with_test_writer()
+        .try_init();
+
+    let pool = generate_pool();
+    let db = open_control_db(&postgres_url).await;
+    reset_and_enroll(&db, &pool).await;
+
+    // --- Bring up the mesh: A (seed), B (bootstraps to A). Sequential so
+    // concurrent first-boot migrations cannot race on the shared database.
+    // Production shape: the headless Service resolves to every pod, so every
+    // node dials every peer directly. The harness expresses that as one
+    // loopback seed per node.
+    let port_a = free_tcp_port();
+    let port_b = free_tcp_port();
+    let (server_a, node_a, peer_a) =
+        spawn_cluster_server(&postgres_url, &pool.pool_env, port_a, &[port_b]);
+    let (server_b, node_b, _peer_b) =
+        spawn_cluster_server(&postgres_url, &pool.pool_env, port_b, &[port_a]);
+
+    // --- The test process joins as node C.
+    let stop = CancellationToken::new();
+    let config = ClusteringConfig {
+        enabled: true,
+        listen_addrs: vec!["/ip4/127.0.0.1/tcp/0".to_string()],
+        bootstrap_peers: vec![
+            ClusteringBootstrapConfig {
+                dns_name: "localhost".to_string(),
+                port: port_a,
+            },
+            ClusteringBootstrapConfig {
+                dns_name: "localhost".to_string(),
+                port: port_b,
+            },
+        ],
+        keypair_pool: pool.pool_env.split(',').map(str::to_string).collect(),
+        lease: ClusteringLeaseConfig {
+            heartbeat_interval: Duration::from_secs(1),
+            lease_ttl: Duration::from_secs(10),
+        },
+        allowlist_refresh_interval: Duration::from_secs(1),
+        dial_interval: Duration::from_secs(1),
+        // The binding transport cap for the timeout criterion below.
+        messaging: waddle_server::config::ClusteringMessagingConfig {
+            request_timeout: Duration::from_secs(2),
+            reply_timeout: Duration::from_secs(2),
+            mailbox_timeout: Duration::from_secs(1),
+            ..waddle_server::config::ClusteringMessagingConfig::default()
+        },
+        fault_injection: false,
+        node_id_file: None,
+    };
+    let handle = swarm::spawn(&config, &db, stop.clone())
+        .await
+        .expect("test-process swarm joins the mesh");
+    assert!(!handle.node_id.is_empty());
+
+    // --- Exit criterion: cross-node ask round-trip (real network, two other
+    // processes), including discovery of B through the mesh (the test only
+    // bootstraps toward A).
+    let mut relay_a = RelayHandle::new(node_a.clone());
+    ping_until(&mut relay_a, &node_a, Duration::from_secs(30))
+        .await
+        .expect("cross-node ping to A");
+    let mut relay_b = RelayHandle::new(node_b.clone());
+    ping_until(&mut relay_b, &node_b, Duration::from_secs(30))
+        .await
+        .expect("cross-node ping to B");
+
+    // --- Exit criterion: the bounded XML codec on the wire — a
+    // thread-carrying stanza survives the round-trip to another process.
+    let echoed = relay_a
+        .echo_stanza(thread_message("e2e-thread", 64))
+        .await
+        .expect("cross-node stanza echo");
+    match echoed.stanza.0 {
+        waddle_xmpp::Stanza::Message(message) => {
+            assert_eq!(message.thread.expect("thread survives").id, "e2e-thread");
+        }
+        other => panic!("expected message, got {}", other.name()),
+    }
+
+    // --- Exit criterion: integrity under concurrent large + small payloads.
+    // (Per-(origin→recipient) sequencing is Phase 4; Phase 2 asserts that
+    // interleaved large/small asks each come back intact.)
+    let mut join_set = tokio::task::JoinSet::new();
+    for index in 0..8u32 {
+        let node = node_a.clone();
+        let size = if index % 2 == 0 { 100 * 1024 } else { 16 };
+        let thread_id = format!("mix-{index}");
+        join_set.spawn(async move {
+            let mut relay = RelayHandle::new(node);
+            let reply = relay
+                .echo_stanza(thread_message(&thread_id, size))
+                .await
+                .expect("concurrent echo");
+            match reply.stanza.0 {
+                waddle_xmpp::Stanza::Message(message) => {
+                    assert_eq!(message.thread.expect("thread").id, thread_id);
+                    let body_len = message.bodies.values().next().map(String::len).unwrap_or(0);
+                    assert_eq!(body_len, size);
+                }
+                other => panic!("expected message, got {}", other.name()),
+            }
+        });
+    }
+    while let Some(result) = join_set.join_next().await {
+        result.expect("concurrent echo task");
+    }
+
+    // --- Exit criterion: an ask whose receiver handler exceeds the sender's
+    // transport request_timeout (2s here) fails SENDER-side — the transport
+    // cap, not reply_timeout, is the binding bound.
+    let started = Instant::now();
+    let result = relay_a.sleep(5_000).await;
+    let elapsed = started.elapsed();
+    assert!(
+        result.is_err(),
+        "5s receiver handler must fail a 2s request_timeout sender-side"
+    );
+    assert!(
+        elapsed < Duration::from_secs(4),
+        "failure must occur at the ~2s transport cap, not after the 5s handler (took {elapsed:?})"
+    );
+
+    // --- Exit criterion: relay crash → supervised respawn + same-name
+    // re-registration; the sender's cached ref goes stale (new ActorId) and
+    // recovers via the bounded-backoff kademlia re-lookup.
+    relay_a.crash().await.expect("crash request goes out");
+    ping_until(&mut relay_a, &node_a, Duration::from_secs(30))
+        .await
+        .expect("relay respawned, re-registered under the same name, and re-resolved");
+
+    // --- Exit criterion: revoked-peer-with-live-connection. Revoke A
+    // cluster-wide (delete its allowlist row, using the peer id A published
+    // in its node-id file): every node's refresh closes live connections to A
+    // within ~1 refresh interval, and re-dials are denied. Observed from the
+    // test process: pings to A start failing.
+    let conn = db.guard().await.expect("guard");
+    conn.execute(
+        "DELETE FROM clustering_peer_allowlist WHERE peer_id = ?",
+        waddle_server::db_params![peer_a.clone()],
+    )
+    .await
+    .expect("revoke A");
+    let revoked_deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        if relay_a.ping().await.is_err() {
+            break; // revocation landed: A unreachable from the test node
+        }
+        assert!(
+            Instant::now() < revoked_deadline,
+            "revoked peer A still reachable after the containment window"
+        );
+    }
+    // Re-enroll A: connectivity must recover via the periodic re-dial.
+    conn.execute(
+        "INSERT INTO clustering_peer_allowlist (peer_id) VALUES (?)",
+        waddle_server::db_params![peer_a.clone()],
+    )
+    .await
+    .expect("re-enroll A");
+    ping_until(&mut relay_a, &node_a, Duration::from_secs(30))
+        .await
+        .expect("re-enrolled peer reachable again");
+
+    // --- Exit criterion: re-discovery after churn. Kill B and replace it
+    // with a fresh process on the SAME swarm port (exactly what a replacement
+    // pod behind the same headless Service looks like): new node_id, new
+    // relay name, new leased slot. The mesh's periodic re-dial reconnects and
+    // the newcomer's periodic re-registration makes its relay resolvable.
+    drop(server_b);
+    let (server_b2, node_b2, _peer_b2) =
+        spawn_cluster_server(&postgres_url, &pool.pool_env, port_b, &[port_a]);
+    assert_ne!(node_b2, node_b, "restarted node must mint a fresh node_id");
+    let mut relay_b2 = RelayHandle::new(node_b2.clone());
+    ping_until(&mut relay_b2, &node_b2, Duration::from_secs(45))
+        .await
+        .expect("restarted node re-discovered via kademlia");
+
+    // --- Shutdown.
+    stop.cancel();
+    drop(server_b2);
+    drop(server_a);
+}
+
+/// DEFERRED (Phase 3): lone-survivor at N=2 keeps serving while a node
+/// isolated from all live swarm peers (Postgres reachable) fences — requires
+/// the `nodes` heartbeat fencing that lands with the ownership control plane.
+#[tokio::test]
+#[ignore = "Phase 3: requires nodes-table heartbeat fencing"]
+async fn lone_survivor_and_isolation_fencing() {}
+
+/// DEFERRED (Phase 3): a single dead link between two of three nodes degrades
+/// routing to the durable fallback without fencing either endpoint — requires
+/// the durable `pending_delivery` cross-node fallback.
+#[tokio::test]
+#[ignore = "Phase 3: requires the durable-queue fallback"]
+async fn partial_partition_degrades_without_fencing() {}
+
+/// DEFERRED (manual go/no-go measurement): the visibility window of a
+/// hard-killed publisher's kademlia provider+metadata records is dominated by
+/// kameo's hardcoded 1h record TTL / 30min republish — measure against the
+/// acceptance threshold out-of-band; graceful stops proactively unregister.
+#[tokio::test]
+#[ignore = "manual measurement: dominated by kademlia's hardcoded 1h record TTL"]
+async fn dead_publisher_record_visibility_window() {}

--- a/server/docs/adrs/0017-phase2-plan-libp2p-swarm.md
+++ b/server/docs/adrs/0017-phase2-plan-libp2p-swarm.md
@@ -2,7 +2,24 @@
 
 Companion execution note to [ADR-0017](./0017-horizontal-scaling-remote-actors.md)
 and the [Phase 1 completion note](./0017-phase1-completion-authoritative-registration.md).
-Status: **Phase 2 in progress.** Tracking: issue #1195.
+Status: **Phase 2 implemented — Slices 0–6 landed** (each council-reviewed;
+review findings folded in as fix commits). Tracking: issue #1195.
+
+Implementation notes vs. this plan:
+- The subsystem lives in `crates/waddle-server/src/clustering/` (config,
+  swarm, lease, allowlist, codec, relay, dns, identity, metrics).
+- The keypair-slot lease + peer-allowlist tables are self-initializing
+  Postgres-only schema (never in the migration stream, so they stay out of
+  non-clustering deployments). The dedicated control-plane pool remains a
+  Phase 3 deliverable as planned.
+- The relay supervisor additionally re-registers its name every 15s: a
+  registration performed before the node's first peer connection stores its
+  provider record only locally, and kademlia's own republish is 30 minutes
+  out — periodic same-name refresh bounds a (re)started node's
+  undiscoverability window (found by the Slice 6 churn harness case).
+- No dedicated CI check was added: `nixTest` runs the workspace with
+  `--all-features` against the Nix-spawned Postgres, which compiles and runs
+  the clustering unit tests and the multi-process harness already.
 
 ## Objective (this phase)
 

--- a/server/docs/adrs/0017-phase2-plan-libp2p-swarm.md
+++ b/server/docs/adrs/0017-phase2-plan-libp2p-swarm.md
@@ -123,7 +123,13 @@ behaviour is unchanged and asserted by the unchanged e2e suite.
   (committed `expired` flag); Release on drain — all on Postgres `now()`),
   behind a `KeypairSlotLease` trait. Startup leases one slot from the configured
   keypair pool and selects that keypair; a heartbeat janitor renews; drain
-  releases. `rows_affected==0` on renewal ⇒ fencing loss ⇒ refuse to serve.
+  releases. `rows_affected==0` on renewal ⇒ fencing loss ⇒ self-fence the
+  clustering subsystem. Additionally, if a full `lease_ttl` elapses without a
+  single successful renewal (e.g. persistent database errors keep every
+  heartbeat from landing), the node defensively self-fences the same way — it
+  can no longer prove it still holds the slot. Self-fencing cancels a
+  clustering-scoped child token, tearing down only the clustering subsystem
+  (swarm, relay, janitors) — never the whole server.
   Duplicate-PeerId rejection at the swarm behaviour layer (reject a second live
   session for an already-connected PeerId) as defence in depth. Runs on the
   shared global pool in Phase 2; the **dedicated small control-plane
@@ -134,12 +140,19 @@ behaviour is unchanged and asserted by the unchanged e2e suite.
 - **Slice 3 — peer allowlist enforcement + live-connection revocation.**
   `peer_allowlist` table (enrolled PeerIds); runtime role `SELECT`-only
   (grants documented here, enforced by the Phase 4 chart). `AllowlistStore`
-  trait + impl. Swarm-layer enforcement: reject non-allowlisted peers at
-  connection establishment (Noise handshake necessary, never sufficient); every
-  inbound remote message re-checks the origin is *currently* allowlisted.
-  Periodic refresh janitor diffs the enrolled set and **actively
-  closes/bans live connections** whose PeerId is no longer enrolled. Containment
-  bound asserted: revoked peer disconnected within one refresh interval.
+  trait + impl. Swarm-layer enforcement is **connection-level**: reject
+  non-allowlisted peers at connection establishment (Noise handshake
+  necessary, never sufficient), and a periodic refresh janitor diffs the
+  enrolled set and **actively closes/bans live connections** whose PeerId is
+  no longer enrolled — so a revoked peer loses its live connections within one
+  refresh interval and cannot re-dial. Containment bound asserted: revoked
+  peer disconnected within one refresh interval. **Deferred:** per-message
+  origin re-validation — kameo's remote ask/tell handlers are not handed the
+  transport-level sender PeerId, so re-checking the allowlist per inbound
+  message requires sender identity surfaced to handlers; it lands with Phase
+  4's cross-node routing (alongside the claim-epoch checks). Until then the
+  enforcement guarantee is exactly: denial at connection establishment, plus
+  revocation of already-connected peers within one refresh interval.
   Postgres-gated tests + the harness revoked-peer-with-live-connection case.
 
 - **Slice 4 — remote codec (XML-text serde wrappers).**
@@ -171,17 +184,32 @@ behaviour is unchanged and asserted by the unchanged e2e suite.
   panic + recover, revoked-peer-with-live-connection. Assert the Phase 2 spike
   exit criteria:
   - cross-node `UserActor`/relay ask round-trip;
-  - **ordering under concurrent large + small stanzas** (libp2p per-substream
-    flow control reorders naive-parallel requests);
-  - **an ask whose receiver handler exceeds `request_timeout` fails sender-side
-    with `OutboundFailure(Timeout)`** — proving the transport cap, not
-    `reply_timeout`, is the binding bound;
-  - kademlia re-discovery after all bootstrap peers churn in a rolling restart;
+  - **integrity under concurrent large + small stanzas** (libp2p per-substream
+    flow control interleaves naive-parallel requests; every interleaved ask
+    comes back intact — per-pair *sequencing* is Phase 4);
+  - **the timeout hierarchy, both halves.** (1) Receiver-applied ask budgets:
+    a handler that outlives `reply_timeout` fails with the typed
+    `ReplyTimeout` classification inside the reply budget. Note that with the
+    validated invariant `mailbox + reply <= request` the receiver *always*
+    replies (success or `ReplyTimeout`) before the transport cap, so this case
+    alone can never exercise `request_timeout`. (2) The transport cap as the
+    binding bound: a dedicated ask deliberately inflates the receiver budgets
+    past both the handler and the cap — the receiver then cannot proactively
+    reply in time, and the sender's libp2p `request_timeout` fails the ask
+    with the typed `Transport` classification (kameo `NetworkTimeout`) at
+    ≈ the cap, proving the `request_timeout` wiring is live;
+  - kademlia re-discovery through a sequential rolling restart of **both**
+    bootstrap peers (at most one node down at any instant; one leg hard-kill,
+    one leg graceful drain): each replacement — fresh node_id, relay name, and
+    leased slot on the same swarm port — is re-discovered, and both
+    replacements are reachable once no original peer survives;
   - **measured visibility window of a dead publisher's provider+metadata
     records** against an explicit acceptance threshold (go/no-go: the window is
     dominated by the hardcoded 1h TTL / 30min republish and cannot be tuned;
     graceful stops proactively unregister so the bound applies to hard-killed
-    nodes);
+    nodes) — carried as an ignored scaffold in the harness and performed as a
+    manual out-of-band measurement, since the window is set by kademlia
+    constants, not by anything the suite could regress;
   - relay respawn re-registration + peer re-resolution after `ActorNotRunning`;
   - revoked-peer disconnect within one allowlist refresh interval.
   **Deferred to Phase 3** (pending scaffolds): lone-survivor at N=2 keeps

--- a/server/docs/adrs/0017-phase2-plan-libp2p-swarm.md
+++ b/server/docs/adrs/0017-phase2-plan-libp2p-swarm.md
@@ -1,0 +1,193 @@
+# ADR-0017 Phase 2 Plan — Owned libp2p Swarm (Discovery-Only, Flag-Gated)
+
+Companion execution note to [ADR-0017](./0017-horizontal-scaling-remote-actors.md)
+and the [Phase 1 completion note](./0017-phase1-completion-authoritative-registration.md).
+Status: **Phase 2 in progress.** Tracking: issue #1195.
+
+## Objective (this phase)
+
+Stand up the inter-node **transport subsystem** — kameo remote actors as the
+transport, over an **owned libp2p swarm** — gated behind a `clustering` flag.
+This phase is **node discovery only**: kademlia is demoted to peer discovery,
+there is **no cross-node stanza routing** (that is Phase 4). The peer allowlist
+is enforced. `replicaCount > 1` and `clustering.enabled` stay **hard-locked in
+the Helm chart until Phase 4** — Phase 2 is exercised exclusively by the
+multi-process test harness against a shared Postgres.
+
+**Prime directive — strictly additive, flag-gated.** With clustering disabled
+(the default) the server's behaviour is **byte-for-byte identical to today's
+single-replica path**. The hot delivery path is not touched in this phase.
+
+## Gating decisions (default; open to change)
+
+1. **Build gate: a `clustering` Cargo feature (default OFF).** The feature
+   enables `kameo/remote` (which pulls libp2p 0.56) and compiles the
+   `swarm`/`codec`/`relay` modules. The default production build links **zero
+   libp2p** and is unchanged. CI still lints the code — clippy runs
+   `--workspace --all-features --all-targets -D warnings` — and a dedicated
+   feature-enabled Postgres check runs the clustering tests. Rationale: libp2p
+   is a heavy dependency the team deliberately kept out of the lockfile; making
+   it opt-in at compile time keeps the default binary identical and lean while
+   the subsystem cannot run in production until Phase 4 regardless. This is a
+   compile-time gate *in addition to* — not instead of — the runtime
+   `clustering.enabled` config the ADR mandates; a clustering-built binary is
+   still inert unless the config flag is set.
+2. **Runtime gate: `clustering.enabled` config (default false), Postgres-only.**
+   The swarm subsystem starts only when the feature is compiled **and**
+   `clustering.enabled` is set **and** the DB driver is Postgres. Enabling the
+   flag on SQLite is a hard startup error (clustering requires the Postgres
+   control plane).
+3. **One draft PR, sliced internally** (mirrors Phase 1 / PR #1177). Each slice
+   is council-reviewed (adversarial concurrency + correctness) and CI-green
+   before commit.
+4. **Harness fencing cases deferred to Phase 3.** The ADR lists lone-survivor
+   (N=2) and single-dead-link-of-3 degrade-without-fencing under the Phase 2
+   harness, but the heartbeat-fencing + durable-queue logic they assert lands
+   in Phase 3. Phase 2 builds the harness and every fault-injection primitive
+   (pause heartbeat, kill link, stale record, relay panic/recover,
+   revoked-peer-with-live-connection) and asserts everything the Phase 2
+   machinery supports; the two fencing-dependent assertions are wired as
+   pending/ignored scaffolds and activated with the Phase 3 fencing they
+   exercise.
+
+## kameo 0.20 `remote` — verified realities
+
+- Enabling `kameo` feature `remote` pulls `libp2p = 0.56` with features
+  `cbor, kad, noise, mdns, quic, request-response, tcp, tokio, yamux`.
+- We do **not** use `remote::bootstrap()` (an mDNS dev helper). We compose our
+  own `#[derive(NetworkBehaviour)]` struct containing `kameo::remote::Behaviour`,
+  build the swarm with `SwarmBuilder` (tcp + noise + yamux + quic), call
+  `behaviour.kameo.try_init_global()` to install the process-global
+  `ActorSwarm`, and drive the event loop ourselves.
+- `messaging::Config` exposes exactly the knobs the ADR names:
+  `with_request_timeout` (default 10s — the binding transport cap),
+  `with_max_concurrent_streams` (default 100), `with_request_size_maximum`
+  (1MB), `with_response_size_maximum` (10MB).
+- Kademlia parameters are **hardcoded by kameo** (query timeout 10s, replication
+  5, record TTL 1h, republish 30min, Server mode; the field is private) — they
+  are documented, not configured.
+- `try_init_global()` sets a **process-global** swarm ⇒ two in-process swarms
+  are impossible ⇒ multi-node tests must be **multi-process**.
+- Neither `xmpp-parsers` nor `minidom` implements serde ⇒ the remote codec is an
+  explicit XML-text wrapper deliverable.
+
+## Slice order
+
+Every slice is behind the `clustering` feature + runtime flag; default-off
+behaviour is unchanged and asserted by the unchanged e2e suite.
+
+- **Slice 0 — deps + config + inert spawn scaffold.**
+  Add the `clustering` Cargo feature (enables `kameo/remote`); add libp2p to the
+  lockfile. Add `ClusteringConfig` to `ServerConfig` (`enabled` default false,
+  swarm listen addrs, bootstrap headless-DNS name, keypair-pool source, the
+  timeout hierarchy values, allowlist/heartbeat refresh intervals) via the
+  established `from_env` / typed-error pattern (`WADDLE_CLUSTERING_*`). Add the
+  conditional, Postgres-gated spawn point in `start_with_config` that currently
+  logs "clustering enabled" and does nothing else. Config parsing unit tests.
+  *Acceptance:* default build links no libp2p; feature build compiles; flag-off
+  path identical.
+
+- **Slice 1 — owned swarm: event loop, transports, identity, kademlia
+  bootstrap (discovery only), headless-DNS dialing.**
+  `swarm` module: composed `NetworkBehaviour`, `SwarmBuilder`, explicit
+  `messaging::Config` (request_timeout sized above the worst-case fenced-write /
+  resume-handshake budget; `reply_timeout ≤ request_timeout` and
+  `mailbox_timeout + handler budget ≤ request_timeout` invariants asserted;
+  size maxima set). Per-pod keypair from the configured source. Listen, kademlia
+  bootstrap, supervised event-loop task on the shared `stop_token`. Headless-DNS
+  peer resolution + dial with re-dial on pod churn. Swarm observability
+  (connected-peer gauge, kademlia routing-table-size gauge, bootstrap-retry
+  counter) via the OTel `metrics.rs` + periodic-task pattern.
+  *Exit:* single-node swarm boots, listens, reports PeerId, bootstraps.
+
+- **Slice 2 — keypair-slot Postgres CAS lease + duplicate-PeerId rejection.**
+  `keypair_slots` lease (Postgres-only CAS: Acquire `INSERT … ON CONFLICT DO
+  NOTHING` + `rows_affected==1`; Heartbeat renewal CAS on freshness; Expire CAS
+  (committed `expired` flag); Release on drain — all on Postgres `now()`),
+  behind a `KeypairSlotLease` trait. Startup leases one slot from the configured
+  keypair pool and selects that keypair; a heartbeat janitor renews; drain
+  releases. `rows_affected==0` on renewal ⇒ fencing loss ⇒ refuse to serve.
+  Duplicate-PeerId rejection at the swarm behaviour layer (reject a second live
+  session for an already-connected PeerId) as defence in depth. Runs on a
+  **dedicated small control-plane pool/handle**, never the shared statement
+  pool. Postgres-gated CAS tests (acquire, renew, expire-steal, at-most-one
+  leaseholder per slot).
+
+- **Slice 3 — peer allowlist enforcement + live-connection revocation.**
+  `peer_allowlist` table (enrolled PeerIds); runtime role `SELECT`-only
+  (grants documented here, enforced by the Phase 4 chart). `AllowlistStore`
+  trait + impl. Swarm-layer enforcement: reject non-allowlisted peers at
+  connection establishment (Noise handshake necessary, never sufficient); every
+  inbound remote message re-checks the origin is *currently* allowlisted.
+  Periodic refresh janitor diffs the enrolled set and **actively
+  closes/bans live connections** whose PeerId is no longer enrolled. Containment
+  bound asserted: revoked peer disconnected within one refresh interval.
+  Postgres-gated tests + the harness revoked-peer-with-live-connection case.
+
+- **Slice 4 — remote codec (XML-text serde wrappers).**
+  `RemoteStanza` / `RemoteElement` newtypes that are `Serialize`/`Deserialize`
+  over the XML-text form (serialize via `stanza_to_string(to_element())`, so the
+  `ensure_thread_element` fixup is preserved; deserialize re-parses through the
+  existing inbound parser). Typed re-parse error path ⇒ NACK to sender, never a
+  silent drop. Bounded deserialization: max envelope size, collection-length
+  caps, **and max XML nesting depth + attribute/namespace count caps enforced
+  before minidom tree construction** (a small deeply-nested payload is a typed
+  re-parse NACK, not a stack overflow). Drop metrics. Dedicated Rust tests:
+  round-trip, `<thread/>` preservation, oversized / deeply-nested → typed NACK
+  not crash.
+
+- **Slice 5 — per-peer relay actors, supervised.**
+  Per-node relay actor registered in kademlia under a per-`node_id` relay name
+  (the only kademlia registration — O(1) names/node; **never per-entity**).
+  Supervised via an owning task: respawn + **mandatory re-registration under the
+  same name**; sender-side `ActorNotRunning`/`UnknownActor`/`BadActorType` ⇒
+  bounded-backoff kademlia re-lookup (a transport-layer refresh path distinct
+  from the Phase 3 `NotOwner` claims-refresh path). **Discovery-only:** the
+  relay proves a cross-node ask round-trip (spike exit criterion) but is **not**
+  wired into the delivery hot path — cross-node routing is Phase 4.
+
+- **Slice 6 — multi-process cluster harness + spike exit criteria.**
+  Extend the `TestServer` binary-spawner to launch N clustering-enabled
+  processes over a shared `WADDLE_TEST_POSTGRES_URL`. Fault-injection
+  primitives: dropped tells, paused heartbeats, stale node records, relay-actor
+  panic + recover, revoked-peer-with-live-connection. Assert the Phase 2 spike
+  exit criteria:
+  - cross-node `UserActor`/relay ask round-trip;
+  - **ordering under concurrent large + small stanzas** (libp2p per-substream
+    flow control reorders naive-parallel requests);
+  - **an ask whose receiver handler exceeds `request_timeout` fails sender-side
+    with `OutboundFailure(Timeout)`** — proving the transport cap, not
+    `reply_timeout`, is the binding bound;
+  - kademlia re-discovery after all bootstrap peers churn in a rolling restart;
+  - **measured visibility window of a dead publisher's provider+metadata
+    records** against an explicit acceptance threshold (go/no-go: the window is
+    dominated by the hardcoded 1h TTL / 30min republish and cannot be tuned;
+    graceful stops proactively unregister so the bound applies to hard-killed
+    nodes);
+  - relay respawn re-registration + peer re-resolution after `ActorNotRunning`;
+  - revoked-peer disconnect within one allowlist refresh interval.
+  **Deferred to Phase 3** (pending scaffolds): lone-survivor at N=2 keeps
+  serving; single-dead-link-of-3 degrades to durable fallback without fencing —
+  both require Phase 3 heartbeat fencing + durable queue.
+
+## Test / CI gates
+
+- `bun test && bun run lint` unaffected (no chat changes).
+- clippy `--workspace --all-features --all-targets -D warnings` clean (feature
+  code included). No `#[allow]`, no `.unwrap()/.expect()` in non-test code.
+- `cargo fmt` before every commit.
+- The unchanged `xmpp_e2e_cue` suite stays green (proves default-off identity).
+- New Postgres-gated clustering tests skip cleanly when
+  `WADDLE_TEST_POSTGRES_URL` is unset (existing convention); a dedicated
+  feature-enabled Nix check runs them in CI against the Nix-spawned Postgres.
+- Every advertised/implemented behaviour carries dedicated Rust tests
+  (codec, lease CAS, allowlist/revocation, relay supervision, harness).
+
+## What Phase 2 does NOT do (guardrails)
+
+- Does **not** unlock `replicaCount > 1` or `clustering.enabled` in Helm (Phase
+  4).
+- Does **not** route any stanza cross-node (Phase 4).
+- Does **not** add the `nodes`/`claims`/`steal_intents` ownership schema, SM
+  fencing, cross-node resume, or durable MUC state (Phase 3).
+- Does **not** touch the hot delivery path's semantics.

--- a/server/docs/adrs/0017-phase2-plan-libp2p-swarm.md
+++ b/server/docs/adrs/0017-phase2-plan-libp2p-swarm.md
@@ -125,9 +125,10 @@ behaviour is unchanged and asserted by the unchanged e2e suite.
   keypair pool and selects that keypair; a heartbeat janitor renews; drain
   releases. `rows_affected==0` on renewal ⇒ fencing loss ⇒ refuse to serve.
   Duplicate-PeerId rejection at the swarm behaviour layer (reject a second live
-  session for an already-connected PeerId) as defence in depth. Runs on a
-  **dedicated small control-plane pool/handle**, never the shared statement
-  pool. Postgres-gated CAS tests (acquire, renew, expire-steal, at-most-one
+  session for an already-connected PeerId) as defence in depth. Runs on the
+  shared global pool in Phase 2; the **dedicated small control-plane
+  pool/handle** is a Phase 3 deliverable (see the implementation notes).
+  Postgres-gated CAS tests (acquire, renew, expire-steal, at-most-one
   leaseholder per slot).
 
 - **Slice 3 — peer allowlist enforcement + live-connection revocation.**


### PR DESCRIPTION
## ADR-0017 Phase 2 — owned libp2p swarm (discovery-only, flag-gated) ✅ complete, CI fully green

Continues the [ADR-0017 horizontal-scaling](https://github.com/waddle-social/waddle/blob/main/server/docs/adrs/0017-horizontal-scaling-remote-actors.md) programme after Phase 1 (#1177). Epic: #1195. Execution plan + implementation notes: [`server/docs/adrs/0017-phase2-plan-libp2p-swarm.md`](../blob/claude/adr0017-phase2-libp2p-swarm-51vrlk/server/docs/adrs/0017-phase2-plan-libp2p-swarm.md).

**What this delivers:** the inter-node transport subsystem — kameo remote actors over an owned libp2p swarm — gated behind a `clustering` Cargo feature (default OFF) **and** a runtime `clustering.enabled` config (default off, Postgres-only). **Node discovery only:** kademlia is demoted to peer discovery, no stanza is routed cross-node (Phase 4), and `replicaCount > 1` + `clustering.enabled` stay hard-locked in the Helm chart until Phase 4. With clustering disabled the default build links zero libp2p and behaviour is byte-for-byte identical to today's single-replica path; the hot delivery path is untouched.

### Slices (each council-reviewed; findings folded in as fix commits)
- **Slice 0** — `clustering` feature (enables `kameo/remote` + libp2p 0.56) + `ClusteringConfig` (`WADDLE_CLUSTERING_*`, incl. the ADR element-5 timeout hierarchy validated at parse) + inert Postgres-gated spawn point
- **Slice 1** — owned swarm: composed `NetworkBehaviour` over `kameo::remote::Behaviour`, tcp+quic/Noise/yamux, explicit kameo messaging limits, headless-DNS seed dialing with off-loop single-flight resolution, observability (connected-peer / routing-table gauges, dial counter)
- **Slice 2** — `clustering_keypair_slots` Postgres CAS lease (ADR element 3): each pod leases one slot of the pre-enrolled ed25519 pool via `now()`-based row CAS (acquire / freshness-gated heartbeat / epoch-gated release; 0-rows renewal = fencing loss → self-fence), so no two live swarm members share a PeerId; duplicate-PeerId connection rejection as defense-in-depth
- **Slice 3** — peer allowlist enforcement: `clustering_peer_allowlist` (runtime SELECTs only; enrollment stays with the pipeline authority), `libp2p::allow_block_list` composed into the behaviour (deny at establishment — Noise necessary, never sufficient; empty list = deny-all), refresh janitor that **closes live connections of revoked peers** within one interval, fail-closed on refresh errors incl. an all-rows-invalid mass-revocation guard
- **Slice 4** — bounded remote XML codec: `RemoteStanza`/`RemoteElement` serde over XML text (thread-preserving), **non-recursive pre-scan enforcing byte/depth/attribute caps before tree construction** (a nesting bomb is a typed NACK, not a crash), reason-labelled drop metrics
- **Slice 5** — supervised per-node relay actor: the node's **only** kademlia registration (O(1) names/node, keyed by per-process node_id, pinned REMOTE_ID); respawn + mandatory same-name re-registration (+ periodic 15s refresh); `RelayHandle` client with bounded-backoff kademlia re-lookup on stale-ref transport errors; discovery-only message set (ping, stanza echo, gated fault injection)
- **Slice 6** — **multi-process cluster harness** (two real server processes + the test process as a third node over shared Postgres) asserting the Phase 2 exit criteria over the real network in ~11s:
  - cross-node ask round-trip + codec on the wire ✅
  - integrity under concurrent large/small payloads ✅
  - receiver handler exceeding the sender's transport `request_timeout` fails **sender-side** at the cap ✅
  - relay crash → respawn + same-name re-registration + sender stale-ref recovery ✅
  - revoked-peer-with-live-connection contained within the refresh interval, recovery on re-enrollment ✅
  - node churn: replacement process on the same port (fresh node_id/relay/slot) re-discovered ✅
  - deferred as documented `#[ignore]` scaffolds: lone-survivor N=2 + dead-link-of-3 (need Phase 3 fencing/durable queue); dead-publisher record-visibility window (manual go/no-go, dominated by kademlia's hardcoded 1h TTL)

### Real defects caught by the reviews + harness (all fixed in-branch)
- kademlia routing tables stayed **empty** on every node (kameo's mDNS helper feeds `add_peer_address`; our owned dialing didn't) — every DHT lookup failed
- sub-second lease TTLs floored to `'0 seconds'` in the CAS SQL → every slot instantly stealable / every renewal fenced (now millisecond-precision, with a 300ms-TTL test)
- unbounded DNS-resolver task pileup during DNS outages (single-flight guard)
- relay supervisor panic racing shutdown (kameo's `SwarmFuture` unwrap; stop path reordered)
- registration-before-connectivity leaving nodes undiscoverable for kademlia's 30min republish (periodic same-name re-registration)
- redial churn against connected endpoints; ~10s idle timeout severing the mesh

### Post-review hardening (13 Greptile + 8 Copilot rounds; final verdicts 5/5 with zero findings)
- **Security:** custom `Debug` redacts the keypair pool (raw ed25519 seeds no longer reachable via `{:?}` of `ServerConfig`); decode buffers zeroized on all paths; duplicate pool entries rejected at parse (two nodes must never share a PeerId); loud startup warnings for fault injection and an unenrolled local PeerId
- **Lifecycle:** a failed bring-up after the slot lease now releases the slot (no more pool exhaustion under crash-restart loops); single-flight guards reset via drop-guards so a panicked refresh task can't permanently disable allowlist revocation; relay respawn backoff is cancellation-aware
- **Config:** unbracketed IPv6 bootstrap seeds fail fast (previously retried forever); full timeout budget enforced (`mailbox + reply <= request`, all non-zero)
- **Typed payloads:** `LeaseIdentity` (NodeId + Uuid), relay reply types (NodeId), and `RelayAskError::Send` (typed `RelaySendFailure` classification) — TEXT/String only at SQL and log boundaries
- **Codec:** self-closing elements count against the depth cap (exact invariant)
- **Efficiency/consistency:** inbound-only peers no longer redialed every interval (addr-owner tracking, pruned on disconnect); deterministic allowlist diffs; listener failures logged; deferred first ticks on heartbeat/allowlist timers
- **Harness:** blocking bring-up moved to the blocking pool; schema provisioned via the production `ensure_schema` path (no divergent inline DDL); messaging config upholds the parse-time invariants; crash-ask tolerates only death-consistent failure classes

### Adversarial deep-review rounds (multi-agent, post-hardening)
A fresh 3-round adversarial review (8 dimension reviewers + 3-lens refute/reproduce/impact verification per finding, then targeted re-review of each fix) found and fixed 6 defects the earlier 21 review rounds missed:
- **Critical — self-fence scope:** a keypair-slot fencing loss cancelled the *process-wide* shutdown token (cloned, never `child_token()`'d), draining the entire XMPP/HTTP server on a clustering control-plane blip. `clustering_scope_token()` now scopes every clustering task; self-fencing cancels only the child, process shutdown still propagates in (unit-tested both directions).
- **Critical — relay register panic race:** both `register()` sites now race cancellation with `biased;` select (the unregister path was hardened, register wasn't; unbiased select only shrank the window since register's first poll sends the swarm command and panics on a closed channel). Verified airtight against tokio/kameo sources: the event loop drops the swarm only after observing the same token.
- **Major — lease-deadline self-fence:** a node partitioned from Postgres (erroring *or hanging*) never gave up its PeerId while another pod could steal the slot and derive the same identity. `run_heartbeat` is now a two-phase loop with a `sleep_until(last_success + lease_ttl)` deadline arm as the sole hang-fencing trigger; renewals are single-flight and polled to completion, never timeout-dropped (dropping in-flight sqlx futures spawns unbounded background pings that would wedge the shared pool within `max_connections` ticks — worst case is now one abandoned connection at fence, two at shutdown-mid-hang, never per-tick). Paused-time tests cover fast-error fencing, hung-renewal fencing, and deadline-restarts-from-last-success.
- **Major — harness:** the 'transport cap is the binding bound' criterion was unprovable as written (the enforced `reply <= request` invariant guarantees ReplyTimeout always fires first); a new inverted-budget scenario (receiver ask budgets 10s/10s vs 2s transport cap) asserts typed `RelaySendFailure::Transport`, and the existing test asserts typed `ReplyTimeout` instead of `is_err()`. The churn scenario is now a genuine two-leg sequential rolling restart (SIGKILL B, then SIGTERM A) leaving zero original peers alive.
- **Minor — plan-doc drift:** the claimed per-message allowlist re-validation does not exist (kameo handlers don't see sender PeerId); the plan now states the connection-level enforcement precisely and defers per-message re-validation to Phase 4. Slice 2/6 wording corrected to match the code (self-fence scope, integrity-not-ordering, ignored scaffolds).

Three additional round-1 findings were adversarially rejected as out of Phase 2 scope (spec-conformant as written); a first-cut fix (per-tick `timeout()` on renewals) was itself caught and replaced by the verification round because it traded split-brain for pool exhaustion. Full harness re-run against a CI-style provisioned Postgres: pass (2×, ~17.5s each).

### Gates
- Default build: zero libp2p, byte-for-byte identical; **all 22 CI checks green** on the final commit — nixClippy `-D warnings` (incl. `--all-features`), **nixTest running the multi-process cluster harness in CI** (Nix-spawned Postgres), all XMPP suites, `xmpp_e2e_cue` untouched
- 70+ clustering/config unit tests + 6 Postgres CAS lease tests + the e2e harness, all against real Postgres (`WADDLE_TEST_POSTGRES_URL`, repo convention); no new CI plumbing needed
- No `#[allow]`, no unwrap/expect in non-test code, typed payloads/errors throughout, XML via builders only

### Explicitly NOT in this PR (deferred per plan)
Phase 3: `nodes`/`claims`/`steal_intents` ownership schema + epoch fencing, fenced SM persistence, cross-node resume, durable MUC state, dedicated control-plane pool, DashMap selection retirement. Phase 4: cross-node routing GA + Helm unlock. Also noted for Phase 4 in-code: `ensure_schema` vs SELECT-only grants, enroll-every-node operational rule.

**Do not merge without explicit approval.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArFFE2Ekzg1gxDywiCQxjs
