### PR TITLE
fix(server): XEP-0198 resume loses stored presence payloads (#1206)

### DIFF
--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -720,6 +720,7 @@ mod orphan_reaper_sweep_tests {
             presence_show: Some(Show::Chat),
             presence_status: Some("at the keyboard".to_string()),
             presence_priority: 5,
+            presence_payloads: Vec::new(),
         }
     }
 

--- a/server/crates/waddle-server/src/sm_persistence.rs
+++ b/server/crates/waddle-server/src/sm_persistence.rs
@@ -36,7 +36,8 @@ mod joined_sessions;
 mod schema;
 
 use codec::{
-    decode_session, decode_unacked, decode_unacked_join_row, serialize_stanza, show_wire_str,
+    decode_session, decode_unacked, decode_unacked_join_row, serialize_presence_payloads,
+    serialize_stanza, show_wire_str,
 };
 
 /// Per-stream insert/update mutex map. Serializes writes for the same
@@ -185,6 +186,7 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
             .map_err(|_| SmPersistenceError::Other("max_resume_duration overflows i64".into()))?;
         let detached_at_ms = session.detached_at.timestamp_millis();
         let presence_show_str = session.presence_show.as_ref().map(show_wire_str);
+        let presence_payloads_xml = serialize_presence_payloads(&session.presence_payloads)?;
 
         // Portable upsert: SQLite and Postgres both support
         // INSERT ... ON CONFLICT (col) DO UPDATE SET ...
@@ -194,8 +196,9 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
                 stream_id, user_id, full_jid, inbound_count, outbound_count,
                 last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms,
                 carbons_enabled, roster_interested, blocklist_interested, presence_available,
-                presence_show, presence_status, presence_priority, replay_gap_through
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                presence_show, presence_status, presence_priority, replay_gap_through,
+                presence_payloads
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (stream_id) DO UPDATE SET
                 user_id = excluded.user_id,
                 full_jid = excluded.full_jid,
@@ -212,7 +215,8 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
                 presence_show = excluded.presence_show,
                 presence_status = excluded.presence_status,
                 presence_priority = excluded.presence_priority,
-                replay_gap_through = excluded.replay_gap_through
+                replay_gap_through = excluded.replay_gap_through,
+                presence_payloads = excluded.presence_payloads
             "#,
             crate::db_params![
                 session.stream_id.as_str().to_string(),
@@ -232,6 +236,7 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
                 session.presence_status,
                 i64::from(session.presence_priority),
                 session.replay_gap_through.map(i64::from),
+                presence_payloads_xml,
             ],
         )
         .await?;
@@ -247,7 +252,8 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
                 "SELECT stream_id, user_id, full_jid, inbound_count, outbound_count, \
                         last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms, \
                         carbons_enabled, roster_interested, blocklist_interested, presence_available, \
-                        presence_show, presence_status, presence_priority, replay_gap_through \
+                        presence_show, presence_status, presence_priority, replay_gap_through, \
+                        presence_payloads \
                  FROM sm_sessions WHERE stream_id = ?",
                 crate::db_params![stream_id.as_str().to_string()],
             )
@@ -418,7 +424,8 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
                 "SELECT stream_id, user_id, full_jid, inbound_count, outbound_count, \
                         last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms, \
                         carbons_enabled, roster_interested, blocklist_interested, presence_available, \
-                        presence_show, presence_status, presence_priority, replay_gap_through \
+                        presence_show, presence_status, presence_priority, replay_gap_through, \
+                        presence_payloads \
                  FROM sm_sessions WHERE detached_at_ms + max_resume_duration_ms <= ?",
                 crate::db_params![now_ms],
             )
@@ -440,7 +447,8 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
                 "SELECT stream_id, user_id, full_jid, inbound_count, outbound_count, \
                         last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms, \
                         carbons_enabled, roster_interested, blocklist_interested, presence_available, \
-                        presence_show, presence_status, presence_priority, replay_gap_through \
+                        presence_show, presence_status, presence_priority, replay_gap_through, \
+                        presence_payloads \
                  FROM sm_sessions",
                 (),
             )

