### PR TITLE
fix(server): SFU reliability bundle — reconciler teardown, 1:1 webhook cleanup, joiner clobber, offline-peer errors, survivor terminate, JWT hygiene (#1127 #1128 #1129 #1130 #1131 #1140 #1142)

### DIFF
--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -190,7 +190,7 @@ use room_subject::persist_room_subject_event;
 use route_to_connection::route_to_connection;
 use routing::{
     deliver_direct_to_full, deliver_peer_to_full, run_fanout_recipient_pass,
-    run_headless_recipient_pass, FanoutPassResult,
+    run_headless_recipient_pass, FanoutPassResult, FullJidDeliveryOutcome,
 };
 
 pub use deps::{Deps, InterpretOutcome, TimerCommand};
@@ -395,7 +395,19 @@ async fn interpret_with_depth(
             // content into logs.
             // -------------------------------------------------------
             OutboundEvent::RouteToConnection { jid, stanza } => {
-                route_to_connection(registry, deps, jid, stanza, recursion_depth).await;
+                for stanza in
+                    route_to_connection(registry, deps, jid, stanza, recursion_depth).await
+                {
+                    match stanza.to_element_string() {
+                        Ok(xml) => outcome.frames.push(xml),
+                        Err(err) => {
+                            error!(
+                                error = %err,
+                                "failed to serialize route fallback stanza; dropping frame"
+                            );
+                        }
+                    }
+                }
             }
             OutboundEvent::DispatchToRoom { room, message } => {
                 // #229 PR18 — MUC cutover. Replaces the legacy

--- a/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
@@ -1,4 +1,5 @@
 use super::*;
+use xmpp_parsers::iq::Iq;
 
 /// Upper bound on each actor `ask` issued from the routing hot path — bounds
 /// both mailbox enqueue and the handler reply so a wedged `UserRegistryActor`
@@ -186,7 +187,7 @@ pub(super) async fn route_to_connection(
     jid: Jid,
     stanza: Box<Stanza>,
     recursion_depth: u8,
-) {
+) -> Vec<Stanza> {
     // #229 PR12 cutover: the destination's main loop is
     // now wired (PR11) to dispatch on `DeliveryKind` and
     // run the recipient-pass pipeline for `PeerStanza`
@@ -228,6 +229,7 @@ pub(super) async fn route_to_connection(
              dropping nested route (full or bare) to prevent duplicate \
              delivery / persistence"
         );
+        Vec::new()
     } else {
         // Notification activity ingest (slice 2b): when the routed
         // stanza is a typed XEP-0085 chat-state on a DM Message (type
@@ -279,8 +281,20 @@ pub(super) async fn route_to_connection(
 
         match jid.clone().try_into_full() {
             Ok(full) => {
-                deliver_peer_to_full(deps.user_registry, deps.sm_session_registry, &full, &stanza)
-                    .await
+                let delivery = deliver_peer_to_full(
+                    deps.user_registry,
+                    deps.sm_session_registry,
+                    &full,
+                    &stanza,
+                )
+                .await;
+                if delivery == FullJidDeliveryOutcome::Unavailable {
+                    service_unavailable_for_undeliverable_iq(stanza.as_ref())
+                        .into_iter()
+                        .collect()
+                } else {
+                    Vec::new()
+                }
             }
             Err(bare) => {
                 // Enumerate XEP-0198 detached-but-resumable
@@ -459,7 +473,7 @@ pub(super) async fn route_to_connection(
                                     ))
                                     .await;
                                 }
-                                return;
+                                return Vec::new();
                             }
                             FanoutPassResult::Unavailable => {
                                 // Shared pass unavailable (no dispatcher
@@ -549,9 +563,35 @@ pub(super) async fn route_to_connection(
                         }
                     }
                 }
+                Vec::new()
             }
         }
     }
+}
+
+fn service_unavailable_for_undeliverable_iq(stanza: &Stanza) -> Option<Stanza> {
+    let Stanza::Iq(iq) = stanza else {
+        return None;
+    };
+    let (from, to, id) = match iq.as_ref() {
+        Iq::Get { from, to, id, .. } | Iq::Set { from, to, id, .. } => {
+            (from.clone(), to.clone(), id.clone())
+        }
+        Iq::Result { .. } | Iq::Error { .. } => return None,
+    };
+    let error = StanzaError::new(
+        ErrorType::Cancel,
+        DefinedCondition::ServiceUnavailable,
+        "en",
+        "Service unavailable at this address.",
+    );
+    Some(Stanza::Iq(Box::new(Iq::Error {
+        from: to,
+        to: from,
+        id,
+        error,
+        payload: None,
+    })))
 }
 
 /// #1106: queue the PROCESSED (recipient-stamped) stanza into the

--- a/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
@@ -289,7 +289,7 @@ pub(super) async fn route_to_connection(
                 )
                 .await;
                 if delivery == FullJidDeliveryOutcome::Unavailable {
-                    service_unavailable_for_undeliverable_iq(stanza.as_ref())
+                    fallback_reply_for_undeliverable_iq(stanza.as_ref())
                         .into_iter()
                         .collect()
                 } else {
@@ -569,16 +569,50 @@ pub(super) async fn route_to_connection(
     }
 }
 
