### PR TITLE
fix(server): preserve remote MUC cleanup provenance

### DIFF
--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -737,12 +737,12 @@ async fn cleanup_remote_muc_presence(
         .ordered_relay_delivery_bridge
         .as_ref()
     else {
-        for (room_jid, nick) in memberships {
+        for membership in &memberships {
             state
                 .deps
                 .protocol
                 .remote_muc_memberships
-                .record_join(jid, &room_jid, &nick);
+                .restore_snapshot_if_current(membership);
         }
         return;
     };
@@ -751,66 +751,127 @@ async fn cleanup_remote_muc_presence(
         Some(origin) => origin,
         None => {
             let Some(origin) = acquire_remote_muc_cleanup_origin(state, jid).await else {
-                for (room_jid, nick) in memberships {
+                for membership in &memberships {
                     state
                         .deps
                         .protocol
                         .remote_muc_memberships
-                        .record_join(jid, &room_jid, &nick);
+                        .restore_snapshot_if_current(membership);
                 }
                 return;
             };
             origin
         }
     };
-    for (room_jid, nick) in memberships {
+    for membership in memberships {
+        let room_jid = membership.room().clone();
+        let nick = membership.nick().to_string();
         let Some(to) = room_jid
             .clone()
             .with_resource_str(&nick)
             .ok()
             .map(jid::Jid::from)
         else {
+            state
+                .deps
+                .protocol
+                .remote_muc_memberships
+                .restore_snapshot_if_current(&membership);
             continue;
         };
+        let _remote_muc_membership_guard = state
+            .deps
+            .protocol
+            .remote_muc_memberships
+            .lock_snapshot(&membership)
+            .await;
+        if !state
+            .deps
+            .protocol
+            .remote_muc_memberships
+            .snapshot_is_current_tombstone(&membership)
+        {
+            debug!(
+                room = %room_jid,
+                nick = %nick,
+                jid = %jid,
+                "skipped stale remote MUC unavailable cleanup after newer membership generation"
+            );
+            continue;
+        }
         super::muc_call_sfu::unregister_participant_from_room(state, &room_jid, jid);
         let mut presence =
             xmpp_parsers::presence::Presence::new(xmpp_parsers::presence::Type::Unavailable);
         presence.from = Some(jid::Jid::from(jid.clone()));
         presence.to = Some(to);
         let stanza = Stanza::Presence(presence);
-        match bridge
+        let outcome = bridge
             .try_proxy_muc_remote(
                 &room_jid,
                 &stanza,
                 crate::clustering::ordered_relay::OrderedRelayMucProxyKind::OccupantPresence,
                 &origin,
             )
-            .await
-        {
-            Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Delivered(_)) => {}
-            Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::MaybeCommitted)
-            | Some(
-                crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::JoinMaybeCommitted,
-            )
-            | Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Unavailable)
-            | Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Dropped)
-            | None => {
-                warn!(
-                    room = %room_jid,
-                    nick = %nick,
-                    jid = %jid,
-                    "failed to relay remote MUC unavailable during disconnect cleanup"
-                );
-                state
-                    .deps
-                    .protocol
-                    .remote_muc_memberships
-                    .record_join(jid, &room_jid, &nick);
+            .await;
+        if let Some(retry_kind) = remote_muc_cleanup_retry_kind(outcome.as_ref()) {
+            match retry_kind {
+                RemoteMucCleanupRetryKind::UncertainCommit => {
+                    debug!(
+                        room = %room_jid,
+                        nick = %nick,
+                        jid = %jid,
+                        outcome = ?outcome,
+                        "remote MUC unavailable cleanup commit uncertain; keeping retry provenance"
+                    );
+                }
+                RemoteMucCleanupRetryKind::DefiniteNoEffect => {
+                    warn!(
+                        room = %room_jid,
+                        nick = %nick,
+                        jid = %jid,
+                        outcome = ?outcome,
+                        "failed to relay remote MUC unavailable during disconnect cleanup"
+                    );
+                }
             }
+            state
+                .deps
+                .protocol
+                .remote_muc_memberships
+                .restore_snapshot_if_current(&membership);
+        } else {
+            state
+                .deps
+                .protocol
+                .remote_muc_memberships
+                .forget_snapshot_if_current(&membership);
         }
     }
     if acquired_user_actor_origin {
         reap_remote_muc_cleanup_origin_if_empty(state, jid).await;
+    }
+}
+
+#[cfg(feature = "clustering")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoteMucCleanupRetryKind {
+    UncertainCommit,
+    DefiniteNoEffect,
+}
+
+#[cfg(feature = "clustering")]
+fn remote_muc_cleanup_retry_kind(
+    outcome: Option<&crate::clustering::route_bridge::OrderedRelayMucProxyOutcome>,
+) -> Option<RemoteMucCleanupRetryKind> {
+    match outcome {
+        Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Delivered(_)) => None,
+        Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::MaybeCommitted)
+        | Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::JoinMaybeCommitted) => {
+            Some(RemoteMucCleanupRetryKind::UncertainCommit)
+        }
+        Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Unavailable)
+        | Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Dropped)
+        | None => Some(RemoteMucCleanupRetryKind::DefiniteNoEffect),
     }
 }
 
