### PR TITLE
fix: reliability bundle — SM queue promotion & durable tombstones, MUC recipient hydration, chat reconnect honesty & catch-up buffering (#1097 #1098 #1135 #1145 #1164 #1165)

### DIFF
--- a/chat/src/channels/live-merge.ts
+++ b/chat/src/channels/live-merge.ts
@@ -72,10 +72,10 @@ export function useChannelLiveMerge(deps: UseChannelLiveMergeDeps) {
    * resolves targets strictly through the room-assigned stanza-id mirror
    * (`reactionTargetId`) and keeps occupant-keyed sender bookkeeping.
    */
-  function applyReaction(messageId: string, nick: string, emojis: string[], senderId: string = nick) {
+  function applyReaction(messageId: string, nick: string, emojis: string[], senderId: string = nick, occurredAt?: string) {
     const next = applyReactionUpdate(
       messages.value,
-      { targetId: messageId, nick, emojis, senderId },
+      { targetId: messageId, nick, emojis, senderId, ...(occurredAt ? { occurredAt } : {}) },
       channelReactionPolicy,
     );
     if (next) messages.value = next;

--- a/chat/src/channels/message-timeline-state.ts
+++ b/chat/src/channels/message-timeline-state.ts
@@ -16,6 +16,7 @@ import {
 } from "@/channels/timeline";
 import { compareTimelineMessages } from "@/lib/timeline-timestamps";
 import { assignCorrectionFields, type CorrectionPayload } from "@/lib/messaging/correction";
+import { isStaleReactionUpdate } from "@/lib/messaging/reactions";
 import { retractTimelineMessage } from "@/lib/messaging/retraction";
 import { mergeRetractionTombstone } from "@/lib/messaging/timeline-insert";
 import { adoptArchiveIdentity, findSynthesizedIdMergeTarget } from "@/lib/messaging/synthesized-id-merge";
@@ -255,7 +256,7 @@ export function buildChannelTimelineFromMamResults(params: {
 }): TimelineMessage[] {
   const { session, channelIsForum, mamResults, existing = [], options = {} } = params;
   const regularMessages: LiveRoomMessage[] = [];
-  const reactionUpdates: { targetId: string; nick: string; senderId: string; emojis: string[] }[] = [];
+  const reactionUpdates: { targetId: string; nick: string; senderId: string; emojis: string[]; occurredAt?: string }[] = [];
   const retractionUpdates: {
     targetId: string;
     retractionSender: { authorJid: string; authorRealJid?: string };
@@ -275,6 +276,7 @@ export function buildChannelTimelineFromMamResults(params: {
         nick: msg.nick,
         senderId: msg._reactionSenderId ?? `${msg.roomJid}/${msg.nick}`,
         emojis: msg._reactionEmojis,
+        ...(msg.createdAt ? { occurredAt: msg.createdAt } : {}),
       });
     } else if (msg.retractsId) {
       if (msg.moderationTargetId && !isMucServiceModeration(msg)) continue;
@@ -404,6 +406,9 @@ export function buildChannelTimelineFromMamResults(params: {
   for (const update of reactionUpdates) {
     const target = timeline.find((message) => message.reactionTargetId === update.targetId);
     if (!target) continue;
+    // C5: XEP-0444 recency — an archived reaction older than one
+    // already applied for the same sender must not clobber it.
+    if (isStaleReactionUpdate(target, update.nick, update.occurredAt)) continue;
     const state = channelReactionState(target, update);
     if (state) {
       target.reactionSenders = state.reactionSenders;
@@ -411,6 +416,9 @@ export function buildChannelTimelineFromMamResults(params: {
     } else {
       delete target.reactionSenders;
       delete target.reactions;
+    }
+    if (update.occurredAt) {
+      target.reactionTimes = { ...(target.reactionTimes ?? {}), [update.nick]: update.occurredAt };
     }
   }
 

--- a/chat/src/channels/message-timeline-state.ts
+++ b/chat/src/channels/message-timeline-state.ts
@@ -407,8 +407,14 @@ export function buildChannelTimelineFromMamResults(params: {
     const target = timeline.find((message) => message.reactionTargetId === update.targetId);
     if (!target) continue;
     // C5: XEP-0444 recency — an archived reaction older than one
-    // already applied for the same sender must not clobber it.
-    if (isStaleReactionUpdate(target, update.nick, update.occurredAt)) continue;
+    // already applied for the same sender must not clobber it. Keyed by
+    // senderId (the replacement key), NOT nick — nicks are not stable.
+    if (isStaleReactionUpdate(target, {
+      senderKey: update.senderId,
+      nick: update.nick,
+      emojis: update.emojis,
+      ...(update.occurredAt ? { occurredAt: update.occurredAt } : {}),
+    })) continue;
     const state = channelReactionState(target, update);
     if (state) {
       target.reactionSenders = state.reactionSenders;
@@ -418,7 +424,7 @@ export function buildChannelTimelineFromMamResults(params: {
       delete target.reactions;
     }
     if (update.occurredAt) {
-      target.reactionTimes = { ...(target.reactionTimes ?? {}), [update.nick]: update.occurredAt };
+      target.reactionTimes = { ...(target.reactionTimes ?? {}), [update.senderId]: update.occurredAt };
     }
   }
 

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -252,6 +252,7 @@ export function useChannelMessages(
           event.nick,
           event.emojis,
           event.authorRealJid ?? `${event.roomJid}/${event.nick}`,
+          event.occurredAt,
         );
       });
       // #414: route pin/unpin system events into the pinned-messages

--- a/chat/src/dms/live-merge.ts
+++ b/chat/src/dms/live-merge.ts
@@ -67,10 +67,10 @@ export function useDmLiveMerge(deps: UseDmLiveMergeDeps) {
    * self reactions are attributed via the orchestrator-side
    * `peerNameFromJid` mapping in onReaction.)
    */
-  function applyReaction(messageId: string, nick: string, emojis: string[]) {
+  function applyReaction(messageId: string, nick: string, emojis: string[], occurredAt?: string) {
     const next = applyReactionUpdate(
       messages.value,
-      { targetId: messageId, nick, emojis, senderId: nick },
+      { targetId: messageId, nick, emojis, senderId: nick, ...(occurredAt ? { occurredAt } : {}) },
       dmReactionPolicy,
     );
     if (next) messages.value = next;

--- a/chat/src/dms/message-timeline-state.ts
+++ b/chat/src/dms/message-timeline-state.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/message-ids";
 import { compareTimelineMessages } from "@/lib/timeline-timestamps";
 import { assignCorrectionFields, type CorrectionPayload } from "@/lib/messaging/correction";
+import { isStaleReactionUpdate } from "@/lib/messaging/reactions";
 import { retractTimelineMessage } from "@/lib/messaging/retraction";
 import { type ArchiveMergeHooks, mergeRetractionTombstone } from "@/lib/messaging/timeline-insert";
 import { adoptArchiveIdentity, findSynthesizedIdMergeTarget } from "@/lib/messaging/synthesized-id-merge";
@@ -155,7 +156,7 @@ export function buildDmTimelineFromMamResults(params: {
 }): TimelineMessage[] {
   const { session, mamResults, existing = [] } = params;
   const regular: LiveDmMessage[] = [];
-  const reactionUpdates: { targetId: string; nick: string; emojis: string[] }[] = [];
+  const reactionUpdates: { targetId: string; nick: string; emojis: string[]; occurredAt?: string }[] = [];
   const retractionUpdates: { targetId: string; fromJid: string }[] = [];
   const correctionUpdates: {
     targetId: string;
@@ -164,7 +165,12 @@ export function buildDmTimelineFromMamResults(params: {
   }[] = [];
   for (const msg of mamResults) {
     if (msg._reactionTarget && msg._reactionEmojis) {
-      reactionUpdates.push({ targetId: msg._reactionTarget, nick: msg.nick, emojis: msg._reactionEmojis });
+      reactionUpdates.push({
+        targetId: msg._reactionTarget,
+        nick: msg.nick,
+        emojis: msg._reactionEmojis,
+        ...(msg.createdAt ? { occurredAt: msg.createdAt } : {}),
+      });
     } else if (msg.retractsId) {
       retractionUpdates.push({ targetId: msg.retractsId, fromJid: msg.fromJid });
     } else if (msg.replacesId) {
@@ -243,9 +249,15 @@ export function buildDmTimelineFromMamResults(params: {
   for (const update of reactionUpdates) {
     const target = findMessageById(timeline, update.targetId);
     if (!target) continue;
+    // C5: XEP-0444 recency — an archived reaction older than one
+    // already applied for the same sender must not clobber it.
+    if (isStaleReactionUpdate(target, update.nick, update.occurredAt)) continue;
     const reactions = replacedNickReactions(target.reactions, update.nick, update.emojis);
     if (reactions) target.reactions = reactions;
     else delete target.reactions;
+    if (update.occurredAt) {
+      target.reactionTimes = { ...(target.reactionTimes ?? {}), [update.nick]: update.occurredAt };
+    }
   }
   return timeline.sort(compareTimelineMessages);
 }

--- a/chat/src/dms/message-timeline-state.ts
+++ b/chat/src/dms/message-timeline-state.ts
@@ -250,8 +250,14 @@ export function buildDmTimelineFromMamResults(params: {
     const target = findMessageById(timeline, update.targetId);
     if (!target) continue;
     // C5: XEP-0444 recency — an archived reaction older than one
-    // already applied for the same sender must not clobber it.
-    if (isStaleReactionUpdate(target, update.nick, update.occurredAt)) continue;
+    // already applied for the same sender must not clobber it. The DM
+    // sender key is the nick (senderId === nick on the DM path).
+    if (isStaleReactionUpdate(target, {
+      senderKey: update.nick,
+      nick: update.nick,
+      emojis: update.emojis,
+      ...(update.occurredAt ? { occurredAt: update.occurredAt } : {}),
+    })) continue;
     const reactions = replacedNickReactions(target.reactions, update.nick, update.emojis);
     if (reactions) target.reactions = reactions;
     else delete target.reactions;

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -411,7 +411,7 @@ export function useDirectMessages(
     // conversation key. For self-sent carbon-forwarded reactions
     // `peerJid` is normalized to the recipient, so deriving the nick
     // from `peerJid` would wrongly credit the partner.
-    applyReaction(event.messageId, peerNameFromJid(event.reactorJid), event.emojis);
+    applyReaction(event.messageId, peerNameFromJid(event.reactorJid), event.emojis, event.occurredAt);
   }
 
   watch(scrollDirection, () => {

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -247,6 +247,9 @@ export interface TimelineMessage {
   reactions?: Record<string, string[]>;
   /** Archived reaction sender identities: emoji -> sender id -> display nick. */
   reactionSenders?: Record<string, Record<string, string>>;
+  /** XEP-0444 recency bookkeeping: sender nick -> RFC 3339 instant of the
+   * last applied reaction, so an older delayed replay can't clobber it. */
+  reactionTimes?: Record<string, string>;
   /** Users who have seen this message (XEP-0333). */
   readBy?: string[];
   /** Whether this received message requested XEP-0333 displayed markers. */

--- a/chat/src/lib/chat-ui.ts
+++ b/chat/src/lib/chat-ui.ts
@@ -194,6 +194,13 @@ export interface ExtensionAnnotation {
   actions: ExtensionAnnotationAction[];
 }
 
+/** Per-sender XEP-0444 recency: a wire-derived RFC 3339 delay stamp, or
+ * a local-domain marker for a live undelayed reaction recording the
+ * newest wire stamp it superseded (`null` when none was seen). The two
+ * clock domains are never compared against each other — see
+ * `isStaleReactionUpdate` in `@/lib/messaging/reactions`. */
+export type ReactionRecencyStamp = string | { appliedAfterWire: string | null };
+
 export interface TimelineMessage {
   id: string;
   /** #1182: `id` is a fabricated UUID — the live stanza carried no wire
@@ -247,9 +254,11 @@ export interface TimelineMessage {
   reactions?: Record<string, string[]>;
   /** Archived reaction sender identities: emoji -> sender id -> display nick. */
   reactionSenders?: Record<string, Record<string, string>>;
-  /** XEP-0444 recency bookkeeping: sender nick -> RFC 3339 instant of the
-   * last applied reaction, so an older delayed replay can't clobber it. */
-  reactionTimes?: Record<string, string>;
+  /** XEP-0444 recency bookkeeping: sender key (MUC: senderId — real
+   * bare JID when known, else occupant JID; DM: nick) -> recency stamp
+   * of the last applied reaction, so an older delayed replay can't
+   * clobber it. */
+  reactionTimes?: Record<string, ReactionRecencyStamp>;
   /** Users who have seen this message (XEP-0333). */
   readBy?: string[];
   /** Whether this received message requested XEP-0333 displayed markers. */

--- a/chat/src/lib/messaging/reactions.ts
+++ b/chat/src/lib/messaging/reactions.ts
@@ -17,6 +17,39 @@ export interface ReactionEvent {
   emojis: string[];
   /** Channel: MUC occupant JID; DM: same as `nick`. */
   senderId: string;
+  /** RFC 3339 instant the reaction was emitted (delay stamp for SM/MAM
+   * replays). Absent on a live undelayed stanza — those always apply. */
+  occurredAt?: string;
+}
+
+/**
+ * XEP-0444 Business Rules recency check: a delayed reaction SHOULD be
+ * accepted only if no NEWER reaction from the same sender was already
+ * accepted. `reactionTimes` on the row records the last-applied instant
+ * per sender nick (nicks are the stable per-conversation sender key on
+ * both the channel and DM paths).
+ */
+export function isStaleReactionUpdate(
+  target: TimelineMessage,
+  senderNick: string,
+  occurredAt: string | undefined,
+): boolean {
+  if (!occurredAt) return false;
+  const applied = target.reactionTimes?.[senderNick];
+  if (!applied) return false;
+  const appliedMs = Date.parse(applied);
+  const incomingMs = Date.parse(occurredAt);
+  return Number.isFinite(appliedMs) && Number.isFinite(incomingMs) && appliedMs > incomingMs;
+}
+
+/** Immutably stamp the sender's last-applied reaction instant on the row. */
+function withReactionTime(
+  row: TimelineMessage,
+  senderNick: string,
+  occurredAt: string | undefined,
+): TimelineMessage {
+  if (!occurredAt) return row;
+  return { ...row, reactionTimes: { ...(row.reactionTimes ?? {}), [senderNick]: occurredAt } };
 }
 
 export interface ReactionPolicy {
@@ -38,7 +71,11 @@ export function applyReactionUpdate(
 ): TimelineMessage[] | null {
   const index = policy.findTargetIndex(messages, event.targetId);
   if (index < 0) return null;
+  const target = messages[index]!;
+  // C5: reject a delayed reaction that is older than one already
+  // applied for the same sender (XEP-0444 Business Rules).
+  if (isStaleReactionUpdate(target, event.nick, event.occurredAt)) return null;
   const next = messages.slice();
-  next[index] = policy.reactedRow(messages[index]!, event);
+  next[index] = withReactionTime(policy.reactedRow(target, event), event.nick, event.occurredAt);
   return next;
 }

--- a/chat/src/lib/messaging/reactions.ts
+++ b/chat/src/lib/messaging/reactions.ts
@@ -1,4 +1,4 @@
-import type { TimelineMessage } from "@/lib/chat-ui";
+import type { ReactionRecencyStamp, TimelineMessage } from "@/lib/chat-ui";
 
 // XEP-0444 reaction merge mechanics shared by the channel and DM
 // pipelines. Replace semantics (the sender's new set replaces their old
@@ -15,58 +15,107 @@ export interface ReactionEvent {
   targetId: string;
   nick: string;
   emojis: string[];
-  /** Channel: MUC occupant JID; DM: same as `nick`. */
+  /** Channel: real bare JID when known, else MUC occupant JID; DM: same
+   * as `nick`. */
   senderId: string;
   /** RFC 3339 instant the reaction was emitted (delay stamp for SM/MAM
    * replays). Absent on a live undelayed stanza — those always apply. */
   occurredAt?: string;
 }
 
+/** Inputs to the XEP-0444 recency gate. */
+export interface ReactionRecencyProbe {
+  /** Recency key — MUST be the same identity the replacement bookkeeping
+   * keys by (`senderId`: real bare JID / occupant JID in MUCs, nick in
+   * DMs). Nicks are NOT stable in MUCs — a rename must not reset the
+   * gate, and nick reuse by another occupant must not trip it. */
+  senderKey: string;
+  /** Display nick, used only for the legacy nick-keyed reaction fallback. */
+  nick: string;
+  emojis: string[];
+  occurredAt?: string;
+}
+
 /**
  * XEP-0444 Business Rules recency check: a delayed reaction SHOULD be
  * accepted only if no NEWER reaction from the same sender was already
- * accepted. `reactionTimes` on the row records the last-applied instant
- * per sender nick (nicks are the stable per-conversation sender key on
- * both the channel and DM paths).
+ * accepted. `reactionTimes` on the row records the last-applied recency
+ * stamp per sender key (see `ReactionRecencyProbe.senderKey`).
  */
 export function isStaleReactionUpdate(
   target: TimelineMessage,
-  senderNick: string,
-  occurredAt: string | undefined,
+  probe: ReactionRecencyProbe,
 ): boolean {
-  if (!occurredAt) return false;
-  const applied = target.reactionTimes?.[senderNick];
-  if (!applied) return false;
+  if (!probe.occurredAt) return false;
+  const applied = target.reactionTimes?.[probe.senderKey];
+  if (applied === undefined) return false;
+  const incomingMs = Date.parse(probe.occurredAt);
+  if (!Number.isFinite(incomingMs)) return false;
+  if (typeof applied !== "string") {
+    // Local-domain stamp (live undelayed reaction). Never compare the
+    // local clock against server delay stamps — a client clock ahead by
+    // Δ would drop every genuinely newer reaction replayed within Δ.
+    // The recorded ordering fact is "applied after wire-stamp X": a
+    // replay stamped at or before X belongs to the superseded past;
+    // anything after X is genuinely newer and applies.
+    if (applied.appliedAfterWire === null) return false;
+    const anchorMs = Date.parse(applied.appliedAfterWire);
+    return Number.isFinite(anchorMs) && incomingMs <= anchorMs;
+  }
   const appliedMs = Date.parse(applied);
-  const incomingMs = Date.parse(occurredAt);
-  // `>=` (not `>`): an exact re-delivery of the already-applied stanza
-  // (SM replay / overlapping MAM) carries the same instant and must be
-  // an idempotent no-op, not a re-apply that could clobber a newer live
-  // reaction stamped in between.
-  return Number.isFinite(appliedMs) && Number.isFinite(incomingMs) && appliedMs >= incomingMs;
+  if (!Number.isFinite(appliedMs)) return false;
+  if (appliedMs !== incomingMs) return appliedMs > incomingMs;
+  // Equal-stamp tie: the server truncates XEP-0203 delay stamps to whole
+  // seconds, so a same-second toggle replays as two stanzas with
+  // identical stamps. XEP-0444 rejects only if a strictly NEWER reaction
+  // was already accepted — on a tie, in-order delivery makes the
+  // later-processed update the newer one, so a different set applies.
+  // Only an exact re-delivery (same set) is a stale idempotent no-op.
+  return sameEmojiSet(appliedEmojiSet(target, probe.senderKey, probe.nick), probe.emojis);
 }
 
-/** Immutably stamp the sender's last-applied reaction instant on the row. */
+function sameEmojiSet(a: string[], b: string[]): boolean {
+  const aSet = new Set(a);
+  const bSet = new Set(b);
+  return aSet.size === bSet.size && [...aSet].every((emoji) => bSet.has(emoji));
+}
+
+/** The sender's currently applied emoji set on the row: prefers the
+ * senderId-keyed `reactionSenders` bookkeeping (channel rows), falling
+ * back to the nick-keyed aggregate (DM rows / legacy channel rows). The
+ * key matching mirrors `removeSenderReactions`. */
+function appliedEmojiSet(target: TimelineMessage, senderKey: string, nick: string): string[] {
+  const senders = target.reactionSenders;
+  if (senders && Object.keys(senders).length > 0) {
+    return Object.entries(senders)
+      .filter(([, bySender]) =>
+        Object.keys(bySender).some((id) => id === senderKey || id === nick || id.endsWith(`/${nick}`)))
+      .map(([emoji]) => emoji);
+  }
+  return Object.entries(target.reactions ?? {})
+    .filter(([, nicks]) => nicks.includes(nick))
+    .map(([emoji]) => emoji);
+}
+
+/** Immutably stamp the sender's last-applied reaction recency on the row. */
 function withReactionTime(
   row: TimelineMessage,
-  senderNick: string,
+  senderKey: string,
   occurredAt: string | undefined,
 ): TimelineMessage {
   // A live undelayed reaction carries no wire instant, but it MUST still
-  // advance the sender's recency stamp — otherwise a later re-delivery of
-  // an older delayed stanza passes the stale check and clobbers it. Stamp
-  // the local receive time. This mixes clock domains (server delay stamps
-  // vs. the local clock), which is acceptable here: the stamp is only
-  // monotonic-enough per-sender bookkeeping, not a wire timestamp. Clamp
-  // to the existing stamp so a skewed-back local clock never regresses it.
-  const stamp = occurredAt ?? localReceiveStamp(row.reactionTimes?.[senderNick]);
-  return { ...row, reactionTimes: { ...(row.reactionTimes ?? {}), [senderNick]: stamp } };
+  // advance the sender's recency — otherwise a later re-delivery of an
+  // older delayed stanza passes the stale check and clobbers it. Never
+  // stamp the local clock (mixed clock domains — see
+  // `isStaleReactionUpdate`); record the local-domain ordering fact
+  // instead: applied after the newest wire stamp seen for this sender.
+  const stamp: ReactionRecencyStamp = occurredAt ?? localDomainStamp(row.reactionTimes?.[senderKey]);
+  return { ...row, reactionTimes: { ...(row.reactionTimes ?? {}), [senderKey]: stamp } };
 }
 
-function localReceiveStamp(applied: string | undefined): string {
-  const appliedMs = applied === undefined ? Number.NaN : Date.parse(applied);
-  const nowMs = Date.now();
-  return new Date(Number.isFinite(appliedMs) ? Math.max(appliedMs, nowMs) : nowMs).toISOString();
+function localDomainStamp(applied: ReactionRecencyStamp | undefined): ReactionRecencyStamp {
+  if (typeof applied === "string") return { appliedAfterWire: applied };
+  return { appliedAfterWire: applied?.appliedAfterWire ?? null };
 }
 
 export interface ReactionPolicy {
@@ -91,8 +140,14 @@ export function applyReactionUpdate(
   const target = messages[index]!;
   // C5: reject a delayed reaction that is older than one already
   // applied for the same sender (XEP-0444 Business Rules).
-  if (isStaleReactionUpdate(target, event.nick, event.occurredAt)) return null;
+  const probe: ReactionRecencyProbe = {
+    senderKey: event.senderId,
+    nick: event.nick,
+    emojis: event.emojis,
+    ...(event.occurredAt ? { occurredAt: event.occurredAt } : {}),
+  };
+  if (isStaleReactionUpdate(target, probe)) return null;
   const next = messages.slice();
-  next[index] = withReactionTime(policy.reactedRow(target, event), event.nick, event.occurredAt);
+  next[index] = withReactionTime(policy.reactedRow(target, event), event.senderId, event.occurredAt);
   return next;
 }

--- a/chat/src/lib/messaging/reactions.ts
+++ b/chat/src/lib/messaging/reactions.ts
@@ -39,7 +39,11 @@ export function isStaleReactionUpdate(
   if (!applied) return false;
   const appliedMs = Date.parse(applied);
   const incomingMs = Date.parse(occurredAt);
-  return Number.isFinite(appliedMs) && Number.isFinite(incomingMs) && appliedMs > incomingMs;
+  // `>=` (not `>`): an exact re-delivery of the already-applied stanza
+  // (SM replay / overlapping MAM) carries the same instant and must be
+  // an idempotent no-op, not a re-apply that could clobber a newer live
+  // reaction stamped in between.
+  return Number.isFinite(appliedMs) && Number.isFinite(incomingMs) && appliedMs >= incomingMs;
 }
 
 /** Immutably stamp the sender's last-applied reaction instant on the row. */
@@ -48,8 +52,21 @@ function withReactionTime(
   senderNick: string,
   occurredAt: string | undefined,
 ): TimelineMessage {
-  if (!occurredAt) return row;
-  return { ...row, reactionTimes: { ...(row.reactionTimes ?? {}), [senderNick]: occurredAt } };
+  // A live undelayed reaction carries no wire instant, but it MUST still
+  // advance the sender's recency stamp — otherwise a later re-delivery of
+  // an older delayed stanza passes the stale check and clobbers it. Stamp
+  // the local receive time. This mixes clock domains (server delay stamps
+  // vs. the local clock), which is acceptable here: the stamp is only
+  // monotonic-enough per-sender bookkeeping, not a wire timestamp. Clamp
+  // to the existing stamp so a skewed-back local clock never regresses it.
+  const stamp = occurredAt ?? localReceiveStamp(row.reactionTimes?.[senderNick]);
+  return { ...row, reactionTimes: { ...(row.reactionTimes ?? {}), [senderNick]: stamp } };
+}
+
+function localReceiveStamp(applied: string | undefined): string {
+  const appliedMs = applied === undefined ? Number.NaN : Date.parse(applied);
+  const nowMs = Date.now();
+  return new Date(Number.isFinite(appliedMs) ? Math.max(appliedMs, nowMs) : nowMs).toISOString();
 }
 
 export interface ReactionPolicy {

--- a/chat/src/lib/xmpp/client-connection.ts
+++ b/chat/src/lib/xmpp/client-connection.ts
@@ -165,7 +165,18 @@ type ReconnectSchedulerDeps = {
   isDestroying: () => boolean;
   connect: () => Promise<void>;
   onScheduled: (info: { attempt: number; delayMs: number }) => void;
+  /** #1164: the attempt budget ran out — the caller should surface a terminal error state. */
+  onExhausted: () => void;
 };
+
+/**
+ * #1164: reconnect attempts before the loop gives up. With the
+ * 2s·2^n backoff capped at 60s this spends ~6 minutes retrying —
+ * long enough to ride out a deploy or a network blip, short enough
+ * that a dead session doesn't spin a "reconnecting" banner forever.
+ * `resetAttempts()` (wired to session-ready) restores the budget.
+ */
+const MAX_RECONNECT_ATTEMPTS = 10;
 
 /** Exponential-backoff reconnect timer + reconnect-duration stopwatch. */
 export class ReconnectScheduler {
@@ -177,6 +188,10 @@ export class ReconnectScheduler {
 
   schedule(): void {
     if (this.deps.isDestroying() || this.timer) return;
+    if (this.attempt >= MAX_RECONNECT_ATTEMPTS) {
+      this.deps.onExhausted();
+      return;
+    }
     const delay = Math.min(2000 * (2 ** this.attempt), 60000);
     this.attempt += 1;
     this.deps.onScheduled({ attempt: this.attempt, delayMs: delay });
@@ -578,6 +593,12 @@ export class OfflineSendQueue {
   }
 
   private noteQueuedMessage(): void {
+    // #1164: a room-scoped queue while the session is healthy (we're
+    // connected, the room just isn't joined yet) must not flip the
+    // global connection banner to offline/reconnecting — the message
+    // drains on join, not on reconnect. Only report a degraded status
+    // when the session itself is unusable.
+    if (this.deps.canUseConnectedSession()) return;
     const queueCount = countQueuedMessages(this.deps.queueScope());
     this.deps.emitStatus({
       state: browserOffline() ? "offline" : "reconnecting",

--- a/chat/src/lib/xmpp/client-connection.ts
+++ b/chat/src/lib/xmpp/client-connection.ts
@@ -213,6 +213,15 @@ export class ReconnectScheduler {
   }
 
   /**
+   * True once the attempt cap is spent and no retry timer is pending —
+   * i.e. the state `onExhausted` announced. While a timer is still
+   * armed the loop is alive, so callers must not treat it as exhausted.
+   */
+  isExhausted(): boolean {
+    return this.attempt >= MAX_RECONNECT_ATTEMPTS && this.timer === null;
+  }
+
+  /**
    * Track the reconnect-duration stopwatch across status transitions.
    * Returns the `statusHook` telemetry meta: `reconnectDurationMs` is
    * present exactly when this status completes a reconnect.

--- a/chat/src/lib/xmpp/client-connection.ts
+++ b/chat/src/lib/xmpp/client-connection.ts
@@ -208,6 +208,17 @@ export class ReconnectScheduler {
     }
   }
 
+  /**
+   * True while a backoff retry timer is armed — the loop owns the next
+   * attempt. Background `connect()` calls must not preempt it: every
+   * fast-failing immediate attempt re-enters `schedule()` and burns an
+   * attempt from the budget, so ten user interactions during a short
+   * outage would exhaust it into a false terminal error.
+   */
+  hasPendingRetry(): boolean {
+    return this.timer !== null;
+  }
+
   resetAttempts(): void {
     this.attempt = 0;
   }

--- a/chat/src/lib/xmpp/client-connection.ts
+++ b/chat/src/lib/xmpp/client-connection.ts
@@ -213,9 +213,14 @@ export class ReconnectScheduler {
   }
 
   /**
-   * True once the attempt cap is spent and no retry timer is pending —
-   * i.e. the state `onExhausted` announced. While a timer is still
-   * armed the loop is alive, so callers must not treat it as exhausted.
+   * True once the attempt cap is spent and no retry timer is pending.
+   * While a timer is still armed the loop is alive, so callers must not
+   * treat it as exhausted. Caveat: the timer is nulled BEFORE the final
+   * attempt's `connect()` is invoked, so this also reads true while
+   * that last attempt is still in flight — callers gating on it must
+   * first join any pending connect promise (see `connect()` in
+   * `client.ts`) so a user action during that window rides the attempt
+   * instead of fast-rejecting.
    */
   isExhausted(): boolean {
     return this.attempt >= MAX_RECONNECT_ATTEMPTS && this.timer === null;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -441,6 +441,13 @@ export class BrowserXmppClient {
   // entry) cannot observe one set without the other.
   private resumeBarrier: { xmpp: XmppClientInstance; promise: Promise<void> } | null = null;
   private pendingDuringResume: InboundWasmMessage[] | null = null;
+  // F2: buffer entries stranded by a barrier that failed mid-catch-up
+  // (the connection died, so `completeResumeBarrier` could not drain
+  // them). Those stanzas were SM-acked — the server will never replay
+  // them, and a MAM refetch surfaces reactions/markers as ignored
+  // message rows — so they are carried into the NEXT barrier's buffer
+  // (arrival order preserved) and drained when it completes.
+  private carriedPendingDuringResume: InboundWasmMessage[] = [];
   // #1164: set when a stream error announced a terminal condition
   // (see `TERMINAL_STREAM_CONDITION_DETAILS`). The wire error and the
   // disconnect arrive as two separate WASM callbacks; this carries
@@ -839,6 +846,18 @@ export class BrowserXmppClient {
     if (this.inTerminalErrorState || this.reconnect.isExhausted()) {
       throw new Error("XMPP session is not ready");
     }
+    // F5: a backoff retry is already armed — leave the schedule intact.
+    // Cancelling it for an immediate attempt lets every background
+    // trigger burn an attempt on a fast failure (re-entering
+    // `handleDisconnected` → `schedule()`), so <1 min of typing during
+    // an outage could exhaust the whole budget into a false terminal
+    // error. Fast-reject like any unavailable session; only the
+    // scheduler itself (`connectFromScheduler`) and user-explicit
+    // recovery (`connectWithFreshBudget`) may clear the timer and
+    // launch.
+    if (this.reconnect.hasPendingRetry()) {
+      throw new Error("XMPP session is not ready");
+    }
     return this.connectInternal();
   }
 
@@ -962,6 +981,10 @@ export class BrowserXmppClient {
     this.inTerminalErrorState = false;
     this.terminalDisconnectDetail = null;
     this.clearResumeState();
+    // A user-explicit teardown drops the carried resume buffer too — a
+    // later session on this instance must not replay another session's
+    // stanzas.
+    this.carriedPendingDuringResume = [];
     const xmpp = this.xmpp;
     const joinedRooms = [...this.joinedMucs.keys()];
     this.stopSelfPing();
@@ -2136,19 +2159,17 @@ export class BrowserXmppClient {
         : { type: "resumed" },
     );
     if (catchupEntries.length === 0) {
+      // No barrier this session: entries carried from a failed barrier
+      // still owe their dispatch (same flush-then-drain order).
+      const carried = this.carriedPendingDuringResume.splice(0);
       this.flushAfterSessionReady(xmpp);
+      if (carried.length > 0) this.drainResumeBuffer(carried);
       this.fulfillOnceConnected();
       return;
     }
-    // Build the barrier promise and the buffer *atomically* — set
-    // both fields together before any `await` so a re-entrant
-    // `handleSessionReady` (synchronous WASM callback) can never
-    // observe `pendingDuringResume` set without `resumeBarrier`
-    // also set.
     const catchupPromise = this.runReconnectCatchup(xmpp, catchupEntries, lifecycle.type);
     const barrierPromise = catchupPromise.finally(() => this.completeResumeBarrier(xmpp));
-    this.pendingDuringResume = [];
-    this.resumeBarrier = { xmpp, promise: barrierPromise };
+    this.openResumeBarrier(xmpp, barrierPromise);
     await barrierPromise;
     if (this.xmpp !== xmpp) return;
     this.fulfillOnceConnected();
@@ -2168,15 +2189,40 @@ export class BrowserXmppClient {
    * own state but don't fire queue flush / buffer drain for the
    * stale handle.
    */
+  /**
+   * Open the resume barrier: build the buffer and the barrier *atomically*
+   * — both fields set together with no `await` in between, so a re-entrant
+   * `handleSessionReady` (synchronous WASM callback) can never observe
+   * `pendingDuringResume` set without `resumeBarrier` also set. Seeds the
+   * buffer with entries carried over from a barrier that failed
+   * mid-catch-up (F2) so they drain with this barrier, ahead of newer
+   * arrivals.
+   */
+  private openResumeBarrier(xmpp: XmppClientInstance, promise: Promise<void>) {
+    this.pendingDuringResume = this.carriedPendingDuringResume.splice(0);
+    this.resumeBarrier = { xmpp, promise };
+  }
+
   private completeResumeBarrier(xmpp: XmppClientInstance) {
     const buffered = this.pendingDuringResume ?? [];
     // Only clear the barrier if it is still ours — a newer handle
     // may have replaced it after a full reconnect.
-    if (this.resumeBarrier?.xmpp === xmpp) {
+    const ownBarrier = this.resumeBarrier?.xmpp === xmpp;
+    if (ownBarrier) {
       this.resumeBarrier = null;
       this.pendingDuringResume = null;
     }
-    if (this.xmpp !== xmpp) return;
+    if (this.xmpp !== xmpp) {
+      // F2: our barrier failed (the connection died mid-catch-up). The
+      // buffered stanzas were SM-acked and will never be replayed —
+      // carry them into the next barrier instead of discarding them.
+      // (When the barrier was NOT ours, `buffered` is the newer
+      // barrier's live buffer — leave it alone.)
+      if (ownBarrier && buffered.length > 0) {
+        this.carriedPendingDuringResume.push(...buffered);
+      }
+      return;
+    }
     // Flush the locally-queued outbound *before* draining the live
     // buffer. Queued messages carry the user's send wall-clock from
     // before the pause; live arrivals from during the pause carry
@@ -2185,6 +2231,10 @@ export class BrowserXmppClient {
     // echoes alongside (or before) the inbound arrivals they belong
     // next to, instead of mis-ordering the tail (Bug 4).
     this.flushAfterSessionReady(xmpp);
+    this.drainResumeBuffer(buffered);
+  }
+
+  private drainResumeBuffer(buffered: InboundWasmMessage[]) {
     // Drain bodies first, then targeted follow-ups (displayed markers
     // + reactions), each kind in arrival order (#1165). A follow-up
     // whose target arrived during the same catch-up window — via MAM

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -208,18 +208,40 @@ type XmppStreamErrorPayload = string | {
  * "reconnecting" spinner. Maps each condition to the user-facing
  * status detail (`connection-notice.ts` renders the copy).
  */
-const TERMINAL_STREAM_CONDITION_DETAILS: Record<string, string> = {
+const TERMINAL_STREAM_CONDITION_DETAILS = {
   // RFC 6120 §4.9.3.12 / SASL failure surfaced as a stream error:
   // the session token is no longer accepted.
   "not-authorized": "Your session expired — sign in again to restore live messaging.",
   // RFC 6120 §4.9.3.3: the server closed this stream in favour of a
   // newer one for the same resource; reconnecting would just fight it.
   conflict: "This session was replaced by a newer sign-in for the same account.",
-};
+} as const;
+
+function isTerminalStreamCondition(
+  condition: string,
+): condition is keyof typeof TERMINAL_STREAM_CONDITION_DETAILS {
+  return condition in TERMINAL_STREAM_CONDITION_DETAILS;
+}
 
 function terminalDisconnectDetail(condition: string | undefined): string | null {
-  if (!condition) return null;
-  return TERMINAL_STREAM_CONDITION_DETAILS[condition] ?? null;
+  if (!condition || !isTerminalStreamCondition(condition)) return null;
+  return TERMINAL_STREAM_CONDITION_DETAILS[condition];
+}
+
+/**
+ * The condition allowed to drive TERMINAL classification. Real stream
+ * errors always arrive structured (`JsStreamError.condition` from the
+ * WASM core); the only free-text payload that legitimately names a
+ * terminal condition is waddle-xmpp-client's SASL ClientError display,
+ * which backtick-quotes it ("… with condition `not-authorized`").
+ * Loose word-matching (`streamErrorConditionFromText`) stays for the
+ * emitted event's diagnostic `condition` field only — a benign error
+ * whose text merely contains "conflict" must never latch terminal
+ * state.
+ */
+function terminalConditionFromPayload(payload: XmppStreamErrorPayload): string | undefined {
+  if (typeof payload !== "string") return payload.condition?.trim() || undefined;
+  return /\bcondition `([a-z0-9-]+)`/.exec(payload)?.[1];
 }
 
 function streamErrorConditionFromText(text: string | null | undefined): string | undefined {
@@ -2475,7 +2497,7 @@ export class BrowserXmppClient {
     xmpp.set_on_error?.((payload: XmppStreamErrorPayload) => {
       if (this.xmpp !== xmpp) return;
       const streamError = normalizeXmppStreamErrorPayload(payload);
-      const terminalDetail = terminalDisconnectDetail(streamError.condition);
+      const terminalDetail = terminalDisconnectDetail(terminalConditionFromPayload(payload));
       if (terminalDetail) this.terminalDisconnectDetail = terminalDetail;
       this.emitError({
         kind: "stream",

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -524,16 +524,28 @@ export class BrowserXmppClient {
     });
     this.reconnect = new ReconnectScheduler({
       isDestroying: () => this.destroying,
-      connect: () => this.connect(),
+      connect: () => this.connectFromScheduler(),
       onScheduled: (info) => this.events.emitSafe("reconnectScheduled", info),
       // #1164: the retry budget ran out — an endless "reconnecting"
-      // banner would be dishonest. Terminal error state; the user can
-      // retry via reload / sign-in (`connect()` resets the budget path
-      // through session-ready's `resetAttempts`).
-      onExhausted: () => this.emitStatus({
-        state: "error",
-        detail: "We couldn't reconnect after several attempts. Check your connection, then reload to try again.",
-      }),
+      // banner would be dishonest. An explicit `connect()` restores
+      // the budget; a network-return `online` event triggers one.
+      onExhausted: () => {
+        this.armOnlineRecovery();
+        if (browserOffline()) {
+          // C2: the truthful state is offline, not a terminal error —
+          // and the armed `online` listener retries when the network
+          // returns instead of demanding a reload.
+          this.emitStatus({
+            state: "offline",
+            detail: "You're offline — reconnecting when the network returns.",
+          });
+          return;
+        }
+        this.emitStatus({
+          state: "error",
+          detail: "We couldn't reconnect after several attempts. Check your connection, then reload to try again.",
+        });
+      },
     });
     this.retainedJoinedRoomJids = new Set(this.resumePersistence.loadJoinedRooms());
   }
@@ -685,6 +697,28 @@ export class BrowserXmppClient {
     this.reconnect.clearTimer();
   }
 
+  // C2: after retry exhaustion nothing would ever try again when the
+  // network returns. Armed from `onExhausted`; a fresh `connect()`
+  // (which the listener fires, with a full budget) disarms it, as does
+  // the `disconnect()` logout path.
+  private onlineRecoveryListener: (() => void) | null = null;
+
+  private armOnlineRecovery(): void {
+    if (typeof window === "undefined" || this.onlineRecoveryListener) return;
+    const listener = () => {
+      this.disarmOnlineRecovery();
+      void this.connect().catch(() => undefined);
+    };
+    this.onlineRecoveryListener = listener;
+    window.addEventListener("online", listener);
+  }
+
+  private disarmOnlineRecovery(): void {
+    if (typeof window === "undefined" || !this.onlineRecoveryListener) return;
+    window.removeEventListener("online", this.onlineRecoveryListener);
+    this.onlineRecoveryListener = null;
+  }
+
   private clearResumeState() {
     this.resume.clearAll();
     // Only called from the `destroying` path — i.e. intentional
@@ -713,8 +747,25 @@ export class BrowserXmppClient {
     try { await xmpp.send_raw_iq(`<iq type="set" id="${crypto.randomUUID()}"><enable xmlns="urn:xmpp:carbons:2"/></iq>`); } catch {}
   }
 
+  /** Seam for tests: instance-level indirection over the module-level
+   * WASM loader so a stalled load can be simulated. */
+  private loadModule: () => Promise<WasmModule> = loadWasmModule;
+  /** C3 (#1164 follow-up): generation token for connect attempts. Bumped
+   * when a new `doConnect` starts and when the connect timeout tears an
+   * attempt down, so a continuation resuming after a stalled `await`
+   * (e.g. the WASM module load) can detect it was superseded and abort
+   * WITHOUT creating a second live handle that would bind the same
+   * resource and trigger a self-inflicted terminal `conflict`. */
+  private connectEpoch = 0;
+
   private async doConnect(): Promise<void> {
-    const mod = await loadWasmModule();
+    const epoch = ++this.connectEpoch;
+    const mod = await this.loadModule();
+    // Stale continuation: a newer connect attempt started (or the
+    // timeout tore this one down) while the module load was pending.
+    // Abort before creating a handle — the current attempt owns the
+    // connection now.
+    if (epoch !== this.connectEpoch || this.destroying) return;
     const config = new mod.WaddleConfig(
       this.session.xmpp_websocket_url,
       this.session.jid,
@@ -741,23 +792,53 @@ export class BrowserXmppClient {
   private connectTimeoutMs = 15_000;
 
   async connect(): Promise<void> {
+    // An explicit connect is a fresh start: restore the retry budget
+    // (C2 — otherwise a post-exhaustion user-triggered connect that
+    // fails re-exhausts instantly) alongside the terminal-error
+    // classification cleared below. Scheduler-driven retries go through
+    // `connectFromScheduler` and do NOT reset the budget.
+    this.reconnect.resetAttempts();
+    return this.connectInternal();
+  }
+
+  /** Reconnect-scheduler entry point: same connect machinery, but the
+   * retry budget is left alone so the attempt cap can exhaust. */
+  private connectFromScheduler(): Promise<void> {
+    return this.connectInternal();
+  }
+
+  private async connectInternal(): Promise<void> {
     if (this.xmpp && this.connected) return;
     if (this.connectPromise) return this.connectPromise;
     this.destroying = false;
     // An explicit connect is a fresh start: drop any terminal-error
     // classification from the previous session (#1164).
     this.terminalDisconnectDetail = null;
+    this.disarmOnlineRecovery();
     this.clearReconnectTimer();
     this.connectPromise = withSpan(
       "xmpp.connect",
       { "waddle.xmpp.transport": "websocket" },
       () => new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
+          // C1: the connect budget measures to session-ready, not to
+          // catch-up completion. `connect()`'s promise still resolves
+          // only after the resume barrier (callers rely on "connected
+          // AND caught up"), but once the session is established a
+          // slow MAM catch-up must not be treated as a stalled
+          // connect — tearing it down would drop the live handle,
+          // lose the buffered resume traffic, and livelock
+          // structurally-slow catch-ups into terminal error.
+          if (this.connected && this.xmpp) return;
           // #1164: a stalled connect must not strand the client in
           // limbo. Tear the half-open handle down (so a late
           // session-ready from it can't land — `isCurrentXmpp` guards
           // key off `this.xmpp`), tell the UI we're still trying, and
           // hand the retry to the backoff scheduler.
+          // C3: invalidate any continuation of this attempt still
+          // stalled on an `await` (module load) so it can't race a
+          // newer attempt into a second live handle.
+          this.connectEpoch += 1;
           this.connectPromise = null;
           this.onceConnected = null;
           this.onceConnectFailed = null;
@@ -793,6 +874,7 @@ export class BrowserXmppClient {
 
   async disconnect() {
     this.destroying = true;
+    this.disarmOnlineRecovery();
     this.clearReconnectTimer();
     this.clearResumeState();
     const xmpp = this.xmpp;
@@ -2124,11 +2206,15 @@ export class BrowserXmppClient {
     // #1164: a terminal failure (auth rejection, resource conflict)
     // means retrying is dishonest — surface `state: "error"` so the
     // connection notice tells the user to sign in again, and do NOT
-    // schedule a reconnect. The classification usually arrives via
-    // the preceding stream-error callback; connect-time failures may
-    // only carry it in the disconnect error's message.
-    const terminalDetail = this.terminalDisconnectDetail
-      ?? terminalDisconnectDetail(streamErrorConditionFromText(error?.message));
+    // schedule a reconnect. The classification comes exclusively from
+    // the preceding `set_on_error` callback (the WASM core reports
+    // stream errors structured, and connect-time SASL failures as the
+    // driver's ClientError display string — both land there BEFORE the
+    // disconnect callback, which itself carries no error). C4: never
+    // word-scan the disconnect error's free-text message — a proxied
+    // close reason like "409 Conflict" must not permanently kill
+    // reconnection.
+    const terminalDetail = this.terminalDisconnectDetail;
     if (terminalDetail) {
       this.terminalDisconnectDetail = null;
       this.emitStatus({ state: "error", detail: terminalDetail });
@@ -2205,7 +2291,7 @@ export class BrowserXmppClient {
    */
   private dispatchLiveMessage(message: InboundWasmMessage) {
     if (message.displayed_marker_id) { if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; this.events.emit("displayed", { roomJid, nick, messageId: message.displayed_marker_id }); } else this.events.emit("dmDisplayed", { peerJid: barePeerJid(message.from ?? message.to ?? ""), messageId: message.displayed_marker_id }); return; }
-    if (message.reaction_target_id) { if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; this.events.emit("reaction", { roomJid, nick, messageId: message.reaction_target_id, emojis: message.reaction_emojis }); } else { const fromBare = barePeerJid(message.from ?? ""); const toBare = barePeerJid(message.to ?? ""); const selfBare = barePeerJid(this.session.jid); const peerJid = fromBare === selfBare ? toBare : fromBare; const reactorJid = fromBare || selfBare; if (peerJid && reactorJid) this.events.emit("dmReaction", { peerJid, reactorJid, messageId: message.reaction_target_id, emojis: message.reaction_emojis }); } return; }
+    if (message.reaction_target_id) { const occurredAt = message.timestamp ? { occurredAt: message.timestamp } : {}; if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; this.events.emit("reaction", { roomJid, nick, messageId: message.reaction_target_id, emojis: message.reaction_emojis, ...occurredAt }); } else { const fromBare = barePeerJid(message.from ?? ""); const toBare = barePeerJid(message.to ?? ""); const selfBare = barePeerJid(this.session.jid); const peerJid = fromBare === selfBare ? toBare : fromBare; const reactorJid = fromBare || selfBare; if (peerJid && reactorJid) this.events.emit("dmReaction", { peerJid, reactorJid, messageId: message.reaction_target_id, emojis: message.reaction_emojis, ...occurredAt }); } return; }
     this.dispatchLiveBodyMessage(message);
   }
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -829,6 +829,13 @@ export class BrowserXmppClient {
    */
   async connect(): Promise<void> {
     if (this.xmpp && this.connected) return;
+    // Join an in-flight attempt BEFORE the terminal/exhausted gate:
+    // during the scheduler's FINAL attempt the timer is already null
+    // and the attempt counter is at the cap, so `isExhausted()` reads
+    // true for the whole (up to `connectTimeoutMs`) window even though
+    // the attempt may still succeed. A user action in that window must
+    // ride the pending attempt, not fast-reject.
+    if (this.connectPromise) return this.connectPromise;
     if (this.inTerminalErrorState || this.reconnect.isExhausted()) {
       throw new Error("XMPP session is not ready");
     }
@@ -892,6 +899,14 @@ export class BrowserXmppClient {
             this.xmpp = null;
             void Promise.resolve(stalled.disconnect?.()).catch(() => undefined);
           }
+          // An armed terminal detail is stale by construction here: it
+          // belongs to the handle we just destroyed, whose disconnect
+          // callback (the sole consumer) is now dropped by the handle
+          // guard. Left in place it would poison the scheduler's next
+          // attempt — its first transient disconnect would read as
+          // terminal. The retry re-encounters a genuinely terminal
+          // condition and re-classifies it via `set_on_error`.
+          this.terminalDisconnectDetail = null;
           if (!this.destroying) {
             this.emitStatus({ state: "reconnecting", detail: "Connection attempt timed out — retrying" });
             this.reconnect.schedule();
@@ -939,8 +954,13 @@ export class BrowserXmppClient {
     this.onceConnectFailed = null;
     failPendingConnect?.(new Error("XMPP disconnected"));
     // A disconnect is user-explicit (logout): the terminal-error latch
-    // must not survive into a later session on this instance.
+    // must not survive into a later session on this instance. The armed
+    // detail moves with it — the disconnect callback that would consume
+    // it is dropped by the handle guard once we tear down here, and a
+    // leftover detail would make the NEXT session's first transient
+    // disconnect flip to a false terminal "sign in again".
     this.inTerminalErrorState = false;
+    this.terminalDisconnectDetail = null;
     this.clearResumeState();
     const xmpp = this.xmpp;
     const joinedRooms = [...this.joinedMucs.keys()];

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -446,8 +446,14 @@ export class BrowserXmppClient {
   // disconnect arrive as two separate WASM callbacks; this carries
   // the classification from the first into `handleDisconnected`,
   // which then emits `state: "error"` instead of scheduling retries.
-  // Cleared by an explicit `connect()` (user-driven fresh attempt).
+  // Cleared by a user-explicit fresh attempt (`connectWithFreshBudget`).
   private terminalDisconnectDetail: string | null = null;
+  // F1: sticky marker that the client surfaced a terminal `state:
+  // "error"` ("sign in again"). While set, internal/background
+  // `connect()` calls reject fast without scheduling — only a
+  // user-explicit recovery intent (`connectWithFreshBudget`, or a
+  // page load constructing a new client) may leave this state.
+  private inTerminalErrorState = false;
 
   constructor(session: WaddleSession, persistence?: ResumePersistence) {
     this.session = session;
@@ -527,8 +533,11 @@ export class BrowserXmppClient {
       connect: () => this.connectFromScheduler(),
       onScheduled: (info) => this.events.emitSafe("reconnectScheduled", info),
       // #1164: the retry budget ran out — an endless "reconnecting"
-      // banner would be dishonest. An explicit `connect()` restores
-      // the budget; a network-return `online` event triggers one.
+      // banner would be dishonest. Only a user-explicit recovery
+      // restores the budget: the network-return `online` event fires
+      // `connectWithFreshBudget`, and a page reload constructs a new
+      // client. Internal `connect()` calls reject while exhausted and
+      // never restart the loop (F1).
       onExhausted: () => {
         this.armOnlineRecovery();
         if (browserOffline()) {
@@ -698,16 +707,19 @@ export class BrowserXmppClient {
   }
 
   // C2: after retry exhaustion nothing would ever try again when the
-  // network returns. Armed from `onExhausted`; a fresh `connect()`
-  // (which the listener fires, with a full budget) disarms it, as does
-  // the `disconnect()` logout path.
+  // network returns. Armed from `onExhausted`; the fresh-budget connect
+  // the listener fires disarms it (via `connectInternal`), as does the
+  // `disconnect()` logout path.
   private onlineRecoveryListener: (() => void) | null = null;
 
   private armOnlineRecovery(): void {
     if (typeof window === "undefined" || this.onlineRecoveryListener) return;
     const listener = () => {
       this.disarmOnlineRecovery();
-      void this.connect().catch(() => undefined);
+      // The network coming back is a user-environment recovery signal —
+      // one of the two fresh-budget entry points (the other being a
+      // page load, which constructs a new client).
+      void this.connectWithFreshBudget().catch(() => undefined);
     };
     this.onlineRecoveryListener = listener;
     window.addEventListener("online", listener);
@@ -790,14 +802,49 @@ export class BrowserXmppClient {
   /** Budget for a single connect attempt to reach session-ready. Instance
    * field (not a module constant) so tests can shrink it. */
   private connectTimeoutMs = 15_000;
+  /** F3: the pending attempt's budget timer, tracked on the instance so
+   * `disconnect()` can cancel it — an orphaned timer surviving a
+   * disconnect would later tear down a NEWER connect's half-open handle
+   * (spurious "reconnecting" + a stray teardown). */
+  private connectTimer: ReturnType<typeof setTimeout> | null = null;
 
+  /**
+   * Internal/background connect path. Nearly every call site routes
+   * through here indirectly (`requireConnectedXmpp`, room switching,
+   * MAM pagers, send fallbacks, the XEP-0319 idle tracker via
+   * `setPresence`) — i.e. background triggers that fire constantly in
+   * an attended tab. This path therefore deliberately does NOT reset
+   * the retry budget (F1: resetting on every mouse move during an
+   * outage made exhaustion unreachable and hammered the server at
+   * restarted backoff) and does NOT clear a terminal-error
+   * classification. While terminal or exhausted it rejects fast
+   * without scheduling retries or emitting status, so
+   * `requireConnectedXmpp` callers fail the same way they do for any
+   * unavailable session and background pollers cause no status churn.
+   *
+   * Fresh-budget recovery is reserved for genuinely user-explicit
+   * intents via `connectWithFreshBudget` — currently the window
+   * `online` recovery listener; a page load gets a fresh budget
+   * implicitly by constructing a new client.
+   */
   async connect(): Promise<void> {
-    // An explicit connect is a fresh start: restore the retry budget
-    // (C2 — otherwise a post-exhaustion user-triggered connect that
-    // fails re-exhausts instantly) alongside the terminal-error
-    // classification cleared below. Scheduler-driven retries go through
-    // `connectFromScheduler` and do NOT reset the budget.
+    if (this.xmpp && this.connected) return;
+    if (this.inTerminalErrorState || this.reconnect.isExhausted()) {
+      throw new Error("XMPP session is not ready");
+    }
+    return this.connectInternal();
+  }
+
+  /**
+   * User-explicit recovery entry (C2/F1): restores the retry budget —
+   * otherwise a post-exhaustion recovery attempt that fails would
+   * re-exhaust instantly — and drops any terminal-error classification
+   * (#1164). Internal/background callers must use `connect()` instead.
+   */
+  private connectWithFreshBudget(): Promise<void> {
     this.reconnect.resetAttempts();
+    this.inTerminalErrorState = false;
+    this.terminalDisconnectDetail = null;
     return this.connectInternal();
   }
 
@@ -811,9 +858,6 @@ export class BrowserXmppClient {
     if (this.xmpp && this.connected) return;
     if (this.connectPromise) return this.connectPromise;
     this.destroying = false;
-    // An explicit connect is a fresh start: drop any terminal-error
-    // classification from the previous session (#1164).
-    this.terminalDisconnectDetail = null;
     this.disarmOnlineRecovery();
     this.clearReconnectTimer();
     this.connectPromise = withSpan(
@@ -839,6 +883,7 @@ export class BrowserXmppClient {
           // stalled on an `await` (module load) so it can't race a
           // newer attempt into a second live handle.
           this.connectEpoch += 1;
+          this.connectTimer = null;
           this.connectPromise = null;
           this.onceConnected = null;
           this.onceConnectFailed = null;
@@ -853,8 +898,10 @@ export class BrowserXmppClient {
           }
           reject(new Error("Reconnection timed out"));
         }, this.connectTimeoutMs);
+        this.connectTimer = timeout;
         const done = (fn: () => void) => {
           clearTimeout(timeout);
+          if (this.connectTimer === timeout) this.connectTimer = null;
           this.connectPromise = null;
           fn();
         };
@@ -876,6 +923,24 @@ export class BrowserXmppClient {
     this.destroying = true;
     this.disarmOnlineRecovery();
     this.clearReconnectTimer();
+    // F3: cancel the pending connect attempt outright. Bump the epoch
+    // so a continuation stalled on the module load aborts, clear the
+    // budget timer so it cannot fire later against a NEWER connect's
+    // half-open handle, and settle the pending `connect()` promise so
+    // its awaiter isn't left dangling (or spuriously rejected by the
+    // orphaned timer long after this disconnect).
+    this.connectEpoch += 1;
+    if (this.connectTimer) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
+    const failPendingConnect = this.onceConnectFailed;
+    this.onceConnected = null;
+    this.onceConnectFailed = null;
+    failPendingConnect?.(new Error("XMPP disconnected"));
+    // A disconnect is user-explicit (logout): the terminal-error latch
+    // must not survive into a later session on this instance.
+    this.inTerminalErrorState = false;
     this.clearResumeState();
     const xmpp = this.xmpp;
     const joinedRooms = [...this.joinedMucs.keys()];
@@ -2217,6 +2282,9 @@ export class BrowserXmppClient {
     const terminalDetail = this.terminalDisconnectDetail;
     if (terminalDetail) {
       this.terminalDisconnectDetail = null;
+      // F1: latch the terminal state so background `connect()` calls
+      // cannot silently exit the "sign in again" error surface.
+      this.inTerminalErrorState = true;
       this.emitStatus({ state: "error", detail: terminalDetail });
       if (this.onceConnectFailed) { const fail = this.onceConnectFailed; this.onceConnected = null; this.onceConnectFailed = null; fail(error ?? new Error(terminalDetail)); }
       return;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -201,6 +201,27 @@ type XmppStreamErrorPayload = string | {
   streamManagementError?: XmppErrorEvent["streamManagementError"] | null;
 };
 
+/**
+ * #1164: stream-error conditions that no amount of retrying can fix —
+ * the credentials or the session itself were rejected, so the honest
+ * UI state is terminal `"error"` ("sign in again"), not an eternal
+ * "reconnecting" spinner. Maps each condition to the user-facing
+ * status detail (`connection-notice.ts` renders the copy).
+ */
+const TERMINAL_STREAM_CONDITION_DETAILS: Record<string, string> = {
+  // RFC 6120 §4.9.3.12 / SASL failure surfaced as a stream error:
+  // the session token is no longer accepted.
+  "not-authorized": "Your session expired — sign in again to restore live messaging.",
+  // RFC 6120 §4.9.3.3: the server closed this stream in favour of a
+  // newer one for the same resource; reconnecting would just fight it.
+  conflict: "This session was replaced by a newer sign-in for the same account.",
+};
+
+function terminalDisconnectDetail(condition: string | undefined): string | null {
+  if (!condition) return null;
+  return TERMINAL_STREAM_CONDITION_DETAILS[condition] ?? null;
+}
+
 function streamErrorConditionFromText(text: string | null | undefined): string | undefined {
   const normalized = text?.trim().toLowerCase();
   if (!normalized) return undefined;
@@ -388,6 +409,14 @@ export class BrowserXmppClient {
   // a `before=` page is in flight can skip or duplicate messages near
   // the page boundary).
   //
+  // Targeted follow-ups — XEP-0333 displayed markers and XEP-0444
+  // reactions — are buffered too (#1165): applying one before its
+  // target row exists makes the merge layer drop it silently. The
+  // drain dispatches bodies first, then follow-ups, preserving
+  // arrival order within each kind. Ephemeral traffic (chat states,
+  // in-call reactions, pin-event store updates) stays live — it is
+  // meaningless to replay after the fact.
+  //
   // `resumeBarrier` coalesces redundant resume triggers. Three event
   // sources can fire `handleSessionReady` for the same xmpp handle:
   // `set_on_session_lifecycle`, `on("session:started")`, and
@@ -412,6 +441,13 @@ export class BrowserXmppClient {
   // entry) cannot observe one set without the other.
   private resumeBarrier: { xmpp: XmppClientInstance; promise: Promise<void> } | null = null;
   private pendingDuringResume: InboundWasmMessage[] | null = null;
+  // #1164: set when a stream error announced a terminal condition
+  // (see `TERMINAL_STREAM_CONDITION_DETAILS`). The wire error and the
+  // disconnect arrive as two separate WASM callbacks; this carries
+  // the classification from the first into `handleDisconnected`,
+  // which then emits `state: "error"` instead of scheduling retries.
+  // Cleared by an explicit `connect()` (user-driven fresh attempt).
+  private terminalDisconnectDetail: string | null = null;
 
   constructor(session: WaddleSession, persistence?: ResumePersistence) {
     this.session = session;
@@ -490,6 +526,14 @@ export class BrowserXmppClient {
       isDestroying: () => this.destroying,
       connect: () => this.connect(),
       onScheduled: (info) => this.events.emitSafe("reconnectScheduled", info),
+      // #1164: the retry budget ran out — an endless "reconnecting"
+      // banner would be dishonest. Terminal error state; the user can
+      // retry via reload / sign-in (`connect()` resets the budget path
+      // through session-ready's `resetAttempts`).
+      onExhausted: () => this.emitStatus({
+        state: "error",
+        detail: "We couldn't reconnect after several attempts. Check your connection, then reload to try again.",
+      }),
     });
     this.retainedJoinedRoomJids = new Set(this.resumePersistence.loadJoinedRooms());
   }
@@ -692,20 +736,42 @@ export class BrowserXmppClient {
 
   private onceConnected: (() => void) | null = null;
   private onceConnectFailed: ((error: Error) => void) | null = null;
+  /** Budget for a single connect attempt to reach session-ready. Instance
+   * field (not a module constant) so tests can shrink it. */
+  private connectTimeoutMs = 15_000;
 
   async connect(): Promise<void> {
     if (this.xmpp && this.connected) return;
     if (this.connectPromise) return this.connectPromise;
     this.destroying = false;
+    // An explicit connect is a fresh start: drop any terminal-error
+    // classification from the previous session (#1164).
+    this.terminalDisconnectDetail = null;
     this.clearReconnectTimer();
     this.connectPromise = withSpan(
       "xmpp.connect",
       { "waddle.xmpp.transport": "websocket" },
       () => new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
+          // #1164: a stalled connect must not strand the client in
+          // limbo. Tear the half-open handle down (so a late
+          // session-ready from it can't land — `isCurrentXmpp` guards
+          // key off `this.xmpp`), tell the UI we're still trying, and
+          // hand the retry to the backoff scheduler.
           this.connectPromise = null;
+          this.onceConnected = null;
+          this.onceConnectFailed = null;
+          const stalled = this.xmpp;
+          if (stalled) {
+            this.xmpp = null;
+            void Promise.resolve(stalled.disconnect?.()).catch(() => undefined);
+          }
+          if (!this.destroying) {
+            this.emitStatus({ state: "reconnecting", detail: "Connection attempt timed out — retrying" });
+            this.reconnect.schedule();
+          }
           reject(new Error("Reconnection timed out"));
-        }, 15000);
+        }, this.connectTimeoutMs);
         const done = (fn: () => void) => {
           clearTimeout(timeout);
           this.connectPromise = null;
@@ -1952,15 +2018,23 @@ export class BrowserXmppClient {
     // echoes alongside (or before) the inbound arrivals they belong
     // next to, instead of mis-ordering the tail (Bug 4).
     this.flushAfterSessionReady(xmpp);
-    // Drain in arrival order. Each replay flows through the same
-    // `dispatchLiveBodyMessage` path that a fresh socket arrival
-    // would, so cursor advance + downstream `message` /
-    // `directMessage` listener dedup behave identically.
+    // Drain bodies first, then targeted follow-ups (displayed markers
+    // + reactions), each kind in arrival order (#1165). A follow-up
+    // whose target arrived during the same catch-up window — via MAM
+    // pagination (already merged: `runReconnectCatchup` completed
+    // before this drain) or via the live buffer itself — must see its
+    // target row already inserted, or `applyReactionUpdate` /
+    // `applyDisplayedMarker` short-circuit on the miss and the merge
+    // layers drop it silently. Each replay flows through the same
+    // `dispatchLiveMessage` path a fresh socket arrival would, so
+    // cursor advance + downstream listener dedup behave identically.
     // Observe-only: the buffer drain is a single synchronous task over
     // everything that arrived during the resume barrier — a prime
     // background-tab HUNG suspect. Measure its size + wall-clock.
     const drainStartedAt = performance.now();
-    for (const m of buffered) this.dispatchLiveBodyMessage(m);
+    const isTargetedFollowUp = (m: InboundWasmMessage) => !!m.displayed_marker_id || !!m.reaction_target_id;
+    for (const m of buffered) if (!isTargetedFollowUp(m)) this.dispatchLiveMessage(m);
+    for (const m of buffered) if (isTargetedFollowUp(m)) this.dispatchLiveMessage(m);
     this.events.emitSafe("resumeDrain", {
       buffered: buffered.length,
       durationMs: performance.now() - drainStartedAt,
@@ -2047,6 +2121,20 @@ export class BrowserXmppClient {
     this.joinedMucReady.clear();
     this.clearRoomPresenceCaches();
     if (this.destroying) { this.clearResumeState(); this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
+    // #1164: a terminal failure (auth rejection, resource conflict)
+    // means retrying is dishonest — surface `state: "error"` so the
+    // connection notice tells the user to sign in again, and do NOT
+    // schedule a reconnect. The classification usually arrives via
+    // the preceding stream-error callback; connect-time failures may
+    // only carry it in the disconnect error's message.
+    const terminalDetail = this.terminalDisconnectDetail
+      ?? terminalDisconnectDetail(streamErrorConditionFromText(error?.message));
+    if (terminalDetail) {
+      this.terminalDisconnectDetail = null;
+      this.emitStatus({ state: "error", detail: terminalDetail });
+      if (this.onceConnectFailed) { const fail = this.onceConnectFailed; this.onceConnected = null; this.onceConnectFailed = null; fail(error ?? new Error(terminalDetail)); }
+      return;
+    }
     // Keep transient reconnect state in this JS context only — see
     // `ResumeStateStore.captureFromDisconnect` for the pagehide-handoff
     // rationale.
@@ -2082,7 +2170,6 @@ export class BrowserXmppClient {
       else this.events.emit("dmChatState", { peerJid: barePeerJid(message.from ?? message.to ?? ""), state: message.chat_state as ChatStateType });
       return;
     }
-    if (message.displayed_marker_id) { if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; this.events.emit("displayed", { roomJid, nick, messageId: message.displayed_marker_id }); } else this.events.emit("dmDisplayed", { peerJid: barePeerJid(message.from ?? message.to ?? ""), messageId: message.displayed_marker_id }); return; }
     if (message.in_call?.kind === "reaction") {
       if (!isInCallReactionForActiveCall($callState.get(), message.in_call.sid)) return;
       receiveInCallReaction({
@@ -2092,7 +2179,6 @@ export class BrowserXmppClient {
       });
       return;
     }
-    if (message.reaction_target_id) { if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; this.events.emit("reaction", { roomJid, nick, messageId: message.reaction_target_id, emojis: message.reaction_emojis }); } else { const fromBare = barePeerJid(message.from ?? ""); const toBare = barePeerJid(message.to ?? ""); const selfBare = barePeerJid(this.session.jid); const peerJid = fromBare === selfBare ? toBare : fromBare; const reactorJid = fromBare || selfBare; if (peerJid && reactorJid) this.events.emit("dmReaction", { peerJid, reactorJid, messageId: message.reaction_target_id, emojis: message.reaction_emojis }); } return; }
     if (message.pin_event) {
       const roomJid = message.is_muc
         ? barePeerJid(message.from ?? message.to ?? "")
@@ -2107,6 +2193,19 @@ export class BrowserXmppClient {
       this.pendingDuringResume.push(message);
       return;
     }
+    this.dispatchLiveMessage(message);
+  }
+
+  /**
+   * Dispatch a live inbound message past the resume gate: targeted
+   * follow-ups (XEP-0333 displayed markers, XEP-0444 reactions) emit
+   * their dedicated events; everything else is a body message. Called
+   * both from `handleMessage` (no barrier) and from the barrier drain
+   * in `completeResumeBarrier` — it never re-enters the buffer.
+   */
+  private dispatchLiveMessage(message: InboundWasmMessage) {
+    if (message.displayed_marker_id) { if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; this.events.emit("displayed", { roomJid, nick, messageId: message.displayed_marker_id }); } else this.events.emit("dmDisplayed", { peerJid: barePeerJid(message.from ?? message.to ?? ""), messageId: message.displayed_marker_id }); return; }
+    if (message.reaction_target_id) { if (message.is_muc) { const roomJid = barePeerJid(message.from ?? message.to ?? ""); const nick = (message.from ?? "").split("/")[1] ?? "unknown"; this.events.emit("reaction", { roomJid, nick, messageId: message.reaction_target_id, emojis: message.reaction_emojis }); } else { const fromBare = barePeerJid(message.from ?? ""); const toBare = barePeerJid(message.to ?? ""); const selfBare = barePeerJid(this.session.jid); const peerJid = fromBare === selfBare ? toBare : fromBare; const reactorJid = fromBare || selfBare; if (peerJid && reactorJid) this.events.emit("dmReaction", { peerJid, reactorJid, messageId: message.reaction_target_id, emojis: message.reaction_emojis }); } return; }
     this.dispatchLiveBodyMessage(message);
   }
 
@@ -2152,9 +2251,11 @@ export class BrowserXmppClient {
     xmpp.set_on_error?.((payload: XmppStreamErrorPayload) => {
       if (this.xmpp !== xmpp) return;
       const streamError = normalizeXmppStreamErrorPayload(payload);
+      const terminalDetail = terminalDisconnectDetail(streamError.condition);
+      if (terminalDetail) this.terminalDisconnectDetail = terminalDetail;
       this.emitError({
         kind: "stream",
-        recoverable: !this.destroying,
+        recoverable: !this.destroying && !terminalDetail,
         detail: streamError.detail,
         ...(streamError.condition ? { condition: streamError.condition } : {}),
         ...(streamError.streamManagementError

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -372,6 +372,9 @@ export interface ReactionEvent {
   authorRealJid?: string;
   messageId: string;
   emojis: string[];
+  /** RFC 3339 instant the reaction stanza was emitted (delay stamp on
+   * SM/MAM replays). Absent on live undelayed stanzas. */
+  occurredAt?: string;
 }
 
 export interface DmConversation {
@@ -416,6 +419,9 @@ export interface DmReactionEvent {
   reactorJid: string;
   messageId: string;
   emojis: string[];
+  /** RFC 3339 instant the reaction stanza was emitted (delay stamp on
+   * SM/MAM replays). Absent on live undelayed stanzas. */
+  occurredAt?: string;
 }
 
 export interface PresenceUpdateEvent {

--- a/chat/tests/client-connection.test.ts
+++ b/chat/tests/client-connection.test.ts
@@ -195,6 +195,31 @@ describe("OfflineSendQueue drain ordering", () => {
     expect(sends).toEqual([{ roomJid: "general@muc.example.com", body: "to general" }]);
   });
 
+  test("queueing while connected (room not joined) does not emit a reconnecting status (#1164)", () => {
+    const { queue, statuses } = createQueue({
+      canUseConnectedSession: () => true,
+      roomIsReady: () => false,
+    });
+
+    queue.queueRoomMessage("general@muc.example.com", "hello", { id: "room-q1" });
+
+    // The message still queues, but the global banner must stay online.
+    expect(listQueuedMessages(SCOPE).map((entry) => entry.id)).toEqual(["room-q1"]);
+    expect(statuses).toHaveLength(0);
+  });
+
+  test("queueing while the session is unusable still reports the reconnecting status", () => {
+    const { queue, statuses } = createQueue({
+      canUseConnectedSession: () => false,
+    });
+
+    queue.queueDirectMessage("bob@example.com", "hello", { id: "dm-q1" });
+
+    expect(statuses).toEqual([
+      { state: "reconnecting", detail: "Message queued until the connection returns" },
+    ]);
+  });
+
   test("seedFromResumeState tracks XEP-0198 replayed stanza ids so acks clear the store", () => {
     const { queue, events } = createQueue();
     const depths: Array<{ persisted: number; inflight: number }> = [];
@@ -222,6 +247,7 @@ describe("ReconnectScheduler", () => {
       isDestroying: () => false,
       connect: async () => undefined,
       onScheduled: (info) => scheduled.push(info),
+      onExhausted: () => undefined,
     });
 
     scheduler.schedule();
@@ -241,12 +267,39 @@ describe("ReconnectScheduler", () => {
     expect(scheduled.at(-1)).toEqual({ attempt: 1, delayMs: 2000 });
   });
 
+  test("caps attempts at 10 and reports exhaustion instead of scheduling forever (#1164)", () => {
+    const scheduled: Array<{ attempt: number; delayMs: number }> = [];
+    let exhausted = 0;
+    const scheduler = new ReconnectScheduler({
+      isDestroying: () => false,
+      connect: async () => undefined,
+      onScheduled: (info) => scheduled.push(info),
+      onExhausted: () => { exhausted += 1; },
+    });
+
+    for (let i = 0; i < 12; i += 1) {
+      scheduler.schedule();
+      scheduler.clearTimer();
+    }
+
+    expect(scheduled).toHaveLength(10);
+    expect(scheduled.at(-1)).toEqual({ attempt: 10, delayMs: 60000 });
+    expect(exhausted).toBe(2);
+
+    // A successful session-ready resets the budget.
+    scheduler.resetAttempts();
+    scheduler.schedule();
+    scheduler.clearTimer();
+    expect(scheduled.at(-1)).toEqual({ attempt: 1, delayMs: 2000 });
+  });
+
   test("does not schedule while destroying and reports reconnect duration on completion", () => {
     const scheduled: Array<{ attempt: number; delayMs: number }> = [];
     const scheduler = new ReconnectScheduler({
       isDestroying: () => true,
       connect: async () => undefined,
       onScheduled: (info) => scheduled.push(info),
+      onExhausted: () => undefined,
     });
     scheduler.schedule();
     expect(scheduled).toHaveLength(0);

--- a/chat/tests/reaction-recency.test.ts
+++ b/chat/tests/reaction-recency.test.ts
@@ -27,6 +27,7 @@ const ROOM_JID = "room@muc.example.com";
 const BOB = `${ROOM_JID}/bob`;
 
 const OLDER = "2026-07-05T10:00:00.000Z";
+const MIDDLE = "2026-07-05T10:02:00.000Z";
 const NEWER = "2026-07-05T10:05:00.000Z";
 
 function channelHarness(seed: TimelineMessage[]) {
@@ -165,6 +166,96 @@ describe("XEP-0444 live undelayed reactions advance the recency stamp (DM)", () 
     h.liveMerge.applyReaction("m1", "bob", ["🎉"], NEWER);
     expect(h.messages.value).toBe(before);
     expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bob"] });
+  });
+});
+
+// F3: the server truncates XEP-0203 delay stamps to whole seconds, so a
+// 👍→❤️ toggle within one second replays as two stanzas with IDENTICAL
+// stamps. XEP-0444 rejects only if a strictly NEWER reaction was already
+// accepted — on a tie, in-order delivery makes the later-processed
+// update the newer one, so a different set must apply. Only an exact
+// re-delivery (same set) stays an idempotent no-op.
+describe("XEP-0444 equal-stamp tie applies a different set (F3)", () => {
+  test("channel: a same-second toggle replayed with an identical stamp applies the final set", () => {
+    const h = channelHarness([channelTarget()]);
+    h.liveMerge.applyReaction("stanza-1", "bob", ["👍"], BOB, NEWER);
+    h.liveMerge.applyReaction("stanza-1", "bob", ["❤️"], BOB, NEWER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "❤️": ["bob"] });
+  });
+
+  test("channel: an exact re-delivery on the tie stays an idempotent no-op", () => {
+    const h = channelHarness([channelTarget()]);
+    h.liveMerge.applyReaction("stanza-1", "bob", ["👍", "🎉"], BOB, NEWER);
+    const before = h.messages.value;
+    h.liveMerge.applyReaction("stanza-1", "bob", ["🎉", "👍"], BOB, NEWER);
+    expect(h.messages.value).toBe(before);
+    expect(h.messages.value[0]?.reactions).toEqual({ "👍": ["bob"], "🎉": ["bob"] });
+  });
+
+  test("dm: a same-second toggle replayed with an identical stamp applies the final set", () => {
+    const h = dmHarness([dmTarget()]);
+    h.liveMerge.applyReaction("m1", "bob", ["👍"], NEWER);
+    h.liveMerge.applyReaction("m1", "bob", ["❤️"], NEWER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "❤️": ["bob"] });
+  });
+});
+
+// F4: live undelayed reactions must never stamp the LOCAL clock into a
+// recency map that is compared against SERVER delay stamps — a client
+// clock ahead by Δ would drop any genuinely newer reaction replayed
+// within Δ. The wire stamps here are in the past relative to the test
+// machine's clock, so the machine's clock IS "ahead" by construction.
+describe("live undelayed stamps never mix clock domains (F4)", () => {
+  test("channel: a replayed reaction newer than the last wire stamp applies despite a skewed-ahead local clock", () => {
+    const h = channelHarness([channelTarget()]);
+    // Wire-stamped 👍 at T0.
+    h.liveMerge.applyReaction("stanza-1", "bob", ["👍"], BOB, OLDER);
+    // Live undelayed toggle — recorded in the local domain.
+    h.liveMerge.applyReaction("stanza-1", "bob", ["🎉"], BOB);
+    // The sender's genuinely newer reaction arrives via SM replay with
+    // a server stamp far below the local clock. It must apply.
+    h.liveMerge.applyReaction("stanza-1", "bob", ["❤️"], BOB, NEWER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "❤️": ["bob"] });
+  });
+
+  test("channel: replays at or before the wire stamp the live reaction superseded stay stale", () => {
+    const h = channelHarness([channelTarget()]);
+    h.liveMerge.applyReaction("stanza-1", "bob", ["👍"], BOB, NEWER);
+    h.liveMerge.applyReaction("stanza-1", "bob", ["🎉"], BOB);
+    // Re-delivery of the superseded stanza and an even older one.
+    h.liveMerge.applyReaction("stanza-1", "bob", ["👍"], BOB, NEWER);
+    h.liveMerge.applyReaction("stanza-1", "bob", ["😅"], BOB, OLDER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bob"] });
+  });
+
+  test("dm: a replayed reaction newer than the last wire stamp applies despite a skewed-ahead local clock", () => {
+    const h = dmHarness([dmTarget()]);
+    h.liveMerge.applyReaction("m1", "bob", ["👍"], OLDER);
+    h.liveMerge.applyReaction("m1", "bob", ["🎉"]);
+    h.liveMerge.applyReaction("m1", "bob", ["❤️"], NEWER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "❤️": ["bob"] });
+  });
+});
+
+// F5: MUC recency must be keyed by the same senderId used for reaction
+// replacement (real bare JID when known) — nicks are NOT stable. A nick
+// rename must not let a re-delivered pre-rename stanza bypass the gate.
+describe("MUC recency is keyed by senderId, not nick (F5)", () => {
+  const REAL = "bob@example.com";
+
+  test("a nick rename does not let a re-delivered pre-rename reaction clobber the newer set", () => {
+    const h = channelHarness([channelTarget()]);
+    // bob reacts pre-rename, then renames to bobby and reacts again
+    // (same real JID).
+    h.liveMerge.applyReaction("stanza-1", "bob", ["👍"], REAL, OLDER);
+    h.liveMerge.applyReaction("stanza-1", "bobby", ["🎉"], REAL, NEWER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bobby"] });
+    // MAM catch-up delivers a pre-rename toggle this client missed live,
+    // under the OLD nick. Under nick-keyed recency it passes the gate
+    // (nick bob's stamp is OLDER) and clobbers the newer post-rename
+    // set; senderId-keyed recency (stamp NEWER) rejects it.
+    h.liveMerge.applyReaction("stanza-1", "bob", ["😀"], REAL, MIDDLE);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bobby"] });
   });
 });
 

--- a/chat/tests/reaction-recency.test.ts
+++ b/chat/tests/reaction-recency.test.ts
@@ -1,0 +1,167 @@
+// XEP-0444 Business Rules: a delayed reaction SHOULD be accepted only
+// if no NEWER reaction from the same sender was already accepted (C5).
+//
+// The trigger in Waddle is the resume-barrier drain ordering: SM replays
+// a delay-stamped old reaction into the resume buffer; MAM catch-up
+// merges a newer reaction from the same sender first; the drain then
+// applies the old one last and must NOT clobber the newer set.
+
+import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
+import { useChannelLiveMerge } from "../src/channels/live-merge";
+import { buildChannelTimelineFromMamResults } from "../src/channels/message-timeline-state";
+import { useDmLiveMerge } from "../src/dms/live-merge";
+import { buildDmTimelineFromMamResults } from "../src/dms/message-timeline-state";
+import type { LiveDmMessage, LiveRoomMessage } from "../src/lib/xmpp-client";
+import type { WaddleSession } from "../src/lib/server-auth";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+
+const session: WaddleSession = {
+  username: "alice",
+  jid: "alice@example.com/desktop",
+  session_id: "tok",
+  xmpp_websocket_url: "wss://example.com/ws",
+};
+
+const ROOM_JID = "room@muc.example.com";
+const BOB = `${ROOM_JID}/bob`;
+
+const OLDER = "2026-07-05T10:00:00.000Z";
+const NEWER = "2026-07-05T10:05:00.000Z";
+
+function channelHarness(seed: TimelineMessage[]) {
+  const messages = ref<TimelineMessage[]>(seed);
+  const liveMerge = useChannelLiveMerge({
+    session: ref(session),
+    messages,
+    activeChannelId: ref("general"),
+    pendingEchoClientIds: new Set<string>(),
+    scrollToPinnedEdgeAndPin: mock(async () => true),
+    persistLastSeen: mock(() => {}),
+  });
+  return { messages, liveMerge };
+}
+
+function dmHarness(seed: TimelineMessage[]) {
+  const messages = ref<TimelineMessage[]>(seed);
+  const liveMerge = useDmLiveMerge({
+    session: ref(session),
+    messages,
+    activePeerJid: ref("bob@example.com"),
+    pendingEchoClientIds: new Set<string>(),
+    scrollToPinnedEdgeAndPin: mock(async () => true),
+    persistLastSeen: mock(() => {}),
+    isFeedVisible: () => true,
+  });
+  return { messages, liveMerge };
+}
+
+function channelTarget(): TimelineMessage {
+  return {
+    id: "m1",
+    reactionTargetId: "stanza-1",
+    body: "hello",
+    nick: "alice",
+    timestamp: 0,
+  } as TimelineMessage;
+}
+
+function dmTarget(): TimelineMessage {
+  return { id: "m1", body: "hello", nick: "alice", timestamp: 0 } as TimelineMessage;
+}
+
+describe("XEP-0444 delayed-reaction recency (channel)", () => {
+  test("an older delayed reaction from the same sender does not clobber a newer applied one", () => {
+    const h = channelHarness([channelTarget()]);
+    h.liveMerge.applyReaction("stanza-1", "bob", ["🎉"], BOB, NEWER);
+    h.liveMerge.applyReaction("stanza-1", "bob", ["👍"], BOB, OLDER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bob"] });
+  });
+
+  test("older-then-newer still applies the newer set", () => {
+    const h = channelHarness([channelTarget()]);
+    h.liveMerge.applyReaction("stanza-1", "bob", ["👍"], BOB, OLDER);
+    h.liveMerge.applyReaction("stanza-1", "bob", ["🎉"], BOB, NEWER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bob"] });
+  });
+
+  test("a different sender's older reaction is unaffected", () => {
+    const h = channelHarness([channelTarget()]);
+    h.liveMerge.applyReaction("stanza-1", "bob", ["🎉"], BOB, NEWER);
+    h.liveMerge.applyReaction("stanza-1", "carol", ["👍"], `${ROOM_JID}/carol`, OLDER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bob"], "👍": ["carol"] });
+  });
+
+  test("a reaction without a timestamp still applies (live undelayed stanza)", () => {
+    const h = channelHarness([channelTarget()]);
+    h.liveMerge.applyReaction("stanza-1", "bob", ["🎉"], BOB, NEWER);
+    h.liveMerge.applyReaction("stanza-1", "bob", ["👍"], BOB);
+    expect(h.messages.value[0]?.reactions).toEqual({ "👍": ["bob"] });
+  });
+
+  test("a MAM-merged newer reaction wins over a drained older live reaction", () => {
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [
+        {
+          type: "message",
+          roomJid: ROOM_JID,
+          fromJid: BOB,
+          nick: "bob",
+          body: "",
+          createdAt: NEWER,
+          _reactionTarget: "stanza-1",
+          _reactionEmojis: ["🎉"],
+        } as unknown as LiveRoomMessage,
+      ],
+      existing: [channelTarget()],
+    });
+    const h = channelHarness(timeline);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bob"] });
+
+    // Resume-barrier drain replays the delay-stamped OLD reaction last.
+    h.liveMerge.applyReaction("stanza-1", "bob", ["👍"], BOB, OLDER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bob"] });
+  });
+});
+
+describe("XEP-0444 delayed-reaction recency (DM)", () => {
+  test("an older delayed reaction from the same sender does not clobber a newer applied one", () => {
+    const h = dmHarness([dmTarget()]);
+    h.liveMerge.applyReaction("m1", "bob", ["🎉"], NEWER);
+    h.liveMerge.applyReaction("m1", "bob", ["👍"], OLDER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bob"] });
+  });
+
+  test("older-then-newer still applies the newer set", () => {
+    const h = dmHarness([dmTarget()]);
+    h.liveMerge.applyReaction("m1", "bob", ["👍"], OLDER);
+    h.liveMerge.applyReaction("m1", "bob", ["🎉"], NEWER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bob"] });
+  });
+
+  test("a MAM-merged newer reaction wins over a drained older live reaction", () => {
+    const timeline = buildDmTimelineFromMamResults({
+      session,
+      mamResults: [
+        {
+          type: "message",
+          peerJid: "bob@example.com",
+          fromJid: "bob@example.com",
+          nick: "bob",
+          body: "",
+          createdAt: NEWER,
+          _reactionTarget: "m1",
+          _reactionEmojis: ["🎉"],
+        } as unknown as LiveDmMessage,
+      ],
+      existing: [dmTarget()],
+    });
+    const h = dmHarness(timeline);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bob"] });
+
+    h.liveMerge.applyReaction("m1", "bob", ["👍"], OLDER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bob"] });
+  });
+});

--- a/chat/tests/reaction-recency.test.ts
+++ b/chat/tests/reaction-recency.test.ts
@@ -126,6 +126,48 @@ describe("XEP-0444 delayed-reaction recency (channel)", () => {
   });
 });
 
+describe("XEP-0444 live undelayed reactions advance the recency stamp (channel)", () => {
+  test("a re-delivered older delayed stanza cannot clobber a newer live undelayed reaction", () => {
+    const h = channelHarness([channelTarget()]);
+    // Delayed reaction T2 applies and stamps bob→T2.
+    h.liveMerge.applyReaction("stanza-1", "bob", ["🎉"], BOB, NEWER);
+    // Bob's NEWER live undelayed reaction replaces the set.
+    h.liveMerge.applyReaction("stanza-1", "bob", ["👍"], BOB);
+    // The T2 stanza re-delivers (SM replay / overlapping MAM): it is
+    // older than the live reaction and must not clobber it.
+    h.liveMerge.applyReaction("stanza-1", "bob", ["🎉"], BOB, NEWER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "👍": ["bob"] });
+  });
+
+  test("exact same-stanza re-delivery is an idempotent no-op", () => {
+    const h = channelHarness([channelTarget()]);
+    h.liveMerge.applyReaction("stanza-1", "bob", ["🎉"], BOB, NEWER);
+    const before = h.messages.value;
+    h.liveMerge.applyReaction("stanza-1", "bob", ["🎉"], BOB, NEWER);
+    expect(h.messages.value).toBe(before);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bob"] });
+  });
+});
+
+describe("XEP-0444 live undelayed reactions advance the recency stamp (DM)", () => {
+  test("a re-delivered older delayed stanza cannot clobber a newer live undelayed reaction", () => {
+    const h = dmHarness([dmTarget()]);
+    h.liveMerge.applyReaction("m1", "bob", ["🎉"], NEWER);
+    h.liveMerge.applyReaction("m1", "bob", ["👍"]);
+    h.liveMerge.applyReaction("m1", "bob", ["🎉"], NEWER);
+    expect(h.messages.value[0]?.reactions).toEqual({ "👍": ["bob"] });
+  });
+
+  test("exact same-stanza re-delivery is an idempotent no-op", () => {
+    const h = dmHarness([dmTarget()]);
+    h.liveMerge.applyReaction("m1", "bob", ["🎉"], NEWER);
+    const before = h.messages.value;
+    h.liveMerge.applyReaction("m1", "bob", ["🎉"], NEWER);
+    expect(h.messages.value).toBe(before);
+    expect(h.messages.value[0]?.reactions).toEqual({ "🎉": ["bob"] });
+  });
+});
+
 describe("XEP-0444 delayed-reaction recency (DM)", () => {
   test("an older delayed reaction from the same sender does not clobber a newer applied one", () => {
     const h = dmHarness([dmTarget()]);

--- a/chat/tests/reconnect-state-machine.test.ts
+++ b/chat/tests/reconnect-state-machine.test.ts
@@ -29,7 +29,17 @@ type PrivateState = {
   connected: boolean;
   wireEvents: (xmpp: StubXmpp) => void;
   reconnect: { clearTimer: () => void };
+  handleDisconnected: (xmpp: unknown, error?: Error) => void;
+  handleMessage: (message: unknown) => void;
+  connectTimeoutMs: number;
+  doConnect: () => Promise<void>;
+  loadModule: () => Promise<unknown>;
+  runSessionReady: (xmpp: unknown, lifecycle: { type: "fresh" | "resumed" }) => Promise<void>;
+  runReconnectCatchup: (...args: unknown[]) => Promise<void>;
+  catchup: { onSessionStarted: () => Array<{ kind: "dm" | "room"; key: string }> };
 };
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function session(): WaddleSession {
   return {
@@ -132,6 +142,219 @@ describe("room-scoped queueing keeps the global banner honest (#1164 slice 4)", 
 
     expect(result?.state).toBe("queued");
     expect(statuses).toHaveLength(0);
+  });
+});
+
+describe("connect budget measures to session-ready, not catch-up completion (C1)", () => {
+  test("a reconnect catch-up outliving connectTimeoutMs does not tear down the established session", async () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState;
+    const statuses: XmppStatusSnapshot[] = [];
+    client.setStatusHandler((snapshot) => statuses.push(snapshot));
+    const bodies: string[] = [];
+    client.setDirectMessageHandler((message) => bodies.push(message.body));
+
+    state.connectTimeoutMs = 20;
+    // Catch-up (behind the resume barrier) outlives the connect budget.
+    state.runReconnectCatchup = () => sleep(60);
+    state.catchup.onSessionStarted = () => [{ kind: "dm", key: "bob@example.com" }];
+    let stalledHandleDisconnects = 0;
+    const handle = { disconnect: async () => { stalledHandleDisconnects += 1; } };
+    state.doConnect = async () => {
+      state.xmpp = handle;
+      void state.runSessionReady(handle, { type: "fresh" });
+    };
+
+    let settled: "resolved" | "rejected" | null = null;
+    const connected = client.connect().then(
+      () => { settled = "resolved"; },
+      () => { settled = "rejected"; },
+    );
+
+    // A live DM arriving mid-barrier is buffered for the drain.
+    await sleep(5);
+    state.handleMessage({
+      id: "dm-1",
+      from: "bob@example.com/phone",
+      to: "alice@example.com/desktop",
+      message_type: "chat",
+      body: "hi",
+      timestamp: "2026-07-05T10:00:00.000Z",
+      reaction_emojis: [],
+      shared_files: [],
+      is_muc: false,
+    });
+
+    // Wait past the connect budget while the barrier is still open.
+    await sleep(40);
+    expect(state.xmpp).toBe(handle);
+    expect(stalledHandleDisconnects).toBe(0);
+    expect(statuses.some((snapshot) => snapshot.state === "reconnecting")).toBe(false);
+
+    await connected;
+    expect(settled).toBe("resolved");
+    expect(state.connected).toBe(true);
+    expect(bodies).toEqual(["hi"]);
+    state.reconnect.clearTimer();
+  });
+});
+
+describe("exhaustion recovery (C2)", () => {
+  test("an explicit connect() after exhaustion restores a fresh retry budget", async () => {
+    const { client, state, stub, scheduled, fireDisconnected } = createHarness();
+    for (let i = 0; i < 11; i += 1) {
+      state.reconnect.clearTimer();
+      state.xmpp = stub;
+      state.connected = true;
+      fireDisconnected();
+    }
+    expect(scheduled).toHaveLength(10);
+
+    // User-triggered connect: the attempt itself fails, but the budget
+    // is fresh — the next disconnect schedules attempt 1 again instead
+    // of re-exhausting instantly.
+    state.doConnect = async () => { throw new Error("still down"); };
+    await client.connect().catch(() => undefined);
+    state.reconnect.clearTimer();
+    state.xmpp = stub;
+    state.connected = true;
+    fireDisconnected();
+
+    expect(scheduled).toHaveLength(11);
+    expect(scheduled.at(-1)?.attempt).toBe(1);
+    state.reconnect.clearTimer();
+  });
+
+  test("exhaustion while the browser is offline reports offline, not terminal error", () => {
+    const originalNavigator = globalThis.navigator;
+    Object.defineProperty(globalThis, "navigator", {
+      value: { onLine: false },
+      configurable: true,
+    });
+    try {
+      const { state, stub, statuses, fireDisconnected } = createHarness();
+      for (let i = 0; i < 11; i += 1) {
+        state.reconnect.clearTimer();
+        state.xmpp = stub;
+        state.connected = true;
+        fireDisconnected();
+      }
+      expect(statuses.at(-1)?.state).toBe("offline");
+      state.reconnect.clearTimer();
+    } finally {
+      Object.defineProperty(globalThis, "navigator", {
+        value: originalNavigator,
+        configurable: true,
+      });
+    }
+  });
+
+  test("a window online event after exhaustion triggers a fresh connect", () => {
+    const listeners: Record<string, Array<() => void>> = {};
+    const globals = globalThis as { window?: unknown };
+    const originalWindow = globals.window;
+    globals.window = {
+      addEventListener: (name: string, cb: () => void) => { (listeners[name] ??= []).push(cb); },
+      removeEventListener: (name: string, cb: () => void) => {
+        listeners[name] = (listeners[name] ?? []).filter((l) => l !== cb);
+      },
+    };
+    try {
+      const { client, state, stub, fireDisconnected } = createHarness();
+      for (let i = 0; i < 11; i += 1) {
+        state.reconnect.clearTimer();
+        state.xmpp = stub;
+        state.connected = true;
+        fireDisconnected();
+      }
+      let connects = 0;
+      (client as unknown as { connect: () => Promise<void> }).connect = async () => { connects += 1; };
+      for (const cb of listeners.online ?? []) cb();
+      expect(connects).toBe(1);
+      state.reconnect.clearTimer();
+    } finally {
+      if (originalWindow === undefined) delete globals.window;
+      else globals.window = originalWindow;
+    }
+  });
+});
+
+describe("stalled WASM load cannot double-connect (C3)", () => {
+  test("a module load resolving after timeout + second connect yields exactly one live handle", async () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState;
+    client.setStatusHandler(() => {});
+
+    class StubConfig {
+      constructor(..._args: unknown[]) {}
+    }
+    const created: Array<{ connects: number; disconnects: number }> = [];
+    class StubClient {
+      connects = 0;
+      disconnects = 0;
+      constructor(..._args: unknown[]) { created.push(this); }
+      async connect() { this.connects += 1; }
+      async disconnect() { this.disconnects += 1; }
+    }
+    const stubModule = { WaddleConfig: StubConfig, WaddleClient: StubClient };
+    let releaseFirstLoad!: () => void;
+    const firstLoad = new Promise((resolve) => { releaseFirstLoad = () => resolve(stubModule); });
+    let loads = 0;
+    state.loadModule = () => {
+      loads += 1;
+      return (loads === 1 ? firstLoad : Promise.resolve(stubModule)) as Promise<never>;
+    };
+    state.connectTimeoutMs = 30;
+
+    // Connect #1: the module load stalls past the connect budget.
+    const first = client.connect();
+    first.catch(() => undefined);
+    await sleep(45);
+    state.reconnect.clearTimer();
+
+    // Connect #2 starts while #1's module load is still pending.
+    const second = client.connect();
+    second.catch(() => undefined);
+    await sleep(5);
+    releaseFirstLoad();
+    await sleep(5);
+
+    // Exactly one handle was created and connected; the stale
+    // continuation from connect #1 aborted without creating a zombie.
+    expect(created).toHaveLength(1);
+    expect(created[0]!.connects).toBe(1);
+    expect(state.xmpp).toBe(created[0]);
+
+    await second.catch(() => undefined);
+    state.reconnect.clearTimer();
+  });
+});
+
+describe("terminal classification requires the structured stream-error (C4)", () => {
+  test("a free-text disconnect reason containing 'conflict' stays recoverable", () => {
+    const { state, stub, statuses, scheduled } = createHarness();
+
+    state.handleDisconnected(stub, new Error("write conflict on shard"));
+
+    expect(statuses.at(-1)?.state).toBe("reconnecting");
+    expect(scheduled).toHaveLength(1);
+    state.reconnect.clearTimer();
+  });
+
+  test("the WASM driver's SASL-rejection string still classifies terminal via set_on_error", () => {
+    const { state, statuses, scheduled, fireError, fireDisconnected } = createHarness();
+
+    // The WASM core reports connect-time SASL failure through
+    // `set_on_error` with the ClientError display string — not through
+    // the disconnect callback (which carries no error at all).
+    (fireError as unknown as (payload: unknown) => void)(
+      "server rejected SASL authentication with condition `not-authorized`",
+    );
+    fireDisconnected();
+
+    expect(statuses.at(-1)?.state).toBe("error");
+    expect(scheduled).toHaveLength(0);
+    state.reconnect.clearTimer();
   });
 });
 

--- a/chat/tests/reconnect-state-machine.test.ts
+++ b/chat/tests/reconnect-state-machine.test.ts
@@ -29,6 +29,7 @@ type PrivateState = {
   connected: boolean;
   wireEvents: (xmpp: StubXmpp) => void;
   reconnect: { clearTimer: () => void };
+  connectWithFreshBudget: () => Promise<void>;
   handleDisconnected: (xmpp: unknown, error?: Error) => void;
   handleMessage: (message: unknown) => void;
   connectTimeoutMs: number;
@@ -200,8 +201,8 @@ describe("connect budget measures to session-ready, not catch-up completion (C1)
 });
 
 describe("exhaustion recovery (C2)", () => {
-  test("an explicit connect() after exhaustion restores a fresh retry budget", async () => {
-    const { client, state, stub, scheduled, fireDisconnected } = createHarness();
+  test("a fresh-budget connect after exhaustion restores the retry budget", async () => {
+    const { state, stub, scheduled, fireDisconnected } = createHarness();
     for (let i = 0; i < 11; i += 1) {
       state.reconnect.clearTimer();
       state.xmpp = stub;
@@ -210,11 +211,11 @@ describe("exhaustion recovery (C2)", () => {
     }
     expect(scheduled).toHaveLength(10);
 
-    // User-triggered connect: the attempt itself fails, but the budget
-    // is fresh — the next disconnect schedules attempt 1 again instead
-    // of re-exhausting instantly.
+    // User-explicit recovery (the online listener's path): the attempt
+    // itself fails, but the budget is fresh — the next disconnect
+    // schedules attempt 1 again instead of re-exhausting instantly.
     state.doConnect = async () => { throw new Error("still down"); };
-    await client.connect().catch(() => undefined);
+    await state.connectWithFreshBudget().catch(() => undefined);
     state.reconnect.clearTimer();
     state.xmpp = stub;
     state.connected = true;
@@ -249,7 +250,7 @@ describe("exhaustion recovery (C2)", () => {
     }
   });
 
-  test("a window online event after exhaustion triggers a fresh connect", () => {
+  test("a window online event after exhaustion triggers a fresh-budget connect and clears terminal state", async () => {
     const listeners: Record<string, Array<() => void>> = {};
     const globals = globalThis as { window?: unknown };
     const originalWindow = globals.window;
@@ -260,22 +261,155 @@ describe("exhaustion recovery (C2)", () => {
       },
     };
     try {
-      const { client, state, stub, fireDisconnected } = createHarness();
+      const { state, stub, scheduled, fireDisconnected } = createHarness();
+      state.doConnect = async () => { throw new Error("still down"); };
       for (let i = 0; i < 11; i += 1) {
         state.reconnect.clearTimer();
         state.xmpp = stub;
         state.connected = true;
         fireDisconnected();
       }
-      let connects = 0;
-      (client as unknown as { connect: () => Promise<void> }).connect = async () => { connects += 1; };
+      expect(scheduled).toHaveLength(10);
+
+      // Network returns: the listener fires the fresh-budget path.
       for (const cb of listeners.online ?? []) cb();
-      expect(connects).toBe(1);
+      await sleep(1);
+
+      // Fresh budget: the next disconnect schedules attempt 1 again —
+      // the exhausted/terminal gate no longer blocks the retry loop.
+      state.reconnect.clearTimer();
+      state.xmpp = stub;
+      state.connected = true;
+      fireDisconnected();
+      expect(scheduled).toHaveLength(11);
+      expect(scheduled.at(-1)?.attempt).toBe(1);
       state.reconnect.clearTimer();
     } finally {
       if (originalWindow === undefined) delete globals.window;
       else globals.window = originalWindow;
     }
+  });
+});
+
+describe("internal connect() must not leak the fresh-budget reset (F1)", () => {
+  test("repeated internal connect() during an outage does not reset the attempt counter", async () => {
+    const { client, state, stub, scheduled, fireDisconnected } = createHarness();
+    state.doConnect = async () => { throw new Error("still down"); };
+    for (let i = 0; i < 3; i += 1) {
+      state.reconnect.clearTimer();
+      state.xmpp = stub;
+      state.connected = true;
+      fireDisconnected();
+    }
+    expect(scheduled.at(-1)?.attempt).toBe(3);
+
+    // Background triggers (idle tracker → setPresence, MAM pagers,
+    // sendGroupMessage fallback) all route through connect() during
+    // the outage — the budget must keep counting up, not restart.
+    await client.connect().catch(() => undefined);
+    await client.connect().catch(() => undefined);
+    state.reconnect.clearTimer();
+    state.xmpp = stub;
+    state.connected = true;
+    fireDisconnected();
+
+    expect(scheduled.at(-1)?.attempt).toBe(4);
+    state.reconnect.clearTimer();
+  });
+
+  test("internal connect() while terminal-error rejects without clearing the error state or scheduling", async () => {
+    const { client, state, statuses, scheduled, fireError, fireDisconnected } = createHarness();
+    let attempts = 0;
+    state.connectTimeoutMs = 10;
+    state.doConnect = async () => { attempts += 1; };
+
+    fireError({ condition: "not-authorized", detail: "SASL authentication failed" });
+    fireDisconnected();
+    expect(statuses.at(-1)?.state).toBe("error");
+    const statusCount = statuses.length;
+
+    await expect(client.connect()).rejects.toThrow();
+
+    expect(attempts).toBe(0);
+    expect(scheduled).toHaveLength(0);
+    // No status churn: the terminal "sign in again" error stays put.
+    expect(statuses).toHaveLength(statusCount);
+    expect(statuses.at(-1)?.state).toBe("error");
+    state.reconnect.clearTimer();
+  });
+
+  test("internal connect() after exhaustion rejects without restarting the retry loop", async () => {
+    const { client, state, stub, statuses, scheduled, fireDisconnected } = createHarness();
+    for (let i = 0; i < 11; i += 1) {
+      state.reconnect.clearTimer();
+      state.xmpp = stub;
+      state.connected = true;
+      fireDisconnected();
+    }
+    expect(scheduled).toHaveLength(10);
+    expect(statuses.at(-1)?.state).toBe("error");
+    const statusCount = statuses.length;
+
+    let attempts = 0;
+    state.connectTimeoutMs = 10;
+    state.doConnect = async () => { attempts += 1; };
+    await expect(client.connect()).rejects.toThrow();
+
+    expect(attempts).toBe(0);
+    expect(scheduled).toHaveLength(10);
+    expect(statuses).toHaveLength(statusCount);
+    state.reconnect.clearTimer();
+  });
+});
+
+describe("disconnect() cancels the pending connect attempt (F3)", () => {
+  test("a stale connect timer cannot tear down a subsequent connect", async () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState;
+    const statuses: XmppStatusSnapshot[] = [];
+    const scheduled: Array<{ attempt: number; delayMs: number }> = [];
+    client.setStatusHandler((snapshot) => statuses.push(snapshot));
+    client.onReconnectScheduled((info) => scheduled.push(info));
+
+    let handleBDisconnects = 0;
+    const handleA = { disconnect: async () => {} };
+    const handleB = { disconnect: async () => { handleBDisconnects += 1; } };
+    let attempt = 0;
+    state.doConnect = async () => {
+      attempt += 1;
+      // Socket opens but the session never establishes (stalled).
+      state.xmpp = attempt === 1 ? handleA : handleB;
+    };
+
+    // Connect A stalls inside a 40ms budget, then the user disconnects.
+    state.connectTimeoutMs = 40;
+    const first = client.connect();
+    first.catch(() => undefined);
+    await sleep(5);
+    await client.disconnect();
+    // A's promise must settle at disconnect, not dangle until the
+    // orphaned timer fires.
+    let firstSettled = false;
+    await Promise.race([first.catch(() => { firstSettled = true; }), sleep(5)]);
+    expect(firstSettled).toBe(true);
+
+    // Connect B starts within A's original budget window.
+    statuses.length = 0;
+    state.connectTimeoutMs = 500;
+    const second = client.connect();
+    second.catch(() => undefined);
+
+    // Advance past A's original 40ms budget: the stale timer must not
+    // tear down B's half-open handle or emit spurious statuses.
+    await sleep(60);
+    expect(state.xmpp).toBe(handleB);
+    expect(handleBDisconnects).toBe(0);
+    expect(statuses.some((snapshot) => snapshot.state === "reconnecting")).toBe(false);
+    expect(scheduled).toHaveLength(0);
+
+    // Cleanup: cancel B's pending attempt too.
+    await client.disconnect();
+    state.reconnect.clearTimer();
   });
 });
 

--- a/chat/tests/reconnect-state-machine.test.ts
+++ b/chat/tests/reconnect-state-machine.test.ts
@@ -363,6 +363,57 @@ describe("internal connect() must not leak the fresh-budget reset (F1)", () => {
   });
 });
 
+describe("background connect() must not preempt an armed backoff timer (F5)", () => {
+  test("connect() while a retry timer is armed fast-rejects without cancelling the timer or launching an attempt", async () => {
+    const { client, state, scheduled, fireDisconnected } = createHarness();
+    let attempts = 0;
+    state.connectTimeoutMs = 50;
+    state.doConnect = async () => { attempts += 1; };
+
+    // Outage begins: the loop arms its first backoff timer.
+    fireDisconnected();
+    expect(scheduled).toHaveLength(1);
+    const scheduler = state.reconnect as unknown as { timer: unknown; attempt: number };
+    expect(scheduler.timer).not.toBeNull();
+
+    // A background trigger (typing chat-state via requireConnectedXmpp,
+    // presence, room switch, MAM pager) calls connect(): it must leave
+    // the schedule intact and start nothing.
+    await expect(client.connect()).rejects.toThrow("XMPP session is not ready");
+    expect(attempts).toBe(0);
+    expect(scheduler.timer).not.toBeNull();
+    expect(scheduler.attempt).toBe(1);
+    expect(scheduled).toHaveLength(1);
+    state.reconnect.clearTimer();
+  });
+
+  test("repeated background connects during a short outage never burn the budget into terminal error", async () => {
+    const { client, state, stub, statuses, scheduled, fireDisconnected } = createHarness();
+    // Every launched attempt fails fast: the socket opens, then drops —
+    // re-entering handleDisconnected → schedule() → attempt++.
+    state.doConnect = async () => {
+      state.xmpp = stub;
+      state.connected = true;
+      state.handleDisconnected(stub, new Error("still down"));
+    };
+
+    // Outage begins: attempt 1 armed.
+    fireDisconnected();
+    expect(scheduled).toHaveLength(1);
+
+    // Ten user interactions while the backoff timer is armed (<1 min of
+    // typing) must not exhaust the 10-attempt budget.
+    for (let i = 0; i < 10; i += 1) {
+      await client.connect().catch(() => undefined);
+    }
+
+    expect(scheduled).toHaveLength(1);
+    expect(statuses.some((snapshot) => snapshot.state === "error")).toBe(false);
+    expect(statuses.at(-1)?.state).toBe("reconnecting");
+    state.reconnect.clearTimer();
+  });
+});
+
 describe("disconnect() cancels the pending connect attempt (F3)", () => {
   test("a stale connect timer cannot tear down a subsequent connect", async () => {
     const client = new BrowserXmppClient(session());

--- a/chat/tests/reconnect-state-machine.test.ts
+++ b/chat/tests/reconnect-state-machine.test.ts
@@ -527,6 +527,34 @@ describe("terminal classification requires the structured stream-error (C4)", ()
     state.reconnect.clearTimer();
   });
 
+  test("a free-text stream error merely containing 'conflict' stays recoverable", () => {
+    // PR-review finding: bare word-matching in free text latched
+    // terminal state on benign errors (e.g. a proxied transport
+    // message). Only a structured condition or the WASM ClientError's
+    // backtick-quoted `condition` may classify terminal.
+    const { state, statuses, scheduled, fireError, fireDisconnected } = createHarness();
+
+    (fireError as unknown as (payload: unknown) => void)(
+      "write conflict on shard while syncing presence",
+    );
+    fireDisconnected();
+
+    expect(statuses.at(-1)?.state).toBe("reconnecting");
+    expect(scheduled).toHaveLength(1);
+    state.reconnect.clearTimer();
+  });
+
+  test("an object payload whose detail merely mentions not-authorized stays recoverable", () => {
+    const { state, statuses, scheduled, fireError, fireDisconnected } = createHarness();
+
+    fireError({ detail: "proxy said: upstream not-authorized for CONNECT" });
+    fireDisconnected();
+
+    expect(statuses.at(-1)?.state).toBe("reconnecting");
+    expect(scheduled).toHaveLength(1);
+    state.reconnect.clearTimer();
+  });
+
   test("the WASM driver's SASL-rejection string still classifies terminal via set_on_error", () => {
     const { state, statuses, scheduled, fireError, fireDisconnected } = createHarness();
 

--- a/chat/tests/reconnect-state-machine.test.ts
+++ b/chat/tests/reconnect-state-machine.test.ts
@@ -30,6 +30,7 @@ type PrivateState = {
   wireEvents: (xmpp: StubXmpp) => void;
   reconnect: { clearTimer: () => void };
   connectWithFreshBudget: () => Promise<void>;
+  connectFromScheduler: () => Promise<void>;
   handleDisconnected: (xmpp: unknown, error?: Error) => void;
   handleMessage: (message: unknown) => void;
   connectTimeoutMs: number;
@@ -488,6 +489,104 @@ describe("terminal classification requires the structured stream-error (C4)", ()
 
     expect(statuses.at(-1)?.state).toBe("error");
     expect(scheduled).toHaveLength(0);
+    state.reconnect.clearTimer();
+  });
+});
+
+describe("stale terminalDisconnectDetail must not survive disconnect()", () => {
+  test("terminal stream error + disconnect() before the disconnect callback: the next session's transient drop stays recoverable", async () => {
+    const { client, state, stub, statuses, scheduled, fireError } = createHarness();
+
+    // Terminal classification arrives, but the user disconnects before
+    // the WASM disconnect callback consumes the armed detail (the
+    // destroying path returns early; the late callback is dropped by
+    // the handle guard).
+    fireError({ condition: "not-authorized", detail: "SASL authentication failed" });
+    await client.disconnect();
+
+    // Next session on the same instance: a connect is in flight...
+    statuses.length = 0;
+    state.connectTimeoutMs = 200;
+    state.doConnect = async () => {
+      state.xmpp = stub;
+      state.connected = true;
+    };
+    const pending = client.connect();
+    pending.catch(() => undefined);
+    await sleep(5);
+
+    // ...and its FIRST transient disconnect must reconnect — not consume
+    // the previous session's stale terminal detail into a false
+    // "sign in again" error with zero retries.
+    state.handleDisconnected(stub);
+
+    expect(statuses.at(-1)?.state).toBe("reconnecting");
+    expect(scheduled).toHaveLength(1);
+    state.reconnect.clearTimer();
+  });
+
+  test("connect-budget timeout after a terminal stream error does not poison the scheduler's next attempt", async () => {
+    const { client, state, stub, statuses, scheduled, fireError, fireDisconnected } = createHarness();
+
+    // A connect attempt is pending; a terminal stream error lands, then
+    // the connect budget fires BEFORE the disconnect callback — nulling
+    // `this.xmpp` and orphaning the armed detail.
+    state.connected = false;
+    state.connectTimeoutMs = 10;
+    state.doConnect = async () => {};
+    const pending = client.connect();
+    pending.catch(() => undefined);
+    fireError({ condition: "not-authorized", detail: "SASL authentication failed" });
+    await sleep(25);
+    expect(scheduled).toHaveLength(1);
+
+    // The scheduler's next attempt suffers a transient disconnect: it
+    // must stay in the reconnecting loop, not flip terminal off the
+    // orphaned detail.
+    state.reconnect.clearTimer();
+    state.xmpp = stub;
+    state.connected = true;
+    fireDisconnected();
+
+    expect(statuses.at(-1)?.state).toBe("reconnecting");
+    expect(scheduled).toHaveLength(2);
+    state.reconnect.clearTimer();
+  });
+});
+
+describe("isExhausted must not fast-reject during the final in-flight attempt", () => {
+  test("connect() during the last scheduled attempt joins it; after it truly exhausts, connect() fast-rejects", async () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState;
+    const statuses: XmppStatusSnapshot[] = [];
+    client.setStatusHandler((snapshot) => statuses.push(snapshot));
+
+    // The budget is fully spent and the scheduler's FINAL timer has just
+    // fired: attempt == MAX, timer == null, the attempt is in flight.
+    (state.reconnect as unknown as { attempt: number }).attempt = 10;
+    state.connectTimeoutMs = 30;
+    state.doConnect = async () => {}; // socket never establishes a session
+    const inflight = state.connectFromScheduler();
+    inflight.catch(() => undefined);
+
+    // A user action during the window must join the in-flight attempt
+    // (which may still succeed), not fast-reject.
+    let rejection: Error | null = null;
+    let settled = false;
+    const joined = client.connect().then(
+      () => { settled = true; },
+      (error: Error) => { settled = true; rejection = error; },
+    );
+    await sleep(5);
+    expect(settled).toBe(false);
+
+    // The final attempt times out → NOW the loop is truly exhausted.
+    await sleep(45);
+    await joined;
+    expect(rejection?.message).toBe("Reconnection timed out");
+    expect(statuses.at(-1)?.state).toBe("error");
+
+    await expect(client.connect()).rejects.toThrow("XMPP session is not ready");
     state.reconnect.clearTimer();
   });
 });

--- a/chat/tests/reconnect-state-machine.test.ts
+++ b/chat/tests/reconnect-state-machine.test.ts
@@ -1,0 +1,165 @@
+/**
+ * #1164: honest reconnect state machine.
+ *
+ * The client must distinguish recoverable drops (keep retrying, show
+ * "reconnecting") from terminal failures (auth failure / resource
+ * conflict / retry exhaustion — emit `state: "error"` and stop), and
+ * a stalled connect attempt must tear down and reschedule instead of
+ * silently rejecting.
+ *
+ * These tests drive `wireEvents` with a stub WASM handle (the same
+ * harness pattern as `xmpp-telemetry.test.ts`) and observe the
+ * user-facing state through the client's status handler.
+ */
+import { describe, expect, test } from "bun:test";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { BrowserXmppClient } from "../src/lib/xmpp-client";
+import type { XmppStatusSnapshot } from "../src/lib/xmpp/types";
+
+type StreamErrorPayload = { detail?: string | null; condition?: string | null };
+
+type StubXmpp = {
+  set_on_error: (cb: (payload: StreamErrorPayload) => void) => void;
+  set_on_disconnected: (cb: () => void) => void;
+  get_resume_state: () => null;
+};
+
+type PrivateState = {
+  xmpp: unknown;
+  connected: boolean;
+  wireEvents: (xmpp: StubXmpp) => void;
+  reconnect: { clearTimer: () => void };
+};
+
+function session(): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com/desktop",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/ws",
+  } as WaddleSession;
+}
+
+function createHarness() {
+  const client = new BrowserXmppClient(session());
+  const state = client as unknown as PrivateState;
+  const statuses: XmppStatusSnapshot[] = [];
+  const scheduled: Array<{ attempt: number; delayMs: number }> = [];
+  client.setStatusHandler((snapshot) => statuses.push(snapshot));
+  client.onReconnectScheduled((info) => scheduled.push(info));
+
+  let fireError: (payload: StreamErrorPayload) => void = () => {};
+  let fireDisconnected: () => void = () => {};
+  const stub: StubXmpp = {
+    set_on_error(cb) { fireError = cb; },
+    set_on_disconnected(cb) { fireDisconnected = cb; },
+    get_resume_state: () => null,
+  };
+  state.xmpp = stub;
+  state.connected = true;
+  state.wireEvents(stub);
+
+  return {
+    client,
+    state,
+    stub,
+    statuses,
+    scheduled,
+    fireError: (payload: StreamErrorPayload) => fireError(payload),
+    fireDisconnected: () => fireDisconnected(),
+  };
+}
+
+describe("terminal error state (#1164 slice 1)", () => {
+  test("a not-authorized stream error reaches state \"error\" and never schedules a retry", () => {
+    const { state, statuses, scheduled, fireError, fireDisconnected } = createHarness();
+
+    fireError({ condition: "not-authorized", detail: "SASL authentication failed" });
+    fireDisconnected();
+
+    expect(statuses.at(-1)?.state).toBe("error");
+    expect(scheduled).toHaveLength(0);
+    state.reconnect.clearTimer();
+  });
+
+  test("a resource conflict is terminal too", () => {
+    const { statuses, scheduled, fireError, fireDisconnected } = createHarness();
+
+    fireError({ condition: "conflict", detail: "replaced by new connection" });
+    fireDisconnected();
+
+    expect(statuses.at(-1)?.state).toBe("error");
+    expect(scheduled).toHaveLength(0);
+  });
+
+  test("a recoverable stream error keeps the reconnecting loop", () => {
+    const { state, statuses, scheduled, fireError, fireDisconnected } = createHarness();
+
+    fireError({ condition: "system-shutdown", detail: "going down" });
+    fireDisconnected();
+
+    expect(statuses.at(-1)?.state).toBe("reconnecting");
+    expect(scheduled).toHaveLength(1);
+    state.reconnect.clearTimer();
+  });
+});
+
+describe("retry-loop cap (#1164 slice 2)", () => {
+  test("exhausting the reconnect attempts flips the client to terminal error", () => {
+    const { state, stub, statuses, scheduled, fireDisconnected } = createHarness();
+
+    for (let i = 0; i < 11; i += 1) {
+      // Re-arm the handle + drop the pending timer so each disconnect
+      // is accepted and each schedule() call actually runs.
+      state.reconnect.clearTimer();
+      state.xmpp = stub;
+      state.connected = true;
+      fireDisconnected();
+    }
+
+    // 10 scheduled attempts, then exhaustion: no 11th schedule.
+    expect(scheduled).toHaveLength(10);
+    expect(statuses.at(-1)?.state).toBe("error");
+    state.reconnect.clearTimer();
+  });
+});
+
+describe("room-scoped queueing keeps the global banner honest (#1164 slice 4)", () => {
+  test("sendGroupMessage to an unjoined room while connected leaves the status untouched", async () => {
+    const { client, statuses } = createHarness();
+
+    const result = await client.sendGroupMessage("space-1", "general", "hello");
+
+    expect(result?.state).toBe("queued");
+    expect(statuses).toHaveLength(0);
+  });
+});
+
+describe("connect-timeout teardown (#1164 slice 3)", () => {
+  test("a stalled connect tears down the handle, emits reconnecting, and reschedules", async () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState & {
+      connectTimeoutMs: number;
+      doConnect: () => Promise<void>;
+    };
+    const statuses: XmppStatusSnapshot[] = [];
+    const scheduled: Array<{ attempt: number; delayMs: number }> = [];
+    client.setStatusHandler((snapshot) => statuses.push(snapshot));
+    client.onReconnectScheduled((info) => scheduled.push(info));
+
+    let stalledHandleDisconnects = 0;
+    state.connectTimeoutMs = 10;
+    state.doConnect = async () => {
+      // Socket opened but the session never establishes.
+      state.xmpp = { disconnect: async () => { stalledHandleDisconnects += 1; } };
+    };
+
+    await expect(client.connect()).rejects.toThrow("Reconnection timed out");
+
+    expect(statuses.at(-1)?.state).toBe("reconnecting");
+    expect(scheduled).toHaveLength(1);
+    expect(state.xmpp).toBeNull();
+    expect(stalledHandleDisconnects).toBe(1);
+    state.reconnect.clearTimer();
+  });
+});

--- a/chat/tests/resume-marker-buffering.test.ts
+++ b/chat/tests/resume-marker-buffering.test.ts
@@ -16,11 +16,13 @@ import type { WaddleSession } from "../src/lib/server-auth";
 import { BrowserXmppClient } from "../src/lib/xmpp-client";
 
 type PrivateState = {
+  xmpp: unknown;
   pendingDuringResume: unknown[] | null;
   resumeBarrier: { xmpp: unknown; promise: Promise<void> } | null;
   currentRoom: string | null;
   joinedMucReady: Set<string>;
   handleMessage: (message: unknown) => void;
+  openResumeBarrier: (xmpp: unknown, promise: Promise<void>) => void;
   completeResumeBarrier: (xmpp: unknown) => void;
 };
 
@@ -196,6 +198,78 @@ describe("resume-time reaction/displayed-marker buffering (#1165)", () => {
     state.completeResumeBarrier(null);
 
     expect(order).toEqual(["reaction:a", "displayed:b", "reaction:c"]);
+  });
+
+  // F2: the barrier's `.finally` fires after the connection died
+  // mid-catch-up (`this.xmpp` moved on). The buffered stanzas were
+  // SM-acked — the server will never replay them — so a failed barrier
+  // must carry them into the NEXT barrier instead of discarding them.
+  test("a reaction buffered during a failed barrier drains exactly once when the next barrier completes", () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState;
+    state.currentRoom = ROOM_JID;
+    state.joinedMucReady.add(ROOM_JID);
+    const reactions: string[] = [];
+    client.setReactionHandler((event) => reactions.push(event.messageId));
+
+    // Barrier A opens on handle A; a reaction arrives mid-catch-up.
+    const handleA = {};
+    state.xmpp = handleA;
+    state.openResumeBarrier(handleA, Promise.resolve());
+    state.handleMessage(roomReactionWasmMessage("room-9"));
+    expect(state.pendingDuringResume).toHaveLength(1);
+
+    // The connection dies mid-catch-up (handleDisconnected nulls
+    // this.xmpp), then barrier A's `.finally` fires: no dispatch, but
+    // no loss either.
+    state.xmpp = null;
+    state.completeResumeBarrier(handleA);
+    expect(reactions).toHaveLength(0);
+
+    // The next session's barrier completes: the carried reaction
+    // drains exactly once.
+    const handleB = {};
+    state.xmpp = handleB;
+    state.openResumeBarrier(handleB, Promise.resolve());
+    state.completeResumeBarrier(handleB);
+    expect(reactions).toEqual(["room-9"]);
+
+    // A third barrier must not re-dispatch it.
+    state.openResumeBarrier(handleB, Promise.resolve());
+    state.completeResumeBarrier(handleB);
+    expect(reactions).toEqual(["room-9"]);
+  });
+
+  test("carried entries keep drain ordering: bodies before targeted follow-ups across barriers", () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState;
+    state.currentRoom = ROOM_JID;
+    state.joinedMucReady.add(ROOM_JID);
+    const order: string[] = [];
+    client.setMessageHandler((message) => order.push(`body:${message.body}`));
+    client.setReactionHandler((event) => order.push(`reaction:${event.messageId}`));
+    client.setDisplayedHandler((event) => order.push(`displayed:${event.messageId}`));
+
+    // Barrier A buffers a reaction and a marker, then fails.
+    const handleA = {};
+    state.xmpp = handleA;
+    state.openResumeBarrier(handleA, Promise.resolve());
+    state.handleMessage(roomReactionWasmMessage("room-7"));
+    state.handleMessage(roomDisplayedWasmMessage("room-7"));
+    state.xmpp = null;
+    state.completeResumeBarrier(handleA);
+    expect(order).toHaveLength(0);
+
+    // Barrier B buffers the follow-ups' target body, then completes:
+    // the body drains before the carried follow-ups, which keep their
+    // relative arrival order.
+    const handleB = {};
+    state.xmpp = handleB;
+    state.openResumeBarrier(handleB, Promise.resolve());
+    state.handleMessage(roomWasmMessage("room-7", "hello", "2026-05-20T10:00:00.000Z"));
+    state.completeResumeBarrier(handleB);
+
+    expect(order).toEqual(["body:hello", "reaction:room-7", "displayed:room-7"]);
   });
 
   test("live (non-barrier) reactions and displayed markers still dispatch immediately", () => {

--- a/chat/tests/resume-marker-buffering.test.ts
+++ b/chat/tests/resume-marker-buffering.test.ts
@@ -1,0 +1,214 @@
+/**
+ * #1165: reactions (XEP-0444) and displayed markers (XEP-0333) that
+ * arrive while the resume barrier is open must be buffered alongside
+ * body messages and drained AFTER the bodies, so a follow-up whose
+ * target arrives in the same catch-up window is applied to an
+ * existing timeline row instead of being dropped by the merge
+ * layer's target-miss short-circuit.
+ *
+ * Like `resume-ordering.test.ts`, these tests drive the resume-gate
+ * in `handleMessage` directly and complete the barrier via
+ * `completeResumeBarrier` — the gate's contract is independent of
+ * the WASM session machinery.
+ */
+import { describe, expect, test } from "bun:test";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { BrowserXmppClient } from "../src/lib/xmpp-client";
+
+type PrivateState = {
+  pendingDuringResume: unknown[] | null;
+  resumeBarrier: { xmpp: unknown; promise: Promise<void> } | null;
+  currentRoom: string | null;
+  joinedMucReady: Set<string>;
+  handleMessage: (message: unknown) => void;
+  completeResumeBarrier: (xmpp: unknown) => void;
+};
+
+const ROOM_JID = "general@conference.example.com";
+
+function session(): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com/desktop",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/ws",
+  } as WaddleSession;
+}
+
+function dmWasmMessage(id: string, body: string, timestamp: string) {
+  return {
+    mam_id: id,
+    id,
+    from: "bob@example.com/phone",
+    to: "alice@example.com/desktop",
+    message_type: "chat",
+    body,
+    timestamp,
+    reaction_emojis: [],
+    shared_files: [],
+    is_muc: false,
+  };
+}
+
+function roomWasmMessage(id: string, body: string, timestamp: string) {
+  return {
+    mam_id: id,
+    id,
+    from: `${ROOM_JID}/bob`,
+    to: "alice@example.com/desktop",
+    message_type: "groupchat",
+    body,
+    timestamp,
+    reaction_emojis: [],
+    is_muc: true,
+    markup_spans: [],
+    mention_uris: [],
+    references: [],
+    is_sticker: false,
+    shared_files: [],
+  };
+}
+
+function roomReactionWasmMessage(targetId: string) {
+  return {
+    id: `reaction-${targetId}`,
+    from: `${ROOM_JID}/bob`,
+    to: "alice@example.com/desktop",
+    message_type: "groupchat",
+    reaction_target_id: targetId,
+    reaction_emojis: ["👍"],
+    shared_files: [],
+    is_muc: true,
+  };
+}
+
+function roomDisplayedWasmMessage(targetId: string) {
+  return {
+    id: `displayed-${targetId}`,
+    from: `${ROOM_JID}/bob`,
+    to: "alice@example.com/desktop",
+    message_type: "groupchat",
+    displayed_marker_id: targetId,
+    reaction_emojis: [],
+    shared_files: [],
+    is_muc: true,
+  };
+}
+
+function dmReactionWasmMessage(targetId: string) {
+  return {
+    id: `reaction-${targetId}`,
+    from: "bob@example.com/phone",
+    to: "alice@example.com/desktop",
+    message_type: "chat",
+    reaction_target_id: targetId,
+    reaction_emojis: ["🎉"],
+    shared_files: [],
+    is_muc: false,
+  };
+}
+
+function dmDisplayedWasmMessage(targetId: string) {
+  return {
+    id: `displayed-${targetId}`,
+    from: "bob@example.com/phone",
+    to: "alice@example.com/desktop",
+    message_type: "chat",
+    displayed_marker_id: targetId,
+    reaction_emojis: [],
+    shared_files: [],
+    is_muc: false,
+  };
+}
+
+function clientWithOpenBarrier() {
+  const client = new BrowserXmppClient(session());
+  const state = client as unknown as PrivateState;
+  state.currentRoom = ROOM_JID;
+  // Ready room ⇒ post-drain queue flush is a no-op instead of a join.
+  state.joinedMucReady.add(ROOM_JID);
+  // Mirror runSessionReady: barrier + buffer are set together.
+  state.pendingDuringResume = [];
+  state.resumeBarrier = { xmpp: null, promise: Promise.resolve() };
+  return { client, state };
+}
+
+describe("resume-time reaction/displayed-marker buffering (#1165)", () => {
+  test("room reaction arriving before its target in the catch-up window drains after the body", () => {
+    const { client, state } = clientWithOpenBarrier();
+    const order: string[] = [];
+    client.setMessageHandler((message) => order.push(`body:${message.body}`));
+    client.setReactionHandler((event) => order.push(`reaction:${event.messageId}`));
+
+    state.handleMessage(roomReactionWasmMessage("room-1"));
+    state.handleMessage(roomWasmMessage("room-1", "hello", "2026-05-20T10:00:00.000Z"));
+    expect(order).toHaveLength(0);
+    expect(state.pendingDuringResume).toHaveLength(2);
+
+    state.completeResumeBarrier(null);
+
+    expect(order).toEqual(["body:hello", "reaction:room-1"]);
+    expect(state.pendingDuringResume).toBeNull();
+  });
+
+  test("room displayed marker arriving before its target drains after the body", () => {
+    const { client, state } = clientWithOpenBarrier();
+    const order: string[] = [];
+    client.setMessageHandler((message) => order.push(`body:${message.body}`));
+    client.setDisplayedHandler((event) => order.push(`displayed:${event.messageId}`));
+
+    state.handleMessage(roomDisplayedWasmMessage("room-2"));
+    state.handleMessage(roomWasmMessage("room-2", "read me", "2026-05-20T10:00:00.000Z"));
+    expect(order).toHaveLength(0);
+
+    state.completeResumeBarrier(null);
+
+    expect(order).toEqual(["body:read me", "displayed:room-2"]);
+  });
+
+  test("DM reaction and displayed marker drain after the DM body", () => {
+    const { client, state } = clientWithOpenBarrier();
+    const order: string[] = [];
+    client.setDirectMessageHandler((message) => order.push(`body:${message.body}`));
+    client.setDmReactionHandler((event) => order.push(`reaction:${event.messageId}`));
+    client.setDmDisplayedHandler((event) => order.push(`displayed:${event.messageId}`));
+
+    state.handleMessage(dmReactionWasmMessage("dm-1"));
+    state.handleMessage(dmDisplayedWasmMessage("dm-1"));
+    state.handleMessage(dmWasmMessage("dm-1", "hi", "2026-05-20T10:00:00.000Z"));
+    expect(order).toHaveLength(0);
+
+    state.completeResumeBarrier(null);
+
+    expect(order).toEqual(["body:hi", "reaction:dm-1", "displayed:dm-1"]);
+  });
+
+  test("relative order within reactions/markers is preserved across the drain", () => {
+    const { client, state } = clientWithOpenBarrier();
+    const order: string[] = [];
+    client.setReactionHandler((event) => order.push(`reaction:${event.messageId}`));
+    client.setDisplayedHandler((event) => order.push(`displayed:${event.messageId}`));
+
+    state.handleMessage(roomReactionWasmMessage("a"));
+    state.handleMessage(roomDisplayedWasmMessage("b"));
+    state.handleMessage(roomReactionWasmMessage("c"));
+
+    state.completeResumeBarrier(null);
+
+    expect(order).toEqual(["reaction:a", "displayed:b", "reaction:c"]);
+  });
+
+  test("live (non-barrier) reactions and displayed markers still dispatch immediately", () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState;
+    const order: string[] = [];
+    client.setReactionHandler((event) => order.push(`reaction:${event.messageId}`));
+    client.setDmDisplayedHandler((event) => order.push(`displayed:${event.messageId}`));
+
+    expect(state.pendingDuringResume).toBeNull();
+    state.handleMessage(roomReactionWasmMessage("live-1"));
+    state.handleMessage(dmDisplayedWasmMessage("live-2"));
+
+    expect(order).toEqual(["reaction:live-1", "displayed:live-2"]);
+  });
+});

--- a/chat/tests/resume-ordering.test.ts
+++ b/chat/tests/resume-ordering.test.ts
@@ -131,7 +131,7 @@ describe("resume-time live-message buffering", () => {
     expect(seen).toHaveLength(1);
   });
 
-  test("non-body events (chat-state, displayed marker) bypass the resume buffer", () => {
+  test("ephemeral events (chat-state) bypass the resume buffer; displayed markers defer (#1165)", () => {
     const client = new BrowserXmppClient(session());
     const state = client as unknown as PrivateState;
     const dmSeen: LiveDmMessage[] = [];
@@ -162,8 +162,10 @@ describe("resume-time live-message buffering", () => {
     });
 
     expect(chatStateFired).toBe(1);
-    expect(displayedFired).toBe(1);
+    // #1165: displayed markers buffer with the bodies so their targets
+    // exist before they apply; they drain via `completeResumeBarrier`.
+    expect(displayedFired).toBe(0);
     expect(dmSeen).toHaveLength(0);
-    expect(state.pendingDuringResume).toHaveLength(0);
+    expect(state.pendingDuringResume).toHaveLength(1);
   });
 });

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -88,6 +88,15 @@ pub const DEFAULT_PAGE_SIZE: u32 = 50;
 pub const MAX_PAGE_SIZE: u32 = 200;
 const MAX_NAME_LEN: usize = 80;
 const NS_MUC_USER: &str = "http://jabber.org/protocol/muc#user";
+
+/// Upper bound on the admin-kick room-actor asks. The room actor
+/// awaits the durable-membership source inside its affiliation
+/// handlers, so a wedged (not dead) permission actor can stall the
+/// room's mailbox; a reply timeout keeps that stall from propagating
+/// into the admin command handler (timeout maps to the existing
+/// catch-all `Err` arm). Magnitude matches the `REAPER_ASK_TIMEOUT`
+/// precedent in `session_janitors.rs`.
+const ADMIN_ROOM_ASK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 type RoomConfigLockMap = dashmap::DashMap<BareJid, Arc<Semaphore>>;
 
 // ---------------------------------------------------------------------------
@@ -3708,6 +3717,7 @@ async fn run_kick(
     // revocation above and synchronize the actor affiliation list.
     let occupants = actor
         .ask(ListOccupants)
+        .reply_timeout(ADMIN_ROOM_ASK_TIMEOUT)
         .await
         .map_err(send_err("room actor ListOccupants"))?;
     let Some(target_nick) = occupants
@@ -3753,6 +3763,7 @@ async fn run_kick(
             sender_role: Role::Moderator,
             items,
         })
+        .reply_timeout(ADMIN_ROOM_ASK_TIMEOUT)
         .await
     {
         Ok(applied) => applied,

--- a/server/crates/waddle-server/src/pending_delivery/database.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database.rs
@@ -584,8 +584,7 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
 
     async fn scrub_for_tombstone(
         &self,
-        target_id: &str,
-        archive_jid: &jid::BareJid,
+        target: &waddle_xmpp::tombstone::TombstoneTarget,
     ) -> Result<u64, PendingStorageError> {
         // Archived pointers: exact (stanza-id, archive-by) match —
         // pure SQL. The MAM row was tombstoned, so the pointer must
@@ -598,8 +597,8 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
                    AND archive_stanza_by = ?",
                 crate::db_params![
                     PAYLOAD_KIND_ARCHIVED,
-                    target_id.to_string(),
-                    archive_jid.to_string(),
+                    target.id().to_string(),
+                    target.archive_jid().to_string(),
                 ],
             )
             .await?;
@@ -634,11 +633,7 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
                 // matcher's parse-error semantics.
                 continue;
             };
-            if waddle_xmpp::tombstone::message_element_matches_tombstone(
-                &element,
-                target_id,
-                archive_jid,
-            ) {
+            if target.matches_message_element(&element) {
                 matched_ids.push(row_id);
             }
         }

--- a/server/crates/waddle-server/src/pending_delivery/database.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database.rs
@@ -582,6 +582,77 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         .await
     }
 
+    async fn scrub_for_tombstone(
+        &self,
+        target_id: &str,
+        archive_jid: &str,
+    ) -> Result<u64, PendingStorageError> {
+        // Archived pointers: exact (stanza-id, archive-by) match —
+        // pure SQL. The MAM row was tombstoned, so the pointer must
+        // not flush a stub for a message the recipient never saw.
+        let mut removed = self
+            .execute(
+                "DELETE FROM pending_delivery \
+                 WHERE payload_kind = ? \
+                   AND archive_stanza_id = ? \
+                   AND archive_stanza_by = ?",
+                crate::db_params![
+                    PAYLOAD_KIND_ARCHIVED,
+                    target_id.to_string(),
+                    archive_jid.to_string(),
+                ],
+            )
+            .await?;
+        // Transient rows carry inline XML — match in Rust with the
+        // shared XEP-0424/0425 predicate, then delete by row_id.
+        // COST NOTE: scans every transient row; scrubs are rare
+        // (retraction / moderation only), so a full listing is
+        // acceptable — mirrors the SM registry's durable sweep.
+        let mut rows = self
+            .query(
+                "SELECT row_id, transient_xml FROM pending_delivery WHERE payload_kind = ?",
+                crate::db_params![PAYLOAD_KIND_TRANSIENT],
+            )
+            .await?;
+        let mut matched_ids: Vec<String> = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| PendingStorageError::Other(e.to_string()))?
+        {
+            let row_id: String = row
+                .get(0)
+                .map_err(|e| PendingStorageError::Other(e.to_string()))?;
+            let transient_xml: Option<String> = row
+                .get(1)
+                .map_err(|e| PendingStorageError::Other(e.to_string()))?;
+            let Some(xml) = transient_xml else {
+                continue;
+            };
+            let Ok(element) = xml.parse::<xmpp_parsers::minidom::Element>() else {
+                // Undecodable rows are skipped, matching the shared
+                // matcher's parse-error semantics.
+                continue;
+            };
+            if waddle_xmpp::tombstone::message_element_matches_tombstone(
+                &element,
+                target_id,
+                archive_jid,
+            ) {
+                matched_ids.push(row_id);
+            }
+        }
+        for row_id in matched_ids {
+            removed += self
+                .execute(
+                    "DELETE FROM pending_delivery WHERE row_id = ?",
+                    crate::db_params![row_id],
+                )
+                .await?;
+        }
+        Ok(removed)
+    }
+
     fn sweep_internal_bookkeeping(&self) -> usize {
         sweep_recipient_locks(&self.recipient_locks)
     }

--- a/server/crates/waddle-server/src/pending_delivery/database.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database.rs
@@ -585,7 +585,7 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
     async fn scrub_for_tombstone(
         &self,
         target_id: &str,
-        archive_jid: &str,
+        archive_jid: &jid::BareJid,
     ) -> Result<u64, PendingStorageError> {
         // Archived pointers: exact (stanza-id, archive-by) match —
         // pure SQL. The MAM row was tombstoned, so the pointer must

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -1389,10 +1389,9 @@ async fn flush_blocked_row_releases_claim_when_delete_fails() {
         }
         async fn scrub_for_tombstone(
             &self,
-            target_id: &str,
-            archive_jid: &jid::BareJid,
+            target: &waddle_xmpp::tombstone::TombstoneTarget,
         ) -> Result<u64, PendingStorageError> {
-            self.inner.scrub_for_tombstone(target_id, archive_jid).await
+            self.inner.scrub_for_tombstone(target).await
         }
     }
 
@@ -2494,7 +2493,11 @@ async fn database_scrub_for_tombstone_removes_transient_and_archived_matches() {
         .expect("insert");
 
     let removed = storage
-        .scrub_for_tombstone("retract-me", &bare("alice@example.com"))
+        .scrub_for_tombstone(&waddle_xmpp::tombstone::TombstoneTarget::Direct {
+            wire_id: "retract-me".to_string(),
+            author: bare("bob@elsewhere"),
+            archive: bare("alice@example.com"),
+        })
         .await
         .expect("scrub");
     assert_eq!(

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -1387,6 +1387,13 @@ async fn flush_blocked_row_releases_claim_when_delete_fails() {
         ) -> Result<u64, PendingStorageError> {
             self.inner.delete_older_than(cutoff).await
         }
+        async fn scrub_for_tombstone(
+            &self,
+            target_id: &str,
+            archive_jid: &str,
+        ) -> Result<u64, PendingStorageError> {
+            self.inner.scrub_for_tombstone(target_id, archive_jid).await
+        }
     }
 
     let storage: Arc<dyn PendingDeliveryStorage> = Arc::new(DeleteRowFails {
@@ -2422,5 +2429,100 @@ async fn transient_deferral_plus_cas_reset_delivers_on_next_presence_flush() {
     assert_eq!(
         body_of(&rx.try_recv().expect("delivered on retry").stanza),
         "after-the-blip"
+    );
+}
+
+fn transient_dm_row_with_id(recipient: &str, wire_id: &str, body: &str) -> PendingRow {
+    let mut m = Message::new(Some(recipient.parse::<jid::Jid>().expect("jid")));
+    m.from = Some("bob@elsewhere/x".parse::<jid::Jid>().expect("jid"));
+    m.id = Some(xmpp_parsers::message::Id(wire_id.to_string()));
+    m.type_ = MessageType::Chat;
+    m.bodies
+        .insert(xmpp_parsers::message::Lang(String::new()), body.to_string());
+    PendingRow {
+        id: PendingRowId::fresh(),
+        recipient: bare(recipient),
+        original_receipt_at: Utc::now(),
+        payload: PendingPayload::Transient(Box::new(m)),
+        flushed_in_session: None,
+        outbound_sequence: None,
+    }
+}
+
+#[tokio::test]
+async fn database_scrub_for_tombstone_removes_transient_and_archived_matches() {
+    // F2: a XEP-0424/0425 retraction must scrub promoted pending rows
+    // in the SQL backend too — a Transient row would otherwise deliver
+    // the retracted content verbatim on the recipient's next login,
+    // and an Archived pointer would flush a tombstone stub.
+    let storage = DatabasePendingDeliveryStorage::open(None, QuotaPolicy::Unlimited)
+        .await
+        .expect("open");
+    storage
+        .insert(transient_dm_row_with_id(
+            "alice@example.com",
+            "retract-me",
+            "secret",
+        ))
+        .await
+        .expect("insert");
+    storage
+        .insert(transient_dm_row_with_id(
+            "alice@example.com",
+            "keep-me",
+            "safe",
+        ))
+        .await
+        .expect("insert");
+    // Same wire id in another conversation: scope guard keeps it.
+    storage
+        .insert(transient_dm_row_with_id(
+            "carol@example.com",
+            "retract-me",
+            "unrelated",
+        ))
+        .await
+        .expect("insert");
+    storage
+        .insert(archived_row("alice@example.com", "retract-me"))
+        .await
+        .expect("insert");
+    storage
+        .insert(archived_row("alice@example.com", "other-archive"))
+        .await
+        .expect("insert");
+
+    let removed = storage
+        .scrub_for_tombstone("retract-me", "alice@example.com")
+        .await
+        .expect("scrub");
+    assert_eq!(
+        removed, 2,
+        "one transient + one archived in-scope match removed"
+    );
+
+    // Next-login flush proxy: the claim (what a fresh session flushes)
+    // must no longer surface the scrubbed rows.
+    let claimed = storage
+        .claim_for_session(&bare("alice@example.com"), &SmSessionId::new("s-next"))
+        .await
+        .expect("claim");
+    assert_eq!(claimed.len(), 2);
+    for row in &claimed {
+        match &row.payload {
+            PendingPayload::Transient(m) => {
+                assert_eq!(m.id.as_ref().map(|id| id.0.as_str()), Some("keep-me"));
+            }
+            PendingPayload::Archived(r) => assert_eq!(r.id.as_str(), "other-archive"),
+        }
+    }
+    // The out-of-scope conversation is untouched.
+    assert_eq!(
+        storage
+            .list(&bare("carol@example.com"))
+            .await
+            .expect("list")
+            .len(),
+        1
     );
 }

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -1561,6 +1561,7 @@ async fn xep0160_promoted_stanzas_carry_original_receipt_time_in_delay() {
         &storage,
         &waddle_xmpp::protocol::session_state::Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
     assert_eq!(summary.queued, 1);

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -1390,7 +1390,7 @@ async fn flush_blocked_row_releases_claim_when_delete_fails() {
         async fn scrub_for_tombstone(
             &self,
             target_id: &str,
-            archive_jid: &str,
+            archive_jid: &jid::BareJid,
         ) -> Result<u64, PendingStorageError> {
             self.inner.scrub_for_tombstone(target_id, archive_jid).await
         }
@@ -2494,7 +2494,7 @@ async fn database_scrub_for_tombstone_removes_transient_and_archived_matches() {
         .expect("insert");
 
     let removed = storage
-        .scrub_for_tombstone("retract-me", "alice@example.com")
+        .scrub_for_tombstone("retract-me", &bare("alice@example.com"))
         .await
         .expect("scrub");
     assert_eq!(

--- a/server/crates/waddle-server/src/server/durable_membership.rs
+++ b/server/crates/waddle-server/src/server/durable_membership.rs
@@ -7,6 +7,7 @@
 //! candidates across deploys and actor respawns.
 
 use std::collections::HashSet;
+use std::time::Duration;
 
 use jid::BareJid;
 use kameo::actor::ActorRef;
@@ -23,6 +24,14 @@ use crate::permissions::{
 /// owner/admin/member at either the channel or the space level all
 /// resolve to `Affiliation::Member`+.
 const MEMBER_RELATIONS: [&str; 3] = ["owner", "admin", "member"];
+
+/// Upper bound on each `ListSubjects` ask (S6). Hydration is the first
+/// message in a freshly spawned `RoomActor`'s mailbox, so an unbounded
+/// ask against a hung (not dead) [`PermissionActor`] would wedge the
+/// room — and the dormancy sweep behind it — forever. A timeout maps to
+/// the existing fail-open `Err` path. Magnitude matches the registry's
+/// `ROOM_REGISTRY_REPLY_TIMEOUT` (5s).
+const MEMBERSHIP_LOOKUP_REPLY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Durable membership source reading `permission_tuples` through the
 /// shared [`PermissionActor`].
@@ -41,6 +50,7 @@ impl PermissionDurableMembershipSource {
                 object,
                 relation: Relation::new(relation),
             })
+            .reply_timeout(MEMBERSHIP_LOOKUP_REPLY_TIMEOUT)
             .await
             .map_err(|error| {
                 XmppError::internal(format!("durable membership lookup failed: {error}"))

--- a/server/crates/waddle-server/src/server/durable_membership.rs
+++ b/server/crates/waddle-server/src/server/durable_membership.rs
@@ -1,0 +1,115 @@
+//! Production [`DurableMembershipSource`] backed by the permission actor.
+//!
+//! Bridges the deployment's Zanzibar-style permission tuples to the
+//! `waddle-xmpp` room registry so every freshly spawned `RoomActor`
+//! hydrates its durable inbox recipient set at spawn (#1135) —
+//! offline members keep receiving inbox rows / notification
+//! candidates across deploys and actor respawns.
+
+use std::collections::HashSet;
+
+use jid::BareJid;
+use kameo::actor::ActorRef;
+use tracing::warn;
+use waddle_xmpp::muc::affiliation::{DurableMembershipFuture, DurableMembershipSource};
+use waddle_xmpp::XmppError;
+
+use crate::permissions::{
+    ListSubjects, Object, ObjectType, PermissionActor, Relation, Subject, SubjectType,
+};
+
+/// Membership-granting relations, mirroring
+/// [`waddle_xmpp::muc::affiliation::AppStateAffiliationResolver`]:
+/// owner/admin/member at either the channel or the space level all
+/// resolve to `Affiliation::Member`+.
+const MEMBER_RELATIONS: [&str; 3] = ["owner", "admin", "member"];
+
+/// Durable membership source reading `permission_tuples` through the
+/// shared [`PermissionActor`].
+pub struct PermissionDurableMembershipSource {
+    permission_actor: ActorRef<PermissionActor>,
+}
+
+impl PermissionDurableMembershipSource {
+    pub fn new(permission_actor: ActorRef<PermissionActor>) -> Self {
+        Self { permission_actor }
+    }
+
+    async fn subjects(&self, object: Object, relation: &str) -> Result<Vec<Subject>, XmppError> {
+        self.permission_actor
+            .ask(ListSubjects {
+                object,
+                relation: Relation::new(relation),
+            })
+            .await
+            .map_err(|error| {
+                XmppError::internal(format!("durable membership lookup failed: {error}"))
+            })
+    }
+}
+
+/// Direct user subjects carry the bare JID as their id (see
+/// `xmpp_permission_state::resolve_subject_jid`). Userset and
+/// non-user subjects do not map to a JID; a malformed user id is
+/// logged and skipped rather than failing the whole hydration.
+fn subject_bare_jid(subject: &Subject) -> Option<BareJid> {
+    if subject.subject_type != SubjectType::User || subject.relation.is_some() {
+        return None;
+    }
+    match subject.id.parse::<BareJid>() {
+        Ok(jid) => Some(jid),
+        Err(error) => {
+            warn!(
+                subject = %subject.id,
+                %error,
+                "skipping durable member with unparseable bare JID"
+            );
+            None
+        }
+    }
+}
+
+impl DurableMembershipSource for PermissionDurableMembershipSource {
+    fn list_durable_member_jids(
+        &self,
+        waddle_id: &str,
+        channel_id: &str,
+    ) -> DurableMembershipFuture<'_> {
+        let waddle_id = waddle_id.to_string();
+        let channel_id = channel_id.to_string();
+        Box::pin(async move {
+            // Mirrors the join-path affiliation derivation
+            // (`AppStateAffiliationResolver`): channel- AND
+            // space-level owner/admin/member all grant Member+;
+            // a channel-level outcast relation excludes the user.
+            let scopes = [
+                Object::new(ObjectType::Channel, channel_id.clone()),
+                Object::new(ObjectType::Space, waddle_id),
+            ];
+            let mut members = Vec::new();
+            for scope in &scopes {
+                for relation in MEMBER_RELATIONS {
+                    for subject in self.subjects(scope.clone(), relation).await? {
+                        if let Some(jid) = subject_bare_jid(&subject) {
+                            members.push(jid);
+                        }
+                    }
+                }
+            }
+            let outcasts: HashSet<BareJid> = self
+                .subjects(Object::new(ObjectType::Channel, channel_id), "outcast")
+                .await?
+                .iter()
+                .filter_map(subject_bare_jid)
+                .collect();
+            members.retain(|jid| !outcasts.contains(jid));
+            members.sort();
+            members.dedup();
+            Ok(members)
+        })
+    }
+}
+
+#[cfg(test)]
+#[path = "durable_membership_tests.rs"]
+mod tests;

--- a/server/crates/waddle-server/src/server/durable_membership.rs
+++ b/server/crates/waddle-server/src/server/durable_membership.rs
@@ -92,23 +92,34 @@ impl DurableMembershipSource for PermissionDurableMembershipSource {
             // (`AppStateAffiliationResolver`): channel- AND
             // space-level owner/admin/member all grant Member+;
             // a channel-level outcast relation excludes the user.
+            //
+            // All seven `ListSubjects` asks are issued CONCURRENTLY
+            // (S6 round-3): hydration runs inside the room actor's
+            // handler, so with a wedged (not dead) permission actor a
+            // sequential chain would stall the room's entire mailbox
+            // for up to seven reply timeouts; concurrent asks bound
+            // the worst case to one. `try_join_all` preserves the
+            // fail-open contract exactly — any single failure yields
+            // `Err` and the caller keeps its existing mirror.
             let scopes = [
                 Object::new(ObjectType::Channel, channel_id.clone()),
                 Object::new(ObjectType::Space, waddle_id),
             ];
-            let mut members = Vec::new();
-            for scope in &scopes {
-                for relation in MEMBER_RELATIONS {
-                    for subject in self.subjects(scope.clone(), relation).await? {
-                        if let Some(jid) = subject_bare_jid(&subject) {
-                            members.push(jid);
-                        }
-                    }
-                }
-            }
-            let outcasts: HashSet<BareJid> = self
-                .subjects(Object::new(ObjectType::Channel, channel_id), "outcast")
-                .await?
+            let member_queries = scopes.iter().flat_map(|scope| {
+                MEMBER_RELATIONS
+                    .into_iter()
+                    .map(move |relation| self.subjects(scope.clone(), relation))
+            });
+            let outcast_query =
+                self.subjects(Object::new(ObjectType::Channel, channel_id), "outcast");
+            let (member_results, outcast_subjects) =
+                futures::try_join!(futures::future::try_join_all(member_queries), outcast_query,)?;
+            let mut members: Vec<BareJid> = member_results
+                .iter()
+                .flatten()
+                .filter_map(subject_bare_jid)
+                .collect();
+            let outcasts: HashSet<BareJid> = outcast_subjects
                 .iter()
                 .filter_map(subject_bare_jid)
                 .collect();

--- a/server/crates/waddle-server/src/server/durable_membership_tests.rs
+++ b/server/crates/waddle-server/src/server/durable_membership_tests.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use jid::BareJid;
 use kameo::actor::{ActorRef, Spawn};
@@ -36,6 +37,58 @@ async fn write_tuple(
 
 fn bare(value: &str) -> BareJid {
     value.parse().expect("valid bare JID")
+}
+
+/// Test-only wedge: a message whose handler never completes, so every
+/// subsequent ask sits behind it forever — simulating a hung (not dead)
+/// [`PermissionActor`].
+struct HangForever;
+
+impl kameo::message::Message<HangForever> for PermissionActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: HangForever,
+        _ctx: &mut kameo::message::Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        std::future::pending::<()>().await
+    }
+}
+
+/// S6: a hung permission actor must not wedge room hydration forever.
+/// Every `ListSubjects` ask is bounded by
+/// [`super::MEMBERSHIP_LOOKUP_REPLY_TIMEOUT`]; on timeout the source
+/// fails open with an `Err`, matching the ask-failure path. The outer
+/// 30s virtual-time budget comfortably exceeds the per-ask timeout, so
+/// without the bound this test fails (the ask never resolves).
+#[tokio::test]
+async fn hung_permission_actor_times_out_instead_of_hanging_hydration() {
+    let actor = spawn_test_permission_actor("durable-membership-hung-actor").await;
+    actor
+        .tell(HangForever)
+        .await
+        .expect("enqueue wedge message");
+
+    // Pause only after DB setup (the sqlx pool misbehaves under paused
+    // time); from here virtual time auto-advances past the reply timeout.
+    tokio::time::pause();
+
+    let source = PermissionDurableMembershipSource::new(actor);
+    let result = tokio::time::timeout(
+        Duration::from_secs(30),
+        source.list_durable_member_jids("w-1", "c-1"),
+    )
+    .await
+    .expect("hydration must complete within the reply-timeout budget");
+
+    let error = result.expect_err("hung permission actor must fail open with Err");
+    assert!(
+        error
+            .to_string()
+            .contains("durable membership lookup failed"),
+        "timeout maps to the existing fail-open internal error, got: {error}"
+    );
 }
 
 /// #1135: the production membership source must return every user

--- a/server/crates/waddle-server/src/server/durable_membership_tests.rs
+++ b/server/crates/waddle-server/src/server/durable_membership_tests.rs
@@ -1,0 +1,129 @@
+use std::sync::Arc;
+
+use jid::BareJid;
+use kameo::actor::{ActorRef, Spawn};
+use waddle_xmpp::muc::affiliation::DurableMembershipSource;
+
+use super::PermissionDurableMembershipSource;
+use crate::db::{Database, MigrationRunner};
+use crate::permissions::{
+    Object, ObjectType, PermissionActor, Relation, Subject, SubjectType, Tuple, WriteTuple,
+};
+
+async fn spawn_test_permission_actor(label: &str) -> ActorRef<PermissionActor> {
+    let db = Database::in_memory(label).await.expect("in-memory db");
+    let db = Arc::new(db);
+    MigrationRunner::global()
+        .run(&db)
+        .await
+        .expect("migrations");
+    PermissionActor::spawn(PermissionActor::new_for_tests(db))
+}
+
+async fn write_tuple(
+    actor: &ActorRef<PermissionActor>,
+    object: Object,
+    relation: &str,
+    subject: Subject,
+) {
+    actor
+        .ask(WriteTuple {
+            tuple: Tuple::new(object, Relation::new(relation), subject),
+        })
+        .await
+        .expect("write tuple");
+}
+
+fn bare(value: &str) -> BareJid {
+    value.parse().expect("valid bare JID")
+}
+
+/// #1135: the production membership source must return every user
+/// durably affiliated at Member+ — channel-level AND space-level
+/// owner/admin/member relations — excluding channel outcasts and
+/// non-user / userset subjects, sorted and deduplicated.
+#[tokio::test]
+async fn lists_channel_and_space_member_tier_users_excluding_outcasts() {
+    let actor = spawn_test_permission_actor("durable-membership-source").await;
+    let channel = Object::new(ObjectType::Channel, "c-1");
+    let space = Object::new(ObjectType::Space, "w-1");
+
+    // Channel-level member; also space member so dedup is exercised.
+    write_tuple(
+        &actor,
+        channel.clone(),
+        "member",
+        Subject::user("alice@example.com"),
+    )
+    .await;
+    write_tuple(
+        &actor,
+        space.clone(),
+        "member",
+        Subject::user("alice@example.com"),
+    )
+    .await;
+    // Space-level admin counts as Member+.
+    write_tuple(
+        &actor,
+        space.clone(),
+        "admin",
+        Subject::user("bob@example.com"),
+    )
+    .await;
+    // Channel-level owner counts as Member+.
+    write_tuple(
+        &actor,
+        channel.clone(),
+        "owner",
+        Subject::user("dave@example.com"),
+    )
+    .await;
+    // Channel outcast wins over their member tuple.
+    write_tuple(
+        &actor,
+        channel.clone(),
+        "member",
+        Subject::user("carol@example.com"),
+    )
+    .await;
+    write_tuple(
+        &actor,
+        channel.clone(),
+        "outcast",
+        Subject::user("carol@example.com"),
+    )
+    .await;
+    // Userset subject must not be treated as a member JID.
+    write_tuple(
+        &actor,
+        channel.clone(),
+        "member",
+        Subject::userset(SubjectType::Space, "w-1", "member"),
+    )
+    .await;
+    // A member of an unrelated channel must not leak in.
+    write_tuple(
+        &actor,
+        Object::new(ObjectType::Channel, "c-other"),
+        "member",
+        Subject::user("erin@example.com"),
+    )
+    .await;
+
+    let source = PermissionDurableMembershipSource::new(actor);
+    let members = source
+        .list_durable_member_jids("w-1", "c-1")
+        .await
+        .expect("list durable members");
+
+    assert_eq!(
+        members,
+        vec![
+            bare("alice@example.com"),
+            bare("bob@example.com"),
+            bare("dave@example.com"),
+        ],
+        "channel+space Member+ users, outcast-excluded, sorted, deduped"
+    );
+}

--- a/server/crates/waddle-server/src/server/durable_membership_tests.rs
+++ b/server/crates/waddle-server/src/server/durable_membership_tests.rs
@@ -59,9 +59,11 @@ impl kameo::message::Message<HangForever> for PermissionActor {
 /// S6: a hung permission actor must not wedge room hydration forever.
 /// Every `ListSubjects` ask is bounded by
 /// [`super::MEMBERSHIP_LOOKUP_REPLY_TIMEOUT`]; on timeout the source
-/// fails open with an `Err`, matching the ask-failure path. The outer
-/// 30s virtual-time budget comfortably exceeds the per-ask timeout, so
-/// without the bound this test fails (the ask never resolves).
+/// fails open with an `Err`, matching the ask-failure path. All seven
+/// asks are issued concurrently (S6 round-3), so total hydration
+/// latency against a wedged actor is bounded by ~ONE reply timeout —
+/// the outer virtual-time budget is deliberately below two timeouts to
+/// pin that bound (a per-ask sequential wait of 7 x 5s would fail it).
 #[tokio::test]
 async fn hung_permission_actor_times_out_instead_of_hanging_hydration() {
     let actor = spawn_test_permission_actor("durable-membership-hung-actor").await;
@@ -76,11 +78,11 @@ async fn hung_permission_actor_times_out_instead_of_hanging_hydration() {
 
     let source = PermissionDurableMembershipSource::new(actor);
     let result = tokio::time::timeout(
-        Duration::from_secs(30),
+        Duration::from_secs(9),
         source.list_durable_member_jids("w-1", "c-1"),
     )
     .await
-    .expect("hydration must complete within the reply-timeout budget");
+    .expect("hydration must complete within roughly one reply timeout");
 
     let error = result.expect_err("hung permission actor must fail open with Err");
     assert!(

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -798,6 +798,22 @@ fn install_profile_publish_hook(
     tracing::debug!("OIDC → PEP profile-publish hook installed");
 }
 
+/// Maximum number of detached XEP-0198 sessions held resumable at
+/// once (issue #1097 sizing item). Overflow evicts the oldest session
+/// through the promote → confirm chain (no message loss), but each
+/// eviction still costs its owner the resume window — size this above
+/// the expected concurrent detached-session peak (roughly: peak
+/// concurrent users × resume-window churn rate).
+fn sm_max_sessions_from_env() -> usize {
+    const MIN_SESSIONS: usize = 100;
+    const MAX_SESSIONS: usize = 10_000_000;
+    std::env::var("WADDLE_SM_MAX_SESSIONS")
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .map(|v| v.clamp(MIN_SESSIONS, MAX_SESSIONS))
+        .unwrap_or(waddle_xmpp::stream_management::DEFAULT_MAX_SESSIONS)
+}
+
 async fn create_sm_session_registry(
     xmpp_config: &XmppConfig,
 ) -> Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry> {
@@ -816,7 +832,10 @@ async fn create_sm_session_registry(
                 .await
                 .expect("open SM persistence storage"),
         );
-    let sm_session_registry = waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()
+    let sm_session_registry =
+        waddle_xmpp::stream_management::InMemorySmSessionRegistry::with_capacity(
+            sm_max_sessions_from_env(),
+        )
         .with_persistence(Arc::clone(&sm_persistence));
     if let Err(error) = sm_session_registry.restore_from_persistence().await {
         warn!(

--- a/server/crates/waddle-server/src/server/mod.rs
+++ b/server/crates/waddle-server/src/server/mod.rs
@@ -2,6 +2,7 @@ mod acme;
 pub(crate) mod caps_resolution;
 mod config;
 pub(crate) mod dual_registration;
+pub(crate) mod durable_membership;
 mod extension_commands;
 pub mod extension_host_adapter;
 mod extension_host_tools;
@@ -168,9 +169,18 @@ pub async fn start_with_config(
     // handle (named bounded mailbox + per-request reply timeout + typed errors),
     // and start the periodic mailbox-depth gauge. The shared graph still stores
     // the underlying `ActorRef`, so existing call sites are unchanged.
+    // #1135: hydrate every freshly spawned RoomActor's durable inbox
+    // recipient set from the permission tuples, so offline channel
+    // members keep receiving inbox rows / notification candidates
+    // across deploys and actor respawns.
+    let durable_membership_source: Arc<dyn waddle_xmpp::muc::affiliation::DurableMembershipSource> =
+        Arc::new(durable_membership::PermissionDurableMembershipSource::new(
+            permission_actor.clone(),
+        ));
     let room_registry_handle = waddle_xmpp::muc::RoomRegistry::spawn(
         xmpp_config.muc_domain.to_string(),
         server_config.occupant_id_secret.clone(),
+        Some(durable_membership_source),
     );
     room_registry_gauge::spawn(room_registry_handle.clone(), stop_token.clone());
     let room_registry = room_registry_handle.actor_ref().clone();

--- a/server/crates/waddle-server/src/server/room_registry_gauge.rs
+++ b/server/crates/waddle-server/src/server/room_registry_gauge.rs
@@ -59,7 +59,7 @@ mod tests {
     fn test_registry() -> RoomRegistry {
         let secret = OccupantIdSecret::new(b"test-occupant-id-secret-32-bytes-long".to_vec())
             .expect("test occupant-id secret meets length floor");
-        RoomRegistry::spawn("muc.example.com".to_string(), secret)
+        RoomRegistry::spawn("muc.example.com".to_string(), secret, None)
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -528,6 +528,7 @@ async fn interpret_with_depth(
                 let tombstoned = apply_groupchat_retraction_tombstone(
                     mam_storage,
                     deps.sm_session_registry,
+                    deps.pending_delivery_storage,
                     &room,
                     &target_message_id,
                     &retraction_message,

--- a/server/crates/waddle-server/src/server/routes/interpret/direct_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/direct_archive.rs
@@ -566,6 +566,7 @@ async fn apply_direct_retraction_tombstone(
             let tombstoned = apply_retraction_tombstone(
                 mam_storage,
                 deps.sm_session_registry,
+                deps.pending_delivery_storage,
                 archive_jid,
                 &retraction.retracts_id,
                 message,

--- a/server/crates/waddle-server/src/server/routes/interpret/direct_retraction.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/direct_retraction.rs
@@ -72,7 +72,7 @@ pub(super) async fn apply_retraction_tombstone(
                 sm_session_registry,
                 pending_storage,
                 target_wire_id,
-                &archive.to_string(),
+                archive,
                 "ApplyRetractionTombstone",
             )
             .await;
@@ -89,7 +89,7 @@ pub(super) async fn apply_retraction_tombstone(
                 sm_session_registry,
                 pending_storage,
                 target_wire_id,
-                &archive.to_string(),
+                archive,
                 "ApplyRetractionTombstone",
             )
             .await;
@@ -106,7 +106,7 @@ pub(super) async fn apply_retraction_tombstone(
         sm_session_registry,
         pending_storage,
         target_wire_id,
-        &archive.to_string(),
+        archive,
         "ApplyRetractionTombstone",
     )
     .await;

--- a/server/crates/waddle-server/src/server/routes/interpret/direct_retraction.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/direct_retraction.rs
@@ -11,6 +11,35 @@ pub(super) async fn apply_retraction_tombstone(
     target_wire_id: &str,
     retraction_message: &Message,
 ) -> bool {
+    // XEP-0424 §"Using the correct ID": a non-groupchat retraction
+    // names the target by the SENDER's wire id, which is client-chosen
+    // and unique only per author. The scrub identity therefore carries
+    // the retraction author's bare JID: a cached message matches on
+    // (wire id, from-bare == author) — never on a colliding wire id
+    // minted by a different sender in the same conversation.
+    // The dispatcher's `RichTargetValidationHandler` has already
+    // enforced the same-author rule for the archive tombstone, so
+    // `retraction_message.from` IS the original message's author. A
+    // from-less retraction (defensive; canonicalization stamps `from`)
+    // still tombstones the archive but skips the cache scrub — without
+    // an author the wire-id match cannot be made precise, and a
+    // cross-sender scrub is the worse failure.
+    let scrub_target = match retraction_message.from.as_ref().map(|from| from.to_bare()) {
+        Some(author) => Some(waddle_xmpp::tombstone::TombstoneTarget::Direct {
+            wire_id: target_wire_id.to_string(),
+            author,
+            archive: archive.clone(),
+        }),
+        None => {
+            warn!(
+                archive = %archive,
+                target = target_wire_id,
+                "ApplyRetractionTombstone: retraction stanza missing from JID; \
+                 the unacked/pending cache scrub is skipped (no author scope)"
+            );
+            None
+        }
+    };
     let original = match mam_storage
         .get_message_by_message_id(archive, target_wire_id)
         .await
@@ -68,14 +97,15 @@ pub(super) async fn apply_retraction_tombstone(
                 original_id = %original.id,
                 "ApplyRetractionTombstone: target row not found at replace time"
             );
-            scrub_unacked_for_tombstone(
-                sm_session_registry,
-                pending_storage,
-                target_wire_id,
-                archive,
-                "ApplyRetractionTombstone",
-            )
-            .await;
+            if let Some(scrub_target) = scrub_target.as_ref() {
+                scrub_unacked_for_tombstone(
+                    sm_session_registry,
+                    pending_storage,
+                    scrub_target,
+                    "ApplyRetractionTombstone",
+                )
+                .await;
+            }
             return false;
         }
         Err(error) => {
@@ -85,14 +115,15 @@ pub(super) async fn apply_retraction_tombstone(
                 %error,
                 "ApplyRetractionTombstone: replace_with_tombstone failed"
             );
-            scrub_unacked_for_tombstone(
-                sm_session_registry,
-                pending_storage,
-                target_wire_id,
-                archive,
-                "ApplyRetractionTombstone",
-            )
-            .await;
+            if let Some(scrub_target) = scrub_target.as_ref() {
+                scrub_unacked_for_tombstone(
+                    sm_session_registry,
+                    pending_storage,
+                    scrub_target,
+                    "ApplyRetractionTombstone",
+                )
+                .await;
+            }
             return false;
         }
     }
@@ -101,14 +132,17 @@ pub(super) async fn apply_retraction_tombstone(
     // pre-scrub stanza on the wire. XEP-0424 §"prevent further
     // distribution" applies to in-flight as well as archived copies.
     // Scope by the recipient archive's bare JID so a colliding wire id
-    // in another conversation is not accidentally scrubbed (Codex P1).
-    scrub_unacked_for_tombstone(
-        sm_session_registry,
-        pending_storage,
-        target_wire_id,
-        archive,
-        "ApplyRetractionTombstone",
-    )
-    .await;
+    // in another conversation is not accidentally scrubbed (Codex P1),
+    // and by the retraction author so a colliding wire id from a
+    // DIFFERENT sender in the same conversation survives.
+    if let Some(scrub_target) = scrub_target.as_ref() {
+        scrub_unacked_for_tombstone(
+            sm_session_registry,
+            pending_storage,
+            scrub_target,
+            "ApplyRetractionTombstone",
+        )
+        .await;
+    }
     true
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/direct_retraction.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/direct_retraction.rs
@@ -4,6 +4,9 @@ use super::*;
 pub(super) async fn apply_retraction_tombstone(
     mam_storage: &Arc<dyn MamStorage>,
     sm_session_registry: Option<&Arc<InMemorySmSessionRegistry>>,
+    pending_storage: Option<
+        &Arc<dyn waddle_xmpp::pending_delivery::storage::PendingDeliveryStorage>,
+    >,
     archive: &jid::BareJid,
     target_wire_id: &str,
     retraction_message: &Message,
@@ -67,6 +70,7 @@ pub(super) async fn apply_retraction_tombstone(
             );
             scrub_unacked_for_tombstone(
                 sm_session_registry,
+                pending_storage,
                 target_wire_id,
                 &archive.to_string(),
                 "ApplyRetractionTombstone",
@@ -83,6 +87,7 @@ pub(super) async fn apply_retraction_tombstone(
             );
             scrub_unacked_for_tombstone(
                 sm_session_registry,
+                pending_storage,
                 target_wire_id,
                 &archive.to_string(),
                 "ApplyRetractionTombstone",
@@ -99,6 +104,7 @@ pub(super) async fn apply_retraction_tombstone(
     // in another conversation is not accidentally scrubbed (Codex P1).
     scrub_unacked_for_tombstone(
         sm_session_registry,
+        pending_storage,
         target_wire_id,
         &archive.to_string(),
         "ApplyRetractionTombstone",

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -142,6 +142,9 @@ pub(super) struct ArchiveStoreResult {
 pub(super) async fn apply_groupchat_retraction_tombstone(
     mam_storage: &Arc<dyn MamStorage>,
     sm_session_registry: Option<&Arc<InMemorySmSessionRegistry>>,
+    pending_storage: Option<
+        &Arc<dyn waddle_xmpp::pending_delivery::storage::PendingDeliveryStorage>,
+    >,
     room: &BareJid,
     target_message_id: &str,
     retraction_message: &Message,
@@ -211,6 +214,7 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
             );
             scrub_unacked_for_tombstone(
                 sm_session_registry,
+                pending_storage,
                 target_message_id,
                 &room.to_string(),
                 "ApplyGroupchatRetractionTombstone",
@@ -227,6 +231,7 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
             );
             scrub_unacked_for_tombstone(
                 sm_session_registry,
+                pending_storage,
                 target_message_id,
                 &room.to_string(),
                 "ApplyGroupchatRetractionTombstone",
@@ -245,6 +250,7 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
     // (Codex P1, Copilot review on PR #305).
     scrub_unacked_for_tombstone(
         sm_session_registry,
+        pending_storage,
         target_message_id,
         &room.to_string(),
         "ApplyGroupchatRetractionTombstone",
@@ -253,41 +259,73 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
     true
 }
 
-/// Walk the SM session registry and drop every unacked outbound
-/// `<message/>` entry that matches a XEP-0424 / XEP-0425 tombstone.
-/// `target_id` is matched against either the cached message's wire
-/// `id` attribute or any XEP-0359 `<stanza-id id='…'/>` child, scoped
-/// to `archive_jid` so cross-conversation collateral damage is
-/// impossible. Returns silently on any registry error (logged at
-/// WARN) — the archive scrub has already happened, and dropping the
-/// in-flight copy is best-effort.
+/// Walk the SM session registry AND the pending-delivery store and
+/// drop every cached `<message/>` copy that matches a XEP-0424 /
+/// XEP-0425 tombstone. `target_id` is matched against either the
+/// cached message's wire `id` attribute or any XEP-0359
+/// `<stanza-id id='…'/>` child (Archived pending pointers match on
+/// their exact stanza-id), scoped to `archive_jid` so
+/// cross-conversation collateral damage is impossible. Returns
+/// silently on any storage error (logged at WARN) — the archive scrub
+/// has already happened, and dropping the in-flight copies is
+/// best-effort.
+///
+/// Both layers are scrubbed from the same call sites because
+/// promotion (#1097/#1098) moves unacked SM stanzas into
+/// pending_delivery: scrubbing only the SM registry would let a
+/// promoted copy deliver the retracted content verbatim at the
+/// recipient's next login.
 pub(super) async fn scrub_unacked_for_tombstone(
     sm_session_registry: Option<&Arc<InMemorySmSessionRegistry>>,
+    pending_storage: Option<
+        &Arc<dyn waddle_xmpp::pending_delivery::storage::PendingDeliveryStorage>,
+    >,
     target_id: &str,
     archive_jid: &str,
     site: &'static str,
 ) {
-    let Some(sm) = sm_session_registry else {
-        return;
-    };
-    use waddle_xmpp::stream_management::SmSessionRegistry as _;
-    match sm.scrub_unacked_for_tombstone(target_id, archive_jid).await {
-        Ok(removed) if removed > 0 => {
-            debug!(
-                target = target_id,
-                archive = archive_jid,
-                removed,
-                "{site}: scrubbed unacked SM queue entries for tombstoned message"
-            );
+    if let Some(sm) = sm_session_registry {
+        use waddle_xmpp::stream_management::SmSessionRegistry as _;
+        match sm.scrub_unacked_for_tombstone(target_id, archive_jid).await {
+            Ok(removed) if removed > 0 => {
+                debug!(
+                    target = target_id,
+                    archive = archive_jid,
+                    removed,
+                    "{site}: scrubbed unacked SM queue entries for tombstoned message"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                warn!(
+                    target = target_id,
+                    archive = archive_jid,
+                    %error,
+                    "{site}: scrub_unacked_for_tombstone failed; pre-scrub stanza may still replay on resume"
+                );
+            }
         }
-        Ok(_) => {}
-        Err(error) => {
-            warn!(
-                target = target_id,
-                archive = archive_jid,
-                %error,
-                "{site}: scrub_unacked_for_tombstone failed; pre-scrub stanza may still replay on resume"
-            );
+    }
+    if let Some(pending) = pending_storage {
+        match pending.scrub_for_tombstone(target_id, archive_jid).await {
+            Ok(removed) if removed > 0 => {
+                debug!(
+                    target = target_id,
+                    archive = archive_jid,
+                    removed,
+                    "{site}: scrubbed pending_delivery rows for tombstoned message"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                warn!(
+                    target = target_id,
+                    archive = archive_jid,
+                    %error,
+                    "{site}: pending_delivery scrub_for_tombstone failed; retracted \
+                     content may still deliver at the recipient's next login"
+                );
+            }
         }
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -156,7 +156,13 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
     // room (the archived `to` is the room JID) — never by the wire `id`
     // attribute or the origin-id. Keyed identically to the
     // validation-time `lookup_groupchat_retraction_target` so both sites
-    // agree.
+    // agree. The scrub target mirrors this: cached reflections match
+    // ONLY on `<stanza-id by=room id=target/>`, never on the
+    // client-chosen wire id (which any occupant could mint to collide).
+    let scrub_target = waddle_xmpp::tombstone::TombstoneTarget::Groupchat {
+        stanza_id: target_message_id.to_string(),
+        room: room.clone(),
+    };
     let original = match mam_storage.get_message(target_message_id).await {
         Ok(Some(row)) if row.to.to_bare() == *room => row,
         Ok(_) => {
@@ -215,8 +221,7 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
             scrub_unacked_for_tombstone(
                 sm_session_registry,
                 pending_storage,
-                target_message_id,
-                room,
+                &scrub_target,
                 "ApplyGroupchatRetractionTombstone",
             )
             .await;
@@ -232,8 +237,7 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
             scrub_unacked_for_tombstone(
                 sm_session_registry,
                 pending_storage,
-                target_message_id,
-                room,
+                &scrub_target,
                 "ApplyGroupchatRetractionTombstone",
             )
             .await;
@@ -251,8 +255,7 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
     scrub_unacked_for_tombstone(
         sm_session_registry,
         pending_storage,
-        target_message_id,
-        room,
+        &scrub_target,
         "ApplyGroupchatRetractionTombstone",
     )
     .await;
@@ -261,14 +264,15 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
 
 /// Walk the SM session registry AND the pending-delivery store and
 /// drop every cached `<message/>` copy that matches a XEP-0424 /
-/// XEP-0425 tombstone. `target_id` is matched against either the
-/// cached message's wire `id` attribute or any XEP-0359
-/// `<stanza-id id='…'/>` child (Archived pending pointers match on
-/// their exact stanza-id), scoped to `archive_jid` so
-/// cross-conversation collateral damage is impossible. Returns
-/// silently on any storage error (logged at WARN) — the archive scrub
-/// has already happened, and dropping the in-flight copies is
-/// best-effort.
+/// XEP-0425 tombstone. `target` carries the typed identity
+/// ([`waddle_xmpp::tombstone::TombstoneTarget`]): groupchat scrubs
+/// match only the room-assigned XEP-0359 stanza-id; 1:1 scrubs match
+/// the author's wire id only for messages FROM that author. Both are
+/// scoped to the conversation archive so cross-conversation (and
+/// cross-sender wire-id-collision) collateral damage is impossible.
+/// Returns silently on any storage error (logged at WARN) — the
+/// archive scrub has already happened, and dropping the in-flight
+/// copies is best-effort.
 ///
 /// Both layers are scrubbed from the same call sites because
 /// promotion (#1097/#1098) moves unacked SM stanzas into
@@ -280,17 +284,16 @@ pub(super) async fn scrub_unacked_for_tombstone(
     pending_storage: Option<
         &Arc<dyn waddle_xmpp::pending_delivery::storage::PendingDeliveryStorage>,
     >,
-    target_id: &str,
-    archive_jid: &jid::BareJid,
+    target: &waddle_xmpp::tombstone::TombstoneTarget,
     site: &'static str,
 ) {
     if let Some(sm) = sm_session_registry {
         use waddle_xmpp::stream_management::SmSessionRegistry as _;
-        match sm.scrub_unacked_for_tombstone(target_id, archive_jid).await {
+        match sm.scrub_unacked_for_tombstone(target).await {
             Ok(removed) if removed > 0 => {
                 debug!(
-                    target = target_id,
-                    archive = %archive_jid,
+                    target = target.id(),
+                    archive = %target.archive_jid(),
                     removed,
                     "{site}: scrubbed unacked SM queue entries for tombstoned message"
                 );
@@ -298,8 +301,8 @@ pub(super) async fn scrub_unacked_for_tombstone(
             Ok(_) => {}
             Err(error) => {
                 warn!(
-                    target = target_id,
-                    archive = %archive_jid,
+                    target = target.id(),
+                    archive = %target.archive_jid(),
                     %error,
                     "{site}: scrub_unacked_for_tombstone failed; pre-scrub stanza may still replay on resume"
                 );
@@ -307,11 +310,11 @@ pub(super) async fn scrub_unacked_for_tombstone(
         }
     }
     if let Some(pending) = pending_storage {
-        match pending.scrub_for_tombstone(target_id, archive_jid).await {
+        match pending.scrub_for_tombstone(target).await {
             Ok(removed) if removed > 0 => {
                 debug!(
-                    target = target_id,
-                    archive = %archive_jid,
+                    target = target.id(),
+                    archive = %target.archive_jid(),
                     removed,
                     "{site}: scrubbed pending_delivery rows for tombstoned message"
                 );
@@ -319,8 +322,8 @@ pub(super) async fn scrub_unacked_for_tombstone(
             Ok(_) => {}
             Err(error) => {
                 warn!(
-                    target = target_id,
-                    archive = %archive_jid,
+                    target = target.id(),
+                    archive = %target.archive_jid(),
                     %error,
                     "{site}: pending_delivery scrub_for_tombstone failed; retracted \
                      content may still deliver at the recipient's next login"

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -216,7 +216,7 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
                 sm_session_registry,
                 pending_storage,
                 target_message_id,
-                &room.to_string(),
+                room,
                 "ApplyGroupchatRetractionTombstone",
             )
             .await;
@@ -233,7 +233,7 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
                 sm_session_registry,
                 pending_storage,
                 target_message_id,
-                &room.to_string(),
+                room,
                 "ApplyGroupchatRetractionTombstone",
             )
             .await;
@@ -252,7 +252,7 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
         sm_session_registry,
         pending_storage,
         target_message_id,
-        &room.to_string(),
+        room,
         "ApplyGroupchatRetractionTombstone",
     )
     .await;
@@ -281,7 +281,7 @@ pub(super) async fn scrub_unacked_for_tombstone(
         &Arc<dyn waddle_xmpp::pending_delivery::storage::PendingDeliveryStorage>,
     >,
     target_id: &str,
-    archive_jid: &str,
+    archive_jid: &jid::BareJid,
     site: &'static str,
 ) {
     if let Some(sm) = sm_session_registry {
@@ -290,7 +290,7 @@ pub(super) async fn scrub_unacked_for_tombstone(
             Ok(removed) if removed > 0 => {
                 debug!(
                     target = target_id,
-                    archive = archive_jid,
+                    archive = %archive_jid,
                     removed,
                     "{site}: scrubbed unacked SM queue entries for tombstoned message"
                 );
@@ -299,7 +299,7 @@ pub(super) async fn scrub_unacked_for_tombstone(
             Err(error) => {
                 warn!(
                     target = target_id,
-                    archive = archive_jid,
+                    archive = %archive_jid,
                     %error,
                     "{site}: scrub_unacked_for_tombstone failed; pre-scrub stanza may still replay on resume"
                 );
@@ -311,7 +311,7 @@ pub(super) async fn scrub_unacked_for_tombstone(
             Ok(removed) if removed > 0 => {
                 debug!(
                     target = target_id,
-                    archive = archive_jid,
+                    archive = %archive_jid,
                     removed,
                     "{site}: scrubbed pending_delivery rows for tombstoned message"
                 );
@@ -320,7 +320,7 @@ pub(super) async fn scrub_unacked_for_tombstone(
             Err(error) => {
                 warn!(
                     target = target_id,
-                    archive = archive_jid,
+                    archive = %archive_jid,
                     %error,
                     "{site}: pending_delivery scrub_for_tombstone failed; retracted \
                      content may still deliver at the recipient's next login"

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -2866,6 +2866,93 @@ async fn xep_0424_apply_groupchat_retraction_tombstone_keys_off_room_stanza_id()
     }
 }
 
+#[tokio::test]
+async fn xep_0424_groupchat_retraction_scrubs_pending_delivery_rows() {
+    // F2: promotion (#1097/#1098) parks undelivered copies in
+    // pending_delivery. The retraction arm must scrub that layer with
+    // the same keys as the SM-queue scrub, or the retracted content
+    // (Transient rows) / a tombstone stub (Archived pointers) delivers
+    // at the recipient's next login.
+    use waddle_xmpp::mam::storage::InMemoryMamStorage;
+    use waddle_xmpp::pending_delivery::storage::{
+        InMemoryPendingDeliveryStorage, PendingDeliveryStorage,
+    };
+    use waddle_xmpp::pending_delivery::{PendingPayload, PendingRow, PendingRowId};
+
+    let registry = ConnectionRegistry::new();
+    let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
+    let inbox: Arc<dyn InboxStorage> =
+        Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
+    let pending: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let mut deps = Deps::test_with_storage(&registry, &mam, &inbox);
+    deps.pending_delivery_storage = Some(&pending);
+
+    let room: jid::BareJid = "retract-pending@muc.example.com".parse().expect("room");
+    let archive_pk = "room-stamp-uuid-PPP";
+    let wire_id = "alice-orig-3";
+    seed_groupchat_archive_row(&mam, &room, archive_pk, wire_id).await;
+
+    // A promoted Archived pointer row for an offline member, keyed by
+    // the room's XEP-0359 stamp (archive id == wire stanza-id
+    // invariant), plus an unrelated row that must survive.
+    let recipient: jid::BareJid = "offline@example.com".parse().expect("jid");
+    pending
+        .insert(PendingRow {
+            id: PendingRowId::fresh(),
+            recipient: recipient.clone(),
+            original_receipt_at: chrono::Utc::now(),
+            payload: PendingPayload::Archived(waddle_xmpp_core::xep0359::StanzaId::new(
+                archive_pk,
+                jid::Jid::from(room.clone()),
+            )),
+            flushed_in_session: None,
+            outbound_sequence: None,
+        })
+        .await
+        .expect("insert");
+    pending
+        .insert(PendingRow {
+            id: PendingRowId::fresh(),
+            recipient: recipient.clone(),
+            original_receipt_at: chrono::Utc::now(),
+            payload: PendingPayload::Archived(waddle_xmpp_core::xep0359::StanzaId::new(
+                "unrelated-stamp",
+                jid::Jid::from(room.clone()),
+            )),
+            flushed_in_session: None,
+            outbound_sequence: None,
+        })
+        .await
+        .expect("insert");
+
+    let mut retraction = xmpp_parsers::message::Message::new(Some(jid::Jid::from(room.clone())));
+    retraction.id = Some(xmpp_parsers::message::Id("retract-stanza-2".to_string()));
+    retraction.from = Some(format!("{room}/alice").parse().expect("room/nick"));
+    retraction.type_ = XmppMessageType::Groupchat;
+    retraction
+        .payloads
+        .push(waddle_xmpp::xep::xep0424::build_retract_element(archive_pk));
+
+    let events = vec![OutboundEvent::ApplyGroupchatRetractionTombstone {
+        room: room.clone(),
+        target_message_id: archive_pk.to_string(),
+        retraction_message: Box::new(retraction),
+    }];
+    let _outcome = interpret(events, &deps).await;
+
+    let rows = pending.list(&recipient).await.expect("list");
+    assert_eq!(
+        rows.len(),
+        1,
+        "retraction must scrub the matching pending row; unrelated rows survive"
+    );
+    match &rows[0].payload {
+        PendingPayload::Archived(r) => assert_eq!(r.id.as_str(), "unrelated-stamp"),
+        other => panic!("expected surviving Archived row, got {other:?}"),
+    }
+}
+
 fn message_thread_id(message: &Message) -> Option<String> {
     message
         .thread

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -316,13 +316,61 @@ pub(super) async fn cleanup_connection_shutdown(
                         .unregister_if_owner(&jid, owner)
                         .is_none()
                     {
-                        debug!(jid = %jid, "Removed detached SM session after ownership moved");
-                        let _ = state
+                        // Ownership moved: the same client fresh-bound on a
+                        // newer connection before this cleanup stored its
+                        // detached session, so the newer bind's
+                        // invalidation pass never saw this stream. The
+                        // just-stored session still carries the unacked
+                        // queue — run the XEP-0198 §5 promote →
+                        // confirm_drained chain on it (issue #1097
+                        // displaced contract) instead of erasing it, or
+                        // the queue is lost with no promotion.
+                        debug!(
+                            jid = %jid,
+                            stream_id = %stream_id,
+                            "detached SM session lost ownership race; promoting its queue"
+                        );
+                        match state
                             .deps
                             .protocol
                             .sm_session_registry
-                            .remove_stored_session_if_unclaimed(&stream_id)
-                            .await;
+                            .displace_stored_session_if_unclaimed(&stream_id)
+                            .await
+                        {
+                            Ok(Some(displaced)) => {
+                                crate::sm_promotion::promote_displaced_sessions(
+                                    vec![displaced],
+                                    crate::sm_promotion::DisplacedPromotionDeps {
+                                        sm_registry: &state.deps.protocol.sm_session_registry,
+                                        connection_registry: &state
+                                            .deps
+                                            .protocol
+                                            .connection_registry,
+                                        pending_storage: &state
+                                            .deps
+                                            .protocol
+                                            .pending_delivery_storage,
+                                        blocking_storage: state
+                                            .deps
+                                            .protocol
+                                            .blocking_storage
+                                            .as_ref(),
+                                        server_domain: state.deps.auth_state.xmpp_domain.as_str(),
+                                    },
+                                )
+                                .await;
+                            }
+                            Ok(None) => {}
+                            Err(error) => {
+                                warn!(
+                                    jid = %jid,
+                                    stream_id = %stream_id,
+                                    error = %error,
+                                    "ownership-moved detach: displace failed; durable rows \
+                                     remain for janitor/restart retry"
+                                );
+                            }
+                        }
                         return;
                     }
                     // ADR-0017 Phase 1: prune the actor-tree entry at detach

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -285,7 +285,30 @@ pub(super) async fn cleanup_connection_shutdown(
                 .store_session(detached)
                 .await
             {
-                Ok(()) => {
+                Ok(displaced) => {
+                    // Issue #1097: sessions the registry displaced to make
+                    // room (max_sessions overflow, or a stale detached
+                    // stream for this same JID) carry unacked queues that
+                    // must run the XEP-0198 §5 promote → confirm chain
+                    // instead of being dropped. Promote before anything
+                    // else in this arm — the early-return below must not
+                    // skip it.
+                    if !displaced.is_empty() {
+                        crate::sm_promotion::promote_displaced_sessions(
+                            displaced.clone(),
+                            crate::sm_promotion::DisplacedPromotionDeps {
+                                sm_registry: &state.deps.protocol.sm_session_registry,
+                                connection_registry: &state.deps.protocol.connection_registry,
+                                pending_storage: &state.deps.protocol.pending_delivery_storage,
+                                blocking_storage: state.deps.protocol.blocking_storage.as_ref(),
+                                server_domain: state.deps.auth_state.xmpp_domain.as_str(),
+                            },
+                        )
+                        .await;
+                        for dead in displaced {
+                            cleanup_invalidated_detached_session(state, dead, None).await;
+                        }
+                    }
                     if state
                         .deps
                         .protocol

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_admin.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_admin.rs
@@ -1,6 +1,16 @@
 use super::*;
 use crate::admin::channels::{acquire_room_config_lock, explicit_channel_affiliations_for_jids};
 
+/// Upper bound on the mutating room-actor asks below. The room actor
+/// awaits the durable-membership source inside its affiliation
+/// handlers, so a wedged (not dead) permission actor can stall the
+/// room's mailbox; without a reply timeout that stall would propagate
+/// into this stanza handler and hold the connection's IQ processing
+/// hostage. A timeout falls into each match's catch-all `Err` arm
+/// (internal-server-error reply). Magnitude matches the
+/// `REAPER_ASK_TIMEOUT` precedent in `session_janitors.rs`.
+const ADMIN_ROOM_ASK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 fn admin_item_has_role_shape(item: &AdminItem) -> bool {
     item.role.is_some()
 }
@@ -138,6 +148,7 @@ pub(super) async fn handle_muc_admin_iq(
         .ask(GetAdminContext {
             sender_jid: sender_jid.clone(),
         })
+        .reply_timeout(ADMIN_ROOM_ASK_TIMEOUT)
         .await
     {
         Ok(context) => context,
@@ -161,7 +172,11 @@ pub(super) async fn handle_muc_admin_iq(
         )];
     }
     if query.is_get {
-        let snapshot = match room_actor.ask(GetSnapshot).await {
+        let snapshot = match room_actor
+            .ask(GetSnapshot)
+            .reply_timeout(ADMIN_ROOM_ASK_TIMEOUT)
+            .await
+        {
             Ok(snapshot) => snapshot.room,
             Err(_) => {
                 return vec![build_iq_error_xml_typed(
@@ -245,7 +260,11 @@ pub(super) async fn handle_muc_admin_iq(
     let actor_previous_affiliations = if affiliation_updates.is_empty() {
         Vec::new()
     } else {
-        match room_actor.ask(GetSnapshot).await {
+        match room_actor
+            .ask(GetSnapshot)
+            .reply_timeout(ADMIN_ROOM_ASK_TIMEOUT)
+            .await
+        {
             Ok(snapshot) => {
                 let mut final_affiliations: std::collections::BTreeMap<BareJid, Affiliation> =
                     snapshot
@@ -400,6 +419,7 @@ pub(super) async fn handle_muc_admin_iq(
             sender_role: context.role,
             items,
         })
+        .reply_timeout(ADMIN_ROOM_ASK_TIMEOUT)
         .await
     {
         Ok(applied) => applied,
@@ -423,6 +443,7 @@ pub(super) async fn handle_muc_admin_iq(
                             jid: previous_jid.clone(),
                             affiliation: *previous_affiliation,
                         })
+                        .reply_timeout(ADMIN_ROOM_ASK_TIMEOUT)
                         .await;
                 }
             }
@@ -453,6 +474,7 @@ pub(super) async fn handle_muc_admin_iq(
                             jid: previous_jid.clone(),
                             affiliation: *previous_affiliation,
                         })
+                        .reply_timeout(ADMIN_ROOM_ASK_TIMEOUT)
                         .await;
                 }
             }
@@ -483,6 +505,7 @@ pub(super) async fn handle_muc_admin_iq(
                             jid: previous_jid.clone(),
                             affiliation: *previous_affiliation,
                         })
+                        .reply_timeout(ADMIN_ROOM_ASK_TIMEOUT)
                         .await;
                 }
             }
@@ -511,6 +534,7 @@ pub(super) async fn handle_muc_admin_iq(
                             jid: previous_jid.clone(),
                             affiliation: *previous_affiliation,
                         })
+                        .reply_timeout(ADMIN_ROOM_ASK_TIMEOUT)
                         .await;
                 }
             }
@@ -539,6 +563,7 @@ pub(super) async fn handle_muc_admin_iq(
                             jid: previous_jid.clone(),
                             affiliation: *previous_affiliation,
                         })
+                        .reply_timeout(ADMIN_ROOM_ASK_TIMEOUT)
                         .await;
                 }
             }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
@@ -476,12 +476,11 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                     // on PR #305).
                     use waddle_xmpp::stream_management::SmSessionRegistry as _;
                     let target_id = request.target_id.as_str();
-                    let room_jid_str = room_jid.to_string();
                     match state
                         .deps
                         .protocol
                         .sm_session_registry
-                        .scrub_unacked_for_tombstone(target_id, &room_jid_str)
+                        .scrub_unacked_for_tombstone(target_id, &room_jid)
                         .await
                     {
                         Ok(removed) if removed > 0 => debug!(
@@ -506,7 +505,7 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                         .deps
                         .protocol
                         .pending_delivery_storage
-                        .scrub_for_tombstone(target_id, &room_jid_str)
+                        .scrub_for_tombstone(target_id, &room_jid)
                         .await
                     {
                         Ok(removed) if removed > 0 => debug!(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
@@ -498,6 +498,31 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                             "XEP-0425 moderation: scrub_unacked_for_tombstone failed; pre-scrub stanza may still replay on resume"
                         ),
                     }
+                    // F2: promotion (#1097/#1098) parks unacked copies
+                    // in pending_delivery — scrub that layer with the
+                    // same keys or the moderated content delivers
+                    // verbatim at the recipient's next login.
+                    match state
+                        .deps
+                        .protocol
+                        .pending_delivery_storage
+                        .scrub_for_tombstone(target_id, &room_jid_str)
+                        .await
+                    {
+                        Ok(removed) if removed > 0 => debug!(
+                            room = %room_jid,
+                            target = target_id,
+                            removed,
+                            "XEP-0425 moderation: scrubbed pending_delivery rows"
+                        ),
+                        Ok(_) => {}
+                        Err(error) => warn!(
+                            room = %room_jid,
+                            target = target_id,
+                            %error,
+                            "XEP-0425 moderation: pending_delivery scrub_for_tombstone failed; moderated content may still deliver at next login"
+                        ),
+                    }
                 }
                 Ok(_) => {}
                 Err(error) => warn!(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
@@ -476,11 +476,20 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                     // on PR #305).
                     use waddle_xmpp::stream_management::SmSessionRegistry as _;
                     let target_id = request.target_id.as_str();
+                    // XEP-0425 moderation targets the room-assigned
+                    // XEP-0359 stanza-id: cached reflections are
+                    // matched ONLY on `<stanza-id by=room/>`, never on
+                    // the client-chosen wire id (which any occupant
+                    // could mint to collide with another reflection).
+                    let scrub_target = waddle_xmpp::tombstone::TombstoneTarget::Groupchat {
+                        stanza_id: request.target_id.clone(),
+                        room: room_jid.clone(),
+                    };
                     match state
                         .deps
                         .protocol
                         .sm_session_registry
-                        .scrub_unacked_for_tombstone(target_id, &room_jid)
+                        .scrub_unacked_for_tombstone(&scrub_target)
                         .await
                     {
                         Ok(removed) if removed > 0 => debug!(
@@ -505,7 +514,7 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                         .deps
                         .protocol
                         .pending_delivery_storage
-                        .scrub_for_tombstone(target_id, &room_jid)
+                        .scrub_for_tombstone(&scrub_target)
                         .await
                     {
                         Ok(removed) if removed > 0 => debug!(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message/group_dm_invite.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message/group_dm_invite.rs
@@ -322,6 +322,17 @@ async fn queue_offline_group_dm_invite(
     }
 }
 
+/// Undo a partially granted group-DM invite.
+///
+/// Ordering is load-bearing: the channel-member permission tuple MUST
+/// be deleted before `ChangeAffiliation(None)` reaches the room actor,
+/// because the `None`-affiliation handler re-hydrates the durable
+/// recipient mirror from the permission tuples — a still-existing
+/// tuple would resurrect the rolled-back invitee as a durable inbox
+/// recipient (content leak to a user who was never told they are in
+/// the room). Every other removal path (`run_group_dm_leave`, the
+/// admin kick/affiliation paths) orders tuple-delete first for the
+/// same reason.
 async fn rollback_group_dm_invite_grant(
     state: &WebSocketState,
     room_actor: kameo::actor::ActorRef<waddle_xmpp::muc::room_actor::RoomActor>,
@@ -329,22 +340,22 @@ async fn rollback_group_dm_invite_grant(
     room_jid: &jid::BareJid,
     invitee: &jid::BareJid,
 ) {
-    let _ = room_actor
-        .ask(ChangeAffiliation {
-            jid: invitee.clone(),
-            affiliation: waddle_xmpp::Affiliation::None,
-        })
-        .await;
-    let _ = delete_group_dm_archive_boundary(state, room_jid, invitee).await;
-    let _ =
-        crate::admin::channels::retract_group_dm_bookmark(&state.deps.app_state, invitee, room_jid)
-            .await;
     crate::admin::channels::rollback_group_dm_member_tuple(
         &state.deps.app_state,
         channel_id,
         invitee,
     )
     .await;
+    let _ = delete_group_dm_archive_boundary(state, room_jid, invitee).await;
+    let _ =
+        crate::admin::channels::retract_group_dm_bookmark(&state.deps.app_state, invitee, room_jid)
+            .await;
+    let _ = room_actor
+        .ask(ChangeAffiliation {
+            jid: invitee.clone(),
+            affiliation: waddle_xmpp::Affiliation::None,
+        })
+        .await;
 }
 
 async fn record_group_dm_archive_boundary(
@@ -367,6 +378,92 @@ async fn record_group_dm_archive_boundary(
         .await
         .map_err(|error| error.to_string())?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kameo::actor::Spawn;
+    use waddle_xmpp::muc::room_actor::{GetRoomSnapshot, HydrateDurableRecipients, RoomActor};
+    use waddle_xmpp::muc::{MucRoom, RoomConfig};
+
+    async fn durable_recipients(
+        room_actor: &kameo::actor::ActorRef<RoomActor>,
+    ) -> Vec<jid::BareJid> {
+        room_actor
+            .ask(GetRoomSnapshot {
+                sender_jid: "observer@example.com/res".parse().expect("observer jid"),
+            })
+            .await
+            .expect("room snapshot")
+            .durable_recipient_bare_jids
+    }
+
+    /// Rolled-back invitee must not survive in the durable-recipient
+    /// mirror: `rollback_group_dm_invite_grant` has to delete the
+    /// channel-member permission tuple BEFORE asking the room actor to
+    /// change the affiliation to `None`, because the `None`-affiliation
+    /// handler re-hydrates the mirror from the permission tuples. In
+    /// the reverse order the re-hydration reads the still-existing
+    /// tuple and resurrects the invitee, who then receives inbox rows
+    /// with full message bodies until the actor respawns — despite
+    /// never being told they are in the room.
+    #[tokio::test]
+    async fn rollback_prunes_invitee_from_durable_recipient_mirror() {
+        let state = crate::server::routes::websocket::tests::create_test_websocket_state().await;
+        let channel_id = "gdm-rollback-order";
+        let room_jid: jid::BareJid = format!("{channel_id}@muc.example.com")
+            .parse()
+            .expect("room jid");
+        let invitee: jid::BareJid = "invitee@example.com".parse().expect("invitee jid");
+
+        // Invite path already persisted the member tuple.
+        crate::admin::channels::persist_group_dm_member_tuple(
+            &state.deps.app_state,
+            channel_id,
+            &invitee,
+        )
+        .await
+        .expect("persist group-DM member tuple");
+
+        // Spawn the room actor hydrated from the SAME permission store
+        // the rollback mutates, exactly like the registry does in
+        // production.
+        let room_actor = RoomActor::spawn(RoomActor::new(
+            MucRoom::new(
+                room_jid.clone(),
+                "waddle-1".to_string(),
+                channel_id.to_string(),
+                RoomConfig::default(),
+            ),
+            waddle_xmpp::xep::xep0421::OccupantIdSecret::new(
+                b"test-occupant-id-secret-32-bytes-long".to_vec(),
+            )
+            .expect("test secret meets length floor"),
+        ));
+        let source = std::sync::Arc::new(
+            crate::server::durable_membership::PermissionDurableMembershipSource::new(
+                state.deps.app_state.permission_actor.clone(),
+            ),
+        );
+        room_actor
+            .ask(HydrateDurableRecipients { source })
+            .await
+            .expect("hydrate durable recipients");
+        assert!(
+            durable_recipients(&room_actor).await.contains(&invitee),
+            "precondition: the granted invitee hydrates into the mirror"
+        );
+
+        rollback_group_dm_invite_grant(&state, room_actor.clone(), channel_id, &room_jid, &invitee)
+            .await;
+
+        assert!(
+            !durable_recipients(&room_actor).await.contains(&invitee),
+            "a rolled-back invitee must not remain a durable inbox \
+             recipient (tuple delete must precede ChangeAffiliation(None))"
+        );
+    }
 }
 
 async fn group_dm_archive_boundary(

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management/registration.rs
@@ -161,6 +161,28 @@ async fn invalidate_older_detached_sessions(
         .await
     {
         Ok(removed) => {
+            if removed.is_empty() {
+                return;
+            }
+            // Issue #1097: the superseded sessions' unacked queues run
+            // the XEP-0198 §5 promote → confirm chain instead of being
+            // dropped. This runs AFTER the fresh bind registered its
+            // connection, so the promotion chain's alt-resource step
+            // naturally live-delivers to the newly bound resource;
+            // otherwise stanzas land in pending delivery storage.
+            // Durable SM rows are erased only after promotion succeeds
+            // (confirm_drained inside the helper).
+            crate::sm_promotion::promote_displaced_sessions(
+                removed.clone(),
+                crate::sm_promotion::DisplacedPromotionDeps {
+                    sm_registry: &state.deps.protocol.sm_session_registry,
+                    connection_registry: &state.deps.protocol.connection_registry,
+                    pending_storage: &state.deps.protocol.pending_delivery_storage,
+                    blocking_storage: state.deps.protocol.blocking_storage.as_ref(),
+                    server_domain: state.deps.auth_state.xmpp_domain.as_str(),
+                },
+            )
+            .await;
             for detached in removed {
                 cleanup_invalidated_detached_session(state, detached, Some(owner)).await;
             }

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -215,6 +215,17 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                     &recent_tombstones,
                 )
                 .await;
+                // Finding B (retraction-vs-promotion TOCTOU): a
+                // retraction recorded after the snapshot above raced
+                // this session's promotion — re-scrub the pending rows
+                // it may have just inserted BEFORE confirm_drained.
+                crate::sm_promotion::scrub_pending_for_tombstones_recorded_during_promotion(
+                    &state.deps.protocol.sm_session_registry,
+                    &state.deps.protocol.pending_delivery_storage,
+                    &recent_tombstones,
+                    "SM janitor",
+                )
+                .await;
                 if summary.queued + summary.redelivered + summary.bounced + summary.not_promotable
                     > 0
                     || summary.storage_failed > 0
@@ -887,6 +898,16 @@ pub(crate) fn spawn_graceful_shutdown_drain(
                     &blocklist,
                     websocket_state.deps.auth_state.xmpp_domain.as_str(),
                     &recent_tombstones,
+                )
+                .await;
+                // Finding B: same TOCTOU close-out as the SM janitor —
+                // re-scrub pending rows for tombstones recorded during
+                // this session's promotion window before confirming.
+                crate::sm_promotion::scrub_pending_for_tombstones_recorded_during_promotion(
+                    &websocket_state.deps.protocol.sm_session_registry,
+                    &websocket_state.deps.protocol.pending_delivery_storage,
+                    &recent_tombstones,
+                    "Graceful shutdown",
                 )
                 .await;
                 info!(

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -123,6 +123,23 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                 count = drained.len(),
                 "SM janitor: cleaning up expired detached sessions"
             );
+            // Round-2 review R2: retractions racing this drain window
+            // are invisible to the registry scrub (the sessions are off
+            // both maps); the promotion-time re-check below drops
+            // matching stanzas. On a poisoned-lock read error, proceed
+            // without the re-check rather than stranding the queues.
+            let recent_tombstones =
+                match state.deps.protocol.sm_session_registry.recent_tombstones() {
+                    Ok(keys) => keys,
+                    Err(error) => {
+                        warn!(
+                            %error,
+                            "SM janitor: recent-tombstone read failed; proceeding \
+                             without the promotion-time tombstone re-check"
+                        );
+                        Vec::new()
+                    }
+                };
             for session in drained {
                 let blocklist = match state
                     .deps
@@ -202,6 +219,7 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                     &state.deps.protocol.pending_delivery_storage,
                     &blocklist,
                     state.deps.auth_state.xmpp_domain.as_str(),
+                    &recent_tombstones,
                 )
                 .await;
                 if summary.queued + summary.redelivered + summary.bounced + summary.not_promotable
@@ -216,6 +234,7 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                         dropped = summary.dropped,
                         not_promotable = summary.not_promotable,
                         unparseable = summary.unparseable,
+                        scrubbed = summary.scrubbed,
                         storage_failed = summary.storage_failed,
                         "SM janitor: Q6 promotion completed"
                     );
@@ -239,9 +258,10 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                                 "SM janitor: record_promotion_failure failed; \
                                  preserving session state for retry"
                             );
-                            crate::sm_promotion::reinsert_failed_session_for_retry(
+                            crate::sm_promotion::prune_promoted_then_reinsert_for_retry(
                                 &state.deps.protocol.sm_session_registry,
                                 session,
+                                &summary,
                             )
                             .await;
                             continue;
@@ -272,9 +292,10 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                         "SM janitor: promotion had storage failures; \
                          preserving session state for retry"
                     );
-                    crate::sm_promotion::reinsert_failed_session_for_retry(
+                    crate::sm_promotion::prune_promoted_then_reinsert_for_retry(
                         &state.deps.protocol.sm_session_registry,
                         session,
+                        &summary,
                     )
                     .await;
                     continue;
@@ -839,6 +860,22 @@ pub(crate) fn spawn_graceful_shutdown_drain(
                 count = drained.len(),
                 "Graceful shutdown: promoting unacked queues for detached SM sessions"
             );
+            let recent_tombstones = match websocket_state
+                .deps
+                .protocol
+                .sm_session_registry
+                .recent_tombstones()
+            {
+                Ok(keys) => keys,
+                Err(error) => {
+                    warn!(
+                        %error,
+                        "Graceful shutdown: recent-tombstone read failed; proceeding \
+                         without the promotion-time tombstone re-check"
+                    );
+                    Vec::new()
+                }
+            };
             for session in drained {
                 let blocklist = match websocket_state
                     .deps
@@ -865,6 +902,7 @@ pub(crate) fn spawn_graceful_shutdown_drain(
                     &websocket_state.deps.protocol.pending_delivery_storage,
                     &blocklist,
                     websocket_state.deps.auth_state.xmpp_domain.as_str(),
+                    &recent_tombstones,
                 )
                 .await;
                 info!(
@@ -874,6 +912,7 @@ pub(crate) fn spawn_graceful_shutdown_drain(
                     bounced = summary.bounced,
                     dropped = summary.dropped,
                     unparseable = summary.unparseable,
+                    scrubbed = summary.scrubbed,
                     storage_failed = summary.storage_failed,
                     "Graceful shutdown: Q6 promotion completed for session"
                 );

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -151,6 +151,11 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                                      record_promotion_failure also failed; preserving \
                                      session state for retry"
                                 );
+                                crate::sm_promotion::reinsert_failed_session_for_retry(
+                                    &state.deps.protocol.sm_session_registry,
+                                    session,
+                                )
+                                .await;
                                 continue;
                             }
                         };
@@ -180,6 +185,14 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                              preserve fail-closed XEP-0191 policy. Durable SM row will \
                              be retried on the next janitor pass."
                         );
+                        // Make the retry promise true: drain_expired scans only
+                        // memory, so the drained session must go back into the
+                        // map for the next tick to see it.
+                        crate::sm_promotion::reinsert_failed_session_for_retry(
+                            &state.deps.protocol.sm_session_registry,
+                            session,
+                        )
+                        .await;
                         continue;
                     }
                 };
@@ -226,6 +239,11 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                                 "SM janitor: record_promotion_failure failed; \
                                  preserving session state for retry"
                             );
+                            crate::sm_promotion::reinsert_failed_session_for_retry(
+                                &state.deps.protocol.sm_session_registry,
+                                session,
+                            )
+                            .await;
                             continue;
                         }
                     };
@@ -254,6 +272,11 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                         "SM janitor: promotion had storage failures; \
                          preserving session state for retry"
                     );
+                    crate::sm_promotion::reinsert_failed_session_for_retry(
+                        &state.deps.protocol.sm_session_registry,
+                        session,
+                    )
+                    .await;
                     continue;
                 }
                 state
@@ -1092,7 +1115,11 @@ pub(crate) async fn sweep_dormant_rooms_once(
                 continue;
             }
         };
-        let is_dormant = match actor.ask(IsDormant).await {
+        // Bounded ask: a hung room actor (e.g. wedged on hydration) must
+        // only skip its own check — timeout lands in the existing
+        // warn-and-skip arm, treating the room as not-dormant (never reap
+        // on uncertainty).
+        let is_dormant = match actor.ask(IsDormant).reply_timeout(REAPER_ASK_TIMEOUT).await {
             Ok(value) => value,
             Err(error) => {
                 warn!(

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -123,23 +123,6 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                 count = drained.len(),
                 "SM janitor: cleaning up expired detached sessions"
             );
-            // Round-2 review R2: retractions racing this drain window
-            // are invisible to the registry scrub (the sessions are off
-            // both maps); the promotion-time re-check below drops
-            // matching stanzas. On a poisoned-lock read error, proceed
-            // without the re-check rather than stranding the queues.
-            let recent_tombstones =
-                match state.deps.protocol.sm_session_registry.recent_tombstones() {
-                    Ok(keys) => keys,
-                    Err(error) => {
-                        warn!(
-                            %error,
-                            "SM janitor: recent-tombstone read failed; proceeding \
-                             without the promotion-time tombstone re-check"
-                        );
-                        Vec::new()
-                    }
-                };
             for session in drained {
                 let blocklist = match state
                     .deps
@@ -213,6 +196,16 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
                         continue;
                     }
                 };
+                // Round-2 review R2 + round-3 finding 1: retractions
+                // racing this drain window are invisible to the registry
+                // scrub (the sessions are off both maps); fetch the
+                // recent-tombstone record PER SESSION, immediately
+                // before this session's promotion, so even a retraction
+                // landing mid-batch is still seen.
+                let recent_tombstones = crate::sm_promotion::recent_tombstones_for_promotion(
+                    &state.deps.protocol.sm_session_registry,
+                    "SM janitor",
+                );
                 let summary = crate::sm_promotion::promote_session_unacked(
                     &session,
                     &state.deps.protocol.connection_registry,
@@ -860,22 +853,6 @@ pub(crate) fn spawn_graceful_shutdown_drain(
                 count = drained.len(),
                 "Graceful shutdown: promoting unacked queues for detached SM sessions"
             );
-            let recent_tombstones = match websocket_state
-                .deps
-                .protocol
-                .sm_session_registry
-                .recent_tombstones()
-            {
-                Ok(keys) => keys,
-                Err(error) => {
-                    warn!(
-                        %error,
-                        "Graceful shutdown: recent-tombstone read failed; proceeding \
-                         without the promotion-time tombstone re-check"
-                    );
-                    Vec::new()
-                }
-            };
             for session in drained {
                 let blocklist = match websocket_state
                     .deps
@@ -896,6 +873,13 @@ pub(crate) fn spawn_graceful_shutdown_drain(
                         continue;
                     }
                 };
+                // Round-2 review R2 + round-3 finding 1: per-session
+                // recent-tombstone fetch so a retraction landing
+                // mid-batch during the shutdown drain is still seen.
+                let recent_tombstones = crate::sm_promotion::recent_tombstones_for_promotion(
+                    &websocket_state.deps.protocol.sm_session_registry,
+                    "Graceful shutdown",
+                );
                 let summary = crate::sm_promotion::promote_session_unacked(
                     &session,
                     &websocket_state.deps.protocol.connection_registry,

--- a/server/crates/waddle-server/src/sm_persistence.rs
+++ b/server/crates/waddle-server/src/sm_persistence.rs
@@ -351,6 +351,30 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
         .await
     }
 
+    #[instrument(skip(self, sequences), fields(stream_id = %stream_id, count = sequences.len()))]
+    async fn delete_unacked(
+        &self,
+        stream_id: &SmSessionId,
+        sequences: &[u32],
+    ) -> Result<u64, SmPersistenceError> {
+        let lock = self.lock_for(stream_id);
+        let _guard = lock.lock().await;
+        let mut removed = 0u64;
+        // One PK-targeted statement per sequence: tombstone scrubs
+        // remove a single stanza per session in practice, so the
+        // per-row round-trip is cheaper than building a dynamic IN
+        // clause the fixed-arity param binder can't express.
+        for sequence in sequences {
+            removed += self
+                .execute(
+                    "DELETE FROM sm_unacked WHERE stream_id = ? AND sequence = ?",
+                    crate::db_params![stream_id.as_str().to_string(), i64::from(*sequence)],
+                )
+                .await?;
+        }
+        Ok(removed)
+    }
+
     async fn list_unacked(
         &self,
         stream_id: &SmSessionId,

--- a/server/crates/waddle-server/src/sm_persistence/tests.rs
+++ b/server/crates/waddle-server/src/sm_persistence/tests.rs
@@ -632,3 +632,55 @@ async fn postgres_handles_i32_overflow_session_and_unacked_timestamps_ms() {
         .await
         .expect("cleanup postgres sm rows");
 }
+
+#[tokio::test]
+async fn delete_unacked_removes_only_named_sequences_for_stream() {
+    // Issue #1145: the tombstone scrub needs a targeted durable
+    // delete keyed on the (stream_id, sequence) PK so retracted
+    // stanzas cannot be rehydrated after a restart. Rows for other
+    // sequences and other streams must be untouched.
+    let storage = DatabaseSmPersistence::open(None).await.unwrap();
+    storage
+        .upsert_session(fixture_session("stream-a"))
+        .await
+        .unwrap();
+    storage
+        .upsert_session(fixture_session("stream-b"))
+        .await
+        .unwrap();
+    for seq in [1u32, 2, 3] {
+        storage
+            .append_unacked(fixture_unacked("stream-a", seq))
+            .await
+            .unwrap();
+    }
+    storage
+        .append_unacked(fixture_unacked("stream-b", 2))
+        .await
+        .unwrap();
+
+    let removed = storage
+        .delete_unacked(&SmSessionId::new("stream-a"), &[1, 3])
+        .await
+        .unwrap();
+    assert_eq!(removed, 2);
+
+    let remaining_a = storage
+        .list_unacked(&SmSessionId::new("stream-a"))
+        .await
+        .unwrap();
+    let seqs: Vec<u32> = remaining_a.iter().map(|r| r.sequence).collect();
+    assert_eq!(seqs, vec![2]);
+    let remaining_b = storage
+        .list_unacked(&SmSessionId::new("stream-b"))
+        .await
+        .unwrap();
+    assert_eq!(remaining_b.len(), 1, "other streams' rows are untouched");
+
+    // Deleting sequences that no longer exist is a no-op, not an error.
+    let removed = storage
+        .delete_unacked(&SmSessionId::new("stream-a"), &[1, 3])
+        .await
+        .unwrap();
+    assert_eq!(removed, 0);
+}

--- a/server/crates/waddle-server/src/sm_promotion.rs
+++ b/server/crates/waddle-server/src/sm_promotion.rs
@@ -72,7 +72,7 @@ pub async fn promote_session_unacked(
     pending_storage: &Arc<dyn PendingDeliveryStorage>,
     blocklist: &Blocklist,
     server_domain: &str,
-    recent_tombstones: &[waddle_xmpp::stream_management::TombstoneKey],
+    recent_tombstones: &[waddle_xmpp::stream_management::RecentTombstoneRecord],
 ) -> PromotionSummary {
     let mut summary = PromotionSummary::default();
     let recipient_bare = session.jid.to_bare();
@@ -85,7 +85,11 @@ pub async fn promote_session_unacked(
 
     // Round-2 review R2: select the sequences a recently applied
     // tombstone matches, using the same shared matcher as the
-    // registry / pending-delivery scrubs.
+    // registry / pending-delivery scrubs. Round-3 review finding 2: a
+    // tombstone applies BACKWARD in time only — a stanza whose
+    // original receipt postdates the tombstone's recording is a NEW
+    // message that merely reuses the wire id in the same scope, not
+    // the retracted one, and must promote normally.
     let tombstoned_sequences: std::collections::HashSet<u32> = if recent_tombstones.is_empty() {
         std::collections::HashSet::new()
     } else {
@@ -94,14 +98,26 @@ pub async fn promote_session_unacked(
             .iter()
             .map(|entry| (entry.sequence, entry.stanza_xml.clone()))
             .collect();
+        let receipt_by_sequence: std::collections::HashMap<u32, DateTime<Utc>> = session
+            .unacked_stanzas
+            .iter()
+            .map(|entry| (entry.sequence, entry.original_receipt_at))
+            .collect();
         recent_tombstones
             .iter()
-            .flat_map(|key| {
+            .flat_map(|record| {
                 waddle_xmpp::tombstone::matching_tombstone_sequences(
                     &entries,
-                    &key.target_id,
-                    &key.archive_jid,
+                    &record.key.target_id,
+                    &record.key.archive_jid,
                 )
+                .into_iter()
+                .filter(|sequence| {
+                    receipt_by_sequence
+                        .get(sequence)
+                        .is_some_and(|received_at| *received_at <= record.recorded_at_utc)
+                })
+                .collect::<Vec<u32>>()
             })
             .collect()
     };
@@ -243,26 +259,39 @@ pub async fn prune_promoted_then_reinsert_for_retry(
     reinsert_failed_session_for_retry(sm_registry, session).await;
 }
 
+/// Read the SM registry's recent-tombstone record immediately before a
+/// SINGLE session's promotion. Round-3 review finding 1: a per-batch
+/// snapshot leaves a mid-loop TOCTOU — a retraction landing after the
+/// snapshot but before a later session's pending insert was missed
+/// (drained sessions are off both registry maps, so the scrub phases
+/// cannot see them either). Fetching per session shrinks the window to
+/// that one session's promotion span, which is the intended contract.
+///
+/// Lock poisoning is process-fatal territory; promotion proceeds
+/// without the re-check (the durable phase-4 scrub already covered
+/// rows present at scrub time).
+pub fn recent_tombstones_for_promotion(
+    sm_registry: &waddle_xmpp::stream_management::InMemorySmSessionRegistry,
+    context: &'static str,
+) -> Vec<waddle_xmpp::stream_management::RecentTombstoneRecord> {
+    match sm_registry.recent_tombstones() {
+        Ok(records) => records,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                context,
+                "recent-tombstone read failed; proceeding without the \
+                 promotion-time tombstone re-check"
+            );
+            Vec::new()
+        }
+    }
+}
+
 pub async fn promote_displaced_sessions(
     sessions: Vec<DetachedSession>,
     deps: DisplacedPromotionDeps<'_>,
 ) {
-    // Round-2 review R2: consult the registry's recent-tombstone
-    // record so a retraction racing the displacement drain still
-    // scrubs the in-flight copies. Lock poisoning is process-fatal
-    // territory; promotion proceeds without the re-check (the durable
-    // phase-4 scrub already covered rows present at scrub time).
-    let recent_tombstones = match deps.sm_registry.recent_tombstones() {
-        Ok(keys) => keys,
-        Err(error) => {
-            tracing::warn!(
-                %error,
-                "displaced SM promotion: recent-tombstone read failed; \
-                 proceeding without the promotion-time tombstone re-check"
-            );
-            Vec::new()
-        }
-    };
     for session in sessions {
         let blocklist = match deps
             .blocking_storage
@@ -299,6 +328,13 @@ pub async fn promote_displaced_sessions(
                 continue;
             }
         };
+        // Round-2 review R2 + round-3 finding 1: consult the registry's
+        // recent-tombstone record PER SESSION, immediately before this
+        // session's promotion, so a retraction racing the displacement
+        // drain — even one landing mid-batch — still scrubs the
+        // in-flight copies.
+        let recent_tombstones =
+            recent_tombstones_for_promotion(deps.sm_registry, "displaced SM promotion");
         let summary = promote_session_unacked(
             &session,
             deps.connection_registry,

--- a/server/crates/waddle-server/src/sm_promotion.rs
+++ b/server/crates/waddle-server/src/sm_promotion.rs
@@ -114,6 +114,124 @@ pub async fn promote_session_unacked(
     summary
 }
 
+/// Dependencies for [`promote_displaced_sessions`]. Grouped so the
+/// two displacement call sites (max_sessions eviction at detach,
+/// fresh-bind invalidation at registration) share one signature.
+pub struct DisplacedPromotionDeps<'a> {
+    pub sm_registry: &'a waddle_xmpp::stream_management::InMemorySmSessionRegistry,
+    pub connection_registry: &'a ConnectionRegistry,
+    pub pending_storage: &'a Arc<dyn PendingDeliveryStorage>,
+    pub blocking_storage: &'a dyn waddle_xmpp::xep::xep0191::BlockingStorage,
+    pub server_domain: &'a str,
+}
+
+/// Run the XEP-0198 §5 promote → confirm chain on sessions the SM
+/// registry displaced (issue #1097): max_sessions overflow eviction
+/// and fresh-bind invalidation previously dropped these sessions'
+/// unacked queues silently.
+///
+/// Mirrors the SM-expiry janitor's contract: a blocklist-load or
+/// promotion storage failure records a promotion failure and
+/// PRESERVES the session's durable rows (a later restart rehydrates
+/// them and the janitor retries, including its dead-letter cap);
+/// success confirms the drain, erasing the durable rows, and releases
+/// any pending_delivery claim held by the dead stream.
+pub async fn promote_displaced_sessions(
+    sessions: Vec<DetachedSession>,
+    deps: DisplacedPromotionDeps<'_>,
+) {
+    for session in sessions {
+        let blocklist = match deps
+            .blocking_storage
+            .list_blocked_jid_entries(&session.jid.to_bare())
+            .await
+        {
+            Ok(jids) => waddle_xmpp::protocol::session_state::Blocklist::new(jids),
+            Err(error) => {
+                waddle_xmpp::prometheus::increment_sm_promotion_blocklist_failed();
+                if let Err(record_error) = deps
+                    .sm_registry
+                    .record_promotion_failure(&session.stream_id)
+                    .await
+                {
+                    tracing::warn!(
+                        jid = %session.jid,
+                        error = %error,
+                        record_error = %record_error,
+                        "displaced SM session: blocklist load and failure recording both \
+                         failed; preserving durable rows for janitor retry"
+                    );
+                    continue;
+                }
+                tracing::warn!(
+                    jid = %session.jid,
+                    stream_id = %session.stream_id,
+                    error = %error,
+                    "displaced SM session: blocklist load failed; SKIPPING promotion to \
+                     preserve fail-closed XEP-0191 policy. Durable rows retry via the \
+                     SM-expiry janitor after restart."
+                );
+                continue;
+            }
+        };
+        let summary = promote_session_unacked(
+            &session,
+            deps.connection_registry,
+            deps.pending_storage,
+            &blocklist,
+            deps.server_domain,
+        )
+        .await;
+        if summary.has_storage_failure() {
+            waddle_xmpp::prometheus::add_sm_promotion_storage_failed(u64::from(
+                summary.storage_failed,
+            ));
+            if let Err(error) = deps
+                .sm_registry
+                .record_promotion_failure(&session.stream_id)
+                .await
+            {
+                tracing::warn!(
+                    jid = %session.jid,
+                    %error,
+                    "displaced SM session: record_promotion_failure failed; \
+                     preserving durable rows for janitor retry"
+                );
+            }
+            tracing::warn!(
+                jid = %session.jid,
+                stream_id = %session.stream_id,
+                storage_failed = summary.storage_failed,
+                "displaced SM session: promotion had storage failures; \
+                 preserving durable rows for janitor retry"
+            );
+            continue;
+        }
+        deps.sm_registry.confirm_drained(&session.stream_id).await;
+        let session_id = waddle_xmpp::pending_delivery::SmSessionId::new(session.stream_id.clone());
+        if let Err(error) = deps.pending_storage.release_claim(&session_id).await {
+            tracing::warn!(
+                jid = %session.jid,
+                stream_id = %session.stream_id,
+                error = %error,
+                "displaced SM session: pending_delivery release_claim failed; \
+                 rows remain claimed and will be released by the claim-expiry janitor"
+            );
+        }
+        debug!(
+            jid = %session.jid,
+            stream_id = %session.stream_id,
+            redelivered = summary.redelivered,
+            queued = summary.queued,
+            bounced = summary.bounced,
+            dropped = summary.dropped,
+            not_promotable = summary.not_promotable,
+            unparseable = summary.unparseable,
+            "displaced SM session: Q6 promotion completed"
+        );
+    }
+}
+
 /// Extract the stamp of a `<delay/>` this server itself added to the
 /// stanza on a prior replay hop, if one is present.
 fn self_stamp_time(

--- a/server/crates/waddle-server/src/sm_promotion.rs
+++ b/server/crates/waddle-server/src/sm_promotion.rs
@@ -136,6 +136,28 @@ pub struct DisplacedPromotionDeps<'a> {
 /// them and the janitor retries, including its dead-letter cap);
 /// success confirms the drain, erasing the durable rows, and releases
 /// any pending_delivery claim held by the dead stream.
+/// Put a session whose promotion failed back into the SM registry
+/// (forced expired, durable state untouched) so the SM-expiry
+/// janitor's next `drain_expired` pass retries the promote → confirm
+/// chain without waiting for a restart. Best-effort: on registry
+/// failure the durable rows still survive and a restart retries.
+pub async fn reinsert_failed_session_for_retry(
+    sm_registry: &waddle_xmpp::stream_management::InMemorySmSessionRegistry,
+    session: DetachedSession,
+) {
+    let stream_id = session.stream_id.clone();
+    let jid = session.jid.clone();
+    if let Err(error) = sm_registry.reinsert_for_retry(session).await {
+        tracing::warn!(
+            jid = %jid,
+            stream_id = %stream_id,
+            %error,
+            "failed to re-insert SM session for promotion retry; durable rows \
+             will only be retried after a restart"
+        );
+    }
+}
+
 pub async fn promote_displaced_sessions(
     sessions: Vec<DetachedSession>,
     deps: DisplacedPromotionDeps<'_>,
@@ -159,8 +181,9 @@ pub async fn promote_displaced_sessions(
                         error = %error,
                         record_error = %record_error,
                         "displaced SM session: blocklist load and failure recording both \
-                         failed; preserving durable rows for janitor retry"
+                         failed; preserving durable rows and re-inserting for janitor retry"
                     );
+                    reinsert_failed_session_for_retry(deps.sm_registry, session).await;
                     continue;
                 }
                 tracing::warn!(
@@ -168,9 +191,10 @@ pub async fn promote_displaced_sessions(
                     stream_id = %session.stream_id,
                     error = %error,
                     "displaced SM session: blocklist load failed; SKIPPING promotion to \
-                     preserve fail-closed XEP-0191 policy. Durable rows retry via the \
-                     SM-expiry janitor after restart."
+                     preserve fail-closed XEP-0191 policy. Re-inserted for retry on the \
+                     SM-expiry janitor's next pass."
                 );
+                reinsert_failed_session_for_retry(deps.sm_registry, session).await;
                 continue;
             }
         };
@@ -203,8 +227,9 @@ pub async fn promote_displaced_sessions(
                 stream_id = %session.stream_id,
                 storage_failed = summary.storage_failed,
                 "displaced SM session: promotion had storage failures; \
-                 preserving durable rows for janitor retry"
+                 preserving durable rows and re-inserting for janitor retry"
             );
+            reinsert_failed_session_for_retry(deps.sm_registry, session).await;
             continue;
         }
         deps.sm_registry.confirm_drained(&session.stream_id).await;

--- a/server/crates/waddle-server/src/sm_promotion.rs
+++ b/server/crates/waddle-server/src/sm_promotion.rs
@@ -119,20 +119,16 @@ pub async fn promote_session_unacked(
         recent_tombstones
             .iter()
             .flat_map(|record| {
-                waddle_xmpp::tombstone::matching_tombstone_sequences(
-                    &entries,
-                    &record.key.target_id,
-                    &record.key.archive_jid,
-                )
-                .into_iter()
-                .filter(|sequence| {
-                    receipt_by_sequence
-                        .get(sequence)
-                        .is_some_and(|received_at| {
-                            *received_at <= record.recorded_at_utc + TOMBSTONE_CLOCK_SKEW_SLACK
-                        })
-                })
-                .collect::<Vec<u32>>()
+                waddle_xmpp::tombstone::matching_tombstone_sequences(&entries, &record.key)
+                    .into_iter()
+                    .filter(|sequence| {
+                        receipt_by_sequence
+                            .get(sequence)
+                            .is_some_and(|received_at| {
+                                *received_at <= record.recorded_at_utc + TOMBSTONE_CLOCK_SKEW_SLACK
+                            })
+                    })
+                    .collect::<Vec<u32>>()
             })
             .collect()
     };
@@ -303,6 +299,70 @@ pub fn recent_tombstones_for_promotion(
     }
 }
 
+/// Close the retraction-vs-promotion TOCTOU (adversarial-review
+/// finding B): the recent-tombstone snapshot is fetched BEFORE
+/// `promote_session_unacked`. A retraction landing after that fetch
+/// finds the session off both registry maps (scrub phases 1-4 see
+/// nothing in memory; the pending row is not inserted yet), and the
+/// promotion then writes the retracted stanza into `pending_delivery`
+/// — delivered verbatim at the next login once `confirm_drained`
+/// erased the SM rows.
+///
+/// Called after `promote_session_unacked` returns and BEFORE
+/// `confirm_drained`: re-read the recent tombstones and, for every
+/// record NOT present in the pre-promotion snapshot (i.e. recorded
+/// during the promotion window), run the pending-delivery scrub so the
+/// just-inserted rows are removed again. Idempotent and best-effort —
+/// a scrub failure is logged; the row also stays covered by the
+/// interpret-layer scrub retry semantics.
+pub async fn scrub_pending_for_tombstones_recorded_during_promotion(
+    sm_registry: &waddle_xmpp::stream_management::InMemorySmSessionRegistry,
+    pending_storage: &Arc<dyn PendingDeliveryStorage>,
+    pre_promotion: &[waddle_xmpp::stream_management::RecentTombstoneRecord],
+    context: &'static str,
+) {
+    let post_promotion = match sm_registry.recent_tombstones() {
+        Ok(records) => records,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                context,
+                "post-promotion recent-tombstone read failed; a retraction that \
+                 raced this promotion window may deliver at next login"
+            );
+            return;
+        }
+    };
+    for record in post_promotion
+        .iter()
+        .filter(|record| !pre_promotion.contains(record))
+    {
+        match pending_storage.scrub_for_tombstone(&record.key).await {
+            Ok(removed) if removed > 0 => {
+                debug!(
+                    target = record.key.id(),
+                    archive = %record.key.archive_jid(),
+                    removed,
+                    context,
+                    "post-promotion re-check: scrubbed pending rows for a \
+                     tombstone recorded mid-promotion"
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                tracing::warn!(
+                    target = record.key.id(),
+                    archive = %record.key.archive_jid(),
+                    %error,
+                    context,
+                    "post-promotion re-check: pending scrub failed; retracted \
+                     content may deliver at the recipient's next login"
+                );
+            }
+        }
+    }
+}
+
 pub async fn promote_displaced_sessions(
     sessions: Vec<DetachedSession>,
     deps: DisplacedPromotionDeps<'_>,
@@ -357,6 +417,16 @@ pub async fn promote_displaced_sessions(
             &blocklist,
             deps.server_domain,
             &recent_tombstones,
+        )
+        .await;
+        // Finding B: a retraction recorded AFTER the snapshot above
+        // raced this session's promotion — re-scrub pending rows
+        // before the drain is confirmed (or the session reinserted).
+        scrub_pending_for_tombstones_recorded_during_promotion(
+            deps.sm_registry,
+            deps.pending_storage,
+            &recent_tombstones,
+            "displaced SM promotion",
         )
         .await;
         if summary.has_storage_failure() {

--- a/server/crates/waddle-server/src/sm_promotion.rs
+++ b/server/crates/waddle-server/src/sm_promotion.rs
@@ -48,6 +48,13 @@ use pending::{insert_pending, promote_as_transient};
 use stanza::{parse_stanza, promote_iq, promote_presence};
 pub use types::{PromotedOutcome, PromotionSummary};
 
+/// Tolerance for comparing a stanza's `original_receipt_at` against a
+/// tombstone's `recorded_at_utc` when the two stamps may come from
+/// different clocks (persistence restore across a restart, multi-node
+/// stamps under ADR-0017, NTP step-back). A receipt reading up to this
+/// much "after" the recording still counts as predating it.
+const TOMBSTONE_CLOCK_SKEW_SLACK: chrono::Duration = chrono::Duration::seconds(60);
+
 /// Walk a session's unacked queue, promoting each stanza per the
 /// locked Q6 = B priority chain. Each promoted `pending_delivery`
 /// row's `original_receipt_at` is the per-stanza receipt time
@@ -89,7 +96,13 @@ pub async fn promote_session_unacked(
     // tombstone applies BACKWARD in time only — a stanza whose
     // original receipt postdates the tombstone's recording is a NEW
     // message that merely reuses the wire id in the same scope, not
-    // the retracted one, and must promote normally.
+    // the retracted one, and must promote normally. Round-4 review:
+    // the two stamps can come from different clocks (persistence
+    // restore across a restart, multi-node stamps, NTP step-back), so
+    // the boundary carries a skew slack — a receipt reading up to
+    // TOMBSTONE_CLOCK_SKEW_SLACK "after" the recording still scrubs.
+    // Real wire-id reuse arriving that close to its own retraction is
+    // implausible; retracted-content delivery is the worse failure.
     let tombstoned_sequences: std::collections::HashSet<u32> = if recent_tombstones.is_empty() {
         std::collections::HashSet::new()
     } else {
@@ -115,7 +128,9 @@ pub async fn promote_session_unacked(
                 .filter(|sequence| {
                     receipt_by_sequence
                         .get(sequence)
-                        .is_some_and(|received_at| *received_at <= record.recorded_at_utc)
+                        .is_some_and(|received_at| {
+                            *received_at <= record.recorded_at_utc + TOMBSTONE_CLOCK_SKEW_SLACK
+                        })
                 })
                 .collect::<Vec<u32>>()
             })

--- a/server/crates/waddle-server/src/sm_promotion.rs
+++ b/server/crates/waddle-server/src/sm_promotion.rs
@@ -54,8 +54,16 @@ pub use types::{PromotedOutcome, PromotionSummary};
 /// preserved on the [`DetachedUnackedStanza`] (issue #209 PR #361:
 /// previously a wall-clock fallback at expiry — now correct per
 /// XEP-0203 §4.1 + XEP-0198 §5 line 364).
+///
+/// `recent_tombstones` is the SM registry's recently applied
+/// XEP-0424/0425 tombstone record (round-2 review R2): a retraction
+/// that raced the drain — session off both registry maps, pending row
+/// not yet inserted — is invisible to the scrub's four phases, so the
+/// promotion re-checks here and drops matching stanzas (counted as
+/// `scrubbed` in the summary) instead of resurrecting retracted
+/// content into `pending_delivery`.
 #[instrument(
-    skip(session, registry, pending_storage, blocklist),
+    skip(session, registry, pending_storage, blocklist, recent_tombstones),
     fields(stream_id = %session.stream_id, jid = %session.jid)
 )]
 pub async fn promote_session_unacked(
@@ -64,6 +72,7 @@ pub async fn promote_session_unacked(
     pending_storage: &Arc<dyn PendingDeliveryStorage>,
     blocklist: &Blocklist,
     server_domain: &str,
+    recent_tombstones: &[waddle_xmpp::stream_management::TombstoneKey],
 ) -> PromotionSummary {
     let mut summary = PromotionSummary::default();
     let recipient_bare = session.jid.to_bare();
@@ -74,7 +83,39 @@ pub async fn promote_session_unacked(
     // unless other resources joined after detach).
     let online = build_online_resources(registry, &recipient_bare);
 
+    // Round-2 review R2: select the sequences a recently applied
+    // tombstone matches, using the same shared matcher as the
+    // registry / pending-delivery scrubs.
+    let tombstoned_sequences: std::collections::HashSet<u32> = if recent_tombstones.is_empty() {
+        std::collections::HashSet::new()
+    } else {
+        let entries: Vec<(u32, String)> = session
+            .unacked_stanzas
+            .iter()
+            .map(|entry| (entry.sequence, entry.stanza_xml.clone()))
+            .collect();
+        recent_tombstones
+            .iter()
+            .flat_map(|key| {
+                waddle_xmpp::tombstone::matching_tombstone_sequences(
+                    &entries,
+                    &key.target_id,
+                    &key.archive_jid,
+                )
+            })
+            .collect()
+    };
+
     for entry in &session.unacked_stanzas {
+        if tombstoned_sequences.contains(&entry.sequence) {
+            debug!(
+                stream_id = %session.stream_id,
+                sequence = entry.sequence,
+                "Q6 promotion: stanza matches a recent tombstone; scrubbed"
+            );
+            summary.record(entry.sequence, &PromotedOutcome::Scrubbed);
+            continue;
+        }
         let outcome = match parse_stanza(&entry.stanza_xml) {
             Some(Stanza::Message(message)) => {
                 let ctx = PromotionContext {
@@ -97,7 +138,7 @@ pub async fn promote_session_unacked(
             ?outcome,
             "Q6 promotion: per-stanza outcome"
         );
-        summary.record(&outcome);
+        summary.record(entry.sequence, &outcome);
     }
 
     debug!(
@@ -108,6 +149,7 @@ pub async fn promote_session_unacked(
         dropped = summary.dropped,
         not_promotable = summary.not_promotable,
         unparseable = summary.unparseable,
+        scrubbed = summary.scrubbed,
         storage_failed = summary.storage_failed,
         "Q6 promotion: session summary"
     );
@@ -158,10 +200,69 @@ pub async fn reinsert_failed_session_for_retry(
     }
 }
 
+/// After a PARTIAL promotion failure, durably erase the successfully
+/// promoted stanzas' `sm_unacked` rows, drop them from the session,
+/// and re-insert the remainder for the janitor's next retry (round-2
+/// review R4). Without this, every retry tick re-promoted the whole
+/// queue and duplicated the already-Queued stanzas.
+///
+/// Crash-safety ordering: each promoted stanza's `pending_delivery`
+/// row was committed inside `promote_session_unacked` BEFORE this
+/// delete runs, so at-least-once is preserved — a crash between the
+/// two duplicates at most one promotion window, not one per tick. If
+/// the durable delete itself fails, the session keeps its FULL queue
+/// (memory and storage stay consistent) and the retry may duplicate —
+/// at-least-once beats losing the failed stanzas' retry rows.
+pub async fn prune_promoted_then_reinsert_for_retry(
+    sm_registry: &waddle_xmpp::stream_management::InMemorySmSessionRegistry,
+    mut session: DetachedSession,
+    summary: &PromotionSummary,
+) {
+    if !summary.promoted_sequences.is_empty() {
+        match sm_registry
+            .delete_unacked_sequences(&session.stream_id, &summary.promoted_sequences)
+            .await
+        {
+            Ok(_) => {
+                session
+                    .unacked_stanzas
+                    .retain(|entry| !summary.promoted_sequences.contains(&entry.sequence));
+            }
+            Err(error) => {
+                tracing::warn!(
+                    jid = %session.jid,
+                    stream_id = %session.stream_id,
+                    %error,
+                    "partial promotion: durable delete of promoted sm_unacked rows \
+                     failed; keeping the full queue for retry (may duplicate — \
+                     at-least-once preserved)"
+                );
+            }
+        }
+    }
+    reinsert_failed_session_for_retry(sm_registry, session).await;
+}
+
 pub async fn promote_displaced_sessions(
     sessions: Vec<DetachedSession>,
     deps: DisplacedPromotionDeps<'_>,
 ) {
+    // Round-2 review R2: consult the registry's recent-tombstone
+    // record so a retraction racing the displacement drain still
+    // scrubs the in-flight copies. Lock poisoning is process-fatal
+    // territory; promotion proceeds without the re-check (the durable
+    // phase-4 scrub already covered rows present at scrub time).
+    let recent_tombstones = match deps.sm_registry.recent_tombstones() {
+        Ok(keys) => keys,
+        Err(error) => {
+            tracing::warn!(
+                %error,
+                "displaced SM promotion: recent-tombstone read failed; \
+                 proceeding without the promotion-time tombstone re-check"
+            );
+            Vec::new()
+        }
+    };
     for session in sessions {
         let blocklist = match deps
             .blocking_storage
@@ -204,6 +305,7 @@ pub async fn promote_displaced_sessions(
             deps.pending_storage,
             &blocklist,
             deps.server_domain,
+            &recent_tombstones,
         )
         .await;
         if summary.has_storage_failure() {
@@ -229,7 +331,7 @@ pub async fn promote_displaced_sessions(
                 "displaced SM session: promotion had storage failures; \
                  preserving durable rows and re-inserting for janitor retry"
             );
-            reinsert_failed_session_for_retry(deps.sm_registry, session).await;
+            prune_promoted_then_reinsert_for_retry(deps.sm_registry, session, &summary).await;
             continue;
         }
         deps.sm_registry.confirm_drained(&session.stream_id).await;
@@ -252,6 +354,7 @@ pub async fn promote_displaced_sessions(
             dropped = summary.dropped,
             not_promotable = summary.not_promotable,
             unparseable = summary.unparseable,
+            scrubbed = summary.scrubbed,
             "displaced SM session: Q6 promotion completed"
         );
     }

--- a/server/crates/waddle-server/src/sm_promotion/tests.rs
+++ b/server/crates/waddle-server/src/sm_promotion/tests.rs
@@ -161,7 +161,7 @@ impl PendingDeliveryStorage for AlwaysFailingPending {
     async fn scrub_for_tombstone(
         &self,
         _target_id: &str,
-        _archive_jid: &str,
+        _archive_jid: &jid::BareJid,
     ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
         Ok(0)
     }
@@ -1352,7 +1352,7 @@ async fn promotion_scrubs_stanzas_matching_recent_tombstone() {
         &[waddle_xmpp::stream_management::RecentTombstoneRecord {
             key: waddle_xmpp::stream_management::TombstoneKey {
                 target_id: "retract-me".to_string(),
-                archive_jid: "alice@example.com".to_string(),
+                archive_jid: bare("alice@example.com"),
             },
             recorded_at_utc: Utc::now(),
         }],
@@ -1405,7 +1405,7 @@ async fn tombstone_does_not_scrub_stanza_received_after_its_recording() {
         &[waddle_xmpp::stream_management::RecentTombstoneRecord {
             key: waddle_xmpp::stream_management::TombstoneKey {
                 target_id: "retract-me".to_string(),
-                archive_jid: "alice@example.com".to_string(),
+                archive_jid: bare("alice@example.com"),
             },
             recorded_at_utc: Utc::now() - chrono::Duration::hours(1),
         }],
@@ -1459,7 +1459,7 @@ async fn tombstone_scrubs_stanza_whose_receipt_reads_slightly_after_recording() 
         &[waddle_xmpp::stream_management::RecentTombstoneRecord {
             key: waddle_xmpp::stream_management::TombstoneKey {
                 target_id: "retract-me".to_string(),
-                archive_jid: "alice@example.com".to_string(),
+                archive_jid: bare("alice@example.com"),
             },
             recorded_at_utc: Utc::now() - chrono::Duration::seconds(30),
         }],
@@ -1516,7 +1516,7 @@ async fn retraction_racing_in_flight_promotion_does_not_deliver_retracted_conten
 
     // Step 2: retraction scrub lands mid-promotion.
     sm_registry
-        .scrub_unacked_for_tombstone("retract-me", "alice@example.com")
+        .scrub_unacked_for_tombstone("retract-me", &bare("alice@example.com"))
         .await
         .unwrap();
 
@@ -1557,7 +1557,7 @@ struct MidBatchRetractingBlocking {
     calls: std::sync::atomic::AtomicU32,
     retract_on_call: u32,
     target_id: &'static str,
-    archive_jid: &'static str,
+    archive_jid: BareJid,
 }
 
 #[async_trait::async_trait]
@@ -1571,7 +1571,7 @@ impl waddle_xmpp::xep::xep0191::BlockingStorage for MidBatchRetractingBlocking {
         let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
         if call == self.retract_on_call {
             self.sm_registry
-                .scrub_unacked_for_tombstone(self.target_id, self.archive_jid)
+                .scrub_unacked_for_tombstone(self.target_id, &self.archive_jid)
                 .await
                 .expect("mid-batch scrub must succeed");
         }
@@ -1616,7 +1616,7 @@ async fn mid_batch_retraction_still_scrubs_later_sessions_in_displaced_promotion
         calls: std::sync::atomic::AtomicU32::new(0),
         retract_on_call: 2,
         target_id: "retract-me",
-        archive_jid: "carol@example.com",
+        archive_jid: bare("carol@example.com"),
     };
     let pending: Arc<dyn PendingDeliveryStorage> =
         Arc::new(InMemoryPendingDeliveryStorage::unlimited());
@@ -1778,7 +1778,7 @@ impl PendingDeliveryStorage for FlakyPending {
     async fn scrub_for_tombstone(
         &self,
         target_id: &str,
-        archive_jid: &str,
+        archive_jid: &jid::BareJid,
     ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
         self.inner.scrub_for_tombstone(target_id, archive_jid).await
     }

--- a/server/crates/waddle-server/src/sm_promotion/tests.rs
+++ b/server/crates/waddle-server/src/sm_promotion/tests.rs
@@ -1347,9 +1347,14 @@ async fn promotion_scrubs_stanzas_matching_recent_tombstone() {
         &storage,
         &Blocklist::empty(),
         "example.com",
-        &[waddle_xmpp::stream_management::TombstoneKey {
-            target_id: "retract-me".to_string(),
-            archive_jid: "alice@example.com".to_string(),
+        // Recorded AFTER the session's stanzas were received, so the
+        // backward-in-time scope applies.
+        &[waddle_xmpp::stream_management::RecentTombstoneRecord {
+            key: waddle_xmpp::stream_management::TombstoneKey {
+                target_id: "retract-me".to_string(),
+                archive_jid: "alice@example.com".to_string(),
+            },
+            recorded_at_utc: Utc::now(),
         }],
     )
     .await;
@@ -1365,6 +1370,58 @@ async fn promotion_scrubs_stanzas_matching_recent_tombstone() {
         transient_bodies(&rows),
         vec!["safe".to_string()],
         "retracted content must not reach pending_delivery"
+    );
+}
+
+#[tokio::test]
+async fn tombstone_does_not_scrub_stanza_received_after_its_recording() {
+    // Round-3 review finding 2: a tombstone applies backward in time
+    // only. A NEW message that legitimately reuses the same wire id
+    // (counter-style client ids) in the same conversation scope,
+    // received AFTER the retraction was recorded, must promote
+    // normally instead of being silently lost.
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+    // The helper stamps original_receipt_at = Utc::now(); the tombstone
+    // predates it by an hour.
+    let session = detached_session_with_unacked(
+        "stream-reuse",
+        full("alice@example.com/laptop"),
+        vec![dm_xml_with_id(
+            "bob@elsewhere/x",
+            "alice@example.com",
+            "retract-me",
+            "fresh reuse",
+        )],
+    );
+
+    let summary = promote_session_unacked(
+        &session,
+        &registry,
+        &storage,
+        &Blocklist::empty(),
+        "example.com",
+        &[waddle_xmpp::stream_management::RecentTombstoneRecord {
+            key: waddle_xmpp::stream_management::TombstoneKey {
+                target_id: "retract-me".to_string(),
+                archive_jid: "alice@example.com".to_string(),
+            },
+            recorded_at_utc: Utc::now() - chrono::Duration::hours(1),
+        }],
+    )
+    .await;
+
+    assert_eq!(
+        summary.scrubbed, 0,
+        "a stanza received after the tombstone's recording must not be scrubbed"
+    );
+    assert_eq!(summary.queued, 1, "the reused-id stanza promotes normally");
+    let rows = storage.list(&bare("alice@example.com")).await.unwrap();
+    assert_eq!(
+        transient_bodies(&rows),
+        vec!["fresh reuse".to_string()],
+        "the legitimate new message must reach pending_delivery"
     );
 }
 
@@ -1436,6 +1493,105 @@ async fn retraction_racing_in_flight_promotion_does_not_deliver_retracted_conten
         vec!["safe".to_string()],
         "the retracted stanza must be absent from pending storage; the \
          other stanza must still be promoted"
+    );
+}
+
+/// BlockingStorage stub whose Nth `list_blocked_jids` call records a
+/// tombstone on the shared SM registry — simulates a XEP-0424/0425
+/// retraction landing MID-BATCH, after earlier sessions in the same
+/// drained batch were already promoted.
+struct MidBatchRetractingBlocking {
+    sm_registry: Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
+    calls: std::sync::atomic::AtomicU32,
+    retract_on_call: u32,
+    target_id: &'static str,
+    archive_jid: &'static str,
+}
+
+#[async_trait::async_trait]
+impl waddle_xmpp::xep::xep0191::BlockingStorage for MidBatchRetractingBlocking {
+    async fn list_blocked_jids(
+        &self,
+        _user: &BareJid,
+    ) -> Result<Vec<BareJid>, waddle_xmpp::xep::xep0191::BlockingStorageError> {
+        use waddle_xmpp::stream_management::SmSessionRegistry;
+
+        let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+        if call == self.retract_on_call {
+            self.sm_registry
+                .scrub_unacked_for_tombstone(self.target_id, self.archive_jid)
+                .await
+                .expect("mid-batch scrub must succeed");
+        }
+        Ok(Vec::new())
+    }
+}
+
+#[tokio::test]
+async fn mid_batch_retraction_still_scrubs_later_sessions_in_displaced_promotion() {
+    // Round-3 review finding 1: the recent-tombstone list must be
+    // fetched PER SESSION inside the batch loop, not once per batch.
+    // A retraction landing after the first session of a drained batch
+    // was promoted (sessions are off-map, so the scrub phases cannot
+    // see them) must still scrub the second session's matching stanza.
+    use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
+
+    let sm_registry = Arc::new(InMemorySmSessionRegistry::new());
+    let sessions = vec![
+        detached_session_with_unacked(
+            "stream-first",
+            full("alice@example.com/laptop"),
+            vec![dm_xml("bob@elsewhere/x", "alice@example.com", "hello")],
+        ),
+        detached_session_with_unacked(
+            "stream-second",
+            full("carol@example.com/laptop"),
+            vec![
+                dm_xml_with_id(
+                    "bob@elsewhere/x",
+                    "carol@example.com",
+                    "retract-me",
+                    "secret",
+                ),
+                dm_xml_with_id("bob@elsewhere/x", "carol@example.com", "keep-me", "safe"),
+            ],
+        ),
+    ];
+    // The retraction lands during the SECOND session's blocklist load —
+    // strictly after the first session's promotion completed.
+    let blocking = MidBatchRetractingBlocking {
+        sm_registry: Arc::clone(&sm_registry),
+        calls: std::sync::atomic::AtomicU32::new(0),
+        retract_on_call: 2,
+        target_id: "retract-me",
+        archive_jid: "carol@example.com",
+    };
+    let pending: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+
+    promote_displaced_sessions(
+        sessions,
+        DisplacedPromotionDeps {
+            sm_registry: &sm_registry,
+            connection_registry: &registry,
+            pending_storage: &pending,
+            blocking_storage: &blocking,
+            server_domain: "example.com",
+        },
+    )
+    .await;
+
+    assert_eq!(
+        transient_bodies(&pending.list(&bare("alice@example.com")).await.unwrap()),
+        vec!["hello".to_string()],
+        "the first session (promoted before the retraction) is unaffected"
+    );
+    assert_eq!(
+        transient_bodies(&pending.list(&bare("carol@example.com")).await.unwrap()),
+        vec!["safe".to_string()],
+        "a retraction landing mid-batch must still scrub the later \
+         session's matching stanza"
     );
 }
 

--- a/server/crates/waddle-server/src/sm_promotion/tests.rs
+++ b/server/crates/waddle-server/src/sm_promotion/tests.rs
@@ -1426,6 +1426,58 @@ async fn tombstone_does_not_scrub_stanza_received_after_its_recording() {
 }
 
 #[tokio::test]
+async fn tombstone_scrubs_stanza_whose_receipt_reads_slightly_after_recording() {
+    // Round-4 review: recorded_at_utc and original_receipt_at can come
+    // from different clocks (persistence restore across a restart,
+    // multi-node stamps, NTP step-back). A retracted stanza whose
+    // receipt stamp reads seconds "after" the tombstone recording due
+    // to skew must still be scrubbed — the backward-only scope carries
+    // a skew slack.
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+    // Helper stamps original_receipt_at = Utc::now(); the tombstone
+    // reads 30s in the past — inside the slack, so this models a
+    // receipt stamp skewed up to 30s ahead of the scrubbing clock.
+    let session = detached_session_with_unacked(
+        "stream-skew",
+        full("alice@example.com/laptop"),
+        vec![dm_xml_with_id(
+            "bob@elsewhere/x",
+            "alice@example.com",
+            "retract-me",
+            "secret",
+        )],
+    );
+
+    let summary = promote_session_unacked(
+        &session,
+        &registry,
+        &storage,
+        &Blocklist::empty(),
+        "example.com",
+        &[waddle_xmpp::stream_management::RecentTombstoneRecord {
+            key: waddle_xmpp::stream_management::TombstoneKey {
+                target_id: "retract-me".to_string(),
+                archive_jid: "alice@example.com".to_string(),
+            },
+            recorded_at_utc: Utc::now() - chrono::Duration::seconds(30),
+        }],
+    )
+    .await;
+
+    assert_eq!(
+        summary.scrubbed, 1,
+        "a receipt stamp within the skew slack must still be scrubbed"
+    );
+    let rows = storage.list(&bare("alice@example.com")).await.unwrap();
+    assert!(
+        transient_bodies(&rows).is_empty(),
+        "retracted content must not reach pending_delivery under clock skew"
+    );
+}
+
+#[tokio::test]
 async fn retraction_racing_in_flight_promotion_does_not_deliver_retracted_content() {
     // R2 end-to-end race: the janitor's drain moves the session off
     // both maps into a local; the retraction scrub then finds it

--- a/server/crates/waddle-server/src/sm_promotion/tests.rs
+++ b/server/crates/waddle-server/src/sm_promotion/tests.rs
@@ -776,3 +776,299 @@ async fn promotion_prefers_existing_self_stamp_time_over_queue_receipt_time() {
          not the unacked queue's redelivery-time receipt"
     );
 }
+
+#[tokio::test]
+async fn restart_outlasting_resume_window_promotes_queue_into_pending_delivery() {
+    // Issue #1098 acceptance: a server restart that outlasts the
+    // XEP-0198 resume window must not lose the dead session's unacked
+    // queue. The restore path hydrates the (already-expired) session,
+    // the janitor-shaped drain → promote → confirm chain lands the
+    // stanza in pending delivery storage, and only then are the
+    // durable SM rows erased.
+    use waddle_xmpp::pending_delivery::SmSessionId;
+    use waddle_xmpp::stream_management::persistence::{
+        InMemorySmPersistence, PersistedSession, PersistedUnackedStanza, SmPersistenceStorage,
+    };
+    use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
+
+    let sm_storage = Arc::new(InMemorySmPersistence::new());
+    let now = Utc::now();
+    sm_storage
+        .upsert_session(PersistedSession {
+            stream_id: SmSessionId::new("stream-dead"),
+            user_id: "alice".to_string(),
+            jid: full("alice@example.com/laptop"),
+            inbound_count: 0,
+            outbound_count: 1,
+            last_acked: 0,
+            replay_gap_through: None,
+            max_resume_time: Some(60),
+            detached_at: now - chrono::Duration::seconds(600),
+            max_resume_duration: std::time::Duration::from_secs(60),
+            carbons_enabled: false,
+            roster_interested: false,
+            blocklist_interested: false,
+            presence_available: false,
+            presence_show: None,
+            presence_status: None,
+            presence_priority: 0,
+        })
+        .await
+        .unwrap();
+    let mut queued =
+        xmpp_parsers::message::Message::new(Some("alice@example.com".parse::<jid::Jid>().unwrap()));
+    queued.from = Some("bob@elsewhere/x".parse::<jid::Jid>().unwrap());
+    queued.type_ = xmpp_parsers::message::MessageType::Chat;
+    queued
+        .bodies
+        .insert(xmpp_parsers::message::Lang::new(), "while down".to_string());
+    sm_storage
+        .append_unacked(PersistedUnackedStanza {
+            stream_id: SmSessionId::new("stream-dead"),
+            sequence: 1,
+            stanza: Box::new(Stanza::Message(queued)),
+            original_receipt_at: now - chrono::Duration::seconds(610),
+        })
+        .await
+        .unwrap();
+
+    // Restart-style bring-up: fresh registry over the same storage.
+    let sm_registry = InMemorySmSessionRegistry::new()
+        .with_persistence(Arc::clone(&sm_storage) as Arc<dyn SmPersistenceStorage>);
+    assert_eq!(sm_registry.restore_from_persistence().await.unwrap(), 1);
+
+    // Janitor pass: drain expired, promote, confirm.
+    let drained = sm_registry.drain_expired().await.unwrap();
+    assert_eq!(drained.len(), 1);
+    let pending: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+    let summary = promote_session_unacked(
+        &drained[0],
+        &registry,
+        &pending,
+        &Blocklist::empty(),
+        "example.com",
+    )
+    .await;
+    assert_eq!(summary.queued, 1);
+    assert!(!summary.has_storage_failure());
+    sm_registry.confirm_drained("stream-dead").await;
+
+    assert_eq!(pending.count(&bare("alice@example.com")).await.unwrap(), 1);
+    assert!(sm_storage
+        .get_session(&SmSessionId::new("stream-dead"))
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn displaced_sessions_are_promoted_and_confirmed() {
+    // Issue #1097 acceptance: sessions displaced from the SM registry
+    // (max_sessions overflow eviction or fresh-bind invalidation) run
+    // the full promote → confirm chain. The queued DM lands in
+    // pending delivery storage and the displaced session's durable SM
+    // rows are erased only afterwards.
+    use waddle_xmpp::pending_delivery::SmSessionId;
+    use waddle_xmpp::stream_management::persistence::{
+        InMemorySmPersistence, SmPersistenceStorage,
+    };
+    use waddle_xmpp::stream_management::{InMemorySmSessionRegistry, SmSessionRegistry};
+    use waddle_xmpp::xep::xep0191::{BlockingStorage, InMemoryBlockingStorage};
+
+    let sm_storage = Arc::new(InMemorySmPersistence::new());
+    let sm_registry = InMemorySmSessionRegistry::with_capacity(1)
+        .with_persistence(Arc::clone(&sm_storage) as Arc<dyn SmPersistenceStorage>);
+    let mut oldest = detached_session_with_unacked(
+        "stream-oldest",
+        full("alice@example.com/web"),
+        vec![dm_xml("bob@elsewhere/x", "alice@example.com", "displaced")],
+    );
+    oldest.detached_at = Instant::now() - std::time::Duration::from_secs(30);
+    assert!(sm_registry.store_session(oldest).await.unwrap().is_empty());
+
+    // Filling past capacity displaces the oldest session.
+    let displaced = sm_registry
+        .store_session(detached_session_with_unacked(
+            "stream-newer",
+            full("carol@example.com/web"),
+            Vec::new(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(displaced.len(), 1);
+
+    let pending: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+    let blocking: Arc<dyn BlockingStorage> = Arc::new(InMemoryBlockingStorage::new());
+    promote_displaced_sessions(
+        displaced,
+        DisplacedPromotionDeps {
+            sm_registry: &sm_registry,
+            connection_registry: &registry,
+            pending_storage: &pending,
+            blocking_storage: blocking.as_ref(),
+            server_domain: "example.com",
+        },
+    )
+    .await;
+
+    // The displaced queue landed in pending delivery — no message lost.
+    assert_eq!(pending.count(&bare("alice@example.com")).await.unwrap(), 1);
+    // Confirmed: durable SM rows for the displaced session are gone.
+    assert!(sm_storage
+        .get_session(&SmSessionId::new("stream-oldest"))
+        .await
+        .unwrap()
+        .is_none());
+    // The surviving session's rows remain.
+    assert!(sm_storage
+        .get_session(&SmSessionId::new("stream-newer"))
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn fresh_bind_invalidation_delivers_displaced_queue_to_new_session() {
+    // Issue #1097 acceptance (fresh-bind path): the resource just
+    // re-bound (registered in the ConnectionRegistry), so promoting
+    // the invalidated old detached session live-delivers its queue to
+    // the new session via the promotion chain's alt-resource step —
+    // then confirms, erasing the stale durable rows.
+    use waddle_xmpp::pending_delivery::SmSessionId;
+    use waddle_xmpp::stream_management::persistence::{
+        InMemorySmPersistence, SmPersistenceStorage,
+    };
+    use waddle_xmpp::stream_management::{InMemorySmSessionRegistry, SmSessionRegistry};
+    use waddle_xmpp::xep::xep0191::{BlockingStorage, InMemoryBlockingStorage};
+
+    let sm_storage = Arc::new(InMemorySmPersistence::new());
+    let sm_registry = InMemorySmSessionRegistry::new()
+        .with_persistence(Arc::clone(&sm_storage) as Arc<dyn SmPersistenceStorage>);
+    let jid = full("alice@example.com/phone");
+    assert!(sm_registry
+        .store_session(detached_session_with_unacked(
+            "stream-stale",
+            jid.clone(),
+            vec![dm_xml(
+                "bob@elsewhere/x",
+                "alice@example.com",
+                "for the new bind"
+            )],
+        ))
+        .await
+        .unwrap()
+        .is_empty());
+
+    // The fresh bind registers its connection BEFORE invalidation runs
+    // (finalize_sm_after_registry_registration ordering).
+    let registry = ConnectionRegistry::new();
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    registry.register(jid.clone(), tx);
+    registry.update_presence(&jid, true, 0);
+
+    let removed = sm_registry.invalidate_sessions_for_jid(&jid).await.unwrap();
+    assert_eq!(removed.len(), 1);
+
+    let pending: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let blocking: Arc<dyn BlockingStorage> = Arc::new(InMemoryBlockingStorage::new());
+    promote_displaced_sessions(
+        removed,
+        DisplacedPromotionDeps {
+            sm_registry: &sm_registry,
+            connection_registry: &registry,
+            pending_storage: &pending,
+            blocking_storage: blocking.as_ref(),
+            server_domain: "example.com",
+        },
+    )
+    .await;
+
+    assert!(
+        rx.try_recv().is_ok(),
+        "displaced queue must be live-delivered to the freshly bound session"
+    );
+    assert_eq!(pending.count(&bare("alice@example.com")).await.unwrap(), 0);
+    assert!(sm_storage
+        .get_session(&SmSessionId::new("stream-stale"))
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn capacity_churn_loses_no_messages_across_restart_style_read() {
+    // Issue #1097 acceptance (churn): fill the registry to capacity,
+    // keep storing so the oldest sessions are evicted, promote every
+    // displaced session, then do a restart-style read: every evicted
+    // user's message must be in pending delivery storage and no
+    // stale durable SM rows may remain for confirmed streams.
+    use waddle_xmpp::stream_management::persistence::{
+        InMemorySmPersistence, SmPersistenceStorage,
+    };
+    use waddle_xmpp::stream_management::{InMemorySmSessionRegistry, SmSessionRegistry};
+    use waddle_xmpp::xep::xep0191::{BlockingStorage, InMemoryBlockingStorage};
+
+    let sm_storage = Arc::new(InMemorySmPersistence::new());
+    let sm_registry = InMemorySmSessionRegistry::with_capacity(2)
+        .with_persistence(Arc::clone(&sm_storage) as Arc<dyn SmPersistenceStorage>);
+    let pending: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+    let blocking: Arc<dyn BlockingStorage> = Arc::new(InMemoryBlockingStorage::new());
+
+    for i in 0..5u32 {
+        let user = format!("user{i}@example.com");
+        let mut session = detached_session_with_unacked(
+            &format!("stream-{i}"),
+            format!("{user}/web").parse().unwrap(),
+            vec![dm_xml("bob@elsewhere/x", &user, &format!("msg-{i}"))],
+        );
+        // Strictly increasing ages so eviction order is deterministic.
+        session.detached_at = Instant::now() - std::time::Duration::from_secs(60 - u64::from(i));
+        let displaced = sm_registry.store_session(session).await.unwrap();
+        promote_displaced_sessions(
+            displaced,
+            DisplacedPromotionDeps {
+                sm_registry: &sm_registry,
+                connection_registry: &registry,
+                pending_storage: &pending,
+                blocking_storage: blocking.as_ref(),
+                server_domain: "example.com",
+            },
+        )
+        .await;
+    }
+
+    // 5 stored into capacity 2 → 3 evictions, all promoted offline.
+    let mut evicted_recipients = 0u32;
+    let mut retained_streams = 0u32;
+    for i in 0..5u32 {
+        let user: BareJid = format!("user{i}@example.com").parse().unwrap();
+        let queued = pending.count(&user).await.unwrap();
+        let still_detached = sm_registry
+            .peek_session(&format!("stream-{i}"))
+            .await
+            .unwrap()
+            .is_some();
+        assert!(
+            (queued == 1) ^ still_detached,
+            "user{i}: message must be either queued for delivery or still \
+             replayable from its detached session — never lost, never both"
+        );
+        evicted_recipients += queued;
+        retained_streams += u32::from(still_detached);
+    }
+    assert_eq!(evicted_recipients, 3);
+    assert_eq!(retained_streams, 2);
+
+    // Restart-style read: a fresh registry over the same durable
+    // storage hydrates exactly the retained (unconfirmed) sessions.
+    let restarted = InMemorySmSessionRegistry::new()
+        .with_persistence(Arc::clone(&sm_storage) as Arc<dyn SmPersistenceStorage>);
+    assert_eq!(restarted.restore_from_persistence().await.unwrap(), 2);
+}

--- a/server/crates/waddle-server/src/sm_promotion/tests.rs
+++ b/server/crates/waddle-server/src/sm_promotion/tests.rs
@@ -58,6 +58,115 @@ fn detached_session_with_unacked(
     }
 }
 
+/// PendingDeliveryStorage whose `insert` always fails — simulates a
+/// down offline-storage backend for promotion-failure tests.
+struct AlwaysFailingPending;
+
+#[async_trait::async_trait]
+impl PendingDeliveryStorage for AlwaysFailingPending {
+    async fn insert(
+        &self,
+        _row: waddle_xmpp::pending_delivery::PendingRow,
+    ) -> Result<
+        waddle_xmpp::pending_delivery::InsertOutcome,
+        waddle_xmpp::pending_delivery::storage::PendingStorageError,
+    > {
+        Err(
+            waddle_xmpp::pending_delivery::storage::PendingStorageError::Other(
+                "simulated backend failure".into(),
+            ),
+        )
+    }
+    async fn list(
+        &self,
+        _recipient: &BareJid,
+    ) -> Result<
+        Vec<waddle_xmpp::pending_delivery::PendingRow>,
+        waddle_xmpp::pending_delivery::storage::PendingStorageError,
+    > {
+        Ok(vec![])
+    }
+    async fn claim_for_session(
+        &self,
+        _recipient: &BareJid,
+        _session: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<
+        Vec<waddle_xmpp::pending_delivery::PendingRow>,
+        waddle_xmpp::pending_delivery::storage::PendingStorageError,
+    > {
+        Ok(vec![])
+    }
+    async fn delete_claimed(
+        &self,
+        _session: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        Ok(0)
+    }
+    async fn delete_row(
+        &self,
+        _id: &waddle_xmpp::pending_delivery::PendingRowId,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        Ok(0)
+    }
+    async fn release_claim(
+        &self,
+        _session: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        Ok(0)
+    }
+    async fn release_row(
+        &self,
+        _id: &waddle_xmpp::pending_delivery::PendingRowId,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        Ok(0)
+    }
+    async fn record_pushed_at(
+        &self,
+        _id: &waddle_xmpp::pending_delivery::PendingRowId,
+        _sequence: u32,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        Ok(0)
+    }
+    async fn delete_acked_through(
+        &self,
+        _session: &waddle_xmpp::pending_delivery::SmSessionId,
+        _sequence_max: u32,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        Ok(0)
+    }
+    async fn list_orphaned_claims(
+        &self,
+        _live_sessions: &[waddle_xmpp::pending_delivery::SmSessionId],
+    ) -> Result<
+        Vec<(
+            waddle_xmpp::pending_delivery::PendingRowId,
+            waddle_xmpp::pending_delivery::SmSessionId,
+        )>,
+        waddle_xmpp::pending_delivery::storage::PendingStorageError,
+    > {
+        Ok(vec![])
+    }
+    async fn count(
+        &self,
+        _recipient: &BareJid,
+    ) -> Result<u32, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        Ok(0)
+    }
+    async fn delete_older_than(
+        &self,
+        _cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        Ok(0)
+    }
+    async fn scrub_for_tombstone(
+        &self,
+        _target_id: &str,
+        _archive_jid: &str,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        Ok(0)
+    }
+}
+
 fn dm_xml(from: &str, to: &str, body: &str) -> String {
     let mut m = xmpp_parsers::message::Message::new(Some(to.parse::<jid::Jid>().unwrap()));
     m.from = Some(from.parse::<jid::Jid>().unwrap());
@@ -626,71 +735,6 @@ async fn storage_failure_records_storage_failed_not_dropped() {
     // lose the unacked stanza. The PromotionSummary must surface
     // a separate `storage_failed` counter so the caller can keep
     // the durable SM row for restart-time retry.
-    use async_trait::async_trait;
-    use waddle_xmpp::pending_delivery::storage::PendingStorageError;
-    use waddle_xmpp::pending_delivery::{InsertOutcome, PendingRow, PendingRowId, SmSessionId};
-
-    struct AlwaysFailingPending;
-    #[async_trait]
-    impl PendingDeliveryStorage for AlwaysFailingPending {
-        async fn insert(&self, _row: PendingRow) -> Result<InsertOutcome, PendingStorageError> {
-            Err(PendingStorageError::Other(
-                "simulated backend failure".into(),
-            ))
-        }
-        async fn list(&self, _recipient: &BareJid) -> Result<Vec<PendingRow>, PendingStorageError> {
-            Ok(vec![])
-        }
-        async fn claim_for_session(
-            &self,
-            _recipient: &BareJid,
-            _session: &SmSessionId,
-        ) -> Result<Vec<PendingRow>, PendingStorageError> {
-            Ok(vec![])
-        }
-        async fn delete_claimed(&self, _session: &SmSessionId) -> Result<u64, PendingStorageError> {
-            Ok(0)
-        }
-        async fn delete_row(&self, _id: &PendingRowId) -> Result<u64, PendingStorageError> {
-            Ok(0)
-        }
-        async fn release_claim(&self, _session: &SmSessionId) -> Result<u64, PendingStorageError> {
-            Ok(0)
-        }
-        async fn release_row(&self, _id: &PendingRowId) -> Result<u64, PendingStorageError> {
-            Ok(0)
-        }
-        async fn record_pushed_at(
-            &self,
-            _id: &PendingRowId,
-            _sequence: u32,
-        ) -> Result<u64, PendingStorageError> {
-            Ok(0)
-        }
-        async fn delete_acked_through(
-            &self,
-            _session: &SmSessionId,
-            _sequence_max: u32,
-        ) -> Result<u64, PendingStorageError> {
-            Ok(0)
-        }
-        async fn list_orphaned_claims(
-            &self,
-            _live_sessions: &[SmSessionId],
-        ) -> Result<Vec<(PendingRowId, SmSessionId)>, PendingStorageError> {
-            Ok(vec![])
-        }
-        async fn count(&self, _recipient: &BareJid) -> Result<u32, PendingStorageError> {
-            Ok(0)
-        }
-        async fn delete_older_than(
-            &self,
-            _cutoff: chrono::DateTime<chrono::Utc>,
-        ) -> Result<u64, PendingStorageError> {
-            Ok(0)
-        }
-    }
-
     let storage: Arc<dyn PendingDeliveryStorage> = Arc::new(AlwaysFailingPending);
     let registry = ConnectionRegistry::new();
     let session = detached_session_with_unacked(
@@ -929,6 +973,237 @@ async fn displaced_sessions_are_promoted_and_confirmed() {
         .await
         .unwrap()
         .is_some());
+}
+
+#[tokio::test]
+async fn ownership_moved_detach_promotes_displaced_queue_instead_of_dropping_it() {
+    // S2 regression (ownership-moved detach path): conn A dies; the
+    // same client fresh-binds on conn B BEFORE A's cleanup stores its
+    // detached session, so B's invalidation pass finds nothing. A's
+    // cleanup then stores, loses the `unregister_if_owner` race, and
+    // previously erased the stored session durably while discarding
+    // the returned queue. The displace + promote chain must instead
+    // land the queue in pending delivery and only then erase the rows.
+    use waddle_xmpp::pending_delivery::SmSessionId;
+    use waddle_xmpp::stream_management::persistence::{
+        InMemorySmPersistence, SmPersistenceStorage,
+    };
+    use waddle_xmpp::stream_management::{InMemorySmSessionRegistry, SmSessionRegistry};
+    use waddle_xmpp::xep::xep0191::{BlockingStorage, InMemoryBlockingStorage};
+
+    let sm_storage = Arc::new(InMemorySmPersistence::new());
+    let sm_registry = InMemorySmSessionRegistry::new()
+        .with_persistence(Arc::clone(&sm_storage) as Arc<dyn SmPersistenceStorage>);
+    assert!(sm_registry
+        .store_session(detached_session_with_unacked(
+            "stream-owner-moved",
+            full("alice@example.com/laptop"),
+            vec![dm_xml("bob@elsewhere/x", "alice@example.com", "keep me")],
+        ))
+        .await
+        .unwrap()
+        .is_empty());
+
+    // Ownership race lost → displace (memory only, rows preserved).
+    let displaced = sm_registry
+        .displace_stored_session_if_unclaimed("stream-owner-moved")
+        .await
+        .unwrap()
+        .expect("stored session must be displaced");
+    assert!(sm_storage
+        .get_session(&SmSessionId::new("stream-owner-moved"))
+        .await
+        .unwrap()
+        .is_some());
+
+    let pending: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+    let blocking: Arc<dyn BlockingStorage> = Arc::new(InMemoryBlockingStorage::new());
+    promote_displaced_sessions(
+        vec![displaced],
+        DisplacedPromotionDeps {
+            sm_registry: &sm_registry,
+            connection_registry: &registry,
+            pending_storage: &pending,
+            blocking_storage: blocking.as_ref(),
+            server_domain: "example.com",
+        },
+    )
+    .await;
+
+    // No message lost, and confirm erased the durable rows.
+    assert_eq!(pending.count(&bare("alice@example.com")).await.unwrap(), 1);
+    assert!(sm_storage
+        .get_session(&SmSessionId::new("stream-owner-moved"))
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn displaced_promotion_storage_failure_keeps_session_drainable_for_retry() {
+    // S4 regression: a promotion failure preserved the durable rows
+    // but the session was already gone from the in-memory map, and
+    // `drain_expired` scans only memory — so the janitor's "retried on
+    // the next pass" promise was false and the queue was stranded
+    // until a restart. On failure the session must be re-inserted
+    // (forced expired) so the next drain retries, and the retry must
+    // succeed once storage recovers.
+    use waddle_xmpp::pending_delivery::SmSessionId;
+    use waddle_xmpp::stream_management::persistence::{
+        InMemorySmPersistence, SmPersistenceStorage,
+    };
+    use waddle_xmpp::stream_management::{InMemorySmSessionRegistry, SmSessionRegistry};
+    use waddle_xmpp::xep::xep0191::{BlockingStorage, InMemoryBlockingStorage};
+
+    let sm_storage = Arc::new(InMemorySmPersistence::new());
+    let sm_registry = InMemorySmSessionRegistry::with_capacity(1)
+        .with_persistence(Arc::clone(&sm_storage) as Arc<dyn SmPersistenceStorage>);
+    let mut oldest = detached_session_with_unacked(
+        "stream-retry",
+        full("alice@example.com/web"),
+        vec![dm_xml("bob@elsewhere/x", "alice@example.com", "retry me")],
+    );
+    oldest.detached_at = Instant::now() - std::time::Duration::from_secs(30);
+    assert!(sm_registry.store_session(oldest).await.unwrap().is_empty());
+    let displaced = sm_registry
+        .store_session(detached_session_with_unacked(
+            "stream-newer",
+            full("carol@example.com/web"),
+            Vec::new(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(displaced.len(), 1);
+
+    // Promotion fails: pending-delivery backend is down.
+    let failing: Arc<dyn PendingDeliveryStorage> = Arc::new(AlwaysFailingPending);
+    let registry = ConnectionRegistry::new();
+    let blocking: Arc<dyn BlockingStorage> = Arc::new(InMemoryBlockingStorage::new());
+    promote_displaced_sessions(
+        displaced,
+        DisplacedPromotionDeps {
+            sm_registry: &sm_registry,
+            connection_registry: &registry,
+            pending_storage: &failing,
+            blocking_storage: blocking.as_ref(),
+            server_domain: "example.com",
+        },
+    )
+    .await;
+
+    // Durable rows preserved (existing contract)...
+    assert!(sm_storage
+        .get_session(&SmSessionId::new("stream-retry"))
+        .await
+        .unwrap()
+        .is_some());
+    // ...AND the session is drainable again without a restart.
+    let drained = sm_registry.drain_expired().await.unwrap();
+    assert_eq!(
+        drained.len(),
+        1,
+        "failed promotion must leave the session in memory for the janitor's next drain"
+    );
+    assert_eq!(drained[0].stream_id, "stream-retry");
+
+    // Storage recovers: the retry promotes and confirms.
+    let recovered: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let summary = promote_session_unacked(
+        &drained[0],
+        &registry,
+        &recovered,
+        &Blocklist::empty(),
+        "example.com",
+    )
+    .await;
+    assert_eq!(summary.queued, 1);
+    assert!(!summary.has_storage_failure());
+    sm_registry.confirm_drained("stream-retry").await;
+    assert_eq!(
+        recovered.count(&bare("alice@example.com")).await.unwrap(),
+        1
+    );
+    assert!(sm_storage
+        .get_session(&SmSessionId::new("stream-retry"))
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn displaced_promotion_blocklist_failure_keeps_session_drainable_for_retry() {
+    // S4 (blocklist-load branch): same retry contract as the storage-
+    // failure branch — fail-closed XEP-0191 skip must not strand the
+    // queue until restart.
+    use async_trait::async_trait;
+    use waddle_xmpp::pending_delivery::SmSessionId;
+    use waddle_xmpp::stream_management::persistence::{
+        InMemorySmPersistence, SmPersistenceStorage,
+    };
+    use waddle_xmpp::stream_management::{InMemorySmSessionRegistry, SmSessionRegistry};
+    use waddle_xmpp::xep::xep0191::{BlockingStorage, BlockingStorageError};
+
+    struct FailingBlocking;
+    #[async_trait]
+    impl BlockingStorage for FailingBlocking {
+        async fn list_blocked_jids(
+            &self,
+            _user: &BareJid,
+        ) -> Result<Vec<BareJid>, BlockingStorageError> {
+            Err(BlockingStorageError::new(std::io::Error::other(
+                "simulated blocklist backend failure",
+            )))
+        }
+    }
+
+    let sm_storage = Arc::new(InMemorySmPersistence::new());
+    let sm_registry = InMemorySmSessionRegistry::new()
+        .with_persistence(Arc::clone(&sm_storage) as Arc<dyn SmPersistenceStorage>);
+    let jid = full("alice@example.com/phone");
+    assert!(sm_registry
+        .store_session(detached_session_with_unacked(
+            "stream-blocklist-retry",
+            jid.clone(),
+            vec![dm_xml("bob@elsewhere/x", "alice@example.com", "held")],
+        ))
+        .await
+        .unwrap()
+        .is_empty());
+    let removed = sm_registry.invalidate_sessions_for_jid(&jid).await.unwrap();
+    assert_eq!(removed.len(), 1);
+
+    let pending: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+    let blocking = FailingBlocking;
+    promote_displaced_sessions(
+        removed,
+        DisplacedPromotionDeps {
+            sm_registry: &sm_registry,
+            connection_registry: &registry,
+            pending_storage: &pending,
+            blocking_storage: &blocking,
+            server_domain: "example.com",
+        },
+    )
+    .await;
+
+    assert!(sm_storage
+        .get_session(&SmSessionId::new("stream-blocklist-retry"))
+        .await
+        .unwrap()
+        .is_some());
+    let drained = sm_registry.drain_expired().await.unwrap();
+    assert_eq!(
+        drained.len(),
+        1,
+        "blocklist-load failure must leave the session drainable for retry"
+    );
+    assert_eq!(drained[0].stream_id, "stream-blocklist-retry");
+    assert_eq!(drained[0].unacked_stanzas.len(), 1);
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/sm_promotion/tests.rs
+++ b/server/crates/waddle-server/src/sm_promotion/tests.rs
@@ -275,6 +275,7 @@ async fn assert_mam_frame_not_promoted_to_pending_delivery(child_name: &str) {
         &storage,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
 
@@ -311,6 +312,7 @@ async fn promotes_to_pending_delivery_when_no_alt_resource() {
         &storage,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
 
@@ -341,6 +343,7 @@ async fn dm_with_mam_payload_is_still_promoted_to_pending_delivery() {
         &storage,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
 
@@ -389,6 +392,7 @@ async fn promotes_to_alt_resource_when_one_is_online() {
         &storage,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
 
@@ -430,6 +434,7 @@ async fn bounces_service_unavailable_when_quota_exceeded() {
         &storage,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
 
@@ -472,6 +477,7 @@ async fn drops_no_store_hint_stanzas_silently() {
         &storage,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
 
@@ -520,6 +526,7 @@ async fn full_jid_target_falls_back_to_bare_jid_fanout() {
         &storage,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
 
@@ -558,6 +565,7 @@ async fn bare_jid_target_fans_out_to_all_routable_resources() {
         &storage,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
 
@@ -599,6 +607,7 @@ async fn iq_unacked_promoted_to_alt_resource_when_addressed_resource_online() {
         &storage,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
 
@@ -641,6 +650,7 @@ async fn iq_unacked_dropped_when_no_resource_online() {
         &storage,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
 
@@ -664,6 +674,7 @@ async fn skips_unparseable_stanzas() {
         &storage,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
     assert_eq!(summary.unparseable, 1);
@@ -714,6 +725,7 @@ async fn promoted_pending_row_carries_per_stanza_original_receipt_at() {
         &storage,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
     assert_eq!(summary.queued, 1);
@@ -753,6 +765,7 @@ async fn storage_failure_records_storage_failed_not_dropped() {
         &storage,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
 
@@ -808,6 +821,7 @@ async fn promotion_prefers_existing_self_stamp_time_over_queue_receipt_time() {
         &storage,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
 
@@ -893,6 +907,7 @@ async fn restart_outlasting_resume_window_promotes_queue_into_pending_delivery()
         &pending,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
     assert_eq!(summary.queued, 1);
@@ -1117,6 +1132,7 @@ async fn displaced_promotion_storage_failure_keeps_session_drainable_for_retry()
         &recovered,
         &Blocklist::empty(),
         "example.com",
+        &[],
     )
     .await;
     assert_eq!(summary.queued, 1);
@@ -1273,6 +1289,411 @@ async fn fresh_bind_invalidation_delivers_displaced_queue_to_new_session() {
         .await
         .unwrap()
         .is_none());
+}
+
+fn dm_xml_with_id(from: &str, to: &str, id: &str, body: &str) -> String {
+    let mut m = xmpp_parsers::message::Message::new(Some(to.parse::<jid::Jid>().unwrap()));
+    m.from = Some(from.parse::<jid::Jid>().unwrap());
+    m.id = Some(xmpp_parsers::message::Id(id.to_string()));
+    m.type_ = xmpp_parsers::message::MessageType::Chat;
+    m.bodies
+        .insert(xmpp_parsers::message::Lang::new(), body.to_string());
+    let element: xmpp_parsers::minidom::Element = m.into();
+    let mut buf = Vec::new();
+    element.write_to(&mut buf).unwrap();
+    String::from_utf8(buf).unwrap()
+}
+
+fn transient_bodies(rows: &[waddle_xmpp::pending_delivery::PendingRow]) -> Vec<String> {
+    let mut bodies: Vec<String> = rows
+        .iter()
+        .filter_map(|row| match &row.payload {
+            waddle_xmpp::pending_delivery::PendingPayload::Transient(message) => {
+                message.bodies.values().next().cloned()
+            }
+            waddle_xmpp::pending_delivery::PendingPayload::Archived(_) => None,
+        })
+        .collect();
+    bodies.sort();
+    bodies
+}
+
+#[tokio::test]
+async fn promotion_scrubs_stanzas_matching_recent_tombstone() {
+    // R2 (round-2 review): the promotion chain must re-check the
+    // registry's recent-tombstone record before writing a drained
+    // session's unacked stanzas into pending_delivery, so a retraction
+    // racing an in-flight promotion cannot resurrect retracted content.
+    let storage: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+    let session = detached_session_with_unacked(
+        "stream-tomb",
+        full("alice@example.com/laptop"),
+        vec![
+            dm_xml_with_id(
+                "bob@elsewhere/x",
+                "alice@example.com",
+                "retract-me",
+                "secret",
+            ),
+            dm_xml_with_id("bob@elsewhere/x", "alice@example.com", "keep-me", "safe"),
+        ],
+    );
+
+    let summary = promote_session_unacked(
+        &session,
+        &registry,
+        &storage,
+        &Blocklist::empty(),
+        "example.com",
+        &[waddle_xmpp::stream_management::TombstoneKey {
+            target_id: "retract-me".to_string(),
+            archive_jid: "alice@example.com".to_string(),
+        }],
+    )
+    .await;
+
+    assert_eq!(summary.scrubbed, 1, "retracted stanza counted as scrubbed");
+    assert_eq!(summary.queued, 1, "the non-matching stanza still promotes");
+    assert_eq!(
+        summary.dropped, 0,
+        "scrubbed must not be counted as dropped"
+    );
+    let rows = storage.list(&bare("alice@example.com")).await.unwrap();
+    assert_eq!(
+        transient_bodies(&rows),
+        vec!["safe".to_string()],
+        "retracted content must not reach pending_delivery"
+    );
+}
+
+#[tokio::test]
+async fn retraction_racing_in_flight_promotion_does_not_deliver_retracted_content() {
+    // R2 end-to-end race: the janitor's drain moves the session off
+    // both maps into a local; the retraction scrub then finds it
+    // nowhere (and its pending row is not yet inserted); the promotion
+    // finally runs. The recent-tombstone re-check must drop the
+    // retracted stanza while the rest of the queue promotes, and
+    // confirm_drained may then erase the SM rows safely.
+    use waddle_xmpp::stream_management::persistence::{
+        InMemorySmPersistence, SmPersistenceStorage,
+    };
+    use waddle_xmpp::stream_management::{InMemorySmSessionRegistry, SmSessionRegistry};
+
+    let sm_storage = Arc::new(InMemorySmPersistence::new());
+    let sm_registry = InMemorySmSessionRegistry::new()
+        .with_persistence(Arc::clone(&sm_storage) as Arc<dyn SmPersistenceStorage>);
+    sm_registry
+        .store_session(detached_session_with_unacked(
+            "stream-race",
+            full("alice@example.com/laptop"),
+            vec![
+                dm_xml_with_id(
+                    "bob@elsewhere/x",
+                    "alice@example.com",
+                    "retract-me",
+                    "secret",
+                ),
+                dm_xml_with_id("bob@elsewhere/x", "alice@example.com", "keep-me", "safe"),
+            ],
+        ))
+        .await
+        .unwrap();
+
+    // Step 1: drain (session now off both maps, held in a local).
+    let drained = sm_registry.drain_all_for_shutdown().await.unwrap();
+    assert_eq!(drained.len(), 1);
+
+    // Step 2: retraction scrub lands mid-promotion.
+    sm_registry
+        .scrub_unacked_for_tombstone("retract-me", "alice@example.com")
+        .await
+        .unwrap();
+
+    // Step 3: promotion runs with the registry's recent tombstones.
+    let pending: Arc<dyn PendingDeliveryStorage> =
+        Arc::new(InMemoryPendingDeliveryStorage::unlimited());
+    let registry = ConnectionRegistry::new();
+    let recent = sm_registry.recent_tombstones().unwrap();
+    let summary = promote_session_unacked(
+        &drained[0],
+        &registry,
+        &pending,
+        &Blocklist::empty(),
+        "example.com",
+        &recent,
+    )
+    .await;
+    assert_eq!(summary.scrubbed, 1);
+    assert_eq!(summary.queued, 1);
+    assert!(!summary.has_storage_failure());
+    sm_registry.confirm_drained("stream-race").await;
+
+    let rows = pending.list(&bare("alice@example.com")).await.unwrap();
+    assert_eq!(
+        transient_bodies(&rows),
+        vec!["safe".to_string()],
+        "the retracted stanza must be absent from pending storage; the \
+         other stanza must still be promoted"
+    );
+}
+
+/// PendingDeliveryStorage that fails exactly one insert (the Nth call)
+/// while armed, delegating everything to a real in-memory store —
+/// simulates a transient partial storage failure mid-promotion.
+struct FlakyPending {
+    inner: InMemoryPendingDeliveryStorage,
+    armed: std::sync::atomic::AtomicBool,
+    insert_calls: std::sync::atomic::AtomicU32,
+    fail_on_call: u32,
+}
+
+impl FlakyPending {
+    fn failing_on(call: u32) -> Self {
+        Self {
+            inner: InMemoryPendingDeliveryStorage::unlimited(),
+            armed: std::sync::atomic::AtomicBool::new(true),
+            insert_calls: std::sync::atomic::AtomicU32::new(0),
+            fail_on_call: call,
+        }
+    }
+
+    fn disarm(&self) {
+        self.armed.store(false, std::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+#[async_trait::async_trait]
+impl PendingDeliveryStorage for FlakyPending {
+    async fn insert(
+        &self,
+        row: waddle_xmpp::pending_delivery::PendingRow,
+    ) -> Result<
+        waddle_xmpp::pending_delivery::InsertOutcome,
+        waddle_xmpp::pending_delivery::storage::PendingStorageError,
+    > {
+        let call = self
+            .insert_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            + 1;
+        if self.armed.load(std::sync::atomic::Ordering::SeqCst) && call == self.fail_on_call {
+            return Err(
+                waddle_xmpp::pending_delivery::storage::PendingStorageError::Other(
+                    "simulated transient backend failure".into(),
+                ),
+            );
+        }
+        self.inner.insert(row).await
+    }
+    async fn list(
+        &self,
+        recipient: &BareJid,
+    ) -> Result<
+        Vec<waddle_xmpp::pending_delivery::PendingRow>,
+        waddle_xmpp::pending_delivery::storage::PendingStorageError,
+    > {
+        self.inner.list(recipient).await
+    }
+    async fn claim_for_session(
+        &self,
+        recipient: &BareJid,
+        session: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<
+        Vec<waddle_xmpp::pending_delivery::PendingRow>,
+        waddle_xmpp::pending_delivery::storage::PendingStorageError,
+    > {
+        self.inner.claim_for_session(recipient, session).await
+    }
+    async fn delete_claimed(
+        &self,
+        session: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.delete_claimed(session).await
+    }
+    async fn delete_row(
+        &self,
+        id: &waddle_xmpp::pending_delivery::PendingRowId,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.delete_row(id).await
+    }
+    async fn release_claim(
+        &self,
+        session: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.release_claim(session).await
+    }
+    async fn release_row(
+        &self,
+        id: &waddle_xmpp::pending_delivery::PendingRowId,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.release_row(id).await
+    }
+    async fn record_pushed_at(
+        &self,
+        id: &waddle_xmpp::pending_delivery::PendingRowId,
+        sequence: u32,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.record_pushed_at(id, sequence).await
+    }
+    async fn delete_acked_through(
+        &self,
+        session: &waddle_xmpp::pending_delivery::SmSessionId,
+        sequence_max: u32,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.delete_acked_through(session, sequence_max).await
+    }
+    async fn list_orphaned_claims(
+        &self,
+        live_sessions: &[waddle_xmpp::pending_delivery::SmSessionId],
+    ) -> Result<
+        Vec<(
+            waddle_xmpp::pending_delivery::PendingRowId,
+            waddle_xmpp::pending_delivery::SmSessionId,
+        )>,
+        waddle_xmpp::pending_delivery::storage::PendingStorageError,
+    > {
+        self.inner.list_orphaned_claims(live_sessions).await
+    }
+    async fn count(
+        &self,
+        recipient: &BareJid,
+    ) -> Result<u32, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.count(recipient).await
+    }
+    async fn delete_older_than(
+        &self,
+        cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.delete_older_than(cutoff).await
+    }
+    async fn scrub_for_tombstone(
+        &self,
+        target_id: &str,
+        archive_jid: &str,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.scrub_for_tombstone(target_id, archive_jid).await
+    }
+}
+
+#[tokio::test]
+async fn partial_storage_failure_retries_only_failed_stanzas_without_duplicates() {
+    // R4 (round-2 review): a partial storage failure used to re-promote
+    // the WHOLE queue on every janitor tick — already-Queued stanzas
+    // included — because promotion kept no per-stanza progress. After a
+    // partial failure the successfully promoted stanzas' durable
+    // sm_unacked rows must be deleted and dropped from the reinserted
+    // session, so retries cover only the failed stanzas and duplication
+    // is bounded to a crash window, not per tick.
+    use waddle_xmpp::pending_delivery::SmSessionId;
+    use waddle_xmpp::stream_management::persistence::{
+        InMemorySmPersistence, SmPersistenceStorage,
+    };
+    use waddle_xmpp::stream_management::{InMemorySmSessionRegistry, SmSessionRegistry};
+    use waddle_xmpp::xep::xep0191::{BlockingStorage, InMemoryBlockingStorage};
+
+    let sm_storage = Arc::new(InMemorySmPersistence::new());
+    let sm_registry = InMemorySmSessionRegistry::new()
+        .with_persistence(Arc::clone(&sm_storage) as Arc<dyn SmPersistenceStorage>);
+    let jid = full("alice@example.com/web");
+    assert!(sm_registry
+        .store_session(detached_session_with_unacked(
+            "stream-partial",
+            jid.clone(),
+            vec![
+                dm_xml("bob@elsewhere/x", "alice@example.com", "msg-1"),
+                dm_xml("bob@elsewhere/x", "alice@example.com", "msg-2"),
+                dm_xml("bob@elsewhere/x", "alice@example.com", "msg-3"),
+            ],
+        ))
+        .await
+        .unwrap()
+        .is_empty());
+    let displaced = sm_registry.invalidate_sessions_for_jid(&jid).await.unwrap();
+    assert_eq!(displaced.len(), 1);
+
+    // Tick 1: stanza 2 of 3 fails to insert.
+    let flaky = Arc::new(FlakyPending::failing_on(2));
+    let pending: Arc<dyn PendingDeliveryStorage> = Arc::clone(&flaky) as _;
+    let registry = ConnectionRegistry::new();
+    let blocking: Arc<dyn BlockingStorage> = Arc::new(InMemoryBlockingStorage::new());
+    promote_displaced_sessions(
+        displaced,
+        DisplacedPromotionDeps {
+            sm_registry: &sm_registry,
+            connection_registry: &registry,
+            pending_storage: &pending,
+            blocking_storage: blocking.as_ref(),
+            server_domain: "example.com",
+        },
+    )
+    .await;
+
+    // Stanzas 1 & 3 landed in pending storage...
+    let rows = pending.list(&bare("alice@example.com")).await.unwrap();
+    assert_eq!(
+        transient_bodies(&rows),
+        vec!["msg-1".to_string(), "msg-3".to_string()]
+    );
+    // ...and their durable sm_unacked rows are gone; only the failed
+    // stanza's row survives for the retry.
+    let stream_id = SmSessionId::new("stream-partial");
+    let surviving: Vec<u32> = sm_storage
+        .list_unacked(&stream_id)
+        .await
+        .unwrap()
+        .iter()
+        .map(|row| row.sequence)
+        .collect();
+    assert_eq!(
+        surviving,
+        vec![2],
+        "successfully promoted stanzas' durable rows must be deleted after tick 1"
+    );
+
+    // Tick 2: janitor drains the reinserted session — it must retry
+    // ONLY the failed stanza.
+    let drained = sm_registry.drain_expired().await.unwrap();
+    assert_eq!(drained.len(), 1);
+    let retry_sequences: Vec<u32> = drained[0]
+        .unacked_stanzas
+        .iter()
+        .map(|entry| entry.sequence)
+        .collect();
+    assert_eq!(
+        retry_sequences,
+        vec![2],
+        "the reinserted session must retain only the failed stanza"
+    );
+
+    // Storage recovers: retry queues stanza 2 exactly once.
+    flaky.disarm();
+    promote_displaced_sessions(
+        drained,
+        DisplacedPromotionDeps {
+            sm_registry: &sm_registry,
+            connection_registry: &registry,
+            pending_storage: &pending,
+            blocking_storage: blocking.as_ref(),
+            server_domain: "example.com",
+        },
+    )
+    .await;
+
+    let rows = pending.list(&bare("alice@example.com")).await.unwrap();
+    assert_eq!(
+        transient_bodies(&rows),
+        vec![
+            "msg-1".to_string(),
+            "msg-2".to_string(),
+            "msg-3".to_string()
+        ],
+        "after recovery every stanza must be queued exactly once — no duplicates"
+    );
+    assert!(
+        sm_storage.get_session(&stream_id).await.unwrap().is_none(),
+        "full success confirms the drain, erasing the durable session row"
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/sm_promotion/tests.rs
+++ b/server/crates/waddle-server/src/sm_promotion/tests.rs
@@ -21,6 +21,18 @@ fn bare(s: &str) -> BareJid {
     s.parse().unwrap()
 }
 
+fn direct_target(
+    wire_id: &str,
+    author: &str,
+    archive: &str,
+) -> waddle_xmpp::tombstone::TombstoneTarget {
+    waddle_xmpp::tombstone::TombstoneTarget::Direct {
+        wire_id: wire_id.to_string(),
+        author: bare(author),
+        archive: bare(archive),
+    }
+}
+
 fn detached_session_with_unacked(
     stream_id: &str,
     jid: FullJid,
@@ -160,8 +172,7 @@ impl PendingDeliveryStorage for AlwaysFailingPending {
     }
     async fn scrub_for_tombstone(
         &self,
-        _target_id: &str,
-        _archive_jid: &jid::BareJid,
+        _target: &waddle_xmpp::tombstone::TombstoneTarget,
     ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
         Ok(0)
     }
@@ -1350,10 +1361,7 @@ async fn promotion_scrubs_stanzas_matching_recent_tombstone() {
         // Recorded AFTER the session's stanzas were received, so the
         // backward-in-time scope applies.
         &[waddle_xmpp::stream_management::RecentTombstoneRecord {
-            key: waddle_xmpp::stream_management::TombstoneKey {
-                target_id: "retract-me".to_string(),
-                archive_jid: bare("alice@example.com"),
-            },
+            key: direct_target("retract-me", "bob@elsewhere", "alice@example.com"),
             recorded_at_utc: Utc::now(),
         }],
     )
@@ -1403,10 +1411,7 @@ async fn tombstone_does_not_scrub_stanza_received_after_its_recording() {
         &Blocklist::empty(),
         "example.com",
         &[waddle_xmpp::stream_management::RecentTombstoneRecord {
-            key: waddle_xmpp::stream_management::TombstoneKey {
-                target_id: "retract-me".to_string(),
-                archive_jid: bare("alice@example.com"),
-            },
+            key: direct_target("retract-me", "bob@elsewhere", "alice@example.com"),
             recorded_at_utc: Utc::now() - chrono::Duration::hours(1),
         }],
     )
@@ -1457,10 +1462,7 @@ async fn tombstone_scrubs_stanza_whose_receipt_reads_slightly_after_recording() 
         &Blocklist::empty(),
         "example.com",
         &[waddle_xmpp::stream_management::RecentTombstoneRecord {
-            key: waddle_xmpp::stream_management::TombstoneKey {
-                target_id: "retract-me".to_string(),
-                archive_jid: bare("alice@example.com"),
-            },
+            key: direct_target("retract-me", "bob@elsewhere", "alice@example.com"),
             recorded_at_utc: Utc::now() - chrono::Duration::seconds(30),
         }],
     )
@@ -1516,7 +1518,11 @@ async fn retraction_racing_in_flight_promotion_does_not_deliver_retracted_conten
 
     // Step 2: retraction scrub lands mid-promotion.
     sm_registry
-        .scrub_unacked_for_tombstone("retract-me", &bare("alice@example.com"))
+        .scrub_unacked_for_tombstone(&direct_target(
+            "retract-me",
+            "bob@elsewhere",
+            "alice@example.com",
+        ))
         .await
         .unwrap();
 
@@ -1556,8 +1562,7 @@ struct MidBatchRetractingBlocking {
     sm_registry: Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
     calls: std::sync::atomic::AtomicU32,
     retract_on_call: u32,
-    target_id: &'static str,
-    archive_jid: BareJid,
+    target: waddle_xmpp::tombstone::TombstoneTarget,
 }
 
 #[async_trait::async_trait]
@@ -1571,7 +1576,7 @@ impl waddle_xmpp::xep::xep0191::BlockingStorage for MidBatchRetractingBlocking {
         let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
         if call == self.retract_on_call {
             self.sm_registry
-                .scrub_unacked_for_tombstone(self.target_id, &self.archive_jid)
+                .scrub_unacked_for_tombstone(&self.target)
                 .await
                 .expect("mid-batch scrub must succeed");
         }
@@ -1615,8 +1620,7 @@ async fn mid_batch_retraction_still_scrubs_later_sessions_in_displaced_promotion
         sm_registry: Arc::clone(&sm_registry),
         calls: std::sync::atomic::AtomicU32::new(0),
         retract_on_call: 2,
-        target_id: "retract-me",
-        archive_jid: bare("carol@example.com"),
+        target: direct_target("retract-me", "bob@elsewhere", "carol@example.com"),
     };
     let pending: Arc<dyn PendingDeliveryStorage> =
         Arc::new(InMemoryPendingDeliveryStorage::unlimited());
@@ -1644,6 +1648,196 @@ async fn mid_batch_retraction_still_scrubs_later_sessions_in_displaced_promotion
         vec!["safe".to_string()],
         "a retraction landing mid-batch must still scrub the later \
          session's matching stanza"
+    );
+}
+
+/// PendingDeliveryStorage wrapper that fires a XEP-0424 retraction on
+/// the shared SM registry immediately BEFORE its first `insert`
+/// commits — models the finding-B TOCTOU: the retraction lands after
+/// the per-session recent-tombstones snapshot was taken (the session
+/// is off both registry maps, so scrub phases 1-4 see nothing, and
+/// the pending row is not inserted yet, so the retraction's own
+/// pending scrub removes nothing either), and the promotion then
+/// inserts the retracted stanza.
+struct RetractDuringInsertPending {
+    inner: InMemoryPendingDeliveryStorage,
+    sm_registry: Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
+    target: waddle_xmpp::tombstone::TombstoneTarget,
+    fired: std::sync::atomic::AtomicBool,
+}
+
+#[async_trait::async_trait]
+impl PendingDeliveryStorage for RetractDuringInsertPending {
+    async fn insert(
+        &self,
+        row: waddle_xmpp::pending_delivery::PendingRow,
+    ) -> Result<
+        waddle_xmpp::pending_delivery::InsertOutcome,
+        waddle_xmpp::pending_delivery::storage::PendingStorageError,
+    > {
+        if !self.fired.swap(true, std::sync::atomic::Ordering::SeqCst) {
+            use waddle_xmpp::stream_management::SmSessionRegistry;
+            // The retraction's registry scrub: records the recent
+            // tombstone; the drained session is off both maps so no
+            // in-memory phase matches.
+            self.sm_registry
+                .scrub_unacked_for_tombstone(&self.target)
+                .await
+                .expect("racing scrub must succeed");
+            // The retraction's own pending-delivery scrub: runs before
+            // this insert commits, so it removes nothing.
+            self.inner
+                .scrub_for_tombstone(&self.target)
+                .await
+                .expect("racing pending scrub must succeed");
+        }
+        self.inner.insert(row).await
+    }
+    async fn list(
+        &self,
+        recipient: &BareJid,
+    ) -> Result<
+        Vec<waddle_xmpp::pending_delivery::PendingRow>,
+        waddle_xmpp::pending_delivery::storage::PendingStorageError,
+    > {
+        self.inner.list(recipient).await
+    }
+    async fn claim_for_session(
+        &self,
+        recipient: &BareJid,
+        session: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<
+        Vec<waddle_xmpp::pending_delivery::PendingRow>,
+        waddle_xmpp::pending_delivery::storage::PendingStorageError,
+    > {
+        self.inner.claim_for_session(recipient, session).await
+    }
+    async fn delete_claimed(
+        &self,
+        session: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.delete_claimed(session).await
+    }
+    async fn delete_row(
+        &self,
+        id: &waddle_xmpp::pending_delivery::PendingRowId,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.delete_row(id).await
+    }
+    async fn release_claim(
+        &self,
+        session: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.release_claim(session).await
+    }
+    async fn release_row(
+        &self,
+        id: &waddle_xmpp::pending_delivery::PendingRowId,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.release_row(id).await
+    }
+    async fn record_pushed_at(
+        &self,
+        id: &waddle_xmpp::pending_delivery::PendingRowId,
+        sequence: u32,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.record_pushed_at(id, sequence).await
+    }
+    async fn delete_acked_through(
+        &self,
+        session: &waddle_xmpp::pending_delivery::SmSessionId,
+        sequence_max: u32,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.delete_acked_through(session, sequence_max).await
+    }
+    async fn list_orphaned_claims(
+        &self,
+        live_sessions: &[waddle_xmpp::pending_delivery::SmSessionId],
+    ) -> Result<
+        Vec<(
+            waddle_xmpp::pending_delivery::PendingRowId,
+            waddle_xmpp::pending_delivery::SmSessionId,
+        )>,
+        waddle_xmpp::pending_delivery::storage::PendingStorageError,
+    > {
+        self.inner.list_orphaned_claims(live_sessions).await
+    }
+    async fn count(
+        &self,
+        recipient: &BareJid,
+    ) -> Result<u32, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.count(recipient).await
+    }
+    async fn delete_older_than(
+        &self,
+        cutoff: chrono::DateTime<chrono::Utc>,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.delete_older_than(cutoff).await
+    }
+    async fn scrub_for_tombstone(
+        &self,
+        target: &waddle_xmpp::tombstone::TombstoneTarget,
+    ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
+        self.inner.scrub_for_tombstone(target).await
+    }
+}
+
+#[tokio::test]
+async fn retraction_landing_after_tombstone_snapshot_still_scrubs_promoted_rows() {
+    // FINDING B (retraction-vs-promotion TOCTOU): the recent-tombstone
+    // snapshot is fetched per session BEFORE promote_session_unacked.
+    // A retraction landing between that fetch and the pending insert
+    // is invisible everywhere: the session is off both registry maps
+    // (scrub phases find nothing) and its pending row isn't inserted
+    // yet (the retraction's pending scrub removes nothing). Without a
+    // post-promotion re-check the retracted stanza reaches
+    // pending_delivery and delivers at the next login.
+    use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
+    use waddle_xmpp::xep::xep0191::{BlockingStorage, InMemoryBlockingStorage};
+
+    let sm_registry = Arc::new(InMemorySmSessionRegistry::new());
+    let sessions = vec![detached_session_with_unacked(
+        "stream-toctou",
+        full("alice@example.com/laptop"),
+        vec![
+            dm_xml_with_id(
+                "bob@elsewhere/x",
+                "alice@example.com",
+                "retract-me",
+                "secret",
+            ),
+            dm_xml_with_id("bob@elsewhere/x", "alice@example.com", "keep-me", "safe"),
+        ],
+    )];
+    let pending_impl = Arc::new(RetractDuringInsertPending {
+        inner: InMemoryPendingDeliveryStorage::unlimited(),
+        sm_registry: Arc::clone(&sm_registry),
+        target: direct_target("retract-me", "bob@elsewhere", "alice@example.com"),
+        fired: std::sync::atomic::AtomicBool::new(false),
+    });
+    let pending: Arc<dyn PendingDeliveryStorage> = Arc::clone(&pending_impl) as _;
+    let registry = ConnectionRegistry::new();
+    let blocking: Arc<dyn BlockingStorage> = Arc::new(InMemoryBlockingStorage::new());
+
+    promote_displaced_sessions(
+        sessions,
+        DisplacedPromotionDeps {
+            sm_registry: &sm_registry,
+            connection_registry: &registry,
+            pending_storage: &pending,
+            blocking_storage: blocking.as_ref(),
+            server_domain: "example.com",
+        },
+    )
+    .await;
+
+    let rows = pending.list(&bare("alice@example.com")).await.unwrap();
+    assert_eq!(
+        transient_bodies(&rows),
+        vec!["safe".to_string()],
+        "a retraction recorded after the pre-promotion tombstone snapshot \
+         must still scrub the promoted pending row before the drain is \
+         confirmed"
     );
 }
 
@@ -1777,10 +1971,9 @@ impl PendingDeliveryStorage for FlakyPending {
     }
     async fn scrub_for_tombstone(
         &self,
-        target_id: &str,
-        archive_jid: &jid::BareJid,
+        target: &waddle_xmpp::tombstone::TombstoneTarget,
     ) -> Result<u64, waddle_xmpp::pending_delivery::storage::PendingStorageError> {
-        self.inner.scrub_for_tombstone(target_id, archive_jid).await
+        self.inner.scrub_for_tombstone(target).await
     }
 }
 

--- a/server/crates/waddle-server/src/sm_promotion/types.rs
+++ b/server/crates/waddle-server/src/sm_promotion/types.rs
@@ -21,6 +21,11 @@ pub enum PromotedOutcome {
     /// Skipped — stanza could not be parsed back to a typed value
     /// (corrupt unacked queue entry). Logged for operator visibility.
     Unparseable,
+    /// Dropped because a recently applied XEP-0424/0425 tombstone
+    /// matches this stanza (round-2 review R2): the retraction raced
+    /// the drain, so the promotion-time re-check scrubs the in-flight
+    /// copy instead of delivering retracted content on next login.
+    Scrubbed,
     /// Storage backend failure — `pending_delivery.insert` returned
     /// `Err`. The caller MUST treat this as a transient promotion
     /// failure and SKIP `confirm_drained` for the owning session so
@@ -40,15 +45,27 @@ pub struct PromotionSummary {
     pub dropped: u32,
     pub not_promotable: u32,
     pub unparseable: u32,
+    /// Number of stanzas dropped by the promotion-time recent-
+    /// tombstone re-check (round-2 review R2). Counted separately
+    /// from `dropped` so retraction-race scrubs stay visible in the
+    /// per-session summary logs.
+    pub scrubbed: u32,
     /// Number of stanzas that failed to insert into pending storage.
     /// Non-zero means the session's promotion was lossy: the caller
     /// MUST NOT call `confirm_drained` for this session, so its
     /// durable SM row survives for restart-time retry.
     pub storage_failed: u32,
+    /// XEP-0198 sequences of every stanza this promotion pass fully
+    /// handled (every outcome except [`PromotedOutcome::StorageFailure`]).
+    /// On a partial failure the retry path durably deletes exactly
+    /// these `sm_unacked` rows and drops them from the reinserted
+    /// session, so the next tick retries only the failed stanzas
+    /// (round-2 review R4) instead of re-promoting the whole queue.
+    pub promoted_sequences: Vec<u32>,
 }
 
 impl PromotionSummary {
-    pub(super) fn record(&mut self, outcome: &PromotedOutcome) {
+    pub(super) fn record(&mut self, sequence: u32, outcome: &PromotedOutcome) {
         match outcome {
             PromotedOutcome::Redelivered { .. } => self.redelivered += 1,
             PromotedOutcome::Queued => self.queued += 1,
@@ -56,7 +73,11 @@ impl PromotionSummary {
             PromotedOutcome::Dropped => self.dropped += 1,
             PromotedOutcome::NotPromotable => self.not_promotable += 1,
             PromotedOutcome::Unparseable => self.unparseable += 1,
+            PromotedOutcome::Scrubbed => self.scrubbed += 1,
             PromotedOutcome::StorageFailure => self.storage_failed += 1,
+        }
+        if !matches!(outcome, PromotedOutcome::StorageFailure) {
+            self.promoted_sequences.push(sequence);
         }
     }
 

--- a/server/crates/waddle-xmpp/src/lib.rs
+++ b/server/crates/waddle-xmpp/src/lib.rs
@@ -44,6 +44,7 @@ pub mod registry;
 pub mod roster;
 pub mod routing;
 pub mod stream_management;
+pub mod tombstone;
 pub mod xep;
 
 mod app_state;

--- a/server/crates/waddle-xmpp/src/muc/affiliation/membership.rs
+++ b/server/crates/waddle-xmpp/src/muc/affiliation/membership.rs
@@ -1,0 +1,42 @@
+//! Durable room-membership source used for spawn-time hydration.
+//!
+//! A freshly spawned [`crate::muc::room_actor::RoomActor`] starts with an
+//! empty in-memory affiliation list; before #1135 the durable inbox
+//! recipient set in [`crate::muc::room_actor::GetRoomSnapshot`] was derived
+//! only from joins and point mutations observed *since spawn*, so offline
+//! members silently dropped out of inbox/notification fan-out after a
+//! deploy or actor respawn. Implementations of this trait bridge to the
+//! deployment's durable membership store (permission tuples) without
+//! introducing a database dependency into `waddle-xmpp`.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use jid::BareJid;
+
+use crate::XmppError;
+
+/// Boxed future returned by [`DurableMembershipSource::list_durable_member_jids`].
+///
+/// Boxed (rather than RPITIT like [`super::AffiliationResolver`]) so the
+/// trait stays dyn-compatible: the room registry holds it as
+/// `Arc<dyn DurableMembershipSource>` and forwards it to each freshly
+/// spawned room actor.
+pub type DurableMembershipFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<Vec<BareJid>, XmppError>> + Send + 'a>>;
+
+/// Source of durable (persisted) room membership.
+///
+/// Returns the bare JIDs of every user durably affiliated at
+/// `Member` or above with the channel identified by
+/// (`waddle_id`, `channel_id`) — the set that must receive durable
+/// inbox rows / notification candidates for groupchat messages even
+/// when they have not joined the current room-actor incarnation.
+pub trait DurableMembershipSource: Send + Sync {
+    /// List the bare JIDs durably affiliated at `Member`+ with the channel.
+    fn list_durable_member_jids(
+        &self,
+        waddle_id: &str,
+        channel_id: &str,
+    ) -> DurableMembershipFuture<'_>;
+}

--- a/server/crates/waddle-xmpp/src/muc/affiliation/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/affiliation/mod.rs
@@ -19,10 +19,12 @@
 
 mod config;
 mod list;
+mod membership;
 mod resolver;
 
 pub use config::{FederatedAffiliationConfig, FederatedPermissionPolicy};
 pub use list::{AffiliationChange, AffiliationEntry, AffiliationList};
+pub use membership::{DurableMembershipFuture, DurableMembershipSource};
 pub use resolver::{AffiliationResolver, AppStateAffiliationResolver};
 
 #[cfg(test)]

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -182,6 +182,15 @@ pub struct RoomActor {
     /// mirror of the durable store it does not block room dormancy
     /// ([`MucRoom::is_dormant`]) the way in-memory-only affiliations do.
     durable_member_recipients: Vec<BareJid>,
+    /// The durable membership source received in
+    /// [`HydrateDurableRecipients`], retained so an affiliation change
+    /// to `None` can re-run hydration (round-2 review R1): the durable
+    /// union covers channel AND space relations, so revoking only the
+    /// explicit channel grant must not prune a user who remains
+    /// space-entitled. `None` until first hydration (tests spawning a
+    /// bare actor; pre-hydration mutations fall back to the plain
+    /// prune, which is the fail-closed direction).
+    membership_source: Option<std::sync::Arc<dyn super::affiliation::DurableMembershipSource>>,
 }
 
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
@@ -222,27 +231,93 @@ impl RoomActor {
             admission_revision: 0,
             occupant_id_secret,
             durable_member_recipients: Vec::new(),
+            membership_source: None,
         }
     }
 
     /// Drop a JID from the spawn-time hydrated durable-recipient
     /// mirror (#1135) when a runtime affiliation mutation removes its
-    /// membership (F1).
+    /// membership (F1). Returns whether the caller must re-run
+    /// hydration afterwards via
+    /// [`Self::refresh_durable_recipients_from_source`].
     ///
     /// Every affiliation-mutating handler must call this with the JID
     /// and the *requested* affiliation — unconditionally, even when
     /// `MucRoom::set_affiliation` reports no stored change, because a
     /// hydrated-only member has no affiliation-list entry (its stored
     /// affiliation is already `None`) yet still needs pruning from the
-    /// mirror. Pruning is respawn-consistent: re-hydration reads the
-    /// already-updated durable tuples, and a later re-grant to
-    /// `Member`+ is covered by the affiliation-list side of the
-    /// durable-recipient union in
+    /// mirror.
+    ///
+    /// - `Outcast` (ban) is unambiguous: the direct prune is final and
+    ///   needs no re-hydration — the snapshot's Outcast filter backs
+    ///   it up regardless of what the durable union reports.
+    /// - `None` only revokes the *requested channel affiliation*; the
+    ///   durable union hydrated at spawn also covers SPACE-level
+    ///   relations (round-2 review R1), so the caller must re-run
+    ///   hydration to converge the mirror to the durable truth —
+    ///   otherwise a space-entitled member silently loses inbox
+    ///   fan-out until respawn. The prune still runs first so a
+    ///   failed re-hydration fails toward NOT delivering (F1).
+    ///
+    /// A later re-grant to `Member`+ is covered by the
+    /// affiliation-list side of the durable-recipient union in
     /// [`snapshot_handlers::GetRoomSnapshot`].
-    fn prune_durable_recipient_if_removed(&mut self, jid: &BareJid, new_affiliation: Affiliation) {
-        if matches!(new_affiliation, Affiliation::None | Affiliation::Outcast) {
-            self.durable_member_recipients
-                .retain(|recipient| recipient != jid);
+    #[must_use]
+    fn prune_durable_recipient_if_removed(
+        &mut self,
+        jid: &BareJid,
+        new_affiliation: Affiliation,
+    ) -> bool {
+        match new_affiliation {
+            Affiliation::Outcast => {
+                self.durable_member_recipients
+                    .retain(|recipient| recipient != jid);
+                false
+            }
+            Affiliation::None => {
+                self.durable_member_recipients
+                    .retain(|recipient| recipient != jid);
+                true
+            }
+            Affiliation::Owner | Affiliation::Admin | Affiliation::Member => false,
+        }
+    }
+
+    /// Re-run durable-membership hydration against the retained source
+    /// (round-2 review R1), replacing the mirror with the query result.
+    ///
+    /// Called by affiliation handlers after a prune-to-`None` so the
+    /// mirror converges to the durable channel∪space truth (rare
+    /// event, one reply-timeout-bounded query). Because the query is
+    /// awaited *inside* the mutating handler and Kameo processes
+    /// messages sequentially, no [`snapshot_handlers::GetRoomSnapshot`]
+    /// can observe an intermediate state — the prune and the refresh
+    /// are atomic from the mailbox's perspective, so a pruned member
+    /// can never transiently resurrect. On query failure the mirror is
+    /// left as pruned: fail toward NOT delivering to the removed jid
+    /// (privacy beats availability — F1).
+    async fn refresh_durable_recipients_from_source(&mut self) {
+        let Some(source) = self.membership_source.clone() else {
+            return;
+        };
+        match source
+            .list_durable_member_jids(&self.room.waddle_id, &self.room.channel_id)
+            .await
+        {
+            Ok(mut members) => {
+                members.sort();
+                members.dedup();
+                self.durable_member_recipients = members;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    room = %self.room.room_jid,
+                    %error,
+                    "durable membership re-hydration after affiliation removal \
+                     failed; keeping the pruned mirror (fail toward not \
+                     delivering to the removed member)"
+                );
+            }
         }
     }
 }
@@ -272,6 +347,10 @@ impl kameo::message::Message<HydrateDurableRecipients> for RoomActor {
         msg: HydrateDurableRecipients,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        // Retain the source so affiliation changes to `None` can
+        // re-run hydration later (round-2 review R1) instead of
+        // guessing whether the member is still space-entitled.
+        self.membership_source = Some(std::sync::Arc::clone(&msg.source));
         match msg
             .source
             .list_durable_member_jids(&self.room.waddle_id, &self.room.channel_id)
@@ -602,13 +681,16 @@ impl kameo::message::Message<ChangeAffiliation> for RoomActor {
         msg: ChangeAffiliation,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        self.prune_durable_recipient_if_removed(&msg.jid, msg.affiliation);
+        let needs_rehydration = self.prune_durable_recipient_if_removed(&msg.jid, msg.affiliation);
         if self
             .room
             .set_affiliation(msg.jid, msg.affiliation)
             .is_some()
         {
             self.admission_revision = self.admission_revision.saturating_add(1);
+        }
+        if needs_rehydration {
+            self.refresh_durable_recipients_from_source().await;
         }
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -224,6 +224,27 @@ impl RoomActor {
             durable_member_recipients: Vec::new(),
         }
     }
+
+    /// Drop a JID from the spawn-time hydrated durable-recipient
+    /// mirror (#1135) when a runtime affiliation mutation removes its
+    /// membership (F1).
+    ///
+    /// Every affiliation-mutating handler must call this with the JID
+    /// and the *requested* affiliation — unconditionally, even when
+    /// `MucRoom::set_affiliation` reports no stored change, because a
+    /// hydrated-only member has no affiliation-list entry (its stored
+    /// affiliation is already `None`) yet still needs pruning from the
+    /// mirror. Pruning is respawn-consistent: re-hydration reads the
+    /// already-updated durable tuples, and a later re-grant to
+    /// `Member`+ is covered by the affiliation-list side of the
+    /// durable-recipient union in
+    /// [`snapshot_handlers::GetRoomSnapshot`].
+    fn prune_durable_recipient_if_removed(&mut self, jid: &BareJid, new_affiliation: Affiliation) {
+        if matches!(new_affiliation, Affiliation::None | Affiliation::Outcast) {
+            self.durable_member_recipients
+                .retain(|recipient| recipient != jid);
+        }
+    }
 }
 
 /// Hydrate this actor incarnation's durable-recipient set from the
@@ -581,6 +602,7 @@ impl kameo::message::Message<ChangeAffiliation> for RoomActor {
         msg: ChangeAffiliation,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.prune_durable_recipient_if_removed(&msg.jid, msg.affiliation);
         if self
             .room
             .set_affiliation(msg.jid, msg.affiliation)

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -173,6 +173,15 @@ pub struct RoomActor {
     config_revision: u64,
     admission_revision: u64,
     occupant_id_secret: crate::xep::xep0421::OccupantIdSecret,
+    /// Durable membership hydrated from the deployment's membership
+    /// source at spawn (#1135). Kept separate from
+    /// `MucRoom.affiliation_list` on purpose: it never grants join /
+    /// admin rights and never clobbers richer session-observed
+    /// affiliations (owner/admin) — it only widens the durable inbox
+    /// recipient set computed by [`GetRoomSnapshot`], and being a pure
+    /// mirror of the durable store it does not block room dormancy
+    /// ([`MucRoom::is_dormant`]) the way in-memory-only affiliations do.
+    durable_member_recipients: Vec<BareJid>,
 }
 
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
@@ -212,6 +221,54 @@ impl RoomActor {
             config_revision: 0,
             admission_revision: 0,
             occupant_id_secret,
+            durable_member_recipients: Vec::new(),
+        }
+    }
+}
+
+/// Hydrate this actor incarnation's durable-recipient set from the
+/// deployment's durable membership store (#1135).
+///
+/// The room registry enqueues this as the *first* message after
+/// spawning a `RoomActor`, before handing the actor ref to any caller.
+/// Because the mailbox is FIFO and the actor processes messages
+/// sequentially, every later [`GetRoomSnapshot`] observes the hydrated
+/// set — there is no window in which a groupchat message fans out
+/// against a not-yet-hydrated recipient list.
+///
+/// Fail-open on source errors: the actor keeps serving with
+/// session-observed affiliations only (pre-#1135 behavior) rather than
+/// wedging the room.
+pub struct HydrateDurableRecipients {
+    pub source: std::sync::Arc<dyn super::affiliation::DurableMembershipSource>,
+}
+
+impl kameo::message::Message<HydrateDurableRecipients> for RoomActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: HydrateDurableRecipients,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        match msg
+            .source
+            .list_durable_member_jids(&self.room.waddle_id, &self.room.channel_id)
+            .await
+        {
+            Ok(mut members) => {
+                members.sort();
+                members.dedup();
+                self.durable_member_recipients = members;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    room = %self.room.room_jid,
+                    %error,
+                    "durable membership hydration failed; durable inbox \
+                     recipients limited to session-observed affiliations"
+                );
+            }
         }
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
@@ -299,6 +299,7 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
         let mut presence_updates: Vec<(FullJid, Presence)> = Vec::new();
         let mut removed_by_moderation: Vec<FullJid> = Vec::new();
         let mut occupants_to_kick: Vec<String> = Vec::new();
+        let mut needs_rehydration = false;
         if is_role_change_query(&msg.items) {
             for item in &msg.items {
                 let Some(target_nick) = item.nick.as_ref() else {
@@ -506,7 +507,8 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                     Some(&actor),
                     item.reason.as_deref(),
                 )?;
-                self.prune_durable_recipient_if_removed(&target_jid, new_affiliation);
+                needs_rehydration |=
+                    self.prune_durable_recipient_if_removed(&target_jid, new_affiliation);
                 if target_current_affiliation != new_affiliation {
                     self.admission_revision = self.admission_revision.saturating_add(1);
                 }
@@ -516,6 +518,13 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
         }
         for nick in occupants_to_kick {
             self.room.remove_occupant(&nick);
+        }
+        if needs_rehydration {
+            // R1: converge the durable-recipient mirror to the durable
+            // channel∪space truth after any removal to `None` — a
+            // space-entitled member must not lose fan-out (see
+            // `RoomActor::refresh_durable_recipients_from_source`).
+            self.refresh_durable_recipients_from_source().await;
         }
         Ok(AdminItemsApplied {
             presence_updates,
@@ -547,9 +556,12 @@ impl kameo::message::Message<ApplyAffiliationChange> for RoomActor {
             msg.actor.as_ref(),
             None,
         )?;
-        self.prune_durable_recipient_if_removed(&msg.jid, msg.affiliation);
+        let needs_rehydration = self.prune_durable_recipient_if_removed(&msg.jid, msg.affiliation);
         if previous_affiliation != msg.affiliation {
             self.admission_revision = self.admission_revision.saturating_add(1);
+        }
+        if needs_rehydration {
+            self.refresh_durable_recipients_from_source().await;
         }
         Ok(updates)
     }
@@ -588,12 +600,17 @@ impl kameo::message::Message<EnforceMembersOnlyAffiliations> for RoomActor {
             .values()
             .map(|occupant| occupant.real_jid.to_bare())
             .collect();
+        let mut needs_rehydration = false;
         for jid in occupied_jids {
             let affiliation = affiliations.get(&jid).copied().unwrap_or(Affiliation::None);
-            self.prune_durable_recipient_if_removed(&jid, affiliation);
+            needs_rehydration |= self.prune_durable_recipient_if_removed(&jid, affiliation);
             if self.room.set_affiliation(jid, affiliation).is_some() {
                 self.admission_revision = self.admission_revision.saturating_add(1);
             }
+        }
+        if needs_rehydration {
+            // R1: see `RoomActor::refresh_durable_recipients_from_source`.
+            self.refresh_durable_recipients_from_source().await;
         }
         enforce_members_only(&mut self.room, &self.occupant_id_secret)
     }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
@@ -501,11 +501,12 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                 let applied = apply_affiliation_change(
                     &mut self.room,
                     &self.occupant_id_secret,
-                    target_jid,
+                    target_jid.clone(),
                     new_affiliation,
                     Some(&actor),
                     item.reason.as_deref(),
                 )?;
+                self.prune_durable_recipient_if_removed(&target_jid, new_affiliation);
                 if target_current_affiliation != new_affiliation {
                     self.admission_revision = self.admission_revision.saturating_add(1);
                 }
@@ -541,11 +542,12 @@ impl kameo::message::Message<ApplyAffiliationChange> for RoomActor {
         let updates = apply_affiliation_change(
             &mut self.room,
             &self.occupant_id_secret,
-            msg.jid,
+            msg.jid.clone(),
             msg.affiliation,
             msg.actor.as_ref(),
             None,
         )?;
+        self.prune_durable_recipient_if_removed(&msg.jid, msg.affiliation);
         if previous_affiliation != msg.affiliation {
             self.admission_revision = self.admission_revision.saturating_add(1);
         }
@@ -588,6 +590,7 @@ impl kameo::message::Message<EnforceMembersOnlyAffiliations> for RoomActor {
             .collect();
         for jid in occupied_jids {
             let affiliation = affiliations.get(&jid).copied().unwrap_or(Affiliation::None);
+            self.prune_durable_recipient_if_removed(&jid, affiliation);
             if self.room.set_affiliation(jid, affiliation).is_some() {
                 self.admission_revision = self.admission_revision.saturating_add(1);
             }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/snapshot_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/snapshot_handlers.rs
@@ -118,6 +118,13 @@ impl kameo::message::Message<GetRoomSnapshot> for RoomActor {
         let sender_nickname_generation = sender_nick
             .as_deref()
             .and_then(|nick| self.room.current_nickname_generation(nick));
+        // Durable recipients = session-observed Member+ affiliations ∪
+        // the spawn-time hydrated durable membership (#1135). The
+        // hydrated set covers offline members who never joined this
+        // actor incarnation; the affiliation-list side keeps runtime
+        // grants visible immediately. A runtime demotion to Outcast
+        // wins over the hydrated mirror so banned members drop out of
+        // inbox fan-out without waiting for a respawn.
         let mut durable_recipient_bare_jids = self
             .room
             .get_all_affiliations()
@@ -125,6 +132,12 @@ impl kameo::message::Message<GetRoomSnapshot> for RoomActor {
             .filter(|entry| entry.affiliation >= Affiliation::Member)
             .map(|entry| entry.jid)
             .collect::<Vec<_>>();
+        durable_recipient_bare_jids.extend(
+            self.durable_member_recipients
+                .iter()
+                .filter(|jid| self.room.get_affiliation(jid) != Affiliation::Outcast)
+                .cloned(),
+        );
         durable_recipient_bare_jids.sort();
         durable_recipient_bare_jids.dedup();
 

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -1418,6 +1418,201 @@ async fn room_snapshot_includes_durable_member_recipients_from_same_actor_read()
     );
 }
 
+// ---------------------------------------------------------------------------
+// F1 — hydrated durable recipients must not survive membership removal.
+//
+// The spawn-time hydrated mirror (#1135) was only filtered against
+// `Affiliation::Outcast`, so every removal path that sets
+// `Affiliation::None` (group-DM leave, XEP-0045 admin removal, tuple
+// deletion) left the ex-member receiving inbox rows with preview text
+// until the actor respawned.
+// ---------------------------------------------------------------------------
+
+/// Fixed-list durable membership source for hydrating a room actor
+/// directly in tests (mirrors the registry-level fake in
+/// `room_registry_actor/tests.rs`).
+struct FixedMembershipSource {
+    members: Vec<BareJid>,
+}
+
+impl crate::muc::affiliation::DurableMembershipSource for FixedMembershipSource {
+    fn list_durable_member_jids(
+        &self,
+        _waddle_id: &str,
+        _channel_id: &str,
+    ) -> crate::muc::affiliation::DurableMembershipFuture<'_> {
+        let members = self.members.clone();
+        Box::pin(async move { Ok(members) })
+    }
+}
+
+async fn hydrate_durable_recipients(actor: &ActorRef<RoomActor>, members: Vec<BareJid>) {
+    actor
+        .ask(HydrateDurableRecipients {
+            source: std::sync::Arc::new(FixedMembershipSource { members }),
+        })
+        .await
+        .expect("hydrate durable recipients");
+}
+
+async fn snapshot_recipient_strings(actor: &ActorRef<RoomActor>) -> Vec<String> {
+    let snapshot = actor
+        .ask(GetRoomSnapshot {
+            sender_jid: test_full_jid("observer"),
+        })
+        .await
+        .expect("snapshot");
+    snapshot
+        .durable_recipient_bare_jids
+        .iter()
+        .map(ToString::to_string)
+        .collect()
+}
+
+#[tokio::test]
+async fn change_affiliation_to_none_prunes_hydrated_durable_recipient() {
+    let actor = spawn_room_actor().await;
+    hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+
+    actor
+        .ask(ChangeAffiliation {
+            jid: bare("alice@example.com"),
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("remove membership");
+
+    assert!(
+        snapshot_recipient_strings(&actor).await.is_empty(),
+        "a hydrated durable recipient whose affiliation is set to None \
+         must stop receiving inbox fan-out immediately, not at respawn"
+    );
+}
+
+#[tokio::test]
+async fn change_affiliation_to_outcast_prunes_hydrated_durable_recipient() {
+    let actor = spawn_room_actor().await;
+    hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+
+    actor
+        .ask(ChangeAffiliation {
+            jid: bare("alice@example.com"),
+            affiliation: Affiliation::Outcast,
+        })
+        .await
+        .expect("ban member");
+
+    assert!(
+        snapshot_recipient_strings(&actor).await.is_empty(),
+        "a banned hydrated durable recipient must drop out of fan-out"
+    );
+}
+
+#[tokio::test]
+async fn readded_member_reappears_in_durable_recipients_after_hydrated_prune() {
+    let actor = spawn_room_actor().await;
+    hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+
+    actor
+        .ask(ChangeAffiliation {
+            jid: bare("alice@example.com"),
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("remove membership");
+    actor
+        .ask(ChangeAffiliation {
+            jid: bare("alice@example.com"),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("re-add membership");
+
+    assert_eq!(
+        snapshot_recipient_strings(&actor).await,
+        vec!["alice@example.com".to_string()],
+        "a re-added member must reappear via the affiliation-list side \
+         of the durable-recipient union"
+    );
+}
+
+#[tokio::test]
+async fn apply_affiliation_change_to_none_prunes_hydrated_durable_recipient() {
+    let actor = spawn_room_actor().await;
+    hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+
+    actor
+        .ask(ApplyAffiliationChange {
+            actor: None,
+            jid: bare("alice@example.com"),
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("apply affiliation change");
+
+    assert!(
+        snapshot_recipient_strings(&actor).await.is_empty(),
+        "ApplyAffiliationChange to None must prune the hydrated mirror"
+    );
+}
+
+#[tokio::test]
+async fn apply_admin_items_removal_prunes_hydrated_durable_recipient() {
+    let actor = spawn_room_actor().await;
+    hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+
+    actor
+        .ask(ApplyAdminItems {
+            sender_jid: test_full_jid("owner"),
+            sender_affiliation: Affiliation::Owner,
+            sender_role: Role::Moderator,
+            items: vec![AdminItem {
+                jid: Some(bare("alice@example.com")),
+                nick: None,
+                affiliation: Some(Affiliation::None),
+                role: None,
+                reason: None,
+            }],
+        })
+        .await
+        .expect("apply admin items");
+
+    assert!(
+        snapshot_recipient_strings(&actor).await.is_empty(),
+        "the XEP-0045 admin batch removal path must prune the hydrated mirror"
+    );
+}
+
+#[tokio::test]
+async fn enforce_members_only_affiliations_prunes_hydrated_durable_recipient() {
+    let actor = spawn_room_actor().await;
+    hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+    actor
+        .ask(Join {
+            nick: "alice".to_string(),
+            real_jid: test_full_jid("alice"),
+            role: Role::Participant,
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("join alice");
+
+    // No durable affiliation tuples: the enforcement pass resolves
+    // every occupant to Affiliation::None.
+    actor
+        .ask(EnforceMembersOnlyAffiliations {
+            affiliations: Vec::new(),
+        })
+        .await
+        .expect("enforce members-only");
+
+    assert!(
+        snapshot_recipient_strings(&actor).await.is_empty(),
+        "the members-only enforcement pass must prune hydrated \
+         recipients whose durable affiliation resolved to None"
+    );
+}
+
 #[tokio::test]
 async fn list_affiliations_filter_outcast_returns_only_outcasts() {
     let actor = spawn_room_actor().await;

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -1428,11 +1428,35 @@ async fn room_snapshot_includes_durable_member_recipients_from_same_actor_read()
 // until the actor respawned.
 // ---------------------------------------------------------------------------
 
-/// Fixed-list durable membership source for hydrating a room actor
+/// Mutable durable membership source for hydrating a room actor
 /// directly in tests (mirrors the registry-level fake in
-/// `room_registry_actor/tests.rs`).
+/// `room_registry_actor/tests.rs`). Its member list can be updated
+/// mid-test to model the durable store changing (a GraphQL
+/// `persist_channel_affiliation` deleting channel tuples), and it can
+/// be armed to fail so the re-hydration failure path is exercisable.
 struct FixedMembershipSource {
-    members: Vec<BareJid>,
+    members: std::sync::Mutex<Vec<BareJid>>,
+    fail: std::sync::atomic::AtomicBool,
+}
+
+impl FixedMembershipSource {
+    fn new(members: Vec<BareJid>) -> Self {
+        Self {
+            members: std::sync::Mutex::new(members),
+            fail: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    /// Replace what the durable store reports — models tuple deletion
+    /// landing before the actor processes the affiliation change.
+    fn set_members(&self, members: Vec<BareJid>) {
+        *self.members.lock().expect("members lock") = members;
+    }
+
+    /// Make every subsequent query fail.
+    fn fail_queries(&self) {
+        self.fail.store(true, std::sync::atomic::Ordering::SeqCst);
+    }
 }
 
 impl crate::muc::affiliation::DurableMembershipSource for FixedMembershipSource {
@@ -1441,18 +1465,32 @@ impl crate::muc::affiliation::DurableMembershipSource for FixedMembershipSource 
         _waddle_id: &str,
         _channel_id: &str,
     ) -> crate::muc::affiliation::DurableMembershipFuture<'_> {
-        let members = self.members.clone();
-        Box::pin(async move { Ok(members) })
+        let fail = self.fail.load(std::sync::atomic::Ordering::SeqCst);
+        let members = self.members.lock().expect("members lock").clone();
+        Box::pin(async move {
+            if fail {
+                Err(crate::XmppError::internal(
+                    "simulated durable membership source failure",
+                ))
+            } else {
+                Ok(members)
+            }
+        })
     }
 }
 
-async fn hydrate_durable_recipients(actor: &ActorRef<RoomActor>, members: Vec<BareJid>) {
+async fn hydrate_durable_recipients(
+    actor: &ActorRef<RoomActor>,
+    members: Vec<BareJid>,
+) -> std::sync::Arc<FixedMembershipSource> {
+    let source = std::sync::Arc::new(FixedMembershipSource::new(members));
     actor
         .ask(HydrateDurableRecipients {
-            source: std::sync::Arc::new(FixedMembershipSource { members }),
+            source: std::sync::Arc::clone(&source) as _,
         })
         .await
         .expect("hydrate durable recipients");
+    source
 }
 
 async fn snapshot_recipient_strings(actor: &ActorRef<RoomActor>) -> Vec<String> {
@@ -1472,7 +1510,10 @@ async fn snapshot_recipient_strings(actor: &ActorRef<RoomActor>) -> Vec<String> 
 #[tokio::test]
 async fn change_affiliation_to_none_prunes_hydrated_durable_recipient() {
     let actor = spawn_room_actor().await;
-    hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+    let source = hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+    // Channel-only member: the durable channel tuples were deleted
+    // before the affiliation change reaches the actor.
+    source.set_members(Vec::new());
 
     actor
         .ask(ChangeAffiliation {
@@ -1492,7 +1533,10 @@ async fn change_affiliation_to_none_prunes_hydrated_durable_recipient() {
 #[tokio::test]
 async fn change_affiliation_to_outcast_prunes_hydrated_durable_recipient() {
     let actor = spawn_room_actor().await;
-    hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+    // The source deliberately KEEPS alice: a ban is unambiguous, so the
+    // direct prune must be final without any re-hydration query (and
+    // the snapshot's Outcast filter backs it up).
+    let _source = hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
 
     actor
         .ask(ChangeAffiliation {
@@ -1511,7 +1555,8 @@ async fn change_affiliation_to_outcast_prunes_hydrated_durable_recipient() {
 #[tokio::test]
 async fn readded_member_reappears_in_durable_recipients_after_hydrated_prune() {
     let actor = spawn_room_actor().await;
-    hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+    let source = hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+    source.set_members(Vec::new());
 
     actor
         .ask(ChangeAffiliation {
@@ -1539,7 +1584,8 @@ async fn readded_member_reappears_in_durable_recipients_after_hydrated_prune() {
 #[tokio::test]
 async fn apply_affiliation_change_to_none_prunes_hydrated_durable_recipient() {
     let actor = spawn_room_actor().await;
-    hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+    let source = hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+    source.set_members(Vec::new());
 
     actor
         .ask(ApplyAffiliationChange {
@@ -1556,10 +1602,124 @@ async fn apply_affiliation_change_to_none_prunes_hydrated_durable_recipient() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// R1 (round-2 review) — revoking only the explicit CHANNEL grant must
+// not prune a user who remains durably entitled via the SPACE: the
+// hydration union covers channel AND space relations, so an
+// affiliation change to None re-runs hydration and the mirror
+// converges to the durable truth instead of guessing. Only a source
+// failure falls back to the prune (privacy beats availability — F1).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn space_entitled_member_survives_channel_grant_revocation() {
+    let actor = spawn_room_actor().await;
+    // The durable union still reports alice (space-level member) even
+    // after her explicit channel grant is deleted.
+    let _source = hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+
+    actor
+        .ask(ChangeAffiliation {
+            jid: bare("alice@example.com"),
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("revoke channel grant");
+
+    assert_eq!(
+        snapshot_recipient_strings(&actor).await,
+        vec!["alice@example.com".to_string()],
+        "a space-entitled member must stay a durable recipient when only \
+         the explicit channel grant is revoked"
+    );
+}
+
+#[tokio::test]
+async fn space_entitled_member_survives_admin_item_revocation() {
+    let actor = spawn_room_actor().await;
+    let _source = hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+
+    actor
+        .ask(ApplyAdminItems {
+            sender_jid: test_full_jid("owner"),
+            sender_affiliation: Affiliation::Owner,
+            sender_role: Role::Moderator,
+            items: vec![AdminItem {
+                jid: Some(bare("alice@example.com")),
+                nick: None,
+                affiliation: Some(Affiliation::None),
+                role: None,
+                reason: None,
+            }],
+        })
+        .await
+        .expect("apply admin items");
+
+    assert_eq!(
+        snapshot_recipient_strings(&actor).await,
+        vec!["alice@example.com".to_string()],
+        "the XEP-0045 admin removal path must also converge to the \
+         durable truth for space-entitled members"
+    );
+}
+
+#[tokio::test]
+async fn space_entitled_member_survives_members_only_enforcement() {
+    let actor = spawn_room_actor().await;
+    let _source = hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+    actor
+        .ask(Join {
+            nick: "alice".to_string(),
+            real_jid: test_full_jid("alice"),
+            role: Role::Participant,
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("join alice");
+
+    actor
+        .ask(EnforceMembersOnlyAffiliations {
+            affiliations: Vec::new(),
+        })
+        .await
+        .expect("enforce members-only");
+
+    assert_eq!(
+        snapshot_recipient_strings(&actor).await,
+        vec!["alice@example.com".to_string()],
+        "members-only enforcement must not drop a member the durable \
+         union still reports (space entitlement)"
+    );
+}
+
+#[tokio::test]
+async fn rehydration_failure_keeps_revoked_jid_excluded() {
+    let actor = spawn_room_actor().await;
+    let source = hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+    // The re-hydration query fails: fail toward NOT delivering to the
+    // removed jid — keep the prune (F1: privacy beats availability).
+    source.fail_queries();
+
+    actor
+        .ask(ChangeAffiliation {
+            jid: bare("alice@example.com"),
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("revoke membership");
+
+    assert!(
+        snapshot_recipient_strings(&actor).await.is_empty(),
+        "when the re-hydration query fails, the None'd jid must stay \
+         excluded from durable fan-out"
+    );
+}
+
 #[tokio::test]
 async fn apply_admin_items_removal_prunes_hydrated_durable_recipient() {
     let actor = spawn_room_actor().await;
-    hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+    let source = hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+    source.set_members(Vec::new());
 
     actor
         .ask(ApplyAdminItems {
@@ -1586,7 +1746,8 @@ async fn apply_admin_items_removal_prunes_hydrated_durable_recipient() {
 #[tokio::test]
 async fn enforce_members_only_affiliations_prunes_hydrated_durable_recipient() {
     let actor = spawn_room_actor().await;
-    hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+    let source = hydrate_durable_recipients(&actor, vec![bare("alice@example.com")]).await;
+    source.set_members(Vec::new());
     actor
         .ask(Join {
             nick: "alice".to_string(),

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -5,6 +5,7 @@
 //! spawns per-room `RoomActor` instances on demand.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use jid::BareJid;
 use kameo::actor::{ActorRef, Spawn};
@@ -13,7 +14,8 @@ use kameo::Actor;
 use thiserror::Error;
 use tracing::{debug, info, warn};
 
-use super::room_actor::RoomActor;
+use super::affiliation::DurableMembershipSource;
+use super::room_actor::{HydrateDurableRecipients, RoomActor};
 use super::{MucRoom, RoomConfig};
 use crate::metrics;
 use crate::xep::xep0421::OccupantIdSecret;
@@ -31,6 +33,11 @@ pub struct RoomRegistryActor {
     /// `RoomActor` at spawn so all rooms in this deployment share the
     /// same keying material.
     occupant_id_secret: OccupantIdSecret,
+    /// Durable membership source used to hydrate each freshly spawned
+    /// `RoomActor`'s durable-recipient set (#1135). `None` in
+    /// deployments/tests without a durable membership store; such
+    /// rooms fall back to session-observed affiliations only.
+    membership_source: Option<Arc<dyn DurableMembershipSource>>,
 }
 
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
@@ -62,13 +69,28 @@ impl RoomRegistryActor {
             poisoned_rooms: HashSet::new(),
             muc_domain,
             occupant_id_secret,
+            membership_source: None,
         }
+    }
+
+    /// Attach a durable membership source so every spawned `RoomActor`
+    /// hydrates its durable-recipient set before serving snapshots (#1135).
+    #[must_use]
+    pub fn with_membership_source(mut self, source: Arc<dyn DurableMembershipSource>) -> Self {
+        self.membership_source = Some(source);
+        self
     }
 
     /// Spawn a `RoomActor` for the given room and insert it into the map.
     ///
+    /// When a [`DurableMembershipSource`] is configured, a
+    /// [`HydrateDurableRecipients`] message is enqueued as the very
+    /// first item in the fresh actor's FIFO mailbox *before* the actor
+    /// ref is handed to any caller, so every later `GetRoomSnapshot`
+    /// observes the hydrated durable-recipient set (#1135).
+    ///
     /// Returns a reference to the spawned actor.
-    fn spawn_room(
+    async fn spawn_room(
         &mut self,
         room_jid: BareJid,
         waddle_id: String,
@@ -77,6 +99,21 @@ impl RoomRegistryActor {
     ) -> ActorRef<RoomActor> {
         let room = MucRoom::new(room_jid.clone(), waddle_id, channel_id, config);
         let actor_ref = RoomActor::spawn(RoomActor::new(room, self.occupant_id_secret.clone()));
+        if let Some(source) = &self.membership_source {
+            if let Err(error) = actor_ref
+                .tell(HydrateDurableRecipients {
+                    source: Arc::clone(source),
+                })
+                .await
+            {
+                warn!(
+                    room = %room_jid,
+                    %error,
+                    "failed to enqueue durable-recipient hydration for \
+                     freshly spawned room actor"
+                );
+            }
+        }
         self.rooms.insert(room_jid, actor_ref.clone());
         actor_ref
     }
@@ -145,7 +182,9 @@ impl kameo::message::Message<GetOrCreateRoom> for RoomRegistryActor {
 
         info!(room = %msg.room_jid, "Creating new room via GetOrCreateRoom");
         self.poisoned_rooms.remove(&msg.room_jid);
-        Ok(self.spawn_room(msg.room_jid, msg.waddle_id, msg.channel_id, msg.config))
+        Ok(self
+            .spawn_room(msg.room_jid, msg.waddle_id, msg.channel_id, msg.config)
+            .await)
     }
 }
 
@@ -181,7 +220,9 @@ impl kameo::message::Message<CreateInstantRoom> for RoomRegistryActor {
         };
 
         self.poisoned_rooms.remove(&msg.room_jid);
-        Ok(self.spawn_room(msg.room_jid, waddle_id, channel_id, config))
+        Ok(self
+            .spawn_room(msg.room_jid, waddle_id, channel_id, config)
+            .await)
     }
 }
 
@@ -207,7 +248,9 @@ impl kameo::message::Message<CreateRoom> for RoomRegistryActor {
 
         info!(room = %msg.room_jid, "Creating new room");
         self.poisoned_rooms.remove(&msg.room_jid);
-        let actor_ref = self.spawn_room(msg.room_jid, msg.waddle_id, msg.channel_id, msg.config);
+        let actor_ref = self
+            .spawn_room(msg.room_jid, msg.waddle_id, msg.channel_id, msg.config)
+            .await;
         Ok(actor_ref)
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -287,3 +287,327 @@ async fn test_get_or_create_fails_fast_for_dead_room_until_explicit_destroy() {
         .expect("recreate room after explicit destroy");
     assert!(recreated.is_alive());
 }
+
+// ---------------------------------------------------------------------------
+// #1135 — durable-recipient hydration at spawn
+// ---------------------------------------------------------------------------
+
+use crate::muc::affiliation::{DurableMembershipFuture, DurableMembershipSource};
+use crate::muc::room_actor::GetRoomSnapshot;
+use std::sync::Arc;
+
+/// Fake durable membership store: returns a fixed member list and
+/// records the (waddle_id, channel_id) pairs it was queried with.
+struct StaticMembershipSource {
+    members: Vec<BareJid>,
+    queries: std::sync::Mutex<Vec<(String, String)>>,
+}
+
+impl StaticMembershipSource {
+    fn new(members: Vec<BareJid>) -> Self {
+        Self {
+            members,
+            queries: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl DurableMembershipSource for StaticMembershipSource {
+    fn list_durable_member_jids(
+        &self,
+        waddle_id: &str,
+        channel_id: &str,
+    ) -> DurableMembershipFuture<'_> {
+        let members = self.members.clone();
+        if let Ok(mut queries) = self.queries.lock() {
+            queries.push((waddle_id.to_string(), channel_id.to_string()));
+        }
+        Box::pin(async move { Ok(members) })
+    }
+}
+
+async fn spawn_registry_with_source(
+    source: Arc<dyn DurableMembershipSource>,
+) -> ActorRef<RoomRegistryActor> {
+    RoomRegistryActor::spawn(
+        RoomRegistryActor::new(
+            "muc.example.com".to_string(),
+            OccupantIdSecret::for_testing(b"test-secret".to_vec()),
+        )
+        .with_membership_source(source),
+    )
+}
+
+fn test_bare(value: &str) -> BareJid {
+    value.parse().expect("valid bare JID")
+}
+
+/// #1135 acceptance 1: a freshly spawned room actor (no joins, no
+/// point mutations — the post-deploy/respawn state) must report the
+/// durable members from the membership source as durable inbox
+/// recipients.
+#[tokio::test]
+async fn respawned_room_reports_durable_members_as_recipients_without_any_join() {
+    let offline_member = test_bare("offline-member@example.com");
+    let source = Arc::new(StaticMembershipSource::new(vec![offline_member.clone()]));
+    let registry = spawn_registry_with_source(source.clone()).await;
+
+    let room_actor: ActorRef<RoomActor> = registry
+        .ask(GetOrCreateRoom {
+            room_jid: test_room_jid("respawned"),
+            waddle_id: "w-1".to_string(),
+            channel_id: "c-1".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("get_or_create");
+
+    let snapshot = room_actor
+        .ask(GetRoomSnapshot {
+            sender_jid: "someone@example.com/web".parse().expect("valid full JID"),
+        })
+        .await
+        .expect("snapshot");
+
+    assert_eq!(
+        snapshot.durable_recipient_bare_jids,
+        vec![offline_member],
+        "fresh actor incarnation must hydrate durable members from the \
+         membership source instead of only join-observed affiliations"
+    );
+    let queries = source.queries.lock().expect("queries lock").clone();
+    assert_eq!(
+        queries,
+        vec![("w-1".to_string(), "c-1".to_string())],
+        "hydration must query the membership source with the room's \
+         waddle_id + channel_id exactly once"
+    );
+}
+
+/// #1135 clobber-safety: hydration must never downgrade a richer
+/// affiliation observed at runtime. The hydrated set lives beside the
+/// affiliation list (it is never written into it), so a post-spawn
+/// Owner grant survives and the member appears exactly once in the
+/// recipient set.
+#[tokio::test]
+async fn hydration_does_not_clobber_richer_runtime_affiliations() {
+    use crate::muc::room_actor::{ChangeAffiliation, ListAffiliations};
+    use crate::types::Affiliation;
+
+    let alice = test_bare("alice@example.com");
+    let source = Arc::new(StaticMembershipSource::new(vec![alice.clone()]));
+    let registry = spawn_registry_with_source(source).await;
+
+    let room_actor: ActorRef<RoomActor> = registry
+        .ask(GetOrCreateRoom {
+            room_jid: test_room_jid("clobber-safety"),
+            waddle_id: "w-1".to_string(),
+            channel_id: "c-1".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("get_or_create");
+
+    room_actor
+        .ask(ChangeAffiliation {
+            jid: alice.clone(),
+            affiliation: Affiliation::Owner,
+        })
+        .await
+        .expect("promote alice to owner");
+
+    let entries = room_actor
+        .ask(ListAffiliations { filter: None })
+        .await
+        .expect("list affiliations");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].jid, alice);
+    assert_eq!(
+        entries[0].affiliation,
+        Affiliation::Owner,
+        "hydrated durable membership must not downgrade a richer \
+         runtime-granted affiliation"
+    );
+
+    let snapshot = room_actor
+        .ask(GetRoomSnapshot {
+            sender_jid: "someone@example.com/web".parse().expect("valid full JID"),
+        })
+        .await
+        .expect("snapshot");
+    assert_eq!(
+        snapshot.durable_recipient_bare_jids,
+        vec![alice],
+        "a JID both hydrated and runtime-affiliated appears exactly once"
+    );
+}
+
+/// #1135: a durable member banned at runtime (Outcast) must drop out
+/// of the durable recipient set immediately — the runtime demotion
+/// wins over the spawn-time hydrated mirror.
+#[tokio::test]
+async fn runtime_outcast_demotion_excludes_hydrated_durable_member() {
+    use crate::muc::room_actor::ChangeAffiliation;
+    use crate::types::Affiliation;
+
+    let banned = test_bare("banned@example.com");
+    let kept = test_bare("kept@example.com");
+    let source = Arc::new(StaticMembershipSource::new(vec![
+        banned.clone(),
+        kept.clone(),
+    ]));
+    let registry = spawn_registry_with_source(source).await;
+
+    let room_actor: ActorRef<RoomActor> = registry
+        .ask(GetOrCreateRoom {
+            room_jid: test_room_jid("runtime-ban"),
+            waddle_id: "w-1".to_string(),
+            channel_id: "c-1".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("get_or_create");
+
+    room_actor
+        .ask(ChangeAffiliation {
+            jid: banned.clone(),
+            affiliation: Affiliation::Outcast,
+        })
+        .await
+        .expect("ban member");
+
+    let snapshot = room_actor
+        .ask(GetRoomSnapshot {
+            sender_jid: "someone@example.com/web".parse().expect("valid full JID"),
+        })
+        .await
+        .expect("snapshot");
+    assert_eq!(
+        snapshot.durable_recipient_bare_jids,
+        vec![kept],
+        "runtime Outcast demotion must exclude the hydrated durable \
+         member from inbox fan-out without waiting for a respawn"
+    );
+}
+
+/// #1135 acceptance 2 + 3 — restart simulation, end-to-end through the
+/// room handler chain's inbox projection:
+///
+/// 1. durable membership exists for an offline member (permission
+///    tuples survive the restart; the fake source stands in for them),
+/// 2. the room actor is a *fresh incarnation* (deploy/respawn) that the
+///    offline member never joined,
+/// 3. a sender joins and sends a groupchat message,
+/// 4. the offline member still gets a `ProjectGroupchatInbox` event
+///    with `is_recipient = true` — the unread-count/inbox-row
+///    candidate the interpreter persists.
+#[tokio::test]
+async fn offline_durable_member_gets_inbox_projection_after_actor_respawn() {
+    use crate::muc::room_actor::JoinWithAffiliation;
+    use crate::protocol::event::OutboundEvent;
+    use crate::protocol::id_gen::FixedIdGenerator;
+    use crate::protocol::room::inbox::MucInboxHandler;
+    use crate::protocol::room::{OccupantSnapshot, RoomContext, RoomHandler, RoomHandlerOutcome};
+    use crate::types::Affiliation;
+    use jid::FullJid;
+
+    let offline_member = test_bare("offline-member@example.com");
+    let source = Arc::new(StaticMembershipSource::new(vec![offline_member.clone()]));
+    let registry = spawn_registry_with_source(source).await;
+
+    let room_jid = test_room_jid("restarted-channel");
+    let room_actor: ActorRef<RoomActor> = registry
+        .ask(GetOrCreateRoom {
+            room_jid: room_jid.clone(),
+            waddle_id: "w-1".to_string(),
+            channel_id: "c-1".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("get_or_create");
+
+    // Only the sender rejoins after the "restart".
+    let sender: FullJid = "sender@example.com/web".parse().expect("valid full JID");
+    room_actor
+        .ask(JoinWithAffiliation {
+            sender_jid: sender.clone(),
+            nick: "sender".to_string(),
+            effective_affiliation: Affiliation::Member,
+            local_domain: "example.com".to_string(),
+            admission_revision: 0,
+        })
+        .await
+        .expect("sender join");
+
+    // Same snapshot → context flow as the DispatchToRoom interpreter arm.
+    let snapshot = room_actor
+        .ask(GetRoomSnapshot {
+            sender_jid: sender.clone(),
+        })
+        .await
+        .expect("snapshot");
+    let occupants: Vec<OccupantSnapshot> = snapshot
+        .occupants
+        .iter()
+        .map(|o| OccupantSnapshot {
+            full_jid: o.full_jid.clone(),
+            nick: o.nick.clone(),
+            affiliation: o.affiliation,
+            role: o.role,
+        })
+        .collect();
+    let id_gen = FixedIdGenerator("ignored".to_string());
+    let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
+    let ctx = RoomContext {
+        room: &room_jid,
+        sender_full: &sender,
+        occupants: &occupants,
+        durable_recipient_bare_jids: &snapshot.durable_recipient_bare_jids,
+        managed_room_forbidden: false,
+        room_moderated: snapshot.config.moderated,
+        room_members_only: snapshot.config.members_only,
+        pin_permission: snapshot.config.pin_permission,
+        id_gen: &id_gen,
+        occupant_id_secret: &secret,
+        sender_nickname_generation: snapshot.sender_nickname_generation.unwrap_or(0),
+        project_sender_inbox: true,
+        synthetic_sender_authority: None,
+        dispatch_timestamp: 1_777_000_000,
+    };
+
+    let mut message = xmpp_parsers::message::Message::new(None::<jid::Jid>);
+    message.from = Some(jid::Jid::from(sender.clone()));
+    message.type_ = xmpp_parsers::message::MessageType::Groupchat;
+    message.bodies.insert(
+        xmpp_parsers::message::Lang::new(),
+        "hello after the deploy".to_string(),
+    );
+
+    let RoomHandlerOutcome::Continue(events) = MucInboxHandler.handle(&mut message, &ctx) else {
+        panic!("inbox handler never halts");
+    };
+    let offline_projection = events
+        .iter()
+        .find_map(|event| match event {
+            OutboundEvent::ProjectGroupchatInbox {
+                owner,
+                is_recipient,
+                is_durable_recipient,
+                is_live_occupant,
+                ..
+            } if owner == &offline_member => {
+                Some((*is_recipient, *is_durable_recipient, *is_live_occupant))
+            }
+            _ => None,
+        })
+        .expect(
+            "offline durable member must receive a ProjectGroupchatInbox \
+             candidate after an actor respawn (#1135)",
+        );
+    assert_eq!(
+        offline_projection,
+        (true, true, false),
+        "offline member's row must bump unread (is_recipient) as a \
+         durable, non-live recipient"
+    );
+}

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -22,6 +22,7 @@
 //! complementary to the coarse per-stanza frame backstop (#808): see
 //! `docs/adr/008-stanza-handler-wedge-backstop.md`.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use jid::BareJid;
@@ -31,6 +32,7 @@ use kameo::mailbox;
 use tokio::time::Instant;
 use tracing::warn;
 
+use super::affiliation::DurableMembershipSource;
 use super::room_actor::RoomActor;
 use super::room_registry_actor::{
     CreateInstantRoom, CreateRoom, DestroyRoom, GetOrCreateRoom, GetRoom, IsMucJid, ListRooms,
@@ -84,8 +86,22 @@ pub struct RoomRegistry {
 impl RoomRegistry {
     /// Spawn the registry actor behind an explicit bounded mailbox and return an
     /// instrumented handle to it.
-    pub fn spawn(muc_domain: String, occupant_id_secret: OccupantIdSecret) -> Self {
-        let actor = RoomRegistryActor::new(muc_domain, occupant_id_secret);
+    ///
+    /// `membership_source` hydrates every freshly spawned `RoomActor`'s
+    /// durable inbox recipient set from the deployment's durable
+    /// membership store (#1135). Pass `None` only when no durable
+    /// membership store exists (tests, tools); production deployments
+    /// must wire one or offline members drop out of groupchat inbox
+    /// fan-out after each room-actor respawn.
+    pub fn spawn(
+        muc_domain: String,
+        occupant_id_secret: OccupantIdSecret,
+        membership_source: Option<Arc<dyn DurableMembershipSource>>,
+    ) -> Self {
+        let mut actor = RoomRegistryActor::new(muc_domain, occupant_id_secret);
+        if let Some(source) = membership_source {
+            actor = actor.with_membership_source(source);
+        }
         let inner = RoomRegistryActor::spawn_with_mailbox(
             actor,
             mailbox::bounded(ROOM_REGISTRY_MAILBOX_CAPACITY),

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle/tests.rs
@@ -6,6 +6,7 @@ fn test_registry() -> RoomRegistry {
     RoomRegistry::spawn(
         "muc.example.com".to_string(),
         OccupantIdSecret::for_testing(b"test-secret".to_vec()),
+        None,
     )
 }
 

--- a/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
@@ -223,6 +223,30 @@ pub trait PendingDeliveryStorage: Send + Sync {
         cutoff: chrono::DateTime<chrono::Utc>,
     ) -> Result<u64, PendingStorageError>;
 
+    /// Remove every pending row matching a XEP-0424 / XEP-0425
+    /// tombstone, returning the number of rows removed.
+    ///
+    /// Promotion (#1097/#1098) parks unacked stanzas here, so the
+    /// retraction/moderation scrub must reach this layer too or the
+    /// retracted content delivers verbatim at the recipient's next
+    /// login. Matching mirrors [`crate::tombstone`]:
+    ///
+    /// - `Transient` rows carry the message inline — matched by the
+    ///   shared per-stanza predicate
+    ///   ([`crate::tombstone::message_element_matches_tombstone`]:
+    ///   wire `id` or XEP-0359 `<stanza-id/>` equals `target_id`,
+    ///   scoped to `archive_jid` via bare-JID `from`/`to`).
+    /// - `Archived` rows are MAM pointers — matched by exact
+    ///   `(stanza_id.id == target_id, stanza_id.by bare-equals
+    ///   archive_jid)`; the MAM row itself has been tombstoned, so the
+    ///   pointer must not flush a stub for a message the recipient
+    ///   never saw.
+    async fn scrub_for_tombstone(
+        &self,
+        target_id: &str,
+        archive_jid: &str,
+    ) -> Result<u64, PendingStorageError>;
+
     /// Periodically GC backend-internal bookkeeping that grows with
     /// distinct keys seen by the process — e.g. per-recipient
     /// insert-serialization locks (issue #209 finding #4). Default
@@ -230,6 +254,22 @@ pub trait PendingDeliveryStorage: Send + Sync {
     /// Returns the number of entries removed for observability.
     fn sweep_internal_bookkeeping(&self) -> usize {
         0
+    }
+}
+
+/// Shared per-row tombstone predicate for [`PendingDeliveryStorage`]
+/// implementations that hold typed [`PendingRow`]s (the in-memory
+/// backend here; SQL backends match on their column representation
+/// with the same semantics).
+pub fn pending_row_matches_tombstone(row: &PendingRow, target_id: &str, archive_jid: &str) -> bool {
+    match &row.payload {
+        super::PendingPayload::Transient(message) => {
+            let element: xmpp_parsers::minidom::Element = (**message).clone().into();
+            crate::tombstone::message_element_matches_tombstone(&element, target_id, archive_jid)
+        }
+        super::PendingPayload::Archived(stanza_id) => {
+            stanza_id.id.as_str() == target_id && stanza_id.by.to_bare().to_string() == archive_jid
+        }
     }
 }
 
@@ -637,6 +677,35 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
             let mut kept = VecDeque::with_capacity(queue.len());
             for row in queue.drain(..) {
                 if row.original_receipt_at < cutoff {
+                    removed_ids.push(row.id);
+                    removed += 1;
+                } else {
+                    kept.push_back(row);
+                }
+            }
+            *queue = kept;
+        }
+        guard.retain(|_, q| !q.is_empty());
+        drop(guard);
+        self.clear_notification_outboxed_markers(&removed_ids)?;
+        Ok(removed)
+    }
+
+    async fn scrub_for_tombstone(
+        &self,
+        target_id: &str,
+        archive_jid: &str,
+    ) -> Result<u64, PendingStorageError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|e| PendingStorageError::Other(e.to_string()))?;
+        let mut removed = 0u64;
+        let mut removed_ids = Vec::new();
+        for queue in guard.values_mut() {
+            let mut kept = VecDeque::with_capacity(queue.len());
+            for row in queue.drain(..) {
+                if pending_row_matches_tombstone(&row, target_id, archive_jid) {
                     removed_ids.push(row.id);
                     removed += 1;
                 } else {

--- a/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
@@ -232,19 +232,18 @@ pub trait PendingDeliveryStorage: Send + Sync {
     /// login. Matching mirrors [`crate::tombstone`]:
     ///
     /// - `Transient` rows carry the message inline — matched by the
-    ///   shared per-stanza predicate
-    ///   ([`crate::tombstone::message_element_matches_tombstone`]:
-    ///   wire `id` or XEP-0359 `<stanza-id/>` equals `target_id`,
-    ///   scoped to `archive_jid` via bare-JID `from`/`to`).
+    ///   shared typed predicate
+    ///   ([`crate::tombstone::TombstoneTarget::matches_message_element`]:
+    ///   room stanza-id for groupchat, author-scoped wire id for 1:1,
+    ///   both scoped to the conversation archive).
     /// - `Archived` rows are MAM pointers — matched by exact
-    ///   `(stanza_id.id == target_id, stanza_id.by bare-equals
-    ///   archive_jid)`; the MAM row itself has been tombstoned, so the
-    ///   pointer must not flush a stub for a message the recipient
-    ///   never saw.
+    ///   `(stanza_id.id == target.id(), stanza_id.by bare-equals
+    ///   target.archive_jid())`; the MAM row itself has been
+    ///   tombstoned, so the pointer must not flush a stub for a
+    ///   message the recipient never saw.
     async fn scrub_for_tombstone(
         &self,
-        target_id: &str,
-        archive_jid: &BareJid,
+        target: &crate::tombstone::TombstoneTarget,
     ) -> Result<u64, PendingStorageError>;
 
     /// Periodically GC backend-internal bookkeeping that grows with
@@ -263,16 +262,15 @@ pub trait PendingDeliveryStorage: Send + Sync {
 /// with the same semantics).
 pub fn pending_row_matches_tombstone(
     row: &PendingRow,
-    target_id: &str,
-    archive_jid: &BareJid,
+    target: &crate::tombstone::TombstoneTarget,
 ) -> bool {
     match &row.payload {
         super::PendingPayload::Transient(message) => {
             let element: xmpp_parsers::minidom::Element = (**message).clone().into();
-            crate::tombstone::message_element_matches_tombstone(&element, target_id, archive_jid)
+            target.matches_message_element(&element)
         }
         super::PendingPayload::Archived(stanza_id) => {
-            stanza_id.id.as_str() == target_id && &stanza_id.by.to_bare() == archive_jid
+            stanza_id.id.as_str() == target.id() && &stanza_id.by.to_bare() == target.archive_jid()
         }
     }
 }
@@ -697,8 +695,7 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
 
     async fn scrub_for_tombstone(
         &self,
-        target_id: &str,
-        archive_jid: &BareJid,
+        target: &crate::tombstone::TombstoneTarget,
     ) -> Result<u64, PendingStorageError> {
         let mut guard = self
             .inner
@@ -709,7 +706,7 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
         for queue in guard.values_mut() {
             let mut kept = VecDeque::with_capacity(queue.len());
             for row in queue.drain(..) {
-                if pending_row_matches_tombstone(&row, target_id, archive_jid) {
+                if pending_row_matches_tombstone(&row, target) {
                     removed_ids.push(row.id);
                     removed += 1;
                 } else {

--- a/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
@@ -244,7 +244,7 @@ pub trait PendingDeliveryStorage: Send + Sync {
     async fn scrub_for_tombstone(
         &self,
         target_id: &str,
-        archive_jid: &str,
+        archive_jid: &BareJid,
     ) -> Result<u64, PendingStorageError>;
 
     /// Periodically GC backend-internal bookkeeping that grows with
@@ -261,14 +261,18 @@ pub trait PendingDeliveryStorage: Send + Sync {
 /// implementations that hold typed [`PendingRow`]s (the in-memory
 /// backend here; SQL backends match on their column representation
 /// with the same semantics).
-pub fn pending_row_matches_tombstone(row: &PendingRow, target_id: &str, archive_jid: &str) -> bool {
+pub fn pending_row_matches_tombstone(
+    row: &PendingRow,
+    target_id: &str,
+    archive_jid: &BareJid,
+) -> bool {
     match &row.payload {
         super::PendingPayload::Transient(message) => {
             let element: xmpp_parsers::minidom::Element = (**message).clone().into();
             crate::tombstone::message_element_matches_tombstone(&element, target_id, archive_jid)
         }
         super::PendingPayload::Archived(stanza_id) => {
-            stanza_id.id.as_str() == target_id && stanza_id.by.to_bare().to_string() == archive_jid
+            stanza_id.id.as_str() == target_id && &stanza_id.by.to_bare() == archive_jid
         }
     }
 }
@@ -694,7 +698,7 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
     async fn scrub_for_tombstone(
         &self,
         target_id: &str,
-        archive_jid: &str,
+        archive_jid: &BareJid,
     ) -> Result<u64, PendingStorageError> {
         let mut guard = self
             .inner

--- a/server/crates/waddle-xmpp/src/pending_delivery/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/storage/tests.rs
@@ -8,6 +8,14 @@ fn bare(s: &str) -> BareJid {
     s.parse().expect("valid bare jid")
 }
 
+fn direct_target(wire_id: &str, author: &str, archive: &str) -> crate::tombstone::TombstoneTarget {
+    crate::tombstone::TombstoneTarget::Direct {
+        wire_id: wire_id.to_string(),
+        author: bare(author),
+        archive: bare(archive),
+    }
+}
+
 fn archived_row(recipient: &str, id: &str) -> PendingRow {
     let archive_jid: jid::Jid = bare(recipient).into();
     PendingRow {
@@ -371,7 +379,11 @@ async fn scrub_for_tombstone_removes_matching_transient_row_only() {
         .unwrap();
 
     let removed = store
-        .scrub_for_tombstone("retract-me", &bare("alice@example.com"))
+        .scrub_for_tombstone(&direct_target(
+            "retract-me",
+            "bob@elsewhere",
+            "alice@example.com",
+        ))
         .await
         .unwrap();
     assert_eq!(removed, 1, "exactly the in-scope matching row is removed");
@@ -412,7 +424,11 @@ async fn scrub_for_tombstone_removes_matching_archived_pointer_row() {
         .unwrap();
 
     let removed = store
-        .scrub_for_tombstone("archive-1", &bare("alice@example.com"))
+        .scrub_for_tombstone(&direct_target(
+            "archive-1",
+            "bob@elsewhere",
+            "alice@example.com",
+        ))
         .await
         .unwrap();
     assert_eq!(removed, 1);

--- a/server/crates/waddle-xmpp/src/pending_delivery/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/storage/tests.rs
@@ -316,3 +316,115 @@ async fn record_pushed_at_is_idempotent_per_row() {
     let rows = store.list(&bare("alice@example.com")).await.unwrap();
     assert_eq!(rows[0].outbound_sequence, Some(12));
 }
+
+fn transient_dm_row(recipient: &str, from: &str, wire_id: &str, body: &str) -> PendingRow {
+    let mut m = Message::new(Some(recipient.parse::<jid::Jid>().expect("jid")));
+    m.from = Some(from.parse::<jid::Jid>().expect("jid"));
+    m.id = Some(xmpp_parsers::message::Id(wire_id.to_string()));
+    m.type_ = xmpp_parsers::message::MessageType::Chat;
+    m.bodies
+        .insert(xmpp_parsers::message::Lang::new(), body.to_string());
+    PendingRow {
+        id: PendingRowId::fresh(),
+        recipient: bare(recipient),
+        original_receipt_at: Utc::now(),
+        payload: PendingPayload::Transient(Box::new(m)),
+        flushed_in_session: None,
+        outbound_sequence: None,
+    }
+}
+
+#[tokio::test]
+async fn scrub_for_tombstone_removes_matching_transient_row_only() {
+    // F2: promotion (#1097/#1098) parks unacked stanzas in pending
+    // delivery; a XEP-0424/0425 retraction must scrub the inline
+    // (Transient) copy or the retracted content delivers verbatim at
+    // the recipient's next login.
+    let store = InMemoryPendingDeliveryStorage::unlimited();
+    store
+        .insert(transient_dm_row(
+            "alice@example.com",
+            "bob@elsewhere/x",
+            "retract-me",
+            "secret",
+        ))
+        .await
+        .unwrap();
+    store
+        .insert(transient_dm_row(
+            "alice@example.com",
+            "bob@elsewhere/x",
+            "keep-me",
+            "safe",
+        ))
+        .await
+        .unwrap();
+    // Same wire id, different conversation: scope guard must keep it.
+    store
+        .insert(transient_dm_row(
+            "carol@example.com",
+            "bob@elsewhere/x",
+            "retract-me",
+            "unrelated",
+        ))
+        .await
+        .unwrap();
+
+    let removed = store
+        .scrub_for_tombstone("retract-me", "alice@example.com")
+        .await
+        .unwrap();
+    assert_eq!(removed, 1, "exactly the in-scope matching row is removed");
+
+    let alice_rows = store.list(&bare("alice@example.com")).await.unwrap();
+    assert_eq!(alice_rows.len(), 1);
+    match &alice_rows[0].payload {
+        PendingPayload::Transient(m) => {
+            assert_eq!(m.id.as_ref().map(|id| id.0.as_str()), Some("keep-me"));
+        }
+        _ => panic!("expected Transient"),
+    }
+    assert_eq!(
+        store.list(&bare("carol@example.com")).await.unwrap().len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn scrub_for_tombstone_removes_matching_archived_pointer_row() {
+    // Archived rows are MAM pointers keyed by (stanza-id, archive-by).
+    // A retraction tombstones the MAM row itself; the pending pointer
+    // must go too so the next-login flush doesn't push a stub for a
+    // message the recipient never saw.
+    let store = InMemoryPendingDeliveryStorage::unlimited();
+    store
+        .insert(archived_row("alice@example.com", "archive-1"))
+        .await
+        .unwrap();
+    store
+        .insert(archived_row("alice@example.com", "archive-2"))
+        .await
+        .unwrap();
+    // Same archive id, different archive owner: out of scope.
+    store
+        .insert(archived_row("carol@example.com", "archive-1"))
+        .await
+        .unwrap();
+
+    let removed = store
+        .scrub_for_tombstone("archive-1", "alice@example.com")
+        .await
+        .unwrap();
+    assert_eq!(removed, 1);
+
+    let alice_rows = store.list(&bare("alice@example.com")).await.unwrap();
+    assert_eq!(alice_rows.len(), 1);
+    match &alice_rows[0].payload {
+        PendingPayload::Archived(r) => assert_eq!(r.id.as_str(), "archive-2"),
+        _ => panic!("expected Archived"),
+    }
+    assert_eq!(
+        store.list(&bare("carol@example.com")).await.unwrap().len(),
+        1
+    );
+}

--- a/server/crates/waddle-xmpp/src/pending_delivery/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/storage/tests.rs
@@ -371,7 +371,7 @@ async fn scrub_for_tombstone_removes_matching_transient_row_only() {
         .unwrap();
 
     let removed = store
-        .scrub_for_tombstone("retract-me", "alice@example.com")
+        .scrub_for_tombstone("retract-me", &bare("alice@example.com"))
         .await
         .unwrap();
     assert_eq!(removed, 1, "exactly the in-scope matching row is removed");
@@ -412,7 +412,7 @@ async fn scrub_for_tombstone_removes_matching_archived_pointer_row() {
         .unwrap();
 
     let removed = store
-        .scrub_for_tombstone("archive-1", "alice@example.com")
+        .scrub_for_tombstone("archive-1", &bare("alice@example.com"))
         .await
         .unwrap();
     assert_eq!(removed, 1);

--- a/server/crates/waddle-xmpp/src/stream_management/mod.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/mod.rs
@@ -36,7 +36,7 @@ mod unacked_queue;
 pub use replay::{stamp_replay_delay, ReplayStanza};
 pub use session_registry::{
     DetachedSession, DetachedUnackedStanza, InMemorySmSessionRegistry, RecentTombstoneRecord,
-    SmClaimCompletion, SmRegistryError, SmSessionRegistry, TombstoneKey, DEFAULT_MAX_SESSIONS,
+    SmClaimCompletion, SmRegistryError, SmSessionRegistry, DEFAULT_MAX_SESSIONS,
 };
 pub use stanzas::{SmAck, SmEnable, SmEnabled, SmFailed, SmRequest, SmResume, SmResumed, SmStanza};
 pub use state::{DetachedSessionSnapshot, StreamManagementState};

--- a/server/crates/waddle-xmpp/src/stream_management/mod.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/mod.rs
@@ -36,7 +36,7 @@ mod unacked_queue;
 pub use replay::{stamp_replay_delay, ReplayStanza};
 pub use session_registry::{
     DetachedSession, DetachedUnackedStanza, InMemorySmSessionRegistry, SmClaimCompletion,
-    SmRegistryError, SmSessionRegistry, DEFAULT_MAX_SESSIONS,
+    SmRegistryError, SmSessionRegistry, TombstoneKey, DEFAULT_MAX_SESSIONS,
 };
 pub use stanzas::{SmAck, SmEnable, SmEnabled, SmFailed, SmRequest, SmResume, SmResumed, SmStanza};
 pub use state::{DetachedSessionSnapshot, StreamManagementState};

--- a/server/crates/waddle-xmpp/src/stream_management/mod.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/mod.rs
@@ -36,7 +36,7 @@ mod unacked_queue;
 pub use replay::{stamp_replay_delay, ReplayStanza};
 pub use session_registry::{
     DetachedSession, DetachedUnackedStanza, InMemorySmSessionRegistry, SmClaimCompletion,
-    SmRegistryError, SmSessionRegistry,
+    SmRegistryError, SmSessionRegistry, DEFAULT_MAX_SESSIONS,
 };
 pub use stanzas::{SmAck, SmEnable, SmEnabled, SmFailed, SmRequest, SmResume, SmResumed, SmStanza};
 pub use state::{DetachedSessionSnapshot, StreamManagementState};

--- a/server/crates/waddle-xmpp/src/stream_management/mod.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/mod.rs
@@ -35,8 +35,8 @@ mod unacked_queue;
 
 pub use replay::{stamp_replay_delay, ReplayStanza};
 pub use session_registry::{
-    DetachedSession, DetachedUnackedStanza, InMemorySmSessionRegistry, SmClaimCompletion,
-    SmRegistryError, SmSessionRegistry, TombstoneKey, DEFAULT_MAX_SESSIONS,
+    DetachedSession, DetachedUnackedStanza, InMemorySmSessionRegistry, RecentTombstoneRecord,
+    SmClaimCompletion, SmRegistryError, SmSessionRegistry, TombstoneKey, DEFAULT_MAX_SESSIONS,
 };
 pub use stanzas::{SmAck, SmEnable, SmEnabled, SmFailed, SmRequest, SmResume, SmResumed, SmStanza};
 pub use state::{DetachedSessionSnapshot, StreamManagementState};

--- a/server/crates/waddle-xmpp/src/stream_management/persistence.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/persistence.rs
@@ -140,6 +140,18 @@ pub trait SmPersistenceStorage: Send + Sync {
         up_to_sequence: u32,
     ) -> Result<u64, SmPersistenceError>;
 
+    /// Remove the named unacked entries — exact `(stream_id,
+    /// sequence)` primary-key matches — and return how many rows were
+    /// deleted. Used by the XEP-0424/0425 tombstone scrub (issue
+    /// #1145) so a retracted stanza cannot be rehydrated into a
+    /// replay queue after a restart. Sequences that do not exist are
+    /// ignored (idempotent).
+    async fn delete_unacked(
+        &self,
+        stream_id: &SmSessionId,
+        sequences: &[u32],
+    ) -> Result<u64, SmPersistenceError>;
+
     /// Read every unacked stanza for a session in sequence order.
     /// Used by `<resumed/>` to replay and by the Q6 promotion path to
     /// drain on session expiry.
@@ -332,6 +344,24 @@ impl SmPersistenceStorage for InMemorySmPersistence {
         };
         let before = queue.len();
         queue.retain(|s| s.sequence > up_to_sequence);
+        Ok((before - queue.len()) as u64)
+    }
+
+    async fn delete_unacked(
+        &self,
+        stream_id: &SmSessionId,
+        sequences: &[u32],
+    ) -> Result<u64, SmPersistenceError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let queue = match guard.unacked.get_mut(stream_id) {
+            Some(q) => q,
+            None => return Ok(0),
+        };
+        let before = queue.len();
+        queue.retain(|s| !sequences.contains(&s.sequence));
         Ok((before - queue.len()) as u64)
     }
 

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -19,7 +19,7 @@ mod traits;
 
 pub use core::InMemorySmSessionRegistry;
 pub use session::{DetachedSession, DetachedUnackedStanza};
-pub use tombstones::{RecentTombstoneRecord, TombstoneKey};
+pub use tombstones::RecentTombstoneRecord;
 pub use traits::{SmClaimCompletion, SmRegistryError, SmSessionRegistry};
 
 /// Default session timeout (5 minutes)

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -13,11 +13,13 @@ mod persistence_codec;
 mod resources;
 mod sequence;
 mod session;
+mod tombstones;
 mod trait_impl;
 mod traits;
 
 pub use core::InMemorySmSessionRegistry;
 pub use session::{DetachedSession, DetachedUnackedStanza};
+pub use tombstones::TombstoneKey;
 pub use traits::{SmClaimCompletion, SmRegistryError, SmSessionRegistry};
 
 /// Default session timeout (5 minutes)

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -19,7 +19,7 @@ mod traits;
 
 pub use core::InMemorySmSessionRegistry;
 pub use session::{DetachedSession, DetachedUnackedStanza};
-pub use tombstones::TombstoneKey;
+pub use tombstones::{RecentTombstoneRecord, TombstoneKey};
 pub use traits::{SmClaimCompletion, SmRegistryError, SmSessionRegistry};
 
 /// Default session timeout (5 minutes)

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -13,7 +13,6 @@ mod persistence_codec;
 mod resources;
 mod sequence;
 mod session;
-mod tombstone;
 mod trait_impl;
 mod traits;
 

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -203,21 +203,44 @@ impl InMemorySmSessionRegistry {
         // rows no longer exist — durable storage is the scrub's source
         // of truth. A read failure keeps the queue verbatim
         // (at-least-once beats dropping stanzas on a storage blip).
+        // The diff is authoritative only when the durable session row
+        // exists (round-6 review): a phase-4 scrub deletes unacked rows
+        // but leaves the session row, whereas a session whose
+        // store_session snapshot write FAILED has neither — dropping
+        // its queue would silently lose messages on the very storage
+        // blip this path tolerates.
         if let Some(storage) = &self.persistence {
             let session_id = crate::pending_delivery::SmSessionId::new(session.stream_id.clone());
-            match storage.list_unacked(&session_id).await {
-                Ok(rows) => {
-                    let durable: std::collections::HashSet<u32> =
-                        rows.iter().map(|row| row.sequence).collect();
-                    session
-                        .unacked_stanzas
-                        .retain(|entry| durable.contains(&entry.sequence));
+            match storage.get_session(&session_id).await {
+                Ok(Some(_)) => match storage.list_unacked(&session_id).await {
+                    Ok(rows) => {
+                        let durable: std::collections::HashSet<u32> =
+                            rows.iter().map(|row| row.sequence).collect();
+                        session
+                            .unacked_stanzas
+                            .retain(|entry| durable.contains(&entry.sequence));
+                    }
+                    Err(error) => {
+                        debug!(
+                            stream_id = %session.stream_id,
+                            error = %error,
+                            "reinsert_for_retry: durable list_unacked failed; keeping the \
+                             in-memory queue verbatim (at-least-once)"
+                        );
+                    }
+                },
+                Ok(None) => {
+                    debug!(
+                        stream_id = %session.stream_id,
+                        "reinsert_for_retry: no durable session row (snapshot never \
+                         landed); keeping the in-memory queue verbatim (at-least-once)"
+                    );
                 }
                 Err(error) => {
                     debug!(
                         stream_id = %session.stream_id,
                         error = %error,
-                        "reinsert_for_retry: durable list_unacked failed; keeping the \
+                        "reinsert_for_retry: durable get_session failed; keeping the \
                          in-memory queue verbatim (at-least-once)"
                     );
                 }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -178,6 +178,14 @@ impl InMemorySmSessionRegistry {
     /// `is_expired()`) while making the janitor's next tick retry the
     /// promote → confirm chain; the persistent promotion-failure
     /// counter still dead-letters runaway loops.
+    ///
+    /// `detached_at` is deliberately preserved (round-2 review R3): a
+    /// reinsert that refreshed it to ≈now made repeatedly-failing
+    /// sessions immortal against the max_sessions min-by-detached_at
+    /// eviction, sacrificing healthy resumable sessions under a
+    /// degraded backend. Forcing `max_resume_time = 0` alone keeps the
+    /// session expired (its true detach time is already in the past),
+    /// so peek/take/claim still refuse it while the janitor retries.
     pub async fn reinsert_for_retry(
         &self,
         mut session: DetachedSession,
@@ -185,10 +193,6 @@ impl InMemorySmSessionRegistry {
         let stream_lock = self.stream_lock(&session.stream_id)?;
         let _stream_guard = stream_lock.lock().await;
         session.max_resume_time = Some(0);
-        if let Some(past) = std::time::Instant::now().checked_sub(std::time::Duration::from_secs(1))
-        {
-            session.detached_at = past;
-        }
         self.sessions
             .write()
             .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -365,14 +365,19 @@ impl InMemorySmSessionRegistry {
 
     /// Invalidate detached sessions for a FullJID after a fresh bind has
     /// replaced that stream identity.
+    ///
+    /// Follows the drain_expired/confirm_drained persist-until-
+    /// confirmed contract (issue #1097): the removed sessions'
+    /// durable rows are deliberately NOT deleted here. The caller
+    /// promotes each returned session's unacked queue (XEP-0198 §5:
+    /// the freshly-bound resource is a natural alt-resource target)
+    /// and calls [`Self::confirm_drained`] on success. If the process
+    /// crashes before promotion, `restore_from_persistence`
+    /// rehydrates the rows and the SM-expiry janitor retries.
     pub async fn invalidate_sessions_for_jid(
         &self,
         jid: &FullJid,
     ) -> Result<Vec<DetachedSession>, SmRegistryError> {
-        // Persist-first: enumerate matching stream-ids under a brief
-        // lock, durably erase each, then remove from in-memory. If
-        // any durable erase fails, abort before in-memory mutation
-        // so a transient storage error doesn't leave orphans.
         let matching_ids: Vec<String> = {
             let sessions = self
                 .sessions
@@ -398,7 +403,6 @@ impl InMemorySmSessionRegistry {
         for stream_id in &matching_ids {
             let stream_lock = self.stream_lock(stream_id)?;
             let _stream_guard = stream_lock.lock().await;
-            self.persist_delete_session(stream_id).await?;
             let mut sessions = self
                 .sessions
                 .write()

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -166,6 +166,36 @@ impl InMemorySmSessionRegistry {
         Ok(drained)
     }
 
+    /// Re-insert a session whose XEP-0198 §5 promotion failed back
+    /// into the in-memory map, forced expired, WITHOUT touching
+    /// durable state (mirrors the #1098 hydrate-expired pattern).
+    ///
+    /// `drain_expired` scans only memory, so a promotion failure that
+    /// left the session out of the map would strand its durable rows
+    /// until the next restart — contradicting the janitor's "retried
+    /// on the next pass" contract. Forcing expiry keeps the session
+    /// non-resumable on the wire (peek/take/claim all gate on
+    /// `is_expired()`) while making the janitor's next tick retry the
+    /// promote → confirm chain; the persistent promotion-failure
+    /// counter still dead-letters runaway loops.
+    pub async fn reinsert_for_retry(
+        &self,
+        mut session: DetachedSession,
+    ) -> Result<(), SmRegistryError> {
+        let stream_lock = self.stream_lock(&session.stream_id)?;
+        let _stream_guard = stream_lock.lock().await;
+        session.max_resume_time = Some(0);
+        if let Some(past) = std::time::Instant::now().checked_sub(std::time::Duration::from_secs(1))
+        {
+            session.detached_at = past;
+        }
+        self.sessions
+            .write()
+            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
+            .insert(session.stream_id.clone(), session);
+        Ok(())
+    }
+
     /// Atomically claim a resumable session for a single resume attempt.
     ///
     /// Claimed sessions stay writable by detached fanout so stanzas routed
@@ -185,6 +215,13 @@ impl InMemorySmSessionRegistry {
             return Ok(None);
         };
         if session.is_expired() {
+            // Re-insert instead of dropping: a #1098-hydrated expired
+            // session must stay visible to the janitor's next
+            // `drain_expired` pass (which scans memory only) so its
+            // unacked queue still runs the XEP-0198 §5 promote →
+            // confirm chain. Dropping it here would strand the queue
+            // until the next restart.
+            sessions.insert(stream_id.to_string(), session);
             return Ok(None);
         }
         let mut claimed = self
@@ -327,34 +364,31 @@ impl InMemorySmSessionRegistry {
         Ok(outcome)
     }
 
-    /// Remove a stored detached session only if it has not been claimed by a
-    /// resume attempt.
-    pub async fn remove_stored_session_if_unclaimed(
+    /// Remove a stored detached session from the in-memory view only
+    /// if it has not been claimed by a resume attempt, WITHOUT
+    /// deleting its durable rows.
+    ///
+    /// Follows the displaced-session persist-until-confirmed contract
+    /// (issue #1097): the caller MUST run the XEP-0198 §5 promote →
+    /// [`Self::confirm_drained`] chain on the returned session — only
+    /// the confirm erases the durable rows. (The previous shape,
+    /// `remove_stored_session_if_unclaimed`, durably deleted up-front;
+    /// the ownership-moved detach path then discarded the returned
+    /// session, losing the unacked queue entirely.)
+    pub async fn displace_stored_session_if_unclaimed(
         &self,
         stream_id: &str,
     ) -> Result<Option<DetachedSession>, SmRegistryError> {
         let stream_lock = self.stream_lock(stream_id)?;
         let _stream_guard = stream_lock.lock().await;
-        // Persist-first ordering: peek + abort if claimed, durably
-        // erase, then remove from in-memory. Same rationale as
-        // complete_claim — failure to durably erase aborts the
-        // operation so a transient storage error doesn't leave an
-        // orphan that restart resurrects.
-        let exists_unclaimed = {
-            let sessions = self
-                .sessions
-                .read()
-                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-            let claimed = self
-                .claimed_sessions
-                .read()
-                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-            sessions.contains_key(stream_id) && !claimed.contains_key(stream_id)
-        };
-        if !exists_unclaimed {
+        let claimed = self
+            .claimed_sessions
+            .read()
+            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
+            .contains_key(stream_id);
+        if claimed {
             return Ok(None);
         }
-        self.persist_delete_session(stream_id).await?;
         let removed = self
             .sessions
             .write()

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -192,6 +192,52 @@ impl InMemorySmSessionRegistry {
     ) -> Result<(), SmRegistryError> {
         let stream_lock = self.stream_lock(&session.stream_id)?;
         let _stream_guard = stream_lock.lock().await;
+        // Retry-horizon guard (adversarial-review finding D): the
+        // uncounted retry path (record_promotion_failure itself
+        // erroring) re-inserted the in-memory copy VERBATIM forever.
+        // A XEP-0424/0425 scrub that ran while the session was off-map
+        // (phase 4) deleted only the durable rows, so once the
+        // RECENT_TOMBSTONE_TTL expired the retained in-memory copy
+        // promoted the retracted stanza anyway. Diff the queue against
+        // the durable rows under the stream lock and drop entries whose
+        // rows no longer exist — durable storage is the scrub's source
+        // of truth. A read failure keeps the queue verbatim
+        // (at-least-once beats dropping stanzas on a storage blip).
+        if let Some(storage) = &self.persistence {
+            let session_id = crate::pending_delivery::SmSessionId::new(session.stream_id.clone());
+            match storage.list_unacked(&session_id).await {
+                Ok(rows) => {
+                    let durable: std::collections::HashSet<u32> =
+                        rows.iter().map(|row| row.sequence).collect();
+                    session
+                        .unacked_stanzas
+                        .retain(|entry| durable.contains(&entry.sequence));
+                }
+                Err(error) => {
+                    debug!(
+                        stream_id = %session.stream_id,
+                        error = %error,
+                        "reinsert_for_retry: durable list_unacked failed; keeping the \
+                         in-memory queue verbatim (at-least-once)"
+                    );
+                }
+            }
+        }
+        self.reinsert_for_retry_unlocked(session)
+    }
+
+    /// Map-insert half of [`Self::reinsert_for_retry`]: force the
+    /// session expired and publish it in the detached map WITHOUT
+    /// taking its stream shard lock. Only for callers that already
+    /// hold a (possibly different stream's) shard lock —
+    /// `store_session`'s snapshot-failure path re-inserts the sessions
+    /// it displaced while still holding the NEW stream's shard lock,
+    /// and two crossed store_session calls taking each other's shard
+    /// locks would deadlock.
+    pub(super) fn reinsert_for_retry_unlocked(
+        &self,
+        mut session: DetachedSession,
+    ) -> Result<(), SmRegistryError> {
         session.max_resume_time = Some(0);
         self.sessions
             .write()

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
@@ -317,10 +317,24 @@ impl InMemorySmSessionRegistry {
             return Ok(true);
         }
 
-        // Fail closed if a future path removes the session without taking the
-        // stream lock. The snapshot was already written durably, so erase it
-        // rather than allowing restart to resurrect an already-consumed stream.
-        self.persist_delete_session(stream_id).await?;
+        // The session vanished from both maps between the stream-lock
+        // read and this recheck. The only remover that does NOT take
+        // this stream's lock is displacement by `store_session` (jid
+        // collision / max_sessions eviction, which holds only the NEW
+        // stream's shard lock) — and displaced sessions follow the
+        // persist-until-confirmed contract (traits.rs): their durable
+        // rows must survive until the promote → confirm_drained chain
+        // erases them. The previous fail-closed `persist_delete_session`
+        // here (PR #486, guarding against hypothetical lock-free
+        // removers resurrecting an already-consumed stream) deleted a
+        // displaced session's rows mid-promotion, losing the queue on a
+        // crash. Every consuming path (take_session, complete_claim,
+        // confirm_drained) takes
+        // this stream lock, so the consumed-stream-resurrection concern
+        // cannot arise here; deletion stays owned by
+        // confirm_drained / the janitor. Worst case is an orphan
+        // snapshot row that restore_from_persistence rehydrates and the
+        // janitor later promotes — at-least-once, never data loss.
         Ok(false)
     }
 }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
@@ -28,6 +28,11 @@ pub struct InMemorySmSessionRegistry {
     pub(super) claimed_sessions: RwLock<HashMap<String, DetachedSession>>,
     pub(super) stream_locks: Vec<Arc<tokio::sync::Mutex<()>>>,
     pub(super) max_sessions: usize,
+    /// Recently applied XEP-0424/0425 tombstones, kept for the
+    /// promotion-time re-check (round-2 review R2). Bounded by
+    /// [`super::tombstones::RECENT_TOMBSTONE_TTL`] +
+    /// [`super::tombstones::MAX_RECENT_TOMBSTONES`].
+    pub(super) recent_tombstones: RwLock<Vec<super::tombstones::RecentTombstone>>,
     /// Optional durable backing store. When `None` the registry is
     /// strictly in-memory (legacy behaviour); production wiring sets
     /// this via [`Self::with_persistence`] before Arc-wrapping.
@@ -67,6 +72,7 @@ impl InMemorySmSessionRegistry {
             claimed_sessions: RwLock::new(HashMap::new()),
             stream_locks: new_stream_locks(),
             max_sessions: DEFAULT_MAX_SESSIONS,
+            recent_tombstones: RwLock::new(Vec::new()),
             persistence: None,
         }
     }
@@ -78,6 +84,7 @@ impl InMemorySmSessionRegistry {
             claimed_sessions: RwLock::new(HashMap::new()),
             stream_locks: new_stream_locks(),
             max_sessions,
+            recent_tombstones: RwLock::new(Vec::new()),
             persistence: None,
         }
     }
@@ -209,6 +216,44 @@ impl InMemorySmSessionRegistry {
         }
         storage
             .store_session_atomic(persisted, unacked_rows)
+            .await
+            .map_err(|e| SmRegistryError::Internal(e.to_string()))
+    }
+
+    /// Durably delete the named unacked rows for a stream — exact
+    /// `(stream_id, sequence)` matches, idempotent for absent rows.
+    ///
+    /// Used by the Q6 promotion retry path (round-2 review R4): after
+    /// a PARTIAL promotion failure, the successfully promoted stanzas'
+    /// `pending_delivery` rows are already committed, so their
+    /// `sm_unacked` rows must be erased before the session is
+    /// re-inserted for retry — otherwise every janitor tick re-promotes
+    /// the whole queue and duplicates the already-queued stanzas.
+    /// Ordering is crash-safe: the pending row commits BEFORE its
+    /// `sm_unacked` row is deleted here, preserving at-least-once.
+    ///
+    /// Takes the stream lock so the delete serializes with
+    /// detached-append full snapshots that could otherwise resurrect
+    /// the rows. No in-memory mutation happens here — the caller owns
+    /// the drained session and drops the entries from its local copy.
+    pub async fn delete_unacked_sequences(
+        &self,
+        stream_id: &str,
+        sequences: &[u32],
+    ) -> Result<u64, SmRegistryError> {
+        let Some(storage) = &self.persistence else {
+            return Ok(0);
+        };
+        if sequences.is_empty() {
+            return Ok(0);
+        }
+        let stream_lock = self.stream_lock(stream_id)?;
+        let _stream_guard = stream_lock.lock().await;
+        storage
+            .delete_unacked(
+                &crate::pending_delivery::SmSessionId::new(stream_id.to_string()),
+                sequences,
+            )
             .await
             .map_err(|e| SmRegistryError::Internal(e.to_string()))
     }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
@@ -116,22 +116,24 @@ impl InMemorySmSessionRegistry {
             .await
             .map_err(|e| SmRegistryError::Internal(e.to_string()))?;
         let mut hydrated_sessions = Vec::with_capacity(stored.len());
-        let mut expired_ids = Vec::new();
+        let mut expired = 0usize;
         let mut bad_rows = 0usize;
         for (persisted, unacked) in stored {
-            // Filter expired-during-downtime: detached_at +
-            // max_resume_duration <= now means the resume window is
-            // already closed. Hydrating these would let them appear
-            // resumable on the wire and silently exceed
-            // max_sessions, plus they'd be re-loaded on every
-            // restart since the in-memory janitor doesn't drain
-            // durable rows. Mark for durable deletion below.
+            // Expired-during-downtime sessions (detached_at +
+            // max_resume_duration <= now) are hydrated too (issue
+            // #1098): deleting their rows here would silently discard
+            // their unacked queues, violating XEP-0198 §5 ("treat
+            // unacknowledged stanzas … like stanzas to an unavailable
+            // resource"). They are not resumable on the wire —
+            // peek/take/claim all gate on `is_expired()` — and the
+            // SM-expiry janitor's next `drain_expired` pass runs the
+            // promote → confirm chain, which is what finally deletes
+            // the durable rows via `confirm_drained`.
             let expires_at = persisted.detached_at
                 + chrono::Duration::from_std(persisted.max_resume_duration)
                     .unwrap_or(chrono::Duration::seconds(0));
             if expires_at <= now {
-                expired_ids.push(persisted.stream_id.clone());
-                continue;
+                expired += 1;
             }
             match persisted_to_detached(&persisted, &unacked) {
                 Ok(session) => hydrated_sessions.push(session),
@@ -143,17 +145,6 @@ impl InMemorySmSessionRegistry {
                     );
                     bad_rows += 1;
                 }
-            }
-        }
-        // Best-effort durable cleanup of expired rows. Failures here
-        // are non-fatal — the janitor's next pass will retry.
-        for stream_id in &expired_ids {
-            if let Err(error) = storage.delete_session(stream_id).await {
-                debug!(
-                    stream_id = %stream_id,
-                    error = %error,
-                    "failed to delete expired persisted SM session during restore; will retry"
-                );
             }
         }
         let hydrated = hydrated_sessions.len();
@@ -168,9 +159,7 @@ impl InMemorySmSessionRegistry {
         }
         debug!(
             hydrated,
-            expired = expired_ids.len(),
-            bad_rows,
-            "restored detached SM sessions from persistence"
+            expired, bad_rows, "restored detached SM sessions from persistence"
         );
         Ok(hydrated)
     }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -948,47 +948,248 @@ async fn complete_claim_deletes_durable_session_on_resume() {
 }
 
 #[tokio::test]
-async fn store_session_evicts_jid_collision_durably() {
+async fn store_session_returns_jid_collision_eviction_and_preserves_rows_until_confirmed() {
     // Two store_session calls for the same JID with different
-    // stream_ids: the second supersedes the first per RFC
-    // resume semantics. The first's durable rows must be
-    // deleted too — otherwise restart_from_persistence
-    // resurrects the obsolete stream and exposes a stale
-    // <resume previd='…'/> path. (Copilot review on PR #344.)
+    // stream_ids: the second supersedes the first per RFC resume
+    // semantics. Issue #1097: the displaced session's unacked queue
+    // must NOT be silently dropped — it is returned to the caller for
+    // XEP-0198 §5 promotion, and its durable rows survive until the
+    // caller confirms via `confirm_drained`.
     let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
     let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
-    registry
+    let displaced = registry
         .store_session(realistic_test_session_for_jid(
             "stream-old",
             "alice@example.com/web".parse().unwrap(),
         ))
         .await
         .unwrap();
-    registry
+    assert!(displaced.is_empty(), "first store displaces nothing");
+    let displaced = registry
         .store_session(realistic_test_session_for_jid(
             "stream-new",
             "alice@example.com/web".parse().unwrap(),
         ))
         .await
         .unwrap();
+    assert_eq!(displaced.len(), 1);
+    assert_eq!(displaced[0].stream_id, "stream-old");
+    assert_eq!(
+        displaced[0].unacked_stanzas.len(),
+        2,
+        "displaced session carries its full unacked queue for promotion"
+    );
     let old_id = crate::pending_delivery::SmSessionId::new("stream-old");
     let new_id = crate::pending_delivery::SmSessionId::new("stream-new");
     assert!(
-        storage.get_session(&old_id).await.unwrap().is_none(),
-        "evicted stream-old should be removed from durable storage"
+        registry.peek_session("stream-old").await.unwrap().is_none(),
+        "displaced session must leave the in-memory pool"
+    );
+    assert!(
+        storage.get_session(&old_id).await.unwrap().is_some(),
+        "displaced rows survive until promotion is confirmed"
     );
     assert!(
         storage.get_session(&new_id).await.unwrap().is_some(),
         "stream-new should remain"
     );
+
+    registry.confirm_drained("stream-old").await;
+    assert!(
+        storage.get_session(&old_id).await.unwrap().is_none(),
+        "confirm_drained erases the displaced session's durable rows"
+    );
 }
 
 #[tokio::test]
-async fn restore_skips_and_deletes_expired_sessions() {
-    // Sessions whose resume window already closed during the
-    // server's downtime must not be rehydrated, AND their
-    // durable rows must be deleted so restart doesn't re-load
-    // them next boot. (Copilot review on PR #344.)
+async fn store_session_returns_capacity_evicted_session_and_preserves_rows() {
+    // Issue #1097: max_sessions overflow eviction must not silently
+    // drop the oldest session's unacked queue. The evicted session is
+    // returned so the waddle-server caller can run the XEP-0198 §5
+    // promote → confirm chain; durable rows survive until
+    // `confirm_drained`.
+    let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+    let registry = InMemorySmSessionRegistry::with_capacity(1).with_persistence(storage.clone());
+    let mut oldest =
+        realistic_test_session_for_jid("stream-oldest", "alice@example.com/web".parse().unwrap());
+    oldest.detached_at = Instant::now() - Duration::from_secs(30);
+    registry.store_session(oldest).await.unwrap();
+
+    let evicted = registry
+        .store_session(realistic_test_session_for_jid(
+            "stream-newer",
+            "bob@example.com/web".parse().unwrap(),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(evicted.len(), 1);
+    assert_eq!(evicted[0].stream_id, "stream-oldest");
+    assert_eq!(
+        evicted[0].unacked_stanzas.len(),
+        2,
+        "evicted session carries its full unacked queue for promotion"
+    );
+    assert!(registry
+        .peek_session("stream-oldest")
+        .await
+        .unwrap()
+        .is_none());
+    assert!(registry
+        .peek_session("stream-newer")
+        .await
+        .unwrap()
+        .is_some());
+
+    let oldest_id = crate::pending_delivery::SmSessionId::new("stream-oldest");
+    assert!(
+        storage.get_session(&oldest_id).await.unwrap().is_some(),
+        "evicted rows survive until promotion is confirmed"
+    );
+    assert_eq!(
+        storage.list_unacked(&oldest_id).await.unwrap().len(),
+        2,
+        "evicted unacked rows survive until promotion is confirmed"
+    );
+
+    registry.confirm_drained("stream-oldest").await;
+    assert!(storage.get_session(&oldest_id).await.unwrap().is_none());
+    assert!(storage.list_unacked(&oldest_id).await.unwrap().is_empty());
+}
+
+fn realistic_dm_stanza_xml(from: &str, to: &str, id: &str, body: &str) -> String {
+    let mut m = xmpp_parsers::message::Message::new(Some(to.parse::<jid::Jid>().expect("jid")));
+    m.from = Some(from.parse::<jid::Jid>().expect("jid"));
+    m.id = Some(xmpp_parsers::message::Id(id.to_string()));
+    m.type_ = xmpp_parsers::message::MessageType::Chat;
+    m.bodies
+        .insert(xmpp_parsers::message::Lang::new(), body.to_string());
+    let element: xmpp_parsers::minidom::Element = m.into();
+    let mut buf = Vec::new();
+    element.write_to(&mut buf).expect("serialize message");
+    String::from_utf8(buf).expect("utf8")
+}
+
+#[tokio::test]
+async fn scrub_for_tombstone_deletes_durable_rows_so_restart_cannot_replay() {
+    // Issue #1145: the tombstone scrub previously mutated memory only.
+    // A restart rehydrated the retracted stanza from sm_unacked and
+    // <resumed/> replayed it on the wire, defeating XEP-0424/0425
+    // retraction. The scrub must durably delete the matched
+    // (stream_id, sequence) rows too.
+    let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+    let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+    let session = make_test_session_with_unacked(
+        "stream-durable-tomb",
+        vec![
+            (
+                6,
+                realistic_dm_stanza_xml(
+                    "alice@example.com/web",
+                    "user@example.com/resource",
+                    "retracted-id",
+                    "secret",
+                ),
+            ),
+            (
+                7,
+                realistic_dm_stanza_xml(
+                    "alice@example.com/web",
+                    "user@example.com/resource",
+                    "kept-id",
+                    "safe",
+                ),
+            ),
+        ],
+    );
+    registry.store_session(session).await.unwrap();
+
+    let removed = registry
+        .scrub_unacked_for_tombstone("retracted-id", "user@example.com")
+        .await
+        .unwrap();
+    assert_eq!(removed, 1);
+
+    // Durable rows for the scrubbed stanza are gone.
+    let stream_id = crate::pending_delivery::SmSessionId::new("stream-durable-tomb");
+    let rows = storage.list_unacked(&stream_id).await.unwrap();
+    let seqs: Vec<u32> = rows.iter().map(|r| r.sequence).collect();
+    assert_eq!(
+        seqs,
+        vec![7],
+        "only the non-retracted stanza's row may remain durably"
+    );
+
+    // Restart simulation: a fresh registry over the same storage must
+    // not resurrect the retracted stanza into the replay queue.
+    let restarted = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+    restarted.restore_from_persistence().await.unwrap();
+    let hydrated = restarted
+        .peek_session("stream-durable-tomb")
+        .await
+        .unwrap()
+        .expect("session survives restart");
+    assert_eq!(hydrated.unacked_stanzas.len(), 1);
+    assert!(
+        !hydrated
+            .unacked_stanzas
+            .iter()
+            .any(|entry| entry.stanza_xml.contains("secret")),
+        "retracted stanza must not be replayable after restart"
+    );
+    assert!(hydrated
+        .unacked_stanzas
+        .iter()
+        .any(|entry| entry.stanza_xml.contains("safe")));
+}
+
+#[tokio::test]
+async fn invalidate_sessions_for_jid_preserves_rows_until_confirmed() {
+    // Issue #1097 (fresh-bind invalidation): superseded detached
+    // sessions removed on a fresh bind carry unacked queues that the
+    // caller must promote (XEP-0198 §5). Durable rows survive until
+    // the caller confirms successful promotion via `confirm_drained`
+    // so a crash mid-promotion retries after restart.
+    let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+    let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+    let jid: FullJid = "alice@example.com/web".parse().unwrap();
+    registry
+        .store_session(realistic_test_session_for_jid("stream-stale", jid.clone()))
+        .await
+        .unwrap();
+
+    let removed = registry.invalidate_sessions_for_jid(&jid).await.unwrap();
+    assert_eq!(removed.len(), 1);
+    assert_eq!(removed[0].stream_id, "stream-stale");
+    assert_eq!(
+        removed[0].unacked_stanzas.len(),
+        2,
+        "invalidated session carries its full unacked queue for promotion"
+    );
+    assert!(registry
+        .peek_session("stream-stale")
+        .await
+        .unwrap()
+        .is_none());
+
+    let stale_id = crate::pending_delivery::SmSessionId::new("stream-stale");
+    assert!(
+        storage.get_session(&stale_id).await.unwrap().is_some(),
+        "invalidated rows survive until promotion is confirmed"
+    );
+
+    registry.confirm_drained("stream-stale").await;
+    assert!(storage.get_session(&stale_id).await.unwrap().is_none());
+    assert!(storage.list_unacked(&stale_id).await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn restore_hydrates_expired_sessions_for_promotion_and_preserves_rows() {
+    // Issue #1098: sessions whose resume window closed during the
+    // server's downtime must NOT be durably deleted at restore time —
+    // that silently discards their unacked queues. Instead they are
+    // hydrated (expired) so the SM-expiry janitor's next
+    // `drain_expired` pass runs the XEP-0198 §5 promote → confirm
+    // chain; durable rows survive until `confirm_drained`.
     let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
 
     // Manually insert an already-expired session by writing
@@ -1000,7 +1201,7 @@ async fn restore_skips_and_deletes_expired_sessions() {
         user_id: "alice".to_string(),
         jid: "alice@example.com/web".parse().unwrap(),
         inbound_count: 0,
-        outbound_count: 0,
+        outbound_count: 1,
         last_acked: 0,
         replay_gap_through: None,
         max_resume_time: Some(60),
@@ -1015,14 +1216,60 @@ async fn restore_skips_and_deletes_expired_sessions() {
         presence_priority: 0,
     };
     storage.upsert_session(expired).await.unwrap();
+    let mut queued =
+        xmpp_parsers::message::Message::new(Some("alice@example.com".parse::<jid::Jid>().unwrap()));
+    queued
+        .bodies
+        .insert(xmpp_parsers::message::Lang::new(), "missed".to_string());
+    storage
+        .append_unacked(super::super::persistence::PersistedUnackedStanza {
+            stream_id: crate::pending_delivery::SmSessionId::new("stream-expired"),
+            sequence: 1,
+            stanza: Box::new(Stanza::Message(queued)),
+            original_receipt_at: now - chrono::Duration::seconds(130),
+        })
+        .await
+        .unwrap();
 
     let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
     let hydrated = registry.restore_from_persistence().await.unwrap();
-    assert_eq!(hydrated, 0);
-    // Durable cleanup of expired rows.
+    assert_eq!(
+        hydrated, 1,
+        "expired session must be hydrated for the janitor"
+    );
+
+    // Expired sessions are never resumable on the wire.
+    assert!(registry
+        .peek_session("stream-expired")
+        .await
+        .unwrap()
+        .is_none());
+
+    // Durable rows survive restore — deletion happens only after the
+    // caller confirms successful promotion.
+    assert!(storage
+        .get_session(&crate::pending_delivery::SmSessionId::new("stream-expired"))
+        .await
+        .unwrap()
+        .is_some());
+
+    // The janitor's drain pass sees the session with its full queue.
+    let drained = registry.drain_expired().await.unwrap();
+    assert_eq!(drained.len(), 1);
+    assert_eq!(drained[0].stream_id, "stream-expired");
+    assert_eq!(drained[0].unacked_stanzas.len(), 1);
+    assert!(drained[0].unacked_stanzas[0].stanza_xml.contains("missed"));
+
+    // Only confirm_drained erases the durable rows.
+    registry.confirm_drained("stream-expired").await;
     assert!(storage
         .get_session(&crate::pending_delivery::SmSessionId::new("stream-expired"))
         .await
         .unwrap()
         .is_none());
+    assert!(storage
+        .list_unacked(&crate::pending_delivery::SmSessionId::new("stream-expired"))
+        .await
+        .unwrap()
+        .is_empty());
 }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -15,6 +15,21 @@ fn bare(s: &str) -> jid::BareJid {
     s.parse().expect("valid bare jid")
 }
 
+fn direct_target(wire_id: &str, author: &str, archive: &str) -> crate::tombstone::TombstoneTarget {
+    crate::tombstone::TombstoneTarget::Direct {
+        wire_id: wire_id.to_string(),
+        author: bare(author),
+        archive: bare(archive),
+    }
+}
+
+fn groupchat_target(stanza_id: &str, room: &str) -> crate::tombstone::TombstoneTarget {
+    crate::tombstone::TombstoneTarget::Groupchat {
+        stanza_id: stanza_id.to_string(),
+        room: bare(room),
+    }
+}
+
 fn message_stanza_xml_with_id(id: String) -> String {
     let mut message = xmpp_parsers::message::Message::new(None::<jid::Jid>);
     message.id = Some(xmpp_parsers::message::Id(id));
@@ -159,7 +174,11 @@ async fn xep_0198_scrub_for_tombstone_removes_matching_1on1_message() {
     registry.store_session(session).await.unwrap();
 
     let removed = registry
-        .scrub_unacked_for_tombstone("target", &bare("user@example.com"))
+        .scrub_unacked_for_tombstone(&direct_target(
+            "target",
+            "alice@example.com",
+            "user@example.com",
+        ))
         .await
         .unwrap();
     assert_eq!(removed, 1, "exactly one matching message should be removed");
@@ -286,7 +305,10 @@ async fn xep_0198_scrub_for_tombstone_matches_groupchat_stanza_id() {
     registry.store_session(session).await.unwrap();
 
     let removed = registry
-        .scrub_unacked_for_tombstone("canonical-archive-id", &bare("room@conf.example.com"))
+        .scrub_unacked_for_tombstone(&groupchat_target(
+            "canonical-archive-id",
+            "room@conf.example.com",
+        ))
         .await
         .unwrap();
     assert_eq!(
@@ -324,7 +346,11 @@ async fn xep_0198_scrub_for_tombstone_does_not_cross_conversations() {
     // remove the carol→user message even though it shares the
     // wire id, because alice is neither its `from` nor `to`.
     let removed = registry
-        .scrub_unacked_for_tombstone("msg-1", &bare("alice@example.com"))
+        .scrub_unacked_for_tombstone(&direct_target(
+            "msg-1",
+            "alice@example.com",
+            "alice@example.com",
+        ))
         .await
         .unwrap();
     assert_eq!(
@@ -364,7 +390,11 @@ async fn xep_0198_scrub_for_tombstone_ignores_non_xep0359_stanza_id_namespace() 
     registry.store_session(session).await.unwrap();
 
     let removed = registry
-        .scrub_unacked_for_tombstone("target", &bare("user@example.com"))
+        .scrub_unacked_for_tombstone(&direct_target(
+            "target",
+            "alice@example.com",
+            "user@example.com",
+        ))
         .await
         .unwrap();
     assert_eq!(
@@ -388,7 +418,11 @@ async fn xep_0198_scrub_for_tombstone_handles_no_match() {
             .await
             .unwrap();
     let removed = registry
-        .scrub_unacked_for_tombstone("not-here", &bare("user@example.com"))
+        .scrub_unacked_for_tombstone(&direct_target(
+            "not-here",
+            "alice@example.com",
+            "user@example.com",
+        ))
         .await
         .unwrap();
     assert_eq!(removed, 0);
@@ -1108,7 +1142,11 @@ async fn scrub_for_tombstone_deletes_durable_rows_so_restart_cannot_replay() {
     registry.store_session(session).await.unwrap();
 
     let removed = registry
-        .scrub_unacked_for_tombstone("retracted-id", &bare("user@example.com"))
+        .scrub_unacked_for_tombstone(&direct_target(
+            "retracted-id",
+            "alice@example.com",
+            "user@example.com",
+        ))
         .await
         .unwrap();
     assert_eq!(removed, 1);
@@ -1530,7 +1568,11 @@ async fn tombstone_scrub_reaches_durable_rows_of_off_map_streams() {
 
     // Retraction arrives during the window.
     let removed = registry
-        .scrub_unacked_for_tombstone("retract-me", &bare("user@example.com"))
+        .scrub_unacked_for_tombstone(&direct_target(
+            "retract-me",
+            "alice@example.com",
+            "user@example.com",
+        ))
         .await
         .unwrap();
     assert_eq!(
@@ -1689,20 +1731,15 @@ async fn scrub_records_recent_tombstone_for_promotion_time_recheck() {
     // promotion path can re-check before inserting into pending
     // delivery.
     let registry = InMemorySmSessionRegistry::new();
+    let target = direct_target("retract-me", "alice@example.com", "user@example.com");
     let before = chrono::Utc::now();
-    registry
-        .scrub_unacked_for_tombstone("retract-me", &bare("user@example.com"))
-        .await
-        .unwrap();
+    registry.scrub_unacked_for_tombstone(&target).await.unwrap();
     let after = chrono::Utc::now();
 
     let records = registry.recent_tombstones().unwrap();
     assert_eq!(
         records.iter().map(|r| r.key.clone()).collect::<Vec<_>>(),
-        vec![TombstoneKey {
-            target_id: "retract-me".to_string(),
-            archive_jid: bare("user@example.com"),
-        }],
+        vec![target],
         "the scrub must record its tombstone identity for promotion-time re-check"
     );
     // Round-3 review finding 2: the record carries the wall-clock
@@ -1721,29 +1758,40 @@ async fn recent_tombstones_evicts_entries_past_ttl() {
     let registry = InMemorySmSessionRegistry::new();
     let stale = Instant::now() - (tombstones::RECENT_TOMBSTONE_TTL + Duration::from_secs(1));
     registry
-        .record_recent_tombstone_at("old-target", &bare("user@example.com"), stale)
+        .record_recent_tombstone_at(
+            &direct_target("old-target", "alice@example.com", "user@example.com"),
+            stale,
+        )
         .unwrap();
+    let fresh = direct_target("fresh-target", "alice@example.com", "user@example.com");
     registry
-        .record_recent_tombstone_at("fresh-target", &bare("user@example.com"), Instant::now())
+        .record_recent_tombstone_at(&fresh, Instant::now())
         .unwrap();
 
     let records = registry.recent_tombstones().unwrap();
     assert_eq!(
         records.iter().map(|r| r.key.clone()).collect::<Vec<_>>(),
-        vec![TombstoneKey {
-            target_id: "fresh-target".to_string(),
-            archive_jid: bare("user@example.com"),
-        }],
+        vec![fresh],
         "entries older than the TTL must be evicted; fresh ones retained"
     );
 }
 
 #[tokio::test]
-async fn recent_tombstones_bounds_entry_count() {
+async fn recent_tombstones_bounds_entry_count_across_archives() {
+    // Global backstop: distinct archives each get one record, so the
+    // per-archive cap never trips; the global hard cap must still
+    // bound the list, evicting the oldest overall.
     let registry = InMemorySmSessionRegistry::new();
     for i in 0..(tombstones::MAX_RECENT_TOMBSTONES + 5) {
         registry
-            .record_recent_tombstone_at(&format!("target-{i}"), &bare("user@example.com"), Instant::now())
+            .record_recent_tombstone_at(
+                &direct_target(
+                    &format!("target-{i}"),
+                    "alice@example.com",
+                    &format!("user{i}@example.com"),
+                ),
+                Instant::now(),
+            )
             .unwrap();
     }
     let records = registry.recent_tombstones().unwrap();
@@ -1753,9 +1801,79 @@ async fn recent_tombstones_bounds_entry_count() {
         "the recent-tombstone record must stay bounded"
     );
     assert_eq!(
-        records.last().map(|r| r.key.target_id.as_str()),
+        records.last().map(|r| r.key.id()),
         Some(format!("target-{}", tombstones::MAX_RECENT_TOMBSTONES + 4).as_str()),
         "overflow must evict the oldest entries, keeping the newest"
+    );
+}
+
+#[tokio::test]
+async fn tombstone_flood_on_one_archive_does_not_evict_other_archives_record() {
+    // FINDING C repro: an authenticated user retracting 1024+ of their
+    // own messages (all one archive) used to flush every other
+    // archive's unexpired record oldest-first, disabling the
+    // promotion-time re-check for the victim's retraction.
+    let registry = InMemorySmSessionRegistry::new();
+    let victim = direct_target("victim-retraction", "bob@example.com", "victim@example.com");
+    registry
+        .record_recent_tombstone_at(&victim, Instant::now())
+        .unwrap();
+
+    // Attacker floods well past the global cap from a single archive.
+    for i in 0..(tombstones::MAX_RECENT_TOMBSTONES + 100) {
+        registry
+            .record_recent_tombstone_at(
+                &direct_target(
+                    &format!("spam-{i}"),
+                    "mallory@example.com",
+                    "mallory-chat@example.com",
+                ),
+                Instant::now(),
+            )
+            .unwrap();
+    }
+
+    let records = registry.recent_tombstones().unwrap();
+    assert!(
+        records.iter().any(|r| r.key == victim),
+        "an unexpired record for another archive must survive a single-archive flood"
+    );
+    let flood_records = records
+        .iter()
+        .filter(|r| r.key.archive_jid() == &bare("mallory-chat@example.com"))
+        .count();
+    assert!(
+        flood_records <= tombstones::MAX_RECENT_TOMBSTONES_PER_ARCHIVE,
+        "one archive's records must be bounded by the per-archive cap \
+         (got {flood_records})"
+    );
+}
+
+#[tokio::test]
+async fn per_archive_cap_evicts_oldest_within_that_archive_only() {
+    let registry = InMemorySmSessionRegistry::new();
+    for i in 0..(tombstones::MAX_RECENT_TOMBSTONES_PER_ARCHIVE + 3) {
+        registry
+            .record_recent_tombstone_at(
+                &direct_target(&format!("id-{i}"), "alice@example.com", "chat@example.com"),
+                Instant::now(),
+            )
+            .unwrap();
+    }
+    let records = registry.recent_tombstones().unwrap();
+    assert_eq!(
+        records.len(),
+        tombstones::MAX_RECENT_TOMBSTONES_PER_ARCHIVE,
+        "same-archive records are bounded by the per-archive cap"
+    );
+    assert!(
+        !records.iter().any(|r| r.key.id() == "id-0"),
+        "the oldest same-archive record is the eviction victim"
+    );
+    assert_eq!(
+        records.last().map(|r| r.key.id()),
+        Some(format!("id-{}", tombstones::MAX_RECENT_TOMBSTONES_PER_ARCHIVE + 2).as_str()),
+        "the newest record survives"
     );
 }
 
@@ -1803,6 +1921,267 @@ async fn reinsert_for_retry_preserves_detached_at_for_eviction_ordering() {
             .is_some(),
         "the healthy resumable session must survive the eviction"
     );
+}
+
+#[tokio::test]
+async fn reinsert_for_retry_drops_entries_whose_durable_rows_were_scrubbed() {
+    // FINDING D repro: the uncounted janitor retry path
+    // (record_promotion_failure erroring) re-inserted the drained
+    // session's IN-MEMORY queue verbatim. A XEP-0424/0425 scrub that
+    // ran while the session was off-map (durable phase-4 sweep)
+    // deleted only the durable rows, so after RECENT_TOMBSTONE_TTL
+    // expired the retained in-memory copy promoted the retracted
+    // stanza anyway. reinsert_for_retry must diff against durable
+    // rows and drop scrubbed entries.
+    let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+    let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+    let mut session = realistic_test_session_for_jid(
+        "stream-retry-scrubbed",
+        "user@example.com/resource".parse().unwrap(),
+    );
+    session.unacked_stanzas = vec![
+        DetachedUnackedStanza {
+            sequence: 6,
+            stanza_xml: realistic_dm_stanza_xml(
+                "alice@example.com/web",
+                "user@example.com/resource",
+                "retract-me",
+                "secret",
+            ),
+            original_receipt_at: Utc::now(),
+        },
+        DetachedUnackedStanza {
+            sequence: 7,
+            stanza_xml: realistic_dm_stanza_xml(
+                "alice@example.com/web",
+                "user@example.com/resource",
+                "keep-me",
+                "safe",
+            ),
+            original_receipt_at: Utc::now(),
+        },
+    ];
+    registry.store_session(session).await.unwrap();
+
+    // Janitor drains the session off both maps (mid-promotion).
+    let drained = registry.drain_all_for_shutdown().await.unwrap();
+    assert_eq!(drained.len(), 1);
+
+    // Retraction lands during the window: the off-map durable sweep
+    // (phase 4) deletes the durable row for sequence 6.
+    let removed = registry
+        .scrub_unacked_for_tombstone(&direct_target(
+            "retract-me",
+            "alice@example.com",
+            "user@example.com",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(removed, 1);
+
+    // Promotion fails AND record_promotion_failure fails → the janitor
+    // re-inserts the drained (pre-scrub) copy for retry.
+    registry
+        .reinsert_for_retry(drained.into_iter().next().unwrap())
+        .await
+        .unwrap();
+
+    // The retry drain must NOT resurrect the scrubbed stanza.
+    let retried = registry.drain_expired().await.unwrap();
+    assert_eq!(retried.len(), 1);
+    let sequences: Vec<u32> = retried[0]
+        .unacked_stanzas
+        .iter()
+        .map(|entry| entry.sequence)
+        .collect();
+    assert_eq!(
+        sequences,
+        vec![7],
+        "a durably-scrubbed stanza must not survive reinsert_for_retry"
+    );
+    assert!(
+        !retried[0]
+            .unacked_stanzas
+            .iter()
+            .any(|entry| entry.stanza_xml.contains("secret")),
+        "retracted content must not be promotable after the retry re-insert"
+    );
+}
+
+/// Persistence wrapper whose `store_session_atomic` fails while armed
+/// — models a durable-backend outage hitting exactly the snapshot
+/// write inside `store_session` (Finding E).
+struct FailingSnapshotPersistence {
+    inner: super::super::persistence::InMemorySmPersistence,
+    fail_snapshots: std::sync::atomic::AtomicBool,
+}
+
+impl FailingSnapshotPersistence {
+    fn new() -> Self {
+        Self {
+            inner: super::super::persistence::InMemorySmPersistence::new(),
+            fail_snapshots: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl super::super::persistence::SmPersistenceStorage for FailingSnapshotPersistence {
+    async fn upsert_session(
+        &self,
+        session: super::super::persistence::PersistedSession,
+    ) -> Result<(), super::super::persistence::SmPersistenceError> {
+        self.inner.upsert_session(session).await
+    }
+
+    async fn get_session(
+        &self,
+        stream_id: &crate::pending_delivery::SmSessionId,
+    ) -> Result<
+        Option<super::super::persistence::PersistedSession>,
+        super::super::persistence::SmPersistenceError,
+    > {
+        self.inner.get_session(stream_id).await
+    }
+
+    async fn delete_session(
+        &self,
+        stream_id: &crate::pending_delivery::SmSessionId,
+    ) -> Result<(), super::super::persistence::SmPersistenceError> {
+        self.inner.delete_session(stream_id).await
+    }
+
+    async fn append_unacked(
+        &self,
+        stanza: super::super::persistence::PersistedUnackedStanza,
+    ) -> Result<(), super::super::persistence::SmPersistenceError> {
+        self.inner.append_unacked(stanza).await
+    }
+
+    async fn ack_through(
+        &self,
+        stream_id: &crate::pending_delivery::SmSessionId,
+        up_to_sequence: u32,
+    ) -> Result<u64, super::super::persistence::SmPersistenceError> {
+        self.inner.ack_through(stream_id, up_to_sequence).await
+    }
+
+    async fn delete_unacked(
+        &self,
+        stream_id: &crate::pending_delivery::SmSessionId,
+        sequences: &[u32],
+    ) -> Result<u64, super::super::persistence::SmPersistenceError> {
+        self.inner.delete_unacked(stream_id, sequences).await
+    }
+
+    async fn list_unacked(
+        &self,
+        stream_id: &crate::pending_delivery::SmSessionId,
+    ) -> Result<
+        Vec<super::super::persistence::PersistedUnackedStanza>,
+        super::super::persistence::SmPersistenceError,
+    > {
+        self.inner.list_unacked(stream_id).await
+    }
+
+    async fn list_expired_sessions(
+        &self,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<
+        Vec<super::super::persistence::PersistedSession>,
+        super::super::persistence::SmPersistenceError,
+    > {
+        self.inner.list_expired_sessions(now).await
+    }
+
+    async fn list_all_sessions(
+        &self,
+    ) -> Result<
+        Vec<super::super::persistence::PersistedSession>,
+        super::super::persistence::SmPersistenceError,
+    > {
+        self.inner.list_all_sessions().await
+    }
+
+    async fn store_session_atomic(
+        &self,
+        session: super::super::persistence::PersistedSession,
+        unacked: Vec<super::super::persistence::PersistedUnackedStanza>,
+    ) -> Result<(), super::super::persistence::SmPersistenceError> {
+        if self
+            .fail_snapshots
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            return Err(super::super::persistence::SmPersistenceError::Other(
+                "simulated snapshot-write failure".into(),
+            ));
+        }
+        self.inner.store_session_atomic(session, unacked).await
+    }
+}
+
+#[tokio::test]
+async fn store_session_snapshot_failure_reinserts_displaced_sessions_for_retry() {
+    // FINDING E repro: store_session removes displaced sessions from
+    // both maps, then writes the NEW session's snapshot. When that
+    // write fails, store_session returns Err and the caller drops the
+    // displaced vec — the displaced sessions are off-map with durable
+    // rows stranded until restart (drain_expired scans memory only).
+    // The failure path must re-insert them as expired-for-retry.
+    let storage = std::sync::Arc::new(FailingSnapshotPersistence::new());
+    let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+    let jid: FullJid = "alice@example.com/web".parse().unwrap();
+    registry
+        .store_session(realistic_test_session_for_jid("stream-victim", jid.clone()))
+        .await
+        .unwrap();
+
+    // Fresh bind for the same JID displaces the victim, but its own
+    // snapshot write fails.
+    storage
+        .fail_snapshots
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    let result = registry
+        .store_session(realistic_test_session_for_jid("stream-new", jid.clone()))
+        .await;
+    assert!(
+        result.is_err(),
+        "snapshot failure must surface to the caller"
+    );
+    storage
+        .fail_snapshots
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+
+    // The displaced victim must be back in the map, expired-for-retry:
+    // not resumable on the wire...
+    assert!(registry
+        .peek_session("stream-victim")
+        .await
+        .unwrap()
+        .is_none());
+    // ...but drainable by the janitor's next pass with its full queue.
+    let drained = registry.drain_expired().await.unwrap();
+    let drained_ids: Vec<&str> = drained.iter().map(|s| s.stream_id.as_str()).collect();
+    assert!(
+        drained_ids.contains(&"stream-victim"),
+        "displaced session must be re-inserted for janitor retry when the \
+         snapshot write fails (got {drained_ids:?})"
+    );
+    let victim = drained
+        .iter()
+        .find(|s| s.stream_id == "stream-victim")
+        .expect("victim drained");
+    assert_eq!(
+        victim.unacked_stanzas.len(),
+        2,
+        "the displaced session keeps its full unacked queue for promotion"
+    );
+    // Its durable rows are untouched (persist-until-confirmed).
+    assert!(storage
+        .get_session(&crate::pending_delivery::SmSessionId::new("stream-victim"))
+        .await
+        .unwrap()
+        .is_some());
 }
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -1685,19 +1685,30 @@ async fn scrub_records_recent_tombstone_for_promotion_time_recheck() {
     // promotion path can re-check before inserting into pending
     // delivery.
     let registry = InMemorySmSessionRegistry::new();
+    let before = chrono::Utc::now();
     registry
         .scrub_unacked_for_tombstone("retract-me", "user@example.com")
         .await
         .unwrap();
+    let after = chrono::Utc::now();
 
-    let keys = registry.recent_tombstones().unwrap();
+    let records = registry.recent_tombstones().unwrap();
     assert_eq!(
-        keys,
+        records.iter().map(|r| r.key.clone()).collect::<Vec<_>>(),
         vec![TombstoneKey {
             target_id: "retract-me".to_string(),
             archive_jid: "user@example.com".to_string(),
         }],
         "the scrub must record its tombstone identity for promotion-time re-check"
+    );
+    // Round-3 review finding 2: the record carries the wall-clock
+    // recording time so promotion can scope the match backward in
+    // time (a stanza received after the retraction must not match).
+    let recorded_at_utc = records[0].recorded_at_utc;
+    assert!(
+        before <= recorded_at_utc && recorded_at_utc <= after,
+        "recorded_at_utc must be the wall-clock time of the scrub \
+         (got {recorded_at_utc}, expected within [{before}, {after}])"
     );
 }
 
@@ -1712,9 +1723,9 @@ async fn recent_tombstones_evicts_entries_past_ttl() {
         .record_recent_tombstone_at("fresh-target", "user@example.com", Instant::now())
         .unwrap();
 
-    let keys = registry.recent_tombstones().unwrap();
+    let records = registry.recent_tombstones().unwrap();
     assert_eq!(
-        keys,
+        records.iter().map(|r| r.key.clone()).collect::<Vec<_>>(),
         vec![TombstoneKey {
             target_id: "fresh-target".to_string(),
             archive_jid: "user@example.com".to_string(),
@@ -1731,14 +1742,14 @@ async fn recent_tombstones_bounds_entry_count() {
             .record_recent_tombstone_at(&format!("target-{i}"), "user@example.com", Instant::now())
             .unwrap();
     }
-    let keys = registry.recent_tombstones().unwrap();
+    let records = registry.recent_tombstones().unwrap();
     assert_eq!(
-        keys.len(),
+        records.len(),
         tombstones::MAX_RECENT_TOMBSTONES,
         "the recent-tombstone record must stay bounded"
     );
     assert_eq!(
-        keys.last().map(|k| k.target_id.as_str()),
+        records.last().map(|r| r.key.target_id.as_str()),
         Some(format!("target-{}", tombstones::MAX_RECENT_TOMBSTONES + 4).as_str()),
         "overflow must evict the oldest entries, keeping the newest"
     );

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -1273,3 +1273,438 @@ async fn restore_hydrates_expired_sessions_for_promotion_and_preserves_rows() {
         .unwrap()
         .is_empty());
 }
+
+/// Persistence wrapper that pauses inside `store_session_atomic` for
+/// one designated stream so a test can deterministically interleave a
+/// displacement (`store_session` for the same JID under a different
+/// stream id) between a detached-append's durable snapshot write and
+/// its post-write in-memory recheck.
+struct GatedSnapshotPersistence {
+    inner: super::super::persistence::InMemorySmPersistence,
+    gate_stream: String,
+    armed: std::sync::atomic::AtomicBool,
+    reached: tokio::sync::Notify,
+    proceed: tokio::sync::Notify,
+}
+
+impl GatedSnapshotPersistence {
+    fn new(gate_stream: &str) -> Self {
+        Self {
+            inner: super::super::persistence::InMemorySmPersistence::new(),
+            gate_stream: gate_stream.to_string(),
+            armed: std::sync::atomic::AtomicBool::new(false),
+            reached: tokio::sync::Notify::new(),
+            proceed: tokio::sync::Notify::new(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl super::super::persistence::SmPersistenceStorage for GatedSnapshotPersistence {
+    async fn upsert_session(
+        &self,
+        session: super::super::persistence::PersistedSession,
+    ) -> Result<(), super::super::persistence::SmPersistenceError> {
+        self.inner.upsert_session(session).await
+    }
+
+    async fn get_session(
+        &self,
+        stream_id: &crate::pending_delivery::SmSessionId,
+    ) -> Result<
+        Option<super::super::persistence::PersistedSession>,
+        super::super::persistence::SmPersistenceError,
+    > {
+        self.inner.get_session(stream_id).await
+    }
+
+    async fn delete_session(
+        &self,
+        stream_id: &crate::pending_delivery::SmSessionId,
+    ) -> Result<(), super::super::persistence::SmPersistenceError> {
+        self.inner.delete_session(stream_id).await
+    }
+
+    async fn append_unacked(
+        &self,
+        stanza: super::super::persistence::PersistedUnackedStanza,
+    ) -> Result<(), super::super::persistence::SmPersistenceError> {
+        self.inner.append_unacked(stanza).await
+    }
+
+    async fn ack_through(
+        &self,
+        stream_id: &crate::pending_delivery::SmSessionId,
+        up_to_sequence: u32,
+    ) -> Result<u64, super::super::persistence::SmPersistenceError> {
+        self.inner.ack_through(stream_id, up_to_sequence).await
+    }
+
+    async fn delete_unacked(
+        &self,
+        stream_id: &crate::pending_delivery::SmSessionId,
+        sequences: &[u32],
+    ) -> Result<u64, super::super::persistence::SmPersistenceError> {
+        self.inner.delete_unacked(stream_id, sequences).await
+    }
+
+    async fn list_unacked(
+        &self,
+        stream_id: &crate::pending_delivery::SmSessionId,
+    ) -> Result<
+        Vec<super::super::persistence::PersistedUnackedStanza>,
+        super::super::persistence::SmPersistenceError,
+    > {
+        self.inner.list_unacked(stream_id).await
+    }
+
+    async fn list_expired_sessions(
+        &self,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<
+        Vec<super::super::persistence::PersistedSession>,
+        super::super::persistence::SmPersistenceError,
+    > {
+        self.inner.list_expired_sessions(now).await
+    }
+
+    async fn list_all_sessions(
+        &self,
+    ) -> Result<
+        Vec<super::super::persistence::PersistedSession>,
+        super::super::persistence::SmPersistenceError,
+    > {
+        self.inner.list_all_sessions().await
+    }
+
+    async fn store_session_atomic(
+        &self,
+        session: super::super::persistence::PersistedSession,
+        unacked: Vec<super::super::persistence::PersistedUnackedStanza>,
+    ) -> Result<(), super::super::persistence::SmPersistenceError> {
+        if self.armed.load(std::sync::atomic::Ordering::SeqCst)
+            && session.stream_id.as_str() == self.gate_stream
+        {
+            self.reached.notify_one();
+            self.proceed.notified().await;
+        }
+        self.inner.store_session_atomic(session, unacked).await
+    }
+}
+
+#[tokio::test]
+async fn detached_append_losing_race_to_displacement_preserves_durable_rows() {
+    // Regression: `update_detached_session_snapshot`'s fail-closed
+    // branch durably deleted the stream's rows when the session
+    // vanished from both maps between the stream-lock read and the
+    // post-write recheck. Displacement by `store_session` (which holds
+    // only the NEW stream's shard lock) is exactly such a removal —
+    // and displaced sessions follow the persist-until-confirmed
+    // contract: their durable rows must survive until
+    // `confirm_drained`. A crash mid-promotion after the fail-closed
+    // delete lost the whole queue.
+    let victim_jid: FullJid = "race@example.com/old".parse().unwrap();
+    let storage = std::sync::Arc::new(GatedSnapshotPersistence::new("stream-race-victim"));
+    let registry =
+        std::sync::Arc::new(InMemorySmSessionRegistry::new().with_persistence(storage.clone()));
+
+    // Pick a displacing stream id on a DIFFERENT lock shard so the
+    // interleaving below cannot self-deadlock on a shared shard.
+    let victim_lock = registry.stream_lock("stream-race-victim").unwrap();
+    let displacing_id = (0..10_000)
+        .map(|i| format!("stream-race-new-{i}"))
+        .find(|candidate| {
+            let lock = registry.stream_lock(candidate).expect("stream lock");
+            !std::sync::Arc::ptr_eq(&lock, &victim_lock)
+        })
+        .expect("some candidate hashes to a different shard");
+
+    registry
+        .store_session(realistic_test_session_for_jid(
+            "stream-race-victim",
+            victim_jid.clone(),
+        ))
+        .await
+        .unwrap();
+
+    // Arm the gate, then run the detached-append snapshot; it pauses
+    // inside its durable write.
+    storage
+        .armed
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    let append_registry = std::sync::Arc::clone(&registry);
+    let append = tokio::spawn(async move {
+        append_registry
+            .update_detached_session_snapshot(
+                "stream-race-victim",
+                |_| true,
+                |session| {
+                    session.record_detached_outbound(
+                        message_stanza_xml_with_id("race-append".to_string()),
+                        Utc::now(),
+                    );
+                },
+            )
+            .await
+    });
+    storage.reached.notified().await;
+    storage
+        .armed
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+
+    // Same client fresh-binds under a new stream id: store_session
+    // displaces the victim from the in-memory maps (jid collision)
+    // while the append is parked mid-write.
+    let displaced = registry
+        .store_session(realistic_test_session_for_jid(&displacing_id, victim_jid))
+        .await
+        .unwrap();
+    assert_eq!(displaced.len(), 1, "victim must be displaced");
+
+    // Let the append finish; it must observe the loss of ownership...
+    storage.proceed.notify_one();
+    let updated = append.await.unwrap().unwrap();
+    assert!(!updated, "append must report the session as gone");
+
+    // ...WITHOUT durably deleting rows it no longer owns. Deletion is
+    // owned by confirm_drained / the janitor after promotion.
+    assert!(
+        storage
+            .get_session(&crate::pending_delivery::SmSessionId::new(
+                "stream-race-victim"
+            ))
+            .await
+            .unwrap()
+            .is_some(),
+        "displaced session's durable rows must survive until promotion confirms"
+    );
+}
+
+#[tokio::test]
+async fn tombstone_scrub_reaches_durable_rows_of_off_map_streams() {
+    // S5 regression: the scrub's in-map phases snapshot only the two
+    // in-memory maps. A stream that is off-map but still durable
+    // (displaced mid-promotion, janitor-drained mid-promotion, or a
+    // promotion-failure retry window) was unreachable — a retraction
+    // arriving in that window was resurrected at the next restart and
+    // promoted verbatim.
+    let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+    let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+    let session = realistic_test_session_for_jid(
+        "stream-offmap",
+        "user@example.com/resource".parse().unwrap(),
+    );
+    let mut session = session;
+    session.unacked_stanzas = vec![
+        DetachedUnackedStanza {
+            sequence: 6,
+            stanza_xml: realistic_dm_stanza_xml(
+                "alice@example.com/web",
+                "user@example.com/resource",
+                "retract-me",
+                "secret",
+            ),
+            original_receipt_at: Utc::now(),
+        },
+        DetachedUnackedStanza {
+            sequence: 7,
+            stanza_xml: realistic_dm_stanza_xml(
+                "alice@example.com/web",
+                "user@example.com/resource",
+                "keep-me",
+                "safe",
+            ),
+            original_receipt_at: Utc::now(),
+        },
+    ];
+    registry.store_session(session).await.unwrap();
+
+    // Simulate mid-promotion: the stream leaves memory (janitor drain /
+    // displacement) but its durable rows survive un-confirmed.
+    let drained = registry.drain_all_for_shutdown().await.unwrap();
+    assert_eq!(drained.len(), 1);
+
+    // Retraction arrives during the window.
+    let removed = registry
+        .scrub_unacked_for_tombstone("retract-me", "user@example.com")
+        .await
+        .unwrap();
+    assert_eq!(
+        removed, 1,
+        "durable-side sweep must scrub off-map streams' rows"
+    );
+
+    // Restart-style read: the retracted stanza must be gone, the
+    // non-matching one preserved.
+    let restarted = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+    assert_eq!(restarted.restore_from_persistence().await.unwrap(), 1);
+    let hydrated = restarted
+        .peek_session("stream-offmap")
+        .await
+        .unwrap()
+        .expect("session rehydrates");
+    assert_eq!(hydrated.unacked_stanzas.len(), 1);
+    assert!(
+        !hydrated
+            .unacked_stanzas
+            .iter()
+            .any(|entry| entry.stanza_xml.contains("secret")),
+        "retracted stanza must not survive the restart"
+    );
+    assert!(hydrated
+        .unacked_stanzas
+        .iter()
+        .any(|entry| entry.stanza_xml.contains("safe")));
+}
+
+#[tokio::test]
+async fn displace_stored_session_if_unclaimed_preserves_durable_rows() {
+    // S2 regression (ownership-moved detach path): when a cleanup
+    // loses the registry ownership race, the just-stored detached
+    // session must be removed from memory FOR PROMOTION — its durable
+    // rows must survive until the promote → confirm_drained chain, not
+    // be durably deleted up-front with the returned session discarded.
+    let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+    let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+    registry
+        .store_session(realistic_test_session("stream-owner-moved"))
+        .await
+        .unwrap();
+
+    let displaced = registry
+        .displace_stored_session_if_unclaimed("stream-owner-moved")
+        .await
+        .unwrap()
+        .expect("unclaimed stored session must be displaced");
+    assert_eq!(displaced.stream_id, "stream-owner-moved");
+    assert_eq!(displaced.unacked_stanzas.len(), 2);
+
+    // Removed from the in-memory view...
+    assert!(registry
+        .peek_session("stream-owner-moved")
+        .await
+        .unwrap()
+        .is_none());
+    // ...but durable rows survive until the caller confirms promotion.
+    assert!(storage
+        .get_session(&crate::pending_delivery::SmSessionId::new(
+            "stream-owner-moved"
+        ))
+        .await
+        .unwrap()
+        .is_some());
+
+    registry.confirm_drained("stream-owner-moved").await;
+    assert!(storage
+        .get_session(&crate::pending_delivery::SmSessionId::new(
+            "stream-owner-moved"
+        ))
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn displace_stored_session_if_unclaimed_leaves_claimed_sessions_alone() {
+    let registry = InMemorySmSessionRegistry::new();
+    registry
+        .store_session(make_test_session("stream-claimed-keep"))
+        .await
+        .unwrap();
+    assert!(registry
+        .claim_session("stream-claimed-keep")
+        .await
+        .unwrap()
+        .is_some());
+
+    assert!(registry
+        .displace_stored_session_if_unclaimed("stream-claimed-keep")
+        .await
+        .unwrap()
+        .is_none());
+
+    // The in-flight resume claim is untouched.
+    assert!(registry
+        .complete_claim("stream-claimed-keep")
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn reinsert_for_retry_makes_session_drainable_but_never_resumable() {
+    // S4 support: a session re-inserted after a promotion failure must
+    // be visible to the janitor's next `drain_expired` pass, must NOT
+    // be resumable on the wire (peek/claim), and must not touch
+    // durable state.
+    let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+    let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+    let session = realistic_test_session("stream-reinsert");
+    registry.store_session(session).await.unwrap();
+
+    let drained = registry.drain_all_for_shutdown().await.unwrap();
+    assert_eq!(drained.len(), 1);
+    assert!(registry.drain_expired().await.unwrap().is_empty());
+
+    // Promotion failed → re-insert for retry.
+    registry
+        .reinsert_for_retry(drained.into_iter().next().unwrap())
+        .await
+        .unwrap();
+
+    // Not resumable on the wire.
+    assert!(registry
+        .peek_session("stream-reinsert")
+        .await
+        .unwrap()
+        .is_none());
+    assert!(registry
+        .claim_session("stream-reinsert")
+        .await
+        .unwrap()
+        .is_none());
+
+    // Drainable on the janitor's next pass, durable rows untouched.
+    let retried = registry.drain_expired().await.unwrap();
+    assert_eq!(retried.len(), 1);
+    assert_eq!(retried[0].stream_id, "stream-reinsert");
+    assert!(storage
+        .get_session(&crate::pending_delivery::SmSessionId::new(
+            "stream-reinsert"
+        ))
+        .await
+        .unwrap()
+        .is_some());
+}
+
+#[tokio::test]
+async fn claim_of_expired_session_keeps_it_drainable_for_promotion() {
+    // Regression: `claim_session` removed the session from the map and
+    // only THEN noticed it was expired, dropping a #1098-hydrated
+    // expired session from memory. A client auto-reconnecting with
+    // `<resume/>` before the janitor's first tick would make the
+    // session vanish — `drain_expired` scans only memory, so its
+    // unacked queue was stranded until the next restart.
+    let mut expired = make_test_session("stream-claim-expired");
+    expired.max_resume_time = Some(0);
+    let registry = InMemorySmSessionRegistry::new();
+    registry.store_session(expired).await.unwrap();
+
+    // Resume attempt: expired sessions are never claimable.
+    let claimed = registry
+        .claim_session("stream-claim-expired")
+        .await
+        .unwrap();
+    assert!(claimed.is_none(), "expired session must not be claimable");
+
+    // But the failed claim must NOT strand the queue: the janitor's
+    // next drain pass still sees the session for XEP-0198 §5 promotion.
+    let drained = registry.drain_expired().await.unwrap();
+    assert_eq!(
+        drained.len(),
+        1,
+        "expired session must remain drainable after a rejected claim"
+    );
+    assert_eq!(drained[0].stream_id, "stream-claim-expired");
+    assert_eq!(drained[0].unacked_stanzas.len(), 3);
+}

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -1678,6 +1678,119 @@ async fn reinsert_for_retry_makes_session_drainable_but_never_resumable() {
 }
 
 #[tokio::test]
+async fn scrub_records_recent_tombstone_for_promotion_time_recheck() {
+    // R2 (round-2 review): a retraction racing an in-flight promotion
+    // finds the drained session in neither map and its pending row not
+    // yet inserted. The scrub must leave a recent-tombstone record the
+    // promotion path can re-check before inserting into pending
+    // delivery.
+    let registry = InMemorySmSessionRegistry::new();
+    registry
+        .scrub_unacked_for_tombstone("retract-me", "user@example.com")
+        .await
+        .unwrap();
+
+    let keys = registry.recent_tombstones().unwrap();
+    assert_eq!(
+        keys,
+        vec![TombstoneKey {
+            target_id: "retract-me".to_string(),
+            archive_jid: "user@example.com".to_string(),
+        }],
+        "the scrub must record its tombstone identity for promotion-time re-check"
+    );
+}
+
+#[tokio::test]
+async fn recent_tombstones_evicts_entries_past_ttl() {
+    let registry = InMemorySmSessionRegistry::new();
+    let stale = Instant::now() - (tombstones::RECENT_TOMBSTONE_TTL + Duration::from_secs(1));
+    registry
+        .record_recent_tombstone_at("old-target", "user@example.com", stale)
+        .unwrap();
+    registry
+        .record_recent_tombstone_at("fresh-target", "user@example.com", Instant::now())
+        .unwrap();
+
+    let keys = registry.recent_tombstones().unwrap();
+    assert_eq!(
+        keys,
+        vec![TombstoneKey {
+            target_id: "fresh-target".to_string(),
+            archive_jid: "user@example.com".to_string(),
+        }],
+        "entries older than the TTL must be evicted; fresh ones retained"
+    );
+}
+
+#[tokio::test]
+async fn recent_tombstones_bounds_entry_count() {
+    let registry = InMemorySmSessionRegistry::new();
+    for i in 0..(tombstones::MAX_RECENT_TOMBSTONES + 5) {
+        registry
+            .record_recent_tombstone_at(&format!("target-{i}"), "user@example.com", Instant::now())
+            .unwrap();
+    }
+    let keys = registry.recent_tombstones().unwrap();
+    assert_eq!(
+        keys.len(),
+        tombstones::MAX_RECENT_TOMBSTONES,
+        "the recent-tombstone record must stay bounded"
+    );
+    assert_eq!(
+        keys.last().map(|k| k.target_id.as_str()),
+        Some(format!("target-{}", tombstones::MAX_RECENT_TOMBSTONES + 4).as_str()),
+        "overflow must evict the oldest entries, keeping the newest"
+    );
+}
+
+#[tokio::test]
+async fn reinsert_for_retry_preserves_detached_at_for_eviction_ordering() {
+    // R3 (round-2 review): `reinsert_for_retry` used to reset
+    // `detached_at` to ≈now, so under a degraded backend a repeatedly
+    // failing session looked perpetually fresh and the max_sessions
+    // min-by-detached_at eviction kept sacrificing HEALTHY resumable
+    // sessions instead. The reinserted session must keep its original
+    // detach time so it sorts as the oldest eviction candidate.
+    let registry = InMemorySmSessionRegistry::with_capacity(2);
+
+    let mut failing =
+        make_test_session_for_jid("stream-failing", "alice@example.com/web".parse().unwrap());
+    failing.detached_at = Instant::now() - Duration::from_secs(100);
+    registry.reinsert_for_retry(failing).await.unwrap();
+
+    let mut healthy =
+        make_test_session_for_jid("stream-healthy", "bob@example.com/web".parse().unwrap());
+    healthy.detached_at = Instant::now() - Duration::from_secs(50);
+    assert!(registry.store_session(healthy).await.unwrap().is_empty());
+
+    // Capacity overflow: the eviction victim must be the genuinely
+    // oldest session (the reinserted one), not the healthy fresher one.
+    let displaced = registry
+        .store_session(make_test_session_for_jid(
+            "stream-newest",
+            "carol@example.com/web".parse().unwrap(),
+        ))
+        .await
+        .unwrap();
+    let displaced_ids: Vec<&str> = displaced.iter().map(|s| s.stream_id.as_str()).collect();
+    assert_eq!(
+        displaced_ids,
+        vec!["stream-failing"],
+        "the reinserted session must keep its original detached_at and \
+         be evicted before a fresher healthy session"
+    );
+    assert!(
+        registry
+            .peek_session("stream-healthy")
+            .await
+            .unwrap()
+            .is_some(),
+        "the healthy resumable session must survive the eviction"
+    );
+}
+
+#[tokio::test]
 async fn claim_of_expired_session_keeps_it_drainable_for_promotion() {
     // Regression: `claim_session` removed the session from the map and
     // only THEN noticed it was expired, dropping a #1098-hydrated

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -2008,6 +2008,51 @@ async fn reinsert_for_retry_drops_entries_whose_durable_rows_were_scrubbed() {
     );
 }
 
+#[tokio::test]
+async fn reinsert_for_retry_keeps_queue_when_session_was_never_persisted() {
+    // Round-6 review: the Finding D durable diff must not misread "no
+    // durable rows because the snapshot write FAILED" (Finding E's
+    // store_session error path leaves the new session in memory with
+    // no durable session row) as "rows scrubbed". A phase-4 scrub
+    // deletes unacked rows but leaves the durable session row, so the
+    // diff is authoritative only when that session row exists; when it
+    // does not, dropping the queue would silently lose messages on the
+    // very storage blip reinsert_for_retry claims to tolerate.
+    let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+    let registry = InMemorySmSessionRegistry::new().with_persistence(storage.clone());
+    let mut session = realistic_test_session_for_jid(
+        "stream-never-persisted",
+        "user@example.com/resource".parse().unwrap(),
+    );
+    session.unacked_stanzas = vec![DetachedUnackedStanza {
+        sequence: 3,
+        stanza_xml: realistic_dm_stanza_xml(
+            "alice@example.com/web",
+            "user@example.com/resource",
+            "keep-me",
+            "safe",
+        ),
+        original_receipt_at: Utc::now(),
+    }];
+
+    // The session never went through a successful store_session
+    // snapshot: no durable session row, no durable unacked rows.
+    registry.reinsert_for_retry(session).await.unwrap();
+
+    let retried = registry.drain_expired().await.unwrap();
+    assert_eq!(retried.len(), 1);
+    assert_eq!(
+        retried[0]
+            .unacked_stanzas
+            .iter()
+            .map(|entry| entry.sequence)
+            .collect::<Vec<_>>(),
+        vec![3],
+        "a never-persisted queue must be kept verbatim (at-least-once), \
+         not dropped by the durable diff"
+    );
+}
+
 /// Persistence wrapper whose `store_session_atomic` fails while armed
 /// — models a durable-backend outage hitting exactly the snapshot
 /// write inside `store_session` (Finding E).

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -11,6 +11,10 @@ fn make_test_jid() -> FullJid {
     "user@example.com/resource".parse().unwrap()
 }
 
+fn bare(s: &str) -> jid::BareJid {
+    s.parse().expect("valid bare jid")
+}
+
 fn message_stanza_xml_with_id(id: String) -> String {
     let mut message = xmpp_parsers::message::Message::new(None::<jid::Jid>);
     message.id = Some(xmpp_parsers::message::Id(id));
@@ -155,7 +159,7 @@ async fn xep_0198_scrub_for_tombstone_removes_matching_1on1_message() {
     registry.store_session(session).await.unwrap();
 
     let removed = registry
-        .scrub_unacked_for_tombstone("target", "user@example.com")
+        .scrub_unacked_for_tombstone("target", &bare("user@example.com"))
         .await
         .unwrap();
     assert_eq!(removed, 1, "exactly one matching message should be removed");
@@ -282,7 +286,7 @@ async fn xep_0198_scrub_for_tombstone_matches_groupchat_stanza_id() {
     registry.store_session(session).await.unwrap();
 
     let removed = registry
-        .scrub_unacked_for_tombstone("canonical-archive-id", "room@conf.example.com")
+        .scrub_unacked_for_tombstone("canonical-archive-id", &bare("room@conf.example.com"))
         .await
         .unwrap();
     assert_eq!(
@@ -320,7 +324,7 @@ async fn xep_0198_scrub_for_tombstone_does_not_cross_conversations() {
     // remove the carol→user message even though it shares the
     // wire id, because alice is neither its `from` nor `to`.
     let removed = registry
-        .scrub_unacked_for_tombstone("msg-1", "alice@example.com")
+        .scrub_unacked_for_tombstone("msg-1", &bare("alice@example.com"))
         .await
         .unwrap();
     assert_eq!(
@@ -360,7 +364,7 @@ async fn xep_0198_scrub_for_tombstone_ignores_non_xep0359_stanza_id_namespace() 
     registry.store_session(session).await.unwrap();
 
     let removed = registry
-        .scrub_unacked_for_tombstone("target", "user@example.com")
+        .scrub_unacked_for_tombstone("target", &bare("user@example.com"))
         .await
         .unwrap();
     assert_eq!(
@@ -384,7 +388,7 @@ async fn xep_0198_scrub_for_tombstone_handles_no_match() {
             .await
             .unwrap();
     let removed = registry
-        .scrub_unacked_for_tombstone("not-here", "user@example.com")
+        .scrub_unacked_for_tombstone("not-here", &bare("user@example.com"))
         .await
         .unwrap();
     assert_eq!(removed, 0);
@@ -1104,7 +1108,7 @@ async fn scrub_for_tombstone_deletes_durable_rows_so_restart_cannot_replay() {
     registry.store_session(session).await.unwrap();
 
     let removed = registry
-        .scrub_unacked_for_tombstone("retracted-id", "user@example.com")
+        .scrub_unacked_for_tombstone("retracted-id", &bare("user@example.com"))
         .await
         .unwrap();
     assert_eq!(removed, 1);
@@ -1526,7 +1530,7 @@ async fn tombstone_scrub_reaches_durable_rows_of_off_map_streams() {
 
     // Retraction arrives during the window.
     let removed = registry
-        .scrub_unacked_for_tombstone("retract-me", "user@example.com")
+        .scrub_unacked_for_tombstone("retract-me", &bare("user@example.com"))
         .await
         .unwrap();
     assert_eq!(
@@ -1687,7 +1691,7 @@ async fn scrub_records_recent_tombstone_for_promotion_time_recheck() {
     let registry = InMemorySmSessionRegistry::new();
     let before = chrono::Utc::now();
     registry
-        .scrub_unacked_for_tombstone("retract-me", "user@example.com")
+        .scrub_unacked_for_tombstone("retract-me", &bare("user@example.com"))
         .await
         .unwrap();
     let after = chrono::Utc::now();
@@ -1697,7 +1701,7 @@ async fn scrub_records_recent_tombstone_for_promotion_time_recheck() {
         records.iter().map(|r| r.key.clone()).collect::<Vec<_>>(),
         vec![TombstoneKey {
             target_id: "retract-me".to_string(),
-            archive_jid: "user@example.com".to_string(),
+            archive_jid: bare("user@example.com"),
         }],
         "the scrub must record its tombstone identity for promotion-time re-check"
     );
@@ -1717,10 +1721,10 @@ async fn recent_tombstones_evicts_entries_past_ttl() {
     let registry = InMemorySmSessionRegistry::new();
     let stale = Instant::now() - (tombstones::RECENT_TOMBSTONE_TTL + Duration::from_secs(1));
     registry
-        .record_recent_tombstone_at("old-target", "user@example.com", stale)
+        .record_recent_tombstone_at("old-target", &bare("user@example.com"), stale)
         .unwrap();
     registry
-        .record_recent_tombstone_at("fresh-target", "user@example.com", Instant::now())
+        .record_recent_tombstone_at("fresh-target", &bare("user@example.com"), Instant::now())
         .unwrap();
 
     let records = registry.recent_tombstones().unwrap();
@@ -1728,7 +1732,7 @@ async fn recent_tombstones_evicts_entries_past_ttl() {
         records.iter().map(|r| r.key.clone()).collect::<Vec<_>>(),
         vec![TombstoneKey {
             target_id: "fresh-target".to_string(),
-            archive_jid: "user@example.com".to_string(),
+            archive_jid: bare("user@example.com"),
         }],
         "entries older than the TTL must be evicted; fresh ones retained"
     );
@@ -1739,7 +1743,7 @@ async fn recent_tombstones_bounds_entry_count() {
     let registry = InMemorySmSessionRegistry::new();
     for i in 0..(tombstones::MAX_RECENT_TOMBSTONES + 5) {
         registry
-            .record_recent_tombstone_at(&format!("target-{i}"), "user@example.com", Instant::now())
+            .record_recent_tombstone_at(&format!("target-{i}"), &bare("user@example.com"), Instant::now())
             .unwrap();
     }
     let records = registry.recent_tombstones().unwrap();

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tombstone.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tombstone.rs
@@ -1,10 +1,11 @@
-use super::DetachedSession;
-
-/// Strip every unacked outbound `<message/>` entry that matches a
-/// XEP-0424 / XEP-0425 tombstone. Returns the number of entries
-/// removed.
+/// Select the sequences of unacked outbound `<message/>` entries that
+/// match a XEP-0424 / XEP-0425 tombstone. Pure — takes a snapshot of
+/// `(sequence, stanza_xml)` pairs so the caller can parse OUTSIDE the
+/// registry's write locks (issue #1145) and later remove exactly the
+/// returned `(stream_id, sequence)` pairs, which is safe even if the
+/// queue changed between snapshot and removal.
 ///
-/// A cached message is removed iff:
+/// A cached message matches iff:
 ///   1. it is a `<message>` element,
 ///   2. its `from` or `to` attribute bare-equals `archive_jid` (scope
 ///      guard — prevents cross-conversation collateral damage when
@@ -16,20 +17,22 @@ use super::DetachedSession;
 ///      invariant).
 ///
 /// Parse errors and non-message frames are skipped silently — only
-/// matching messages are removed.
-pub(super) fn scrub_session_unacked(
-    session: &mut DetachedSession,
+/// matching messages are selected.
+pub(super) fn matching_tombstone_sequences(
+    entries: &[(u32, String)],
     target_id: &str,
     archive_jid: &str,
-) -> usize {
-    let before = session.unacked_stanzas.len();
-    session
-        .unacked_stanzas
-        .retain(|entry| match entry.stanza_xml.parse::<minidom::Element>() {
-            Ok(el) => !cached_message_matches_tombstone(&el, target_id, archive_jid),
-            Err(_) => true,
-        });
-    before - session.unacked_stanzas.len()
+) -> Vec<u32> {
+    entries
+        .iter()
+        .filter(
+            |(_, stanza_xml)| match stanza_xml.parse::<minidom::Element>() {
+                Ok(el) => cached_message_matches_tombstone(&el, target_id, archive_jid),
+                Err(_) => false,
+            },
+        )
+        .map(|(sequence, _)| *sequence)
+        .collect()
 }
 
 fn cached_message_matches_tombstone(

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tombstones.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tombstones.rs
@@ -36,7 +36,7 @@ pub const MAX_RECENT_TOMBSTONES: usize = 1024;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TombstoneKey {
     pub target_id: String,
-    pub archive_jid: String,
+    pub archive_jid: jid::BareJid,
 }
 
 /// A recorded tombstone as seen by the promotion-time re-check: its
@@ -70,7 +70,7 @@ impl InMemorySmSessionRegistry {
     pub(super) fn record_recent_tombstone(
         &self,
         target_id: &str,
-        archive_jid: &str,
+        archive_jid: &jid::BareJid,
     ) -> Result<(), SmRegistryError> {
         self.record_recent_tombstone_at(target_id, archive_jid, Instant::now())
     }
@@ -80,7 +80,7 @@ impl InMemorySmSessionRegistry {
     pub(super) fn record_recent_tombstone_at(
         &self,
         target_id: &str,
-        archive_jid: &str,
+        archive_jid: &jid::BareJid,
         recorded_at: Instant,
     ) -> Result<(), SmRegistryError> {
         let mut recent = self
@@ -95,7 +95,7 @@ impl InMemorySmSessionRegistry {
         recent.push(RecentTombstone {
             key: TombstoneKey {
                 target_id: target_id.to_string(),
-                archive_jid: archive_jid.to_string(),
+                archive_jid: archive_jid.clone(),
             },
             recorded_at,
             recorded_at_utc: Utc::now(),

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tombstones.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tombstones.rs
@@ -13,42 +13,45 @@
 //! tombstone identity here and `promote_session_unacked` filters
 //! matching stanzas out before running the promotion chain. Entries
 //! are bounded by a generous TTL (promotion windows are seconds) plus
-//! a hard size cap.
+//! per-archive and global size caps.
 
 use std::time::{Duration, Instant};
 
 use chrono::{DateTime, Utc};
+use tracing::warn;
 
 use super::core::InMemorySmSessionRegistry;
 use super::SmRegistryError;
+use crate::tombstone::TombstoneTarget;
 
 /// How long a recorded tombstone stays visible to the promotion-time
 /// re-check. Promotion windows are seconds; ten minutes is generous.
 pub const RECENT_TOMBSTONE_TTL: Duration = Duration::from_secs(600);
 
-/// Hard cap on retained tombstone records. Scrubs are rare
-/// (retraction / moderation only); overflow evicts the oldest.
+/// Hard cap on retained tombstone records — the global backstop.
+/// Scrubs are rare (retraction / moderation only); when even the
+/// per-archive cap can't keep the list under this bound, the oldest
+/// record is evicted with a WARN (an unexpired foreign record is
+/// being sacrificed).
 pub const MAX_RECENT_TOMBSTONES: usize = 1024;
 
-/// Identity of a recently applied XEP-0424/0425 tombstone: the target
-/// message id plus the conversation (archive) scope, matching the two
-/// inputs of [`crate::tombstone::message_element_matches_tombstone`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct TombstoneKey {
-    pub target_id: String,
-    pub archive_jid: jid::BareJid,
-}
+/// Per-archive-JID cap. Bounds how many records a single conversation
+/// (one attacker retracting their own messages in a flood) can hold,
+/// so one archive's flood evicts only ITS OWN oldest records and can
+/// never flush another archive's unexpired record out of the
+/// promotion-time re-check window.
+pub const MAX_RECENT_TOMBSTONES_PER_ARCHIVE: usize = 64;
 
 /// A recorded tombstone as seen by the promotion-time re-check: its
-/// identity plus the wall-clock time the retraction was recorded.
-/// Round-3 review finding 2: a tombstone applies BACKWARD in time
-/// only — promotion treats a match as scrubbed only for stanzas whose
-/// `original_receipt_at` predates `recorded_at_utc`, so a new message
-/// that legitimately reuses a wire id in the same conversation scope
-/// after the retraction is not silently lost.
+/// typed identity plus the wall-clock time the retraction was
+/// recorded. Round-3 review finding 2: a tombstone applies BACKWARD in
+/// time only — promotion treats a match as scrubbed only for stanzas
+/// whose `original_receipt_at` predates `recorded_at_utc`, so a new
+/// message that legitimately reuses a wire id in the same conversation
+/// scope after the retraction is not silently lost.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RecentTombstoneRecord {
-    pub key: TombstoneKey,
+    pub key: TombstoneTarget,
     pub recorded_at_utc: DateTime<Utc>,
 }
 
@@ -58,7 +61,7 @@ pub struct RecentTombstoneRecord {
 /// backward in time against each stanza's `original_receipt_at`.
 #[derive(Debug)]
 pub(super) struct RecentTombstone {
-    pub(super) key: TombstoneKey,
+    pub(super) key: TombstoneTarget,
     pub(super) recorded_at: Instant,
     pub(super) recorded_at_utc: DateTime<Utc>,
 }
@@ -69,18 +72,25 @@ impl InMemorySmSessionRegistry {
     /// runs, so even a partially failed scrub leaves the record.
     pub(super) fn record_recent_tombstone(
         &self,
-        target_id: &str,
-        archive_jid: &jid::BareJid,
+        target: &TombstoneTarget,
     ) -> Result<(), SmRegistryError> {
-        self.record_recent_tombstone_at(target_id, archive_jid, Instant::now())
+        self.record_recent_tombstone_at(target, Instant::now())
     }
 
     /// Test-visible variant taking an explicit record time so the TTL
     /// eviction is exercisable without wall-clock sleeps.
+    ///
+    /// Eviction policy (adversarial-review finding: an authenticated
+    /// user retracting 1024+ of their own messages must not flush a
+    /// victim's unexpired record):
+    ///   1. expired entries go first (TTL sweep),
+    ///   2. the inserting archive's own oldest entries go next
+    ///      (per-archive cap), and only then
+    ///   3. the global hard cap evicts the oldest entry overall,
+    ///      warning that an unexpired foreign record was sacrificed.
     pub(super) fn record_recent_tombstone_at(
         &self,
-        target_id: &str,
-        archive_jid: &jid::BareJid,
+        target: &TombstoneTarget,
         recorded_at: Instant,
     ) -> Result<(), SmRegistryError> {
         let mut recent = self
@@ -88,15 +98,40 @@ impl InMemorySmSessionRegistry {
             .write()
             .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
         Self::evict_stale_tombstones(&mut recent, Instant::now());
-        if recent.len() >= MAX_RECENT_TOMBSTONES {
-            let overflow = recent.len() + 1 - MAX_RECENT_TOMBSTONES;
-            recent.drain(..overflow);
+        // Per-archive cap: evict oldest entries WITHIN this archive
+        // (the vec is push-ordered, so the first match is the oldest).
+        let archive = target.archive_jid().clone();
+        loop {
+            let same_archive = recent
+                .iter()
+                .filter(|entry| entry.key.archive_jid() == &archive)
+                .count();
+            if same_archive < MAX_RECENT_TOMBSTONES_PER_ARCHIVE {
+                break;
+            }
+            let Some(oldest_same_archive) = recent
+                .iter()
+                .position(|entry| entry.key.archive_jid() == &archive)
+            else {
+                break;
+            };
+            recent.remove(oldest_same_archive);
+        }
+        // Global backstop: everything left is unexpired and belongs to
+        // other archives; evicting is lossy for their promotion-time
+        // re-check, so surface it.
+        while recent.len() >= MAX_RECENT_TOMBSTONES {
+            let evicted = recent.remove(0);
+            warn!(
+                evicted_archive = %evicted.key.archive_jid(),
+                inserting_archive = %archive,
+                "recent-tombstone list at global cap: evicting an UNEXPIRED \
+                 record for another archive; its promotion-time re-check \
+                 window is truncated"
+            );
         }
         recent.push(RecentTombstone {
-            key: TombstoneKey {
-                target_id: target_id.to_string(),
-                archive_jid: archive_jid.clone(),
-            },
+            key: target.clone(),
             recorded_at,
             recorded_at_utc: Utc::now(),
         });

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tombstones.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tombstones.rs
@@ -17,6 +17,8 @@
 
 use std::time::{Duration, Instant};
 
+use chrono::{DateTime, Utc};
+
 use super::core::InMemorySmSessionRegistry;
 use super::SmRegistryError;
 
@@ -37,11 +39,28 @@ pub struct TombstoneKey {
     pub archive_jid: String,
 }
 
-/// One recorded tombstone with its record time, for TTL eviction.
+/// A recorded tombstone as seen by the promotion-time re-check: its
+/// identity plus the wall-clock time the retraction was recorded.
+/// Round-3 review finding 2: a tombstone applies BACKWARD in time
+/// only — promotion treats a match as scrubbed only for stanzas whose
+/// `original_receipt_at` predates `recorded_at_utc`, so a new message
+/// that legitimately reuses a wire id in the same conversation scope
+/// after the retraction is not silently lost.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecentTombstoneRecord {
+    pub key: TombstoneKey,
+    pub recorded_at_utc: DateTime<Utc>,
+}
+
+/// One recorded tombstone with its record times: the monotonic
+/// `recorded_at` drives TTL eviction (never mix domains for expiry);
+/// the wall-clock `recorded_at_utc` scopes the promotion-time match
+/// backward in time against each stanza's `original_receipt_at`.
 #[derive(Debug)]
 pub(super) struct RecentTombstone {
     pub(super) key: TombstoneKey,
     pub(super) recorded_at: Instant,
+    pub(super) recorded_at_utc: DateTime<Utc>,
 }
 
 impl InMemorySmSessionRegistry {
@@ -79,22 +98,29 @@ impl InMemorySmSessionRegistry {
                 archive_jid: archive_jid.to_string(),
             },
             recorded_at,
+            recorded_at_utc: Utc::now(),
         });
         Ok(())
     }
 
-    /// Snapshot the tombstone identities recorded within the TTL,
-    /// oldest first. The Q6 promotion path consults this before
-    /// inserting a drained session's unacked stanzas into
-    /// `pending_delivery`, so a retraction that raced the drain still
-    /// scrubs the in-flight copy.
-    pub fn recent_tombstones(&self) -> Result<Vec<TombstoneKey>, SmRegistryError> {
+    /// Snapshot the tombstone records recorded within the TTL, oldest
+    /// first. The Q6 promotion path consults this before inserting a
+    /// drained session's unacked stanzas into `pending_delivery`, so a
+    /// retraction that raced the drain still scrubs the in-flight copy
+    /// — but only stanzas received before `recorded_at_utc`.
+    pub fn recent_tombstones(&self) -> Result<Vec<RecentTombstoneRecord>, SmRegistryError> {
         let mut recent = self
             .recent_tombstones
             .write()
             .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
         Self::evict_stale_tombstones(&mut recent, Instant::now());
-        Ok(recent.iter().map(|entry| entry.key.clone()).collect())
+        Ok(recent
+            .iter()
+            .map(|entry| RecentTombstoneRecord {
+                key: entry.key.clone(),
+                recorded_at_utc: entry.recorded_at_utc,
+            })
+            .collect())
     }
 
     fn evict_stale_tombstones(recent: &mut Vec<RecentTombstone>, now: Instant) {

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tombstones.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tombstones.rs
@@ -1,0 +1,106 @@
+//! Recent-tombstone record for the promotion-time re-check (round-2
+//! review R2).
+//!
+//! A XEP-0424/0425 retraction can race an in-flight XEP-0198 §5
+//! promotion: the janitor's `drain_expired` has already moved the
+//! session out of both in-memory maps into a local, the scrub finds
+//! the stream nowhere (its pending row is not yet inserted either),
+//! and the promotion then writes the retracted stanza into
+//! `pending_delivery` AFTER the scrub ran — `confirm_drained` erases
+//! the SM rows and the next login delivers retracted content.
+//!
+//! To close the window, `scrub_unacked_for_tombstone` records its
+//! tombstone identity here and `promote_session_unacked` filters
+//! matching stanzas out before running the promotion chain. Entries
+//! are bounded by a generous TTL (promotion windows are seconds) plus
+//! a hard size cap.
+
+use std::time::{Duration, Instant};
+
+use super::core::InMemorySmSessionRegistry;
+use super::SmRegistryError;
+
+/// How long a recorded tombstone stays visible to the promotion-time
+/// re-check. Promotion windows are seconds; ten minutes is generous.
+pub const RECENT_TOMBSTONE_TTL: Duration = Duration::from_secs(600);
+
+/// Hard cap on retained tombstone records. Scrubs are rare
+/// (retraction / moderation only); overflow evicts the oldest.
+pub const MAX_RECENT_TOMBSTONES: usize = 1024;
+
+/// Identity of a recently applied XEP-0424/0425 tombstone: the target
+/// message id plus the conversation (archive) scope, matching the two
+/// inputs of [`crate::tombstone::message_element_matches_tombstone`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TombstoneKey {
+    pub target_id: String,
+    pub archive_jid: String,
+}
+
+/// One recorded tombstone with its record time, for TTL eviction.
+#[derive(Debug)]
+pub(super) struct RecentTombstone {
+    pub(super) key: TombstoneKey,
+    pub(super) recorded_at: Instant,
+}
+
+impl InMemorySmSessionRegistry {
+    /// Record a tombstone identity for the promotion-time re-check.
+    /// Called by `scrub_unacked_for_tombstone` before any scrub phase
+    /// runs, so even a partially failed scrub leaves the record.
+    pub(super) fn record_recent_tombstone(
+        &self,
+        target_id: &str,
+        archive_jid: &str,
+    ) -> Result<(), SmRegistryError> {
+        self.record_recent_tombstone_at(target_id, archive_jid, Instant::now())
+    }
+
+    /// Test-visible variant taking an explicit record time so the TTL
+    /// eviction is exercisable without wall-clock sleeps.
+    pub(super) fn record_recent_tombstone_at(
+        &self,
+        target_id: &str,
+        archive_jid: &str,
+        recorded_at: Instant,
+    ) -> Result<(), SmRegistryError> {
+        let mut recent = self
+            .recent_tombstones
+            .write()
+            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+        Self::evict_stale_tombstones(&mut recent, Instant::now());
+        if recent.len() >= MAX_RECENT_TOMBSTONES {
+            let overflow = recent.len() + 1 - MAX_RECENT_TOMBSTONES;
+            recent.drain(..overflow);
+        }
+        recent.push(RecentTombstone {
+            key: TombstoneKey {
+                target_id: target_id.to_string(),
+                archive_jid: archive_jid.to_string(),
+            },
+            recorded_at,
+        });
+        Ok(())
+    }
+
+    /// Snapshot the tombstone identities recorded within the TTL,
+    /// oldest first. The Q6 promotion path consults this before
+    /// inserting a drained session's unacked stanzas into
+    /// `pending_delivery`, so a retraction that raced the drain still
+    /// scrubs the in-flight copy.
+    pub fn recent_tombstones(&self) -> Result<Vec<TombstoneKey>, SmRegistryError> {
+        let mut recent = self
+            .recent_tombstones
+            .write()
+            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+        Self::evict_stale_tombstones(&mut recent, Instant::now());
+        Ok(recent.iter().map(|entry| entry.key.clone()).collect())
+    }
+
+    fn evict_stale_tombstones(recent: &mut Vec<RecentTombstone>, now: Instant) {
+        recent.retain(|entry| {
+            now.checked_duration_since(entry.recorded_at)
+                .is_none_or(|age| age <= RECENT_TOMBSTONE_TTL)
+        });
+    }
+}

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tombstones.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tombstones.rs
@@ -144,13 +144,23 @@ impl InMemorySmSessionRegistry {
     /// retraction that raced the drain still scrubs the in-flight copy
     /// — but only stanzas received before `recorded_at_utc`.
     pub fn recent_tombstones(&self) -> Result<Vec<RecentTombstoneRecord>, SmRegistryError> {
-        let mut recent = self
+        // Read lock only (PR-review finding): every per-session
+        // promotion consults this, and a write lock here stalls
+        // concurrent `record_recent_tombstone` calls during a drain
+        // burst. Expired entries are filtered out of the SNAPSHOT
+        // without mutating the list — eviction happens on every
+        // insert, which also bounds the list's size.
+        let recent = self
             .recent_tombstones
-            .write()
+            .read()
             .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-        Self::evict_stale_tombstones(&mut recent, Instant::now());
+        let now = Instant::now();
         Ok(recent
             .iter()
+            .filter(|entry| {
+                now.checked_duration_since(entry.recorded_at)
+                    .is_none_or(|age| age <= RECENT_TOMBSTONE_TTL)
+            })
             .map(|entry| RecentTombstoneRecord {
                 key: entry.key.clone(),
                 recorded_at_utc: entry.recorded_at_utc,

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/trait_impl.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/trait_impl.rs
@@ -2,8 +2,8 @@ use async_trait::async_trait;
 use tracing::debug;
 
 use super::core::InMemorySmSessionRegistry;
-use super::tombstone::matching_tombstone_sequences;
 use super::{DetachedSession, SmRegistryError, SmSessionRegistry};
+use crate::tombstone::matching_tombstone_sequences;
 
 #[async_trait]
 impl SmSessionRegistry for InMemorySmSessionRegistry {
@@ -337,6 +337,80 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
             };
             removed_total += removed_here;
         }
+
+        // Phase 4 (durable-side sweep): durable rows can exist for
+        // streams absent from BOTH in-memory maps — displaced
+        // mid-promotion, janitor-drained mid-promotion, or parked
+        // between a promotion failure and its retry re-insert
+        // (persist-until-confirmed contract). Those rows are invisible
+        // to phases 1-3, but a restart resurrects and promotes them,
+        // so a retraction landing in that window must scrub them too.
+        // COST NOTE: this enumerates every durable session + queue;
+        // scrubs are rare (retraction / moderation only), so a full
+        // listing is acceptable here.
+        if let Some(storage) = &self.persistence {
+            let stored = storage
+                .list_all_sessions_with_unacked()
+                .await
+                .map_err(|e| SmRegistryError::Internal(e.to_string()))?;
+            for (persisted, unacked) in stored {
+                let stream_id = persisted.stream_id.as_str().to_string();
+                // Stream lock first: serializes with store_session /
+                // reinsert_for_retry so the off-map check and the
+                // durable delete are atomic with respect to a stream
+                // re-entering the maps.
+                let stream_lock = self.stream_lock(&stream_id)?;
+                let _stream_guard = stream_lock.lock().await;
+                let in_map = self
+                    .sessions
+                    .read()
+                    .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
+                    .contains_key(&stream_id)
+                    || self
+                        .claimed_sessions
+                        .read()
+                        .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
+                        .contains_key(&stream_id);
+                if in_map {
+                    // Already covered by the in-map phases above.
+                    continue;
+                }
+                let sequences: Vec<u32> = unacked
+                    .iter()
+                    .filter(|entry| {
+                        crate::tombstone::message_element_matches_tombstone(
+                            &entry.stanza.to_element(),
+                            target_id,
+                            archive_jid,
+                        )
+                    })
+                    .map(|entry| entry.sequence)
+                    .collect();
+                if sequences.is_empty() {
+                    continue;
+                }
+                match storage
+                    .delete_unacked(
+                        &crate::pending_delivery::SmSessionId::new(stream_id.clone()),
+                        &sequences,
+                    )
+                    .await
+                {
+                    Ok(deleted) => removed_total += deleted as usize,
+                    Err(error) => {
+                        durable_failures += 1;
+                        debug!(
+                            stream_id = %stream_id,
+                            error = %error,
+                            "tombstone scrub: durable-side delete_unacked failed for an \
+                             off-map stream; rows preserved and the caller's error path \
+                             surfaces the possible replay"
+                        );
+                    }
+                }
+            }
+        }
+
         if durable_failures > 0 {
             return Err(SmRegistryError::Internal(format!(
                 "tombstone scrub: durable delete_unacked failed for {durable_failures} \

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/trait_impl.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/trait_impl.rs
@@ -2,12 +2,15 @@ use async_trait::async_trait;
 use tracing::debug;
 
 use super::core::InMemorySmSessionRegistry;
-use super::tombstone::scrub_session_unacked;
+use super::tombstone::matching_tombstone_sequences;
 use super::{DetachedSession, SmRegistryError, SmSessionRegistry};
 
 #[async_trait]
 impl SmSessionRegistry for InMemorySmSessionRegistry {
-    async fn store_session(&self, session: DetachedSession) -> Result<(), SmRegistryError> {
+    async fn store_session(
+        &self,
+        session: DetachedSession,
+    ) -> Result<Vec<DetachedSession>, SmRegistryError> {
         let stream_id = session.stream_id.clone();
         let jid = session.jid.clone();
         let stream_lock = self.stream_lock(&stream_id)?;
@@ -16,9 +19,11 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
         // dropped before any await point. RwLockWriteGuard is not
         // Send, and explicit `drop()` doesn't satisfy the async
         // future's lifetime analysis. Capture eviction victims
-        // (jid-collision retain + max_sessions oldest) so we can
-        // mirror their durable rows after releasing the lock.
-        let mut evicted_stream_ids: Vec<String> = Vec::new();
+        // (jid-collision retain + max_sessions oldest) IN FULL so the
+        // caller can run XEP-0198 §5 promotion on their unacked
+        // queues (issue #1097) — previously they were silently
+        // dropped and their durable rows mirror-deleted.
+        let mut displaced: Vec<DetachedSession> = Vec::new();
         let count = {
             let mut sessions = self
                 .sessions
@@ -32,12 +37,12 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
             // retain mutates; same for `claimed`.
             for (id, existing) in sessions.iter() {
                 if id != &stream_id && existing.jid == jid {
-                    evicted_stream_ids.push(id.clone());
+                    displaced.push(existing.clone());
                 }
             }
             for (id, existing) in claimed.iter() {
                 if id != &stream_id && existing.jid == jid {
-                    evicted_stream_ids.push(id.clone());
+                    displaced.push(existing.clone());
                 }
             }
             sessions.retain(|existing_stream_id, existing| {
@@ -54,38 +59,24 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
                     .min_by_key(|(_, s)| s.detached_at)
                     .map(|(k, _)| k.clone())
                 {
-                    sessions.remove(&oldest_key);
-                    debug!(stream_id = %oldest_key, "Evicted oldest SM session to make room");
-                    evicted_stream_ids.push(oldest_key);
+                    if let Some(oldest) = sessions.remove(&oldest_key) {
+                        debug!(stream_id = %oldest_key, "Evicted oldest SM session to make room");
+                        displaced.push(oldest);
+                    }
                 }
             }
 
             sessions.insert(stream_id.clone(), session.clone());
             sessions.len()
         };
-        // Mirror in-memory evictions to durable storage so a restart
-        // doesn't resurrect sessions that were displaced by a fresh
-        // bind for the same JID or by max_sessions overflow. (Copilot
-        // review on PR #344: durable rows for evicted streams must
-        // not be silently rehydrated.)
-        for evicted in &evicted_stream_ids {
-            // Best-effort: failure to delete an evictee row means
-            // the next restart MAY resurrect it via
-            // restore_from_persistence (until its resume window
-            // expires and the restore-time expired-filter drops it).
-            // Bubbling the error here would fail the whole detach
-            // because an unrelated evictee row couldn't be cleaned;
-            // log loudly instead so operators can spot storage
-            // health issues.
-            if let Err(error) = self.persist_delete_session(evicted).await {
-                debug!(
-                    stream_id = %evicted,
-                    error = %error,
-                    "evicted SM session: durable delete failed; row will be \
-                     filtered by restore-time expiry check"
-                );
-            }
-        }
+        // Durable rows for displaced sessions are deliberately NOT
+        // deleted here. They follow the drain_expired/confirm_drained
+        // persist-until-confirmed contract: the caller promotes each
+        // displaced session's unacked queue (XEP-0198 §5 alt-resource
+        // → offline storage → error chain) and calls
+        // `confirm_drained` on success, which erases the rows. If the
+        // process crashes before promotion, restore_from_persistence
+        // rehydrates them and the SM-expiry janitor retries.
 
         // `store_session` publishes the session in memory before its first
         // durable snapshot is written so the cleanup path can keep draining
@@ -96,7 +87,7 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
         self.persist_detached_session_snapshot(&session).await?;
 
         debug!(stream_id = %stream_id, count = count, "Stored detached SM session");
-        Ok(())
+        Ok(displaced)
     }
 
     async fn take_session(
@@ -228,21 +219,129 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
         target_id: &str,
         archive_jid: &str,
     ) -> Result<usize, SmRegistryError> {
-        let mut removed_total = 0usize;
-        let mut sessions = self
-            .sessions
-            .write()
-            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-        for session in sessions.values_mut() {
-            removed_total += scrub_session_unacked(session, target_id, archive_jid);
+        // Phase 1 (issue #1145 lock-scope fix): snapshot every queue
+        // under READ locks only. XML parsing of every entry used to
+        // run under the sessions write lock, stalling all detach /
+        // resume traffic for the duration of a full-registry scan.
+        let mut snapshots: Vec<(String, Vec<(u32, String)>)> = Vec::new();
+        {
+            let sessions = self
+                .sessions
+                .read()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            for (stream_id, session) in sessions.iter() {
+                snapshots.push((
+                    stream_id.clone(),
+                    session
+                        .unacked_stanzas
+                        .iter()
+                        .map(|entry| (entry.sequence, entry.stanza_xml.clone()))
+                        .collect(),
+                ));
+            }
         }
-        drop(sessions);
-        let mut claimed = self
-            .claimed_sessions
-            .write()
-            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-        for session in claimed.values_mut() {
-            removed_total += scrub_session_unacked(session, target_id, archive_jid);
+        {
+            let claimed = self
+                .claimed_sessions
+                .read()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            for (stream_id, session) in claimed.iter() {
+                snapshots.push((
+                    stream_id.clone(),
+                    session
+                        .unacked_stanzas
+                        .iter()
+                        .map(|entry| (entry.sequence, entry.stanza_xml.clone()))
+                        .collect(),
+                ));
+            }
+        }
+
+        // Phase 2: parse and match with NO registry lock held. A
+        // queue can change between snapshot and removal; removing by
+        // exact (stream_id, sequence) pairs below is safe regardless.
+        let mut matched: Vec<(String, Vec<u32>)> = Vec::new();
+        for (stream_id, entries) in snapshots {
+            let sequences = matching_tombstone_sequences(&entries, target_id, archive_jid);
+            if !sequences.is_empty() {
+                matched.push((stream_id, sequences));
+            }
+        }
+
+        // Phase 3 (issue #1145 durability fix): per stream, under its
+        // stream lock (serializing with detached-append snapshots so a
+        // concurrent full-snapshot write cannot resurrect the rows we
+        // just deleted), erase the durable rows FIRST and only then
+        // the in-memory entries. If the durable delete fails, the
+        // in-memory entries are deliberately left in place — memory
+        // and storage stay consistent, and the caller's error path
+        // logs that the pre-scrub stanza may still replay so the
+        // failure is never silent.
+        let mut removed_total = 0usize;
+        let mut durable_failures = 0usize;
+        for (stream_id, sequences) in matched {
+            let stream_lock = self.stream_lock(&stream_id)?;
+            let _stream_guard = stream_lock.lock().await;
+            if let Some(storage) = &self.persistence {
+                if let Err(error) = storage
+                    .delete_unacked(
+                        &crate::pending_delivery::SmSessionId::new(stream_id.clone()),
+                        &sequences,
+                    )
+                    .await
+                {
+                    durable_failures += 1;
+                    debug!(
+                        stream_id = %stream_id,
+                        error = %error,
+                        "tombstone scrub: durable delete_unacked failed; keeping the \
+                         in-memory entries so memory and storage stay consistent"
+                    );
+                    continue;
+                }
+            }
+            let removed_here = {
+                let mut sessions = self
+                    .sessions
+                    .write()
+                    .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+                match sessions.get_mut(&stream_id) {
+                    Some(session) => {
+                        let before = session.unacked_stanzas.len();
+                        session
+                            .unacked_stanzas
+                            .retain(|entry| !sequences.contains(&entry.sequence));
+                        Some(before - session.unacked_stanzas.len())
+                    }
+                    None => None,
+                }
+            };
+            let removed_here = match removed_here {
+                Some(count) => count,
+                None => {
+                    let mut claimed = self
+                        .claimed_sessions
+                        .write()
+                        .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+                    match claimed.get_mut(&stream_id) {
+                        Some(session) => {
+                            let before = session.unacked_stanzas.len();
+                            session
+                                .unacked_stanzas
+                                .retain(|entry| !sequences.contains(&entry.sequence));
+                            before - session.unacked_stanzas.len()
+                        }
+                        None => 0,
+                    }
+                }
+            };
+            removed_total += removed_here;
+        }
+        if durable_failures > 0 {
+            return Err(SmRegistryError::Internal(format!(
+                "tombstone scrub: durable delete_unacked failed for {durable_failures} \
+                 stream(s); matching entries were preserved for retry"
+            )));
         }
         Ok(removed_total)
     }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/trait_impl.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/trait_impl.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::core::InMemorySmSessionRegistry;
 use super::{DetachedSession, SmRegistryError, SmSessionRegistry};
-use crate::tombstone::matching_tombstone_sequences;
+use crate::tombstone::{matching_tombstone_sequences, TombstoneTarget};
 
 #[async_trait]
 impl SmSessionRegistry for InMemorySmSessionRegistry {
@@ -84,7 +84,40 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
         // append snapshots until the initial snapshot has landed; otherwise a
         // concurrent append can persist a newer queue and then get overwritten
         // by this stale first snapshot.
-        self.persist_detached_session_snapshot(&session).await?;
+        //
+        // Displaced-session limbo guard: at this point the displaced
+        // sessions are already off both maps. If the snapshot write
+        // fails we return Err and the caller drops the displaced vec —
+        // without re-insertion their durable rows would be stranded
+        // (invisible to drain_expired, which scans memory only) until
+        // a restart. Re-insert them as expired-for-retry BEFORE
+        // propagating the error so the SM-expiry janitor's next pass
+        // runs their promote → confirm chain. The map insert happens
+        // WITHOUT taking each displaced stream's shard lock — we hold
+        // this stream's shard lock, and two crossed store_session
+        // calls re-inserting each other's displaced sessions would
+        // otherwise deadlock.
+        if let Err(error) = self.persist_detached_session_snapshot(&session).await {
+            for displaced_session in displaced {
+                if displaced_session.stream_id == stream_id {
+                    // Already (re)inserted above as the new session's
+                    // map entry; taking it through the retry path would
+                    // clobber that entry.
+                    continue;
+                }
+                let displaced_stream_id = displaced_session.stream_id.clone();
+                if let Err(reinsert_error) = self.reinsert_for_retry_unlocked(displaced_session) {
+                    warn!(
+                        stream_id = %displaced_stream_id,
+                        error = %reinsert_error,
+                        "store_session: snapshot write failed and re-inserting a \
+                         displaced session for retry also failed; its durable rows \
+                         are stranded until restart"
+                    );
+                }
+            }
+            return Err(error);
+        }
 
         debug!(stream_id = %stream_id, count = count, "Stored detached SM session");
         Ok(displaced)
@@ -216,15 +249,14 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
 
     async fn scrub_unacked_for_tombstone(
         &self,
-        target_id: &str,
-        archive_jid: &jid::BareJid,
+        target: &TombstoneTarget,
     ) -> Result<usize, SmRegistryError> {
         // Phase 0 (round-2 review R2): record the tombstone identity
         // BEFORE any scrub phase runs so a promotion already holding a
         // drained copy of a session (off both maps, pending row not
         // yet inserted) re-checks it and drops matching stanzas
         // instead of delivering retracted content on the next login.
-        self.record_recent_tombstone(target_id, archive_jid)?;
+        self.record_recent_tombstone(target)?;
         // Phase 1 (issue #1145 lock-scope fix): snapshot every queue
         // under READ locks only. XML parsing of every entry used to
         // run under the sessions write lock, stalling all detach /
@@ -268,7 +300,7 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
         // exact (stream_id, sequence) pairs below is safe regardless.
         let mut matched: Vec<(String, Vec<u32>)> = Vec::new();
         for (stream_id, entries) in snapshots {
-            let sequences = matching_tombstone_sequences(&entries, target_id, archive_jid);
+            let sequences = matching_tombstone_sequences(&entries, target);
             if !sequences.is_empty() {
                 matched.push((stream_id, sequences));
             }
@@ -383,13 +415,7 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
                 }
                 let sequences: Vec<u32> = unacked
                     .iter()
-                    .filter(|entry| {
-                        crate::tombstone::message_element_matches_tombstone(
-                            &entry.stanza.to_element(),
-                            target_id,
-                            archive_jid,
-                        )
-                    })
+                    .filter(|entry| target.matches_message_element(&entry.stanza.to_element()))
                     .map(|entry| entry.sequence)
                     .collect();
                 if sequences.is_empty() {

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/trait_impl.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/trait_impl.rs
@@ -219,6 +219,12 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
         target_id: &str,
         archive_jid: &str,
     ) -> Result<usize, SmRegistryError> {
+        // Phase 0 (round-2 review R2): record the tombstone identity
+        // BEFORE any scrub phase runs so a promotion already holding a
+        // drained copy of a session (off both maps, pending row not
+        // yet inserted) re-checks it and drops matching stanzas
+        // instead of delivering retracted content on the next login.
+        self.record_recent_tombstone(target_id, archive_jid)?;
         // Phase 1 (issue #1145 lock-scope fix): snapshot every queue
         // under READ locks only. XML parsing of every entry used to
         // run under the sessions write lock, stalling all detach /

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/trait_impl.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/trait_impl.rs
@@ -217,7 +217,7 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
     async fn scrub_unacked_for_tombstone(
         &self,
         target_id: &str,
-        archive_jid: &str,
+        archive_jid: &jid::BareJid,
     ) -> Result<usize, SmRegistryError> {
         // Phase 0 (round-2 review R2): record the tombstone identity
         // BEFORE any scrub phase runs so a promotion already holding a

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/traits.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/traits.rs
@@ -26,8 +26,21 @@ pub enum SmRegistryError {
 pub trait SmSessionRegistry: Send + Sync {
     /// Store a detached session.
     ///
-    /// The session can be retrieved later using `take_session` with the stream_id.
-    async fn store_session(&self, session: DetachedSession) -> Result<(), SmRegistryError>;
+    /// The session can be retrieved later using `take_session` with the
+    /// stream_id.
+    ///
+    /// Returns the sessions this store displaced from the in-memory
+    /// pool — a superseded detached stream for the same full JID and/or
+    /// the oldest session evicted on `max_sessions` overflow. Their
+    /// unacked queues must NOT be discarded (XEP-0198 §5): the caller
+    /// runs the promote → confirm chain on each and calls
+    /// `confirm_drained` afterwards; durable rows for displaced
+    /// sessions survive until that confirmation so a crash mid-
+    /// promotion retries on the next startup.
+    async fn store_session(
+        &self,
+        session: DetachedSession,
+    ) -> Result<Vec<DetachedSession>, SmRegistryError>;
 
     /// Take (retrieve and remove) a session by stream ID.
     ///

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/traits.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/traits.rs
@@ -93,7 +93,7 @@ pub trait SmSessionRegistry: Send + Sync {
     async fn scrub_unacked_for_tombstone(
         &self,
         _target_id: &str,
-        _archive_jid: &str,
+        _archive_jid: &jid::BareJid,
     ) -> Result<usize, SmRegistryError> {
         Ok(0)
     }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/traits.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/traits.rs
@@ -72,19 +72,14 @@ pub trait SmSessionRegistry: Send + Sync {
     /// Called when a tombstone is applied so a recipient mid-resume does
     /// not replay the pre-scrub stanza on the wire.
     ///
-    /// `target_id` matches either the cached message's wire `id`
-    /// attribute (typical for 1:1 retractions targeting the original
-    /// message id) **or** any XEP-0359 `<stanza-id id='…'/>` child
-    /// (typical for groupchat retractions that key by the room's
-    /// stanza-id per the "archive id == wire stanza-id" invariant).
-    ///
-    /// `archive_jid` scopes the match to a specific conversation: a
-    /// cached message is only removed if its `from` or `to` bare-equals
-    /// `archive_jid`. This prevents cross-conversation collateral
-    /// damage when two clients independently reuse a short message id
-    /// in different chats — without scoping, retracting "msg-1" in one
-    /// chat would silently delete unrelated "msg-1" stanzas queued for
-    /// other recipients.
+    /// `target` carries the typed tombstone identity
+    /// ([`crate::tombstone::TombstoneTarget`]): groupchat/moderation
+    /// scrubs match only the room-assigned XEP-0359 `<stanza-id
+    /// by=room/>`; 1:1 retraction scrubs match the author's wire id
+    /// only for messages FROM that author (plus the archive-stamped
+    /// stanza-id branch). Both are scoped to the conversation archive,
+    /// so a colliding client-chosen wire id from another sender or
+    /// another chat can never be scrubbed.
     ///
     /// Returns the number of stanza entries removed across all stored
     /// sessions. Default impl is a no-op so registry implementations
@@ -92,8 +87,7 @@ pub trait SmSessionRegistry: Send + Sync {
     /// overrides it.
     async fn scrub_unacked_for_tombstone(
         &self,
-        _target_id: &str,
-        _archive_jid: &jid::BareJid,
+        _target: &crate::tombstone::TombstoneTarget,
     ) -> Result<usize, SmRegistryError> {
         Ok(0)
     }

--- a/server/crates/waddle-xmpp/src/tombstone.rs
+++ b/server/crates/waddle-xmpp/src/tombstone.rs
@@ -19,7 +19,7 @@
 pub fn matching_tombstone_sequences(
     entries: &[(u32, String)],
     target_id: &str,
-    archive_jid: &str,
+    archive_jid: &jid::BareJid,
 ) -> Vec<u32> {
     entries
         .iter()
@@ -46,7 +46,7 @@ pub fn matching_tombstone_sequences(
 pub fn message_element_matches_tombstone(
     el: &minidom::Element,
     target_id: &str,
-    archive_jid: &str,
+    archive_jid: &jid::BareJid,
 ) -> bool {
     if el.name() != "message" {
         return false;
@@ -73,9 +73,52 @@ pub fn message_element_matches_tombstone(
         .any(|c| c.is("stanza-id", "urn:xmpp:sid:0") && c.attr("id") == Some(target_id))
 }
 
-fn jid_bare_equals(jid_str: &str, archive_jid: &str) -> bool {
+fn jid_bare_equals(jid_str: &str, archive_jid: &jid::BareJid) -> bool {
     match jid_str.parse::<jid::Jid>() {
-        Ok(jid) => jid.to_bare().to_string() == archive_jid,
+        Ok(jid) => &jid.to_bare() == archive_jid,
         Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn message_with_scope(to: &str, wire_id: &str) -> minidom::Element {
+        format!("<message xmlns='jabber:client' to='{to}' id='{wire_id}'/>")
+            .parse()
+            .expect("valid message element")
+    }
+
+    #[test]
+    fn matches_are_scoped_by_normalized_bare_jid_not_raw_string() {
+        // The archive scope is a typed BareJid, so IDNA/nodeprep
+        // normalization applies on both sides: a stanza addressed to a
+        // mixed-case JID matches an archive JID that normalizes to the
+        // same value. A raw-string comparison would have missed this
+        // and silently skipped the scrub, leaking the retracted
+        // message.
+        let archive: jid::BareJid = "room@conference.example.com"
+            .parse()
+            .expect("valid bare jid");
+        let el = message_with_scope("Room@Conference.EXAMPLE.com", "retract-me");
+        assert!(message_element_matches_tombstone(
+            &el,
+            "retract-me",
+            &archive
+        ));
+    }
+
+    #[test]
+    fn does_not_match_a_different_conversation() {
+        let archive: jid::BareJid = "room@conference.example.com"
+            .parse()
+            .expect("valid bare jid");
+        let el = message_with_scope("other@conference.example.com", "retract-me");
+        assert!(!message_element_matches_tombstone(
+            &el,
+            "retract-me",
+            &archive
+        ));
     }
 }

--- a/server/crates/waddle-xmpp/src/tombstone.rs
+++ b/server/crates/waddle-xmpp/src/tombstone.rs
@@ -1,3 +1,12 @@
+//! Shared XEP-0424 / XEP-0425 tombstone matching.
+//!
+//! One matcher, two consumers: the XEP-0198 SM session registry scrub
+//! (`stream_management::session_registry`) and the XEP-0160
+//! `pending_delivery` scrub (in-memory impl here, libSQL/Postgres impl
+//! in `waddle-server`). Keeping the per-stanza predicate in one place
+//! guarantees a retraction removes the SAME set of cached copies from
+//! every replay-capable store.
+
 /// Select the sequences of unacked outbound `<message/>` entries that
 /// match a XEP-0424 / XEP-0425 tombstone. Pure — takes a snapshot of
 /// `(sequence, stanza_xml)` pairs so the caller can parse OUTSIDE the
@@ -5,7 +14,26 @@
 /// returned `(stream_id, sequence)` pairs, which is safe even if the
 /// queue changed between snapshot and removal.
 ///
-/// A cached message matches iff:
+/// Parse errors and non-message frames are skipped silently — only
+/// matching messages are selected.
+pub fn matching_tombstone_sequences(
+    entries: &[(u32, String)],
+    target_id: &str,
+    archive_jid: &str,
+) -> Vec<u32> {
+    entries
+        .iter()
+        .filter(
+            |(_, stanza_xml)| match stanza_xml.parse::<minidom::Element>() {
+                Ok(el) => message_element_matches_tombstone(&el, target_id, archive_jid),
+                Err(_) => false,
+            },
+        )
+        .map(|(sequence, _)| *sequence)
+        .collect()
+}
+
+/// Per-stanza tombstone predicate. A cached message matches iff:
 ///   1. it is a `<message>` element,
 ///   2. its `from` or `to` attribute bare-equals `archive_jid` (scope
 ///      guard — prevents cross-conversation collateral damage when
@@ -15,27 +43,7 @@
 ///      (groupchat case where the retraction keyed by the room's
 ///      XEP-0359 stamp per the "archive id == wire stanza-id"
 ///      invariant).
-///
-/// Parse errors and non-message frames are skipped silently — only
-/// matching messages are selected.
-pub(super) fn matching_tombstone_sequences(
-    entries: &[(u32, String)],
-    target_id: &str,
-    archive_jid: &str,
-) -> Vec<u32> {
-    entries
-        .iter()
-        .filter(
-            |(_, stanza_xml)| match stanza_xml.parse::<minidom::Element>() {
-                Ok(el) => cached_message_matches_tombstone(&el, target_id, archive_jid),
-                Err(_) => false,
-            },
-        )
-        .map(|(sequence, _)| *sequence)
-        .collect()
-}
-
-fn cached_message_matches_tombstone(
+pub fn message_element_matches_tombstone(
     el: &minidom::Element,
     target_id: &str,
     archive_jid: &str,

--- a/server/crates/waddle-xmpp/src/tombstone.rs
+++ b/server/crates/waddle-xmpp/src/tombstone.rs
@@ -7,6 +7,135 @@
 //! guarantees a retraction removes the SAME set of cached copies from
 //! every replay-capable store.
 
+/// Typed identity of a XEP-0424 / XEP-0425 tombstone target.
+///
+/// XEP-0424 §"Using the correct ID" distinguishes how a retraction
+/// names its target: groupchat retractions use the room-assigned
+/// XEP-0359 `<stanza-id/>` (`by` == room bare JID); all other types
+/// use the sender's client-chosen wire `id`. The wire id is NOT
+/// unique across senders, so an untyped `(target_id, archive_jid)`
+/// pair let one sender's retraction scrub a colliding message from a
+/// DIFFERENT author queued for the same recipient. Carrying the id
+/// kind plus the author/room identity makes the match precise.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TombstoneTarget {
+    /// Groupchat retraction / XEP-0425 moderation: keyed by the
+    /// room-assigned XEP-0359 stanza-id. A cached reflection matches
+    /// ONLY on `<stanza-id xmlns='urn:xmpp:sid:0' id=stanza_id
+    /// by=room>` — never on the client-chosen wire `id` attribute.
+    Groupchat {
+        /// The room-assigned archive id (== wire stanza-id per the
+        /// "archive id == wire stanza-id" invariant).
+        stanza_id: String,
+        /// The room's bare JID — both the conversation scope and the
+        /// required `by` of the matched stanza-id.
+        room: jid::BareJid,
+    },
+    /// 1:1 retraction: keyed by the retracting author's wire id. A
+    /// cached message matches on (wire `id` == `wire_id` AND
+    /// from-bare == `author`), or on an archive-stamped
+    /// `<stanza-id id=wire_id by=archive>`; both branches are scoped
+    /// to the conversation archive.
+    Direct {
+        /// The retracted message's wire `id` (client-chosen, unique
+        /// only per author).
+        wire_id: String,
+        /// Bare JID of the retraction author — the original message's
+        /// sender. A colliding wire id from any other sender must
+        /// never match.
+        author: jid::BareJid,
+        /// The archive (conversation) scope: the message's `from` or
+        /// `to` must bare-equal this JID.
+        archive: jid::BareJid,
+    },
+}
+
+impl TombstoneTarget {
+    /// The target message id string (room stanza-id or author wire id).
+    pub fn id(&self) -> &str {
+        match self {
+            Self::Groupchat { stanza_id, .. } => stanza_id,
+            Self::Direct { wire_id, .. } => wire_id,
+        }
+    }
+
+    /// The conversation (archive) scope of the tombstone: the room's
+    /// bare JID for groupchat, the archive owner's bare JID for 1:1.
+    pub fn archive_jid(&self) -> &jid::BareJid {
+        match self {
+            Self::Groupchat { room, .. } => room,
+            Self::Direct { archive, .. } => archive,
+        }
+    }
+
+    /// Per-stanza tombstone predicate. A cached message matches iff:
+    ///   1. it is a `<message>` element,
+    ///   2. its `from` or `to` attribute bare-equals
+    ///      [`Self::archive_jid`] (scope guard — prevents
+    ///      cross-conversation collateral damage when short message
+    ///      ids collide across chats), AND
+    ///   3. the variant-specific identity matches:
+    ///      - [`Self::Groupchat`]: a `<stanza-id
+    ///        xmlns='urn:xmpp:sid:0' id=stanza_id by=room/>` child
+    ///        (XEP-0424 groupchat retractions key by the room's
+    ///        XEP-0359 stamp; the client-chosen wire `id` is never
+    ///        consulted),
+    ///      - [`Self::Direct`]: wire `id` equals `wire_id` AND the
+    ///        message's `from` bare-equals `author`, OR an
+    ///        archive-stamped `<stanza-id id=wire_id by=archive/>`
+    ///        child.
+    ///
+    /// XEP-0359 §3 scopes `<stanza-id/>` to `urn:xmpp:sid:0`; the
+    /// namespace is matched explicitly so an unrelated extension
+    /// element named "stanza-id" cannot trigger a scrub, and the `by`
+    /// attribute is verified so an occupant-forged stanza-id cannot
+    /// either.
+    pub fn matches_message_element(&self, el: &minidom::Element) -> bool {
+        if el.name() != "message" {
+            return false;
+        }
+        let archive_jid = self.archive_jid();
+        let in_scope = el
+            .attr("from")
+            .map(|s| jid_bare_equals(s, archive_jid))
+            .unwrap_or(false)
+            || el
+                .attr("to")
+                .map(|s| jid_bare_equals(s, archive_jid))
+                .unwrap_or(false);
+        if !in_scope {
+            return false;
+        }
+        match self {
+            Self::Groupchat { stanza_id, room } => has_stanza_id_by(el, stanza_id, room),
+            Self::Direct {
+                wire_id,
+                author,
+                archive,
+            } => {
+                let wire_match = el.attr("id") == Some(wire_id.as_str())
+                    && el
+                        .attr("from")
+                        .map(|s| jid_bare_equals(s, author))
+                        .unwrap_or(false);
+                wire_match || has_stanza_id_by(el, wire_id, archive)
+            }
+        }
+    }
+}
+
+/// True iff `el` carries a XEP-0359 `<stanza-id xmlns='urn:xmpp:sid:0'
+/// id=target_id/>` child whose `by` bare-equals `by_jid`.
+fn has_stanza_id_by(el: &minidom::Element, target_id: &str, by_jid: &jid::BareJid) -> bool {
+    el.children().any(|c| {
+        c.is("stanza-id", "urn:xmpp:sid:0")
+            && c.attr("id") == Some(target_id)
+            && c.attr("by")
+                .map(|by| jid_bare_equals(by, by_jid))
+                .unwrap_or(false)
+    })
+}
+
 /// Select the sequences of unacked outbound `<message/>` entries that
 /// match a XEP-0424 / XEP-0425 tombstone. Pure — takes a snapshot of
 /// `(sequence, stanza_xml)` pairs so the caller can parse OUTSIDE the
@@ -18,59 +147,18 @@
 /// matching messages are selected.
 pub fn matching_tombstone_sequences(
     entries: &[(u32, String)],
-    target_id: &str,
-    archive_jid: &jid::BareJid,
+    target: &TombstoneTarget,
 ) -> Vec<u32> {
     entries
         .iter()
         .filter(
             |(_, stanza_xml)| match stanza_xml.parse::<minidom::Element>() {
-                Ok(el) => message_element_matches_tombstone(&el, target_id, archive_jid),
+                Ok(el) => target.matches_message_element(&el),
                 Err(_) => false,
             },
         )
         .map(|(sequence, _)| *sequence)
         .collect()
-}
-
-/// Per-stanza tombstone predicate. A cached message matches iff:
-///   1. it is a `<message>` element,
-///   2. its `from` or `to` attribute bare-equals `archive_jid` (scope
-///      guard — prevents cross-conversation collateral damage when
-///      short message ids collide across chats), AND
-///   3. either its wire `id` attribute matches `target_id` (1:1 case)
-///      or any child `<stanza-id id='…'/>` matches `target_id`
-///      (groupchat case where the retraction keyed by the room's
-///      XEP-0359 stamp per the "archive id == wire stanza-id"
-///      invariant).
-pub fn message_element_matches_tombstone(
-    el: &minidom::Element,
-    target_id: &str,
-    archive_jid: &jid::BareJid,
-) -> bool {
-    if el.name() != "message" {
-        return false;
-    }
-    let in_scope = el
-        .attr("from")
-        .map(|s| jid_bare_equals(s, archive_jid))
-        .unwrap_or(false)
-        || el
-            .attr("to")
-            .map(|s| jid_bare_equals(s, archive_jid))
-            .unwrap_or(false);
-    if !in_scope {
-        return false;
-    }
-    if el.attr("id") == Some(target_id) {
-        return true;
-    }
-    // XEP-0359 §3 scopes `<stanza-id/>` to `urn:xmpp:sid:0`. Match that
-    // namespace explicitly so an unrelated extension element happening
-    // to be named "stanza-id" in a different namespace cannot trigger
-    // a tombstone scrub (Copilot review on PR #305).
-    el.children()
-        .any(|c| c.is("stanza-id", "urn:xmpp:sid:0") && c.attr("id") == Some(target_id))
 }
 
 fn jid_bare_equals(jid_str: &str, archive_jid: &jid::BareJid) -> bool {
@@ -84,41 +172,123 @@ fn jid_bare_equals(jid_str: &str, archive_jid: &jid::BareJid) -> bool {
 mod tests {
     use super::*;
 
-    fn message_with_scope(to: &str, wire_id: &str) -> minidom::Element {
-        format!("<message xmlns='jabber:client' to='{to}' id='{wire_id}'/>")
+    fn bare(s: &str) -> jid::BareJid {
+        s.parse().expect("valid bare jid")
+    }
+
+    fn direct(wire_id: &str, author: &str, archive: &str) -> TombstoneTarget {
+        TombstoneTarget::Direct {
+            wire_id: wire_id.to_string(),
+            author: bare(author),
+            archive: bare(archive),
+        }
+    }
+
+    fn message_from_to(from: &str, to: &str, wire_id: &str) -> minidom::Element {
+        format!("<message xmlns='jabber:client' from='{from}' to='{to}' id='{wire_id}'/>")
             .parse()
             .expect("valid message element")
     }
 
     #[test]
     fn matches_are_scoped_by_normalized_bare_jid_not_raw_string() {
-        // The archive scope is a typed BareJid, so IDNA/nodeprep
-        // normalization applies on both sides: a stanza addressed to a
-        // mixed-case JID matches an archive JID that normalizes to the
-        // same value. A raw-string comparison would have missed this
-        // and silently skipped the scrub, leaking the retracted
-        // message.
-        let archive: jid::BareJid = "room@conference.example.com"
-            .parse()
-            .expect("valid bare jid");
-        let el = message_with_scope("Room@Conference.EXAMPLE.com", "retract-me");
-        assert!(message_element_matches_tombstone(
-            &el,
-            "retract-me",
-            &archive
-        ));
+        // The archive scope and author identity are typed BareJids, so
+        // IDNA/nodeprep normalization applies on both sides: a stanza
+        // addressed with mixed-case JIDs matches a target whose JIDs
+        // normalize to the same values. A raw-string comparison would
+        // have missed this and silently skipped the scrub, leaking the
+        // retracted message.
+        let target = direct("retract-me", "alice@example.com", "bob@example.com");
+        let el = message_from_to("Alice@EXAMPLE.com/web", "Bob@Example.COM", "retract-me");
+        assert!(target.matches_message_element(&el));
+    }
+
+    #[test]
+    fn groupchat_stanza_id_by_is_bare_jid_normalized() {
+        let target = TombstoneTarget::Groupchat {
+            stanza_id: "room-id-1".to_string(),
+            room: bare("room@conference.example.com"),
+        };
+        let el: minidom::Element =
+            "<message xmlns='jabber:client' from='Room@Conference.EXAMPLE.com/alice' \
+             to='bob@example.com/web' id='wire' type='groupchat'>\
+             <stanza-id xmlns='urn:xmpp:sid:0' by='Room@Conference.EXAMPLE.com' id='room-id-1'/>\
+             </message>"
+                .parse()
+                .expect("valid message element");
+        assert!(target.matches_message_element(&el));
     }
 
     #[test]
     fn does_not_match_a_different_conversation() {
-        let archive: jid::BareJid = "room@conference.example.com"
-            .parse()
-            .expect("valid bare jid");
-        let el = message_with_scope("other@conference.example.com", "retract-me");
-        assert!(!message_element_matches_tombstone(
-            &el,
-            "retract-me",
-            &archive
-        ));
+        let target = direct("retract-me", "alice@example.com", "bob@example.com");
+        let el = message_from_to("alice@example.com/web", "carol@example.com", "retract-me");
+        assert!(!target.matches_message_element(&el));
+    }
+
+    #[test]
+    fn direct_retraction_does_not_scrub_another_senders_colliding_wire_id() {
+        // FINDING A repro: Mallory sends Bob a message whose wire id
+        // collides with Alice's undelivered message to Bob, then
+        // retracts her own message. The wire id is client-chosen and
+        // non-unique, so a 1:1 retraction must also verify the cached
+        // message's author (from-bare) — Alice's message must survive.
+        let mallorys_retraction = direct("collide", "mallory@example.com", "bob@example.com");
+        let alices_message = message_from_to("alice@example.com/web", "bob@example.com", "collide");
+        assert!(
+            !mallorys_retraction.matches_message_element(&alices_message),
+            "a retraction must not scrub a colliding wire id from a different author"
+        );
+        // Mallory's own message DOES match.
+        let mallorys_message =
+            message_from_to("mallory@example.com/web", "bob@example.com", "collide");
+        assert!(mallorys_retraction.matches_message_element(&mallorys_message));
+    }
+
+    #[test]
+    fn groupchat_retraction_does_not_match_client_chosen_wire_id() {
+        // FINDING A repro: XEP-0424 groupchat retractions target the
+        // room-assigned XEP-0359 stanza-id (by == room bare JID), never
+        // the client-chosen wire @id. Matching the wire id lets any
+        // occupant mint a colliding id and scrub someone else's
+        // reflection.
+        let target = TombstoneTarget::Groupchat {
+            stanza_id: "victim-target".to_string(),
+            room: bare("room@conference.example.com"),
+        };
+        let reflection: minidom::Element =
+            "<message xmlns='jabber:client' from='room@conference.example.com/alice' \
+             to='bob@example.com/web' id='victim-target' type='groupchat'>\
+             <body>hi</body>\
+             <stanza-id xmlns='urn:xmpp:sid:0' by='room@conference.example.com' id='room-id-1'/>\
+             </message>"
+                .parse()
+                .expect("valid message element");
+        assert!(
+            !target.matches_message_element(&reflection),
+            "groupchat scrub must key on the room stanza-id, not the wire id"
+        );
+    }
+
+    #[test]
+    fn stanza_id_match_requires_by_to_equal_archive() {
+        // FINDING A repro: the stanza-id branch previously ignored the
+        // `by` attribute entirely, so any occupant-injected fake
+        // <stanza-id id=target by=attacker/> triggered the scrub.
+        let target = TombstoneTarget::Groupchat {
+            stanza_id: "room-id-1".to_string(),
+            room: bare("room@conference.example.com"),
+        };
+        let forged: minidom::Element =
+            "<message xmlns='jabber:client' from='room@conference.example.com/mallory' \
+             to='bob@example.com/web' type='groupchat'>\
+             <stanza-id xmlns='urn:xmpp:sid:0' by='mallory@example.com' id='room-id-1'/>\
+             </message>"
+                .parse()
+                .expect("valid message element");
+        assert!(
+            !target.matches_message_element(&forged),
+            "a stanza-id whose by= is not the archive must never match"
+        );
     }
 }

--- a/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
+++ b/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
@@ -114,6 +114,14 @@ impl SmPersistenceStorage for BlockingFirstAtomicStore {
         self.inner.ack_through(stream_id, up_to_sequence).await
     }
 
+    async fn delete_unacked(
+        &self,
+        stream_id: &SmSessionId,
+        sequences: &[u32],
+    ) -> Result<u64, SmPersistenceError> {
+        self.inner.delete_unacked(stream_id, sequences).await
+    }
+
     async fn list_unacked(
         &self,
         stream_id: &SmSessionId,
@@ -191,6 +199,14 @@ impl SmPersistenceStorage for MislabelingStore {
         up_to_sequence: u32,
     ) -> Result<u64, SmPersistenceError> {
         self.inner.ack_through(stream_id, up_to_sequence).await
+    }
+
+    async fn delete_unacked(
+        &self,
+        stream_id: &SmSessionId,
+        sequences: &[u32],
+    ) -> Result<u64, SmPersistenceError> {
+        self.inner.delete_unacked(stream_id, sequences).await
     }
 
     async fn list_unacked(


### PR DESCRIPTION
Reliability bundle fixing six audit issues test-first, hardened through four adversarial review rounds.

Closes #1097, closes #1098, closes #1135, closes #1145, closes #1164, closes #1165.

## Server (Rust)

### #1097 — SM promotes unacked queues before discard (eviction + fresh-bind)
- `store_session` returns displaced sessions (capacity eviction and jid-collision) instead of dropping them; `invalidate_sessions_for_jid` no longer persist-deletes. Callers run the XEP-0198 §5 promote → confirm chain (`promote_displaced_sessions`): alt-resource delivery → offline storage → bounce, with per-stanza XEP-0203 delay stamps. Fresh-bind promotion runs after the new resource registers, so the queue live-delivers to the new session.
- The ownership-moved detach branch also displaces + promotes (was: durable delete, queue lost).
- `MAX_SESSIONS` configurable via `WADDLE_SM_MAX_SESSIONS` (default 10 000, clamp 100..10M).

### #1098 — startup promotes window-expired sessions
- `restore_from_persistence` hydrates expired sessions (wire-invisible; `peek`/`take`/`claim` gate on expiry) so the SM-expiry janitor's first drain runs them through the existing promote/confirm/retry/dead-letter machinery. A client `<resume>` racing the janitor re-inserts instead of dropping.

### #1145 — durable, lock-scoped tombstone scrub
- New `SmPersistenceStorage::delete_unacked(stream_id, sequences)`; scrub snapshots under read locks, parses with no lock held, then per stream deletes durable rows first, memory second (failure keeps memory consistent and surfaces a typed error). Phase-4 sweep covers off-map streams.
- New `PendingDeliveryStorage::scrub_for_tombstone` wired into all retraction/moderation call sites (promoted rows + archived pointers).
- Scrubs record a TTL/size-bounded recent-tombstone list; every promotion driver re-checks it, closing the retraction-vs-in-flight-promotion race.

### #1135 — MUC durable inbox recipients across respawn
- Room actors hydrate a durable-recipient mirror at spawn from a new `DurableMembershipSource` (PermissionActor-backed, reply-timeout-bounded, fail-open), enqueued as the first mailbox item so no snapshot observes a pre-hydration set. The mirror unions with session-observed affiliations; it never writes into the affiliation list.
- Affiliation change to Outcast prunes directly; None prunes then re-hydrates in the same handler turn, so revoking an explicit channel grant doesn't drop a space-entitled member; hydration-query failure keeps the prune (privacy over availability).

### Promotion-failure hygiene
- All non-dead-letter failure paths re-insert the session (original `detached_at` preserved) for next-tick janitor retry; partial storage failures durably delete the promoted sequences and retry only the failed remainder, bounding duplication to a crash window.

## Chat (TypeScript)

### #1165 — reactions/read-markers survive reconnect catch-up
- XEP-0333 displayed markers and XEP-0444 reactions arriving during the resume barrier are buffered and drained bodies-first via a shared `dispatchLiveMessage` (never re-enters the buffer). Ephemeral traffic (chat states, in-call reactions) stays live.
- XEP-0444 delayed-reaction rule: reaction events carry `occurredAt`, per-sender recency (`reactionTimes`) is enforced in room + DM merge paths; exact re-deliveries are idempotent. Round 5 hardened this: recency is keyed by `senderId` (real bare JID, per XEP-0444's MUC identity rule) not nick; equal-stamp ties apply unless the emoji set is identical (server truncates XEP-0203 stamps to whole seconds); live undelayed reactions record an applied-after-wire-anchor ordering fact instead of a local `Date.now()` stamp, so a skewed client clock can never drop a genuinely newer replayed reaction.
- A resume barrier that fails mid-catchup carries its undrained reaction/marker buffer into the next barrier (the stanzas were SM-acked and MAM page appliers ignore reaction rows, so discarding lost them until reload); `disconnect()` clears the carry.

### #1164 — honest reconnect state machine
- Terminal `state:"error"` (the previously dead "sign in again" branch) on structured `not-authorized`/`conflict` stream errors only — the free-text disconnect-message scan is removed (the WASM disconnect callback carries no payload; SASL failures arrive via the structured error path first).
- Retry loop caps at 10 attempts (~6 min of 2s·2^n backoff, 60s max delay), then terminal error. Fresh budget only from user-explicit recovery (window `online` listener, page load); internal/background `connect()` calls neither reset the budget nor exit terminal state, and reject fast while terminal/exhausted. Round 5: a background `connect()` also fast-rejects while a backoff timer is armed instead of cancelling it and launching an immediate attempt — previously ten user interactions (typing indicators, presence) during a short outage burned the whole budget at interaction speed and latched the terminal error.
- Connect timeout measures to session-ready: an established session with a slow catch-up is never torn down; a genuinely stalled connect tears down, emits `reconnecting`, and reschedules. Connect attempts carry a generation token so a stalled WASM load can't double-bind the resource; `disconnect()` clears the pending attempt's timer and settles its promise.
- Queuing a room message on a healthy-but-unjoined room no longer flips the global banner to "Reconnecting…".

### Round 5 server hardening

- **Typed tombstone targets** (`TombstoneTarget::{Groupchat, Direct}` replacing `(target_id, archive_jid)` strings): groupchat scrubs match only `<stanza-id xmlns='urn:xmpp:sid:0' by=room>` (XEP-0424 correct-ID rule, never the client-chosen wire id); direct scrubs require the cached message's `from`-bare to equal the retraction author. Closes a cross-sender attack where a wire-id collision let one user scrub another user's undelivered messages from SM queues and `pending_delivery`.
- **Post-promotion tombstone re-check**: after `promote_session_unacked` and before `confirm_drained`, every promotion driver re-reads `recent_tombstones()` and scrubs pending rows for records that landed mid-promotion, closing the last retraction-vs-promotion TOCTOU.
- **Flood-resistant recent-tombstone eviction**: TTL sweep first, then a per-archive cap (64), then the global backstop (1024) with a warn — a retraction flood on one conversation can no longer evict another conversation's unexpired record.
- **Retry-horizon guard**: `reinsert_for_retry` diffs the in-memory queue against durable rows so a durably-scrubbed stanza cannot outlive `RECENT_TOMBSTONE_TTL` via the uncounted retry path; round 6 scoped the diff to sessions whose durable session row exists (a failed first snapshot must not read as "scrubbed" and drop the queue).
- **Displaced-session limbo guard**: `store_session` snapshot-write failure re-inserts displaced sessions expired-for-retry (lock-free variant avoids crossed-shard deadlock) instead of stranding their durable rows until restart.
- **Group-DM rollback ordering**: `rollback_group_dm_invite_grant` deletes the member permission tuple *before* `ChangeAffiliation(None)`, so the None-handler's durable-recipient re-hydration cannot resurrect the rolled-back invitee as an inbox recipient (content leak).
- **Room-actor liveness**: `DurableMembershipSource` runs its seven `ListSubjects` queries concurrently (worst case one 5s reply timeout, not seven sequential); admin-IQ room-actor asks get the same 5s timeout as the reaper precedent.

## Review process

Six adversarial rounds. Rounds 1–4 during initial development (concurrency, XEP conformance, security/data-integrity, TS state-machine personas). Round 5 re-ran all four personas against the finished PR — 12 real findings, all reproduced with failing tests first and fixed (commits `98c9f02f..dde85e7b`). Round 6 adversarially re-reviewed the round-5 fixes — one real finding (the durable-diff/never-persisted interaction above), fixed the same way. XEP-0198/0203/0333/0424/0425/0444/0045 wire behavior verified against ./xeps.

Accepted (documented): narrow double-delivery race when a displaced claimed session is mid-resume-replay (client id/synthesizedId dedup absorbs; XEP-0198 §5 permits duplicates); startup promotion burst after mass expiry is sequential and operator-bounded. Residual (documented): a retraction flood *within the same conversation* (64+ in <10 min, precisely timed against a mid-drain promotion) can still evict that conversation's own recent-tombstone record — the full fix is durable tombstone persistence, out of scope here; the promotion re-check plus per-archive cap reduce the window to that single-conversation, high-volume case.

## Testing

- Rust: TDD per behavior; full `cargo test -p waddle-xmpp -p waddle-server` green (known flake #1188 fails on main identically); clippy `-D warnings` clean; `cargo fmt --check` clean.
- Chat: TDD per behavior; `bun run build` + `bun test` 3275 pass / 0 fail; knip + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

