### PR TITLE
fix(chat): server-restart reconnect corrupts chat state until refresh — side-effect-free MAM catch-up re-emission + dedup scan fix

### DIFF
--- a/chat/src/channels/inbox.ts
+++ b/chat/src/channels/inbox.ts
@@ -164,7 +164,9 @@ export function useChannelInbox(
     const startRevision = localMutationRevision;
     try {
       const inbox = await client.fetchInbox();
-      if (requestId !== hydrateRequestId || client !== xmppClient.value) return false;
+      // Superseded is success, not failure — see the DM-side twin in
+      // `dms/conversations.ts` for the retry-churn rationale.
+      if (requestId !== hydrateRequestId || client !== xmppClient.value) return true;
 
       let next = applyEntries(createInboxState(), inbox.conversations);
       next = applyReadClearBarriers(next);

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -90,6 +90,12 @@ export function useChannelMessages(
   const activeChannels = ref<Set<string>>(new Set());
   const mentionedChannelCounts = ref<Record<string, number>>({});
   const lastMentionActivity = ref<RoomActivityEvent | null>(null);
+  // Stanza-ids whose mention has been counted, insertion-ordered for FIFO
+  // eviction. Bounds memory across long sessions; the cap only needs to
+  // outlast the window in which a live copy and its MAM catch-up
+  // re-emission can both arrive.
+  const recordedMentionStanzaIds = new Set<string>();
+  const RECORDED_MENTION_STANZA_IDS_CAP = 512;
   const pendingNotificationActivities = ref<RoomActivityEvent[]>([]);
   const roomAvatarHashes = ref<Record<string, string>>({});
   const roomJidOverrides = ref<Record<string, string>>({});
@@ -219,10 +225,6 @@ export function useChannelMessages(
         // it depends on cross-room session state and the tab-visibility
         // signal, both of which are out of scope for live-merge.
         if (classified.kind !== "live") return;
-        // Archive decodes (MAM catch-up re-emissions for the focused room)
-        // merge into the timeline above but never notify — see
-        // `recordRoomActivity` for the rationale.
-        if (msg.createdAtSource === "archive") return;
         if (msg.nick !== session.value?.username && isTabHidden()) {
           const isMentioned =
             !!msg.broadcastMention ||
@@ -235,8 +237,12 @@ export function useChannelMessages(
           if (msg.stanzaId) activity.stanzaId = msg.stanzaId;
           if (msg.mentions) activity.mentions = msg.mentions;
           if (msg.broadcastMention) activity.broadcastMention = msg.broadcastMention;
-          enqueueNotificationActivity(activity);
-          if (isMentioned) {
+          if (msg.createdAtSource === "archive") activity.fromArchive = true;
+          // Same policy as `recordRoomActivity`: archive decodes (MAM
+          // catch-up re-emissions) never notify, but a genuinely-missed
+          // mention still records — idempotent by stanza-id.
+          if (!activity.fromArchive) enqueueNotificationActivity(activity);
+          if (isMentioned && shouldRecordMentionOnce(activity)) {
             recordMentionActivity(activity);
             lastMentionActivity.value = activity;
           }
@@ -651,6 +657,7 @@ export function useChannelMessages(
     mentionedChannelCounts.value = {};
     lastMentionActivity.value = null;
     pendingNotificationActivities.value = [];
+    recordedMentionStanzaIds.clear();
   }
 
   function isOwnMentionActivity(event: RoomActivityEvent): boolean {
@@ -674,18 +681,40 @@ export function useChannelMessages(
   function recordRoomActivity(event: RoomActivityEvent) {
     const roomJid = barePeerJid(event.roomJid);
     activeChannels.value = new Set([...activeChannels.value, roomJid]);
-    // MAM catch-up re-emissions may duplicate messages already seen (and
-    // counted) live before a reconnect — they never notify or bump
-    // mention badges; the server inbox hydrate accounts genuinely-missed
-    // messages authoritatively.
-    if (event.fromArchive) return;
-    if (event.nick !== session.value?.username && isTabHidden()) {
+    // MAM catch-up re-emissions never notify: a replayed banner for a
+    // message the user may already have seen is spam, and the push
+    // pipeline covers the disconnected window.
+    if (!event.fromArchive && event.nick !== session.value?.username && isTabHidden()) {
       enqueueNotificationActivity(event);
     }
-    if (isOwnMentionActivity(event)) {
+    // Mentions DO record from catch-up — the server inbox tracks unread
+    // only, not mentions, so a mention missed while disconnected has no
+    // other path to the badge. Idempotent by XEP-0359 stanza-id (identical
+    // on the live and archive copies of a message), so a catch-up
+    // re-emission of an already-recorded mention cannot inflate the count.
+    if (isOwnMentionActivity(event) && shouldRecordMentionOnce(event)) {
       recordMentionActivity(event);
       lastMentionActivity.value = event;
     }
+  }
+
+  /**
+   * Stanza-id-keyed idempotency for mention accounting. Events without a
+   * stanza-id cannot be deduplicated: live ones record (a conformant
+   * server stamps every archived message, so an unstamped stanza has no
+   * archive copy to collide with), archive ones skip (their live twin may
+   * already have recorded, and a missed count is recoverable while an
+   * inflated one is not).
+   */
+  function shouldRecordMentionOnce(event: RoomActivityEvent): boolean {
+    if (!event.stanzaId) return !event.fromArchive;
+    if (recordedMentionStanzaIds.has(event.stanzaId)) return false;
+    recordedMentionStanzaIds.add(event.stanzaId);
+    if (recordedMentionStanzaIds.size > RECORDED_MENTION_STANZA_IDS_CAP) {
+      const oldest = recordedMentionStanzaIds.values().next().value;
+      if (oldest !== undefined) recordedMentionStanzaIds.delete(oldest);
+    }
+    return true;
   }
 
   function isTabHidden(): boolean {

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -197,6 +197,7 @@ export function useChannelMessages(
             ...(msg.stanzaId ? { stanzaId: msg.stanzaId } : {}),
             ...(msg.mentions ? { mentions: msg.mentions } : {}),
             ...(msg.broadcastMention ? { broadcastMention: msg.broadcastMention } : {}),
+            ...(msg.createdAtSource === "archive" ? { fromArchive: true } : {}),
           });
           return;
         }
@@ -218,6 +219,10 @@ export function useChannelMessages(
         // it depends on cross-room session state and the tab-visibility
         // signal, both of which are out of scope for live-merge.
         if (classified.kind !== "live") return;
+        // Archive decodes (MAM catch-up re-emissions for the focused room)
+        // merge into the timeline above but never notify — see
+        // `recordRoomActivity` for the rationale.
+        if (msg.createdAtSource === "archive") return;
         if (msg.nick !== session.value?.username && isTabHidden()) {
           const isMentioned =
             !!msg.broadcastMention ||
@@ -669,6 +674,11 @@ export function useChannelMessages(
   function recordRoomActivity(event: RoomActivityEvent) {
     const roomJid = barePeerJid(event.roomJid);
     activeChannels.value = new Set([...activeChannels.value, roomJid]);
+    // MAM catch-up re-emissions may duplicate messages already seen (and
+    // counted) live before a reconnect — they never notify or bump
+    // mention badges; the server inbox hydrate accounts genuinely-missed
+    // messages authoritatively.
+    if (event.fromArchive) return;
     if (event.nick !== session.value?.username && isTabHidden()) {
       enqueueNotificationActivity(event);
     }

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -7,6 +7,7 @@ import {
   bareJidKey,
   barePeerJid,
   type CatchupConversationFailure,
+  type LiveRoomMessage,
   type RoomActivityEvent,
   type SessionLifecycleEvent,
   type RoomAuthority,
@@ -246,12 +247,14 @@ export function useChannelMessages(
             recordMentionActivity(activity);
             lastMentionActivity.value = activity;
           }
-        } else if (isMentioned && msg.stanzaId) {
+        } else if (isMentioned && msg.stanzaId && isFeedVisibleRoomMessage(msg)) {
           // Rendered in the open channel with the tab visible: the
           // mention is SEEN, not missed. Account it without recording so
           // a later re-emission of the same stanza (catch-up page, or
           // the activity route after a room switch) cannot badge a
-          // message the user already read.
+          // message the user already read. Thread replies are excluded —
+          // the feed hides them (mirroring the `isFeedVisible` read-marker
+          // policy), so on-screen never meant seen for those.
           accountMentionStanzaId(msg.stanzaId);
         }
       });
@@ -703,6 +706,12 @@ export function useChannelMessages(
       recordMentionActivity(event);
       lastMentionActivity.value = event;
     }
+  }
+
+  /** `isFeedTimelineMessage` for the raw live shape: thread replies are
+   * hidden from the feed, so being in the open channel never showed them. */
+  function isFeedVisibleRoomMessage(msg: LiveRoomMessage): boolean {
+    return !msg.threadId || msg.id === msg.threadId || !!msg.callThread;
   }
 
   /**

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -225,10 +225,10 @@ export function useChannelMessages(
         // it depends on cross-room session state and the tab-visibility
         // signal, both of which are out of scope for live-merge.
         if (classified.kind !== "live") return;
+        const isMentioned =
+          !!msg.broadcastMention ||
+          msg.mentions?.some(isSessionMention);
         if (msg.nick !== session.value?.username && isTabHidden()) {
-          const isMentioned =
-            !!msg.broadcastMention ||
-            msg.mentions?.some(isSessionMention);
           const activity: RoomActivityEvent = {
             roomJid: msg.roomJid,
             nick: msg.nick,
@@ -246,6 +246,13 @@ export function useChannelMessages(
             recordMentionActivity(activity);
             lastMentionActivity.value = activity;
           }
+        } else if (isMentioned && msg.stanzaId) {
+          // Rendered in the open channel with the tab visible: the
+          // mention is SEEN, not missed. Account it without recording so
+          // a later re-emission of the same stanza (catch-up page, or
+          // the activity route after a room switch) cannot badge a
+          // message the user already read.
+          accountMentionStanzaId(msg.stanzaId);
         }
       });
       client.setChatStateHandler((event) => {
@@ -699,22 +706,31 @@ export function useChannelMessages(
   }
 
   /**
-   * Stanza-id-keyed idempotency for mention accounting. Events without a
-   * stanza-id cannot be deduplicated: live ones record (a conformant
-   * server stamps every archived message, so an unstamped stanza has no
-   * archive copy to collide with), archive ones skip (their live twin may
-   * already have recorded, and a missed count is recoverable while an
-   * inflated one is not).
+   * Marks a mention's stanza-id as accounted (badge recorded OR read on
+   * screen). Returns false when it was already accounted, so a MAM
+   * catch-up re-emission of the same message can never badge twice.
    */
-  function shouldRecordMentionOnce(event: RoomActivityEvent): boolean {
-    if (!event.stanzaId) return !event.fromArchive;
-    if (recordedMentionStanzaIds.has(event.stanzaId)) return false;
-    recordedMentionStanzaIds.add(event.stanzaId);
+  function accountMentionStanzaId(stanzaId: string): boolean {
+    if (recordedMentionStanzaIds.has(stanzaId)) return false;
+    recordedMentionStanzaIds.add(stanzaId);
     if (recordedMentionStanzaIds.size > RECORDED_MENTION_STANZA_IDS_CAP) {
       const oldest = recordedMentionStanzaIds.values().next().value;
       if (oldest !== undefined) recordedMentionStanzaIds.delete(oldest);
     }
     return true;
+  }
+
+  /**
+   * Stanza-id-keyed idempotency for mention accounting. Events without a
+   * stanza-id cannot be deduplicated: live ones record (a conformant
+   * server stamps every archived message, so an unstamped stanza has no
+   * archive copy to collide with), archive ones skip (their live twin may
+   * already have been seen, and a missed count is recoverable while an
+   * inflated one is not).
+   */
+  function shouldRecordMentionOnce(event: RoomActivityEvent): boolean {
+    if (!event.stanzaId) return !event.fromArchive;
+    return accountMentionStanzaId(event.stanzaId);
   }
 
   function isTabHidden(): boolean {

--- a/chat/src/dms/conversations.ts
+++ b/chat/src/dms/conversations.ts
@@ -320,8 +320,14 @@ export function useDirectMessageConversations(
     const existing = ensureConversation(bare);
     const isSelfMessage = barePeerJid(msg.fromJid) === selfBareJid.value;
     const isActiveConversation = activePeerJid.value === bare;
+    // Archive-decoded arrivals are MAM catch-up re-emissions: the message
+    // may already have been counted live before a reconnect, and
+    // genuinely-missed messages are accounted by the server inbox
+    // (hydrateFromInbox runs on every session-ready). Only live arrivals
+    // increment locally.
     const shouldIncrementUnread = !isSelfMessage
       && !isActiveConversation
+      && msg.createdAtSource !== "archive"
       && !wasUnreadAccountedByInbox(bare, msg);
 
     conversations.value = sortByRecent(conversations.value.map((c) => (

--- a/chat/src/dms/conversations.ts
+++ b/chat/src/dms/conversations.ts
@@ -262,11 +262,14 @@ export function useDirectMessageConversations(
     );
     try {
       const inbox = await currentClient.fetchInbox();
+      // Superseded is success, not failure: a newer hydrate (or session)
+      // owns the inbox now — reporting `false` would make retry chains
+      // re-fetch and supersede each other in a loop.
       if (
         requestId !== inboxRequestId
         || currentClient !== xmppClient.value
         || currentSessionJid !== (session.value?.jid ?? null)
-      ) return false;
+      ) return true;
 
       const directConversations = inbox.conversations.filter((conversation) => conversation.kind === "direct");
       mergeInboxConversations(directConversations);

--- a/chat/src/dms/conversations.ts
+++ b/chat/src/dms/conversations.ts
@@ -330,19 +330,22 @@ export function useDirectMessageConversations(
       && msg.createdAtSource !== "archive"
       && !wasUnreadAccountedByInbox(bare, msg);
 
-    conversations.value = sortByRecent(conversations.value.map((c) => (
-      c.peerJid === bare
-        ? {
-            ...c,
-            peerUsername: existing.peerUsername || peerUsername(bare),
-            lastMessageBody: msg.body,
-            lastMessageAt: msg.createdAt,
-            unreadCount: shouldIncrementUnread ? c.unreadCount + 1 : c.unreadCount,
-            presenceShow: presenceByJid.value[bare] ?? c.presenceShow,
-            presenceIdleSince: presenceIdleByJid.value[bare] ?? c.presenceIdleSince,
-          }
-        : c
-    )));
+    conversations.value = sortByRecent(conversations.value.map((c) => {
+      if (c.peerJid !== bare) return c;
+      // Monotonic preview: an archive re-emission of an OLDER message
+      // (MAM catch-up after a reconnect) must not roll the preview or the
+      // recency ordering back behind a newer live arrival.
+      const isNewestMessage =
+        conversationTimestamp(msg.createdAt) >= conversationTimestamp(c.lastMessageAt);
+      return {
+        ...c,
+        peerUsername: existing.peerUsername || peerUsername(bare),
+        ...(isNewestMessage ? { lastMessageBody: msg.body, lastMessageAt: msg.createdAt } : {}),
+        unreadCount: shouldIncrementUnread ? c.unreadCount + 1 : c.unreadCount,
+        presenceShow: presenceByJid.value[bare] ?? c.presenceShow,
+        presenceIdleSince: presenceIdleByJid.value[bare] ?? c.presenceIdleSince,
+      };
+    }));
   }
 
   function updatePresence(event: PresenceUpdateEvent) {

--- a/chat/src/lib/message-ids.ts
+++ b/chat/src/lib/message-ids.ts
@@ -56,18 +56,25 @@ export function findMessageIndexById<T extends MessageIdCarrier>(
   if (!normalized) return -1;
 
   let aliasIndex = -1;
+  let aliasAmbiguous = false;
   for (let i = 0; i < messages.length; i++) {
     const message = messages[i]!;
     if (predicate && !predicate(message)) continue;
+    // Primary ids win over alias ambiguity, so the scan must complete
+    // before the ambiguity verdict: bailing out on the second alias
+    // claimant would hide a later row whose PRIMARY id matches (e.g. a
+    // redelivered copy reconciling into its own row while two other rows
+    // share the candidate as a reused origin-id alias) — the caller would
+    // then append a duplicate instead of merging.
     if (message.id === normalized) return i;
     if (!message.wireIds?.includes(normalized)) continue;
     if (aliasIndex < 0) {
       aliasIndex = i;
       continue;
     }
-    if (messages[aliasIndex]!.id !== message.id) return -1;
+    if (messages[aliasIndex]!.id !== message.id) aliasAmbiguous = true;
   }
-  return aliasIndex;
+  return aliasAmbiguous ? -1 : aliasIndex;
 }
 
 export function findMessageById<T extends MessageIdCarrier>(

--- a/chat/src/lib/xmpp/client-mam.ts
+++ b/chat/src/lib/xmpp/client-mam.ts
@@ -53,6 +53,7 @@ export function roomActivityEventFromMessage(message: LiveRoomMessage): RoomActi
   if (message.stanzaId) activity.stanzaId = message.stanzaId;
   if (message.mentions) activity.mentions = message.mentions;
   if (message.broadcastMention) activity.broadcastMention = message.broadcastMention;
+  if (message.createdAtSource === "archive") activity.fromArchive = true;
   return activity;
 }
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -2459,6 +2459,10 @@ export class BrowserXmppClient {
     if (message.is_muc) {
       const converted = roomMessageFromArchived({ ...message, mam_id: message.id ?? crypto.randomUUID() } as WasmArchivedMessage, "live", { trustedMediaOrigin: this.trustedLinkPreviewMediaOrigin() });
       if (!converted) return;
+      // Deliberately no archive-cursor advance here: a live stanza-id
+      // cannot prove delivery continuity (MUC gap during a kick/rejoin,
+      // SM replay-window eviction), so catch-up re-fetches from the last
+      // archive-CONFIRMED cursor and filters via `seenIds` instead.
       this.catchup.recordRoomSeen(converted.roomJid, converted.createdAt, undefined, rawMessageSeenIds(message));
       if (converted.roomJid !== this.currentRoom && isRoomActivityMessage(converted)) { this.events.emit("activity", roomActivityEventFromMessage(converted)); return; }
       this.events.emit("message", converted); return;

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -501,4 +501,9 @@ export interface RoomActivityEvent {
   mentions?: string[];
   /** XEP-0513 */
   broadcastMention?: "everyone" | "here";
+  /** True when the event is a MAM catch-up re-emission (XEP-0313 archive
+   * decode) rather than a live arrival. Notification/unread accounting
+   * must skip these — the message may already have been seen and counted
+   * live, and the server inbox is the authority for offline unread. */
+  fromArchive?: boolean;
 }

--- a/chat/src/shell/controllers/use-connection-lifecycle.ts
+++ b/chat/src/shell/controllers/use-connection-lifecycle.ts
@@ -55,6 +55,8 @@ interface ConnectionLifecycleDeps {
   activeRightPanel: Ref<ActiveRightPanel | null>;
   selectedChannelRoomJids: Ref<Record<string, string>>;
   isActiveDirectDmSurface: () => boolean;
+  /** Backoff between inbox-hydrate retries; injectable for tests. */
+  inboxHydrateRetryDelaysMs?: number[];
   presence: ReturnType<typeof usePresenceSync>;
   notificationOrchestration: ReturnType<typeof useNotificationOrchestration>;
   routeSync: ReturnType<typeof useRouteSync>;
@@ -117,9 +119,25 @@ export function useConnectionLifecycle(deps: ConnectionLifecycleDeps) {
   // resources only — a detached session misses them (e.g. cross-device
   // mark-read while detached), so the local unread map can be stale
   // after any resume.
+  // With catch-up re-emissions no longer bumping unread locally, the
+  // inbox hydrate is the sole unread source for messages missed while
+  // disconnected — a single failed IQ on a still-flaky reconnect link
+  // must not leave badges stuck at zero until the next session.
+  const inboxHydrateRetryDelaysMs = deps.inboxHydrateRetryDelaysMs ?? [2_000, 8_000];
+  function hydrateInboxWithRetry(hydrate: () => Promise<boolean>) {
+    void (async () => {
+      if (await hydrate()) return;
+      for (const delayMs of inboxHydrateRetryDelaysMs) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+        if (!connectionStore.session) return;
+        if (await hydrate()) return;
+      }
+    })();
+  }
+
   function runSessionBootstrap(client: BrowserXmppClient, lifecycle: "fresh" | "resumed") {
-    void dmConversations.hydrateFromInbox();
-    void channelUnread.hydrateFromInbox();
+    hydrateInboxWithRetry(() => dmConversations.hydrateFromInbox());
+    hydrateInboxWithRetry(() => channelUnread.hydrateFromInbox());
     void socialFeed.refresh();
     void stories.refresh();
     void communityEvents.refresh();

--- a/chat/src/shell/controllers/use-connection-lifecycle.ts
+++ b/chat/src/shell/controllers/use-connection-lifecycle.ts
@@ -125,11 +125,16 @@ export function useConnectionLifecycle(deps: ConnectionLifecycleDeps) {
   // must not leave badges stuck at zero until the next session.
   const inboxHydrateRetryDelaysMs = deps.inboxHydrateRetryDelaysMs ?? [2_000, 8_000];
   function hydrateInboxWithRetry(hydrate: () => Promise<boolean>) {
+    // Bound the chain to the session that started it: after a
+    // logout→re-login inside the backoff window the new session runs its
+    // own bootstrap — a stale chain firing into it would supersede that
+    // hydrate and burn its retry budget.
+    const ownerJid = connectionStore.session?.jid ?? null;
     void (async () => {
       if (await hydrate()) return;
       for (const delayMs of inboxHydrateRetryDelaysMs) {
         await new Promise((resolve) => setTimeout(resolve, delayMs));
-        if (!connectionStore.session) return;
+        if ((connectionStore.session?.jid ?? null) !== ownerJid || !connectionStore.session) return;
         if (await hydrate()) return;
       }
     })();

--- a/chat/src/shell/controllers/use-notification-orchestration.ts
+++ b/chat/src/shell/controllers/use-notification-orchestration.ts
@@ -83,6 +83,10 @@ export function useNotificationOrchestration(deps: NotificationOrchestrationDeps
   /** Inbound DM surfaced by the connection layer — show a banner/sound
    * unless the user is looking at that conversation right now. */
   function notifyDmActivity(msg: LiveDmMessage): void {
+    // MAM catch-up re-emissions (archive decodes) never notify: the
+    // message may already have been shown live before a reconnect, and
+    // replaying a banner/sound per re-fetched row spams the user.
+    if (msg.createdAtSource === "archive") return;
     showForegroundNotificationForDmActivity(msg, {
       notifySettings,
       notifications,

--- a/chat/tests/channel-activity.test.ts
+++ b/chat/tests/channel-activity.test.ts
@@ -90,6 +90,103 @@ describe("channel activity", () => {
     }
   });
 
+  test("catch-up re-emissions record missed mentions exactly once and never notify", async () => {
+    let onActivity: ((event: RoomActivityEvent) => void) | null = null;
+    const actionError = ref("");
+    const scope = effectScope();
+    let cleanupDocument: (() => void) | null = null;
+
+    try {
+      cleanupDocument = installHiddenDocument();
+      const messaging = scope.run(() =>
+        useChannelMessages(
+          ref(session()),
+          ref({
+            ...handlerStubs(),
+            setActivityHandler(handler: (event: RoomActivityEvent) => void) {
+              onActivity = handler;
+            },
+          } as never),
+          ref("team"),
+          ref("general"),
+          ref({ id: "general", name: "General", jid: "general@conference.example.com" }),
+          String,
+          actionError,
+          () => {
+            actionError.value = "";
+          },
+        )
+      );
+      if (!messaging) throw new Error("channel messages composable did not initialize");
+      await nextTick();
+
+      const missedMention: RoomActivityEvent = {
+        roomJid: "random@conference.example.com",
+        nick: "bob",
+        body: "missed @alice",
+        mentions: ["xmpp:alice@example.com"],
+        stanzaId: "sid-missed",
+        fromArchive: true,
+      };
+      // A mention missed while disconnected has no other path to the
+      // badge (the server inbox tracks unread only) — it must record.
+      onActivity?.(missedMention);
+      expect(messaging.mentionedChannelCounts.value).toEqual({
+        "random@conference.example.com": 1,
+      });
+      // ...but a replayed banner is spam: archive decodes never notify.
+      expect(messaging.pendingNotificationActivities.value).toHaveLength(0);
+
+      // A second re-emission of the same stanza-id cannot inflate.
+      onActivity?.(missedMention);
+      expect(messaging.mentionedChannelCounts.value).toEqual({
+        "random@conference.example.com": 1,
+      });
+
+      // Live-then-archive: the live copy records (and notifies), the
+      // catch-up twin sharing the stanza-id dedupes.
+      onActivity?.({
+        roomJid: "random@conference.example.com",
+        nick: "bob",
+        body: "live @alice",
+        mentions: ["xmpp:alice@example.com"],
+        stanzaId: "sid-live",
+      });
+      expect(messaging.mentionedChannelCounts.value).toEqual({
+        "random@conference.example.com": 2,
+      });
+      expect(messaging.pendingNotificationActivities.value).toHaveLength(1);
+      onActivity?.({
+        roomJid: "random@conference.example.com",
+        nick: "bob",
+        body: "live @alice",
+        mentions: ["xmpp:alice@example.com"],
+        stanzaId: "sid-live",
+        fromArchive: true,
+      });
+      expect(messaging.mentionedChannelCounts.value).toEqual({
+        "random@conference.example.com": 2,
+      });
+      expect(messaging.pendingNotificationActivities.value).toHaveLength(1);
+
+      // An unstamped archive row cannot be deduplicated against its live
+      // twin — it must not risk inflating the count.
+      onActivity?.({
+        roomJid: "random@conference.example.com",
+        nick: "bob",
+        body: "unstamped @alice",
+        mentions: ["xmpp:alice@example.com"],
+        fromArchive: true,
+      });
+      expect(messaging.mentionedChannelCounts.value).toEqual({
+        "random@conference.example.com": 2,
+      });
+    } finally {
+      cleanupDocument?.();
+      scope.stop();
+    }
+  });
+
   test("counts current-room hidden personal mentions by bare JID, not localpart", async () => {
     let onMessage: ((message: LiveRoomMessage) => void) | null = null;
     const actionError = ref("");

--- a/chat/tests/channel-activity.test.ts
+++ b/chat/tests/channel-activity.test.ts
@@ -247,6 +247,93 @@ describe("channel activity", () => {
     }
   });
 
+  test("archive re-emissions never re-badge a mention seen live with the tab visible", async () => {
+    let onMessage: ((message: LiveRoomMessage) => void) | null = null;
+    let onActivity: ((event: RoomActivityEvent) => void) | null = null;
+    const actionError = ref("");
+    const scope = effectScope();
+    let cleanupDocument: (() => void) | null = null;
+
+    try {
+      const messaging = scope.run(() =>
+        useChannelMessages(
+          ref(session()),
+          ref({
+            ...handlerStubs(),
+            setMessageHandler(handler: (message: LiveRoomMessage) => void) {
+              onMessage = handler;
+            },
+            setActivityHandler(handler: (event: RoomActivityEvent) => void) {
+              onActivity = handler;
+            },
+          } as never),
+          ref("team"),
+          ref("general"),
+          ref({ id: "general", name: "General", jid: "general@conference.example.com" }),
+          String,
+          actionError,
+          () => {
+            actionError.value = "";
+          },
+        )
+      );
+      if (!messaging) throw new Error("channel messages composable did not initialize");
+      await nextTick();
+
+      // Tab visible: the mention renders in the open channel — seen, no
+      // badge, but it must be ACCOUNTED for later re-emissions.
+      onMessage?.(roomMessage({
+        id: "m-seen",
+        body: "hi @alice",
+        mentions: ["xmpp:alice@example.com"],
+        stanzaId: "sid-seen",
+      }));
+      expect(messaging.mentionedChannelCounts.value).toEqual({});
+
+      cleanupDocument = installHiddenDocument();
+
+      // Catch-up re-emission of the SAME stanza after a server restart,
+      // tab now hidden — via the focused-room route...
+      onMessage?.(roomMessage({
+        id: "m-seen",
+        body: "hi @alice",
+        mentions: ["xmpp:alice@example.com"],
+        stanzaId: "sid-seen",
+        createdAtSource: "archive",
+      }));
+      expect(messaging.mentionedChannelCounts.value).toEqual({});
+      expect(messaging.pendingNotificationActivities.value).toHaveLength(0);
+
+      // ...and via the activity route (user switched rooms meanwhile).
+      onActivity?.({
+        roomJid: "general@conference.example.com",
+        nick: "bob",
+        body: "hi @alice",
+        mentions: ["xmpp:alice@example.com"],
+        stanzaId: "sid-seen",
+        fromArchive: true,
+      });
+      expect(messaging.mentionedChannelCounts.value).toEqual({});
+
+      // A genuinely-missed focused-room mention (archive-only, never seen
+      // live) still records exactly once, without a banner.
+      onMessage?.(roomMessage({
+        id: "m-missed",
+        body: "missed @alice",
+        mentions: ["xmpp:alice@example.com"],
+        stanzaId: "sid-missed",
+        createdAtSource: "archive",
+      }));
+      expect(messaging.mentionedChannelCounts.value).toEqual({
+        "general@conference.example.com": 1,
+      });
+      expect(messaging.pendingNotificationActivities.value).toHaveLength(0);
+    } finally {
+      scope.stop();
+      cleanupDocument?.();
+    }
+  });
+
   test("records current-room hidden plain messages as foreground notification candidates", async () => {
     let onMessage: ((message: LiveRoomMessage) => void) | null = null;
     const actionError = ref("");

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -2843,6 +2843,10 @@ describe("room activity adapter", () => {
         nick: "bob",
         body: "missed hello alice",
         mentions: ["alice@example.com"],
+        // Catch-up re-emissions are flagged so unread/mention/notification
+        // accounting stays idempotent (the server inbox accounts
+        // genuinely-missed messages authoritatively).
+        fromArchive: true,
       },
     ]);
   });

--- a/chat/tests/dm-conversations.test.ts
+++ b/chat/tests/dm-conversations.test.ts
@@ -325,6 +325,23 @@ describe("useDirectMessageConversations", () => {
     expect(composable.conversations.value[0].lastMessageBody).toBe("hello again");
   });
 
+  test("an archive re-emission of an older message does not roll the preview back", () => {
+    const { composable } = makeComposable();
+    composable.receiveIncomingDm(makeDmMessage({
+      id: "msg-new",
+      body: "newest live",
+      createdAt: "2026-01-02T00:00:10Z",
+    }));
+    composable.receiveIncomingDm(makeDmMessage({
+      id: "msg-old-archive-copy",
+      body: "older archive copy",
+      createdAt: "2026-01-02T00:00:00Z",
+      createdAtSource: "archive",
+    }));
+    expect(composable.conversations.value[0].lastMessageBody).toBe("newest live");
+    expect(composable.conversations.value[0].lastMessageAt).toBe("2026-01-02T00:00:10Z");
+  });
+
   test("openDm does not auto-mark-read on its own", async () => {
     // Auto-mark-read responsibility lives in useChatReadReceipts (gated on
     // viewport + window focus); openDm only sets the active peer.

--- a/chat/tests/dm-conversations.test.ts
+++ b/chat/tests/dm-conversations.test.ts
@@ -306,6 +306,25 @@ describe("useDirectMessageConversations", () => {
     expect(composable.conversations.value[0].unreadCount).toBe(0);
   });
 
+  test("receiveIncomingDm does not increment unread for archive-decoded catch-up re-emissions", () => {
+    // MAM reconnect catch-up re-emits archive rows through the same
+    // directMessage event; a message already counted live before the
+    // reconnect must not be counted a second time. Genuinely-missed
+    // messages are accounted by the server inbox hydrate instead.
+    const { composable } = makeComposable();
+    composable.receiveIncomingDm(makeDmMessage({ createdAt: "2026-01-02T00:00:00Z" }));
+    expect(composable.conversations.value[0].unreadCount).toBe(1);
+    composable.receiveIncomingDm(makeDmMessage({
+      id: "msg-1-archive-copy",
+      body: "hello again",
+      createdAt: "2026-01-02T00:00:01Z",
+      createdAtSource: "archive",
+    }));
+    expect(composable.conversations.value[0].unreadCount).toBe(1);
+    // Preview/ordering still converge on the re-emitted content.
+    expect(composable.conversations.value[0].lastMessageBody).toBe("hello again");
+  });
+
   test("openDm does not auto-mark-read on its own", async () => {
     // Auto-mark-read responsibility lives in useChatReadReceipts (gated on
     // viewport + window focus); openDm only sets the active peer.

--- a/chat/tests/message-ids.test.ts
+++ b/chat/tests/message-ids.test.ts
@@ -34,6 +34,23 @@ describe("message id aliasing", () => {
     expect(findMessageIndexById(messages, null)).toBe(-1);
   });
 
+  test("a later primary-id match wins over earlier alias ambiguity", () => {
+    // Two rows share a reused origin-id alias; a third row's PRIMARY id is
+    // the lookup candidate. The scan must reach the primary match instead
+    // of short-circuiting to the ambiguity sentinel — otherwise a
+    // redelivered copy of "c" (e.g. MAM catch-up after a server restart)
+    // fails to reconcile and appends a duplicate row.
+    const messages: Message[] = [
+      { id: "a", wireIds: ["c"], body: "first-claimer" },
+      { id: "b", wireIds: ["c"], body: "second-claimer" },
+      { id: "c", body: "primary-owner" },
+    ];
+    expect(findMessageIndexById(messages, "c")).toBe(2);
+    expect(findMessageById(messages, "c")?.body).toBe("primary-owner");
+    // Without a primary owner the alias stays ambiguous.
+    expect(findMessageIndexById(messages.slice(0, 2), "c")).toBe(-1);
+  });
+
   test("findMessageIndexById predicate narrows candidates without losing collision safety", () => {
     const messages = [
       { id: "remote-1", wireIds: ["origin"], body: "remote", isSelf: false },

--- a/chat/tests/reconnect-catchup-cursor.test.ts
+++ b/chat/tests/reconnect-catchup-cursor.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Gap-safety of the reconnect catch-up cursor: live arrivals must NOT
+ * advance the archive `after` cursor, even though they carry the
+ * XEP-0359 stanza-id that is the XEP-0313 archive UID. A live stanza-id
+ * cannot prove delivery continuity (a message can be missed while later
+ * live messages still arrive — MUC gap during a kick/rejoin, XEP-0198
+ * replay-window eviction), so catch-up re-fetches from the last
+ * archive-CONFIRMED cursor and filters already-seen ids via `seenIds`.
+ * The re-emitted archive rows are side-effect-free (see the
+ * `fromArchive` flag below) so the re-fetch cannot corrupt unread or
+ * notification state.
+ */
+import { describe, expect, test } from "bun:test";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { BrowserXmppClient, type LiveRoomMessage } from "../src/lib/xmpp-client";
+import { roomActivityEventFromMessage } from "../src/lib/xmpp/client-mam";
+import type { ReconnectCatchup } from "../src/lib/xmpp/reconnect-catchup";
+
+type PrivateState = {
+  catchup: ReconnectCatchup;
+  dispatchLiveBodyMessage: (message: unknown) => void;
+};
+
+function session(jid: string): WaddleSession {
+  return {
+    username: jid.split("@")[0],
+    jid,
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/ws",
+  } as WaddleSession;
+}
+
+function clientState(jid: string): PrivateState {
+  return new BrowserXmppClient(session(jid)) as unknown as PrivateState;
+}
+
+describe("reconnect catch-up cursor gap-safety", () => {
+  test("a live room stanza-id does not advance the archive `after` cursor", () => {
+    const state = clientState("cursor-room@example.com/desktop");
+    expect(state.catchup.onSessionStarted()).toEqual([]);
+    state.catchup.recordRoomSeen(
+      "general@conference.example.com",
+      "2026-06-01T09:00:00.000Z",
+      "archive-confirmed-1",
+    );
+
+    state.dispatchLiveBodyMessage({
+      id: "wire-1",
+      from: "general@conference.example.com/bob",
+      to: "cursor-room@example.com/desktop",
+      message_type: "groupchat",
+      body: "hello room",
+      timestamp: "2026-06-01T10:00:00.000Z",
+      stanza_ids: [{ id: "room-arch-42", by: "general@conference.example.com" }],
+      reaction_emojis: [],
+      is_muc: true,
+      markup_spans: [],
+      mention_uris: [],
+      references: [],
+      is_sticker: false,
+      shared_files: [],
+    });
+
+    const entries = state.catchup.onSessionStarted();
+    expect(entries).toHaveLength(1);
+    // The cursor stays at the archive-confirmed point; the live message's
+    // ids join `seenIds` so its re-fetch is filtered, not re-emitted.
+    expect(entries[0]).toMatchObject({
+      kind: "room",
+      key: "general@conference.example.com",
+      after: "archive-confirmed-1",
+    });
+    expect((entries[0] as { seenIds?: string[] }).seenIds).toContain("room-arch-42");
+  });
+
+  test("a live-only room keeps the timestamp fallback (no fabricated archive cursor)", () => {
+    const state = clientState("cursor-fallback@example.com/desktop");
+    expect(state.catchup.onSessionStarted()).toEqual([]);
+
+    state.dispatchLiveBodyMessage({
+      id: "wire-3",
+      from: "general@conference.example.com/bob",
+      to: "cursor-fallback@example.com/desktop",
+      message_type: "groupchat",
+      body: "seen live only",
+      timestamp: "2026-06-01T12:00:00.000Z",
+      stanza_ids: [{ id: "room-arch-7", by: "general@conference.example.com" }],
+      reaction_emojis: [],
+      is_muc: true,
+      markup_spans: [],
+      mention_uris: [],
+      references: [],
+      is_sticker: false,
+      shared_files: [],
+    });
+
+    const entries = state.catchup.onSessionStarted();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      kind: "room",
+      key: "general@conference.example.com",
+      since: "2026-06-01T12:00:00.000Z",
+    });
+    expect(entries[0]).not.toHaveProperty("after");
+  });
+});
+
+describe("archive-sourced activity flag", () => {
+  const base: LiveRoomMessage = {
+    id: "m-1",
+    roomJid: "general@conference.example.com",
+    nick: "bob",
+    body: "hi",
+    createdAt: "2026-06-01T10:00:00.000Z",
+    createdAtSource: "archive",
+    type: "message",
+  };
+
+  test("roomActivityEventFromMessage marks archive decodes", () => {
+    expect(roomActivityEventFromMessage(base).fromArchive).toBe(true);
+  });
+
+  test("live decodes carry no archive flag", () => {
+    const live = { ...base, createdAtSource: "delay" as const };
+    expect(roomActivityEventFromMessage(live).fromArchive).toBeUndefined();
+  });
+});

--- a/chat/tests/session-bootstrap-choreography.test.ts
+++ b/chat/tests/session-bootstrap-choreography.test.ts
@@ -54,7 +54,11 @@ afterAll(() => {
   else delete (globalThis as Record<string, unknown>).window;
 });
 
-function makeHarness() {
+function makeHarness(options: {
+  inboxHydrateRetryDelaysMs?: number[];
+  dmInbox?: () => Promise<boolean>;
+  channelInbox?: () => Promise<boolean>;
+} = {}) {
   let lifecycleHandler: ((event: SessionLifecycleEvent) => void) | null = null;
   const client = {
     ...handlerStubs(),
@@ -89,8 +93,8 @@ function makeHarness() {
     bootstrap: async () => {},
   });
 
-  const hydrateDmInbox = mock(async () => {});
-  const hydrateChannelInbox = mock(async () => {});
+  const hydrateDmInbox = mock(options.dmInbox ?? (async () => true));
+  const hydrateChannelInbox = mock(options.channelInbox ?? (async () => true));
   const refreshSocialFeed = mock(async () => {});
   const refreshStories = mock(async () => {});
   const refreshCommunityEvents = mock(async () => {});
@@ -168,6 +172,7 @@ function makeHarness() {
     activeRightPanel: ref(null),
     selectedChannelRoomJids: ref({}),
     isActiveDirectDmSurface: () => false,
+    inboxHydrateRetryDelaysMs: options.inboxHydrateRetryDelaysMs ?? [],
     presence: {
       onClientCleared: mock(() => {}),
       handlePresenceUpdate: mock(() => {}),
@@ -302,6 +307,46 @@ describe("session bootstrap choreography (#754)", () => {
       communityEvents: 2,
       notifySettings: 2,
     });
+    h.scope.stop();
+  });
+
+  test("a failed inbox hydrate retries with backoff until it succeeds", async () => {
+    // With MAM catch-up re-emissions now side-effect-free, the inbox
+    // hydrate is the sole unread source for messages missed while
+    // disconnected — a single failed IQ must not strand badges at zero
+    // until the next session-ready.
+    let dmAttempts = 0;
+    const h = makeHarness({
+      inboxHydrateRetryDelaysMs: [0, 0],
+      dmInbox: async () => {
+        dmAttempts += 1;
+        return dmAttempts >= 2;
+      },
+    });
+    await nextTick();
+
+    h.dispatchLifecycle(freshEvent);
+    await flushAsync();
+
+    // Succeeds on the second attempt; the remaining delay is not consumed.
+    expect(h.counts().dmInbox).toBe(2);
+    // The channel hydrate succeeded immediately — no retries.
+    expect(h.counts().channelInbox).toBe(1);
+    h.scope.stop();
+  });
+
+  test("a persistently failing inbox hydrate gives up after the configured retries", async () => {
+    const h = makeHarness({
+      inboxHydrateRetryDelaysMs: [0],
+      dmInbox: async () => false,
+    });
+    await nextTick();
+
+    h.dispatchLifecycle(freshEvent);
+    await flushAsync();
+
+    // Initial attempt + exactly one retry.
+    expect(h.counts().dmInbox).toBe(2);
     h.scope.stop();
   });
 });

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=8e87e9ea4e64";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=8e87e9ea4e64";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=8e87e9ea4e64";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=0b8f635e8d15";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=0b8f635e8d15";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=0b8f635e8d15";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=8e87e9ea4e64";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=0b8f635e8d15";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=0b8f635e8d15";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=0b8f635e8d15";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=0b8f635e8d15";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=8e87e9ea4e64";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=8e87e9ea4e64";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=8e87e9ea4e64";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=0b8f635e8d15";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=8e87e9ea4e64";


### PR DESCRIPTION
## Problem

When the server restarts, the open chat tab degrades — duplicate messages in the timeline, inflated DM unread badges, inflated mention counts, churned conversation previews, replayed notification banners — until the tab is hard-refreshed.

## Diagnosis

A server restart fails XEP-0198 resumption, so the client runs the fresh-session path: MUC rejoins plus XEP-0313 reconnect catch-up. By design, catch-up re-fetches from the last **archive-confirmed** cursor (live arrivals deliberately do not advance it — a live stanza-id cannot prove delivery continuity: MUC gap during a kick/rejoin, XEP-0198 replay-window eviction) and filters already-seen ids via a capped `seenIds` set. After a restart the re-fetch window can span hours, so a large slice of **already-displayed history is re-emitted through the live event pipeline**.

Timeline id-dedup absorbs most re-emissions (the server preserves `@id` through MUC reflection and archives, stamps identical XEP-0359 stanza-ids on live and archive copies, and dedups re-sent unacked messages by origin-id), but the side-effect layers corrupted state:

1. `findMessageIndexById` could return the ambiguous-alias sentinel (−1) **before completing the primary-id scan** — a redelivered copy whose own row sat after two alias-sharing rows appended a duplicate instead of reconciling (`chat/src/lib/message-ids.ts`).
2. DM conversation accounting has no id-dedup: every re-emitted DM bumped `unreadCount`, rewrote previews (including rolling them back to older messages), and fired foreground banners (`dms/conversations.ts`, `use-notification-orchestration.ts`).
3. Room activity from catch-up re-inflated `mentionedChannelCounts` and enqueued notification banners (`channels/messages.ts`).

A tab refresh heals everything because it rebuilds wholesale from MAM + the server inbox without re-emission.

## Fix

**Catch-up re-emission is now side-effect-free where server truth covers the state, and idempotent where it doesn't** — converging on the same state a refresh produces:

- `RoomActivityEvent` gains `fromArchive` (set for `createdAtSource === "archive"` decodes). Archive decodes never enqueue notification banners or foreground DM banners (replays are spam; the push pipeline covers the disconnected window) and never bump DM `unreadCount` (the server inbox hydrate is the authority and runs on every session-ready).
- **Mentions are the exception**: the server inbox tracks unread only, so a mention delivered solely via catch-up has no other path to the badge. Mention recording is now idempotent by XEP-0359 stanza-id (identical on the live and archive copies, FIFO-capped set): genuinely-missed mentions still badge, re-emissions cannot inflate, and a mention **seen live in the open channel with the tab visible** is accounted as seen so its catch-up twin cannot badge later (thread replies excluded — the feed hides them, so on-screen never meant seen).
- With re-emissions no longer bumping unread locally, a single failed `fetchInbox` IQ would strand badges at zero; the session bootstrap now retries inbox hydrates with bounded backoff. Retry chains are bound to the session that started them, and a superseded hydrate reports success (a newer owner exists) so overlapping chains cannot cancel each other's successful fetches.
- DM conversation previews are monotonic: an archive re-emission of an older message cannot roll the preview/recency ordering back behind a newer live arrival.
- `findMessageIndexById` completes the primary-id scan before declaring alias ambiguity, so redelivered copies always reconcile into their own row.

**Explicitly rejected alternative:** advancing the catch-up cursor with the live XEP-0359 stanza-id (the XEP-0313 §5.1 archive UID). An existing regression test proved that converts duplicate-risk into message loss when a message is missed while later live messages still arrive. A new test (`chat/tests/reconnect-catchup-cursor.test.ts`) now encodes that gap-safety property.

## Review

Four adversarial review rounds (XMPP semantics, reconnect state-machine, and two delta verifiers) ran over the branch; every real finding was fixed in a follow-up commit (missed-mention badge loss → stanza-id idempotency; unretried inbox hydrate → bounded retry; false badge for mentions seen with the tab visible → seen-accounting; retry-chain mutual cancellation → superseded-is-success; stale chain firing into the next session → session-bound chains; thread-reply mentions wrongly accounted as seen → feed-visibility guard).

**Documented follow-ups (pre-existing or explicitly traded off, not regressions):**
- Catch-up re-emissions re-light the channel-list activity dot (`activeChannels`) for fully-read channels; `activeChannels` doubles as a channelId→roomJid discovery mechanism in `TopicsPanel.vue`, so the fix is a role split, not a gate.
- A budget-less superseding hydrate (markRead recovery, service-worker push) that itself fails can stop a bootstrap retry chain whose successful fetch was discarded — badges stay stale until the next SW push/session-ready. Proper fix: single-flight/coalesced `hydrateFromInbox` that returns the joined outcome.
- The mention-idempotency set is in-memory while catch-up cursors persist, so seen-accounting does not survive a page reload (pre-existing behavior for recording, too).

## Validation

- `cd chat && bun test` — 3288 pass, 0 fail (new tests: cursor gap-safety, archive-flag propagation, ambiguity-scan primary-id win, DM archive-unread skip, preview monotonicity, mention idempotency incl. live↔archive and seen-live↔activity-route dedup, focused-room archive route, inbox hydrate retry/give-up).
- `bun run lint` (knip) clean; `astro check` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
