### PR TITLE
fix(server): presence relay carries the client's real presence/caps instead of a server-caps rebuild

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/probe.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/probe.rs
@@ -97,7 +97,7 @@ pub(super) async fn handle_presence_probe(
             .protocol
             .connection_registry
             .get_presence_state(&resource);
-        let presence = Stanza::Presence(build_available_presence(
+        let mut probe_response = build_available_presence(
             &resource,
             &from,
             presence_state
@@ -110,7 +110,16 @@ pub(super) async fn handle_presence_probe(
                 .as_ref()
                 .map(|state| state.priority)
                 .unwrap_or(0),
-        ));
+        );
+        // Relay the resource's own stored extension payloads (XEP-0115 caps,
+        // XEP-0319 idle, anything else) verbatim — never server-rebuilt ones
+        // (issue #1101).
+        if let Some(state) = &presence_state {
+            probe_response
+                .payloads
+                .extend(state.payloads.iter().cloned());
+        }
+        let presence = Stanza::Presence(probe_response);
         for requester_resource in &requester_resources {
             let _ = state
                 .deps

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/probe.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/probe.rs
@@ -114,10 +114,10 @@ pub(super) async fn handle_presence_probe(
         // Relay the resource's own stored extension payloads (XEP-0115 caps,
         // XEP-0319 idle, anything else) verbatim — never server-rebuilt ones
         // (issue #1101).
-        if let Some(state) = &presence_state {
+        if let Some(stored) = &presence_state {
             probe_response
                 .payloads
-                .extend(state.payloads.iter().cloned());
+                .extend(stored.payloads.iter().cloned());
         }
         let presence = Stanza::Presence(probe_response);
         for requester_resource in &requester_resources {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
@@ -13,14 +13,6 @@ pub(super) async fn handle_regular_presence_update(
 ) {
     let available = presence.type_ != xmpp_parsers::presence::Type::Unavailable;
     let priority: i8 = priority_to_i8(&presence.priority);
-    // XEP-0319 last-interaction instant, parsed once from the inbound stanza.
-    // Carried through the rebuilt presence so subscribers see the idle age,
-    // and persisted so a later probe of this resource keeps it.
-    let idle_since = if available {
-        waddle_xmpp::xep::xep0319::extract_idle_from_presence(&presence).map(|info| info.since)
-    } else {
-        None
-    };
     if available {
         state
             .deps
@@ -52,7 +44,10 @@ pub(super) async fn handle_regular_presence_update(
                     .map(|show| show_name(show).to_string()),
                 presence.statuses.values().next().cloned(),
                 priority,
-                idle_since,
+                // The client's extension payloads (XEP-0115 caps, XEP-0319
+                // idle, ...) are stored verbatim so probe/subscription
+                // delivery relays the real advertisements (issue #1101).
+                presence.payloads.clone(),
             );
         for stanza in state
             .deps
@@ -87,7 +82,7 @@ pub(super) async fn handle_regular_presence_update(
                 presence.statuses.values().next().cloned(),
             );
     }
-    broadcast_presence_to_subscribers(state, sender_jid, &presence, available, idle_since).await;
+    broadcast_presence_to_subscribers(state, sender_jid, &presence).await;
 }
 
 /// XEP-0160 §3 step 5 + locked Q7a / Q7c / Q7d: on the recovering
@@ -171,13 +166,10 @@ async fn broadcast_presence_to_subscribers(
     state: &WebSocketState,
     sender_jid: &FullJid,
     presence: &xmpp_parsers::presence::Presence,
-    available: bool,
-    idle_since: Option<chrono::DateTime<chrono::Utc>>,
 ) {
     let Some(storage) = roster_storage(state).await else {
         return;
     };
-    let priority = priority_to_i8(&presence.priority);
     let subscribers = match storage
         .get_presence_subscribers(&sender_jid.to_bare())
         .await
@@ -195,27 +187,13 @@ async fn broadcast_presence_to_subscribers(
         if recipient_blocks_sender(state, &subscriber_bare, &sender_jid.to_bare()).await {
             continue;
         }
-        let stanza = if available {
-            let show = presence.show.as_ref().map(show_name);
-            let mut rebuilt = build_available_presence(
-                sender_jid,
-                &subscriber_bare,
-                show,
-                presence.statuses.values().next().map(String::as_str),
-                priority,
-            );
-            // Carry the XEP-0319 idle stamp the rebuild would otherwise drop,
-            // so subscribers can render the contact's idle age.
-            if let Some(since) = idle_since {
-                waddle_xmpp::xep::xep0319::add_idle(&mut rebuilt, since);
-            }
-            Stanza::Presence(rebuilt)
-        } else {
-            let mut unavailable = presence.clone();
-            unavailable.from = Some(Jid::from(sender_jid.clone()));
-            unavailable.to = Some(Jid::from(subscriber_bare.clone()));
-            Stanza::Presence(unavailable)
-        };
+        // RFC 6121 §4.4.2: relay the user's own stanza (readdressed), never a
+        // rebuild — a rebuild drops extensions and would misattribute the
+        // server's XEP-0115 caps to the contact (issue #1101).
+        let mut relayed = presence.clone();
+        relayed.from = Some(Jid::from(sender_jid.clone()));
+        relayed.to = Some(Jid::from(subscriber_bare.clone()));
+        let stanza = Stanza::Presence(relayed);
         let mut delivered_resources = Vec::new();
         for resource in state
             .deps

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
@@ -11,6 +11,21 @@ pub(super) async fn handle_regular_presence_update(
     sender_jid: &FullJid,
     presence: xmpp_parsers::presence::Presence,
 ) {
+    // Defense in depth behind `parse_subscription_presence`: only the normal
+    // available/unavailable forms may update state and be relayed. The
+    // broadcast below forwards the stanza verbatim, so any other type leaking
+    // in here would reach subscribers.
+    if !matches!(
+        presence.type_,
+        xmpp_parsers::presence::Type::None | xmpp_parsers::presence::Type::Unavailable
+    ) {
+        warn!(
+            jid = %sender_jid,
+            presence_type = ?presence.type_,
+            "Dropping non-broadcastable presence type from regular update path"
+        );
+        return;
+    }
     let available = presence.type_ != xmpp_parsers::presence::Type::Unavailable;
     let priority: i8 = priority_to_i8(&presence.priority);
     if available {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/subscription/delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/subscription/delivery.rs
@@ -108,8 +108,8 @@ pub(in crate::server::routes::websocket::handlers) async fn send_current_presenc
         // Relay the resource's own stored extension payloads (XEP-0115 caps,
         // XEP-0319 idle, anything else) verbatim so a subscription-approval
         // push carries the contact's real advertisements (issue #1101).
-        if let Some(state) = &presence_state {
-            presence.payloads.extend(state.payloads.iter().cloned());
+        if let Some(stored) = &presence_state {
+            presence.payloads.extend(stored.payloads.iter().cloned());
         }
         let stanza = Stanza::Presence(presence);
         send_stanza_to_available_user_resources_and_detached_available(
@@ -146,8 +146,8 @@ pub(in crate::server::routes::websocket::handlers) async fn send_current_presenc
         );
         // Relay the resource's own stored extension payloads (XEP-0115 caps,
         // XEP-0319 idle, anything else) verbatim (issue #1101).
-        if let Some(state) = &presence_state {
-            presence.payloads.extend(state.payloads.iter().cloned());
+        if let Some(stored) = &presence_state {
+            presence.payloads.extend(stored.payloads.iter().cloned());
         }
         presence.to = Some(to.clone());
         send_presence_stanza_to_jid(state, to, Stanza::Presence(presence), "current presence")

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/subscription/delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/subscription/delivery.rs
@@ -105,10 +105,11 @@ pub(in crate::server::routes::websocket::handlers) async fn send_current_presenc
                 .map(|state| state.priority)
                 .unwrap_or(0),
         );
-        // Carry the XEP-0319 idle stamp (same as the `_to_jid` probe path) so a
-        // subscription-approval push shows the idle age, not a bare away dot.
-        if let Some(since) = presence_state.as_ref().and_then(|state| state.idle_since) {
-            waddle_xmpp::xep::xep0319::add_idle(&mut presence, since);
+        // Relay the resource's own stored extension payloads (XEP-0115 caps,
+        // XEP-0319 idle, anything else) verbatim so a subscription-approval
+        // push carries the contact's real advertisements (issue #1101).
+        if let Some(state) = &presence_state {
+            presence.payloads.extend(state.payloads.iter().cloned());
         }
         let stanza = Stanza::Presence(presence);
         send_stanza_to_available_user_resources_and_detached_available(
@@ -143,10 +144,10 @@ pub(in crate::server::routes::websocket::handlers) async fn send_current_presenc
                 .map(|state| state.priority)
                 .unwrap_or(0),
         );
-        // Carry the XEP-0319 idle stamp so a probing contact sees the idle age,
-        // not just a bare away dot.
-        if let Some(since) = presence_state.as_ref().and_then(|state| state.idle_since) {
-            waddle_xmpp::xep::xep0319::add_idle(&mut presence, since);
+        // Relay the resource's own stored extension payloads (XEP-0115 caps,
+        // XEP-0319 idle, anything else) verbatim (issue #1101).
+        if let Some(state) = &presence_state {
+            presence.payloads.extend(state.payloads.iter().cloned());
         }
         presence.to = Some(to.clone());
         send_presence_stanza_to_jid(state, to, Stanza::Presence(presence), "current presence")
@@ -331,7 +332,7 @@ async fn presence_state_for_available_resource(
             show: state.show.as_deref().and_then(show_from_name),
             status: state.status,
             priority: state.priority,
-            idle_since: state.idle_since,
+            payloads: state.payloads,
         });
     }
     match state
@@ -345,8 +346,9 @@ async fn presence_state_for_available_resource(
             show,
             status,
             priority,
-            // Detached (XEP-0198) presence state does not yet persist idle.
-            idle_since: None,
+            // Detached (XEP-0198) presence state does not yet persist
+            // extension payloads (idle, caps, ...).
+            payloads: Vec::new(),
         }),
         Ok(None) => None,
         Err(error) => {
@@ -360,9 +362,10 @@ struct PresenceStateSnapshot {
     show: Option<xmpp_parsers::presence::Show>,
     status: Option<String>,
     priority: i8,
-    /// XEP-0319 idle instant for a probing contact's rebuilt presence. Only
-    /// the live registry persists it; the detached (XEP-0198) path has none yet.
-    idle_since: Option<chrono::DateTime<chrono::Utc>>,
+    /// The resource's original presence extension payloads (XEP-0115 caps,
+    /// XEP-0319 idle, anything else), relayed verbatim (issue #1101). Only the
+    /// live registry persists them; the detached (XEP-0198) path has none yet.
+    payloads: Vec<Element>,
 }
 
 async fn send_stanza_to_available_user_resources_and_detached_available(

--- a/server/crates/waddle-server/src/server/routes/websocket/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/registration.rs
@@ -118,10 +118,11 @@ pub(super) async fn register_bound_connection_after_frame(
                     .map(str::to_string),
                 conn.presence_status.clone(),
                 conn.presence_priority,
-                // XEP-0198 resume restores show/status/priority; idle is not
-                // carried in SM session state yet (deferred), so a probe during
-                // a detached window omits the stamp until the next live update.
-                None,
+                // XEP-0198 resume restores show/status/priority; extension
+                // payloads (idle, caps, ...) are not carried in SM session
+                // state yet (deferred), so a probe during a detached window
+                // omits them until the next live update.
+                Vec::new(),
             );
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -2151,7 +2151,7 @@ async fn cleanup_shutdown_detaches_resumable_session_on_transport_drop() {
             Some("away".to_string()),
             Some("stepped out".to_string()),
             3,
-            None,
+            Vec::new(),
         );
 
     let mut conn = WsConnState::new();

--- a/server/crates/waddle-server/tests/rfc6121_presence_ws.rs
+++ b/server/crates/waddle-server/tests/rfc6121_presence_ws.rs
@@ -174,6 +174,164 @@ async fn websocket_full_jid_probe_returns_rich_resource_presence() {
     let _ = alice.close().await;
 }
 
+/// The Waddle server's own XEP-0115 caps node. Relayed *user* presence must
+/// never carry it — caps belong to the generating entity (XEP-0115 §1).
+const SERVER_CAPS_NODE: &str = "https://waddle.social/caps";
+
+#[tokio::test]
+async fn websocket_presence_broadcast_relays_contacts_own_caps_not_servers() {
+    let (_server, mut alice, mut bob) = connect_alice_bob().await;
+
+    establish_subscription_to_alice(&mut alice, &mut bob).await;
+    alice
+        .send(
+            r#"<presence xmlns="jabber:client"><c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://example.com/client" ver="zHyEOgxTrkpSdGcQKH8EFPLsriY="/></presence>"#,
+        )
+        .await
+        .expect("alice sends presence with her own caps");
+    let broadcast = bob
+        .recv_matching(|frame| {
+            frame.contains("from='alice@localhost/")
+                && frame.contains("http://jabber.org/protocol/caps")
+        })
+        .await
+        .expect("bob receives alice's broadcast presence with a caps element");
+    assert!(
+        broadcast.contains("zHyEOgxTrkpSdGcQKH8EFPLsriY=")
+            && broadcast.contains("https://example.com/client"),
+        "broadcast must carry the contact's own caps hash: {broadcast}"
+    );
+    assert!(
+        !broadcast.contains(SERVER_CAPS_NODE),
+        "broadcast must not substitute the server's caps: {broadcast}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}
+
+#[tokio::test]
+async fn websocket_presence_broadcast_relays_arbitrary_extensions_verbatim() {
+    let (_server, mut alice, mut bob) = connect_alice_bob().await;
+
+    establish_subscription_to_alice(&mut alice, &mut bob).await;
+    alice
+        .send(
+            r#"<presence xmlns="jabber:client"><show>away</show><idle xmlns="urn:xmpp:idle:1" since="2026-07-06T10:00:00Z"/><x xmlns="urn:example:future-extension:0"><detail>opaque</detail></x></presence>"#,
+        )
+        .await
+        .expect("alice sends presence with idle and an unknown extension");
+    let broadcast = bob
+        .recv_matching(|frame| {
+            frame.contains("from='alice@localhost/")
+                && frame.contains("urn:example:future-extension:0")
+        })
+        .await
+        .expect("bob receives the relayed presence with the unknown extension");
+    assert!(
+        broadcast.contains("<detail>opaque</detail>"),
+        "extension content must survive relay verbatim: {broadcast}"
+    );
+    assert!(
+        broadcast.contains("urn:xmpp:idle:1") && broadcast.contains("2026-07-06T10:00:00"),
+        "XEP-0319 idle must survive relay without hand re-attachment: {broadcast}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}
+
+#[tokio::test]
+async fn websocket_presence_probe_returns_contacts_own_caps_and_extensions() {
+    let (_server, mut alice, mut bob) = connect_alice_bob().await;
+    let alice_jid = alice.full_jid.clone().expect("alice full jid");
+
+    establish_subscription_to_alice(&mut alice, &mut bob).await;
+    alice
+        .send(
+            r#"<presence xmlns="jabber:client"><show>away</show><c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://example.com/client" ver="zHyEOgxTrkpSdGcQKH8EFPLsriY="/><x xmlns="urn:example:future-extension:0"/></presence>"#,
+        )
+        .await
+        .expect("alice sends presence with her own caps and an extension");
+    bob.recv_matching(|frame| frame.contains("urn:example:future-extension:0"))
+        .await
+        .expect("bob receives alice's broadcast");
+
+    bob.send(&format!(
+        r#"<presence xmlns="jabber:client" type="probe" to="{alice_jid}"/>"#
+    ))
+    .await
+    .expect("bob probes alice");
+    let probe = bob
+        .recv_matching(|frame| {
+            frame.contains("from='alice@localhost/") && frame.contains("<show>away</show>")
+        })
+        .await
+        .expect("probe response");
+    assert!(
+        probe.contains("zHyEOgxTrkpSdGcQKH8EFPLsriY=")
+            && probe.contains("https://example.com/client")
+            && probe.contains("urn:example:future-extension:0"),
+        "probe response must carry the contact's stored caps and extensions: {probe}"
+    );
+    assert!(
+        !probe.contains(SERVER_CAPS_NODE),
+        "probe response must not substitute the server's caps: {probe}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}
+
+#[tokio::test]
+async fn websocket_subscription_approval_push_carries_contacts_own_payloads() {
+    let (_server, mut alice, mut bob) = connect_alice_bob().await;
+
+    send_roster_get(&mut alice, "alice-approval-roster").await;
+    send_roster_get(&mut bob, "bob-approval-roster").await;
+    alice
+        .send(
+            r#"<presence xmlns="jabber:client"><c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://example.com/client" ver="zHyEOgxTrkpSdGcQKH8EFPLsriY="/><x xmlns="urn:example:future-extension:0"/></presence>"#,
+        )
+        .await
+        .expect("alice is available with her own caps and an extension");
+    bob.send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("bob is available");
+    bob.send(r#"<presence xmlns="jabber:client" type="subscribe" to="alice@localhost"/>"#)
+        .await
+        .expect("bob subscribes to alice");
+    alice
+        .recv_matching(|frame| frame.contains("type='subscribe'"))
+        .await
+        .expect("alice receives subscribe");
+    alice
+        .send(r#"<presence xmlns="jabber:client" type="subscribed" to="bob@localhost"/>"#)
+        .await
+        .expect("alice approves bob");
+
+    let pushed = bob
+        .recv_matching(|frame| {
+            frame.contains("from='alice@localhost/")
+                && frame.contains("http://jabber.org/protocol/caps")
+        })
+        .await
+        .expect("bob receives alice's current presence after approval");
+    assert!(
+        pushed.contains("zHyEOgxTrkpSdGcQKH8EFPLsriY=")
+            && pushed.contains("https://example.com/client")
+            && pushed.contains("urn:example:future-extension:0"),
+        "approval push must carry the contact's stored caps and extensions: {pushed}"
+    );
+    assert!(
+        !pushed.contains(SERVER_CAPS_NODE),
+        "approval push must not substitute the server's caps: {pushed}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}
+
 #[tokio::test]
 async fn websocket_blocking_prevents_presence_probe_response() {
     let (_server, mut alice, mut bob) = connect_alice_bob().await;

--- a/server/crates/waddle-server/tests/rfc6121_presence_ws.rs
+++ b/server/crates/waddle-server/tests/rfc6121_presence_ws.rs
@@ -169,14 +169,25 @@ async fn websocket_full_jid_probe_returns_rich_resource_presence() {
             && probe.contains("<priority>7</priority>"),
         "full-JID probe must preserve rich resource presence: {probe}"
     );
+    // Alice sent no <c/>: the probe response must not add one either
+    // (issue #1101 — server caps were previously injected here).
+    assert!(
+        !probe.contains("http://jabber.org/protocol/caps"),
+        "server must not attach caps to a caps-less probe response: {probe}"
+    );
 
     let _ = bob.close().await;
     let _ = alice.close().await;
 }
 
-/// The Waddle server's own XEP-0115 caps node. Relayed *user* presence must
-/// never carry it — caps belong to the generating entity (XEP-0115 §1).
-const SERVER_CAPS_NODE: &str = "https://waddle.social/caps";
+/// Count the `<c` XEP-0115 caps elements in a raw frame. Relayed user
+/// presence must carry exactly the caps the client sent — never an extra
+/// server-injected one (caps belong to the generating entity, XEP-0115 §1).
+fn caps_element_count(frame: &str) -> usize {
+    frame
+        .matches("<c xmlns='http://jabber.org/protocol/caps'")
+        .count()
+}
 
 #[tokio::test]
 async fn websocket_presence_broadcast_relays_contacts_own_caps_not_servers() {
@@ -201,9 +212,10 @@ async fn websocket_presence_broadcast_relays_contacts_own_caps_not_servers() {
             && broadcast.contains("https://example.com/client"),
         "broadcast must carry the contact's own caps hash: {broadcast}"
     );
-    assert!(
-        !broadcast.contains(SERVER_CAPS_NODE),
-        "broadcast must not substitute the server's caps: {broadcast}"
+    assert_eq!(
+        caps_element_count(&broadcast),
+        1,
+        "broadcast must carry exactly the client's caps element, nothing extra: {broadcast}"
     );
 
     let _ = bob.close().await;
@@ -235,6 +247,13 @@ async fn websocket_presence_broadcast_relays_arbitrary_extensions_verbatim() {
     assert!(
         broadcast.contains("urn:xmpp:idle:1") && broadcast.contains("2026-07-06T10:00:00"),
         "XEP-0319 idle must survive relay without hand re-attachment: {broadcast}"
+    );
+    // Alice sent no <c/>: the relay must not add one either — the historical
+    // bug (ensure_caps_payload) only decorated caps-less presence, so this
+    // negative assertion is what actually pins it down.
+    assert!(
+        !broadcast.contains("http://jabber.org/protocol/caps"),
+        "server must not attach any caps to a caps-less relayed presence: {broadcast}"
     );
 
     let _ = bob.close().await;
@@ -274,9 +293,10 @@ async fn websocket_presence_probe_returns_contacts_own_caps_and_extensions() {
             && probe.contains("urn:example:future-extension:0"),
         "probe response must carry the contact's stored caps and extensions: {probe}"
     );
-    assert!(
-        !probe.contains(SERVER_CAPS_NODE),
-        "probe response must not substitute the server's caps: {probe}"
+    assert_eq!(
+        caps_element_count(&probe),
+        1,
+        "probe response must carry exactly the client's caps element, nothing extra: {probe}"
     );
 
     let _ = bob.close().await;
@@ -323,9 +343,10 @@ async fn websocket_subscription_approval_push_carries_contacts_own_payloads() {
             && pushed.contains("urn:example:future-extension:0"),
         "approval push must carry the contact's stored caps and extensions: {pushed}"
     );
-    assert!(
-        !pushed.contains(SERVER_CAPS_NODE),
-        "approval push must not substitute the server's caps: {pushed}"
+    assert_eq!(
+        caps_element_count(&pushed),
+        1,
+        "approval push must carry exactly the client's caps element, nothing extra: {pushed}"
     );
 
     let _ = bob.close().await;

--- a/server/crates/waddle-server/tests/rfc6121_presence_ws.rs
+++ b/server/crates/waddle-server/tests/rfc6121_presence_ws.rs
@@ -152,11 +152,9 @@ async fn websocket_full_jid_probe_returns_rich_resource_presence() {
         .await
         .expect("bob receives broadcast rich presence");
 
-    bob.send(&format!(
-        r#"<presence xmlns="jabber:client" type="probe" to="{alice_jid}"/>"#
-    ))
-    .await
-    .expect("bob probes alice full jid");
+    bob.send(&probe_presence_xml(&alice_jid))
+        .await
+        .expect("bob probes alice full jid");
     let probe = bob
         .recv_matching(|frame| {
             frame.contains("from='alice@localhost/") || frame.contains("from='alice@localhost/")
@@ -187,6 +185,22 @@ fn caps_element_count(frame: &str) -> usize {
     frame
         .matches("<c xmlns='http://jabber.org/protocol/caps'")
         .count()
+}
+
+/// Serialize a `<presence type="probe" to=…/>` via minidom — stanzas with
+/// interpolated values (JIDs) are built with the XML builder, never `format!`.
+fn probe_presence_xml(to: &str) -> String {
+    let attr = |name: &str| {
+        <minidom::rxml::NcName as std::convert::TryFrom<&str>>::try_from(name)
+            .expect("static ncname is valid")
+    };
+    let element = minidom::Element::builder("presence", "jabber:client")
+        .attr(attr("type"), "probe")
+        .attr(attr("to"), to)
+        .build();
+    let mut bytes = Vec::new();
+    element.write_to(&mut bytes).expect("serialize element");
+    String::from_utf8(bytes).expect("serializer emits utf-8")
 }
 
 #[tokio::test]
@@ -261,6 +275,29 @@ async fn websocket_presence_broadcast_relays_arbitrary_extensions_verbatim() {
 }
 
 #[tokio::test]
+async fn websocket_error_typed_presence_is_not_broadcast_to_subscribers() {
+    let (_server, mut alice, mut bob) = connect_alice_bob().await;
+
+    establish_subscription_to_alice(&mut alice, &mut bob).await;
+    alice
+        .send(
+            r#"<presence xmlns="jabber:client" type="error"><status>bogus error relay</status></presence>"#,
+        )
+        .await
+        .expect("alice sends an error-typed presence");
+    assert_no_frame_matching(
+        &mut bob,
+        Duration::from_millis(250),
+        |frame| frame.contains("bogus error relay"),
+        "an error-typed presence must be dropped, not relayed to subscribers",
+    )
+    .await;
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}
+
+#[tokio::test]
 async fn websocket_presence_probe_returns_contacts_own_caps_and_extensions() {
     let (_server, mut alice, mut bob) = connect_alice_bob().await;
     let alice_jid = alice.full_jid.clone().expect("alice full jid");
@@ -276,11 +313,9 @@ async fn websocket_presence_probe_returns_contacts_own_caps_and_extensions() {
         .await
         .expect("bob receives alice's broadcast");
 
-    bob.send(&format!(
-        r#"<presence xmlns="jabber:client" type="probe" to="{alice_jid}"/>"#
-    ))
-    .await
-    .expect("bob probes alice");
+    bob.send(&probe_presence_xml(&alice_jid))
+        .await
+        .expect("bob probes alice");
     let probe = bob
         .recv_matching(|frame| {
             frame.contains("from='alice@localhost/") && frame.contains("<show>away</show>")

--- a/server/crates/waddle-server/tests/xep0115_caps_ws.rs
+++ b/server/crates/waddle-server/tests/xep0115_caps_ws.rs
@@ -1098,10 +1098,23 @@ async fn caps_repeated_advert_while_resolution_pending_sends_one_query() {
     admin.send(&presence).await.expect("second caps presence");
     admin.send(&presence).await.expect("third caps presence");
 
-    // FIFO anchor: everything the server emitted in response to the
-    // three presences is on the wire before the ping result. Collect
-    // every frame up to the anchor and count the disco#info queries
-    // among them.
+    // The disco#info query is emitted from the async caps-resolution path,
+    // so it is NOT FIFO-ordered against a ping anchor sent after the
+    // presences (issue #1188 flake). Wait for the query itself first, then
+    // anchor and assert no *further* query snuck out for the repeats.
+    let first_query = admin
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type='get'"#)
+                && frame.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("one disco#info query for the unresolved (hash, ver)");
+    assert!(
+        first_query.contains(&format!(r#"node='{node}#{ver}'"#)),
+        "query targets the advertised node#ver: {first_query}"
+    );
+
     admin
         .send(r#"<iq xmlns="jabber:client" type="get" id="caps-pending-anchor-1"><ping xmlns="urn:xmpp:ping"/></iq>"#)
         .await
@@ -1113,7 +1126,7 @@ async fn caps_repeated_advert_while_resolution_pending_sends_one_query() {
         .await
         .expect("frames up to ping anchor");
 
-    let disco_queries: Vec<&String> = frames
+    let extra_queries: Vec<&String> = frames
         .iter()
         .filter(|frame| {
             frame.contains("<iq")
@@ -1121,15 +1134,9 @@ async fn caps_repeated_advert_while_resolution_pending_sends_one_query() {
                 && frame.contains(NS_DISCO_INFO)
         })
         .collect();
-    assert_eq!(
-        disco_queries.len(),
-        1,
-        "exactly one disco#info may be in flight for a repeated (hash, ver): {disco_queries:?}"
-    );
     assert!(
-        disco_queries[0].contains(&format!(r#"node='{node}#{ver}'"#)),
-        "query targets the advertised node#ver: {}",
-        disco_queries[0]
+        extra_queries.is_empty(),
+        "exactly one disco#info may be in flight for a repeated (hash, ver); got extras: {extra_queries:?}"
     );
 
     let _ = admin.close().await;
@@ -1206,9 +1213,12 @@ async fn caps_element_in_broadcast_presence_is_the_publishing_clients_own() {
             && relayed.contains("8RovUdtOmiAjzj+xI7SK5BCw3A8="),
         "relayed presence must carry the client's own node/ver: {relayed}"
     );
-    assert!(
-        !relayed.contains("https://waddle.social/caps"),
-        "server caps must never be substituted into relayed user presence: {relayed}"
+    assert_eq!(
+        relayed
+            .matches("<c xmlns='http://jabber.org/protocol/caps'")
+            .count(),
+        1,
+        "relayed presence must carry exactly the client's own caps element: {relayed}"
     );
 
     let _ = bob.close().await;

--- a/server/crates/waddle-server/tests/xep0115_caps_ws.rs
+++ b/server/crates/waddle-server/tests/xep0115_caps_ws.rs
@@ -1134,3 +1134,83 @@ async fn caps_repeated_advert_while_resolution_pending_sends_one_query() {
 
     let _ = admin.close().await;
 }
+
+/// XEP-0115 §1: caps describe the *generating entity*. Presence relayed to a
+/// subscriber must carry the publishing client's own `<c/>` verbatim — the
+/// server must never substitute its own caps element (issue #1101), or
+/// subscribers cache a wrong ver hash per contact resource and feature
+/// detection (e.g. Jingle) breaks.
+#[tokio::test]
+async fn caps_element_in_broadcast_presence_is_the_publishing_clients_own() {
+    let _serial = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let bob_password = format!("bob-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[
+        ("alice", &alice_password),
+        ("bob", &bob_password),
+    ]);
+    let mut alice = extra_client(&server, "alice", &alice_password, "caps-relay-alice").await;
+    let mut bob = extra_client(&server, "bob", &bob_password, "caps-relay-bob").await;
+
+    // Roster interest is required before subscription pushes are delivered.
+    for (client, id) in [
+        (&mut alice, "caps-relay-roster-alice"),
+        (&mut bob, "caps-relay-roster-bob"),
+    ] {
+        client
+            .send(&format!(
+                r#"<iq xmlns="jabber:client" type="get" id="{id}"><query xmlns="jabber:iq:roster"/></iq>"#
+            ))
+            .await
+            .expect("send roster get");
+        client
+            .recv_matching(|frame| frame.contains(id))
+            .await
+            .expect("roster result");
+    }
+
+    alice
+        .send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("alice available");
+    bob.send(r#"<presence xmlns="jabber:client" type="subscribe" to="alice@localhost"/>"#)
+        .await
+        .expect("bob subscribes");
+    alice
+        .recv_matching(|frame| frame.contains("type='subscribe'"))
+        .await
+        .expect("alice sees subscribe");
+    alice
+        .send(r#"<presence xmlns="jabber:client" type="subscribed" to="bob@localhost"/>"#)
+        .await
+        .expect("alice approves");
+    bob.recv_matching(|frame| frame.contains("type='subscribed'"))
+        .await
+        .expect("bob sees approval");
+    bob.send(r#"<presence xmlns="jabber:client"/>"#)
+        .await
+        .expect("bob available");
+
+    alice
+        .send(
+            r#"<presence xmlns="jabber:client"><c xmlns="http://jabber.org/protocol/caps" hash="sha-1" node="https://client.example/caps" ver="8RovUdtOmiAjzj+xI7SK5BCw3A8="/></presence>"#,
+        )
+        .await
+        .expect("alice advertises her client's caps");
+    let relayed = bob
+        .recv_matching(|frame| frame.contains("from='alice@localhost/") && frame.contains(NS_CAPS))
+        .await
+        .expect("bob receives relayed caps presence");
+    assert!(
+        relayed.contains("https://client.example/caps")
+            && relayed.contains("8RovUdtOmiAjzj+xI7SK5BCw3A8="),
+        "relayed presence must carry the client's own node/ver: {relayed}"
+    );
+    assert!(
+        !relayed.contains("https://waddle.social/caps"),
+        "server caps must never be substituted into relayed user presence: {relayed}"
+    );
+
+    let _ = bob.close().await;
+    let _ = alice.close().await;
+}

--- a/server/crates/waddle-server/tests/xep0115_caps_ws.rs
+++ b/server/crates/waddle-server/tests/xep0115_caps_ws.rs
@@ -1142,6 +1142,23 @@ async fn caps_repeated_advert_while_resolution_pending_sends_one_query() {
     let _ = admin.close().await;
 }
 
+/// Serialize a roster-get `<iq id=…>` via minidom — stanzas with interpolated
+/// values are built with the XML builder, never `format!`.
+fn roster_get_iq_xml(id: &str) -> String {
+    let attr = |name: &str| {
+        <minidom::rxml::NcName as std::convert::TryFrom<&str>>::try_from(name)
+            .expect("static ncname is valid")
+    };
+    let element = minidom::Element::builder("iq", "jabber:client")
+        .attr(attr("type"), "get")
+        .attr(attr("id"), id)
+        .append(minidom::Element::builder("query", "jabber:iq:roster").build())
+        .build();
+    let mut bytes = Vec::new();
+    element.write_to(&mut bytes).expect("serialize element");
+    String::from_utf8(bytes).expect("serializer emits utf-8")
+}
+
 /// XEP-0115 §1: caps describe the *generating entity*. Presence relayed to a
 /// subscriber must carry the publishing client's own `<c/>` verbatim — the
 /// server must never substitute its own caps element (issue #1101), or
@@ -1165,9 +1182,7 @@ async fn caps_element_in_broadcast_presence_is_the_publishing_clients_own() {
         (&mut bob, "caps-relay-roster-bob"),
     ] {
         client
-            .send(&format!(
-                r#"<iq xmlns="jabber:client" type="get" id="{id}"><query xmlns="jabber:iq:roster"/></iq>"#
-            ))
+            .send(&roster_get_iq_xml(id))
             .await
             .expect("send roster get");
         client

--- a/server/crates/waddle-xmpp-core/src/presence/subscription.rs
+++ b/server/crates/waddle-xmpp-core/src/presence/subscription.rs
@@ -143,7 +143,19 @@ pub fn parse_subscription_presence(
         return Ok(PresenceAction::Subscription(request));
     }
 
-    Ok(PresenceAction::PresenceUpdate(pres.clone()))
+    // Only the normal available (no type attribute) and unavailable forms are
+    // broadcastable presence updates. Anything else that reaches this point
+    // (i.e. type="error") must never be relayed to subscribers — the caller
+    // logs and drops it without answering (RFC 6120 §8.3.1: never respond to
+    // an error with an error).
+    match pres.type_ {
+        PresenceType::None | PresenceType::Unavailable => {
+            Ok(PresenceAction::PresenceUpdate(pres.clone()))
+        }
+        ref other => Err(CoreError::bad_request(Some(format!(
+            "presence of type {other:?} is not a broadcastable presence update"
+        )))),
+    }
 }
 
 /// Build a subscription presence stanza.

--- a/server/crates/waddle-xmpp/src/presence/subscription.rs
+++ b/server/crates/waddle-xmpp/src/presence/subscription.rs
@@ -47,9 +47,12 @@ use xmpp_parsers::presence::Presence;
 
 use crate::roster::{AskType, RosterItem, Subscription};
 use crate::XmppError;
+// `build_available_presence` is re-exported without caps decoration: relayed
+// user presence must carry the *client's* own XEP-0115 caps, never
+// server-substituted ones (issue #1101).
 pub use waddle_xmpp_core::presence::subscription::{
-    build_subscription_presence, build_unavailable_presence, PendingSubscription, PresenceAction,
-    PresenceSubscriptionRequest, SubscriptionType,
+    build_available_presence, build_subscription_presence, build_unavailable_presence,
+    PendingSubscription, PresenceAction, PresenceSubscriptionRequest, SubscriptionType,
 };
 
 /// Parse a presence stanza and determine if it's subscription-related.
@@ -59,21 +62,6 @@ pub fn parse_subscription_presence(
 ) -> Result<PresenceAction, XmppError> {
     waddle_xmpp_core::presence::subscription::parse_subscription_presence(pres, sender_jid)
         .map_err(Into::into)
-}
-
-/// Build an available presence stanza for broadcasting to subscribers.
-pub fn build_available_presence(
-    from: &jid::FullJid,
-    to: &BareJid,
-    show: Option<&str>,
-    status: Option<&str>,
-    priority: i8,
-) -> Presence {
-    let mut pres = waddle_xmpp_core::presence::subscription::build_available_presence(
-        from, to, show, status, priority,
-    );
-    crate::xep::ensure_caps_payload(&mut pres.payloads);
-    pres
 }
 
 /// Subscription state machine for managing state transitions.

--- a/server/crates/waddle-xmpp/src/presence/subscription/tests.rs
+++ b/server/crates/waddle-xmpp/src/presence/subscription/tests.rs
@@ -176,19 +176,21 @@ fn test_build_subscription_presence() {
 }
 
 #[test]
-fn test_build_available_presence_includes_waddle_caps() {
+fn test_build_available_presence_adds_no_payloads() {
     let from: jid::FullJid = "user@example.com/resource".parse().unwrap();
     let to: BareJid = "contact@example.com".parse().unwrap();
 
     let pres = build_available_presence(&from, &to, Some("chat"), Some("Ready"), 5);
 
-    let caps = pres
-        .payloads
-        .iter()
-        .find(|payload| payload.name() == "c" && payload.ns() == crate::xep::NS_CAPS)
-        .expect("available presence must include caps");
-
-    assert_eq!(caps.attr("node"), Some(crate::xep::WADDLE_CAPS_NODE));
+    // Issue #1101: relayed user presence must never be decorated with
+    // server-owned payloads (the old wrapper injected the server's XEP-0115
+    // caps here). Payloads are the caller's responsibility — they attach the
+    // client's own stored extensions verbatim.
+    assert!(
+        pres.payloads.is_empty(),
+        "builder must not inject payloads: {:?}",
+        pres.payloads
+    );
 }
 
 #[test]

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/presence.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/presence.rs
@@ -21,14 +21,16 @@ impl ConnectionRegistry {
         }
     }
 
-    /// Update full presence state (show/status/priority/idle) for a connected resource.
+    /// Update full presence state (show/status/priority/payloads) for a
+    /// connected resource. XEP-0319 idle rides in `payloads` verbatim, like
+    /// every other presence extension (issue #1101).
     pub fn update_presence_state(
         &self,
         jid: &FullJid,
         show: Option<String>,
         status: Option<String>,
         priority: i8,
-        idle_since: Option<chrono::DateTime<Utc>>,
+        payloads: Vec<minidom::Element>,
     ) {
         self.presence_states.insert(
             jid.clone(),
@@ -36,7 +38,7 @@ impl ConnectionRegistry {
                 show,
                 status,
                 priority,
-                idle_since,
+                payloads,
             },
         );
     }

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/state.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/state.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use minidom::Element;
 
 /// Presence state for a connected resource (show, status, priority, idle).
 #[derive(Debug, Clone, Default)]
@@ -9,10 +10,11 @@ pub struct PresenceState {
     pub status: Option<String>,
     /// Presence priority (-128..127)
     pub priority: i8,
-    /// XEP-0319 last-interaction instant from the resource's `<idle/>`, so a
-    /// probing contact's rebuilt presence carries the idle stamp too. `None`
-    /// when the resource is interacting (no `<idle/>`).
-    pub idle_since: Option<DateTime<Utc>>,
+    /// Extension children of the resource's last available presence
+    /// (XEP-0115 `<c/>`, `<idle/>`, and any other payloads), relayed verbatim
+    /// on probe/subscription delivery so the contact's own advertisements are
+    /// never replaced by server-rebuilt ones (issue #1101).
+    pub payloads: Vec<Element>,
 }
 
 /// Last recorded offline activity for a bare JID.

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/tests.rs
@@ -460,30 +460,34 @@ fn test_presence_state_tracking() {
     // No state initially
     assert!(registry.get_presence_state(&jid).is_none());
 
-    // Store presence state, including an XEP-0319 idle stamp.
-    let idle_since = "2024-06-01T12:00:00Z"
-        .parse::<chrono::DateTime<chrono::Utc>>()
-        .expect("valid xs:dateTime");
+    // Store presence state, including the resource's extension payloads
+    // (relayed verbatim on probe/subscription delivery — issue #1101).
+    let idle_payload = minidom::Element::builder("idle", "urn:xmpp:idle:1")
+        .attr(
+            minidom::rxml::xml_ncname!("since").to_owned(),
+            "2024-06-01T12:00:00Z",
+        )
+        .build();
     registry.update_presence_state(
         &jid,
         Some("away".to_string()),
         Some("Gone fishing".to_string()),
         5,
-        Some(idle_since),
+        vec![idle_payload.clone()],
     );
 
     let state = registry.get_presence_state(&jid).expect("should exist");
     assert_eq!(state.show.as_deref(), Some("away"));
     assert_eq!(state.status.as_deref(), Some("Gone fishing"));
     assert_eq!(state.priority, 5);
-    assert_eq!(state.idle_since, Some(idle_since));
+    assert_eq!(state.payloads, vec![idle_payload]);
 
-    // Update with different values — and no idle (return from idle).
-    registry.update_presence_state(&jid, None, None, 0, None);
+    // Update with different values — and no payloads (return from idle).
+    registry.update_presence_state(&jid, None, None, 0, Vec::new());
     let state = registry.get_presence_state(&jid).expect("should exist");
     assert!(state.show.is_none());
     assert!(state.status.is_none());
-    assert!(state.idle_since.is_none());
+    assert!(state.payloads.is_empty());
     assert_eq!(state.priority, 0);
 
     // Clean up on unregister

--- a/server/crates/waddle-xmpp/src/registry/user_actor.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_actor.rs
@@ -281,9 +281,9 @@ impl kameo::message::Message<UpdatePresenceState> for UserActor {
                 show: msg.show,
                 status: msg.status,
                 priority: msg.priority,
-                // This actor store is not on the XEP-0319 idle relay path
-                // (the connection registry is); it never carries an idle stamp.
-                idle_since: None,
+                // This actor store is not on the payload relay path (the
+                // connection registry is); it never carries extension payloads.
+                payloads: Vec::new(),
             },
         );
     }

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -33,10 +33,9 @@ pub use super::xep0077::{
 };
 
 pub use super::xep0115::{
-    build_caps_element, build_caps_element_with_extensions, build_waddle_caps_element,
-    compute_caps_hash, compute_caps_hash_with_extensions, ensure_caps_payload,
-    extract_caps_from_presence, is_caps_node_query, parse_caps_node, CachedDiscoInfo, Caps,
-    CapsCache, NS_CAPS, WADDLE_CAPS_NODE,
+    build_caps_element, build_caps_element_with_extensions, compute_caps_hash,
+    compute_caps_hash_with_extensions, extract_caps_from_presence, is_caps_node_query,
+    parse_caps_node, CachedDiscoInfo, Caps, CapsCache, NS_CAPS, WADDLE_CAPS_NODE,
 };
 
 pub use super::xep0249::{

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -33,9 +33,9 @@ pub use super::xep0077::{
 };
 
 pub use super::xep0115::{
-    build_caps_element, build_caps_element_with_extensions, compute_caps_hash,
-    compute_caps_hash_with_extensions, extract_caps_from_presence, is_caps_node_query,
-    parse_caps_node, CachedDiscoInfo, Caps, CapsCache, NS_CAPS, WADDLE_CAPS_NODE,
+    compute_caps_hash, compute_caps_hash_with_extensions, extract_caps_from_presence,
+    is_caps_node_query, parse_caps_node, CachedDiscoInfo, Caps, CapsCache, NS_CAPS,
+    WADDLE_CAPS_NODE,
 };
 
 pub use super::xep0249::{

--- a/server/crates/waddle-xmpp/src/xep/xep0115.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0115.rs
@@ -484,28 +484,6 @@ pub fn build_caps_element_with_extensions(
     Caps::new(node, &ver).build_element()
 }
 
-/// Build Waddle's standard entity capabilities element for presence stanzas.
-pub fn build_waddle_caps_element() -> Element {
-    let identities = vec![crate::disco::Identity::server(Some("Waddle XMPP Server"))];
-    let features = crate::disco::server_features();
-    build_caps_element(WADDLE_CAPS_NODE, &identities, &features)
-}
-
-/// Ensure a payload list contains an entity capabilities advertisement.
-///
-/// If the payload list already contains any XEP-0115 `<c/>` element, it is
-/// preserved as-is to avoid duplicating caps payloads in the same stanza.
-pub fn ensure_caps_payload(payloads: &mut Vec<Element>) {
-    if payloads
-        .iter()
-        .any(|payload| payload.name() == "c" && payload.ns() == NS_CAPS)
-    {
-        return;
-    }
-
-    payloads.push(build_waddle_caps_element());
-}
-
 /// Extract Caps from a presence stanza.
 pub fn extract_caps_from_presence(presence: &Element) -> Option<Caps> {
     presence

--- a/server/crates/waddle-xmpp/src/xep/xep0115.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0115.rs
@@ -458,32 +458,6 @@ fn hash_verification_string(verification_string: &str) -> String {
     BASE64.encode(result)
 }
 
-/// Build a `<c>` caps element for presence stanzas.
-///
-/// ## Arguments
-///
-/// * `node` - The node URL (e.g., "https://waddle.social/caps")
-/// * `identities` - Server/client identities for hash computation
-/// * `features` - Supported features for hash computation
-///
-/// ## Returns
-///
-/// A minidom Element containing the `<c>` element with computed hash.
-pub fn build_caps_element(node: &str, identities: &[Identity], features: &[Feature]) -> Element {
-    build_caps_element_with_extensions(node, identities, features, &[])
-}
-
-/// Build a `<c>` caps element whose `ver` accounts for XEP-0128 extensions.
-pub fn build_caps_element_with_extensions(
-    node: &str,
-    identities: &[Identity],
-    features: &[Feature],
-    extensions: &[Element],
-) -> Element {
-    let ver = compute_caps_hash_with_extensions(identities, features, extensions);
-    Caps::new(node, &ver).build_element()
-}
-
 /// Extract Caps from a presence stanza.
 pub fn extract_caps_from_presence(presence: &Element) -> Option<Caps> {
     presence

--- a/server/crates/waddle-xmpp/src/xep/xep0115/tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0115/tests.rs
@@ -609,41 +609,6 @@ fn test_build_caps_element_with_extensions_uses_extension_hash() {
 }
 
 #[test]
-fn test_build_waddle_caps_element() {
-    let elem = build_waddle_caps_element();
-
-    assert_eq!(elem.name(), "c");
-    assert_eq!(elem.ns(), NS_CAPS);
-    assert_eq!(elem.attr("node"), Some(WADDLE_CAPS_NODE));
-    assert_eq!(elem.attr("hash"), Some("sha-1"));
-}
-
-#[test]
-fn test_ensure_caps_payload_adds_caps_once() {
-    let mut payloads = Vec::new();
-
-    ensure_caps_payload(&mut payloads);
-    ensure_caps_payload(&mut payloads);
-
-    let caps_payloads: Vec<_> = payloads
-        .iter()
-        .filter(|payload| payload.name() == "c" && payload.ns() == NS_CAPS)
-        .collect();
-    assert_eq!(caps_payloads.len(), 1);
-    assert_eq!(caps_payloads[0].attr("node"), Some(WADDLE_CAPS_NODE));
-}
-
-#[test]
-fn test_ensure_caps_payload_preserves_existing_caps() {
-    let existing = Caps::new("https://example.com/caps", "existing").build_element();
-    let mut payloads = vec![existing.clone()];
-
-    ensure_caps_payload(&mut payloads);
-
-    assert_eq!(payloads, vec![existing]);
-}
-
-#[test]
 fn test_extract_caps_from_presence() {
     let caps_elem = Caps::new("https://test.com", "abc123").build_element();
     let presence = Element::builder("presence", "jabber:client")

--- a/server/crates/waddle-xmpp/src/xep/xep0115/tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0115/tests.rs
@@ -574,22 +574,22 @@ fn test_compute_caps_hash_different_for_different_inputs() {
 }
 
 #[test]
-fn test_build_caps_element() {
+fn test_caps_element_from_computed_hash() {
     let identities = vec![Identity::server(Some("Waddle"))];
     let features = vec![Feature::disco_info()];
 
-    let elem = build_caps_element(WADDLE_CAPS_NODE, &identities, &features);
+    let ver = compute_caps_hash(&identities, &features);
+    let elem = Caps::new(WADDLE_CAPS_NODE, &ver).build_element();
 
     assert_eq!(elem.name(), "c");
     assert_eq!(elem.ns(), NS_CAPS);
     assert_eq!(elem.attr("hash"), Some("sha-1"));
     assert_eq!(elem.attr("node"), Some(WADDLE_CAPS_NODE));
-    let ver = elem.attr("ver").unwrap();
-    assert!(BASE64.decode(ver).is_ok());
+    assert!(BASE64.decode(&ver).is_ok());
 }
 
 #[test]
-fn test_build_caps_element_with_extensions_uses_extension_hash() {
+fn test_extension_hash_matches_xep0115_spec_example() {
     let identities = vec![
         Identity::new("client", "pc", Some("Psi 0.11")).with_lang(Some("en")),
         Identity::new("client", "pc", Some("\u{03A8} 0.11")).with_lang(Some("el")),
@@ -602,10 +602,10 @@ fn test_build_caps_element_with_extensions_uses_extension_hash() {
     ];
     let extensions = vec![software_info_form()];
 
-    let elem =
-        build_caps_element_with_extensions(WADDLE_CAPS_NODE, &identities, &features, &extensions);
+    // XEP-0115 §5.3 complex generation example — known-good ver string.
+    let ver = compute_caps_hash_with_extensions(&identities, &features, &extensions);
 
-    assert_eq!(elem.attr("ver"), Some("q07IKJEyjvHSyhy//CH0CxmKi8w="));
+    assert_eq!(ver, "q07IKJEyjvHSyhy//CH0CxmKi8w=");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #1101.

## Problem

Broadcast, probe, and subscription-approval delivery rebuilt available presence from stored `show`/`status`/`priority` and then appended the **server's** XEP-0115 entity-caps element (`ensure_caps_payload`). Subscribers cached the server's caps hash against every contact resource (breaking client feature detection, e.g. Jingle), and every presence extension except a hand-re-attached `<idle/>` was silently dropped.

## What changed

- **Broadcast relays the client's own stanza.** `broadcast_presence_to_subscribers` now clones the sender's original presence and rewrites `from`/`to` (RFC 6121 §4.4.2), exactly as the unavailable branch already did — no rebuild, no server caps, every extension survives verbatim.
- **Probe and subscription-approval delivery relay stored payloads.** `PresenceState` gained `payloads: Vec<minidom::Element>` holding the extension children of the resource's last available presence; the probe live path and `send_current_presence_from_user_to_*` attach them verbatim instead of server caps.
- **Server-caps injection deleted.** `ensure_caps_payload`, `build_waddle_caps_element`, the caps-decorating `build_available_presence` wrapper, and the transitively-orphaned `build_caps_element`/`build_caps_element_with_extensions` are all removed. The server never decorates relayed user presence; caps belong to the generating entity (XEP-0115 §1).
- **`idle_since` registry field deleted.** XEP-0319 idle now rides in the stored payloads like any other extension, so the manual `add_idle` re-attachment at probe/delivery sites is gone along with the field's plumbing.
- **Test flake #1188 fixed in passing.** `caps_repeated_advert_while_resolution_pending_sends_one_query` now waits for the disco#info query itself before anchoring (the query is emitted from the async caps-resolution path and is not FIFO-ordered against a ping anchor).

## Acceptance criteria → tests

Developed TDD (red/green per behavior) against the real WebSocket C2S transport:

- **Subscribers receive the contact's own caps hash and payloads** — `websocket_presence_broadcast_relays_contacts_own_caps_not_servers` (rfc6121_presence_ws) and `caps_element_in_broadcast_presence_is_the_publishing_clients_own` (xep0115_caps_ws, the XEP's dedicated suite). Both assert exactly one `<c/>` with the client's node/ver.
- **Arbitrary presence extensions survive relay** — `websocket_presence_broadcast_relays_arbitrary_extensions_verbatim`: an unknown-namespace extension plus `<idle/>` relay verbatim, and (negative half) a caps-less presence relays with **no** caps element at all — this pins the exact historical bug, since `ensure_caps_payload` only decorated caps-less presence.
- **Probe/approval push carry the client's stored payloads** — `websocket_presence_probe_returns_contacts_own_caps_and_extensions`, `websocket_subscription_approval_push_carries_contacts_own_payloads`, plus a negative caps assertion on the pre-existing full-JID probe test.
- **Server caps only on server-originated presence** — the server currently originates no available presence, so the injection helpers are deleted outright rather than gated; nothing can attach server caps to relayed presence anymore. `test_build_available_presence_adds_no_payloads` pins the builder at the unit level.

## Adversarial review (3 personas + second round)

All actionable findings fixed in-branch: stale unit test asserting the removed injection (inverted), missing negative caps assertions (added), fragile server-node substring assertions (replaced with exact `<c/>` counts — the Waddle client library shares the `https://waddle.social/caps` node string), orphaned caps builders (deleted). Reviews also verified: no stale-payload window (payloads cleared on unavailable/unregister/detach/eviction), no duplicate idle/caps (the core builder adds zero payloads before `extend`), no privacy leak (probe payloads gated by subscription authorization and sourced only from broadcast presence), memory bounded by the 1 MiB frame limit per resource.

**Known gap (deferred, tracked as #1206):** detached/resumed XEP-0198 sessions restore presence with empty payloads (SM session state persists only show/status/priority), so probes during a detached window — or after a resume until the next presence update — relay caps-less presence. Pre-existing class of gap; the pre-fix behavior was worse (server caps substituted, idle lost).

## Review follow-ups (post-CI round)

- **Non-broadcastable presence types are dropped before relay.** The verbatim relay forwarded whatever `type_` reached the regular-update path; `parse_subscription_presence` now routes only `Type::None`/`Type::Unavailable` into `PresenceUpdate` and returns a typed bad-request for anything else (i.e. `type="error"`), logged and dropped without answering (RFC 6120 §8.3.1). `handle_regular_presence_update` carries a matching defense-in-depth guard. New wire test: an error-typed presence is never relayed to subscribers.
- **Test stanzas with interpolated values are built via minidom** (probe presence, roster-get iq) instead of `format!`, per the XML-generation hard rule.

## Verification

- `cargo test --workspace` green (incl. 2254 waddle-xmpp lib tests, 9/9 rfc6121_presence_ws, 14/14 xep0115_caps_ws)
- `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt` applied
- De-flaked #1188 test passed 5/5 consecutive runs (previously ~50% fail under load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