--- a/server/crates/waddle-server/src/sm_persistence/atomic_store.rs
+++ b/server/crates/waddle-server/src/sm_persistence/atomic_store.rs
@@ -12,6 +12,7 @@ pub(super) async fn store_session_atomic(
         .map_err(|_| SmPersistenceError::Other("max_resume_duration overflows i64".into()))?;
     let detached_at_ms = session.detached_at.timestamp_millis();
     let presence_show_str = session.presence_show.as_ref().map(show_wire_str);
+    let presence_payloads_xml = serialize_presence_payloads(&session.presence_payloads)?;
 
     let mut tx = storage
         .db
@@ -44,8 +45,9 @@ pub(super) async fn store_session_atomic(
             stream_id, user_id, full_jid, inbound_count, outbound_count,
             last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms,
             carbons_enabled, roster_interested, blocklist_interested, presence_available,
-            presence_show, presence_status, presence_priority, replay_gap_through
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            presence_show, presence_status, presence_priority, replay_gap_through,
+            presence_payloads
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT (stream_id) DO UPDATE SET
             user_id = excluded.user_id,
             full_jid = excluded.full_jid,
@@ -62,7 +64,8 @@ pub(super) async fn store_session_atomic(
             presence_show = excluded.presence_show,
             presence_status = excluded.presence_status,
             presence_priority = excluded.presence_priority,
-            replay_gap_through = excluded.replay_gap_through
+            replay_gap_through = excluded.replay_gap_through,
+            presence_payloads = excluded.presence_payloads
         "#,
         crate::db_params![
             session.stream_id.as_str().to_string(),
@@ -82,6 +85,7 @@ pub(super) async fn store_session_atomic(
             session.presence_status.clone(),
             i64::from(session.presence_priority),
             session.replay_gap_through.map(i64::from),
+            presence_payloads_xml,
         ],
     )
     .await

--- a/server/crates/waddle-server/src/sm_persistence/codec.rs
+++ b/server/crates/waddle-server/src/sm_persistence/codec.rs
@@ -256,6 +256,19 @@ pub(crate) fn parse_presence_payloads(
     let wrapper: xmpp_parsers::minidom::Element = raw
         .parse()
         .map_err(|e: xmpp_parsers::minidom::Error| SmPersistenceError::Other(e.to_string()))?;
+    // Validate the wrapper shape so a well-formed-but-wrong-root cell (e.g. a
+    // corruption that leaves only a lone `<c/>`) is a typed error, not a
+    // silent empty/wrong result — otherwise it would bypass the caller's
+    // warn+degrade path in `decode_session` (Greptile/Qodo review).
+    if wrapper.name() != PRESENCE_PAYLOADS_WRAPPER_NAME
+        || wrapper.ns() != PRESENCE_PAYLOADS_WRAPPER_NS
+    {
+        return Err(SmPersistenceError::Other(format!(
+            "unexpected presence_payloads wrapper <{} xmlns='{}'>",
+            wrapper.name(),
+            wrapper.ns()
+        )));
+    }
     Ok(wrapper.children().cloned().collect())
 }
 
@@ -312,8 +325,20 @@ mod presence_payloads_tests {
     #[test]
     fn malformed_column_is_a_typed_error_not_a_panic() {
         // A corrupted / truncated column must surface as a typed decode
-        // error (which drops the session as a poison pill on restore),
-        // never a panic that bricks cold startup.
+        // error — never a panic — so `decode_session` can catch it and
+        // degrade the session to caps-less rather than crashing cold startup.
         assert!(parse_presence_payloads(Some("<c xmlns='urn:x'".to_string())).is_err());
+    }
+
+    #[test]
+    fn well_formed_wrong_root_is_a_typed_error_so_the_caller_can_degrade() {
+        // A cell that still parses as valid XML but is NOT the server-written
+        // wrapper (e.g. corruption leaving a lone `<c/>`) must be a typed
+        // error, not a silent empty result — otherwise it would bypass
+        // `decode_session`'s warn+degrade path and lose payloads without a
+        // trace.
+        let lone_caps =
+            r#"<c xmlns='http://jabber.org/protocol/caps' hash='sha-1' node='n' ver='v'/>"#;
+        assert!(parse_presence_payloads(Some(lone_caps.to_string())).is_err());
     }
 }

--- a/server/crates/waddle-server/src/sm_persistence/codec.rs
+++ b/server/crates/waddle-server/src/sm_persistence/codec.rs
@@ -55,6 +55,9 @@ pub(crate) fn decode_session(row: &crate::db::Row) -> Result<PersistedSession, S
     let replay_gap_through: Option<i64> = row
         .get(16)
         .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+    let presence_payloads_raw: Option<String> = row
+        .get(17)
+        .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
 
     let detached_at = DateTime::<Utc>::from_timestamp_millis(detached_at_ms)
         .ok_or_else(|| SmPersistenceError::Other("invalid detached_at_ms".into()))?;
@@ -80,9 +83,7 @@ pub(crate) fn decode_session(row: &crate::db::Row) -> Result<PersistedSession, S
         presence_show,
         presence_status,
         presence_priority: presence_priority.clamp(i8::MIN as i64, i8::MAX as i64) as i8,
-        // Slice 2 wires this to the `presence_payloads` column; the field
-        // exists first so the workspace compiles with the new struct shape.
-        presence_payloads: Vec::new(),
+        presence_payloads: parse_presence_payloads(presence_payloads_raw)?,
     })
 }
 
@@ -119,8 +120,10 @@ pub(crate) fn decode_unacked(
 
 /// Decode an unacked-stanza row from a JOIN result. Reads
 /// `stream_id` from column 0 (the session's stream_id),
-/// `stanza_xml` from column 18, and `original_receipt_at_ms`
-/// from column 19. Caller already has `sequence` (column 17).
+/// `stanza_xml` from column 19, and `original_receipt_at_ms`
+/// from column 20. Caller already has `sequence` (column 18).
+/// The unacked columns sit after the 18 session columns
+/// (0..=17, presence_payloads added at 17 for #1206).
 /// Used by `list_all_sessions_with_unacked` (issue #209 PR #405).
 pub(super) fn decode_unacked_join_row(
     row: &crate::db::Row,
@@ -130,10 +133,10 @@ pub(super) fn decode_unacked_join_row(
         .get(0)
         .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
     let stanza_xml: String = row
-        .get(18)
+        .get(19)
         .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
     let receipt_ms: i64 = row
-        .get(19)
+        .get(20)
         .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
     let original_receipt_at = DateTime::<Utc>::from_timestamp_millis(receipt_ms)
         .ok_or_else(|| SmPersistenceError::Other("invalid unacked receipt timestamp".into()))?;
@@ -183,6 +186,58 @@ pub(crate) fn serialize_stanza(stanza: &Stanza) -> Result<String, SmPersistenceE
         .write_to(&mut buf)
         .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
     String::from_utf8(buf).map_err(|e| SmPersistenceError::Other(e.to_string()))
+}
+
+/// Wrapper element name+namespace for encoding a resource's presence
+/// extension payloads into the single `sm_sessions.presence_payloads`
+/// TEXT column. This is an internal storage encoding only — the wrapper
+/// is never written to the XMPP wire (only its children are, individually,
+/// on probe/subscription delivery), so a `urn:waddle:*` namespace is
+/// appropriate and does not fall under the XEP wire-conformance rule.
+const PRESENCE_PAYLOADS_WRAPPER_NAME: &str = "payloads";
+const PRESENCE_PAYLOADS_WRAPPER_NS: &str = "urn:waddle:sm:presence-payloads:0";
+
+/// Serialize a resource's presence extension payloads to a single XML
+/// string for durable storage, or `None` when there are none (so the
+/// column stays NULL). The children are wrapped in one container element
+/// built via the minidom element builder — never `format!`/string concat,
+/// per the XML hard rule.
+pub(crate) fn serialize_presence_payloads(
+    payloads: &[xmpp_parsers::minidom::Element],
+) -> Result<Option<String>, SmPersistenceError> {
+    if payloads.is_empty() {
+        return Ok(None);
+    }
+    let mut builder = xmpp_parsers::minidom::Element::builder(
+        PRESENCE_PAYLOADS_WRAPPER_NAME,
+        PRESENCE_PAYLOADS_WRAPPER_NS,
+    );
+    for child in payloads {
+        builder = builder.append(child.clone());
+    }
+    let mut buf = Vec::new();
+    builder
+        .build()
+        .write_to(&mut buf)
+        .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+    String::from_utf8(buf)
+        .map(Some)
+        .map_err(|e| SmPersistenceError::Other(e.to_string()))
+}
+
+/// Parse the durable `presence_payloads` column back into typed elements
+/// (exactly once, per the typed-payloads hard rule). A NULL / empty column
+/// yields an empty vec.
+pub(crate) fn parse_presence_payloads(
+    raw: Option<String>,
+) -> Result<Vec<xmpp_parsers::minidom::Element>, SmPersistenceError> {
+    let Some(raw) = raw.filter(|s| !s.is_empty()) else {
+        return Ok(Vec::new());
+    };
+    let wrapper: xmpp_parsers::minidom::Element = raw
+        .parse()
+        .map_err(|e: xmpp_parsers::minidom::Error| SmPersistenceError::Other(e.to_string()))?;
+    Ok(wrapper.children().cloned().collect())
 }
 
 fn parse_stanza(element: xmpp_parsers::minidom::Element) -> Result<Stanza, SmPersistenceError> {

--- a/server/crates/waddle-server/src/sm_persistence/codec.rs
+++ b/server/crates/waddle-server/src/sm_persistence/codec.rs
@@ -80,6 +80,9 @@ pub(crate) fn decode_session(row: &crate::db::Row) -> Result<PersistedSession, S
         presence_show,
         presence_status,
         presence_priority: presence_priority.clamp(i8::MIN as i64, i8::MAX as i64) as i8,
+        // Slice 2 wires this to the `presence_payloads` column; the field
+        // exists first so the workspace compiles with the new struct shape.
+        presence_payloads: Vec::new(),
     })
 }
 

