### PR TITLE
feat(product): establish switchable-alternative roadmap foundation

### DIFF
--- a/.github/workflows/waddle-server-default.yml
+++ b/.github/workflows/waddle-server-default.yml
@@ -13,10 +13,21 @@ on:
     - .gitignore/**
     - .rules.cue
     - .rules.cue/**
+    - apps/apple/**/Tests/**
     - apps/apple/Waddle/RustClient/Generated/**
+    - chat/tests/**
     - cue.mod/**
     - cuenv.lock
     - cuenv.lock/**
+    - docs/evidence/**
+    - docs/planning/switchable-alternative.md
+    - docs/planning/switchable-alternative.md/**
+    - docs/product/critical-journeys.json
+    - docs/product/critical-journeys.json/**
+    - docs/product/gate-evidence.json
+    - docs/product/gate-evidence.json/**
+    - docs/product/performance-profile.json
+    - docs/product/performance-profile.json/**
     - env.cue
     - env.cue/**
     - flake.lock
@@ -33,17 +44,26 @@ on:
     - server/Cargo.lock/**
     - server/Cargo.toml
     - server/Cargo.toml/**
+    - server/capabilities.toml
+    - server/capabilities.toml/**
     - server/charts/waddle-server/**
     - server/crates/**
+    - server/crates/**/tests/**
+    - server/crates/waddle-server/src/server/routes/websocket/tests/**
+    - server/crates/waddle-server/tests/server_capability_manifest.rs
+    - server/crates/waddle-server/tests/server_capability_manifest.rs/**
     - server/deployment.cue
     - server/deployment.cue/**
     - server/env.cue
+    - server/env.cue/**
     - server/extensions/**
     - server/rust-toolchain.toml
     - server/rust-toolchain.toml/**
     - server/schema/**
     - server/scripts/**
     - server/wit/**
+    - tests/**
+    - xeps/xep-*.xml
   workflow_dispatch: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -203,6 +223,52 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: checkRootSyncDrift
       run: cuenv task checkRootSyncDrift --skip-dependencies
+      working-directory: server
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_REF_TYPE: ${{ github.ref_type }}
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+  checkSwitchableAlternativeProgram:
+    name: checkSwitchableAlternativeProgram
+    runs-on: namespace-profile-linux-x86
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - name: Cache /nix on Namespace volume
+      uses: namespacelabs/nscloud-cache-action@v1
+      with:
+        cache: nix
+    - name: Hand /nix to the runner user
+      run: sudo chown -R runner /nix
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: accept-flake-config = true
+    - name: Setup cuenv (release)
+      run: |-
+        arch="$(uname -m)"
+        case "$arch" in
+          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
+          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
+          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
+        esac
+        cuenv_version="0.53.2"
+        if [ -z "$cuenv_version" ]; then
+          cuenv_version="latest"
+        fi
+        if [ "$cuenv_version" = "latest" ]; then
+          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
+        else
+          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
+        fi
+        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: checkSwitchableAlternativeProgram
+      run: cuenv task checkSwitchableAlternativeProgram --skip-dependencies
       working-directory: server
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/waddle-server-pullrequest.yml
+++ b/.github/workflows/waddle-server-pullrequest.yml
@@ -11,10 +11,21 @@ on:
     - .gitignore/**
     - .rules.cue
     - .rules.cue/**
+    - apps/apple/**/Tests/**
     - apps/apple/Waddle/RustClient/Generated/**
+    - chat/tests/**
     - cue.mod/**
     - cuenv.lock
     - cuenv.lock/**
+    - docs/evidence/**
+    - docs/planning/switchable-alternative.md
+    - docs/planning/switchable-alternative.md/**
+    - docs/product/critical-journeys.json
+    - docs/product/critical-journeys.json/**
+    - docs/product/gate-evidence.json
+    - docs/product/gate-evidence.json/**
+    - docs/product/performance-profile.json
+    - docs/product/performance-profile.json/**
     - env.cue
     - env.cue/**
     - flake.lock
@@ -31,17 +42,26 @@ on:
     - server/Cargo.lock/**
     - server/Cargo.toml
     - server/Cargo.toml/**
+    - server/capabilities.toml
+    - server/capabilities.toml/**
     - server/charts/waddle-server/**
     - server/crates/**
+    - server/crates/**/tests/**
+    - server/crates/waddle-server/src/server/routes/websocket/tests/**
+    - server/crates/waddle-server/tests/server_capability_manifest.rs
+    - server/crates/waddle-server/tests/server_capability_manifest.rs/**
     - server/deployment.cue
     - server/deployment.cue/**
     - server/env.cue
+    - server/env.cue/**
     - server/extensions/**
     - server/rust-toolchain.toml
     - server/rust-toolchain.toml/**
     - server/schema/**
     - server/scripts/**
     - server/wit/**
+    - tests/**
+    - xeps/xep-*.xml
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
@@ -138,6 +158,52 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: checkRootSyncDrift
       run: cuenv task checkRootSyncDrift --skip-dependencies
+      working-directory: server
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_ACTOR: ${{ github.actor }}
+        GITHUB_REF_TYPE: ${{ github.ref_type }}
+        GITHUB_REF_NAME: ${{ github.ref_name }}
+  checkSwitchableAlternativeProgram:
+    name: checkSwitchableAlternativeProgram
+    runs-on: namespace-profile-linux-x86
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 2
+    - name: Cache /nix on Namespace volume
+      uses: namespacelabs/nscloud-cache-action@v1
+      with:
+        cache: nix
+    - name: Hand /nix to the runner user
+      run: sudo chown -R runner /nix
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: accept-flake-config = true
+    - name: Setup cuenv (release)
+      run: |-
+        arch="$(uname -m)"
+        case "$arch" in
+          x86_64|amd64) cuenv_asset="cuenv-linux-x64" ;;
+          aarch64|arm64) cuenv_asset="cuenv-linux-arm64" ;;
+          *) echo "Unsupported Linux architecture: $arch" >&2; exit 1 ;;
+        esac
+        cuenv_version="0.53.2"
+        if [ -z "$cuenv_version" ]; then
+          cuenv_version="latest"
+        fi
+        if [ "$cuenv_version" = "latest" ]; then
+          cuenv_url="https://github.com/cuenv/cuenv/releases/latest/download/${cuenv_asset}"
+        else
+          cuenv_url="https://github.com/cuenv/cuenv/releases/download/${cuenv_version}/${cuenv_asset}"
+        fi
+        curl -fsSL -o /usr/local/bin/cuenv "$cuenv_url" && chmod +x /usr/local/bin/cuenv && /usr/local/bin/cuenv sync -A
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: checkSwitchableAlternativeProgram
+      run: cuenv task checkSwitchableAlternativeProgram --skip-dependencies
       working-directory: server
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/planning/switchable-alternative.md
+++ b/docs/planning/switchable-alternative.md
@@ -1,0 +1,140 @@
+# Waddle switchable-alternative program
+
+## Outcome
+
+Waddle becomes a credible primary home for developer communities with 50–500
+active members. Success means three pilot communities—at least one hosted, one
+self-hosted, and one actively federating—use Waddle for eight consecutive weeks
+without Slack or Discord as their primary fallback.
+
+The supported client set for this program is web/installable PWA, iOS, and
+macOS. Android uses the PWA. The initial adoption path is a fresh community with
+templates and onboarding; Slack/Discord import, native Android, enterprise
+identity/compliance suites, default end-to-end encryption, and broad AI features
+are explicitly deferred.
+
+## Program status
+
+Status values are `planned`, `in-progress`, `blocked`, and `complete`. A gate can
+be marked `complete` only when every exit criterion has durable evidence linked
+from this document. Dates are assigned only after a gate has been decomposed and
+sized; they are not substitutes for passing the gate.
+
+**Current gate: Gate 0**
+
+When all gates are complete this marker becomes `Current gate: Program
+complete`; completion requires Gate 5 pilot evidence as well as a `ready`
+critical-journey ledger.
+
+| Gate | Status | Evidence |
+| ---: | --- | --- |
+| 0 | in-progress | [XEP conformance audit](../xep-conformance-audit.md); [server capability manifest](../../server/capabilities.toml); [critical journeys](../product/critical-journeys.json); [typed gate evidence](../product/gate-evidence.json); baseline audit pending |
+| 1 | planned | Reliability SLO report, restore exercise, and multi-replica auth/reconnect results pending |
+| 2 | planned | Federation profile and Prosody/ejabberd/Snikket interoperability results pending |
+| 3 | planned | Shared web/PWA, iOS, and macOS journey report pending |
+| 4 | planned | Pilot onboarding, moderation, audit, and administration evidence pending |
+| 5 | planned | Views/catch-up adoption and extension isolation evidence pending |
+
+## Gate 0 — Establish an honest capability baseline
+
+- Derive the server capability inventory from typed disco declarations and
+  reconcile it with dedicated XEP suites, end-to-end scenarios, web support,
+  Apple support, PWA behavior, and federated behavior.
+- Classify capabilities as `production`, `beta`, `experimental`, or
+  `unsupported`; module existence and documentation claims do not count as
+  implementation evidence.
+- Define shared critical journeys for authentication, invite/join, rooms, DMs,
+  history, unread state, search, files, threads, reactions, moderation,
+  notifications, calls, reconnect, multi-device use, and federation.
+- Instrument privacy-respecting product measures and service-level indicators
+  before pilot recruitment.
+
+Exit: the published inventory agrees with live service discovery and automated
+tests, every advertised XEP has a dedicated Rust suite, and each critical
+journey has an owner, supported-client matrix, and executable or explicitly
+manual evidence requirements with an explicit current status. The switchable
+release remains blocked until every generated scenario has complete evidence.
+
+## Gate 1 — Make Waddle trustworthy as a daily driver
+
+- Move authorization and temporary credential state out of replica-local
+  memory into shared, expiring, atomically consumed storage.
+- Prove encrypted backups, WAL archival, restore procedures, and alerting.
+- Finish clustered delivery, archive, offline, notification, and reconnect
+  correctness, including XEP-0352 client-state behavior.
+- Keep XMPP authoritative for calls and add operational dashboards/runbooks.
+
+Exit: messaging availability is at least 99.95%; at least 99.99% of accepted
+messages are delivered or durably queued; same-region p95 send-to-visible is
+under 500 ms; reconnect/resume succeeds at least 99%; authentication succeeds
+at least 99.5% excluding cancellation; RPO is at most five minutes and a restore
+demonstrates RTO of at most 30 minutes.
+
+## Gate 2 — Add secure, interoperable XMPP federation
+
+- Implement a dedicated S2S subsystem with RFC 6120 discovery and TLS,
+  XEP-0368 direct TLS, SASL EXTERNAL, and encrypted XEP-0220 dialback fallback.
+- Support federated DMs, roster/presence, room participation, invitations,
+  archives, moderation, and capability-aware rich-message degradation.
+- Add per-domain policy, resource limits, retry/dead-letter behavior, abuse
+  handling, diagnostics, and administration.
+
+Exit: bidirectional messaging, remote room participation, moderation,
+reconnect, and failure recovery pass against current Prosody, ejabberd,
+Snikket, and multi-node Waddle deployments without allowing a failing domain to
+exhaust shared resources.
+
+## Gate 3 — Complete the cross-platform collaboration core
+
+- Make web/PWA, iOS, and macOS pass one critical-journey contract; the PWA must
+  provide installability, Android-quality responsive behavior, offline shell,
+  notifications, deep links, and safe updates.
+- Complete permission-aware workspace search and dependable 1:1/room calls
+  with screen sharing, participant controls, device selection, and reconnect.
+- Enforce accessibility, keyboard, performance, and recovery requirements.
+
+Exit: all critical journeys pass on desktop web, Android PWA, iOS, and macOS,
+including offline/reconnect, multi-device, and federated variants.
+
+## Gate 4 — Make communities easy and safe to operate
+
+- Ship invite/rules/role/template onboarding and the complete member lifecycle.
+- Add block/report, moderator queues, evidence and reasons, timeout/kick/ban,
+  appeals, basic automod, and durable audit history.
+- Permission-check and attribute every privileged action, with role-preview and
+  operational health surfaces for administrators.
+
+Exit: median invite-to-first-message is under three minutes; at least 60% of
+accepted invitees engage within 24 hours; reports reach moderators within five
+seconds; emergency bans propagate within two seconds; every destructive or
+administrative action has a durable audit record.
+
+## Gate 5 — Build Waddle's moat and ecosystem
+
+- Add opt-in personal/shared views and catch-up workflows over familiar rooms,
+  forums, threads, mentions, people, tags, integrations, and time windows.
+- Harden feeds, stories, calendars/events, forums, and stage-style calls for
+  developer communities.
+- Productize the WASM extension runtime with a signed catalog, explicit grants,
+  XMPP-native lifecycle management, quotas, health, audit, and crash isolation;
+  ship curated RSS, GitHub, YouTube, calendar, and automation extensions.
+
+Exit: an administrator can manage a curated extension without redeploying the
+server, an extension failure cannot degrade messaging, and pilot evidence shows
+repeat adoption of views or catch-up workflows.
+
+## Delivery rules
+
+- XMPP service discovery is the runtime source of truth. Generated inventories
+  are documentation and test artifacts derived from it.
+- Official namespaces and advertised features must match their XEPs in
+  [`./xeps`](../../xeps); Waddle namespaces require a documented gap, typed Rust
+  models, fallback behavior, exact advertisement, and dedicated tests.
+- Every slice is validated at the typed parser/builder, server behavior, client
+  journey, and multi-node/federated end-to-end layers appropriate to its scope.
+- Gates 0, 1, and 5 use the typed immutable evidence ledger; Gates 2–4 use the
+  per-scenario journey ledger. Tracker links summarize evidence but cannot mark
+  a gate complete unless its machine-readable ledger is also `ready`.
+- Rollout proceeds through dogfood, three design partners, and then the
+  eight-week switchable beta. At least one pilot exercises supported
+  self-hosting and restore procedures.

--- a/docs/product/critical-journeys.json
+++ b/docs/product/critical-journeys.json
@@ -1,0 +1,344 @@
+{
+  "schemaVersion": 1,
+  "milestone": "switchable-alternative",
+  "journeyStatus": "not-ready",
+  "gateReadiness": { "2": "not-ready", "3": "not-ready", "4": "not-ready" },
+  "performanceProfile": "docs/product/performance-profile.json",
+  "releasePolicy": "Every generated scenario is release-blocking and must have end-to-end evidence before the milestone can ship.",
+  "dimensions": {
+    "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+    "topologies": ["local", "federated"]
+  },
+  "journeys": [
+    {
+      "id": "authenticate",
+      "title": "Authenticate and restore a session",
+      "owner": "identity",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": [],
+      "requirements": [
+        { "id": "valid-login", "given": "a valid account on the home server", "when": "the member authenticates", "then": "the client reaches the workspace with the correct identity" },
+        { "id": "session-restore", "given": "an authenticated member who restarts the client", "when": "the client opens again", "then": "the session is restored or reauthentication is requested without losing local state" },
+        { "id": "invalid-login", "given": "invalid or expired credentials", "when": "authentication is attempted", "then": "access is denied with a recoverable, non-secret-bearing error" }
+      ]
+    },
+    {
+      "id": "invite-and-join",
+      "title": "Accept an invite and join the community",
+      "owner": "community-onboarding",
+      "gate": 4,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e", "metric"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0045", "XEP-0401", "XEP-0503"],
+      "requirements": [
+        { "id": "accept-invite", "given": "a valid invitation", "when": "a new member accepts it", "then": "the member joins the intended community and starter conversations" },
+        { "id": "rules-roles-and-template", "given": "a community with rules, default roles, starter rooms, and a selected developer-community template", "when": "a new member completes onboarding", "then": "rules acceptance is durably recorded and only the configured roles, rooms, forums, and welcome checklist are applied" },
+        { "id": "invalid-invite", "given": "an expired, revoked, or unauthorized invitation", "when": "it is opened", "then": "joining is refused without creating partial membership" },
+        { "id": "activation-metric", "given": "a pilot onboarding cohort", "when": "invite acceptance and first engagement are measured", "then": "median invite-to-first-message is below three minutes and at least 60 percent of accepted invitees read, react, or post within 24 hours" }
+      ]
+    },
+    {
+      "id": "room-messaging",
+      "title": "Discover, join, and converse in a room",
+      "owner": "messaging",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0045", "XEP-0359"],
+      "requirements": [
+        { "id": "join-room", "given": "an authorized member and visible room", "when": "the member joins the room", "then": "membership, occupants, and recent context become visible" },
+        { "id": "exchange-message", "given": "two joined members", "when": "either sends a message", "then": "both clients show one stable, correctly attributed message" },
+        { "id": "leave-room", "given": "a joined member", "when": "the member leaves", "then": "the room stops producing member-only traffic for that member" }
+      ]
+    },
+    {
+      "id": "direct-messaging",
+      "title": "Exchange direct messages",
+      "owner": "messaging",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0280", "XEP-0359"],
+      "requirements": [
+        { "id": "exchange-message", "given": "two members permitted to contact each other", "when": "one sends a direct message", "then": "both members see one stable, correctly attributed message" },
+        { "id": "blocked-sender", "given": "a blocked sender", "when": "the sender attempts contact", "then": "the recipient receives no message or presence leak" }
+      ]
+    },
+    {
+      "id": "history",
+      "title": "Load and navigate durable history",
+      "owner": "messaging-history",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0059", "XEP-0313"],
+      "requirements": [
+        { "id": "page-history", "given": "a conversation with archived messages", "when": "the member pages backward and jumps to context", "then": "messages remain ordered, deduplicated, and permission-filtered" },
+        { "id": "revoked-access", "given": "a member whose access was revoked", "when": "history is requested", "then": "protected history is not disclosed" }
+      ]
+    },
+    {
+      "id": "unread-state",
+      "title": "Track unread, mentions, and displayed state",
+      "owner": "inbox",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0333", "XEP-0430", "XEP-0490"],
+      "requirements": [
+        { "id": "increment-and-clear", "given": "new messages in an unfocused conversation", "when": "the member opens and reads through them", "then": "unread and mention counts increment once and clear on every device" },
+        { "id": "restart-consistency", "given": "read state recorded before restart", "when": "the client reconnects", "then": "counts converge without resurrecting cleared items" }
+      ]
+    },
+    {
+      "id": "notifications",
+      "title": "Deliver notification preferences and alerts",
+      "owner": "notifications",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0357", "XEP-0492"],
+      "requirements": [
+        { "id": "eligible-alert", "given": "an eligible message while the client is backgrounded", "when": "the message is accepted", "then": "one privacy-preserving alert reaches the member and opens the correct context" },
+        { "id": "muted-alert", "given": "a muted conversation or disabled notification class", "when": "a matching message arrives", "then": "no alert is emitted while unread state remains correct" }
+      ]
+    },
+    {
+      "id": "search",
+      "title": "Search the workspace and jump to context",
+      "owner": "search",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0313"],
+      "requirements": [
+        { "id": "find-result", "given": "authorized searchable messages, people, rooms, forums, threads, and files", "when": "the member searches with entity, sender, room, and date filters and selects a result", "then": "matching results identify their type and context and open at the selected entity" },
+        { "id": "permission-filter", "given": "history outside the member's permissions", "when": "the member searches", "then": "no result, snippet, count, or identifier leaks that history" }
+      ]
+    },
+    {
+      "id": "file-sharing",
+      "title": "Upload, send, and open a file",
+      "owner": "files",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0363", "XEP-0446", "XEP-0447"],
+      "requirements": [
+        { "id": "share-file", "given": "an authorized member and supported file", "when": "the member uploads and sends it", "then": "recipients can inspect metadata and open the uncorrupted file" },
+        { "id": "failed-upload", "given": "a rejected or interrupted upload", "when": "the transfer fails", "then": "no successful message is shown and retry is safe" }
+      ]
+    },
+    {
+      "id": "threads-and-replies",
+      "title": "Reply in and catch up with a thread",
+      "owner": "threads",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0201", "XEP-0461"],
+      "requirements": [
+        { "id": "reply", "given": "a message that can be replied to", "when": "a member replies in its thread", "then": "the reply retains stable parent and thread context on every client" },
+        { "id": "thread-catch-up", "given": "unread thread activity", "when": "the member opens the thread inbox", "then": "the activity is discoverable and can be marked read without changing unrelated conversations" }
+      ]
+    },
+    {
+      "id": "reactions",
+      "title": "Add and remove message reactions",
+      "owner": "messaging",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0444"],
+      "requirements": [
+        { "id": "toggle-reaction", "given": "a visible message", "when": "members add or remove reactions", "then": "all clients converge on the same per-sender reaction set without duplicate counts" }
+      ]
+    },
+    {
+      "id": "moderation",
+      "title": "Report, moderate, and block abuse",
+      "owner": "trust-and-safety",
+      "gate": 4,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e", "authorization", "audit", "metric"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0191", "XEP-0377", "XEP-0425"],
+      "requirements": [
+        { "id": "report-content", "given": "reportable content", "when": "a member submits a report", "then": "authorized moderators receive attributable evidence without notifying the reported member" },
+        { "id": "moderation-queue", "given": "open reports with evidence and reasons", "when": "a moderator reviews, assigns, resolves, or escalates them", "then": "queue state is durable, permission-scoped, auditable, and visible to the moderation team within five seconds" },
+        { "id": "moderate-content", "given": "an authorized moderator", "when": "the moderator retracts content or applies timeout, kick, or ban", "then": "the action propagates within two seconds, is auditable, and is denied to unauthorized actors" },
+        { "id": "automod-and-appeal", "given": "configured keyword or rate rules and an appeal policy", "when": "automod acts or a sanctioned member appeals", "then": "the rule, evidence, decision, reviewer, and resulting action remain attributable and fail closed" }
+      ]
+    },
+    {
+      "id": "calls",
+      "title": "Start, join, recover, and leave a call",
+      "owner": "calls",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0166", "XEP-0167", "XEP-0215", "XEP-0272", "XEP-0353"],
+      "requirements": [
+        { "id": "call-lifecycle", "given": "permitted members and available media devices", "when": "a member starts or joins a direct or room call", "then": "participants can exchange media, observe participant state, and leave cleanly" },
+        { "id": "screen-share-and-controls", "given": "an active call with permitted participants", "when": "a member selects input/output devices, shares or stops sharing a screen, mutes, raises a hand, or a moderator manages a participant", "then": "every participant observes the authorized state transition exactly once and denied controls remain unavailable" },
+        { "id": "call-recovery", "given": "an active call with a transient connection loss", "when": "connectivity returns", "then": "the call recovers or ends with an explicit actionable state" }
+      ]
+    },
+    {
+      "id": "reconnect",
+      "title": "Reconnect without message loss or duplication",
+      "owner": "connection-reliability",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e", "chaos"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0198", "XEP-0313", "XEP-0359"],
+      "requirements": [
+        { "id": "resume-or-catch-up", "given": "a connected client with in-flight and missed traffic", "when": "the connection drops and returns", "then": "stream resumption or archive catch-up produces a complete deduplicated timeline" },
+        { "id": "expired-resume", "given": "an expired resumable session", "when": "the client reconnects", "then": "the client establishes a fresh stream and catches up without silent gaps" }
+      ]
+    },
+    {
+      "id": "multi-device",
+      "title": "Keep simultaneous devices consistent",
+      "owner": "multi-device",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0280", "XEP-0333", "XEP-0490"],
+      "requirements": [
+        { "id": "cross-device-convergence", "given": "the same member online on two clients", "when": "either client sends, receives, or displays a message", "then": "both clients converge on message and read state without duplicate notifications" },
+        { "id": "device-revocation", "given": "a revoked client session", "when": "that client attempts to reconnect", "then": "access is denied without disrupting other active clients" }
+      ]
+    },
+    {
+      "id": "accessibility",
+      "title": "Operate core collaboration journeys accessibly",
+      "owner": "design-system",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e", "accessibility"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": [],
+      "requirements": [
+        { "id": "wcag-core-flows", "given": "a member using screen-reader, high-contrast, zoom, reduced-motion, or switch-control settings", "when": "the member completes authentication, navigation, messaging, search, files, calls, and moderation flows", "then": "the flow meets WCAG 2.2 AA with named controls, logical focus order, announced state changes, and no pointer-only action" }
+      ]
+    },
+    {
+      "id": "keyboard-navigation",
+      "title": "Operate core collaboration journeys by keyboard",
+      "owner": "design-system",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e", "accessibility"], "records": [] },
+      "clients": ["desktop-web", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": [],
+      "requirements": [
+        { "id": "keyboard-core-flows", "given": "a keyboard-only member", "when": "the member navigates workspaces, conversations, messages, threads, search, composer actions, settings, calls, and moderation", "then": "every action is reachable with visible focus, documented shortcuts do not conflict, and focus returns to the initiating control after dismissal" }
+      ]
+    },
+    {
+      "id": "performance-budgets",
+      "title": "Meet interactive performance budgets",
+      "owner": "web-platform",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e", "performance"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": [],
+      "requirements": [
+        { "id": "interactive-budgets", "given": "the versioned dataset, hardware, and network in the contract performance profile", "when": "a member launches, opens a conversation, searches, sends, or joins a call", "then": "web p75 LCP is at most 2.5 seconds, web p75 INP is at most 200 milliseconds, native launch-to-interactive is at most 2.5 seconds, and conversation/search actions acknowledge input within 100 milliseconds" }
+      ]
+    },
+    {
+      "id": "pwa-lifecycle",
+      "title": "Install, update, and recover the Android PWA",
+      "owner": "web-platform",
+      "gate": 3,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e", "device"], "records": [] },
+      "clients": ["android-pwa"],
+      "topologies": ["local", "federated"],
+      "protocols": [],
+      "requirements": [
+        { "id": "install-and-launch", "given": "a supported Android browser and authenticated member", "when": "the member installs and launches Waddle", "then": "the standalone app restores the authenticated workspace and deep links to the intended conversation" },
+        { "id": "offline-shell", "given": "a previously launched installation", "when": "the device temporarily loses connectivity", "then": "the app shell and cached context remain usable and clearly distinguish unavailable network actions" },
+        { "id": "safe-update", "given": "an installed older application version with queued local state", "when": "a new service worker activates", "then": "the update preserves queued state and either migrates or explicitly rejects incompatible state without silent loss" }
+      ]
+    },
+    {
+      "id": "member-lifecycle-and-administration",
+      "title": "Administer member and role lifecycles",
+      "owner": "community-administration",
+      "gate": 4,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e", "authorization", "audit", "metric"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0050", "XEP-0191", "XEP-0503"],
+      "requirements": [
+        { "id": "member-lifecycle", "given": "an authorized community administrator", "when": "the administrator invites, approves, assigns roles, suspends, bans, revokes sessions, removes, exports, or deletes a member", "then": "the requested lifecycle transition is atomic, permission-scoped, visible on active clients within 60 seconds, and durably audited" },
+        { "id": "role-preview", "given": "a configured role and channel policy", "when": "an administrator previews the community as that role", "then": "the preview matches server authorization without granting the administrator a new session or mutating membership" },
+        { "id": "audit-completeness", "given": "destructive and administrative actions", "when": "the audit ledger is reconciled", "then": "100 percent contain actor, target, reason, timestamp, result, and correlation identifier" }
+      ]
+    },
+    {
+      "id": "admin-operational-health",
+      "title": "Operate community health surfaces",
+      "owner": "community-administration",
+      "gate": 4,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e", "authorization", "metric"], "records": [] },
+      "clients": ["desktop-web", "macos"],
+      "topologies": ["local", "federated"],
+      "protocols": ["XEP-0050"],
+      "requirements": [
+        { "id": "health-overview", "given": "an authorized administrator", "when": "the administrator opens operational health", "then": "delivery, push, federation, extensions, backups, and recent incidents show freshness, degraded state, and an actionable diagnostic without exposing member content" },
+        { "id": "health-authorization", "given": "a non-administrator", "when": "the member requests operational health", "then": "the request is denied without leaking infrastructure, identity, or incident details" }
+      ]
+    },
+    {
+      "id": "federation-interoperability",
+      "title": "Interoperate with supported XMPP servers",
+      "owner": "federation",
+      "gate": 2,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e", "interop", "security"], "records": [] },
+      "clients": ["desktop-web"],
+      "topologies": ["federated"],
+      "protocols": ["XEP-0045", "XEP-0156", "XEP-0220", "XEP-0313", "XEP-0368", "XEP-0425"],
+      "requirements": [
+        { "id": "prosody", "given": "a current supported Prosody peer", "when": "users exchange presence, direct messages, history, and reconnect across domains", "then": "delivery is bidirectional, ordered, deduplicated, and capability-aware" },
+        { "id": "ejabberd", "given": "a current supported ejabberd peer", "when": "users exchange presence, direct messages, history, and reconnect across domains", "then": "delivery is bidirectional, ordered, deduplicated, and capability-aware" },
+        { "id": "snikket", "given": "a current supported Snikket peer", "when": "users exchange presence, direct messages, history, and reconnect across domains", "then": "delivery is bidirectional, ordered, deduplicated, and capability-aware" },
+        { "id": "remote-room-lifecycle", "given": "authorized local and remote members", "when": "a remote member accepts an invitation, joins a Waddle room, exchanges messages and files, reconnects, and is moderated", "then": "room state, archive visibility, invitation semantics, moderation, and recovery remain conformant across domains" },
+        { "id": "transport-authentication", "given": "valid, invalid, expired, and mismatched peer certificates plus dialback fallback", "when": "S2S streams negotiate", "then": "TLS, SASL EXTERNAL, SRV/direct-TLS discovery, and encrypted dialback enforce the configured trust policy without downgrade" }
+      ]
+    },
+    {
+      "id": "federation-failure-isolation",
+      "title": "Recover safely from a remote-domain failure",
+      "owner": "federation",
+      "gate": 2,
+      "evidence": { "defaultStatus": "missing", "requiredKinds": ["e2e", "chaos", "security"], "records": [] },
+      "clients": ["desktop-web", "android-pwa", "ios", "macos"],
+      "topologies": ["federated"],
+      "protocols": ["XEP-0198", "XEP-0359"],
+      "requirements": [
+        { "id": "remote-outage", "given": "a remote domain that is unavailable or rejects delivery", "when": "local members continue using Waddle", "then": "local traffic remains healthy and remote delivery is queued, retried, or visibly failed without duplication" },
+        { "id": "hostile-domain", "given": "a blocked, malformed, or quota-exhausting remote domain", "when": "it sends traffic", "then": "the traffic is rejected and cannot exhaust shared resources or bypass moderation policy" }
+      ]
+    }
+  ]
+}

--- a/docs/product/gate-evidence.json
+++ b/docs/product/gate-evidence.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "gates": {
+    "0": {
+      "status": "not-ready",
+      "requiredKinds": ["capability-baseline", "journey-baseline", "telemetry-baseline"],
+      "records": []
+    },
+    "1": {
+      "status": "not-ready",
+      "requiredKinds": ["availability-slo", "delivery-slo", "authentication-slo", "restore-drill", "security"],
+      "records": []
+    },
+    "5": {
+      "status": "not-ready",
+      "requiredKinds": ["hosted-pilot", "self-hosted-pilot", "federated-pilot", "eight-week-retention", "restore-drill", "extension-isolation", "views-adoption"],
+      "records": []
+    }
+  }
+}

--- a/docs/product/performance-profile.json
+++ b/docs/product/performance-profile.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "id": "switchable-500-v1",
+  "dataset": {
+    "generatorSeed": 20260709,
+    "members": 500,
+    "rooms": 100,
+    "messages": 1000000,
+    "threads": 10000,
+    "files": 5000
+  },
+  "network": {
+    "downMbps": 10,
+    "upMbps": 2,
+    "roundTripMs": 80
+  },
+  "clients": {
+    "desktop-web": { "hardware": "Mac mini M1 2020", "ramGiB": 8, "resolvedRuntimeRequired": true },
+    "android-pwa": { "hardware": "Google Pixel 7", "ramGiB": 8, "resolvedRuntimeRequired": true },
+    "ios": { "hardware": "Apple iPhone 13", "ramGiB": 4, "resolvedRuntimeRequired": true },
+    "macos": { "hardware": "Mac mini M1 2020", "ramGiB": 8, "resolvedRuntimeRequired": true }
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -60,6 +60,7 @@
             fileset = lib.fileset.unions [
               ./server/Cargo.toml
               ./server/Cargo.lock
+              ./server/capabilities.toml
               ./server/crates
               ./server/extensions
               ./server/wit
@@ -194,6 +195,7 @@
             fileset = lib.fileset.unions [
               ./server/Cargo.toml
               ./server/Cargo.lock
+              ./server/capabilities.toml
               ./server/crates
               ./server/extensions
               ./server/wit

--- a/server/capabilities.toml
+++ b/server/capabilities.toml
@@ -1,0 +1,167 @@
+schema_version = 1
+
+# This curated inventory describes user-visible server capabilities; the
+# exhaustive advertised-feature/XEP coverage gate remains in xmpp_e2e_cue.rs.
+# `server_maturity` is intentionally server-scoped. Cross-client readiness and
+# evidence live in docs/product/critical-journeys.json.
+
+[[capability]]
+id = "room-messaging"
+server_maturity = "production"
+protocols = ["XEP-0045", "XEP-0359"]
+advertised_features = ["http://jabber.org/protocol/muc", "urn:xmpp:sid:0"]
+server_evidence = ["crates/waddle-server/tests/xep0045_join_lifecycle_ws.rs"]
+topologies = { local = "production", federated = "unsupported" }
+[capability.protocol_evidence]
+XEP-0045 = ["crates/waddle-server/tests/xep0045_join_lifecycle_ws.rs"]
+XEP-0359 = ["crates/waddle-server/tests/xep0359_stanza_ids_ws.rs"]
+
+[[capability]]
+id = "direct-messaging"
+server_maturity = "production"
+protocols = ["XEP-0280", "XEP-0359"]
+advertised_features = ["urn:xmpp:carbons:2", "urn:xmpp:sid:0"]
+server_evidence = ["crates/waddle-server/tests/xep0280_carbons_integration.rs"]
+topologies = { local = "production", federated = "unsupported" }
+[capability.protocol_evidence]
+XEP-0280 = ["crates/waddle-server/tests/xep0280_carbons_integration.rs"]
+XEP-0359 = ["crates/waddle-server/tests/xep0359_stanza_ids_ws.rs"]
+
+[[capability]]
+id = "durable-history"
+server_maturity = "production"
+protocols = ["XEP-0059", "XEP-0313"]
+advertised_features = ["urn:xmpp:mam:2"]
+server_evidence = ["crates/waddle-server/tests/xep0313_mam_integration.rs"]
+topologies = { local = "production", federated = "unsupported" }
+[capability.protocol_evidence]
+XEP-0059 = ["crates/waddle-server/tests/xep0313_mam_integration.rs"]
+XEP-0313 = ["crates/waddle-server/tests/xep0313_mam_integration.rs"]
+
+[[capability]]
+id = "unread-and-read-state"
+server_maturity = "beta"
+protocols = ["XEP-0333", "XEP-0430", "XEP-0490"]
+advertised_features = ["urn:xmpp:chat-markers:0", "urn:xmpp:inbox:1"]
+server_evidence = ["crates/waddle-server/tests/xep0430_inbox_ws.rs", "crates/waddle-server/tests/xep0490_mds_ws.rs"]
+topologies = { local = "beta", federated = "unsupported" }
+[capability.protocol_evidence]
+XEP-0333 = ["crates/waddle-server/tests/xep0490_mds_ws.rs"]
+XEP-0430 = ["crates/waddle-server/tests/xep0430_inbox_ws.rs"]
+XEP-0490 = ["crates/waddle-server/tests/xep0490_mds_ws.rs"]
+
+[[capability]]
+id = "push-notifications"
+server_maturity = "beta"
+protocols = ["XEP-0357", "XEP-0492"]
+advertised_features = ["urn:xmpp:push:0"]
+server_evidence = ["crates/waddle-server/tests/xep0357_push_service_ws.rs"]
+topologies = { local = "beta", federated = "unsupported" }
+[capability.protocol_evidence]
+XEP-0357 = ["crates/waddle-server/tests/xep0357_push_service_ws.rs"]
+XEP-0492 = ["crates/waddle-server/tests/xep0492_push_enforcement_ws.rs"]
+
+[[capability]]
+id = "message-search"
+server_maturity = "beta"
+protocols = ["XEP-0313"]
+advertised_features = ["urn:xmpp:mam:2", "urn:xmpp:mam:2#extended"]
+server_evidence = ["crates/waddle-server/tests/xep0313_mam_integration.rs"]
+topologies = { local = "beta", federated = "unsupported" }
+[capability.protocol_evidence]
+XEP-0313 = ["crates/waddle-server/tests/xep0313_mam_integration.rs"]
+
+[[capability]]
+id = "file-sharing"
+server_maturity = "beta"
+protocols = ["XEP-0363", "XEP-0446", "XEP-0447"]
+advertised_features = ["urn:xmpp:http:upload:0"]
+server_evidence = ["crates/waddle-server/src/server/routes/websocket/tests/iq.rs", "crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0447_stateless_file_sharing.cue"]
+topologies = { local = "beta", federated = "unsupported" }
+[capability.protocol_evidence]
+XEP-0363 = ["crates/waddle-xmpp/tests/xep0363_http_upload.rs"]
+XEP-0446 = ["crates/waddle-xmpp/tests/xep0446_file_metadata.rs"]
+XEP-0447 = ["crates/waddle-xmpp/tests/xep0447_stateless_file_sharing.rs"]
+
+[[capability]]
+id = "threads-and-replies"
+server_maturity = "beta"
+protocols = ["XEP-0201", "XEP-0461"]
+advertised_features = ["urn:xmpp:reply:0"]
+server_evidence = ["crates/waddle-server/tests/xep0461_replies_ws.rs", "crates/waddle-server/tests/waddle_threads_query_ws.rs"]
+topologies = { local = "beta", federated = "unsupported" }
+[capability.protocol_evidence]
+XEP-0201 = ["crates/waddle-server/tests/waddle_threads_query_ws.rs"]
+XEP-0461 = ["crates/waddle-server/tests/xep0461_replies_ws.rs"]
+
+[[capability]]
+id = "reactions"
+server_maturity = "production"
+protocols = ["XEP-0444"]
+advertised_features = ["urn:xmpp:reactions:0"]
+server_evidence = ["crates/waddle-server/tests/xep0444_reactions_ws.rs"]
+topologies = { local = "production", federated = "unsupported" }
+[capability.protocol_evidence]
+XEP-0444 = ["crates/waddle-server/tests/xep0444_reactions_ws.rs"]
+
+[[capability]]
+id = "moderation"
+server_maturity = "experimental"
+protocols = ["XEP-0191", "XEP-0425"]
+advertised_features = ["urn:xmpp:blocking", "urn:xmpp:message-moderate:1"]
+server_evidence = ["crates/waddle-server/tests/xep0425_message_moderation_ws.rs"]
+topologies = { local = "experimental", federated = "unsupported" }
+[capability.protocol_evidence]
+XEP-0191 = ["crates/waddle-server/tests/xep0054_0049_0191_ws.rs"]
+XEP-0425 = ["crates/waddle-server/tests/xep0425_message_moderation_ws.rs"]
+
+[[capability]]
+id = "audio-video-calls"
+server_maturity = "beta"
+availability = "configured"
+protocols = ["XEP-0166", "XEP-0167", "XEP-0215", "XEP-0272", "XEP-0353"]
+advertised_features = ["urn:xmpp:jingle:1", "urn:xmpp:jingle:apps:rtp:1", "urn:xmpp:jingle:apps:rtp:audio", "urn:xmpp:jingle:apps:rtp:video", "urn:xmpp:jingle-message:0", "urn:xmpp:extdisco:2", "urn:xmpp:jingle:muji:0"]
+custom_namespaces = ["urn:waddle:transports:livekit:0"]
+server_evidence = ["crates/waddle-server/tests/calls_e2e_ws.rs"]
+topologies = { local = "beta", federated = "unsupported" }
+[capability.protocol_evidence]
+XEP-0166 = ["crates/waddle-server/tests/calls_e2e_ws.rs"]
+XEP-0167 = ["crates/waddle-server/tests/calls_e2e_ws.rs"]
+XEP-0215 = ["crates/waddle-server/tests/calls_e2e_ws.rs"]
+XEP-0272 = ["crates/waddle-server/tests/calls_e2e_ws.rs"]
+XEP-0353 = ["crates/waddle-server/tests/calls_e2e_ws.rs"]
+
+[[capability]]
+id = "reconnect-and-resume"
+server_maturity = "beta"
+protocols = ["XEP-0198", "XEP-0313", "XEP-0359"]
+advertised_features = ["urn:xmpp:sm:3", "urn:xmpp:mam:2", "urn:xmpp:sid:0"]
+server_evidence = ["crates/waddle-server/tests/xep0198_cross_node_resume.rs", "crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0313_reconnect_after_catchup.cue"]
+topologies = { local = "beta", federated = "unsupported" }
+[capability.protocol_evidence]
+XEP-0198 = ["crates/waddle-server/tests/xep0198_cross_node_resume.rs"]
+XEP-0313 = ["crates/waddle-server/tests/xmpp_e2e_scenarios/xep_0313_reconnect_after_catchup.cue"]
+XEP-0359 = ["crates/waddle-server/tests/xep0359_stanza_ids_ws.rs"]
+
+[[capability]]
+id = "spaces-and-administration"
+server_maturity = "beta"
+protocols = ["XEP-0050", "XEP-0503"]
+advertised_features = ["http://jabber.org/protocol/commands", "urn:xmpp:spaces:0"]
+server_evidence = ["crates/waddle-server/tests/admin_spaces_ws.rs", "crates/waddle-server/tests/admin_channels_ws.rs"]
+topologies = { local = "beta", federated = "unsupported" }
+[capability.protocol_evidence]
+XEP-0050 = ["crates/waddle-server/tests/admin_spaces_ws.rs", "crates/waddle-server/tests/admin_channels_ws.rs"]
+XEP-0503 = ["crates/waddle-server/tests/xep0503_spaces_ws.rs"]
+
+[[capability]]
+id = "community-feed-stories"
+server_maturity = "experimental"
+protocols = ["XEP-0060", "XEP-0472", "XEP-0501"]
+advertised_features = ["http://jabber.org/protocol/pubsub", "urn:xmpp:pubsub-social-feed:1", "urn:xmpp:pubsub-social-feed:stories:0"]
+server_evidence = ["crates/waddle-server/tests/xep0472_social_feed_ws.rs", "crates/waddle-server/tests/xep0501_stories_ws.rs"]
+topologies = { local = "experimental", federated = "unsupported" }
+[capability.protocol_evidence]
+XEP-0060 = ["crates/waddle-server/tests/xep0060_pubsub_ws.rs"]
+XEP-0472 = ["crates/waddle-server/tests/xep0472_social_feed_ws.rs"]
+XEP-0501 = ["crates/waddle-server/tests/xep0501_stories_ws.rs"]

--- a/server/crates/waddle-server/tests/server_capability_manifest.rs
+++ b/server/crates/waddle-server/tests/server_capability_manifest.rs
@@ -1,0 +1,202 @@
+use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const MATURITY: &[&str] = &["production", "beta", "experimental", "unsupported"];
+const TOPOLOGIES: &[&str] = &["local", "federated"];
+const MANIFEST_SOURCE: &str = include_str!("../../../capabilities.toml");
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Manifest {
+    schema_version: u32,
+    capability: Vec<Capability>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Capability {
+    id: String,
+    server_maturity: String,
+    #[serde(default = "default_availability")]
+    availability: String,
+    protocols: Vec<String>,
+    advertised_features: Vec<String>,
+    #[serde(default)]
+    custom_namespaces: Vec<String>,
+    server_evidence: Vec<String>,
+    protocol_evidence: BTreeMap<String, Vec<String>>,
+    topologies: BTreeMap<String, String>,
+}
+
+fn default_availability() -> String {
+    "always".to_string()
+}
+
+fn server_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn load_manifest() -> Manifest {
+    toml::from_str(MANIFEST_SOURCE).expect("parse embedded server capability manifest")
+}
+
+#[test]
+fn capability_manifest_has_complete_unique_release_claims() {
+    let manifest = load_manifest();
+    assert_eq!(manifest.schema_version, 1);
+    assert!(!manifest.capability.is_empty());
+
+    let mut ids = BTreeSet::new();
+    for capability in &manifest.capability {
+        assert!(
+            ids.insert(&capability.id),
+            "duplicate capability {}",
+            capability.id
+        );
+        assert!(
+            capability
+                .id
+                .chars()
+                .all(|character| character.is_ascii_lowercase()
+                    || character.is_ascii_digit()
+                    || character == '-'),
+            "capability ids must be lowercase kebab-case: {}",
+            capability.id
+        );
+        assert!(MATURITY.contains(&capability.server_maturity.as_str()));
+        assert!(["always", "configured"].contains(&capability.availability.as_str()));
+        assert!(!capability.protocols.is_empty());
+        assert!(!capability.server_evidence.is_empty());
+        assert_eq!(
+            capability.protocols.iter().collect::<BTreeSet<_>>(),
+            capability.protocol_evidence.keys().collect::<BTreeSet<_>>(),
+            "every protocol on {} must have its own evidence",
+            capability.id
+        );
+        assert_eq!(
+            capability
+                .topologies
+                .keys()
+                .map(String::as_str)
+                .collect::<BTreeSet<_>>(),
+            TOPOLOGIES.iter().copied().collect()
+        );
+        for status in capability.topologies.values() {
+            assert!(
+                MATURITY.contains(&status.as_str()),
+                "invalid maturity {status} on {}",
+                capability.id
+            );
+        }
+    }
+}
+
+#[test]
+fn capability_manifest_references_vendored_xeps_and_existing_evidence() {
+    let root = server_root();
+    for capability in load_manifest().capability {
+        for protocol in capability.protocols {
+            protocol
+                .strip_prefix("XEP-")
+                .filter(|number| number.len() == 4 && number.chars().all(|c| c.is_ascii_digit()))
+                .unwrap_or_else(|| panic!("invalid protocol {protocol} on {}", capability.id));
+        }
+        for (protocol, evidence_paths) in capability.protocol_evidence {
+            assert!(
+                !evidence_paths.is_empty(),
+                "{} has no evidence for {protocol}",
+                capability.id
+            );
+            for evidence in evidence_paths {
+                let path = root.join(&evidence);
+                assert!(
+                    path.is_file(),
+                    "{} has missing {protocol} evidence {evidence}",
+                    capability.id
+                );
+                let source = fs::read_to_string(&path).expect("read capability evidence");
+                match path.extension().and_then(|extension| extension.to_str()) {
+                    Some("rs") => assert!(
+                        source.contains("#[test]") || source.contains("#[tokio::test]"),
+                        "{} evidence for {protocol} contains no Rust test: {evidence}",
+                        capability.id
+                    ),
+                    Some("cue") => assert!(
+                        source.contains(&protocol),
+                        "{} CUE evidence does not declare {protocol}: {evidence}",
+                        capability.id
+                    ),
+                    extension => panic!(
+                        "{} evidence for {protocol} has unsupported extension {extension:?}: {evidence}",
+                        capability.id
+                    ),
+                }
+            }
+        }
+        for evidence in capability.server_evidence {
+            let path = root.join(&evidence);
+            assert!(
+                path.is_file(),
+                "{} has missing server evidence {evidence}",
+                capability.id
+            );
+            let source = fs::read_to_string(&path).expect("read server evidence");
+            match path.extension().and_then(|extension| extension.to_str()) {
+                Some("rs") => assert!(
+                    source.contains("#[test]") || source.contains("#[tokio::test]"),
+                    "{} server evidence contains no Rust test: {evidence}",
+                    capability.id
+                ),
+                Some("cue") => assert!(
+                    source.contains("steps:") && source.contains("xeps:"),
+                    "{} server evidence is not an XEP scenario: {evidence}",
+                    capability.id
+                ),
+                extension => panic!(
+                    "{} server evidence has unsupported extension {extension:?}: {evidence}",
+                    capability.id
+                ),
+            }
+        }
+    }
+}
+
+#[test]
+fn advertised_feature_claims_exist_in_runtime_feature_vectors() {
+    use waddle_xmpp::disco::info::{
+        call_features, community_service_features, muc_room_features, muc_service_features,
+        pubsub_service_features, push_service_features, server_features, spaces_service_features,
+        upload_service_features,
+    };
+
+    let mut advertised = BTreeSet::new();
+    for feature in server_features()
+        .into_iter()
+        .chain(upload_service_features())
+        .chain(pubsub_service_features())
+        .chain(push_service_features())
+        .chain(spaces_service_features())
+        .chain(community_service_features())
+        .chain(muc_service_features())
+        .chain(muc_room_features(true, true, true, true, true))
+        .chain(call_features())
+    {
+        advertised.insert(feature.0);
+    }
+
+    for capability in load_manifest().capability {
+        for feature in capability
+            .advertised_features
+            .into_iter()
+            .chain(capability.custom_namespaces)
+        {
+            assert!(
+                advertised.contains(&feature),
+                "{} claims feature absent from assembled runtime feature vectors: {feature}",
+                capability.id
+            );
+        }
+    }
+}

--- a/server/env.cue
+++ b/server/env.cue
@@ -146,6 +146,7 @@ schema.#Project & {
 			tasks: [
 				_t.checkRootSyncDrift,
 				_t.checkCiDrift,
+				_t.checkSwitchableAlternativeProgram,
 				_t.fmt,
 				_t.clippy,
 				_t.test,
@@ -184,7 +185,7 @@ schema.#Project & {
 				packages:        "read"
 				"pull-requests": "none"
 			}
-			tasks: [_t.checkRootSyncDrift, _t.checkCiDrift, _t.nixFmt, _t.nixClippy, _t.nixTest, _t.checkXmppClientFfiBindings, _t.renderDeployment, _t.nixBuildExtensionModules, _t.nixBuildCi]
+			tasks: [_t.checkRootSyncDrift, _t.checkCiDrift, _t.checkSwitchableAlternativeProgram, _t.nixFmt, _t.nixClippy, _t.nixTest, _t.checkXmppClientFfiBindings, _t.renderDeployment, _t.nixBuildExtensionModules, _t.nixBuildCi]
 		}
 		xmppCompliance: {
 			mode: "expanded"
@@ -232,6 +233,85 @@ schema.#Project & {
 				"../cuenv.lock",
 				"../.rules.cue",
 				"../.gitignore",
+			]
+		}
+
+		checkSwitchableAlternativeProgram: schema.#Task & {
+			command: "bash"
+			args: ["-c", #"""
+					set -euo pipefail
+					tracker=../docs/planning/switchable-alternative.md
+					test -f capabilities.toml
+					test -f ../docs/product/critical-journeys.json
+					test -f ../docs/product/gate-evidence.json
+					for gate in 0 1 2 3 4 5; do
+					  test "$(grep -c "^## Gate ${gate} —" "${tracker}")" -eq 1
+					done
+					test "$(grep -Ec '^\| [0-5] \| (planned|in-progress|blocked|complete) \|' "${tracker}")" -eq 6
+					test "$(grep -Ec '^\*\*Current gate: (Gate [0-5]|Program complete)\*\*$' "${tracker}")" -eq 1
+					journey_status="$(bun -e 'const contract = await Bun.file("../docs/product/critical-journeys.json").json(); console.log(contract.journeyStatus)')"
+					if grep -q '^\*\*Current gate: Program complete\*\*$' "${tracker}"; then
+					  test "$(grep -Ec '^\| [0-5] \| complete \|' "${tracker}")" -eq 6
+					  test "$(grep -Ec '^\| [0-5] \| in-progress \|' "${tracker}")" -eq 0
+					  test "${journey_status}" = ready
+					else
+					  test "$(grep -Ec '^\| [0-5] \| in-progress \|' "${tracker}")" -eq 1
+					  current_gate="$(grep '^\*\*Current gate: Gate [0-5]\*\*$' "${tracker}" | grep -Eo '[0-5]')"
+					  grep -q "^| ${current_gate} | in-progress |" "${tracker}"
+					  for gate in 0 1 2 3 4 5; do
+					    status="$(grep "^| ${gate} |" "${tracker}" | cut -d '|' -f 3 | xargs)"
+					    if [ "${gate}" -lt "${current_gate}" ]; then
+					      test "${status}" = complete
+					    elif [ "${gate}" -gt "${current_gate}" ]; then
+					      test "${status}" = planned -o "${status}" = blocked
+					    fi
+					  done
+					fi
+					for gate in 2 3 4; do
+					  tracker_status="$(grep "^| ${gate} |" "${tracker}" | cut -d '|' -f 3 | xargs)"
+					  evidence_status="$(GATE="${gate}" bun -e 'const contract = await Bun.file("../docs/product/critical-journeys.json").json(); console.log(contract.gateReadiness[process.env.GATE])')"
+					  if [ "${tracker_status}" = complete ]; then
+					    test "${evidence_status}" = ready
+					  elif [ "${evidence_status}" = ready ]; then
+					    echo "Gate ${gate} journey evidence cannot be ready before the tracker gate is complete" >&2
+					    exit 1
+					  fi
+					done
+					for gate in 0 1 5; do
+					  tracker_status="$(grep "^| ${gate} |" "${tracker}" | cut -d '|' -f 3 | xargs)"
+					  evidence_status="$(GATE="${gate}" bun -e 'const ledger = await Bun.file("../docs/product/gate-evidence.json").json(); console.log(ledger.gates[process.env.GATE].status)')"
+					  if [ "${tracker_status}" = complete ]; then
+					    test "${evidence_status}" = ready
+					  elif [ "${evidence_status}" = ready ]; then
+					    echo "Gate ${gate} evidence cannot be ready before the tracker gate is complete" >&2
+					    exit 1
+					  fi
+					done
+					while IFS= read -r row; do
+					  echo "${row}" | grep -Eq '\[[^]]+\]\([^)]+\)'
+					  if echo "${row}" | grep -Eq 'pending|[[:space:]][—-][[:space:]]'; then
+					    echo "completed program gates must link durable non-pending evidence" >&2
+					    exit 1
+					  fi
+					done < <(grep '^| [0-5] | complete |' "${tracker}" || true)
+					bun test ../tests/critical-journeys.test.ts
+				"""#]
+			inputs: [
+				"../apps/apple/**/Tests/**",
+				"../chat/tests/**",
+				"../docs/evidence/**",
+				"capabilities.toml",
+				"crates/**/tests/**",
+				"crates/waddle-server/src/server/routes/websocket/tests/**",
+				"crates/waddle-server/tests/server_capability_manifest.rs",
+				"../docs/product/critical-journeys.json",
+				"../docs/product/gate-evidence.json",
+				"../docs/product/performance-profile.json",
+				"../docs/planning/switchable-alternative.md",
+				"../tests/**",
+				"../cuenv.lock",
+				"../xeps/xep-*.xml",
+				"env.cue",
 			]
 		}
 

--- a/tests/critical-journeys.test.ts
+++ b/tests/critical-journeys.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const repositoryRoot = resolve(import.meta.dir, "..");
+const contractPath = resolve(repositoryRoot, "docs/product/critical-journeys.json");
+const contract = await Bun.file(contractPath).json();
+const capabilityManifest = Bun.TOML.parse(
+  await Bun.file(resolve(repositoryRoot, "server/capabilities.toml")).text()
+) as { capability: Array<{ id: string; protocols: string[] }> };
+const performanceProfilePath = resolve(repositoryRoot, contract.performanceProfile);
+const performanceProfile = await Bun.file(performanceProfilePath).json();
+
+const expectedClients = ["desktop-web", "android-pwa", "ios", "macos"];
+const expectedTopologies = ["local", "federated"];
+
+const sorted = (values: string[]) => [...values].sort();
+
+async function validateEvidenceReference(reference: Record<string, string>) {
+  expect(["repo-test", "ci-run", "manual-report"]).toContain(reference.type);
+  if (reference.type === "repo-test") {
+    expect(reference.path).toMatch(
+      /^(chat\/tests\/|server\/crates\/(?:[^/]+\/tests\/|waddle-server\/src\/server\/routes\/websocket\/tests\/)|apps\/apple\/.+\/Tests\/|tests\/)/
+    );
+    const path = resolve(repositoryRoot, reference.path);
+    expect(existsSync(path)).toBeTrue();
+    expect(reference.testId).toMatch(/^[A-Za-z][A-Za-z0-9_. :>-]+$/);
+    const source = await Bun.file(path).text();
+    const escapedId = reference.testId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    if (reference.path.endsWith(".rs")) {
+      expect(source).toMatch(new RegExp(`#\\[(?:tokio::)?test\\][\\s\\S]{0,240}(?:async\\s+)?fn\\s+${escapedId}\\s*\\(`));
+    } else if (reference.path.endsWith(".ts")) {
+      expect(source).toMatch(new RegExp(`(?:test|it)\\(\\s*["']${escapedId}["']`));
+    } else if (reference.path.endsWith(".swift")) {
+      const swiftTesting = new RegExp(`@Test[\\s\\S]{0,240}func\\s+${escapedId}\\s*\\(`).test(source);
+      const xctest = /^test[A-Z0-9_]/.test(reference.testId)
+        && new RegExp(`func\\s+${escapedId}\\s*\\(`).test(source);
+      expect(swiftTesting || xctest).toBeTrue();
+    } else if (reference.path.endsWith(".cue")) {
+      expect(source).toMatch(new RegExp(`name:\\s*["']${escapedId}["']`));
+    } else {
+      throw new Error(`unsupported repo-test evidence path: ${reference.path}`);
+    }
+  } else if (reference.type === "ci-run") {
+    expect(reference.url).toMatch(/^https:\/\/github\.com\/waddle-social\/waddle\/actions\/runs\/[0-9]+$/);
+    expect(reference.commit).toMatch(/^[0-9a-f]{40}$/);
+  } else {
+    expect(reference.path).toMatch(/^docs\/evidence\/.+\.md$/);
+    const reportPath = resolve(repositoryRoot, reference.path);
+    expect(existsSync(reportPath)).toBeTrue();
+    expect(reference.sha256).toMatch(/^[0-9a-f]{64}$/);
+    const digest = createHash("sha256").update(readFileSync(reportPath)).digest("hex");
+    expect(reference.sha256).toBe(digest);
+  }
+}
+
+describe("switchable-alternative critical journey contract", () => {
+  test("uses the supported schema and release dimensions", async () => {
+    expect(contract.schemaVersion).toBe(1);
+    expect(contract.milestone).toBe("switchable-alternative");
+    expect(["not-ready", "ready"]).toContain(contract.journeyStatus);
+    expect(Object.keys(contract.gateReadiness).sort()).toEqual(["2", "3", "4"]);
+    for (const status of Object.values(contract.gateReadiness)) {
+      expect(["not-ready", "ready"]).toContain(status);
+    }
+    expect(sorted(contract.dimensions.clients)).toEqual(sorted(expectedClients));
+    expect(sorted(contract.dimensions.topologies)).toEqual(sorted(expectedTopologies));
+    expect(contract.releasePolicy).toBeString();
+    expect(contract.releasePolicy.length).toBeGreaterThan(0);
+    expect(contract.performanceProfile).toBe("docs/product/performance-profile.json");
+    expect(performanceProfile.schemaVersion).toBe(1);
+    expect(performanceProfile.dataset.members).toBe(500);
+    expect(Object.keys(performanceProfile.clients).sort()).toEqual(sorted(expectedClients));
+  });
+
+  test("defines unique, complete, release-blocking scenarios", () => {
+    const journeyIds = contract.journeys.map((journey: { id: string }) => journey.id);
+    expect(new Set(journeyIds).size).toBe(journeyIds.length);
+
+    const scenarioIds = new Set<string>();
+    for (const journey of contract.journeys) {
+      expect(journey.id).toMatch(/^[a-z][a-z0-9-]+$/);
+      expect(journey.title).toBeString();
+      expect(journey.owner).toMatch(/^[a-z][a-z0-9-]+$/);
+      expect(Object.keys(contract.gateReadiness)).toContain(String(journey.gate));
+      expect(journey.clients.length).toBeGreaterThan(0);
+      for (const client of journey.clients) {
+        expect(expectedClients).toContain(client);
+      }
+      expect(journey.topologies.length).toBeGreaterThan(0);
+      for (const topology of journey.topologies) {
+        expect(expectedTopologies).toContain(topology);
+      }
+      expect(journey.requirements.length).toBeGreaterThan(0);
+      expect(["missing", "partial", "complete"]).toContain(journey.evidence.defaultStatus);
+      expect(journey.evidence.requiredKinds.length).toBeGreaterThan(0);
+      expect(new Set(journey.evidence.requiredKinds).size).toBe(journey.evidence.requiredKinds.length);
+
+      const requirementIds = new Set<string>();
+      for (const requirement of journey.requirements) {
+        expect(requirement.id).toMatch(/^[a-z][a-z0-9-]+$/);
+        expect(requirementIds.has(requirement.id)).toBeFalse();
+        requirementIds.add(requirement.id);
+        for (const field of ["given", "when", "then"] as const) {
+          expect(requirement[field]).toBeString();
+          expect(requirement[field].trim().length).toBeGreaterThan(0);
+        }
+
+        for (const client of journey.clients) {
+          for (const topology of journey.topologies) {
+            const scenarioId = `${journey.id}/${requirement.id}/${client}/${topology}`;
+            expect(scenarioIds.has(scenarioId)).toBeFalse();
+            scenarioIds.add(scenarioId);
+          }
+        }
+      }
+    }
+
+    expect(scenarioIds.size).toBeGreaterThanOrEqual(100);
+  });
+
+  test("keeps scenario evidence explicit and blocks an unevidenced release", async () => {
+    const allScenarioIds = new Set<string>();
+    const completeEvidence = new Map<string, Set<string>>();
+
+    for (const journey of contract.journeys) {
+      const journeyScenarioIds = new Set<string>();
+      for (const requirement of journey.requirements) {
+        for (const client of journey.clients) {
+          for (const topology of journey.topologies) {
+            const scenarioId = `${journey.id}/${requirement.id}/${client}/${topology}`;
+            allScenarioIds.add(scenarioId);
+            journeyScenarioIds.add(scenarioId);
+          }
+        }
+      }
+
+      const evidenceKeys = new Set<string>();
+      for (const record of journey.evidence.records) {
+        expect(journeyScenarioIds).toContain(record.scenarioId);
+        expect(["partial", "complete"]).toContain(record.status);
+        expect(journey.evidence.requiredKinds).toContain(record.kind);
+        await validateEvidenceReference(record.reference);
+        if (record.kind === "performance") {
+          expect(record.environment.profileId).toBe("switchable-500-v1");
+          expect(expectedClients).toContain(record.environment.client);
+          const expectedEnvironment = performanceProfile.clients[record.environment.client];
+          expect(expectedEnvironment).toBeDefined();
+          expect(record.environment.hardware).toBe(expectedEnvironment.hardware);
+          expect(record.environment.ramGiB).toBe(expectedEnvironment.ramGiB);
+          expect(record.environment.network).toEqual(performanceProfile.network);
+          expect(record.environment.osVersion).toMatch(/^[A-Za-z0-9][A-Za-z0-9_. -]+$/);
+          expect(record.environment.appCommit).toMatch(/^[0-9a-f]{40}$/);
+          if (["desktop-web", "android-pwa"].includes(record.environment.client)) {
+            expect(record.environment.browserVersion).toMatch(/^[A-Za-z]+\/[0-9]+(?:\.[0-9]+){1,3}$/);
+          }
+        }
+        const key = `${record.scenarioId}/${record.kind}`;
+        expect(evidenceKeys.has(key)).toBeFalse();
+        evidenceKeys.add(key);
+        if (record.status === "complete") {
+          const kinds = completeEvidence.get(record.scenarioId) ?? new Set<string>();
+          kinds.add(record.kind);
+          completeEvidence.set(record.scenarioId, kinds);
+        }
+      }
+
+      if (journey.evidence.defaultStatus === "complete") {
+        expect(journey.evidence.records.length).toBe(journeyScenarioIds.size * journey.evidence.requiredKinds.length);
+      }
+    }
+
+    if (contract.journeyStatus === "ready") {
+      for (const status of Object.values(contract.gateReadiness)) {
+        expect(status).toBe("ready");
+      }
+    }
+
+    for (const [gate, status] of Object.entries(contract.gateReadiness)) {
+      if (status !== "ready") continue;
+      for (const scenarioId of allScenarioIds) {
+        const journeyId = scenarioId.split("/", 1)[0];
+        const journey = contract.journeys.find((entry: { id: string }) => entry.id === journeyId);
+        expect(journey).toBeDefined();
+        if (String(journey.gate) !== gate) continue;
+        const kinds = completeEvidence.get(scenarioId) ?? new Set<string>();
+        for (const requiredKind of journey.evidence.requiredKinds) {
+          expect(kinds).toContain(requiredKind);
+        }
+      }
+    }
+  });
+
+  test("references only vendored XEP specifications", () => {
+    const protocolClaims = [
+      ...contract.journeys.map((journey: { id: string; protocols: string[] }) => journey),
+      ...capabilityManifest.capability
+    ];
+    for (const claim of protocolClaims) {
+      expect(new Set(claim.protocols).size).toBe(claim.protocols.length);
+      for (const protocol of claim.protocols) {
+        expect(protocol).toMatch(/^XEP-[0-9]{4}$/);
+        const number = protocol.slice("XEP-".length);
+        expect(existsSync(resolve(repositoryRoot, `xeps/xep-${number}.xml`))).toBeTrue();
+      }
+    }
+  });
+
+  test("requires typed durable evidence for trust and pilot gates", async () => {
+    const ledgerPath = resolve(repositoryRoot, "docs/product/gate-evidence.json");
+    const ledger = await Bun.file(ledgerPath).json();
+    expect(ledger.schemaVersion).toBe(1);
+    expect(Object.keys(ledger.gates).sort()).toEqual(["0", "1", "5"]);
+
+    for (const gate of Object.values(ledger.gates) as Array<{
+      status: string;
+      requiredKinds: string[];
+      records: Array<{ kind: string; status: string; reference: Record<string, string> }>;
+    }>) {
+      expect(["not-ready", "ready"]).toContain(gate.status);
+      expect(gate.requiredKinds.length).toBeGreaterThan(0);
+      expect(new Set(gate.requiredKinds).size).toBe(gate.requiredKinds.length);
+      const completedKinds = new Set<string>();
+      for (const record of gate.records) {
+        expect(gate.requiredKinds).toContain(record.kind);
+        expect(["partial", "complete"]).toContain(record.status);
+        await validateEvidenceReference(record.reference);
+        if (record.status === "complete") completedKinds.add(record.kind);
+      }
+      if (gate.status === "ready") {
+        for (const kind of gate.requiredKinds) expect(completedKinds).toContain(kind);
+      }
+    }
+  });
+
+  test("covers every release dimension and named critical journey", () => {
+    const clients = new Set<string>();
+    const topologies = new Set<string>();
+    const journeyIds = new Set<string>();
+    for (const journey of contract.journeys) {
+      journeyIds.add(journey.id);
+      journey.clients.forEach((client: string) => clients.add(client));
+      journey.topologies.forEach((topology: string) => topologies.add(topology));
+    }
+
+    expect(sorted([...clients])).toEqual(sorted(expectedClients));
+    expect(sorted([...topologies])).toEqual(sorted(expectedTopologies));
+    expect(journeyIds).toEqual(
+      new Set([
+        "authenticate",
+        "invite-and-join",
+        "room-messaging",
+        "direct-messaging",
+        "history",
+        "unread-state",
+        "notifications",
+        "search",
+        "file-sharing",
+        "threads-and-replies",
+        "reactions",
+        "moderation",
+        "member-lifecycle-and-administration",
+        "admin-operational-health",
+        "calls",
+        "reconnect",
+        "multi-device",
+        "accessibility",
+        "keyboard-navigation",
+        "performance-budgets",
+        "pwa-lifecycle",
+        "federation-interoperability",
+        "federation-failure-isolation"
+      ])
+    );
+  });
+});


### PR DESCRIPTION
## Goal

Establish the enforceable product and release foundation for making Waddle a switchable Slack/Discord alternative for developer communities with 50-500 active members.

## Program plan

The ratified program remains gate-based:

1. Honest capability and critical-journey baseline.
2. Trustworthy daily driver: shared auth state, backups, SLOs, clustered delivery, push, and reconnect.
3. Secure XMPP federation with Prosody, ejabberd, Snikket, and Waddle interoperability.
4. Cross-platform collaboration parity across desktop web, Android PWA, iOS, and macOS.
5. Safe onboarding, administration, member lifecycle, moderation, audit, and operator health.
6. Personalized views, catch-up, community surfaces, and an admin-managed extension ecosystem.

The complete gate definitions, exit metrics, and deferrals are tracked in `docs/planning/switchable-alternative.md`.

## Implemented in this PR

- Added a server capability manifest with explicit server maturity, local/federated topology status, configured availability, advertised runtime features, per-XEP evidence, custom namespaces, and separate server-behavior evidence.
- Added hermetic Rust drift tests that deny unknown manifest fields, verify real server test evidence, and compare claimed features with assembled runtime feature vectors.
- Added a machine-readable critical-journey contract covering authentication, onboarding, messaging, history, notifications, search, files, threads, calls, accessibility, keyboard use, performance, PWA lifecycle, federation interoperability/failure isolation, moderation, administration, and member lifecycle.
- Split desktop web from Android PWA and bound performance evidence to a versioned 500-member dataset, exact hardware/RAM/network profile, resolved OS/browser versions, and application commit.
- Added typed durable evidence rules. Accepted evidence is limited to resolvable repository tests, immutable GitHub Actions runs tied to a commit, or SHA-256-bound manual reports under `docs/evidence`.
- Added a typed Gate 0/1/5 evidence ledger and per-scenario Gate 2/3/4 readiness, coupled bidirectionally to the program tracker.
- Added a root Bun contract that validates release client dimensions and every journey/capability protocol against the lock-pinned XEP corpus.
- Added CUE/CI checks that enforce sequential gates, evidence readiness, program completion rules, artifact drift, and complete cache/affected-task inputs; regenerated the server default and pull-request workflows from CUE.

Gate 0 remains honestly `in-progress`: product telemetry and the baseline evidence records are intentionally not fabricated by this foundation PR.

## Protocol decisions

- XMPP disco remains authoritative; manifest feature claims are checked against assembled runtime feature vectors.
- Official namespaces are tied to the lock-pinned `./xeps` corpus and protocol-specific evidence.
- Conditional call features are marked `configured`, and the custom LiveKit transport is named explicitly.
- Unsupported XEP-0377 server behavior is not claimed by the current capability inventory; it remains a future Gate 4 requirement.
- Full S2S federation is a later gate and is marked unsupported in the current server inventory.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p waddle-server --test server_capability_manifest --locked` (3 passed)
- `cargo clippy -p waddle-server --test server_capability_manifest -- -D warnings`
- `bun test tests/critical-journeys.test.ts` (6 passed, 1375 assertions)
- `nix build .#checks.aarch64-darwin.waddle-server-xmpp-server-tests`
- `cuenv task checkSwitchableAlternativeProgram --skip-dependencies`
- `git diff --check`
- Six adversarial review rounds across protocol/claim honesty, product/release correctness, and CI/maintainability; all reviewers converged with no remaining actionable findings.

CI is the authoritative generated-workflow drift check because it runs the repository-pinned cuenv 0.53.2; the local environment has cuenv 0.54.0.

## Explicit deferrals

Native Android, Slack/Discord import or bridging, enterprise SCIM/SAML suites, legal hold/DLP/EKM, default E2EE, recording, marketplace monetization, public discovery, and broad AI features.
