### PR TITLE
fix(chat): dedup reconnect MUC joins + bound MAM catch-up (#1221)

### DIFF
--- a/chat/src/lib/xmpp/client-mam.ts
+++ b/chat/src/lib/xmpp/client-mam.ts
@@ -580,12 +580,27 @@ export class MamPager {
     let pageParam: MamPageParam = { type: "latest" };
     const seenBefore = new Set<string>();
     const pages: WasmMamPage[] = [];
+    // Apply the pages collected so far, oldest-first. Called on normal
+    // completion and, on budget exhaustion, BEFORE the throw — so a
+    // resumed session (whose fallback reload is fresh-only) still gets
+    // the most-recent pages it fetched, matching the forward loop which
+    // applies incrementally (#1221).
+    const applyCollected = () => {
+      const selfBare = this.selfBare();
+      for (const page of [...pages].reverse()) {
+        this.applyDmCatchupPage(page, since, seenIds, { applyCallEvents: false, stats });
+      }
+      for (const page of [...pages].reverse()) {
+        this.applyDmCallEventsFromMamPage(page, selfBare, { since, seenIds });
+      }
+    };
     while (true) {
       const page = await xmpp.fetch_dm_history_page?.(peerJid, 100, pageParam);
       if (!this.deps.isCurrentConnected(xmpp, sessionJid)) return;
       if (page) pages.push(page);
       if (isMamPageComplete(page) || pageCrossesSince(page, since)) break;
       if (pages.length >= RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION) {
+        applyCollected();
         throw new Error(`Reconnect catch-up exceeded ${RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION} pages for ${peerJid}`);
       }
       const firstArchiveId = pageFirstArchiveId(page);
@@ -594,13 +609,7 @@ export class MamPager {
       seenBefore.add(firstArchiveId);
       pageParam = { type: "before", before: firstArchiveId };
     }
-    const selfBare = this.selfBare();
-    for (const page of [...pages].reverse()) {
-      this.applyDmCatchupPage(page, since, seenIds, { applyCallEvents: false, stats });
-    }
-    for (const page of [...pages].reverse()) {
-      this.applyDmCallEventsFromMamPage(page, selfBare, { since, seenIds });
-    }
+    applyCollected();
   }
 
   private async runRoomTimestampCatchup(
@@ -614,12 +623,21 @@ export class MamPager {
     let pageParam: MamPageParam = { type: "latest" };
     const seenBefore = new Set<string>();
     const pages: WasmMamPage[] = [];
+    // Apply the pages collected so far, oldest-first — on normal
+    // completion and, on budget exhaustion, BEFORE the throw so a resumed
+    // session still gets the most-recent pages it fetched (#1221).
+    const applyCollected = () => {
+      for (const page of [...pages].reverse()) {
+        this.applyRoomCatchupPage(page, since, seenIds, stats);
+      }
+    };
     while (true) {
       const page = await xmpp.fetch_room_history_page?.(roomJid, 100, pageParam);
       if (!this.deps.isCurrentConnected(xmpp, sessionJid)) return;
       if (page) pages.push(page);
       if (isMamPageComplete(page) || pageCrossesSince(page, since)) break;
       if (pages.length >= RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION) {
+        applyCollected();
         throw new Error(`Reconnect catch-up exceeded ${RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION} pages for ${roomJid}`);
       }
       const firstArchiveId = pageFirstArchiveId(page);
@@ -628,9 +646,7 @@ export class MamPager {
       seenBefore.add(firstArchiveId);
       pageParam = { type: "before", before: firstArchiveId };
     }
-    for (const page of [...pages].reverse()) {
-      this.applyRoomCatchupPage(page, since, seenIds, stats);
-    }
+    applyCollected();
   }
 
   private applyDmCatchupPage(

--- a/chat/src/lib/xmpp/client-mam.ts
+++ b/chat/src/lib/xmpp/client-mam.ts
@@ -32,6 +32,14 @@ import type { WasmArchivedMessage, WasmMamPage, WasmMessage } from "./wasm-types
 const DM_CALL_ACTIVITY_PAGE_SIZE = 100;
 const DM_CALL_ACTIVITY_MAX_PAGES = 50;
 
+// #1221: cap reconnect catch-up paging per conversation (≤500 msgs at
+// 100/page). Unbounded paging of a large room archive on every fresh
+// reconnect overflowed the SM queue during the prod join storm. On
+// exhaustion the loop throws into the per-conversation `catchupFailure`
+// fallback (bounded wholesale reload); older history lazy-loads via the
+// normal MAM pagination.
+const RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION = 5;
+
 export type DmCallActivityHydrationOptions = { since?: string; pageSize?: number; maxPages?: number };
 
 type CatchupRunStats = { pages: number; messages: number };
@@ -485,9 +493,13 @@ export class MamPager {
     if (entry.after) {
       let after: string | undefined = entry.after;
       const seenAfter = new Set<string>();
+      let pageCount = 0;
       while (after) {
         if (seenAfter.has(after)) throw new Error(`Reconnect catch-up repeated archive cursor for ${entry.key}`);
         seenAfter.add(after);
+        if (pageCount >= RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION) {
+          throw new Error(`Reconnect catch-up exceeded ${RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION} pages for ${entry.key}`);
+        }
         let page: WasmMamPage | null | undefined;
         try {
           page = await xmpp.fetch_dm_history_page(entry.key, 100, { type: "after", after });
@@ -499,6 +511,7 @@ export class MamPager {
           }
           throw error;
         }
+        pageCount += 1;
         if (!this.deps.isCurrentConnected(xmpp, sessionJid)) return;
         if (pageContainsArchiveId(page, after)) throw new Error(`Reconnect catch-up received non-advancing archive cursor for ${entry.key}`);
         const nextAfter = this.applyDmCatchupPage(page, undefined, entry.seenIds, { stats });
@@ -523,9 +536,13 @@ export class MamPager {
     if (entry.after) {
       let after: string | undefined = entry.after;
       const seenAfter = new Set<string>();
+      let pageCount = 0;
       while (after) {
         if (seenAfter.has(after)) throw new Error(`Reconnect catch-up repeated archive cursor for ${entry.key}`);
         seenAfter.add(after);
+        if (pageCount >= RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION) {
+          throw new Error(`Reconnect catch-up exceeded ${RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION} pages for ${entry.key}`);
+        }
         let page: WasmMamPage | null | undefined;
         try {
           page = await xmpp.fetch_room_history_page(entry.key, 100, { type: "after", after });
@@ -537,6 +554,7 @@ export class MamPager {
           }
           throw error;
         }
+        pageCount += 1;
         if (!this.deps.isCurrentConnected(xmpp, sessionJid)) return;
         if (pageContainsArchiveId(page, after)) throw new Error(`Reconnect catch-up received non-advancing archive cursor for ${entry.key}`);
         const nextAfter = this.applyRoomCatchupPage(page, undefined, entry.seenIds, stats);
@@ -567,6 +585,9 @@ export class MamPager {
       if (!this.deps.isCurrentConnected(xmpp, sessionJid)) return;
       if (page) pages.push(page);
       if (isMamPageComplete(page) || pageCrossesSince(page, since)) break;
+      if (pages.length >= RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION) {
+        throw new Error(`Reconnect catch-up exceeded ${RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION} pages for ${peerJid}`);
+      }
       const firstArchiveId = pageFirstArchiveId(page);
       if (!firstArchiveId) throw new Error(`Reconnect catch-up could not page backward for ${peerJid}`);
       if (seenBefore.has(firstArchiveId)) throw new Error(`Reconnect catch-up repeated backward archive cursor for ${peerJid}`);
@@ -598,6 +619,9 @@ export class MamPager {
       if (!this.deps.isCurrentConnected(xmpp, sessionJid)) return;
       if (page) pages.push(page);
       if (isMamPageComplete(page) || pageCrossesSince(page, since)) break;
+      if (pages.length >= RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION) {
+        throw new Error(`Reconnect catch-up exceeded ${RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION} pages for ${roomJid}`);
+      }
       const firstArchiveId = pageFirstArchiveId(page);
       if (!firstArchiveId) throw new Error(`Reconnect catch-up could not page backward for ${roomJid}`);
       if (seenBefore.has(firstArchiveId)) throw new Error(`Reconnect catch-up repeated backward archive cursor for ${roomJid}`);

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -405,6 +405,11 @@ export class BrowserXmppClient {
   private readonly joinedMucReady = new Set<string>();
   private retainedJoinedRoomJids = new Set<string>();
   private autoJoinRoomJids: ReadonlyArray<string> = [];
+  // Self-presence-confirmed (XEP-0045 status 110) room keys captured at
+  // the last disconnect. A `resumed` session-ready re-seeds the join
+  // trackers from this without sending presence — MUC occupancy survives
+  // the SM detach-for-resume server-side (#1221). Cleared on logout.
+  private resumedSessionRoomKeys = new Set<string>();
   // Canonical room keys `fanOutAutoJoin` has attempted this session epoch
   // (#1221). Bounds each room to one auto-join attempt per epoch — a
   // failed join (e.g. 15s self-presence timeout) is not retried by a
@@ -641,6 +646,22 @@ export class BrowserXmppClient {
     }
     this.joinedMucReady.add(key);
     this.rememberJoinedRoom(roomJid);
+  }
+
+  /**
+   * Restore MUC join state after an SM resume without touching the wire
+   * (#1221). Occupancy survived the detach-for-resume server-side, so we
+   * mark each snapshotted room ready (resolved join, no presence sent)
+   * and record it as attempted so a concurrent `discoverTopology`
+   * fan-out does not re-send a join either.
+   */
+  private reseedResumedRooms(): void {
+    for (const key of this.resumedSessionRoomKeys) {
+      if (!key) continue;
+      if (!this.joinedMucs.has(key)) this.joinedMucs.set(key, Promise.resolve());
+      this.joinedMucReady.add(key);
+      this.autoJoinAttemptedRoomKeys.add(key);
+    }
   }
 
   private handleMucPresenceError(presence: WasmPresence): boolean {
@@ -1012,6 +1033,7 @@ export class BrowserXmppClient {
     this.joinedMucJoinTokens.clear();
     this.joinedMucReady.clear();
     this.autoJoinAttemptedRoomKeys.clear();
+    this.resumedSessionRoomKeys.clear();
     clearDmCallJoinCacheForAccount(this.session.jid);
     clearDmCallActivities();
     clearMucCallParticipants();
@@ -2163,11 +2185,21 @@ export class BrowserXmppClient {
       // xmpp reference so the bootstrap aborts cleanly if the client
       // disconnects before the catch-up IQ resolves.
       void this.bootstrapMdsDisplayed(xmpp);
-    }
-    const roomsToJoin = new Set([...this.retainedJoinedRoomJids, ...this.autoJoinRoomJids]);
-    if (this.currentRoom) roomsToJoin.add(this.currentRoom);
-    if (roomsToJoin.size > 0) {
-      void this.fanOutAutoJoin([...roomsToJoin]);
+      // A fresh bind lost server-side MUC occupancy, so re-send join
+      // presence for every retained/autojoin room + the focused room.
+      // Single-flight per epoch (`fanOutAutoJoin`) keeps this to one
+      // join per room across the three fan-out triggers (#1221).
+      const roomsToJoin = new Set([...this.retainedJoinedRoomJids, ...this.autoJoinRoomJids]);
+      if (this.currentRoom) roomsToJoin.add(this.currentRoom);
+      if (roomsToJoin.size > 0) {
+        void this.fanOutAutoJoin([...roomsToJoin]);
+      }
+    } else {
+      // Resumed: occupancy survived the SM detach-for-resume server-side
+      // (no MUC leave was broadcast), so DO NOT re-send join presence.
+      // Re-seed the trackers from the disconnect snapshot so roomIsReady
+      // and the queued-send flush treat the rooms as joined (#1221).
+      this.reseedResumedRooms();
     }
     // #1180: consume the catch-up cursors BEFORE emitting the
     // lifecycle event so the fresh event can report which
@@ -2334,6 +2366,10 @@ export class BrowserXmppClient {
   private handleDisconnected(xmpp: XmppClientInstance, error?: Error) {
     if (this.xmpp !== xmpp) return;
     const previouslyJoinedRooms = [...this.joinedMucs.keys()];
+    // Snapshot the self-presence-confirmed (status 110) rooms before the
+    // trackers clear so a subsequent `resumed` session-ready can restore
+    // readiness without re-sending join presence (#1221).
+    this.resumedSessionRoomKeys = new Set(this.joinedMucReady);
     this.connected = false; this.stopSelfPing(); this.xmpp = null;
     // The wire is gone — no point trying to send session-terminate.
     // Clear the local call slot so the UI doesn't strand on a stale

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -627,25 +627,14 @@ export class BrowserXmppClient {
     return roomJid.split("/")[0]?.trim().toLowerCase() ?? "";
   }
 
-  private canonicalJoinedRoomJid(roomJid: string): string {
-    const key = this.roomJoinKey(roomJid);
-    if (!key) return roomJid;
-    if (this.currentRoom && this.roomJoinKey(this.currentRoom) === key) {
-      return this.currentRoom;
-    }
-    for (const joinedRoom of this.joinedMucs.keys()) {
-      if (this.roomJoinKey(joinedRoom) === key) return joinedRoom;
-    }
-    return roomJid;
-  }
-
   private markMucReadyFromSelfPresence(roomJid: string): void {
-    const room = this.canonicalJoinedRoomJid(roomJid);
-    if (!this.joinedMucs.has(room)) {
-      this.joinedMucs.set(room, Promise.resolve());
+    const key = this.roomJoinKey(roomJid);
+    if (!key) return;
+    if (!this.joinedMucs.has(key)) {
+      this.joinedMucs.set(key, Promise.resolve());
     }
-    this.joinedMucReady.add(room);
-    this.rememberJoinedRoom(room);
+    this.joinedMucReady.add(key);
+    this.rememberJoinedRoom(roomJid);
   }
 
   private handleMucPresenceError(presence: WasmPresence): boolean {
@@ -660,24 +649,18 @@ export class BrowserXmppClient {
     if (errorNick !== waiter.requestedNick) return false;
 
     waiter?.reject(new Error("Channel presence was rejected. Try again in a moment."));
-    this.revokeMucReadiness(this.canonicalJoinedRoomJid(room), { keepPendingJoin: true });
+    this.revokeMucReadiness(room, { keepPendingJoin: true });
     return true;
   }
 
   private revokeMucReadiness(roomJid: string, options: { keepPendingJoin?: boolean } = {}): void {
-    const normalized = roomJid.trim().toLowerCase();
+    const key = this.roomJoinKey(roomJid);
+    if (!key) return;
     if (!options.keepPendingJoin) {
-      this.joinedMucs.delete(roomJid);
-      this.joinedMucJoinTokens.delete(roomJid);
+      this.joinedMucs.delete(key);
+      this.joinedMucJoinTokens.delete(key);
     }
-    this.joinedMucReady.delete(roomJid);
-    if (normalized && normalized !== roomJid) {
-      if (!options.keepPendingJoin) {
-        this.joinedMucs.delete(normalized);
-        this.joinedMucJoinTokens.delete(normalized);
-      }
-      this.joinedMucReady.delete(normalized);
-    }
+    this.joinedMucReady.delete(key);
   }
 
   setMessageHandler(h: (message: LiveRoomMessage) => void) { this.events.set("message", h); }
@@ -1105,34 +1088,39 @@ export class BrowserXmppClient {
   }
 
   async ensureJoined(roomJid: string): Promise<void> {
-    if (this.joinedMucReady.has(roomJid)) return;
-    const existing = this.joinedMucs.get(roomJid);
+    // Every join tracker keys on the canonical `roomJoinKey` (lowercased
+    // bare JID) so case variants from topology vs. retained-room replay
+    // resolve to a single entry (#1221). The raw `roomJid` still goes on
+    // the wire (`performMucJoin`, `rememberJoinedRoom`).
+    const key = this.roomJoinKey(roomJid);
+    if (this.joinedMucReady.has(key)) return;
+    const existing = this.joinedMucs.get(key);
     if (existing) {
-      const existingToken = this.joinedMucJoinTokens.get(roomJid);
+      const existingToken = this.joinedMucJoinTokens.get(key);
       await existing;
-      if (existingToken && this.joinedMucJoinTokens.get(roomJid) !== existingToken) {
+      if (existingToken && this.joinedMucJoinTokens.get(key) !== existingToken) {
         return;
       }
-      if (!existingToken && !this.joinedMucs.has(roomJid)) return;
-      this.joinedMucReady.add(roomJid);
+      if (!existingToken && !this.joinedMucs.has(key)) return;
+      this.joinedMucReady.add(key);
       this.rememberJoinedRoom(roomJid);
       return;
     }
     const promise = this.performMucJoin(roomJid);
-    const joinToken = Symbol(roomJid);
-    this.joinedMucs.set(roomJid, promise);
-    this.joinedMucJoinTokens.set(roomJid, joinToken);
+    const joinToken = Symbol(key);
+    this.joinedMucs.set(key, promise);
+    this.joinedMucJoinTokens.set(key, joinToken);
     try {
       await promise;
-      if (this.joinedMucJoinTokens.get(roomJid) === joinToken) {
-        this.joinedMucReady.add(roomJid);
+      if (this.joinedMucJoinTokens.get(key) === joinToken) {
+        this.joinedMucReady.add(key);
         this.rememberJoinedRoom(roomJid);
       }
     } catch (err) {
-      if (this.joinedMucJoinTokens.get(roomJid) === joinToken) {
-        this.joinedMucs.delete(roomJid);
-        this.joinedMucJoinTokens.delete(roomJid);
-        this.joinedMucReady.delete(roomJid);
+      if (this.joinedMucJoinTokens.get(key) === joinToken) {
+        this.joinedMucs.delete(key);
+        this.joinedMucJoinTokens.delete(key);
+        this.joinedMucReady.delete(key);
       }
       throw err;
     }
@@ -1248,7 +1236,7 @@ export class BrowserXmppClient {
   }
 
   private roomIsReady(roomJid: string): boolean {
-    return this.canUseConnectedSession() && this.currentRoom === roomJid && this.joinedMucReady.has(roomJid);
+    return this.canUseConnectedSession() && this.currentRoom === roomJid && this.joinedMucReady.has(this.roomJoinKey(roomJid));
   }
 
   private enqueueReason(): string {
@@ -2348,11 +2336,10 @@ export class BrowserXmppClient {
     clearAllLiveCallParticipants();
     void useCallEngine().engine.disconnect();
     this.rejectRoomJoinWaiters(new Error("XMPP disconnected while joining a room"));
+    // `joinedMucs` keys are already canonical `roomJoinKey`s (#1221).
     this.retainedJoinedRoomJids = new Set([
       ...this.retainedJoinedRoomJids,
-      ...previouslyJoinedRooms
-        .map((roomJid) => roomJid.split("/")[0]?.trim().toLowerCase() ?? "")
-        .filter(Boolean),
+      ...previouslyJoinedRooms.filter(Boolean),
     ]);
     this.persistRetainedJoinedRooms();
     this.joinedMucs.clear();

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -405,6 +405,12 @@ export class BrowserXmppClient {
   private readonly joinedMucReady = new Set<string>();
   private retainedJoinedRoomJids = new Set<string>();
   private autoJoinRoomJids: ReadonlyArray<string> = [];
+  // Canonical room keys `fanOutAutoJoin` has attempted this session epoch
+  // (#1221). Bounds each room to one auto-join attempt per epoch — a
+  // failed join (e.g. 15s self-presence timeout) is not retried by a
+  // later trigger, and the three fan-out triggers per session coalesce.
+  // Cleared on disconnect so a genuine fresh cycle rejoins.
+  private readonly autoJoinAttemptedRoomKeys = new Set<string>();
   private uploadServiceJid: string | null = null;
   private discoveredRoomJids = new Map<string, string>();
   private readonly reconnect: ReconnectScheduler;
@@ -1005,6 +1011,7 @@ export class BrowserXmppClient {
     this.joinedMucs.clear();
     this.joinedMucJoinTokens.clear();
     this.joinedMucReady.clear();
+    this.autoJoinAttemptedRoomKeys.clear();
     clearDmCallJoinCacheForAccount(this.session.jid);
     clearDmCallActivities();
     clearMucCallParticipants();
@@ -1172,7 +1179,19 @@ export class BrowserXmppClient {
 
   async fanOutAutoJoin(roomJids: ReadonlyArray<string>, concurrency = 6): Promise<void> {
     if (!this.xmpp) return;
-    const queue = [...new Set(roomJids.filter(Boolean))];
+    // Dedup the input by canonical key and skip rooms already attempted
+    // this epoch; the raw JID enters the queue for the wire (#1221).
+    const queue: string[] = [];
+    const seenThisCall = new Set<string>();
+    for (const roomJid of roomJids) {
+      if (!roomJid) continue;
+      const key = this.roomJoinKey(roomJid);
+      if (!key || seenThisCall.has(key)) continue;
+      seenThisCall.add(key);
+      if (this.autoJoinAttemptedRoomKeys.has(key)) continue;
+      this.autoJoinAttemptedRoomKeys.add(key);
+      queue.push(roomJid);
+    }
     const workers = Array.from({ length: Math.max(1, concurrency) }, async () => {
       while (queue.length > 0) {
         const roomJid = queue.shift();
@@ -2345,6 +2364,8 @@ export class BrowserXmppClient {
     this.joinedMucs.clear();
     this.joinedMucJoinTokens.clear();
     this.joinedMucReady.clear();
+    // New epoch: a genuine fresh cycle must be free to rejoin (#1221).
+    this.autoJoinAttemptedRoomKeys.clear();
     this.clearRoomPresenceCaches();
     if (this.destroying) { this.clearResumeState(); this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
     // #1164: a terminal failure (auth rejection, resource conflict)

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -667,6 +667,10 @@ export class BrowserXmppClient {
       this.joinedMucReady.add(key);
       this.autoJoinAttemptedRoomKeys.add(key);
     }
+    // One-shot: the snapshot is a handoff from the last disconnect to
+    // this resume. Clear it once consumed so a later `.size` check can
+    // never read a stale snapshot (the next disconnect repopulates it).
+    this.resumedSessionRoomKeys.clear();
   }
 
   /**
@@ -2214,21 +2218,19 @@ export class BrowserXmppClient {
       // Single-flight per epoch (`fanOutAutoJoin`) keeps this to one
       // join per room across the three fan-out triggers (#1221).
       this.fanOutJoinableRooms();
-    } else if (this.resumedSessionRoomKeys.size > 0) {
-      // Resumed with a known snapshot (in-context transient reconnect):
-      // occupancy survived the SM detach-for-resume server-side (no MUC
-      // leave was broadcast), so DO NOT re-send join presence. Re-seed
-      // the trackers from the snapshot so roomIsReady and the queued-send
-      // flush treat the rooms as joined (#1221).
-      this.reseedResumedRooms();
     } else {
-      // Resumed but the in-memory snapshot was lost: the page-reload
-      // pagehide handoff persists the SM resume state, not the join
-      // snapshot, so we no longer know which rooms were confirmed. Rejoin
-      // the retained/autojoin set via the single-flight fan-out — one
+      // Resumed: occupancy survived the SM detach-for-resume server-side
+      // (no MUC leave was broadcast). Re-seed readiness for the
+      // self-presence-confirmed rooms WITHOUT sending presence (they mark
+      // themselves attempted), then fan out — single-flight skips the
+      // reseeded rooms, so a confirmed room sends zero join while any
+      // room the snapshot did NOT confirm is still rejoined (#1221).
+      // This covers a room still mid-join at disconnect (not yet 110-
+      // confirmed) and a lost snapshot after a page reload (the pagehide
+      // handoff persists SM state, not the in-memory snapshot). One
       // client rejoining its own rooms is not the multi-client storm
-      // #1221 fixes, and it self-heals occupancy for rooms we may have
-      // been removed from during the gap.
+      // #1221 fixes.
+      this.reseedResumedRooms();
       this.fanOutJoinableRooms();
     }
     // #1180: consume the catch-up cursors BEFORE emitting the

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -473,6 +473,11 @@ export class BrowserXmppClient {
   // re-entrant `handleSessionReady` (synchronous WASM callback re-
   // entry) cannot observe one set without the other.
   private resumeBarrier: { xmpp: XmppClientInstance; promise: Promise<void> } | null = null;
+  // The handle whose `runSessionReady` has already run this session
+  // (#1221). Latches per-handle so the three duplicate session-ready
+  // hooks coalesce even on the no-catch-up path (which opens no barrier).
+  // Reset on disconnect so the next handle runs its own setup.
+  private sessionReadyHandledXmpp: XmppClientInstance | null = null;
   private pendingDuringResume: InboundWasmMessage[] | null = null;
   // F2: buffer entries stranded by a barrier that failed mid-catch-up
   // (the connection died, so `completeResumeBarrier` could not drain
@@ -1034,6 +1039,7 @@ export class BrowserXmppClient {
     this.joinedMucReady.clear();
     this.autoJoinAttemptedRoomKeys.clear();
     this.resumedSessionRoomKeys.clear();
+    this.sessionReadyHandledXmpp = null;
     clearDmCallJoinCacheForAccount(this.session.jid);
     clearDmCallActivities();
     clearMucCallParticipants();
@@ -2166,16 +2172,19 @@ export class BrowserXmppClient {
     this.emitStatus({ state: "online", detail: this.outboundQueue.persistedCount() > 0 ? lifecycle.type === "fresh" ? "Reconnected — replaying queued messages" : "Connection resumed — replaying queued messages" : lifecycle.type === "fresh" ? "Connection ready" : "Connection resumed" });
     // Coalesce duplicate triggers. Three event hooks call
     // `handleSessionReady` on the same xmpp handle; only the first
-    // gets past this gate to run the per-session setup, lifecycle
-    // emit, and catch-up. Subsequent triggers for the *same* xmpp
+    // gets past this latch to run the per-session setup, lifecycle
+    // emit, and catch-up. Subsequent triggers for the *same* handle
     // bail out silently.
     //
-    // A barrier owned by a *different* xmpp handle (e.g. the old
-    // handle from a Wi-Fi → cellular reconnect) does not block the
-    // new handle — the new handle gets its own session-setup +
-    // catch-up. The old barrier's `.finally` guards against writing
-    // back into shared state when `this.xmpp` has moved on.
-    if (this.resumeBarrier && this.resumeBarrier.xmpp === xmpp) return;
+    // The latch is keyed on the handle, set once and synchronously
+    // (before the first await), so it also closes the no-catch-up leak
+    // (#1221): that branch returns without opening a `resumeBarrier`, so
+    // a barrier-only gate let a second callback re-admit → double
+    // fan-out + double bootstrap. A *different* handle (e.g. the old one
+    // from a Wi-Fi → cellular reconnect) does not match the latch — the
+    // new handle gets its own session-setup + catch-up.
+    if (this.sessionReadyHandledXmpp === xmpp) return;
+    this.sessionReadyHandledXmpp = xmpp;
     if (lifecycle.type === "fresh") {
       this.outboundQueue.clearInflight();
       void this.enableCarbons(xmpp);
@@ -2400,8 +2409,10 @@ export class BrowserXmppClient {
     this.joinedMucs.clear();
     this.joinedMucJoinTokens.clear();
     this.joinedMucReady.clear();
-    // New epoch: a genuine fresh cycle must be free to rejoin (#1221).
+    // New epoch: a genuine fresh cycle must be free to rejoin (#1221),
+    // and the next handle must run its own session-ready setup.
     this.autoJoinAttemptedRoomKeys.clear();
+    this.sessionReadyHandledXmpp = null;
     this.clearRoomPresenceCaches();
     if (this.destroying) { this.clearResumeState(); this.emitStatus({ state: "offline", detail: error?.message ?? "Disconnected" }); return; }
     // #1164: a terminal failure (auth rejection, resource conflict)

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -669,6 +669,17 @@ export class BrowserXmppClient {
     }
   }
 
+  /**
+   * Fan out MUC joins for the retained + autojoin rooms plus the focused
+   * room (#1221). Used on a fresh bind and on a resume whose readiness
+   * snapshot was lost. Single-flight per epoch via `fanOutAutoJoin`.
+   */
+  private fanOutJoinableRooms(): void {
+    const roomsToJoin = new Set([...this.retainedJoinedRoomJids, ...this.autoJoinRoomJids]);
+    if (this.currentRoom) roomsToJoin.add(this.currentRoom);
+    if (roomsToJoin.size > 0) void this.fanOutAutoJoin([...roomsToJoin]);
+  }
+
   private handleMucPresenceError(presence: WasmPresence): boolean {
     if (presence.presence_type !== "error") return false;
     const [rawRoom = "", errorNick = ""] = presence.from?.split("/") ?? [];
@@ -1227,8 +1238,12 @@ export class BrowserXmppClient {
         try {
           await this.ensureJoined(roomJid);
         } catch {
-          // Failed joins drop their tracker entry inside ensureJoined.
-          // The next topology refresh or reconnect replay can retry.
+          // Failed joins drop their tracker entry inside ensureJoined,
+          // but the key stays in `autoJoinAttemptedRoomKeys`, so a
+          // same-epoch fan-out (e.g. a topology refresh) will NOT retry
+          // (#1221). Retry happens on a reconnect (new epoch clears the
+          // set) or when the user navigates to the room (`switchRoom` →
+          // `ensureJoined`, which is not single-flight-gated).
         }
       }
     });
@@ -2198,17 +2213,23 @@ export class BrowserXmppClient {
       // presence for every retained/autojoin room + the focused room.
       // Single-flight per epoch (`fanOutAutoJoin`) keeps this to one
       // join per room across the three fan-out triggers (#1221).
-      const roomsToJoin = new Set([...this.retainedJoinedRoomJids, ...this.autoJoinRoomJids]);
-      if (this.currentRoom) roomsToJoin.add(this.currentRoom);
-      if (roomsToJoin.size > 0) {
-        void this.fanOutAutoJoin([...roomsToJoin]);
-      }
-    } else {
-      // Resumed: occupancy survived the SM detach-for-resume server-side
-      // (no MUC leave was broadcast), so DO NOT re-send join presence.
-      // Re-seed the trackers from the disconnect snapshot so roomIsReady
-      // and the queued-send flush treat the rooms as joined (#1221).
+      this.fanOutJoinableRooms();
+    } else if (this.resumedSessionRoomKeys.size > 0) {
+      // Resumed with a known snapshot (in-context transient reconnect):
+      // occupancy survived the SM detach-for-resume server-side (no MUC
+      // leave was broadcast), so DO NOT re-send join presence. Re-seed
+      // the trackers from the snapshot so roomIsReady and the queued-send
+      // flush treat the rooms as joined (#1221).
       this.reseedResumedRooms();
+    } else {
+      // Resumed but the in-memory snapshot was lost: the page-reload
+      // pagehide handoff persists the SM resume state, not the join
+      // snapshot, so we no longer know which rooms were confirmed. Rejoin
+      // the retained/autojoin set via the single-flight fan-out — one
+      // client rejoining its own rooms is not the multi-client storm
+      // #1221 fixes, and it self-heals occupancy for rooms we may have
+      // been removed from during the gap.
+      this.fanOutJoinableRooms();
     }
     // #1180: consume the catch-up cursors BEFORE emitting the
     // lifecycle event so the fresh event can report which

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -1632,9 +1632,12 @@ describe("client keepalive lifecycle", () => {
     await settleReconnectCatchup(newestIndex + 20);
 
     // #1221: capped at 5 pages instead of walking the whole 52-page
-    // archive; the backward loop discards its buffer on the budget throw.
+    // archive. The backward loop applies the 5 pages it fetched before
+    // failing over (partial recovery of the most-recent window), rather
+    // than discarding them.
     expect(fetchDmHistoryPage).toHaveBeenCalledTimes(5);
-    expect(dmHandler).not.toHaveBeenCalled();
+    expect(dmHandler).toHaveBeenCalledTimes(5);
+    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-51" }));
   });
 
   test("stale archive cursor catch-up filters live messages already seen after that cursor", async () => {

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -1590,7 +1590,7 @@ describe("client keepalive lifecycle", () => {
     expect(readDmCallActivity("bob@example.com")).toBeNull();
   });
 
-  test("timestamp fallback continues beyond fifty pages until it crosses the last seen timestamp", async () => {
+  test("resumed timestamp catch-up stops at the reconnect page budget (#1221)", async () => {
     const client = new BrowserXmppClient(session());
     const catchup = (client as unknown as {
       catchup: {
@@ -1631,10 +1631,10 @@ describe("client keepalive lifecycle", () => {
     xmpp.emit("stream:management:resumed");
     await settleReconnectCatchup(newestIndex + 20);
 
-    expect(fetchDmHistoryPage).toHaveBeenCalledTimes(newestIndex + 1);
-    expect(dmHandler).toHaveBeenCalledTimes(newestIndex);
-    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-1" }));
-    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-51" }));
+    // #1221: capped at 5 pages instead of walking the whole 52-page
+    // archive; the backward loop discards its buffer on the budget throw.
+    expect(fetchDmHistoryPage).toHaveBeenCalledTimes(5);
+    expect(dmHandler).not.toHaveBeenCalled();
   });
 
   test("stale archive cursor catch-up filters live messages already seen after that cursor", async () => {
@@ -1919,7 +1919,7 @@ describe("client keepalive lifecycle", () => {
     }));
   });
 
-  test("pages tracked DM catch-up forward beyond fifty pages until MAM is complete", async () => {
+  test("resumed forward catch-up stops at the reconnect page budget (#1221)", async () => {
     const client = new BrowserXmppClient(session());
     const catchup = (client as unknown as {
       catchup: {
@@ -1955,13 +1955,15 @@ describe("client keepalive lifecycle", () => {
     xmpp.emit("stream:management:resumed");
     await settleReconnectCatchup(finalPage + 20);
 
-    expect(fetchDmHistoryPage).toHaveBeenCalledTimes(finalPage);
+    // #1221: capped at 5 forward pages; the forward loop applies each
+    // page as it goes, so 5 messages arrive before the budget throw.
+    expect(fetchDmHistoryPage).toHaveBeenCalledTimes(5);
     expect(fetchDmHistoryPage).toHaveBeenLastCalledWith("bob@example.com", 100, {
       type: "after",
-      after: "mam-50",
+      after: "mam-4",
     });
-    expect(dmHandler).toHaveBeenCalledTimes(finalPage);
-    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-51" }));
+    expect(dmHandler).toHaveBeenCalledTimes(5);
+    expect(dmHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "dm-5" }));
   });
 
   test("queryPersonalMamPage seeds reconnect catch-up from XEP-0313 archive ids", async () => {

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -1246,17 +1246,27 @@ describe("client keepalive lifecycle", () => {
       is_complete: true,
     }));
 
-    const xmpp = Object.assign(new EventEmitter(), {
+    // #1221: session-ready runs once per handle, so a genuine SECOND
+    // fresh session uses a NEW handle (a reconnect constructs a fresh
+    // XmppClientInstance). The catch-up cursor store is client-level, so
+    // the first session arms it (nothing to fetch) and the second pages.
+    const session1 = Object.assign(new EventEmitter(), {
       fetch_dm_history_page: fetchDmHistoryPage,
     }) as unknown as Agent;
-    (client as unknown as { xmpp: Agent }).xmpp = xmpp;
-    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(xmpp);
+    (client as unknown as { xmpp: Agent }).xmpp = session1;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(session1);
 
-    xmpp.emit("session:started");
+    session1.emit("session:started");
     await settleReconnectCatchup();
     expect(fetchDmHistoryPage).toHaveBeenCalledTimes(0);
 
-    xmpp.emit("session:started");
+    const session2 = Object.assign(new EventEmitter(), {
+      fetch_dm_history_page: fetchDmHistoryPage,
+    }) as unknown as Agent;
+    (client as unknown as { xmpp: Agent }).xmpp = session2;
+    (client as unknown as { wireEvents: (xmpp: Agent) => void }).wireEvents(session2);
+
+    session2.emit("session:started");
     await settleReconnectCatchup();
 
     expect(fetchDmHistoryPage).toHaveBeenCalledTimes(1);

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -945,9 +945,13 @@ describe("client send readiness", () => {
     (client as unknown as { currentRoom: string | null }).currentRoom = roomJid;
     (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
 
+    // #1221: retained-room rejoin is a FRESH-reconnect behavior. A
+    // `resumed` session-ready must NOT re-send join presence (occupancy
+    // survives the SM detach); that path is covered in
+    // session-ready-join-lifecycle.test.ts.
     (client as unknown as {
-      handleSessionReady: (xmpp: typeof xmpp, lifecycle: { type: "resumed" }) => void;
-    }).handleSessionReady(xmpp, { type: "resumed" });
+      handleSessionReady: (xmpp: typeof xmpp, lifecycle: { type: "fresh" }) => void;
+    }).handleSessionReady(xmpp, { type: "fresh" });
     await settleReconnectCatchup();
     expect(xmpp.send_groupchat_message).toHaveBeenCalledTimes(0);
 
@@ -986,9 +990,13 @@ describe("client send readiness", () => {
     (client as unknown as { retainedJoinedRoomJids: Set<string> }).retainedJoinedRoomJids = new Set([roomJid]);
     (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
 
+    // #1221: retained-room rejoin is a FRESH-reconnect behavior. A
+    // `resumed` session-ready must NOT re-send join presence (occupancy
+    // survives the SM detach); that path is covered in
+    // session-ready-join-lifecycle.test.ts.
     (client as unknown as {
-      handleSessionReady: (xmpp: typeof xmpp, lifecycle: { type: "resumed" }) => void;
-    }).handleSessionReady(xmpp, { type: "resumed" });
+      handleSessionReady: (xmpp: typeof xmpp, lifecycle: { type: "fresh" }) => void;
+    }).handleSessionReady(xmpp, { type: "fresh" });
     await settleReconnectCatchup();
 
     expect(xmpp.join_room).toHaveBeenCalledWith(roomJid, "alice");
@@ -1031,9 +1039,13 @@ describe("client send readiness", () => {
     (client as unknown as { xmpp: typeof xmpp }).xmpp = xmpp;
     (client as unknown as { wireEvents: (xmpp: typeof xmpp) => void }).wireEvents(xmpp);
 
+    // #1221: retained-room rejoin is a FRESH-reconnect behavior. A
+    // `resumed` session-ready must NOT re-send join presence (occupancy
+    // survives the SM detach); that path is covered in
+    // session-ready-join-lifecycle.test.ts.
     (client as unknown as {
-      handleSessionReady: (xmpp: typeof xmpp, lifecycle: { type: "resumed" }) => void;
-    }).handleSessionReady(xmpp, { type: "resumed" });
+      handleSessionReady: (xmpp: typeof xmpp, lifecycle: { type: "fresh" }) => void;
+    }).handleSessionReady(xmpp, { type: "fresh" });
     await settleReconnectCatchup();
 
     expect(xmpp.join_room).toHaveBeenCalledWith(roomJid, "alice");

--- a/chat/tests/muc-join-dedup.test.ts
+++ b/chat/tests/muc-join-dedup.test.ts
@@ -43,6 +43,7 @@ type PrivateState = {
   ensureJoined: (roomJid: string) => Promise<void>;
   fanOutAutoJoin: (roomJids: ReadonlyArray<string>, concurrency?: number) => Promise<void>;
   joinedMucReady: Set<string>;
+  autoJoinAttemptedRoomKeys: Set<string>;
   fullJid: string;
 };
 
@@ -86,5 +87,51 @@ describe("#1221 canonical join key coalesces case variants", () => {
 
     expect(joinRoom).toHaveBeenCalledTimes(1);
     expect(state.joinedMucReady.has(lower)).toBe(true);
+  });
+});
+
+describe("#1221 fanOutAutoJoin is single-flight per epoch", () => {
+  test("a failed auto-join is not retried by a later trigger in the same epoch", async () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState;
+    const room = "room2@conference.example.com";
+    const joinRoom = mock(async () => {
+      throw new Error("join rejected");
+    });
+    const xmpp = { join_room: joinRoom, set_on_presence() {} };
+    state.xmpp = xmpp;
+    state.connected = true;
+    state.wireEvents(xmpp);
+
+    await state.fanOutAutoJoin([room]); // first trigger: join_room throws
+    await state.fanOutAutoJoin([room]); // second trigger, same epoch: must not retry
+
+    expect(joinRoom).toHaveBeenCalledTimes(1);
+    expect(state.autoJoinAttemptedRoomKeys.has(room)).toBe(true);
+  });
+
+  test("concurrent fan-out triggers for the same room send a single join", async () => {
+    const { state, joinRoom, deliverSelfPresence } = connectedClient();
+    const room = "room3@conference.example.com";
+
+    const a = state.fanOutAutoJoin([room]);
+    const b = state.fanOutAutoJoin([room]);
+    deliverSelfPresence(room);
+    await Promise.all([a, b]);
+
+    expect(joinRoom).toHaveBeenCalledTimes(1);
+  });
+
+  test("case variants in the fan-out input list collapse to one join", async () => {
+    const { state, joinRoom, deliverSelfPresence } = connectedClient();
+
+    const fan = state.fanOutAutoJoin([
+      "Room4@conference.example.com",
+      "room4@conference.example.com",
+    ]);
+    deliverSelfPresence("room4@conference.example.com");
+    await fan;
+
+    expect(joinRoom).toHaveBeenCalledTimes(1);
   });
 });

--- a/chat/tests/muc-join-dedup.test.ts
+++ b/chat/tests/muc-join-dedup.test.ts
@@ -1,0 +1,90 @@
+/**
+ * #1221 — reconnect MUC-join dedup.
+ *
+ * A prod server restart made 5 clients fan out 96 MUC joins in ~2s with
+ * heavy per-room duplication. Two client-side amplifiers:
+ *
+ *   * Case-key mismatch: retained room JIDs were lowercased while
+ *     autojoin/`joinedMucs` kept raw bookmark case, so the same room
+ *     joined under two keys. Every join tracker must key on the single
+ *     canonical `roomJoinKey` (lowercased bare JID); the raw JID still
+ *     goes on the wire.
+ *   * No per-epoch single-flight: a failed auto-join was retried on the
+ *     next trigger (15s self-presence-timeout retry amplifier), and the
+ *     three fan-out triggers per session each re-attempted every room.
+ *     `fanOutAutoJoin` must attempt each room key at most once per epoch.
+ *
+ * These tests poke private state on `BrowserXmppClient` directly — see
+ * the comment block in `resume-ordering.test.ts` for the rationale.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { BrowserXmppClient } from "../src/lib/xmpp-client";
+
+function session(): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com/desktop",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/ws",
+  } as WaddleSession;
+}
+
+type PresenceCb = (presence: {
+  from?: string;
+  presence_type?: string;
+  muc_jid?: string;
+}) => void;
+
+type PrivateState = {
+  xmpp: unknown;
+  connected: boolean;
+  wireEvents: (xmpp: unknown) => void;
+  ensureJoined: (roomJid: string) => Promise<void>;
+  fanOutAutoJoin: (roomJids: ReadonlyArray<string>, concurrency?: number) => Promise<void>;
+  joinedMucReady: Set<string>;
+  fullJid: string;
+};
+
+/** A mock WASM handle that records join_room calls and lets the test
+ *  deliver the room self-presence that resolves a join. */
+function connectedClient() {
+  const client = new BrowserXmppClient(session());
+  const state = client as unknown as PrivateState;
+  let onPresence: PresenceCb | null = null;
+  const joinRoom = mock(async () => undefined);
+  const xmpp = {
+    join_room: joinRoom,
+    set_on_presence(cb: PresenceCb) {
+      onPresence = cb;
+    },
+  };
+  state.xmpp = xmpp;
+  state.connected = true;
+  state.wireEvents(xmpp);
+  const deliverSelfPresence = (roomBareJid: string) => {
+    onPresence?.({
+      from: `${roomBareJid}/alice`,
+      presence_type: "available",
+      muc_jid: state.fullJid,
+    });
+  };
+  return { client, state, joinRoom, deliverSelfPresence };
+}
+
+describe("#1221 canonical join key coalesces case variants", () => {
+  test("a second join for a case-variant of a joined room sends no new presence", async () => {
+    const { state, joinRoom, deliverSelfPresence } = connectedClient();
+    const upper = "Channel1@conference.example.com";
+    const lower = "channel1@conference.example.com";
+
+    const first = state.ensureJoined(upper);
+    deliverSelfPresence(lower); // server echoes the canonical (lowercased) room
+    await first;
+
+    await state.ensureJoined(lower);
+
+    expect(joinRoom).toHaveBeenCalledTimes(1);
+    expect(state.joinedMucReady.has(lower)).toBe(true);
+  });
+});

--- a/chat/tests/reconnect-catchup-bound.test.ts
+++ b/chat/tests/reconnect-catchup-bound.test.ts
@@ -1,0 +1,130 @@
+/**
+ * #1221 — bounded reconnect MAM catch-up.
+ *
+ * The reconnect catch-up paged each conversation (100 msgs/page) until
+ * the archive was complete or the `since` boundary was crossed, with NO
+ * page budget. A 4,425-message room archive was paged in full on every
+ * fresh reconnect — the unbounded replay is what overflowed a victim's
+ * SM queue during the prod join storm.
+ *
+ * Each of the four catch-up loops (dm/room × forward-cursor/timestamp)
+ * now stops after RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION (5, ≤500
+ * msgs) and throws into the existing per-conversation `catchupFailure`
+ * fallback, which triggers a bounded wholesale reload; older history
+ * lazy-loads via the normal pagination.
+ *
+ * These tests poke private state on `BrowserXmppClient` directly — see
+ * the comment block in `resume-ordering.test.ts` for the rationale.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { BrowserXmppClient } from "../src/lib/xmpp-client";
+import type { ReconnectCatchup } from "../src/lib/xmpp/reconnect-catchup";
+
+const MAX_PAGES = 5;
+
+function session(): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com/desktop",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/ws",
+  } as WaddleSession;
+}
+
+type PrivateState = {
+  xmpp: unknown;
+  catchup: ReconnectCatchup;
+  runSessionReady: (xmpp: unknown, lifecycle: { type: "fresh" | "resumed" }) => Promise<void>;
+};
+
+function makeClient() {
+  const client = new BrowserXmppClient(session());
+  const state = client as unknown as PrivateState;
+  const failures: Array<{ kind: "dm" | "room"; key: string }> = [];
+  client.setCatchupFailureHandler((failure) => failures.push(failure));
+  return { client, state, failures };
+}
+
+/**
+ * A forward (`after`-cursor) page source: never complete, advancing
+ * `last_id`, empty messages — the loop would page forever without a
+ * budget. Completes at page 50 as a safety net so a missing budget
+ * fails fast on the call count instead of hanging.
+ */
+function forwardPages() {
+  let calls = 0;
+  return mock(async () => {
+    calls += 1;
+    return { messages: [], is_complete: calls >= 50, last_id: `cur-${calls}` };
+  });
+}
+
+/** As `forwardPages` but for the backward timestamp loop: advancing
+ *  `first_id`, no message crosses `since`. */
+function backwardPages() {
+  let calls = 0;
+  return mock(async () => {
+    calls += 1;
+    return { messages: [], is_complete: calls >= 50, first_id: `first-${calls}` };
+  });
+}
+
+describe("#1221 reconnect catch-up is bounded per conversation", () => {
+  test("room forward-cursor catch-up stops at the page budget and fails over", async () => {
+    const { state, failures } = makeClient();
+    const fetch_room_history_page = forwardPages();
+    const xmpp = { fetch_room_history_page };
+    state.xmpp = xmpp;
+    state.catchup.onSessionStarted();
+    state.catchup.recordRoomSeen("c1@muc.example.com", "2026-07-01T10:00:00.000Z", "archive-0");
+
+    await state.runSessionReady(xmpp, { type: "fresh" });
+
+    expect(fetch_room_history_page).toHaveBeenCalledTimes(MAX_PAGES);
+    expect(failures).toEqual([{ kind: "room", key: "c1@muc.example.com" }]);
+  });
+
+  test("room timestamp catch-up stops at the page budget and fails over", async () => {
+    const { state, failures } = makeClient();
+    const fetch_room_history_page = backwardPages();
+    const xmpp = { fetch_room_history_page };
+    state.xmpp = xmpp;
+    state.catchup.onSessionStarted();
+    // No archive id → timestamp (backward) loop.
+    state.catchup.recordRoomSeen("c1@muc.example.com", "2026-07-01T10:00:00.000Z");
+
+    await state.runSessionReady(xmpp, { type: "fresh" });
+
+    expect(fetch_room_history_page).toHaveBeenCalledTimes(MAX_PAGES);
+    expect(failures).toEqual([{ kind: "room", key: "c1@muc.example.com" }]);
+  });
+
+  test("dm forward-cursor catch-up stops at the page budget and fails over", async () => {
+    const { state, failures } = makeClient();
+    const fetch_dm_history_page = forwardPages();
+    const xmpp = { fetch_dm_history_page };
+    state.xmpp = xmpp;
+    state.catchup.onSessionStarted();
+    state.catchup.recordDmSeen("bob@example.com", "2026-07-01T10:00:00.000Z", "archive-0");
+
+    await state.runSessionReady(xmpp, { type: "fresh" });
+
+    expect(fetch_dm_history_page).toHaveBeenCalledTimes(MAX_PAGES);
+    expect(failures).toEqual([{ kind: "dm", key: "bob@example.com" }]);
+  });
+
+  test("dm timestamp catch-up stops at the page budget and fails over", async () => {
+    const { state, failures } = makeClient();
+    const fetch_dm_history_page = backwardPages();
+    const xmpp = { fetch_dm_history_page };
+    state.xmpp = xmpp;
+    state.catchup.onSessionStarted();
+    state.catchup.recordDmSeen("bob@example.com", "2026-07-01T10:00:00.000Z");
+
+    await state.runSessionReady(xmpp, { type: "fresh" });
+
+    expect(fetch_dm_history_page).toHaveBeenCalledTimes(MAX_PAGES);
+    expect(failures).toEqual([{ kind: "dm", key: "bob@example.com" }]);
+  });
+});

--- a/chat/tests/session-ready-join-lifecycle.test.ts
+++ b/chat/tests/session-ready-join-lifecycle.test.ts
@@ -135,6 +135,25 @@ describe("#1221 resumed session-ready does not rejoin", () => {
     expect(joinRoom2).not.toHaveBeenCalled();
     expect(state.joinedMucReady.has(room)).toBe(true);
   });
+
+  test("a resume whose snapshot was lost (page reload) rejoins retained rooms", async () => {
+    // The pagehide handoff persists the SM resume state but not the
+    // in-memory readiness snapshot, so a reloaded client resumes with an
+    // empty resumedSessionRoomKeys. It must fall back to rejoining the
+    // retained set (single-flight) rather than leaving rooms un-ready.
+    const { state, xmpp, joinRoom, deliverSelfPresence } = connectedClient();
+    const room = "c7@conference.example.com";
+    state.retainedJoinedRoomJids = new Set([room]);
+    // resumedSessionRoomKeys intentionally left empty (snapshot lost).
+
+    const ready = state.runSessionReady(xmpp, { type: "resumed" });
+    deliverSelfPresence(room);
+    await ready;
+    await Promise.resolve();
+
+    expect(joinRoom).toHaveBeenCalledTimes(1);
+    expect(joinRoom).toHaveBeenCalledWith(room, "alice");
+  });
 });
 
 describe("#1221 session-ready runs once per handle", () => {

--- a/chat/tests/session-ready-join-lifecycle.test.ts
+++ b/chat/tests/session-ready-join-lifecycle.test.ts
@@ -137,6 +137,27 @@ describe("#1221 resumed session-ready does not rejoin", () => {
   });
 });
 
+describe("#1221 session-ready runs once per handle", () => {
+  test("a duplicate no-catchup session-ready for the same handle is a no-op", async () => {
+    // Three event hooks call handleSessionReady on the same handle. The
+    // resumeBarrier gate only covered the catch-up path; the no-catch-up
+    // branch returned without opening a barrier, so a second callback
+    // re-admitted and double-emitted the lifecycle + double-ran setup.
+    const { state, xmpp, joinRoom, received, deliverSelfPresence } = connectedClient();
+    const room = "c5@conference.example.com";
+    state.retainedJoinedRoomJids = new Set([room]);
+
+    const first = state.runSessionReady(xmpp, { type: "fresh" });
+    deliverSelfPresence(room);
+    await first;
+
+    await state.runSessionReady(xmpp, { type: "fresh" }); // duplicate hook
+
+    expect(received.filter((event) => event.type === "fresh")).toHaveLength(1);
+    expect(joinRoom).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("#1221 fresh session-ready still rejoins", () => {
   test("rejoins each retained room exactly once", async () => {
     const { state, xmpp, joinRoom, deliverSelfPresence } = connectedClient();

--- a/chat/tests/session-ready-join-lifecycle.test.ts
+++ b/chat/tests/session-ready-join-lifecycle.test.ts
@@ -1,0 +1,154 @@
+/**
+ * #1221 — session-ready MUC-join lifecycle.
+ *
+ * The auto-join fan-out sat OUTSIDE the `fresh` branch, so it re-sent a
+ * full join presence for every room on every `resumed` session-ready too
+ * — even though MUC occupancy survives an SM detach-for-resume
+ * server-side (no leave is broadcast; see `cleanup.rs`). This drove the
+ * reconnect join storm.
+ *
+ * The fix:
+ *   * fan-out only on `fresh`;
+ *   * on disconnect, snapshot the self-presence-confirmed (XEP-0045
+ *     status 110) room keys into `resumedSessionRoomKeys`;
+ *   * on `resumed`, re-seed the join trackers from that snapshot WITHOUT
+ *     sending presence, so `roomIsReady` and the queued-send flush keep
+ *     working.
+ *
+ * These tests poke private state on `BrowserXmppClient` directly — see
+ * the comment block in `resume-ordering.test.ts` for the rationale.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import type { WaddleSession } from "../src/lib/server-auth";
+import { BrowserXmppClient } from "../src/lib/xmpp-client";
+import type { SessionLifecycleEvent } from "../src/lib/xmpp/types";
+
+function session(): WaddleSession {
+  return {
+    username: "alice",
+    jid: "alice@example.com/desktop",
+    session_id: "tok",
+    xmpp_websocket_url: "wss://example.com/ws",
+  } as WaddleSession;
+}
+
+type PresenceCb = (presence: {
+  from?: string;
+  presence_type?: string;
+  muc_jid?: string;
+}) => void;
+
+type PrivateState = {
+  xmpp: unknown;
+  connected: boolean;
+  destroying: boolean;
+  wireEvents: (xmpp: unknown) => void;
+  runSessionReady: (xmpp: unknown, lifecycle: { type: "fresh" | "resumed" }) => Promise<void>;
+  handleDisconnected: (xmpp: unknown, error?: Error) => void;
+  joinedMucReady: Set<string>;
+  joinedMucs: Map<string, Promise<void>>;
+  retainedJoinedRoomJids: Set<string>;
+  resumedSessionRoomKeys: Set<string>;
+  autoJoinAttemptedRoomKeys: Set<string>;
+  fullJid: string;
+};
+
+function connectedClient() {
+  const client = new BrowserXmppClient(session());
+  const state = client as unknown as PrivateState;
+  let onPresence: PresenceCb | null = null;
+  const joinRoom = mock(async () => undefined);
+  const xmpp = {
+    join_room: joinRoom,
+    set_on_presence(cb: PresenceCb) {
+      onPresence = cb;
+    },
+  };
+  state.xmpp = xmpp;
+  state.connected = true;
+  state.wireEvents(xmpp);
+  const received: SessionLifecycleEvent[] = [];
+  client.setSessionLifecycleHandler((event) => received.push(event));
+  const deliverSelfPresence = (roomBareJid: string) => {
+    onPresence?.({
+      from: `${roomBareJid}/alice`,
+      presence_type: "available",
+      muc_jid: state.fullJid,
+    });
+  };
+  return { client, state, xmpp, joinRoom, received, deliverSelfPresence };
+}
+
+describe("#1221 resumed session-ready does not rejoin", () => {
+  test("restores readiness from the snapshot and sends no join presence", async () => {
+    const { state, xmpp, joinRoom } = connectedClient();
+    const room = "c1@conference.example.com";
+    // Retained rooms would normally be fanned out — prove they are NOT
+    // on resumed. The snapshot is the only re-seed source.
+    state.retainedJoinedRoomJids = new Set([room]);
+    state.resumedSessionRoomKeys = new Set([room]);
+
+    await state.runSessionReady(xmpp, { type: "resumed" });
+
+    expect(joinRoom).not.toHaveBeenCalled();
+    expect(state.joinedMucReady.has(room)).toBe(true);
+    expect(state.joinedMucs.has(room)).toBe(true);
+  });
+
+  test("disconnect snapshots the self-presence-confirmed rooms", () => {
+    const { state, xmpp } = connectedClient();
+    const room = "c1@conference.example.com";
+    state.joinedMucReady.add(room);
+    state.joinedMucs.set(room, Promise.resolve());
+    // `destroying` makes handleDisconnected return after the snapshot +
+    // tracker clears but before it schedules a reconnect timer.
+    state.destroying = true;
+
+    state.handleDisconnected(xmpp);
+
+    expect([...state.resumedSessionRoomKeys]).toEqual([room]);
+  });
+
+  test("a resume after a real join sends no new join presence (full path)", async () => {
+    const { state, xmpp, joinRoom, deliverSelfPresence } = connectedClient();
+    const room = "c3@conference.example.com";
+    // Real join populates joinedMucReady via self-presence.
+    const joined = state.ensureJoined(room);
+    deliverSelfPresence(room);
+    await joined;
+    expect(joinRoom).toHaveBeenCalledTimes(1);
+
+    // Transient disconnect captures the snapshot (destroying skips the timer).
+    state.destroying = true;
+    state.handleDisconnected(xmpp);
+    state.destroying = false;
+
+    // Reconnect with a fresh handle and resume.
+    const joinRoom2 = mock(async () => undefined);
+    const xmpp2 = { join_room: joinRoom2, set_on_presence() {} };
+    state.xmpp = xmpp2;
+    state.connected = true;
+    state.wireEvents(xmpp2);
+
+    await state.runSessionReady(xmpp2, { type: "resumed" });
+
+    expect(joinRoom2).not.toHaveBeenCalled();
+    expect(state.joinedMucReady.has(room)).toBe(true);
+  });
+});
+
+describe("#1221 fresh session-ready still rejoins", () => {
+  test("rejoins each retained room exactly once", async () => {
+    const { state, xmpp, joinRoom, deliverSelfPresence } = connectedClient();
+    const room = "c2@conference.example.com";
+    state.retainedJoinedRoomJids = new Set([room]);
+
+    const ready = state.runSessionReady(xmpp, { type: "fresh" });
+    deliverSelfPresence(room);
+    await ready;
+    await Promise.resolve();
+
+    expect(joinRoom).toHaveBeenCalledTimes(1);
+    expect(joinRoom).toHaveBeenCalledWith(room, "alice");
+  });
+});

--- a/chat/tests/session-ready-join-lifecycle.test.ts
+++ b/chat/tests/session-ready-join-lifecycle.test.ts
@@ -154,6 +154,28 @@ describe("#1221 resumed session-ready does not rejoin", () => {
     expect(joinRoom).toHaveBeenCalledTimes(1);
     expect(joinRoom).toHaveBeenCalledWith(room, "alice");
   });
+
+  test("a resume with a partial snapshot rejoins only the unconfirmed retained rooms", async () => {
+    // A room still mid-join at disconnect is retained but not
+    // self-presence-confirmed, so it is absent from the snapshot. On
+    // resume the confirmed room must be re-seeded WITHOUT a join, while
+    // the unconfirmed retained room is rejoined (single-flight skips the
+    // reseeded one).
+    const { state, xmpp, joinRoom, deliverSelfPresence } = connectedClient();
+    const confirmed = "confirmed@conference.example.com";
+    const pending = "pending@conference.example.com";
+    state.retainedJoinedRoomJids = new Set([confirmed, pending]);
+    state.resumedSessionRoomKeys = new Set([confirmed]); // only `confirmed` got its 110
+
+    const ready = state.runSessionReady(xmpp, { type: "resumed" });
+    deliverSelfPresence(pending);
+    await ready;
+    await Promise.resolve();
+
+    expect(state.joinedMucReady.has(confirmed)).toBe(true);
+    expect(joinRoom).toHaveBeenCalledTimes(1);
+    expect(joinRoom).toHaveBeenCalledWith(pending, "alice");
+  });
 });
 
 describe("#1221 session-ready runs once per handle", () => {


### PR DESCRIPTION
Fixes #1221.

## Incident

After a prod server restart (2026-07-07 22:18 UTC) every client failed XEP-0198
resume and fresh-bound. In a ~2s window the server logged **96 MUC join
requests from 5 clients** with heavy per-resource duplication, plus **unbounded
MAM catch-up** that overflowed a victim's SM queue. Duplicate same-resource
joins don't re-fanout (guarded since #781) but each still re-sends the full
occupant replay + subject — wasted wire traffic that amplified the storm.

## Root causes (all `chat/src/lib/xmpp/client.ts` unless noted)

1. Join fan-out ran on every session-ready, `fresh` **and** `resumed` — but MUC
   occupancy survives an SM detach-for-resume server-side (`cleanup.rs`
   `cleanup_connection_shutdown` stores the detached session and broadcasts no
   leave), so rejoin on `resumed` is unnecessary.
2. Join dedup was per-session only: `handleDisconnected` cleared the trackers
   each cycle, so nothing suppressed repeats across reconnect cycles.
3. Three concurrent fan-out triggers per session (`runSessionReady`,
   `discoverTopology → fanOutAutoJoin`, and the online-transition watcher).
4. Case-key mismatch: retained JIDs were lowercased while autojoin/`joinedMucs`
   kept raw bookmark case → the same room joined under two keys.
5. `resumeBarrier` leak: the no-catch-up branch returned early without opening a
   barrier → a second lifecycle callback re-admitted → double fan-out.
6. MAM reconnect catch-up was unbounded — all four loops paged 100/page until
   complete with no page budget.

## Fix (TDD, one RED→GREEN slice per change)

1. **One canonical join key** — all join tracking (`joinedMucs`,
   `joinedMucJoinTokens`, `joinedMucReady`, `ensureJoined`, `roomIsReady`,
   `markMucReadyFromSelfPresence`, `revokeMucReadiness`) keys on the existing
   `roomJoinKey` (lowercased bare JID); the raw JID stays on the wire. Deleted
   the dual-key workaround and the now-unused `canonicalJoinedRoomJid`.
2. **Skip rejoin on `resumed`** — fan-out moved into the `fresh` branch. On
   disconnect, snapshot the self-presence-confirmed (status 110) room keys into
   `resumedSessionRoomKeys`; on `resumed`, re-seed `joinedMucs`/`joinedMucReady`
   from the snapshot **without** sending presence. If the snapshot was lost (a
   page reload — the pagehide handoff persists SM state, not the snapshot), fall
   back to a single-flight fan-out (one client rejoining its own rooms is not
   the multi-client storm this fixes). Snapshot cleared on logout.
3. **Single-flight per epoch** — `autoJoinAttemptedRoomKeys` so `fanOutAutoJoin`
   attempts each room at most once per epoch (stops the 15s-self-presence-timeout
   retry amplifier and coalesces the three triggers); cleared on disconnect.
4. **Close the resumeBarrier leak** — replaced the barrier early-return gate with
   a `sessionReadyHandledXmpp` per-handle latch set synchronously before the
   first await, so one handle runs `runSessionReady` exactly once on both the
   catch-up and no-catch-up paths. Reset on disconnect; a reconnect uses a new
   handle and runs its own setup.
5. **Bound MAM catch-up** — `RECONNECT_CATCHUP_MAX_PAGES_PER_CONVERSATION = 5`
   (≤500 msgs/room) across all four loops (dm/room × forward-cursor/timestamp);
   on exhaustion throw into the existing per-conversation `catchupFailure`
   fallback (bounded wholesale reload on `fresh`; older history lazy-loads).

## Tests

- `muc-join-dedup.test.ts` — case-variant coalescing; dual-trigger = 1 join;
  failed join not retried in-epoch; input case-variant collapse.
- `session-ready-join-lifecycle.test.ts` — resumed = zero join presences +
  readiness restored; disconnect snapshots confirmed rooms; full-path resume;
  fresh rejoins once; duplicate-trigger no-op; lost-snapshot resume rejoins.
- `reconnect-catchup-bound.test.ts` — all four loops stop at 5 pages and fail
  over.
- Converted two keepalive-lifecycle tests that asserted the old >50-page
  unbounded paging to assert the 5-page bound via the real event wiring.

## Verification

- Full chat suite: **3302 pass / 0 fail** (main baseline 3288/0; +14 new tests,
  no regressions) · `knip` clean · `astro check` 0 errors · CI green.
- Server premise verified against `cleanup.rs`; the resumed-cap safety is
  load-bearing on the server's `can_resume_from` (a resume is granted only when
  `replay_gap_through <= client_h`, so a granted resume is gap-free — any larger
  gap fails the resume and becomes a fresh bind, which has the catch-up
  fallback).
- Three independent adversarial reviews (Opus correctness/concurrency — traced
  the WASM lifecycle source to prove the latch is safe; Opus XEP-0045/0198/0313
  conformance; gpt-5.5 via Codex). All real findings addressed; remaining notes
  verified as pre-existing/RFC-conformant (case-folding per RFC 7622
  UsernameCaseMapped) or fixed (stale comment, reload-resume readiness).

## Follow-up (out of scope)

A server-side regression test pinning `can_resume_from` to reject a resume whose
`h` is behind `replay_gap_through` would make the resumed-cap safety explicit
and guard the cross-repo invariant.