--- a/server/crates/waddle-server/src/sm_persistence/codec.rs
+++ b/server/crates/waddle-server/src/sm_persistence/codec.rs
@@ -256,3 +256,45 @@ fn parse_stanza(element: xmpp_parsers::minidom::Element) -> Result<Stanza, SmPer
         ))),
     }
 }
+
+#[cfg(test)]
+mod presence_payloads_tests {
+    use super::{parse_presence_payloads, serialize_presence_payloads};
+    use xmpp_parsers::minidom::Element;
+
+    #[test]
+    fn empty_payloads_serialize_to_none_so_the_column_stays_null() {
+        assert_eq!(serialize_presence_payloads(&[]).unwrap(), None);
+    }
+
+    #[test]
+    fn null_or_empty_column_parses_to_no_payloads() {
+        assert!(parse_presence_payloads(None).unwrap().is_empty());
+        assert!(parse_presence_payloads(Some(String::new()))
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn multiple_payloads_round_trip_verbatim_and_in_order() {
+        let caps: Element = r#"<c xmlns='http://jabber.org/protocol/caps' hash='sha-1' node='https://example.com/client' ver='zHyEOgxTrkpSdGcQKH8EFPLsriY='/>"#
+            .parse()
+            .unwrap();
+        let idle: Element = r#"<idle xmlns='urn:xmpp:idle:1' since='2026-07-08T10:00:00+00:00'/>"#
+            .parse()
+            .unwrap();
+        let encoded = serialize_presence_payloads(&[caps.clone(), idle.clone()])
+            .unwrap()
+            .expect("non-empty payloads serialize to Some");
+        let decoded = parse_presence_payloads(Some(encoded)).unwrap();
+        assert_eq!(decoded, vec![caps, idle]);
+    }
+
+    #[test]
+    fn malformed_column_is_a_typed_error_not_a_panic() {
+        // A corrupted / truncated column must surface as a typed decode
+        // error (which drops the session as a poison pill on restore),
+        // never a panic that bricks cold startup.
+        assert!(parse_presence_payloads(Some("<c xmlns='urn:x'".to_string())).is_err());
+    }
+}

--- a/server/crates/waddle-server/src/sm_persistence/codec.rs
+++ b/server/crates/waddle-server/src/sm_persistence/codec.rs
@@ -64,6 +64,25 @@ pub(crate) fn decode_session(row: &crate::db::Row) -> Result<PersistedSession, S
     let max_resume_duration =
         std::time::Duration::from_millis(max_resume_duration_ms.max(0) as u64);
     let presence_show = presence_show_raw.as_deref().map(parse_show).transpose()?;
+    // Degrade a malformed `presence_payloads` cell to caps-less rather than
+    // failing the whole session decode. Presence extension payloads are
+    // non-essential decoration that the client re-advertises on its next
+    // presence broadcast, whereas a decode error here would poison the
+    // session on cold start (`list_all_sessions_with_unacked`) and drop its
+    // XEP-0198 unacked message queue with it — a strictly worse trade
+    // (#1206 review). The column is always server-serialized well-formed XML
+    // via the minidom builder, so this only guards against storage-layer
+    // corruption of that single cell.
+    let presence_payloads =
+        parse_presence_payloads(presence_payloads_raw).unwrap_or_else(|error| {
+            tracing::warn!(
+                stream_id = %stream_id,
+                %error,
+                "sm session presence_payloads failed to decode; restoring the session \
+                 caps-less rather than dropping it (its unacked queue is preserved)"
+            );
+            Vec::new()
+        });
 
     Ok(PersistedSession {
         stream_id: SmSessionId::new(stream_id),
@@ -83,7 +102,7 @@ pub(crate) fn decode_session(row: &crate::db::Row) -> Result<PersistedSession, S
         presence_show,
         presence_status,
         presence_priority: presence_priority.clamp(i8::MIN as i64, i8::MAX as i64) as i8,
-        presence_payloads: parse_presence_payloads(presence_payloads_raw)?,
+        presence_payloads,
     })
 }
 

--- a/server/crates/waddle-server/src/sm_persistence/joined_sessions.rs
+++ b/server/crates/waddle-server/src/sm_persistence/joined_sessions.rs
@@ -10,7 +10,7 @@ pub(super) async fn list_all_sessions_with_unacked(
                     s.detached_at_ms, s.max_resume_duration_ms, \
                     s.carbons_enabled, s.roster_interested, s.blocklist_interested, s.presence_available, \
                     s.presence_show, s.presence_status, s.presence_priority, \
-                    s.replay_gap_through, \
+                    s.replay_gap_through, s.presence_payloads, \
                     u.sequence, u.stanza_xml, u.original_receipt_at_ms \
              FROM sm_sessions s \
              LEFT JOIN sm_unacked u ON s.stream_id = u.stream_id \
@@ -53,7 +53,8 @@ pub(super) async fn list_all_sessions_with_unacked(
         };
         let starts_new_group = current_stream_id.as_deref() != Some(row_stream_id.as_str());
         if starts_new_group {
-            // Decode the session columns (0..=16, 17 columns)
+            // Decode the session columns (0..=17, 18 columns;
+            // presence_payloads added at 17 for #1206)
             // exactly once per stream_id group. On decode
             // failure, skip the entire group's rows so a single
             // poison-pill session can't brick cold startup
@@ -85,11 +86,12 @@ pub(super) async fn list_all_sessions_with_unacked(
             // session; drop this unacked row too.
             continue;
         }
-        // Unacked columns: sequence (17), stanza_xml (18),
-        // original_receipt_at_ms (19). NULL when LEFT JOIN had
-        // no match. Per-row decode failure skips that row but
-        // keeps the rest of the session's queue.
-        let sequence_opt: Option<i64> = match row.get(17) {
+        // Unacked columns: sequence (18), stanza_xml (19),
+        // original_receipt_at_ms (20) — shifted +1 by the
+        // presence_payloads session column (17) added for #1206.
+        // NULL when LEFT JOIN had no match. Per-row decode failure
+        // skips that row but keeps the rest of the session's queue.
+        let sequence_opt: Option<i64> = match row.get(18) {
             Ok(v) => v,
             Err(error) => {
                 tracing::debug!(

--- a/server/crates/waddle-server/src/sm_persistence/schema.rs
+++ b/server/crates/waddle-server/src/sm_persistence/schema.rs
@@ -49,7 +49,8 @@ pub(super) async fn initialize(storage: &DatabaseSmPersistence) -> Result<(), Sm
                 presence_status TEXT,
                 presence_priority INTEGER NOT NULL,
                 replay_gap_through {bigint},
-                promotion_attempts INTEGER NOT NULL DEFAULT 0
+                promotion_attempts INTEGER NOT NULL DEFAULT 0,
+                presence_payloads TEXT
             )
             "#
             ),
@@ -102,6 +103,10 @@ pub(super) async fn initialize(storage: &DatabaseSmPersistence) -> Result<(), Sm
         "promotion_attempts INTEGER NOT NULL DEFAULT 0",
     )
     .await?;
+    // #1206: durable storage of the resource's own presence extension
+    // payloads (XEP-0115 caps, XEP-0319 idle, ...) so a rehydrated session
+    // relays them verbatim on probe instead of coming back caps-less.
+    add_column_if_missing(storage, "sm_sessions", "presence_payloads TEXT").await?;
     // ADR-0017 Phase 3 Slice 5 / element 5 — schema-only groundwork,
     // mirroring `pending_delivery`'s identical column group (see that
     // migration's doc comment for the full rationale and the "deferred,

--- a/server/crates/waddle-server/src/sm_persistence/tests.rs
+++ b/server/crates/waddle-server/src/sm_persistence/tests.rs
@@ -29,6 +29,7 @@ fn fixture_session(stream_id: &str) -> PersistedSession {
         presence_show: Some(Show::Chat),
         presence_status: Some("at the keyboard".to_string()),
         presence_priority: 5,
+        presence_payloads: Vec::new(),
     }
 }
 

--- a/server/crates/waddle-server/src/sm_persistence/tests.rs
+++ b/server/crates/waddle-server/src/sm_persistence/tests.rs
@@ -73,6 +73,40 @@ async fn round_trip_session_preserves_every_field() {
     assert_eq!(loaded.presence_show, s.presence_show);
     assert_eq!(loaded.presence_status, s.presence_status);
     assert_eq!(loaded.presence_priority, s.presence_priority);
+    assert_eq!(loaded.presence_payloads, s.presence_payloads);
+}
+
+/// #1206: the durable shape must carry the resource's own presence
+/// extension payloads (XEP-0115 `<c/>` caps, XEP-0319 `<idle/>`) so a
+/// session rehydrated from storage relays them verbatim on probe instead
+/// of coming back caps-less. The payloads survive a serialize→TEXT→parse
+/// round-trip, verbatim and in order.
+#[tokio::test]
+async fn round_trip_session_preserves_presence_payloads() {
+    use xmpp_parsers::minidom::Element;
+
+    let caps: Element = r#"<c xmlns='http://jabber.org/protocol/caps' hash='sha-1' node='https://example.com/client' ver='zHyEOgxTrkpSdGcQKH8EFPLsriY='/>"#
+        .parse()
+        .expect("valid XEP-0115 caps element");
+    let idle: Element = r#"<idle xmlns='urn:xmpp:idle:1' since='2026-07-08T10:00:00+00:00'/>"#
+        .parse()
+        .expect("valid XEP-0319 idle element");
+
+    let storage = DatabaseSmPersistence::open(None).await.unwrap();
+    let mut s = fixture_session("stream-payloads");
+    s.presence_payloads = vec![caps.clone(), idle.clone()];
+    storage.upsert_session(s.clone()).await.unwrap();
+
+    let loaded = storage
+        .get_session(&SmSessionId::new("stream-payloads"))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        loaded.presence_payloads,
+        vec![caps, idle],
+        "durable get_session must return the stored presence payloads verbatim and in order"
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/sm_persistence/tests.rs
+++ b/server/crates/waddle-server/src/sm_persistence/tests.rs
@@ -440,6 +440,61 @@ async fn store_session_atomic_and_join_read_preserve_presence_payloads() {
     assert_eq!(body, Some("m1".to_string()));
 }
 
+/// #1206 hardening (review): a corrupt `presence_payloads` cell must NOT
+/// poison the whole session on restore. Presence caps are non-essential and
+/// self-heal on the client's next presence broadcast, but the session's
+/// XEP-0198 unacked message queue is precious — decode degrades to caps-less
+/// and keeps the session (and its queue) instead of dropping it.
+#[tokio::test]
+async fn corrupt_presence_payloads_cell_degrades_to_caps_less_not_session_drop() {
+    let storage = DatabaseSmPersistence::open(None).await.unwrap();
+    storage
+        .store_session_atomic(
+            fixture_session("corrupt-payloads"),
+            vec![fixture_unacked("corrupt-payloads", 1)],
+        )
+        .await
+        .unwrap();
+
+    // Simulate storage-layer corruption of ONLY the presence_payloads cell
+    // (unclosed element — parses to an error).
+    storage
+        .execute(
+            "UPDATE sm_sessions SET presence_payloads = ? WHERE stream_id = ?",
+            crate::db_params![
+                "<c xmlns='urn:x'".to_string(),
+                "corrupt-payloads".to_string(),
+            ],
+        )
+        .await
+        .unwrap();
+
+    // get_session: session survives, caps-less.
+    let loaded = storage
+        .get_session(&SmSessionId::new("corrupt-payloads"))
+        .await
+        .unwrap()
+        .expect("session must survive a corrupt presence_payloads cell");
+    assert!(
+        loaded.presence_payloads.is_empty(),
+        "a corrupt payloads cell degrades to caps-less"
+    );
+
+    // Cold-start JOIN restore: the session AND its unacked queue survive
+    // (the corrupt cell must not turn it into a dropped poison pill).
+    let grouped = storage.list_all_sessions_with_unacked().await.unwrap();
+    let (session, unacked) = grouped
+        .iter()
+        .find(|(s, _)| s.stream_id.as_str() == "corrupt-payloads")
+        .expect("session must not be dropped as a poison pill");
+    assert!(session.presence_payloads.is_empty());
+    assert_eq!(
+        unacked.len(),
+        1,
+        "the unacked message queue must be preserved despite the corrupt payloads cell"
+    );
+}
+
 /// Issue #209 PR #405 (Greptile/Copilot P2 review):
 /// `store_session_atomic` MUST roll back the entire transaction
 /// on any mid-batch failure — including the session-row update.

--- a/server/crates/waddle-server/src/sm_persistence/tests.rs
+++ b/server/crates/waddle-server/src/sm_persistence/tests.rs
@@ -392,6 +392,54 @@ async fn store_session_atomic_round_trips_via_transaction() {
     assert_eq!(listed[2].sequence, 3);
 }
 
+/// #1206: the production store path is `store_session` → the OVERRIDDEN
+/// `store_session_atomic`, and cold-start restore reads back through the
+/// `list_all_sessions_with_unacked` JOIN. Both must carry the resource's
+/// presence payloads. This drives the end-to-end write+JOIN-read path and
+/// simultaneously guards the JOIN column indices: the unacked stanza must
+/// still decode after `presence_payloads` was inserted as a session column.
+#[tokio::test]
+async fn store_session_atomic_and_join_read_preserve_presence_payloads() {
+    use xmpp_parsers::minidom::Element;
+
+    let caps: Element = r#"<c xmlns='http://jabber.org/protocol/caps' hash='sha-1' node='https://example.com/client' ver='zHyEOgxTrkpSdGcQKH8EFPLsriY='/>"#
+        .parse()
+        .expect("valid XEP-0115 caps element");
+    let idle: Element = r#"<idle xmlns='urn:xmpp:idle:1' since='2026-07-08T10:00:00+00:00'/>"#
+        .parse()
+        .expect("valid XEP-0319 idle element");
+
+    let storage = DatabaseSmPersistence::open(None).await.unwrap();
+    let mut session = fixture_session("atomic-payloads");
+    session.presence_payloads = vec![caps.clone(), idle.clone()];
+    storage
+        .store_session_atomic(session, vec![fixture_unacked("atomic-payloads", 1)])
+        .await
+        .unwrap();
+
+    let grouped = storage.list_all_sessions_with_unacked().await.unwrap();
+    let (restored, unacked) = grouped
+        .iter()
+        .find(|(s, _)| s.stream_id.as_str() == "atomic-payloads")
+        .expect("session present in cold-start restore set");
+
+    assert_eq!(
+        restored.presence_payloads,
+        vec![caps, idle],
+        "the atomic store + JOIN restore must preserve the resource's presence payloads"
+    );
+
+    // Column-index guard: the unacked stanza still decodes end-to-end after
+    // presence_payloads shifted the JOIN's unacked columns by one.
+    assert_eq!(unacked.len(), 1, "the unacked stanza must survive the JOIN");
+    assert_eq!(unacked[0].sequence, 1);
+    let body = match &*unacked[0].stanza {
+        Stanza::Message(m) => m.bodies.values().next().cloned(),
+        _ => panic!("expected Message"),
+    };
+    assert_eq!(body, Some("m1".to_string()));
+}
+
 /// Issue #209 PR #405 (Greptile/Copilot P2 review):
 /// `store_session_atomic` MUST roll back the entire transaction
 /// on any mid-batch failure — including the session-row update.

--- a/server/crates/waddle-server/src/sm_persistence_fenced.rs
+++ b/server/crates/waddle-server/src/sm_persistence_fenced.rs
@@ -139,7 +139,7 @@ use waddle_xmpp::stream_management::persistence::{
 
 use crate::db::{Database, DatabaseDriver, Transaction};
 use crate::sm_persistence::codec::{
-    decode_session, decode_unacked, serialize_stanza, show_wire_str,
+    decode_session, decode_unacked, serialize_presence_payloads, serialize_stanza, show_wire_str,
 };
 
 /// FIX 3: map a [`ClaimError`] to the [`SmPersistenceError`] this trait's
@@ -291,9 +291,20 @@ impl PostgresFencedSmPersistence {
                 presence_status TEXT,
                 presence_priority INTEGER NOT NULL,
                 replay_gap_through BIGINT,
-                promotion_attempts INTEGER NOT NULL DEFAULT 0
+                promotion_attempts INTEGER NOT NULL DEFAULT 0,
+                presence_payloads TEXT
             )
             "#,
+            (),
+        )
+        .await
+        .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        // #1206: presence extension payloads (XEP-0115 caps, XEP-0319 idle,
+        // ...). ADD COLUMN IF NOT EXISTS (not folded into CREATE TABLE alone)
+        // so a table left by an earlier run of this impl gains the column —
+        // matching the sibling column-group migration below.
+        conn.execute(
+            "ALTER TABLE sm_sessions ADD COLUMN IF NOT EXISTS presence_payloads TEXT",
             (),
         )
         .await
@@ -458,6 +469,7 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
         let max_resume_duration_ms = i64::try_from(session.max_resume_duration.as_millis())
             .map_err(|_| SmPersistenceError::Other("max_resume_duration overflows i64".into()))?;
         let presence_show_str = session.presence_show.as_ref().map(show_wire_str);
+        let presence_payloads_xml = serialize_presence_payloads(&session.presence_payloads)?;
 
         let mut tx = self
             .db
@@ -476,8 +488,9 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
                 stream_id, user_id, full_jid, inbound_count, outbound_count,
                 last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms,
                 carbons_enabled, roster_interested, blocklist_interested, presence_available,
-                presence_show, presence_status, presence_priority, replay_gap_through
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, (EXTRACT(EPOCH FROM now()) * 1000)::bigint, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                presence_show, presence_status, presence_priority, replay_gap_through,
+                presence_payloads
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, (EXTRACT(EPOCH FROM now()) * 1000)::bigint, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (stream_id) DO UPDATE SET
                 user_id = excluded.user_id,
                 full_jid = excluded.full_jid,
@@ -494,7 +507,8 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
                 presence_show = excluded.presence_show,
                 presence_status = excluded.presence_status,
                 presence_priority = excluded.presence_priority,
-                replay_gap_through = excluded.replay_gap_through
+                replay_gap_through = excluded.replay_gap_through,
+                presence_payloads = excluded.presence_payloads
             "#,
             crate::db_params![
                 stream_id.as_str().to_string(),
@@ -513,6 +527,7 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
                 session.presence_status,
                 i64::from(session.presence_priority),
                 session.replay_gap_through.map(i64::from),
+                presence_payloads_xml,
             ],
         )
         .await
@@ -536,7 +551,8 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
                 "SELECT stream_id, user_id, full_jid, inbound_count, outbound_count, \
                         last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms, \
                         carbons_enabled, roster_interested, blocklist_interested, presence_available, \
-                        presence_show, presence_status, presence_priority, replay_gap_through \
+                        presence_show, presence_status, presence_priority, replay_gap_through, \
+                        presence_payloads \
                  FROM sm_sessions WHERE stream_id = ?",
                 crate::db_params![stream_id.as_str().to_string()],
             )
@@ -712,7 +728,8 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
                 "SELECT stream_id, user_id, full_jid, inbound_count, outbound_count, \
                         last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms, \
                         carbons_enabled, roster_interested, blocklist_interested, presence_available, \
-                        presence_show, presence_status, presence_priority, replay_gap_through \
+                        presence_show, presence_status, presence_priority, replay_gap_through, \
+                        presence_payloads \
                  FROM sm_sessions \
                  WHERE detached_at_ms + max_resume_duration_ms <= (EXTRACT(EPOCH FROM now()) * 1000)::bigint",
                 (),
@@ -735,7 +752,8 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
                 "SELECT stream_id, user_id, full_jid, inbound_count, outbound_count, \
                         last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms, \
                         carbons_enabled, roster_interested, blocklist_interested, presence_available, \
-                        presence_show, presence_status, presence_priority, replay_gap_through \
+                        presence_show, presence_status, presence_priority, replay_gap_through, \
+                        presence_payloads \
                  FROM sm_sessions",
                 (),
             )
@@ -769,6 +787,7 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
         let max_resume_duration_ms = i64::try_from(session.max_resume_duration.as_millis())
             .map_err(|_| SmPersistenceError::Other("max_resume_duration overflows i64".into()))?;
         let presence_show_str = session.presence_show.as_ref().map(show_wire_str);
+        let presence_payloads_xml = serialize_presence_payloads(&session.presence_payloads)?;
 
         let mut tx = self
             .db
@@ -795,8 +814,9 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
                 stream_id, user_id, full_jid, inbound_count, outbound_count,
                 last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms,
                 carbons_enabled, roster_interested, blocklist_interested, presence_available,
-                presence_show, presence_status, presence_priority, replay_gap_through
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, (EXTRACT(EPOCH FROM now()) * 1000)::bigint, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                presence_show, presence_status, presence_priority, replay_gap_through,
+                presence_payloads
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, (EXTRACT(EPOCH FROM now()) * 1000)::bigint, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (stream_id) DO UPDATE SET
                 user_id = excluded.user_id,
                 full_jid = excluded.full_jid,
@@ -813,7 +833,8 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
                 presence_show = excluded.presence_show,
                 presence_status = excluded.presence_status,
                 presence_priority = excluded.presence_priority,
-                replay_gap_through = excluded.replay_gap_through
+                replay_gap_through = excluded.replay_gap_through,
+                presence_payloads = excluded.presence_payloads
             "#,
             crate::db_params![
                 stream_id.as_str().to_string(),
@@ -832,6 +853,7 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
                 session.presence_status.clone(),
                 i64::from(session.presence_priority),
                 session.replay_gap_through.map(i64::from),
+                presence_payloads_xml,
             ],
         )
         .await

