### PR TITLE
fix(server): build clustering-enabled production image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
             version = "0.1.0";
             src = serverPackageSrc;
             strictDeps = true;
-            cargoExtraArgs = "--locked --package waddle-server --bin waddle-server";
+            cargoExtraArgs = "--locked --package waddle-server --bin waddle-server --features clustering";
             nativeBuildInputs = [
               pkgs.pkg-config
               pkgs.protobuf
@@ -303,7 +303,7 @@
             baseArgs
             // {
               CARGO_PROFILE = "ci";
-              cargoExtraArgs = "--locked --package waddle-server --bin waddle-server";
+              cargoExtraArgs = "--locked --package waddle-server --bin waddle-server --features clustering";
               cargoCheckExtraArgs = "";
               cargoBuildExtraArgs = "";
               cargoTestExtraArgs = "";
@@ -350,7 +350,7 @@
               pname = "waddle-server-ci-build";
               CARGO_PROFILE = "ci";
               cargoArtifacts = ciServerArtifacts;
-              cargoExtraArgs = "--locked --package waddle-server --bin waddle-server";
+              cargoExtraArgs = "--locked --package waddle-server --bin waddle-server --features clustering";
             }
           );
           waddle-server-extension-modules = craneLib.cargoBuild (


### PR DESCRIPTION
## Context

ADR-0017 Phase 4 merged and main CI published image/tag `sha-b50f62d`, but the production rollout stalled after Flux applied `gitops-waddle-server` digest `latest@sha256:ce674c3acd09c431e7c4ff9547f82ec8f28d1ebb91e65abf1aa0e1f1a12ebf01`.

The new pod on image digest `sha256:7a75a4bd11dca2ed0e355e921a145f6441e281ea78a3479c53e5bf423cc8f2c5` crash-looped with:

```text
clustering.enabled=true but this binary was built without the `clustering` cargo feature; rebuild with `--features clustering`
```

The chart/runtime config correctly enables clustering and mounts the keypool secret. The bug is that the production Nix package/image path still built `waddle-server` without the `clustering` cargo feature.

## Plan

1. Build the production `waddle-server` package and `waddle-server-image-stream` with `--features clustering`.
2. Keep the CI build derivation aligned with the production package path so this cannot publish again without the clustering feature.
3. Run narrow local gates for the binary/package path.
4. Wait for PR CI, merge, then monitor the main publish job and Flux rollout until the `waddle-server` deployment reaches two ready clustered replicas.

## Validation

- [x] `cargo check --manifest-path server/Cargo.toml -p waddle-server --features clustering --bin waddle-server`
- [x] `rg -n 'cargoExtraArgs = "--locked --package waddle-server --bin waddle-server' flake.nix` shows all three production/CI binary build invocations include `--features clustering`
- [x] `nix build .#checks.aarch64-darwin.waddle-server-ci-build`
- [x] `nix build .#waddle-server`
- [x] PR CI green (`nixBuildCi`, `nixClippy`, `nixXmppServerTests`, CodeQL, render/drift checks)
- [ ] main publish green after merge
- [ ] Flux rollout healthy: HelmRelease ready, deployment `2/2`, no startup crash loop