@@ -1105,6 +1166,90 @@ mod eviction_tests {
         format!("{local}@muc.example.com")
             .parse()
             .expect("bare jid")
+    }
+
+    #[cfg(feature = "clustering")]
+    #[test]
+    fn remote_muc_cleanup_classifies_retry_outcomes() {
+        use crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::{
+            Delivered, Dropped, JoinMaybeCommitted, MaybeCommitted, Unavailable,
+        };
+
+        assert_eq!(
+            remote_muc_cleanup_retry_kind(Some(&Delivered(Vec::new()))),
+            None
+        );
+        assert_eq!(
+            remote_muc_cleanup_retry_kind(Some(&MaybeCommitted)),
+            Some(RemoteMucCleanupRetryKind::UncertainCommit)
+        );
+        assert_eq!(
+            remote_muc_cleanup_retry_kind(Some(&JoinMaybeCommitted)),
+            Some(RemoteMucCleanupRetryKind::UncertainCommit)
+        );
+
+        assert_eq!(
+            remote_muc_cleanup_retry_kind(Some(&Unavailable)),
+            Some(RemoteMucCleanupRetryKind::DefiniteNoEffect)
+        );
+        assert_eq!(
+            remote_muc_cleanup_retry_kind(Some(&Dropped)),
+            Some(RemoteMucCleanupRetryKind::DefiniteNoEffect)
+        );
+        assert_eq!(
+            remote_muc_cleanup_retry_kind(None),
+            Some(RemoteMucCleanupRetryKind::DefiniteNoEffect)
+        );
+    }
+
+    #[cfg(feature = "clustering")]
+    #[test]
+    fn remote_muc_cleanup_retry_restore_does_not_overwrite_fresh_join() {
+        let memberships = crate::server::routes::websocket::state::RemoteMucMemberships::default();
+        let occupant = full_jid("alice@example.com/web");
+        let room = room_bare_jid("race");
+
+        memberships.record_join(&occupant, &room, "old-nick");
+        let snapshot = memberships.take_for_occupant(&occupant);
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].room(), &room);
+        assert_eq!(snapshot[0].nick(), "old-nick");
+
+        memberships.record_join(&occupant, &room, "fresh-nick");
+        memberships.restore_snapshot_if_current(&snapshot[0]);
+
+        assert_eq!(
+            memberships.nick_for(&occupant, &room).as_deref(),
+            Some("fresh-nick")
+        );
+    }
+
+    #[cfg(feature = "clustering")]
+    #[test]
+    fn remote_muc_cleanup_success_leaves_fresh_join_untouched() {
+        use crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Delivered;
+
+        let memberships = crate::server::routes::websocket::state::RemoteMucMemberships::default();
+        let occupant = full_jid("alice@example.com/web");
+        let room = room_bare_jid("race-success");
+
+        memberships.record_join(&occupant, &room, "old-nick");
+        let snapshot = memberships.take_for_occupant(&occupant);
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].room(), &room);
+        assert_eq!(snapshot[0].nick(), "old-nick");
+
+        memberships.record_join(&occupant, &room, "fresh-nick");
+        assert_eq!(
+            remote_muc_cleanup_retry_kind(Some(&Delivered(Vec::new()))),
+            None
+        );
+        memberships.forget_snapshot_if_current(&snapshot[0]);
+
+        assert_eq!(
+            memberships.nick_for(&occupant, &room).as_deref(),
+            Some("fresh-nick")
+        );
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -233,6 +233,14 @@ enum RemoteMucJoinDecision {
 }
 
 #[cfg(feature = "clustering")]