--- a/server/crates/waddle-server/src/sm_persistence_fenced/tests.rs
+++ b/server/crates/waddle-server/src/sm_persistence_fenced/tests.rs
@@ -203,6 +203,43 @@ async fn upsert_and_get_session_round_trip_except_divergent_detached_at() {
     );
 }
 
+/// #1206: the fenced backend must persist the resource's presence extension
+/// payloads (XEP-0115 caps, XEP-0319 idle) so a cross-node resume rehydrates
+/// them verbatim instead of coming back caps-less. Mirrors the portable
+/// backend's `round_trip_session_preserves_presence_payloads`.
+#[tokio::test]
+async fn upsert_and_get_session_preserves_presence_payloads() {
+    let Some(f) = fixture().await else { return };
+    use xmpp_parsers::minidom::Element;
+
+    let caps: Element = r#"<c xmlns='http://jabber.org/protocol/caps' hash='sha-1' node='https://example.com/client' ver='zHyEOgxTrkpSdGcQKH8EFPLsriY='/>"#
+        .parse()
+        .expect("valid XEP-0115 caps element");
+    let idle: Element = r#"<idle xmlns='urn:xmpp:idle:1' since='2026-07-08T10:00:00+00:00'/>"#
+        .parse()
+        .expect("valid XEP-0319 idle element");
+
+    let mut session = fixture_session("stream-payloads");
+    session.presence_payloads = vec![caps.clone(), idle.clone()];
+    f.fenced
+        .upsert_session(session)
+        .await
+        .expect("upsert_session with payloads");
+
+    let loaded = f
+        .fenced
+        .get_session(&SmSessionId::new("stream-payloads"))
+        .await
+        .expect("get_session")
+        .expect("session present");
+
+    assert_eq!(
+        loaded.presence_payloads,
+        vec![caps, idle],
+        "fenced get_session must return the stored presence payloads verbatim and in order"
+    );
+}
+
 #[tokio::test]
 async fn store_session_atomic_also_applies_divergence_a() {
     let Some(f) = fixture().await else { return };

--- a/server/crates/waddle-server/src/sm_persistence_fenced/tests.rs
+++ b/server/crates/waddle-server/src/sm_persistence_fenced/tests.rs
@@ -41,6 +41,7 @@ fn fixture_session(stream_id: &str) -> PersistedSession {
         presence_show: Some(Show::Chat),
         presence_status: Some("at the keyboard".to_string()),
         presence_priority: 5,
+        presence_payloads: Vec::new(),
     }
 }
 

