### PR TITLE
fix(server): push reliability — per-device idempotent retry, janitor claim floor, unread-0 suppression + retry jitter (#1123 #1124 #1126)

### DIFF
--- a/TODO-ISSUES.md
+++ b/TODO-ISSUES.md
@@ -48,7 +48,7 @@ Bundles marked `[one PR]` touch the same files and should land together.
 _Residual (tracked, not #945-gating): survivor-check TOCTOU needs per-call locking → #1148/#1195._
 
 ### Lane C — Push server reliability + conformance
-1. #1123 + #1124 + #1126 `[one PR]` — duplicate/spurious push trio: partial-success retry re-sends delivered devices; janitor sweeps live transient flush claims; suppress at unread=0 + retry jitter. (#1124 also touches `pending_delivery` — coordinate with Lane H work.)
+1. ✅ **#1123 + #1124 + #1126 `[one PR]` — duplicate/spurious push trio: per-device idempotent retry (delivered-device filter + all-delivered→published), janitor claim-recency floor (`claimed_at_ms` + 3-interval floor), unread-0 suppression (typed `Suppressed` outcome + `unread_zero_at_publish` audit reason) + ±25% retry jitter on all three backoff paths. DONE (PR #1236).**
 2. #779 + #780 `[one PR]` — preserve XEP-0359 stanza-id through XEP-0357 publish (SW dedupe is dead by construction); suppress push for XEP-0444 reaction-only messages.
 3. #774 + #772 + #773 + #776 + #777 `[one PR]` — XEP-0357/0050 polish: strict publish-options FORM_TYPE validation, emit SessionExpired, session-lifecycle robustness, single-tx register-device, typed composer errors.
 4. #775 — finish §6 forward cleanup on 410 GONE (device half done; user-server invalidation + client notify remain).

--- a/server/crates/waddle-server/src/notification_outbox/publish.rs
+++ b/server/crates/waddle-server/src/notification_outbox/publish.rs
@@ -237,6 +237,11 @@ impl NotificationOutboxStore {
                 NotificationOutboxPublishOutcome::Failed { .. } => {
                     waddle_xmpp::prometheus::increment_push_outbox_dead_lettered();
                 }
+                NotificationOutboxPublishOutcome::Suppressed { .. } => {
+                    waddle_xmpp::prometheus::increment_push_suppressed(
+                        SuppressedReason::UnreadZeroAtPublish.as_db_value(),
+                    );
+                }
             }
             outcomes.push(outcome);
         }
@@ -329,7 +334,31 @@ impl NotificationOutboxStore {
             });
         }
 
-        let message_count = current_unread_count_for_job(job, inbox_storage).await?;
+        let unread = current_unread_count_for_job(job, inbox_storage).await?;
+        // #1126: the recipient reconnected and read the conversation
+        // inside the notification window — an OS push now would be
+        // for a message they already saw. Drop the job terminally.
+        //
+        // Suppress ONLY when a matching inbox entry EXISTS with
+        // unread 0 (a positive "read it" signal). An ABSENT entry is
+        // NOT the same thing: the inbox projection is written on a
+        // separate, non-atomic path whose failures are swallowed
+        // (`direct_inbox.rs` logs and drops), so "no entry" can mean
+        // "projection lagged or failed", and suppressing there would
+        // compound a partial failure into total notification loss.
+        // Absent entries keep the pre-#1126 behavior: publish with
+        // count 0.
+        if unread == Some(0) {
+            if self.suppress_claimed_job(job).await? {
+                return Ok(NotificationOutboxPublishOutcome::Suppressed {
+                    job_id: job.job_id.clone(),
+                });
+            }
+            return Ok(NotificationOutboxPublishOutcome::RetryScheduled {
+                job_id: job.job_id.clone(),
+            });
+        }
+        let message_count = unread.unwrap_or(0);
         let item = job.to_xep0357_pubsub_item_with_count(message_count);
         let push_service_jid = job.push_service_jid.to_string();
         match push_service
@@ -477,6 +506,36 @@ impl NotificationOutboxStore {
         Ok(affected > 0)
     }
 
+    /// #1126 terminal suppression: delete the claimed job outright.
+    /// Suppression is not a publish (nothing was sent) and not a
+    /// failure (nothing went wrong) — the job simply became moot, so
+    /// no terminal row is kept. The audit trail is the labeled
+    /// `unread_zero_at_publish` prometheus counter incremented by the
+    /// drain loop. The `claim_token` predicate keeps the delete
+    /// at-most-once: a stale claim deletes nothing and reports
+    /// `false`, leaving the final state to the current claim-holder.
+    async fn suppress_claimed_job(
+        &self,
+        job: &NotificationOutboxJob,
+    ) -> Result<bool, NotificationOutboxError> {
+        let affected = self
+            .execute(
+                r#"
+            DELETE FROM notification_outbox
+            WHERE job_id = ?
+              AND status = ?
+              AND claim_token = ?
+            "#,
+                crate::db_params![
+                    job.job_id.as_str(),
+                    STATUS_IN_PROGRESS,
+                    job.claim_token.as_deref(),
+                ],
+            )
+            .await?;
+        Ok(affected > 0)
+    }
+
     async fn mark_job_failed(
         &self,
         job: &NotificationOutboxJob,
@@ -561,10 +620,16 @@ impl NotificationOutboxStore {
     }
 }
 