+enum RemoteMucLeaveDecision {
+    Delivered(Vec<Stanza>),
+    MaybeCommitted,
+    RetryableNoEffect,
+    LocalFallback,
+}
+
+#[cfg(feature = "clustering")]
 fn remote_muc_join_decision(
     outcome: Option<crate::clustering::route_bridge::OrderedRelayMucProxyOutcome>,
 ) -> Option<RemoteMucJoinDecision> {
@@ -247,6 +255,26 @@ fn remote_muc_join_decision(
         Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Unavailable)
         | Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Dropped)
         | None => None,
+    }
+}
+
+#[cfg(feature = "clustering")]
+fn remote_muc_leave_decision(
+    outcome: Option<crate::clustering::route_bridge::OrderedRelayMucProxyOutcome>,
+) -> RemoteMucLeaveDecision {
+    match outcome {
+        Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Delivered(replies)) => {
+            RemoteMucLeaveDecision::Delivered(replies)
+        }
+        Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::MaybeCommitted)
+        | Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::JoinMaybeCommitted) => {
+            RemoteMucLeaveDecision::MaybeCommitted
+        }
+        Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Unavailable)
+        | Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Dropped) => {
+            RemoteMucLeaveDecision::RetryableNoEffect
+        }
+        None => RemoteMucLeaveDecision::LocalFallback,
     }
 }
 
@@ -302,6 +330,48 @@ mod tests {
             panic!("expected delivered replies");
         };
         assert_eq!(replies.len(), 1);
+    }
+
+    #[test]
+    fn remote_muc_leave_decision_preserves_membership_for_uncertain_commit() {
+        assert!(matches!(
+            remote_muc_leave_decision(Some(
+                crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::MaybeCommitted,
+            )),
+            RemoteMucLeaveDecision::MaybeCommitted
+        ));
+        assert!(matches!(
+            remote_muc_leave_decision(Some(
+                crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::JoinMaybeCommitted,
+            )),
+            RemoteMucLeaveDecision::MaybeCommitted
+        ));
+    }
+
+    #[test]
+    fn remote_muc_leave_decision_clears_only_on_delivered() {
+        let decision = remote_muc_leave_decision(Some(
+            crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Delivered(vec![
+                Stanza::Presence(xmpp_parsers::presence::Presence::new(
+                    xmpp_parsers::presence::Type::None,
+                )),
+            ]),
+        ));
+        let RemoteMucLeaveDecision::Delivered(replies) = decision else {
+            panic!("expected delivered replies");
+        };
+        assert_eq!(replies.len(), 1);
+
+        assert!(matches!(
+            remote_muc_leave_decision(Some(
+                crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Unavailable,
+            )),
+            RemoteMucLeaveDecision::RetryableNoEffect
+        ));
+        assert!(matches!(
+            remote_muc_leave_decision(None),
+            RemoteMucLeaveDecision::LocalFallback
+        ));
     }
 }
 
@@ -607,6 +677,12 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                                     presence.show = Some(show.to_xep0045());
                                 }
                                 let stanza = Stanza::Presence(presence);
