### PR TITLE
fix(server): register clustered remote resources

### DIFF
--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -10,14 +10,13 @@
 //! panics (removing this node from the routing fabric while its Postgres
 //! heartbeat stays fresh — a steady-state, cluster-wide degradation with no
 //! self-healing path), so an owning task respawns it and **re-registers it
-//! under the same name**. Sender-side stale-ref errors (`ActorNotRunning`/
-//! `ActorStopped`/`UnknownActor`/`BadActorType`) trigger a bounded-backoff
-//! kademlia re-lookup — the transport-layer refresh path, distinct from
-//! Phase 3's `NotOwner` claims-refresh path.
+//! under the same name**. Sender-side no-effect stale-ref errors
+//! (`ActorNotRunning`/`UnknownActor`/`BadActorType`) trigger a bounded-backoff
+//! kademlia re-lookup for non-idempotent delivery paths; `ActorStopped` is
+//! treated as maybe committed so callers do not duplicate user-visible work.
 //!
-//! Phase 2 is **discovery only**: the relay's message set proves the
-//! cross-node ask round-trip and the XML codec on the wire (spike exit
-//! criteria); it is not wired into the stanza delivery path (Phase 4).
+//! Phase 4 wires DM/MUC/presence routing through this relay. Kademlia still
+//! discovers node relays only; entity ownership remains in Postgres claims.
 
 use super::codec::RemoteStanza;
 use super::local_claims::RoomLocalClaims;
@@ -27,7 +26,11 @@ use super::ordered_relay::{
     OrderedRelayReceiverState, OrderedRelayReply, OrderedRelayReservation, RemoteStanzaEnvelope,
 };
 use super::resume_bridge::ResumeStealBridge;
-use super::route_bridge::OrderedRelayDeliveryBridge;
+use super::route_bridge::{
+    OrderedRelayDeliveryBridge, RemoteResourceOutboundFrame, RemoteResourceRegistrationId,
+    RemoteResourceRouteOutcome, RemoteResourceRouteTarget, RemoteResourceSocketGeneration,
+    RemoteResourceStateSnapshot, RemoteResourceStateUpdate, RemoteUserSideEffect,
+};
 use super::self_fence::LocallyClaimedEntities;
 use super::NodeId;
 use kameo::actor::{ActorRef, RemoteActorRef, Spawn};