--- a/server/crates/waddle-server/src/sm_promotion/tests.rs
+++ b/server/crates/waddle-server/src/sm_promotion/tests.rs
@@ -949,6 +949,7 @@ async fn restart_outlasting_resume_window_promotes_queue_into_pending_delivery()
             presence_show: None,
             presence_status: None,
             presence_priority: 0,
+            presence_payloads: Vec::new(),
         })
         .await
         .unwrap();

--- a/server/crates/waddle-xmpp/src/stream_management/persistence.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/persistence.rs
@@ -126,6 +126,15 @@ pub struct PersistedSession {
     pub presence_show: Option<Show>,
     pub presence_status: Option<String>,
     pub presence_priority: i8,
+    /// The resource's presence extension payloads (XEP-0115 `<c/>` caps,
+    /// XEP-0319 `<idle/>`, arbitrary extensions) as last broadcast while
+    /// available, so a session rehydrated from durable storage (restart or
+    /// cross-node resume) relays the resource's own advertisements verbatim
+    /// instead of coming back caps-less (issue #1206, follow-up to #1101 /
+    /// #1103). Typed arbitrary-XML per the typed-payloads hard rule; the
+    /// libSQL/Postgres backend serializes to a single TEXT column on write
+    /// and parses back to typed on read.
+    pub presence_payloads: Vec<minidom::Element>,
 }
 
 /// One row in the `sm_unacked` table — a stanza sent to a session