-fn service_unavailable_for_undeliverable_iq(stanza: &Stanza) -> Option<Stanza> {
+/// Synthesize the reply for a full-JID **request** IQ (`get`/`set`) that
+/// could not be delivered because the addressed resource is confirmed
+/// offline (#1130). Returns `None` for `result`/`error` IQs (nothing
+/// expects a reply) and for non-IQ stanzas.
+///
+/// A Jingle `session-terminate` is special-cased: hanging up on a peer
+/// who is already gone is *success*, not failure. When the terminate
+/// handler tore the call down (both sides unregistered, JTIs revoked)
+/// and then forwarded the terminate to a peer whose XMPP resource had
+/// already vanished, bouncing `<service-unavailable/>` back would make
+/// the caller's completed hangup look failed. We ack it with an empty
+/// `<iq type='result'/>` instead. Every other undeliverable request IQ
+/// gets a typed `cancel`/`<service-unavailable/>` that echoes the
+/// original request payload per RFC 6120 §8.3.1.
+fn fallback_reply_for_undeliverable_iq(stanza: &Stanza) -> Option<Stanza> {
     let Stanza::Iq(iq) = stanza else {
         return None;
     };
-    let (from, to, id) = match iq.as_ref() {
-        Iq::Get { from, to, id, .. } | Iq::Set { from, to, id, .. } => {
-            (from.clone(), to.clone(), id.clone())
+    let (from, to, id, payload) = match iq.as_ref() {
+        Iq::Get {
+            from,
+            to,
+            id,
+            payload,
+            ..
         }
+        | Iq::Set {
+            from,
+            to,
+            id,
+            payload,
+            ..
+        } => (from.clone(), to.clone(), id.clone(), payload.clone()),
         Iq::Result { .. } | Iq::Error { .. } => return None,
     };
+    if is_jingle_session_terminate(&payload) {
+        // The server already completed the teardown; ack the hangup.
+        return Some(Stanza::Iq(Box::new(Iq::Result {
+            from: to,
+            to: from,
+            id,
+            payload: None,
+        })));
+    }
     let error = StanzaError::new(
         ErrorType::Cancel,
         DefinedCondition::ServiceUnavailable,
@@ -590,8 +624,16 @@ fn service_unavailable_for_undeliverable_iq(stanza: &Stanza) -> Option<Stanza> {
         to: from,
         id,
         error,
-        payload: None,
+        // RFC 6120 §8.3.1: echo the offending request so the sender can
+        // correlate which stanza failed.
+        payload: Some(payload),
     })))
+}
+
+/// Whether an IQ request payload is a Jingle `session-terminate` action.
+fn is_jingle_session_terminate(payload: &minidom::Element) -> bool {
+    payload.is("jingle", waddle_xmpp::xep::xep0166::NS_JINGLE)
+        && payload.attr("action") == Some("session-terminate")
 }
 
 /// #1106: queue the PROCESSED (recipient-stamped) stanza into the

--- a/server/crates/waddle-server/src/server/routes/interpret/routing.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/routing.rs
@@ -315,6 +315,40 @@ enum ActorSendFailure {
     MaybeEnqueued,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum FullJidDeliveryOutcome {
+    Delivered,
+    QueuedDetached,
+    Unavailable,
+    Dropped,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum DetachedDeliveryOutcome {
+    Queued,
+    Unavailable,
+    Failed,
+}
+
+impl From<DetachedDeliveryOutcome> for FullJidDeliveryOutcome {
+    fn from(outcome: DetachedDeliveryOutcome) -> Self {
+        match outcome {
+            DetachedDeliveryOutcome::Queued => Self::QueuedDetached,
+            DetachedDeliveryOutcome::Unavailable => Self::Unavailable,
+            DetachedDeliveryOutcome::Failed => Self::Dropped,
+        }
+    }
+}
+
+fn detached_after_routing_failure(outcome: DetachedDeliveryOutcome) -> FullJidDeliveryOutcome {
+    match outcome {
+        DetachedDeliveryOutcome::Queued => FullJidDeliveryOutcome::QueuedDetached,
+        DetachedDeliveryOutcome::Unavailable | DetachedDeliveryOutcome::Failed => {
+            FullJidDeliveryOutcome::Dropped
+        }
+    }
+}
+
 /// Classify a terminal `SendError` for the delivery fallback decision.
 ///
 /// `Timeout` discriminates by payload: `.mailbox_timeout()` elapsing hands the
@@ -357,7 +391,7 @@ async fn deliver_one_via_actor(
     target: &jid::FullJid,
     stanza: &Stanza,
     kind: ActorSendKind,
-) {
+) -> FullJidDeliveryOutcome {
     // FUTURE CLEANUP (ADR-0017; Greptile review on PR #1177, tracked in #1195):
     // for a bare-JID DM this is the SECOND `GetUser` for the same bare JID —
     // `select_bare_jid_live_targets` already resolved the `UserActor` during
@@ -379,13 +413,15 @@ async fn deliver_one_via_actor(
         // No live actor for this bare JID — no delivery was attempted, so the
         // detached replay buffer is a safe (non-duplicating) fallback.
         Ok(None) => {
-            deliver_to_detached(sm_session_registry, target, stanza).await;
-            return;
+            return deliver_to_detached(sm_session_registry, target, stanza)
+                .await
+                .into();
         }
         Err(error) => {
             warn!(jid = %target, %error, "actor delivery: GetUser failed; routing to detached");
-            deliver_to_detached(sm_session_registry, target, stanza).await;
-            return;
+            return detached_after_routing_failure(
+                deliver_to_detached(sm_session_registry, target, stanza).await,
+            );
         }
     };
 
@@ -418,13 +454,17 @@ async fn deliver_one_via_actor(
     match outcome {
         Ok(waddle_xmpp::registry::BroadcastOutcome::Delivered) => {
             debug!(jid = %target, "actor delivery: queued for recipient");
+            FullJidDeliveryOutcome::Delivered
         }
         Ok(waddle_xmpp::registry::BroadcastOutcome::DroppedFull) => {
             debug!(jid = %target, "actor delivery: recipient channel full; dropped");
+            FullJidDeliveryOutcome::Dropped
         }
         Ok(waddle_xmpp::registry::BroadcastOutcome::NotConnected)
         | Ok(waddle_xmpp::registry::BroadcastOutcome::DroppedClosed) => {
-            deliver_to_detached(sm_session_registry, target, stanza).await;
+            deliver_to_detached(sm_session_registry, target, stanza)
+                .await
+                .into()
         }
         // Provably never enqueued — no delivery was attempted, so the detached
         // replay buffer is a lossless, non-duplicating fallback.
@@ -434,7 +474,9 @@ async fn deliver_one_via_actor(
                 %error,
                 "actor delivery: TrySend ask failed before enqueue; routing to detached"
             );
-            deliver_to_detached(sm_session_registry, target, stanza).await;
+            detached_after_routing_failure(
+                deliver_to_detached(sm_session_registry, target, stanza).await,
+            )
         }
         // May have been enqueued — kameo does not cancel the enqueued handler,
         // so a post-timeout run plus a detached replay would double-deliver.
@@ -449,6 +491,7 @@ async fn deliver_one_via_actor(
                 "actor delivery: TrySend ask failed terminally (possibly enqueued); \
                  dropping to avoid double-delivery"
             );
+            FullJidDeliveryOutcome::Dropped
         }
     }
 }
@@ -466,7 +509,7 @@ pub(super) async fn deliver_peer_to_full(
     sm_session_registry: Option<&Arc<InMemorySmSessionRegistry>>,
     target: &jid::FullJid,
     stanza: &Stanza,
-) {
+) -> FullJidDeliveryOutcome {
     match user_registry {
         Some(user_registry) => {
             deliver_one_via_actor(
@@ -478,7 +521,9 @@ pub(super) async fn deliver_peer_to_full(
             )
             .await
         }
-        None => deliver_to_detached(sm_session_registry, target, stanza).await,
+        None => deliver_to_detached(sm_session_registry, target, stanza)
+            .await
+            .into(),
     }
 }
 
@@ -494,7 +539,7 @@ pub(super) async fn deliver_direct_to_full(
     sm_session_registry: Option<&Arc<InMemorySmSessionRegistry>>,
     target: &jid::FullJid,
     stanza: &Stanza,
-) {
+) -> FullJidDeliveryOutcome {
     match user_registry {
         Some(user_registry) => {
             deliver_one_via_actor(
@@ -506,7 +551,9 @@ pub(super) async fn deliver_direct_to_full(
             )
             .await
         }
-        None => deliver_to_detached(sm_session_registry, target, stanza).await,
+        None => deliver_to_detached(sm_session_registry, target, stanza)
+            .await
+            .into(),
     }
 }
 
@@ -531,10 +578,10 @@ pub(super) async fn deliver_to_detached(
     sm_session_registry: Option<&Arc<InMemorySmSessionRegistry>>,
     target: &jid::FullJid,
     stanza: &Stanza,
-) {
+) -> DetachedDeliveryOutcome {
     let Some(sm) = sm_session_registry else {
         debug!(jid = %target, "RouteToConnection: target offline, dropping");
-        return;
+        return DetachedDeliveryOutcome::Unavailable;
     };
     match sm
         .record_stanza_for_detached_bound_resource(target, stanza, chrono::Utc::now())
@@ -545,12 +592,14 @@ pub(super) async fn deliver_to_detached(
                 jid = %target,
                 "RouteToConnection: recipient detached, queued for XEP-0198 replay"
             );
+            DetachedDeliveryOutcome::Queued
         }
         Ok(false) => {
             debug!(
                 jid = %target,
                 "RouteToConnection: target offline and no detached session, dropping"
             );
+            DetachedDeliveryOutcome::Unavailable
         }
         Err(error) => {
             warn!(
@@ -558,6 +607,7 @@ pub(super) async fn deliver_to_detached(
                 %error,
                 "RouteToConnection: failed to record stanza for detached resource"
             );
+            DetachedDeliveryOutcome::Failed
         }
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -1476,6 +1476,129 @@ async fn route_to_connection_full_jid_queues_peer_stanza_kind() {
     );
 }
 
+fn jingle_payload_for_route_test(action: &str, sid: &str) -> Element {
+    Element::builder("jingle", waddle_xmpp::xep::xep0166::NS_JINGLE)
+        .attr(minidom::rxml::xml_ncname!("action").to_owned(), action)
+        .attr(minidom::rxml::xml_ncname!("sid").to_owned(), sid)
+        .build()
+}
+
+fn call_iq_set_for_route_test(id: &str, from: &jid::FullJid, to: &jid::FullJid) -> Iq {
+    Iq::Set {
+        from: Some(jid::Jid::from(from.clone())),
+        to: Some(jid::Jid::from(to.clone())),
+        id: id.to_string(),
+        payload: jingle_payload_for_route_test("session-info", "offline-sid"),
+    }
+}
+
+#[tokio::test]
+async fn route_to_connection_offline_full_jid_call_iq_returns_service_unavailable() {
+    use waddle_xmpp::registry::UserRegistryActor;
+    use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType};
+
+    let registry = ConnectionRegistry::new();
+    let user_registry = UserRegistryActor::spawn(UserRegistryActor::new());
+    let alice: jid::FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob: jid::FullJid = "bob@example.com/phone".parse().expect("bob jid");
+    let events = vec![OutboundEvent::RouteToConnection {
+        jid: jid::Jid::from(bob.clone()),
+        stanza: Box::new(Stanza::Iq(Box::new(call_iq_set_for_route_test(
+            "call-offline-1",
+            &alice,
+            &bob,
+        )))),
+    }];
+
+    let outcome = interpret(
+        events,
+        &Deps::registry_with_user_registry(&registry, &user_registry),
+    )
+    .await;
+
+    assert_eq!(
+        outcome.frames.len(),
+        1,
+        "offline full-JID request IQ should produce one error frame: {:?}",
+        outcome.frames
+    );
+    let element = Element::from_str(&outcome.frames[0]).expect("parseable IQ error");
+    let iq = Iq::try_from(element).expect("typed IQ");
+    let Iq::Error {
+        from,
+        to,
+        id,
+        error,
+        payload,
+    } = iq
+    else {
+        panic!("expected IQ error, got {iq:?}");
+    };
+    assert_eq!(id, "call-offline-1");
+    assert_eq!(from, Some(jid::Jid::from(bob)));
+    assert_eq!(to, Some(jid::Jid::from(alice)));
+    assert_eq!(error.type_, ErrorType::Cancel);
+    assert_eq!(
+        error.defined_condition,
+        DefinedCondition::ServiceUnavailable
+    );
+    assert!(
+        payload.is_none(),
+        "error does not need to echo the original payload"
+    );
+}
+
+#[tokio::test]
+async fn route_to_connection_offline_full_jid_call_iq_result_error_do_not_bounce() {
+    use waddle_xmpp::registry::UserRegistryActor;
+    use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
+
+    let registry = ConnectionRegistry::new();
+    let user_registry = UserRegistryActor::spawn(UserRegistryActor::new());
+    let alice: jid::FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob: jid::FullJid = "bob@example.com/phone".parse().expect("bob jid");
+    let result_iq = Iq::Result {
+        from: Some(jid::Jid::from(alice.clone())),
+        to: Some(jid::Jid::from(bob.clone())),
+        id: "call-result-1".to_string(),
+        payload: None,
+    };
+    let error_iq = Iq::Error {
+        from: Some(jid::Jid::from(alice)),
+        to: Some(jid::Jid::from(bob.clone())),
+        id: "call-error-1".to_string(),
+        error: StanzaError::new(
+            ErrorType::Cancel,
+            DefinedCondition::NotAllowed,
+            "en",
+            "already failed",
+        ),
+        payload: None,
+    };
+    let events = vec![
+        OutboundEvent::RouteToConnection {
+            jid: jid::Jid::from(bob.clone()),
+            stanza: Box::new(Stanza::Iq(Box::new(result_iq))),
+        },
+        OutboundEvent::RouteToConnection {
+            jid: jid::Jid::from(bob),
+            stanza: Box::new(Stanza::Iq(Box::new(error_iq))),
+        },
+    ];
+
+    let outcome = interpret(
+        events,
+        &Deps::registry_with_user_registry(&registry, &user_registry),
+    )
+    .await;
+
+    assert!(
+        outcome.frames.is_empty(),
+        "IQ result/error stanzas must not receive synthesized service-unavailable bounces: {:?}",
+        outcome.frames
+    );
+}
+
 #[tokio::test]
 async fn route_to_connection_bare_jid_selects_highest_priority_available_resources() {
     // RFC 6121 §8.5.2.1 resource selection: deliver to every

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -1542,10 +1542,62 @@ async fn route_to_connection_offline_full_jid_call_iq_returns_service_unavailabl
         error.defined_condition,
         DefinedCondition::ServiceUnavailable
     );
-    assert!(
-        payload.is_none(),
-        "error does not need to echo the original payload"
+    // RFC 6120 §8.3.1: the error echoes the original request payload so
+    // the sender can correlate which stanza failed.
+    let echoed = payload.expect("service-unavailable echoes the original payload");
+    assert_eq!(echoed.name(), "jingle");
+    assert_eq!(echoed.attr("sid"), Some("offline-sid"));
+}
+
+#[tokio::test]
+async fn route_to_connection_offline_full_jid_session_terminate_is_acked() {
+    // #1130 + #1131 interaction: a session-terminate forwarded to a peer
+    // whose resource is already gone is a *successful* hangup — the caller
+    // must get an empty <iq type='result'/> ack, never <service-unavailable/>.
+    use waddle_xmpp::registry::UserRegistryActor;
+
+    let registry = ConnectionRegistry::new();
+    let user_registry = UserRegistryActor::spawn(UserRegistryActor::new());
+    let alice: jid::FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob: jid::FullJid = "bob@example.com/phone".parse().expect("bob jid");
+    let terminate = Iq::Set {
+        from: Some(jid::Jid::from(alice.clone())),
+        to: Some(jid::Jid::from(bob.clone())),
+        id: "term-offline-1".to_string(),
+        payload: jingle_payload_for_route_test("session-terminate", "offline-sid"),
+    };
+    let events = vec![OutboundEvent::RouteToConnection {
+        jid: jid::Jid::from(bob.clone()),
+        stanza: Box::new(Stanza::Iq(Box::new(terminate))),
+    }];
+
+    let outcome = interpret(
+        events,
+        &Deps::registry_with_user_registry(&registry, &user_registry),
+    )
+    .await;
+
+    assert_eq!(
+        outcome.frames.len(),
+        1,
+        "an undeliverable session-terminate should be acked, not dropped: {:?}",
+        outcome.frames
     );
+    let iq = Iq::try_from(Element::from_str(&outcome.frames[0]).expect("parseable IQ"))
+        .expect("typed IQ");
+    let Iq::Result {
+        from,
+        to,
+        id,
+        payload,
+    } = iq
+    else {
+        panic!("expected empty IQ result ack, got {iq:?}");
+    };
+    assert_eq!(id, "term-offline-1");
+    assert_eq!(from, Some(jid::Jid::from(bob)));
+    assert_eq!(to, Some(jid::Jid::from(alice)));
+    assert!(payload.is_none(), "terminate ack carries no payload");
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
+++ b/server/crates/waddle-server/src/server/routes/livekit_webhook.rs
@@ -37,7 +37,7 @@ use waddle_sfu::{
 };
 
 use super::muc_muji_clear::clear_muji_presence_for_departure;
-use super::websocket::WebSocketState;
+use super::websocket::{note_participant_left_by_call_id, WebSocketState};
 
 /// Upper bound on remembered event ids for delivery deduplication.
 /// LiveKit retries up to 5 times per delivery; a small LRU is enough
@@ -261,21 +261,37 @@ async fn process_participant_left_for_identity(
         );
         return;
     };
-    let Ok(room_jid) = room_name.parse::<BareJid>() else {
+    if let Ok(room_jid) = room_name.parse::<BareJid>() {
+        clear_muji_presence_for_departure(state, &room_jid, &full_jid).await;
+        return;
+    }
+
+    let Ok(call_id) = CallId::new(room_name.to_owned()) else {
         warn!(
             room = %room_name,
             identity = %identity,
-            "LiveKit room name is not a valid MUC bare JID; skipping cleanup",
+            "LiveKit room name is neither a MUC bare JID nor a valid raw call id; skipping cleanup",
         );
         return;
     };
 
-    clear_muji_presence_for_departure(state, &room_jid, &full_jid).await;
+    debug!(
+        room = %room_name,
+        identity = %identity,
+        "LiveKit room name is not a MUC bare JID; clearing SFU registry by raw call id",
+    );
+    note_participant_left_by_call_id(state, &call_id, &full_jid);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::server::routes::websocket::handlers::iq::handle_iq;
+    use crate::server::routes::websocket::tests::{
+        create_test_websocket_state_with_calls, create_test_websocket_state_with_sfu, RecordingSfu,
+    };
+    use waddle_sfu::{Identity, MediaCapabilities};
+    use waddle_xmpp::protocol::ConnectionPhase;
 
     #[test]
     fn seen_event_ids_deduplicates_repeat_observations() {
@@ -313,5 +329,99 @@ mod tests {
         // The oldest entry should now be evicted, so re-observing it
         // returns "fresh".
         assert!(seen.observe(Some("EV_0")));
+    }
+
+    #[tokio::test]
+    async fn participant_left_scoped_1to1_call_id_cleans_sfu_registry() {
+        let recorder = Arc::new(RecordingSfu::default());
+        let state = create_test_websocket_state_with_sfu(recorder.clone()).await;
+        let call_id = "alice@example.com::dm-1128";
+        let departed = "bob@example.com/phone";
+
+        process_participant_left_for_identity(state.as_ref(), call_id, departed).await;
+
+        let notes = recorder.note_snapshot();
+        assert_eq!(
+            notes.len(),
+            1,
+            "participant-left must use local-only SFU cleanup"
+        );
+        assert_eq!(notes[0].0.as_str(), call_id);
+        assert_eq!(notes[0].1.as_livekit_identity(), departed);
+        assert!(
+            recorder.snapshot().is_empty(),
+            "participant-left webhook must not call the admin-evict unregister path"
+        );
+    }
+
+    #[tokio::test]
+    async fn participant_left_scoped_1to1_revokes_jti_and_survivor_terminate_succeeds() {
+        let state = create_test_websocket_state_with_calls().await;
+        let sfu = state
+            .deps
+            .protocol
+            .sfu
+            .as_ref()
+            .expect("call-enabled fixture has SFU")
+            .clone();
+        let alice: FullJid = "alice@example.com/web".parse().expect("alice full jid");
+        let bob: FullJid = "bob@example.com/phone".parse().expect("bob full jid");
+        let call_id = CallId::new("alice@example.com::dm-1128").expect("scoped call id");
+        let alice_identity = Identity::from_jid(alice.clone());
+        let bob_identity = Identity::from_jid(bob.clone());
+        let bob_token = sfu
+            .issue_join_token(
+                &call_id,
+                &bob_identity,
+                MediaCapabilities::full_participant(),
+            )
+            .expect("bob token");
+        sfu.register_call_participant(&call_id, &alice_identity);
+        sfu.register_call_participant(&call_id, &bob_identity);
+
+        process_participant_left_for_identity(state.as_ref(), call_id.as_str(), bob.as_str()).await;
+
+        assert!(
+            !sfu.has_call_participant(&call_id, &bob_identity),
+            "participant-left must remove the crashed peer from the 1:1 call registry"
+        );
+        assert!(
+            sfu.is_revoked(&bob_token.jti),
+            "participant-left must revoke the crashed peer's issued join token"
+        );
+        assert!(
+            sfu.has_call_participant(&call_id, &alice_identity),
+            "survivor must remain registered until their own terminate"
+        );
+
+        let terminate = r#"<iq xmlns='jabber:client' id='term-1128' type='set' to='bob@example.com/phone'>
+            <jingle xmlns='urn:xmpp:jingle:1' action='session-terminate' sid='dm-1128'>
+                <reason><success/></reason>
+            </jingle>
+        </iq>"#;
+        let responses = handle_iq(
+            terminate,
+            "example.com",
+            "muc.example.com",
+            state.as_ref(),
+            &None,
+            &ConnectionPhase::ready(alice.clone(), false),
+        )
+        .await;
+
+        assert_eq!(
+            responses.len(),
+            1,
+            "survivor terminate should be acked: {responses:?}"
+        );
+        let reply = responses[0].as_str();
+        assert!(
+            reply.contains(r#"type='result'"#) && reply.contains(r#"id='term-1128'"#),
+            "survivor terminate should return an empty IQ result, got: {reply}"
+        );
+        assert!(
+            !sfu.has_call_participant(&call_id, &alice_identity),
+            "survivor terminate must unregister the remaining participant"
+        );
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -102,7 +102,9 @@ pub use state::{
 pub(crate) use cleanup::{
     destroy_room_actor, get_or_create_room_actor, get_room_actor, is_muc_room_jid,
 };
-pub(crate) use muc_call_sfu::note_participant_left_from_webhook;
+pub(crate) use muc_call_sfu::{
+    note_participant_left_by_call_id, note_participant_left_from_webhook,
+};
 pub(crate) use transport_xml::{
     build_iq_error_xml_typed, build_iq_result_xml, element_to_xml, iq_to_xml, stanza_to_xml,
 };

--- a/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/muc_call_sfu.rs
@@ -75,14 +75,28 @@ pub(crate) fn note_participant_left_from_webhook(
     room_jid: &BareJid,
     jid: &FullJid,
 ) {
-    let Some(sfu) = state.deps.protocol.sfu.as_ref() else {
-        return;
-    };
     let Ok(call_id) = CallId::new(room_jid.to_string()) else {
         return;
     };
+    note_participant_left_by_call_id(state, &call_id, jid);
+}
+
+/// Raw-`CallId` variant of [`note_participant_left_from_webhook`] for
+/// call ids that are NOT MUC room JIDs (#1128): 1:1 scoped ids
+/// (`<initiator-bare>::<sid>`) deliberately fail the `BareJid` parse,
+/// but their SFU registry entries and un-revoked JTIs still must be
+/// cleaned when LiveKit reports the participant gone — otherwise a
+/// crashed 1:1 peer lingers until reconciliation.
+pub(crate) fn note_participant_left_by_call_id(
+    state: &WebSocketState,
+    call_id: &CallId,
+    jid: &FullJid,
+) {
+    let Some(sfu) = state.deps.protocol.sfu.as_ref() else {
+        return;
+    };
     let identity = Identity::from_jid(jid.clone());
-    sfu.note_participant_left(&call_id, &identity);
+    sfu.note_participant_left(call_id, &identity);
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-sfu/src/admin.rs
+++ b/server/crates/waddle-sfu/src/admin.rs
@@ -30,18 +30,14 @@ use url::Url;
 use crate::call::{CallId, Identity};
 use crate::config::{ApiKey, ApiSecret, WebsocketUrl};
 use crate::error::SfuError;
+use crate::token::JWT_CLOCK_SKEW;
 
 /// TTL of every admin JWT minted by [`ReqwestLiveKitAdmin`]. Each
 /// admin call is a single HTTP round-trip; a 60-second TTL with `nbf`
-/// pre-dated by [`ADMIN_JWT_CLOCK_SKEW`] absorbs typical NTP skew
-/// without keeping a long-lived bearer token in flight.
+/// pre-dated by [`crate::token::JWT_CLOCK_SKEW`] absorbs typical NTP
+/// skew without keeping a long-lived bearer token in flight. The
+/// skew constant is shared with join-token minting (#1140).
 const ADMIN_JWT_TTL: Duration = Duration::seconds(60);
-
-/// Backdate `nbf` by this much when minting admin JWTs so a LiveKit
-/// pod whose wall clock is slightly ahead does not immediately
-/// reject a freshly-minted token with `token not yet valid`. Matches
-/// the slack LiveKit's own server SDKs apply.
-const ADMIN_JWT_CLOCK_SKEW: Duration = Duration::seconds(30);
 
 /// HTTP timeout for admin requests. Tight because the call sites are
 /// fire-and-forget from the teardown hot path: a stuck SFU must not
@@ -128,7 +124,7 @@ impl ReqwestLiveKitAdmin {
             // rotation events.
             sub: self.api_key.as_str().to_string(),
             iat: now.timestamp(),
-            nbf: (now - ADMIN_JWT_CLOCK_SKEW).timestamp(),
+            nbf: (now - JWT_CLOCK_SKEW).timestamp(),
             exp: (now + ADMIN_JWT_TTL).timestamp(),
             video: AdminGrant {
                 room: room.as_str().to_string(),

--- a/server/crates/waddle-sfu/src/livekit.rs
+++ b/server/crates/waddle-sfu/src/livekit.rs
@@ -205,7 +205,11 @@ impl LiveKitSfu {
     /// Number of currently-tracked issued JTIs for `(call, identity)`.
     /// Exposed for test inspection (this crate's FIFO-bound tests and
     /// the `waddle-xmpp` XEP-0166 suite's one-JTI-per-stanza pin,
-    /// #1142); production code never branches on it.
+    /// #1142); production code never branches on it. `#[doc(hidden)]`
+    /// signals it is not a stable public surface (it must be `pub`, not
+    /// `pub(crate)`, only because the consumer lives in another crate's
+    /// integration tests).
+    #[doc(hidden)]
     pub fn issued_count(&self, call_id: &CallId, identity: &Identity) -> usize {
         self.issued
             .get(&(call_id.clone(), identity.clone()))

--- a/server/crates/waddle-sfu/src/livekit.rs
+++ b/server/crates/waddle-sfu/src/livekit.rs
@@ -46,11 +46,35 @@ const ADMIN_CONCURRENCY: usize = 32;
 /// keeps reconciliation to genuinely stale entries.
 pub const RECONCILE_GRACE_SECONDS: i64 = 120;
 
+/// Number of consecutive reconciliation passes a participant must be
+/// observed absent from LiveKit before being swept (#1127). One
+/// not-found observation is a weak signal: a LiveKit pod restart makes
+/// a single pass report every room as gone while clients silently
+/// reconnect and media keeps flowing. Requiring absence across two
+/// consecutive passes turns the sweep into "confirmed gone for a full
+/// reconcile interval" while still reaping genuinely departed
+/// participants within ~2 passes.
+pub(crate) const RECONCILE_ABSENT_PASSES: u32 = 2;
+
 /// Shared registry of in-call participants. Held in an `Arc` so the
 /// spawned admin teardown future can re-check membership before
 /// firing `DeleteRoom`, closing the race where a fresh joiner
 /// re-creates the call between local-clear and the remote evict.
 type CallRegistry = Arc<DashMap<CallId, HashSet<Identity>>>;
+
+/// Result of [`LiveKitSfu::clear_local_state`].
+#[derive(Debug, Clone, Copy)]
+struct ClearOutcome {
+    /// `identity` was actually registered against the call.
+    was_present: bool,
+    /// The call entry was removed because it was empty at the moment
+    /// of the atomic conditional removal — i.e. we (and nobody
+    /// concurrent) hold no participant for it any more. Only this
+    /// flag may gate a `DeleteRoom` (#1129).
+    emptied: bool,
+    /// Participants still registered after the clear.
+    remaining: usize,
+}
 
 pub struct LiveKitSfu {
     config: SfuConfig,
@@ -72,6 +96,15 @@ pub struct LiveKitSfu {
     /// written in `register_call_participant`, removed in
     /// `clear_local_state`.
     registered_at: DashMap<(CallId, Identity), DateTime<Utc>>,
+    /// Consecutive reconciliation passes each `(call, identity)` has
+    /// been observed absent from LiveKit's `ListParticipants` (#1127).
+    /// A participant is only swept once the streak reaches
+    /// [`RECONCILE_ABSENT_PASSES`]; the streak resets when the
+    /// participant is observed connected, when the pass for its call
+    /// fails (absence unconfirmed), and on (re-)registration. Entries
+    /// are removed in `clear_local_state` so the map cannot outgrow
+    /// the registry.
+    absent_streak: DashMap<(CallId, Identity), u32>,
     /// Map of revoked JWT identifiers to the `exp` of the token they
     /// belonged to. Entries are swept lazily once `Utc::now() > exp`:
     /// a revoked token past its expiry cannot be replayed regardless
@@ -142,6 +175,7 @@ impl LiveKitSfu {
             calls: Arc::new(DashMap::new()),
             issued: DashMap::new(),
             registered_at: DashMap::new(),
+            absent_streak: DashMap::new(),
             revoked: DashMap::new(),
             admin,
             runtime: Handle::try_current().ok(),
@@ -169,9 +203,10 @@ impl LiveKitSfu {
     }
 
     /// Number of currently-tracked issued JTIs for `(call, identity)`.
-    /// Exposed for tests to pin the per-participant FIFO bound.
-    #[cfg(test)]
-    pub(crate) fn issued_count(&self, call_id: &CallId, identity: &Identity) -> usize {
+    /// Exposed for test inspection (this crate's FIFO-bound tests and
+    /// the `waddle-xmpp` XEP-0166 suite's one-JTI-per-stanza pin,
+    /// #1142); production code never branches on it.
+    pub fn issued_count(&self, call_id: &CallId, identity: &Identity) -> usize {
         self.issued
             .get(&(call_id.clone(), identity.clone()))
             .map(|e| e.len())
@@ -187,18 +222,25 @@ impl LiveKitSfu {
     }
 
     /// Drop `identity` from the in-memory registry and revoke every
-    /// JWT it ever held. Returns `(was_present, remaining_after)` so
-    /// the caller can distinguish "this participant just left the
-    /// last seat" from "we never knew about this participant at all"
-    /// — both look like `remaining == 0` but only the first warrants
-    /// a `DeleteRoom` admin call.
-    fn clear_local_state(&self, call_id: &CallId, identity: &Identity) -> (bool, usize) {
-        let (was_present, remaining) = match self.calls.get_mut(call_id) {
-            Some(mut entry) => {
-                let was_present = entry.remove(identity);
-                (was_present, entry.len())
-            }
-            None => (false, 0),
+    /// JWT it ever held. Returns the [`ClearOutcome`] the caller uses
+    /// to distinguish "this participant just left the last seat"
+    /// (warrants a `DeleteRoom` admin call) from "we never knew about
+    /// this participant at all" and from "others remain".
+    ///
+    /// #1129: the call entry is dropped via an atomic
+    /// `remove_if(|_, set| set.is_empty())` rather than an
+    /// unconditional `remove`. Between releasing the per-entry guard
+    /// (after removing `identity`) and the entry removal, a concurrent
+    /// joiner may have registered into the same call; the conditional
+    /// remove observes that registration under the shard lock and
+    /// keeps the entry, so the joiner is neither evicted from the
+    /// registry nor exposed to the spawned `DeleteRoom` (the caller
+    /// derives its emptiness decision from `emptied`, which is `false`
+    /// in that case).
+    fn clear_local_state(&self, call_id: &CallId, identity: &Identity) -> ClearOutcome {
+        let was_present = match self.calls.get_mut(call_id) {
+            Some(mut entry) => entry.remove(identity),
+            None => false,
         };
 
         if let Some((_, issued)) = self.issued.remove(&(call_id.clone(), identity.clone())) {
@@ -208,13 +250,27 @@ impl LiveKitSfu {
         }
         self.registered_at
             .remove(&(call_id.clone(), identity.clone()));
+        self.absent_streak
+            .remove(&(call_id.clone(), identity.clone()));
         self.sweep_expired_revoked(Utc::now());
 
-        if remaining == 0 {
-            self.calls.remove(call_id);
-        }
+        // Atomic conditional removal: only drop the call entry if it
+        // is *still* empty at removal time (see doc comment above).
+        let emptied = self
+            .calls
+            .remove_if(call_id, |_, participants| participants.is_empty())
+            .is_some();
+        let remaining = if emptied {
+            0
+        } else {
+            self.calls.get(call_id).map(|e| e.len()).unwrap_or(0)
+        };
 
-        (was_present, remaining)
+        ClearOutcome {
+            was_present,
+            emptied,
+            remaining,
+        }
     }
 
     /// Fire-and-forget the LiveKit admin REST calls that mirror a
@@ -300,7 +356,19 @@ impl LiveKitSfu {
     ///
     /// A `ListParticipants` failure for a given call (network/5xx) is
     /// logged and that call is skipped this pass — absence cannot be
-    /// confirmed, so nothing is swept. The next pass retries.
+    /// confirmed, so nothing is swept and the call's absence streaks
+    /// are reset. The next pass retries.
+    ///
+    /// #1127: a single absent observation never sweeps. Each pass a
+    /// (grace-aged) participant is absent from `ListParticipants`
+    /// bumps its absence streak; the sweep fires only once the streak
+    /// reaches [`RECONCILE_ABSENT_PASSES`] — i.e. the participant was
+    /// gone across two consecutive passes a full reconcile interval
+    /// apart. A LiveKit pod restart therefore cannot mass-terminate
+    /// live calls: the first post-restart pass (rooms not found ⇒
+    /// empty participant lists) only marks streaks, clients silently
+    /// rejoin, and the second pass observes them connected and clears
+    /// the streaks.
     async fn reconcile_active_calls_inner(&self, grace: ChronoDuration) -> Vec<(CallId, Identity)> {
         let now = Utc::now();
         // Snapshot the registry into owned values up front so no
@@ -321,6 +389,13 @@ impl LiveKitSfu {
                         error = %err,
                         "SFU reconcile: ListParticipants failed; skipping this call this pass"
                     );
+                    // Absence cannot be confirmed this pass, so the
+                    // streaks accumulated so far are no longer
+                    // "consecutive" — reset them (#1127) rather than
+                    // let a failed pass count towards the sweep.
+                    for identity in registered {
+                        self.absent_streak.remove(&(call_id.clone(), identity));
+                    }
                     continue;
                 }
             };
@@ -328,15 +403,20 @@ impl LiveKitSfu {
                 live.iter().map(Identity::as_livekit_identity).collect();
 
             for identity in registered {
+                let key = (call_id.clone(), identity.clone());
                 if live_set.contains(&identity.as_livekit_identity()) {
-                    continue; // genuinely connected — not a ghost
+                    // Genuinely connected — not a ghost. Clear any
+                    // absence streak from a transient not-found
+                    // observation (e.g. a LiveKit restart).
+                    self.absent_streak.remove(&key);
+                    continue;
                 }
-                // Absent from LiveKit. Only sweep once past the grace
-                // window; a freshly-registered participant may simply
-                // not have finished connecting yet.
+                // Absent from LiveKit. Only count the observation once
+                // past the grace window; a freshly-registered
+                // participant may simply not have finished connecting.
                 let aged_out = self
                     .registered_at
-                    .get(&(call_id.clone(), identity.clone()))
+                    .get(&key)
                     .map(|entry| now - *entry.value() >= grace)
                     // No timestamp recorded (e.g. an entry registered
                     // before this field existed) → treat as eligible.
@@ -344,8 +424,30 @@ impl LiveKitSfu {
                 if !aged_out {
                     continue;
                 }
-                let (was_present, _) = self.clear_local_state(&call_id, &identity);
-                if was_present {
+                // #1127: require the absence to persist across
+                // RECONCILE_ABSENT_PASSES consecutive passes before
+                // sweeping. Room-not-found (empty list) right after a
+                // LiveKit restart is indistinguishable from a real
+                // departure on one observation — the second pass
+                // disambiguates, because reconnected clients are
+                // reported again while genuinely departed ones stay
+                // absent.
+                let streak = {
+                    let mut entry = self.absent_streak.entry(key.clone()).or_insert(0);
+                    *entry += 1;
+                    *entry
+                };
+                if streak < RECONCILE_ABSENT_PASSES {
+                    tracing::debug!(
+                        call_id = %call_id,
+                        identity = %identity.as_livekit_identity(),
+                        streak,
+                        "SFU reconcile: participant absent; awaiting a confirming pass"
+                    );
+                    continue;
+                }
+                let outcome = self.clear_local_state(&call_id, &identity);
+                if outcome.was_present {
                     tracing::info!(
                         call_id = %call_id,
                         identity = %identity.as_livekit_identity(),
@@ -417,9 +519,14 @@ impl SfuService for LiveKitSfu {
             .insert(identity.clone());
         // Stamp (or refresh) the registration time so the
         // reconciliation backstop's grace window is measured from the
-        // most recent (re)join, not a stale earlier attempt.
+        // most recent (re)join, not a stale earlier attempt. A
+        // (re-)registration also resets the absence streak (#1127):
+        // any prior not-seen observations belong to the previous
+        // connection attempt.
         self.registered_at
             .insert((call_id.clone(), identity.clone()), Utc::now());
+        self.absent_streak
+            .remove(&(call_id.clone(), identity.clone()));
     }
 
     fn has_call_participant(&self, call_id: &CallId, identity: &Identity) -> bool {
@@ -429,9 +536,13 @@ impl SfuService for LiveKitSfu {
     }
 
     fn unregister_call_participant(&self, call_id: &CallId, identity: &Identity) -> CallState {
-        let (was_present, remaining) = self.clear_local_state(call_id, identity);
+        let ClearOutcome {
+            was_present,
+            emptied,
+            remaining,
+        } = self.clear_local_state(call_id, identity);
 
-        let state = if was_present && remaining == 0 {
+        let state = if was_present && emptied {
             CallState::Ended
         } else {
             // `Active { remaining }` covers two cases that look the
@@ -448,10 +559,12 @@ impl SfuService for LiveKitSfu {
         // Schedule the LiveKit-side evict. `RemoveParticipant` always
         // runs (LiveKit may know about the participant even when our
         // local registry has lost track — federation, stale state).
-        // `DeleteRoom` only fires when we know we just emptied a
-        // call we previously tracked, and the spawn re-checks the
-        // registry inside the future to close the rejoin race.
-        let we_just_emptied = was_present && remaining == 0;
+        // `DeleteRoom` only fires when the atomic conditional removal
+        // confirmed we just emptied a call we previously tracked
+        // (#1129 — a concurrent joiner keeps `emptied == false`), and
+        // the spawn re-checks the registry inside the future to close
+        // the rejoin race.
+        let we_just_emptied = was_present && emptied;
         self.schedule_remote_teardown(call_id.clone(), identity.clone(), we_just_emptied);
 
         state
@@ -741,7 +854,11 @@ mod tests {
         }
 
         fn fail_list(&self) {
-            *self.list_errors.lock().expect("recording lock") = true;
+            self.set_list_failing(true);
+        }
+
+        fn set_list_failing(&self, failing: bool) {
+            *self.list_errors.lock().expect("recording lock") = failing;
         }
     }
 
@@ -971,9 +1088,10 @@ mod tests {
     async fn reconcile_sweeps_ghost_absent_from_livekit() {
         // Alice + Bob registered; LiveKit reports only Alice connected
         // (Bob's participant_left webhook was lost). With a zero grace
-        // window Bob must be swept and returned for presence cleanup;
-        // Alice must remain. No admin remove/delete is fired — the
-        // ghost is already gone from LiveKit.
+        // window Bob must be swept — after TWO consecutive absent
+        // passes (#1127) — and returned for presence cleanup; Alice
+        // must remain. No admin remove/delete is fired — the ghost is
+        // already gone from LiveKit.
         let admin = Arc::new(RecordingAdmin::default());
         let sfu = LiveKitSfu::with_admin(fixture_config(), Arc::clone(&admin) as Arc<_>);
         let call = CallId::new("general@muc.waddle.social").unwrap();
@@ -982,6 +1100,16 @@ mod tests {
         sfu.register_call_participant(&call, &alice);
         sfu.register_call_participant(&call, &bob);
         admin.set_live(&call, vec![alice.clone()]);
+
+        let first_pass = sfu.reconcile_active_calls(ChronoDuration::zero()).await;
+        assert!(
+            first_pass.is_empty(),
+            "one absent observation must not sweep (#1127): {first_pass:?}"
+        );
+        assert!(
+            sfu.has_call_participant(&call, &bob),
+            "Bob must survive the first absent pass"
+        );
 
         let swept = sfu.reconcile_active_calls(ChronoDuration::zero()).await;
 
@@ -1055,5 +1183,182 @@ mod tests {
             "a call whose participant list could not be fetched must not be swept"
         );
         assert_eq!(sfu.participant_count(&call), 1);
+    }
+
+    #[tokio::test]
+    async fn reconcile_livekit_restart_does_not_mass_terminate_live_calls() {
+        // #1127: a LiveKit pod restart makes one pass report every
+        // room as not-found (empty participant list). Clients silently
+        // rejoin before the next pass. Nothing may be swept.
+        let admin = Arc::new(RecordingAdmin::default());
+        let sfu = LiveKitSfu::with_admin(fixture_config(), Arc::clone(&admin) as Arc<_>);
+        let call_a = CallId::new("standup@muc.waddle.social").unwrap();
+        let call_b = CallId::new("alice@waddle.social::dm-1").unwrap();
+        let alice = fixture_identity("alice");
+        let bob = fixture_identity("bob");
+        sfu.register_call_participant(&call_a, &alice);
+        sfu.register_call_participant(&call_b, &bob);
+
+        // Pass 1: restart — LiveKit knows no rooms (both list empty).
+        let pass1 = sfu.reconcile_active_calls(ChronoDuration::zero()).await;
+        assert!(pass1.is_empty(), "restart pass must not sweep: {pass1:?}");
+        assert_eq!(sfu.participant_count(&call_a), 1);
+        assert_eq!(sfu.participant_count(&call_b), 1);
+
+        // Clients reconnected before pass 2.
+        admin.set_live(&call_a, vec![alice.clone()]);
+        admin.set_live(&call_b, vec![bob.clone()]);
+        let pass2 = sfu.reconcile_active_calls(ChronoDuration::zero()).await;
+        assert!(pass2.is_empty(), "reconnected clients must not be swept");
+
+        // Pass 3: streaks were reset by the connected observation, so
+        // a later single absent blip still does not sweep.
+        admin.set_live(&call_a, vec![]);
+        let pass3 = sfu.reconcile_active_calls(ChronoDuration::zero()).await;
+        assert!(
+            pass3.is_empty(),
+            "streak must have been reset by the connected pass: {pass3:?}"
+        );
+        assert!(sfu.has_call_participant(&call_a, &alice));
+    }
+
+    #[tokio::test]
+    async fn reconcile_failed_pass_resets_absence_streak() {
+        // #1127 AC: the absence tracker resets on a failed pass — two
+        // absent observations separated by a ListParticipants failure
+        // are not "consecutive".
+        let admin = Arc::new(RecordingAdmin::default());
+        let sfu = LiveKitSfu::with_admin(fixture_config(), Arc::clone(&admin) as Arc<_>);
+        let call = CallId::new("room@muc.waddle.social").unwrap();
+        let alice = fixture_identity("alice");
+        sfu.register_call_participant(&call, &alice);
+        admin.set_live(&call, vec![]);
+
+        // Absent pass 1 → streak 1.
+        assert!(sfu
+            .reconcile_active_calls(ChronoDuration::zero())
+            .await
+            .is_empty());
+        // Failed pass → streak reset.
+        admin.set_list_failing(true);
+        assert!(sfu
+            .reconcile_active_calls(ChronoDuration::zero())
+            .await
+            .is_empty());
+        admin.set_list_failing(false);
+        // Absent pass again → streak restarts at 1, still no sweep.
+        let third = sfu.reconcile_active_calls(ChronoDuration::zero()).await;
+        assert!(
+            third.is_empty(),
+            "failed pass must reset the streak: {third:?}"
+        );
+        assert_eq!(sfu.participant_count(&call), 1);
+        // Second CONSECUTIVE absent pass → swept.
+        let fourth = sfu.reconcile_active_calls(ChronoDuration::zero()).await;
+        assert_eq!(fourth, vec![(call.clone(), alice)]);
+        assert_eq!(sfu.participant_count(&call), 0);
+    }
+
+    #[tokio::test]
+    async fn reconcile_streak_resets_on_reregistration() {
+        // A participant re-registering (fresh session-initiate /
+        // rejoin) invalidates absence observed against the previous
+        // attempt.
+        let admin = Arc::new(RecordingAdmin::default());
+        let sfu = LiveKitSfu::with_admin(fixture_config(), Arc::clone(&admin) as Arc<_>);
+        let call = CallId::new("room@muc.waddle.social").unwrap();
+        let alice = fixture_identity("alice");
+        sfu.register_call_participant(&call, &alice);
+        admin.set_live(&call, vec![]);
+
+        assert!(sfu
+            .reconcile_active_calls(ChronoDuration::zero())
+            .await
+            .is_empty());
+        // Rejoin between passes.
+        sfu.register_call_participant(&call, &alice);
+        // This absent pass is the FIRST of the new registration.
+        assert!(
+            sfu.reconcile_active_calls(ChronoDuration::zero())
+                .await
+                .is_empty(),
+            "re-registration must reset the absence streak"
+        );
+        assert_eq!(sfu.participant_count(&call), 1);
+    }
+
+    // -------- #1129 teardown/join race --------
+
+    #[test]
+    fn concurrent_join_during_teardown_is_never_clobbered() {
+        // #1129: `clear_local_state` used to compute `remaining == 0`
+        // under the entry guard, drop it, then unconditionally remove
+        // the call entry — deleting a joiner who registered in the
+        // window. The atomic `remove_if` closes that: after BOTH an
+        // unregister(alice) and a register(bob) have completed, bob
+        // must always be present in the registry, whatever the
+        // interleaving. Run many racing iterations to exercise the
+        // window.
+        let sfu = Arc::new(
+            LiveKitSfu::new(fixture_config()).expect("LiveKitSfu init in test (no runtime)"),
+        );
+        let alice = fixture_identity("alice");
+        let bob = fixture_identity("bob");
+
+        for i in 0..200 {
+            let call = CallId::new(format!("race-{i}")).unwrap();
+            sfu.register_call_participant(&call, &alice);
+
+            let leaver = {
+                let sfu = Arc::clone(&sfu);
+                let call = call.clone();
+                let alice = alice.clone();
+                std::thread::spawn(move || {
+                    let _ = sfu.unregister_call_participant(&call, &alice);
+                })
+            };
+            sfu.register_call_participant(&call, &bob);
+            leaver.join().expect("leaver thread");
+
+            assert!(
+                sfu.has_call_participant(&call, &bob),
+                "iteration {i}: concurrent joiner was clobbered by teardown (#1129)"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_room_not_fired_when_joiner_lands_before_conditional_remove() {
+        // #1129 second half: when the joiner wins the race, the
+        // unregister must report the call as still active (not Ended)
+        // so no DeleteRoom is scheduled against the fresh joiner.
+        let admin = Arc::new(RecordingAdmin::default());
+        let sfu = LiveKitSfu::with_admin(fixture_config(), Arc::clone(&admin) as Arc<_>);
+        let call = CallId::new("r-joiner-race").unwrap();
+        let alice = fixture_identity("alice");
+        let bob = fixture_identity("bob");
+
+        sfu.register_call_participant(&call, &alice);
+        // Simulate the joiner landing inside alice's teardown window:
+        // remove alice from the set (step 1 of clear_local_state),
+        // register bob, then run the full unregister — the conditional
+        // removal must observe bob and keep the entry.
+        sfu.calls
+            .get_mut(&call)
+            .expect("entry exists")
+            .remove(&alice);
+        sfu.register_call_participant(&call, &bob);
+
+        let state = sfu.unregister_call_participant(&call, &alice);
+        assert!(
+            matches!(state, CallState::Active { remaining: 1 }),
+            "joiner present at conditional-remove time must keep the call active; got {state:?}"
+        );
+        drain_admin_tasks().await;
+        assert!(
+            admin.delete_snapshot().is_empty(),
+            "DeleteRoom must not fire while the fresh joiner is registered"
+        );
+        assert!(sfu.has_call_participant(&call, &bob));
     }
 }

--- a/server/crates/waddle-sfu/src/token.rs
+++ b/server/crates/waddle-sfu/src/token.rs
@@ -14,6 +14,15 @@ use crate::call::{CallId, Identity, MediaCapabilities};
 use crate::config::{ApiKey, ApiSecret, WebsocketUrl};
 use crate::error::SfuError;
 
+/// Backdate `nbf` by this much when minting LiveKit JWTs so a
+/// LiveKit pod whose wall clock is slightly ahead of ours does not
+/// reject a freshly-minted token with `token not yet valid`. Matches
+/// the slack LiveKit's own server SDKs apply. Shared by the join
+/// tokens minted here and the admin tokens in [`crate::admin`]
+/// (#1140 — join tokens previously set `nbf = now` exactly, causing
+/// intermittent not-yet-valid rejections under small clock skew).
+pub(crate) const JWT_CLOCK_SKEW: Duration = Duration::seconds(30);
+
 /// JWT identifier (RFC 7519 §4.1.7). A fresh UUID is minted per
 /// token so the SFU can track and revoke individual issuances even
 /// when the same (call, identity) pair gets multiple tokens.
@@ -158,7 +167,11 @@ pub(crate) fn mint_join_token(inputs: MintInputs<'_>) -> Result<JoinToken, SfuEr
         iss: inputs.api_key.as_str().to_string(),
         sub: inputs.identity.as_livekit_identity(),
         iat: now.timestamp(),
-        nbf: now.timestamp(),
+        // Backdated for clock skew (#1140): the token becomes valid
+        // slightly "in the past" from our perspective so a LiveKit
+        // pod running a few seconds ahead still accepts it. The
+        // lifetime end (`exp`) is unchanged.
+        nbf: (now - JWT_CLOCK_SKEW).timestamp(),
         exp: expires_at.timestamp(),
         jti: jti.as_str().to_string(),
         video: VideoGrant::from_capabilities(inputs.call_id, inputs.capabilities),
@@ -247,7 +260,9 @@ mod tests {
         assert_eq!(claims.iss, api_key.as_str());
         assert_eq!(claims.sub, identity.as_livekit_identity());
         assert!(claims.exp > claims.iat);
-        assert_eq!(claims.iat, claims.nbf);
+        // #1140: nbf is backdated by the shared clock-skew constant,
+        // matching the admin-token behaviour.
+        assert_eq!(claims.nbf, claims.iat - JWT_CLOCK_SKEW.num_seconds());
         assert_eq!(claims.jti, token.jti.as_str());
         assert!(!claims.jti.is_empty());
         assert!(claims.video.room_join);
@@ -255,6 +270,45 @@ mod tests {
         assert!(claims.video.can_publish);
         assert!(claims.video.can_subscribe);
         assert!(claims.video.can_publish_data);
+    }
+
+    #[test]
+    fn join_token_nbf_is_backdated_for_clock_skew() {
+        // #1140: a LiveKit pod whose clock runs slightly behind ours
+        // must still accept a fresh join token. `nbf` is backdated by
+        // the shared skew constant; `iat`/`exp` (the actual lifetime)
+        // are unchanged, so the TTL is not silently extended.
+        let api_key = ApiKey::new("APIxxxxxxxx");
+        let secret = ApiSecret::from_text("super-secret-secret-32-bytes-min")
+            .expect("test secret meets min length");
+        let ws_url = WebsocketUrl::new("wss://livekit.waddle.social".parse().expect("valid URL"))
+            .expect("valid ws url");
+        let call_id = CallId::new("call-skew").expect("valid call id");
+        let identity = fixture_identity();
+
+        let before = Utc::now().timestamp();
+        let token = mint_join_token(fixture_inputs(
+            &api_key, &secret, &ws_url, &call_id, &identity,
+        ))
+        .expect("mint should succeed");
+        let after = Utc::now().timestamp();
+
+        let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
+        validation.validate_nbf = true;
+        validation.leeway = 0;
+        let key = DecodingKey::from_secret(secret.as_bytes());
+        let decoded = decode::<DecodedClaims>(token.jwt.as_str(), &key, &validation)
+            .expect("token with zero leeway decodes — nbf is already in the past");
+        let claims = decoded.claims;
+
+        let skew = JWT_CLOCK_SKEW.num_seconds();
+        assert_eq!(claims.nbf, claims.iat - skew, "nbf backdated by the skew");
+        assert!(claims.iat >= before && claims.iat <= after, "iat stays now");
+        assert_eq!(
+            claims.exp - claims.iat,
+            3600,
+            "token lifetime (iat→exp) is unchanged by the backdate"
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/jingle.rs
@@ -351,21 +351,19 @@ impl JingleHandler {
             None
         };
 
-        for content in &mut jingle.contents {
-            match rewrite_content_transport(content, &call_id, &peer_identity, &*self.sfu) {
-                Ok(()) => {}
-                Err(reason) => {
-                    if let Some(invite) = claimed_invite.clone() {
-                        let mut pending = self.lock_pending_dm_invites();
-                        pending.entry(call_id.clone()).or_insert(invite);
-                    }
-                    // 1:1 P2P path: the requester addressed the
-                    // session-initiate to `peer`, so the Jingle-level
-                    // rejection must appear from that peer resource,
-                    // not from the requester back to itself.
-                    return reason.into_error_reply(iq, &jingle.sid, &peer);
-                }
+        // One join token per stanza, shared across contents (#1142).
+        if let Err(reason) =
+            rewrite_contents_transport(&mut jingle.contents, &call_id, &peer_identity, &*self.sfu)
+        {
+            if let Some(invite) = claimed_invite.clone() {
+                let mut pending = self.lock_pending_dm_invites();
+                pending.entry(call_id.clone()).or_insert(invite);
             }
+            // 1:1 P2P path: the requester addressed the
+            // session-initiate to `peer`, so the Jingle-level
+            // rejection must appear from that peer resource,
+            // not from the requester back to itself.
+            return reason.into_error_reply(iq, &jingle.sid, &peer);
         }
 
         if claimed_invite.is_some() && self.lock_pending_dm_invites().contains_key(&call_id) {
@@ -526,19 +524,18 @@ impl JingleHandler {
         // identity — multi-resource correct.
         let identity = Identity::from_jid(ctx.full_jid.clone());
 
-        // Rewrite each `<content>`'s transport with an issued token.
-        // Every content shares the same token because LiveKit's
-        // identity model is "one identity per participant"; the
-        // audio/video split lives below the LiveKit layer.
+        // Rewrite the contents' transports with ONE issued token
+        // shared across every content (#1142): LiveKit's identity
+        // model is "one identity per participant"; the audio/video
+        // split lives below the LiveKit layer.
         // Mixer JID becomes the `from` of any session-terminate
         // we emit per XEP-0166 §10.2 — the conference focus is the
         // source of the rejection, not the requester.
         let mixer_jid: Jid = calls_mixer_jid(ctx.domain).into();
-        for content in &mut jingle.contents {
-            match rewrite_content_transport(content, &call_id, &identity, &*self.sfu) {
-                Ok(()) => {}
-                Err(reason) => return reason.into_error_reply(iq, &jingle.sid, &mixer_jid),
-            }
+        if let Err(reason) =
+            rewrite_contents_transport(&mut jingle.contents, &call_id, &identity, &*self.sfu)
+        {
+            return reason.into_error_reply(iq, &jingle.sid, &mixer_jid);
         }
         self.sfu.register_call_participant(&call_id, &identity);
 
@@ -643,6 +640,33 @@ impl JingleHandler {
         ))))]
     }
 
+    /// Handle a 1:1 `session-terminate` (#1131).
+    ///
+    /// Authorization is on the SENDER's call membership — requiring
+    /// the addressed peer to still be registered meant a survivor
+    /// whose peer had already been swept (crashed client cleaned up
+    /// via the LiveKit webhook or the reconciler) got `<forbidden/>`
+    /// and NO cleanup: their registration and un-revoked JTIs
+    /// lingered until reconciliation.
+    ///
+    /// Resolution order over the two sid-scoped call-id candidates
+    /// (`<sender-bare>::<sid>`, `<peer-bare>::<sid>`):
+    ///
+    /// 1. Both sender and peer registered → unregister both (revoking
+    ///    their JTIs) and forward the terminate to the peer, whose
+    ///    client acks per XEP-0166 §6.7.
+    /// 2. Sender is the ONLY remaining registered party (survivor
+    ///    terminate) → unregister the sender and ack the IQ on the
+    ///    departed peer's behalf — the peer is gone, so there is
+    ///    nobody left to forward to.
+    /// 3. A candidate call still has participants but the sender+peer
+    ///    pairing is not among them → `<forbidden/>`: a third party
+    ///    (or a revoked/superseded responder) must not tear down or
+    ///    probe someone else's call.
+    /// 4. No candidate call exists at all (duplicate terminate,
+    ///    terminate glare, long-dead session) → `<item-not-found/>` +
+    ///    `<unknown-session/>` per the XEP-0166 error table — never
+    ///    `<forbidden/>`, and idempotent (no state is touched).
     fn handle_session_terminate(
         &self,
         iq: &Iq,
@@ -661,34 +685,59 @@ impl JingleHandler {
         let peer_bare = peer.to_bare();
         let sender_identity = Identity::from_jid(ctx.full_jid.clone());
         let peer_identity = Identity::from_jid(peer_full);
-        let mut matched_call_id = None;
-        for initiator_bare in [ctx_bare, peer_bare] {
-            let Ok(call_id) = scoped_call_id(&initiator_bare, &jingle.sid.0) else {
-                continue;
-            };
-            if !self.sfu.has_call_participant(&call_id, &sender_identity)
-                || !self.sfu.has_call_participant(&call_id, &peer_identity)
-            {
-                continue;
-            }
-            matched_call_id = Some(call_id);
-            break;
+
+        let candidates: Vec<CallId> = [ctx_bare, peer_bare]
+            .into_iter()
+            .filter_map(|initiator_bare| scoped_call_id(&initiator_bare, &jingle.sid.0).ok())
+            .collect();
+
+        // Case 1: the fully-live session — both parties registered.
+        if let Some(call_id) = candidates.iter().find(|call_id| {
+            self.sfu.has_call_participant(call_id, &sender_identity)
+                && self.sfu.has_call_participant(call_id, &peer_identity)
+        }) {
+            let _ = self
+                .sfu
+                .unregister_call_participant(call_id, &sender_identity);
+            let _ = self
+                .sfu
+                .unregister_call_participant(call_id, &peer_identity);
+            self.lock_pending_dm_invites().remove(call_id);
+            return self.route_unchanged(iq, peer, ctx);
         }
-        let Some(call_id) = matched_call_id else {
+
+        // Case 2: survivor terminate — the peer's registration is
+        // gone (webhook / reconciler sweep) and the sender is the
+        // only remaining party. Unregister the sender (revoking its
+        // JTIs) and ack per XEP-0166 §6.7 on the departed peer's
+        // behalf.
+        if let Some(call_id) = candidates.iter().find(|call_id| {
+            let participants = self.sfu.participants_for_call(call_id);
+            !participants.is_empty() && participants.iter().all(|p| p == &sender_identity)
+        }) {
+            let _ = self
+                .sfu
+                .unregister_call_participant(call_id, &sender_identity);
+            self.lock_pending_dm_invites().remove(call_id);
+            return terminate_ack(iq);
+        }
+
+        // Case 3: some candidate call is live but the sender+peer
+        // pairing is not part of it — a third party or a superseded
+        // responder probing/terminating someone else's call.
+        if candidates
+            .iter()
+            .any(|call_id| !self.sfu.participants_for_call(call_id).is_empty())
+        {
             return error_reply(
                 iq,
                 DefinedCondition::Forbidden,
                 "Jingle terminator is not a participant in this call",
             );
-        };
-        let _ = self
-            .sfu
-            .unregister_call_participant(&call_id, &sender_identity);
-        let _ = self
-            .sfu
-            .unregister_call_participant(&call_id, &peer_identity);
-        self.lock_pending_dm_invites().remove(&call_id);
-        self.route_unchanged(iq, peer, ctx)
+        }
+
+        // Case 4: fully-unknown session — XEP-0166 unknown-session.
+        unknown_session_reply(iq)
     }
 
     /// Forward the stanza verbatim with a sanitised `from` so the
@@ -880,12 +929,11 @@ fn unsupported_transports_termination(iq: &Iq, sid: &SessionId, from: &Jid) -> V
     ]
 }
 
-fn rewrite_content_transport(
-    content: &mut Content,
-    call_id: &CallId,
-    peer_identity: &Identity,
-    sfu: &dyn SfuService,
-) -> Result<(), RewriteError> {
+/// Validate that `content` carries the empty Waddle LiveKit transport
+/// placeholder (`urn:waddle:transports:livekit:0` in its `Request`
+/// form). Client-supplied issued credentials and foreign transports
+/// are rejected without minting anything.
+fn validate_transport_placeholder(content: &Content) -> Result<(), RewriteError> {
     let Some(Transport::Unknown(transport_elem)) = &content.transport else {
         return Err(RewriteError::UnsupportedTransport);
     };
@@ -896,24 +944,53 @@ fn rewrite_content_transport(
         .map_err(RewriteError::InvalidWaddleTransport)?;
     match parsed {
         WaddleLiveKitTransport::Issued(_) => Err(RewriteError::ClientSuppliedIssuedTransport),
-        WaddleLiveKitTransport::Request => {
-            let token = sfu
-                .issue_join_token(
-                    call_id,
-                    peer_identity,
-                    MediaCapabilities::full_participant(),
-                )
-                .map_err(RewriteError::SfuFailed)?;
-            let issued = WaddleLiveKitTransport::Issued(IssuedTransport {
-                url: token.url,
-                room: token.room,
-                identity: token.identity,
-                token: token.jwt,
-            });
-            content.transport = Some(Transport::Unknown(issued.to_element()));
-            Ok(())
-        }
+        WaddleLiveKitTransport::Request => Ok(()),
     }
+}
+
+/// Rewrite every `<content/>`'s transport placeholder with ONE
+/// freshly-issued LiveKit join token shared across all contents.
+///
+/// #1142: LiveKit's identity model is "one identity per participant";
+/// the audio/video split lives below the LiveKit layer, so all
+/// contents of a negotiation stanza must share the same credential.
+/// Minting per content burned one JTI per `<content/>` — a few
+/// two-content renegotiations pushed still-live JTIs out of the
+/// 16-slot per-participant FIFO, leaving them unrevocable on hangup.
+///
+/// Every placeholder is validated *before* the single mint so a
+/// malformed later content cannot leave an orphaned JTI in the
+/// tracker.
+fn rewrite_contents_transport(
+    contents: &mut [Content],
+    call_id: &CallId,
+    peer_identity: &Identity,
+    sfu: &dyn SfuService,
+) -> Result<(), RewriteError> {
+    for content in contents.iter() {
+        validate_transport_placeholder(content)?;
+    }
+    if contents.is_empty() {
+        return Ok(());
+    }
+    let token = sfu
+        .issue_join_token(
+            call_id,
+            peer_identity,
+            MediaCapabilities::full_participant(),
+        )
+        .map_err(RewriteError::SfuFailed)?;
+    let issued = WaddleLiveKitTransport::Issued(IssuedTransport {
+        url: token.url,
+        room: token.room,
+        identity: token.identity,
+        token: token.jwt,
+    });
+    let issued_elem = issued.to_element();
+    for content in contents.iter_mut() {
+        content.transport = Some(Transport::Unknown(issued_elem.clone()));
+    }
+    Ok(())
 }
 
 fn revoke_other_dm_participants(
@@ -941,6 +1018,49 @@ fn iq_set_jingle(iq: &Iq) -> Option<&Element> {
         }
         _ => None,
     }
+}
+
+/// Empty `<iq type='result'/>` acknowledging a `session-terminate`
+/// per XEP-0166 §6.7, emitted server-side when the addressed peer's
+/// registration is already gone (survivor terminate, #1131) and there
+/// is nobody left to forward the terminate to. `from` mirrors the
+/// stanza's `to` so the ack appears from the party the terminate was
+/// addressed to, matching the §6.7 example shape.
+fn terminate_ack(original: &Iq) -> Vec<OutboundEvent> {
+    let ack = Iq::Result {
+        from: original.to().cloned(),
+        to: original.from().cloned(),
+        id: original.id().to_string(),
+        payload: None,
+    };
+    vec![OutboundEvent::SendStanza(Box::new(Stanza::Iq(Box::new(
+        ack,
+    ))))]
+}
+
+/// `<item-not-found/>` + `<unknown-session xmlns='urn:xmpp:jingle:errors:1'/>`
+/// per the XEP-0166 error table: the stanza references a `sid` with no
+/// live session (duplicate terminate, terminate glare, long-dead
+/// session). Deliberately NOT `<forbidden/>` (#1131) — nothing was
+/// torn down and repeating the request changes nothing.
+fn unknown_session_reply(original: &Iq) -> Vec<OutboundEvent> {
+    let mut error = StanzaError::new(
+        ErrorType::Cancel,
+        DefinedCondition::ItemNotFound,
+        "en",
+        "unknown Jingle session",
+    );
+    error.other = Some(crate::xep::xep0166::unknown_session_condition());
+    let err = Iq::Error {
+        from: original.to().cloned(),
+        to: original.from().cloned(),
+        id: original.id().to_string(),
+        error,
+        payload: None,
+    };
+    vec![OutboundEvent::SendStanza(Box::new(Stanza::Iq(Box::new(
+        err,
+    ))))]
 }
 
 fn error_reply(original: &Iq, cond: DefinedCondition, text: &str) -> Vec<OutboundEvent> {

--- a/server/crates/waddle-xmpp/src/xep/xep0166.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0166.rs
@@ -24,6 +24,20 @@ use std::collections::BTreeMap;
 
 pub const NS_JINGLE: &str = "urn:xmpp:jingle:1";
 
+/// XEP-0166 "Error Handling": namespace qualifying the Jingle-specific
+/// error condition elements (`<unknown-session/>`, `<out-of-order/>`,
+/// `<tie-break/>`, `<unsupported-info/>`).
+pub const NS_JINGLE_ERRORS: &str = "urn:xmpp:jingle:errors:1";
+
+/// Build the `<unknown-session xmlns='urn:xmpp:jingle:errors:1'/>`
+/// application-specific error condition. Per the XEP-0166 error table
+/// it accompanies the XMPP `<item-not-found/>` condition when a stanza
+/// references a `sid` unknown to the recipient (e.g. a
+/// session-terminate for a session that already ended).
+pub fn unknown_session_condition() -> minidom::Element {
+    minidom::Element::builder("unknown-session", NS_JINGLE_ERRORS).build()
+}
+
 /// Build a `<reason/>` element with no human-readable text.
 pub fn reason_element(reason: Reason) -> ReasonElement {
     ReasonElement {
@@ -90,6 +104,14 @@ mod tests {
             .find(|c| c.name() == "reason")
             .expect("<reason/> present");
         assert!(reason.children().any(|c| c.name() == "success"));
+    }
+
+    #[test]
+    fn unknown_session_condition_matches_xep_0166_error_table() {
+        let cond = unknown_session_condition();
+        assert_eq!(cond.name(), "unknown-session");
+        assert_eq!(cond.ns(), NS_JINGLE_ERRORS);
+        assert_eq!(NS_JINGLE_ERRORS, "urn:xmpp:jingle:errors:1");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/tests/xep0166_jingle.rs
+++ b/server/crates/waddle-xmpp/tests/xep0166_jingle.rs
@@ -1143,3 +1143,368 @@ fn xep_0166_session_terminate_typed_helper_round_trips() {
     let reason = reparsed.reason.expect("reason preserved");
     assert!(matches!(reason.reason, Reason::Cancel));
 }
+
+// ── #1131 survivor / unknown-session terminate ───────────────────────
+
+fn first_result_ack(events: &[OutboundEvent]) -> Option<&Iq> {
+    events.iter().find_map(|event| {
+        let OutboundEvent::SendStanza(stanza) = event else {
+            return None;
+        };
+        let Stanza::Iq(reply) = stanza.as_ref() else {
+            return None;
+        };
+        matches!(reply.as_ref(), Iq::Result { .. }).then_some(reply.as_ref())
+    })
+}
+
+fn first_stanza_error(
+    events: &[OutboundEvent],
+) -> Option<&xmpp_parsers::stanza_error::StanzaError> {
+    events.iter().find_map(|event| {
+        let OutboundEvent::SendStanza(stanza) = event else {
+            return None;
+        };
+        let Stanza::Iq(reply) = stanza.as_ref() else {
+            return None;
+        };
+        let Iq::Error { error, .. } = reply.as_ref() else {
+            return None;
+        };
+        Some(error)
+    })
+}
+
+#[test]
+fn xep_0166_survivor_terminate_after_peer_swept_acks_and_cleans_up() {
+    // #1131: Bob's client crashed; the LiveKit webhook (or the
+    // reconciler) already removed his registration. Alice's hangup
+    // must NOT be `<forbidden/>` — the server unregisters her,
+    // revokes her JTIs, and acks the terminate per XEP-0166 §6.7 on
+    // the departed peer's behalf.
+    let sfu = fixture_livekit_sfu();
+    let handler = JingleHandler::new(sfu.clone());
+    let alice: FullJid = "alice@waddle.test/desktop".parse().expect("valid JID");
+    let bob: FullJid = "bob@waddle.test/phone".parse().expect("valid JID");
+    let call = waddle_sfu::CallId::new("alice@waddle.test::dm-survivor").expect("valid call id");
+    let alice_identity = Identity::from_jid(alice.clone());
+    let bob_identity = Identity::from_jid(bob.clone());
+
+    let invite = dm_jingle_iq(
+        Action::SessionInitiate,
+        "alice@waddle.test/desktop",
+        "bob@waddle.test/phone",
+        "dm-survivor",
+    );
+    assert!(has_route_to(
+        &handler.handle(&invite, &ctx(&alice)),
+        "bob@waddle.test/phone"
+    ));
+    let accept = dm_jingle_iq(
+        Action::SessionAccept,
+        "bob@waddle.test/phone",
+        "alice@waddle.test/desktop",
+        "dm-survivor",
+    );
+    assert!(has_route_to(
+        &handler.handle(&accept, &ctx(&bob)),
+        "alice@waddle.test/desktop"
+    ));
+    // The accept minted Alice's join token; she now holds a live JTI.
+    assert_eq!(sfu.issued_count(&call, &alice_identity), 1);
+
+    // Peer crash: the webhook's registry cleanup removed Bob.
+    sfu.note_participant_left(&call, &bob_identity);
+    assert!(!sfu.has_call_participant(&call, &bob_identity));
+    assert!(sfu.has_call_participant(&call, &alice_identity));
+
+    // Survivor hangup.
+    let terminate = dm_jingle_iq(
+        Action::SessionTerminate,
+        "alice@waddle.test/desktop",
+        "bob@waddle.test/phone",
+        "dm-survivor",
+    );
+    let events = handler.handle(&terminate, &ctx(&alice));
+
+    assert_eq!(
+        first_error_condition(&events),
+        None,
+        "survivor terminate must not error (#1131): {events:?}"
+    );
+    let ack = first_result_ack(&events).expect("server must ack the survivor terminate");
+    assert_eq!(ack.id(), terminate.id(), "ack answers the terminate IQ");
+    assert!(
+        matches!(ack, Iq::Result { payload: None, .. }),
+        "XEP-0166 §6.7 termination ack is an EMPTY IQ result"
+    );
+    assert_eq!(
+        sfu.participant_count(&call),
+        0,
+        "survivor terminate must unregister the remaining party"
+    );
+    assert_eq!(
+        sfu.issued_count(&call, &alice_identity),
+        0,
+        "survivor terminate must revoke the survivor's JTIs"
+    );
+}
+
+#[test]
+fn xep_0166_unknown_session_terminate_returns_item_not_found_unknown_session() {
+    // #1131 / XEP-0166 error table: a terminate for a sid with no
+    // live session anywhere gets `<item-not-found/>` plus the
+    // application-specific `<unknown-session/>` — never
+    // `<forbidden/>`, and no state is touched (idempotent).
+    let sfu = fixture_livekit_sfu();
+    let handler = JingleHandler::new(sfu);
+    let alice: FullJid = "alice@waddle.test/desktop".parse().expect("valid JID");
+
+    let terminate = dm_jingle_iq(
+        Action::SessionTerminate,
+        "alice@waddle.test/desktop",
+        "bob@waddle.test/phone",
+        "dm-never-existed",
+    );
+    let events = handler.handle(&terminate, &ctx(&alice));
+
+    assert_eq!(
+        first_error_condition(&events),
+        Some(DefinedCondition::ItemNotFound),
+        "unknown session terminate must be item-not-found: {events:?}"
+    );
+    let error = first_stanza_error(&events).expect("stanza error present");
+    let unknown = error
+        .other
+        .as_ref()
+        .expect("application-specific condition present");
+    assert_eq!(unknown.name(), "unknown-session");
+    assert_eq!(unknown.ns(), "urn:xmpp:jingle:errors:1");
+}
+
+#[test]
+fn xep_0166_terminate_glare_second_terminate_is_not_forbidden() {
+    // #1131: both parties hang up at once. The first terminate tears
+    // the session down; the second must be answered with the
+    // idempotent unknown-session shape, not `<forbidden/>`.
+    let sfu = fixture_livekit_sfu();
+    let handler = JingleHandler::new(sfu.clone());
+    let alice: FullJid = "alice@waddle.test/desktop".parse().expect("valid JID");
+    let bob: FullJid = "bob@waddle.test/phone".parse().expect("valid JID");
+    let call = waddle_sfu::CallId::new("alice@waddle.test::dm-glare").expect("valid call id");
+
+    let invite = dm_jingle_iq(
+        Action::SessionInitiate,
+        "alice@waddle.test/desktop",
+        "bob@waddle.test/phone",
+        "dm-glare",
+    );
+    assert!(has_route_to(
+        &handler.handle(&invite, &ctx(&alice)),
+        "bob@waddle.test/phone"
+    ));
+
+    let alice_terminate = dm_jingle_iq(
+        Action::SessionTerminate,
+        "alice@waddle.test/desktop",
+        "bob@waddle.test/phone",
+        "dm-glare",
+    );
+    let first = handler.handle(&alice_terminate, &ctx(&alice));
+    assert!(
+        has_route_to(&first, "bob@waddle.test/phone"),
+        "live terminate forwards to the peer: {first:?}"
+    );
+    assert_eq!(sfu.participant_count(&call), 0);
+
+    let bob_terminate = dm_jingle_iq(
+        Action::SessionTerminate,
+        "bob@waddle.test/phone",
+        "alice@waddle.test/desktop",
+        "dm-glare",
+    );
+    let second = handler.handle(&bob_terminate, &ctx(&bob));
+    assert_ne!(
+        first_error_condition(&second),
+        Some(DefinedCondition::Forbidden),
+        "terminate glare must not be forbidden (#1131): {second:?}"
+    );
+    assert_eq!(
+        first_error_condition(&second),
+        Some(DefinedCondition::ItemNotFound),
+        "glare loser gets the idempotent unknown-session shape: {second:?}"
+    );
+    assert_eq!(
+        sfu.participant_count(&call),
+        0,
+        "no state change (idempotent)"
+    );
+}
+
+#[test]
+fn xep_0166_duplicate_terminate_is_idempotent() {
+    // #1131: a client retrying its own terminate (lost ack) must not
+    // see `<forbidden/>` on the retry.
+    let sfu = fixture_livekit_sfu();
+    let handler = JingleHandler::new(sfu.clone());
+    let alice: FullJid = "alice@waddle.test/desktop".parse().expect("valid JID");
+    let call = waddle_sfu::CallId::new("alice@waddle.test::dm-dup").expect("valid call id");
+
+    let invite = dm_jingle_iq(
+        Action::SessionInitiate,
+        "alice@waddle.test/desktop",
+        "bob@waddle.test/phone",
+        "dm-dup",
+    );
+    assert!(has_route_to(
+        &handler.handle(&invite, &ctx(&alice)),
+        "bob@waddle.test/phone"
+    ));
+
+    let terminate = dm_jingle_iq(
+        Action::SessionTerminate,
+        "alice@waddle.test/desktop",
+        "bob@waddle.test/phone",
+        "dm-dup",
+    );
+    let first = handler.handle(&terminate, &ctx(&alice));
+    assert!(has_route_to(&first, "bob@waddle.test/phone"));
+    assert_eq!(sfu.participant_count(&call), 0);
+
+    let retry = handler.handle(&terminate, &ctx(&alice));
+    assert_ne!(
+        first_error_condition(&retry),
+        Some(DefinedCondition::Forbidden),
+        "duplicate terminate must not be forbidden: {retry:?}"
+    );
+    assert_eq!(
+        first_error_condition(&retry),
+        Some(DefinedCondition::ItemNotFound),
+        "duplicate terminate resolves to unknown-session: {retry:?}"
+    );
+}
+
+// ── #1142 one JWT per negotiation stanza ─────────────────────────────
+
+fn video_content_with_waddle_transport() -> Content {
+    let mut content = Content::new(Creator::Initiator, ContentId("video".into()));
+    let description = Element::builder("description", NS_JINGLE_RTP)
+        .attr(minidom::rxml::xml_ncname!("media").to_owned(), "video")
+        .build();
+    content.description = Some(xmpp_parsers::jingle::Description::Rtp(
+        xmpp_parsers::jingle_rtp::Description::try_from(description).expect("rtp desc"),
+    ));
+    let transport = Element::builder("transport", NS_WADDLE_LIVEKIT_TRANSPORT).build();
+    content.transport = Some(Transport::Unknown(transport));
+    content
+}
+
+fn two_content_initiate(from: &str, to: &str, sid: &str) -> Iq {
+    let mut jingle = Jingle::new(Action::SessionInitiate, SessionId(sid.into()));
+    jingle.initiator = Some(from.parse().expect("valid initiator JID"));
+    jingle.contents.push(audio_content_with_waddle_transport());
+    jingle.contents.push(video_content_with_waddle_transport());
+    Iq::Set {
+        from: Some(from.parse().expect("valid from JID")),
+        to: Some(to.parse().expect("valid to JID")),
+        id: format!("jingle-{sid}"),
+        payload: jingle.into(),
+    }
+}
+
+fn forwarded_content_tokens(events: &[OutboundEvent]) -> Vec<String> {
+    use waddle_xmpp::xep::xep_waddle_livekit_transport::WaddleLiveKitTransport;
+    let forwarded = events
+        .iter()
+        .find_map(|event| {
+            let OutboundEvent::RouteToConnection { stanza, .. } = event else {
+                return None;
+            };
+            let Stanza::Iq(iq) = stanza.as_ref() else {
+                return None;
+            };
+            let Iq::Set { payload, .. } = iq.as_ref() else {
+                return None;
+            };
+            Jingle::try_from(payload.clone()).ok()
+        })
+        .expect("forwarded jingle stanza present");
+    forwarded
+        .contents
+        .iter()
+        .map(|content| {
+            let Some(Transport::Unknown(elem)) = &content.transport else {
+                panic!("content missing Waddle transport");
+            };
+            match WaddleLiveKitTransport::try_from(elem).expect("transport parses") {
+                WaddleLiveKitTransport::Issued(issued) => issued.token.as_str().to_string(),
+                WaddleLiveKitTransport::Request => panic!("server must issue the transport"),
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn xep_0166_multi_content_stanza_mints_one_shared_token() {
+    // #1142: an audio+video session-initiate must mint exactly ONE
+    // join token (one JTI) for the peer and stamp the same issued
+    // transport into every `<content/>` — per the LiveKit model of
+    // one identity/credential per participant.
+    let sfu = fixture_livekit_sfu();
+    let handler = JingleHandler::new(sfu.clone());
+    let alice: FullJid = "alice@waddle.test/desktop".parse().expect("valid JID");
+    let bob: FullJid = "bob@waddle.test/phone".parse().expect("valid JID");
+    let call = waddle_sfu::CallId::new("alice@waddle.test::dm-two-content").expect("call id");
+    let bob_identity = Identity::from_jid(bob);
+
+    let invite = two_content_initiate(
+        "alice@waddle.test/desktop",
+        "bob@waddle.test/phone",
+        "dm-two-content",
+    );
+    let events = handler.handle(&invite, &ctx(&alice));
+
+    let tokens = forwarded_content_tokens(&events);
+    assert_eq!(tokens.len(), 2, "both contents carry an issued transport");
+    assert_eq!(
+        tokens[0], tokens[1],
+        "audio and video contents must share ONE token (#1142)"
+    );
+    assert_eq!(
+        sfu.issued_count(&call, &bob_identity),
+        1,
+        "exactly one JTI minted per negotiation stanza"
+    );
+}
+
+#[test]
+fn xep_0166_multi_content_renegotiations_do_not_burn_jti_budget() {
+    // #1142: repeated two-content renegotiations of the same call
+    // must consume one JTI each, not one per content — otherwise the
+    // 16-slot per-participant FIFO evicts still-live JTIs which then
+    // can never be revoked on hangup.
+    let sfu = fixture_livekit_sfu();
+    let handler = JingleHandler::new(sfu.clone());
+    let alice: FullJid = "alice@waddle.test/desktop".parse().expect("valid JID");
+    let bob: FullJid = "bob@waddle.test/phone".parse().expect("valid JID");
+    let call = waddle_sfu::CallId::new("alice@waddle.test::dm-renegotiate").expect("call id");
+    let bob_identity = Identity::from_jid(bob);
+
+    for round in 1..=3usize {
+        let invite = two_content_initiate(
+            "alice@waddle.test/desktop",
+            "bob@waddle.test/phone",
+            "dm-renegotiate",
+        );
+        let events = handler.handle(&invite, &ctx(&alice));
+        assert!(
+            has_route_to(&events, "bob@waddle.test/phone"),
+            "renegotiation {round} forwards: {events:?}"
+        );
+        assert_eq!(
+            sfu.issued_count(&call, &bob_identity),
+            round,
+            "each two-content stanza mints exactly one JTI"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1127, #1128, #1129, #1130, #1131, #1140, #1142.

A bundle of seven independent SFU / 1:1-call reliability fixes (all in `waddle-sfu`, `jingle.rs`, `livekit_webhook.rs`, and the peer-routing path). Several compound each other, so they ship together.

## Fixes

**#1131 — survivor hangup no longer fails `<forbidden/>`.** `session-terminate` previously required *both* parties still registered, so when a peer's registration was gone (crash, webhook cleanup, reconciler) the survivor's hangup got `<forbidden/>`. Reworked into a 4-case handler per XEP-0166 §6.7/§10:
1. both parties registered → forward terminate to peer;
2. survivor terminate (peer's registration gone) → unregister the survivor, revoke JTIs, and ack with an empty `<iq type='result'/>`;
3. sender's pairing not among live calls → `<forbidden/>` (genuine third party);
4. no matching session at all → `<item-not-found/>` + `<unknown-session xmlns='urn:xmpp:jingle:errors:1'/>`, idempotent (touches no state).

**#1128 — 1:1 webhook cleanup no longer a no-op.** LiveKit `participant_left` early-returned when the room name didn't parse as a `BareJid`; scoped 1:1 call ids (`<initiator-bare>::<sid>`) deliberately don't, so a crashed 1:1 peer's registry entry + JTIs leaked until reconciliation. The MUC/`BareJid` Muji-presence path is preserved; non-BareJid ids now clean the SFU registry and revoke JTIs via `note_participant_left_by_call_id`.

**#1130 — forwarded call IQ to an offline peer no longer silently dropped.** A confirmed-offline full-JID request IQ (`get`/`set`) now returns a typed `cancel`/`<service-unavailable/>` to the original sender per RFC 6120 §8.5.3. Transient `GetUser`/actor failures are classified separately (`Dropped`, not `Unavailable`) so they are never misreported as a permanent error; IQ `result`/`error` and message/presence stanzas never bounce.

**#1127 — reconciler no longer mass-tears-down live calls on a LiveKit restart.** A participant is only swept after being observed absent from `ListParticipants` across `RECONCILE_ABSENT_PASSES` consecutive passes (`absent_streak`); the streak resets on a connected observation, a failed pass (absence unconfirmed), and (re-)registration.

**#1129 — `clear_local_state` no longer clobbers a concurrent joiner.** Room-entry removal is now gated on an atomic `emptied` outcome computed under the registry guard, so a `DeleteRoom` can never evict a participant who joined between the count read and the removal.

**#1142 — one join token per participant, not per `<content/>`.** `rewrite_contents_transport` mints a single LiveKit JWT and shares it across all contents, ending the per-content JTI burn against the per-participant FIFO budget.

**#1140 — join-token `nbf` backdated for clock skew.** Join tokens now backdate `nbf` by a shared `JWT_CLOCK_SKEW` (30s), matching the admin-token path, ending intermittent not-yet-valid rejections. Token lifetime (`iat`→`exp`) is unchanged.

## Tests

Dedicated Rust tests: `xep0166_jingle` suite (survivor/third-party/unknown-session terminate cases, `unknown-session` condition, one-JTI-per-stanza), `token.rs` (nbf backdate), `livekit.rs` (two-pass reconcile, concurrent-joiner clobber, JTI FIFO), the offline-peer IQ tests in `interpret/tests.rs` (offline → service-unavailable; result/error → no bounce), and the compound `participant_left` + survivor-terminate test tying #1128 to #1131. The #1016 regression guard (`dm_call_session_initiate_forwards_to_peer_not_feature_not_implemented`) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
