### PR TITLE
fix(server): MUC RoomFull join returns service-unavailable presence error (#1111)

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -519,8 +519,52 @@ async fn handle_muc_join_unlocked(
                         StanzaError::new(error_type, condition, "en", message),
                     )];
                 }
+                if matches!(
+                    &error,
+                    kameo::error::SendError::HandlerError(
+                        waddle_xmpp::muc::room_actor::RoomActorError::RoomFull
+                    )
+                ) {
+                    // XEP-0045 §7.2.9: the room has reached its maximum
+                    // number of occupants — deny access with a presence
+                    // error of type "wait" carrying <service-unavailable/>.
+                    // Returning an empty reply here left the client
+                    // stalled forever waiting for self-presence (#1111).
+                    warn!(
+                        room = %room_jid,
+                        nick = %nick,
+                        sender = %sender_jid,
+                        "MUC join refused: room is full"
+                    );
+                    return vec![build_muc_presence_error_xml(
+                        room_jid,
+                        &nick,
+                        sender_jid,
+                        StanzaError::new(
+                            ErrorType::Wait,
+                            DefinedCondition::ServiceUnavailable,
+                            "en",
+                            "The room has reached its maximum number of occupants.",
+                        ),
+                    )];
+                }
+                // Unreachable for the current JoinWithAffiliation error
+                // surface (every RoomActorError variant it returns has a
+                // typed arm above, and transport failures take the #1108
+                // retry path) — kept as a typed fail-safe so a future
+                // variant can never stall the client with an empty reply.
                 warn!(room = %room_jid, nick = %nick, error = ?error, "Failed to join MUC room");