+/// Current unread count for the job's conversation, or `None` when no
+/// matching inbox entry exists. The distinction is load-bearing for
+/// #1126: `Some(0)` is a positive "recipient read it" signal (the
+/// entry exists, unread was cleared) and suppresses the push; `None`
+/// means "no information" (inbox projection lagged or its write
+/// failed) and must NOT suppress.
 pub(super) async fn current_unread_count_for_job(
     job: &NotificationOutboxJob,
     inbox_storage: &dyn InboxStorage,
-) -> Result<u32, NotificationOutboxError> {
+) -> Result<Option<u32>, NotificationOutboxError> {
     let entries = if job.thread_id.as_str().is_empty() {
         inbox_storage
             .list(job.recipient_bare_jid())
@@ -582,28 +647,79 @@ pub(super) async fn current_unread_count_for_job(
             entry.partner == *job.conversation_jid()
                 && entry.thread_id.as_deref().unwrap_or("") == job.thread_id.as_str()
         })
-        .map(|entry| entry.unread)
-        .unwrap_or(0))
+        .map(|entry| entry.unread))
 }
 
 pub(super) fn retry_delay_ms(attempt_count: i64) -> i64 {
     let exponent = (attempt_count - 1).clamp(0, 10) as u32;
-    BASE_RETRY_DELAY_MS
-        .saturating_mul(2_i64.saturating_pow(exponent))
-        .min(MAX_RETRY_DELAY_MS)
+    apply_retry_jitter(
+        BASE_RETRY_DELAY_MS
+            .saturating_mul(2_i64.saturating_pow(exponent))
+            .min(MAX_RETRY_DELAY_MS),
+    )
 }
 
 pub(super) fn policy_retry_delay_ms(policy_error_count: i64) -> i64 {
     let exponent = (policy_error_count - 1).clamp(0, 10) as u32;
-    BASE_POLICY_RETRY_DELAY_MS
-        .saturating_mul(2_i64.saturating_pow(exponent))
-        .min(MAX_RETRY_DELAY_MS)
+    apply_retry_jitter(
+        BASE_POLICY_RETRY_DELAY_MS
+            .saturating_mul(2_i64.saturating_pow(exponent))
+            .min(MAX_RETRY_DELAY_MS),
+    )
+}
+
+/// #1126: randomize a retry delay by ±25% so a fleet of jobs failed
+/// by one outage does not drain in synchronized waves — deterministic
+/// backoff re-aligns every retry onto the same instant, re-creating
+/// the thundering herd on each cycle.
+pub(super) fn apply_retry_jitter(delay_ms: i64) -> i64 {
+    use rand::RngExt as _;
+    let factor: f64 = rand::rng().random_range(0.75..=1.25);
+    // `as` clamps on overflow and the factor keeps the product within
+    // 1.25x of an i64 that started life as a bounded delay constant.
+    ((delay_ms as f64) * factor) as i64
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::notification_outbox::test_support::*;
+
+    // #1126: exponential backoff carries ±25% jitter so retries after
+    // an outage do not drain in synchronized waves.
+    #[test]
+    fn retry_delays_are_jittered_within_bounds() {
+        let mut distinct = std::collections::HashSet::new();
+        for _ in 0..200 {
+            let delay = retry_delay_ms(1);
+            assert!(
+                (3_750..=6_250).contains(&delay),
+                "attempt-1 jittered delay {delay} outside ±25% of {BASE_RETRY_DELAY_MS}"
+            );
+            distinct.insert(delay);
+
+            let policy_delay = policy_retry_delay_ms(1);
+            assert!(
+                (45_000..=75_000).contains(&policy_delay),
+                "policy jittered delay {policy_delay} outside ±25% of {BASE_POLICY_RETRY_DELAY_MS}"
+            );
+        }
+        assert!(
+            distinct.len() > 1,
+            "200 samples produced a single delay — backoff is not jittered"
+        );
+    }
+
+    // The jitter factor must respect the MAX cap direction too: a
+    // capped delay may exceed the cap by at most +25%.
+    #[test]
+    fn jittered_delay_never_exceeds_cap_plus_jitter() {
+        for attempt in 1..=12 {
+            let delay = retry_delay_ms(attempt);
+            assert!(delay <= (MAX_RETRY_DELAY_MS as f64 * 1.25) as i64);
+            assert!(delay >= (BASE_RETRY_DELAY_MS as f64 * 0.75) as i64);
+        }
+    }
 
     #[tokio::test]
     async fn xep0357_publish_count_is_derived_from_current_inbox_unread() {
@@ -623,7 +739,8 @@ mod tests {
 
         let current_count = current_unread_count_for_job(&claimed, &inbox)
             .await
-            .expect("current unread");
+            .expect("current unread")
+            .expect("inbox entry present");
         let item = claimed.to_xep0357_pubsub_item_with_count(current_count);
         let payload = item.payload.expect("payload");
         let summary = payload

--- a/server/crates/waddle-server/src/notification_outbox/schema.rs
+++ b/server/crates/waddle-server/src/notification_outbox/schema.rs
@@ -35,7 +35,7 @@ const NOTIFICATION_OUTBOX_CLASS_VALUES: [&str; 6] = [
 const NOTIFICATION_OUTBOX_CLASS_CHECK_SQL: &str = "class IN ('dm', 'dm_mention', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')";
 const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_NAME: &str =
     "notification_candidates_suppressed_reason_check";
-pub(super) const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES: [&str; 12] = [
+pub(super) const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES: [&str; 13] = [
     "xep0357_self",
     "xep0357_no_registration",
     "xep0357_registration_disabled",
@@ -48,8 +48,9 @@ pub(super) const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES: [&str; 12] = 
     "provider_rejected",
     "provider_token_expired",
     "xep0357_push_service_degraded",
+    "unread_zero_at_publish",
 ];
-const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_SQL: &str = "suppressed_reason IS NULL OR suppressed_reason IN ('xep0357_self', 'xep0357_no_registration', 'xep0357_registration_disabled', 'xep0492_never', 'xep0492_on_mention_miss', 'xep0191_blocked', 'xep0513_noping', 'xep0513_active_miss', 'waddle_dnd', 'provider_rejected', 'provider_token_expired', 'xep0357_push_service_degraded')";
+const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_SQL: &str = "suppressed_reason IS NULL OR suppressed_reason IN ('xep0357_self', 'xep0357_no_registration', 'xep0357_registration_disabled', 'xep0492_never', 'xep0492_on_mention_miss', 'xep0191_blocked', 'xep0513_noping', 'xep0513_active_miss', 'waddle_dnd', 'provider_rejected', 'provider_token_expired', 'xep0357_push_service_degraded', 'unread_zero_at_publish')";
 const NOTIFICATION_CANDIDATES_INDEXES: [&str; 4] = [
     "idx_notification_candidates_recipient_created",
     "idx_notification_candidates_identity",
@@ -1279,7 +1280,7 @@ mod tests {
 
     #[test]
     fn postgres_suppressed_reason_constraint_match_accepts_current_definition() {
-        let postgres_definition = "CHECK (((suppressed_reason IS NULL) OR ((suppressed_reason)::text = ANY ((ARRAY['xep0357_self'::character varying, 'xep0357_no_registration'::character varying, 'xep0357_registration_disabled'::character varying, 'xep0492_never'::character varying, 'xep0492_on_mention_miss'::character varying, 'xep0191_blocked'::character varying, 'xep0513_noping'::character varying, 'xep0513_active_miss'::character varying, 'waddle_dnd'::character varying, 'provider_rejected'::character varying, 'provider_token_expired'::character varying, 'xep0357_push_service_degraded'::character varying])::text[]))))";
+        let postgres_definition = "CHECK (((suppressed_reason IS NULL) OR ((suppressed_reason)::text = ANY ((ARRAY['xep0357_self'::character varying, 'xep0357_no_registration'::character varying, 'xep0357_registration_disabled'::character varying, 'xep0492_never'::character varying, 'xep0492_on_mention_miss'::character varying, 'xep0191_blocked'::character varying, 'xep0513_noping'::character varying, 'xep0513_active_miss'::character varying, 'waddle_dnd'::character varying, 'provider_rejected'::character varying, 'provider_token_expired'::character varying, 'xep0357_push_service_degraded'::character varying, 'unread_zero_at_publish'::character varying])::text[]))))";
         assert!(
             notification_candidates_suppressed_reason_constraint_matches_expected(
                 postgres_definition

--- a/server/crates/waddle-server/src/notification_outbox/types.rs
+++ b/server/crates/waddle-server/src/notification_outbox/types.rs
@@ -193,6 +193,12 @@ pub(crate) enum SuppressedReason {
     /// this variant is never emitted — the audit shape is in
     /// place for the day one is added.
     Xep0357PushServiceDegraded,
+    /// The conversation's unread count was already 0 when the
+    /// outbox job reached publish — the recipient reconnected and
+    /// read the message inside the notification window, so an OS
+    /// push would be spurious (#1126). Emitted at publish time;
+    /// the job is dropped terminally instead of published.
+    UnreadZeroAtPublish,
 }
 
 impl SuppressedReason {
@@ -217,6 +223,7 @@ impl SuppressedReason {
         Self::ProviderRejected,
         Self::ProviderTokenExpired,
         Self::Xep0357PushServiceDegraded,
+        Self::UnreadZeroAtPublish,
     ];
 
     pub(crate) fn as_db_value(self) -> &'static str {
@@ -233,6 +240,7 @@ impl SuppressedReason {
             Self::ProviderRejected => "provider_rejected",
             Self::ProviderTokenExpired => "provider_token_expired",
             Self::Xep0357PushServiceDegraded => "xep0357_push_service_degraded",
+            Self::UnreadZeroAtPublish => "unread_zero_at_publish",
         }
     }
 
@@ -418,6 +426,12 @@ pub enum NotificationOutboxPublishOutcome {
         job_id: NotificationOutboxJobId,
     },
     Failed {
+        job_id: NotificationOutboxJobId,
+    },
+    /// The job was terminally dropped at publish time because the
+    /// recipient had already read the conversation (unread count 0)
+    /// — pushing would be spurious (#1126).
+    Suppressed {
         job_id: NotificationOutboxJobId,
     },
 }

--- a/server/crates/waddle-server/src/pending_delivery/database.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database.rs
@@ -642,9 +642,14 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         // IS NULL filter ensures we don't trample another session's
         // ongoing claim).
         self.execute(
-            "UPDATE pending_delivery SET flushed_in_session = ?, outbound_sequence = NULL \
+            "UPDATE pending_delivery SET flushed_in_session = ?, outbound_sequence = NULL, \
+                                          claimed_at_ms = ? \
              WHERE recipient_jid = ? AND flushed_in_session IS NULL",
-            crate::db_params![session.as_str().to_string(), recipient.to_string()],
+            crate::db_params![
+                session.as_str().to_string(),
+                chrono::Utc::now().timestamp_millis(),
+                recipient.to_string()
+            ],
         )
         .await?;
         // Return ONLY the rows this claim just tagged, identified by
@@ -722,7 +727,8 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         let mut rows = match after {
             Some(after) => {
                 self.query(
-                    "UPDATE pending_delivery SET flushed_in_session = ?, outbound_sequence = NULL \
+                    "UPDATE pending_delivery SET flushed_in_session = ?, outbound_sequence = NULL, \
+                                                 claimed_at_ms = ? \
                      WHERE flushed_in_session IS NULL AND row_id IN ( \
                          SELECT row_id FROM pending_delivery \
                          WHERE recipient_jid = ? AND flushed_in_session IS NULL AND row_id > ? \
@@ -733,6 +739,7 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
                                flushed_in_session, outbound_sequence",
                     crate::db_params![
                         session.as_str().to_string(),
+                        chrono::Utc::now().timestamp_millis(),
                         recipient.to_string(),
                         after.as_str().to_string(),
                         limit as i64,
@@ -742,7 +749,8 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
             }
             None => {
                 self.query(
-                    "UPDATE pending_delivery SET flushed_in_session = ?, outbound_sequence = NULL \
+                    "UPDATE pending_delivery SET flushed_in_session = ?, outbound_sequence = NULL, \
+                                                 claimed_at_ms = ? \
                      WHERE flushed_in_session IS NULL AND row_id IN ( \
                          SELECT row_id FROM pending_delivery \
                          WHERE recipient_jid = ? AND flushed_in_session IS NULL \
@@ -753,6 +761,7 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
                                flushed_in_session, outbound_sequence",
                     crate::db_params![
                         session.as_str().to_string(),
+                        chrono::Utc::now().timestamp_millis(),
                         recipient.to_string(),
                         limit as i64,
                     ],
@@ -799,7 +808,8 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         // row. (Qodo review on PR #358.)
         self.execute(
             "UPDATE pending_delivery SET flushed_in_session = NULL, \
-                                          outbound_sequence = NULL \
+                                          outbound_sequence = NULL, \
+                                          claimed_at_ms = NULL \
              WHERE flushed_in_session = ?",
             crate::db_params![session.as_str().to_string()],
         )
@@ -809,7 +819,8 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
     async fn release_row(&self, id: &PendingRowId) -> Result<u64, PendingStorageError> {
         self.execute(
             "UPDATE pending_delivery SET flushed_in_session = NULL, \
-                                          outbound_sequence = NULL \
+                                          outbound_sequence = NULL, \
+                                          claimed_at_ms = NULL \
              WHERE row_id = ?",
             crate::db_params![id.as_str().to_string()],
         )
@@ -826,7 +837,8 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         // be stale if a fresh bind re-claims the row before release.
         self.execute(
             "UPDATE pending_delivery SET flushed_in_session = NULL, \
-                                          outbound_sequence = NULL \
+                                          outbound_sequence = NULL, \
+                                          claimed_at_ms = NULL \
              WHERE row_id = ? AND flushed_in_session = ?",
             crate::db_params![
                 id.as_str().to_string(),
@@ -885,6 +897,7 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
     async fn list_orphaned_claims(
         &self,
         live_sessions: &[SmSessionId],
+        claimed_before_ms: i64,
     ) -> Result<Vec<(PendingRowId, SmSessionId)>, PendingStorageError> {
         // SELECT every claimed row, then filter in-memory against the
         // live-set. This avoids generating a `WHERE flushed_in_session
@@ -892,11 +905,17 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         // unbounded for production deployments. The expected orphan
         // population is small (low hundreds) compared to live-session
         // count, so the filter cost is negligible.
+        //
+        // #1124 recency floor: claims stamped after `claimed_before_ms`
+        // belong to in-flight flushes (a `transient:` non-SM flush is
+        // never in the live-set) and are skipped in SQL. Rows with no
+        // stamp (legacy claims) stay release-eligible.
         let mut rows = self
             .query(
                 "SELECT row_id, flushed_in_session FROM pending_delivery \
-                 WHERE flushed_in_session IS NOT NULL",
-                (),
+                 WHERE flushed_in_session IS NOT NULL \
+                   AND (claimed_at_ms IS NULL OR claimed_at_ms <= ?)",
+                crate::db_params![claimed_before_ms],
             )
             .await?;
         let live: std::collections::HashSet<&str> =

--- a/server/crates/waddle-server/src/pending_delivery/database.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database.rs
@@ -908,13 +908,18 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         //
         // #1124 recency floor: claims stamped after `claimed_before_ms`
         // belong to in-flight flushes (a `transient:` non-SM flush is
-        // never in the live-set) and are skipped in SQL. Rows with no
-        // stamp (legacy claims) stay release-eligible.
+        // never in the live-set) and are skipped in SQL. Rows with NO
+        // stamp are skipped too — "recency unknown" (a pre-#1124
+        // binary during a rolling deploy) must not be treated as old,
+        // or the mid-flight release re-opens exactly during the
+        // deploy. The janitor adopts unstamped claims first via
+        // `stamp_unstamped_claims`, so they age into eligibility.
         let mut rows = self
             .query(
                 "SELECT row_id, flushed_in_session FROM pending_delivery \
                  WHERE flushed_in_session IS NOT NULL \
-                   AND (claimed_at_ms IS NULL OR claimed_at_ms <= ?)",
+                   AND claimed_at_ms IS NOT NULL \
+                   AND claimed_at_ms <= ?",
                 crate::db_params![claimed_before_ms],
             )
             .await?;
@@ -937,6 +942,15 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
             }
         }
         Ok(out)
+    }
+
+    async fn stamp_unstamped_claims(&self, now_ms: i64) -> Result<u64, PendingStorageError> {
+        self.execute(
+            "UPDATE pending_delivery SET claimed_at_ms = ? \
+             WHERE flushed_in_session IS NOT NULL AND claimed_at_ms IS NULL",
+            crate::db_params![now_ms],
+        )
+        .await
     }
 
     async fn count(&self, recipient: &BareJid) -> Result<u32, PendingStorageError> {

--- a/server/crates/waddle-server/src/pending_delivery/database/schema.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database/schema.rs
@@ -31,7 +31,8 @@ pub(super) async fn initialize(
             transient_xml TEXT,
             flushed_in_session TEXT,
             outbound_sequence INTEGER,
-            notification_outboxed_at_ms {bigint}
+            notification_outboxed_at_ms {bigint},
+            claimed_at_ms {bigint}
         )
         "#
             ),
@@ -103,6 +104,27 @@ pub(super) async fn initialize(
         let msg = error.to_string().to_lowercase();
         if msg.contains("duplicate column") || msg.contains("already exists") {
             debug!("pending_delivery.notification_outboxed_at_ms column already present");
+        } else {
+            return Err(error);
+        }
+    }
+    // #1124: claim recency stamp. `claim_for_session` /
+    // `claim_batch_for_session` set it alongside `flushed_in_session`;
+    // the release paths clear both together. The claim-expiry janitor
+    // only releases claims older than its recency floor, so an
+    // in-flight non-SM (`transient:`) flush — whose synthetic session
+    // id is never in the live-set — cannot have its claims stolen
+    // mid-flush by an overlapping janitor pass.
+    let alter_sql = match storage.db.driver() {
+        DatabaseDriver::Postgres => {
+            "ALTER TABLE pending_delivery ADD COLUMN IF NOT EXISTS claimed_at_ms BIGINT"
+        }
+        DatabaseDriver::Sqlite => "ALTER TABLE pending_delivery ADD COLUMN claimed_at_ms INTEGER",
+    };
+    if let Err(error) = storage.execute(alter_sql, ()).await {
+        let msg = error.to_string().to_lowercase();
+        if msg.contains("duplicate column") || msg.contains("already exists") {
+            debug!("pending_delivery.claimed_at_ms column already present");
         } else {
             return Err(error);
         }

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -1203,7 +1203,7 @@ async fn list_orphaned_claims_returns_only_dead_session_rows() {
         storage.insert(row).await.unwrap();
     }
     let orphans = storage
-        .list_orphaned_claims(std::slice::from_ref(&session_live))
+        .list_orphaned_claims(std::slice::from_ref(&session_live), i64::MAX)
         .await
         .unwrap();
     assert_eq!(orphans.len(), 1, "only the dead-session row is orphaned");
@@ -1214,7 +1214,7 @@ async fn list_orphaned_claims_returns_only_dead_session_rows() {
     // Releasing the orphan via `release_row` clears the claim.
     storage.release_row(&orphans[0].0).await.unwrap();
     let after = storage
-        .list_orphaned_claims(std::slice::from_ref(&session_live))
+        .list_orphaned_claims(std::slice::from_ref(&session_live), i64::MAX)
         .await
         .unwrap();
     assert!(after.is_empty(), "no orphans after release");
@@ -1234,7 +1234,7 @@ async fn list_orphaned_claims_with_empty_live_set_returns_all_claims() {
         row.flushed_in_session = Some(SmSessionId::new("sm-stream-pre-restart"));
         storage.insert(row).await.unwrap();
     }
-    let orphans = storage.list_orphaned_claims(&[]).await.unwrap();
+    let orphans = storage.list_orphaned_claims(&[], i64::MAX).await.unwrap();
     assert_eq!(orphans.len(), 2);
 }
 
@@ -1485,7 +1485,7 @@ async fn list_orphaned_claims_excludes_active_session_rows() {
 
     // Sweep with active_session in the live set: NOT an orphan.
     let orphans = storage
-        .list_orphaned_claims(std::slice::from_ref(&active_session))
+        .list_orphaned_claims(std::slice::from_ref(&active_session), i64::MAX)
         .await
         .unwrap();
     assert!(
@@ -1499,7 +1499,7 @@ async fn list_orphaned_claims_excludes_active_session_rows() {
     // which would have produced this incorrect result.
     let dead_session = SmSessionId::new("sm-stream-something-else");
     let orphans = storage
-        .list_orphaned_claims(std::slice::from_ref(&dead_session))
+        .list_orphaned_claims(std::slice::from_ref(&dead_session), i64::MAX)
         .await
         .unwrap();
     assert_eq!(
@@ -1549,7 +1549,7 @@ async fn janitor_releases_rows_with_dead_sessions() {
 
     // Janitor sweep step 1: ask for orphans given the live set.
     let orphans = storage
-        .list_orphaned_claims(std::slice::from_ref(&live_session))
+        .list_orphaned_claims(std::slice::from_ref(&live_session), i64::MAX)
         .await
         .unwrap();
     assert_eq!(orphans.len(), 2, "two dead-session rows are orphaned");
@@ -1595,6 +1595,106 @@ async fn janitor_releases_rows_with_dead_sessions() {
     assert!(dead_b.flushed_in_session.is_none());
     let unclaimed = by_body.get("unclaimed").expect("unclaimed present");
     assert!(unclaimed.flushed_in_session.is_none());
+}
+
+// #1124: an in-flight non-SM flush claims rows under a synthetic
+// `transient:` session id that is never in the janitor's live-set.
+// The claim recency floor must keep the janitor's hands off those
+// claims while the flush is running, and still release them once
+// they age past the floor (post-crash orphan recovery).
+#[tokio::test]
+async fn janitor_floor_protects_in_flight_transient_claims() {
+    let storage = InMemoryPendingDeliveryStorage::unlimited();
+    let alice = bare("alice@example.com");
+    for body in ["a", "b"] {
+        storage
+            .insert(transient_row("alice@example.com", body))
+            .await
+            .unwrap();
+    }
+    let transient_session = SmSessionId::new("transient:web-resource:0197fe2a");
+    let claimed = storage
+        .claim_batch_for_session(&alice, &transient_session, None, 10)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 2);
+
+    // Janitor pass with a floor 3 intervals in the past (the
+    // production shape): the just-claimed rows are fresh → skipped,
+    // even though `transient:` is not in the (empty) live-set.
+    let floor_in_past = chrono::Utc::now().timestamp_millis() - 180_000;
+    let orphans = storage
+        .list_orphaned_claims(&[], floor_in_past)
+        .await
+        .unwrap();
+    assert!(
+        orphans.is_empty(),
+        "#1124: an overlapping janitor pass must not release in-flight transient claims"
+    );
+
+    // Once the claim ages past the floor (post-crash scenario,
+    // simulated with a floor in the future), it is release-eligible.
+    let orphans = storage.list_orphaned_claims(&[], i64::MAX).await.unwrap();
+    assert_eq!(
+        orphans.len(),
+        2,
+        "genuinely orphaned claims must still be released after the floor"
+    );
+}
+
+// #1124 DB-backend mirror of the floor contract, including the
+// release path clearing the recency stamp so a released-then-
+// re-claimed row gets a fresh stamp.
+#[tokio::test]
+async fn db_storage_orphan_listing_respects_claim_recency_floor() {
+    let storage = DatabasePendingDeliveryStorage::open(None, QuotaPolicy::Unlimited)
+        .await
+        .unwrap();
+    let alice = bare("alice@example.com");
+    for body in ["a", "b"] {
+        storage
+            .insert(transient_row("alice@example.com", body))
+            .await
+            .unwrap();
+    }
+    let transient_session = SmSessionId::new("transient:web-resource:0197fe2a");
+    let claimed = storage
+        .claim_batch_for_session(&alice, &transient_session, None, 10)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 2);
+
+    let floor_in_past = chrono::Utc::now().timestamp_millis() - 180_000;
+    let orphans = storage
+        .list_orphaned_claims(&[], floor_in_past)
+        .await
+        .unwrap();
+    assert!(
+        orphans.is_empty(),
+        "#1124: fresh transient claims must be invisible to the janitor"
+    );
+
+    let orphans = storage.list_orphaned_claims(&[], i64::MAX).await.unwrap();
+    assert_eq!(orphans.len(), 2, "aged claims are release-eligible");
+    for (row_id, session) in &orphans {
+        assert_eq!(
+            storage
+                .release_row_if_session(row_id, session)
+                .await
+                .unwrap(),
+            1
+        );
+    }
+    // Released rows carry no claim (and no stale recency stamp): a
+    // repeat janitor pass sees nothing.
+    let orphans = storage.list_orphaned_claims(&[], i64::MAX).await.unwrap();
+    assert!(orphans.is_empty(), "release clears the claim + stamp");
+    // And the rows are re-claimable by a recovering resource.
+    let reclaimed = storage
+        .claim_batch_for_session(&alice, &SmSessionId::new("sm-stream-fresh"), None, 10)
+        .await
+        .unwrap();
+    assert_eq!(reclaimed.len(), 2);
 }
 
 #[tokio::test]
@@ -1681,11 +1781,14 @@ async fn flush_blocked_row_releases_claim_when_delete_fails() {
         async fn list_orphaned_claims(
             &self,
             live: &[waddle_xmpp::pending_delivery::SmSessionId],
+            claimed_before_ms: i64,
         ) -> Result<
             Vec<(PendingRowId, waddle_xmpp::pending_delivery::SmSessionId)>,
             PendingStorageError,
         > {
-            self.inner.list_orphaned_claims(live).await
+            self.inner
+                .list_orphaned_claims(live, claimed_before_ms)
+                .await
         }
         async fn count(&self, recipient: &BareJid) -> Result<u32, PendingStorageError> {
             self.inner.count(recipient).await

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -1202,6 +1202,12 @@ async fn list_orphaned_claims_returns_only_dead_session_rows() {
         row.flushed_in_session = session_opt.cloned();
         storage.insert(row).await.unwrap();
     }
+    // Janitor sequence: adopt unstamped claims (these rows were
+    // inserted with the claim pre-set, so no stamp exists), then list.
+    storage
+        .stamp_unstamped_claims(chrono::Utc::now().timestamp_millis())
+        .await
+        .unwrap();
     let orphans = storage
         .list_orphaned_claims(std::slice::from_ref(&session_live), i64::MAX)
         .await
@@ -1234,8 +1240,54 @@ async fn list_orphaned_claims_with_empty_live_set_returns_all_claims() {
         row.flushed_in_session = Some(SmSessionId::new("sm-stream-pre-restart"));
         storage.insert(row).await.unwrap();
     }
+    storage
+        .stamp_unstamped_claims(chrono::Utc::now().timestamp_millis())
+        .await
+        .unwrap();
     let orphans = storage.list_orphaned_claims(&[], i64::MAX).await.unwrap();
     assert_eq!(orphans.len(), 2);
+}
+
+// #1124 mixed-version guard (Greptile review): a claim with NO
+// recency stamp — written by a pre-#1124 binary during a rolling
+// deploy — means "recency unknown" and must NOT be release-eligible
+// until the janitor adopts it, even with an empty live-set and a
+// wide-open floor. Otherwise the mid-flight release re-opens exactly
+// during the deploy window.
+#[tokio::test]
+async fn unstamped_claim_is_skipped_until_adopted() {
+    let storage = InMemoryPendingDeliveryStorage::unlimited();
+    let mut row = transient_row("alice@example.com", "legacy-claimed");
+    row.flushed_in_session = Some(SmSessionId::new("transient:web:legacy"));
+    storage.insert(row).await.unwrap();
+
+    let orphans = storage.list_orphaned_claims(&[], i64::MAX).await.unwrap();
+    assert!(
+        orphans.is_empty(),
+        "an unstamped claim must be invisible until adopted"
+    );
+
+    let adopted = storage
+        .stamp_unstamped_claims(chrono::Utc::now().timestamp_millis())
+        .await
+        .unwrap();
+    assert_eq!(adopted, 1);
+    // Adoption starts the floor clock: still fresh under the
+    // production floor, eligible once aged past it.
+    let floor_in_past = chrono::Utc::now().timestamp_millis() - 180_000;
+    assert!(storage
+        .list_orphaned_claims(&[], floor_in_past)
+        .await
+        .unwrap()
+        .is_empty());
+    assert_eq!(
+        storage
+            .list_orphaned_claims(&[], i64::MAX)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
 }
 
 #[tokio::test]
@@ -1484,6 +1536,10 @@ async fn list_orphaned_claims_excludes_active_session_rows() {
     storage.insert(row).await.unwrap();
 
     // Sweep with active_session in the live set: NOT an orphan.
+    storage
+        .stamp_unstamped_claims(chrono::Utc::now().timestamp_millis())
+        .await
+        .unwrap();
     let orphans = storage
         .list_orphaned_claims(std::slice::from_ref(&active_session), i64::MAX)
         .await
@@ -1547,7 +1603,12 @@ async fn janitor_releases_rows_with_dead_sessions() {
     }
     assert_eq!(storage.count(&alice).await.unwrap(), 4);
 
-    // Janitor sweep step 1: ask for orphans given the live set.
+    // Janitor sweep step 1: adopt unstamped claims, then ask for
+    // orphans given the live set.
+    storage
+        .stamp_unstamped_claims(chrono::Utc::now().timestamp_millis())
+        .await
+        .unwrap();
     let orphans = storage
         .list_orphaned_claims(std::slice::from_ref(&live_session), i64::MAX)
         .await
@@ -1695,6 +1756,72 @@ async fn db_storage_orphan_listing_respects_claim_recency_floor() {
         .await
         .unwrap();
     assert_eq!(reclaimed.len(), 2);
+}
+
+// #1124 mixed-version guard, DB backend: a claim row written by a
+// pre-#1124 binary (flushed_in_session set, claimed_at_ms NULL) must
+// be invisible to the janitor until adopted, then age normally.
+#[tokio::test]
+async fn db_storage_unstamped_claim_is_skipped_until_adopted() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir
+        .path()
+        .join("pending_delivery-unstamped.sqlite")
+        .to_str()
+        .expect("utf-8 path")
+        .to_string();
+    let url = format!("sqlite://{path}");
+    let storage = DatabasePendingDeliveryStorage::open(Some(&url), QuotaPolicy::Unlimited)
+        .await
+        .unwrap();
+    let raw = crate::db::Database::from_config(
+        "pending_delivery_unstamped_raw",
+        &crate::db::DatabaseConfig::new(crate::db::DatabaseDriver::Sqlite, url.clone()),
+    )
+    .await
+    .expect("raw db handle");
+    storage
+        .insert(transient_row("alice@example.com", "legacy"))
+        .await
+        .unwrap();
+    // Simulate the old binary's claim: session tag without a stamp
+    // (claim_batch always stamps in this binary, so write it raw).
+    let conn = raw.guard().await.expect("db guard");
+    conn.execute(
+        "UPDATE pending_delivery SET flushed_in_session = 'transient:web:legacy'",
+        (),
+    )
+    .await
+    .unwrap();
+    drop(conn);
+
+    assert!(
+        storage
+            .list_orphaned_claims(&[], i64::MAX)
+            .await
+            .unwrap()
+            .is_empty(),
+        "unstamped claim must be invisible until adopted"
+    );
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    assert_eq!(storage.stamp_unstamped_claims(now_ms).await.unwrap(), 1);
+    assert!(
+        storage
+            .list_orphaned_claims(&[], now_ms - 180_000)
+            .await
+            .unwrap()
+            .is_empty(),
+        "adopted claim is fresh under the production floor"
+    );
+    assert_eq!(
+        storage
+            .list_orphaned_claims(&[], i64::MAX)
+            .await
+            .unwrap()
+            .len(),
+        1,
+        "adopted claim ages into release-eligibility"
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/push_service/publish_jobs.rs
+++ b/server/crates/waddle-server/src/push_service/publish_jobs.rs
@@ -177,6 +177,47 @@ pub(super) async fn get_publish_job_payload_xml_tx(
     Ok(Some(payload_xml))
 }
 
+/// Device ids that already recorded a terminal-success attempt for
+/// this `(node, item_id)` — `web-delivered` for real Web Push sends,
+/// `fake-sent` for the stubbed APNS/FCM platforms. A retried publish
+/// job filters its fan-out against this set so one transiently
+/// failing sibling does not turn into duplicate OS notifications on
+/// every device that already received the item (#1123).
+pub(super) async fn delivered_device_ids_for_item_tx(
+    tx: &mut crate::db::Transaction<'_>,
+    node: &str,
+    item_id: &str,
+) -> Result<std::collections::HashSet<String>, XmppError> {
+    let mut rows = tx
+        .query(
+            r#"
+            SELECT DISTINCT device_id
+            FROM push_delivery_attempts
+            WHERE node = ? AND item_id = ? AND status IN (?, ?)
+            "#,
+            crate::db_params![
+                node,
+                item_id,
+                super::dispatch::ATTEMPT_STATUS_WEB_DELIVERED,
+                super::dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB,
+            ],
+        )
+        .await
+        .map_err(|error| XmppError::internal(error.to_string()))?;
+    let mut delivered = std::collections::HashSet::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|error| XmppError::internal(error.to_string()))?
+    {
+        let device_id: String = row
+            .get(0)
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        delivered.insert(device_id);
+    }
+    Ok(delivered)
+}
+
 /// Read the row's current `claim_token` so phase 3 can verify the
 /// claim is still ours before persisting any side effects. Returns
 /// `None` when the row was recovered (token cleared) or deleted.
@@ -327,7 +368,14 @@ pub(super) async fn delete_retryable_publish_jobs_for_node_tx(
 }
 
 pub(super) fn retry_at_ms(now_ms: i64) -> i64 {
-    now_ms.saturating_add(PUBLISH_JOB_RETRY_DELAY_MS)
+    // #1126: ±25% jitter so publish jobs requeued by one relay outage
+    // do not all retry on the same 60s beat.
+    let jitter = {
+        use rand::RngExt as _;
+        let factor: f64 = rand::rng().random_range(0.75..=1.25);
+        ((PUBLISH_JOB_RETRY_DELAY_MS as f64) * factor) as i64
+    };
+    now_ms.saturating_add(jitter)
 }
 
 fn decode_publish_job(row: &crate::db::Row) -> Result<PushPublishJob, XmppError> {
@@ -718,6 +766,27 @@ mod tests {
     use crate::push_service::dispatch;
     use crate::push_service::test_support::{notification_item, owner, scalar_i64, store};
     use crate::push_service::{PushDevicePlatform, PushDeviceRegistration};
+
+    // #1126: the requeue delay carries ±25% jitter so a relay outage
+    // does not produce synchronized retry waves on the 60s beat.
+    #[test]
+    fn retry_at_ms_is_jittered_within_bounds() {
+        let now_ms = 1_000_000;
+        let mut seen = std::collections::HashSet::new();
+        for _ in 0..200 {
+            let retry_at = retry_at_ms(now_ms);
+            let delay = retry_at - now_ms;
+            assert!(
+                (45_000..=75_000).contains(&delay),
+                "jittered delay {delay} outside ±25% of {PUBLISH_JOB_RETRY_DELAY_MS}"
+            );
+            seen.insert(delay);
+        }
+        assert!(
+            seen.len() > 1,
+            "200 samples produced a single delay — backoff is not jittered"
+        );
+    }
 
     #[tokio::test]
     async fn publish_job_claim_is_exclusive_after_first_claim_commits() {

--- a/server/crates/waddle-server/src/push_service/publish_jobs.rs
+++ b/server/crates/waddle-server/src/push_service/publish_jobs.rs
@@ -299,6 +299,15 @@ pub(super) async fn prune_delivery_attempts_tx(
     node: &str,
     limit: i64,
 ) -> Result<(), XmppError> {
+    // Terminal-success attempts of a still-retryable job are exempt
+    // from the retention tail (#1123, Greptile review): the per-device
+    // idempotency filter reads `web-delivered`/`fake-sent` rows for
+    // the job's `(node, item_id)` on every retry, so evicting one
+    // mid-retry would re-push the item to a device that already
+    // received it. Only that narrow slice is protected — failure/
+    // transient attempts (pure audit) and attempts of terminal jobs
+    // (published/failed/deleted — no re-dispatch to protect) prune
+    // normally.
     tx.execute(
         r#"
         DELETE FROM push_delivery_attempts
@@ -310,8 +319,26 @@ pub(super) async fn prune_delivery_attempts_tx(
               ORDER BY created_at_ms DESC, attempt_id DESC
               LIMIT ?
           )
+          AND NOT (
+              status IN (?, ?)
+              AND item_id IN (
+                  SELECT item_id
+                  FROM push_publish_jobs
+                  WHERE node = ?
+                    AND status IN (?, ?)
+              )
+          )
         "#,
-        crate::db_params![node, node, limit],
+        crate::db_params![
+            node,
+            node,
+            limit,
+            super::dispatch::ATTEMPT_STATUS_WEB_DELIVERED,
+            super::dispatch::ATTEMPT_STATUS_FAKE_SENT_NON_WEB,
+            node,
+            PUBLISH_JOB_STATUS_QUEUED,
+            PUBLISH_JOB_STATUS_IN_PROGRESS,
+        ],
     )
     .await
     .map_err(|error| XmppError::internal(error.to_string()))?;
@@ -923,5 +950,94 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(item_ids, vec!["item-2", "item-3", "item-4"]);
+    }
+
+    // #1123 (Greptile review): retention pruning must not evict the
+    // delivered-attempt record of a job that is still retryable — the
+    // per-device idempotency filter reads it on the next retry, and
+    // losing it would re-push the item to an already-delivered device.
+    #[tokio::test]
+    async fn delivery_attempt_pruning_exempts_still_retryable_jobs() {
+        let store = store().await;
+        let owner = owner();
+        let node = store.ensure_node(&owner, "web").await.expect("push node");
+        store
+            .upsert_device(
+                &owner,
+                PushDeviceRegistration::new("web-1", node.node(), PushDevicePlatform::Web, "test"),
+            )
+            .await
+            .expect("device");
+        // A QUEUED (retryable) publish job for the oldest item.
+        store
+            .enqueue_notification_publish_job_from_user_server(
+                node.node(),
+                &notification_item("retrying-item"),
+                &owner,
+            )
+            .await
+            .expect("enqueue retryable job");
+        // Oldest attempt belongs to the retryable job; the rest are
+        // newer attempts for terminal (no-job) items.
+        for (idx, item_id) in ["retrying-item", "done-1", "done-2", "done-3", "done-4"]
+            .iter()
+            .enumerate()
+        {
+            store
+                .execute(
+                    r#"
+                    INSERT INTO push_delivery_attempts (
+                        attempt_id,
+                        node,
+                        device_id,
+                        platform,
+                        item_id,
+                        status,
+                        last_error,
+                        created_at_ms
+                    ) VALUES (?, ?, ?, ?, ?, ?, NULL, ?)
+                    "#,
+                    crate::db_params![
+                        format!("attempt-{idx}"),
+                        node.node(),
+                        "web-1",
+                        PushDevicePlatform::Web.to_string(),
+                        item_id.to_string(),
+                        dispatch::ATTEMPT_STATUS_WEB_DELIVERED,
+                        idx as i64,
+                    ],
+                )
+                .await
+                .expect("attempt row");
+        }
+
+        let db = store.database();
+        let mut tx = db.begin().await.expect("transaction");
+        prune_delivery_attempts_tx(&mut tx, node.node(), 2)
+            .await
+            .expect("prune attempts");
+        tx.commit().await.expect("commit prune");
+
+        let attempts = store
+            .delivery_attempts_for_node(node.node())
+            .await
+            .expect("attempts");
+        let item_ids = attempts
+            .iter()
+            .map(|attempt| attempt.item_id())
+            .collect::<Vec<_>>();
+
+        assert!(
+            item_ids.contains(&"retrying-item"),
+            "the retryable job's delivered attempt must survive pruning, got {item_ids:?}"
+        );
+        assert!(
+            item_ids.contains(&"done-3") && item_ids.contains(&"done-4"),
+            "the newest terminal attempts stay within the retention tail"
+        );
+        assert!(
+            !item_ids.contains(&"done-1"),
+            "terminal items past the tail still prune"
+        );
     }
 }

--- a/server/crates/waddle-server/src/push_service/store.rs
+++ b/server/crates/waddle-server/src/push_service/store.rs
@@ -263,6 +263,16 @@ impl DatabasePushServiceStore {
             (),
         )
         .await?;
+        // #1123 retry-path idempotency lookup:
+        // `delivered_device_ids_for_item_tx` filters by
+        // (node, item_id, status) and reads device_id — this covering
+        // index keeps the per-retry query off a node-wide scan.
+        self.execute(
+            "CREATE INDEX IF NOT EXISTS idx_push_delivery_attempts_item_status \
+             ON push_delivery_attempts (node, item_id, status, device_id)",
+            (),
+        )
+        .await?;
         self.execute(
             &format!(
                 r#"

--- a/server/crates/waddle-server/src/push_service/worker.rs
+++ b/server/crates/waddle-server/src/push_service/worker.rs
@@ -75,6 +75,13 @@ struct PublishWorkPhase1 {
     job: PushPublishJob,
     sealed_devices: Vec<dispatch::SealedActiveDevice>,
     payload_xml: String,
+    /// How many active devices were filtered out of this pass because
+    /// an earlier pass already delivered the item to them (#1123).
+    /// Finalize uses this to disable the "all devices returned an
+    /// encoder-bug status" FAILED classification: with a prior
+    /// success, a uniform failure among the REMAINING devices is not
+    /// "all devices" and the job must still complete.
+    prior_delivered_devices: usize,
 }
 
 /// Phase 1 can either continue into phase 2/3 with a [`PublishWorkPhase1`]
@@ -408,6 +415,7 @@ impl DatabasePushServiceStore {
             job,
             sealed_devices,
             payload_xml,
+            prior_delivered_devices,
         } = phase1;
 
         // ---- Phase 2: outside any tx — encrypt, sign, and send.
@@ -447,8 +455,14 @@ impl DatabasePushServiceStore {
 
         // ---- Phase 3: tx2 — record attempts and finalize the job.
         let attempted_devices = attempts.len();
-        self.finalize_publish_job(&job, &attempts, retention_limit, now_ms)
-            .await?;
+        self.finalize_publish_job(
+            &job,
+            &attempts,
+            prior_delivered_devices,
+            retention_limit,
+            now_ms,
+        )
+        .await?;
         Ok(Some(PushFanoutResult {
             item_id: job.item_id().to_string(),
             attempted_devices,
@@ -590,10 +604,12 @@ impl DatabasePushServiceStore {
         // by earlier passes.
         let already_delivered =
             delivered_device_ids_for_item_tx(&mut tx, job.node(), job.item_id()).await?;
+        let device_count_before_filter = sealed_devices.len();
         let sealed_devices: Vec<_> = sealed_devices
             .into_iter()
             .filter(|device| !already_delivered.contains(&device.device_id))
             .collect();
+        let prior_delivered_devices = device_count_before_filter - sealed_devices.len();
         if sealed_devices.is_empty() {
             // Every remaining active device already received this
             // item (the failing sibling was disabled or unregistered
@@ -648,6 +664,7 @@ impl DatabasePushServiceStore {
             job,
             sealed_devices,
             payload_xml,
+            prior_delivered_devices,
         }))
     }
 
@@ -754,6 +771,7 @@ impl DatabasePushServiceStore {
         &self,
         job: &PushPublishJob,
         attempts: &[DispatchedAttempt],
+        prior_delivered_devices: usize,
         retention_limit: i64,
         now_ms: i64,
     ) -> Result<(), XmppError> {
@@ -946,7 +964,16 @@ impl DatabasePushServiceStore {
                 .await
                 .map_err(|error| XmppError::internal(error.to_string()))?;
             }
-        } else if let Some(uniform_status) = all_attempts_with_encoder_bug_signature(attempts) {
+        } else if let Some(uniform_status) = all_attempts_with_encoder_bug_signature(attempts)
+            .filter(|_| prior_delivered_devices == 0)
+        {
+            // The `prior_delivered_devices == 0` guard (#1123, Codex
+            // review): on a retry whose fan-out excluded devices that
+            // already received the item, a uniform encoder-bug status
+            // among the REMAINING devices is not "all devices" — the
+            // payload demonstrably encoded and delivered for a
+            // sibling, so the job completes as PUBLISHED (same
+            // outcome a single mixed-result pass would produce).
             // Every device returned the same encoder-bug status —
             // either all `web-bad-request` (the relay rejected our
             // payload shape) or all `web-payload-too-large` (every

--- a/server/crates/waddle-server/src/push_service/worker.rs
+++ b/server/crates/waddle-server/src/push_service/worker.rs
@@ -14,12 +14,13 @@ use super::devices::{active_devices_with_subscription_for_node_tx, mark_device_d
 use super::dispatch;
 use super::nodes::get_node_tx;
 use super::publish_jobs::{
-    claim_publish_job_tx, get_publish_job_payload_xml_tx, get_publish_job_tx,
-    mark_publish_job_failed_tx, prune_delivery_attempts_tx, prune_publish_jobs_tx,
-    read_publish_job_attempt_count_tx, read_publish_job_claim_token_tx, retry_at_ms,
-    MAX_DELIVERY_ATTEMPTS_PER_NODE, MAX_PUBLISH_JOBS_PER_NODE, PUBLISH_JOB_ERROR_NO_ACTIVE_DEVICES,
-    PUBLISH_JOB_MAX_RETRY_AFTER_MS, PUBLISH_JOB_MAX_TRANSIENT_ATTEMPTS, PUBLISH_JOB_STATUS_FAILED,
-    PUBLISH_JOB_STATUS_IN_PROGRESS, PUBLISH_JOB_STATUS_PUBLISHED, PUBLISH_JOB_STATUS_QUEUED,
+    claim_publish_job_tx, delivered_device_ids_for_item_tx, get_publish_job_payload_xml_tx,
+    get_publish_job_tx, mark_publish_job_failed_tx, prune_delivery_attempts_tx,
+    prune_publish_jobs_tx, read_publish_job_attempt_count_tx, read_publish_job_claim_token_tx,
+    retry_at_ms, MAX_DELIVERY_ATTEMPTS_PER_NODE, MAX_PUBLISH_JOBS_PER_NODE,
+    PUBLISH_JOB_ERROR_NO_ACTIVE_DEVICES, PUBLISH_JOB_MAX_RETRY_AFTER_MS,
+    PUBLISH_JOB_MAX_TRANSIENT_ATTEMPTS, PUBLISH_JOB_STATUS_FAILED, PUBLISH_JOB_STATUS_IN_PROGRESS,
+    PUBLISH_JOB_STATUS_PUBLISHED, PUBLISH_JOB_STATUS_QUEUED,
 };
 use super::registration::ensure_active_registration_tx;
 use super::secrets::PushSecretCipher;
@@ -570,6 +571,56 @@ impl DatabasePushServiceStore {
                     now_ms,
                     job.job_id().to_string(),
                     PUBLISH_JOB_STATUS_IN_PROGRESS,
+                ],
+            )
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+            tx.commit()
+                .await
+                .map_err(|error| XmppError::internal(error.to_string()))?;
+            return Ok(Phase1Outcome::ShortCircuit(Some(PushFanoutResult {
+                item_id: job.item_id().to_string(),
+                attempted_devices: 0,
+            })));
+        }
+        // #1123 per-device idempotency: a requeued job (one sibling
+        // failed transiently) must not fan out again to devices whose
+        // attempt for this same item already succeeded. Filter the
+        // dispatch set against the terminal-success attempts recorded
+        // by earlier passes.
+        let already_delivered =
+            delivered_device_ids_for_item_tx(&mut tx, job.node(), job.item_id()).await?;
+        let sealed_devices: Vec<_> = sealed_devices
+            .into_iter()
+            .filter(|device| !already_delivered.contains(&device.device_id))
+            .collect();
+        if sealed_devices.is_empty() {
+            // Every remaining active device already received this
+            // item (the failing sibling was disabled or unregistered
+            // between retries). The job is complete — finalize as
+            // PUBLISHED instead of spinning in the no-active-devices
+            // requeue loop. The `claim_token` predicate keeps the
+            // transition at-most-once (see `finalize_publish_job`).
+            tx.execute(
+                r#"
+                UPDATE push_publish_jobs
+                SET status = ?,
+                    attempt_count = attempt_count + 1,
+                    last_error = NULL,
+                    next_retry_at_ms = NULL,
+                    claimed_at_ms = NULL,
+                    claim_token = NULL,
+                    updated_at_ms = ?,
+                    published_at_ms = ?
+                WHERE job_id = ? AND status = ? AND claim_token = ?
+                "#,
+                crate::db_params![
+                    PUBLISH_JOB_STATUS_PUBLISHED,
+                    now_ms,
+                    now_ms,
+                    job.job_id().to_string(),
+                    PUBLISH_JOB_STATUS_IN_PROGRESS,
+                    job.claim_token().to_string(),
                 ],
             )
             .await

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -1186,6 +1186,12 @@ mod orphan_reaper_sweep_tests {
     }
 }
 
+/// #1124: how many janitor intervals a claim must age before the
+/// claim-expiry janitor may release it. Three intervals (180s at the
+/// default 60s cadence) comfortably outlasts an in-flight flush batch
+/// while keeping post-crash orphan recovery prompt.
+const PENDING_CLAIM_RELEASE_FLOOR_INTERVALS: i64 = 3;
+
 pub(crate) fn spawn_pending_delivery_claim_janitor(websocket_state: &Arc<WebSocketState>) {
     // pending_delivery claim-expiry janitor (issue #209 slice (d)
     // phase 6 / PR #360): catches claims whose session no longer exists.
@@ -1232,11 +1238,25 @@ pub(crate) fn spawn_pending_delivery_claim_janitor(websocket_state: &Arc<WebSock
                 .active_sm_stream_ids();
             let mut live_sessions = detached_live;
             live_sessions.extend(active_live);
+            // #1124 claim recency floor: only release claims older
+            // than several janitor intervals. Non-SM flushes claim
+            // rows under a synthetic `transient:` session id that is
+            // never in the live-set; without the floor, a janitor
+            // pass overlapping an in-flight flush releases its claims
+            // mid-flight and a second resource re-pushes the same
+            // offline messages. Fresh claims are skipped this pass and
+            // re-examined on later sweeps, so genuinely orphaned
+            // (post-crash) claims are still released — just a few
+            // intervals later.
+            let claim_release_floor_ms = (interval_secs as i64)
+                .saturating_mul(1_000)
+                .saturating_mul(PENDING_CLAIM_RELEASE_FLOOR_INTERVALS);
+            let claimed_before_ms = chrono::Utc::now().timestamp_millis() - claim_release_floor_ms;
             match state
                 .deps
                 .protocol
                 .pending_delivery_storage
-                .list_orphaned_claims(&live_sessions)
+                .list_orphaned_claims(&live_sessions, claimed_before_ms)
                 .await
             {
                 Ok(orphans) if !orphans.is_empty() => {

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -1248,10 +1248,34 @@ pub(crate) fn spawn_pending_delivery_claim_janitor(websocket_state: &Arc<WebSock
             // re-examined on later sweeps, so genuinely orphaned
             // (post-crash) claims are still released — just a few
             // intervals later.
-            let claim_release_floor_ms = (interval_secs as i64)
+            let claim_release_floor_ms = i64::try_from(interval_secs)
+                .unwrap_or(i64::MAX)
                 .saturating_mul(1_000)
                 .saturating_mul(PENDING_CLAIM_RELEASE_FLOOR_INTERVALS);
-            let claimed_before_ms = chrono::Utc::now().timestamp_millis() - claim_release_floor_ms;
+            let now_ms = chrono::Utc::now().timestamp_millis();
+            let claimed_before_ms = now_ms.saturating_sub(claim_release_floor_ms);
+            // Adopt claims written without a recency stamp (a
+            // pre-#1124 binary during a rolling deploy) so they age
+            // into release-eligibility instead of being skipped
+            // forever — `list_orphaned_claims` ignores unstamped rows.
+            match state
+                .deps
+                .protocol
+                .pending_delivery_storage
+                .stamp_unstamped_claims(now_ms)
+                .await
+            {
+                Ok(adopted) if adopted > 0 => {
+                    debug!(
+                        adopted,
+                        "claim-expiry janitor: adopted unstamped pending_delivery claims"
+                    );
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    warn!(error = %error, "claim-expiry janitor: stamp_unstamped_claims failed");
+                }
+            }
             match state
                 .deps
                 .protocol

--- a/server/crates/waddle-server/src/sm_promotion/tests.rs
+++ b/server/crates/waddle-server/src/sm_promotion/tests.rs
@@ -199,6 +199,7 @@ impl PendingDeliveryStorage for AlwaysFailingPending {
     async fn list_orphaned_claims(
         &self,
         _live_sessions: &[waddle_xmpp::pending_delivery::SmSessionId],
+        _claimed_before_ms: i64,
     ) -> Result<
         Vec<(
             waddle_xmpp::pending_delivery::PendingRowId,
@@ -1874,6 +1875,7 @@ impl PendingDeliveryStorage for RetractDuringInsertPending {
     async fn list_orphaned_claims(
         &self,
         live_sessions: &[waddle_xmpp::pending_delivery::SmSessionId],
+        claimed_before_ms: i64,
     ) -> Result<
         Vec<(
             waddle_xmpp::pending_delivery::PendingRowId,
@@ -1881,7 +1883,9 @@ impl PendingDeliveryStorage for RetractDuringInsertPending {
         )>,
         waddle_xmpp::pending_delivery::storage::PendingStorageError,
     > {
-        self.inner.list_orphaned_claims(live_sessions).await
+        self.inner
+            .list_orphaned_claims(live_sessions, claimed_before_ms)
+            .await
     }
     async fn count(
         &self,
@@ -2088,6 +2092,7 @@ impl PendingDeliveryStorage for FlakyPending {
     async fn list_orphaned_claims(
         &self,
         live_sessions: &[waddle_xmpp::pending_delivery::SmSessionId],
+        claimed_before_ms: i64,
     ) -> Result<
         Vec<(
             waddle_xmpp::pending_delivery::PendingRowId,
@@ -2095,7 +2100,9 @@ impl PendingDeliveryStorage for FlakyPending {
         )>,
         waddle_xmpp::pending_delivery::storage::PendingStorageError,
     > {
-        self.inner.list_orphaned_claims(live_sessions).await
+        self.inner
+            .list_orphaned_claims(live_sessions, claimed_before_ms)
+            .await
     }
     async fn count(
         &self,

--- a/server/crates/waddle-server/tests/notification_outbox/publish.rs
+++ b/server/crates/waddle-server/tests/notification_outbox/publish.rs
@@ -418,6 +418,302 @@ async fn stale_claim_does_not_enqueue_push_service_publish_job() {
     assert_eq!(pending[0].claim_token(), fresh_claim.claim_token());
 }
 
+/// Full first-party Push Service setup (node, device, first-party +
+/// XEP-0357 registrations) for tests that drive `publish_claimed_job`
+/// end-to-end. Returns the push service store, the subscription
+/// store, and an outbox target aimed at the provisioned node.
+async fn first_party_push_setup(
+    recipient: &jid::BareJid,
+) -> (
+    waddle_server::push_service::DatabasePushServiceStore,
+    waddle_xmpp::push::InMemoryPushStore,
+    NotificationOutboxTarget,
+) {
+    let push_service = waddle_server::push_service::DatabasePushServiceStore::new_with_secret_key(
+        Database::in_memory("push-service").await.unwrap(),
+        b"waddle-push-service-test-secret-key",
+    )
+    .await
+    .expect("push service");
+    waddle_server::push_registrations::DatabasePushRegistrationStore::new(push_service.database())
+        .await
+        .expect("push registration schema");
+    let push_node = push_service
+        .ensure_node(recipient, "web")
+        .await
+        .expect("push node");
+    push_service
+        .upsert_device(
+            recipient,
+            waddle_server::push_service::PushDeviceRegistration::new(
+                "web-1",
+                push_node.node(),
+                waddle_server::push_service::PushDevicePlatform::Web,
+                "test",
+            ),
+        )
+        .await
+        .expect("push device");
+    push_service
+        .register_first_party_node_for_owner(recipient, "push.example.com", push_node.node(), None)
+        .await
+        .expect("first-party registration");
+    let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+    push_store
+        .register(waddle_xmpp::push::PushSubscription {
+            user_jid: recipient.to_string(),
+            service_jid: "push.example.com".to_string(),
+            node: Some(push_node.node().to_string()),
+            publish_options: None,
+            endpoint: None,
+            p256dh: None,
+            auth_key: None,
+        })
+        .await
+        .expect("xep0357 registration");
+    let target = NotificationOutboxTarget::new(
+        bare("push.example.com"),
+        PushServiceNodeName::new(push_node.node()).expect("push node target"),
+    );
+    (push_service, push_store, target)
+}
+
+/// Inbox with one entry for `conversation` whose unread count is 0 —
+/// the positive "recipient read it" signal (#1126 suppression
+/// requires the entry to EXIST; absence means "no information").
+async fn inbox_with_read_entry(
+    recipient: &jid::BareJid,
+    conversation: &jid::BareJid,
+    kind: waddle_xmpp::inbox::ConversationKind,
+) -> waddle_xmpp::inbox::storage::InMemoryInboxStorage {
+    use waddle_xmpp::inbox::storage::InboxStorage as _;
+    let inbox = waddle_xmpp::inbox::storage::InMemoryInboxStorage::new();
+    inbox
+        .upsert(
+            recipient,
+            waddle_xmpp::inbox::InboxEntry::new(
+                conversation.clone(),
+                kind,
+                "archive-read".to_string(),
+                1,
+            ),
+            false,
+        )
+        .await
+        .expect("upsert read entry");
+    inbox
+}
+
+// #1126: a user who reconnects and reads the message inside the
+// notification window must not get an OS push for it. At publish
+// time the conversation's inbox entry exists with unread 0 →
+// suppress, terminally.
+#[tokio::test]
+async fn unread_zero_job_is_suppressed_not_published() {
+    let store = store().await;
+    let recipient = bare("alice@example.com");
+    let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+    let (push_service, push_store, target) = first_party_push_setup(&recipient).await;
+    enqueue_jobs_for_test(&store, &candidate("archive-1"), &[target]).await;
+    let claimed = store
+        .claim_due_outbox_jobs(16)
+        .await
+        .expect("claim")
+        .into_iter()
+        .next()
+        .expect("claimed job");
+    // Recipient read everything before the outbox drained: the entry
+    // exists and its unread count was cleared to 0.
+    let inbox = inbox_with_read_entry(
+        &recipient,
+        &bare("bob@example.com"),
+        waddle_xmpp::inbox::ConversationKind::Direct,
+    )
+    .await;
+
+    let outcome = store
+        .publish_claimed_job(
+            &claimed,
+            &push_service,
+            &push_store,
+            &inbox,
+            &blocking,
+            &bare("push.example.com"),
+        )
+        .await
+        .expect("publish");
+
+    assert!(
+        matches!(outcome, NotificationOutboxPublishOutcome::Suppressed { .. }),
+        "#1126: unread-count 0 at publish time must suppress, got {outcome:?}"
+    );
+    assert!(
+        push_service
+            .queued_publish_jobs()
+            .await
+            .expect("queued push jobs")
+            .is_empty(),
+        "a suppressed job must not enqueue a durable Push Service publish job"
+    );
+    assert!(
+        store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty(),
+        "suppression is terminal — the job must not stay queued or retry"
+    );
+}
+
+// #1126 safety valve: an ABSENT inbox entry is "no information", not
+// "read". The inbox projection is written on a separate path whose
+// failures are swallowed, so suppressing on absence would turn a
+// transient projection failure into total notification loss. Absent
+// entries keep the pre-#1126 behavior: publish (with count 0).
+#[tokio::test]
+async fn missing_inbox_entry_still_publishes() {
+    let store = store().await;
+    let recipient = bare("alice@example.com");
+    let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+    let (push_service, push_store, target) = first_party_push_setup(&recipient).await;
+    enqueue_jobs_for_test(&store, &candidate("archive-1"), &[target]).await;
+    let claimed = store
+        .claim_due_outbox_jobs(16)
+        .await
+        .expect("claim")
+        .into_iter()
+        .next()
+        .expect("claimed job");
+    // No inbox entry at all for the conversation (projection lagged
+    // or its write failed).
+    let inbox = waddle_xmpp::inbox::storage::InMemoryInboxStorage::new();
+
+    let outcome = store
+        .publish_claimed_job(
+            &claimed,
+            &push_service,
+            &push_store,
+            &inbox,
+            &blocking,
+            &bare("push.example.com"),
+        )
+        .await
+        .expect("publish");
+
+    assert!(
+        matches!(outcome, NotificationOutboxPublishOutcome::Published { .. }),
+        "an absent inbox entry must NOT suppress the push, got {outcome:?}"
+    );
+    assert_eq!(
+        push_service
+            .queued_publish_jobs()
+            .await
+            .expect("queued push jobs")
+            .len(),
+        1
+    );
+}
+
+// #1126 groupchat coverage: mention classes resolve their unread via
+// the MUC room's inbox entry — a read room entry (unread 0) must
+// suppress just like the DM path.
+#[tokio::test]
+async fn read_channel_mention_job_is_suppressed() {
+    let store = store().await;
+    let recipient = bare("alice@example.com");
+    let room = bare("room@conference.example.com");
+    let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+    let (push_service, push_store, target) = first_party_push_setup(&recipient).await;
+    let candidate = groupchat_candidate_for(
+        &recipient,
+        &room,
+        "room@conference.example.com/bob".parse().expect("occupant"),
+        "archive-mention-1",
+        NotificationClass::PersonalMention,
+    );
+    enqueue_jobs_for_test(&store, &candidate, &[target]).await;
+    let claimed = store
+        .claim_due_outbox_jobs(16)
+        .await
+        .expect("claim")
+        .into_iter()
+        .next()
+        .expect("claimed job");
+    let inbox = inbox_with_read_entry(
+        &recipient,
+        &room,
+        waddle_xmpp::inbox::ConversationKind::MucRoom,
+    )
+    .await;
+
+    let outcome = store
+        .publish_claimed_job(
+            &claimed,
+            &push_service,
+            &push_store,
+            &inbox,
+            &blocking,
+            &bare("push.example.com"),
+        )
+        .await
+        .expect("publish");
+
+    assert!(
+        matches!(outcome, NotificationOutboxPublishOutcome::Suppressed { .. }),
+        "#1126: a read MUC room entry must suppress a mention push, got {outcome:?}"
+    );
+    assert!(push_service
+        .queued_publish_jobs()
+        .await
+        .expect("queued push jobs")
+        .is_empty());
+}
+
+// #1126 companion: a genuinely offline recipient (unread >= 1) still
+// gets the push — suppression only applies to already-read messages.
+#[tokio::test]
+async fn unread_nonzero_job_still_publishes() {
+    let store = store().await;
+    let recipient = bare("alice@example.com");
+    let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+    let (push_service, push_store, target) = first_party_push_setup(&recipient).await;
+    enqueue_jobs_for_test(&store, &candidate("archive-1"), &[target]).await;
+    let claimed = store
+        .claim_due_outbox_jobs(16)
+        .await
+        .expect("claim")
+        .into_iter()
+        .next()
+        .expect("claimed job");
+    let inbox = inbox_with_unread(&recipient, &bare("bob@example.com"), 2).await;
+
+    let outcome = store
+        .publish_claimed_job(
+            &claimed,
+            &push_service,
+            &push_store,
+            &inbox,
+            &blocking,
+            &bare("push.example.com"),
+        )
+        .await
+        .expect("publish");
+
+    assert!(
+        matches!(outcome, NotificationOutboxPublishOutcome::Published { .. }),
+        "legitimate offline pushes must still fire, got {outcome:?}"
+    );
+    assert_eq!(
+        push_service
+            .queued_publish_jobs()
+            .await
+            .expect("queued push jobs")
+            .len(),
+        1,
+        "an unread conversation must enqueue the durable Push Service publish job"
+    );
+}
+
 #[tokio::test]
 async fn new_candidate_after_claim_creates_fresh_queued_job() {
     let store = store().await;

--- a/server/crates/waddle-server/tests/push_service_web_push_dispatch.rs
+++ b/server/crates/waddle-server/tests/push_service_web_push_dispatch.rs
@@ -89,6 +89,54 @@ impl WebPushSender for FixedOutcomeSender {
     }
 }
 
+/// A `WebPushSender` that picks its outcome by matching the request
+/// endpoint against a configured substring, and records every
+/// endpoint it was invoked for so tests can assert exactly which
+/// devices were (re-)dispatched.
+#[derive(Clone)]
+struct PerEndpointSender {
+    outcomes: Arc<Vec<(String, WebPushOutcome)>>,
+    calls: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+impl PerEndpointSender {
+    fn new(outcomes: Vec<(String, WebPushOutcome)>) -> Self {
+        Self {
+            outcomes: Arc::new(outcomes),
+            calls: Arc::new(std::sync::Mutex::new(Vec::new())),
+        }
+    }
+
+    fn calls_matching(&self, endpoint_fragment: &str) -> usize {
+        self.calls
+            .lock()
+            .expect("calls lock")
+            .iter()
+            .filter(|endpoint| endpoint.contains(endpoint_fragment))
+            .count()
+    }
+}
+
+impl WebPushSender for PerEndpointSender {
+    fn send(
+        &self,
+        request: WebPushRequest<'_>,
+    ) -> Pin<Box<dyn Future<Output = WebPushOutcome> + Send + '_>> {
+        let endpoint = request.endpoint.to_string();
+        self.calls
+            .lock()
+            .expect("calls lock")
+            .push(endpoint.clone());
+        let outcome = self
+            .outcomes
+            .iter()
+            .find(|(fragment, _)| endpoint.contains(fragment.as_str()))
+            .map(|(_, outcome)| outcome.clone())
+            .unwrap_or(WebPushOutcome::Delivered { status: 201 });
+        Box::pin(async move { outcome })
+    }
+}
+
 /// Build a Web Push-shape `<notification>` payload with the typed
 /// `urn:waddle:push:context:0` element the chat publisher emits.
 /// `class` is the db-form value (e.g. `"dm"`, `"personal_mention"`).
@@ -165,6 +213,12 @@ fn fresh_subscription_material() -> (String, String) {
 async fn store_with_web_push_provider(
     outcome: WebPushOutcome,
 ) -> (DatabasePushServiceStore, FixedOutcomeSender) {
+    let sender = FixedOutcomeSender::new(outcome);
+    let store = store_with_web_push_sender(Arc::new(sender.clone())).await;
+    (store, sender)
+}
+
+async fn store_with_web_push_sender(sender: Arc<dyn WebPushSender>) -> DatabasePushServiceStore {
     let db = Database::in_memory("push-service-web-push")
         .await
         .expect("db");
@@ -177,11 +231,8 @@ async fn store_with_web_push_provider(
     let signer = VapidStorage::load_or_provision(db, b"root-key")
         .await
         .expect("VAPID signer");
-    let sender = FixedOutcomeSender::new(outcome);
-    let sender_arc: Arc<dyn WebPushSender> = Arc::new(sender.clone());
     let sub = VapidSub::default_for_domain("example.com").expect("vapid sub");
-    let store = store.with_web_push_provider(signer, sender_arc, sub);
-    (store, sender)
+    store.with_web_push_provider(signer, sender, sub)
 }
 
 async fn device_status(store: &DatabasePushServiceStore, node: &str, device_id: &str) -> String {
@@ -334,6 +385,169 @@ async fn transient_outcome_keeps_device_active_and_requeues() {
         device_status(&store, node.node(), "web-1").await,
         DEVICE_STATUS_ACTIVE,
         "Transient outcomes must keep the device active — XEP-0357 §6 disable applies only to permanent failures"
+    );
+}
+
+/// Register a fresh active web device with valid subscription
+/// material whose endpoint contains `endpoint_fragment`.
+async fn register_web_device(
+    store: &DatabasePushServiceStore,
+    owner: &BareJid,
+    node: &str,
+    device_id: &str,
+    endpoint_fragment: &str,
+) {
+    let (p256dh, auth) = fresh_subscription_material();
+    store
+        .upsert_device(
+            owner,
+            PushDeviceRegistration::new(device_id, node, PushDevicePlatform::Web, "test")
+                .with_provider_endpoint(Some(format!(
+                    "https://push.example.com/{endpoint_fragment}"
+                )))
+                .with_provider_token(Some(auth))
+                .with_provider_key_material(Some(p256dh)),
+        )
+        .await
+        .expect("device");
+}
+
+/// Make every queued publish job immediately retry-eligible.
+async fn force_retry_eligibility(store: &DatabasePushServiceStore) {
+    let db = store.database();
+    let conn = db.guard().await.expect("db guard");
+    conn.execute("UPDATE push_publish_jobs SET next_retry_at_ms = 0", ())
+        .await
+        .expect("reset retry deadline");
+}
+
+// #1123: a retried publish job must not re-push to devices whose
+// previous attempt for the same item already succeeded — one
+// rate-limited sibling must not turn into duplicate OS notifications
+// on every other device sharing the node.
+#[tokio::test]
+async fn retried_job_skips_devices_already_delivered() {
+    let sender = PerEndpointSender::new(vec![
+        (
+            "delivered-device".to_string(),
+            WebPushOutcome::Delivered { status: 201 },
+        ),
+        (
+            "flaky-device".to_string(),
+            WebPushOutcome::Transient {
+                kind: waddle_xmpp::push::types::TransientFailure::Network,
+            },
+        ),
+    ]);
+    let store = store_with_web_push_sender(Arc::new(sender.clone())).await;
+    let owner = owner();
+    let node = store.ensure_node(&owner, "web").await.expect("node");
+    register_web_device(&store, &owner, node.node(), "web-ok", "delivered-device").await;
+    register_web_device(&store, &owner, node.node(), "web-flaky", "flaky-device").await;
+    store
+        .publish_notification_from_user_server(
+            node.node(),
+            &web_push_notification_item("partial-item-1", "alice@example.com", "dm", 1),
+            &owner,
+        )
+        .await
+        .expect("publish");
+
+    store
+        .drain_queued_notification_publish_jobs(16)
+        .await
+        .expect("first drain");
+    assert_eq!(sender.calls_matching("delivered-device"), 1);
+    assert_eq!(sender.calls_matching("flaky-device"), 1);
+
+    force_retry_eligibility(&store).await;
+    store
+        .drain_queued_notification_publish_jobs(16)
+        .await
+        .expect("retry drain");
+
+    assert_eq!(
+        sender.calls_matching("delivered-device"),
+        1,
+        "#1123: the already-delivered device must not receive a duplicate web-push on retry"
+    );
+    assert_eq!(
+        sender.calls_matching("flaky-device"),
+        2,
+        "the transiently-failing device must still be retried"
+    );
+}
+
+// #1123 companion: when every remaining device for a requeued job has
+// already succeeded (e.g. the failing sibling was disabled between
+// retries), the job must finalize as published instead of spinning in
+// the no-active-devices retry loop.
+#[tokio::test]
+async fn retried_job_with_all_devices_delivered_finalizes_published() {
+    let sender = PerEndpointSender::new(vec![
+        (
+            "delivered-device".to_string(),
+            WebPushOutcome::Delivered { status: 201 },
+        ),
+        (
+            "gone-device".to_string(),
+            WebPushOutcome::Transient {
+                kind: waddle_xmpp::push::types::TransientFailure::Network,
+            },
+        ),
+    ]);
+    let store = store_with_web_push_sender(Arc::new(sender.clone())).await;
+    let owner = owner();
+    let node = store.ensure_node(&owner, "web").await.expect("node");
+    register_web_device(&store, &owner, node.node(), "web-ok", "delivered-device").await;
+    register_web_device(&store, &owner, node.node(), "web-gone", "gone-device").await;
+    store
+        .publish_notification_from_user_server(
+            node.node(),
+            &web_push_notification_item("all-done-item-1", "alice@example.com", "dm", 1),
+            &owner,
+        )
+        .await
+        .expect("publish");
+    store
+        .drain_queued_notification_publish_jobs(16)
+        .await
+        .expect("first drain");
+
+    // The flaky device disappears (user unregistered / device
+    // disabled) before the retry fires.
+    let db = store.database();
+    let conn = db.guard().await.expect("db guard");
+    conn.execute(
+        "UPDATE push_devices SET status = 'disabled' WHERE device_id = 'web-gone'",
+        (),
+    )
+    .await
+    .expect("disable flaky device");
+    drop(conn);
+    force_retry_eligibility(&store).await;
+
+    store
+        .drain_queued_notification_publish_jobs(16)
+        .await
+        .expect("retry drain");
+
+    assert_eq!(
+        sender.calls_matching("delivered-device"),
+        1,
+        "#1123: no duplicate web-push when the retry has nothing left to send"
+    );
+    let mut rows = query(
+        &store,
+        "SELECT status FROM push_publish_jobs WHERE item_id = 'all-done-item-1'",
+        (),
+    )
+    .await;
+    let row = rows.next().await.expect("job row").expect("job present");
+    assert_eq!(
+        row.get::<String>(0).expect("status"),
+        "published",
+        "a fully-delivered job must finalize as published, not requeue forever"
     );
 }
 

--- a/server/crates/waddle-server/tests/push_service_web_push_dispatch.rs
+++ b/server/crates/waddle-server/tests/push_service_web_push_dispatch.rs
@@ -92,15 +92,26 @@ impl WebPushSender for FixedOutcomeSender {
 /// A `WebPushSender` that picks its outcome by matching the request
 /// endpoint against a configured substring, and records every
 /// endpoint it was invoked for so tests can assert exactly which
-/// devices were (re-)dispatched.
+/// devices were (re-)dispatched. Each endpoint carries a SEQUENCE of
+/// outcomes consumed per call (the last one repeats), so a test can
+/// model "transient on the first pass, permanent on the retry".
 #[derive(Clone)]
 struct PerEndpointSender {
-    outcomes: Arc<Vec<(String, WebPushOutcome)>>,
+    outcomes: Arc<Vec<(String, Vec<WebPushOutcome>)>>,
     calls: Arc<std::sync::Mutex<Vec<String>>>,
 }
 
 impl PerEndpointSender {
     fn new(outcomes: Vec<(String, WebPushOutcome)>) -> Self {
+        Self::with_sequences(
+            outcomes
+                .into_iter()
+                .map(|(fragment, outcome)| (fragment, vec![outcome]))
+                .collect(),
+        )
+    }
+
+    fn with_sequences(outcomes: Vec<(String, Vec<WebPushOutcome>)>) -> Self {
         Self {
             outcomes: Arc::new(outcomes),
             calls: Arc::new(std::sync::Mutex::new(Vec::new())),
@@ -123,15 +134,18 @@ impl WebPushSender for PerEndpointSender {
         request: WebPushRequest<'_>,
     ) -> Pin<Box<dyn Future<Output = WebPushOutcome> + Send + '_>> {
         let endpoint = request.endpoint.to_string();
-        self.calls
-            .lock()
-            .expect("calls lock")
-            .push(endpoint.clone());
+        let mut calls = self.calls.lock().expect("calls lock");
+        let prior_calls = calls
+            .iter()
+            .filter(|called| called.as_str() == endpoint)
+            .count();
+        calls.push(endpoint.clone());
+        drop(calls);
         let outcome = self
             .outcomes
             .iter()
             .find(|(fragment, _)| endpoint.contains(fragment.as_str()))
-            .map(|(_, outcome)| outcome.clone())
+            .map(|(_, sequence)| sequence[prior_calls.min(sequence.len() - 1)].clone())
             .unwrap_or(WebPushOutcome::Delivered { status: 201 });
         Box::pin(async move { outcome })
     }
@@ -548,6 +562,68 @@ async fn retried_job_with_all_devices_delivered_finalizes_published() {
         row.get::<String>(0).expect("status"),
         "published",
         "a fully-delivered job must finalize as published, not requeue forever"
+    );
+}
+
+// #1123 companion (Codex review): on a retry whose fan-out excluded an
+// already-delivered sibling, a permanent encoder-bug status from the
+// one REMAINING device must not trip the "all devices returned an
+// encoder-bug status" FAILED classification — the payload demonstrably
+// delivered to the sibling, so the job completes as PUBLISHED (the
+// same outcome a single mixed-result pass would produce).
+#[tokio::test]
+async fn retry_with_prior_delivery_does_not_fail_job_on_uniform_encoder_status() {
+    let sender = PerEndpointSender::with_sequences(vec![
+        (
+            "delivered-device".to_string(),
+            vec![WebPushOutcome::Delivered { status: 201 }],
+        ),
+        (
+            "flaky-device".to_string(),
+            vec![
+                WebPushOutcome::Transient {
+                    kind: waddle_xmpp::push::types::TransientFailure::Network,
+                },
+                WebPushOutcome::PayloadTooLarge { status: 413 },
+            ],
+        ),
+    ]);
+    let store = store_with_web_push_sender(Arc::new(sender.clone())).await;
+    let owner = owner();
+    let node = store.ensure_node(&owner, "web").await.expect("node");
+    register_web_device(&store, &owner, node.node(), "web-ok", "delivered-device").await;
+    register_web_device(&store, &owner, node.node(), "web-flaky", "flaky-device").await;
+    store
+        .publish_notification_from_user_server(
+            node.node(),
+            &web_push_notification_item("mixed-retry-item-1", "alice@example.com", "dm", 1),
+            &owner,
+        )
+        .await
+        .expect("publish");
+    store
+        .drain_queued_notification_publish_jobs(16)
+        .await
+        .expect("first drain");
+    force_retry_eligibility(&store).await;
+    store
+        .drain_queued_notification_publish_jobs(16)
+        .await
+        .expect("retry drain");
+
+    assert_eq!(sender.calls_matching("delivered-device"), 1);
+    assert_eq!(sender.calls_matching("flaky-device"), 2);
+    let mut rows = query(
+        &store,
+        "SELECT status FROM push_publish_jobs WHERE item_id = 'mixed-retry-item-1'",
+        (),
+    )
+    .await;
+    let row = rows.next().await.expect("job row").expect("job present");
+    assert_eq!(
+        row.get::<String>(0).expect("status"),
+        "published",
+        "a prior delivered sibling means the retry's uniform 413 is not an all-device encoder bug"
     );
 }
 

--- a/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
@@ -312,9 +312,13 @@ pub trait PendingDeliveryStorage: Send + Sync {
     /// janitor pass overlapping an in-flight flush would release its
     /// claims mid-flight and let a second resource re-push the same
     /// offline messages. Claims stamped after the floor are
-    /// considered in-flight and skipped; a claim with no stamp
-    /// (legacy row) is always release-eligible. Pass `i64::MAX` to
-    /// disable the floor (startup recovery).
+    /// considered in-flight and skipped. A claim with NO stamp is
+    /// also skipped — an unstamped claim means "recency unknown"
+    /// (e.g. written by a pre-#1124 binary during a rolling deploy),
+    /// and treating unknown as old would re-open the mid-flight
+    /// release. Callers first adopt unstamped claims via
+    /// [`Self::stamp_unstamped_claims`], which starts their floor
+    /// clock, so they become release-eligible one floor-window later.
     ///
     /// Implementations MUST scan only rows with
     /// `flushed_in_session IS NOT NULL`. The caller passes a
@@ -327,6 +331,22 @@ pub trait PendingDeliveryStorage: Send + Sync {
         live_sessions: &[SmSessionId],
         claimed_before_ms: i64,
     ) -> Result<Vec<(PendingRowId, SmSessionId)>, PendingStorageError>;
+
+    /// Stamp `now_ms` onto every claimed row that has no claim-recency
+    /// stamp, returning the number of rows stamped. The claim-expiry
+    /// janitor calls this before [`Self::list_orphaned_claims`] so a
+    /// claim written without a stamp (a pre-#1124 binary during a
+    /// rolling deploy) is adopted into the recency floor instead of
+    /// being either released mid-flight (unknown treated as old) or
+    /// leaked forever (unknown treated as always-fresh). Adopted
+    /// claims become release-eligible one floor-window after adoption.
+    ///
+    /// Default impl is a no-op: backends that always stamp on claim
+    /// (every in-process backend) have nothing to adopt.
+    async fn stamp_unstamped_claims(&self, now_ms: i64) -> Result<u64, PendingStorageError> {
+        let _ = now_ms;
+        Ok(0)
+    }
 
     /// Current row count for `recipient` (used by the quota check;
     /// also exposed for metrics).
@@ -899,18 +919,42 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
                     // #1124 recency floor: a claim stamped after the
                     // floor is an in-flight flush (e.g. a `transient:`
                     // non-SM flush the live-set can never contain) —
-                    // skip it. A missing stamp means no recency info;
-                    // treat as always release-eligible.
-                    let claim_is_fresh = stamps
+                    // skip it. A missing stamp means "recency unknown"
+                    // and is also skipped; the janitor adopts such
+                    // claims via `stamp_unstamped_claims` first, so
+                    // they age into eligibility instead of being
+                    // released while possibly mid-flight.
+                    let release_eligible = stamps
                         .get(&row.id)
-                        .is_some_and(|claimed_at| *claimed_at > claimed_before_ms);
-                    if !live.contains(session) && !claim_is_fresh {
+                        .is_some_and(|claimed_at| *claimed_at <= claimed_before_ms);
+                    if !live.contains(session) && release_eligible {
                         out.push((row.id.clone(), session.clone()));
                     }
                 }
             }
         }
         Ok(out)
+    }
+
+    async fn stamp_unstamped_claims(&self, now_ms: i64) -> Result<u64, PendingStorageError> {
+        let guard = self
+            .inner
+            .lock()
+            .map_err(|e| PendingStorageError::Other(e.to_string()))?;
+        let mut stamps = self
+            .claimed_at_ms
+            .lock()
+            .map_err(|e| PendingStorageError::Other(e.to_string()))?;
+        let mut adopted = 0u64;
+        for queue in guard.values() {
+            for row in queue.iter() {
+                if row.flushed_in_session.is_some() && !stamps.contains_key(&row.id) {
+                    stamps.insert(row.id.clone(), now_ms);
+                    adopted += 1;
+                }
+            }
+        }
+        Ok(adopted)
     }
 
     async fn count(&self, recipient: &BareJid) -> Result<u32, PendingStorageError> {

--- a/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/storage.rs
@@ -297,7 +297,8 @@ pub trait PendingDeliveryStorage: Send + Sync {
     ) -> Result<u64, PendingStorageError>;
 
     /// List rows whose `flushed_in_session` references a session
-    /// that is NOT in `live_sessions`. Used by the claim-expiry
+    /// that is NOT in `live_sessions` AND whose claim was stamped at
+    /// or before `claimed_before_ms`. Used by the claim-expiry
     /// janitor (issue #209 PR #360) to find orphaned claims left
     /// behind by sessions that closed without going through the SM
     /// janitor / shutdown drain (e.g. non-SM sessions, or SM
@@ -305,14 +306,26 @@ pub trait PendingDeliveryStorage: Send + Sync {
     /// then calls [`Self::release_row`] on each entry to make the
     /// rows eligible for re-flush.
     ///
+    /// `claimed_before_ms` is the recency floor (#1124): non-SM
+    /// flushes claim rows under a synthetic `transient:` session id
+    /// that is never in the live-set, so without the floor any
+    /// janitor pass overlapping an in-flight flush would release its
+    /// claims mid-flight and let a second resource re-push the same
+    /// offline messages. Claims stamped after the floor are
+    /// considered in-flight and skipped; a claim with no stamp
+    /// (legacy row) is always release-eligible. Pass `i64::MAX` to
+    /// disable the floor (startup recovery).
+    ///
     /// Implementations MUST scan only rows with
     /// `flushed_in_session IS NOT NULL`. The caller passes a
     /// snapshot of currently-live SM session ids; an empty
-    /// `live_sessions` slice returns every claimed row (useful for
-    /// startup recovery when the SM registry is empty).
+    /// `live_sessions` slice matches every claimed row older than
+    /// the floor (useful for startup recovery when the SM registry
+    /// is empty).
     async fn list_orphaned_claims(
         &self,
         live_sessions: &[SmSessionId],
+        claimed_before_ms: i64,
     ) -> Result<Vec<(PendingRowId, SmSessionId)>, PendingStorageError>;
 
     /// Current row count for `recipient` (used by the quota check;
@@ -414,6 +427,14 @@ pub fn sequence_in_ack_window(seq: u32, from_exclusive: u32, to_inclusive: u32) 
 pub struct InMemoryPendingDeliveryStorage {
     inner: Mutex<HashMap<BareJid, VecDeque<PendingRow>>>,
     notification_outboxed: Mutex<HashSet<PendingRowId>>,
+    /// Claim recency stamps (#1124): row id → `timestamp_millis()` of
+    /// the claim that set `flushed_in_session`. Kept beside the rows
+    /// (not on [`PendingRow`]) because no consumer of the row needs
+    /// it — only [`PendingDeliveryStorage::list_orphaned_claims`]
+    /// reads it, to skip in-flight claims. Cleared on release; a
+    /// missing entry means "no recency information" and the claim is
+    /// always release-eligible.
+    claimed_at_ms: Mutex<HashMap<PendingRowId, i64>>,
     quota: QuotaPolicy,
 }
 
@@ -423,8 +444,38 @@ impl InMemoryPendingDeliveryStorage {
         Self {
             inner: Mutex::new(HashMap::new()),
             notification_outboxed: Mutex::new(HashSet::new()),
+            claimed_at_ms: Mutex::new(HashMap::new()),
             quota,
         }
+    }
+
+    fn stamp_claimed_at(&self, ids: &[PendingRowId]) -> Result<(), PendingStorageError> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let mut stamps = self
+            .claimed_at_ms
+            .lock()
+            .map_err(|e| PendingStorageError::Other(e.to_string()))?;
+        for id in ids {
+            stamps.insert(id.clone(), now_ms);
+        }
+        Ok(())
+    }
+
+    fn clear_claimed_at(&self, ids: &[PendingRowId]) -> Result<(), PendingStorageError> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let mut stamps = self
+            .claimed_at_ms
+            .lock()
+            .map_err(|e| PendingStorageError::Other(e.to_string()))?;
+        for id in ids {
+            stamps.remove(id);
+        }
+        Ok(())
     }
 
     /// Build with the default count cap (locked Q9e default).
@@ -599,6 +650,9 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
                 claimed.push(row.clone());
             }
         }
+        drop(guard);
+        let claimed_ids: Vec<PendingRowId> = claimed.iter().map(|row| row.id.clone()).collect();
+        self.stamp_claimed_at(&claimed_ids)?;
         Ok(claimed)
     }
 
@@ -642,6 +696,9 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
             row.outbound_sequence = None;
             claimed.push(row.clone());
         }
+        drop(guard);
+        let claimed_ids: Vec<PendingRowId> = claimed.iter().map(|row| row.id.clone()).collect();
+        self.stamp_claimed_at(&claimed_ids)?;
         Ok(claimed)
     }
 
@@ -667,6 +724,7 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
         guard.retain(|_, q| !q.is_empty());
         drop(guard);
         self.clear_notification_outboxed_markers(&removed_ids)?;
+        self.clear_claimed_at(&removed_ids)?;
         Ok(removed)
     }
 
@@ -685,6 +743,7 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
         drop(guard);
         if removed > 0 {
             self.clear_notification_outboxed_markers(std::slice::from_ref(id))?;
+            self.clear_claimed_at(std::slice::from_ref(id))?;
         }
         Ok(removed)
     }
@@ -699,15 +758,19 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
             .lock()
             .map_err(|e| PendingStorageError::Other(e.to_string()))?;
         let mut released = 0u64;
+        let mut released_ids = Vec::new();
         for queue in guard.values_mut() {
             for row in queue.iter_mut() {
                 if row.flushed_in_session.as_ref() == Some(session) {
                     row.flushed_in_session = None;
                     row.outbound_sequence = None;
+                    released_ids.push(row.id.clone());
                     released += 1;
                 }
             }
         }
+        drop(guard);
+        self.clear_claimed_at(&released_ids)?;
         Ok(released)
     }
 
@@ -721,6 +784,8 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
                 if &row.id == id {
                     row.flushed_in_session = None;
                     row.outbound_sequence = None;
+                    drop(guard);
+                    self.clear_claimed_at(std::slice::from_ref(id))?;
                     return Ok(1);
                 }
             }
@@ -745,6 +810,8 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
                     }
                     row.flushed_in_session = None;
                     row.outbound_sequence = None;
+                    drop(guard);
+                    self.clear_claimed_at(std::slice::from_ref(id))?;
                     return Ok(1);
                 }
             }
@@ -804,12 +871,14 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
         guard.retain(|_, q| !q.is_empty());
         drop(guard);
         self.clear_notification_outboxed_markers(&removed_ids)?;
+        self.clear_claimed_at(&removed_ids)?;
         Ok(removed)
     }
 
     async fn list_orphaned_claims(
         &self,
         live_sessions: &[SmSessionId],
+        claimed_before_ms: i64,
     ) -> Result<Vec<(PendingRowId, SmSessionId)>, PendingStorageError> {
         // O(rows) lookup via a HashSet of `&SmSessionId` references —
         // avoids the O(rows × live_sessions) `Vec::contains` scan.
@@ -819,11 +888,23 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
             .inner
             .lock()
             .map_err(|e| PendingStorageError::Other(e.to_string()))?;
+        let stamps = self
+            .claimed_at_ms
+            .lock()
+            .map_err(|e| PendingStorageError::Other(e.to_string()))?;
         let mut out = Vec::new();
         for queue in guard.values() {
             for row in queue.iter() {
                 if let Some(session) = row.flushed_in_session.as_ref() {
-                    if !live.contains(session) {
+                    // #1124 recency floor: a claim stamped after the
+                    // floor is an in-flight flush (e.g. a `transient:`
+                    // non-SM flush the live-set can never contain) —
+                    // skip it. A missing stamp means no recency info;
+                    // treat as always release-eligible.
+                    let claim_is_fresh = stamps
+                        .get(&row.id)
+                        .is_some_and(|claimed_at| *claimed_at > claimed_before_ms);
+                    if !live.contains(session) && !claim_is_fresh {
                         out.push((row.id.clone(), session.clone()));
                     }
                 }
@@ -865,6 +946,7 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
         guard.retain(|_, q| !q.is_empty());
         drop(guard);
         self.clear_notification_outboxed_markers(&removed_ids)?;
+        self.clear_claimed_at(&removed_ids)?;
         Ok(removed)
     }
 
@@ -893,6 +975,7 @@ impl PendingDeliveryStorage for InMemoryPendingDeliveryStorage {
         guard.retain(|_, q| !q.is_empty());
         drop(guard);
         self.clear_notification_outboxed_markers(&removed_ids)?;
+        self.clear_claimed_at(&removed_ids)?;
         Ok(removed)
     }
 }

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -263,6 +263,7 @@ pub(crate) const PUSH_SUPPRESSED_REASONS: &[&str] = &[
     "provider_rejected",
     "provider_token_expired",
     "xep0357_push_service_degraded",
+    "unread_zero_at_publish",
 ];
 
 const PUSH_SUPPRESSED_COUNTERS_LEN: usize = PUSH_SUPPRESSED_REASONS.len();
@@ -274,6 +275,7 @@ static PUSH_SUPPRESSED_COUNTERS: [AtomicU64; PUSH_SUPPRESSED_COUNTERS_LEN] = {
     // below, so a future reason addition that forgets a slot fails to
     // compile.
     [
+        AtomicU64::new(0),
         AtomicU64::new(0),
         AtomicU64::new(0),
         AtomicU64::new(0),


### PR DESCRIPTION
Fixes #1123. Fixes #1124. Fixes #1126.

Lane C item 1 — the duplicate/spurious push trio (one PR bundle, disjoint subsystems that compound in production).

## What shipped

### #1123 — per-device delivery idempotency on publish-job retry

Today one transient device failure requeues the whole publish job, and the retry reloads **all** active devices with no filter against prior successes (`push_service/worker.rs` `finalize_publish_job` → requeue; `active_devices_with_subscription_for_node_tx` reloads everything). Devices that already received the web-push get up to the max transient-attempt count of duplicates.

- Add a `delivered_device_ids_for_item(node, item_id)` query over the existing `push_delivery_attempts` log (terminal-success statuses).
- Filter the dispatch set in `process_publish_phase1` so already-delivered devices are skipped on re-dispatch; XEP-0357 fan-out semantics unchanged, per-device idempotency added.
- Tests: partial-failure scenario — device A delivered + device B transient → requeue; retry dispatches only B; no duplicate web-push to A.

### #1124 — janitor must not sweep live in-flight transient flush claims

Non-SM flushes claim `pending_delivery` rows under a synthetic `transient:<resource>:<uuid>` session id that never appears in the janitor's live-session set, and claims carry no claimed-at timestamp — any janitor pass overlapping an in-flight flush releases the claims mid-flight, letting a second resource re-claim and re-push the same offline message (matches the 121 orphan-claim releases observed in production).

- Add a `claimed_at_ms` column to `pending_delivery`; stamp it in `claim_batch_for_session` (both DB and in-memory backends, trait updated).
- `list_orphaned_claims` takes a claimed-before floor; the janitor only releases claims older than several janitor intervals, so genuinely orphaned (post-crash) claims are still released.
- Tests: concurrent flush + janitor pass → no release mid-flight, no duplicate delivery; stale claim past the floor → released.

### #1126 — suppress push at unread 0 + jitter on retry backoff

Publish fires unconditionally even when the recipient's unread count for the conversation is already 0 (they reconnected and read the message inside the window), and all retry backoff is deterministic, producing synchronized retry waves after an outage.

- In `notification_outbox/publish.rs`, suppress jobs terminally (claim-token-gated DELETE, typed `Suppressed` outcome + `unread_zero_at_publish` audit reason/metric) when the conversation's inbox entry **exists** with unread 0. An **absent** entry is "no information", not "read" — the inbox projection is written on a separate path whose failures are swallowed, so absence still publishes (pre-existing count-0 behavior). This distinction came out of the adversarial review round.
- Add randomized jitter (±25%) to the outbox retry backoff (`retry_delay_ms` / `policy_retry_delay_ms`) and to the push-service `retry_at_ms` requeue delay.
- Tests: read-entry (unread 0) suppression for DM and MUC personal-mention classes; absent-entry publishes; unread ≥ 1 publishes; jitter bounds + non-constant; janitor floor protects in-flight transient claims (both backends) while aged orphans still release + re-claim.

## Review rounds

Two adversarial review agents (concurrency/at-most-once, XEP-conformance/repo-rules) ran before push. Both converged on one real finding — suppressing on an absent inbox entry would turn a swallowed inbox-projection failure into total notification loss — fixed by making `current_unread_count_for_job` return `Option<u32>` and suppressing only on `Some(0)`, with tests for the absent-entry and MUC-mention paths. All other axes (claim-token interlocks, prune-window safety, item_id = job_id uniqueness for the delivered-filter, SuppressedReason five-way lockstep, migration idempotence both drivers) verified clean.

Also marks Lane C item 1 done in TODO-ISSUES.md.

## XEP conformance

XEP-0357 §7 leaves publish policy to the server ("the server SHOULD publish…" on its own criteria); per-device idempotent fan-out and unread-0 suppression are server policy, not wire-shape changes. No advertised feature or namespace changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