--- a/server/crates/waddle-xmpp/src/stream_management/persistence/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/persistence/tests.rs
@@ -28,6 +28,7 @@ fn fixture_session(stream_id: &str) -> PersistedSession {
         presence_show: None,
         presence_status: None,
         presence_priority: 1,
+        presence_payloads: Vec::new(),
     }
 }
 

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/cross_node_resume.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/cross_node_resume.rs
@@ -1267,6 +1267,7 @@ mod tests {
             presence_show: None,
             presence_status: None,
             presence_priority: 0,
+            presence_payloads: Vec::new(),
         }
     }
 

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/persistence_codec.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/persistence_codec.rs
@@ -38,6 +38,7 @@ pub(super) fn detached_to_persisted(
         presence_show: session.presence_show.clone(),
         presence_status: session.presence_status.clone(),
         presence_priority: session.presence_priority,
+        presence_payloads: session.presence_payloads.clone(),
     })
 }
 
@@ -155,11 +156,11 @@ pub(super) fn persisted_to_detached(
         presence_show: persisted.presence_show.clone(),
         presence_status: persisted.presence_status.clone(),
         presence_priority: persisted.presence_priority,
-        // The durable shape does not persist presence extension payloads;
-        // a restart-rehydrated detached session reports bare
-        // show/status/priority (issue #1103 limitation, documented on
-        // `DetachedSession::presence_payloads`).
-        presence_payloads: Vec::new(),
+        // Durable rehydration carries the resource's own presence extension
+        // payloads (XEP-0115 caps, XEP-0319 idle, ...) so a restart /
+        // cross-node resume relays them verbatim on probe rather than
+        // reporting a caps-less resource (issue #1206).
+        presence_payloads: persisted.presence_payloads.clone(),
         // Not persisted: durable rehydration may re-deliver the pending
         // subscribes once after a restart — acceptable.
         pending_subscribes_flushed: false,

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/session.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/session.rs
@@ -91,9 +91,11 @@ pub struct DetachedSession {
     /// The resource's presence extension payloads (XEP-0115 caps,
     /// XEP-0319 idle, anything else) as last broadcast while available,
     /// relayed verbatim by probe/subscription delivery for detached
-    /// resources (issue #1103). In-memory only: the durable persisted
-    /// shape does not carry payloads, so sessions rehydrated after a
-    /// process restart report bare show/status/priority.
+    /// resources (issue #1103). The durable persisted shape
+    /// ([`PersistedSession`](super::super::persistence::PersistedSession))
+    /// now carries these too (issue #1206), so a session rehydrated after
+    /// a process restart or cross-node resume reports its full presence,
+    /// payloads included — not bare show/status/priority.
     pub presence_payloads: Vec<minidom::Element>,
     /// Whether the once-per-session pending-subscribe flush (RFC 6121
     /// §3.1.3, issue #1104) was already consumed before detach. Resume

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -1406,6 +1406,7 @@ async fn restore_hydrates_expired_sessions_for_promotion_and_preserves_rows() {
         presence_show: None,
         presence_status: None,
         presence_priority: 0,
+        presence_payloads: Vec::new(),
     };
     storage.upsert_session(expired).await.unwrap();
     let mut queued =
@@ -2566,6 +2567,7 @@ async fn hydrate_reclaimed_skips_when_stream_id_already_present_in_memory() {
             presence_show: None,
             presence_status: None,
             presence_priority: 0,
+            presence_payloads: Vec::new(),
         })
         .await
         .expect("seed decoy durable row");
@@ -2762,6 +2764,7 @@ async fn hydrate_reclaimed_serializes_against_a_concurrent_live_mutator_for_the_
             presence_show: None,
             presence_status: None,
             presence_priority: 0,
+            presence_payloads: Vec::new(),
         })
         .await
         .expect("seed durable row");