+                                let _remote_muc_membership_guard = state
+                                    .deps
+                                    .protocol
+                                    .remote_muc_memberships
+                                    .lock_membership(sender_jid, room_jid)
+                                    .await;
                                 match remote_muc_join_decision(
                                     bridge
                                         .try_proxy_muc_remote(
@@ -1151,18 +1227,23 @@ pub async fn handle_muc_leave(
                     .ok()
                     .map(jid::Jid::from);
                 let stanza = Stanza::Presence(presence);
-                match bridge
-                    .try_proxy_muc_remote(
-                        room_jid,
-                        &stanza,
-                        crate::clustering::ordered_relay::OrderedRelayMucProxyKind::OccupantPresence,
-                        origin,
-                    )
-                    .await
-                {
-                    Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Delivered(
-                        replies,
-                    )) => {
+                let _remote_muc_membership_guard = state
+                    .deps
+                    .protocol
+                    .remote_muc_memberships
+                    .lock_membership(sender_jid, room_jid)
+                    .await;
+                match remote_muc_leave_decision(
+                    bridge
+                        .try_proxy_muc_remote(
+                            room_jid,
+                            &stanza,
+                            crate::clustering::ordered_relay::OrderedRelayMucProxyKind::OccupantPresence,
+                            origin,
+                        )
+                        .await,
+                ) {
+                    RemoteMucLeaveDecision::Delivered(replies) => {
                         state
                             .deps
                             .protocol
@@ -1173,21 +1254,10 @@ pub async fn handle_muc_leave(
                             .map(|reply| stanza_to_xml(&reply))
                             .collect();
                     }
-                    Some(
-                        crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::MaybeCommitted,
-                    )
-                    | Some(
-                        crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::JoinMaybeCommitted,
-                    ) => {
-                        state
-                            .deps
-                            .protocol
-                            .remote_muc_memberships
-                            .record_leave(sender_jid, room_jid);
+                    RemoteMucLeaveDecision::MaybeCommitted => {
                         return Vec::new();
                     }
-                    Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Unavailable)
-                    | Some(crate::clustering::route_bridge::OrderedRelayMucProxyOutcome::Dropped) => {
+                    RemoteMucLeaveDecision::RetryableNoEffect => {
                         return vec![build_muc_presence_error_xml(
                             room_jid,
                             nick,
@@ -1200,7 +1270,7 @@ pub async fn handle_muc_leave(
                             ),
                         )];
                     }
-                    None => {}
+                    RemoteMucLeaveDecision::LocalFallback => {}
                 }
             }
         }

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -45,42 +45,246 @@ pub struct PendingDmCallOffer {
 
 #[derive(Debug, Default)]
 pub struct RemoteMucMemberships {
-    entries: dashmap::DashMap<(FullJid, BareJid), String>,
+    entries: dashmap::DashMap<(FullJid, BareJid), RemoteMucMembershipEntry>,
+    locks: dashmap::DashMap<(FullJid, BareJid), std::sync::Arc<tokio::sync::Mutex<()>>>,
+    next_generation: std::sync::atomic::AtomicU64,
+}
+
+pub struct RemoteMucMembershipLockGuard {
+    _guard: tokio::sync::OwnedMutexGuard<()>,
+}
+
+#[derive(Debug, Clone)]
+enum RemoteMucMembershipEntry {
+    Active(RemoteMucMembership),
+    Tombstone { generation: u64 },
+}
+
+#[derive(Debug, Clone)]
+struct RemoteMucMembership {
+    nick: String,
+    generation: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RemoteMucMembershipSnapshot {
+    occupant: FullJid,
+    room: BareJid,
+    nick: String,
+    generation: u64,
+}
+
+impl RemoteMucMembershipSnapshot {
+    pub fn room(&self) -> &BareJid {
+        &self.room
+    }
+
+    pub fn nick(&self) -> &str {
+        &self.nick
+    }
 }
 
 impl RemoteMucMemberships {
+    pub async fn lock_membership(
+        &self,
+        occupant: &FullJid,
+        room: &BareJid,
+    ) -> RemoteMucMembershipLockGuard {
+        let lock = self
+            .locks
+            .entry((occupant.clone(), room.clone()))
+            .or_insert_with(|| std::sync::Arc::new(tokio::sync::Mutex::new(())))
+            .clone();
+        RemoteMucMembershipLockGuard {
+            _guard: lock.lock_owned().await,
+        }
+    }
+
+    pub async fn lock_snapshot(
+        &self,
+        snapshot: &RemoteMucMembershipSnapshot,
+    ) -> RemoteMucMembershipLockGuard {
+        self.lock_membership(&snapshot.occupant, &snapshot.room)
+            .await
+    }
+
     pub fn record_join(&self, occupant: &FullJid, room: &BareJid, nick: &str) {
-        self.entries
-            .insert((occupant.clone(), room.clone()), nick.to_string());
+        let generation = self.next_generation();
+        self.entries.insert(
+            (occupant.clone(), room.clone()),
+            RemoteMucMembershipEntry::Active(RemoteMucMembership {
+                nick: nick.to_string(),
+                generation,
+            }),
+        );
     }
 
     pub fn record_leave(&self, occupant: &FullJid, room: &BareJid) {
-        self.entries.remove(&(occupant.clone(), room.clone()));
+        let generation = self.next_generation();
+        self.entries.insert(
+            (occupant.clone(), room.clone()),
+            RemoteMucMembershipEntry::Tombstone { generation },
+        );
     }
 
     pub fn contains(&self, occupant: &FullJid, room: &BareJid) -> bool {
-        self.entries.contains_key(&(occupant.clone(), room.clone()))
+        self.entries
+            .get(&(occupant.clone(), room.clone()))
+            .is_some_and(|entry| matches!(entry.value(), RemoteMucMembershipEntry::Active(_)))
     }
 
-    pub fn take_for_occupant(&self, occupant: &FullJid) -> Vec<(BareJid, String)> {
-        let keys: Vec<(FullJid, BareJid)> = self
+    pub fn nick_for(&self, occupant: &FullJid, room: &BareJid) -> Option<String> {
+        self.entries
+            .get(&(occupant.clone(), room.clone()))
+            .and_then(|entry| match entry.value() {
+                RemoteMucMembershipEntry::Active(membership) => Some(membership.nick.clone()),
+                RemoteMucMembershipEntry::Tombstone { .. } => None,
+            })
+    }
+
+    pub fn take_for_occupant(&self, occupant: &FullJid) -> Vec<RemoteMucMembershipSnapshot> {
+        let snapshots: Vec<RemoteMucMembershipSnapshot> = self
             .entries
             .iter()
             .filter_map(|entry| {
                 let (entry_occupant, room) = entry.key();
-                if entry_occupant == occupant {
-                    Some((entry_occupant.clone(), room.clone()))
-                } else {
-                    None
+                if entry_occupant != occupant {
+                    return None;
                 }
+                let RemoteMucMembershipEntry::Active(membership) = entry.value() else {
+                    return None;
+                };
+                Some(RemoteMucMembershipSnapshot {
+                    occupant: entry_occupant.clone(),
+                    room: room.clone(),
+                    nick: membership.nick.clone(),
+                    generation: membership.generation,
+                })
             })
             .collect();
-        keys.into_iter()
-            .filter_map(|key| {
-                let room = key.1.clone();
-                self.entries.remove(&key).map(|(_, nick)| (room, nick))
-            })
+        snapshots
+            .into_iter()
+            .filter_map(|snapshot| self.mark_snapshot_taken(snapshot))
             .collect()
+    }
+
+    pub fn restore_snapshot_if_current(&self, snapshot: &RemoteMucMembershipSnapshot) {
+        let key = (snapshot.occupant.clone(), snapshot.room.clone());
+        if let dashmap::mapref::entry::Entry::Occupied(mut entry) = self.entries.entry(key) {
+            if matches!(
+                entry.get(),
+                RemoteMucMembershipEntry::Tombstone { generation }
+                    if *generation == snapshot.generation
+            ) {
+                entry.insert(RemoteMucMembershipEntry::Active(RemoteMucMembership {
+                    nick: snapshot.nick.clone(),
+                    generation: snapshot.generation,
+                }));
+            }
+        }
+    }
+
+    pub fn forget_snapshot_if_current(&self, snapshot: &RemoteMucMembershipSnapshot) {
+        let key = (snapshot.occupant.clone(), snapshot.room.clone());
+        self.entries.remove_if(&key, |_, current| {
+            matches!(
+                current,
+                RemoteMucMembershipEntry::Tombstone { generation }
+                    if *generation == snapshot.generation
+            )
+        });
+    }
+
+    pub fn snapshot_is_current_tombstone(&self, snapshot: &RemoteMucMembershipSnapshot) -> bool {
+        let key = (snapshot.occupant.clone(), snapshot.room.clone());
+        self.entries.get(&key).is_some_and(|entry| {
+            matches!(
+                entry.value(),
+                RemoteMucMembershipEntry::Tombstone { generation }
+                    if *generation == snapshot.generation
+            )
+        })
+    }
+
+    fn mark_snapshot_taken(
+        &self,
+        snapshot: RemoteMucMembershipSnapshot,
+    ) -> Option<RemoteMucMembershipSnapshot> {
+        let key = (snapshot.occupant.clone(), snapshot.room.clone());
+        let mut entry = self.entries.get_mut(&key)?;
+        match entry.value() {
+            RemoteMucMembershipEntry::Active(membership)
+                if membership.generation == snapshot.generation =>
+            {
+                *entry = RemoteMucMembershipEntry::Tombstone {
+                    generation: snapshot.generation,
+                };
+                Some(snapshot)
+            }
+            RemoteMucMembershipEntry::Active(_) | RemoteMucMembershipEntry::Tombstone { .. } => {
+                None
+            }
+        }
+    }
+
+    fn next_generation(&self) -> u64 {
+        self.next_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod remote_muc_membership_tests {
+    use super::*;
+
+    fn full_jid(s: &str) -> FullJid {
+        s.parse().expect("valid full jid")
+    }
+
+    fn room_bare_jid(local: &str) -> BareJid {
+        format!("{local}@muc.example.com")
+            .parse()
+            .expect("bare jid")
+    }
+
+    #[test]
+    fn stale_snapshot_does_not_remove_newer_same_nick_join() {
+        let memberships = RemoteMucMemberships::default();
+        let occupant = full_jid("alice@example.com/web");
+        let room = room_bare_jid("race");
+
+        memberships.record_join(&occupant, &room, "alice");
+        let stale_snapshots = memberships.take_for_occupant(&occupant);
+        assert_eq!(stale_snapshots.len(), 1);
+        assert!(memberships.snapshot_is_current_tombstone(&stale_snapshots[0]));
+
+        memberships.record_join(&occupant, &room, "alice");
+        assert!(!memberships.snapshot_is_current_tombstone(&stale_snapshots[0]));
+        memberships.restore_snapshot_if_current(&stale_snapshots[0]);
+
+        assert_eq!(
+            memberships.nick_for(&occupant, &room).as_deref(),
+            Some("alice")
+        );
+    }
+
+    #[test]
+    fn stale_snapshot_does_not_resurrect_after_newer_join_leaves() {
+        let memberships = RemoteMucMemberships::default();
+        let occupant = full_jid("alice@example.com/web");
+        let room = room_bare_jid("race-left");
+
+        memberships.record_join(&occupant, &room, "alice");
+        let stale_snapshots = memberships.take_for_occupant(&occupant);
+        assert_eq!(stale_snapshots.len(), 1);
+        assert!(memberships.snapshot_is_current_tombstone(&stale_snapshots[0]));
+
+        memberships.record_join(&occupant, &room, "alice");
+        memberships.record_leave(&occupant, &room);
+        assert!(!memberships.snapshot_is_current_tombstone(&stale_snapshots[0]));
+        memberships.restore_snapshot_if_current(&stale_snapshots[0]);
+
+        assert_eq!(memberships.nick_for(&occupant, &room), None);
     }
 }
 


### PR DESCRIPTION
## Plan

Production soak after PR #1232 exposed noisy remote-MUC disconnect cleanup warnings around uncertain ordered-relay outcomes. The follow-up scope is to keep the XEP-0045 cleanup semantics conservative while removing false failure behavior:

1. Treat only `Delivered` as proof that a remote MUC leave/unavailable cleanup committed.
2. Preserve cleanup provenance for `MaybeCommitted` / `JoinMaybeCommitted` so later disconnect/expiry cleanup can retry safely.
3. Prevent stale disconnect cleanup from overwriting, resurrecting, or sending unavailable for a newer same full-JID/room membership.
4. Add focused regression coverage and rerun the clustered server gates.

## Implementation

- Reworked `RemoteMucMemberships` from a plain nick map into an `Active` / `Tombstone` generation-tracked state machine.
- Added per-`(FullJid, room)` async serialization around remote MUC join, explicit remote leave, and disconnect cleanup relay.
- Changed disconnect cleanup to restore/forget only the exact snapshot generation it took.
- Added a pre-send tombstone check so stale cleanup skips after a newer membership generation appears.
- Changed explicit remote leave so `MaybeCommitted` / `JoinMaybeCommitted` preserve membership provenance; only `Delivered` clears it.
- Kept definite no-effect cleanup outcomes (`Unavailable`, `Dropped`, `None`) warning-level and uncertain commit outcomes debug-level.

## Adversarial Review

- Correctness review found and verified fixes for:
  - stale restore overwriting a fresh join,
  - stale snapshot removal of a newer same-key membership,
  - stale restore resurrecting an older membership after a newer join left,
  - stale cleanup sending unavailable while a newer join relay was in flight.
- XEP/protocol review found and verified fixes for:
  - treating uncertain disconnect cleanup as success,
  - explicit remote leave clearing membership on uncertain commit.
- Final correctness and XEP/protocol re-reviews reported no blockers.

## Verification

- `cargo fmt --manifest-path server/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path server/Cargo.toml --package waddle-server -- -D warnings`
- `cargo clippy --manifest-path server/Cargo.toml --package waddle-server --all-features -- -D warnings`
- `cargo test --manifest-path server/Cargo.toml --features clustering --package waddle-server --lib remote_muc_membership`
- `cargo test --manifest-path server/Cargo.toml --features clustering --package waddle-server --lib server::routes::websocket::cleanup`
- `cargo test --manifest-path server/Cargo.toml --features clustering --package waddle-server --lib websocket::handlers::presence::muc`
- `cargo test --manifest-path server/Cargo.toml --features clustering --package waddle-server --lib route_bridge`
- `cargo test --manifest-path server/Cargo.toml --package waddle-server --features clustering --lib` (1704 tests)

## Production Observation

Before publishing this follow-up, the live 3-replica clustered rollout was steady: all `waddle-server` pods Ready, and the last 10-minute log aggregate had no WARN groups, no ERROR groups, and no route-signature matches.