-                return vec![];
+                return vec![build_muc_presence_error_xml(
+                    room_jid,
+                    &nick,
+                    sender_jid,
+                    StanzaError::new(
+                        ErrorType::Wait,
+                        DefinedCondition::InternalServerError,
+                        "en",
+                        "Failed to join the room; please retry.",
+                    ),
+                )];
             }
         };
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/xml.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/xml.rs
@@ -111,12 +111,16 @@ pub(super) fn build_muc_presence_error_xml(
     room_jid: &BareJid,
     nick: &str,
     to_jid: &FullJid,
-    error: StanzaError,
+    mut error: StanzaError,
 ) -> String {
     let from_jid = room_jid
         .clone()
         .with_resource_str(nick)
         .unwrap_or_else(|_| to_jid.clone());
+    // XEP-0045 §7.2 error examples stamp the room bare JID as the
+    // erroring entity (`<error by='room@service'>`); preserve an
+    // explicitly-set `by` should a caller ever provide one.
+    error.by.get_or_insert_with(|| room_jid.clone().into());
 
     element_to_xml(
         Element::builder("presence", waddle_xmpp::ns::JABBER_CLIENT)
@@ -129,6 +133,10 @@ pub(super) fn build_muc_presence_error_xml(
                 to_jid.to_string(),
             )
             .attr(minidom::rxml::xml_ncname!("type").to_owned(), "error")
+            // XEP-0045 §7.2: join-failure presence errors echo the
+            // `<x xmlns='http://jabber.org/protocol/muc'/>` element so
+            // clients can associate the error with the join request.
+            .append(Element::from(xmpp_parsers::muc::Muc::new()))
             .append(Element::from(error))
             .build(),
     )

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -233,12 +233,12 @@ async fn muc_join_full_room_returns_service_unavailable() {
     );
     assert!(
         error_presence
-            .get_child("x", "http://jabber.org/protocol/muc")
+            .get_child("x", xmpp_parsers::ns::MUC)
             .is_some(),
         "join-failure presence echoes <x xmlns='http://jabber.org/protocol/muc'/>: {responses:?}"
     );
     let error = error_presence
-        .get_child("error", "jabber:client")
+        .get_child("error", waddle_xmpp::parser::ns::JABBER_CLIENT)
         .expect("typed error element");
     assert_eq!(
         error.attr("type"),
@@ -252,7 +252,7 @@ async fn muc_join_full_room_returns_service_unavailable() {
     );
     assert!(
         error
-            .get_child("service-unavailable", "urn:ietf:params:xml:ns:xmpp-stanzas")
+            .get_child("service-unavailable", waddle_xmpp::parser::ns::STANZAS)
             .is_some(),
         "XEP-0045 §7.2.9 max-users refusal uses <service-unavailable/>: {responses:?}"
     );

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -163,6 +163,105 @@ async fn muc_join_under_second_nick_returns_not_acceptable() {
     assert_eq!(room.find_nick_by_real_jid(&sender_jid), Some("alice"));
 }
 
+/// #1111 / XEP-0045 §7.2.9: joining a room that has reached its maximum
+/// number of occupants returns `<presence type='error'>` with
+/// `<error type='wait'><service-unavailable/></error>` from the
+/// requested room-nick to the joiner — never an empty reply that
+/// leaves the client stalled waiting for self-presence.
+#[tokio::test]
+async fn muc_join_full_room_returns_service_unavailable() {
+    let state = create_test_websocket_state().await;
+    let alice_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let bob_session = create_test_session(state.as_ref(), "bob").await;
+    let room_jid: BareJid = "full-room@muc.example.com".parse().expect("room jid");
+    let alice: FullJid = "alice@example.com/web".parse().expect("alice jid");
+    let bob: FullJid = "bob@example.com/web".parse().expect("bob jid");
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice,
+        "alice",
+        None,
+        &Some(alice_session),
+    )
+    .await;
+
+    let room_actor = get_room_actor(state.as_ref(), &room_jid)
+        .await
+        .expect("room actor");
+    let mut config = room_actor
+        .ask(GetSnapshot)
+        .await
+        .expect("room snapshot")
+        .room
+        .config;
+    config.max_occupants = 1;
+    room_actor
+        .ask(UpdateConfig { config })
+        .await
+        .expect("room config update");
+
+    let responses = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &bob,
+        "bob",
+        None,
+        &Some(bob_session),
+    )
+    .await;
+    assert_eq!(
+        responses.len(),
+        1,
+        "exactly one error presence (never an empty reply): {responses:?}"
+    );
+    let error_presence = Element::from_str(&responses[0]).expect("error presence xml");
+    assert_eq!(error_presence.name(), "presence");
+    assert_eq!(error_presence.attr("type"), Some("error"));
+    assert_eq!(
+        error_presence.attr("from"),
+        Some(format!("{room_jid}/bob").as_str()),
+        "XEP-0045 §7.2.9: the error comes from the requested room-nick: {responses:?}"
+    );
+    assert_eq!(
+        error_presence.attr("to"),
+        Some(bob.to_string().as_str()),
+        "the error is addressed to the joining full JID: {responses:?}"
+    );
+    assert!(
+        error_presence
+            .get_child("x", "http://jabber.org/protocol/muc")
+            .is_some(),
+        "join-failure presence echoes <x xmlns='http://jabber.org/protocol/muc'/>: {responses:?}"
+    );
+    let error = error_presence
+        .get_child("error", "jabber:client")
+        .expect("typed error element");
+    assert_eq!(
+        error.attr("type"),
+        Some("wait"),
+        "XEP-0045 §7.2.9 max-users refusal uses error type='wait': {responses:?}"
+    );
+    assert_eq!(
+        error.attr("by"),
+        Some(room_jid.to_string().as_str()),
+        "the erroring entity is the room bare JID: {responses:?}"
+    );
+    assert!(
+        error
+            .get_child("service-unavailable", "urn:ietf:params:xml:ns:xmpp-stanzas")
+            .is_some(),
+        "XEP-0045 §7.2.9 max-users refusal uses <service-unavailable/>: {responses:?}"
+    );
+
+    let room = snapshot_room(state.as_ref(), &room_jid).await.room;
+    assert_eq!(room.occupant_count(), 1, "the full room admits no one");
+    assert_eq!(room.find_nick_by_real_jid(&bob), None);
+}
+
 /// #1134 / XEP-0045 §10.1.1: only the room creator receives Owner. The
 /// second user to join an unmanaged room must not be granted Owner —
 /// the created-bit comes from the registry, not from call-site


### PR DESCRIPTION
Fixes #1111.

## Problem

A MUC join that failed because the room had reached its maximum occupant count (`RoomActorError::RoomFull`) fell through to the catch-all `warn!(...); return vec![]` in the presence-join handler. The joining client received **no stanza at all** and stalled forever waiting for self-presence.

## Fix

- Add a typed `RoomFull` arm returning a presence error per **XEP-0045 §7.2.9**: `<presence type='error'>` from the requested room-nick to the joiner, carrying `<error type='wait'><service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/></error>`.
- Harden the remaining catch-all: instead of an empty reply it now returns a typed `internal-server-error` (type='wait') presence error, so no future `RoomActorError` variant can ever silently stall a client again.
- `build_muc_presence_error_xml` now stamps the room bare JID as the erroring entity (`<error by='room@service'>`) and echoes the `<x xmlns='http://jabber.org/protocol/muc'/>` element, matching the XEP-0045 §7.2 error examples.

All XML is built with typed `minidom`/`xmpp_parsers` builders — no `format!`.

## Tests

`muc_join_full_room_returns_service_unavailable` (waddle-server): sets `max_occupants = 1`, admits one occupant, then asserts the second join yields exactly one presence error with `type='error'`, `from=room/nick`, `to=joiner`, the `<x/>` MUC child, `error type='wait'`, `by=room`, and `<service-unavailable/>` — and that the full room admits no one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