--- a/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
+++ b/server/crates/waddle-xmpp/tests/xep0198_session_registry.rs
@@ -698,6 +698,62 @@ async fn xep0198_session_round_trips_through_persistence() {
     assert!(resumed.carbons_enabled);
 }
 
+/// #1206 (follow-up to #1101/#1103): the SM durable shape must carry a
+/// resource's own presence extension payloads (XEP-0115 `<c/>`, XEP-0319
+/// `<idle/>`, arbitrary extensions) across a restart / cross-node
+/// rehydration. Without this, a session rebuilt from durable storage comes
+/// back caps-less, and — because XEP-0198 resume means the client does NOT
+/// resend presence — every subsequent probe response relays the resource as
+/// available with no `<c/>` for the rest of the session, breaking feature
+/// detection toward its subscribers (RFC 6121 §4.3.2 requires the probe
+/// response to reproduce the complete presence stanza).
+#[tokio::test]
+async fn xep0198_persistence_round_trip_preserves_presence_payloads() {
+    use std::sync::Arc;
+    use waddle_xmpp::stream_management::persistence::InMemorySmPersistence;
+    use xmpp_parsers::minidom::Element;
+
+    let caps: Element = r#"<c xmlns='http://jabber.org/protocol/caps' hash='sha-1' node='https://example.com/client' ver='zHyEOgxTrkpSdGcQKH8EFPLsriY='/>"#
+        .parse()
+        .expect("valid XEP-0115 caps element");
+    let idle: Element = r#"<idle xmlns='urn:xmpp:idle:1' since='2026-07-08T10:00:00+00:00'/>"#
+        .parse()
+        .expect("valid XEP-0319 idle element");
+
+    let persistence: Arc<dyn SmPersistenceStorage> = Arc::new(InMemorySmPersistence::new());
+    let registry = InMemorySmSessionRegistry::new().with_persistence(Arc::clone(&persistence));
+
+    let mut session = detached_session("stream-payloads", "alice@example.com/laptop");
+    session.presence_payloads = vec![caps.clone(), idle.clone()];
+    registry.store_session(session).await.expect("store");
+
+    // Simulate restart: drop the registry, build a fresh one over the same
+    // persistence handle, restore from durable storage.
+    drop(registry);
+    let restored = InMemorySmSessionRegistry::new().with_persistence(Arc::clone(&persistence));
+    let count = restored
+        .restore_from_persistence()
+        .await
+        .expect("restore from persistence");
+    assert_eq!(count, 1, "one session restored");
+
+    // AC2: a probe of the still-detached available resource carries its
+    // stored payloads. `detached_presence_state` is the exact source the
+    // probe / subscription-delivery paths read from.
+    let jid: FullJid = "alice@example.com/laptop".parse().unwrap();
+    let state = restored
+        .detached_presence_state(&jid)
+        .await
+        .expect("query detached presence state")
+        .expect("detached available resource present after restore");
+    assert_eq!(
+        state.payloads,
+        vec![caps, idle],
+        "durable rehydration must preserve the resource's own presence payloads \
+         verbatim and in order"
+    );
+}
+
 /// Locked Q8 = B persist-after-promotion contract (issue #209
 /// PR #346, post-Copilot-review): `drain_expired` and
 /// `drain_all_for_shutdown` MUST NOT delete the durable SM row