@@ -317,6 +320,234 @@ fn record_ordered_relay_reply(reply: &OrderedRelayReply) {
         OrderedRelayReply::Nack(nack) => {
             metrics::record_ordered_relay_nack(nack.reason.metric_label());
         }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayRegisterRemoteUserResource {
+    pub jid: jid::FullJid,
+    pub registration_id: RemoteResourceRegistrationId,
+    pub socket_generation: RemoteResourceSocketGeneration,
+    pub socket_node: NodeId,
+    pub state: RemoteResourceStateSnapshot,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RelayRemoteResourceRegistrationStatus {
+    Registered,
+    StaleRegistration,
+    NotOwner,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Reply)]
+pub struct RelayRemoteResourceRegistrationReply {
+    pub status: RelayRemoteResourceRegistrationStatus,
+}
+
+#[kameo::remote_message("waddle.clustering.relay.remote_resource_register.v1")]
+impl Message<RelayRegisterRemoteUserResource> for RelayActor {
+    type Reply = kameo::reply::DelegatedReply<RelayRemoteResourceRegistrationReply>;
+
+    async fn handle(
+        &mut self,
+        msg: RelayRegisterRemoteUserResource,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let bridge = Arc::clone(&self.ordered_delivery_bridge);
+        ctx.spawn(async move { bridge.register_remote_user_resource_on_owner(msg).await })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayUnregisterRemoteUserResource {
+    pub jid: jid::FullJid,
+    pub registration_id: RemoteResourceRegistrationId,
+    pub socket_generation: RemoteResourceSocketGeneration,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Reply)]
+pub struct RelayRemoteResourceUnregisterReply {
+    pub removed: bool,
+}
+
+#[kameo::remote_message("waddle.clustering.relay.remote_resource_unregister.v1")]
+impl Message<RelayUnregisterRemoteUserResource> for RelayActor {
+    type Reply = kameo::reply::DelegatedReply<RelayRemoteResourceUnregisterReply>;
+
+    async fn handle(
+        &mut self,
+        msg: RelayUnregisterRemoteUserResource,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let bridge = Arc::clone(&self.ordered_delivery_bridge);
+        ctx.spawn(async move { bridge.unregister_remote_user_resource_on_owner(msg).await })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayUpdateRemoteUserResource {
+    pub jid: jid::FullJid,
+    pub registration_id: RemoteResourceRegistrationId,
+    pub socket_generation: RemoteResourceSocketGeneration,
+    pub update: RemoteResourceStateUpdate,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RelayRemoteResourceUpdateStatus {
+    Updated,
+    StaleRegistration,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Reply)]
+pub struct RelayRemoteResourceUpdateReply {
+    pub status: RelayRemoteResourceUpdateStatus,
+}
+
+#[kameo::remote_message("waddle.clustering.relay.remote_resource_update.v1")]
+impl Message<RelayUpdateRemoteUserResource> for RelayActor {
+    type Reply = kameo::reply::DelegatedReply<RelayRemoteResourceUpdateReply>;
+
+    async fn handle(
+        &mut self,
+        msg: RelayUpdateRemoteUserResource,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let bridge = Arc::clone(&self.ordered_delivery_bridge);
+        ctx.spawn(async move { bridge.update_remote_user_resource_on_owner(msg).await })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayRemoteUserSideEffect {
+    pub source_jid: jid::FullJid,
+    pub registration_id: RemoteResourceRegistrationId,
+    pub socket_generation: RemoteResourceSocketGeneration,
+    pub effect: RemoteUserSideEffect,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RelayRemoteUserSideEffectStatus {
+    Applied,
+    StaleRegistration,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Reply)]
+pub struct RelayRemoteUserSideEffectReply {
+    pub status: RelayRemoteUserSideEffectStatus,
+}
+
+#[kameo::remote_message("waddle.clustering.relay.remote_user_side_effect.v1")]
+impl Message<RelayRemoteUserSideEffect> for RelayActor {
+    type Reply = kameo::reply::DelegatedReply<RelayRemoteUserSideEffectReply>;
+
+    async fn handle(
+        &mut self,
+        msg: RelayRemoteUserSideEffect,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let bridge = Arc::clone(&self.ordered_delivery_bridge);
+        ctx.spawn(async move { bridge.apply_remote_user_side_effect_on_owner(msg).await })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayRouteRemoteResourceStanza {
+    pub source_jid: jid::FullJid,
+    pub registration_id: RemoteResourceRegistrationId,
+    pub socket_generation: RemoteResourceSocketGeneration,
+    pub target: RemoteResourceRouteTarget,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Reply)]
+pub struct RelayRouteRemoteResourceStanzaReply {
+    pub outcome: RemoteResourceRouteOutcome,
+    pub replies: Vec<RemoteStanza>,
+}
+
+#[kameo::remote_message("waddle.clustering.relay.remote_resource_route.v1")]
+impl Message<RelayRouteRemoteResourceStanza> for RelayActor {
+    type Reply = kameo::reply::DelegatedReply<RelayRouteRemoteResourceStanzaReply>;
+
+    async fn handle(
+        &mut self,
+        msg: RelayRouteRemoteResourceStanza,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let bridge = Arc::clone(&self.ordered_delivery_bridge);
+        ctx.spawn(async move { bridge.route_remote_resource_stanza_on_owner(msg).await })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayDeliverRemoteResourceFrame {
+    pub frame: RemoteResourceOutboundFrame,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RelayRemoteResourceFrameStatus {
+    Delivered,
+    Backpressure,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Reply)]
+pub struct RelayRemoteResourceFrameReply {
+    pub status: RelayRemoteResourceFrameStatus,
+}
+
+#[kameo::remote_message("waddle.clustering.relay.remote_resource_frame.v1")]
+impl Message<RelayDeliverRemoteResourceFrame> for RelayActor {
+    type Reply = kameo::reply::DelegatedReply<RelayRemoteResourceFrameReply>;
+
+    async fn handle(
+        &mut self,
+        msg: RelayDeliverRemoteResourceFrame,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let bridge = Arc::clone(&self.ordered_delivery_bridge);
+        ctx.spawn(async move { bridge.deliver_remote_resource_frame_on_socket(msg).await })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelayForceDetachRemoteUserResource {
+    pub jid: jid::FullJid,
+    pub registration_id: RemoteResourceRegistrationId,
+    pub requester_bare_jid: jid::BareJid,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RelayRemoteResourceForceDetachStatus {
+    Detached,
+    NotLive,
+    Refused,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Reply)]
+pub struct RelayForceDetachRemoteUserResourceReply {
+    pub outcome: waddle_xmpp::registry::ForceDetachOutcome,
+    pub status: RelayRemoteResourceForceDetachStatus,
+}
+
+#[kameo::remote_message("waddle.clustering.relay.remote_resource_force_detach.v1")]
+impl Message<RelayForceDetachRemoteUserResource> for RelayActor {
+    type Reply = kameo::reply::DelegatedReply<RelayForceDetachRemoteUserResourceReply>;
+
+    async fn handle(
+        &mut self,
+        msg: RelayForceDetachRemoteUserResource,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let bridge = Arc::clone(&self.ordered_delivery_bridge);
+        ctx.spawn(async move {
+            bridge
+                .force_detach_remote_user_resource_on_socket(msg)
+                .await
+        })
     }
 }
 
@@ -996,7 +1227,7 @@ impl RelayHandle {
             .await
         {
             Ok(reply) => Ok(reply),
-            Err(error) if is_stale_ref_error(&error) => {
+            Err(error) if is_no_effect_stale_ref_relookup_error(&error) => {
                 self.cached = None;
                 let remote_ref = self.resolve().await?;
                 remote_ref
@@ -1040,7 +1271,7 @@ impl RelayHandle {
             .await
         {
             Ok(reply) => Ok(reply),
-            Err(error) if is_ordered_relookup_retry_error(&error) => {
+            Err(error) if is_no_effect_stale_ref_relookup_error(&error) => {
                 self.cached = None;
                 let remote_ref = self.resolve().await?;
                 match remote_ref
@@ -1054,6 +1285,259 @@ impl RelayHandle {
                 }
             }
             Err(error) => ordered_send_error(&message.envelope, error),
+        }
+    }
+
+    pub async fn register_remote_user_resource(
+        &mut self,
+        message: RelayRegisterRemoteUserResource,
+    ) -> Result<RelayRemoteResourceRegistrationReply, RelayAskError> {
+        let stop_token = self.stop_token.clone();
+        tokio::select! {
+            biased;
+            _ = stop_token.cancelled() => Err(RelayAskError::Cancelled),
+            result = self.register_remote_user_resource_inner(message) => result,
+        }
+    }
+
+    async fn register_remote_user_resource_inner(
+        &mut self,
+        message: RelayRegisterRemoteUserResource,
+    ) -> Result<RelayRemoteResourceRegistrationReply, RelayAskError> {
+        let remote_ref = self.resolve().await?;
+        match remote_ref
+            .ask(&message)
+            .mailbox_timeout(self.mailbox_timeout)
+            .reply_timeout(self.reply_timeout)
+            .await
+        {
+            Ok(reply) => Ok(reply),
+            Err(error) if is_no_effect_stale_ref_relookup_error(&error) => {
+                self.cached = None;
+                let remote_ref = self.resolve().await?;
+                remote_ref
+                    .ask(&message)
+                    .mailbox_timeout(self.mailbox_timeout)
+                    .reply_timeout(self.reply_timeout)
+                    .await
+                    .map_err(send_error)
+            }
+            Err(error) => Err(send_error(error)),
+        }
+    }
+
+    pub async fn unregister_remote_user_resource(
+        &mut self,
+        message: RelayUnregisterRemoteUserResource,
+    ) -> Result<RelayRemoteResourceUnregisterReply, RelayAskError> {
+        let stop_token = self.stop_token.clone();
+        tokio::select! {
+            biased;
+            _ = stop_token.cancelled() => Err(RelayAskError::Cancelled),
+            result = self.unregister_remote_user_resource_inner(message) => result,
+        }
+    }
+
+    async fn unregister_remote_user_resource_inner(
+        &mut self,
+        message: RelayUnregisterRemoteUserResource,
+    ) -> Result<RelayRemoteResourceUnregisterReply, RelayAskError> {
+        let remote_ref = self.resolve().await?;
+        match remote_ref
+            .ask(&message)
+            .mailbox_timeout(self.mailbox_timeout)
+            .reply_timeout(self.reply_timeout)
+            .await
+        {
+            Ok(reply) => Ok(reply),
+            Err(error) if is_no_effect_stale_ref_relookup_error(&error) => {
+                self.cached = None;
+                let remote_ref = self.resolve().await?;
+                remote_ref
+                    .ask(&message)
+                    .mailbox_timeout(self.mailbox_timeout)
+                    .reply_timeout(self.reply_timeout)
+                    .await
+                    .map_err(send_error)
+            }
+            Err(error) => Err(send_error(error)),
+        }
+    }
+
+    pub async fn update_remote_user_resource(
+        &mut self,
+        message: RelayUpdateRemoteUserResource,
+    ) -> Result<RelayRemoteResourceUpdateReply, RelayAskError> {
+        let stop_token = self.stop_token.clone();
+        tokio::select! {
+            biased;
+            _ = stop_token.cancelled() => Err(RelayAskError::Cancelled),
+            result = self.update_remote_user_resource_inner(message) => result,
+        }
+    }
+
+    async fn update_remote_user_resource_inner(
+        &mut self,
+        message: RelayUpdateRemoteUserResource,
+    ) -> Result<RelayRemoteResourceUpdateReply, RelayAskError> {
+        let remote_ref = self.resolve().await?;
+        match remote_ref
+            .ask(&message)
+            .mailbox_timeout(self.mailbox_timeout)
+            .reply_timeout(self.reply_timeout)
+            .await
+        {
+            Ok(reply) => Ok(reply),
+            Err(error) if is_no_effect_stale_ref_relookup_error(&error) => {
+                self.cached = None;
+                let remote_ref = self.resolve().await?;
+                remote_ref
+                    .ask(&message)
+                    .mailbox_timeout(self.mailbox_timeout)
+                    .reply_timeout(self.reply_timeout)
+                    .await
+                    .map_err(send_error)
+            }
+            Err(error) => Err(send_error(error)),
+        }
+    }
+
+    pub async fn remote_user_side_effect(
+        &mut self,
+        message: RelayRemoteUserSideEffect,
+    ) -> Result<RelayRemoteUserSideEffectReply, RelayAskError> {
+        let stop_token = self.stop_token.clone();
+        tokio::select! {
+            biased;
+            _ = stop_token.cancelled() => Err(RelayAskError::Cancelled),
+            result = self.remote_user_side_effect_inner(message) => result,
+        }
+    }
+
+    async fn remote_user_side_effect_inner(
+        &mut self,
+        message: RelayRemoteUserSideEffect,
+    ) -> Result<RelayRemoteUserSideEffectReply, RelayAskError> {
+        let remote_ref = self.resolve().await?;
+        remote_ref
+            .ask(&message)
+            .mailbox_timeout(self.mailbox_timeout)
+            .reply_timeout(self.reply_timeout)
+            .await
+            .map_err(send_error)
+    }
+
+    pub async fn route_remote_resource_stanza(
+        &mut self,
+        message: RelayRouteRemoteResourceStanza,
+    ) -> Result<RelayRouteRemoteResourceStanzaReply, RelayAskError> {
+        let stop_token = self.stop_token.clone();
+        tokio::select! {
+            biased;
+            _ = stop_token.cancelled() => Err(RelayAskError::Cancelled),
+            result = self.route_remote_resource_stanza_inner(message) => result,
+        }
+    }
+
+    async fn route_remote_resource_stanza_inner(
+        &mut self,
+        message: RelayRouteRemoteResourceStanza,
+    ) -> Result<RelayRouteRemoteResourceStanzaReply, RelayAskError> {
+        let remote_ref = self.resolve().await?;
+        match remote_ref
+            .ask(&message)
+            .mailbox_timeout(self.mailbox_timeout)
+            .reply_timeout(self.reply_timeout)
+            .await
+        {
+            Ok(reply) => Ok(reply),
+            Err(error) if is_no_effect_stale_ref_relookup_error(&error) => {
+                self.cached = None;
+                let remote_ref = self.resolve().await?;
+                remote_ref
+                    .ask(&message)
+                    .mailbox_timeout(self.mailbox_timeout)
+                    .reply_timeout(self.reply_timeout)
+                    .await
+                    .map_err(send_error)
+            }
+            Err(error) => Err(send_error(error)),
+        }
+    }
+
+    pub async fn deliver_remote_resource_frame(
+        &mut self,
+        message: RelayDeliverRemoteResourceFrame,
+    ) -> Result<RelayRemoteResourceFrameReply, RelayAskError> {
+        let stop_token = self.stop_token.clone();
+        tokio::select! {
+            biased;
+            _ = stop_token.cancelled() => Err(RelayAskError::Cancelled),
+            result = self.deliver_remote_resource_frame_inner(message) => result,
+        }
+    }
+
+    async fn deliver_remote_resource_frame_inner(
+        &mut self,
+        message: RelayDeliverRemoteResourceFrame,
+    ) -> Result<RelayRemoteResourceFrameReply, RelayAskError> {
+        let remote_ref = self.resolve().await?;
+        match remote_ref
+            .ask(&message)
+            .mailbox_timeout(self.mailbox_timeout)
+            .reply_timeout(self.reply_timeout)
+            .await
+        {
+            Ok(reply) => Ok(reply),
+            Err(error) if is_no_effect_stale_ref_relookup_error(&error) => {
+                self.cached = None;
+                let remote_ref = self.resolve().await?;
+                remote_ref
+                    .ask(&message)
+                    .mailbox_timeout(self.mailbox_timeout)
+                    .reply_timeout(self.reply_timeout)
+                    .await
+                    .map_err(send_error)
+            }
+            Err(error) => Err(send_error(error)),
+        }
+    }
+
+    pub async fn force_detach_remote_user_resource(
+        &mut self,
+        message: RelayForceDetachRemoteUserResource,
+    ) -> Result<RelayForceDetachRemoteUserResourceReply, RelayAskError> {
+        let stop_token = self.stop_token.clone();
+        tokio::select! {
+            biased;
+            _ = stop_token.cancelled() => Err(RelayAskError::Cancelled),
+            result = self.force_detach_remote_user_resource_inner(message) => result,
+        }
+    }
+
+    async fn force_detach_remote_user_resource_inner(
+        &mut self,
+        message: RelayForceDetachRemoteUserResource,
+    ) -> Result<RelayForceDetachRemoteUserResourceReply, RelayAskError> {
+        let remote_ref = self.resolve().await?;
+        match remote_ref
+            .ask(&message)
+            .mailbox_timeout(self.mailbox_timeout)
+            .reply_timeout(self.reply_timeout)
+            .await
+        {
+            Ok(reply) => Ok(reply),
+            Err(error) if is_stale_ref_error(&error) => {
+                self.cached = None;
+                let remote_ref = self.resolve().await?;
+                remote_ref
+                    .ask(&message)
+                    .mailbox_timeout(self.mailbox_timeout)
+                    .reply_timeout(self.reply_timeout)
+                    .await
+                    .map_err(send_error)
+            }
+            Err(error) => Err(send_error(error)),
         }
     }
 
@@ -1167,12 +1651,12 @@ fn is_stale_ref_error<E>(error: &RemoteSendError<E>) -> bool {
     classify(error) == RelaySendFailure::StaleRef
 }
 
-/// Ordered relay envelopes are not retried after `ActorStopped`: that error
-/// may have been enqueued before the actor stopped, so a re-send against a
-/// respawned relay could duplicate a committed side effect once production
-/// delivery is wired. `ActorNotRunning`/`UnknownActor`/`BadActorType` are
-/// still safe re-lookup cases because they prove the cached ref was unusable.
-fn is_ordered_relookup_retry_error<E>(error: &RemoteSendError<E>) -> bool {
+/// Non-idempotent relay messages are not retried after `ActorStopped`: that
+/// error may have been enqueued before the actor stopped, so a re-send against
+/// a respawned relay could duplicate a committed side effect.
+/// `ActorNotRunning`/`UnknownActor`/`BadActorType` are still safe re-lookup
+/// cases because they prove the cached ref was unusable.
+fn is_no_effect_stale_ref_relookup_error<E>(error: &RemoteSendError<E>) -> bool {
     matches!(
         error,
         RemoteSendError::ActorNotRunning
@@ -1539,23 +2023,19 @@ mod tests {
     }
 
     #[test]
-    fn ordered_relookup_excludes_maybe_enqueued_actor_stopped() {
-        assert!(is_ordered_relookup_retry_error::<std::convert::Infallible>(
-            &RemoteSendError::ActorNotRunning
-        ));
-        assert!(is_ordered_relookup_retry_error::<std::convert::Infallible>(
-            &RemoteSendError::BadActorType
-        ));
-        assert!(
-            !is_ordered_relookup_retry_error::<std::convert::Infallible>(
-                &RemoteSendError::ActorStopped
-            )
-        );
-        assert!(
-            !is_ordered_relookup_retry_error::<std::convert::Infallible>(
-                &RemoteSendError::ReplyTimeout
-            )
-        );
+    fn no_effect_relookup_excludes_maybe_enqueued_actor_stopped() {
+        assert!(is_no_effect_stale_ref_relookup_error::<
+            std::convert::Infallible,
+        >(&RemoteSendError::ActorNotRunning));
+        assert!(is_no_effect_stale_ref_relookup_error::<
+            std::convert::Infallible,
+        >(&RemoteSendError::BadActorType));
+        assert!(!is_no_effect_stale_ref_relookup_error::<
+            std::convert::Infallible,
+        >(&RemoteSendError::ActorStopped));
+        assert!(!is_no_effect_stale_ref_relookup_error::<
+            std::convert::Infallible,
+        >(&RemoteSendError::ReplyTimeout));
     }
 
     #[test]

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -10,24 +10,31 @@
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock, Weak};
 use std::time::Duration;
 
 use kameo::actor::ActorRef;
 use libp2p::identity::{Keypair, PublicKey};
-use tokio::sync::Mutex;
+use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
 use waddle_xmpp::ownership::{
     ClaimSnapshot, ClaimStore, Entity, EntityType, NodeIdentity, SharedNodeIdentity,
 };
-use waddle_xmpp::registry::{BroadcastOutcome, ConnectionRegistry, UserRegistryActor};
+use waddle_xmpp::protocol::CarbonKind;
+use waddle_xmpp::registry::{
+    BroadcastOutcome, ConnectionEntry, ConnectionRegistry, DeliveryKind, ForceDetachOutcome,
+    ForceDetachRequest, OutboundStanza, PresenceState, RegisterUserResourceIfOwnerOrAbsent,
+    UnregisterUserResource, UserRegistryActor,
+};
+use waddle_xmpp::roster::{RosterItem, RosterVersion};
 use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
 use waddle_xmpp::xep::xep0191::BlockingStorage;
 use waddle_xmpp::Stanza;
 
 use super::allowlist::AllowlistStore;
 use super::claims::NodeLeaseStore;
-use super::codec::RemoteStanza;
+use super::codec::{RemoteElement, RemoteStanza};
 use super::ordered_relay::{
     OrderedRelayChannel, OrderedRelayClaim, OrderedRelayClaimRole, OrderedRelayDiversion,
     OrderedRelayDiversionReason, OrderedRelayEnvelopeClaims, OrderedRelayMucProxyKind,
@@ -35,7 +42,17 @@ use super::ordered_relay::{
     OrderedRelayPayload, OrderedRelayRecipient, OrderedRelayReply, OrderedRelaySenderState,
     OriginInboundSequence, RemoteStanzaEnvelope,
 };
-use super::relay::{RelayAskError, RelayHandle, RelaySendEffect, RelaySendFailure};
+use super::relay::{
+    RelayAskError, RelayDeliverRemoteResourceFrame, RelayForceDetachRemoteUserResource,
+    RelayForceDetachRemoteUserResourceReply, RelayHandle, RelayRegisterRemoteUserResource,
+    RelayRemoteResourceForceDetachStatus, RelayRemoteResourceFrameReply,
+    RelayRemoteResourceFrameStatus, RelayRemoteResourceRegistrationReply,
+    RelayRemoteResourceRegistrationStatus, RelayRemoteResourceUnregisterReply,
+    RelayRemoteResourceUpdateReply, RelayRemoteResourceUpdateStatus, RelayRemoteUserSideEffect,
+    RelayRemoteUserSideEffectReply, RelayRemoteUserSideEffectStatus,
+    RelayRouteRemoteResourceStanza, RelayRouteRemoteResourceStanzaReply, RelaySendEffect,
+    RelaySendFailure, RelayUnregisterRemoteUserResource, RelayUpdateRemoteUserResource,
+};
 use super::NodeId;
 use crate::config::ClusteringMessagingConfig;
 use crate::server::routes::interpret::{
@@ -47,6 +64,8 @@ const ORDERED_DELIVERY_REPLY_TIMEOUT: Duration = Duration::from_secs(8);
 const ORDERED_RECEIVER_DELIVERY_TIMEOUT: Duration = Duration::from_secs(6);
 const ORDERED_RECEIVER_EFFECT_TIMEOUT_MARGIN: Duration = Duration::from_millis(250);
 const MAX_ORDERED_RELAY_CHANNEL_LOCKS: usize = 4096;
+const MAX_REMOTE_OWNER_REGISTRATION_LOCKS: usize = 4096;
+const REMOTE_RESOURCE_OUTBOUND_CHANNEL_SIZE: usize = 256;
 
 type RemoteDeliveryFuture<'a> =
     Pin<Box<dyn Future<Output = Option<FullJidDeliveryOutcome>> + Send + 'a>>;
@@ -63,6 +82,237 @@ pub struct OrderedRelayDeliveryServices {
     pub sm_session_registry: Arc<InMemorySmSessionRegistry>,
     pub blocking_storage: Arc<dyn BlockingStorage>,
     pub web_socket_state: Weak<WebSocketState>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct RemoteResourceRegistrationId(uuid::Uuid);
+
+impl RemoteResourceRegistrationId {
+    fn fresh() -> Self {
+        Self(uuid::Uuid::new_v4())
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(transparent)]
+pub struct RemoteResourceSocketGeneration(u64);
+
+impl RemoteResourceSocketGeneration {
+    fn next(current: Option<Self>) -> Self {
+        Self(
+            current
+                .map(|generation| generation.0)
+                .unwrap_or(0)
+                .saturating_add(1),
+        )
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RemotePresenceStateSnapshot {
+    pub show: Option<String>,
+    pub status: Option<String>,
+    pub priority: i8,
+    pub payloads: Vec<RemoteElement>,
+}
+
+impl From<PresenceState> for RemotePresenceStateSnapshot {
+    fn from(state: PresenceState) -> Self {
+        Self {
+            show: state.show,
+            status: state.status,
+            priority: state.priority,
+            payloads: state.payloads.into_iter().map(RemoteElement).collect(),
+        }
+    }
+}
+
+impl From<RemotePresenceStateSnapshot> for PresenceState {
+    fn from(state: RemotePresenceStateSnapshot) -> Self {
+        Self {
+            show: state.show,
+            status: state.status,
+            priority: state.priority,
+            payloads: state
+                .payloads
+                .into_iter()
+                .map(|element| element.0)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RemoteResourceStateSnapshot {
+    pub carbons_enabled: bool,
+    pub roster_interested: bool,
+    pub blocklist_interested: bool,
+    pub presence_available: bool,
+    pub presence_priority: i8,
+    pub presence_state: Option<RemotePresenceStateSnapshot>,
+}
+
+impl RemoteResourceStateSnapshot {
+    fn from_entry(entry: &ConnectionEntry, presence_state: Option<PresenceState>) -> Self {
+        Self {
+            carbons_enabled: entry.carbons_enabled.load(Ordering::Relaxed),
+            roster_interested: entry.roster_interested.load(Ordering::Relaxed),
+            blocklist_interested: entry.blocklist_interested.load(Ordering::Relaxed),
+            presence_available: entry.presence_available.load(Ordering::Relaxed),
+            presence_priority: entry.presence_priority.load(Ordering::Relaxed),
+            presence_state: presence_state.map(RemotePresenceStateSnapshot::from),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum RemoteResourceStateUpdate {
+    Presence {
+        available: bool,
+        priority: i8,
+        state: Option<RemotePresenceStateSnapshot>,
+    },
+    Carbons {
+        enabled: bool,
+    },
+    RosterInterested,
+    BlocklistInterested,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
+pub enum RemoteCarbonKind {
+    Sent,
+    Received,
+}
+
+impl From<CarbonKind> for RemoteCarbonKind {
+    fn from(kind: CarbonKind) -> Self {
+        match kind {
+            CarbonKind::Sent => Self::Sent,
+            CarbonKind::Received => Self::Received,
+        }
+    }
+}
+
+impl From<RemoteCarbonKind> for CarbonKind {
+    fn from(kind: RemoteCarbonKind) -> Self {
+        match kind {
+            RemoteCarbonKind::Sent => Self::Sent,
+            RemoteCarbonKind::Received => Self::Received,
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum RemoteUserSideEffect {
+    Carbons {
+        owner: jid::BareJid,
+        message: RemoteStanza,
+        kind: RemoteCarbonKind,
+        exclude: Vec<jid::FullJid>,
+    },
+    RosterPush {
+        user_jid: jid::BareJid,
+        source_jid: jid::FullJid,
+        item: RosterItem,
+        version: RosterVersion,
+    },
+    BlocklistPush {
+        user_bare: jid::BareJid,
+        blocked: bool,
+        jids: Vec<jid::Jid>,
+    },
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct RemoteResourceOutboundFrame {
+    pub jid: jid::FullJid,
+    pub registration_id: RemoteResourceRegistrationId,
+    pub stanza: RemoteStanza,
+    pub kind: DeliveryKind,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum RemoteResourceRouteTarget {
+    FullJid {
+        target: jid::FullJid,
+        stanza: RemoteStanza,
+    },
+    BareJid {
+        target: jid::BareJid,
+        stanza: RemoteStanza,
+    },
+    MucProxy {
+        room_jid: jid::BareJid,
+        kind: OrderedRelayMucProxyKind,
+        stanza: RemoteStanza,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum RemoteResourceRouteOutcome {
+    Delivered,
+    QueuedDetached,
+    Unavailable,
+    Dropped,
+    StaleRegistration,
+}
+
+impl From<FullJidDeliveryOutcome> for RemoteResourceRouteOutcome {
+    fn from(outcome: FullJidDeliveryOutcome) -> Self {
+        match outcome {
+            FullJidDeliveryOutcome::Delivered => Self::Delivered,
+            FullJidDeliveryOutcome::QueuedDetached => Self::QueuedDetached,
+            FullJidDeliveryOutcome::Unavailable => Self::Unavailable,
+            FullJidDeliveryOutcome::Dropped => Self::Dropped,
+        }
+    }
+}
+
+impl From<RemoteResourceRouteOutcome> for FullJidDeliveryOutcome {
+    fn from(outcome: RemoteResourceRouteOutcome) -> Self {
+        match outcome {
+            RemoteResourceRouteOutcome::Delivered => Self::Delivered,
+            RemoteResourceRouteOutcome::QueuedDetached => Self::QueuedDetached,
+            RemoteResourceRouteOutcome::Unavailable
+            | RemoteResourceRouteOutcome::StaleRegistration => Self::Unavailable,
+            RemoteResourceRouteOutcome::Dropped => Self::Dropped,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RemoteResourceRegisterOutcome {
+    Registered,
+    NotRemote,
+    Failed,
+}
+
+#[derive(Debug, Clone)]
+struct RemoteSocketRegistration {
+    registration_id: RemoteResourceRegistrationId,
+    socket_generation: RemoteResourceSocketGeneration,
+    owner: Arc<AtomicBool>,
+    user_owner: NodeId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteResourceOriginSnapshot {
+    pub jid: jid::FullJid,
+    pub registration_id: RemoteResourceRegistrationId,
+    pub socket_generation: RemoteResourceSocketGeneration,
+    pub user_owner: NodeId,
+}
+
+#[derive(Debug, Clone)]
+struct RemoteOwnerRegistration {
+    registration_id: RemoteResourceRegistrationId,
+    socket_node: NodeId,
+    socket_generation: RemoteResourceSocketGeneration,
+    owner: Arc<AtomicBool>,
 }
 
 struct RelayOriginSigner {
@@ -120,6 +370,10 @@ pub struct OrderedRelayDeliveryBridge {
     origin_signer: OnceLock<RelayOriginSigner>,
     sender_state: Mutex<OrderedRelaySenderState>,
     channel_locks: Mutex<HashMap<OrderedRelayChannel, Arc<Mutex<()>>>>,
+    remote_socket_resources: Mutex<HashMap<jid::FullJid, RemoteSocketRegistration>>,
+    remote_socket_generations: Mutex<HashMap<jid::FullJid, RemoteResourceSocketGeneration>>,
+    remote_owner_resources: Mutex<HashMap<jid::FullJid, RemoteOwnerRegistration>>,
+    remote_owner_registration_locks: Mutex<HashMap<jid::FullJid, Arc<Mutex<()>>>>,
     stop_token: CancellationToken,
     mailbox_timeout: Duration,
     reply_timeout: Duration,
@@ -141,6 +395,10 @@ impl OrderedRelayDeliveryBridge {
             origin_signer: OnceLock::new(),
             sender_state: Mutex::new(OrderedRelaySenderState::default()),
             channel_locks: Mutex::new(HashMap::new()),
+            remote_socket_resources: Mutex::new(HashMap::new()),
+            remote_socket_generations: Mutex::new(HashMap::new()),
+            remote_owner_resources: Mutex::new(HashMap::new()),
+            remote_owner_registration_locks: Mutex::new(HashMap::new()),
             stop_token,
             // WebSocket stanza dispatch has a 15s wedge backstop. Full-JID
             // ordered delivery must resolve before that backstop can cancel
@@ -182,6 +440,44 @@ impl OrderedRelayDeliveryBridge {
             .unwrap_or_else(|| self.reply_timeout / 2)
     }
 
+    pub(crate) async fn remote_resource_origin_if_owner(
+        &self,
+        jid: &jid::FullJid,
+        owner: &Arc<AtomicBool>,
+    ) -> Option<RemoteResourceOriginSnapshot> {
+        let registrations = self.remote_socket_resources.lock().await;
+        let registration = registrations
+            .get(jid)
+            .filter(|registration| Arc::ptr_eq(&registration.owner, owner))?;
+        Some(RemoteResourceOriginSnapshot {
+            jid: jid.clone(),
+            registration_id: registration.registration_id,
+            socket_generation: registration.socket_generation,
+            user_owner: registration.user_owner.clone(),
+        })
+    }
+
+    pub(crate) async fn try_deliver_registered_remote_resource(
+        &self,
+        target: &jid::FullJid,
+        stanza: &Stanza,
+        kind: DeliveryKind,
+    ) -> Option<FullJidDeliveryOutcome> {
+        let registration = {
+            let registrations = self.remote_owner_resources.lock().await;
+            registrations.get(target).cloned()
+        }?;
+        Some(
+            self.deliver_registered_remote_resource_with_registration(
+                target,
+                stanza,
+                kind,
+                &registration,
+            )
+            .await,
+        )
+    }
+
     /// Return `Some` only when this exact full-JID target is currently owned
     /// by a fresh foreign `UserActor` claim and an ordered-relay send was
     /// attempted. `None` means the caller must keep the existing local path.
@@ -192,6 +488,19 @@ impl OrderedRelayDeliveryBridge {
         origin: &'a OrderedRelayRouteOrigin,
     ) -> RemoteDeliveryFuture<'a> {
         Box::pin(async move {
+            if let Some(remote_origin) = remote_resource_origin(origin) {
+                return Arc::clone(self)
+                    .route_remote_resource_origin(
+                        remote_origin,
+                        RemoteResourceRouteTarget::FullJid {
+                            target: target.clone(),
+                            stanza: RemoteStanza(stanza.clone()),
+                        },
+                        stanza,
+                        origin,
+                    )
+                    .await;
+            }
             let services = self.services.get()?.clone();
             let target_entity = user_entity(&target.to_bare());
             let target_snapshot = current_claim(&services, &target_entity).await?;
@@ -286,6 +595,19 @@ impl OrderedRelayDeliveryBridge {
         origin: &'a OrderedRelayRouteOrigin,
     ) -> RemoteDeliveryFuture<'a> {
         Box::pin(async move {
+            if let Some(remote_origin) = remote_resource_origin(origin) {
+                return Arc::clone(self)
+                    .route_remote_resource_origin(
+                        remote_origin,
+                        RemoteResourceRouteTarget::BareJid {
+                            target: target.clone(),
+                            stanza: RemoteStanza(stanza.clone()),
+                        },
+                        stanza,
+                        origin,
+                    )
+                    .await;
+            }
             let services = self.services.get()?.clone();
             let target_entity = user_entity(target);
             let target_snapshot = current_claim(&services, &target_entity).await?;
@@ -381,6 +703,20 @@ impl OrderedRelayDeliveryBridge {
         kind: OrderedRelayMucProxyKind,
         origin: &OrderedRelayRouteOrigin,
     ) -> Option<OrderedRelayMucProxyOutcome> {
+        if let Some(remote_origin) = remote_resource_origin(origin) {
+            return Arc::clone(self)
+                .route_remote_resource_origin_muc(
+                    remote_origin,
+                    RemoteResourceRouteTarget::MucProxy {
+                        room_jid: room_jid.clone(),
+                        kind,
+                        stanza: RemoteStanza(stanza.clone()),
+                    },
+                    stanza,
+                    origin,
+                )
+                .await;
+        }
         let services = self.services.get()?.clone();
         let target_entity = room_entity(room_jid);
         let target_snapshot = current_claim(&services, &target_entity).await?;
@@ -507,6 +843,1430 @@ impl OrderedRelayDeliveryBridge {
             FullJidDeliveryOutcome::Unavailable => OrderedRelayMucProxyOutcome::Unavailable,
             FullJidDeliveryOutcome::Dropped => OrderedRelayMucProxyOutcome::Dropped,
         })
+    }
+
+    pub(crate) async fn try_register_remote_user_resource(
+        self: &Arc<Self>,
+        jid: &jid::FullJid,
+        entry: ConnectionEntry,
+        owner: Arc<AtomicBool>,
+    ) -> RemoteResourceRegisterOutcome {
+        let Some(services) = self.services.get().cloned() else {
+            return RemoteResourceRegisterOutcome::Failed;
+        };
+        let target_entity = user_entity(&jid.to_bare());
+        let Some(target_snapshot) = current_claim(&services, &target_entity).await else {
+            return RemoteResourceRegisterOutcome::NotRemote;
+        };
+        if !target_snapshot.owner_lease_fresh {
+            return RemoteResourceRegisterOutcome::NotRemote;
+        }
+        let me = services.node_identity.current();
+        if target_snapshot.owner == me {
+            return RemoteResourceRegisterOutcome::NotRemote;
+        }
+
+        let registration_id = RemoteResourceRegistrationId::fresh();
+        let socket_generation = {
+            let mut generations = self.remote_socket_generations.lock().await;
+            let next = RemoteResourceSocketGeneration::next(generations.get(jid).copied());
+            generations.insert(jid.clone(), next);
+            next
+        };
+        let socket_node = NodeId::new(me.node_id.clone());
+        let user_owner = NodeId::new(target_snapshot.owner.node_id.clone());
+        let state = RemoteResourceStateSnapshot::from_entry(
+            &entry,
+            services.connection_registry.get_presence_state(jid),
+        );
+        let mut handle = RelayHandle::new(user_owner.clone(), self.stop_token.clone())
+            .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        let reply = match handle
+            .register_remote_user_resource(RelayRegisterRemoteUserResource {
+                jid: jid.clone(),
+                registration_id,
+                socket_generation,
+                socket_node,
+                state,
+            })
+            .await
+        {
+            Ok(reply) => reply,
+            Err(error) => {
+                tracing::warn!(
+                    jid = %jid,
+                    owner_node = %user_owner.as_str(),
+                    %error,
+                    "clustered remote-resource register ask failed"
+                );
+                return RemoteResourceRegisterOutcome::Failed;
+            }
+        };
+        match reply.status {
+            RelayRemoteResourceRegistrationStatus::Registered => {
+                if services
+                    .connection_registry
+                    .entry_if_owner(jid, &owner)
+                    .is_none()
+                {
+                    let _ = handle
+                        .unregister_remote_user_resource(RelayUnregisterRemoteUserResource {
+                            jid: jid.clone(),
+                            registration_id,
+                            socket_generation,
+                        })
+                        .await;
+                    return RemoteResourceRegisterOutcome::Failed;
+                }
+                self.remote_socket_resources.lock().await.insert(
+                    jid.clone(),
+                    RemoteSocketRegistration {
+                        registration_id,
+                        socket_generation,
+                        owner,
+                        user_owner,
+                    },
+                );
+                RemoteResourceRegisterOutcome::Registered
+            }
+            RelayRemoteResourceRegistrationStatus::NotOwner => {
+                RemoteResourceRegisterOutcome::NotRemote
+            }
+            RelayRemoteResourceRegistrationStatus::StaleRegistration
+            | RelayRemoteResourceRegistrationStatus::Unavailable => {
+                RemoteResourceRegisterOutcome::Failed
+            }
+        }
+    }
+
+    pub(crate) async fn unregister_remote_user_resource_if_owner(
+        &self,
+        jid: &jid::FullJid,
+        owner: &Arc<AtomicBool>,
+    ) {
+        let registration = {
+            let mut registrations = self.remote_socket_resources.lock().await;
+            match registrations.get(jid) {
+                Some(registration) if Arc::ptr_eq(&registration.owner, owner) => {
+                    registrations.remove(jid)
+                }
+                _ => None,
+            }
+        };
+        let Some(registration) = registration else {
+            return;
+        };
+        let mut handle = RelayHandle::new(registration.user_owner.clone(), self.stop_token.clone())
+            .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        if let Err(error) = handle
+            .unregister_remote_user_resource(RelayUnregisterRemoteUserResource {
+                jid: jid.clone(),
+                registration_id: registration.registration_id,
+                socket_generation: registration.socket_generation,
+            })
+            .await
+        {
+            tracing::warn!(
+                jid = %jid,
+                %error,
+                "clustered remote-resource unregister ask failed; owner-side stale \
+                 entry will self-heal on closed-channel delivery"
+            );
+        }
+    }
+
+    pub(crate) async fn update_remote_user_resource_if_owner(
+        &self,
+        jid: &jid::FullJid,
+        owner: &Arc<AtomicBool>,
+        update: RemoteResourceStateUpdate,
+    ) {
+        let registration = {
+            let registrations = self.remote_socket_resources.lock().await;
+            registrations
+                .get(jid)
+                .filter(|registration| Arc::ptr_eq(&registration.owner, owner))
+                .cloned()
+        };
+        let Some(registration) = registration else {
+            return;
+        };
+        let mut handle = RelayHandle::new(registration.user_owner.clone(), self.stop_token.clone())
+            .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        match handle
+            .update_remote_user_resource(RelayUpdateRemoteUserResource {
+                jid: jid.clone(),
+                registration_id: registration.registration_id,
+                socket_generation: registration.socket_generation,
+                update,
+            })
+            .await
+        {
+            Ok(RelayRemoteResourceUpdateReply {
+                status: RelayRemoteResourceUpdateStatus::Updated,
+            }) => {}
+            Ok(RelayRemoteResourceUpdateReply { status }) => {
+                tracing::warn!(
+                    jid = %jid,
+                    status = ?status,
+                    "clustered remote-resource state update failed closed; detaching socket"
+                );
+                self.detach_stale_remote_socket_resource(jid, &registration)
+                    .await;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    jid = %jid,
+                    %error,
+                    "clustered remote-resource state update ask failed; detaching socket"
+                );
+                self.detach_stale_remote_socket_resource(jid, &registration)
+                    .await;
+            }
+        }
+    }
+
+    pub(crate) async fn try_fanout_remote_user_carbons(
+        &self,
+        source_jid: &jid::FullJid,
+        owner: &jid::BareJid,
+        message: &xmpp_parsers::message::Message,
+        kind: CarbonKind,
+        exclude: Vec<jid::FullJid>,
+    ) -> bool {
+        self.try_remote_user_side_effect(
+            source_jid,
+            RemoteUserSideEffect::Carbons {
+                owner: owner.clone(),
+                message: RemoteStanza(Stanza::Message(message.clone())),
+                kind: kind.into(),
+                exclude,
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn try_fanout_remote_user_roster_push(
+        &self,
+        source_jid: &jid::FullJid,
+        user_jid: &jid::BareJid,
+        item: &RosterItem,
+        version: &RosterVersion,
+    ) -> bool {
+        self.try_remote_user_side_effect(
+            source_jid,
+            RemoteUserSideEffect::RosterPush {
+                user_jid: user_jid.clone(),
+                source_jid: source_jid.clone(),
+                item: item.clone(),
+                version: version.clone(),
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn try_fanout_remote_user_blocklist_push(
+        &self,
+        source_jid: &jid::FullJid,
+        user_bare: &jid::BareJid,
+        blocked: bool,
+        jids: &[jid::Jid],
+    ) -> bool {
+        self.try_remote_user_side_effect(
+            source_jid,
+            RemoteUserSideEffect::BlocklistPush {
+                user_bare: user_bare.clone(),
+                blocked,
+                jids: jids.to_vec(),
+            },
+        )
+        .await
+    }
+
+    async fn try_remote_user_side_effect(
+        &self,
+        source_jid: &jid::FullJid,
+        effect: RemoteUserSideEffect,
+    ) -> bool {
+        let Some(registration) = self.remote_socket_registration_if_current(source_jid).await
+        else {
+            return false;
+        };
+        let mut handle = RelayHandle::new(registration.user_owner.clone(), self.stop_token.clone())
+            .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        match handle
+            .remote_user_side_effect(RelayRemoteUserSideEffect {
+                source_jid: source_jid.clone(),
+                registration_id: registration.registration_id,
+                socket_generation: registration.socket_generation,
+                effect,
+            })
+            .await
+        {
+            Ok(RelayRemoteUserSideEffectReply {
+                status: RelayRemoteUserSideEffectStatus::Applied,
+            }) => true,
+            Ok(RelayRemoteUserSideEffectReply {
+                status: RelayRemoteUserSideEffectStatus::StaleRegistration,
+            }) => {
+                self.remove_remote_socket_registration_if_current(source_jid, &registration)
+                    .await;
+                false
+            }
+            Ok(RelayRemoteUserSideEffectReply {
+                status: RelayRemoteUserSideEffectStatus::Unavailable,
+            }) => false,
+            Err(RelayAskError::Send {
+                effect: RelaySendEffect::MaybeCommitted,
+                message,
+                ..
+            }) => {
+                tracing::warn!(
+                    jid = %source_jid,
+                    %message,
+                    "clustered remote-user side-effect relay may have committed; suppressing local fallback"
+                );
+                true
+            }
+            Err(error) => {
+                tracing::warn!(
+                    jid = %source_jid,
+                    %error,
+                    "clustered remote-user side-effect relay ask failed"
+                );
+                false
+            }
+        }
+    }
+
+    async fn remote_socket_registration_if_current(
+        &self,
+        jid: &jid::FullJid,
+    ) -> Option<RemoteSocketRegistration> {
+        let registration = self
+            .remote_socket_resources
+            .lock()
+            .await
+            .get(jid)
+            .cloned()?;
+        let services = self.services.get()?;
+        services
+            .connection_registry
+            .entry_if_owner(jid, &registration.owner)
+            .map(|_| registration)
+    }
+
+    async fn remove_remote_socket_registration_if_current(
+        &self,
+        jid: &jid::FullJid,
+        registration: &RemoteSocketRegistration,
+    ) {
+        let mut registrations = self.remote_socket_resources.lock().await;
+        if registrations.get(jid).is_some_and(|current| {
+            current.registration_id == registration.registration_id
+                && current.socket_generation == registration.socket_generation
+                && current.user_owner == registration.user_owner
+                && Arc::ptr_eq(&current.owner, &registration.owner)
+        }) {
+            registrations.remove(jid);
+        }
+    }
+
+    async fn remove_remote_owner_registration_if_current(
+        &self,
+        jid: &jid::FullJid,
+        registration: &RemoteOwnerRegistration,
+    ) {
+        let mut registrations = self.remote_owner_resources.lock().await;
+        if registrations
+            .get(jid)
+            .is_some_and(|current| remote_owner_registration_matches(current, registration))
+        {
+            registrations.remove(jid);
+        }
+    }
+
+    pub(crate) async fn register_remote_user_resource_on_owner(
+        self: &Arc<Self>,
+        msg: RelayRegisterRemoteUserResource,
+    ) -> RelayRemoteResourceRegistrationReply {
+        let jid = msg.jid.clone();
+        let Some(lock) = self.lock_for_remote_owner_registration(&jid).await else {
+            return RelayRemoteResourceRegistrationReply {
+                status: RelayRemoteResourceRegistrationStatus::Unavailable,
+            };
+        };
+        let guard = lock.lock().await;
+        let reply = self
+            .register_remote_user_resource_on_owner_locked(msg)
+            .await;
+        drop(guard);
+        self.remove_remote_owner_registration_lock_if_unused(&jid, &lock)
+            .await;
+        reply
+    }
+
+    async fn register_remote_user_resource_on_owner_locked(
+        self: &Arc<Self>,
+        msg: RelayRegisterRemoteUserResource,
+    ) -> RelayRemoteResourceRegistrationReply {
+        let Some(services) = self.services.get().cloned() else {
+            return RelayRemoteResourceRegistrationReply {
+                status: RelayRemoteResourceRegistrationStatus::Unavailable,
+            };
+        };
+        let target_entity = user_entity(&msg.jid.to_bare());
+        let Some(snapshot) = current_claim(&services, &target_entity).await else {
+            return RelayRemoteResourceRegistrationReply {
+                status: RelayRemoteResourceRegistrationStatus::NotOwner,
+            };
+        };
+        let me = services.node_identity.current();
+        if !snapshot.owner_lease_fresh || snapshot.owner != me {
+            return RelayRemoteResourceRegistrationReply {
+                status: RelayRemoteResourceRegistrationStatus::NotOwner,
+            };
+        }
+
+        if let Some(displaced) = self
+            .remote_owner_resources
+            .lock()
+            .await
+            .get(&msg.jid)
+            .cloned()
+        {
+            if displaced.registration_id == msg.registration_id
+                && displaced.socket_node == msg.socket_node
+                && displaced.socket_generation == msg.socket_generation
+            {
+                match remote_owner_registration_is_current(&services, &msg.jid, &displaced).await {
+                    Ok(()) => {
+                        return RelayRemoteResourceRegistrationReply {
+                            status: RelayRemoteResourceRegistrationStatus::Registered,
+                        };
+                    }
+                    Err(RelayRemoteResourceRegistrationStatus::StaleRegistration) => {
+                        self.remove_remote_owner_registration_if_current(&msg.jid, &displaced)
+                            .await;
+                    }
+                    Err(status) => return RelayRemoteResourceRegistrationReply { status },
+                }
+            } else if displaced.socket_node == msg.socket_node
+                && displaced.socket_generation >= msg.socket_generation
+            {
+                return RelayRemoteResourceRegistrationReply {
+                    status: RelayRemoteResourceRegistrationStatus::StaleRegistration,
+                };
+            } else {
+                if !self
+                    .retire_remote_owner_registration(&services, &msg.jid, &displaced)
+                    .await
+                {
+                    return RelayRemoteResourceRegistrationReply {
+                        status: RelayRemoteResourceRegistrationStatus::Unavailable,
+                    };
+                }
+                let mut registrations = self.remote_owner_resources.lock().await;
+                match registrations.get(&msg.jid) {
+                    Some(current) if remote_owner_registration_matches(current, &displaced) => {
+                        registrations.remove(&msg.jid);
+                    }
+                    Some(_) => {
+                        return RelayRemoteResourceRegistrationReply {
+                            status: RelayRemoteResourceRegistrationStatus::StaleRegistration,
+                        };
+                    }
+                    None => {}
+                }
+            }
+            if self
+                .remote_owner_resources
+                .lock()
+                .await
+                .contains_key(&msg.jid)
+            {
+                return RelayRemoteResourceRegistrationReply {
+                    status: RelayRemoteResourceRegistrationStatus::StaleRegistration,
+                };
+            }
+        }
+
+        let (tx, rx) = mpsc::channel(REMOTE_RESOURCE_OUTBOUND_CHANNEL_SIZE);
+        let entry = ConnectionEntry::new(tx);
+        apply_remote_resource_state(&entry, &msg.state);
+        let owner = entry.carbons_handle();
+        let force_detach_rx = entry.take_force_detach_rx();
+        match services
+            .user_registry
+            .ask(RegisterUserResourceIfOwnerOrAbsent {
+                jid: msg.jid.clone(),
+                entry: entry.clone(),
+                owner: owner.clone(),
+            })
+            .mailbox_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+            .reply_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+            .await
+        {
+            Ok(true) => {
+                let registration = RemoteOwnerRegistration {
+                    registration_id: msg.registration_id,
+                    socket_node: msg.socket_node.clone(),
+                    socket_generation: msg.socket_generation,
+                    owner: owner.clone(),
+                };
+                if !services
+                    .connection_registry
+                    .register_entry_if_owner_or_absent(msg.jid.clone(), entry.clone(), &owner)
+                {
+                    if !unregister_remote_owner_actor_entry(&services, &msg.jid, &owner).await {
+                        return RelayRemoteResourceRegistrationReply {
+                            status: RelayRemoteResourceRegistrationStatus::Unavailable,
+                        };
+                    }
+                    return RelayRemoteResourceRegistrationReply {
+                        status: RelayRemoteResourceRegistrationStatus::StaleRegistration,
+                    };
+                }
+                match remote_owner_registration_is_current(&services, &msg.jid, &registration).await
+                {
+                    Ok(()) => {}
+                    Err(status) => {
+                        if !unregister_remote_owner_actor_entry(&services, &msg.jid, &owner).await {
+                            return RelayRemoteResourceRegistrationReply {
+                                status: RelayRemoteResourceRegistrationStatus::Unavailable,
+                            };
+                        }
+                        services
+                            .connection_registry
+                            .unregister_if_owner(&msg.jid, &owner);
+                        return RelayRemoteResourceRegistrationReply { status };
+                    }
+                }
+                apply_remote_resource_presence_to_registry(
+                    &services.connection_registry,
+                    &msg.jid,
+                    &owner,
+                    msg.state.presence_available,
+                    msg.state.presence_priority,
+                    msg.state.presence_state.clone(),
+                );
+                self.remote_owner_resources
+                    .lock()
+                    .await
+                    .insert(msg.jid.clone(), registration);
+                self.spawn_remote_resource_forwarder(
+                    msg.jid,
+                    msg.registration_id,
+                    msg.socket_node,
+                    rx,
+                    force_detach_rx,
+                );
+                RelayRemoteResourceRegistrationReply {
+                    status: RelayRemoteResourceRegistrationStatus::Registered,
+                }
+            }
+            Ok(false) => RelayRemoteResourceRegistrationReply {
+                status: RelayRemoteResourceRegistrationStatus::StaleRegistration,
+            },
+            Err(error) => {
+                tracing::warn!(
+                    jid = %msg.jid,
+                    %error,
+                    "clustered remote-resource owner registration failed"
+                );
+                RelayRemoteResourceRegistrationReply {
+                    status: RelayRemoteResourceRegistrationStatus::Unavailable,
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn unregister_remote_user_resource_on_owner(
+        &self,
+        msg: RelayUnregisterRemoteUserResource,
+    ) -> RelayRemoteResourceUnregisterReply {
+        let Some(services) = self.services.get().cloned() else {
+            return RelayRemoteResourceUnregisterReply { removed: false };
+        };
+        let registration = self
+            .remote_owner_resources
+            .lock()
+            .await
+            .get(&msg.jid)
+            .filter(|registration| {
+                registration.registration_id == msg.registration_id
+                    && registration.socket_generation == msg.socket_generation
+            })
+            .cloned();
+        let Some(registration) = registration else {
+            return RelayRemoteResourceUnregisterReply { removed: false };
+        };
+        let actor_removed = services
+            .user_registry
+            .ask(UnregisterUserResource {
+                jid: msg.jid.clone(),
+                owner: Some(registration.owner.clone()),
+            })
+            .mailbox_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+            .reply_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+            .await
+            .is_ok();
+        if !actor_removed {
+            return RelayRemoteResourceUnregisterReply { removed: false };
+        }
+        let registry_removed = services
+            .connection_registry
+            .unregister_if_owner(&msg.jid, &registration.owner)
+            .is_some();
+        let mut registrations = self.remote_owner_resources.lock().await;
+        if registrations.get(&msg.jid).is_some_and(|registration| {
+            registration.registration_id == msg.registration_id
+                && registration.socket_generation == msg.socket_generation
+        }) {
+            registrations.remove(&msg.jid);
+        }
+        RelayRemoteResourceUnregisterReply {
+            removed: registry_removed,
+        }
+    }
+
+    pub(crate) async fn update_remote_user_resource_on_owner(
+        &self,
+        msg: RelayUpdateRemoteUserResource,
+    ) -> RelayRemoteResourceUpdateReply {
+        let Some(services) = self.services.get().cloned() else {
+            return RelayRemoteResourceUpdateReply {
+                status: RelayRemoteResourceUpdateStatus::Unavailable,
+            };
+        };
+        let registration = self
+            .remote_owner_resources
+            .lock()
+            .await
+            .get(&msg.jid)
+            .filter(|registration| {
+                registration.registration_id == msg.registration_id
+                    && registration.socket_generation == msg.socket_generation
+            })
+            .cloned();
+        let Some(registration) = registration else {
+            return RelayRemoteResourceUpdateReply {
+                status: RelayRemoteResourceUpdateStatus::StaleRegistration,
+            };
+        };
+        let actor = match services
+            .user_registry
+            .ask(waddle_xmpp::registry::GetUser {
+                bare_jid: msg.jid.to_bare(),
+            })
+            .mailbox_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+            .reply_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+            .await
+        {
+            Ok(Some(actor)) => actor,
+            Ok(None) => {
+                return RelayRemoteResourceUpdateReply {
+                    status: RelayRemoteResourceUpdateStatus::StaleRegistration,
+                };
+            }
+            Err(error) => {
+                tracing::warn!(
+                    jid = %msg.jid,
+                    %error,
+                    "clustered remote-resource state update could not resolve owner UserActor"
+                );
+                return RelayRemoteResourceUpdateReply {
+                    status: RelayRemoteResourceUpdateStatus::Unavailable,
+                };
+            }
+        };
+        let jid = msg.jid;
+        let status = match msg.update {
+            RemoteResourceStateUpdate::Presence {
+                available,
+                priority,
+                state,
+            } => {
+                match owner_remote_entry_if_current(
+                    &actor,
+                    &services.connection_registry,
+                    &jid,
+                    &registration.owner,
+                )
+                .await
+                {
+                    Ok(_) => {
+                        if apply_remote_resource_presence_to_registry(
+                            &services.connection_registry,
+                            &jid,
+                            &registration.owner,
+                            available,
+                            priority,
+                            state,
+                        ) {
+                            RelayRemoteResourceUpdateStatus::Updated
+                        } else {
+                            RelayRemoteResourceUpdateStatus::StaleRegistration
+                        }
+                    }
+                    Err(status) => status,
+                }
+            }
+            RemoteResourceStateUpdate::Carbons { enabled } => {
+                match owner_remote_entry_if_current(
+                    &actor,
+                    &services.connection_registry,
+                    &jid,
+                    &registration.owner,
+                )
+                .await
+                {
+                    Ok(entry) => {
+                        entry.carbons_enabled.store(enabled, Ordering::Relaxed);
+                        RelayRemoteResourceUpdateStatus::Updated
+                    }
+                    Err(status) => status,
+                }
+            }
+            RemoteResourceStateUpdate::RosterInterested => match owner_remote_entry_if_current(
+                &actor,
+                &services.connection_registry,
+                &jid,
+                &registration.owner,
+            )
+            .await
+            {
+                Ok(entry) => {
+                    entry.roster_interested.store(true, Ordering::Relaxed);
+                    RelayRemoteResourceUpdateStatus::Updated
+                }
+                Err(status) => status,
+            },
+            RemoteResourceStateUpdate::BlocklistInterested => {
+                match owner_remote_entry_if_current(
+                    &actor,
+                    &services.connection_registry,
+                    &jid,
+                    &registration.owner,
+                )
+                .await
+                {
+                    Ok(entry) => {
+                        entry.blocklist_interested.store(true, Ordering::Relaxed);
+                        RelayRemoteResourceUpdateStatus::Updated
+                    }
+                    Err(status) => status,
+                }
+            }
+        };
+        RelayRemoteResourceUpdateReply { status }
+    }
+
+    pub(crate) async fn apply_remote_user_side_effect_on_owner(
+        &self,
+        msg: RelayRemoteUserSideEffect,
+    ) -> RelayRemoteUserSideEffectReply {
+        let Some(services) = self.services.get().cloned() else {
+            return RelayRemoteUserSideEffectReply {
+                status: RelayRemoteUserSideEffectStatus::Unavailable,
+            };
+        };
+        let registration = self
+            .remote_owner_resources
+            .lock()
+            .await
+            .get(&msg.source_jid)
+            .filter(|registration| {
+                registration.registration_id == msg.registration_id
+                    && registration.socket_generation == msg.socket_generation
+            })
+            .cloned();
+        let Some(registration) = registration else {
+            return RelayRemoteUserSideEffectReply {
+                status: RelayRemoteUserSideEffectStatus::StaleRegistration,
+            };
+        };
+        let actor = match services
+            .user_registry
+            .ask(waddle_xmpp::registry::GetUser {
+                bare_jid: msg.source_jid.to_bare(),
+            })
+            .mailbox_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+            .reply_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+            .await
+        {
+            Ok(Some(actor)) => actor,
+            Ok(None) => {
+                return RelayRemoteUserSideEffectReply {
+                    status: RelayRemoteUserSideEffectStatus::StaleRegistration,
+                };
+            }
+            Err(error) => {
+                tracing::warn!(
+                    jid = %msg.source_jid,
+                    %error,
+                    "clustered remote-user side effect could not resolve owner UserActor"
+                );
+                return RelayRemoteUserSideEffectReply {
+                    status: RelayRemoteUserSideEffectStatus::Unavailable,
+                };
+            }
+        };
+        if let Err(status) = owner_remote_entry_if_current(
+            &actor,
+            &services.connection_registry,
+            &msg.source_jid,
+            &registration.owner,
+        )
+        .await
+        {
+            return RelayRemoteUserSideEffectReply {
+                status: match status {
+                    RelayRemoteResourceUpdateStatus::Updated => {
+                        RelayRemoteUserSideEffectStatus::Applied
+                    }
+                    RelayRemoteResourceUpdateStatus::StaleRegistration => {
+                        RelayRemoteUserSideEffectStatus::StaleRegistration
+                    }
+                    RelayRemoteResourceUpdateStatus::Unavailable => {
+                        RelayRemoteUserSideEffectStatus::Unavailable
+                    }
+                },
+            };
+        }
+
+        let status = match msg.effect {
+            RemoteUserSideEffect::Carbons {
+                owner,
+                message,
+                kind,
+                exclude,
+            } => match message.0 {
+                Stanza::Message(message) => {
+                    crate::server::routes::interpret::carbons::send_carbons_to_registry(
+                        &services.connection_registry,
+                        Some(&services.sm_session_registry),
+                        owner,
+                        Box::new(message),
+                        kind.into(),
+                        exclude,
+                    )
+                    .await;
+                    RelayRemoteUserSideEffectStatus::Applied
+                }
+                _ => RelayRemoteUserSideEffectStatus::StaleRegistration,
+            },
+            RemoteUserSideEffect::RosterPush {
+                user_jid,
+                source_jid,
+                item,
+                version,
+            } => {
+                let Some(state) = services.web_socket_state.upgrade() else {
+                    return RelayRemoteUserSideEffectReply {
+                        status: RelayRemoteUserSideEffectStatus::Unavailable,
+                    };
+                };
+                crate::server::routes::websocket::handlers::iq::roster::push::send_roster_push_to_sibling_resources(
+                    &state,
+                    &user_jid,
+                    &source_jid,
+                    &item,
+                    &version,
+                )
+                .await;
+                RelayRemoteUserSideEffectStatus::Applied
+            }
+            RemoteUserSideEffect::BlocklistPush {
+                user_bare,
+                blocked,
+                jids,
+            } => {
+                let Some(state) = services.web_socket_state.upgrade() else {
+                    return RelayRemoteUserSideEffectReply {
+                        status: RelayRemoteUserSideEffectStatus::Unavailable,
+                    };
+                };
+                crate::server::routes::websocket::handlers::iq::blocking::send_blocking_pushes(
+                    &state, &user_bare, blocked, &jids,
+                )
+                .await;
+                RelayRemoteUserSideEffectStatus::Applied
+            }
+        };
+        RelayRemoteUserSideEffectReply { status }
+    }
+
+    async fn route_remote_resource_origin(
+        self: Arc<Self>,
+        remote_origin: RemoteResourceOriginSnapshot,
+        target: RemoteResourceRouteTarget,
+        origin_stanza: &Stanza,
+        origin: &OrderedRelayRouteOrigin,
+    ) -> Option<FullJidDeliveryOutcome> {
+        if let Some(handoff) = origin.handoff.clone() {
+            if handoff.mark_deferred() {
+                let bridge = Arc::clone(&self);
+                let origin_stanza = origin_stanza.clone();
+                tokio::spawn(async move {
+                    let outcome = bridge
+                        .route_remote_resource_origin_once(remote_origin, target)
+                        .await
+                        .unwrap_or(FullJidDeliveryOutcome::Dropped);
+                    handoff.complete(replies_for_origin_handoff(&origin_stanza, outcome));
+                });
+                return Some(FullJidDeliveryOutcome::Delivered);
+            }
+        }
+        self.route_remote_resource_origin_once(remote_origin, target)
+            .await
+    }
+
+    async fn route_remote_resource_origin_once(
+        &self,
+        remote_origin: RemoteResourceOriginSnapshot,
+        target: RemoteResourceRouteTarget,
+    ) -> Option<FullJidDeliveryOutcome> {
+        let mut handle =
+            RelayHandle::new(remote_origin.user_owner.clone(), self.stop_token.clone())
+                .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        let reply = handle
+            .route_remote_resource_stanza(RelayRouteRemoteResourceStanza {
+                source_jid: remote_origin.jid,
+                registration_id: remote_origin.registration_id,
+                socket_generation: remote_origin.socket_generation,
+                target,
+            })
+            .await;
+        match reply {
+            Ok(reply) => Some(reply.outcome.into()),
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "clustered remote-resource origin route ask failed"
+                );
+                Some(FullJidDeliveryOutcome::Dropped)
+            }
+        }
+    }
+
+    async fn route_remote_resource_origin_muc(
+        self: Arc<Self>,
+        remote_origin: RemoteResourceOriginSnapshot,
+        target: RemoteResourceRouteTarget,
+        origin_stanza: &Stanza,
+        origin: &OrderedRelayRouteOrigin,
+    ) -> Option<OrderedRelayMucProxyOutcome> {
+        if let Some(handoff) = origin.handoff.clone() {
+            if handoff.mark_deferred() {
+                let bridge = Arc::clone(&self);
+                let origin_stanza = origin_stanza.clone();
+                tokio::spawn(async move {
+                    let outcome = bridge
+                        .route_remote_resource_origin_muc_once(remote_origin, target)
+                        .await
+                        .unwrap_or(OrderedRelayMucProxyOutcome::Dropped);
+                    let replies = match outcome {
+                        OrderedRelayMucProxyOutcome::Delivered(replies) => replies,
+                        OrderedRelayMucProxyOutcome::Unavailable => {
+                            fallback_reply_for_remote_muc_handoff(&origin_stanza)
+                        }
+                        OrderedRelayMucProxyOutcome::Dropped
+                        | OrderedRelayMucProxyOutcome::MaybeCommitted
+                        | OrderedRelayMucProxyOutcome::JoinMaybeCommitted => Vec::new(),
+                    };
+                    handoff.complete(replies);
+                });
+                return Some(OrderedRelayMucProxyOutcome::Delivered(Vec::new()));
+            }
+        }
+        self.route_remote_resource_origin_muc_once(remote_origin, target)
+            .await
+    }
+
+    async fn route_remote_resource_origin_muc_once(
+        &self,
+        remote_origin: RemoteResourceOriginSnapshot,
+        target: RemoteResourceRouteTarget,
+    ) -> Option<OrderedRelayMucProxyOutcome> {
+        let mut handle =
+            RelayHandle::new(remote_origin.user_owner.clone(), self.stop_token.clone())
+                .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        match handle
+            .route_remote_resource_stanza(RelayRouteRemoteResourceStanza {
+                source_jid: remote_origin.jid,
+                registration_id: remote_origin.registration_id,
+                socket_generation: remote_origin.socket_generation,
+                target,
+            })
+            .await
+        {
+            Ok(reply) => Some(match reply.outcome {
+                RemoteResourceRouteOutcome::Delivered
+                | RemoteResourceRouteOutcome::QueuedDetached => {
+                    OrderedRelayMucProxyOutcome::Delivered(
+                        reply.replies.into_iter().map(|reply| reply.0).collect(),
+                    )
+                }
+                RemoteResourceRouteOutcome::Unavailable
+                | RemoteResourceRouteOutcome::StaleRegistration => {
+                    OrderedRelayMucProxyOutcome::Unavailable
+                }
+                RemoteResourceRouteOutcome::Dropped => OrderedRelayMucProxyOutcome::Dropped,
+            }),
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "clustered remote-resource MUC origin route ask failed"
+                );
+                Some(OrderedRelayMucProxyOutcome::Dropped)
+            }
+        }
+    }
+
+    pub(crate) async fn route_remote_resource_stanza_on_owner(
+        self: &Arc<Self>,
+        msg: RelayRouteRemoteResourceStanza,
+    ) -> RelayRouteRemoteResourceStanzaReply {
+        let Some(services) = self.services.get().cloned() else {
+            return remote_resource_route_reply(RemoteResourceRouteOutcome::Dropped);
+        };
+        let Some(registration) = self
+            .remote_owner_resources
+            .lock()
+            .await
+            .get(&msg.source_jid)
+            .filter(|registration| {
+                registration.registration_id == msg.registration_id
+                    && registration.socket_generation == msg.socket_generation
+            })
+            .cloned()
+        else {
+            return remote_resource_route_reply(RemoteResourceRouteOutcome::StaleRegistration);
+        };
+        let actor = match services
+            .user_registry
+            .ask(waddle_xmpp::registry::GetUser {
+                bare_jid: msg.source_jid.to_bare(),
+            })
+            .mailbox_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+            .reply_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+            .await
+        {
+            Ok(Some(actor)) => actor,
+            Ok(None) => {
+                return remote_resource_route_reply(RemoteResourceRouteOutcome::StaleRegistration);
+            }
+            Err(error) => {
+                tracing::warn!(
+                    jid = %msg.source_jid,
+                    %error,
+                    "clustered remote-resource origin route could not resolve owner UserActor"
+                );
+                return remote_resource_route_reply(RemoteResourceRouteOutcome::Dropped);
+            }
+        };
+        if let Err(status) = owner_remote_entry_if_current(
+            &actor,
+            &services.connection_registry,
+            &msg.source_jid,
+            &registration.owner,
+        )
+        .await
+        {
+            return remote_resource_route_reply(match status {
+                RelayRemoteResourceUpdateStatus::Updated => RemoteResourceRouteOutcome::Delivered,
+                RelayRemoteResourceUpdateStatus::StaleRegistration => {
+                    RemoteResourceRouteOutcome::StaleRegistration
+                }
+                RelayRemoteResourceUpdateStatus::Unavailable => RemoteResourceRouteOutcome::Dropped,
+            });
+        }
+
+        let sender_entity = user_entity(&msg.source_jid.to_bare());
+        let origin = OrderedRelayRouteOrigin {
+            kind: OrderedRelayRouteOriginKind::Entity(sender_entity.clone()),
+            sender_entity,
+            inbound_sequence: 0,
+            handoff: None,
+        };
+
+        match msg.target {
+            RemoteResourceRouteTarget::FullJid { target, stanza } => {
+                let outcome = if let Some(remote) = self
+                    .try_deliver_full_jid_remote(&target, &stanza.0, &origin)
+                    .await
+                {
+                    remote
+                } else if let Some(registered) = self
+                    .try_deliver_registered_remote_resource(
+                        &target,
+                        &stanza.0,
+                        DeliveryKind::PeerStanza,
+                    )
+                    .await
+                {
+                    registered
+                } else {
+                    deliver_local_full_jid_after_target_refresh(&services, &target, &stanza.0).await
+                };
+                remote_resource_route_reply(outcome.into())
+            }
+            RemoteResourceRouteTarget::BareJid { target, stanza } => {
+                match route_local_bare_jid_with_timeout(&services, &target, &stanza.0, Some(origin))
+                    .await
+                {
+                    Ok(replies) if replies.is_empty() => {
+                        remote_resource_route_reply(RemoteResourceRouteOutcome::Delivered)
+                    }
+                    Ok(_) => remote_resource_route_reply(RemoteResourceRouteOutcome::Unavailable),
+                    Err(OrderedRelayNackReason::TargetUnavailable) => {
+                        remote_resource_route_reply(RemoteResourceRouteOutcome::Unavailable)
+                    }
+                    Err(_) => remote_resource_route_reply(RemoteResourceRouteOutcome::Dropped),
+                }
+            }
+            RemoteResourceRouteTarget::MucProxy {
+                room_jid,
+                kind,
+                stanza,
+            } => {
+                let outcome = if let Some(remote) = self
+                    .try_proxy_muc_remote(&room_jid, &stanza.0, kind, &origin)
+                    .await
+                {
+                    remote
+                } else {
+                    muc_proxy_result_to_ordered_outcome(
+                        deliver_reserved_muc_proxy(&services, &room_jid, kind, &stanza.0).await,
+                    )
+                };
+                match outcome {
+                    OrderedRelayMucProxyOutcome::Delivered(replies) => {
+                        RelayRouteRemoteResourceStanzaReply {
+                            outcome: RemoteResourceRouteOutcome::Delivered,
+                            replies: replies.into_iter().map(RemoteStanza).collect(),
+                        }
+                    }
+                    OrderedRelayMucProxyOutcome::Unavailable => {
+                        remote_resource_route_reply(RemoteResourceRouteOutcome::Unavailable)
+                    }
+                    OrderedRelayMucProxyOutcome::Dropped
+                    | OrderedRelayMucProxyOutcome::MaybeCommitted
+                    | OrderedRelayMucProxyOutcome::JoinMaybeCommitted => {
+                        remote_resource_route_reply(RemoteResourceRouteOutcome::Dropped)
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn deliver_remote_resource_frame_on_socket(
+        &self,
+        msg: RelayDeliverRemoteResourceFrame,
+    ) -> RelayRemoteResourceFrameReply {
+        let Some(services) = self.services.get().cloned() else {
+            return RelayRemoteResourceFrameReply {
+                status: RelayRemoteResourceFrameStatus::Unavailable,
+            };
+        };
+        let registration = {
+            let registrations = self.remote_socket_resources.lock().await;
+            registrations
+                .get(&msg.frame.jid)
+                .filter(|registration| registration.registration_id == msg.frame.registration_id)
+                .cloned()
+        };
+        let Some(registration) = registration else {
+            return RelayRemoteResourceFrameReply {
+                status: RelayRemoteResourceFrameStatus::Unavailable,
+            };
+        };
+        let outbound = OutboundStanza {
+            stanza: msg.frame.stanza.0,
+            kind: msg.frame.kind,
+            pending_row_id: None,
+            pending_row_original_receipt_at: None,
+        };
+        let outcome = services.connection_registry.try_send_outbound_if_owner(
+            &msg.frame.jid,
+            &registration.owner,
+            outbound,
+        );
+        let status = match outcome {
+            BroadcastOutcome::Delivered => RelayRemoteResourceFrameStatus::Delivered,
+            BroadcastOutcome::DroppedFull => RelayRemoteResourceFrameStatus::Backpressure,
+            BroadcastOutcome::NotConnected | BroadcastOutcome::DroppedClosed => {
+                RelayRemoteResourceFrameStatus::Unavailable
+            }
+        };
+        RelayRemoteResourceFrameReply { status }
+    }
+
+    async fn deliver_registered_remote_resource_with_registration(
+        &self,
+        target: &jid::FullJid,
+        stanza: &Stanza,
+        kind: DeliveryKind,
+        registration: &RemoteOwnerRegistration,
+    ) -> FullJidDeliveryOutcome {
+        let mut handle =
+            RelayHandle::new(registration.socket_node.clone(), self.stop_token.clone())
+                .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        match handle
+            .deliver_remote_resource_frame(RelayDeliverRemoteResourceFrame {
+                frame: RemoteResourceOutboundFrame {
+                    jid: target.clone(),
+                    registration_id: registration.registration_id,
+                    stanza: RemoteStanza(stanza.clone()),
+                    kind,
+                },
+            })
+            .await
+        {
+            Ok(RelayRemoteResourceFrameReply {
+                status: RelayRemoteResourceFrameStatus::Delivered,
+            }) => FullJidDeliveryOutcome::Delivered,
+            Ok(RelayRemoteResourceFrameReply {
+                status: RelayRemoteResourceFrameStatus::Backpressure,
+            }) => FullJidDeliveryOutcome::Dropped,
+            Ok(RelayRemoteResourceFrameReply {
+                status: RelayRemoteResourceFrameStatus::Unavailable,
+            }) => {
+                self.cleanup_remote_owner_resource_if_registration(
+                    target,
+                    registration.registration_id,
+                )
+                .await;
+                FullJidDeliveryOutcome::Unavailable
+            }
+            Err(error) => {
+                tracing::warn!(
+                    jid = %target,
+                    %error,
+                    "clustered remote-resource acked delivery relay ask failed"
+                );
+                FullJidDeliveryOutcome::Dropped
+            }
+        }
+    }
+
+    pub(crate) async fn force_detach_remote_user_resource_on_socket(
+        &self,
+        msg: RelayForceDetachRemoteUserResource,
+    ) -> RelayForceDetachRemoteUserResourceReply {
+        let Some(services) = self.services.get().cloned() else {
+            return RelayForceDetachRemoteUserResourceReply {
+                outcome: ForceDetachOutcome::NotPersisted,
+                status: RelayRemoteResourceForceDetachStatus::Unknown,
+            };
+        };
+        let registration = {
+            let registrations = self.remote_socket_resources.lock().await;
+            registrations
+                .get(&msg.jid)
+                .filter(|registration| registration.registration_id == msg.registration_id)
+                .cloned()
+        };
+        let Some(registration) = registration else {
+            return RelayForceDetachRemoteUserResourceReply {
+                outcome: ForceDetachOutcome::NotPersisted,
+                status: RelayRemoteResourceForceDetachStatus::NotLive,
+            };
+        };
+        let Some(entry) = services
+            .connection_registry
+            .entry_if_owner(&msg.jid, &registration.owner)
+        else {
+            return RelayForceDetachRemoteUserResourceReply {
+                outcome: ForceDetachOutcome::NotPersisted,
+                status: RelayRemoteResourceForceDetachStatus::NotLive,
+            };
+        };
+        let (ack, ack_rx) = tokio::sync::oneshot::channel();
+        let request = ForceDetachRequest {
+            requester_bare_jid: msg.requester_bare_jid,
+            ack,
+        };
+        if entry.force_detach_sender().try_send(request).is_err() {
+            return RelayForceDetachRemoteUserResourceReply {
+                outcome: ForceDetachOutcome::NotPersisted,
+                status: RelayRemoteResourceForceDetachStatus::Unknown,
+            };
+        }
+        let (outcome, status) =
+            match tokio::time::timeout(ORDERED_DELIVERY_REPLY_TIMEOUT, ack_rx).await {
+                Ok(Ok(ForceDetachOutcome::Detached)) => (
+                    ForceDetachOutcome::Detached,
+                    RelayRemoteResourceForceDetachStatus::Detached,
+                ),
+                Ok(Ok(ForceDetachOutcome::NotPersisted)) => (
+                    ForceDetachOutcome::NotPersisted,
+                    RelayRemoteResourceForceDetachStatus::Detached,
+                ),
+                Ok(Ok(ForceDetachOutcome::IdentityMismatch)) => (
+                    ForceDetachOutcome::IdentityMismatch,
+                    RelayRemoteResourceForceDetachStatus::Refused,
+                ),
+                Ok(Err(_)) | Err(_) => (
+                    ForceDetachOutcome::NotPersisted,
+                    RelayRemoteResourceForceDetachStatus::Unknown,
+                ),
+            };
+        RelayForceDetachRemoteUserResourceReply { outcome, status }
+    }
+
+    async fn detach_stale_remote_socket_resource(
+        &self,
+        jid: &jid::FullJid,
+        registration: &RemoteSocketRegistration,
+    ) {
+        let Some(services) = self.services.get().cloned() else {
+            return;
+        };
+        {
+            let mut registrations = self.remote_socket_resources.lock().await;
+            if registrations.get(jid).is_some_and(|current| {
+                current.registration_id == registration.registration_id
+                    && current.socket_generation == registration.socket_generation
+            }) {
+                registrations.remove(jid);
+            }
+        }
+        let Some(entry) = services
+            .connection_registry
+            .entry_if_owner(jid, &registration.owner)
+        else {
+            return;
+        };
+        let (ack, _ack_rx) = tokio::sync::oneshot::channel();
+        let _ = entry.force_detach_sender().try_send(ForceDetachRequest {
+            requester_bare_jid: jid.to_bare(),
+            ack,
+        });
+    }
+
+    async fn retire_remote_owner_registration(
+        &self,
+        services: &OrderedRelayDeliveryServices,
+        jid: &jid::FullJid,
+        registration: &RemoteOwnerRegistration,
+    ) -> bool {
+        let mut handle =
+            RelayHandle::new(registration.socket_node.clone(), self.stop_token.clone())
+                .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        let detach = handle
+            .force_detach_remote_user_resource(RelayForceDetachRemoteUserResource {
+                jid: jid.clone(),
+                registration_id: registration.registration_id,
+                requester_bare_jid: jid.to_bare(),
+            })
+            .await;
+        let Ok(reply) = detach else {
+            return false;
+        };
+        if !matches!(
+            reply.status,
+            RelayRemoteResourceForceDetachStatus::Detached
+                | RelayRemoteResourceForceDetachStatus::NotLive
+        ) {
+            tracing::warn!(
+                jid = %jid,
+                status = ?reply.status,
+                "clustered remote-resource replacement refused uncertain old-socket detach"
+            );
+            return false;
+        }
+        if !unregister_remote_owner_actor_entry(services, jid, &registration.owner).await {
+            return false;
+        }
+        services
+            .connection_registry
+            .unregister_if_owner(jid, &registration.owner);
+        true
+    }
+
+    async fn cleanup_remote_owner_resource_if_registration(
+        &self,
+        jid: &jid::FullJid,
+        registration_id: RemoteResourceRegistrationId,
+    ) {
+        let Some(services) = self.services.get().cloned() else {
+            return;
+        };
+        let registration = self
+            .remote_owner_resources
+            .lock()
+            .await
+            .get(jid)
+            .filter(|registration| registration.registration_id == registration_id)
+            .cloned();
+        let Some(registration) = registration else {
+            return;
+        };
+        let actor_removed = services
+            .user_registry
+            .ask(UnregisterUserResource {
+                jid: jid.clone(),
+                owner: Some(registration.owner.clone()),
+            })
+            .mailbox_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+            .reply_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+            .await
+            .is_ok();
+        if !actor_removed {
+            return;
+        }
+        services
+            .connection_registry
+            .unregister_if_owner(jid, &registration.owner);
+        let mut registrations = self.remote_owner_resources.lock().await;
+        if registrations
+            .get(jid)
+            .is_some_and(|registration| registration.registration_id == registration_id)
+        {
+            registrations.remove(jid);
+        }
+    }
+
+    fn spawn_remote_resource_forwarder(
+        self: &Arc<Self>,
+        jid: jid::FullJid,
+        registration_id: RemoteResourceRegistrationId,
+        socket_node: NodeId,
+        mut rx: mpsc::Receiver<OutboundStanza>,
+        force_detach_rx: Option<mpsc::Receiver<ForceDetachRequest>>,
+    ) {
+        let outbound_bridge = Arc::clone(self);
+        let outbound_jid = jid.clone();
+        let outbound_socket_node = socket_node.clone();
+        tokio::spawn(async move {
+            while let Some(outbound) = rx.recv().await {
+                forward_remote_resource_outbound(
+                    &outbound_bridge,
+                    &outbound_jid,
+                    registration_id,
+                    &outbound_socket_node,
+                    outbound,
+                )
+                .await;
+            }
+        });
+        if let Some(mut force_detach_rx) = force_detach_rx {
+            let control_bridge = Arc::clone(self);
+            tokio::spawn(async move {
+                while let Some(request) = force_detach_rx.recv().await {
+                    forward_remote_resource_force_detach(
+                        &control_bridge,
+                        &jid,
+                        registration_id,
+                        &socket_node,
+                        request,
+                    )
+                    .await;
+                }
+            });
+        }
     }
 
     async fn try_proxy_muc_join_repair(
@@ -699,6 +2459,43 @@ impl OrderedRelayDeliveryBridge {
             .is_some_and(|existing| Arc::ptr_eq(existing, lock) && Arc::strong_count(lock) == 2)
         {
             locks.remove(channel);
+        }
+    }
+
+    async fn lock_for_remote_owner_registration(
+        &self,
+        jid: &jid::FullJid,
+    ) -> Option<Arc<Mutex<()>>> {
+        let mut locks = self.remote_owner_registration_locks.lock().await;
+        if !locks.contains_key(jid) && locks.len() >= MAX_REMOTE_OWNER_REGISTRATION_LOCKS {
+            locks.retain(|_, lock| Arc::strong_count(lock) > 1);
+        }
+        if !locks.contains_key(jid) && locks.len() >= MAX_REMOTE_OWNER_REGISTRATION_LOCKS {
+            tracing::warn!(
+                limit = MAX_REMOTE_OWNER_REGISTRATION_LOCKS,
+                "clustered remote-resource registration lock map is full"
+            );
+            return None;
+        }
+        Some(
+            locks
+                .entry(jid.clone())
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone(),
+        )
+    }
+
+    async fn remove_remote_owner_registration_lock_if_unused(
+        &self,
+        jid: &jid::FullJid,
+        lock: &Arc<Mutex<()>>,
+    ) {
+        let mut locks = self.remote_owner_registration_locks.lock().await;
+        if locks
+            .get(jid)
+            .is_some_and(|existing| Arc::ptr_eq(existing, lock) && Arc::strong_count(lock) == 2)
+        {
+            locks.remove(jid);
         }
     }
 
@@ -925,11 +2722,10 @@ impl OrderedRelayDeliveryBridge {
         };
         validate_claims(&services, envelope).await?;
         match relay_payload_target(envelope)? {
-            RelayPayloadTarget::Full(target, stanza) => {
-                deliver_reserved_full_jid(&services, target, stanza)
-                    .await
-                    .map(|()| Vec::new())
-            }
+            RelayPayloadTarget::Full(target, stanza) => self
+                .deliver_reserved_full_jid(&services, target, stanza)
+                .await
+                .map(|()| Vec::new()),
             RelayPayloadTarget::Bare(target, stanza) => {
                 deliver_reserved_bare_jid(&services, &target, stanza)
                     .await
@@ -993,25 +2789,269 @@ impl OrderedRelayDeliveryBridge {
     }
 }
 
-async fn deliver_reserved_full_jid(
-    services: &OrderedRelayDeliveryServices,
-    target: &jid::FullJid,
-    stanza: &Stanza,
-) -> Result<(), OrderedRelayNackReason> {
-    if matches!(stanza, Stanza::Iq(_)) {
-        return deliver_reserved_full_jid_peer_live_only(services, target, stanza).await;
+fn apply_remote_resource_presence_to_registry(
+    registry: &ConnectionRegistry,
+    jid: &jid::FullJid,
+    owner: &Arc<AtomicBool>,
+    available: bool,
+    priority: i8,
+    state: Option<RemotePresenceStateSnapshot>,
+) -> bool {
+    if !registry.update_presence_if_owner(jid, owner, available, priority) {
+        return false;
     }
-    match crate::server::routes::interpret::deliver_peer_to_full(
-        Some(&services.user_registry),
-        Some(&services.sm_session_registry),
-        target,
-        stanza,
+    if available {
+        let state = state.map(PresenceState::from).unwrap_or(PresenceState {
+            show: None,
+            status: None,
+            priority,
+            payloads: Vec::new(),
+        });
+        registry.update_presence_state_if_owner(
+            jid,
+            owner,
+            state.show,
+            state.status,
+            state.priority,
+            state.payloads,
+        )
+    } else {
+        registry.clear_presence_state_if_owner(jid, owner)
+    }
+}
+
+async fn owner_remote_entry_if_current(
+    actor: &ActorRef<waddle_xmpp::registry::user_actor::UserActor>,
+    registry: &ConnectionRegistry,
+    jid: &jid::FullJid,
+    owner: &Arc<AtomicBool>,
+) -> Result<ConnectionEntry, RelayRemoteResourceUpdateStatus> {
+    let actor_entry = match actor
+        .ask(waddle_xmpp::registry::GetConnectionEntry { jid: jid.clone() })
+        .mailbox_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+        .reply_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+        .await
+    {
+        Ok(Some(entry)) => entry,
+        Ok(None) => return Err(RelayRemoteResourceUpdateStatus::StaleRegistration),
+        Err(_) => return Err(RelayRemoteResourceUpdateStatus::Unavailable),
+    };
+    if !Arc::ptr_eq(&actor_entry.carbons_enabled, owner) {
+        return Err(RelayRemoteResourceUpdateStatus::StaleRegistration);
+    }
+    let Some(registry_entry) = registry.entry_if_owner(jid, owner) else {
+        return Err(RelayRemoteResourceUpdateStatus::StaleRegistration);
+    };
+    if !Arc::ptr_eq(
+        &registry_entry.carbons_enabled,
+        &actor_entry.carbons_enabled,
+    ) {
+        return Err(RelayRemoteResourceUpdateStatus::StaleRegistration);
+    }
+    Ok(registry_entry)
+}
+
+async fn remote_owner_registration_is_current(
+    services: &OrderedRelayDeliveryServices,
+    jid: &jid::FullJid,
+    registration: &RemoteOwnerRegistration,
+) -> Result<(), RelayRemoteResourceRegistrationStatus> {
+    let actor = match services
+        .user_registry
+        .ask(waddle_xmpp::registry::GetUser {
+            bare_jid: jid.to_bare(),
+        })
+        .mailbox_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+        .reply_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+        .await
+    {
+        Ok(Some(actor)) => actor,
+        Ok(None) => return Err(RelayRemoteResourceRegistrationStatus::StaleRegistration),
+        Err(_) => return Err(RelayRemoteResourceRegistrationStatus::Unavailable),
+    };
+    owner_remote_entry_if_current(
+        &actor,
+        &services.connection_registry,
+        jid,
+        &registration.owner,
     )
     .await
+    .map(|_| ())
+    .map_err(|status| match status {
+        RelayRemoteResourceUpdateStatus::Updated => {
+            RelayRemoteResourceRegistrationStatus::Registered
+        }
+        RelayRemoteResourceUpdateStatus::StaleRegistration => {
+            RelayRemoteResourceRegistrationStatus::StaleRegistration
+        }
+        RelayRemoteResourceUpdateStatus::Unavailable => {
+            RelayRemoteResourceRegistrationStatus::Unavailable
+        }
+    })
+}
+
+async fn unregister_remote_owner_actor_entry(
+    services: &OrderedRelayDeliveryServices,
+    jid: &jid::FullJid,
+    owner: &Arc<AtomicBool>,
+) -> bool {
+    match services
+        .user_registry
+        .ask(UnregisterUserResource {
+            jid: jid.clone(),
+            owner: Some(owner.clone()),
+        })
+        .mailbox_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+        .reply_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+        .await
     {
-        FullJidDeliveryOutcome::Delivered | FullJidDeliveryOutcome::QueuedDetached => Ok(()),
-        FullJidDeliveryOutcome::Dropped => Err(OrderedRelayNackReason::Backpressure),
-        FullJidDeliveryOutcome::Unavailable => Err(OrderedRelayNackReason::TargetUnavailable),
+        Ok(()) => true,
+        Err(error) => {
+            tracing::warn!(
+                jid = %jid,
+                %error,
+                "clustered remote-resource owner actor unregister failed"
+            );
+            false
+        }
+    }
+}
+
+fn remote_owner_registration_matches(
+    left: &RemoteOwnerRegistration,
+    right: &RemoteOwnerRegistration,
+) -> bool {
+    left.registration_id == right.registration_id
+        && left.socket_node == right.socket_node
+        && left.socket_generation == right.socket_generation
+        && Arc::ptr_eq(&left.owner, &right.owner)
+}
+
+async fn forward_remote_resource_outbound(
+    bridge: &Arc<OrderedRelayDeliveryBridge>,
+    jid: &jid::FullJid,
+    registration_id: RemoteResourceRegistrationId,
+    socket_node: &NodeId,
+    outbound: OutboundStanza,
+) {
+    if outbound.pending_row_id.is_some() {
+        tracing::warn!(
+            jid = %jid,
+            "clustered remote-resource forwarder received pending-delivery \
+             flush frame; dropping to avoid breaking SM row ack accounting"
+        );
+        return;
+    }
+    let kind = outbound.kind;
+    let frame = RemoteResourceOutboundFrame {
+        jid: jid.clone(),
+        registration_id,
+        stanza: RemoteStanza(outbound.stanza),
+        kind,
+    };
+    let mut handle = RelayHandle::new(socket_node.clone(), bridge.stop_token.clone())
+        .with_ask_timeouts(bridge.mailbox_timeout, bridge.reply_timeout);
+    match handle
+        .deliver_remote_resource_frame(RelayDeliverRemoteResourceFrame { frame })
+        .await
+    {
+        Ok(RelayRemoteResourceFrameReply {
+            status: RelayRemoteResourceFrameStatus::Delivered,
+        }) => {}
+        Ok(RelayRemoteResourceFrameReply {
+            status: RelayRemoteResourceFrameStatus::Unavailable,
+        }) => {
+            tracing::debug!(
+                jid = %jid,
+                "clustered remote-resource socket registration unavailable; cleaning owner mirror"
+            );
+            bridge
+                .cleanup_remote_owner_resource_if_registration(jid, registration_id)
+                .await;
+        }
+        Ok(reply) => {
+            tracing::debug!(
+                jid = %jid,
+                status = ?reply.status,
+                "clustered remote-resource forwarder did not deliver frame"
+            );
+        }
+        Err(error) => {
+            tracing::warn!(
+                jid = %jid,
+                %error,
+                "clustered remote-resource forwarder relay ask failed"
+            );
+        }
+    }
+}
+
+async fn forward_remote_resource_force_detach(
+    bridge: &Arc<OrderedRelayDeliveryBridge>,
+    jid: &jid::FullJid,
+    registration_id: RemoteResourceRegistrationId,
+    socket_node: &NodeId,
+    request: ForceDetachRequest,
+) {
+    let mut handle = RelayHandle::new(socket_node.clone(), bridge.stop_token.clone())
+        .with_ask_timeouts(bridge.mailbox_timeout, bridge.reply_timeout);
+    let outcome = match handle
+        .force_detach_remote_user_resource(RelayForceDetachRemoteUserResource {
+            jid: jid.clone(),
+            registration_id,
+            requester_bare_jid: request.requester_bare_jid,
+        })
+        .await
+    {
+        Ok(reply) => reply.outcome,
+        Err(error) => {
+            tracing::warn!(
+                jid = %jid,
+                %error,
+                "clustered remote-resource force-detach relay ask failed"
+            );
+            ForceDetachOutcome::NotPersisted
+        }
+    };
+    let _ = request.ack.send(outcome);
+}
+
+impl OrderedRelayDeliveryBridge {
+    async fn deliver_reserved_full_jid(
+        &self,
+        services: &OrderedRelayDeliveryServices,
+        target: &jid::FullJid,
+        stanza: &Stanza,
+    ) -> Result<(), OrderedRelayNackReason> {
+        if let Some(outcome) = self
+            .try_deliver_registered_remote_resource(target, stanza, DeliveryKind::PeerStanza)
+            .await
+        {
+            return match outcome {
+                FullJidDeliveryOutcome::Delivered | FullJidDeliveryOutcome::QueuedDetached => {
+                    Ok(())
+                }
+                FullJidDeliveryOutcome::Dropped => Err(OrderedRelayNackReason::Backpressure),
+                FullJidDeliveryOutcome::Unavailable => {
+                    Err(OrderedRelayNackReason::TargetUnavailable)
+                }
+            };
+        }
+        if matches!(stanza, Stanza::Iq(_)) {
+            return deliver_reserved_full_jid_peer_live_only(services, target, stanza).await;
+        }
+        match crate::server::routes::interpret::deliver_peer_to_full(
+            Some(&services.user_registry),
+            Some(&services.sm_session_registry),
+            target,
+            stanza,
+        )
+        .await
+        {
+            FullJidDeliveryOutcome::Delivered | FullJidDeliveryOutcome::QueuedDetached => Ok(()),
+            FullJidDeliveryOutcome::Dropped => Err(OrderedRelayNackReason::Backpressure),
+            FullJidDeliveryOutcome::Unavailable => Err(OrderedRelayNackReason::TargetUnavailable),
+        }
     }
 }
 
@@ -1115,14 +3155,7 @@ async fn deliver_reserved_bare_presence_direct(
         live_targets.iter().map(|(jid, _)| jid.clone()).collect();
     let mut landed = false;
     for resource in live_targets.into_iter().map(|(jid, _)| jid) {
-        match crate::server::routes::interpret::deliver_direct_to_full(
-            Some(&services.user_registry),
-            Some(&services.sm_session_registry),
-            &resource,
-            stanza,
-        )
-        .await
-        {
+        match deliver_direct_or_registered_remote_resource(services, &resource, stanza).await {
             FullJidDeliveryOutcome::Delivered | FullJidDeliveryOutcome::QueuedDetached => {
                 landed = true;
             }
@@ -1173,6 +3206,36 @@ async fn deliver_reserved_bare_presence_direct(
     } else {
         Err(OrderedRelayNackReason::TargetUnavailable)
     }
+}
+
+async fn deliver_direct_or_registered_remote_resource(
+    services: &OrderedRelayDeliveryServices,
+    target: &jid::FullJid,
+    stanza: &Stanza,
+) -> FullJidDeliveryOutcome {
+    if let Some(state) = services.web_socket_state.upgrade() {
+        if let Some(bridge) = state
+            .deps
+            .app_state
+            .clustering_claims
+            .ordered_relay_delivery_bridge
+            .as_ref()
+        {
+            if let Some(outcome) = bridge
+                .try_deliver_registered_remote_resource(target, stanza, DeliveryKind::DirectFrame)
+                .await
+            {
+                return outcome;
+            }
+        }
+    }
+    crate::server::routes::interpret::deliver_direct_to_full(
+        Some(&services.user_registry),
+        Some(&services.sm_session_registry),
+        target,
+        stanza,
+    )
+    .await
 }
 
 async fn remote_presence_blocked_for_recipient(
@@ -1305,6 +3368,15 @@ fn no_client_reply_outcome(delivery: FullJidDeliveryOutcome) -> RemoteDeliveryOu
     no_client_reply_outcome_with_commit_state(delivery, false)
 }
 
+fn remote_resource_route_reply(
+    outcome: RemoteResourceRouteOutcome,
+) -> RelayRouteRemoteResourceStanzaReply {
+    RelayRouteRemoteResourceStanzaReply {
+        outcome,
+        replies: Vec::new(),
+    }
+}
+
 fn no_client_reply_outcome_with_commit_state(
     delivery: FullJidDeliveryOutcome,
     maybe_committed: bool,
@@ -1338,6 +3410,19 @@ fn route_origin_claim(kind: &OrderedRelayRouteOriginKind) -> (Entity, OrderedRel
         OrderedRelayRouteOriginKind::Entity(entity) => {
             (entity.clone(), OrderedRelayOrigin::Entity(entity.clone()))
         }
+        OrderedRelayRouteOriginKind::RemoteResource(remote) => {
+            let entity = user_entity(&remote.jid.to_bare());
+            (entity.clone(), OrderedRelayOrigin::Entity(entity))
+        }
+    }
+}
+
+fn remote_resource_origin(
+    origin: &OrderedRelayRouteOrigin,
+) -> Option<RemoteResourceOriginSnapshot> {
+    match &origin.kind {
+        OrderedRelayRouteOriginKind::RemoteResource(remote) => Some(remote.clone()),
+        OrderedRelayRouteOriginKind::SmSession(_) | OrderedRelayRouteOriginKind::Entity(_) => None,
     }
 }
 
@@ -1382,6 +3467,24 @@ fn payload_for_recipient(recipient: jid::Jid, stanza: &Stanza) -> Option<Ordered
             stanza: RemoteStanza(stanza.clone()),
         }),
     }
+}
+
+fn apply_remote_resource_state(entry: &ConnectionEntry, state: &RemoteResourceStateSnapshot) {
+    entry
+        .carbons_enabled
+        .store(state.carbons_enabled, Ordering::Relaxed);
+    entry
+        .roster_interested
+        .store(state.roster_interested, Ordering::Relaxed);
+    entry
+        .blocklist_interested
+        .store(state.blocklist_interested, Ordering::Relaxed);
+    entry
+        .presence_available
+        .store(state.presence_available, Ordering::Relaxed);
+    entry
+        .presence_priority
+        .store(state.presence_priority, Ordering::Relaxed);
 }
 
 enum RelayPayloadTarget<'a> {
@@ -1681,6 +3784,18 @@ fn muc_proxy_result_to_outcome(
             no_client_reply_outcome(FullJidDeliveryOutcome::Unavailable)
         }
         Err(_) => no_client_reply_outcome(FullJidDeliveryOutcome::Dropped),
+    }
+}
+
+fn muc_proxy_result_to_ordered_outcome(
+    result: Result<Vec<RemoteStanza>, OrderedRelayNackReason>,
+) -> OrderedRelayMucProxyOutcome {
+    match result {
+        Ok(replies) => OrderedRelayMucProxyOutcome::Delivered(
+            replies.into_iter().map(|reply| reply.0).collect(),
+        ),
+        Err(OrderedRelayNackReason::TargetUnavailable) => OrderedRelayMucProxyOutcome::Unavailable,
+        Err(_) => OrderedRelayMucProxyOutcome::Dropped,
     }
 }
 
@@ -2037,6 +4152,10 @@ fn replies_for_origin_handoff(stanza: &Stanza, outcome: FullJidDeliveryOutcome) 
         | FullJidDeliveryOutcome::QueuedDetached
         | FullJidDeliveryOutcome::Dropped => Vec::new(),
     }
+}
+
+fn fallback_reply_for_remote_muc_handoff(stanza: &Stanza) -> Vec<Stanza> {
+    replies_for_origin_handoff(stanza, FullJidDeliveryOutcome::Unavailable)
 }
 
 fn diversion_reason_for_nack(nack: &OrderedRelayNack) -> OrderedRelayDiversionReason {

--- a/server/crates/waddle-server/src/server/dual_registration.rs
+++ b/server/crates/waddle-server/src/server/dual_registration.rs
@@ -42,9 +42,11 @@ use std::time::Duration;
 
 use jid::FullJid;
 use kameo::actor::ActorRef;
+use kameo::error::SendError;
 use tracing::warn;
 use waddle_xmpp::registry::{
     ConnectionEntry, RegisterUserResource, UnregisterUserResource, UserRegistryActor,
+    UserRegistryError,
 };
 
 /// Upper bound on how long the fail-closed register `ask` may wait for the
@@ -59,6 +61,13 @@ const BIND_REGISTER_TIMEOUT: Duration = Duration::from_secs(2);
 /// wedged actor cannot meaningfully delay teardown.
 const MIRROR_TIMEOUT: Duration = Duration::from_secs(2);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MirrorRegisterOutcome {
+    Registered,
+    ForeignOwner,
+    Failed,
+}
+
 /// Mirror a resource registration into the actor tree (authoritative, bounded).
 ///
 /// `entry` MUST be the live DashMap [`ConnectionEntry`] (obtained via
@@ -72,11 +81,23 @@ const MIRROR_TIMEOUT: Duration = Duration::from_secs(2);
 /// resource (ADR-0017 Phase 1 completion).
 #[must_use = "a false return means the actor tree did not record the resource; \
               the caller must roll back the DashMap registration and fail the bind"]
+#[cfg(test)]
 pub(crate) async fn mirror_register(
     user_registry: &ActorRef<UserRegistryActor>,
     jid: FullJid,
     entry: ConnectionEntry,
 ) -> bool {
+    matches!(
+        mirror_register_outcome(user_registry, jid, entry).await,
+        MirrorRegisterOutcome::Registered
+    )
+}
+
+pub(crate) async fn mirror_register_outcome(
+    user_registry: &ActorRef<UserRegistryActor>,
+    jid: FullJid,
+    entry: ConnectionEntry,
+) -> MirrorRegisterOutcome {
     // `RegisterUserResource` replies `Result<(), UserRegistryError>`, and kameo
     // *flattens* a `Result` reply: `ask().await` yields
     // `Result<(), SendError<RegisterUserResource, UserRegistryError>>`, NOT a
@@ -94,7 +115,10 @@ pub(crate) async fn mirror_register(
         .reply_timeout(BIND_REGISTER_TIMEOUT)
         .await
     {
-        Ok(()) => true,
+        Ok(()) => MirrorRegisterOutcome::Registered,
+        Err(SendError::HandlerError(UserRegistryError::ClaimHeldByAnotherNode(_))) => {
+            MirrorRegisterOutcome::ForeignOwner
+        }
         Err(error) => {
             warn!(
                 jid = %jid,
@@ -103,7 +127,7 @@ pub(crate) async fn mirror_register(
                  actor failed; rolling back DashMap registration and failing \
                  the bind"
             );
-            false
+            MirrorRegisterOutcome::Failed
         }
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -150,7 +150,7 @@ use crate::server::routes::websocket::WebSocketState;
 mod archive_groupchat_event;
 mod archive_lookup;
 mod bot;
-mod carbons;
+pub(crate) mod carbons;
 mod deps;
 mod direct_archive;
 mod direct_call_thread;

--- a/server/crates/waddle-server/src/server/routes/interpret/carbons.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/carbons.rs
@@ -8,6 +8,50 @@ pub(super) async fn send_carbons(
     kind: CarbonKind,
     exclude: Vec<FullJid>,
 ) {
+    #[cfg(feature = "clustering")]
+    if let Some(state) = deps.web_socket_state {
+        if let Some(bridge) = state
+            .deps
+            .app_state
+            .clustering_claims
+            .ordered_relay_delivery_bridge
+            .as_ref()
+        {
+            for source_jid in &exclude {
+                if bridge
+                    .try_fanout_remote_user_carbons(
+                        source_jid,
+                        &owner,
+                        &message,
+                        kind,
+                        exclude.clone(),
+                    )
+                    .await
+                {
+                    return;
+                }
+            }
+        }
+    }
+    send_carbons_to_registry(
+        registry,
+        deps.sm_session_registry,
+        owner,
+        message,
+        kind,
+        exclude,
+    )
+    .await;
+}
+
+pub(crate) async fn send_carbons_to_registry(
+    registry: &ConnectionRegistry,
+    sm_session_registry: Option<&Arc<InMemorySmSessionRegistry>>,
+    owner: BareJid,
+    message: Box<Message>,
+    kind: CarbonKind,
+    exclude: Vec<FullJid>,
+) {
     // Per XEP-0280 §5, a carbon copy is the original
     // <message/> wrapped in <sent>/<received> →
     // <forwarded xmlns='urn:xmpp:forward:0'> → original.
@@ -41,7 +85,7 @@ pub(super) async fn send_carbons(
     // resources via
     // `record_stanza_for_detached_bound_resource`; the
     // interpreter does the same here.
-    let detached_targets: Vec<jid::FullJid> = match deps.sm_session_registry {
+    let detached_targets: Vec<jid::FullJid> = match sm_session_registry {
         Some(sm) => sm
             .detached_carbon_resources_for_user(&owner, &exclude)
             .await
@@ -105,7 +149,7 @@ pub(super) async fn send_carbons(
     }
     // Detached pass — queue the same envelope for replay
     // when the resource resumes its XEP-0198 session.
-    if let Some(sm) = deps.sm_session_registry {
+    if let Some(sm) = sm_session_registry {
         for target in detached_targets {
             let envelope = match build_carbon_envelope(kind, &message, &owner_str, &target) {
                 Ok(env) => env,

--- a/server/crates/waddle-server/src/server/routes/interpret/deps.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/deps.rs
@@ -13,6 +13,7 @@ use waddle_xmpp::protocol::TimerId;
 pub enum OrderedRelayRouteOriginKind {
     SmSession(waddle_xmpp::pending_delivery::SmSessionId),
     Entity(waddle_xmpp::ownership::Entity),
+    RemoteResource(crate::clustering::route_bridge::RemoteResourceOriginSnapshot),
 }
 
 #[derive(Clone, Debug)]

--- a/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/route_to_connection.rs
@@ -167,13 +167,7 @@ pub(crate) async fn route_to_connection(
                     match deliver_full_jid_via_ordered_relay(deps, &full, stanza.as_ref()).await {
                         Some(outcome) => outcome,
                         None => {
-                            deliver_peer_to_full(
-                                deps.user_registry,
-                                deps.sm_session_registry,
-                                &full,
-                                &stanza,
-                            )
-                            .await
+                            deliver_peer_to_full_with_registered_remote(deps, &full, &stanza).await
                         }
                     };
                 if delivery == FullJidDeliveryOutcome::Unavailable {
@@ -319,11 +313,8 @@ pub(crate) async fn route_to_connection(
                                     // (`TrySendDirect`, non-blocking) via
                                     // `deliver_direct_to_full`.
                                     for full in &live_targets {
-                                        deliver_direct_to_full(
-                                            deps.user_registry,
-                                            deps.sm_session_registry,
-                                            full,
-                                            &processed,
+                                        deliver_direct_to_full_with_registered_remote(
+                                            deps, full, &processed,
                                         )
                                         .await;
                                     }
@@ -397,13 +388,8 @@ pub(crate) async fn route_to_connection(
                     // above already runs.
                     let mut any_landed = false;
                     for full in live_targets {
-                        let disposition = deliver_peer_to_full(
-                            deps.user_registry,
-                            deps.sm_session_registry,
-                            &full,
-                            &stanza,
-                        )
-                        .await;
+                        let disposition =
+                            deliver_peer_to_full_with_registered_remote(deps, &full, &stanza).await;
                         if matches!(
                             disposition,
                             FullJidDeliveryOutcome::Delivered
@@ -534,6 +520,68 @@ fn deliver_full_jid_via_ordered_relay<'a>(
             None
         }
     })
+}
+
+async fn deliver_peer_to_full_with_registered_remote(
+    deps: &Deps<'_>,
+    target: &jid::FullJid,
+    stanza: &Stanza,
+) -> FullJidDeliveryOutcome {
+    if let Some(outcome) = deliver_registered_remote_resource(
+        deps,
+        target,
+        stanza,
+        waddle_xmpp::registry::DeliveryKind::PeerStanza,
+    )
+    .await
+    {
+        return outcome;
+    }
+    deliver_peer_to_full(deps.user_registry, deps.sm_session_registry, target, stanza).await
+}
+
+async fn deliver_direct_to_full_with_registered_remote(
+    deps: &Deps<'_>,
+    target: &jid::FullJid,
+    stanza: &Stanza,
+) -> FullJidDeliveryOutcome {
+    if let Some(outcome) = deliver_registered_remote_resource(
+        deps,
+        target,
+        stanza,
+        waddle_xmpp::registry::DeliveryKind::DirectFrame,
+    )
+    .await
+    {
+        return outcome;
+    }
+    deliver_direct_to_full(deps.user_registry, deps.sm_session_registry, target, stanza).await
+}
+
+async fn deliver_registered_remote_resource(
+    deps: &Deps<'_>,
+    target: &jid::FullJid,
+    stanza: &Stanza,
+    kind: waddle_xmpp::registry::DeliveryKind,
+) -> Option<FullJidDeliveryOutcome> {
+    #[cfg(feature = "clustering")]
+    {
+        let state = deps.web_socket_state?;
+        let bridge = state
+            .deps
+            .app_state
+            .clustering_claims
+            .ordered_relay_delivery_bridge
+            .as_ref()?;
+        bridge
+            .try_deliver_registered_remote_resource(target, stanza, kind)
+            .await
+    }
+    #[cfg(not(feature = "clustering"))]
+    {
+        let _ = (deps, target, stanza, kind);
+        None
+    }
 }
 
 fn deliver_bare_jid_via_ordered_relay<'a>(

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -8,6 +8,33 @@ use waddle_xmpp::muc::RoomRegistry;
 use waddle_xmpp::xep::xep0272::Muji;
 use waddle_xmpp::xep::xep0421::OccupantIdentity;
 
+#[cfg(feature = "clustering")]
+async fn unregister_remote_user_resource_if_owner(
+    state: &WebSocketState,
+    jid: &FullJid,
+    owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    if let Some(bridge) = state
+        .deps
+        .app_state
+        .clustering_claims
+        .ordered_relay_delivery_bridge
+        .as_ref()
+    {
+        bridge
+            .unregister_remote_user_resource_if_owner(jid, owner)
+            .await;
+    }
+}
+
+#[cfg(not(feature = "clustering"))]
+async fn unregister_remote_user_resource_if_owner(
+    _state: &WebSocketState,
+    _jid: &FullJid,
+    _owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+}
+
 fn muji_reflection_rank(muji: &Muji) -> u8 {
     if muji.is_empty() {
         0
@@ -462,6 +489,7 @@ pub(super) async fn cleanup_connection_shutdown(
                         Some(std::sync::Arc::clone(owner)),
                     )
                     .await;
+                    unregister_remote_user_resource_if_owner(state, &jid, owner).await;
                     outbound_rx.close();
                     // Second detach drain: anything that arrived
                     // between the first drain and the registry
@@ -520,6 +548,7 @@ pub(super) async fn cleanup_connection_shutdown(
                             Some(std::sync::Arc::clone(owner)),
                         )
                         .await;
+                        unregister_remote_user_resource_if_owner(state, &jid, owner).await;
                     }
                     // PR #438 review (Copilot): when SM detachment
                     // fails we fall back to a full unregister, so the
@@ -567,9 +596,10 @@ pub(super) async fn cleanup_connection_shutdown(
         crate::server::dual_registration::mirror_unregister(
             &state.deps.protocol.user_registry,
             &jid,
-            Some(owner),
+            Some(std::sync::Arc::clone(&owner)),
         )
         .await;
+        unregister_remote_user_resource_if_owner(state, &jid, &owner).await;
     } else {
         debug!(jid = %jid, "Skipped websocket cleanup for non-owned registry entry");
     }
@@ -919,6 +949,8 @@ pub(super) async fn cleanup_invalidated_detached_session(
                 Some(std::sync::Arc::clone(&entry.carbons_enabled)),
             )
             .await;
+            unregister_remote_user_resource_if_owner(state, &detached.jid, &entry.carbons_enabled)
+                .await;
         }
         // XEP-0115 §6: clear the resource→ver mapping AND any stuck
         // pending disco#info resolution for this resource so an

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -225,11 +225,14 @@ async fn handle_xmpp_frame_impl(
                 .enabled
                 .then(|| sm_inbound_completion.reserve(sm_state));
             let ordered_relay_origin = ordered_relay_origin_for_inbound_stanza(
+                state,
                 sm_state,
                 phase.bound_jid(),
+                registry_owner.as_ref(),
                 reserved_inbound_for_sm,
                 ordered_relay_handoff_tx.as_ref(),
-            );
+            )
+            .await;
 
             // Resource binding is stream setup, not request processing: handle
             // it inline and return BEFORE the wedge backstop (#808 ADR-008 scope
@@ -264,6 +267,7 @@ async fn handle_xmpp_frame_impl(
                             carbons_enabled,
                             roster_interested,
                             blocklist_interested,
+                            registry_owner: registry_owner.as_ref(),
                             state_machine: state_machine.as_mut(),
                             ordered_relay_origin: ordered_relay_origin.clone(),
                         };
@@ -320,9 +324,11 @@ async fn handle_xmpp_frame_impl(
 }
 
 #[cfg(feature = "clustering")]
-fn ordered_relay_origin_for_inbound_stanza(
+async fn ordered_relay_origin_for_inbound_stanza(
+    state: &WebSocketState,
     sm_state: &waddle_xmpp::stream_management::StreamManagementState,
     bound_jid: Option<&jid::FullJid>,
+    registry_owner: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
     inbound_sequence: Option<crate::server::routes::interpret::OrderedRelayInboundSequence>,
     handoff_tx: Option<
         &tokio::sync::mpsc::UnboundedSender<
@@ -336,6 +342,38 @@ fn ordered_relay_origin_for_inbound_stanza(
             jid.to_bare().to_string(),
         )
     })?;
+    if let (Some(jid), Some(owner), Some(bridge)) = (
+        bound_jid,
+        registry_owner,
+        state
+            .deps
+            .app_state
+            .clustering_claims
+            .ordered_relay_delivery_bridge
+            .as_ref(),
+    ) {
+        if let Some(remote) = bridge.remote_resource_origin_if_owner(jid, owner).await {
+            return Some(crate::server::routes::interpret::OrderedRelayRouteOrigin {
+                kind: crate::server::routes::interpret::OrderedRelayRouteOriginKind::RemoteResource(
+                    remote,
+                ),
+                sender_entity,
+                inbound_sequence: inbound_sequence.map(|sequence| sequence.0).unwrap_or(0),
+                handoff: if sm_state.enabled {
+                    inbound_sequence.and_then(|sequence| {
+                        handoff_tx.map(|tx| {
+                            crate::server::routes::interpret::OrderedRelayHandoffHandle::new(
+                                sequence,
+                                tx.clone(),
+                            )
+                        })
+                    })
+                } else {
+                    None
+                },
+            });
+        }
+    }
     if sm_state.enabled {
         let stream_id = sm_state.stream_id.as_ref()?;
         let inbound_sequence = inbound_sequence?;
@@ -364,9 +402,11 @@ fn ordered_relay_origin_for_inbound_stanza(
 }
 
 #[cfg(not(feature = "clustering"))]
-fn ordered_relay_origin_for_inbound_stanza(
+async fn ordered_relay_origin_for_inbound_stanza(
+    state: &WebSocketState,
     sm_state: &waddle_xmpp::stream_management::StreamManagementState,
     bound_jid: Option<&jid::FullJid>,
+    registry_owner: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
     inbound_sequence: Option<crate::server::routes::interpret::OrderedRelayInboundSequence>,
     handoff_tx: Option<
         &tokio::sync::mpsc::UnboundedSender<
@@ -374,7 +414,14 @@ fn ordered_relay_origin_for_inbound_stanza(
         >,
     >,
 ) -> Option<crate::server::routes::interpret::OrderedRelayRouteOrigin> {
-    let _ = (sm_state, bound_jid, inbound_sequence, handoff_tx);
+    let _ = (
+        state,
+        sm_state,
+        bound_jid,
+        registry_owner,
+        inbound_sequence,
+        handoff_tx,
+    );
     None
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/blocking.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/blocking.rs
@@ -7,8 +7,7 @@ pub(super) async fn handle_blocking_iq(
     sender_jid: Option<&FullJid>,
     response_from: Option<&str>,
     response_to: Option<&str>,
-    blocklist_interested: &mut bool,
-    state_machine: Option<&mut waddle_xmpp::protocol::XmppStateMachine>,
+    conn_state: &mut IqConnState<'_>,
 ) -> Vec<String> {
     let Some(sender_jid) = sender_jid else {
         return vec![build_iq_error_xml_typed(
@@ -54,7 +53,10 @@ pub(super) async fn handle_blocking_iq(
                         .protocol
                         .connection_registry
                         .mark_blocklist_interested(sender_jid);
-                    *blocklist_interested = true;
+                    if let Some(owner) = conn_state.registry_owner {
+                        mirror_remote_blocklist_interest(state, sender_jid, owner).await;
+                    }
+                    *conn_state.blocklist_interested = true;
                     vec![iq_to_xml(
                         waddle_xmpp::xep::xep0191::build_blocklist_response(iq, &blocked),
                     )]
@@ -81,7 +83,9 @@ pub(super) async fn handle_blocking_iq(
                 )];
             }
             send_blocking_presence_side_effects(state, &user_bare, &jids, true, None).await;
-            send_blocking_pushes(state, &user_bare, true, &jids).await;
+            if !try_remote_owner_blocklist_push(state, sender_jid, &user_bare, true, &jids).await {
+                send_blocking_pushes(state, &user_bare, true, &jids).await;
+            }
             vec![iq_to_xml(
                 waddle_xmpp::xep::xep0191::build_blocking_success(iq),
             )]
@@ -147,7 +151,11 @@ pub(super) async fn handle_blocking_iq(
             } else {
                 unblocked_jids.as_slice()
             };
-            send_blocking_pushes(state, &user_bare, false, push_jids).await;
+            if !try_remote_owner_blocklist_push(state, sender_jid, &user_bare, false, push_jids)
+                .await
+            {
+                send_blocking_pushes(state, &user_bare, false, push_jids).await;
+            }
             vec![iq_to_xml(
                 waddle_xmpp::xep::xep0191::build_blocking_success(iq),
             )]
@@ -165,7 +173,7 @@ pub(super) async fn handle_blocking_iq(
     // storage layer is authoritative on disk and the next bind will
     // reload, while the request itself already succeeded for the
     // client.
-    if let Some(sm) = state_machine {
+    if let Some(sm) = conn_state.state_machine.as_deref_mut() {
         match storage.list_blocked_jid_entries(&user_bare).await {
             Ok(jids) => {
                 sm.set_blocklist(waddle_xmpp::protocol::Blocklist::new(jids));
@@ -182,6 +190,37 @@ pub(super) async fn handle_blocking_iq(
     }
 
     response
+}
+
+#[cfg(feature = "clustering")]
+async fn mirror_remote_blocklist_interest(
+    state: &WebSocketState,
+    jid: &FullJid,
+    owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    if let Some(bridge) = state
+        .deps
+        .app_state
+        .clustering_claims
+        .ordered_relay_delivery_bridge
+        .as_ref()
+    {
+        bridge
+            .update_remote_user_resource_if_owner(
+                jid,
+                owner,
+                crate::clustering::route_bridge::RemoteResourceStateUpdate::BlocklistInterested,
+            )
+            .await;
+    }
+}
+
+#[cfg(not(feature = "clustering"))]
+async fn mirror_remote_blocklist_interest(
+    _state: &WebSocketState,
+    _jid: &FullJid,
+    _owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
 }
 
 async fn send_blocking_presence_side_effects(
@@ -262,7 +301,7 @@ async fn send_blocking_presence_side_effects(
     }
 }
 
-async fn send_blocking_pushes(
+pub(crate) async fn send_blocking_pushes(
     state: &WebSocketState,
     user_bare: &BareJid,
     blocked: bool,
@@ -342,4 +381,37 @@ async fn send_blocking_pushes(
             .send_to(&resource_jid, Stanza::Iq(Box::new(push)))
             .await;
     }
+}
+
+#[cfg(feature = "clustering")]
+async fn try_remote_owner_blocklist_push(
+    state: &WebSocketState,
+    source_jid: &FullJid,
+    user_bare: &BareJid,
+    blocked: bool,
+    jids: &[Jid],
+) -> bool {
+    let Some(bridge) = state
+        .deps
+        .app_state
+        .clustering_claims
+        .ordered_relay_delivery_bridge
+        .as_ref()
+    else {
+        return false;
+    };
+    bridge
+        .try_fanout_remote_user_blocklist_push(source_jid, user_bare, blocked, jids)
+        .await
+}
+
+#[cfg(not(feature = "clustering"))]
+async fn try_remote_owner_blocklist_push(
+    _state: &WebSocketState,
+    _source_jid: &FullJid,
+    _user_bare: &BareJid,
+    _blocked: bool,
+    _jids: &[Jid],
+) -> bool {
+    false
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/conn_state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/conn_state.rs
@@ -2,6 +2,7 @@ pub struct IqConnState<'a> {
     pub carbons_enabled: &'a mut bool,
     pub roster_interested: &'a mut bool,
     pub blocklist_interested: &'a mut bool,
+    pub registry_owner: Option<&'a std::sync::Arc<std::sync::atomic::AtomicBool>>,
     /// Per-connection [`waddle_xmpp::protocol::XmppStateMachine`].
     /// Required so XEP-0191 block/unblock IQs can mirror their
     /// effect into the dispatcher's session-state snapshot — without

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -76,7 +76,7 @@ use waddle_xmpp::{
 use xmpp_parsers::minidom::Element;
 
 mod archive_inbox_upload;
-mod blocking;
+pub(crate) mod blocking;
 mod caps_result;
 mod commands;
 mod community_items;
@@ -106,7 +106,7 @@ mod pin_query;
 mod pubsub_admin;
 mod pubsub_dispatch;
 mod push;
-mod roster;
+pub(crate) mod roster;
 mod sans_io;
 mod search;
 mod session_jid;
@@ -318,6 +318,7 @@ pub async fn handle_iq_with_conn_state(
             state,
             phase.bound_jid(),
             conn_state.roster_interested,
+            conn_state.registry_owner,
         )
         .await;
     }
@@ -406,8 +407,7 @@ pub async fn handle_iq_with_conn_state(
             phase.bound_jid(),
             response_from,
             response_to,
-            conn_state.blocklist_interested,
-            conn_state.state_machine.as_deref_mut(),
+            conn_state,
         )
         .await
     } else if is_push_enable(&iq) || is_push_disable(&iq) {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/roster.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/roster.rs
@@ -6,6 +6,7 @@ pub(super) async fn handle_roster_iq(
     state: &WebSocketState,
     bound_jid: Option<&FullJid>,
     roster_interested: &mut bool,
+    registry_owner: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
 ) -> Vec<String> {
     let Some(full_jid) = bound_jid else {
         return vec![build_xmpp_error_response(
@@ -31,8 +32,16 @@ pub(super) async fn handle_roster_iq(
     };
 
     if waddle_xmpp::roster::is_roster_get(iq) {
-        return handle_roster_get(iq, &storage, state, &user_jid, full_jid, roster_interested)
-            .await;
+        return handle_roster_get(
+            iq,
+            &storage,
+            state,
+            &user_jid,
+            full_jid,
+            roster_interested,
+            registry_owner,
+        )
+        .await;
     }
     if waddle_xmpp::roster::is_roster_set(iq) {
         return handle_roster_set(iq, &storage, state, &user_jid, full_jid).await;
@@ -48,6 +57,7 @@ async fn handle_roster_get(
     user_jid: &BareJid,
     full_jid: &FullJid,
     roster_interested: &mut bool,
+    registry_owner: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
 ) -> Vec<String> {
     let query = match parse_roster_get(iq) {
         Ok(query) => query,
@@ -82,6 +92,9 @@ async fn handle_roster_get(
         .protocol
         .connection_registry
         .mark_roster_interested(full_jid);
+    if let Some(owner) = registry_owner {
+        mirror_remote_roster_interest(state, full_jid, owner).await;
+    }
     *roster_interested = true;
     // XEP-0237 §2.6: matching ver -> empty <iq type='result'/> (no <query>);
     // anything else (Absent, Bootstrap, Cached(stale)) -> full roster + ver.
@@ -91,6 +104,37 @@ async fn handle_roster_get(
         }
     }
     vec![iq_to_xml(build_roster_result(iq, &items, Some(&version)))]
+}
+
+#[cfg(feature = "clustering")]
+async fn mirror_remote_roster_interest(
+    state: &WebSocketState,
+    jid: &FullJid,
+    owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    if let Some(bridge) = state
+        .deps
+        .app_state
+        .clustering_claims
+        .ordered_relay_delivery_bridge
+        .as_ref()
+    {
+        bridge
+            .update_remote_user_resource_if_owner(
+                jid,
+                owner,
+                crate::clustering::route_bridge::RemoteResourceStateUpdate::RosterInterested,
+            )
+            .await;
+    }
+}
+
+#[cfg(not(feature = "clustering"))]
+async fn mirror_remote_roster_interest(
+    _state: &WebSocketState,
+    _jid: &FullJid,
+    _owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
 }
 
 async fn handle_roster_set(
@@ -225,7 +269,10 @@ async fn handle_roster_set(
         )));
     }
 
-    send_roster_push_to_sibling_resources(state, user_jid, full_jid, &push_item, &version).await;
+    if !try_remote_owner_roster_push(state, full_jid, user_jid, &push_item, &version).await {
+        send_roster_push_to_sibling_resources(state, user_jid, full_jid, &push_item, &version)
+            .await;
+    }
     // Drop the user_jid mutation lock before invoking subscription side
     // effects on the *contact's* roster — the side-effect path acquires the
     // contact's lock, and holding two user-locks simultaneously could
@@ -241,8 +288,41 @@ async fn handle_roster_set(
     frames
 }
 
-mod push;
+pub(crate) mod push;
 use push::{send_roster_push_to_sibling_resources, send_roster_remove_subscription_side_effects};
+
+#[cfg(feature = "clustering")]
+async fn try_remote_owner_roster_push(
+    state: &WebSocketState,
+    source_jid: &FullJid,
+    user_jid: &BareJid,
+    item: &RosterItem,
+    version: &RosterVersion,
+) -> bool {
+    let Some(bridge) = state
+        .deps
+        .app_state
+        .clustering_claims
+        .ordered_relay_delivery_bridge
+        .as_ref()
+    else {
+        return false;
+    };
+    bridge
+        .try_fanout_remote_user_roster_push(source_jid, user_jid, item, version)
+        .await
+}
+
+#[cfg(not(feature = "clustering"))]
+async fn try_remote_owner_roster_push(
+    _state: &WebSocketState,
+    _source_jid: &FullJid,
+    _user_jid: &BareJid,
+    _item: &RosterItem,
+    _version: &RosterVersion,
+) -> bool {
+    false
+}
 
 fn roster_target_allowed(iq: &xmpp_parsers::iq::Iq, domain: &str, user_jid: &BareJid) -> bool {
     match iq.to() {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/roster/push.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/roster/push.rs
@@ -241,7 +241,7 @@ async fn send_roster_push_to_all_resources(
     }
 }
 
-pub(super) async fn send_roster_push_to_sibling_resources(
+pub(crate) async fn send_roster_push_to_sibling_resources(
     state: &WebSocketState,
     user_jid: &BareJid,
     source_jid: &FullJid,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
@@ -117,6 +117,9 @@ pub(super) async fn handle_sans_io_iq(
                 .protocol
                 .connection_registry
                 .set_carbons_enabled(full_jid, enabled);
+            if let Some(owner) = conn_state.registry_owner {
+                mirror_remote_carbons_update(state, full_jid, owner, enabled).await;
+            }
         }
         // XMPP-native MUC-call membership gate (XEP-0272 Muji): a
         // session may only mint a LiveKit JWT for a room it has
@@ -180,4 +183,37 @@ pub(super) async fn handle_sans_io_iq(
         return Some(outcome.frames);
     }
     None
+}
+
+#[cfg(feature = "clustering")]
+async fn mirror_remote_carbons_update(
+    state: &WebSocketState,
+    jid: &FullJid,
+    owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    enabled: bool,
+) {
+    if let Some(bridge) = state
+        .deps
+        .app_state
+        .clustering_claims
+        .ordered_relay_delivery_bridge
+        .as_ref()
+    {
+        bridge
+            .update_remote_user_resource_if_owner(
+                jid,
+                owner,
+                crate::clustering::route_bridge::RemoteResourceStateUpdate::Carbons { enabled },
+            )
+            .await;
+    }
+}
+
+#[cfg(not(feature = "clustering"))]
+async fn mirror_remote_carbons_update(
+    _state: &WebSocketState,
+    _jid: &FullJid,
+    _owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    _enabled: bool,
+) {
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/test_helpers.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/test_helpers.rs
@@ -33,6 +33,7 @@ pub async fn handle_iq(
         carbons_enabled: &mut carbons_enabled,
         roster_interested: &mut roster_interested,
         blocklist_interested: &mut blocklist_interested,
+        registry_owner: None,
         state_machine: None,
         ordered_relay_origin: None,
     };

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/regular.rs
@@ -73,7 +73,7 @@ pub(super) async fn handle_regular_presence_update(
             if priority >= 0 {
                 maybe_flush_pending_delivery(state, sender_jid, owner).await;
             }
-            state
+            let presence_state_written = state
                 .deps
                 .protocol
                 .connection_registry
@@ -91,6 +91,16 @@ pub(super) async fn handle_regular_presence_update(
                     // delivery relays the real advertisements (issue #1101).
                     presence.payloads.clone(),
                 );
+            mirror_remote_presence_update(
+                state,
+                sender_jid,
+                owner,
+                true,
+                priority,
+                presence_state_written
+                    .then(|| remote_presence_state_from_presence(&presence, priority)),
+            )
+            .await;
             // RFC 6121 §3.1.3: deliver queued inbound subscription requests on
             // this resource's INITIAL available presence only. The per-connection
             // CAS mirrors `claim_offline_flush` so auto-away/available flips
@@ -132,6 +142,7 @@ pub(super) async fn handle_regular_presence_update(
             .protocol
             .connection_registry
             .clear_presence_state_if_owner(sender_jid, owner);
+        mirror_remote_presence_update(state, sender_jid, owner, false, priority, None).await;
         state
             .deps
             .protocol
@@ -147,6 +158,75 @@ pub(super) async fn handle_regular_presence_update(
         );
     }
     broadcast_presence_to_subscribers(state, sender_jid, &presence, ordered_relay_origin).await;
+}
+
+#[cfg(feature = "clustering")]
+async fn mirror_remote_presence_update(
+    state: &WebSocketState,
+    jid: &FullJid,
+    owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    available: bool,
+    priority: i8,
+    presence_state: Option<crate::clustering::route_bridge::RemotePresenceStateSnapshot>,
+) {
+    if let Some(bridge) = state
+        .deps
+        .app_state
+        .clustering_claims
+        .ordered_relay_delivery_bridge
+        .as_ref()
+    {
+        bridge
+            .update_remote_user_resource_if_owner(
+                jid,
+                owner,
+                crate::clustering::route_bridge::RemoteResourceStateUpdate::Presence {
+                    available,
+                    priority,
+                    state: presence_state,
+                },
+            )
+            .await;
+    }
+}
+
+#[cfg(not(feature = "clustering"))]
+async fn mirror_remote_presence_update(
+    _state: &WebSocketState,
+    _jid: &FullJid,
+    _owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    _available: bool,
+    _priority: i8,
+    _presence_state: Option<()>,
+) {
+}
+
+#[cfg(feature = "clustering")]
+fn remote_presence_state_from_presence(
+    presence: &xmpp_parsers::presence::Presence,
+    priority: i8,
+) -> crate::clustering::route_bridge::RemotePresenceStateSnapshot {
+    crate::clustering::route_bridge::RemotePresenceStateSnapshot {
+        show: presence
+            .show
+            .as_ref()
+            .map(|show| show_name(show).to_string()),
+        status: presence.statuses.values().next().cloned(),
+        priority,
+        payloads: presence
+            .payloads
+            .iter()
+            .cloned()
+            .map(crate::clustering::codec::RemoteElement)
+            .collect(),
+    }
+}
+
+#[cfg(not(feature = "clustering"))]
+fn remote_presence_state_from_presence(
+    _presence: &xmpp_parsers::presence::Presence,
+    _priority: i8,
+) {
 }
 
 /// XEP-0160 §3 step 5 + locked Q7a / Q7c / Q7d: on the recovering

--- a/server/crates/waddle-server/src/server/routes/websocket/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/registration.rs
@@ -196,12 +196,19 @@ pub(super) async fn register_bound_connection_after_frame(
         .connection_registry
         .entry_if_owner(&jid, &owner)
     {
-        let registered = crate::server::dual_registration::mirror_register(
+        let mirror_outcome = crate::server::dual_registration::mirror_register_outcome(
             &state.deps.protocol.user_registry,
             jid.clone(),
-            entry,
+            entry.clone(),
         )
         .await;
+        let registered = match mirror_outcome {
+            crate::server::dual_registration::MirrorRegisterOutcome::Registered => true,
+            crate::server::dual_registration::MirrorRegisterOutcome::ForeignOwner => {
+                register_remote_clustered_resource(state, &jid, entry, owner.clone()).await
+            }
+            crate::server::dual_registration::MirrorRegisterOutcome::Failed => false,
+        };
         if !registered {
             // Rollback also clears the presence_states published above.
             state
@@ -235,4 +242,40 @@ pub(super) async fn register_bound_connection_after_frame(
     );
 
     RegistrationAfterFrame::Registered(sm_finalization)
+}
+
+#[cfg(feature = "clustering")]
+async fn register_remote_clustered_resource(
+    state: &WebSocketState,
+    jid: &FullJid,
+    entry: waddle_xmpp::registry::ConnectionEntry,
+    owner: std::sync::Arc<std::sync::atomic::AtomicBool>,
+) -> bool {
+    let Some(bridge) = state
+        .deps
+        .app_state
+        .clustering_claims
+        .ordered_relay_delivery_bridge
+        .as_ref()
+    else {
+        return false;
+    };
+    match bridge
+        .try_register_remote_user_resource(jid, entry, owner)
+        .await
+    {
+        crate::clustering::route_bridge::RemoteResourceRegisterOutcome::Registered => true,
+        crate::clustering::route_bridge::RemoteResourceRegisterOutcome::NotRemote
+        | crate::clustering::route_bridge::RemoteResourceRegisterOutcome::Failed => false,
+    }
+}
+
+#[cfg(not(feature = "clustering"))]
+async fn register_remote_clustered_resource(
+    _state: &WebSocketState,
+    _jid: &FullJid,
+    _entry: waddle_xmpp::registry::ConnectionEntry,
+    _owner: std::sync::Arc<std::sync::atomic::AtomicBool>,
+) -> bool {
+    false
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management/registration.rs
@@ -10,6 +10,33 @@ use super::super::{
     cleanup::cleanup_invalidated_detached_session, state::WsConnState, WebSocketState,
 };
 
+#[cfg(feature = "clustering")]
+async fn unregister_remote_user_resource_if_owner(
+    state: &WebSocketState,
+    jid: &FullJid,
+    owner: &Arc<std::sync::atomic::AtomicBool>,
+) {
+    if let Some(bridge) = state
+        .deps
+        .app_state
+        .clustering_claims
+        .ordered_relay_delivery_bridge
+        .as_ref()
+    {
+        bridge
+            .unregister_remote_user_resource_if_owner(jid, owner)
+            .await;
+    }
+}
+
+#[cfg(not(feature = "clustering"))]
+async fn unregister_remote_user_resource_if_owner(
+    _state: &WebSocketState,
+    _jid: &FullJid,
+    _owner: &Arc<std::sync::atomic::AtomicBool>,
+) {
+}
+
 /// Finish the XEP-0198 side effects that become safe only after the resumed
 /// or freshly-bound resource has been published to the connection registry.
 ///
@@ -248,6 +275,7 @@ async fn reset_registered_resume_attempt(
             Some(Arc::clone(owner)),
         )
         .await;
+        unregister_remote_user_resource_if_owner(state, jid, owner).await;
     }
     conn.registry_owner = None;
     conn.phase = ConnectionPhase::authenticated(jid);
@@ -293,6 +321,7 @@ async fn close_registered_resume_attempt(
             Some(Arc::clone(owner)),
         )
         .await;
+        unregister_remote_user_resource_if_owner(state, jid, owner).await;
     }
     conn.registry_owner = None;
     conn.phase = ConnectionPhase::closing(Some(jid.clone()));

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -85,6 +85,7 @@ async fn link_preview_lookup_for_test(
         carbons_enabled: &mut carbons_enabled,
         roster_interested: &mut roster_interested,
         blocklist_interested: &mut blocklist_interested,
+        registry_owner: None,
         state_machine: None,
         ordered_relay_origin: None,
     };
@@ -674,6 +675,7 @@ async fn handle_iq_command_request_requires_ready_phase() {
         carbons_enabled: &mut carbons_enabled,
         roster_interested: &mut roster_interested,
         blocklist_interested: &mut blocklist_interested,
+        registry_owner: None,
         state_machine: None,
         ordered_relay_origin: None,
     };

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -4635,6 +4635,7 @@ async fn inbox_query_requires_ready_phase() {
         carbons_enabled: &mut carbons_enabled,
         roster_interested: &mut roster_interested,
         blocklist_interested: &mut blocklist_interested,
+        registry_owner: None,
         state_machine: None,
         ordered_relay_origin: None,
     };

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -822,6 +822,99 @@ async fn cluster_exit_criteria_end_to_end() {
         "origin handled count should include the cross-node stanza: {origin_ack}"
     );
 
+    // PR #1231 regression: a second resource for the SAME bare JID can land on
+    // a non-owner node. The authoritative UserActor claim stays on node A, but
+    // node A registers a remote resource whose outbound frames are relayed back
+    // to node B's real WebSocket.
+    let remote_resource = format!("ordered-remote-device-{}", uuid::Uuid::new_v4());
+    let mut remote_target_client = WsXmppClient::connect_and_auth(
+        &server_b.ws_url(),
+        "localhost",
+        CLUSTER_PEER_USERNAME,
+        CLUSTER_PEER_PASSWORD,
+        &remote_resource,
+    )
+    .await
+    .expect("same-bare remote resource binds on node B without stealing node A's UserActor");
+    let remote_target_full: jid::FullJid = remote_target_client
+        .full_jid
+        .as_ref()
+        .expect("remote target bind full jid")
+        .parse()
+        .expect("remote target full jid");
+    let after_remote_bind = claim_store
+        .current_claim(&target_entity)
+        .await
+        .expect("target claim lookup after same-bare remote bind")
+        .expect("target claim remains present after same-bare remote bind");
+    assert_eq!(
+        after_remote_bind.owner.node_id, node_a,
+        "same-bare remote bind must not steal the authoritative UserActor claim"
+    );
+    assert_eq!(
+        after_remote_bind.claim_epoch, target_snapshot.claim_epoch,
+        "same-bare remote bind must not advance the UserActor claim epoch"
+    );
+
+    let mut same_bare_message =
+        xmpp_parsers::message::Message::new(Some(jid::Jid::from(remote_target_full.clone())));
+    same_bare_message.thread = Some(xmpp_parsers::message::Thread {
+        id: "ordered-remote-same-bare".to_string(),
+        parent: None,
+    });
+    same_bare_message.bodies.insert(
+        xmpp_parsers::message::Lang::new(),
+        "phase4 same-bare remote resource".to_string(),
+    );
+    let same_bare_xml = waddle_xmpp::parser::message_to_string(&same_bare_message)
+        .expect("serialize typed same-bare remote message");
+    ordered_origin_client
+        .send(&same_bare_xml)
+        .await
+        .expect("origin sends full-JID message to same-bare remote resource");
+    let same_bare_delivered = remote_target_client
+        .recv_matching(|frame| {
+            frame.contains("ordered-remote-same-bare")
+                && frame.contains("phase4 same-bare remote resource")
+        })
+        .await
+        .expect("same-bare remote resource receives owner-forwarded message");
+    assert!(
+        same_bare_delivered.contains(remote_target_full.as_str()),
+        "same-bare remote frame should remain addressed to the node-B full JID: \
+         {same_bare_delivered}"
+    );
+
+    let mut remote_origin_message =
+        xmpp_parsers::message::Message::new(Some(jid::Jid::from(ordered_target_full.clone())));
+    remote_origin_message.thread = Some(xmpp_parsers::message::Thread {
+        id: "ordered-remote-origin".to_string(),
+        parent: None,
+    });
+    remote_origin_message.bodies.insert(
+        xmpp_parsers::message::Lang::new(),
+        "phase4 remote resource origin route".to_string(),
+    );
+    let remote_origin_xml = waddle_xmpp::parser::message_to_string(&remote_origin_message)
+        .expect("serialize typed remote-origin message");
+    remote_target_client
+        .send(&remote_origin_xml)
+        .await
+        .expect("same-bare remote resource sends to owner-node sibling resource");
+    let remote_origin_delivered = ordered_target_client
+        .recv_matching(|frame| {
+            frame.contains("ordered-remote-origin")
+                && frame.contains("phase4 remote resource origin route")
+        })
+        .await
+        .expect("owner-node sibling receives message originated by remote resource");
+    assert!(
+        remote_origin_delivered.contains(ordered_target_full.as_str()),
+        "remote-origin frame should remain addressed to the owner-node full JID: \
+         {remote_origin_delivered}"
+    );
+    let _ = remote_target_client.close().await;
+
     let ordered_origin_node = NodeId::new(handle.node_id.as_str().to_string());
     let ordered_channel = ordered_channel(
         ordered_stream_id,

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/connections.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/connections.rs
@@ -59,6 +59,57 @@ impl ConnectionRegistry {
         carbons_handle
     }
 
+    /// Register an already-constructed connection entry.
+    ///
+    /// This is used by clustering's owner-side remote-resource mirror: the
+    /// owner `UserActor` and owner `ConnectionRegistry` must share the exact
+    /// same [`ConnectionEntry`] so registry-backed fanout surfaces and
+    /// actor-backed full-JID routing both drain into the remote-resource
+    /// forwarder.
+    #[instrument(skip(self, entry), fields(jid = %jid))]
+    pub fn register_entry(&self, jid: FullJid, entry: ConnectionEntry) -> Arc<AtomicBool> {
+        let carbons_handle = entry.carbons_handle();
+        let existing = self.connections.insert(jid, entry);
+        if existing.is_some() {
+            debug!("Replaced existing connection registration");
+        } else {
+            prometheus::increment_connected_users();
+            debug!("Registered new connection");
+        }
+        carbons_handle
+    }
+
+    /// Register a prebuilt entry only when the full-JID slot is empty or still
+    /// belongs to the provided owner token.
+    pub fn register_entry_if_owner_or_absent(
+        &self,
+        jid: FullJid,
+        entry: ConnectionEntry,
+        owner: &Arc<AtomicBool>,
+    ) -> bool {
+        if !Arc::ptr_eq(&entry.carbons_enabled, owner) {
+            debug!("Skipped register: entry owner does not match guard owner");
+            return false;
+        }
+        match self.connections.entry(jid) {
+            dashmap::mapref::entry::Entry::Occupied(mut occupied) => {
+                if !Arc::ptr_eq(&occupied.get().carbons_enabled, owner) {
+                    debug!("Skipped register: ownership moved to replacement connection");
+                    return false;
+                }
+                occupied.insert(entry);
+                debug!("Replaced owned connection registration");
+                true
+            }
+            dashmap::mapref::entry::Entry::Vacant(vacant) => {
+                vacant.insert(entry);
+                prometheus::increment_connected_users();
+                debug!("Registered new connection");
+                true
+            }
+        }
+    }
+
     /// Unregister a connection.
     ///
     /// Returns the connection entry if the connection was registered, None otherwise.

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/outbound.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/outbound.rs
@@ -12,7 +12,7 @@ use super::*;
 /// runs in production for peer-routed stanzas.
 ///
 /// [`OutboundEvent::RouteToConnection`]: crate::protocol::OutboundEvent::RouteToConnection
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum DeliveryKind {
     /// **Peer-routed stanza** — the destination connection's main
     /// loop must feed this through its [`crate::protocol::XmppStateMachine`]
@@ -144,7 +144,7 @@ pub struct ForceDetachRequest {
 }
 
 /// Outcome of a [`ForceDetachRequest`], reported back to the asker.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ForceDetachOutcome {
     /// Identity matched, the connection sent `<conflict/>` and closed, AND
     /// its subsequent XEP-0198 detach-for-resume cleanup actually persisted

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/sending.rs
@@ -143,6 +143,47 @@ impl ConnectionRegistry {
         }
     }
 
+    /// Non-blocking send of an already-tagged outbound frame, gated on the
+    /// resource still belonging to the provided connection owner.
+    ///
+    /// Clustered remote-resource delivery uses this on the socket node: the
+    /// authoritative `UserActor` may live on another node, but the real
+    /// WebSocket channel remains in this registry. The owner check mirrors
+    /// [`Self::entry_if_owner`] so a delayed relay frame from an older same
+    /// full-JID connection cannot be written to a replacement session.
+    pub fn try_send_outbound_if_owner(
+        &self,
+        jid: &FullJid,
+        owner: &Arc<AtomicBool>,
+        outbound: OutboundStanza,
+    ) -> BroadcastOutcome {
+        let sender = match self.connections.get(jid) {
+            Some(entry) if Arc::ptr_eq(&entry.value().carbons_enabled, owner) => {
+                entry.value().sender.clone()
+            }
+            _ => {
+                prometheus::increment_broadcast_not_connected();
+                return BroadcastOutcome::NotConnected;
+            }
+        };
+
+        match sender.try_send(outbound) {
+            Ok(()) => {
+                prometheus::increment_broadcast_delivered();
+                BroadcastOutcome::Delivered
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                prometheus::increment_broadcast_dropped_full();
+                BroadcastOutcome::DroppedFull
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                prometheus::increment_broadcast_dropped_closed();
+                self.remove_if_sender_closed_owner(jid, &sender);
+                BroadcastOutcome::DroppedClosed
+            }
+        }
+    }
+
     /// Race-safe eviction of a stale entry whose outbound channel is closed.
     ///
     /// Used on the non-blocking broadcast path to clean up zombies without

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/tests.rs
@@ -70,6 +70,69 @@ fn test_register_replaces_existing() {
     assert_eq!(registry.connection_count(), 1);
 }
 
+#[tokio::test]
+async fn test_register_entry_preserves_prebuilt_entry_state_and_sender() {
+    let registry = ConnectionRegistry::new();
+    let jid: FullJid = "user@example.com/web".parse().unwrap();
+    let bare = jid.to_bare();
+    let (tx, mut rx) = mpsc::channel(16);
+    let entry = ConnectionEntry::new(tx);
+    entry.carbons_enabled.store(true, Ordering::Relaxed);
+    entry.roster_interested.store(true, Ordering::Relaxed);
+    entry.blocklist_interested.store(true, Ordering::Relaxed);
+    entry.presence_available.store(true, Ordering::Relaxed);
+    entry.presence_priority.store(7, Ordering::Relaxed);
+
+    let owner = registry.register_entry(jid.clone(), entry.clone());
+
+    assert!(Arc::ptr_eq(&owner, &entry.carbons_enabled));
+    assert!(registry.is_carbons_enabled(&jid));
+    assert_eq!(
+        registry.get_roster_interested_resources_for_user(&bare),
+        vec![jid.clone()]
+    );
+    assert_eq!(
+        registry.get_blocklist_interested_resources_for_user(&bare),
+        vec![jid.clone()]
+    );
+    assert_eq!(
+        registry.get_available_resources_for_user(&bare),
+        vec![(jid.clone(), 7)]
+    );
+
+    let message = Stanza::Message(make_test_message("user@example.com"));
+    assert!(registry.send_to(&jid, message.clone()).await.is_sent());
+    let outbound = rx
+        .try_recv()
+        .expect("prebuilt sender receives registry fanout");
+    assert_eq!(outbound.stanza.name(), message.name());
+}
+
+#[test]
+fn test_register_entry_if_owner_or_absent_refuses_replacement_owner() {
+    let registry = ConnectionRegistry::new();
+    let jid: FullJid = "user@example.com/web".parse().unwrap();
+    let (tx1, _rx1) = mpsc::channel(16);
+    let entry1 = ConnectionEntry::new(tx1);
+    let owner1 = entry1.carbons_handle();
+
+    assert!(registry.register_entry_if_owner_or_absent(jid.clone(), entry1.clone(), &owner1));
+    assert!(registry.entry_if_owner(&jid, &owner1).is_some());
+
+    let (tx2, _rx2) = mpsc::channel(16);
+    let entry2 = ConnectionEntry::new(tx2);
+    let owner2 = entry2.carbons_handle();
+
+    assert!(!registry.register_entry_if_owner_or_absent(jid.clone(), entry2.clone(), &owner2));
+    assert!(registry.entry_if_owner(&jid, &owner1).is_some());
+    assert!(registry.entry_if_owner(&jid, &owner2).is_none());
+    assert_eq!(registry.connection_count(), 1);
+
+    assert!(registry.register_entry_if_owner_or_absent(jid.clone(), entry1.clone(), &owner1));
+    assert!(registry.entry_if_owner(&jid, &owner1).is_some());
+    assert_eq!(registry.connection_count(), 1);
+}
+
 #[test]
 fn test_register_replacement_does_not_inherit_roster_interest() {
     let registry = ConnectionRegistry::new();
@@ -814,4 +877,33 @@ fn update_presence_state_if_owner_refuses_absent_entry() {
         Vec::new(),
     ));
     assert!(registry.get_presence_state(&jid).is_none());
+}
+
+#[test]
+fn try_send_outbound_if_owner_preserves_kind_and_refuses_stale_owner() {
+    let registry = ConnectionRegistry::new();
+    let jid = test_jid("alice");
+
+    let (tx_a, _rx_a) = mpsc::channel(4);
+    let stale_owner = registry.register(jid.clone(), tx_a);
+
+    let (tx_b, mut rx_b) = mpsc::channel(4);
+    let live_owner = registry.register(jid.clone(), tx_b);
+
+    let stale = registry.try_send_outbound_if_owner(
+        &jid,
+        &stale_owner,
+        OutboundStanza::peer_stanza(Stanza::Message(make_test_message("alice@example.com"))),
+    );
+    assert_eq!(stale, BroadcastOutcome::NotConnected);
+    assert!(rx_b.try_recv().is_err());
+
+    let live = registry.try_send_outbound_if_owner(
+        &jid,
+        &live_owner,
+        OutboundStanza::peer_stanza(Stanza::Message(make_test_message("alice@example.com"))),
+    );
+    assert_eq!(live, BroadcastOutcome::Delivered);
+    let outbound = rx_b.try_recv().expect("live owner should receive frame");
+    assert_eq!(outbound.kind, DeliveryKind::PeerStanza);
 }

--- a/server/crates/waddle-xmpp/src/registry/mod.rs
+++ b/server/crates/waddle-xmpp/src/registry/mod.rs
@@ -23,7 +23,7 @@ pub mod user_registry;
 
 pub use connection_registry::{
     BroadcastOutcome, ConnectionEntry, ConnectionRegistry, DeliveryKind, ForceDetachOutcome,
-    ForceDetachRequest, OutboundStanza, SendResult,
+    ForceDetachRequest, OutboundStanza, PresenceState, SendResult,
 };
 pub use selection::{
     available_resources_for_user, get_resources_for_user, select_routable_resources_for_user,
@@ -34,6 +34,6 @@ pub use user_actor::delivery::{
 pub use user_actor::GetResources;
 pub use user_registry::{
     DemoteUserActor, GetOrCreateUser, GetUser, GetUserForLocalClaim, ListUsers, ReapUserIfEmpty,
-    RegisterUserResource, RemoveUser, UnregisterUserResource, UserCount, UserRegistryActor,
-    UserRegistryError, WireUserClusteringClaims,
+    RegisterUserResource, RegisterUserResourceIfOwnerOrAbsent, RemoveUser, UnregisterUserResource,
+    UserCount, UserRegistryActor, UserRegistryError, WireUserClusteringClaims,
 };

--- a/server/crates/waddle-xmpp/src/registry/user_actor.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_actor.rs
@@ -124,6 +124,41 @@ impl kameo::message::Message<RegisterConnection> for UserActor {
     }
 }
 
+/// Register a resource only if the slot is empty or still belongs to `owner`.
+///
+/// Used by clustered remote-resource mirrors, where the socket node has already
+/// published a local registry entry and the owner node must not clobber a newer
+/// local same-resource bind while mirroring the remote entry.
+pub struct RegisterConnectionIfOwnerOrAbsent {
+    pub jid: FullJid,
+    pub entry: ConnectionEntry,
+    pub owner: Arc<AtomicBool>,
+}
+
+impl kameo::message::Message<RegisterConnectionIfOwnerOrAbsent> for UserActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: RegisterConnectionIfOwnerOrAbsent,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if !Arc::ptr_eq(&msg.entry.carbons_enabled, &msg.owner) {
+            return false;
+        }
+        if self
+            .connections
+            .get(&msg.jid)
+            .is_some_and(|entry| !Arc::ptr_eq(&entry.carbons_enabled, &msg.owner))
+        {
+            return false;
+        }
+        debug!(jid = %msg.jid, bare = %self.bare_jid, "Registering owner-gated connection");
+        self.connections.insert(msg.jid, msg.entry);
+        true
+    }
+}
+
 /// Unregister a connection (resource) for this user.
 ///
 /// `owner` is the ownership token (the resource's `carbons_enabled`

--- a/server/crates/waddle-xmpp/src/registry/user_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_actor/tests.rs
@@ -114,6 +114,44 @@ async fn test_unregister_cleans_up() {
 }
 
 #[tokio::test]
+async fn test_register_if_owner_or_absent_refuses_replacement_owner() {
+    let actor = spawn_actor("alice").await;
+    let jid = full("alice", "phone");
+
+    let (entry1, _rx1) = entry();
+    let owner1 = std::sync::Arc::clone(&entry1.carbons_enabled);
+    let registered: bool = actor
+        .ask(RegisterConnectionIfOwnerOrAbsent {
+            jid: jid.clone(),
+            entry: entry1,
+            owner: owner1.clone(),
+        })
+        .await
+        .expect("guarded register empty slot");
+    assert!(registered);
+
+    let (entry2, _rx2) = entry();
+    let owner2 = std::sync::Arc::clone(&entry2.carbons_enabled);
+    let registered: bool = actor
+        .ask(RegisterConnectionIfOwnerOrAbsent {
+            jid: jid.clone(),
+            entry: entry2,
+            owner: owner2.clone(),
+        })
+        .await
+        .expect("guarded register occupied slot");
+    assert!(!registered);
+
+    let current = actor
+        .ask(GetConnectionEntry { jid })
+        .await
+        .expect("entry lookup")
+        .expect("entry remains registered");
+    assert!(std::sync::Arc::ptr_eq(&current.carbons_enabled, &owner1));
+    assert!(!std::sync::Arc::ptr_eq(&current.carbons_enabled, &owner2));
+}
+
+#[tokio::test]
 async fn test_unregister_and_report_empty_is_atomic_per_user_actor() {
     let actor = spawn_actor("alice").await;
     let jid = full("alice", "phone");

--- a/server/crates/waddle-xmpp/src/registry/user_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_registry.rs
@@ -22,7 +22,8 @@ use tracing::{debug, info, warn};
 use super::connection_registry::{ConnectionEntry, ForceDetachOutcome, ForceDetachRequest};
 use super::user_actor::delivery::GetConnectionEntry;
 use super::user_actor::{
-    GetResources, RegisterConnection, ResourceCount, UnregisterConnectionAndReportEmpty, UserActor,
+    GetResources, RegisterConnection, RegisterConnectionIfOwnerOrAbsent, ResourceCount,
+    UnregisterConnectionAndReportEmpty, UserActor,
 };
 use crate::metrics;
 use crate::ownership::{
@@ -545,6 +546,60 @@ impl kameo::message::Message<RegisterUserResource> for UserRegistryActor {
         }
 
         Ok(())
+    }
+}
+
+/// Register a user resource without replacing a different owner token.
+///
+/// This keeps clustered remote-resource mirrors from deleting a live local
+/// same-full-JID resource that won the slot while the remote register was in
+/// flight. It otherwise follows [`RegisterUserResource`] so user lifecycle and
+/// claim acquisition remain serialized by this actor.
+pub struct RegisterUserResourceIfOwnerOrAbsent {
+    pub jid: FullJid,
+    pub entry: ConnectionEntry,
+    pub owner: Arc<AtomicBool>,
+}
+
+impl kameo::message::Message<RegisterUserResourceIfOwnerOrAbsent> for UserRegistryActor {
+    type Reply = Result<bool, UserRegistryError>;
+
+    async fn handle(
+        &mut self,
+        msg: RegisterUserResourceIfOwnerOrAbsent,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let bare_jid = msg.jid.to_bare();
+        if self.poisoned_users.contains(&bare_jid) {
+            return Err(UserRegistryError::UserActorStateLost(bare_jid));
+        }
+
+        let user_actor = if let Some(actor_ref) = self
+            .existing_user_actor_for_current_claim(&bare_jid)
+            .await?
+        {
+            actor_ref
+        } else {
+            let claim = self.acquire_user_claim(&bare_jid).await?;
+            self.spawn_user_actor(bare_jid.clone(), claim)
+        };
+
+        match user_actor
+            .ask(RegisterConnectionIfOwnerOrAbsent {
+                jid: msg.jid.clone(),
+                entry: msg.entry,
+                owner: msg.owner,
+            })
+            .mailbox_timeout(CHILD_ACTOR_TIMEOUT)
+            .reply_timeout(CHILD_ACTOR_TIMEOUT)
+            .await
+        {
+            Ok(registered) => Ok(registered),
+            Err(SendError::MailboxFull(_) | SendError::Timeout(_)) => {
+                Err(UserRegistryError::UserActorBusy(bare_jid))
+            }
+            Err(_) => Err(self.mark_actor_state_lost(&bare_jid).await),
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

ADR-0017 Phase 4 wires the first production-grade cross-node resource path for clustered WebSocket sessions:

- remote-resource bind registration now succeeds when a socket lands on a node that does not own the bare JID, without stealing the authoritative `UserActor` claim
- owner-side synthetic remote entries route outbound DM/MUC/presence frames back to the socket node over the relay
- client-originated stanzas from remote resources now carry a `RemoteResource` ordered-relay origin so owner-side routing, receipts, and fallback handling use the correct provenance
- owner-side carbons, roster pushes, and blocklist pushes relay back to remote socket nodes instead of being handled twice or lost locally
- remote presence mirrors availability, show/status, priority, and extension payloads through owner-gated registry updates
- same-full-JID replacement is fail-closed and only retires an old remote mirror after confirmed force-detach or confirmed not-live
- non-idempotent remote-resource route/frame relay paths no longer retry `ActorStopped`/maybe-committed failures
- the real multiprocess clustering harness now proves same-bare remote bind, owner-claim stability, full-JID delivery to a remote resource, and remote-resource-origin delivery back to an owner-node sibling

The Phase 4 plan remains in `server/docs/adrs/0017-phase4-plan-cross-node-routing-ga.md`; this PR implements the remote-resource routing slice needed before `replicaCount > 1` can be safely treated as a production path.

## Review

Adversarial review converged:

- correctness reviewer: converged after fixes for cross-node same-full-JID replacement and maybe-committed relay retry/double-delivery risk
- XEP reviewer: converged with no blockers across 1:1/MUC/presence, XEP-0280 carbons, XEP-0184 receipts, MAM implications, roster/blocklist pushes, addressing, and namespace usage

## Validation

- `cargo fmt --manifest-path server/Cargo.toml --all --check`
- `cargo clippy --manifest-path server/Cargo.toml --all-targets -- -D warnings`
- `cargo clippy --manifest-path server/Cargo.toml --all-targets --features clustering -- -D warnings`
- `cargo test --manifest-path server/Cargo.toml --features clustering -p waddle-server --lib relay`
- `cargo test --manifest-path server/Cargo.toml --features clustering -p waddle-server --lib route_bridge`
- `cargo test --manifest-path server/Cargo.toml --features clustering -p waddle-server --lib` outside the sandbox: 1691 passed
- `cargo test --manifest-path server/Cargo.toml -p waddle-xmpp --lib` outside the sandbox: 2348 passed
- disposable-Postgres multiprocess harness:
  `cargo test --manifest-path server/Cargo.toml --features clustering -p waddle-server --test clustering_cluster_e2e cluster_exit_criteria_end_to_end -- --nocapture`

## Production Monitoring

While this PR was finalized, the existing production `waddle-server` rollout remained steady:

- 2/2 pods Ready
- zero restarts observed
- health and metrics probes returning 200
- no Phase-4 rollout has happened yet; this PR still needs CI, merge, Flux rollout, and post-rollout soak monitoring