### PR DESCRIPTION
Fixes #1206.

Follow-up to #1101 (PR #1205) and #1103 (PR #1207), found in adversarial review.

## Problem

PR #1207 wired a resource's presence extension payloads (XEP-0115 `<c/>`,
XEP-0319 `<idle/>`, arbitrary extensions) through the **in-memory** XEP-0198
detached-session boundary: `DetachedSession.presence_payloads` is carried into
resume (`registration.rs`) and served from the detached-window probe /
subscription-delivery paths.

The **durable** persistence layer was explicitly deferred (a `Vec::new()`
placeholder in `persisted_to_detached`). `PersistedSession` had no payloads
field, so `detached_to_persisted` dropped them on write and
`persisted_to_detached` hard-coded empty on read. Every session rehydrated
from durable storage — a **cross-node resume** (clustered) or a **restart
resume** (single-node) — therefore came back caps-less. Since XEP-0198 resume
means the client does **not** resend presence, every subsequent probe response
and subscription-approval push then relayed that resource as available with no
`<c/>` for the rest of the session, breaking feature detection (e.g. Jingle)
toward its subscribers — the same class of bug #1101 fixed, reintroduced
through the durable-rehydration door. (RFC 6121 §4.3.2 requires a probe
response to reproduce the complete presence stanza.)

## Fix

Persist the payloads in the SM durable shape and restore them:

- `PersistedSession` gains `presence_payloads: Vec<minidom::Element>` — typed
  arbitrary-XML per the typed-payloads hard rule. The two codec conversions
  (`detached_to_persisted` / `persisted_to_detached`) carry the field.
- New `sm_sessions.presence_payloads` TEXT column (portable **and**
  Postgres-fenced backends). Encoded as one `minidom` wrapper element built via
  the element builder (never `format!`/string concat, per the XML hard rule);
  serialization to the column happens only at the DB I/O boundary, parsed back
  to typed exactly once on read. Empty payloads → NULL column → empty vec.
- The shared `decode_session` now reads column 17, so the plain SELECTs and the
  `list_all_sessions_with_unacked` JOIN both carry it; the JOIN's unacked reads
  shift to 18/19/20 (existing JOIN/poison-pill tests guard the shift).
- The wrapper's `urn:waddle:sm:presence-payloads:0` namespace is an internal
  storage encoding only — never on the wire; only the wrapper's children (the
  original extension elements) are ever relayed.
- `decode_session` degrades a malformed `presence_payloads` cell to caps-less
  (log + empty) rather than failing the whole decode: caps are non-essential
  and self-heal on the next presence broadcast, whereas poisoning the session
  would drop its XEP-0198 unacked message queue on cold start — a strictly
  worse trade (review hardening).

Out of scope (noted in #1206): `user_actor.rs` `UpdatePresenceState` still
stores empty payloads (no production senders today); ADR-0017 later phases that
cut probe responses over to the actor store must carry payloads too.

## Tests (TDD, vertical slices — RED→GREEN per slice)

- `xep0198_persistence_round_trip_preserves_presence_payloads` (XEP-0198 suite):
  store a detached session with real XEP-0115 caps + XEP-0319 idle, persist,
  restart the registry, restore — a probe of the still-detached resource
  (`detached_presence_state`) returns the payloads verbatim (AC1 + AC2).
- `round_trip_session_preserves_presence_payloads` (portable SQLite backend):
  `upsert_session` → `get_session` preserves payloads.
- `store_session_atomic_and_join_read_preserve_presence_payloads`: the real
  production store path + cold-start JOIN restore preserves payloads AND the
  unacked stanza still decodes (end-to-end JOIN column-index guard).
- `presence_payloads_tests` (codec): empty→NULL→empty, in-order multi-payload
  round-trip, and malformed column → typed error (poison-pill, not a panic).
- `upsert_and_get_session_preserves_presence_payloads` (Postgres-fenced,
  env-gated) mirrors the portable round-trip.

## Acceptance criteria

- [x] After detach + resume (no presence resend), a probe for the resumed
      resource returns its pre-detach caps and extensions
- [x] Probe of a *detached* (not yet resumed) available resource carries its
      stored payloads
- [x] Dedicated Rust test in the XEP-0198/XEP-0115 suites

## Verification

`cargo fmt --check` clean; `cargo clippy -D warnings` clean for default **and**
`--features clustering`; portable backend + XEP-0198 suites green; fenced
backend compiles under `--features clustering`. Reviewed by two independent
adversarial personas (opus) plus gpt-5.5 (codex) — no real defects; the two
review-response items (stale doc + codec edge-case tests) are folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
