### PR TITLE
fix(server): make clustered resource ownership and recovery exact

### DIFF
--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -31,14 +31,14 @@ use kameo::actor::ActorRef;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use waddle_xmpp::commands::{CommandContext, CommandResult};
 use waddle_xmpp::muc::room_registry_actor::{
-    CreateRoom, DestroyRoom, GetOrCreateRoom, GetRoom, ListRooms,
+    CreateRoom, DestroyRoom, DestroyRoomExact, GetOrCreateRoom, GetRoom, ListRooms,
 };
 use waddle_xmpp::muc::{
     affiliation::FederatedAffiliationConfig,
     room_actor::{
-        ApplyAdminItems, ApplyAffiliationChange, ChangeAffiliation, EnforceMembersOnlyAffiliations,
-        GetAffiliation, GetConfig, LeaveByRealJid, ListAffiliations, ListOccupants, OccupantCount,
-        RoomActor, UpdateConfig,
+        ApplyAdminItems, ApplyAffiliationChange, ChangeAffiliation, CheckMutationOwnership,
+        EnforceMembersOnlyAffiliations, GetAffiliation, GetConfig, LeaveByRealJid,
+        ListAffiliations, ListOccupants, OccupantCount, RoomActor, RoomMutationError, UpdateConfig,
     },
     AdminItem, PinPermission, RoomConfig,
 };
@@ -514,6 +514,63 @@ fn unavailable(text: impl Into<String>) -> AdminErr {
     Box::new(CommandResult::Error(XmppError::service_unavailable(Some(
         text.into(),
     ))))
+}
+
+fn ownership_retry(text: impl Into<String>) -> AdminErr {
+    Box::new(CommandResult::Error(XmppError::Stanza {
+        condition: waddle_xmpp::StanzaErrorCondition::ResourceConstraint,
+        error_type: waddle_xmpp::StanzaErrorType::Wait,
+        text: Some(text.into()),
+    }))
+}
+
+/// Demote only the actor incarnation that returned `NotOwner`. Any E2 that
+/// replaced retained E1 under the same room JID must survive this cleanup.
+async fn demote_retained_room_actor(state: &AppState, room: &BareJid, actor: &ActorRef<RoomActor>) {
+    remove_retained_room_actor(&state.room_registry, room, actor).await;
+}
+
+async fn remove_retained_room_actor(
+    room_registry: &ActorRef<waddle_xmpp::muc::room_registry_actor::RoomRegistryActor>,
+    room: &BareJid,
+    actor: &ActorRef<RoomActor>,
+) {
+    let _ = room_registry
+        .ask(DestroyRoomExact {
+            room_jid: room.clone(),
+            expected_actor: actor.clone(),
+        })
+        .await;
+    actor.kill();
+}
+
+async fn admit_managed_room_mutation(
+    state: &AppState,
+    actor: &ActorRef<RoomActor>,
+    room: &BareJid,
+) -> Result<(), AdminErr> {
+    match actor.ask(CheckMutationOwnership).await {
+        Ok(()) => Ok(()),
+        Err(kameo::error::SendError::HandlerError(RoomMutationError::NotOwner)) => {
+            demote_retained_room_actor(state, room, actor).await;
+            Err(ownership_retry(
+                "This room's ownership recently moved to another node; please retry.",
+            ))
+        }
+        Err(kameo::error::SendError::HandlerError(RoomMutationError::OwnershipUncertain)) => Err(
+            ownership_retry("This room's ownership cannot currently be verified; please retry."),
+        ),
+        Err(kameo::error::SendError::HandlerError(RoomMutationError::PersistFailed(detail))) => {
+            Err(Box::new(CommandResult::Error(
+                XmppError::internal_server_error(Some(format!(
+                    "Room ownership admission could not converge: {detail}"
+                ))),
+            )))
+        }
+        Err(error) => Err(internal_err(format!(
+            "room actor CheckMutationOwnership: {error}"
+        ))),
+    }
 }
 
 async fn handle_list(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
@@ -1858,7 +1915,7 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
     config.max_occupants = 0;
     config.enable_logging = true;
 
-    state
+    let room_actor = state
         .room_registry
         .ask(CreateRoom {
             room_jid: channel_jid.clone(),
@@ -1871,12 +1928,7 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
 
     if let Err(error) = upsert_channel_catalog(state, &localpart, &config, args.channel_type).await
     {
-        let _ = state
-            .room_registry
-            .ask(DestroyRoom {
-                room_jid: channel_jid.clone(),
-            })
-            .await;
+        rollback_created_room(&state.room_registry, &channel_jid, &room_actor).await;
         return Err(error);
     }
 
@@ -1898,12 +1950,7 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
             Ok(created) => created,
             Err(error) => {
                 let _ = delete_xmpp_channel(state.db_pool.global_actor().clone(), &localpart).await;
-                let _ = state
-                    .room_registry
-                    .ask(DestroyRoom {
-                        room_jid: channel_jid.clone(),
-                    })
-                    .await;
+                rollback_created_room(&state.room_registry, &channel_jid, &room_actor).await;
                 return Err(error);
             }
         };
@@ -1942,11 +1989,7 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
                         let _ =
                             delete_xmpp_channel(state.db_pool.global_actor().clone(), &localpart)
                                 .await;
-                        let _ = state
-                            .room_registry
-                            .ask(DestroyRoom {
-                                room_jid: channel_jid.clone(),
-                            })
+                        rollback_created_room(&state.room_registry, &channel_jid, &room_actor)
                             .await;
                     }
                     Err(retract_error) => {
@@ -2013,12 +2056,7 @@ async fn run_group_dm_create(
         .map_err(send_err("room_registry ask CreateRoom"))?;
 
     if let Err(error) = upsert_group_dm_catalog(state, &localpart, &config).await {
-        let _ = state
-            .room_registry
-            .ask(DestroyRoom {
-                room_jid: room_jid.clone(),
-            })
-            .await;
+        rollback_created_room(&state.room_registry, &room_jid, &actor).await;
         return Err(error);
     }
 
@@ -2029,7 +2067,8 @@ async fn run_group_dm_create(
     let mut persisted_members: Vec<BareJid> = Vec::with_capacity(members.len());
     for member_jid in members {
         if let Err(error) = persist_group_dm_member_tuple(state, &localpart, &member_jid).await {
-            rollback_group_dm_create(state, &localpart, &room_jid, &persisted_members).await;
+            rollback_group_dm_create(state, &localpart, &room_jid, &actor, &persisted_members)
+                .await;
             return Err(Box::new(CommandResult::Error(error)));
         }
         persisted_members.push(member_jid.clone());
@@ -2040,13 +2079,15 @@ async fn run_group_dm_create(
             })
             .await
         {
-            rollback_group_dm_create(state, &localpart, &room_jid, &persisted_members).await;
+            rollback_group_dm_create(state, &localpart, &room_jid, &actor, &persisted_members)
+                .await;
             return Err(send_err("room actor ChangeAffiliation")(error));
         }
         if let Err(error) =
             publish_group_dm_bookmark(state, &member_jid, &room_jid, Some(&args.name)).await
         {
-            rollback_group_dm_create(state, &localpart, &room_jid, &persisted_members).await;
+            rollback_group_dm_create(state, &localpart, &room_jid, &actor, &persisted_members)
+                .await;
             return Err(error);
         }
     }
@@ -2133,6 +2174,7 @@ async fn run_group_dm_leave(
     resources.sort();
     resources.dedup();
 
+    admit_managed_room_mutation(state, &actor, &args.room_jid).await?;
     delete_group_dm_member_tuple(state, &channel_id, &caller_bare)
         .await
         .map_err(|error| Box::new(CommandResult::Error(error)))?;
@@ -2147,6 +2189,10 @@ async fn run_group_dm_leave(
         })
         .await
     {
+        // The actor rejected the affiliation mutation, so restore the
+        // external membership projections before classifying the typed
+        // ownership error. `NotOwner`/`OwnershipUncertain` are explicitly
+        // no-effect outcomes and must not strand a half-completed leave.
         let _ = persist_group_dm_member_tuple(state, &channel_id, &caller_bare).await;
         let _ = publish_group_dm_bookmark(
             state,
@@ -2155,16 +2201,47 @@ async fn run_group_dm_leave(
             group_dm_shared_name(&record.name),
         )
         .await;
+        if matches!(
+            &error,
+            kameo::error::SendError::HandlerError(RoomMutationError::NotOwner)
+        ) {
+            demote_retained_room_actor(state, &args.room_jid, &actor).await;
+            return Err(ownership_retry(
+                "This room's ownership recently moved to another node; please retry.",
+            ));
+        }
+        if matches!(
+            &error,
+            kameo::error::SendError::HandlerError(RoomMutationError::OwnershipUncertain)
+        ) {
+            return Err(ownership_retry(
+                "This room's ownership cannot currently be verified; please retry.",
+            ));
+        }
         return Err(send_err("room actor ChangeAffiliation")(error));
     }
     for resource in resources {
-        if let Some(outcome) = actor
+        let leave = actor
             .ask(LeaveByRealJid {
                 sender_jid: resource.clone(),
             })
-            .await
-            .map_err(send_err("room actor LeaveByRealJid"))?
-        {
+            .await;
+        let outcome = match leave {
+            Ok(outcome) => outcome,
+            Err(kameo::error::SendError::HandlerError(RoomMutationError::NotOwner)) => {
+                demote_retained_room_actor(state, &args.room_jid, &actor).await;
+                return Err(ownership_retry(
+                    "This room's ownership recently moved to another node; please retry.",
+                ));
+            }
+            Err(kameo::error::SendError::HandlerError(RoomMutationError::OwnershipUncertain)) => {
+                return Err(ownership_retry(
+                    "This room's ownership cannot currently be verified; please retry.",
+                ));
+            }
+            Err(error) => return Err(send_err("room actor LeaveByRealJid")(error)),
+        };
+        if let Some(outcome) = outcome {
             broadcast_group_dm_leave(
                 state,
                 connections,
@@ -2241,7 +2318,9 @@ async fn run_group_dm_rename(
         .await
     {
         Ok(snapshot) => snapshot,
-        Err(error) => return Err(group_dm_rename_update_error(state, &args.room_jid, error).await),
+        Err(error) => {
+            return Err(group_dm_rename_update_error(state, &args.room_jid, &actor, error).await)
+        }
     };
     let expected_revision = updated_snapshot.config_revision;
     if find_occupant_for_full_jid(&updated_snapshot, caller_full_jid).is_none() {
@@ -2610,6 +2689,7 @@ fn group_dm_shared_name(name: &str) -> Option<&str> {
 async fn group_dm_rename_update_error(
     state: &AppState,
     room_jid: &BareJid,
+    room_actor: &ActorRef<RoomActor>,
     error: kameo::error::SendError<
         waddle_xmpp::muc::room_actor::UpdateGroupDmConfigByMember,
         waddle_xmpp::muc::room_actor::UpdateGroupDmConfigByMemberError,
@@ -2638,8 +2718,11 @@ async fn group_dm_rename_update_error(
             // retry-able error, same flavor `dispatch_to_room`'s own
             // ownership-gap bounce uses.
             UpdateGroupDmConfigByMemberError::NotOwner => {
-                state.clustering_claims.demote_room_actor(room_jid).await;
+                demote_retained_room_actor(state, room_jid, room_actor).await;
                 unavailable("This room's ownership recently moved to another node; please retry.")
+            }
+            UpdateGroupDmConfigByMemberError::OwnershipUncertain => {
+                unavailable("This room's ownership cannot currently be verified; please retry.")
             }
             UpdateGroupDmConfigByMemberError::PersistFailed(detail) => internal_err(format!(
                 "group-DM rename applied but durable persist failed: {detail}"
@@ -2719,6 +2802,7 @@ async fn rollback_group_dm_create(
     state: &AppState,
     group_dm_id: &str,
     room_jid: &BareJid,
+    room_actor: &ActorRef<RoomActor>,
     persisted_members: &[BareJid],
 ) {
     for persisted_member in persisted_members {
@@ -2726,12 +2810,21 @@ async fn rollback_group_dm_create(
         let _ = delete_group_dm_member_tuple(state, group_dm_id, persisted_member).await;
     }
     let _ = delete_xmpp_channel(state.db_pool.global_actor().clone(), group_dm_id).await;
-    let _ = state
-        .room_registry
-        .ask(DestroyRoom {
-            room_jid: room_jid.clone(),
-        })
-        .await;
+    rollback_created_room(&state.room_registry, room_jid, room_actor).await;
+}
+
+/// Roll back only the actor incarnation created by the operation.
+///
+/// Catalog, tuple, and bookmark cleanup all await external work. A room can
+/// therefore be deleted and recreated under the same JID before rollback
+/// reaches the registry; a room-only destroy would incorrectly delete that
+/// replacement.
+async fn rollback_created_room(
+    room_registry: &ActorRef<waddle_xmpp::muc::room_registry_actor::RoomRegistryActor>,
+    room_jid: &BareJid,
+    room_actor: &ActorRef<RoomActor>,
+) {
+    remove_retained_room_actor(room_registry, room_jid, room_actor).await;
 }
 
 pub(crate) async fn persist_group_dm_member_tuple(
@@ -3029,12 +3122,36 @@ async fn run_update(
         None
     };
 
-    let expected_revision = actor
+    let expected_revision = match actor
         .ask(UpdateConfig {
             config: updated.clone(),
         })
         .await
-        .map_err(send_err("room actor UpdateConfig"))?;
+    {
+        Ok(revision) => revision,
+        Err(kameo::error::SendError::HandlerError(RoomMutationError::NotOwner)) => {
+            demote_retained_room_actor(state, &args.channel_jid, &actor).await;
+            return Err(ownership_retry(
+                "This room's ownership recently moved to another node; please retry.",
+            ));
+        }
+        Err(kameo::error::SendError::HandlerError(RoomMutationError::OwnershipUncertain)) => {
+            return Err(ownership_retry(
+                "This room's ownership cannot currently be verified; please retry.",
+            ));
+        }
+        Err(kameo::error::SendError::HandlerError(RoomMutationError::PersistFailed(detail))) => {
+            return Err(Box::new(CommandResult::Error(
+                XmppError::internal_server_error(Some(detail)),
+            )));
+        }
+        Err(error) => return Err(send_err("room actor UpdateConfig")(error)),
+    };
+
+    // Re-admit immediately before the first managed catalog/bookmark write.
+    // Ownership may have moved after the actor mutation linearized; a stale
+    // node must not then publish external channel state.
+    admit_managed_room_mutation(state, &actor, &args.channel_jid).await?;
 
     if let Err(error) = upsert_channel_catalog(state, &channel_id, &updated, new_channel_type).await
     {
@@ -3085,12 +3202,35 @@ async fn run_update(
     }
 
     if let Some(explicit_affiliations) = members_only_enforcement_affiliations {
-        let updates = actor
+        let updates = match actor
             .ask(EnforceMembersOnlyAffiliations {
                 affiliations: explicit_affiliations,
             })
             .await
-            .map_err(send_err("room actor EnforceMembersOnlyAffiliations"))?;
+        {
+            Ok(updates) => updates,
+            Err(kameo::error::SendError::HandlerError(RoomMutationError::NotOwner)) => {
+                demote_retained_room_actor(state, &args.channel_jid, &actor).await;
+                return Err(ownership_retry(
+                    "This room's ownership recently moved to another node; please retry.",
+                ));
+            }
+            Err(kameo::error::SendError::HandlerError(RoomMutationError::OwnershipUncertain)) => {
+                return Err(ownership_retry(
+                    "This room's ownership cannot currently be verified; please retry.",
+                ));
+            }
+            Err(kameo::error::SendError::HandlerError(RoomMutationError::PersistFailed(
+                detail,
+            ))) => {
+                return Err(Box::new(CommandResult::Error(
+                    XmppError::internal_server_error(Some(detail)),
+                )));
+            }
+            Err(error) => {
+                return Err(send_err("room actor EnforceMembersOnlyAffiliations")(error));
+            }
+        };
         broadcast_presence_updates(connections, updates).await;
     }
 
@@ -3310,6 +3450,10 @@ async fn run_delete(state: &AppState, args: &ChannelsDeleteArgs) -> Result<(), A
         }
     }
 
+    // This is the explicit administrator delete operation for the logical
+    // room JID, not rollback of a retained actor incarnation. Deleting the
+    // current room is therefore intentional even if it was recreated while
+    // the preceding catalog/bookmark cleanup awaited.
     match state
         .room_registry
         .ask(DestroyRoom {
@@ -3582,6 +3726,7 @@ async fn run_set_affiliation(
                 format!("no channel '{}'", args.channel_jid),
             ))))
         })?;
+    admit_managed_room_mutation(state, &actor, &args.channel_jid).await?;
     let previous_affiliation = actor
         .ask(GetAffiliation {
             jid: args.member_jid.clone(),
@@ -3628,6 +3773,30 @@ async fn run_set_affiliation(
     {
         Ok(applied) => applied,
         Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::NotOwner,
+        )) => {
+            demote_retained_room_actor(state, &args.channel_jid, &actor).await;
+            return Err(ownership_retry(
+                "This room's ownership recently moved to another node; please retry.",
+            ));
+        }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::OwnershipUncertain,
+        )) => {
+            return Err(ownership_retry(
+                "This room's ownership cannot currently be verified; please retry.",
+            ));
+        }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::PersistFailed(detail),
+        )) => {
+            return Err(Box::new(CommandResult::Error(
+                XmppError::internal_server_error(Some(format!(
+                    "Affiliation mutation could not converge durably: {detail}"
+                ))),
+            )));
+        }
+        Err(kameo::error::SendError::HandlerError(
             waddle_xmpp::muc::room_actor::AdminApplyError::CannotRemoveLastOwner,
         )) => {
             let _ = persist_channel_affiliation(
@@ -3652,27 +3821,50 @@ async fn run_set_affiliation(
             return Err(send_err("room actor ApplyAffiliationChange")(error));
         }
     };
+    let persist_failure = applied.persist_failure.clone();
     broadcast_presence_updates(connections, applied.presence_updates).await;
     // Membership-scoped visibility (#935): an admin-V2 ban (Outcast)
     // ends the occupant's room membership, so their live SFU call
     // participation ends with it. Fire-and-forget inside the SFU
     // layer; the moderation result is never blocked on LiveKit.
     evict_moderation_removals(sfu, &args.channel_jid, &applied.removed_by_moderation);
+    if let Some(error) = persist_failure {
+        return Err(Box::new(CommandResult::Error(
+            XmppError::internal_server_error(Some(format!(
+                "Affiliation effects were applied but durable convergence failed: {error}"
+            ))),
+        )));
+    }
     Ok(ChannelsSetAffiliationResult {
         member_jid: args.member_jid.clone(),
         affiliation: args.affiliation,
     })
 }
 
-async fn sync_private_kick_affiliation_revocation(
-    state: &AppState,
-    connections: &ConnectionRegistry,
-    actor: &ActorRef<RoomActor>,
-    channel_id: &str,
-    caller_bare: &BareJid,
-    occupant_jid: &BareJid,
+struct PrivateKickAffiliationSync<'a> {
+    state: &'a AppState,
+    connections: &'a ConnectionRegistry,
+    actor: &'a ActorRef<RoomActor>,
+    room_jid: &'a BareJid,
+    channel_id: &'a str,
+    caller_bare: &'a BareJid,
+    occupant_jid: &'a BareJid,
     durable_previous_affiliation: Affiliation,
+}
+
+async fn sync_private_kick_affiliation_revocation(
+    context: PrivateKickAffiliationSync<'_>,
 ) -> Result<(), AdminErr> {
+    let PrivateKickAffiliationSync {
+        state,
+        connections,
+        actor,
+        room_jid,
+        channel_id,
+        caller_bare,
+        occupant_jid,
+        durable_previous_affiliation,
+    } = context;
     match actor
         .ask(ApplyAffiliationChange {
             actor: Some(caller_bare.clone()),
@@ -3682,9 +3874,35 @@ async fn sync_private_kick_affiliation_revocation(
         .await
     {
         Ok(applied) => {
+            let persist_failure = applied.persist_failure.clone();
             broadcast_presence_updates(connections, applied.presence_updates).await;
-            Ok(())
+            match persist_failure {
+                Some(error) => Err(Box::new(CommandResult::Error(
+                    XmppError::internal_server_error(Some(format!(
+                        "Kick affiliation effects applied but durable convergence failed: {error}"
+                    ))),
+                ))),
+                None => Ok(()),
+            }
         }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::NotOwner,
+        )) => {
+            demote_retained_room_actor(state, room_jid, actor).await;
+            Err(ownership_retry(
+                "This room's ownership recently moved to another node; please retry.",
+            ))
+        }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::OwnershipUncertain,
+        )) => Err(ownership_retry(
+            "This room's ownership cannot currently be verified; please retry.",
+        )),
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::PersistFailed(detail),
+        )) => Err(Box::new(CommandResult::Error(
+            XmppError::internal_server_error(Some(detail)),
+        ))),
         Err(error) => {
             let _ = persist_channel_affiliation(
                 state,
@@ -3729,6 +3947,7 @@ async fn run_kick(
                 format!("no channel '{}'", args.channel_jid),
             ))))
         })?;
+    admit_managed_room_mutation(state, &actor, &args.channel_jid).await?;
     let config = actor
         .ask(GetConfig)
         .await
@@ -3774,15 +3993,16 @@ async fn run_kick(
         .map(|info| info.nick)
     else {
         if revoke_members_only_member {
-            sync_private_kick_affiliation_revocation(
+            sync_private_kick_affiliation_revocation(PrivateKickAffiliationSync {
                 state,
                 connections,
-                &actor,
-                &channel_id,
-                &caller_bare,
-                &args.occupant_jid,
+                actor: &actor,
+                room_jid: &args.channel_jid,
+                channel_id: &channel_id,
+                caller_bare: &caller_bare,
+                occupant_jid: &args.occupant_jid,
                 durable_previous_affiliation,
-            )
+            })
             .await?;
         }
         return Ok(ChannelsKickResult {
@@ -3816,17 +4036,40 @@ async fn run_kick(
     {
         Ok(applied) => applied,
         Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::NotOwner,
+        )) => {
+            demote_retained_room_actor(state, &args.channel_jid, &actor).await;
+            return Err(ownership_retry(
+                "This room's ownership recently moved to another node; please retry.",
+            ));
+        }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::OwnershipUncertain,
+        )) => {
+            return Err(ownership_retry(
+                "This room's ownership cannot currently be verified; please retry.",
+            ));
+        }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::PersistFailed(detail),
+        )) => {
+            return Err(Box::new(CommandResult::Error(
+                XmppError::internal_server_error(Some(detail)),
+            )));
+        }
+        Err(kameo::error::SendError::HandlerError(
             waddle_xmpp::muc::room_actor::AdminApplyError::OccupantNotFound(_),
         )) if revoke_members_only_member => {
-            sync_private_kick_affiliation_revocation(
+            sync_private_kick_affiliation_revocation(PrivateKickAffiliationSync {
                 state,
                 connections,
-                &actor,
-                &channel_id,
-                &caller_bare,
-                &args.occupant_jid,
+                actor: &actor,
+                room_jid: &args.channel_jid,
+                channel_id: &channel_id,
+                caller_bare: &caller_bare,
+                occupant_jid: &args.occupant_jid,
                 durable_previous_affiliation,
-            )
+            })
             .await?;
             return Ok(ChannelsKickResult {
                 occupant_jid: args.occupant_jid.clone(),
@@ -3867,6 +4110,7 @@ async fn run_kick(
     // fallible affiliation-revocation ask below, so an actor-
     // infrastructure failure there can't strand an applied kick with
     // no occupant notification and a live call session (#935 review).
+    let persist_failure = applied.persist_failure.clone();
     for (recipient, presence) in applied.presence_updates {
         let _ = connections
             .send_to(&recipient, Stanza::Presence(presence))
@@ -3877,16 +4121,25 @@ async fn run_kick(
     // participation ends with it.
     evict_moderation_removals(sfu, &args.channel_jid, &applied.removed_by_moderation);
 
+    if let Some(error) = persist_failure {
+        return Err(Box::new(CommandResult::Error(
+            XmppError::internal_server_error(Some(format!(
+                "Kick effects were applied but durable convergence failed: {error}"
+            ))),
+        )));
+    }
+
     if revoke_members_only_member {
-        sync_private_kick_affiliation_revocation(
+        sync_private_kick_affiliation_revocation(PrivateKickAffiliationSync {
             state,
             connections,
-            &actor,
-            &channel_id,
-            &caller_bare,
-            &args.occupant_jid,
+            actor: &actor,
+            room_jid: &args.channel_jid,
+            channel_id: &channel_id,
+            caller_bare: &caller_bare,
+            occupant_jid: &args.occupant_jid,
             durable_previous_affiliation,
-        )
+        })
         .await?;
     }
 
@@ -4107,6 +4360,97 @@ pub fn build_kick_form(result: &ChannelsKickResult) -> DataForm {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kameo::actor::Spawn;
+    use waddle_xmpp::muc::room_registry_actor::RoomRegistryActor;
+    use waddle_xmpp::xep::xep0421::OccupantIdSecret;
+
+    enum DelayedCleanup {
+        CreateRollback,
+        NotOwnerDemotion,
+    }
+
+    async fn assert_delayed_cleanup_preserves_replacement(
+        room_name: &str,
+        cleanup: DelayedCleanup,
+    ) {
+        let registry = RoomRegistryActor::spawn(RoomRegistryActor::new(
+            "muc.example.com".to_string(),
+            OccupantIdSecret::new(vec![b'a'; 32]).expect("test secret"),
+        ));
+        let room_jid: BareJid = format!("{room_name}@muc.example.com")
+            .parse()
+            .expect("room JID");
+        let stale_actor = registry
+            .ask(CreateRoom {
+                room_jid: room_jid.clone(),
+                waddle_id: "test".to_string(),
+                channel_id: room_name.to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create original actor");
+        registry
+            .ask(DestroyRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("replace: destroy original actor");
+        let replacement = registry
+            .ask(CreateRoom {
+                room_jid: room_jid.clone(),
+                waddle_id: "replacement".to_string(),
+                channel_id: format!("{room_name}-replacement"),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create replacement actor");
+
+        match cleanup {
+            DelayedCleanup::CreateRollback => {
+                rollback_created_room(&registry, &room_jid, &stale_actor).await;
+            }
+            DelayedCleanup::NotOwnerDemotion => {
+                remove_retained_room_actor(&registry, &room_jid, &stale_actor).await;
+            }
+        }
+
+        let current = registry
+            .ask(GetRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("lookup replacement")
+            .expect("replacement remains registered");
+        assert_eq!(current, replacement);
+        assert!(replacement.is_alive());
+    }
+
+    #[tokio::test]
+    async fn delayed_channel_create_rollback_does_not_destroy_replacement() {
+        assert_delayed_cleanup_preserves_replacement(
+            "channel-rollback",
+            DelayedCleanup::CreateRollback,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn delayed_group_dm_create_rollback_does_not_destroy_replacement() {
+        assert_delayed_cleanup_preserves_replacement(
+            "group-dm-rollback",
+            DelayedCleanup::CreateRollback,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn delayed_not_owner_demotion_does_not_destroy_replacement() {
+        assert_delayed_cleanup_preserves_replacement(
+            "not-owner-demotion",
+            DelayedCleanup::NotOwnerDemotion,
+        )
+        .await;
+    }
 
     #[test]
     fn wire_affiliation_round_trips() {

--- a/server/crates/waddle-server/src/admin/spaces.rs
+++ b/server/crates/waddle-server/src/admin/spaces.rs
@@ -1299,6 +1299,9 @@ async fn run_delete(state: &AppState, args: &SpacesDeleteArgs) -> Result<(), Adm
     let mut destroyed_rooms: std::collections::BTreeSet<BareJid> =
         std::collections::BTreeSet::new();
     for room_jid in &destroy_targets {
+        // Space deletion is an explicit administrator operation over each
+        // logical child-room JID, not rollback of a previously captured actor
+        // incarnation. Destroying the current room is the intended policy.
         if let Err(error) = state
             .room_registry
             .ask(waddle_xmpp::muc::room_registry_actor::DestroyRoom {

--- a/server/crates/waddle-server/src/clustering/claims.rs
+++ b/server/crates/waddle-server/src/clustering/claims.rs
@@ -62,17 +62,24 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use waddle_xmpp::ownership::{
-    ClaimEpoch, ClaimError, ClaimStore, Entity, EntityType, NodeIdentity, ResumeIdentityProof,
-    StalePredicate,
+    ClaimEpoch, ClaimError, ClaimGrant, ClaimStore, Entity, EntityType, NodeIdentity,
+    ResumeIdentityProof, StalePredicate,
 };
 
-use crate::db::{Database, DatabaseError};
+use crate::db::{Database, DatabaseError, Transaction};
 
 /// Convert a backend database failure into the upstream `ClaimError`. The
 /// concrete diagnostic (`DatabaseError`'s `Display`) is preserved as
 /// human-facing text; see [`ClaimError::Backend`]'s doc comment for why a
 /// richer, `waddle-server`-local error type can't cross this boundary.
 fn db_err(error: DatabaseError) -> ClaimError {
+    if matches!(
+        &error,
+        DatabaseError::Internal(sqlx::Error::Database(inner))
+            if inner.code().as_deref() == Some("2200H")
+    ) {
+        return ClaimError::EpochExhausted;
+    }
     ClaimError::Backend(error.to_string())
 }
 
@@ -231,12 +238,118 @@ mod entity_key_tests {
 /// SM-session ownership.
 pub struct PostgresClaimStore {
     db: Database,
+    /// Lease deadline stamped on every node incarnation registered through
+    /// this handle. Persisting the configured value with the row lets every
+    /// ownership and durable-write fence reject a process that wakes after
+    /// its deadline but before a watchdog has committed `expired = true`.
+    lease_ttl: Duration,
 }
 
 impl PostgresClaimStore {
+    const DEFAULT_LEASE_TTL: Duration = Duration::from_secs(30);
+
     pub fn new(db: Database) -> Self {
-        Self { db }
+        Self::with_lease_ttl(db, Self::DEFAULT_LEASE_TTL)
     }
+
+    /// Construct a store whose node registrations carry the exact configured
+    /// node-lease deadline. Production must use this constructor; `new` keeps
+    /// legacy test fixtures concise at the shipped 30-second default.
+    pub fn with_lease_ttl(db: Database, lease_ttl: Duration) -> Self {
+        Self { db, lease_ttl }
+    }
+
+    /// Exact incarnation currently occupying a stable node id, including an
+    /// expired row. Startup uses this only to build an expected-old CAS; the
+    /// row is never replaced from an unlocked observation alone.
+    pub(crate) async fn registered_identity(
+        &self,
+        node_id: &str,
+    ) -> Result<Option<NodeIdentity>, ClaimError> {
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let mut rows = conn
+            .query(
+                "SELECT node_epoch FROM clustering_nodes WHERE node_id = ?",
+                crate::db_params![node_id.to_string()],
+            )
+            .await
+            .map_err(db_err)?;
+        Ok(rows
+            .next()
+            .await
+            .map_err(db_err)?
+            .map(|row| row.get::<String>(0))
+            .transpose()
+            .map_err(db_err)?
+            .map(|epoch| NodeIdentity::new(node_id, epoch)))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum GrantDestinationPolicy {
+    Active,
+    DrainingRecovery,
+    ActiveOrDraining,
+}
+
+/// Lock and validate the destination incarnation after the claim mutation has
+/// obtained the entity row lock. The mutation is still uncommitted, so a
+/// failed proof rolls it back. This ordering matters: validating the node
+/// first lets a claim-row wait consume the whole lease while the early proof
+/// remains materialized as true.
+async fn validate_grant_destination(
+    tx: &mut Transaction<'_>,
+    me: &NodeIdentity,
+    policy: GrantDestinationPolicy,
+    caller_ttl: Option<Duration>,
+) -> Result<bool, ClaimError> {
+    let policy = match policy {
+        GrantDestinationPolicy::Active => "active",
+        GrantDestinationPolicy::DrainingRecovery => "draining",
+        GrantDestinationPolicy::ActiveOrDraining => "either",
+    };
+    let (ttl_mode, ttl_ms) = caller_ttl
+        .map(|ttl| ("bounded", ttl.as_millis().to_string()))
+        .unwrap_or(("row", "0".to_string()));
+    let mut rows = tx
+        .query(
+            r#"
+            WITH locked AS MATERIALIZED (
+                SELECT node_id, node_epoch, heartbeat, expired, draining, lease_ttl_ms
+                FROM clustering_nodes
+                WHERE node_id = ? AND node_epoch = ?
+                FOR SHARE
+            )
+            SELECT EXISTS (
+                SELECT 1 FROM locked
+                WHERE NOT expired
+                  AND (? = 'either'
+                       OR (? = 'active' AND NOT draining)
+                       OR (? = 'draining' AND draining))
+                  AND heartbeat >= clock_timestamp()
+                      - (lease_ttl_ms::text || ' milliseconds')::interval
+                  AND (? = 'row' OR heartbeat >= clock_timestamp()
+                      - (? || ' milliseconds')::interval)
+            )
+            "#,
+            crate::db_params![
+                me.node_id.clone(),
+                me.node_epoch.clone(),
+                policy.to_string(),
+                policy.to_string(),
+                policy.to_string(),
+                ttl_mode.to_string(),
+                ttl_ms,
+            ],
+        )
+        .await
+        .map_err(db_err)?;
+    rows.next()
+        .await
+        .map_err(db_err)?
+        .map(|row| row.get::<bool>(0).map_err(db_err))
+        .transpose()
+        .map(|eligible| eligible.unwrap_or(false))
 }
 
 #[async_trait]
@@ -263,6 +376,10 @@ impl ClaimStore for PostgresClaimStore {
                 -- signed origin envelopes against this value before applying
                 -- delivery effects.
                 peer_id           TEXT,
+                -- Exact deadline for this incarnation. Authority checks use
+                -- this row-local value so mixed/rolling configuration cannot
+                -- accidentally grant a longer lease than the owner registered.
+                lease_ttl_ms      BIGINT NOT NULL DEFAULT 30000,
                 -- ADR-0017 Phase 3 Slice 10 (Q5's operational definition of
                 -- "the current deployment generation" — realized here):
                 -- stamped once, at this row's FIRST registration, and never
@@ -292,6 +409,12 @@ impl ClaimStore for PostgresClaimStore {
         .await
         .map_err(db_err)?;
         conn.execute(
+            "ALTER TABLE clustering_nodes ADD COLUMN IF NOT EXISTS lease_ttl_ms BIGINT NOT NULL DEFAULT 30000",
+            (),
+        )
+        .await
+        .map_err(db_err)?;
+        conn.execute(
             r#"
             CREATE TABLE IF NOT EXISTS clustering_claims (
                 entity      TEXT PRIMARY KEY,
@@ -314,6 +437,51 @@ impl ClaimStore for PostgresClaimStore {
         )
         .await
         .map_err(db_err)?;
+        // Global, never-reset claim generations close release/reacquire ABA:
+        // deleting a claim row must not make a later grant reuse epoch 0 (or
+        // any earlier epoch). The singleton seed row is published in the
+        // same statement that advances the sequence above every legacy row;
+        // grant statements take a share lock on it before calling `nextval`,
+        // so concurrent startup cannot allocate before seeding commits.
+        conn.execute(
+            "CREATE SEQUENCE IF NOT EXISTS clustering_claim_epoch_seq AS BIGINT",
+            (),
+        )
+        .await
+        .map_err(db_err)?;
+        conn.execute(
+            r#"
+            CREATE TABLE IF NOT EXISTS clustering_claim_epoch_seed (
+                singleton BOOLEAN PRIMARY KEY CHECK (singleton)
+            )
+            "#,
+            (),
+        )
+        .await
+        .map_err(db_err)?;
+        conn.execute(
+            r#"
+            WITH won AS (
+                INSERT INTO clustering_claim_epoch_seed (singleton)
+                VALUES (TRUE)
+                ON CONFLICT (singleton) DO NOTHING
+                RETURNING 1
+            )
+            SELECT CASE
+                WHEN EXISTS (SELECT 1 FROM won) THEN setval(
+                    'clustering_claim_epoch_seq',
+                    GREATEST(
+                        (SELECT COALESCE(MAX(claim_epoch), 0) FROM clustering_claims),
+                        nextval('clustering_claim_epoch_seq')
+                    )
+                )
+                ELSE NULL
+            END
+            "#,
+            (),
+        )
+        .await
+        .map_err(db_err)?;
         // ADR-0017 Phase 3 Slice 3: steal-intents unwedge/owner-veto path
         // (element 4's "Unwedge" text, quoted verbatim in the phase plan).
         // `UNIQUE (entity, reporter_node)` + the upsert in
@@ -323,9 +491,13 @@ impl ClaimStore for PostgresClaimStore {
         conn.execute(
             r#"
             CREATE TABLE IF NOT EXISTS clustering_steal_intents (
-                entity        TEXT NOT NULL,
-                reporter_node TEXT NOT NULL,
-                created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+                entity             TEXT NOT NULL,
+                reporter_node      TEXT NOT NULL,
+                reporter_epoch     TEXT NOT NULL,
+                target_node        TEXT NOT NULL,
+                target_node_epoch  TEXT NOT NULL,
+                target_claim_epoch BIGINT NOT NULL,
+                created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
                 UNIQUE (entity, reporter_node)
             )
             "#,
@@ -333,6 +505,32 @@ impl ClaimStore for PostgresClaimStore {
         )
         .await
         .map_err(db_err)?;
+        for ddl in [
+            "ALTER TABLE clustering_steal_intents ADD COLUMN IF NOT EXISTS reporter_epoch TEXT",
+            "ALTER TABLE clustering_steal_intents ADD COLUMN IF NOT EXISTS target_node TEXT",
+            "ALTER TABLE clustering_steal_intents ADD COLUMN IF NOT EXISTS target_node_epoch TEXT",
+            "ALTER TABLE clustering_steal_intents ADD COLUMN IF NOT EXISTS target_claim_epoch BIGINT",
+        ] {
+            conn.execute(ddl, ()).await.map_err(db_err)?;
+        }
+        // Legacy intent rows cannot be made safe: they identify neither the
+        // reporter incarnation nor the target grant. Drop only those
+        // unbound rows during the one-time schema transition, then make the
+        // exact bindings mandatory for every future report.
+        conn.execute(
+            "DELETE FROM clustering_steal_intents WHERE reporter_epoch IS NULL OR target_node IS NULL OR target_node_epoch IS NULL OR target_claim_epoch IS NULL",
+            (),
+        )
+        .await
+        .map_err(db_err)?;
+        for ddl in [
+            "ALTER TABLE clustering_steal_intents ALTER COLUMN reporter_epoch SET NOT NULL",
+            "ALTER TABLE clustering_steal_intents ALTER COLUMN target_node SET NOT NULL",
+            "ALTER TABLE clustering_steal_intents ALTER COLUMN target_node_epoch SET NOT NULL",
+            "ALTER TABLE clustering_steal_intents ALTER COLUMN target_claim_epoch SET NOT NULL",
+        ] {
+            conn.execute(ddl, ()).await.map_err(db_err)?;
+        }
         // Backs both the steal CAS's per-entity `EXISTS` probe (hot path)
         // and `owner_steal_intents`'s per-owner read. The abandoned-intent
         // sweep (a future orphan-reaper concern, Slice 5) is deliberately
@@ -352,14 +550,15 @@ impl ClaimStore for PostgresClaimStore {
     }
 
     async fn acquire(&self, entity: &Entity, me: &NodeIdentity) -> Result<ClaimEpoch, ClaimError> {
-        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
         // Acquire CAS (element 4): a fresh claim only inserts; a
         // still-live claim on the same entity leaves the row untouched and
         // affects zero rows.
         //
-        // ADR-0017 Phase 3 Slice 10: the `INSERT ... SELECT ... WHERE NOT
-        // EXISTS (draining)` guard makes "a draining node never acquires a
-        // NEW claim" atomic with the CAS itself — never a separate
+        // ADR-0017 Phase 3 Slice 10 + stable-node-id hardening: the `INSERT
+        // ... SELECT ... WHERE EXISTS (exact live incarnation)` guard makes
+        // "only the current non-expired, non-draining epoch acquires a NEW
+        // claim" atomic with the CAS itself — never a separate
         // check-then-act read, which would leave a TOCTOU window between
         // observing "not draining" and the INSERT actually landing. A
         // draining node's own `mark_draining` UPDATE (issued once, at the
@@ -368,57 +567,84 @@ impl ClaimStore for PostgresClaimStore {
         // every subsequent `acquire`/`steal_stale` call under ordinary
         // READ COMMITTED semantics by the time this node's drain loop
         // itself proceeds to iterate owned entities.
-        let affected = conn
-            .execute(
+        // A missing claim row cannot itself be locked. Serialize the absence
+        // with a transaction-scoped advisory lock derived from the injective
+        // entity key; hash collisions only reduce concurrency, never safety.
+        tx.execute(
+            "SELECT pg_advisory_xact_lock(hashtextextended(?, 8717))",
+            crate::db_params![entity_key(entity)],
+        )
+        .await
+        .map_err(db_err)?;
+
+        let mut granted_rows = tx
+            .query(
                 r#"
-                INSERT INTO clustering_claims (entity, entity_type, node_id, node_epoch, claim_epoch)
-                SELECT ?, ?, ?, ?, 0
-                WHERE NOT EXISTS (
-                    SELECT 1 FROM clustering_nodes
-                    WHERE node_id = ? AND node_epoch = ? AND draining
+                WITH epoch_seed AS MATERIALIZED (
+                    SELECT 1 FROM clustering_claim_epoch_seed
+                    WHERE singleton
+                    FOR SHARE
+                ),
+                granted AS (
+                    INSERT INTO clustering_claims (entity, entity_type, node_id, node_epoch, claim_epoch)
+                    SELECT ?, ?, ?, ?, nextval('clustering_claim_epoch_seq')
+                    FROM epoch_seed
+                    ON CONFLICT (entity) DO NOTHING
+                    RETURNING claim_epoch
                 )
-                ON CONFLICT (entity) DO NOTHING
+                SELECT claim_epoch FROM granted
                 "#,
                 crate::db_params![
                     entity_key(entity),
                     entity.entity_type.as_db_str().to_string(),
                     me.node_id.clone(),
                     me.node_epoch.clone(),
-                    me.node_id.clone(),
-                    me.node_epoch.clone(),
                 ],
             )
             .await
             .map_err(db_err)?;
-        if affected == 1 {
-            return Ok(ClaimEpoch(0));
+        if let Some(row) = granted_rows.next().await.map_err(db_err)? {
+            let epoch = ClaimEpoch(row.get::<i64>(0).map_err(db_err)?);
+            drop(granted_rows);
+            if !validate_grant_destination(&mut tx, me, GrantDestinationPolicy::Active, None)
+                .await?
+            {
+                return Err(ClaimError::Draining);
+            }
+            tx.execute(
+                "DELETE FROM clustering_steal_intents WHERE entity = ?",
+                crate::db_params![entity_key(entity)],
+            )
+            .await
+            .map_err(db_err)?;
+            tx.commit().await.map_err(db_err)?;
+            return Ok(epoch);
         }
+        drop(granted_rows);
         // Zero rows affected: either a genuine conflict (someone already
-        // holds this entity) or this node's own draining gate blocked the
-        // INSERT before it ever reached `ON CONFLICT`. Distinguish with one
-        // follow-up read — only ever taken on this already-cold "lost the
-        // race" path, never the common uncontended-acquire case above.
-        let mut rows = conn
+        // holds this entity) or this exact node incarnation is not eligible
+        // to acquire. Distinguish with one follow-up read — only ever taken
+        // on this already-cold "lost the race" path.
+        let mut rows = tx
             .query(
-                r#"
-                SELECT
-                    EXISTS (SELECT 1 FROM clustering_claims WHERE entity = ?) AS claimed,
-                    COALESCE(
-                        (SELECT draining FROM clustering_nodes WHERE node_id = ? AND node_epoch = ?),
-                        false
-                    ) AS draining
-                "#,
-                crate::db_params![entity_key(entity), me.node_id.clone(), me.node_epoch.clone()],
+                "SELECT EXISTS (SELECT 1 FROM clustering_claims WHERE entity = ?)",
+                crate::db_params![entity_key(entity)],
             )
             .await
             .map_err(db_err)?;
         match rows.next().await.map_err(db_err)? {
             Some(row) => {
                 let claimed: bool = row.get(0).map_err(db_err)?;
-                let draining: bool = row.get(1).map_err(db_err)?;
                 if claimed {
                     Err(ClaimError::AlreadyClaimed)
-                } else if draining {
+                } else if !validate_grant_destination(
+                    &mut tx,
+                    me,
+                    GrantDestinationPolicy::Active,
+                    None,
+                )
+                .await?
+                {
                     Err(ClaimError::Draining)
                 } else {
                     // A genuine race: the entity was momentarily claimed by
@@ -462,7 +688,21 @@ impl ClaimStore for PostgresClaimStore {
                 let conn = self.db.control_plane_guard().await.map_err(db_err)?;
                 let mut rows = conn
                     .query(
-                        "SELECT node_id, node_epoch, claim_epoch FROM clustering_claims WHERE entity = ?",
+                        r#"
+                        SELECT
+                            c.node_id,
+                            c.node_epoch,
+                            c.claim_epoch,
+                            EXISTS (
+                                SELECT 1 FROM clustering_nodes n
+                                WHERE n.node_id = c.node_id
+                                  AND n.node_epoch = c.node_epoch
+                                  AND NOT n.expired
+                                  AND n.heartbeat >= now() - (n.lease_ttl_ms::text || ' milliseconds')::interval
+                            ) AS owner_incarnation_live
+                        FROM clustering_claims c
+                        WHERE c.entity = ?
+                        "#,
                         crate::db_params![entity_key(entity)],
                     )
                     .await
@@ -472,7 +712,11 @@ impl ClaimStore for PostgresClaimStore {
                         let node_id: String = row.get(0).map_err(db_err)?;
                         let node_epoch: String = row.get(1).map_err(db_err)?;
                         let claim_epoch: i64 = row.get(2).map_err(db_err)?;
-                        if node_id == me.node_id && node_epoch == me.node_epoch {
+                        let owner_incarnation_live: bool = row.get(3).map_err(db_err)?;
+                        if node_id == me.node_id
+                            && node_epoch == me.node_epoch
+                            && owner_incarnation_live
+                        {
                             // Self-reacquire: this exact node/epoch already
                             // holds the claim (either the losing side of a
                             // concurrent first-write race against itself, or
@@ -480,6 +724,12 @@ impl ClaimStore for PostgresClaimStore {
                             // this same identity) — idempotent, not a
                             // conflict.
                             Ok(ClaimEpoch(claim_epoch))
+                        } else if node_id == me.node_id && node_epoch == me.node_epoch {
+                            // The claim still names this caller's stale epoch,
+                            // but the corresponding node incarnation is gone
+                            // or expired. Never resurrect it through the
+                            // idempotent self-reacquire path.
+                            Err(err)
                         } else {
                             Err(ClaimError::AlreadyClaimed)
                         }
@@ -525,8 +775,7 @@ impl ClaimStore for PostgresClaimStore {
                 if entity.entity_type == EntityType::SmSession {
                     return Err(ClaimError::SmSessionExcludedFromStealIntent);
                 }
-                let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-                let next_epoch = observed.0 + 1;
+                let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
                 // FIX 1(a) — council-adjudicated redesign closing the veto
                 // race (write skew under READ COMMITTED between this CAS
                 // and `clear_steal_intent`'s DELETE, both previously gated
@@ -599,46 +848,68 @@ impl ClaimStore for PostgresClaimStore {
                 // missing, expired, or draining local lease must not be able
                 // to acquire a new claim merely because it won this CAS after
                 // another node's watchdog expired it.
-                let affected = conn
-                    .execute(
+                // Acquire every existing intent-row lock before deciding
+                // whether its age has crossed the threshold. PostgreSQL may
+                // evaluate a DELETE predicate before waiting on a row lock;
+                // the separate lock phase makes `clock_timestamp()` below a
+                // genuinely post-wait freshness decision.
+                let mut intent_rows = tx
+                    .query(
+                        "SELECT 1 FROM clustering_steal_intents WHERE entity = ? ORDER BY reporter_node FOR UPDATE",
+                        crate::db_params![entity_key(entity)],
+                    )
+                    .await
+                    .map_err(db_err)?;
+                while intent_rows.next().await.map_err(db_err)?.is_some() {}
+                drop(intent_rows);
+
+                let mut granted_rows = tx
+                    .query(
                         r#"
-                        WITH live_stealer AS (
-                            SELECT 1 FROM clustering_nodes
-                            WHERE node_id = ?
-                              AND node_epoch = ?
-                              AND NOT expired
-                              AND NOT draining
+                        WITH epoch_seed AS MATERIALIZED (
+                            SELECT 1 FROM clustering_claim_epoch_seed
+                            WHERE singleton
+                            FOR SHARE
                         ),
                         consumed AS (
+                            DELETE FROM clustering_steal_intents si
+                            USING clustering_claims c
+                            WHERE si.entity = ?
+                              AND c.entity = si.entity
+                              AND c.claim_epoch = ?
+                              AND si.target_node = c.node_id
+                              AND si.target_node_epoch = c.node_epoch
+                              AND si.target_claim_epoch = c.claim_epoch
+                              AND si.created_at < clock_timestamp() - (? || ' milliseconds')::interval
+                            RETURNING 1
+                        ),
+                        granted AS (
+                            UPDATE clustering_claims
+                            SET node_id = ?,
+                                node_epoch = ?,
+                                claim_epoch = nextval('clustering_claim_epoch_seq')
+                            WHERE entity = ?
+                              AND claim_epoch = ?
+                              AND EXISTS (SELECT 1 FROM consumed)
+                              AND EXISTS (SELECT 1 FROM epoch_seed)
+                            RETURNING claim_epoch
+                        ),
+                        cleared AS (
                             DELETE FROM clustering_steal_intents
                             WHERE entity = ?
-                              AND created_at < now() - (? || ' milliseconds')::interval
-                              AND EXISTS (SELECT 1 FROM live_stealer)
-                              AND EXISTS (
-                                  SELECT 1 FROM clustering_claims
-                                  WHERE entity = ? AND claim_epoch = ?
-                              )
-                            RETURNING 1
+                              AND EXISTS (SELECT 1 FROM granted)
                         )
-                        UPDATE clustering_claims
-                        SET node_id = ?, node_epoch = ?, claim_epoch = ?
-                        WHERE entity = ?
-                          AND claim_epoch = ?
-                          AND EXISTS (SELECT 1 FROM consumed)
-                          AND EXISTS (SELECT 1 FROM live_stealer)
+                        SELECT claim_epoch FROM granted
                         "#,
                         crate::db_params![
-                            me.node_id.clone(),
-                            me.node_epoch.clone(),
                             entity_key(entity),
+                            observed.0,
                             intent_ttl.as_millis().to_string(),
-                            entity_key(entity),
-                            observed.0,
                             me.node_id.clone(),
                             me.node_epoch.clone(),
-                            next_epoch,
                             entity_key(entity),
                             observed.0,
+                            entity_key(entity),
                         ],
                     )
                     .await
@@ -650,15 +921,27 @@ impl ClaimStore for PostgresClaimStore {
                         );
                         db_err(error)
                     })?;
-                if affected == 1 {
-                    Ok(ClaimEpoch(next_epoch))
+                if let Some(row) = granted_rows.next().await.map_err(db_err)? {
+                    let epoch = ClaimEpoch(row.get::<i64>(0).map_err(db_err)?);
+                    drop(granted_rows);
+                    if !validate_grant_destination(
+                        &mut tx,
+                        me,
+                        GrantDestinationPolicy::Active,
+                        None,
+                    )
+                    .await?
+                    {
+                        return Err(ClaimError::Conflict);
+                    }
+                    tx.commit().await.map_err(db_err)?;
+                    Ok(epoch)
                 } else {
                     Err(ClaimError::Conflict)
                 }
             }
             StalePredicate::OwnerStale => {
-                let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-                let next_epoch = observed.0 + 1;
+                let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
                 // Owner-stale steal CAS (element 4): the `NOT EXISTS`
                 // correlated subquery realizes the ADR's "LEFT JOIN"
                 // predicate (`nodes.node_id IS NULL OR nodes.expired OR
@@ -680,45 +963,143 @@ impl ClaimStore for PostgresClaimStore {
                 // live-stealer predicate, not just "not draining". A node
                 // whose own row is missing or committed expired is not allowed
                 // to win orphaned claims under its dead identity.
-                let affected = conn
-                    .execute(
+                let mut granted_rows = tx
+                    .query(
                         r#"
-                        UPDATE clustering_claims
-                        SET node_id = ?, node_epoch = ?, claim_epoch = ?
-                        WHERE entity = ?
-                          AND claim_epoch = ?
-                          AND NOT EXISTS (
-                            SELECT 1 FROM clustering_nodes n
-                            WHERE n.node_id = clustering_claims.node_id
-                              AND NOT n.expired
-                              AND n.node_epoch = clustering_claims.node_epoch
-                          )
-                          AND EXISTS (
-                            SELECT 1 FROM clustering_nodes
-                            WHERE node_id = ?
-                              AND node_epoch = ?
-                              AND NOT expired
-                              AND NOT draining
-                          )
+                        WITH epoch_seed AS MATERIALIZED (
+                            SELECT 1 FROM clustering_claim_epoch_seed
+                            WHERE singleton
+                            FOR SHARE
+                        ),
+                        granted AS (
+                            UPDATE clustering_claims
+                            SET node_id = ?,
+                                node_epoch = ?,
+                                claim_epoch = nextval('clustering_claim_epoch_seq')
+                            WHERE entity = ?
+                              AND claim_epoch = ?
+                              AND NOT EXISTS (
+                                SELECT 1 FROM clustering_nodes n
+                                WHERE n.node_id = clustering_claims.node_id
+                                  AND NOT n.expired
+                                  AND n.node_epoch = clustering_claims.node_epoch
+                              )
+                              AND EXISTS (SELECT 1 FROM epoch_seed)
+                            RETURNING claim_epoch
+                        ),
+                        cleared AS (
+                            DELETE FROM clustering_steal_intents
+                            WHERE entity = ?
+                              AND EXISTS (SELECT 1 FROM granted)
+                        )
+                        SELECT claim_epoch FROM granted
                         "#,
                         crate::db_params![
                             me.node_id.clone(),
                             me.node_epoch.clone(),
-                            next_epoch,
                             entity_key(entity),
                             observed.0,
-                            me.node_id.clone(),
-                            me.node_epoch.clone(),
+                            entity_key(entity),
                         ],
                     )
                     .await
                     .map_err(db_err)?;
-                if affected == 1 {
-                    Ok(ClaimEpoch(next_epoch))
+                if let Some(row) = granted_rows.next().await.map_err(db_err)? {
+                    let epoch = ClaimEpoch(row.get::<i64>(0).map_err(db_err)?);
+                    drop(granted_rows);
+                    if !validate_grant_destination(
+                        &mut tx,
+                        me,
+                        GrantDestinationPolicy::Active,
+                        None,
+                    )
+                    .await?
+                    {
+                        return Err(ClaimError::Conflict);
+                    }
+                    tx.commit().await.map_err(db_err)?;
+                    Ok(epoch)
                 } else {
                     Err(ClaimError::Conflict)
                 }
             }
+        }
+    }
+
+    async fn reclaim_after_self_fence(
+        &self,
+        entity: &Entity,
+        observed: ClaimEpoch,
+        expected_owner: &NodeIdentity,
+        me: &NodeIdentity,
+        lease_ttl: Duration,
+    ) -> Result<ClaimEpoch, ClaimError> {
+        if expected_owner.node_id != me.node_id {
+            return Err(ClaimError::Conflict);
+        }
+        let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
+        let mut granted_rows = tx
+            .query(
+                r#"
+                WITH epoch_seed AS MATERIALIZED (
+                    SELECT 1 FROM clustering_claim_epoch_seed
+                    WHERE singleton
+                    FOR SHARE
+                ),
+                granted AS (
+                    UPDATE clustering_claims
+                    SET node_id = ?,
+                        node_epoch = ?,
+                        claim_epoch = nextval('clustering_claim_epoch_seq')
+                    WHERE entity = ?
+                      AND node_id = ?
+                      AND node_epoch = ?
+                      AND claim_epoch = ?
+                      AND NOT EXISTS (
+                        SELECT 1 FROM clustering_nodes n
+                        WHERE n.node_id = clustering_claims.node_id
+                          AND n.node_epoch = clustering_claims.node_epoch
+                          AND NOT n.expired
+                      )
+                      AND EXISTS (SELECT 1 FROM epoch_seed)
+                    RETURNING claim_epoch
+                ),
+                cleared AS (
+                    DELETE FROM clustering_steal_intents
+                    WHERE entity = ?
+                      AND EXISTS (SELECT 1 FROM granted)
+                )
+                SELECT claim_epoch FROM granted
+                "#,
+                crate::db_params![
+                    me.node_id.clone(),
+                    me.node_epoch.clone(),
+                    entity_key(entity),
+                    expected_owner.node_id.clone(),
+                    expected_owner.node_epoch.clone(),
+                    observed.0,
+                    entity_key(entity),
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        if let Some(row) = granted_rows.next().await.map_err(db_err)? {
+            let epoch = ClaimEpoch(row.get::<i64>(0).map_err(db_err)?);
+            drop(granted_rows);
+            if !validate_grant_destination(
+                &mut tx,
+                me,
+                GrantDestinationPolicy::DrainingRecovery,
+                Some(lease_ttl),
+            )
+            .await?
+            {
+                return Err(ClaimError::Conflict);
+            }
+            tx.commit().await.map_err(db_err)?;
+            Ok(epoch)
+        } else {
+            Err(ClaimError::Conflict)
         }
     }
 
@@ -729,31 +1110,66 @@ impl ClaimStore for PostgresClaimStore {
         _witness: ResumeIdentityProof,
         me: &NodeIdentity,
     ) -> Result<ClaimEpoch, ClaimError> {
-        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        let next_epoch = observed.0 + 1;
+        let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
         // Consent/epoch-only steal CAS (element 4's third variant): no
-        // staleness predicate at all — authorized exclusively by the
-        // caller already holding a `ResumeIdentityProof`, which only
-        // `ownership::resume::verify_resume_identity` can mint.
-        let affected = conn
-            .execute(
+        // OWNER-staleness predicate — authorized by the caller already
+        // holding a `ResumeIdentityProof`. The destination incarnation must
+        // nevertheless still have an exact, non-expired, heartbeat-fresh
+        // node row; otherwise
+        // a task carrying a pre-fence SharedNodeIdentity could resurrect an
+        // immediately orphaned claim after this process rotates its epoch.
+        // Draining remains allowed for this consent path so resumable
+        // sessions already in flight can finish during an orderly drain.
+        let mut granted_rows = tx
+            .query(
                 r#"
-                UPDATE clustering_claims
-                SET node_id = ?, node_epoch = ?, claim_epoch = ?
-                WHERE entity = ? AND claim_epoch = ?
+                WITH epoch_seed AS MATERIALIZED (
+                    SELECT 1 FROM clustering_claim_epoch_seed
+                    WHERE singleton
+                    FOR SHARE
+                ),
+                granted AS (
+                    UPDATE clustering_claims
+                    SET node_id = ?,
+                        node_epoch = ?,
+                        claim_epoch = nextval('clustering_claim_epoch_seq')
+                    WHERE entity = ?
+                      AND claim_epoch = ?
+                      AND EXISTS (SELECT 1 FROM epoch_seed)
+                    RETURNING claim_epoch
+                ),
+                cleared AS (
+                    DELETE FROM clustering_steal_intents
+                    WHERE entity = ?
+                      AND EXISTS (SELECT 1 FROM granted)
+                )
+                SELECT claim_epoch FROM granted
                 "#,
                 crate::db_params![
                     me.node_id.clone(),
                     me.node_epoch.clone(),
-                    next_epoch,
                     entity_key(entity),
                     observed.0,
+                    entity_key(entity),
                 ],
             )
             .await
             .map_err(db_err)?;
-        if affected == 1 {
-            Ok(ClaimEpoch(next_epoch))
+        if let Some(row) = granted_rows.next().await.map_err(db_err)? {
+            let epoch = ClaimEpoch(row.get::<i64>(0).map_err(db_err)?);
+            drop(granted_rows);
+            if !validate_grant_destination(
+                &mut tx,
+                me,
+                GrantDestinationPolicy::ActiveOrDraining,
+                None,
+            )
+            .await?
+            {
+                return Err(ClaimError::Conflict);
+            }
+            tx.commit().await.map_err(db_err)?;
+            Ok(epoch)
         } else {
             Err(ClaimError::Conflict)
         }
@@ -770,11 +1186,11 @@ impl ClaimStore for PostgresClaimStore {
         // applies and to learn the observed epoch to bind into a later
         // `steal_for_resume` call.
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        // `owner_lease_fresh` (council-adjudicated fix, Slice 6): the exact
-        // same `NOT EXISTS` owner-stale predicate `steal_stale`'s
-        // `OwnerStale` arm uses, read here read-only/unlocked alongside the
-        // claim row itself — never a raw heartbeat comparison, only the
-        // committed `expired` flag (see that predicate's own doc comment).
+        // `owner_lease_fresh` is serving authority, not steal authority: it
+        // requires the exact non-expired incarnation and its row-local
+        // heartbeat deadline. `steal_stale(OwnerStale)` deliberately remains
+        // stricter and consumes only committed `expired`; a raw deadline
+        // lapse can fail closed without letting another node steal.
         let mut rows = conn
             .query(
                 r#"
@@ -787,6 +1203,7 @@ impl ClaimStore for PostgresClaimStore {
                         WHERE n.node_id = c.node_id
                           AND NOT n.expired
                           AND n.node_epoch = c.node_epoch
+                          AND n.heartbeat >= now() - (n.lease_ttl_ms::text || ' milliseconds')::interval
                     ) AS owner_lease_fresh
                 FROM clustering_claims c
                 WHERE c.entity = ?
@@ -811,6 +1228,54 @@ impl ClaimStore for PostgresClaimStore {
         }
     }
 
+    async fn owned_claims(
+        &self,
+        entities: &[Entity],
+        me: &NodeIdentity,
+    ) -> Result<Vec<ClaimGrant>, ClaimError> {
+        if entities.is_empty() {
+            return Ok(Vec::new());
+        }
+        let by_key = entities
+            .iter()
+            .cloned()
+            .map(|entity| (entity_key(&entity), entity))
+            .collect::<std::collections::HashMap<_, _>>();
+        let requested = serde_json::to_string(&by_key.keys().collect::<Vec<_>>())
+            .map_err(|error| ClaimError::Backend(error.to_string()))?;
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let mut rows = conn
+            .query(
+                r#"
+                WITH requested AS MATERIALIZED (
+                    SELECT jsonb_array_elements_text(?::jsonb) AS entity
+                )
+                SELECT c.entity, c.claim_epoch
+                FROM clustering_claims c
+                JOIN requested r ON r.entity = c.entity
+                JOIN clustering_nodes n
+                  ON n.node_id = c.node_id
+                 AND n.node_epoch = c.node_epoch
+                WHERE c.node_id = ?
+                  AND c.node_epoch = ?
+                  AND NOT n.expired
+                  AND n.heartbeat >= now() - (n.lease_ttl_ms::text || ' milliseconds')::interval
+                "#,
+                crate::db_params![requested, me.node_id.clone(), me.node_epoch.clone(),],
+            )
+            .await
+            .map_err(db_err)?;
+        let mut grants = Vec::new();
+        while let Some(row) = rows.next().await.map_err(db_err)? {
+            let key = row.get::<String>(0).map_err(db_err)?;
+            let epoch = ClaimEpoch(row.get::<i64>(1).map_err(db_err)?);
+            if let Some(entity) = by_key.get(&key) {
+                grants.push(ClaimGrant::new(entity.clone(), me.clone(), epoch));
+            }
+        }
+        Ok(grants)
+    }
+
     async fn fence(
         &self,
         entity: &Entity,
@@ -825,10 +1290,24 @@ impl ClaimStore for PostgresClaimStore {
         let mut rows = conn
             .query(
                 r#"
-                SELECT 1 FROM clustering_claims
-                WHERE entity = ? AND node_id = ? AND claim_epoch = ?
+                SELECT 1
+                FROM clustering_claims c
+                JOIN clustering_nodes n
+                  ON n.node_id = c.node_id
+                 AND n.node_epoch = c.node_epoch
+                WHERE c.entity = ?
+                  AND c.node_id = ?
+                  AND c.node_epoch = ?
+                  AND c.claim_epoch = ?
+                  AND NOT n.expired
+                  AND n.heartbeat >= now() - (n.lease_ttl_ms::text || ' milliseconds')::interval
                 "#,
-                crate::db_params![entity_key(entity), me.node_id.clone(), mine.0],
+                crate::db_params![
+                    entity_key(entity),
+                    me.node_id.clone(),
+                    me.node_epoch.clone(),
+                    mine.0,
+                ],
             )
             .await
             .map_err(db_err)?;
@@ -841,18 +1320,28 @@ impl ClaimStore for PostgresClaimStore {
         me: &NodeIdentity,
         mine: ClaimEpoch,
     ) -> Result<(), ClaimError> {
-        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
         // Epoch-gated release: best-effort. A claim already stolen out
         // from under `me` (0 rows affected) is a no-op, not an error —
         // graceful drain releases whatever it still owns and does not
         // treat a lost race as a failure.
-        let affected = conn
+        let affected = tx
             .execute(
                 r#"
+                WITH live_owner AS MATERIALIZED (
+                    SELECT 1 FROM clustering_nodes
+                    WHERE node_id = ?
+                      AND node_epoch = ?
+                      AND NOT expired
+                    FOR SHARE
+                )
                 DELETE FROM clustering_claims
                 WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ?
+                  AND EXISTS (SELECT 1 FROM live_owner)
                 "#,
                 crate::db_params![
+                    me.node_id.clone(),
+                    me.node_epoch.clone(),
                     entity_key(entity),
                     me.node_id.clone(),
                     me.node_epoch.clone(),
@@ -861,6 +1350,7 @@ impl ClaimStore for PostgresClaimStore {
             )
             .await
             .map_err(db_err)?;
+        tx.commit().await.map_err(db_err)?;
         if affected == 0 {
             tracing::debug!(
                 entity = %entity.id,
@@ -872,36 +1362,56 @@ impl ClaimStore for PostgresClaimStore {
         Ok(())
     }
 
-    async fn release_many(&self, entities: &[Entity], me: &NodeIdentity) -> Result<(), ClaimError> {
-        if entities.is_empty() {
+    async fn release_many(&self, grants: &[ClaimGrant]) -> Result<(), ClaimError> {
+        if grants.is_empty() {
             return Ok(());
         }
-        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        // One round trip for the whole batch (Slice 10's ~18k modeled
-        // drain claims): release does not pin a per-entity epoch, only
-        // "still owned by me, under my current node identity, whatever
-        // the epoch." This is exactly the epoch-blind ABA window documented
-        // on `ClaimStore::release_many`'s trait doc comment — see there for
-        // the mitigations (Slice 2 draining marker, Slice 10 batch
-        // ordering).
-        // `db_params!` only accepts a fixed, comma-separated literal list,
-        // not a runtime-length one, so the dynamically-sized `IN (...)`
-        // parameter list is built as a plain `Vec<Value>` directly (`Vec<Value>`
-        // implements `IntoParams`).
-        let placeholders = entities.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-        let sql = format!(
-            "DELETE FROM clustering_claims WHERE node_id = ? AND node_epoch = ? AND entity IN ({placeholders})"
-        );
-        let mut params: Vec<crate::db::Value> = vec![
-            crate::db::Value::from(me.node_id.clone()),
-            crate::db::Value::from(me.node_epoch.clone()),
-        ];
-        params.extend(
-            entities
-                .iter()
-                .map(|entity| crate::db::Value::from(entity_key(entity))),
-        );
-        conn.execute(&sql, params).await.map_err(db_err)?;
+        let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
+        // One round trip for the whole ~18k-claim modeled drain, with every
+        // row matched by its exact grant. A JSON recordset uses one bind
+        // parameter instead of four per grant; the latter would exceed
+        // PostgreSQL's 65,535-parameter protocol limit at modeled scale.
+        let requested = grants
+            .iter()
+            .map(|grant| {
+                serde_json::json!({
+                    "entity": entity_key(&grant.entity),
+                    "node_id": grant.owner.node_id,
+                    "node_epoch": grant.owner.node_epoch,
+                    "claim_epoch": grant.epoch.0,
+                })
+            })
+            .collect::<Vec<_>>();
+        let requested = serde_json::to_string(&requested)
+            .map_err(|error| ClaimError::Backend(error.to_string()))?;
+        let sql = "WITH requested AS MATERIALIZED (\
+                 SELECT entity, node_id, node_epoch, claim_epoch \
+                 FROM jsonb_to_recordset(?::jsonb) AS r(\
+                     entity TEXT, node_id TEXT, node_epoch TEXT, claim_epoch BIGINT\
+                 )\
+             ), \
+             live_owners AS MATERIALIZED (\
+                 SELECT n.node_id, n.node_epoch \
+                 FROM clustering_nodes n \
+                 WHERE NOT n.expired \
+                   AND EXISTS (\
+                       SELECT 1 FROM requested r \
+                       WHERE r.node_id = n.node_id AND r.node_epoch = n.node_epoch\
+                   ) \
+                 FOR SHARE OF n\
+             ) \
+             DELETE FROM clustering_claims c \
+             USING requested r, live_owners l \
+             WHERE c.entity = r.entity \
+               AND c.node_id = r.node_id \
+               AND c.node_epoch = r.node_epoch \
+               AND c.claim_epoch = r.claim_epoch \
+               AND l.node_id = r.node_id \
+               AND l.node_epoch = r.node_epoch";
+        tx.execute(sql, crate::db_params![requested])
+            .await
+            .map_err(db_err)?;
+        tx.commit().await.map_err(db_err)?;
         Ok(())
     }
 }
@@ -928,7 +1438,7 @@ impl ClaimStore for PostgresClaimStore {
 #[async_trait]
 pub trait NodeLeaseStore: Send + Sync {
     /// Register this node's liveness row: fresh startup, or re-registration
-    /// under a new `node_id`/`node_epoch` after a self-fence (Q7/element 4).
+    /// under a new `node_epoch` after a self-fence (Q7/element 4).
     /// Idempotent (`ON CONFLICT` upsert) so a retried registration is safe.
     async fn register(
         &self,
@@ -948,6 +1458,57 @@ pub trait NodeLeaseStore: Send + Sync {
         _peer_id: Option<String>,
     ) -> Result<(), ClaimError> {
         self.register(me, pod_template_hash).await
+    }
+
+    /// Initial process registration after the caller has proved any
+    /// pre-existing exact incarnation stale. `expected_previous = None`
+    /// means the stable node id must be absent; `Some` is an exact
+    /// compare-and-swap source and may not match any later incarnation.
+    async fn register_initial_with_peer_id(
+        &self,
+        expected_previous: Option<&NodeIdentity>,
+        me: &NodeIdentity,
+        pod_template_hash: Option<String>,
+        peer_id: Option<String>,
+    ) -> Result<(), ClaimError> {
+        let _ = expected_previous;
+        self.register_with_peer_id(me, pod_template_hash, peer_id)
+            .await
+    }
+
+    /// Publish a post-fence incarnation as draining while recovery admission
+    /// is still in progress. Production implementations must make the epoch
+    /// upsert and `draining = true` one atomic statement: a candidate that has
+    /// not passed hysteresis and terminal teardown must never be observable as
+    /// a serving node.
+    async fn register_draining_with_peer_id(
+        &self,
+        expected_previous: &NodeIdentity,
+        me: &NodeIdentity,
+        pod_template_hash: Option<String>,
+        peer_id: Option<String>,
+        _lease_ttl: Duration,
+    ) -> Result<(), ClaimError> {
+        let _ = expected_previous;
+        self.register_with_peer_id(me, pod_template_hash, peer_id)
+            .await?;
+        self.mark_draining(me).await
+    }
+
+    /// Commit a draining post-fence incarnation to serving state. Returns
+    /// `false` if the exact node/epoch row no longer exists or was expired.
+    async fn activate(&self, _me: &NodeIdentity, _lease_ttl: Duration) -> Result<bool, ClaimError> {
+        Ok(true)
+    }
+
+    /// Exact incarnation currently occupying `node_id`, including an
+    /// expired row. Recovery uses this only to reconcile an ambiguous
+    /// registration result; it never authorizes claim writes by itself.
+    async fn registered_identity(
+        &self,
+        _node_id: &str,
+    ) -> Result<Option<NodeIdentity>, ClaimError> {
+        Ok(None)
     }
 
     /// Renew this node's heartbeat. `Ok(false)` (zero rows affected) is
@@ -989,6 +1550,18 @@ pub trait NodeLeaseStore: Send + Sync {
     /// The default supports fakes/no-op stores that have no lease table.
     async fn is_fresh(&self, _me: &NodeIdentity, _lease_ttl: Duration) -> Result<bool, ClaimError> {
         Ok(true)
+    }
+
+    /// Refresh and prove a recovery candidate is serving-eligible in one
+    /// exact-incarnation CAS. Unlike [`Self::heartbeat`], this rejects a
+    /// draining row; recovery calls it immediately before publishing
+    /// readiness after potentially long-running state hydration.
+    async fn renew_active(
+        &self,
+        me: &NodeIdentity,
+        lease_ttl: Duration,
+    ) -> Result<bool, ClaimError> {
+        self.is_fresh(me, lease_ttl).await
     }
 
     /// Read the PeerId currently bound to this exact `node_id`/`node_epoch`
@@ -1086,6 +1659,8 @@ pub trait NodeLeaseStore: Send + Sync {
     async fn report_steal_intent(
         &self,
         entity: &Entity,
+        target_owner: &NodeIdentity,
+        target_epoch: ClaimEpoch,
         reporter: &NodeIdentity,
     ) -> Result<(), ClaimError>;
 
@@ -1208,37 +1783,127 @@ pub struct OrphanedSmSessionClaim {
     pub owner: NodeIdentity,
 }
 
+#[derive(Clone, Copy)]
+enum RegistrationPrecondition<'a> {
+    Bootstrap,
+    InitialReplacement(&'a NodeIdentity),
+    Recovery(&'a NodeIdentity),
+}
+
 async fn register_node(
     store: &PostgresClaimStore,
     me: &NodeIdentity,
     pod_template_hash: Option<String>,
     peer_id: Option<String>,
+    draining: bool,
+    precondition: RegistrationPrecondition<'_>,
+    exact_retry_ttl: Option<Duration>,
 ) -> Result<(), ClaimError> {
     // Runs on the control-plane pool (element 4/12, Slice 0): node
     // registration is liveness-control-plane traffic, never the main pool.
-    let conn = store.db.control_plane_guard().await.map_err(db_err)?;
-    conn.execute(
-        r#"
-        INSERT INTO clustering_nodes (node_id, node_epoch, heartbeat, expired, pod_template_hash, draining, peer_id)
-        VALUES (?, ?, now(), false, ?, false, ?)
-        ON CONFLICT (node_id) DO UPDATE SET
-            node_epoch = EXCLUDED.node_epoch,
-            heartbeat = now(),
-            expired = false,
-            pod_template_hash = EXCLUDED.pod_template_hash,
-            draining = false,
-            peer_id = EXCLUDED.peer_id
-        "#,
-        crate::db_params![
-            me.node_id.clone(),
-            me.node_epoch.clone(),
-            pod_template_hash,
-            peer_id,
-        ],
+    if matches!(
+        precondition,
+        RegistrationPrecondition::InitialReplacement(previous)
+            | RegistrationPrecondition::Recovery(previous)
+            if previous.node_id != me.node_id
+    ) {
+        return Err(ClaimError::Conflict);
+    }
+    let mut tx = store
+        .db
+        .control_plane_begin_fenced()
+        .await
+        .map_err(db_err)?;
+    tx.execute(
+        "SELECT pg_advisory_xact_lock(hashtextextended(?, 8718))",
+        crate::db_params![me.node_id.clone()],
     )
     .await
     .map_err(db_err)?;
-    Ok(())
+    let mut locked = tx
+        .query(
+            "SELECT node_id FROM clustering_nodes WHERE node_id = ? FOR UPDATE",
+            crate::db_params![me.node_id.clone()],
+        )
+        .await
+        .map_err(db_err)?;
+    let _ = locked.next().await.map_err(db_err)?;
+    drop(locked);
+    let values = if draining { "true" } else { "false" };
+    let sql = format!(
+        r#"
+        INSERT INTO clustering_nodes (
+            node_id, node_epoch, heartbeat, expired, pod_template_hash,
+            draining, peer_id, lease_ttl_ms
+        )
+        VALUES (?, ?, clock_timestamp(), false, ?, {values}, ?, CAST(? AS BIGINT))
+        ON CONFLICT (node_id) DO UPDATE SET
+            node_epoch = EXCLUDED.node_epoch,
+            heartbeat = clock_timestamp(),
+            expired = false,
+            pod_template_hash = EXCLUDED.pod_template_hash,
+            lease_ttl_ms = EXCLUDED.lease_ttl_ms,
+            -- An exact-identity retry is idempotent with respect to the
+            -- lifecycle state. In particular, a delayed recovery-register
+            -- retry must not flip an already-activated incarnation back to
+            -- draining (and a delayed initial-register retry must not
+            -- activate a recovery candidate).
+            draining = CASE
+                WHEN clustering_nodes.node_epoch = EXCLUDED.node_epoch
+                    THEN clustering_nodes.draining
+                ELSE EXCLUDED.draining
+            END,
+            peer_id = EXCLUDED.peer_id
+        WHERE (clustering_nodes.node_epoch = EXCLUDED.node_epoch
+               AND NOT clustering_nodes.expired
+               AND clustering_nodes.heartbeat >= clock_timestamp() - (
+                   clustering_nodes.lease_ttl_ms::text || ' milliseconds'
+               )::interval
+               AND (? = 'unbounded'
+                    OR clustering_nodes.heartbeat >= clock_timestamp() - (? || ' milliseconds')::interval))
+           OR (? = 'initial'
+               AND clustering_nodes.node_epoch = ?
+               AND clustering_nodes.expired)
+           OR (? = 'recovery'
+               AND clustering_nodes.node_epoch = ?)
+        "#
+    );
+    let (mode, expected_epoch) = match precondition {
+        RegistrationPrecondition::Bootstrap => ("bootstrap", String::new()),
+        RegistrationPrecondition::InitialReplacement(previous) => {
+            ("initial", previous.node_epoch.clone())
+        }
+        RegistrationPrecondition::Recovery(previous) => ("recovery", previous.node_epoch.clone()),
+    };
+    let (retry_mode, retry_ttl_ms) = match exact_retry_ttl {
+        Some(ttl) => ("bounded", ttl.as_millis().to_string()),
+        None => ("unbounded", "0".to_string()),
+    };
+    let affected = tx
+        .execute(
+            &sql,
+            crate::db_params![
+                me.node_id.clone(),
+                me.node_epoch.clone(),
+                pod_template_hash,
+                peer_id,
+                store.lease_ttl.as_millis().to_string(),
+                retry_mode.to_string(),
+                retry_ttl_ms,
+                mode.to_string(),
+                expected_epoch.clone(),
+                mode.to_string(),
+                expected_epoch,
+            ],
+        )
+        .await
+        .map_err(db_err)?;
+    if affected == 1 {
+        tx.commit().await.map_err(db_err)?;
+        Ok(())
+    } else {
+        Err(ClaimError::Conflict)
+    }
 }
 
 #[async_trait]
@@ -1248,7 +1913,16 @@ impl NodeLeaseStore for PostgresClaimStore {
         me: &NodeIdentity,
         pod_template_hash: Option<String>,
     ) -> Result<(), ClaimError> {
-        register_node(self, me, pod_template_hash, None).await
+        register_node(
+            self,
+            me,
+            pod_template_hash,
+            None,
+            false,
+            RegistrationPrecondition::Bootstrap,
+            Some(self.lease_ttl),
+        )
+        .await
     }
 
     async fn register_with_peer_id(
@@ -1257,7 +1931,95 @@ impl NodeLeaseStore for PostgresClaimStore {
         pod_template_hash: Option<String>,
         peer_id: Option<String>,
     ) -> Result<(), ClaimError> {
-        register_node(self, me, pod_template_hash, peer_id).await
+        register_node(
+            self,
+            me,
+            pod_template_hash,
+            peer_id,
+            false,
+            RegistrationPrecondition::Bootstrap,
+            Some(self.lease_ttl),
+        )
+        .await
+    }
+
+    async fn register_initial_with_peer_id(
+        &self,
+        expected_previous: Option<&NodeIdentity>,
+        me: &NodeIdentity,
+        pod_template_hash: Option<String>,
+        peer_id: Option<String>,
+    ) -> Result<(), ClaimError> {
+        let precondition = expected_previous
+            .map(RegistrationPrecondition::InitialReplacement)
+            .unwrap_or(RegistrationPrecondition::Bootstrap);
+        register_node(
+            self,
+            me,
+            pod_template_hash,
+            peer_id,
+            false,
+            precondition,
+            Some(self.lease_ttl),
+        )
+        .await
+    }
+
+    async fn register_draining_with_peer_id(
+        &self,
+        expected_previous: &NodeIdentity,
+        me: &NodeIdentity,
+        pod_template_hash: Option<String>,
+        peer_id: Option<String>,
+        lease_ttl: Duration,
+    ) -> Result<(), ClaimError> {
+        register_node(
+            self,
+            me,
+            pod_template_hash,
+            peer_id,
+            true,
+            RegistrationPrecondition::Recovery(expected_previous),
+            Some(lease_ttl),
+        )
+        .await
+    }
+
+    async fn activate(&self, me: &NodeIdentity, lease_ttl: Duration) -> Result<bool, ClaimError> {
+        let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
+        let affected = tx
+            .execute(
+                r#"
+                WITH locked AS MATERIALIZED (
+                    SELECT node_id, node_epoch
+                    FROM clustering_nodes
+                    WHERE node_id = ? AND node_epoch = ?
+                    FOR UPDATE
+                )
+                UPDATE clustering_nodes AS n
+                SET draining = false, heartbeat = clock_timestamp()
+                FROM locked
+                WHERE n.node_id = locked.node_id
+                  AND n.node_epoch = locked.node_epoch
+                  AND NOT n.expired
+                  AND n.draining
+                  AND n.heartbeat >= clock_timestamp() - (? || ' milliseconds')::interval
+                  AND n.heartbeat >= clock_timestamp() - (n.lease_ttl_ms::text || ' milliseconds')::interval
+                "#,
+                crate::db_params![
+                    me.node_id.clone(),
+                    me.node_epoch.clone(),
+                    lease_ttl.as_millis().to_string(),
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        tx.commit().await.map_err(db_err)?;
+        Ok(affected == 1)
+    }
+
+    async fn registered_identity(&self, node_id: &str) -> Result<Option<NodeIdentity>, ClaimError> {
+        PostgresClaimStore::registered_identity(self, node_id).await
     }
 
     async fn peer_id_for_node(&self, node: &NodeIdentity) -> Result<Option<String>, ClaimError> {
@@ -1270,6 +2032,7 @@ impl NodeLeaseStore for PostgresClaimStore {
                 WHERE node_id = ?
                   AND node_epoch = ?
                   AND NOT expired
+                  AND heartbeat >= now() - (lease_ttl_ms::text || ' milliseconds')::interval
                 "#,
                 crate::db_params![node.node_id.clone(), node.node_epoch.clone()],
             )
@@ -1282,18 +2045,26 @@ impl NodeLeaseStore for PostgresClaimStore {
     }
 
     async fn heartbeat(&self, me: &NodeIdentity, lease_ttl: Duration) -> Result<bool, ClaimError> {
-        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
         // Heartbeat CAS (element 4, locked verbatim): renew only while the
         // lease is still fresh under our own identity.
-        let affected = conn
+        let affected = tx
             .execute(
                 r#"
-                UPDATE clustering_nodes
-                SET heartbeat = now()
-                WHERE node_id = ?
-                  AND node_epoch = ?
-                  AND NOT expired
-                  AND heartbeat >= now() - (? || ' milliseconds')::interval
+                WITH locked AS MATERIALIZED (
+                    SELECT node_id, node_epoch
+                    FROM clustering_nodes
+                    WHERE node_id = ? AND node_epoch = ?
+                    FOR UPDATE
+                )
+                UPDATE clustering_nodes AS n
+                SET heartbeat = clock_timestamp()
+                FROM locked
+                WHERE n.node_id = locked.node_id
+                  AND n.node_epoch = locked.node_epoch
+                  AND NOT n.expired
+                  AND n.heartbeat >= clock_timestamp() - (? || ' milliseconds')::interval
+                  AND n.heartbeat >= clock_timestamp() - (n.lease_ttl_ms::text || ' milliseconds')::interval
                 "#,
                 crate::db_params![
                     me.node_id.clone(),
@@ -1303,24 +2074,33 @@ impl NodeLeaseStore for PostgresClaimStore {
             )
             .await
             .map_err(db_err)?;
+        tx.commit().await.map_err(db_err)?;
         Ok(affected == 1)
     }
 
     async fn expire(&self, owner: &NodeIdentity, lease_ttl: Duration) -> Result<bool, ClaimError> {
-        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
         // Expire CAS (element 4, locked verbatim): the single serialized
         // ordering point that makes lease expiry monotone — see this
         // module's own doc comment and `steal_stale`'s NOT EXISTS predicate,
         // which reads only the committed flag this statement sets.
-        let affected = conn
+        let affected = tx
             .execute(
                 r#"
-                UPDATE clustering_nodes
+                WITH locked AS MATERIALIZED (
+                    SELECT node_id, node_epoch
+                    FROM clustering_nodes
+                    WHERE node_id = ? AND node_epoch = ?
+                    FOR UPDATE
+                )
+                UPDATE clustering_nodes AS n
                 SET expired = true
-                WHERE node_id = ?
-                  AND node_epoch = ?
-                  AND NOT expired
-                  AND heartbeat < now() - (? || ' milliseconds')::interval
+                FROM locked
+                WHERE n.node_id = locked.node_id
+                  AND n.node_epoch = locked.node_epoch
+                  AND NOT n.expired
+                  AND n.heartbeat < clock_timestamp() - (? || ' milliseconds')::interval
+                  AND n.heartbeat < clock_timestamp() - (n.lease_ttl_ms::text || ' milliseconds')::interval
                 "#,
                 crate::db_params![
                     owner.node_id.clone(),
@@ -1331,6 +2111,7 @@ impl NodeLeaseStore for PostgresClaimStore {
             .await
             .map_err(db_err)?;
         if affected == 1 {
+            tx.commit().await.map_err(db_err)?;
             return Ok(true);
         }
         // We did not flip the flag ourselves — either it is already
@@ -1338,17 +2119,20 @@ impl NodeLeaseStore for PostgresClaimStore {
         // entirely. Distinguish those (a missing/expired row means "proceed,
         // this owner is stale" — the same vacuous-stale treatment
         // `steal_stale`'s NOT EXISTS predicate gives a vanished node).
-        let mut rows = conn
+        let mut rows = tx
             .query(
                 "SELECT expired FROM clustering_nodes WHERE node_id = ? AND node_epoch = ?",
                 crate::db_params![owner.node_id.clone(), owner.node_epoch.clone()],
             )
             .await
             .map_err(db_err)?;
-        match rows.next().await.map_err(db_err)? {
+        let result = match rows.next().await.map_err(db_err)? {
             Some(row) => row.get::<bool>(0).map_err(db_err),
             None => Ok(true),
-        }
+        }?;
+        drop(rows);
+        tx.commit().await.map_err(db_err)?;
+        Ok(result)
     }
 
     async fn list_heartbeat_stale_nodes(
@@ -1368,6 +2152,7 @@ impl NodeLeaseStore for PostgresClaimStore {
                 FROM clustering_nodes
                 WHERE NOT expired
                   AND heartbeat < now() - (? || ' milliseconds')::interval
+                  AND heartbeat < now() - (lease_ttl_ms::text || ' milliseconds')::interval
                 ORDER BY heartbeat ASC, node_id ASC, node_epoch ASC
                 LIMIT ?
                 "#,
@@ -1395,6 +2180,7 @@ impl NodeLeaseStore for PostgresClaimStore {
                   AND NOT expired
                   AND NOT draining
                   AND heartbeat >= now() - (? || ' milliseconds')::interval
+                  AND heartbeat >= now() - (lease_ttl_ms::text || ' milliseconds')::interval
                 "#,
                 crate::db_params![
                     me.node_id.clone(),
@@ -1407,14 +2193,52 @@ impl NodeLeaseStore for PostgresClaimStore {
         Ok(rows.next().await.map_err(db_err)?.is_some())
     }
 
+    async fn renew_active(
+        &self,
+        me: &NodeIdentity,
+        lease_ttl: Duration,
+    ) -> Result<bool, ClaimError> {
+        let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
+        let affected = tx
+            .execute(
+                r#"
+                WITH locked AS MATERIALIZED (
+                    SELECT node_id, node_epoch
+                    FROM clustering_nodes
+                    WHERE node_id = ? AND node_epoch = ?
+                    FOR UPDATE
+                )
+                UPDATE clustering_nodes AS n
+                SET heartbeat = clock_timestamp()
+                FROM locked
+                WHERE n.node_id = locked.node_id
+                  AND n.node_epoch = locked.node_epoch
+                  AND NOT n.expired
+                  AND NOT n.draining
+                  AND n.heartbeat >= clock_timestamp() - (? || ' milliseconds')::interval
+                  AND n.heartbeat >= clock_timestamp() - (n.lease_ttl_ms::text || ' milliseconds')::interval
+                "#,
+                crate::db_params![
+                    me.node_id.clone(),
+                    me.node_epoch.clone(),
+                    lease_ttl.as_millis().to_string(),
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        tx.commit().await.map_err(db_err)?;
+        Ok(affected == 1)
+    }
+
     async fn mark_draining(&self, me: &NodeIdentity) -> Result<(), ClaimError> {
-        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        conn.execute(
+        let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
+        tx.execute(
             "UPDATE clustering_nodes SET draining = true WHERE node_id = ? AND node_epoch = ?",
             crate::db_params![me.node_id.clone(), me.node_epoch.clone()],
         )
         .await
         .map_err(db_err)?;
+        tx.commit().await.map_err(db_err)?;
         Ok(())
     }
 
@@ -1436,6 +2260,7 @@ impl NodeLeaseStore for PostgresClaimStore {
                   AND NOT expired
                   AND NOT draining
                   AND heartbeat >= now() - (? || ' milliseconds')::interval
+                  AND heartbeat >= now() - (lease_ttl_ms::text || ' milliseconds')::interval
                 "#,
                 crate::db_params![me.node_id.clone(), lease_ttl.as_millis().to_string()],
             )
@@ -1462,7 +2287,17 @@ impl NodeLeaseStore for PostgresClaimStore {
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
         let mut rows = conn
             .query(
-                "SELECT entity FROM clustering_claims WHERE node_id = ? AND node_epoch = ?",
+                r#"
+                SELECT c.entity
+                FROM clustering_claims c
+                JOIN clustering_nodes n
+                  ON n.node_id = c.node_id
+                 AND n.node_epoch = c.node_epoch
+                WHERE c.node_id = ?
+                  AND c.node_epoch = ?
+                  AND NOT n.expired
+                  AND n.heartbeat >= now() - (n.lease_ttl_ms::text || ' milliseconds')::interval
+                "#,
                 crate::db_params![me.node_id.clone(), me.node_epoch.clone()],
             )
             .await
@@ -1481,22 +2316,159 @@ impl NodeLeaseStore for PostgresClaimStore {
     async fn report_steal_intent(
         &self,
         entity: &Entity,
+        target_owner: &NodeIdentity,
+        target_epoch: ClaimEpoch,
         reporter: &NodeIdentity,
     ) -> Result<(), ClaimError> {
         if entity.entity_type == EntityType::SmSession {
             return Err(ClaimError::SmSessionExcludedFromStealIntent);
         }
-        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        conn.execute(
-            r#"
-            INSERT INTO clustering_steal_intents (entity, reporter_node, created_at)
-            VALUES (?, ?, now())
-            ON CONFLICT (entity, reporter_node) DO UPDATE SET created_at = EXCLUDED.created_at
-            "#,
-            crate::db_params![entity_key(entity), reporter.node_id.clone()],
+        let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
+        // Serialize reports even while the `(entity, reporter)` row is absent;
+        // otherwise two first reports can both reach the unique insert and
+        // make one statement's pre-conflict timestamp stale while it waits.
+        tx.execute(
+            "SELECT pg_advisory_xact_lock(hashtextextended(?, 8719))",
+            crate::db_params![format!("{}:{}", entity_key(entity), reporter.node_id)],
         )
         .await
         .map_err(db_err)?;
+
+        // Lock the exact reporter incarnation and target grant first, without
+        // materializing a freshness decision before a later intent-row wait.
+        let mut exact_rows = tx
+            .query(
+                r#"
+                WITH locked_reporter AS MATERIALIZED (
+                    SELECT 1
+                    FROM clustering_nodes
+                    WHERE node_id = ? AND node_epoch = ?
+                    FOR SHARE
+                ),
+                locked_target AS MATERIALIZED (
+                    SELECT 1
+                    FROM clustering_claims c
+                    JOIN clustering_nodes n
+                      ON n.node_id = c.node_id
+                     AND n.node_epoch = c.node_epoch
+                    WHERE c.entity = ?
+                      AND c.node_id = ?
+                      AND c.node_epoch = ?
+                      AND c.claim_epoch = ?
+                    FOR SHARE OF c, n
+                )
+                SELECT EXISTS (SELECT 1 FROM locked_reporter)
+                   AND EXISTS (SELECT 1 FROM locked_target)
+                "#,
+                crate::db_params![
+                    reporter.node_id.clone(),
+                    reporter.node_epoch.clone(),
+                    entity_key(entity),
+                    target_owner.node_id.clone(),
+                    target_owner.node_epoch.clone(),
+                    target_epoch.0,
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        let exact = exact_rows
+            .next()
+            .await
+            .map_err(db_err)?
+            .map(|row| row.get::<bool>(0).map_err(db_err))
+            .transpose()?
+            .unwrap_or(false);
+        drop(exact_rows);
+        if !exact {
+            return Err(ClaimError::Conflict);
+        }
+
+        // An existing row may be held by clear/steal. Wait for it explicitly;
+        // only after this lock resolves do we evaluate wall-clock freshness
+        // and choose the new intent age.
+        let mut intent_rows = tx
+            .query(
+                "SELECT 1 FROM clustering_steal_intents WHERE entity = ? AND reporter_node = ? FOR UPDATE",
+                crate::db_params![entity_key(entity), reporter.node_id.clone()],
+            )
+            .await
+            .map_err(db_err)?;
+        let _ = intent_rows.next().await.map_err(db_err)?;
+        drop(intent_rows);
+
+        let mut fresh_rows = tx
+            .query(
+                r#"
+                SELECT
+                    EXISTS (
+                        SELECT 1 FROM clustering_nodes n
+                        WHERE n.node_id = ? AND n.node_epoch = ?
+                          AND NOT n.expired AND NOT n.draining
+                          AND n.heartbeat >= clock_timestamp() - (
+                              n.lease_ttl_ms::text || ' milliseconds'
+                          )::interval
+                    )
+                    AND EXISTS (
+                        SELECT 1
+                        FROM clustering_claims c
+                        JOIN clustering_nodes n
+                          ON n.node_id = c.node_id AND n.node_epoch = c.node_epoch
+                        WHERE c.entity = ?
+                          AND c.node_id = ? AND c.node_epoch = ? AND c.claim_epoch = ?
+                          AND NOT n.expired
+                          AND n.heartbeat >= clock_timestamp() - (
+                              n.lease_ttl_ms::text || ' milliseconds'
+                          )::interval
+                    )
+                "#,
+                crate::db_params![
+                    reporter.node_id.clone(),
+                    reporter.node_epoch.clone(),
+                    entity_key(entity),
+                    target_owner.node_id.clone(),
+                    target_owner.node_epoch.clone(),
+                    target_epoch.0,
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        let fresh = fresh_rows
+            .next()
+            .await
+            .map_err(db_err)?
+            .map(|row| row.get::<bool>(0).map_err(db_err))
+            .transpose()?
+            .unwrap_or(false);
+        drop(fresh_rows);
+        if !fresh {
+            return Err(ClaimError::Conflict);
+        }
+
+        tx.execute(
+            r#"
+            INSERT INTO clustering_steal_intents (
+                entity, reporter_node, reporter_epoch, target_node,
+                target_node_epoch, target_claim_epoch, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, clock_timestamp())
+            ON CONFLICT (entity, reporter_node) DO UPDATE SET
+                reporter_epoch = EXCLUDED.reporter_epoch,
+                target_node = EXCLUDED.target_node,
+                target_node_epoch = EXCLUDED.target_node_epoch,
+                target_claim_epoch = EXCLUDED.target_claim_epoch,
+                created_at = EXCLUDED.created_at
+            "#,
+            crate::db_params![
+                entity_key(entity),
+                reporter.node_id.clone(),
+                reporter.node_epoch.clone(),
+                target_owner.node_id.clone(),
+                target_owner.node_epoch.clone(),
+                target_epoch.0,
+            ],
+        )
+        .await
+        .map_err(db_err)?;
+        tx.commit().await.map_err(db_err)?;
         Ok(())
     }
 
@@ -1511,8 +2483,17 @@ impl NodeLeaseStore for PostgresClaimStore {
                 r#"
                 SELECT DISTINCT c.entity, c.entity_type, c.claim_epoch
                 FROM clustering_claims c
-                JOIN clustering_steal_intents si ON si.entity = c.entity
+                JOIN clustering_steal_intents si
+                  ON si.entity = c.entity
+                 AND si.target_node = c.node_id
+                 AND si.target_node_epoch = c.node_epoch
+                 AND si.target_claim_epoch = c.claim_epoch
+                JOIN clustering_nodes n
+                  ON n.node_id = c.node_id
+                 AND n.node_epoch = c.node_epoch
                 WHERE c.node_id = ? AND c.node_epoch = ? AND c.entity_type != ?
+                  AND NOT n.expired
+                  AND n.heartbeat >= now() - (n.lease_ttl_ms::text || ' milliseconds')::interval
                 "#,
                 crate::db_params![
                     me.node_id.clone(),
@@ -1558,7 +2539,7 @@ impl NodeLeaseStore for PostgresClaimStore {
         me: &NodeIdentity,
         mine: ClaimEpoch,
     ) -> Result<u64, ClaimError> {
-        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
         // FIX 1(b) — council-adjudicated redesign closing the veto race:
         // the previous shape gated the DELETE on an *unlocked* `EXISTS`
         // read over `clustering_claims`, which could observe "still owned"
@@ -1584,30 +2565,51 @@ impl NodeLeaseStore for PostgresClaimStore {
         // [`log_if_postgres_deadlock`] — the loser retries next
         // tick/scan).
         //
-        // A deposed owner's stale `(node_id, mine)` pair matches no
+        // A deposed owner's stale `(node_id, node_epoch, mine)` tuple matches no
         // `clustering_claims` row, so `fenced` is empty, the DELETE's
         // `EXISTS (SELECT 1 FROM fenced)` is false, and it affects zero
         // rows — a silent no-op, exactly like `release`'s epoch-gated
         // semantics, but now observable by the caller via the returned
         // count (FIX 1(b): see the trait doc for why `run_node_lease`
         // needs to distinguish this from a genuine veto).
-        let affected = conn
+        let affected = tx
             .execute(
                 r#"
-                WITH fenced AS (
+                WITH locked_owner AS MATERIALIZED (
+                    SELECT heartbeat, expired, lease_ttl_ms FROM clustering_nodes
+                    WHERE node_id = ?
+                      AND node_epoch = ?
+                    FOR SHARE
+                ),
+                live_owner AS MATERIALIZED (
+                    SELECT 1 FROM locked_owner
+                    WHERE NOT expired
+                      AND heartbeat >= clock_timestamp() - (lease_ttl_ms::text || ' milliseconds')::interval
+                ),
+                fenced AS MATERIALIZED (
                     SELECT 1 FROM clustering_claims
-                    WHERE entity = ? AND node_id = ? AND claim_epoch = ?
+                    WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ?
+                      AND EXISTS (SELECT 1 FROM live_owner)
                     FOR SHARE
                 )
                 DELETE FROM clustering_steal_intents
                 WHERE entity = ?
+                  AND target_node = ?
+                  AND target_node_epoch = ?
+                  AND target_claim_epoch = ?
                   AND EXISTS (SELECT 1 FROM fenced)
                 "#,
                 crate::db_params![
+                    me.node_id.clone(),
+                    me.node_epoch.clone(),
                     entity_key(entity),
                     me.node_id.clone(),
+                    me.node_epoch.clone(),
                     mine.0,
                     entity_key(entity),
+                    me.node_id.clone(),
+                    me.node_epoch.clone(),
+                    mine.0,
                 ],
             )
             .await
@@ -1615,6 +2617,7 @@ impl NodeLeaseStore for PostgresClaimStore {
                 log_if_postgres_deadlock(&error, &entity_key(entity), "clear_steal_intent");
                 db_err(error)
             })?;
+        tx.commit().await.map_err(db_err)?;
         Ok(affected)
     }
 
@@ -1690,52 +2693,70 @@ impl NodeLeaseStore for PostgresClaimStore {
         me: &NodeIdentity,
         lease_ttl: Duration,
     ) -> Result<ClaimEpoch, ClaimError> {
-        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        let next_epoch = observed.0 + 1;
-        let affected = conn
-            .execute(
+        let mut tx = self.db.control_plane_begin_fenced().await.map_err(db_err)?;
+        let mut granted_rows = tx
+            .query(
                 r#"
-                UPDATE clustering_claims
-                SET node_id = ?, node_epoch = ?, claim_epoch = ?
-                WHERE entity = ?
-                  AND entity_type = ?
-                  AND claim_epoch = ?
-                  AND NOT EXISTS (
-                    SELECT 1 FROM clustering_nodes n
-                    WHERE n.node_id = clustering_claims.node_id
-                      AND NOT n.expired
-                      AND n.node_epoch = clustering_claims.node_epoch
-                  )
-                  AND EXISTS (
-                    SELECT 1 FROM sm_sessions s
-                    WHERE clustering_claims.entity = (? || ':' || s.stream_id)
-                  )
-                  AND EXISTS (
-                    SELECT 1 FROM clustering_nodes
-                    WHERE node_id = ?
-                      AND node_epoch = ?
-                      AND NOT expired
-                      AND NOT draining
-                      AND heartbeat >= now() - (? || ' milliseconds')::interval
-                  )
+                WITH epoch_seed AS MATERIALIZED (
+                    SELECT 1 FROM clustering_claim_epoch_seed
+                    WHERE singleton
+                    FOR SHARE
+                ),
+                granted AS (
+                    UPDATE clustering_claims
+                    SET node_id = ?,
+                        node_epoch = ?,
+                        claim_epoch = nextval('clustering_claim_epoch_seq')
+                    WHERE entity = ?
+                      AND entity_type = ?
+                      AND claim_epoch = ?
+                      AND NOT EXISTS (
+                        SELECT 1 FROM clustering_nodes n
+                        WHERE n.node_id = clustering_claims.node_id
+                          AND NOT n.expired
+                          AND n.node_epoch = clustering_claims.node_epoch
+                      )
+                      AND EXISTS (
+                        SELECT 1 FROM sm_sessions s
+                        WHERE clustering_claims.entity = (? || ':' || s.stream_id)
+                      )
+                      AND EXISTS (SELECT 1 FROM epoch_seed)
+                    RETURNING claim_epoch
+                ),
+                cleared AS (
+                    DELETE FROM clustering_steal_intents
+                    WHERE entity = ?
+                      AND EXISTS (SELECT 1 FROM granted)
+                )
+                SELECT claim_epoch FROM granted
                 "#,
                 crate::db_params![
                     me.node_id.clone(),
                     me.node_epoch.clone(),
-                    next_epoch,
                     entity_key(entity),
                     EntityType::SmSession.as_db_str().to_string(),
                     observed.0,
                     EntityType::SmSession.as_db_str().to_string(),
-                    me.node_id.clone(),
-                    me.node_epoch.clone(),
-                    lease_ttl.as_millis().to_string(),
+                    entity_key(entity),
                 ],
             )
             .await
             .map_err(db_err)?;
-        if affected == 1 {
-            Ok(ClaimEpoch(next_epoch))
+        if let Some(row) = granted_rows.next().await.map_err(db_err)? {
+            let epoch = ClaimEpoch(row.get::<i64>(0).map_err(db_err)?);
+            drop(granted_rows);
+            if !validate_grant_destination(
+                &mut tx,
+                me,
+                GrantDestinationPolicy::Active,
+                Some(lease_ttl),
+            )
+            .await?
+            {
+                return Err(ClaimError::Conflict);
+            }
+            tx.commit().await.map_err(db_err)?;
+            Ok(epoch)
         } else {
             Err(ClaimError::Conflict)
         }
@@ -1759,6 +2780,7 @@ impl NodeLeaseStore for PostgresClaimStore {
                 SELECT pod_template_hash
                 FROM clustering_nodes
                 WHERE NOT expired
+                  AND heartbeat >= now() - (lease_ttl_ms::text || ' milliseconds')::interval
                 ORDER BY first_seen DESC
                 LIMIT 1
                 "#,
@@ -1842,6 +2864,13 @@ mod tests {
         Some(store)
     }
 
+    async fn register_live_node(store: &PostgresClaimStore, identity: &NodeIdentity) {
+        store
+            .register(identity, None)
+            .await
+            .expect("register live test node");
+    }
+
     /// Seed a `clustering_nodes` row directly with a caller-chosen `expired`
     /// flag. `NodeLeaseStore` (below, this same file) exists, but its own
     /// `register`/`heartbeat` API always stamps `heartbeat = now()` and has
@@ -1851,6 +2880,14 @@ mod tests {
     /// fixture shape the steal-CAS tests need, mirroring how
     /// `allowlist.rs`'s tests seed rows directly for shapes its own store
     /// API has no fast path for.
+    ///
+    /// Several fixtures acquire a claim through the production API first,
+    /// which now requires and therefore registers the exact node incarnation.
+    /// Treat that same-incarnation row as an idempotent fixture update instead
+    /// of issuing a second bare INSERT. A different epoch under the same stable
+    /// node id remains a hard fixture error: silently replacing it here would
+    /// bypass the production registration CAS this test suite is meant to
+    /// exercise.
     ///
     /// `expired` is spliced into the SQL text as a literal, not bound as a
     /// parameter: Postgres types every bind parameter by its Rust source
@@ -1862,14 +2899,29 @@ mod tests {
     async fn seed_node(db: &Database, identity: &NodeIdentity, expired: bool) {
         let conn = db.guard().await.expect("guard");
         let expired_literal = if expired { "true" } else { "false" };
-        conn.execute(
-            &format!(
-                "INSERT INTO clustering_nodes (node_id, node_epoch, expired) VALUES (?, ?, {expired_literal})"
-            ),
-            crate::db_params![identity.node_id.clone(), identity.node_epoch.clone()],
-        )
-        .await
-        .expect("seed node");
+        let affected = conn
+            .execute(
+                &format!(
+                    r#"
+                INSERT INTO clustering_nodes (
+                    node_id, node_epoch, heartbeat, expired, draining
+                )
+                VALUES (?, ?, clock_timestamp(), {expired_literal}, false)
+                ON CONFLICT (node_id) DO UPDATE SET
+                    heartbeat = clock_timestamp(),
+                    expired = EXCLUDED.expired,
+                    draining = false
+                WHERE clustering_nodes.node_epoch = EXCLUDED.node_epoch
+                "#
+                ),
+                crate::db_params![identity.node_id.clone(), identity.node_epoch.clone()],
+            )
+            .await
+            .expect("seed node");
+        assert_eq!(
+            affected, 1,
+            "seed_node must only insert or update the exact requested node incarnation"
+        );
     }
 
     async fn backdate_heartbeat(db: &Database, identity: &NodeIdentity) {
@@ -1908,6 +2960,68 @@ mod tests {
         .expect("seed sm_sessions row");
     }
 
+    async fn while_claim_is_locked_past_ttl<F, T>(
+        db: &Database,
+        entity: &Entity,
+        ttl: Duration,
+        operation: F,
+    ) -> T
+    where
+        F: std::future::Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let mut blocker = db.begin().await.expect("begin claim blocker");
+        let mut rows = blocker
+            .query(
+                "SELECT 1 FROM clustering_claims WHERE entity = ? FOR SHARE",
+                crate::db_params![entity_key(entity)],
+            )
+            .await
+            .expect("lock claim row");
+        assert!(rows.next().await.expect("read lock row").is_some());
+        drop(rows);
+        let task = tokio::spawn(operation);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(
+            !task.is_finished(),
+            "claim operation must wait on the held row"
+        );
+        tokio::time::sleep(ttl * 3).await;
+        blocker.commit().await.expect("release claim blocker");
+        task.await.expect("join blocked claim operation")
+    }
+
+    async fn while_node_is_locked_past_ttl<F, T>(
+        db: &Database,
+        identity: &NodeIdentity,
+        ttl: Duration,
+        operation: F,
+    ) -> T
+    where
+        F: std::future::Future<Output = T> + Send + 'static,
+        T: Send + 'static,
+    {
+        let mut blocker = db.begin().await.expect("begin node blocker");
+        let mut rows = blocker
+            .query(
+                "SELECT 1 FROM clustering_nodes WHERE node_id = ? AND node_epoch = ? FOR SHARE",
+                crate::db_params![identity.node_id.clone(), identity.node_epoch.clone()],
+            )
+            .await
+            .expect("lock node row");
+        assert!(rows.next().await.expect("read lock row").is_some());
+        drop(rows);
+        let task = tokio::spawn(operation);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(
+            !task.is_finished(),
+            "node operation must wait on the held row"
+        );
+        tokio::time::sleep(ttl * 3).await;
+        blocker.commit().await.expect("release node blocker");
+        task.await.expect("join blocked node operation")
+    }
+
     #[tokio::test]
     async fn acquire_succeeds_once_then_conflicts() {
         let _guard = clustering_control_plane_table_lock().lock().await;
@@ -1915,16 +3029,403 @@ mod tests {
             return;
         };
         let me = node_identity();
+        register_live_node(&store, &me).await;
         let entity = sm_entity("stream-1");
         let epoch = store.acquire(&entity, &me).await.expect("first acquire");
-        assert_eq!(epoch, ClaimEpoch(0));
+        assert!(epoch.0 >= 0, "the global claim generation must not wrap");
 
         let other = node_identity();
+        register_live_node(&store, &other).await;
         let err = store
             .acquire(&entity, &other)
             .await
             .expect_err("second acquire loses the race");
         assert!(matches!(err, ClaimError::AlreadyClaimed));
+    }
+
+    #[tokio::test]
+    async fn registration_persists_the_exact_configured_lease_ttl() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(clean) = clean_store().await else {
+            return;
+        };
+        let configured_ttl = Duration::from_millis(12_345);
+        let store = PostgresClaimStore::with_lease_ttl(clean.db.clone(), configured_ttl);
+        let me = node_identity();
+        store.register(&me, None).await.expect("register node");
+
+        let conn = store.db.guard().await.expect("guard");
+        let mut rows = conn
+            .query(
+                "SELECT lease_ttl_ms FROM clustering_nodes WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![me.node_id.clone(), me.node_epoch.clone()],
+            )
+            .await
+            .expect("query registered TTL");
+        let persisted = rows
+            .next()
+            .await
+            .expect("row read")
+            .expect("registered row")
+            .get::<i64>(0)
+            .expect("lease_ttl_ms");
+        assert_eq!(persisted, 12_345);
+    }
+
+    #[tokio::test]
+    async fn lapsed_but_not_expired_incarnation_has_no_claim_or_relay_authority() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let me = node_identity();
+        store
+            .register_with_peer_id(&me, None, Some("peer-before-lapse".to_owned()))
+            .await
+            .expect("register live node");
+        let owned = room_entity("lapsed-owned@muc.example.com");
+        let epoch = store.acquire(&owned, &me).await.expect("initial acquire");
+
+        // Leave the terminal bit deliberately untouched. Every authority
+        // check must enforce the row-local deadline itself during the gap
+        // before a watchdog commits `expired = true`.
+        backdate_heartbeat(&store.db, &me).await;
+        let conn = store.db.guard().await.expect("guard");
+        let mut rows = conn
+            .query(
+                "SELECT expired FROM clustering_nodes WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![me.node_id.clone(), me.node_epoch.clone()],
+            )
+            .await
+            .expect("query terminal bit");
+        assert!(!rows
+            .next()
+            .await
+            .expect("row read")
+            .expect("node row")
+            .get::<bool>(0)
+            .expect("expired"));
+        drop(rows);
+        drop(conn);
+
+        let fresh = room_entity("lapsed-new@muc.example.com");
+        assert!(matches!(
+            store.acquire(&fresh, &me).await,
+            Err(ClaimError::Draining)
+        ));
+        assert!(store.ensure_claimed(&owned, &me).await.is_err());
+        let snapshot = store
+            .current_claim(&owned)
+            .await
+            .expect("read claim")
+            .expect("claim remains on file");
+        assert_eq!(snapshot.owner, me);
+        assert!(!snapshot.owner_lease_fresh);
+        assert!(!store.fence(&owned, &me, epoch).await.expect("fence"));
+        assert!(store
+            .owned_claims(std::slice::from_ref(&owned), &me)
+            .await
+            .expect("owned snapshot")
+            .is_empty());
+        assert_eq!(
+            store
+                .reconcile(&me, std::slice::from_ref(&owned))
+                .await
+                .expect("reconcile"),
+            vec![owned]
+        );
+        assert_eq!(
+            store.peer_id_for_node(&me).await.expect("peer lookup"),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn every_claim_grant_cas_rejects_a_lapsed_nonexpired_destination() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+
+        let stale_owner = node_identity();
+        register_live_node(&store, &stale_owner).await;
+        let stale_entity = room_entity("lapsed-owner-stale-steal@muc.example.com");
+        let stale_epoch = store
+            .acquire(&stale_entity, &stale_owner)
+            .await
+            .expect("owner acquires stale-steal fixture");
+        store
+            .db
+            .guard()
+            .await
+            .expect("guard")
+            .execute(
+                "UPDATE clustering_nodes SET expired = true WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![stale_owner.node_id.clone(), stale_owner.node_epoch.clone()],
+            )
+            .await
+            .expect("commit source expiry");
+
+        let resume_owner = node_identity();
+        register_live_node(&store, &resume_owner).await;
+        let resume_entity = sm_entity("lapsed-resume-destination");
+        let resume_epoch = store
+            .acquire(&resume_entity, &resume_owner)
+            .await
+            .expect("owner acquires resume fixture");
+
+        let destination = node_identity();
+        register_live_node(&store, &destination).await;
+        backdate_heartbeat(&store.db, &destination).await;
+        assert!(matches!(
+            store
+                .steal_stale(
+                    &stale_entity,
+                    stale_epoch,
+                    StalePredicate::OwnerStale,
+                    &destination,
+                )
+                .await,
+            Err(ClaimError::Conflict)
+        ));
+        let jid: jid::BareJid = "alice@example.com".parse().expect("valid jid");
+        let proof = waddle_xmpp::ownership::verify_resume_identity(&jid, &jid)
+            .expect("matching resume identity");
+        assert!(matches!(
+            store
+                .steal_for_resume(&resume_entity, resume_epoch, proof, &destination)
+                .await,
+            Err(ClaimError::Conflict)
+        ));
+
+        // Recovery has the one deliberate draining-destination exception,
+        // but it is still deadline-fenced inside the same reclaim CAS.
+        let predecessor = NodeIdentity::new("lapsed-recovery-node", "old");
+        register_live_node(&store, &predecessor).await;
+        let recovery_entity = sm_entity("lapsed-recovery-destination");
+        let recovery_epoch = store
+            .acquire(&recovery_entity, &predecessor)
+            .await
+            .expect("predecessor acquires recovery fixture");
+        let recovery = NodeIdentity::new(predecessor.node_id.clone(), "candidate");
+        store
+            .register_draining_with_peer_id(&predecessor, &recovery, None, None, NODE_LEASE_TTL)
+            .await
+            .expect("register draining recovery candidate");
+        backdate_heartbeat(&store.db, &recovery).await;
+        assert!(matches!(
+            store
+                .reclaim_after_self_fence(
+                    &recovery_entity,
+                    recovery_epoch,
+                    &predecessor,
+                    &recovery,
+                    NODE_LEASE_TTL,
+                )
+                .await,
+            Err(ClaimError::Conflict)
+        ));
+    }
+
+    #[tokio::test]
+    async fn lapsed_steal_intent_destination_cannot_consume_the_intent() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let owner = node_identity();
+        register_live_node(&store, &owner).await;
+        let entity = user_actor_entity("lapsed-intent-destination");
+        let epoch = store
+            .acquire(&entity, &owner)
+            .await
+            .expect("owner acquires");
+        let destination = node_identity();
+        register_live_node(&store, &destination).await;
+        store
+            .report_steal_intent(&entity, &owner, epoch, &destination)
+            .await
+            .expect("report intent while destination is fresh");
+        let conn = store.db.guard().await.expect("guard");
+        conn.execute(
+            "UPDATE clustering_steal_intents SET created_at = now() - interval '1 hour' WHERE entity = ?",
+            crate::db_params![entity_key(&entity)],
+        )
+        .await
+        .expect("age intent deterministically");
+        drop(conn);
+        backdate_heartbeat(&store.db, &destination).await;
+
+        let intent_ttl = Duration::from_secs(1);
+        assert!(matches!(
+            store
+                .steal_stale(
+                    &entity,
+                    epoch,
+                    StalePredicate::StealIntentExpired { intent_ttl },
+                    &destination,
+                )
+                .await,
+            Err(ClaimError::Conflict)
+        ));
+        assert_eq!(
+            store
+                .owner_steal_intents(&owner)
+                .await
+                .expect("intent remains visible to owner"),
+            vec![(entity.clone(), epoch)]
+        );
+
+        let fresh_destination = node_identity();
+        register_live_node(&store, &fresh_destination).await;
+        store
+            .steal_stale(
+                &entity,
+                epoch,
+                StalePredicate::StealIntentExpired { intent_ttl },
+                &fresh_destination,
+            )
+            .await
+            .expect("fresh destination consumes the surviving intent");
+    }
+
+    #[tokio::test]
+    async fn acquire_serializes_with_same_node_id_epoch_rotation() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let old = node_identity();
+        register_live_node(&store, &old).await;
+        let fresh = NodeIdentity::new(old.node_id.clone(), uuid::Uuid::new_v4().to_string());
+        let entity = sm_entity("acquire-vs-node-epoch-rotation");
+
+        let mut rotation = store.db.begin().await.expect("begin node epoch rotation");
+        assert_eq!(
+            rotation
+                .execute(
+                    "UPDATE clustering_nodes SET node_epoch = ? WHERE node_id = ? AND node_epoch = ?",
+                    crate::db_params![
+                        fresh.node_epoch.clone(),
+                        old.node_id.clone(),
+                        old.node_epoch.clone(),
+                    ],
+                )
+                .await
+                .expect("rotate node epoch while holding row lock"),
+            1
+        );
+
+        let store_db = store.db.clone();
+        let old_claimant = old.clone();
+        let claim_entity = entity.clone();
+        let acquire = tokio::spawn(async move {
+            PostgresClaimStore::new(store_db)
+                .acquire(&claim_entity, &old_claimant)
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !acquire.is_finished(),
+            "claim acquire must wait on the exact node-row share lock"
+        );
+
+        rotation.commit().await.expect("commit node epoch rotation");
+        assert!(matches!(
+            acquire.await.expect("acquire task"),
+            Err(ClaimError::Draining)
+        ));
+        assert!(
+            store
+                .current_claim(&entity)
+                .await
+                .expect("read claim")
+                .is_none(),
+            "the superseded epoch must not publish a claim after rotation commits"
+        );
+    }
+
+    #[tokio::test]
+    async fn owner_stale_steal_serializes_with_same_node_id_epoch_rotation() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let dead_owner = node_identity();
+        register_live_node(&store, &dead_owner).await;
+        let entity = sm_entity("steal-vs-node-epoch-rotation");
+        let observed = store
+            .acquire(&entity, &dead_owner)
+            .await
+            .expect("dead owner acquires claim");
+        store
+            .db
+            .guard()
+            .await
+            .expect("guard")
+            .execute(
+                "UPDATE clustering_nodes SET expired = true WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![dead_owner.node_id.clone(), dead_owner.node_epoch.clone()],
+            )
+            .await
+            .expect("expire old owner");
+
+        let old_stealer = node_identity();
+        register_live_node(&store, &old_stealer).await;
+        let fresh_stealer = NodeIdentity::new(
+            old_stealer.node_id.clone(),
+            uuid::Uuid::new_v4().to_string(),
+        );
+        let mut rotation = store.db.begin().await.expect("begin node epoch rotation");
+        assert_eq!(
+            rotation
+                .execute(
+                    "UPDATE clustering_nodes SET node_epoch = ? WHERE node_id = ? AND node_epoch = ?",
+                    crate::db_params![
+                        fresh_stealer.node_epoch.clone(),
+                        old_stealer.node_id.clone(),
+                        old_stealer.node_epoch.clone(),
+                    ],
+                )
+                .await
+                .expect("rotate stealer epoch while holding row lock"),
+            1
+        );
+
+        let store_db = store.db.clone();
+        let stale_stealer = old_stealer.clone();
+        let steal_entity = entity.clone();
+        let steal = tokio::spawn(async move {
+            PostgresClaimStore::new(store_db)
+                .steal_stale(
+                    &steal_entity,
+                    observed,
+                    StalePredicate::OwnerStale,
+                    &stale_stealer,
+                )
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !steal.is_finished(),
+            "claim steal must wait on the exact destination node-row share lock"
+        );
+
+        rotation
+            .commit()
+            .await
+            .expect("commit stealer epoch rotation");
+        assert!(matches!(
+            steal.await.expect("steal task"),
+            Err(ClaimError::Conflict)
+        ));
+        let current = store
+            .current_claim(&entity)
+            .await
+            .expect("read claim")
+            .expect("claim remains");
+        assert_eq!(current.owner, dead_owner);
+        assert_eq!(current.claim_epoch, observed);
     }
 
     /// FIX 1: `ensure_claimed` on a not-yet-claimed entity is a plain fresh
@@ -1936,12 +3437,13 @@ mod tests {
             return;
         };
         let me = node_identity();
+        register_live_node(&store, &me).await;
         let entity = sm_entity("ensure-claimed-fresh");
         let epoch = store
             .ensure_claimed(&entity, &me)
             .await
             .expect("ensure_claimed acquires fresh");
-        assert_eq!(epoch, ClaimEpoch(0));
+        assert!(epoch.0 >= 0, "the global claim generation must not wrap");
     }
 
     /// FIX 1: a second `ensure_claimed` call under the exact same
@@ -1957,6 +3459,7 @@ mod tests {
             return;
         };
         let me = node_identity();
+        register_live_node(&store, &me).await;
         let entity = sm_entity("ensure-claimed-idempotent");
         let first = store
             .ensure_claimed(&entity, &me)
@@ -1967,7 +3470,6 @@ mod tests {
             .await
             .expect("second ensure_claimed under the same identity self-reacquires");
         assert_eq!(first, second);
-        assert_eq!(second, ClaimEpoch(0));
     }
 
     /// FIX 1: `ensure_claimed` under a genuinely different node/epoch than
@@ -1981,6 +3483,7 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = sm_entity("ensure-claimed-foreign");
         store
             .ensure_claimed(&entity, &owner)
@@ -1988,6 +3491,7 @@ mod tests {
             .expect("owner's ensure_claimed acquires");
 
         let foreign = node_identity();
+        register_live_node(&store, &foreign).await;
         let err = store
             .ensure_claimed(&entity, &foreign)
             .await
@@ -2025,6 +3529,7 @@ mod tests {
             .expect("clean nodes");
 
         let me = node_identity();
+        register_live_node(&store, &me).await;
         let entity = sm_entity("ensure-claimed-concurrent");
         let store = std::sync::Arc::new(store);
 
@@ -2069,51 +3574,52 @@ mod tests {
             return;
         };
         let me = node_identity();
+        register_live_node(&store, &me).await;
         let user_entity = Entity::new(EntityType::UserActor, "42");
         let room_entity = Entity::new(EntityType::RoomActor, "42");
         let sm_entity_same_id = Entity::new(EntityType::SmSession, "42");
 
-        store
+        let user_epoch = store
             .acquire(&user_entity, &me)
             .await
             .expect("acquire user_actor:42");
-        store
+        let room_epoch = store
             .acquire(&room_entity, &me)
             .await
             .expect("acquire room_actor:42 must not collide with user_actor:42");
-        store
+        let sm_epoch = store
             .acquire(&sm_entity_same_id, &me)
             .await
             .expect("acquire sm_session:42 must not collide with either of the above");
 
         assert!(store
-            .fence(&user_entity, &me, ClaimEpoch(0))
+            .fence(&user_entity, &me, user_epoch)
             .await
             .expect("fence user_actor:42"));
         assert!(store
-            .fence(&room_entity, &me, ClaimEpoch(0))
+            .fence(&room_entity, &me, room_epoch)
             .await
             .expect("fence room_actor:42"));
         assert!(store
-            .fence(&sm_entity_same_id, &me, ClaimEpoch(0))
+            .fence(&sm_entity_same_id, &me, sm_epoch)
             .await
             .expect("fence sm_session:42"));
 
         // Releasing one must not affect the others.
         store
-            .release(&user_entity, &me, ClaimEpoch(0))
+            .release(&user_entity, &me, user_epoch)
             .await
             .expect("release user_actor:42");
         assert!(!store
-            .fence(&user_entity, &me, ClaimEpoch(0))
+            .fence(&user_entity, &me, user_epoch)
             .await
             .expect("fence user_actor:42 after release"));
         assert!(store
-            .fence(&room_entity, &me, ClaimEpoch(0))
+            .fence(&room_entity, &me, room_epoch)
             .await
             .expect("room_actor:42 untouched by user_actor:42's release"));
         assert!(store
-            .fence(&sm_entity_same_id, &me, ClaimEpoch(0))
+            .fence(&sm_entity_same_id, &me, sm_epoch)
             .await
             .expect("sm_session:42 untouched by user_actor:42's release"));
     }
@@ -2129,6 +3635,7 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = sm_entity("stream-1");
         let epoch0 = store.acquire(&entity, &owner).await.expect("acquire");
 
@@ -2162,7 +3669,7 @@ mod tests {
             .steal_stale(&entity, epoch0, StalePredicate::OwnerStale, &stealer)
             .await
             .expect("steal succeeds once the owner is committed-expired");
-        assert_eq!(epoch1, ClaimEpoch(1));
+        assert!(epoch1 > epoch0);
         assert!(store.fence(&entity, &stealer, epoch1).await.expect("fence"));
     }
 
@@ -2176,8 +3683,21 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = sm_entity("stream-1");
         let epoch0 = store.acquire(&entity, &owner).await.expect("acquire");
+
+        store
+            .db
+            .guard()
+            .await
+            .expect("guard")
+            .execute(
+                "DELETE FROM clustering_nodes WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![owner.node_id.clone(), owner.node_epoch.clone()],
+            )
+            .await
+            .expect("remove vanished owner node row");
 
         let stealer = node_identity();
         seed_node(&store.db, &stealer, false).await;
@@ -2185,7 +3705,7 @@ mod tests {
             .steal_stale(&entity, epoch0, StalePredicate::OwnerStale, &stealer)
             .await
             .expect("steal from a node with no nodes-row succeeds");
-        assert_eq!(epoch1, ClaimEpoch(1));
+        assert!(epoch1 > epoch0);
     }
 
     #[tokio::test]
@@ -2195,6 +3715,7 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = sm_entity("stream-1");
         store.acquire(&entity, &owner).await.expect("acquire");
 
@@ -2227,6 +3748,7 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = sm_entity("stream-1");
         let epoch0 = store.acquire(&entity, &owner).await.expect("acquire");
 
@@ -2255,11 +3777,13 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = sm_entity("stream-1");
         let epoch0 = store.acquire(&entity, &owner).await.expect("acquire");
         seed_node(&store.db, &owner, false).await;
 
         let stealer = node_identity();
+        register_live_node(&store, &stealer).await;
         let jid: jid::BareJid = "alice@example.com".parse().expect("valid jid");
         let proof =
             waddle_xmpp::ownership::verify_resume_identity(&jid, &jid).expect("identity match");
@@ -2267,7 +3791,7 @@ mod tests {
             .steal_for_resume(&entity, epoch0, proof, &stealer)
             .await
             .expect("consent CAS steals from a fresh owner");
-        assert_eq!(epoch1, ClaimEpoch(1));
+        assert!(epoch1 > epoch0);
     }
 
     #[tokio::test]
@@ -2277,10 +3801,12 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = sm_entity("stream-1");
         store.acquire(&entity, &owner).await.expect("acquire");
 
         let stealer = node_identity();
+        register_live_node(&store, &stealer).await;
         let jid: jid::BareJid = "alice@example.com".parse().expect("valid jid");
         let proof =
             waddle_xmpp::ownership::verify_resume_identity(&jid, &jid).expect("identity match");
@@ -2298,6 +3824,7 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = sm_entity("stream-1");
         let epoch0 = store.acquire(&entity, &owner).await.expect("acquire");
         assert!(store.fence(&entity, &owner, epoch0).await.expect("fence"));
@@ -2311,6 +3838,13 @@ mod tests {
             .fence(&entity, &stranger, epoch0)
             .await
             .expect("fence wrong node"));
+
+        let recovered_incarnation =
+            NodeIdentity::new(owner.node_id.clone(), uuid::Uuid::new_v4().to_string());
+        assert!(!store
+            .fence(&entity, &recovered_incarnation, epoch0)
+            .await
+            .expect("fence wrong node epoch"));
     }
 
     #[tokio::test]
@@ -2320,13 +3854,15 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = sm_entity("stream-1");
         let epoch0 = store.acquire(&entity, &owner).await.expect("acquire");
 
         // Releasing under the wrong epoch is a silent no-op — the claim
         // must survive.
+        let wrong_epoch = ClaimEpoch(epoch0.0 + 1);
         store
-            .release(&entity, &owner, ClaimEpoch(99))
+            .release(&entity, &owner, wrong_epoch)
             .await
             .expect("release under wrong epoch is a no-op");
         assert!(store.fence(&entity, &owner, epoch0).await.expect("fence"));
@@ -2345,6 +3881,23 @@ mod tests {
             .release(&entity, &owner, epoch0)
             .await
             .expect("re-release is a no-op, not an error");
+
+        let epoch1 = store
+            .acquire(&entity, &owner)
+            .await
+            .expect("reacquire after release");
+        assert!(
+            epoch1 > epoch0,
+            "the global allocator must not reuse a deleted row's generation"
+        );
+        store
+            .release(&entity, &owner, epoch0)
+            .await
+            .expect("delayed old release remains a no-op");
+        assert!(store
+            .fence(&entity, &owner, epoch1)
+            .await
+            .expect("new grant survives old release"));
     }
 
     #[tokio::test]
@@ -2354,30 +3907,32 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let a = sm_entity("stream-a");
         let b = sm_entity("stream-b");
         let c = sm_entity("stream-c");
-        store.acquire(&a, &owner).await.expect("acquire a");
-        store.acquire(&b, &owner).await.expect("acquire b");
+        let a_epoch = store.acquire(&a, &owner).await.expect("acquire a");
+        let b_epoch = store.acquire(&b, &owner).await.expect("acquire b");
         // c is owned by someone else — release_many must not touch it.
         let other = node_identity();
-        store.acquire(&c, &other).await.expect("acquire c");
+        register_live_node(&store, &other).await;
+        let c_epoch = store.acquire(&c, &other).await.expect("acquire c");
 
         store
-            .release_many(&[a.clone(), b.clone(), c.clone()], &owner)
+            .release_many(&[
+                ClaimGrant::new(a.clone(), owner.clone(), a_epoch),
+                ClaimGrant::new(b.clone(), owner.clone(), b_epoch),
+                // Deliberately carry the wrong owner for c: exact matching
+                // must leave the other node's claim untouched.
+                ClaimGrant::new(c.clone(), owner.clone(), c_epoch),
+            ])
             .await
             .expect("release_many");
 
-        assert!(!store
-            .fence(&a, &owner, ClaimEpoch(0))
-            .await
-            .expect("fence a"));
-        assert!(!store
-            .fence(&b, &owner, ClaimEpoch(0))
-            .await
-            .expect("fence b"));
+        assert!(!store.fence(&a, &owner, a_epoch).await.expect("fence a"));
+        assert!(!store.fence(&b, &owner, b_epoch).await.expect("fence b"));
         assert!(store
-            .fence(&c, &other, ClaimEpoch(0))
+            .fence(&c, &other, c_epoch)
             .await
             .expect("fence c: untouched, still owned by other"));
     }
@@ -2389,40 +3944,75 @@ mod tests {
             return;
         };
         store
-            .release_many(&[], &node_identity())
+            .release_many(&[])
             .await
             .expect("empty release_many does not error");
     }
 
-    // ADR-0017 Phase 3 Slice 10, `ClaimStore::release_many`'s own
-    // "plan-sanctioned ABA window" doc comment: literal proof, at the SQL
-    // level, that `release_many` is blind to an entity's individual
-    // `claim_epoch` and matches only `(node_id, node_epoch)` — so a batch
-    // entry queued for release, then legitimately re-claimed by the SAME
-    // node/epoch at a HIGHER epoch before the batched DELETE actually
-    // runs (the doc comment's own example: "a resumed XEP-0198 session
-    // legitimately steals back onto this node via `steal_for_resume`"),
-    // is deleted by the stale batch entry regardless. This is the
-    // documented, accepted risk — not a bug — and Slice 10's own
-    // `crate::clustering::drain::tests::
-    // drain_seals_then_releases_only_room_entities_skipping_sm_sessions`
-    // proves the mitigation: `SmSession` entities (the only ones reachable
-    // via `steal_for_resume`) never enter a `release_many` batch in the
-    // first place, so this window is real at the store level but
-    // unreachable through the production drain path.
     #[tokio::test]
-    async fn release_many_epoch_blind_window_deletes_a_fresh_same_node_resume() {
+    async fn stale_epoch_cleanup_cannot_delete_claims_after_node_incarnation_rotation() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let old = NodeIdentity::new("stable-cleanup-node", uuid::Uuid::new_v4().to_string());
+        register_live_node(&store, &old).await;
+        let single = sm_entity("stale-single-release");
+        let batched = sm_entity("stale-batched-release");
+        let single_epoch = store.acquire(&single, &old).await.expect("single acquire");
+        let batched_epoch = store.acquire(&batched, &old).await.expect("batch acquire");
+
+        let fresh = NodeIdentity::new(old.node_id.clone(), uuid::Uuid::new_v4().to_string());
+        store
+            .register_draining_with_peer_id(&old, &fresh, None, None, Duration::from_secs(30))
+            .await
+            .expect("rotate exact node incarnation");
+
+        store
+            .release(&single, &old, single_epoch)
+            .await
+            .expect("stale single cleanup is a no-op");
+        store
+            .release_many(&[ClaimGrant::new(batched.clone(), old.clone(), batched_epoch)])
+            .await
+            .expect("stale batch cleanup is a no-op");
+
+        assert_eq!(
+            store
+                .current_claim(&single)
+                .await
+                .expect("single claim read")
+                .expect("single claim remains")
+                .claim_epoch,
+            single_epoch
+        );
+        assert_eq!(
+            store
+                .current_claim(&batched)
+                .await
+                .expect("batch claim read")
+                .expect("batch claim remains")
+                .claim_epoch,
+            batched_epoch
+        );
+    }
+
+    // Exact-grant regression: a batch captured before a same-node regrant
+    // must not delete the newer claim when it finally executes.
+    #[tokio::test]
+    async fn delayed_release_many_is_a_no_op_after_same_node_regrant() {
         let _guard = clustering_control_plane_table_lock().lock().await;
         let Some(store) = clean_store().await else {
             return;
         };
         let me = node_identity();
+        register_live_node(&store, &me).await;
         let entity = sm_entity("stream-aba");
         let epoch0 = store.acquire(&entity, &me).await.expect("initial acquire");
 
         // Drain decides to release this entity (its final write already
         // committed) and queues it for the batch...
-        let batch = vec![entity.clone()];
+        let batch = vec![ClaimGrant::new(entity.clone(), me.clone(), epoch0)];
 
         // ...but before `release_many` actually runs, the SAME node
         // legitimately re-wins this exact entity at a HIGHER epoch via the
@@ -2436,7 +4026,7 @@ mod tests {
             .steal_for_resume(&entity, epoch0, proof, &me)
             .await
             .expect("same-node resume steal succeeds (no staleness required)");
-        assert_eq!(epoch1, ClaimEpoch(1), "epoch bumped by the resume steal");
+        assert_ne!(epoch1, epoch0, "every grant receives a new global epoch");
         assert!(
             store
                 .fence(&entity, &me, epoch1)
@@ -2445,17 +4035,14 @@ mod tests {
             "the entity is genuinely, freshly re-claimed under epoch 1"
         );
 
-        // The stale batch entry's `release_many` call is blind to that
-        // epoch bump — it deletes the fresh claim anyway.
-        store.release_many(&batch, &me).await.expect("release_many");
+        store.release_many(&batch).await.expect("release_many");
 
         assert!(
-            !store
+            store
                 .fence(&entity, &me, epoch1)
                 .await
                 .expect("fence check"),
-            "release_many's epoch-blind DELETE removes the fresh, genuinely-live claim too — \
-             the documented ABA window, reproduced here at the SQL level"
+            "the delayed old batch must not delete the newer exact grant"
         );
     }
 
@@ -2473,6 +4060,7 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = sm_entity("stream-1");
         let epoch0 = store.acquire(&entity, &owner).await.expect("acquire");
         seed_node(&store.db, &owner, true).await; // owner already stale
@@ -2482,8 +4070,13 @@ mod tests {
         let mut fencing_tx = store.db.begin().await.expect("begin fencing tx");
         let held = fencing_tx
             .query(
-                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                crate::db_params![entity_key(&entity), owner.node_id.clone(), epoch0.0],
+                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
+                crate::db_params![
+                    entity_key(&entity),
+                    owner.node_id.clone(),
+                    owner.node_epoch.clone(),
+                    epoch0.0,
+                ],
             )
             .await
             .expect("fencing select")
@@ -2514,7 +4107,7 @@ mod tests {
             .await
             .expect("steal task join")
             .expect("steal succeeds once the FOR SHARE lock is released");
-        assert_eq!(stolen_epoch, ClaimEpoch(1));
+        assert!(stolen_epoch > epoch0);
 
         // The original owner's fencing check against its old epoch now
         // observes zero rows — it has been fenced out.
@@ -2563,7 +4156,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn register_is_idempotent_and_refreshes_the_epoch() {
+    async fn register_is_idempotent_only_for_the_exact_incarnation() {
         let _guard = clustering_control_plane_table_lock().lock().await;
         let Some(store) = clean_store().await else {
             return;
@@ -2574,34 +4167,89 @@ mod tests {
             .register(&first, None)
             .await
             .expect("first registration");
-
-        // Re-registration under the SAME node_id but a fresh epoch (the
-        // post-fence re-registration shape) must supersede the old epoch:
-        // the old epoch's heartbeat must now fail.
-        let second = NodeIdentity::new(node_id, uuid::Uuid::new_v4().to_string());
         store
+            .register(&first, None)
+            .await
+            .expect("exact registration retry is idempotent");
+
+        // A caller with no expected-old proof cannot overwrite the row with
+        // a fresh epoch. Recovery and startup replacement use their explicit
+        // expected-old CAS methods instead.
+        let second = NodeIdentity::new(node_id, uuid::Uuid::new_v4().to_string());
+        let delayed = store
             .register(&second, None)
             .await
-            .expect("re-registration");
+            .expect_err("bootstrap registration cannot replace an incarnation");
+        assert!(matches!(delayed, ClaimError::Conflict));
 
-        assert!(!store
+        assert!(store
             .heartbeat(&first, NODE_LEASE_TTL)
             .await
             .expect("heartbeat call succeeds"));
-        assert!(store
+        assert!(!store
             .heartbeat(&second, NODE_LEASE_TTL)
             .await
             .expect("heartbeat call succeeds"));
     }
 
     #[tokio::test]
-    async fn expire_commits_the_flag_and_is_idempotent_once_true() {
+    async fn initial_registration_replacement_is_an_exact_expected_old_cas() {
         let _guard = clustering_control_plane_table_lock().lock().await;
         let Some(store) = clean_store().await else {
             return;
         };
+        let stable_id = uuid::Uuid::new_v4().to_string();
+        let old = NodeIdentity::new(stable_id.clone(), uuid::Uuid::new_v4().to_string());
+        store.register(&old, None).await.expect("register old");
+        backdate_heartbeat(&store.db, &old).await;
+        assert!(store
+            .expire(&old, NODE_LEASE_TTL)
+            .await
+            .expect("commit old incarnation expired"));
+
+        let fresh = NodeIdentity::new(stable_id.clone(), uuid::Uuid::new_v4().to_string());
+        store
+            .register_initial_with_peer_id(Some(&old), &fresh, None, None)
+            .await
+            .expect("exact expired predecessor may be replaced");
+        assert_eq!(
+            store
+                .registered_identity(&stable_id)
+                .await
+                .expect("read current identity"),
+            Some(fresh.clone())
+        );
+
+        let delayed = NodeIdentity::new(stable_id.clone(), uuid::Uuid::new_v4().to_string());
+        let stale_replacement = store
+            .register_initial_with_peer_id(Some(&old), &delayed, None, None)
+            .await
+            .expect_err("the old predecessor proof cannot replace a later incarnation");
+        assert!(matches!(stale_replacement, ClaimError::Conflict));
+        let stale_bootstrap = store
+            .register(&old, None)
+            .await
+            .expect_err("a delayed bootstrap cannot overwrite the later incarnation");
+        assert!(matches!(stale_bootstrap, ClaimError::Conflict));
+        assert_eq!(
+            store
+                .registered_identity(&stable_id)
+                .await
+                .expect("read identity after delayed writes"),
+            Some(fresh),
+            "neither stale registration may overwrite the current epoch"
+        );
+    }
+
+    #[tokio::test]
+    async fn expire_commits_the_flag_and_is_idempotent_once_true() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(clean) = clean_store().await else {
+            return;
+        };
         let owner = node_identity();
         let short_ttl = Duration::from_millis(200);
+        let store = PostgresClaimStore::with_lease_ttl(clean.db.clone(), short_ttl);
         store.register(&owner, None).await.expect("register");
 
         // Not yet lapsed: expire must not flip the flag.
@@ -3012,11 +4660,192 @@ mod tests {
         assert!(draining);
     }
 
+    #[tokio::test]
+    async fn post_fence_registration_stays_draining_until_exact_epoch_activation() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let old = NodeIdentity::new("stable-relay-node", "old-epoch");
+        store
+            .register(&old, None)
+            .await
+            .expect("register old epoch");
+        let fresh = NodeIdentity::new(old.node_id.clone(), "fresh-epoch");
+
+        store
+            .register_draining_with_peer_id(
+                &old,
+                &fresh,
+                Some("test-generation".to_string()),
+                Some("test-peer".to_string()),
+                NODE_LEASE_TTL,
+            )
+            .await
+            .expect("register recovery candidate");
+
+        let conn = store.db.guard().await.expect("guard");
+        let mut rows = conn
+            .query(
+                "SELECT node_epoch, draining FROM clustering_nodes WHERE node_id = ?",
+                crate::db_params![fresh.node_id.clone()],
+            )
+            .await
+            .expect("query candidate row");
+        let row = rows
+            .next()
+            .await
+            .expect("row")
+            .expect("candidate row present");
+        assert_eq!(row.get::<String>(0).expect("node_epoch"), fresh.node_epoch);
+        assert!(row.get::<bool>(1).expect("draining"));
+        drop(rows);
+        drop(conn);
+
+        assert!(
+            !store
+                .activate(&old, NODE_LEASE_TTL)
+                .await
+                .expect("stale activation CAS"),
+            "the superseded epoch must not activate the recovery row"
+        );
+        assert!(
+            store
+                .activate(&fresh, NODE_LEASE_TTL)
+                .await
+                .expect("fresh activation CAS"),
+            "the exact recovery epoch must activate once"
+        );
+        store
+            .register_draining_with_peer_id(
+                &old,
+                &fresh,
+                Some("test-generation".to_string()),
+                Some("test-peer".to_string()),
+                NODE_LEASE_TTL,
+            )
+            .await
+            .expect("delayed exact recovery registration is an idempotent retry");
+        assert!(
+            store
+                .is_fresh(&fresh, NODE_LEASE_TTL)
+                .await
+                .expect("freshness check"),
+            "a delayed exact registration retry must not put an activated node back into draining"
+        );
+    }
+
+    #[tokio::test]
+    async fn elapsed_recovery_candidate_cannot_be_revived_and_can_rotate_forward() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let ttl = Duration::from_millis(100);
+        let old = NodeIdentity::new("stable-expired-recovery", "old");
+        store.register(&old, None).await.expect("register old");
+        let elapsed = NodeIdentity::new(old.node_id.clone(), "elapsed");
+        store
+            .register_draining_with_peer_id(&old, &elapsed, None, None, ttl)
+            .await
+            .expect("register draining candidate");
+        store
+            .db
+            .guard()
+            .await
+            .expect("guard")
+            .execute(
+                "UPDATE clustering_nodes SET heartbeat = now() - interval '1 second' WHERE node_id = ?",
+                crate::db_params![old.node_id.clone()],
+            )
+            .await
+            .expect("backdate candidate");
+
+        assert!(
+            !store
+                .activate(&elapsed, ttl)
+                .await
+                .expect("elapsed activation CAS"),
+            "activation must not refresh an epoch whose lease deadline elapsed"
+        );
+        assert!(matches!(
+            store
+                .register_draining_with_peer_id(&old, &elapsed, None, None, ttl)
+                .await,
+            Err(ClaimError::Conflict)
+        ));
+
+        store
+            .db
+            .guard()
+            .await
+            .expect("guard")
+            .execute(
+                "UPDATE clustering_nodes SET expired = true WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![elapsed.node_id.clone(), elapsed.node_epoch.clone()],
+            )
+            .await
+            .expect("expire candidate");
+        let replacement = NodeIdentity::new(old.node_id.clone(), "replacement");
+        store
+            .register_draining_with_peer_id(&elapsed, &replacement, None, None, ttl)
+            .await
+            .expect("an exact expired candidate can be superseded by a new epoch");
+        assert!(store
+            .activate(&replacement, ttl)
+            .await
+            .expect("activate replacement"));
+    }
+
     fn room_entity(id: &str) -> Entity {
         Entity::new(EntityType::RoomActor, id.to_string())
     }
 
     // --- ADR-0017 Phase 3 Slice 10: the acquire-side draining gate -------
+
+    #[tokio::test]
+    async fn acquire_and_self_reacquire_reject_a_superseded_node_epoch() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let old = NodeIdentity::new("stable-claim-node", "old-epoch");
+        register_live_node(&store, &old).await;
+        let owned = room_entity("old-epoch-owned@muc.example.com");
+        let owned_epoch = store
+            .ensure_claimed(&owned, &old)
+            .await
+            .expect("old epoch initially owns claim");
+
+        let fresh = NodeIdentity::new(old.node_id.clone(), "fresh-epoch");
+        store
+            .register_draining_with_peer_id(&old, &fresh, None, None, NODE_LEASE_TTL)
+            .await
+            .expect("rotate stable node to fresh epoch");
+        assert!(store
+            .activate(&fresh, NODE_LEASE_TTL)
+            .await
+            .expect("activate fresh epoch"));
+
+        let new_entity = room_entity("old-epoch-new@muc.example.com");
+        assert!(matches!(
+            store.acquire(&new_entity, &old).await,
+            Err(ClaimError::Draining)
+        ));
+        assert!(
+            store.ensure_claimed(&owned, &old).await.is_err(),
+            "the idempotent path must not resurrect a claim whose exact owner incarnation is gone"
+        );
+        let jid: jid::BareJid = "old-epoch@example.com".parse().expect("valid jid");
+        let proof =
+            waddle_xmpp::ownership::verify_resume_identity(&jid, &jid).expect("identity match");
+        assert!(matches!(
+            store
+                .steal_for_resume(&owned, owned_epoch, proof, &old)
+                .await,
+            Err(ClaimError::Conflict)
+        ));
+    }
 
     #[tokio::test]
     async fn acquire_refuses_a_new_claim_once_the_caller_is_marked_draining() {
@@ -3041,6 +4870,7 @@ mod tests {
         // The entity must genuinely remain unclaimed — a non-draining node
         // (or this same node, once done draining) can still acquire it.
         let other = node_identity();
+        register_live_node(&store, &other).await;
         store
             .acquire(&entity, &other)
             .await
@@ -3102,6 +4932,7 @@ mod tests {
             return;
         };
         let dead_owner = node_identity();
+        register_live_node(&store, &dead_owner).await;
         let entity = room_entity("orphaned@muc.example.com");
         let epoch0 = store.acquire(&entity, &dead_owner).await.expect("acquire");
         seed_node(&store.db, &dead_owner, true).await; // dead owner: expired
@@ -3139,6 +4970,7 @@ mod tests {
             return;
         };
         let dead_owner = node_identity();
+        register_live_node(&store, &dead_owner).await;
         let entity = room_entity("orphaned-live-stealer@muc.example.com");
         let epoch0 = store.acquire(&entity, &dead_owner).await.expect("acquire");
         seed_node(&store.db, &dead_owner, true).await;
@@ -3174,7 +5006,7 @@ mod tests {
             .steal_stale(&entity, epoch0, StalePredicate::OwnerStale, &live_stealer)
             .await
             .expect("a live stealer can still reclaim the dead owner's claim");
-        assert_eq!(epoch1, ClaimEpoch(epoch0.0 + 1));
+        assert!(epoch1 > epoch0);
     }
 
     #[tokio::test]
@@ -3184,6 +5016,7 @@ mod tests {
             return;
         };
         let dead_owner = node_identity();
+        register_live_node(&store, &dead_owner).await;
         let entity = sm_entity("orphaned-sm-heartbeat-fresh-stealer");
         let epoch0 = store.acquire(&entity, &dead_owner).await.expect("acquire");
         seed_node(&store.db, &dead_owner, true).await;
@@ -3222,7 +5055,7 @@ mod tests {
             .steal_orphaned_sm_session_claim(&entity, epoch0, &live_stealer, NODE_LEASE_TTL)
             .await
             .expect("a heartbeat-fresh stealer can reclaim the orphaned SM session claim");
-        assert_eq!(epoch1, ClaimEpoch(epoch0.0 + 1));
+        assert!(epoch1 > epoch0);
     }
 
     // --- ADR-0017 Phase 3 Slice 10: current_generation (Q5's mechanism) --
@@ -3301,9 +5134,9 @@ mod tests {
 
     #[tokio::test]
     async fn current_generation_preserves_first_seen_across_re_registration() {
-        // Register/re-register under the SAME node_id must NOT refresh
-        // `first_seen` — `register`'s `ON CONFLICT (node_id) DO UPDATE`
-        // deliberately omits `first_seen` from its SET list.
+        // A proven replacement under the SAME node_id must NOT refresh
+        // `first_seen` — the registration upsert deliberately omits
+        // `first_seen` from its SET list.
         let _guard = clustering_control_plane_table_lock().lock().await;
         let Some(store) = clean_store().await else {
             return;
@@ -3333,14 +5166,28 @@ mod tests {
             .expect("row present")
             .get(0)
             .expect("column present");
+        drop(rows);
+        drop(conn);
+
+        backdate_heartbeat(&store.db, &node).await;
+        assert!(store
+            .expire(&node, NODE_LEASE_TTL)
+            .await
+            .expect("commit predecessor expiry"));
 
         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         let node_reregistered = NodeIdentity::new("stable-node-id", "epoch-1");
         store
-            .register(&node_reregistered, Some("gen-b".to_string()))
+            .register_initial_with_peer_id(
+                Some(&node),
+                &node_reregistered,
+                Some("gen-b".to_string()),
+                None,
+            )
             .await
-            .expect("re-register under the same node_id, new node_epoch");
+            .expect("replace the exact expired incarnation under the same node_id");
 
+        let conn = store.db.guard().await.expect("guard");
         let mut rows = conn
             .query(
                 "SELECT first_seen::text FROM clustering_nodes WHERE node_id = ?",
@@ -3378,6 +5225,10 @@ mod tests {
         let me = node_identity();
         let other = node_identity();
         store.register(&me, None).await.expect("register me");
+        store
+            .register(&other, None)
+            .await
+            .expect("register resume destination");
 
         let still_owned = sm_entity("stream-still-owned");
         let stolen = sm_entity("stream-stolen");
@@ -3432,7 +5283,7 @@ mod tests {
         let reporter = node_identity();
         let entity = sm_entity("stream-1");
         let err = store
-            .report_steal_intent(&entity, &reporter)
+            .report_steal_intent(&entity, &reporter, ClaimEpoch(0), &reporter)
             .await
             .expect_err("SM-session claims are excluded from the steal-intent path");
         assert!(matches!(err, ClaimError::SmSessionExcludedFromStealIntent));
@@ -3448,6 +5299,7 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = user_actor_entity("room-1");
         let epoch0 = store.acquire(&entity, &owner).await.expect("acquire");
 
@@ -3457,7 +5309,7 @@ mod tests {
             .await
             .expect("register live stealer");
         store
-            .report_steal_intent(&entity, &stealer)
+            .report_steal_intent(&entity, &owner, epoch0, &stealer)
             .await
             .expect("report intent");
 
@@ -3519,6 +5371,7 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = user_actor_entity("room-2");
         let epoch0 = store.acquire(&entity, &owner).await.expect("acquire");
         // The owner's node lease is perfectly fresh — this CAS variant must
@@ -3531,7 +5384,7 @@ mod tests {
             .await
             .expect("register live stealer");
         store
-            .report_steal_intent(&entity, &stealer)
+            .report_steal_intent(&entity, &owner, epoch0, &stealer)
             .await
             .expect("report intent");
 
@@ -3547,7 +5400,7 @@ mod tests {
             )
             .await
             .expect("an uncleared, aged-out intent makes the entity stealable");
-        assert_eq!(epoch1, ClaimEpoch(1));
+        assert!(epoch1 > epoch0);
     }
 
     #[tokio::test]
@@ -3557,15 +5410,18 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = user_actor_entity("room-live-intent-stealer");
         let epoch0 = store.acquire(&entity, &owner).await.expect("acquire");
         seed_node(&store.db, &owner, false).await;
 
-        let missing_stealer = node_identity();
+        let reporter = node_identity();
+        register_live_node(&store, &reporter).await;
         store
-            .report_steal_intent(&entity, &missing_stealer)
+            .report_steal_intent(&entity, &owner, epoch0, &reporter)
             .await
             .expect("report intent");
+        let missing_stealer = node_identity();
         let intent_ttl = std::time::Duration::from_millis(50);
         tokio::time::sleep(intent_ttl * 2).await;
 
@@ -3623,7 +5479,7 @@ mod tests {
             )
             .await
             .expect("a live stealer can consume and win the aged intent");
-        assert_eq!(epoch1, ClaimEpoch(epoch0.0 + 1));
+        assert!(epoch1 > epoch0);
     }
 
     #[tokio::test]
@@ -3636,12 +5492,14 @@ mod tests {
             return;
         };
         let old_owner = node_identity();
+        register_live_node(&store, &old_owner).await;
         let entity = user_actor_entity("room-3");
         let epoch0 = store.acquire(&entity, &old_owner).await.expect("acquire");
 
         let reporter = node_identity();
+        register_live_node(&store, &reporter).await;
         store
-            .report_steal_intent(&entity, &reporter)
+            .report_steal_intent(&entity, &old_owner, epoch0, &reporter)
             .await
             .expect("report intent");
 
@@ -3650,6 +5508,7 @@ mod tests {
         // only care that Postgres no longer attributes the claim to
         // old_owner/epoch0.
         let new_owner = node_identity();
+        register_live_node(&store, &new_owner).await;
         let jid: jid::BareJid = "alice@example.com".parse().expect("valid jid");
         let proof =
             waddle_xmpp::ownership::verify_resume_identity(&jid, &jid).expect("identity match");
@@ -3657,6 +5516,14 @@ mod tests {
             .steal_for_resume(&entity, epoch0, proof, &new_owner)
             .await
             .expect("steal succeeds");
+
+        // Every successful grant clears intents bound to the displaced
+        // generation. Report a fresh intent against the new exact grant so
+        // the stale owner's delayed veto cannot erase it.
+        store
+            .report_steal_intent(&entity, &new_owner, epoch1, &reporter)
+            .await
+            .expect("report intent against new grant");
 
         // The deposed owner's clear call, still under its old epoch, is a
         // silent no-op: the intent row must survive.
@@ -3676,7 +5543,7 @@ mod tests {
         assert_eq!(
             survives,
             vec![(entity.clone(), epoch1)],
-            "the intent row must survive a deposed owner's stale-epoch clear attempt"
+            "the new grant's exact intent must survive a deposed owner's stale-epoch clear attempt"
         );
 
         // The new, current owner's clear call succeeds.
@@ -3696,6 +5563,129 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn report_steal_intent_rejects_a_delayed_target_grant_and_stale_reporter_incarnation() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let old_owner = node_identity();
+        register_live_node(&store, &old_owner).await;
+        let entity = user_actor_entity("intent-exact-grant");
+        let old_epoch = store
+            .acquire(&entity, &old_owner)
+            .await
+            .expect("old owner acquires");
+        let reporter = node_identity();
+        register_live_node(&store, &reporter).await;
+
+        let new_owner = node_identity();
+        register_live_node(&store, &new_owner).await;
+        let jid: jid::BareJid = "alice@example.com".parse().expect("valid jid");
+        let proof =
+            waddle_xmpp::ownership::verify_resume_identity(&jid, &jid).expect("identity match");
+        let new_epoch = store
+            .steal_for_resume(&entity, old_epoch, proof, &new_owner)
+            .await
+            .expect("move claim to a new exact grant");
+
+        let delayed_old_target = store
+            .report_steal_intent(&entity, &old_owner, old_epoch, &reporter)
+            .await
+            .expect_err("a delayed report must not bind itself to a replacement grant");
+        assert!(matches!(delayed_old_target, ClaimError::Conflict));
+
+        let recovered_reporter =
+            NodeIdentity::new(reporter.node_id.clone(), uuid::Uuid::new_v4().to_string());
+        store
+            .register_draining_with_peer_id(
+                &reporter,
+                &recovered_reporter,
+                None,
+                None,
+                NODE_LEASE_TTL,
+            )
+            .await
+            .expect("rotate reporter node row");
+        let delayed_old_reporter = store
+            .report_steal_intent(&entity, &new_owner, new_epoch, &reporter)
+            .await
+            .expect_err("a deposed reporter incarnation must not create an intent");
+        assert!(matches!(delayed_old_reporter, ClaimError::Conflict));
+        assert!(
+            store
+                .owner_steal_intents(&new_owner)
+                .await
+                .expect("scan after rejected reports")
+                .is_empty(),
+            "neither stale input may leave an intent attached to the current grant"
+        );
+
+        assert!(store
+            .activate(&recovered_reporter, NODE_LEASE_TTL)
+            .await
+            .expect("activate recovered reporter"));
+        store
+            .report_steal_intent(&entity, &new_owner, new_epoch, &recovered_reporter)
+            .await
+            .expect("the exact live reporter and target grant may report");
+        assert_eq!(
+            store
+                .owner_steal_intents(&new_owner)
+                .await
+                .expect("scan current exact intent"),
+            vec![(entity, new_epoch)]
+        );
+    }
+
+    #[tokio::test]
+    async fn clear_steal_intent_rejects_an_old_epoch_of_the_same_node_id() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let old_owner = node_identity();
+        store
+            .register(&old_owner, None)
+            .await
+            .expect("register old owner");
+        let entity = user_actor_entity("same-node-new-epoch");
+        let epoch = store.acquire(&entity, &old_owner).await.expect("acquire");
+        let reporter = node_identity();
+        register_live_node(&store, &reporter).await;
+        store
+            .report_steal_intent(&entity, &old_owner, epoch, &reporter)
+            .await
+            .expect("report intent");
+
+        let recovered_owner =
+            NodeIdentity::new(old_owner.node_id.clone(), uuid::Uuid::new_v4().to_string());
+        store
+            .register_draining_with_peer_id(
+                &old_owner,
+                &recovered_owner,
+                None,
+                None,
+                NODE_LEASE_TTL,
+            )
+            .await
+            .expect("rotate node row without moving the claim");
+
+        let stale_clear = store
+            .clear_steal_intent(&entity, &old_owner, epoch)
+            .await
+            .expect("stale clear is a no-op");
+        assert_eq!(stale_clear, 0);
+        let current_clear = store
+            .clear_steal_intent(&entity, &recovered_owner, epoch)
+            .await
+            .expect("recovered incarnation does not own the old claim");
+        assert_eq!(
+            current_clear, 0,
+            "cleanup requires both the exact live node incarnation and exact claim tuple"
+        );
+    }
+
+    #[tokio::test]
     async fn stale_epoch_steal_attempt_does_not_burn_the_intents() {
         // A data-modifying CTE runs to completion even when the outer
         // UPDATE matches nothing, so without the epoch gate on the
@@ -3708,6 +5698,7 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = user_actor_entity("room-stale-burn");
         let epoch0 = store.acquire(&entity, &owner).await.expect("acquire");
         seed_node(&store.db, &owner, false).await;
@@ -3717,14 +5708,16 @@ mod tests {
         let proof =
             waddle_xmpp::ownership::verify_resume_identity(&jid, &jid).expect("identity match");
         let current_owner = node_identity();
+        register_live_node(&store, &current_owner).await;
         let epoch1 = store
             .steal_for_resume(&entity, epoch0, proof, &current_owner)
             .await
             .expect("epoch bump");
 
         let reporter = node_identity();
+        register_live_node(&store, &reporter).await;
         store
-            .report_steal_intent(&entity, &reporter)
+            .report_steal_intent(&entity, &current_owner, epoch1, &reporter)
             .await
             .expect("report intent");
         let intent_ttl = std::time::Duration::from_millis(100);
@@ -3772,7 +5765,7 @@ mod tests {
             )
             .await
             .expect("current-epoch stealer wins on the surviving intent");
-        assert_eq!(epoch2, ClaimEpoch(epoch1.0 + 1));
+        assert!(epoch2 > epoch1);
         let consumed = store
             .owner_steal_intents(&real_stealer)
             .await
@@ -3790,6 +5783,7 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let with_intent = user_actor_entity("room-with-intent");
         let without_intent = Entity::new(EntityType::RoomActor, "room-without-intent".to_string());
         let epoch_with_intent = store
@@ -3802,8 +5796,9 @@ mod tests {
             .expect("acquire without_intent");
 
         let reporter = node_identity();
+        register_live_node(&store, &reporter).await;
         store
-            .report_steal_intent(&with_intent, &reporter)
+            .report_steal_intent(&with_intent, &owner, epoch_with_intent, &reporter)
             .await
             .expect("report intent");
 
@@ -3825,19 +5820,21 @@ mod tests {
             return;
         };
         let owner = node_identity();
+        register_live_node(&store, &owner).await;
         let entity = user_actor_entity("room-4");
         let epoch0 = store.acquire(&entity, &owner).await.expect("acquire");
         let reporter = node_identity();
+        register_live_node(&store, &reporter).await;
 
         store
-            .report_steal_intent(&entity, &reporter)
+            .report_steal_intent(&entity, &owner, epoch0, &reporter)
             .await
             .expect("first report");
         let intent_ttl = std::time::Duration::from_millis(150);
         tokio::time::sleep(intent_ttl / 2).await;
         // Refresh before the first report ages out.
         store
-            .report_steal_intent(&entity, &reporter)
+            .report_steal_intent(&entity, &owner, epoch0, &reporter)
             .await
             .expect("refreshed report");
         tokio::time::sleep(intent_ttl / 2 + std::time::Duration::from_millis(20)).await;
@@ -3875,6 +5872,284 @@ mod tests {
         assert_eq!(count, 1, "repeated reports must refresh, not accumulate");
     }
 
+    #[tokio::test]
+    async fn report_steal_intent_starts_its_full_age_after_intent_lock_wait() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let owner = node_identity();
+        let reporter = node_identity();
+        register_live_node(&store, &owner).await;
+        register_live_node(&store, &reporter).await;
+        let entity = user_actor_entity("intent-post-lock-clock");
+        let epoch = store.acquire(&entity, &owner).await.unwrap();
+        store
+            .report_steal_intent(&entity, &owner, epoch, &reporter)
+            .await
+            .unwrap();
+
+        let mut blocker = store.db.begin().await.unwrap();
+        let mut rows = blocker
+            .query(
+                "SELECT 1 FROM clustering_steal_intents WHERE entity = ? AND reporter_node = ? FOR UPDATE",
+                crate::db_params![entity_key(&entity), reporter.node_id.clone()],
+            )
+            .await
+            .unwrap();
+        assert!(rows.next().await.unwrap().is_some());
+        drop(rows);
+
+        let reporter_store = PostgresClaimStore::new(store.db.clone());
+        let task_entity = entity.clone();
+        let task_owner = owner.clone();
+        let task_reporter = reporter.clone();
+        let refresh = tokio::spawn(async move {
+            reporter_store
+                .report_steal_intent(&task_entity, &task_owner, epoch, &task_reporter)
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        assert!(
+            !refresh.is_finished(),
+            "refresh must wait on the intent row"
+        );
+        tokio::time::sleep(Duration::from_millis(360)).await;
+        blocker.commit().await.unwrap();
+        refresh.await.unwrap().unwrap();
+
+        let mut rows = store
+            .db
+            .guard()
+            .await
+            .unwrap()
+            .query(
+                "SELECT (EXTRACT(EPOCH FROM clock_timestamp() - created_at) * 1000)::double precision FROM clustering_steal_intents WHERE entity = ? AND reporter_node = ?",
+                crate::db_params![entity_key(&entity), reporter.node_id],
+            )
+            .await
+            .unwrap();
+        let age_ms = rows.next().await.unwrap().unwrap().get::<f64>(0).unwrap();
+        assert!(
+            age_ms < 200.0,
+            "the refreshed intent age must start after the 400ms lock wait, got {age_ms}ms"
+        );
+    }
+
+    #[tokio::test]
+    async fn report_steal_intent_rechecks_leases_after_intent_lock_wait() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let owner = node_identity();
+        let reporter = node_identity();
+        register_live_node(&store, &owner).await;
+        register_live_node(&store, &reporter).await;
+        let entity = user_actor_entity("intent-post-lock-lease");
+        let epoch = store.acquire(&entity, &owner).await.unwrap();
+        store
+            .report_steal_intent(&entity, &owner, epoch, &reporter)
+            .await
+            .unwrap();
+        store
+            .db
+            .guard()
+            .await
+            .unwrap()
+            .execute(
+                "UPDATE clustering_steal_intents SET created_at = clock_timestamp() - interval '1 hour' WHERE entity = ? AND reporter_node = ?",
+                crate::db_params![entity_key(&entity), reporter.node_id.clone()],
+            )
+            .await
+            .unwrap();
+        store
+            .db
+            .guard()
+            .await
+            .unwrap()
+            .execute(
+                "UPDATE clustering_nodes SET heartbeat = clock_timestamp(), lease_ttl_ms = 100 WHERE (node_id = ? AND node_epoch = ?) OR (node_id = ? AND node_epoch = ?)",
+                crate::db_params![
+                    owner.node_id.clone(),
+                    owner.node_epoch.clone(),
+                    reporter.node_id.clone(),
+                    reporter.node_epoch.clone(),
+                ],
+            )
+            .await
+            .unwrap();
+
+        let mut blocker = store.db.begin().await.unwrap();
+        let mut rows = blocker
+            .query(
+                "SELECT 1 FROM clustering_steal_intents WHERE entity = ? AND reporter_node = ? FOR UPDATE",
+                crate::db_params![entity_key(&entity), reporter.node_id.clone()],
+            )
+            .await
+            .unwrap();
+        assert!(rows.next().await.unwrap().is_some());
+        drop(rows);
+
+        let reporter_store = PostgresClaimStore::new(store.db.clone());
+        let task_entity = entity.clone();
+        let task_owner = owner.clone();
+        let task_reporter = reporter.clone();
+        let refresh = tokio::spawn(async move {
+            reporter_store
+                .report_steal_intent(&task_entity, &task_owner, epoch, &task_reporter)
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        assert!(
+            !refresh.is_finished(),
+            "refresh must wait on the intent row"
+        );
+        tokio::time::sleep(Duration::from_millis(360)).await;
+        blocker.commit().await.unwrap();
+        assert!(matches!(refresh.await.unwrap(), Err(ClaimError::Conflict)));
+
+        let mut rows = store
+            .db
+            .guard()
+            .await
+            .unwrap()
+            .query(
+                "SELECT created_at < clock_timestamp() - interval '30 minutes' FROM clustering_steal_intents WHERE entity = ? AND reporter_node = ?",
+                crate::db_params![entity_key(&entity), reporter.node_id],
+            )
+            .await
+            .unwrap();
+        assert!(
+            rows.next().await.unwrap().unwrap().get::<bool>(0).unwrap(),
+            "a report rejected after the wait must not refresh the intent age"
+        );
+    }
+
+    #[tokio::test]
+    async fn steal_intent_age_is_evaluated_after_intent_row_lock_wait() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let owner = node_identity();
+        let stealer = node_identity();
+        register_live_node(&store, &owner).await;
+        register_live_node(&store, &stealer).await;
+        let entity = user_actor_entity("steal-intent-post-lock-age");
+        let epoch = store.acquire(&entity, &owner).await.unwrap();
+        store
+            .report_steal_intent(&entity, &owner, epoch, &stealer)
+            .await
+            .unwrap();
+
+        let mut blocker = store.db.begin().await.unwrap();
+        let mut rows = blocker
+            .query(
+                "SELECT 1 FROM clustering_steal_intents WHERE entity = ? FOR UPDATE",
+                crate::db_params![entity_key(&entity)],
+            )
+            .await
+            .unwrap();
+        assert!(rows.next().await.unwrap().is_some());
+        drop(rows);
+
+        let task_store = PostgresClaimStore::new(store.db.clone());
+        let task_entity = entity.clone();
+        let task_stealer = stealer.clone();
+        let steal = tokio::spawn(async move {
+            task_store
+                .steal_stale(
+                    &task_entity,
+                    epoch,
+                    StalePredicate::StealIntentExpired {
+                        intent_ttl: Duration::from_millis(100),
+                    },
+                    &task_stealer,
+                )
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        assert!(!steal.is_finished(), "steal must lock before deciding age");
+        tokio::time::sleep(Duration::from_millis(360)).await;
+        blocker.commit().await.unwrap();
+        assert!(steal.await.unwrap().unwrap() > epoch);
+    }
+
+    #[tokio::test]
+    async fn clear_steal_intent_rechecks_owner_lease_after_node_lock_wait() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let owner = node_identity();
+        let reporter = node_identity();
+        register_live_node(&store, &owner).await;
+        register_live_node(&store, &reporter).await;
+        let entity = user_actor_entity("clear-intent-post-lock-lease");
+        let epoch = store.acquire(&entity, &owner).await.unwrap();
+        store
+            .report_steal_intent(&entity, &owner, epoch, &reporter)
+            .await
+            .unwrap();
+        store
+            .db
+            .guard()
+            .await
+            .unwrap()
+            .execute(
+                "UPDATE clustering_nodes SET heartbeat = clock_timestamp(), lease_ttl_ms = 100 WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![owner.node_id.clone(), owner.node_epoch.clone()],
+            )
+            .await
+            .unwrap();
+
+        let mut blocker = store.db.begin().await.unwrap();
+        let mut rows = blocker
+            .query(
+                "SELECT 1 FROM clustering_nodes WHERE node_id = ? AND node_epoch = ? FOR UPDATE",
+                crate::db_params![owner.node_id.clone(), owner.node_epoch.clone()],
+            )
+            .await
+            .unwrap();
+        assert!(rows.next().await.unwrap().is_some());
+        drop(rows);
+
+        let task_store = PostgresClaimStore::new(store.db.clone());
+        let task_entity = entity.clone();
+        let task_owner = owner.clone();
+        let clear = tokio::spawn(async move {
+            task_store
+                .clear_steal_intent(&task_entity, &task_owner, epoch)
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        assert!(
+            !clear.is_finished(),
+            "clear must wait on the owner node row"
+        );
+        tokio::time::sleep(Duration::from_millis(360)).await;
+        blocker.commit().await.unwrap();
+        assert_eq!(clear.await.unwrap().unwrap(), 0);
+
+        let mut rows = store
+            .db
+            .guard()
+            .await
+            .unwrap()
+            .query(
+                "SELECT COUNT(*) FROM clustering_steal_intents WHERE entity = ?",
+                crate::db_params![entity_key(&entity)],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.next().await.unwrap().unwrap().get::<i64>(0).unwrap(),
+            1,
+            "a stale owner cannot clear the reporter's intent after the wait"
+        );
+    }
+
     // FIX 1(d): a genuinely concurrent stress test proving the veto race is
     // closed. Two real Postgres connections hammer `clear_steal_intent`
     // (the owner's veto) against `steal_stale(StealIntentExpired)` (a
@@ -3900,9 +6175,17 @@ mod tests {
     #[tokio::test]
     async fn steal_intent_veto_vs_steal_stress_never_both_succeed_same_round() {
         let _guard = clustering_control_plane_table_lock().lock().await;
-        let Some(store) = clean_store().await else {
+        let Some(clean) = clean_store().await else {
             return;
         };
+        // Keep liveness out of this deliberately long Postgres stress loop.
+        // The invariant under test is the intent-veto/steal row-lock race;
+        // allowing the default node lease to lapse partway through 200 CI
+        // rounds turns `report_steal_intent` into an unrelated liveness test.
+        let store = PostgresClaimStore::with_lease_ttl(
+            clean.db.clone(),
+            std::time::Duration::from_secs(5 * 60),
+        );
         let store = std::sync::Arc::new(store);
 
         let mut owner = node_identity();
@@ -3934,19 +6217,31 @@ mod tests {
             // instead of sleeping out a real `intent_ttl` every round (200
             // rounds of real sleeps would make this test unreasonably
             // slow).
+            store
+                .report_steal_intent(&entity, &owner, epoch, &stealer)
+                .await
+                .expect("seed an exact current-grant intent");
             {
                 let conn = store.db.guard().await.expect("guard");
                 conn.execute(
                     r#"
-                    INSERT INTO clustering_steal_intents (entity, reporter_node, created_at)
-                    VALUES (?, ?, now() - (? || ' milliseconds')::interval)
-                    ON CONFLICT (entity, reporter_node)
-                        DO UPDATE SET created_at = EXCLUDED.created_at
+                    UPDATE clustering_steal_intents
+                    SET created_at = now() - (? || ' milliseconds')::interval
+                    WHERE entity = ?
+                      AND reporter_node = ?
+                      AND reporter_epoch = ?
+                      AND target_node = ?
+                      AND target_node_epoch = ?
+                      AND target_claim_epoch = ?
                     "#,
                     crate::db_params![
+                        (intent_ttl.as_millis() * 10).to_string(),
                         entity_key(&entity),
                         stealer.node_id.clone(),
-                        (intent_ttl.as_millis() * 10).to_string(),
+                        stealer.node_epoch.clone(),
+                        owner.node_id.clone(),
+                        owner.node_epoch.clone(),
+                        epoch.0,
                     ],
                 )
                 .await
@@ -4057,7 +6352,7 @@ mod tests {
             .expect("acquire under fresh owner");
 
         let stale_owner = node_identity();
-        seed_node(&store.db, &stale_owner, true).await;
+        seed_node(&store.db, &stale_owner, false).await;
         let orphaned_entity = sm_entity("orphaned-stream");
         let orphaned_epoch = store
             .acquire(&orphaned_entity, &stale_owner)
@@ -4074,6 +6369,7 @@ mod tests {
             .acquire(&non_sm_entity, &stale_owner)
             .await
             .expect("acquire a non-sm_session entity under the same stale owner");
+        seed_node(&store.db, &stale_owner, true).await;
 
         let candidates = store
             .list_orphaned_sm_session_claims()
@@ -4112,6 +6408,353 @@ mod tests {
             candidates_after.is_empty(),
             "the reclaimed claim (now owned by a fresh, registered node) must no longer \
              be reported as orphaned"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_grant_revalidates_destination_after_claim_lock_waits_past_ttl() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(clean) = clean_store().await else {
+            return;
+        };
+        let ttl = Duration::from_millis(80);
+        let store = PostgresClaimStore::with_lease_ttl(clean.db.clone(), ttl);
+        let owner = node_identity();
+        let destination = node_identity();
+        register_live_node(&store, &owner).await;
+        register_live_node(&store, &destination).await;
+        let entity = sm_entity("post-lock-resume");
+        let epoch = store.acquire(&entity, &owner).await.expect("acquire");
+        let contender = PostgresClaimStore::with_lease_ttl(clean.db.clone(), ttl);
+        let task_entity = entity.clone();
+        let task_destination = destination.clone();
+        let jid: jid::BareJid = "alice@example.com".parse().unwrap();
+        let proof = waddle_xmpp::ownership::verify_resume_identity(&jid, &jid).unwrap();
+        let result = while_claim_is_locked_past_ttl(&clean.db, &entity, ttl, async move {
+            contender
+                .steal_for_resume(&task_entity, epoch, proof, &task_destination)
+                .await
+        })
+        .await;
+        assert!(matches!(result, Err(ClaimError::Conflict)));
+        assert_eq!(
+            store.current_claim(&entity).await.unwrap().unwrap().owner,
+            owner
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_revalidates_after_unique_conflict_waits_past_ttl() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(clean) = clean_store().await else {
+            return;
+        };
+        let ttl = Duration::from_millis(80);
+        let store = PostgresClaimStore::with_lease_ttl(clean.db.clone(), ttl);
+        let destination = node_identity();
+        register_live_node(&store, &destination).await;
+        let entity = sm_entity("post-lock-acquire");
+        let mut blocker = clean.db.begin().await.unwrap();
+        blocker
+            .execute(
+                "INSERT INTO clustering_claims (entity, entity_type, node_id, node_epoch, claim_epoch) VALUES (?, ?, ?, ?, -1)",
+                crate::db_params![
+                    entity_key(&entity),
+                    EntityType::SmSession.as_db_str().to_string(),
+                    "temporary".to_string(),
+                    "temporary".to_string(),
+                ],
+            )
+            .await
+            .unwrap();
+        let contender = PostgresClaimStore::with_lease_ttl(clean.db.clone(), ttl);
+        let task_entity = entity.clone();
+        let task_destination = destination.clone();
+        let task =
+            tokio::spawn(async move { contender.acquire(&task_entity, &task_destination).await });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(
+            !task.is_finished(),
+            "acquire must wait on the unique conflict"
+        );
+        tokio::time::sleep(ttl * 3).await;
+        blocker.rollback().await.unwrap();
+        assert!(matches!(task.await.unwrap(), Err(ClaimError::Draining)));
+        assert!(store.current_claim(&entity).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn intent_recovery_and_orphan_grants_revalidate_after_claim_lock_wait() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(clean) = clean_store().await else {
+            return;
+        };
+        let ttl = Duration::from_millis(80);
+        let store = PostgresClaimStore::with_lease_ttl(clean.db.clone(), ttl);
+
+        let intent_owner = node_identity();
+        let reporter = node_identity();
+        register_live_node(&store, &intent_owner).await;
+        register_live_node(&store, &reporter).await;
+        let intent_entity = room_entity("post-lock-intent@muc.example.com");
+        let intent_epoch = store.acquire(&intent_entity, &intent_owner).await.unwrap();
+        store
+            .report_steal_intent(&intent_entity, &intent_owner, intent_epoch, &reporter)
+            .await
+            .unwrap();
+        store
+            .db
+            .guard()
+            .await
+            .unwrap()
+            .execute(
+                "UPDATE clustering_steal_intents SET created_at = clock_timestamp() - interval '1 hour' WHERE entity = ?",
+                crate::db_params![entity_key(&intent_entity)],
+            )
+            .await
+            .unwrap();
+        let intent_store = PostgresClaimStore::with_lease_ttl(clean.db.clone(), ttl);
+        let intent_task_entity = intent_entity.clone();
+        let intent_task_reporter = reporter.clone();
+        let intent_result =
+            while_claim_is_locked_past_ttl(&clean.db, &intent_entity, ttl, async move {
+                intent_store
+                    .steal_stale(
+                        &intent_task_entity,
+                        intent_epoch,
+                        StalePredicate::StealIntentExpired {
+                            intent_ttl: Duration::from_millis(1),
+                        },
+                        &intent_task_reporter,
+                    )
+                    .await
+            })
+            .await;
+        assert!(matches!(intent_result, Err(ClaimError::Conflict)));
+        let mut intent_rows = store
+            .db
+            .guard()
+            .await
+            .unwrap()
+            .query(
+                "SELECT 1 FROM clustering_steal_intents WHERE entity = ?",
+                crate::db_params![entity_key(&intent_entity)],
+            )
+            .await
+            .unwrap();
+        assert!(intent_rows.next().await.unwrap().is_some());
+
+        let predecessor = NodeIdentity::new("post-lock-recovery", "old");
+        register_live_node(&store, &predecessor).await;
+        let recovery_entity = sm_entity("post-lock-recovery-session");
+        let recovery_epoch = store.acquire(&recovery_entity, &predecessor).await.unwrap();
+        let candidate = NodeIdentity::new(predecessor.node_id.clone(), "candidate");
+        store
+            .register_draining_with_peer_id(&predecessor, &candidate, None, None, ttl)
+            .await
+            .unwrap();
+        let recovery_store = PostgresClaimStore::with_lease_ttl(clean.db.clone(), ttl);
+        let recovery_task_entity = recovery_entity.clone();
+        let recovery_task_source = predecessor.clone();
+        let recovery_task_candidate = candidate.clone();
+        let recovery_result =
+            while_claim_is_locked_past_ttl(&clean.db, &recovery_entity, ttl, async move {
+                recovery_store
+                    .reclaim_after_self_fence(
+                        &recovery_task_entity,
+                        recovery_epoch,
+                        &recovery_task_source,
+                        &recovery_task_candidate,
+                        ttl,
+                    )
+                    .await
+            })
+            .await;
+        assert!(matches!(recovery_result, Err(ClaimError::Conflict)));
+
+        let orphan_owner = node_identity();
+        let orphan_destination = node_identity();
+        register_live_node(&store, &orphan_owner).await;
+        let orphan_entity = sm_entity("post-lock-orphan-session");
+        let orphan_epoch = store.acquire(&orphan_entity, &orphan_owner).await.unwrap();
+        seed_sm_session_row(&store.db, &orphan_entity.id).await;
+        store
+            .db
+            .guard()
+            .await
+            .unwrap()
+            .execute(
+                "UPDATE clustering_nodes SET expired = true WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![
+                    orphan_owner.node_id.clone(),
+                    orphan_owner.node_epoch.clone()
+                ],
+            )
+            .await
+            .unwrap();
+        register_live_node(&store, &orphan_destination).await;
+        let orphan_store = PostgresClaimStore::with_lease_ttl(clean.db.clone(), ttl);
+        let orphan_task_entity = orphan_entity.clone();
+        let orphan_task_destination = orphan_destination.clone();
+        let orphan_result =
+            while_claim_is_locked_past_ttl(&clean.db, &orphan_entity, ttl, async move {
+                orphan_store
+                    .steal_orphaned_sm_session_claim(
+                        &orphan_task_entity,
+                        orphan_epoch,
+                        &orphan_task_destination,
+                        ttl,
+                    )
+                    .await
+            })
+            .await;
+        assert!(matches!(orphan_result, Err(ClaimError::Conflict)));
+        assert_eq!(
+            store
+                .current_claim(&orphan_entity)
+                .await
+                .unwrap()
+                .unwrap()
+                .owner,
+            orphan_owner
+        );
+    }
+
+    #[tokio::test]
+    async fn lifecycle_updates_revalidate_after_node_lock_waits_past_ttl() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(clean) = clean_store().await else {
+            return;
+        };
+        let ttl = Duration::from_millis(80);
+        let store = PostgresClaimStore::with_lease_ttl(clean.db.clone(), ttl);
+
+        let heartbeat_node = node_identity();
+        register_live_node(&store, &heartbeat_node).await;
+        let heartbeat_store = PostgresClaimStore::with_lease_ttl(clean.db.clone(), ttl);
+        let heartbeat_task_node = heartbeat_node.clone();
+        let renewed = while_node_is_locked_past_ttl(&clean.db, &heartbeat_node, ttl, async move {
+            heartbeat_store.heartbeat(&heartbeat_task_node, ttl).await
+        })
+        .await
+        .unwrap();
+        assert!(!renewed);
+
+        let predecessor = NodeIdentity::new("post-lock-activation", "old");
+        register_live_node(&store, &predecessor).await;
+        let candidate = NodeIdentity::new(predecessor.node_id.clone(), "candidate");
+        store
+            .register_draining_with_peer_id(&predecessor, &candidate, None, None, ttl)
+            .await
+            .unwrap();
+        let activation_store = PostgresClaimStore::with_lease_ttl(clean.db.clone(), ttl);
+        let activation_task_candidate = candidate.clone();
+        let activated = while_node_is_locked_past_ttl(&clean.db, &candidate, ttl, async move {
+            activation_store
+                .activate(&activation_task_candidate, ttl)
+                .await
+        })
+        .await
+        .unwrap();
+        assert!(!activated);
+
+        let retry_node = node_identity();
+        register_live_node(&store, &retry_node).await;
+        let retry_store = PostgresClaimStore::with_lease_ttl(clean.db.clone(), ttl);
+        let retry_task_node = retry_node.clone();
+        let retry = while_node_is_locked_past_ttl(&clean.db, &retry_node, ttl, async move {
+            retry_store.register(&retry_task_node, None).await
+        })
+        .await;
+        assert!(matches!(retry, Err(ClaimError::Conflict)));
+
+        let stable_id = format!("absent-register-{}", uuid::Uuid::new_v4());
+        let first = NodeIdentity::new(stable_id.clone(), "first");
+        let second = NodeIdentity::new(stable_id.clone(), "second");
+        let first_store = PostgresClaimStore::with_lease_ttl(clean.db.clone(), ttl);
+        let second_store = PostgresClaimStore::with_lease_ttl(clean.db.clone(), ttl);
+        let (first_result, second_result) = tokio::join!(
+            first_store.register(&first, None),
+            second_store.register(&second, None),
+        );
+        assert_ne!(first_result.is_ok(), second_result.is_ok());
+        let current = store
+            .registered_identity(&stable_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(current == first || current == second);
+    }
+
+    #[tokio::test]
+    async fn fenced_transaction_budget_releases_claim_and_node_locks() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let owner = node_identity();
+        register_live_node(&store, &owner).await;
+        let entity = sm_entity("bounded-fenced-transaction");
+        let epoch = store.acquire(&entity, &owner).await.unwrap();
+
+        let budget = waddle_xmpp::ownership::FencedTransactionBudget::from_millis(200);
+        let mut stalled = store.db.begin().await.unwrap();
+        stalled.configure_fenced(budget).await.unwrap();
+        let mut rows = stalled
+            .query(
+                r#"
+                SELECT 1
+                FROM clustering_claims c
+                JOIN clustering_nodes n
+                  ON n.node_id = c.node_id AND n.node_epoch = c.node_epoch
+                WHERE c.entity = ?
+                  AND c.node_id = ?
+                  AND c.node_epoch = ?
+                  AND c.claim_epoch = ?
+                FOR SHARE OF c, n
+                "#,
+                crate::db_params![
+                    entity_key(&entity),
+                    owner.node_id.clone(),
+                    owner.node_epoch.clone(),
+                    epoch.0,
+                ],
+            )
+            .await
+            .unwrap();
+        assert!(rows.next().await.unwrap().is_some());
+        drop(rows);
+
+        let contender_db = store.db.clone();
+        let contender_owner = owner.clone();
+        let contender = tokio::spawn(async move {
+            contender_db
+                .control_plane_guard()
+                .await
+                .unwrap()
+                .execute(
+                    "UPDATE clustering_nodes SET draining = true WHERE node_id = ? AND node_epoch = ?",
+                    crate::db_params![
+                        contender_owner.node_id,
+                        contender_owner.node_epoch,
+                    ],
+                )
+                .await
+        });
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        assert!(
+            !contender.is_finished(),
+            "the exact node fence must initially block the lifecycle update"
+        );
+        let affected = tokio::time::timeout(Duration::from_secs(3), contender)
+            .await
+            .expect("database-side fenced transaction timeout must release locks")
+            .unwrap()
+            .unwrap();
+        assert_eq!(affected, 1);
+        assert!(
+            stalled.execute("SELECT 1", ()).await.is_err(),
+            "the transaction itself must be terminated, not merely its waiting statement"
         );
     }
 }

--- a/server/crates/waddle-server/src/clustering/drain.rs
+++ b/server/crates/waddle-server/src/clustering/drain.rs
@@ -35,7 +35,9 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use waddle_xmpp::ownership::{ClaimStore, Entity, EntityType, NodeIdentity};
+#[cfg(test)]
+use waddle_xmpp::ownership::Entity;
+use waddle_xmpp::ownership::{ClaimGrant, ClaimStore, EntityType, NodeIdentity};
 
 use super::claims::NodeLeaseStore;
 use super::metrics;
@@ -81,18 +83,60 @@ pub(crate) async fn run_shutdown_drain<L>(
     mark_draining_bounded(lease, identity, MARK_DRAINING_BOUND.min(budget)).await;
 
     let deadline = start + budget;
-    let owned = local_claims.owned().await;
-    let mut to_release: Vec<Entity> = Vec::new();
+    let eligible = local_claims
+        .owned()
+        .await
+        .into_iter()
+        .filter(|entity| entity.entity_type == EntityType::RoomActor)
+        .collect::<Vec<_>>();
+    let snapshot_remaining = deadline.saturating_duration_since(Instant::now());
+    let grants = match tokio::time::timeout(
+        snapshot_remaining,
+        claim_store.owned_claims(&eligible, identity),
+    )
+    .await
+    {
+        Ok(Ok(grants)) => grants,
+        Ok(Err(error)) => {
+            let abandoned = eligible.len() as u64;
+            tracing::warn!(
+                %error,
+                count = abandoned,
+                "clustering drain: bulk exact-grant snapshot failed; leaving entities claimed"
+            );
+            if abandoned > 0 {
+                metrics::record_claims_abandoned_on_drain(abandoned);
+            }
+            metrics::record_drain_duration_ms(start.elapsed().as_secs_f64() * 1000.0);
+            return;
+        }
+        Err(_) => {
+            let abandoned = eligible.len() as u64;
+            tracing::warn!(
+                count = abandoned,
+                "clustering drain: budget exhausted during bulk exact-grant snapshot; leaving entities claimed"
+            );
+            if abandoned > 0 {
+                metrics::record_claims_abandoned_on_drain(abandoned);
+            }
+            metrics::record_drain_duration_ms(start.elapsed().as_secs_f64() * 1000.0);
+            return;
+        }
+    };
+    let mut grants_by_entity = grants
+        .into_iter()
+        .map(|grant| (grant.entity.clone(), grant))
+        .collect::<std::collections::HashMap<_, _>>();
+    let mut to_release: Vec<ClaimGrant> = Vec::new();
     let mut abandoned: u64 = 0;
 
-    for entity in owned {
-        // Only entities this generic loop owns draining for — see the
-        // module doc for why `SmSession` is deliberately excluded (the
-        // existing Q6 drain owns those) and `UserActor` has no production
-        // claim-acquisition call site yet (deviation 34).
-        if entity.entity_type != EntityType::RoomActor {
+    for entity in eligible {
+        let Some(grant) = grants_by_entity.remove(&entity) else {
+            // The bulk snapshot already proved this local entry is no longer
+            // authoritatively owned by `identity`; there is no claim to
+            // release. Reconciliation will demote the stale local copy.
             continue;
-        }
+        };
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
             tracing::warn!(
@@ -111,7 +155,7 @@ pub(crate) async fn run_shutdown_drain<L>(
             // entity enters `to_release` strictly after `seal_before_release`
             // — which performs/confirms the entity's final fenced write —
             // has already returned `true`, never before.
-            to_release.push(entity);
+            to_release.push(grant);
         } else {
             tracing::warn!(
                 entity_id = %entity.id,
@@ -124,16 +168,24 @@ pub(crate) async fn run_shutdown_drain<L>(
 
     if !to_release.is_empty() {
         let attempted = to_release.len() as u64;
-        match claim_store.release_many(&to_release, identity).await {
-            Ok(()) => {
+        let release_remaining = deadline.saturating_duration_since(Instant::now());
+        match tokio::time::timeout(release_remaining, claim_store.release_many(&to_release)).await {
+            Ok(Ok(())) => {
                 metrics::record_claims_released_on_drain(attempted);
             }
-            Err(error) => {
+            Ok(Err(error)) => {
                 tracing::warn!(
                     %error,
                     count = attempted,
                     "clustering drain: release_many failed; entities remain claimed \
                      (fenced-safe, reclaimed later)"
+                );
+                abandoned += attempted;
+            }
+            Err(_) => {
+                tracing::warn!(
+                    count = attempted,
+                    "clustering drain: budget exhausted during release_many; entities remain claimed"
                 );
                 abandoned += attempted;
             }
@@ -235,7 +287,10 @@ mod tests {
     use std::sync::Mutex;
 
     use async_trait::async_trait;
-    use waddle_xmpp::ownership::{ClaimEpoch, ClaimError, InProcessClaimStore, NodeIdentity};
+    use waddle_xmpp::ownership::{
+        ClaimEpoch, ClaimError, ClaimGrant, ClaimSnapshot, InProcessClaimStore, NodeIdentity,
+        ResumeIdentityProof, StalePredicate,
+    };
 
     // --- rollout_backoff_delay: pure-function coverage -----------------
 
@@ -310,6 +365,8 @@ mod tests {
         async fn report_steal_intent(
             &self,
             _entity: &Entity,
+            _target_owner: &NodeIdentity,
+            _target_epoch: ClaimEpoch,
             _reporter: &NodeIdentity,
         ) -> Result<(), ClaimError> {
             Ok(())
@@ -356,6 +413,111 @@ mod tests {
         outcome: SealOutcome,
         seal_calls: Arc<Mutex<Vec<String>>>,
         demote_calls: Arc<AtomicU32>,
+    }
+
+    #[derive(Clone, Copy)]
+    enum HangingStoreOperation {
+        OwnedClaims,
+        ReleaseMany,
+    }
+
+    /// Delegates real claim bookkeeping to `InProcessClaimStore`, but
+    /// wedges one selected bulk operation forever. This deterministically
+    /// proves that both newly-added bulk phases share the total shutdown
+    /// budget instead of extending shutdown indefinitely.
+    struct HangingBulkClaimStore {
+        inner: Arc<InProcessClaimStore>,
+        operation: HangingStoreOperation,
+    }
+
+    #[async_trait]
+    impl ClaimStore for HangingBulkClaimStore {
+        async fn ensure_schema(&self) -> Result<(), ClaimError> {
+            self.inner.ensure_schema().await
+        }
+
+        async fn acquire(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner.acquire(entity, me).await
+        }
+
+        async fn ensure_claimed(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner.ensure_claimed(entity, me).await
+        }
+
+        async fn steal_stale(
+            &self,
+            entity: &Entity,
+            observed: ClaimEpoch,
+            staleness: StalePredicate,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner
+                .steal_stale(entity, observed, staleness, me)
+                .await
+        }
+
+        async fn steal_for_resume(
+            &self,
+            entity: &Entity,
+            observed: ClaimEpoch,
+            witness: ResumeIdentityProof,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner
+                .steal_for_resume(entity, observed, witness, me)
+                .await
+        }
+
+        async fn current_claim(
+            &self,
+            entity: &Entity,
+        ) -> Result<Option<ClaimSnapshot>, ClaimError> {
+            self.inner.current_claim(entity).await
+        }
+
+        async fn owned_claims(
+            &self,
+            entities: &[Entity],
+            me: &NodeIdentity,
+        ) -> Result<Vec<ClaimGrant>, ClaimError> {
+            if matches!(self.operation, HangingStoreOperation::OwnedClaims) {
+                return std::future::pending().await;
+            }
+            self.inner.owned_claims(entities, me).await
+        }
+
+        async fn fence(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<bool, ClaimError> {
+            self.inner.fence(entity, me, mine).await
+        }
+
+        async fn release(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<(), ClaimError> {
+            self.inner.release(entity, me, mine).await
+        }
+
+        async fn release_many(&self, grants: &[ClaimGrant]) -> Result<(), ClaimError> {
+            if matches!(self.operation, HangingStoreOperation::ReleaseMany) {
+                return std::future::pending().await;
+            }
+            self.inner.release_many(grants).await
+        }
     }
 
     #[async_trait]
@@ -412,15 +574,15 @@ mod tests {
         let room_a = room("room-a@muc.example.com");
         let room_b = room("room-b@muc.example.com");
         let sm_c = sm("stream-c");
-        claim_store
+        let room_a_epoch = claim_store
             .acquire(&room_a, &me)
             .await
             .expect("acquire room a");
-        claim_store
+        let room_b_epoch = claim_store
             .acquire(&room_b, &me)
             .await
             .expect("acquire room b");
-        claim_store.acquire(&sm_c, &me).await.expect("acquire sm c");
+        let sm_c_epoch = claim_store.acquire(&sm_c, &me).await.expect("acquire sm c");
 
         let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(FakeLocalClaims {
             owned: vec![room_a.clone(), room_b.clone(), sm_c.clone()],
@@ -440,21 +602,21 @@ mod tests {
 
         assert!(
             !claim_store
-                .fence(&room_a, &me, ClaimEpoch(0))
+                .fence(&room_a, &me, room_a_epoch)
                 .await
                 .unwrap_or(true),
             "room_a's claim must be released by the drain"
         );
         assert!(
             !claim_store
-                .fence(&room_b, &me, ClaimEpoch(0))
+                .fence(&room_b, &me, room_b_epoch)
                 .await
                 .unwrap_or(true),
             "room_b's claim must be released by the drain"
         );
         assert!(
             claim_store
-                .fence(&sm_c, &me, ClaimEpoch(0))
+                .fence(&sm_c, &me, sm_c_epoch)
                 .await
                 .unwrap_or(false),
             "the sm_session entity must be left untouched by the generic drain loop \
@@ -524,6 +686,74 @@ mod tests {
                 .unwrap_or(false),
             "a hung seal, once the budget overruns, must leave the claim held (merely \
              un-released, fenced-safe) rather than block shutdown indefinitely"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_abandons_claims_when_the_bulk_exact_grant_snapshot_hangs() {
+        let inner = Arc::new(InProcessClaimStore::new());
+        let me = identity();
+        let room_a = room("room-snapshot-hangs@muc.example.com");
+        let epoch = inner.acquire(&room_a, &me).await.expect("acquire");
+        let claim_store: Arc<dyn ClaimStore> = Arc::new(HangingBulkClaimStore {
+            inner: Arc::clone(&inner),
+            operation: HangingStoreOperation::OwnedClaims,
+        });
+        let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(FakeLocalClaims {
+            owned: vec![room_a.clone()],
+            outcome: SealOutcome::Succeed,
+            seal_calls: Arc::new(Mutex::new(Vec::new())),
+            demote_calls: Arc::new(AtomicU32::new(0)),
+        });
+
+        let budget = Duration::from_millis(50);
+        let task_me = me.clone();
+        let drain = tokio::spawn(async move {
+            run_shutdown_drain(&NoopLease, &claim_store, &task_me, &local_claims, budget).await;
+        });
+        tokio::time::advance(budget * 4).await;
+        drain.await.expect("drain task must stop at its budget");
+
+        assert!(
+            inner.fence(&room_a, &me, epoch).await.unwrap_or(false),
+            "a timed-out authority snapshot must leave the exact claim held"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn drain_abandons_sealed_claims_when_the_exact_batch_release_hangs() {
+        let inner = Arc::new(InProcessClaimStore::new());
+        let me = identity();
+        let room_a = room("room-release-hangs@muc.example.com");
+        let epoch = inner.acquire(&room_a, &me).await.expect("acquire");
+        let claim_store: Arc<dyn ClaimStore> = Arc::new(HangingBulkClaimStore {
+            inner: Arc::clone(&inner),
+            operation: HangingStoreOperation::ReleaseMany,
+        });
+        let seal_calls = Arc::new(Mutex::new(Vec::new()));
+        let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(FakeLocalClaims {
+            owned: vec![room_a.clone()],
+            outcome: SealOutcome::Succeed,
+            seal_calls: Arc::clone(&seal_calls),
+            demote_calls: Arc::new(AtomicU32::new(0)),
+        });
+
+        let budget = Duration::from_millis(50);
+        let task_me = me.clone();
+        let drain = tokio::spawn(async move {
+            run_shutdown_drain(&NoopLease, &claim_store, &task_me, &local_claims, budget).await;
+        });
+        tokio::time::advance(budget * 4).await;
+        drain.await.expect("drain task must stop at its budget");
+
+        assert_eq!(
+            seal_calls.lock().expect("seal calls lock").as_slice(),
+            [room_a.id.as_str()],
+            "the final fenced write must finish before the batch release is attempted"
+        );
+        assert!(
+            inner.fence(&room_a, &me, epoch).await.unwrap_or(false),
+            "a timed-out exact release must abandon, never silently drop, the claim"
         );
     }
 
@@ -626,6 +856,10 @@ mod tests {
             return;
         };
         let me = identity();
+        claim_store_typed
+            .register(&me, None)
+            .await
+            .expect("register modeled-scale owner");
         const MODELED_ENTITY_COUNT: usize = 2_000;
         let mut entities = Vec::with_capacity(MODELED_ENTITY_COUNT);
         for i in 0..MODELED_ENTITY_COUNT {
@@ -703,7 +937,7 @@ mod tests {
             .await
             .expect("register");
         let entity = room("room-post-release@muc.example.com");
-        claim_store_typed
+        let epoch = claim_store_typed
             .acquire(&entity, &me)
             .await
             .expect("acquire");
@@ -714,9 +948,15 @@ mod tests {
             .mark_draining(&me)
             .await
             .expect("mark draining");
+        let other = identity();
+        claim_store_typed
+            .register(&other, None)
+            .await
+            .expect("register non-draining claimant");
         let claim_store: Arc<dyn ClaimStore> = Arc::new(claim_store_typed);
+        let grant = ClaimGrant::new(entity.clone(), me.clone(), epoch);
         claim_store
-            .release_many(std::slice::from_ref(&entity), &me)
+            .release_many(std::slice::from_ref(&grant))
             .await
             .expect("release_many");
 
@@ -729,7 +969,6 @@ mod tests {
         );
 
         // A genuinely different, non-draining node can.
-        let other = identity();
         claim_store
             .acquire(&entity, &other)
             .await

--- a/server/crates/waddle-server/src/clustering/isr.rs
+++ b/server/crates/waddle-server/src/clustering/isr.rs
@@ -76,7 +76,7 @@ use subtle::ConstantTimeEq;
 use waddle_xmpp::isr::{
     generate_isr_token, IsrConsumeOutcome, IsrTokenStore, IsrTokenStoreError, IssuedIsrToken,
 };
-use waddle_xmpp::ownership::{ClaimEpoch, EntityType, NodeIdentity};
+use waddle_xmpp::ownership::{ClaimEpoch, ClaimGrant, EntityType, NodeIdentity};
 
 use crate::db::{Database, DatabaseError};
 
@@ -112,6 +112,32 @@ impl PostgresIsrTokenStore {
     pub fn new(db: Database) -> Self {
         Self { db }
     }
+
+    /// Wait for the exact token row (or serialize its absence) before a
+    /// caller computes a database-owned effect timestamp. PostgreSQL may
+    /// evaluate an `INSERT .. ON CONFLICT` VALUES expression before it
+    /// waits on the conflicting row, so the explicit lock must precede
+    /// `clock_timestamp()`.
+    async fn lock_token_effect_row(
+        tx: &mut crate::db::Transaction<'_>,
+        sm_id: &str,
+    ) -> Result<(), IsrTokenStoreError> {
+        tx.execute(
+            "SELECT pg_advisory_xact_lock(hashtextextended(?, 8721))",
+            crate::db_params![sm_id.to_string()],
+        )
+        .await
+        .map_err(db_err)?;
+        let mut rows = tx
+            .query(
+                "SELECT 1 FROM clustering_isr_tokens WHERE sm_id = ? FOR UPDATE",
+                crate::db_params![sm_id.to_string()],
+            )
+            .await
+            .map_err(db_err)?;
+        let _ = rows.next().await.map_err(db_err)?;
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -138,18 +164,49 @@ impl IsrTokenStore for PostgresIsrTokenStore {
         &self,
         sm_id: &str,
         mechanism: &str,
+        grant: &ClaimGrant,
     ) -> Result<IssuedIsrToken, IsrTokenStoreError> {
         let token = generate_isr_token();
-        let conn = self.db.guard().await.map_err(db_err)?;
-        conn.execute(
+        if grant.entity.entity_type != EntityType::SmSession || grant.entity.id != sm_id {
+            return Err(IsrTokenStoreError::NotOwner);
+        }
+        let mut tx = self.db.begin_fenced().await.map_err(db_err)?;
+        let mut fence_rows = tx
+            .query(
+                "WITH locked AS MATERIALIZED ( \
+                     SELECT n.heartbeat, n.expired, n.lease_ttl_ms \
+                     FROM clustering_claims c \
+                     JOIN clustering_nodes n ON n.node_id = c.node_id AND n.node_epoch = c.node_epoch \
+                     WHERE c.entity = ? AND c.node_id = ? AND c.node_epoch = ? AND c.claim_epoch = ? \
+                     FOR SHARE OF c, n \
+                 ) \
+                 SELECT 1 FROM locked WHERE NOT expired \
+                   AND heartbeat >= clock_timestamp() - (lease_ttl_ms::text || ' milliseconds')::interval",
+                crate::db_params![
+                    sm_session_entity_key(sm_id),
+                    grant.owner.node_id.clone(),
+                    grant.owner.node_epoch.clone(),
+                    grant.epoch.0,
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        let fenced = fence_rows.next().await.map_err(db_err)?.is_some();
+        drop(fence_rows);
+        if !fenced {
+            return Err(IsrTokenStoreError::NotOwner);
+        }
+        Self::lock_token_effect_row(&mut tx, sm_id).await?;
+        tx.execute(
             "INSERT INTO clustering_isr_tokens (sm_id, token, mechanism, created_at) \
-             VALUES (?, ?, ?, now()) \
+             VALUES (?, ?, ?, clock_timestamp()) \
              ON CONFLICT (sm_id) DO UPDATE SET \
-                 token = EXCLUDED.token, mechanism = EXCLUDED.mechanism, created_at = now()",
+                 token = EXCLUDED.token, mechanism = EXCLUDED.mechanism, created_at = clock_timestamp()",
             crate::db_params![sm_id.to_string(), token.clone(), mechanism.to_string()],
         )
         .await
         .map_err(db_err)?;
+        tx.commit().await.map_err(db_err)?;
         Ok(IssuedIsrToken {
             token,
             mechanism: mechanism.to_string(),
@@ -164,7 +221,7 @@ impl IsrTokenStore for PostgresIsrTokenStore {
         me: &NodeIdentity,
         mine: ClaimEpoch,
     ) -> Result<IsrConsumeOutcome, IsrTokenStoreError> {
-        let mut tx = self.db.begin().await.map_err(db_err)?;
+        let mut tx = self.db.begin_fenced().await.map_err(db_err)?;
 
         // Fencing check: identical shape to `assert_fenced` in
         // `sm_persistence_fenced.rs`/`muc_durable.rs` — one connection, one
@@ -172,8 +229,16 @@ impl IsrTokenStore for PostgresIsrTokenStore {
         let key = sm_session_entity_key(sm_id);
         let mut fence_rows = tx
             .query(
-                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                crate::db_params![key, me.node_id.clone(), mine.0],
+                "WITH locked AS MATERIALIZED ( \
+                     SELECT n.heartbeat, n.expired, n.lease_ttl_ms \
+                     FROM clustering_claims c \
+                     JOIN clustering_nodes n ON n.node_id = c.node_id AND n.node_epoch = c.node_epoch \
+                     WHERE c.entity = ? AND c.node_id = ? AND c.node_epoch = ? AND c.claim_epoch = ? \
+                     FOR SHARE OF c, n \
+                 ) \
+                 SELECT 1 FROM locked WHERE NOT expired \
+                   AND heartbeat >= clock_timestamp() - (lease_ttl_ms::text || ' milliseconds')::interval",
+                crate::db_params![key, me.node_id.clone(), me.node_epoch.clone(), mine.0],
             )
             .await
             .map_err(db_err)?;
@@ -293,7 +358,7 @@ impl IsrTokenStore for PostgresIsrTokenStore {
         let rotated_token = generate_isr_token();
         tx.execute(
             "INSERT INTO clustering_isr_tokens (sm_id, token, mechanism, created_at) \
-             VALUES (?, ?, ?, now())",
+             VALUES (?, ?, ?, clock_timestamp())",
             crate::db_params![
                 sm_id.to_string(),
                 rotated_token.clone(),
@@ -340,7 +405,9 @@ impl IsrTokenStore for PostgresIsrTokenStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::clustering::claims::{clustering_control_plane_table_lock, PostgresClaimStore};
+    use crate::clustering::claims::{
+        clustering_control_plane_table_lock, NodeLeaseStore, PostgresClaimStore,
+    };
     use crate::db::{DatabaseConfig, DatabaseDriver};
     use waddle_xmpp::ownership::{ClaimStore, Entity};
 
@@ -371,17 +438,22 @@ mod tests {
     /// `consume` test can present a genuinely fenced `(me, epoch)` pair —
     /// mirrors how `sm_persistence_fenced.rs`'s own Postgres-gated tests
     /// establish a fenceable claim before exercising a fenced write.
-    async fn claim_sm_session(db: &Database, sm_id: &str, me: &NodeIdentity) -> ClaimEpoch {
+    async fn claim_sm_session(db: &Database, sm_id: &str, me: &NodeIdentity) -> ClaimGrant {
         let claim_store = PostgresClaimStore::new(db.clone());
         claim_store
             .ensure_schema()
             .await
             .expect("ensure claims schema");
-        let entity = Entity::new(EntityType::SmSession, sm_id.to_string());
         claim_store
+            .register(me, None)
+            .await
+            .expect("register live claimant");
+        let entity = Entity::new(EntityType::SmSession, sm_id.to_string());
+        let epoch = claim_store
             .acquire(&entity, me)
             .await
-            .expect("acquire sm_session claim")
+            .expect("acquire sm_session claim");
+        ClaimGrant::new(entity, me.clone(), epoch)
     }
 
     #[tokio::test]
@@ -394,11 +466,11 @@ mod tests {
         store.ensure_schema().await.expect("ensure isr schema");
         let me = node_identity();
         let sm_id = format!("sm-{}", uuid::Uuid::new_v4());
-        let epoch = claim_sm_session(&db, &sm_id, &me).await;
+        let grant = claim_sm_session(&db, &sm_id, &me).await;
 
-        let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
+        let issued = store.issue(&sm_id, "PLAIN", &grant).await.expect("issue");
         let outcome = store
-            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, epoch)
+            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, grant.epoch)
             .await
             .expect("consume");
         let IsrConsumeOutcome::Matched { rotated } = outcome else {
@@ -408,7 +480,7 @@ mod tests {
 
         // Single-use: the OLD token fails now, even under the same fence.
         let replay = store
-            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, epoch)
+            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, grant.epoch)
             .await
             .expect("consume");
         assert_eq!(replay, IsrConsumeOutcome::Mismatched);
@@ -424,11 +496,11 @@ mod tests {
         store.ensure_schema().await.expect("ensure isr schema");
         let me = node_identity();
         let sm_id = format!("sm-{}", uuid::Uuid::new_v4());
-        let epoch = claim_sm_session(&db, &sm_id, &me).await;
+        let grant = claim_sm_session(&db, &sm_id, &me).await;
 
-        let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
+        let issued = store.issue(&sm_id, "PLAIN", &grant).await.expect("issue");
         let outcome = store
-            .consume(&sm_id, b"not-the-token", "PLAIN", &me, epoch)
+            .consume(&sm_id, b"not-the-token", "PLAIN", &me, grant.epoch)
             .await
             .expect("consume");
         assert_eq!(outcome, IsrConsumeOutcome::Mismatched);
@@ -438,7 +510,7 @@ mod tests {
         // from the genuine `Mismatched` above), proving unconditional
         // destruction happened.
         let second = store
-            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, epoch)
+            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, grant.epoch)
             .await
             .expect("consume");
         assert_eq!(second, IsrConsumeOutcome::NoSuchToken);
@@ -460,10 +532,10 @@ mod tests {
         store.ensure_schema().await.expect("ensure isr schema");
         let me = node_identity();
         let sm_id = format!("sm-{}", uuid::Uuid::new_v4());
-        let epoch = claim_sm_session(&db, &sm_id, &me).await;
+        let grant = claim_sm_session(&db, &sm_id, &me).await;
 
         let outcome = store
-            .consume(&sm_id, b"anything", "PLAIN", &me, epoch)
+            .consume(&sm_id, b"anything", "PLAIN", &me, grant.epoch)
             .await
             .expect("consume");
         assert_eq!(outcome, IsrConsumeOutcome::NoSuchToken);
@@ -471,9 +543,9 @@ mod tests {
         // Nothing was touched: issuing a token AFTER this failed attempt
         // and consuming it must succeed normally — proving the no-row
         // branch never wrote anything that could poison a later issuance.
-        let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
+        let issued = store.issue(&sm_id, "PLAIN", &grant).await.expect("issue");
         let second = store
-            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, epoch)
+            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, grant.epoch)
             .await
             .expect("consume");
         assert!(matches!(second, IsrConsumeOutcome::Matched { .. }));
@@ -513,12 +585,15 @@ mod tests {
 
         let fresh_sm_id = format!("sm-{}", uuid::Uuid::new_v4());
         let stale_sm_id = format!("sm-{}", uuid::Uuid::new_v4());
+        let me = node_identity();
+        let fresh_grant = claim_sm_session(&db, &fresh_sm_id, &me).await;
+        let stale_grant = claim_sm_session(&db, &stale_sm_id, &me).await;
         store
-            .issue(&fresh_sm_id, "PLAIN")
+            .issue(&fresh_sm_id, "PLAIN", &fresh_grant)
             .await
             .expect("issue fresh token");
         store
-            .issue(&stale_sm_id, "PLAIN")
+            .issue(&stale_sm_id, "PLAIN", &stale_grant)
             .await
             .expect("issue stale token");
 
@@ -542,11 +617,8 @@ mod tests {
 
         // The fresh row survives; the stale one is gone (a subsequent
         // consume for it finds no row at all).
-        let me = node_identity();
-        let fresh_epoch = claim_sm_session(&db, &fresh_sm_id, &me).await;
-        let stale_epoch = claim_sm_session(&db, &stale_sm_id, &me).await;
         let stale_outcome = store
-            .consume(&stale_sm_id, b"anything", "PLAIN", &me, stale_epoch)
+            .consume(&stale_sm_id, b"anything", "PLAIN", &me, stale_grant.epoch)
             .await
             .expect("consume stale");
         assert_eq!(stale_outcome, IsrConsumeOutcome::NoSuchToken);
@@ -556,7 +628,7 @@ mod tests {
                 b"wrong-token-but-row-must-exist",
                 "PLAIN",
                 &me,
-                fresh_epoch,
+                fresh_grant.epoch,
             )
             .await
             .expect("consume fresh");
@@ -578,10 +650,10 @@ mod tests {
         store.ensure_schema().await.expect("ensure isr schema");
         let me = node_identity();
         let sm_id = format!("sm-{}", uuid::Uuid::new_v4());
-        let epoch = claim_sm_session(&db, &sm_id, &me).await;
+        let grant = claim_sm_session(&db, &sm_id, &me).await;
 
-        let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
-        let wrong_epoch = ClaimEpoch(epoch.0 + 1);
+        let issued = store.issue(&sm_id, "PLAIN", &grant).await.expect("issue");
+        let wrong_epoch = ClaimEpoch(grant.epoch.0 + 1);
         let outcome = store
             .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, wrong_epoch)
             .await;
@@ -589,10 +661,289 @@ mod tests {
 
         // Fencing failure must not have touched the token row.
         let still_valid = store
-            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, epoch)
+            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, grant.epoch)
             .await
             .expect("consume");
         assert!(matches!(still_valid, IsrConsumeOutcome::Matched { .. }));
+    }
+
+    #[tokio::test]
+    async fn issue_and_consume_reject_a_lapsed_owner_before_committed_expiry() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(db) = test_db().await else {
+            return;
+        };
+        let store = PostgresIsrTokenStore::new(db.clone());
+        store.ensure_schema().await.expect("ensure isr schema");
+        let me = node_identity();
+        let sm_id = format!("sm-lapsed-{}", uuid::Uuid::new_v4());
+        let grant = claim_sm_session(&db, &sm_id, &me).await;
+        let issued = store.issue(&sm_id, "PLAIN", &grant).await.expect("issue");
+
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "UPDATE clustering_nodes SET heartbeat = now() - interval '1 hour', expired = false \
+             WHERE node_id = ? AND node_epoch = ?",
+            crate::db_params![me.node_id.clone(), me.node_epoch.clone()],
+        )
+        .await
+        .expect("lapse owner heartbeat");
+        drop(conn);
+
+        assert!(matches!(
+            store.issue(&sm_id, "PLAIN", &grant).await,
+            Err(IsrTokenStoreError::NotOwner)
+        ));
+        assert!(matches!(
+            store
+                .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, grant.epoch)
+                .await,
+            Err(IsrTokenStoreError::NotOwner)
+        ));
+
+        let conn = db.guard().await.expect("guard");
+        let mut rows = conn
+            .query(
+                "SELECT token FROM clustering_isr_tokens WHERE sm_id = ?",
+                crate::db_params![sm_id],
+            )
+            .await
+            .expect("query untouched token");
+        assert_eq!(
+            rows.next()
+                .await
+                .expect("row read")
+                .expect("token remains")
+                .get::<String>(0)
+                .expect("token"),
+            issued.token
+        );
+    }
+
+    #[tokio::test]
+    async fn issue_revalidates_wall_clock_after_node_lock_wait() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(db) = test_db().await else {
+            return;
+        };
+        let store = PostgresIsrTokenStore::new(db.clone());
+        store.ensure_schema().await.unwrap();
+        let me = node_identity();
+        let sm_id = format!("sm-clock-{}", uuid::Uuid::new_v4());
+        let grant = claim_sm_session(&db, &sm_id, &me).await;
+        db.guard()
+            .await
+            .unwrap()
+            .execute(
+                "UPDATE clustering_nodes SET heartbeat = clock_timestamp(), lease_ttl_ms = 50 WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![me.node_id.clone(), me.node_epoch.clone()],
+            )
+            .await
+            .unwrap();
+        let mut blocker = db.begin().await.unwrap();
+        let mut rows = blocker
+            .query(
+                "SELECT 1 FROM clustering_nodes WHERE node_id = ? AND node_epoch = ? FOR UPDATE",
+                crate::db_params![me.node_id.clone(), me.node_epoch.clone()],
+            )
+            .await
+            .unwrap();
+        assert!(rows.next().await.unwrap().is_some());
+        drop(rows);
+        let task_store = PostgresIsrTokenStore::new(db.clone());
+        let task = tokio::spawn(async move { task_store.issue(&sm_id, "PLAIN", &grant).await });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert!(
+            !task.is_finished(),
+            "ISR issue must wait on the held node row"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        blocker.commit().await.unwrap();
+        assert!(matches!(
+            task.await.unwrap(),
+            Err(IsrTokenStoreError::NotOwner)
+        ));
+    }
+
+    #[tokio::test]
+    async fn issue_stamps_created_at_after_token_row_lock_wait() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(db) = test_db().await else {
+            return;
+        };
+        let store = PostgresIsrTokenStore::new(db.clone());
+        store.ensure_schema().await.unwrap();
+        let me = node_identity();
+        let sm_id = format!("sm-created-at-{}", uuid::Uuid::new_v4());
+        let grant = claim_sm_session(&db, &sm_id, &me).await;
+        store.issue(&sm_id, "PLAIN", &grant).await.unwrap();
+
+        let mut blocker = db.begin().await.unwrap();
+        let mut rows = blocker
+            .query(
+                "SELECT 1 FROM clustering_isr_tokens WHERE sm_id = ? FOR UPDATE",
+                crate::db_params![sm_id.clone()],
+            )
+            .await
+            .unwrap();
+        assert!(rows.next().await.unwrap().is_some());
+        drop(rows);
+
+        let task_store = PostgresIsrTokenStore::new(db.clone());
+        let task_sm_id = sm_id.clone();
+        let task =
+            tokio::spawn(async move { task_store.issue(&task_sm_id, "PLAIN", &grant).await });
+        tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+        assert!(!task.is_finished(), "issue must wait on the token row");
+        tokio::time::sleep(std::time::Duration::from_millis(360)).await;
+        blocker.commit().await.unwrap();
+        task.await.unwrap().unwrap();
+
+        let mut rows = db
+            .guard()
+            .await
+            .unwrap()
+            .query(
+                "SELECT (EXTRACT(EPOCH FROM clock_timestamp() - created_at) * 1000)::double precision FROM clustering_isr_tokens WHERE sm_id = ?",
+                crate::db_params![sm_id],
+            )
+            .await
+            .unwrap();
+        let age_ms = rows.next().await.unwrap().unwrap().get::<f64>(0).unwrap();
+        assert!(
+            age_ms < 200.0,
+            "created_at must start after the 400ms token-row wait, got {age_ms}ms"
+        );
+    }
+
+    #[tokio::test]
+    async fn issue_rejects_the_old_grant_after_same_node_id_recovery() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(db) = test_db().await else {
+            return;
+        };
+        let store = PostgresIsrTokenStore::new(db.clone());
+        store.ensure_schema().await.expect("ensure isr schema");
+        let old = node_identity();
+        let sm_id = format!("sm-issue-same-node-{}", uuid::Uuid::new_v4());
+        let grant = claim_sm_session(&db, &sm_id, &old).await;
+        let original = store
+            .issue(&sm_id, "PLAIN", &grant)
+            .await
+            .expect("initial issue");
+
+        // Rotate only the node-liveness row. The claim intentionally still
+        // names the old incarnation, so a fence that checked claim columns
+        // alone would incorrectly authorize this stale issuer.
+        let recovered = NodeIdentity::new(old.node_id.clone(), uuid::Uuid::new_v4().to_string());
+        let claim_store = PostgresClaimStore::new(db.clone());
+        claim_store
+            .register_draining_with_peer_id(
+                &old,
+                &recovered,
+                None,
+                None,
+                std::time::Duration::from_secs(30),
+            )
+            .await
+            .expect("rotate node row without moving claim");
+
+        let stale_issue = store.issue(&sm_id, "PLAIN", &grant).await;
+        assert!(
+            matches!(stale_issue, Err(IsrTokenStoreError::NotOwner)),
+            "the deposed node incarnation must not rotate the token: {stale_issue:?}"
+        );
+
+        let recovered_epoch = claim_store
+            .reclaim_after_self_fence(
+                &grant.entity,
+                grant.epoch,
+                &old,
+                &recovered,
+                std::time::Duration::from_secs(30),
+            )
+            .await
+            .expect("reclaim exact old claim");
+        assert!(claim_store
+            .activate(&recovered, std::time::Duration::from_secs(30))
+            .await
+            .expect("activate recovered incarnation"));
+        let current = store
+            .consume(
+                &sm_id,
+                original.token.as_bytes(),
+                "PLAIN",
+                &recovered,
+                recovered_epoch,
+            )
+            .await
+            .expect("current incarnation consumes original token");
+        assert!(
+            matches!(current, IsrConsumeOutcome::Matched { .. }),
+            "stale issuance failure must leave the original token untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn consume_rejects_the_old_epoch_after_same_node_id_recovery() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(db) = test_db().await else {
+            return;
+        };
+        let store = PostgresIsrTokenStore::new(db.clone());
+        store.ensure_schema().await.expect("ensure isr schema");
+        let old = node_identity();
+        let sm_id = format!("sm-same-node-{}", uuid::Uuid::new_v4());
+        let grant = claim_sm_session(&db, &sm_id, &old).await;
+        let issued = store.issue(&sm_id, "PLAIN", &grant).await.expect("issue");
+
+        let recovered = NodeIdentity::new(old.node_id.clone(), uuid::Uuid::new_v4().to_string());
+        let claim_store = PostgresClaimStore::new(db.clone());
+        claim_store
+            .register_draining_with_peer_id(
+                &old,
+                &recovered,
+                None,
+                None,
+                std::time::Duration::from_secs(30),
+            )
+            .await
+            .expect("rotate node row without moving claim");
+
+        let stale = store
+            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &old, grant.epoch)
+            .await;
+        assert!(
+            matches!(stale, Err(IsrTokenStoreError::NotOwner)),
+            "the old node epoch must fail before consuming the token: {stale:?}"
+        );
+
+        let recovered_epoch = claim_store
+            .reclaim_after_self_fence(
+                &grant.entity,
+                grant.epoch,
+                &old,
+                &recovered,
+                std::time::Duration::from_secs(30),
+            )
+            .await
+            .expect("reclaim exact old claim");
+        assert!(claim_store
+            .activate(&recovered, std::time::Duration::from_secs(30))
+            .await
+            .expect("activate recovered incarnation"));
+
+        let current = store
+            .consume(
+                &sm_id,
+                issued.token.as_bytes(),
+                "PLAIN",
+                &recovered,
+                recovered_epoch,
+            )
+            .await
+            .expect("current incarnation consumes untouched token");
+        assert!(matches!(current, IsrConsumeOutcome::Matched { .. }));
     }
 
     /// Council-adjudicated FIX 1: strengthens the pre-existing exactly-once
@@ -630,8 +981,9 @@ mod tests {
         store.ensure_schema().await.expect("ensure isr schema");
         let me = node_identity();
         let sm_id = format!("sm-{}", uuid::Uuid::new_v4());
-        let epoch = claim_sm_session(&db, &sm_id, &me).await;
-        let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
+        let grant = claim_sm_session(&db, &sm_id, &me).await;
+        let issued = store.issue(&sm_id, "PLAIN", &grant).await.expect("issue");
+        let epoch = grant.epoch;
 
         // Manually hold the token row's lock open — standing in for
         // `consume()`'s own winning transaction, but under this test's

--- a/server/crates/waddle-server/src/clustering/local_claims.rs
+++ b/server/crates/waddle-server/src/clustering/local_claims.rs
@@ -22,10 +22,13 @@
 //! registry is created later in `server/http.rs`, then wired into the handle
 //! that `start_if_enabled` already handed to `run_node_lease`.
 
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use futures::future::join_all;
 use jid::{BareJid, FullJid};
 use kameo::actor::ActorRef;
 use waddle_xmpp::muc::room_actor::HealthCheck;
@@ -33,12 +36,13 @@ use waddle_xmpp::muc::RoomRegistry;
 use waddle_xmpp::ownership::{Entity, EntityType};
 use waddle_xmpp::registry::user_actor::HealthCheck as UserHealthCheck;
 use waddle_xmpp::registry::{
-    ConnectionRegistry, DemoteUserActor, ForceDetachOutcome, ForceDetachRequest, GetResources,
-    GetUserForLocalClaim, ListUsers, UserRegistryActor,
+    ConnectionEntry, ConnectionPlacement, ConnectionRegistry, DemoteAllUserActors, DemoteUserActor,
+    ForceDetachOutcome, ForceDetachReason, ForceDetachRequest, GetUserForLocalClaim, ListUsers,
+    UserRegistryActor,
 };
-use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
+use waddle_xmpp::stream_management::{InMemorySmSessionRegistry, ReclaimedSessionHydration};
 
-use super::self_fence::LocallyClaimedEntities;
+use super::self_fence::{LocallyClaimedEntities, ReclaimedEntityHydration};
 
 /// Bound on the health-ask this impl issues against a locally-claimed
 /// room's `RoomActor` (ADR-0017 Phase 3 Slice 7's `RoomActor` counterpart
@@ -48,10 +52,12 @@ use super::self_fence::LocallyClaimedEntities;
 const ROOM_HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
 const USER_HEALTH_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
 const USER_FORCE_DETACH_ACK_TIMEOUT: Duration = Duration::from_secs(2);
+const USER_HARD_RETIRE_TIMEOUT: Duration = Duration::from_secs(1);
 
 /// See the module doc for the construction-order rationale.
 pub struct SmSessionLocalClaims {
     registry: OnceLock<Arc<InMemorySmSessionRegistry>>,
+    initialized: AtomicBool,
 }
 
 impl SmSessionLocalClaims {
@@ -59,6 +65,7 @@ impl SmSessionLocalClaims {
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
             registry: OnceLock::new(),
+            initialized: AtomicBool::new(false),
         })
     }
 
@@ -70,9 +77,15 @@ impl SmSessionLocalClaims {
         if self.registry.set(registry).is_err() {
             tracing::error!(
                 "SmSessionLocalClaims::wire called more than once; the SM session \
-                 registry handle was already wired (ignoring this call)"
+                registry handle was already wired (ignoring this call)"
             );
+            return;
         }
+        // `wire` is intentionally called only after startup restoration has
+        // completed. Release-publishing this bit makes a concurrent
+        // self-fence retry observe both the registry pointer and all sessions
+        // restored before it is allowed to rotate the node epoch.
+        self.initialized.store(true, Ordering::Release);
     }
 }
 
@@ -88,6 +101,25 @@ impl LocallyClaimedEntities for SmSessionLocalClaims {
             .into_iter()
             .map(|stream_id| Entity::new(EntityType::SmSession, stream_id))
             .collect()
+    }
+
+    async fn demote_all_on_self_fence(&self) -> bool {
+        if !self.initialized.load(Ordering::Acquire) {
+            tracing::warn!("SM local claims are not initialized; refusing node-epoch recovery");
+            return false;
+        }
+        let Some(registry) = self.registry.get() else {
+            return false;
+        };
+        let Some(stream_ids) = registry.live_session_ids() else {
+            return false;
+        };
+        for stream_id in stream_ids {
+            if !registry.forget_claim_locally(&stream_id).await {
+                return false;
+            }
+        }
+        true
     }
 
     async fn demote(&self, entity: &Entity) {
@@ -118,15 +150,37 @@ impl LocallyClaimedEntities for SmSessionLocalClaims {
     /// reclaim and the general reaper share one hydration implementation.
     /// A no-op before `wire` runs, mirroring `demote`/`owned`'s identical
     /// unwired behavior.
-    async fn hydrate_reclaimed(&self, entities: &[(Entity, waddle_xmpp::ownership::ClaimEpoch)]) {
+    async fn hydrate_reclaimed(
+        &self,
+        owner: &waddle_xmpp::ownership::NodeIdentity,
+        entity: &Entity,
+        epoch: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> ReclaimedEntityHydration {
+        if !self.initialized.load(Ordering::Acquire) {
+            return ReclaimedEntityHydration::Retry;
+        }
         let Some(registry) = self.registry.get() else {
-            return;
+            return ReclaimedEntityHydration::Retry;
         };
-        if let Err(error) = registry.hydrate_reclaimed(entities).await {
-            tracing::warn!(
-                %error,
-                "SmSessionLocalClaims::hydrate_reclaimed: registry hydrate_reclaimed failed"
-            );
+        match registry
+            .hydrate_reclaimed_one_as(entity, epoch, owner)
+            .await
+        {
+            Ok(ReclaimedSessionHydration::Hydrated | ReclaimedSessionHydration::AlreadyLocal) => {
+                ReclaimedEntityHydration::Local
+            }
+            Ok(ReclaimedSessionHydration::Elsewhere) => ReclaimedEntityHydration::Elsewhere,
+            Ok(ReclaimedSessionHydration::TerminallyReleased) => {
+                ReclaimedEntityHydration::TerminallyReleased
+            }
+            Ok(ReclaimedSessionHydration::Retry) => ReclaimedEntityHydration::Retry,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "SmSessionLocalClaims::hydrate_reclaimed: strict hydration failed"
+                );
+                ReclaimedEntityHydration::Retry
+            }
         }
     }
 }
@@ -191,6 +245,30 @@ impl RoomLocalClaims {
             }
         }
     }
+
+    pub async fn demote_if_superseded(
+        &self,
+        entity: &Entity,
+        expected_owner: waddle_xmpp::ownership::NodeIdentity,
+        new_epoch: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> bool {
+        let Some(registry) = self.registry.get() else {
+            return false;
+        };
+        let Some(room_jid) = Self::room_jid(entity) else {
+            return false;
+        };
+        match registry
+            .demote_room_if_superseded(room_jid, expected_owner, new_epoch)
+            .await
+        {
+            Ok(demoted) => demoted,
+            Err(error) => {
+                tracing::warn!(%error, %entity, "failed exact-incarnation RoomActor demotion");
+                false
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -221,6 +299,25 @@ impl LocallyClaimedEntities for RoomLocalClaims {
                      cannot itself observe)"
                 );
                 Vec::new()
+            }
+        }
+    }
+
+    async fn demote_all_on_self_fence(&self) -> bool {
+        let Some(registry) = self.registry.get() else {
+            return true;
+        };
+        match registry.demote_all_rooms().await {
+            Ok(count) => {
+                tracing::warn!(count, "demoted every local RoomActor after node self-fence");
+                true
+            }
+            Err(error) => {
+                tracing::error!(
+                    %error,
+                    "failed to demote every local RoomActor after node self-fence"
+                );
+                false
             }
         }
     }
@@ -353,6 +450,7 @@ impl LocallyClaimedEntities for RoomLocalClaims {
 pub struct UserLocalClaims {
     registry: OnceLock<ActorRef<UserRegistryActor>>,
     connection_registry: OnceLock<Arc<ConnectionRegistry>>,
+    remote_resource_bridge: OnceLock<Arc<super::route_bridge::OrderedRelayDeliveryBridge>>,
 }
 
 impl UserLocalClaims {
@@ -360,6 +458,7 @@ impl UserLocalClaims {
         Arc::new(Self {
             registry: OnceLock::new(),
             connection_registry: OnceLock::new(),
+            remote_resource_bridge: OnceLock::new(),
         })
     }
 
@@ -381,6 +480,17 @@ impl UserLocalClaims {
         }
     }
 
+    pub fn wire_remote_resource_bridge(
+        &self,
+        bridge: Arc<super::route_bridge::OrderedRelayDeliveryBridge>,
+    ) {
+        if self.remote_resource_bridge.set(bridge).is_err() {
+            tracing::error!(
+                "UserLocalClaims::wire_remote_resource_bridge called more than once; ignoring"
+            );
+        }
+    }
+
     fn user_jid(entity: &Entity) -> Option<BareJid> {
         if entity.entity_type != EntityType::UserActor {
             return None;
@@ -398,193 +508,233 @@ impl UserLocalClaims {
         }
     }
 
-    async fn actor_resources(
-        registry: &ActorRef<UserRegistryActor>,
-        bare_jid: &BareJid,
-    ) -> Vec<FullJid> {
-        let actor_ref = match registry
-            .ask(GetUserForLocalClaim {
-                bare_jid: bare_jid.clone(),
-            })
-            .mailbox_timeout(USER_HEALTH_CHECK_TIMEOUT)
-            .reply_timeout(USER_HEALTH_CHECK_TIMEOUT)
-            .await
-        {
-            Ok(Some(actor_ref)) => actor_ref,
-            Ok(None) => return Vec::new(),
-            Err(error) => {
-                tracing::warn!(
-                    jid = %bare_jid,
-                    ?error,
-                    "UserLocalClaims::demote: user registry lookup failed before force-detach"
-                );
-                return Vec::new();
-            }
-        };
-        match actor_ref
-            .ask(GetResources)
-            .mailbox_timeout(USER_HEALTH_CHECK_TIMEOUT)
-            .reply_timeout(USER_HEALTH_CHECK_TIMEOUT)
-            .await
-        {
-            Ok(resources) => resources,
-            Err(error) => {
-                tracing::warn!(
-                    jid = %bare_jid,
-                    ?error,
-                    "UserLocalClaims::demote: UserActor resource enumeration failed before force-detach"
-                );
-                Vec::new()
-            }
-        }
-    }
-
     fn connection_registry_resources(
         connection_registry: &ConnectionRegistry,
-        bare_jid: &BareJid,
-    ) -> Vec<FullJid> {
+    ) -> Vec<(FullJid, ConnectionEntry)> {
         connection_registry
             .list_connections()
             .into_iter()
-            .filter(|jid| jid.to_bare() == *bare_jid)
+            .filter_map(|jid| {
+                let entry = connection_registry.get_entry(&jid)?;
+                Some((jid, entry))
+            })
             .collect()
     }
 
-    fn merge_resources(resources: &mut Vec<FullJid>, extra: Vec<FullJid>) {
-        for jid in extra {
-            if !resources.contains(&jid) {
-                resources.push(jid);
+    fn merge_resource_targets(
+        resources: &mut Vec<(FullJid, ConnectionEntry)>,
+        extra: Vec<(FullJid, ConnectionEntry)>,
+    ) {
+        let mut seen: HashMap<FullJid, Vec<Arc<std::sync::atomic::AtomicBool>>> = HashMap::new();
+        for (jid, entry) in resources.iter() {
+            seen.entry(jid.clone())
+                .or_default()
+                .push(entry.carbons_handle());
+        }
+        for (jid, entry) in extra {
+            let owner = entry.carbons_handle();
+            let owners = seen.entry(jid.clone()).or_default();
+            if owners.iter().any(|existing| Arc::ptr_eq(existing, &owner)) {
+                continue;
             }
+            owners.push(owner);
+            resources.push((jid, entry));
         }
     }
 
-    async fn force_detach_resources(&self, bare_jid: &BareJid, resources: Vec<FullJid>) {
+    async fn force_detach_resources(
+        &self,
+        resources: Vec<(FullJid, ConnectionEntry)>,
+        reason: ForceDetachReason,
+    ) -> bool {
         if resources.is_empty() {
-            return;
+            return true;
         }
         let Some(connection_registry) = self.connection_registry.get() else {
             tracing::warn!(
-                jid = %bare_jid,
                 resource_count = resources.len(),
-                "UserLocalClaims::demote: no ConnectionRegistry wired; cannot force-detach live resources"
+                ?reason,
+                "UserLocalClaims::force_detach_resources: no ConnectionRegistry wired; cannot force-detach live resources"
             );
-            return;
+            return false;
         };
-        for jid in resources {
-            let Some(entry) = connection_registry.get_entry(&jid) else {
-                continue;
-            };
-            let owner = entry.carbons_handle();
-            let (ack, ack_rx) = tokio::sync::oneshot::channel();
-            let request = ForceDetachRequest {
-                requester_bare_jid: bare_jid.clone(),
-                ack,
-            };
-            let mut remove_after_wait = false;
-            match entry.force_detach_sender().try_send(request) {
-                Ok(()) => match tokio::time::timeout(USER_FORCE_DETACH_ACK_TIMEOUT, ack_rx).await {
-                    Ok(Ok(ForceDetachOutcome::Detached | ForceDetachOutcome::NotPersisted)) => {
-                        remove_after_wait = true;
-                        tracing::debug!(
-                            jid = %jid,
-                            "UserLocalClaims::demote: connection task acknowledged force-detach"
-                        );
-                    }
-                    Ok(Ok(ForceDetachOutcome::IdentityMismatch)) => {
-                        remove_after_wait = false;
-                        tracing::warn!(
-                            jid = %jid,
-                            requester = %bare_jid,
-                            "UserLocalClaims::demote: force-detach identity mismatch; leaving registry entry untouched"
-                        );
-                    }
-                    Ok(Err(_closed)) => {
-                        tracing::warn!(
-                            jid = %jid,
-                            "UserLocalClaims::demote: force-detach ack channel closed before response; leaving registry entry for connection-owned cleanup"
-                        );
-                    }
-                    Err(_elapsed) => {
-                        tracing::warn!(
-                            jid = %jid,
-                            timeout_ms = USER_FORCE_DETACH_ACK_TIMEOUT.as_millis() as u64,
-                            "UserLocalClaims::demote: force-detach timed out; leaving registry entry so the connection task does not misclassify cleanup as superseded"
-                        );
-                    }
-                },
+
+        let retirements = resources.into_iter().map(|(jid, entry)| async move {
+            self.force_detach_resource(connection_registry, jid, entry, reason)
+                .await
+        });
+        join_all(retirements)
+            .await
+            .into_iter()
+            .all(|retired| retired)
+    }
+
+    async fn force_detach_resource(
+        &self,
+        connection_registry: &ConnectionRegistry,
+        jid: FullJid,
+        entry: ConnectionEntry,
+        reason: ForceDetachReason,
+    ) -> bool {
+        let owner = entry.carbons_handle();
+        let requester_bare_jid = jid.to_bare();
+        let (ack, ack_rx) = tokio::sync::oneshot::channel();
+        let request = ForceDetachRequest {
+            requester_bare_jid: requester_bare_jid.clone(),
+            reason,
+            ack,
+        };
+
+        if entry.placement() == ConnectionPlacement::RemoteMirror {
+            let relayed = match entry.force_detach_sender().try_send(request) {
+                Ok(()) => matches!(
+                    tokio::time::timeout(USER_FORCE_DETACH_ACK_TIMEOUT, ack_rx).await,
+                    Ok(Ok(
+                        ForceDetachOutcome::Detached | ForceDetachOutcome::NotPersisted
+                    ))
+                ),
                 Err(error) => {
                     tracing::warn!(
                         jid = %jid,
+                        ?reason,
                         ?error,
-                        "UserLocalClaims::demote: force-detach request could not be queued; leaving registry entry for connection-owned cleanup"
+                        "remote-mirror force-detach control queue unavailable; attempting direct terminal compensation"
                     );
+                    false
                 }
+            };
+            let retired = if relayed {
+                true
+            } else {
+                let Some(bridge) = self.remote_resource_bridge.get() else {
+                    tracing::error!(
+                        jid = %jid,
+                        ?reason,
+                        "remote-mirror force-detach is uncertain and no direct compensation bridge is wired"
+                    );
+                    return false;
+                };
+                bridge
+                    .terminally_force_detach_remote_mirror_if_owner(&jid, &owner, reason)
+                    .await
+            };
+            if !retired {
+                tracing::error!(
+                    jid = %jid,
+                    ?reason,
+                    "remote physical socket retirement remains uncertain; keeping terminal teardown incomplete"
+                );
+                return false;
             }
-            if remove_after_wait
-                && connection_registry
-                    .unregister_if_owner(&jid, &owner)
-                    .is_some()
-            {
+            connection_registry.unregister_if_owner(&jid, &owner);
+            self.forget_remote_resource_state(&jid, &owner, entry.placement())
+                .await;
+            return true;
+        }
+
+        let retired = match entry.force_detach_sender().try_send(request) {
+            Ok(()) => match tokio::time::timeout(USER_FORCE_DETACH_ACK_TIMEOUT, ack_rx).await {
+                Ok(Ok(ForceDetachOutcome::Detached | ForceDetachOutcome::NotPersisted)) => {
+                    connection_registry.unregister_if_owner(&jid, &owner);
+                    tracing::debug!(
+                        jid = %jid,
+                        ?reason,
+                        "local connection acknowledged force-detach"
+                    );
+                    true
+                }
+                Ok(Ok(ForceDetachOutcome::IdentityMismatch)) => {
+                    tracing::error!(
+                        jid = %jid,
+                        requester = %requester_bare_jid,
+                        ?reason,
+                        "local connection refused force-detach identity; not hard-aborting"
+                    );
+                    false
+                }
+                Ok(Err(_closed)) => {
+                    tracing::warn!(jid = %jid, ?reason, "force-detach ack channel closed; hard-retiring local socket");
+                    Self::hard_retire_local_resource(connection_registry, &jid, &entry, &owner)
+                        .await
+                }
+                Err(_elapsed) => {
+                    tracing::warn!(
+                        jid = %jid,
+                        ?reason,
+                        timeout_ms = USER_FORCE_DETACH_ACK_TIMEOUT.as_millis() as u64,
+                        "force-detach timed out; hard-retiring local socket"
+                    );
+                    Self::hard_retire_local_resource(connection_registry, &jid, &entry, &owner)
+                        .await
+                }
+            },
+            Err(error) => {
                 tracing::warn!(
                     jid = %jid,
-                    "UserLocalClaims::demote: removed deposed resource from ConnectionRegistry"
+                    ?reason,
+                    ?error,
+                    "force-detach request could not be queued; hard-retiring local socket"
                 );
+                Self::hard_retire_local_resource(connection_registry, &jid, &entry, &owner).await
             }
+        };
+        if retired {
+            self.forget_remote_resource_state(&jid, &owner, entry.placement())
+                .await;
         }
-    }
-}
-
-#[async_trait]
-impl LocallyClaimedEntities for UserLocalClaims {
-    async fn owned(&self) -> Vec<Entity> {
-        let mut owned = Vec::new();
-        if let Some(registry) = self.registry.get() {
-            match registry
-                .ask(ListUsers)
-                .mailbox_timeout(USER_HEALTH_CHECK_TIMEOUT)
-                .reply_timeout(USER_HEALTH_CHECK_TIMEOUT)
-                .await
-            {
-                Ok(jids) => {
-                    owned.extend(
-                        jids.into_iter()
-                            .map(|jid| Entity::new(EntityType::UserActor, jid.to_string())),
-                    );
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        ?error,
-                        "UserLocalClaims::owned: user registry list_users failed; \
-                         falling back to ConnectionRegistry resource enumeration"
-                    );
-                }
-            }
-        }
-        if let Some(connection_registry) = self.connection_registry.get() {
-            for jid in connection_registry.list_connections() {
-                let entity = Entity::new(EntityType::UserActor, jid.to_bare().to_string());
-                if !owned.contains(&entity) {
-                    owned.push(entity);
-                }
-            }
-        }
-        owned
+        retired
     }
 
-    async fn demote(&self, entity: &Entity) {
-        let Some(registry) = self.registry.get() else {
-            return;
-        };
-        let Some(bare_jid) = Self::user_jid(entity) else {
-            return;
-        };
-        let mut resources = Self::actor_resources(registry, &bare_jid).await;
-        if let Some(connection_registry) = self.connection_registry.get() {
-            Self::merge_resources(
-                &mut resources,
-                Self::connection_registry_resources(connection_registry, &bare_jid),
+    async fn forget_remote_resource_state(
+        &self,
+        jid: &FullJid,
+        owner: &Arc<std::sync::atomic::AtomicBool>,
+        placement: ConnectionPlacement,
+    ) {
+        if let Some(bridge) = self.remote_resource_bridge.get() {
+            bridge
+                .forget_remote_resource_state_if_owner(jid, owner, placement)
+                .await;
+        }
+    }
+
+    async fn hard_retire_local_resource(
+        connection_registry: &ConnectionRegistry,
+        jid: &FullJid,
+        entry: &ConnectionEntry,
+        owner: &Arc<std::sync::atomic::AtomicBool>,
+    ) -> bool {
+        let Some(retirement) = entry.retirement_handle() else {
+            tracing::error!(
+                jid = %jid,
+                "local socket has no hard-retirement handle; keeping terminal teardown incomplete"
             );
+            return false;
+        };
+        retirement.abort();
+        if tokio::time::timeout(USER_HARD_RETIRE_TIMEOUT, retirement.terminated())
+            .await
+            .is_err()
+        {
+            tracing::error!(
+                jid = %jid,
+                timeout_ms = USER_HARD_RETIRE_TIMEOUT.as_millis() as u64,
+                "hard-retired socket did not terminate; keeping terminal teardown incomplete"
+            );
+            return false;
         }
+        connection_registry.unregister_if_owner(jid, owner);
+        tracing::warn!(jid = %jid, "hard-retired non-cooperative local socket");
+        true
+    }
+
+    async fn demote_user_actor(
+        &self,
+        bare_jid: &BareJid,
+    ) -> Option<Vec<(FullJid, ConnectionEntry)>> {
+        let Some(registry) = self.registry.get() else {
+            return Some(Vec::new());
+        };
         match registry
             .ask(DemoteUserActor {
                 bare_jid: bare_jid.clone(),
@@ -593,23 +743,118 @@ impl LocallyClaimedEntities for UserLocalClaims {
             .reply_timeout(USER_HEALTH_CHECK_TIMEOUT)
             .await
         {
-            Ok(true) => {
+            Ok(resources) => {
                 tracing::warn!(
                     jid = %bare_jid,
+                    resource_count = resources.len(),
                     "demoted (hard-killed) a locally-claimed UserActor: Postgres \
                      no longer attributes this user claim to this node"
                 );
+                Some(resources)
             }
-            Ok(false) => {}
             Err(error) => {
                 tracing::warn!(
                     jid = %bare_jid,
                     ?error,
                     "UserLocalClaims::demote: user registry demotion failed"
                 );
+                None
             }
         }
-        self.force_detach_resources(&bare_jid, resources).await;
+    }
+
+    async fn demote_all_user_actors(&self) -> Option<Vec<(FullJid, ConnectionEntry)>> {
+        let Some(registry) = self.registry.get() else {
+            return Some(Vec::new());
+        };
+        match registry
+            .ask(DemoteAllUserActors)
+            .mailbox_timeout(USER_HEALTH_CHECK_TIMEOUT)
+            .reply_timeout(USER_HEALTH_CHECK_TIMEOUT)
+            .await
+        {
+            Ok(resources) => {
+                tracing::warn!(
+                    resource_count = resources.len(),
+                    "demoted every local UserActor after node self-fence"
+                );
+                Some(resources)
+            }
+            Err(error) => {
+                tracing::error!(
+                    ?error,
+                    "failed to demote every local UserActor after node self-fence"
+                );
+                None
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl LocallyClaimedEntities for UserLocalClaims {
+    async fn owned(&self) -> Vec<Entity> {
+        let Some(registry) = self.registry.get() else {
+            return Vec::new();
+        };
+        match registry
+            .ask(ListUsers)
+            .mailbox_timeout(USER_HEALTH_CHECK_TIMEOUT)
+            .reply_timeout(USER_HEALTH_CHECK_TIMEOUT)
+            .await
+        {
+            Ok(jids) => jids
+                .into_iter()
+                .map(|jid| Entity::new(EntityType::UserActor, jid.to_string()))
+                .collect(),
+            Err(error) => {
+                tracing::warn!(
+                    ?error,
+                    "UserLocalClaims::owned: authoritative user registry enumeration failed; \
+                     skipping UserActor reconciliation this interval"
+                );
+                Vec::new()
+            }
+        }
+    }
+
+    async fn demote_all_on_self_fence(&self) -> bool {
+        let mut resources = self
+            .connection_registry
+            .get()
+            .map(|registry| Self::connection_registry_resources(registry))
+            .unwrap_or_default();
+        let Some(actor_resources) = self.demote_all_user_actors().await else {
+            return false;
+        };
+        Self::merge_resource_targets(&mut resources, actor_resources);
+        if !self
+            .force_detach_resources(resources, ForceDetachReason::NodeSelfFenced)
+            .await
+        {
+            return false;
+        }
+        let Some(bridge) = self.remote_resource_bridge.get() else {
+            return true;
+        };
+        tokio::time::timeout(
+            USER_HARD_RETIRE_TIMEOUT,
+            bridge.clear_remote_resource_state_on_self_fence(),
+        )
+        .await
+        .is_ok()
+    }
+
+    async fn demote(&self, entity: &Entity) {
+        let Some(bare_jid) = Self::user_jid(entity) else {
+            return;
+        };
+        let Some(resources) = self.demote_user_actor(&bare_jid).await else {
+            return;
+        };
+        let _ = self
+            .force_detach_resources(resources, ForceDetachReason::OwnershipLost)
+            .await;
     }
 
     async fn health_check(&self, entity: &Entity) -> bool {
@@ -702,6 +947,15 @@ impl LocallyClaimedEntities for CombinedLocalClaims {
         owned
     }
 
+    async fn demote_all_on_self_fence(&self) -> bool {
+        let (sm, room, user) = tokio::join!(
+            self.sm.demote_all_on_self_fence(),
+            self.room.demote_all_on_self_fence(),
+            self.user.demote_all_on_self_fence(),
+        );
+        sm && room && user
+    }
+
     async fn demote(&self, entity: &Entity) {
         match entity.entity_type {
             EntityType::SmSession => self.sm.demote(entity).await,
@@ -718,19 +972,17 @@ impl LocallyClaimedEntities for CombinedLocalClaims {
         }
     }
 
-    async fn hydrate_reclaimed(&self, entities: &[(Entity, waddle_xmpp::ownership::ClaimEpoch)]) {
-        let (sm_entities, rest): (Vec<_>, Vec<_>) = entities
-            .iter()
-            .cloned()
-            .partition(|(entity, _)| entity.entity_type == EntityType::SmSession);
-        if !sm_entities.is_empty() {
-            self.sm.hydrate_reclaimed(&sm_entities).await;
+    async fn hydrate_reclaimed(
+        &self,
+        owner: &waddle_xmpp::ownership::NodeIdentity,
+        entity: &Entity,
+        epoch: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> ReclaimedEntityHydration {
+        if entity.entity_type == EntityType::SmSession {
+            self.sm.hydrate_reclaimed(owner, entity, epoch).await
+        } else {
+            ReclaimedEntityHydration::Retry
         }
-        // `RoomLocalClaims`/`UserLocalClaims` have no reclaim-hydration
-        // consumer yet (they are created through their registries' own
-        // `ensure_claimed`/`steal_stale` paths), so `rest` is intentionally
-        // not forwarded anywhere.
-        let _ = rest;
     }
 
     /// ADR-0017 Phase 3 Slice 10 FIX 1: dispatch by `EntityType`, mirroring
@@ -789,6 +1041,21 @@ mod tests {
     async fn unwired_instance_owns_nothing() {
         let local_claims = SmSessionLocalClaims::new();
         assert!(local_claims.owned().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unwired_instance_blocks_terminal_recovery_until_post_restore_wire() {
+        let local_claims = SmSessionLocalClaims::new();
+        assert!(
+            !local_claims.demote_all_on_self_fence().await,
+            "an unwired startup registry must keep node-epoch recovery fenced"
+        );
+
+        local_claims.wire(Arc::new(InMemorySmSessionRegistry::new()));
+        assert!(
+            local_claims.demote_all_on_self_fence().await,
+            "post-restore wiring publishes initialization to the recovery loop"
+        );
     }
 
     #[tokio::test]
@@ -875,7 +1142,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn user_owned_falls_back_to_connection_registry_resources() {
+    async fn user_reconciliation_ownership_excludes_connection_only_resources() {
         let user_local_claims = UserLocalClaims::new();
         let connection_registry = Arc::new(ConnectionRegistry::new());
         user_local_claims.wire_connection_registry(Arc::clone(&connection_registry));
@@ -886,10 +1153,216 @@ mod tests {
         let (outbound_tx, _outbound_rx) = tokio::sync::mpsc::channel(4);
         connection_registry.register(jid.clone(), outbound_tx);
 
-        assert_eq!(
-            user_local_claims.owned().await,
-            vec![Entity::new(EntityType::UserActor, jid.to_bare().to_string())],
-            "terminal self-fence must still see live user resources when the user registry cannot be enumerated"
+        assert!(
+            user_local_claims.owned().await.is_empty(),
+            "a physically hosted resource is not an authoritative local UserActor claim"
+        );
+    }
+
+    #[tokio::test]
+    async fn user_self_fence_force_detaches_connection_only_resources() {
+        let user_local_claims = UserLocalClaims::new();
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        user_local_claims.wire_connection_registry(Arc::clone(&connection_registry));
+
+        let jid: FullJid = "remote-socket@example.com/web"
+            .parse()
+            .expect("valid full JID");
+        let bare_jid = jid.to_bare();
+        let (outbound_tx, _outbound_rx) = tokio::sync::mpsc::channel(4);
+        let owner = connection_registry.register(jid.clone(), outbound_tx);
+        let entry = connection_registry
+            .entry_if_owner(&jid, &owner)
+            .expect("registered entry");
+        let mut force_detach_rx = entry
+            .take_force_detach_rx()
+            .expect("connection task owns force-detach receiver");
+        let force_detach_task = tokio::spawn(async move {
+            let request = force_detach_rx.recv().await.expect("force-detach request");
+            assert_eq!(request.requester_bare_jid, bare_jid);
+            assert_eq!(request.reason, ForceDetachReason::NodeSelfFenced);
+            let _ = request.ack.send(ForceDetachOutcome::NotPersisted);
+        });
+
+        assert!(user_local_claims.demote_all_on_self_fence().await);
+        force_detach_task.await.expect("force-detach task");
+
+        assert!(
+            !connection_registry.is_connected(&jid),
+            "whole-node self-fence must still close every socket physically hosted here"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn user_self_fence_force_detach_timeout_is_concurrent_across_resources() {
+        let user_local_claims = UserLocalClaims::new();
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        user_local_claims.wire_connection_registry(Arc::clone(&connection_registry));
+
+        let mut receivers = Vec::new();
+        for resource in ["phone", "tablet", "desktop"] {
+            let jid: FullJid = format!("remote-socket@example.com/{resource}")
+                .parse()
+                .expect("valid full JID");
+            let (outbound_tx, _outbound_rx) = tokio::sync::mpsc::channel(4);
+            let owner = connection_registry.register(jid.clone(), outbound_tx);
+            let entry = connection_registry
+                .entry_if_owner(&jid, &owner)
+                .expect("registered entry");
+            receivers.push(
+                entry
+                    .take_force_detach_rx()
+                    .expect("connection task owns force-detach receiver"),
+            );
+        }
+
+        let teardown = tokio::spawn({
+            let user_local_claims = Arc::clone(&user_local_claims);
+            async move { user_local_claims.demote_all_on_self_fence().await }
+        });
+        let mut pending_requests = Vec::new();
+        for receiver in &mut receivers {
+            let request = receiver.recv().await.expect("force-detach request");
+            assert_eq!(request.reason, ForceDetachReason::NodeSelfFenced);
+            pending_requests.push(request);
+        }
+
+        tokio::time::advance(USER_FORCE_DETACH_ACK_TIMEOUT + Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            teardown.is_finished(),
+            "three unresponsive resources must share one timeout window, not wait serially"
+        );
+        assert!(
+            !teardown.await.expect("terminal teardown task"),
+            "an unacknowledged physical socket must keep terminal teardown incomplete"
+        );
+        drop(pending_requests);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn user_self_fence_hard_retires_non_cooperative_local_socket() {
+        let user_local_claims = UserLocalClaims::new();
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        user_local_claims.wire_connection_registry(Arc::clone(&connection_registry));
+
+        let jid: FullJid = "wedged@example.com/phone".parse().expect("valid full JID");
+        let (outbound_tx, _outbound_rx) = tokio::sync::mpsc::channel(4);
+        let owner = connection_registry.register(jid.clone(), outbound_tx);
+        let entry = connection_registry
+            .entry_if_owner(&jid, &owner)
+            .expect("registered entry");
+        let mut force_detach_rx = entry
+            .take_force_detach_rx()
+            .expect("connection owns force-detach receiver");
+        let (abort, abort_registration) = futures::future::AbortHandle::new_pair();
+        let terminated = tokio_util::sync::CancellationToken::new();
+        assert!(entry.install_retirement_handle(
+            waddle_xmpp::registry::ConnectionRetirementHandle::new(abort, terminated.clone(),)
+        ));
+        let connection_task = tokio::spawn(async move {
+            let _ =
+                futures::future::Abortable::new(std::future::pending::<()>(), abort_registration)
+                    .await;
+            terminated.cancel();
+        });
+
+        let teardown = tokio::spawn({
+            let user_local_claims = Arc::clone(&user_local_claims);
+            async move { user_local_claims.demote_all_on_self_fence().await }
+        });
+        let pending_request = force_detach_rx.recv().await.expect("force-detach request");
+        tokio::time::advance(USER_FORCE_DETACH_ACK_TIMEOUT + Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+
+        assert!(teardown.await.expect("terminal teardown task"));
+        assert!(!connection_registry.is_connected(&jid));
+        connection_task.await.expect("hard-retired connection task");
+        drop(pending_request);
+    }
+
+    #[tokio::test]
+    async fn user_self_fence_retires_remote_mirror_after_confirmed_socket_retirement() {
+        let user_local_claims = UserLocalClaims::new();
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        user_local_claims.wire_connection_registry(Arc::clone(&connection_registry));
+
+        let jid: FullJid = "remote-mirror@example.com/tablet"
+            .parse()
+            .expect("valid full JID");
+        let (outbound_tx, _outbound_rx) = tokio::sync::mpsc::channel(4);
+        let entry = ConnectionEntry::new_remote_mirror(outbound_tx);
+        let mut force_detach_rx = entry
+            .take_force_detach_rx()
+            .expect("mirror forwarder owns force-detach receiver");
+        connection_registry.register_entry(jid.clone(), entry);
+
+        let teardown = tokio::spawn({
+            let user_local_claims = Arc::clone(&user_local_claims);
+            async move { user_local_claims.demote_all_on_self_fence().await }
+        });
+        let request = force_detach_rx.recv().await.expect("relay request");
+        assert_eq!(request.reason, ForceDetachReason::NodeSelfFenced);
+        request
+            .ack
+            .send(ForceDetachOutcome::NotPersisted)
+            .expect("confirmed remote socket retirement");
+        assert!(teardown.await.expect("terminal teardown task"));
+        assert!(
+            !connection_registry.is_connected(&jid),
+            "owner-side proxy state must not pin this node's readiness on a remote relay"
+        );
+    }
+
+    #[tokio::test]
+    async fn closed_remote_mirror_control_queue_cannot_claim_terminal_teardown_without_compensation(
+    ) {
+        let user_local_claims = UserLocalClaims::new();
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        user_local_claims.wire_connection_registry(Arc::clone(&connection_registry));
+
+        let jid: FullJid = "remote-mirror@example.com/closed"
+            .parse()
+            .expect("valid full JID");
+        let (outbound_tx, _outbound_rx) = tokio::sync::mpsc::channel(4);
+        let entry = ConnectionEntry::new_remote_mirror(outbound_tx);
+        drop(
+            entry
+                .take_force_detach_rx()
+                .expect("mirror forwarder owns force-detach receiver"),
+        );
+        connection_registry.register_entry(jid.clone(), entry);
+
+        assert!(
+            !user_local_claims.demote_all_on_self_fence().await,
+            "without a relay compensation bridge, a closed queue must keep terminal teardown incomplete"
+        );
+        assert!(
+            connection_registry.is_connected(&jid),
+            "uncertain physical-socket retirement must retain proxy state for retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn user_self_fence_bulk_demotes_every_actor_in_one_registry_operation() {
+        let user_local_claims = UserLocalClaims::new();
+        let registry = spawn_user_registry();
+        user_local_claims.wire(registry.clone());
+        for username in ["one", "two", "three"] {
+            registry
+                .ask(waddle_xmpp::registry::GetOrCreateUser {
+                    bare_jid: user_jid(username),
+                })
+                .await
+                .expect("create user actor");
+        }
+        assert_eq!(user_local_claims.owned().await.len(), 3);
+
+        assert!(user_local_claims.demote_all_on_self_fence().await);
+
+        assert!(
+            user_local_claims.owned().await.is_empty(),
+            "terminal bulk demotion must atomically drain the user registry"
         );
     }
 
@@ -1061,6 +1534,122 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn user_demote_detaches_exact_stale_actor_entry_not_same_jid_replacement() {
+        let user_local_claims = UserLocalClaims::new();
+        let registry = spawn_user_registry();
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        user_local_claims.wire(registry.clone());
+        user_local_claims.wire_connection_registry(Arc::clone(&connection_registry));
+
+        let jid: FullJid = "replacement@example.com/phone"
+            .parse()
+            .expect("valid full JID");
+        let (old_tx, _old_outbound_rx) = tokio::sync::mpsc::channel(4);
+        let old_owner = connection_registry.register(jid.clone(), old_tx);
+        let old_entry = connection_registry
+            .entry_if_owner(&jid, &old_owner)
+            .expect("old entry");
+        let mut old_force_detach_rx = old_entry
+            .take_force_detach_rx()
+            .expect("old connection owns force-detach receiver");
+        registry
+            .ask(waddle_xmpp::registry::RegisterUserResource {
+                jid: jid.clone(),
+                entry: old_entry,
+            })
+            .await
+            .expect("register old actor resource");
+
+        let (new_tx, _new_outbound_rx) = tokio::sync::mpsc::channel(4);
+        let new_owner = connection_registry.register(jid.clone(), new_tx);
+        let new_entry = connection_registry
+            .entry_if_owner(&jid, &new_owner)
+            .expect("replacement entry");
+        let mut new_force_detach_rx = new_entry
+            .take_force_detach_rx()
+            .expect("replacement owns force-detach receiver");
+        let old_detach = tokio::spawn(async move {
+            let request = old_force_detach_rx
+                .recv()
+                .await
+                .expect("old exact entry receives force-detach");
+            assert_eq!(request.reason, ForceDetachReason::OwnershipLost);
+            let _ = request.ack.send(ForceDetachOutcome::NotPersisted);
+        });
+
+        user_local_claims
+            .demote(&Entity::new(
+                EntityType::UserActor,
+                jid.to_bare().to_string(),
+            ))
+            .await;
+        old_detach.await.expect("old detach task");
+
+        assert!(matches!(
+            new_force_detach_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+        assert!(
+            connection_registry
+                .entry_if_owner(&jid, &new_owner)
+                .is_some(),
+            "reconciling the stale actor must not detach its same-JID replacement"
+        );
+    }
+
+    #[tokio::test]
+    async fn user_self_fence_detaches_actor_only_and_current_same_jid_incarnations() {
+        let user_local_claims = UserLocalClaims::new();
+        let registry = spawn_user_registry();
+        let connection_registry = Arc::new(ConnectionRegistry::new());
+        user_local_claims.wire(registry.clone());
+        user_local_claims.wire_connection_registry(Arc::clone(&connection_registry));
+
+        let jid: FullJid = "fence-race@example.com/phone"
+            .parse()
+            .expect("valid full JID");
+        let (old_tx, _old_outbound_rx) = tokio::sync::mpsc::channel(4);
+        let old_owner = connection_registry.register(jid.clone(), old_tx);
+        let old_entry = connection_registry
+            .entry_if_owner(&jid, &old_owner)
+            .expect("old entry");
+        let mut old_rx = old_entry
+            .take_force_detach_rx()
+            .expect("old connection receiver");
+        registry
+            .ask(waddle_xmpp::registry::RegisterUserResource {
+                jid: jid.clone(),
+                entry: old_entry,
+            })
+            .await
+            .expect("register old actor resource");
+
+        let (new_tx, _new_outbound_rx) = tokio::sync::mpsc::channel(4);
+        let new_owner = connection_registry.register(jid.clone(), new_tx);
+        let new_entry = connection_registry
+            .entry_if_owner(&jid, &new_owner)
+            .expect("new entry");
+        let mut new_rx = new_entry
+            .take_force_detach_rx()
+            .expect("new connection receiver");
+        let old_detach = tokio::spawn(async move {
+            let request = old_rx.recv().await.expect("old detach");
+            assert_eq!(request.reason, ForceDetachReason::NodeSelfFenced);
+            let _ = request.ack.send(ForceDetachOutcome::NotPersisted);
+        });
+        let new_detach = tokio::spawn(async move {
+            let request = new_rx.recv().await.expect("new detach");
+            assert_eq!(request.reason, ForceDetachReason::NodeSelfFenced);
+            let _ = request.ack.send(ForceDetachOutcome::NotPersisted);
+        });
+
+        assert!(user_local_claims.demote_all_on_self_fence().await);
+        old_detach.await.expect("old detach task");
+        new_detach.await.expect("new detach task");
+        assert!(!connection_registry.is_connected(&jid));
+    }
+
+    #[tokio::test]
     async fn combined_local_claims_routes_user_actor_operations() {
         let sm_local_claims = SmSessionLocalClaims::new();
         let room_local_claims = RoomLocalClaims::new();
@@ -1122,6 +1711,39 @@ mod tests {
         assert!(
             !room_local_claims.health_check(&entity).await,
             "no live local actor must report unhealthy, never healthy"
+        );
+    }
+
+    #[tokio::test]
+    async fn room_self_fence_bulk_demotes_every_actor_in_one_registry_operation() {
+        let room_local_claims = RoomLocalClaims::new();
+        let registry = waddle_xmpp::muc::RoomRegistry::spawn(
+            "muc.example.com".to_string(),
+            test_occupant_id_secret(),
+            None,
+        );
+        room_local_claims.wire(registry.clone());
+        for room in ["one", "two", "three"] {
+            let room_jid: jid::BareJid = format!("{room}@muc.example.com")
+                .parse()
+                .expect("valid room JID");
+            registry
+                .get_or_create_room(
+                    room_jid,
+                    format!("waddle-{room}"),
+                    format!("channel-{room}"),
+                    waddle_xmpp::muc::RoomConfig::default(),
+                )
+                .await
+                .expect("create room");
+        }
+        assert_eq!(room_local_claims.owned().await.len(), 3);
+
+        assert!(room_local_claims.demote_all_on_self_fence().await);
+
+        assert!(
+            room_local_claims.owned().await.is_empty(),
+            "terminal bulk demotion must atomically drain the room registry"
         );
     }
 

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -77,6 +77,8 @@ pub mod ordered_relay;
 /// builds on the relay message set.
 #[cfg(feature = "clustering")]
 pub mod relay;
+#[cfg(feature = "clustering")]
+pub mod remote_resource_admission;
 /// The `RemoteResumeAsker` implementation over `RelayHandle` (ADR-0017
 /// Phase 3 Slice 6) — the resuming node's side of the cross-node XEP-0198
 /// resume live-steal handshake. Public so `server/http.rs` can construct it.
@@ -158,31 +160,99 @@ pub(crate) fn keypair_slot_table_lock() -> &'static tokio::sync::Mutex<()> {
 /// plane (ADR-0017 element 4, Phase 3 Slice 2): flipped to not-ready the
 /// instant a node self-fences (node-lease heartbeat CAS returns zero rows,
 /// or Postgres is unreachable past the lease deadline) and back to ready
-/// only once the node has re-registered under a fresh `node_id`/
-/// `node_epoch` and satisfied the re-acquisition hysteresis gate. Cloning
-/// shares the same underlying flag (cheap `Arc` clone).
+/// only once the node has re-registered under a fresh `node_epoch` and
+/// satisfied the re-acquisition hysteresis gate. Cloning shares the same
+/// underlying state (cheap `Arc` clone).
 ///
 /// Unconditionally compiled (no `clustering` feature gate) so `AppState`
 /// and the `/ready`/`/readyz` handlers can hold one field regardless of
 /// build: a non-clustering deployment (or a `clustering`-feature build with
 /// `clustering.enabled = false`) never flips it, so it stays ready forever
 /// — today's behavior, unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClusteringAdmissionToken(u64);
+
+/// Readiness and its admission generation are packed into one atomic word:
+/// bit 0 is the ready flag and the remaining bits are the generation. This
+/// makes a ready -> fenced -> ready transition observably different from the
+/// original ready state, even when a connection is suspended across the
+/// complete transition.
 #[derive(Clone)]
-pub struct ClusteringReadiness(std::sync::Arc<std::sync::atomic::AtomicBool>);
+pub struct ClusteringReadiness(std::sync::Arc<std::sync::atomic::AtomicU64>);
 
 impl ClusteringReadiness {
+    const TERMINAL_FENCED_STATE: u64 = u64::MAX - 1;
+
     pub fn new() -> Self {
-        Self(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
-            true,
-        )))
+        Self(std::sync::Arc::new(std::sync::atomic::AtomicU64::new(1)))
     }
 
     pub fn is_ready(&self) -> bool {
-        self.0.load(std::sync::atomic::Ordering::Acquire)
+        self.0.load(std::sync::atomic::Ordering::Acquire) & 1 == 1
     }
 
     pub fn set_ready(&self, ready: bool) {
-        self.0.store(ready, std::sync::atomic::Ordering::Release);
+        if ready {
+            let _ = self.0.fetch_update(
+                std::sync::atomic::Ordering::AcqRel,
+                std::sync::atomic::Ordering::Acquire,
+                |state| {
+                    (state != Self::TERMINAL_FENCED_STATE && state & 1 == 0).then_some(state | 1)
+                },
+            );
+            return;
+        }
+
+        let _ = self.0.fetch_update(
+            std::sync::atomic::Ordering::AcqRel,
+            std::sync::atomic::Ordering::Acquire,
+            |state| {
+                if state & 1 == 0 {
+                    return None;
+                }
+                Some(state.checked_add(1).unwrap_or(Self::TERMINAL_FENCED_STATE))
+            },
+        );
+    }
+
+    /// Capture the exact ready generation a physical connection started in.
+    /// `None` fails closed when the node is already fenced.
+    pub fn capture_admission(&self) -> Option<ClusteringAdmissionToken> {
+        let state = self.0.load(std::sync::atomic::Ordering::Acquire);
+        (state & 1 == 1).then_some(ClusteringAdmissionToken(state >> 1))
+    }
+
+    /// True only while `token` still names the currently-ready generation.
+    /// A complete false -> true ABA transition increments the generation and
+    /// therefore cannot re-admit a pre-fence connection.
+    pub fn admits(&self, token: ClusteringAdmissionToken) -> bool {
+        let state = self.0.load(std::sync::atomic::Ordering::Acquire);
+        state & 1 == 1 && state >> 1 == token.0
+    }
+}
+
+#[cfg(test)]
+mod readiness_tests {
+    use super::*;
+
+    #[test]
+    fn admission_generation_exhaustion_is_terminally_fail_closed() {
+        let readiness = ClusteringReadiness(std::sync::Arc::new(
+            std::sync::atomic::AtomicU64::new(u64::MAX),
+        ));
+        let token = readiness
+            .capture_admission()
+            .expect("the boundary state starts ready");
+
+        readiness.set_ready(false);
+        assert!(!readiness.is_ready());
+        assert!(!readiness.admits(token));
+
+        readiness.set_ready(true);
+        assert!(
+            !readiness.is_ready(),
+            "the terminal exhausted state must never be re-opened"
+        );
     }
 }
 
@@ -256,6 +326,10 @@ pub enum ClusteringError {
     #[cfg(feature = "clustering")]
     #[error("clustering ISR token store initialization failed: {0}")]
     IsrTokenStoreInit(waddle_xmpp::isr::IsrTokenStoreError),
+
+    #[cfg(feature = "clustering")]
+    #[error("clustered remote-resource admission store initialization failed: {0}")]
+    RemoteResourceAdmissionStoreInit(remote_resource_admission::RemoteResourceAdmissionError),
 }
 
 /// Derive the clustering subsystem's own cancellation scope from the
@@ -372,6 +446,9 @@ pub struct ClusteringHandles {
     /// as `local_claims`: `NodeLeaseStore` only exists behind `clustering`.
     #[cfg(feature = "clustering")]
     pub node_lease: Option<Arc<dyn claims::NodeLeaseStore>>,
+    #[cfg(feature = "clustering")]
+    pub remote_resource_admission_store:
+        Option<Arc<dyn remote_resource_admission::RemoteResourceAdmissionStore>>,
     /// The configured node-lease TTL (ADR-0017 element 4/Q6) — the orphan
     /// reaper janitor needs this same value to bind into its `expire` calls
     /// and has no other route to `ClusteringNodeLeaseConfig` (it runs off
@@ -473,41 +550,6 @@ impl ClusteringHandles {
         #[cfg(not(feature = "clustering"))]
         {
             None
-        }
-    }
-
-    /// ADR-0017 Phase 3 Slice 7 FIX 2 (council-adjudicated): hard-kill the
-    /// locally-claimed `RoomActor` for `room_jid`, mirroring the Demote
-    /// relay ask's exact receiving-side call
-    /// (`RelayActor`'s `Demote` handler calling
-    /// `room_local_claims.demote(&entity)`). Every mutation-handler call
-    /// site that observes `RoomMutationError::NotOwner`/an equivalent
-    /// per-message `NotOwner` variant calls this so the deposed actor
-    /// genuinely stops serving (hard `ActorRef::kill()`), instead of only
-    /// bouncing the one request that discovered the ownership loss and
-    /// leaving the actor to keep answering (and re-discovering the same
-    /// staleness) for every subsequent ask.
-    ///
-    /// A no-op when clustering is disabled, this binary lacks the
-    /// `clustering` Cargo feature, or `room_local_claims` was never wired
-    /// (defensive — `NotOwner` can only ever be produced when a durable
-    /// store, and therefore `room_local_claims`, is configured).
-    pub async fn demote_room_actor(&self, room_jid: &jid::BareJid) {
-        #[cfg(feature = "clustering")]
-        {
-            use self_fence::LocallyClaimedEntities as _;
-            let Some(room_local_claims) = &self.room_local_claims else {
-                return;
-            };
-            let entity = waddle_xmpp::ownership::Entity::new(
-                waddle_xmpp::ownership::EntityType::RoomActor,
-                room_jid.to_string(),
-            );
-            room_local_claims.demote(&entity).await;
-        }
-        #[cfg(not(feature = "clustering"))]
-        {
-            let _ = room_jid;
         }
     }
 }
@@ -638,7 +680,8 @@ pub async fn start_if_enabled(
         // coupling" precedent). Register once, up front (fail startup on a
         // genuine registration failure, exactly like the keypair-slot
         // acquire above), then hand the loop off to the background task.
-        let node_lease = claims::PostgresClaimStore::new(db.clone());
+        let node_lease =
+            claims::PostgresClaimStore::with_lease_ttl(db.clone(), config.node_lease.lease_ttl);
         let node_identity = waddle_xmpp::ownership::NodeIdentity::new(
             handle.node_id.as_str().to_string(),
             uuid::Uuid::new_v4().to_string(),
@@ -648,13 +691,17 @@ pub async fn start_if_enabled(
         // sibling var) rather than a raw `std::env::var` at this call site.
         let pod_template_hash = config.pod_template_hash.clone();
         let local_peer_id = handle.local_peer_id.to_string();
-        prepare_node_lease(
+        let startup_recovery_source = prepare_node_lease(
             &node_lease,
             &node_identity,
             pod_template_hash.clone(),
             Some(local_peer_id.clone()),
+            config.node_lease.lease_ttl,
         )
         .await?;
+        if startup_recovery_source.is_some() {
+            readiness.set_ready(false);
+        }
 
         // ADR-0017 Phase 3 Slice 4 follow-up plumbing: hand back a
         // `ClaimStore` view onto the same `clustering_claims` rows the
@@ -665,9 +712,27 @@ pub async fn start_if_enabled(
         // acquire/fence calls instead of capturing a stale one at
         // construction time. `claim_store_handle` wraps the same `db`
         // clone as `node_lease` — not a second, independent store.
-        let claim_store_handle: Arc<dyn waddle_xmpp::ownership::ClaimStore> =
-            Arc::new(claims::PostgresClaimStore::new(db.clone()));
+        let claim_store_handle: Arc<dyn waddle_xmpp::ownership::ClaimStore> = Arc::new(
+            claims::PostgresClaimStore::with_lease_ttl(db.clone(), config.node_lease.lease_ttl),
+        );
         let live_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(node_identity.clone());
+        let remote_resource_admission_store: Arc<
+            dyn remote_resource_admission::RemoteResourceAdmissionStore,
+        > = {
+            use remote_resource_admission::RemoteResourceAdmissionStore as _;
+            let store =
+                remote_resource_admission::PostgresRemoteResourceAdmissionStore::new(db.clone());
+            store
+                .ensure_schema()
+                .await
+                .map_err(ClusteringError::RemoteResourceAdmissionStoreInit)?;
+            Arc::new(store)
+        };
+        // The relay actor was spawned before the claims layer existed, so
+        // complete its destructive resume-steal gate now. A delayed ask is
+        // authorized only when both this exact live incarnation and the
+        // request's observed claim generation still match Postgres.
+        resume_bridge.wire_claim_fence(Arc::clone(&claim_store_handle), live_identity.clone());
         // ADR-0017 Phase 3 Slice 5 (carried debt (b)): construct the real
         // `LocallyClaimedEntities` empty now, hand the same `Arc` to both
         // `run_node_lease` (below) and the returned handles — the SM
@@ -686,8 +751,9 @@ pub async fn start_if_enabled(
             Arc::clone(&room_local_claims),
             Arc::clone(&user_local_claims),
         );
-        let node_lease_handle: Arc<dyn claims::NodeLeaseStore> =
-            Arc::new(claims::PostgresClaimStore::new(db.clone()));
+        let node_lease_handle: Arc<dyn claims::NodeLeaseStore> = Arc::new(
+            claims::PostgresClaimStore::with_lease_ttl(db.clone(), config.node_lease.lease_ttl),
+        );
         // ADR-0017 Phase 3 Slice 7: the durable MUC room store. Built here
         // (not deferred to `server/mod.rs`) because it only needs `db`/
         // `live_identity`/`clustering_stop` — all already in scope — unlike
@@ -734,6 +800,7 @@ pub async fn start_if_enabled(
             muc_durable_store: Some(muc_durable_store),
             isr_token_store: Some(isr_token_store),
             node_lease: Some(node_lease_handle),
+            remote_resource_admission_store: Some(remote_resource_admission_store),
             lease_ttl: Some(config.node_lease.lease_ttl),
             pod_template_hash: pod_template_hash.clone(),
             resume_bridge: Some(resume_bridge),
@@ -763,8 +830,12 @@ pub async fn start_if_enabled(
                 // `clustering_claims` as `claim_store_handle` above —
                 // wraps the same `db` clone, never a second, independent
                 // store.
-                claim_store: Arc::new(claims::PostgresClaimStore::new(db.clone())),
+                claim_store: Arc::new(claims::PostgresClaimStore::with_lease_ttl(
+                    db.clone(),
+                    config.node_lease.lease_ttl,
+                )),
                 claim_release_budget: config.node_lease.claim_release_budget,
+                startup_recovery_source,
             },
         ));
         Ok((handles, ClusteringShutdown(Some(node_lease_task))))
@@ -778,13 +849,14 @@ pub async fn start_if_enabled(
 #[cfg(feature = "clustering")]
 async fn register_node_lease(
     node_lease: &claims::PostgresClaimStore,
+    expected_previous: Option<&waddle_xmpp::ownership::NodeIdentity>,
     identity: &waddle_xmpp::ownership::NodeIdentity,
     pod_template_hash: Option<String>,
     peer_id: Option<String>,
 ) -> Result<(), ClusteringError> {
     use claims::NodeLeaseStore as _;
     node_lease
-        .register_with_peer_id(identity, pod_template_hash, peer_id)
+        .register_initial_with_peer_id(expected_previous, identity, pod_template_hash, peer_id)
         .await
         .map_err(ClusteringError::NodeLease)
 }
@@ -799,14 +871,54 @@ async fn prepare_node_lease(
     identity: &waddle_xmpp::ownership::NodeIdentity,
     pod_template_hash: Option<String>,
     peer_id: Option<String>,
-) -> Result<(), ClusteringError> {
+    lease_ttl: Duration,
+) -> Result<Option<waddle_xmpp::ownership::NodeIdentity>, ClusteringError> {
+    use claims::NodeLeaseStore as _;
     use waddle_xmpp::ownership::ClaimStore as _;
 
     node_lease
         .ensure_schema()
         .await
         .map_err(ClusteringError::ClaimStoreSchema)?;
-    register_node_lease(node_lease, identity, pod_template_hash, peer_id).await
+    let previous = node_lease
+        .registered_identity(&identity.node_id)
+        .await
+        .map_err(ClusteringError::NodeLease)?;
+    let replaced = previous
+        .as_ref()
+        .filter(|previous| *previous != identity)
+        .cloned();
+    if let Some(previous) = replaced.as_ref() {
+        let expired = node_lease
+            .expire(previous, lease_ttl)
+            .await
+            .map_err(ClusteringError::NodeLease)?;
+        if !expired {
+            return Err(ClusteringError::NodeLease(
+                waddle_xmpp::ownership::ClaimError::Conflict,
+            ));
+        }
+        node_lease
+            .register_draining_with_peer_id(
+                previous,
+                identity,
+                pod_template_hash,
+                peer_id,
+                lease_ttl,
+            )
+            .await
+            .map_err(ClusteringError::NodeLease)?;
+        return Ok(replaced);
+    }
+    register_node_lease(
+        node_lease,
+        previous.as_ref(),
+        identity,
+        pod_template_hash,
+        peer_id,
+    )
+    .await?;
+    Ok(None)
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -895,6 +1007,7 @@ mod tests {
                 &identity,
                 Some("test-template".to_string()),
                 Some("test-peer".to_string()),
+                Duration::from_secs(30),
             )
             .await
             .map_err(|error| anyhow::anyhow!("prepare node lease: {error}"))?;
@@ -937,6 +1050,56 @@ mod tests {
                 .map_err(|error| anyhow::anyhow!("decode expired: {error}"))?;
             if expired {
                 anyhow::bail!("fresh node lease row must start non-expired");
+            }
+            drop(rows);
+            conn.execute(
+                "UPDATE clustering_nodes SET heartbeat = now() - interval '2 minutes' WHERE node_id = ?",
+                crate::db_params![identity.node_id.clone()],
+            )
+            .await
+            .map_err(|error| anyhow::anyhow!("backdate prior incarnation: {error}"))?;
+            drop(conn);
+
+            // A later process may lease the same stable swarm node id. It
+            // must first expire the exact prior incarnation and then replace
+            // it through an expected-old CAS.
+            let restarted = NodeIdentity::new(
+                identity.node_id.clone(),
+                uuid::Uuid::new_v4().to_string(),
+            );
+            prepare_node_lease(
+                &store,
+                &restarted,
+                Some("test-template-2".to_string()),
+                Some("test-peer".to_string()),
+                Duration::from_secs(30),
+            )
+            .await
+            .map_err(|error| anyhow::anyhow!("prepare restarted node lease: {error}"))?;
+            if store
+                .registered_identity(&identity.node_id)
+                .await
+                .map_err(|error| anyhow::anyhow!("read restarted identity: {error}"))?
+                != Some(restarted.clone())
+            {
+                anyhow::bail!("restart did not install the expected fresh incarnation");
+            }
+
+            use claims::NodeLeaseStore as _;
+            let delayed_old = store
+                .register_with_peer_id(
+                    &identity,
+                    Some("stale-template".to_string()),
+                    Some("test-peer".to_string()),
+                )
+                .await;
+            if !matches!(
+                delayed_old,
+                Err(waddle_xmpp::ownership::ClaimError::Conflict)
+            ) {
+                anyhow::bail!(
+                    "a delayed old bootstrap registration rolled back the newer epoch: {delayed_old:?}"
+                );
             }
             Ok(())
         }

--- a/server/crates/waddle-server/src/clustering/ordered_relay.rs
+++ b/server/crates/waddle-server/src/clustering/ordered_relay.rs
@@ -6,11 +6,10 @@
 //! ConnectionRegistry, pending delivery, or XEP-0198 state.
 
 use super::codec::RemoteStanza;
-use super::NodeId;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
 use std::hash::{Hash, Hasher};
-use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType};
+use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
 use waddle_xmpp::pending_delivery::SmSessionId;
 
 const RECENT_ACK_CACHE_PER_CHANNEL: usize = 64;
@@ -288,7 +287,7 @@ pub struct RemoteStanzaEnvelope {
     /// against the authenticated relay transport/registry origin before any
     /// delivery effect; this field is not proof by itself and is deliberately
     /// not part of the ordering key.
-    pub asserted_origin_node: NodeId,
+    pub asserted_origin_node: NodeIdentity,
     pub channel: OrderedRelayChannel,
     /// Per-channel sender sequence for the origin-stream/recipient pair.
     pub sequence: OrderedRelaySequence,
@@ -325,7 +324,7 @@ impl RemoteStanzaEnvelope {
 
 #[derive(Serialize)]
 struct RemoteStanzaEnvelopeSigningView<'a> {
-    asserted_origin_node: &'a NodeId,
+    asserted_origin_node: &'a NodeIdentity,
     channel: &'a OrderedRelayChannel,
     sequence: OrderedRelaySequence,
     origin_inbound_sequence: OriginInboundSequence,
@@ -512,7 +511,7 @@ pub struct OrderedRelaySenderState {
 impl OrderedRelaySenderState {
     pub fn next_envelope(
         &mut self,
-        asserted_origin_node: NodeId,
+        asserted_origin_node: NodeIdentity,
         channel: OrderedRelayChannel,
         origin_inbound_sequence: OriginInboundSequence,
         claims: OrderedRelayEnvelopeClaims,
@@ -1027,8 +1026,8 @@ mod invariant_tests {
         }
     }
 
-    fn origin_node() -> NodeId {
-        NodeId::new("origin-node".to_string())
+    fn origin_node() -> NodeIdentity {
+        NodeIdentity::new("origin-node", "origin-epoch")
     }
 
     fn inbound(sequence: u32) -> OriginInboundSequence {
@@ -1163,8 +1162,8 @@ mod tests {
         }
     }
 
-    fn origin_node() -> NodeId {
-        NodeId::new("origin-node".to_string())
+    fn origin_node() -> NodeIdentity {
+        NodeIdentity::new("origin-node", "origin-epoch")
     }
 
     fn room_jid() -> jid::BareJid {
@@ -1299,7 +1298,7 @@ mod tests {
 
         let first = state
             .next_envelope(
-                NodeId::new("old-node".to_string()),
+                NodeIdentity::new("old-node", "old-epoch"),
                 channel.clone(),
                 inbound(1),
                 claims(),
@@ -1308,7 +1307,7 @@ mod tests {
             .expect("first");
         let second = state
             .next_envelope(
-                NodeId::new("new-node".to_string()),
+                NodeIdentity::new("new-node", "new-epoch"),
                 channel,
                 inbound(2),
                 claims(),
@@ -1482,7 +1481,7 @@ mod tests {
     fn receiver_replays_duplicate_ack_across_mutable_provenance_changes() {
         let mut receiver = OrderedRelayReceiverState::default();
         let envelope = RemoteStanzaEnvelope {
-            asserted_origin_node: NodeId::new("old-node".to_string()),
+            asserted_origin_node: NodeIdentity::new("old-node", "old-epoch"),
             channel: channel(),
             sequence: OrderedRelaySequence(1),
             origin_inbound_sequence: inbound(1),
@@ -1501,7 +1500,7 @@ mod tests {
         ));
 
         let retry_after_move = RemoteStanzaEnvelope {
-            asserted_origin_node: NodeId::new("new-node".to_string()),
+            asserted_origin_node: NodeIdentity::new("new-node", "new-epoch"),
             origin_claim: OrderedRelayClaim {
                 epoch: ClaimEpoch(99),
                 ..origin_claim()

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -31,7 +31,6 @@ use super::route_bridge::{
     RemoteResourceRouteOutcome, RemoteResourceRouteTarget, RemoteResourceSocketGeneration,
     RemoteResourceStateSnapshot, RemoteResourceStateUpdate, RemoteUserSideEffect,
 };
-use super::self_fence::LocallyClaimedEntities;
 use super::NodeId;
 use kameo::actor::{ActorRef, RemoteActorRef, Spawn};
 use kameo::error::RemoteSendError;
@@ -42,7 +41,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
-use waddle_xmpp::ownership::{ClaimEpoch, Entity};
+use waddle_xmpp::ownership::{ClaimEpoch, Entity, NodeIdentity};
 
 /// Bound on this node's own wait for a local force-detach to complete when
 /// answering a [`RelayResumeSteal`] ask (ADR-0017 Phase 3 Slice 6).
@@ -327,8 +326,16 @@ fn record_ordered_relay_reply(reply: &OrderedRelayReply) {
 pub struct RelayRegisterRemoteUserResource {
     pub jid: jid::FullJid,
     pub registration_id: RemoteResourceRegistrationId,
+    pub admission_epoch: super::route_bridge::RemoteResourceAdmissionEpoch,
     pub socket_generation: RemoteResourceSocketGeneration,
-    pub socket_node: NodeId,
+    pub socket_node: NodeIdentity,
+    /// Exact UserActor-owner incarnation the socket node resolved before
+    /// sending this registration. The receiver rejects a delayed request when
+    /// its stable process node id has since rotated to a new lease epoch.
+    pub expected_user_owner: NodeIdentity,
+    /// Exact UserActor claim generation observed alongside
+    /// `expected_user_owner`.
+    pub expected_user_claim_epoch: ClaimEpoch,
     pub state: RemoteResourceStateSnapshot,
 }
 
@@ -363,12 +370,25 @@ impl Message<RelayRegisterRemoteUserResource> for RelayActor {
 pub struct RelayUnregisterRemoteUserResource {
     pub jid: jid::FullJid,
     pub registration_id: RemoteResourceRegistrationId,
+    pub admission_epoch: super::route_bridge::RemoteResourceAdmissionEpoch,
     pub socket_generation: RemoteResourceSocketGeneration,
+    pub socket_node: NodeIdentity,
+    pub expected_user_owner: NodeIdentity,
+    pub expected_user_claim_epoch: ClaimEpoch,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Reply)]
 pub struct RelayRemoteResourceUnregisterReply {
-    pub removed: bool,
+    pub status: RelayRemoteResourceUnregisterStatus,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RelayRemoteResourceUnregisterStatus {
+    /// The exact owner mirror was removed or is proven absent.
+    Terminal,
+    /// Cleanup could not be proven; the socket node must retain and retry its
+    /// exact registration evidence.
+    Retry,
 }
 
 #[kameo::remote_message("waddle.clustering.relay.remote_resource_unregister.v1")]
@@ -389,7 +409,11 @@ impl Message<RelayUnregisterRemoteUserResource> for RelayActor {
 pub struct RelayUpdateRemoteUserResource {
     pub jid: jid::FullJid,
     pub registration_id: RemoteResourceRegistrationId,
+    pub admission_epoch: super::route_bridge::RemoteResourceAdmissionEpoch,
     pub socket_generation: RemoteResourceSocketGeneration,
+    pub socket_node: NodeIdentity,
+    pub expected_user_owner: NodeIdentity,
+    pub expected_user_claim_epoch: ClaimEpoch,
     pub update: RemoteResourceStateUpdate,
 }
 
@@ -423,7 +447,11 @@ impl Message<RelayUpdateRemoteUserResource> for RelayActor {
 pub struct RelayRemoteUserSideEffect {
     pub source_jid: jid::FullJid,
     pub registration_id: RemoteResourceRegistrationId,
+    pub admission_epoch: super::route_bridge::RemoteResourceAdmissionEpoch,
     pub socket_generation: RemoteResourceSocketGeneration,
+    pub socket_node: NodeIdentity,
+    pub expected_user_owner: NodeIdentity,
+    pub expected_user_claim_epoch: ClaimEpoch,
     pub effect: RemoteUserSideEffect,
 }
 
@@ -457,7 +485,11 @@ impl Message<RelayRemoteUserSideEffect> for RelayActor {
 pub struct RelayRouteRemoteResourceStanza {
     pub source_jid: jid::FullJid,
     pub registration_id: RemoteResourceRegistrationId,
+    pub admission_epoch: super::route_bridge::RemoteResourceAdmissionEpoch,
     pub socket_generation: RemoteResourceSocketGeneration,
+    pub socket_node: NodeIdentity,
+    pub expected_user_owner: NodeIdentity,
+    pub expected_user_claim_epoch: ClaimEpoch,
     pub target: RemoteResourceRouteTarget,
 }
 
@@ -490,6 +522,7 @@ pub struct RelayDeliverRemoteResourceFrame {
 pub enum RelayRemoteResourceFrameStatus {
     Delivered,
     Backpressure,
+    StaleRegistration,
     Unavailable,
 }
 
@@ -516,12 +549,21 @@ impl Message<RelayDeliverRemoteResourceFrame> for RelayActor {
 pub struct RelayForceDetachRemoteUserResource {
     pub jid: jid::FullJid,
     pub registration_id: RemoteResourceRegistrationId,
+    pub admission_epoch: super::route_bridge::RemoteResourceAdmissionEpoch,
+    pub socket_generation: RemoteResourceSocketGeneration,
+    pub socket_node: NodeIdentity,
+    pub expected_user_owner: NodeIdentity,
+    pub expected_user_claim_epoch: ClaimEpoch,
     pub requester_bare_jid: jid::BareJid,
+    pub reason: waddle_xmpp::registry::ForceDetachReason,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RelayRemoteResourceForceDetachStatus {
     Detached,
+    /// The requested authority was stale, so the socket node terminally
+    /// invalidated its own matching physical registration instead.
+    Invalidated,
     NotLive,
     Refused,
     Unknown,
@@ -563,6 +605,12 @@ impl Message<RelayForceDetachRemoteUserResource> for RelayActor {
 pub struct RelayResumeSteal {
     pub stream_id: waddle_xmpp::pending_delivery::SmSessionId,
     pub requester_bare_jid: jid::BareJid,
+    /// Exact node incarnation observed as owner by the asker. A delayed ask
+    /// must not detach a session hosted by a newer incarnation that reused
+    /// the same stable relay address.
+    pub expected_owner: NodeIdentity,
+    /// Exact claim generation observed alongside `expected_owner`.
+    pub observed: ClaimEpoch,
 }
 
 /// Reply to [`RelayResumeSteal`].
@@ -614,6 +662,8 @@ impl Message<RelayResumeSteal> for RelayActor {
                 .request_forced_detach(
                     &msg.stream_id,
                     &msg.requester_bare_jid,
+                    &msg.expected_owner,
+                    msg.observed,
                     LOCAL_FORCE_DETACH_ACK_TIMEOUT,
                 )
                 .await
@@ -645,6 +695,7 @@ impl Message<RelayResumeSteal> for RelayActor {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Demote {
     pub entity: Entity,
+    pub expected_previous_owner: NodeIdentity,
     pub new_epoch: ClaimEpoch,
 }
 
@@ -666,7 +717,9 @@ impl Message<Demote> for RelayActor {
     type Reply = DemoteReply;
 
     async fn handle(&mut self, msg: Demote, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
-        self.room_local_claims.demote(&msg.entity).await;
+        self.room_local_claims
+            .demote_if_superseded(&msg.entity, msg.expected_previous_owner, msg.new_epoch)
+            .await;
         DemoteReply::Acked
     }
 }
@@ -1554,12 +1607,14 @@ impl RelayHandle {
         &mut self,
         stream_id: waddle_xmpp::pending_delivery::SmSessionId,
         requester_bare_jid: jid::BareJid,
+        expected_owner: NodeIdentity,
+        observed: ClaimEpoch,
     ) -> Result<RelayResumeStealReply, RelayAskError> {
         let stop_token = self.stop_token.clone();
         tokio::select! {
             biased;
             _ = stop_token.cancelled() => Err(RelayAskError::Cancelled),
-            result = self.resume_steal_inner(stream_id, requester_bare_jid) => result,
+            result = self.resume_steal_inner(stream_id, requester_bare_jid, expected_owner, observed) => result,
         }
     }
 
@@ -1567,10 +1622,14 @@ impl RelayHandle {
         &mut self,
         stream_id: waddle_xmpp::pending_delivery::SmSessionId,
         requester_bare_jid: jid::BareJid,
+        expected_owner: NodeIdentity,
+        observed: ClaimEpoch,
     ) -> Result<RelayResumeStealReply, RelayAskError> {
         let message = RelayResumeSteal {
             stream_id,
             requester_bare_jid,
+            expected_owner,
+            observed,
         };
         let remote_ref = self.resolve().await?;
         match remote_ref
@@ -1605,22 +1664,28 @@ impl RelayHandle {
     pub async fn demote(
         &mut self,
         entity: Entity,
+        expected_previous_owner: NodeIdentity,
         new_epoch: ClaimEpoch,
     ) -> Result<DemoteReply, RelayAskError> {
         let stop_token = self.stop_token.clone();
         tokio::select! {
             biased;
             _ = stop_token.cancelled() => Err(RelayAskError::Cancelled),
-            result = self.demote_inner(entity, new_epoch) => result,
+            result = self.demote_inner(entity, expected_previous_owner, new_epoch) => result,
         }
     }
 
     async fn demote_inner(
         &mut self,
         entity: Entity,
+        expected_previous_owner: NodeIdentity,
         new_epoch: ClaimEpoch,
     ) -> Result<DemoteReply, RelayAskError> {
-        let message = Demote { entity, new_epoch };
+        let message = Demote {
+            entity,
+            expected_previous_owner,
+            new_epoch,
+        };
         let remote_ref = self.resolve().await?;
         match remote_ref
             .ask(&message)
@@ -1784,8 +1849,7 @@ mod tests {
 
         async fn release_many(
             &self,
-            _entities: &[Entity],
-            _me: &NodeIdentity,
+            _grants: &[waddle_xmpp::ownership::ClaimGrant],
         ) -> Result<(), ClaimError> {
             unreachable!("ordered relay timeout test only calls current_claim")
         }
@@ -1842,6 +1906,8 @@ mod tests {
         async fn report_steal_intent(
             &self,
             _entity: &Entity,
+            _target_owner: &NodeIdentity,
+            _target_epoch: ClaimEpoch,
             _reporter: &NodeIdentity,
         ) -> Result<(), ClaimError> {
             Ok(())
@@ -1908,7 +1974,7 @@ mod tests {
             .insert(Lang::new(), "timeout test".to_string());
 
         RemoteStanzaEnvelope {
-            asserted_origin_node: NodeId::new("origin-node".to_string()),
+            asserted_origin_node: NodeIdentity::new("origin-node", "origin-epoch"),
             channel: OrderedRelayChannel {
                 origin: OrderedRelayOrigin::SmSession(origin_stream.clone()),
                 recipient: OrderedRelayRecipient::FullJid(target.clone()),
@@ -1954,6 +2020,9 @@ mod tests {
             claim_store: Arc::new(HangingClaimStore),
             allowlist_store: Arc::new(NoopAllowlist),
             node_lease: Arc::new(NoopNodeLease),
+            remote_resource_admission_store: Arc::new(
+                crate::clustering::remote_resource_admission::InMemoryRemoteResourceAdmissionStore::default(),
+            ),
             node_identity: SharedNodeIdentity::new(NodeIdentity::new("receiver", "epoch")),
             connection_registry: Arc::new(ConnectionRegistry::new()),
             user_registry: UserRegistryActor::spawn(UserRegistryActor::new()),
@@ -2128,12 +2197,22 @@ mod tests {
     #[tokio::test]
     async fn slow_force_detach_does_not_delay_a_concurrent_relay_ping() {
         use kameo::actor::Spawn;
+        use waddle_xmpp::ownership::{ClaimStore, EntityType, InProcessClaimStore};
         use waddle_xmpp::pending_delivery::SmSessionId;
         use waddle_xmpp::registry::{ConnectionRegistry, ForceDetachOutcome};
 
         let jid: jid::FullJid = "alice@example.com/phone".parse().expect("valid full jid");
         let requester: jid::BareJid = "alice@example.com".parse().expect("valid bare jid");
         let stream_id = SmSessionId::new("stream-slow-detach");
+        let expected_owner = NodeIdentity::new("node-under-test", "owner-epoch");
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let claim_epoch = claim_store
+            .acquire(
+                &Entity::new(EntityType::SmSession, stream_id.as_str()),
+                &expected_owner,
+            )
+            .await
+            .expect("seed stream claim");
 
         let registry = Arc::new(ConnectionRegistry::new());
         let (outbound_tx, _outbound_rx) = tokio::sync::mpsc::channel(1);
@@ -2157,6 +2236,11 @@ mod tests {
 
         let resume_bridge = ResumeStealBridge::new();
         resume_bridge.wire(Arc::clone(&registry));
+        let claim_store_handle: Arc<dyn ClaimStore> = claim_store;
+        resume_bridge.wire_claim_fence(
+            claim_store_handle,
+            waddle_xmpp::ownership::SharedNodeIdentity::new(expected_owner.clone()),
+        );
         let actor_ref: kameo::actor::ActorRef<RelayActor> = RelayActor::spawn(RelayActor::new(
             NodeId::new("node-under-test".to_string()),
             false,
@@ -2179,6 +2263,8 @@ mod tests {
                     .ask(RelayResumeSteal {
                         stream_id,
                         requester_bare_jid: requester,
+                        expected_owner,
+                        observed: claim_epoch,
                     })
                     .await
             }

--- a/server/crates/waddle-server/src/clustering/remote_resource_admission.rs
+++ b/server/crates/waddle-server/src/clustering/remote_resource_admission.rs
@@ -1,0 +1,898 @@
+//! Durable, cluster-wide ordering for physical full-JID socket admissions.
+//!
+//! A per-process socket generation cannot order two concurrent binds hosted by
+//! different nodes. This store gives each bind a Postgres-sequenced epoch and
+//! keeps only the newest exact reservation for a full JID. Owner-side relay
+//! handlers prove that reservation before every effect, so a delayed register
+//! or cleanup cannot displace a newer socket.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use jid::FullJid;
+use tokio::sync::Mutex;
+use waddle_xmpp::ownership::NodeIdentity;
+
+use crate::db::{Database, DatabaseError, Transaction};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct RemoteResourceRegistrationId(uuid::Uuid);
+
+impl RemoteResourceRegistrationId {
+    pub(crate) fn fresh() -> Self {
+        Self(uuid::Uuid::new_v4())
+    }
+
+    fn as_db_string(self) -> String {
+        self.0.to_string()
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(transparent)]
+pub struct RemoteResourceAdmissionEpoch(pub(crate) i64);
+
+#[derive(Debug, thiserror::Error)]
+pub enum RemoteResourceAdmissionError {
+    #[error("remote-resource admission backend failed: {0}")]
+    Backend(String),
+    #[error("remote-resource admission epoch space is exhausted")]
+    EpochExhausted,
+    #[error("physical socket node is not serving-eligible")]
+    StaleSocketNode,
+}
+
+fn db_error(error: DatabaseError) -> RemoteResourceAdmissionError {
+    if matches!(
+        &error,
+        DatabaseError::Internal(sqlx::Error::Database(inner))
+            if inner.code().as_deref() == Some("2200H")
+    ) {
+        return RemoteResourceAdmissionError::EpochExhausted;
+    }
+    RemoteResourceAdmissionError::Backend(error.to_string())
+}
+
+async fn lock_full_jid(
+    tx: &mut Transaction<'_>,
+    jid: &FullJid,
+) -> Result<(), RemoteResourceAdmissionError> {
+    let mut rows = tx
+        .query(
+            "SELECT pg_advisory_xact_lock(hashtextextended(?, 8718))",
+            crate::db_params![jid.to_string()],
+        )
+        .await
+        .map_err(db_error)?;
+    let _ = rows.next().await.map_err(db_error)?;
+    Ok(())
+}
+
+#[async_trait]
+pub trait RemoteResourceAdmissionStore: Send + Sync {
+    async fn ensure_schema(&self) -> Result<(), RemoteResourceAdmissionError>;
+
+    async fn reserve(
+        &self,
+        jid: &FullJid,
+        registration_id: RemoteResourceRegistrationId,
+        socket_node: &NodeIdentity,
+    ) -> Result<RemoteResourceAdmissionEpoch, RemoteResourceAdmissionError>;
+
+    async fn is_current(
+        &self,
+        jid: &FullJid,
+        registration_id: RemoteResourceRegistrationId,
+        admission_epoch: RemoteResourceAdmissionEpoch,
+        socket_node: &NodeIdentity,
+    ) -> Result<bool, RemoteResourceAdmissionError>;
+
+    async fn cancel(
+        &self,
+        jid: &FullJid,
+        registration_id: RemoteResourceRegistrationId,
+        admission_epoch: RemoteResourceAdmissionEpoch,
+        socket_node: &NodeIdentity,
+    ) -> Result<bool, RemoteResourceAdmissionError>;
+
+    /// Bounded cleanup for admissions whose exact socket-node incarnation is
+    /// absent or committed expired. Raw heartbeat age is deliberately not an
+    /// authority for deleting another node's reservation.
+    async fn prune_stale(&self, limit: usize) -> Result<u64, RemoteResourceAdmissionError>;
+}
+
+pub struct PostgresRemoteResourceAdmissionStore {
+    db: Database,
+}
+
+impl PostgresRemoteResourceAdmissionStore {
+    pub fn new(db: Database) -> Self {
+        Self { db }
+    }
+}
+
+#[async_trait]
+impl RemoteResourceAdmissionStore for PostgresRemoteResourceAdmissionStore {
+    async fn ensure_schema(&self) -> Result<(), RemoteResourceAdmissionError> {
+        let conn = self.db.guard().await.map_err(db_error)?;
+        conn.execute(
+            "CREATE SEQUENCE IF NOT EXISTS clustering_remote_resource_admission_epoch_seq AS BIGINT",
+            (),
+        )
+        .await
+        .map_err(db_error)?;
+        conn.execute(
+            r#"
+            CREATE TABLE IF NOT EXISTS clustering_remote_resource_admissions (
+                full_jid        TEXT PRIMARY KEY,
+                registration_id TEXT NOT NULL,
+                admission_epoch BIGINT NOT NULL,
+                socket_node_id  TEXT NOT NULL,
+                socket_epoch    TEXT NOT NULL
+            )
+            "#,
+            (),
+        )
+        .await
+        .map_err(db_error)?;
+        conn.execute(
+            r#"
+            CREATE INDEX IF NOT EXISTS clustering_remote_resource_admissions_socket_identity
+                ON clustering_remote_resource_admissions (
+                    socket_node_id, socket_epoch, full_jid
+                )
+            "#,
+            (),
+        )
+        .await
+        .map_err(db_error)?;
+        Ok(())
+    }
+
+    async fn reserve(
+        &self,
+        jid: &FullJid,
+        registration_id: RemoteResourceRegistrationId,
+        socket_node: &NodeIdentity,
+    ) -> Result<RemoteResourceAdmissionEpoch, RemoteResourceAdmissionError> {
+        let mut tx = self
+            .db
+            .control_plane_begin_fenced()
+            .await
+            .map_err(db_error)?;
+        lock_full_jid(&mut tx, jid).await?;
+        let mut live_rows = tx
+            .query(
+                r#"
+                WITH locked AS MATERIALIZED (
+                    SELECT n.heartbeat, n.expired, n.draining, n.lease_ttl_ms
+                    FROM clustering_nodes n
+                    WHERE n.node_id = ?
+                      AND n.node_epoch = ?
+                    FOR SHARE OF n
+                )
+                SELECT 1 FROM locked
+                WHERE NOT expired
+                  AND NOT draining
+                  AND heartbeat >= clock_timestamp() - (
+                      lease_ttl_ms::text || ' milliseconds'
+                  )::interval
+                "#,
+                crate::db_params![socket_node.node_id.clone(), socket_node.node_epoch.clone(),],
+            )
+            .await
+            .map_err(db_error)?;
+        let socket_is_live = live_rows.next().await.map_err(db_error)?.is_some();
+        drop(live_rows);
+        if !socket_is_live {
+            return Err(RemoteResourceAdmissionError::StaleSocketNode);
+        }
+        let mut rows = tx
+            .query(
+                r#"
+                INSERT INTO clustering_remote_resource_admissions (
+                    full_jid, registration_id, admission_epoch,
+                    socket_node_id, socket_epoch
+                )
+                VALUES (?, ?, nextval('clustering_remote_resource_admission_epoch_seq'), ?, ?)
+                ON CONFLICT (full_jid) DO UPDATE SET
+                    registration_id = EXCLUDED.registration_id,
+                    admission_epoch = EXCLUDED.admission_epoch,
+                    socket_node_id = EXCLUDED.socket_node_id,
+                    socket_epoch = EXCLUDED.socket_epoch
+                RETURNING admission_epoch
+                "#,
+                crate::db_params![
+                    jid.to_string(),
+                    registration_id.as_db_string(),
+                    socket_node.node_id.clone(),
+                    socket_node.node_epoch.clone(),
+                ],
+            )
+            .await
+            .map_err(db_error)?;
+        let Some(row) = rows.next().await.map_err(db_error)? else {
+            return Err(RemoteResourceAdmissionError::Backend(
+                "remote-resource admission upsert returned no epoch".to_string(),
+            ));
+        };
+        let epoch = row
+            .get::<i64>(0)
+            .map(RemoteResourceAdmissionEpoch)
+            .map_err(db_error)?;
+        drop(rows);
+        tx.commit().await.map_err(db_error)?;
+        Ok(epoch)
+    }
+
+    async fn is_current(
+        &self,
+        jid: &FullJid,
+        registration_id: RemoteResourceRegistrationId,
+        admission_epoch: RemoteResourceAdmissionEpoch,
+        socket_node: &NodeIdentity,
+    ) -> Result<bool, RemoteResourceAdmissionError> {
+        let mut tx = self
+            .db
+            .control_plane_begin_fenced()
+            .await
+            .map_err(db_error)?;
+        lock_full_jid(&mut tx, jid).await?;
+        let mut rows = tx
+            .query(
+                r#"
+                WITH locked AS MATERIALIZED (
+                    SELECT n.heartbeat, n.expired, n.lease_ttl_ms
+                    FROM clustering_remote_resource_admissions a
+                    JOIN clustering_nodes n
+                      ON n.node_id = a.socket_node_id
+                     AND n.node_epoch = a.socket_epoch
+                    WHERE a.full_jid = ?
+                      AND a.registration_id = ?
+                      AND a.admission_epoch = ?
+                      AND a.socket_node_id = ?
+                      AND a.socket_epoch = ?
+                    FOR SHARE OF n
+                )
+                SELECT 1 FROM locked
+                WHERE NOT expired
+                  AND heartbeat >= clock_timestamp() - (
+                      lease_ttl_ms::text || ' milliseconds'
+                  )::interval
+                "#,
+                crate::db_params![
+                    jid.to_string(),
+                    registration_id.as_db_string(),
+                    admission_epoch.0,
+                    socket_node.node_id.clone(),
+                    socket_node.node_epoch.clone(),
+                ],
+            )
+            .await
+            .map_err(db_error)?;
+        let current = rows.next().await.map_err(db_error)?.is_some();
+        drop(rows);
+        tx.commit().await.map_err(db_error)?;
+        Ok(current)
+    }
+
+    async fn cancel(
+        &self,
+        jid: &FullJid,
+        registration_id: RemoteResourceRegistrationId,
+        admission_epoch: RemoteResourceAdmissionEpoch,
+        socket_node: &NodeIdentity,
+    ) -> Result<bool, RemoteResourceAdmissionError> {
+        let mut tx = self
+            .db
+            .control_plane_begin_fenced()
+            .await
+            .map_err(db_error)?;
+        lock_full_jid(&mut tx, jid).await?;
+        let affected = tx
+            .execute(
+                r#"
+                DELETE FROM clustering_remote_resource_admissions
+                WHERE full_jid = ?
+                  AND registration_id = ?
+                  AND admission_epoch = ?
+                  AND socket_node_id = ?
+                  AND socket_epoch = ?
+                "#,
+                crate::db_params![
+                    jid.to_string(),
+                    registration_id.as_db_string(),
+                    admission_epoch.0,
+                    socket_node.node_id.clone(),
+                    socket_node.node_epoch.clone(),
+                ],
+            )
+            .await
+            .map_err(db_error)?;
+        tx.commit().await.map_err(db_error)?;
+        Ok(affected == 1)
+    }
+
+    async fn prune_stale(&self, limit: usize) -> Result<u64, RemoteResourceAdmissionError> {
+        let mut tx = self
+            .db
+            .control_plane_begin_fenced()
+            .await
+            .map_err(db_error)?;
+        let affected = tx
+            .execute(
+                r#"
+            WITH candidates AS MATERIALIZED (
+                SELECT
+                    a.full_jid,
+                    a.registration_id,
+                    a.admission_epoch,
+                    a.socket_node_id,
+                    a.socket_epoch
+                FROM clustering_remote_resource_admissions a
+                LEFT JOIN clustering_nodes n
+                  ON n.node_id = a.socket_node_id
+                 AND n.node_epoch = a.socket_epoch
+                WHERE n.node_id IS NULL OR n.expired
+                ORDER BY a.full_jid
+                LIMIT ?
+            )
+            DELETE FROM clustering_remote_resource_admissions a
+            USING candidates c
+            WHERE a.full_jid = c.full_jid
+              AND a.registration_id = c.registration_id
+              AND a.admission_epoch = c.admission_epoch
+              AND a.socket_node_id = c.socket_node_id
+              AND a.socket_epoch = c.socket_epoch
+            "#,
+                crate::db_params![i64::try_from(limit).unwrap_or(i64::MAX)],
+            )
+            .await
+            .map_err(db_error)?;
+        tx.commit().await.map_err(db_error)?;
+        Ok(affected)
+    }
+}
+
+#[derive(Clone)]
+struct InMemoryAdmission {
+    registration_id: RemoteResourceRegistrationId,
+    admission_epoch: RemoteResourceAdmissionEpoch,
+    socket_node: NodeIdentity,
+}
+
+/// Exact in-memory implementation used by deterministic relay unit tests.
+#[derive(Default)]
+pub struct InMemoryRemoteResourceAdmissionStore {
+    next_epoch: std::sync::atomic::AtomicI64,
+    rows: Mutex<HashMap<FullJid, InMemoryAdmission>>,
+}
+
+#[async_trait]
+impl RemoteResourceAdmissionStore for InMemoryRemoteResourceAdmissionStore {
+    async fn ensure_schema(&self) -> Result<(), RemoteResourceAdmissionError> {
+        Ok(())
+    }
+
+    async fn reserve(
+        &self,
+        jid: &FullJid,
+        registration_id: RemoteResourceRegistrationId,
+        socket_node: &NodeIdentity,
+    ) -> Result<RemoteResourceAdmissionEpoch, RemoteResourceAdmissionError> {
+        let raw = self
+            .next_epoch
+            .fetch_update(
+                std::sync::atomic::Ordering::SeqCst,
+                std::sync::atomic::Ordering::SeqCst,
+                |current| current.checked_add(1),
+            )
+            .map_err(|_| RemoteResourceAdmissionError::EpochExhausted)?
+            .checked_add(1)
+            .ok_or(RemoteResourceAdmissionError::EpochExhausted)?;
+        let admission_epoch = RemoteResourceAdmissionEpoch(raw);
+        self.rows.lock().await.insert(
+            jid.clone(),
+            InMemoryAdmission {
+                registration_id,
+                admission_epoch,
+                socket_node: socket_node.clone(),
+            },
+        );
+        Ok(admission_epoch)
+    }
+
+    async fn is_current(
+        &self,
+        jid: &FullJid,
+        registration_id: RemoteResourceRegistrationId,
+        admission_epoch: RemoteResourceAdmissionEpoch,
+        socket_node: &NodeIdentity,
+    ) -> Result<bool, RemoteResourceAdmissionError> {
+        Ok(self.rows.lock().await.get(jid).is_some_and(|current| {
+            current.registration_id == registration_id
+                && current.admission_epoch == admission_epoch
+                && current.socket_node == *socket_node
+        }))
+    }
+
+    async fn cancel(
+        &self,
+        jid: &FullJid,
+        registration_id: RemoteResourceRegistrationId,
+        admission_epoch: RemoteResourceAdmissionEpoch,
+        socket_node: &NodeIdentity,
+    ) -> Result<bool, RemoteResourceAdmissionError> {
+        let mut rows = self.rows.lock().await;
+        let current = rows.get(jid).is_some_and(|current| {
+            current.registration_id == registration_id
+                && current.admission_epoch == admission_epoch
+                && current.socket_node == *socket_node
+        });
+        if current {
+            rows.remove(jid);
+        }
+        Ok(current)
+    }
+
+    async fn prune_stale(&self, _limit: usize) -> Result<u64, RemoteResourceAdmissionError> {
+        Ok(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::clustering::claims::PostgresClaimStore;
+    use crate::db::{DatabaseConfig, DatabaseDriver};
+    use waddle_xmpp::ownership::ClaimStore as _;
+
+    fn socket_node(epoch: &str) -> NodeIdentity {
+        NodeIdentity::new("socket-node", epoch)
+    }
+
+    fn full_jid(resource: &str) -> FullJid {
+        format!("juliet@example.test/{resource}")
+            .parse()
+            .expect("test full JID")
+    }
+
+    #[tokio::test]
+    async fn newer_reservation_wins_and_exact_old_cancel_cannot_delete_it() {
+        let store = InMemoryRemoteResourceAdmissionStore::default();
+        let jid = full_jid("phone");
+        let node = socket_node("epoch-1");
+        let first_id = RemoteResourceRegistrationId::fresh();
+        let first_epoch = store
+            .reserve(&jid, first_id, &node)
+            .await
+            .expect("first admission");
+        let second_id = RemoteResourceRegistrationId::fresh();
+        let second_epoch = store
+            .reserve(&jid, second_id, &node)
+            .await
+            .expect("second admission");
+
+        assert!(second_epoch > first_epoch);
+        assert!(!store
+            .is_current(&jid, first_id, first_epoch, &node)
+            .await
+            .expect("check first admission"));
+        assert!(!store
+            .cancel(&jid, first_id, first_epoch, &node)
+            .await
+            .expect("cancel superseded admission"));
+        assert!(store
+            .is_current(&jid, second_id, second_epoch, &node)
+            .await
+            .expect("check second admission"));
+    }
+
+    #[tokio::test]
+    async fn unregister_before_delayed_register_makes_that_register_terminally_stale() {
+        let store = InMemoryRemoteResourceAdmissionStore::default();
+        let jid = full_jid("laptop");
+        let node = socket_node("epoch-1");
+        let registration_id = RemoteResourceRegistrationId::fresh();
+        let admission_epoch = store
+            .reserve(&jid, registration_id, &node)
+            .await
+            .expect("reserve admission");
+
+        assert!(store
+            .cancel(&jid, registration_id, admission_epoch, &node)
+            .await
+            .expect("unregister cancels admission"));
+        assert!(!store
+            .is_current(&jid, registration_id, admission_epoch, &node)
+            .await
+            .expect("delayed register re-proves admission"));
+    }
+
+    async fn postgres_store() -> Option<(Database, PostgresRemoteResourceAdmissionStore)> {
+        let url = std::env::var("WADDLE_TEST_POSTGRES_URL").ok()?;
+        let db = Database::from_config(
+            "remote-resource-admission-test",
+            &DatabaseConfig::new(DatabaseDriver::Postgres, url)
+                .with_control_plane_pool(crate::db::DEFAULT_CONTROL_PLANE_POOL_SIZE),
+        )
+        .await
+        .expect("open test Postgres");
+        PostgresClaimStore::new(db.clone())
+            .ensure_schema()
+            .await
+            .expect("ensure clustering node schema");
+        let store = PostgresRemoteResourceAdmissionStore::new(db.clone());
+        store
+            .ensure_schema()
+            .await
+            .expect("ensure admission schema");
+        let conn = db.guard().await.expect("test database guard");
+        conn.execute("DELETE FROM clustering_remote_resource_admissions", ())
+            .await
+            .expect("clean admissions");
+        conn.execute("DELETE FROM clustering_nodes", ())
+            .await
+            .expect("clean nodes");
+        Some((db, store))
+    }
+
+    async fn insert_live_node(db: &Database, node: &NodeIdentity) {
+        db.guard()
+            .await
+            .expect("test database guard")
+            .execute(
+                r#"
+                INSERT INTO clustering_nodes (
+                    node_id, node_epoch, heartbeat, expired, draining, lease_ttl_ms
+                ) VALUES (?, ?, clock_timestamp(), false, false, 30000)
+                "#,
+                crate::db_params![node.node_id.clone(), node.node_epoch.clone()],
+            )
+            .await
+            .expect("insert live socket node");
+    }
+
+    async fn admission_count(db: &Database) -> i64 {
+        let mut rows = db
+            .guard()
+            .await
+            .expect("test database guard")
+            .query(
+                "SELECT COUNT(*) FROM clustering_remote_resource_admissions",
+                (),
+            )
+            .await
+            .expect("count admissions");
+        rows.next()
+            .await
+            .expect("read admission count")
+            .expect("admission count row")
+            .get::<i64>(0)
+            .expect("decode admission count")
+    }
+
+    async fn socket_identity_index_exists(db: &Database) -> bool {
+        let mut rows = db
+            .guard()
+            .await
+            .expect("test database guard")
+            .query(
+                r#"
+                SELECT 1
+                FROM pg_indexes
+                WHERE schemaname = current_schema()
+                  AND tablename = 'clustering_remote_resource_admissions'
+                  AND indexname = 'clustering_remote_resource_admissions_socket_identity'
+                "#,
+                (),
+            )
+            .await
+            .expect("query admission cleanup index");
+        rows.next()
+            .await
+            .expect("read admission cleanup index query")
+            .is_some()
+    }
+
+    async fn waiting_advisory_lock_exists(db: &Database) -> bool {
+        let mut rows = db
+            .guard()
+            .await
+            .expect("test database guard")
+            .query(
+                "SELECT EXISTS (SELECT 1 FROM pg_locks WHERE locktype = 'advisory' AND NOT granted)",
+                (),
+            )
+            .await
+            .expect("query waiting advisory locks");
+        rows.next()
+            .await
+            .expect("read waiting advisory lock query")
+            .expect("waiting advisory lock row")
+            .get::<bool>(0)
+            .expect("decode waiting advisory lock flag")
+    }
+
+    #[tokio::test]
+    async fn postgres_reserve_and_cancel_are_exact_and_globally_ordered() {
+        let _table_guard = super::super::claims::clustering_control_plane_table_lock()
+            .lock()
+            .await;
+        let Some((db, store)) = postgres_store().await else {
+            return;
+        };
+        let jid = full_jid("phone");
+        let node = socket_node("epoch-1");
+        insert_live_node(&db, &node).await;
+        let first_id = RemoteResourceRegistrationId::fresh();
+        let first_epoch = store
+            .reserve(&jid, first_id, &node)
+            .await
+            .expect("first Postgres admission");
+        let second_id = RemoteResourceRegistrationId::fresh();
+        let second_epoch = store
+            .reserve(&jid, second_id, &node)
+            .await
+            .expect("second Postgres admission");
+
+        assert!(second_epoch > first_epoch);
+        assert!(!store
+            .cancel(&jid, first_id, first_epoch, &node)
+            .await
+            .expect("cancel old exact tuple"));
+        assert!(store
+            .is_current(&jid, second_id, second_epoch, &node)
+            .await
+            .expect("new admission remains current"));
+        db.guard()
+            .await
+            .expect("test database guard")
+            .execute(
+                "UPDATE clustering_nodes SET draining = true WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![node.node_id.clone(), node.node_epoch.clone()],
+            )
+            .await
+            .expect("mark socket node draining");
+        assert!(
+            store
+                .is_current(&jid, second_id, second_epoch, &node)
+                .await
+                .expect("existing admission remains current while draining"),
+            "draining refuses new sockets but does not retroactively revoke an existing one"
+        );
+        assert!(matches!(
+            store
+                .reserve(
+                    &full_jid("new-while-draining"),
+                    RemoteResourceRegistrationId::fresh(),
+                    &node,
+                )
+                .await,
+            Err(RemoteResourceAdmissionError::StaleSocketNode)
+        ));
+        assert!(store
+            .cancel(&jid, second_id, second_epoch, &node)
+            .await
+            .expect("cancel current exact tuple"));
+        assert_eq!(admission_count(&db).await, 0);
+    }
+
+    #[tokio::test]
+    async fn postgres_normal_cancel_and_bounded_expired_node_pruning_bound_cardinality() {
+        let _table_guard = super::super::claims::clustering_control_plane_table_lock()
+            .lock()
+            .await;
+        let Some((db, store)) = postgres_store().await else {
+            return;
+        };
+        assert!(socket_identity_index_exists(&db).await);
+        let node = socket_node("epoch-1");
+        insert_live_node(&db, &node).await;
+        let mut admissions = Vec::new();
+        for index in 0..8 {
+            let jid = full_jid(&format!("resource-{index}"));
+            let registration_id = RemoteResourceRegistrationId::fresh();
+            let admission_epoch = store
+                .reserve(&jid, registration_id, &node)
+                .await
+                .expect("reserve Postgres admission");
+            admissions.push((jid, registration_id, admission_epoch));
+        }
+        for (jid, registration_id, admission_epoch) in admissions.iter().take(2) {
+            assert!(store
+                .cancel(jid, *registration_id, *admission_epoch, &node)
+                .await
+                .expect("normal exact cancellation"));
+        }
+        assert_eq!(admission_count(&db).await, 6);
+
+        db.guard()
+            .await
+            .expect("test database guard")
+            .execute(
+                "UPDATE clustering_nodes SET expired = true WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![node.node_id.clone(), node.node_epoch.clone()],
+            )
+            .await
+            .expect("commit socket-node expiry");
+        assert_eq!(store.prune_stale(2).await.expect("first bounded prune"), 2);
+        assert_eq!(admission_count(&db).await, 4);
+        assert_eq!(store.prune_stale(2).await.expect("second bounded prune"), 2);
+        assert_eq!(admission_count(&db).await, 2);
+        assert_eq!(store.prune_stale(2).await.expect("final bounded prune"), 2);
+        assert_eq!(admission_count(&db).await, 0);
+        assert_eq!(store.prune_stale(2).await.expect("empty bounded prune"), 0);
+    }
+
+    #[tokio::test]
+    async fn postgres_reserve_validates_socket_lease_after_waiting_for_full_jid_lock() {
+        let _table_guard = super::super::claims::clustering_control_plane_table_lock()
+            .lock()
+            .await;
+        let Some((db, _store)) = postgres_store().await else {
+            return;
+        };
+        let jid = full_jid("locked");
+        let node = socket_node("epoch-1");
+        insert_live_node(&db, &node).await;
+
+        let mut blocker = db
+            .control_plane_begin()
+            .await
+            .expect("begin advisory-lock blocker");
+        lock_full_jid(&mut blocker, &jid)
+            .await
+            .expect("hold full-JID advisory lock");
+        let reserve = tokio::spawn({
+            let db = db.clone();
+            let jid = jid.clone();
+            let node = node.clone();
+            async move {
+                PostgresRemoteResourceAdmissionStore::new(db)
+                    .reserve(&jid, RemoteResourceRegistrationId::fresh(), &node)
+                    .await
+            }
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while !waiting_advisory_lock_exists(&db).await {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("reserve waits on the per-full-JID advisory lock");
+
+        db.guard()
+            .await
+            .expect("test database guard")
+            .execute(
+                r#"
+                UPDATE clustering_nodes
+                SET heartbeat = clock_timestamp() - interval '1 hour'
+                WHERE node_id = ? AND node_epoch = ?
+                "#,
+                crate::db_params![node.node_id.clone(), node.node_epoch.clone()],
+            )
+            .await
+            .expect("expire socket lease while reserve is waiting");
+        blocker.commit().await.expect("release advisory lock");
+
+        assert!(matches!(
+            reserve.await.expect("join blocked reserve"),
+            Err(RemoteResourceAdmissionError::StaleSocketNode)
+        ));
+        assert_eq!(admission_count(&db).await, 0);
+    }
+
+    #[tokio::test]
+    async fn postgres_reserve_validates_socket_lease_after_node_row_lock_wait() {
+        let _table_guard = super::super::claims::clustering_control_plane_table_lock()
+            .lock()
+            .await;
+        let Some((db, _store)) = postgres_store().await else {
+            return;
+        };
+        let jid = full_jid("node-row-locked");
+        let node = socket_node("epoch-1");
+        insert_live_node(&db, &node).await;
+        db.guard()
+            .await
+            .unwrap()
+            .execute(
+                "UPDATE clustering_nodes SET heartbeat = clock_timestamp(), lease_ttl_ms = 100 WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![node.node_id.clone(), node.node_epoch.clone()],
+            )
+            .await
+            .unwrap();
+
+        let mut blocker = db.begin().await.unwrap();
+        let mut rows = blocker
+            .query(
+                "SELECT 1 FROM clustering_nodes WHERE node_id = ? AND node_epoch = ? FOR UPDATE",
+                crate::db_params![node.node_id.clone(), node.node_epoch.clone()],
+            )
+            .await
+            .unwrap();
+        assert!(rows.next().await.unwrap().is_some());
+        drop(rows);
+
+        let reserve = tokio::spawn({
+            let db = db.clone();
+            let jid = jid.clone();
+            let node = node.clone();
+            async move {
+                PostgresRemoteResourceAdmissionStore::new(db)
+                    .reserve(&jid, RemoteResourceRegistrationId::fresh(), &node)
+                    .await
+            }
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+        assert!(!reserve.is_finished(), "reserve must wait on the node row");
+        tokio::time::sleep(std::time::Duration::from_millis(360)).await;
+        blocker.commit().await.unwrap();
+
+        assert!(matches!(
+            reserve.await.unwrap(),
+            Err(RemoteResourceAdmissionError::StaleSocketNode)
+        ));
+        assert_eq!(admission_count(&db).await, 0);
+    }
+
+    #[tokio::test]
+    async fn postgres_is_current_validates_socket_lease_after_node_row_lock_wait() {
+        let _table_guard = super::super::claims::clustering_control_plane_table_lock()
+            .lock()
+            .await;
+        let Some((db, store)) = postgres_store().await else {
+            return;
+        };
+        let jid = full_jid("current-node-row-locked");
+        let node = socket_node("epoch-1");
+        insert_live_node(&db, &node).await;
+        let registration_id = RemoteResourceRegistrationId::fresh();
+        let admission_epoch = store.reserve(&jid, registration_id, &node).await.unwrap();
+        db.guard()
+            .await
+            .unwrap()
+            .execute(
+                "UPDATE clustering_nodes SET heartbeat = clock_timestamp(), lease_ttl_ms = 100 WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![node.node_id.clone(), node.node_epoch.clone()],
+            )
+            .await
+            .unwrap();
+
+        let mut blocker = db.begin().await.unwrap();
+        let mut rows = blocker
+            .query(
+                "SELECT 1 FROM clustering_nodes WHERE node_id = ? AND node_epoch = ? FOR UPDATE",
+                crate::db_params![node.node_id.clone(), node.node_epoch.clone()],
+            )
+            .await
+            .unwrap();
+        assert!(rows.next().await.unwrap().is_some());
+        drop(rows);
+
+        let current = tokio::spawn({
+            let db = db.clone();
+            let jid = jid.clone();
+            let node = node.clone();
+            async move {
+                PostgresRemoteResourceAdmissionStore::new(db)
+                    .is_current(&jid, registration_id, admission_epoch, &node)
+                    .await
+            }
+        });
+        tokio::time::sleep(std::time::Duration::from_millis(40)).await;
+        assert!(
+            !current.is_finished(),
+            "is_current must wait on the node row"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(360)).await;
+        blocker.commit().await.unwrap();
+
+        assert!(!current.await.unwrap().unwrap());
+    }
+}

--- a/server/crates/waddle-server/src/clustering/resume_asker.rs
+++ b/server/crates/waddle-server/src/clustering/resume_asker.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use jid::BareJid;
 use tokio_util::sync::CancellationToken;
+use waddle_xmpp::ownership::{ClaimEpoch, NodeIdentity};
 use waddle_xmpp::stream_management::{RemoteResumeAskOutcome, RemoteResumeAsker};
 
 use super::relay::{RelayHandle, RelayResumeStealReply};
@@ -42,16 +43,22 @@ impl SwarmRemoteResumeAsker {
 impl RemoteResumeAsker for SwarmRemoteResumeAsker {
     async fn ask_remote_detach(
         &self,
-        node_id: &str,
+        expected_owner: &NodeIdentity,
+        observed: ClaimEpoch,
         stream_id: &str,
         requester_bare_jid: &BareJid,
     ) -> RemoteResumeAskOutcome {
-        let mut relay = RelayHandle::new(NodeId::new(node_id.to_string()), self.stop_token.clone())
-            .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        let mut relay = RelayHandle::new(
+            NodeId::new(expected_owner.node_id.clone()),
+            self.stop_token.clone(),
+        )
+        .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
         match relay
             .resume_steal(
                 waddle_xmpp::pending_delivery::SmSessionId::new(stream_id.to_string()),
                 requester_bare_jid.clone(),
+                expected_owner.clone(),
+                observed,
             )
             .await
         {
@@ -60,7 +67,9 @@ impl RemoteResumeAsker for SwarmRemoteResumeAsker {
             Ok(RelayResumeStealReply::NotLiveLocally) => RemoteResumeAskOutcome::NotLiveRemotely,
             Err(error) => {
                 tracing::debug!(
-                    node_id,
+                    node_id = %expected_owner.node_id,
+                    node_epoch = %expected_owner.node_epoch,
+                    claim_epoch = observed.0,
                     stream_id,
                     %error,
                     "cross-node resume: resume_steal ask failed; treating as owner-unreachable"

--- a/server/crates/waddle-server/src/clustering/resume_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/resume_bridge.rs
@@ -28,6 +28,9 @@ use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use jid::BareJid;
+use waddle_xmpp::ownership::{
+    ClaimEpoch, ClaimStore, Entity, EntityType, NodeIdentity, SharedNodeIdentity,
+};
 use waddle_xmpp::pending_delivery::SmSessionId;
 use waddle_xmpp::registry::{ConnectionRegistry, ForceDetachOutcome, ForceDetachRequest};
 
@@ -55,6 +58,12 @@ pub enum LocalForcedDetachOutcome {
 /// rationale.
 pub struct ResumeStealBridge {
     connection_registry: OnceLock<Arc<ConnectionRegistry>>,
+    claim_fence: OnceLock<ResumeClaimFence>,
+}
+
+struct ResumeClaimFence {
+    claim_store: Arc<dyn ClaimStore>,
+    node_identity: SharedNodeIdentity,
 }
 
 impl ResumeStealBridge {
@@ -62,6 +71,7 @@ impl ResumeStealBridge {
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
             connection_registry: OnceLock::new(),
+            claim_fence: OnceLock::new(),
         })
     }
 
@@ -77,6 +87,65 @@ impl ResumeStealBridge {
         }
     }
 
+    /// Wire the exact-incarnation/claim-generation authority used to reject
+    /// delayed resume asks before they can close a local connection. This is
+    /// separate from [`Self::wire`] because the claim store and node identity
+    /// exist during clustering startup, while the connection registry is
+    /// constructed later by the HTTP dependency graph.
+    pub fn wire_claim_fence(
+        &self,
+        claim_store: Arc<dyn ClaimStore>,
+        node_identity: SharedNodeIdentity,
+    ) {
+        if self
+            .claim_fence
+            .set(ResumeClaimFence {
+                claim_store,
+                node_identity,
+            })
+            .is_err()
+        {
+            tracing::error!(
+                "ResumeStealBridge::wire_claim_fence called more than once; the claim-fence \
+                 handles were already wired (ignoring this call)"
+            );
+        }
+    }
+
+    async fn request_matches_current_claim(
+        &self,
+        stream_id: &SmSessionId,
+        expected_owner: &NodeIdentity,
+        observed: ClaimEpoch,
+    ) -> bool {
+        let Some(fence) = self.claim_fence.get() else {
+            return false;
+        };
+        if fence.node_identity.current() != *expected_owner {
+            return false;
+        }
+        let entity = Entity::new(EntityType::SmSession, stream_id.as_str());
+        let snapshot = match fence.claim_store.current_claim(&entity).await {
+            Ok(Some(snapshot)) => snapshot,
+            Ok(None) => return false,
+            Err(error) => {
+                tracing::warn!(
+                    stream_id = %stream_id,
+                    %error,
+                    "cross-node resume force-detach: current-claim validation failed"
+                );
+                return false;
+            }
+        };
+        snapshot.owner == *expected_owner
+            && snapshot.claim_epoch == observed
+            && snapshot.owner_lease_fresh
+            // Re-check after the database await. A local self-fence can
+            // rotate SharedNodeIdentity while the claim read is in flight;
+            // that delayed read must not authorize the destructive send.
+            && fence.node_identity.current() == *expected_owner
+    }
+
     /// Ask this node's own live connection registry to force-detach
     /// `stream_id` on behalf of `requester_bare_jid`, bounded by `budget`.
     /// See [`LocalForcedDetachOutcome`] for the outcome shape.
@@ -84,6 +153,8 @@ impl ResumeStealBridge {
         &self,
         stream_id: &SmSessionId,
         requester_bare_jid: &BareJid,
+        expected_owner: &NodeIdentity,
+        observed: ClaimEpoch,
         budget: Duration,
     ) -> LocalForcedDetachOutcome {
         let Some(registry) = self.connection_registry.get() else {
@@ -101,9 +172,20 @@ impl ResumeStealBridge {
         if entry.sm_stream_id().as_ref() != Some(stream_id) {
             return LocalForcedDetachOutcome::NotLiveLocally;
         }
+        // This is the final gate before the destructive request enters the
+        // connection task. Stable relay node ids are intentionally reused
+        // across self-fence recovery, so both the exact node incarnation and
+        // the exact claim generation observed by the asker are required.
+        if !self
+            .request_matches_current_claim(stream_id, expected_owner, observed)
+            .await
+        {
+            return LocalForcedDetachOutcome::NotLiveLocally;
+        }
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
         let request = ForceDetachRequest {
             requester_bare_jid: requester_bare_jid.clone(),
+            reason: waddle_xmpp::registry::ForceDetachReason::SessionResumed,
             ack: ack_tx,
         };
         // Council-adjudicated FIX 5: `try_send`, not a blocking
@@ -162,8 +244,15 @@ mod tests {
         let bridge = ResumeStealBridge::new();
         let stream_id = SmSessionId::new("stream-1");
         let jid: BareJid = "alice@example.com".parse().expect("valid jid");
+        let owner = NodeIdentity::new("node-a", "epoch-a");
         let outcome = bridge
-            .request_forced_detach(&stream_id, &jid, Duration::from_millis(50))
+            .request_forced_detach(
+                &stream_id,
+                &jid,
+                &owner,
+                ClaimEpoch(0),
+                Duration::from_millis(50),
+            )
             .await;
         assert_eq!(outcome, LocalForcedDetachOutcome::NotLiveLocally);
     }
@@ -174,9 +263,46 @@ mod tests {
         bridge.wire(Arc::new(ConnectionRegistry::new()));
         let stream_id = SmSessionId::new("stream-1");
         let jid: BareJid = "alice@example.com".parse().expect("valid jid");
+        let owner = NodeIdentity::new("node-a", "epoch-a");
         let outcome = bridge
-            .request_forced_detach(&stream_id, &jid, Duration::from_millis(50))
+            .request_forced_detach(
+                &stream_id,
+                &jid,
+                &owner,
+                ClaimEpoch(0),
+                Duration::from_millis(50),
+            )
             .await;
         assert_eq!(outcome, LocalForcedDetachOutcome::NotLiveLocally);
+    }
+
+    #[tokio::test]
+    async fn stale_epoch_of_same_stable_node_id_fails_before_detach_authorization() {
+        use waddle_xmpp::ownership::InProcessClaimStore;
+
+        let bridge = ResumeStealBridge::new();
+        let stream_id = SmSessionId::new("stream-stale-owner");
+        let current = NodeIdentity::new("stable-node", "current-epoch");
+        let stale = NodeIdentity::new(current.node_id.clone(), "stale-epoch");
+        let store = Arc::new(InProcessClaimStore::new());
+        let entity = Entity::new(EntityType::SmSession, stream_id.as_str());
+        let epoch = store
+            .acquire(&entity, &current)
+            .await
+            .expect("seed current claim");
+        let store_handle: Arc<dyn ClaimStore> = store;
+        bridge.wire_claim_fence(store_handle, SharedNodeIdentity::new(current.clone()));
+
+        assert!(
+            bridge
+                .request_matches_current_claim(&stream_id, &current, epoch)
+                .await
+        );
+        assert!(
+            !bridge
+                .request_matches_current_claim(&stream_id, &stale, epoch)
+                .await,
+            "a delayed ask for the previous incarnation must not authorize a force-detach"
+        );
     }
 }

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -7,11 +7,11 @@
 //! spawn time, then wire the narrow services it needs once
 //! `create_websocket_state` has built the live registries.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, OnceLock, Weak};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex, OnceLock, Weak};
 use std::time::Duration;
 
 use kameo::actor::ActorRef;
@@ -19,13 +19,13 @@ use libp2p::identity::{Keypair, PublicKey};
 use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
 use waddle_xmpp::ownership::{
-    ClaimSnapshot, ClaimStore, Entity, EntityType, NodeIdentity, SharedNodeIdentity,
+    ClaimEpoch, ClaimSnapshot, ClaimStore, Entity, EntityType, NodeIdentity, SharedNodeIdentity,
 };
 use waddle_xmpp::protocol::CarbonKind;
 use waddle_xmpp::registry::{
-    BroadcastOutcome, ConnectionEntry, ConnectionRegistry, DeliveryKind, ForceDetachOutcome,
-    ForceDetachRequest, OutboundStanza, PresenceState, RegisterUserResourceIfOwnerOrAbsent,
-    UnregisterUserResource, UserRegistryActor,
+    BroadcastOutcome, ConnectionEntry, ConnectionPlacement, ConnectionRegistry, DeliveryKind,
+    ForceDetachOutcome, ForceDetachReason, ForceDetachRequest, GetOrCreateUser, OutboundStanza,
+    PresenceState, RegisterUserResourceIfOwnerOrAbsent, UnregisterUserResource, UserRegistryActor,
 };
 use waddle_xmpp::roster::{RosterItem, RosterVersion};
 use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
@@ -48,10 +48,14 @@ use super::relay::{
     RelayRemoteResourceForceDetachStatus, RelayRemoteResourceFrameReply,
     RelayRemoteResourceFrameStatus, RelayRemoteResourceRegistrationReply,
     RelayRemoteResourceRegistrationStatus, RelayRemoteResourceUnregisterReply,
-    RelayRemoteResourceUpdateReply, RelayRemoteResourceUpdateStatus, RelayRemoteUserSideEffect,
-    RelayRemoteUserSideEffectReply, RelayRemoteUserSideEffectStatus,
-    RelayRouteRemoteResourceStanza, RelayRouteRemoteResourceStanzaReply, RelaySendEffect,
-    RelaySendFailure, RelayUnregisterRemoteUserResource, RelayUpdateRemoteUserResource,
+    RelayRemoteResourceUnregisterStatus, RelayRemoteResourceUpdateReply,
+    RelayRemoteResourceUpdateStatus, RelayRemoteUserSideEffect, RelayRemoteUserSideEffectReply,
+    RelayRemoteUserSideEffectStatus, RelayRouteRemoteResourceStanza,
+    RelayRouteRemoteResourceStanzaReply, RelaySendEffect, RelaySendFailure,
+    RelayUnregisterRemoteUserResource, RelayUpdateRemoteUserResource,
+};
+pub use super::remote_resource_admission::{
+    RemoteResourceAdmissionEpoch, RemoteResourceRegistrationId,
 };
 use super::NodeId;
 use crate::config::ClusteringMessagingConfig;
@@ -65,7 +69,17 @@ const ORDERED_RECEIVER_DELIVERY_TIMEOUT: Duration = Duration::from_secs(6);
 const ORDERED_RECEIVER_EFFECT_TIMEOUT_MARGIN: Duration = Duration::from_millis(250);
 const MAX_ORDERED_RELAY_CHANNEL_LOCKS: usize = 4096;
 const MAX_REMOTE_OWNER_REGISTRATION_LOCKS: usize = 4096;
+const MAX_PENDING_REMOTE_SOCKET_CLEANUPS_PER_JID: usize = 8;
+const MAX_REMOTE_SOCKET_CLEANUP_REGISTRATIONS: usize = 4096;
+const REMOTE_SOCKET_GLOBAL_CLEANUP_RETRY_BATCH: usize = 32;
+const MAX_PENDING_REMOTE_OWNER_CLEANUPS_PER_JID: usize = 8;
+const MAX_REMOTE_OWNER_CLEANUP_REGISTRATIONS: usize = 4096;
+const REMOTE_OWNER_GLOBAL_CLEANUP_RETRY_BATCH: usize = 32;
 const REMOTE_RESOURCE_OUTBOUND_CHANNEL_SIZE: usize = 256;
+#[cfg(not(test))]
+const REMOTE_RESOURCE_STALE_DETACH_TIMEOUT: Duration = Duration::from_secs(1);
+#[cfg(test)]
+const REMOTE_RESOURCE_STALE_DETACH_TIMEOUT: Duration = Duration::from_millis(50);
 
 type RemoteDeliveryFuture<'a> =
     Pin<Box<dyn Future<Output = Option<FullJidDeliveryOutcome>> + Send + 'a>>;
@@ -74,6 +88,8 @@ type RemoteDeliveryFuture<'a> =
 /// and hand an inbound full-JID stanza to the local `UserActor` delivery path.
 pub struct OrderedRelayDeliveryServices {
     pub claim_store: Arc<dyn ClaimStore>,
+    pub remote_resource_admission_store:
+        Arc<dyn super::remote_resource_admission::RemoteResourceAdmissionStore>,
     pub allowlist_store: Arc<dyn AllowlistStore>,
     pub node_lease: Arc<dyn NodeLeaseStore>,
     pub node_identity: SharedNodeIdentity,
@@ -84,16 +100,6 @@ pub struct OrderedRelayDeliveryServices {
     pub web_socket_state: Weak<WebSocketState>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[serde(transparent)]
-pub struct RemoteResourceRegistrationId(uuid::Uuid);
-
-impl RemoteResourceRegistrationId {
-    fn fresh() -> Self {
-        Self(uuid::Uuid::new_v4())
-    }
-}
-
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
@@ -101,6 +107,7 @@ impl RemoteResourceRegistrationId {
 pub struct RemoteResourceSocketGeneration(u64);
 
 impl RemoteResourceSocketGeneration {
+    #[cfg(test)]
     fn next(current: Option<Self>) -> Self {
         Self(
             current
@@ -231,6 +238,11 @@ pub enum RemoteUserSideEffect {
 pub struct RemoteResourceOutboundFrame {
     pub jid: jid::FullJid,
     pub registration_id: RemoteResourceRegistrationId,
+    pub admission_epoch: RemoteResourceAdmissionEpoch,
+    pub socket_generation: RemoteResourceSocketGeneration,
+    pub socket_node: NodeIdentity,
+    pub expected_user_owner: NodeIdentity,
+    pub expected_user_claim_epoch: ClaimEpoch,
     pub stanza: RemoteStanza,
     pub kind: DeliveryKind,
 }
@@ -307,32 +319,122 @@ pub(crate) enum RemoteResourceRegisterOutcome {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum RemoteResourceOriginRefresh {
     Remote(RemoteResourceOriginSnapshot),
-    LocalOwner,
     Failed,
+}
+
+/// Exact cluster-wide identity of one physical full-JID socket admission.
+///
+/// Every clustered socket carries this token, including a socket colocated
+/// with its authoritative `UserActor`. It is deliberately independent of
+/// placement: moving the actor must never create a second ordering domain for
+/// the same physical full JID.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PhysicalResourceAdmissionToken {
+    registration_id: RemoteResourceRegistrationId,
+    admission_epoch: RemoteResourceAdmissionEpoch,
+    socket_generation: RemoteResourceSocketGeneration,
+    socket_node: NodeIdentity,
+}
+
+/// Exact admission proof for one inbound physical socket. Local placements
+/// continue through the ordinary in-process SM/entity path; only a physical
+/// socket whose authoritative `UserActor` is remote becomes a relay origin.
+pub(crate) enum PhysicalResourceRouteOrigin {
+    LocalSocket,
+    RemoteMirror(RemoteResourceOriginSnapshot),
 }
 
 #[derive(Debug, Clone)]
 struct RemoteSocketRegistration {
     registration_id: RemoteResourceRegistrationId,
+    admission_epoch: RemoteResourceAdmissionEpoch,
     socket_generation: RemoteResourceSocketGeneration,
+    socket_node: NodeIdentity,
     owner: Arc<AtomicBool>,
-    user_owner: NodeId,
+    user_owner: NodeIdentity,
+    user_claim_epoch: ClaimEpoch,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RemoteResourceOriginSnapshot {
     pub jid: jid::FullJid,
     pub registration_id: RemoteResourceRegistrationId,
+    pub admission_epoch: RemoteResourceAdmissionEpoch,
     pub socket_generation: RemoteResourceSocketGeneration,
-    pub user_owner: NodeId,
+    pub socket_node: NodeIdentity,
+    pub user_owner: NodeIdentity,
+    pub user_claim_epoch: ClaimEpoch,
 }
 
 #[derive(Debug, Clone)]
 struct RemoteOwnerRegistration {
     registration_id: RemoteResourceRegistrationId,
-    socket_node: NodeId,
+    admission_epoch: RemoteResourceAdmissionEpoch,
+    socket_node: NodeIdentity,
     socket_generation: RemoteResourceSocketGeneration,
+    user_owner: NodeIdentity,
+    user_claim_epoch: ClaimEpoch,
     owner: Arc<AtomicBool>,
+    placement: ConnectionPlacement,
+}
+
+/// Holds the per-full-JID publication lock from durable reservation through
+/// final XEP-0198 registration. A newer node may reserve a later durable epoch
+/// while this guard is held, but its owner-side publication cannot interleave
+/// with this one; the final exact reproof makes the older publisher roll back.
+pub(crate) struct PhysicalResourceRegistrationGuard {
+    jid: jid::FullJid,
+    registration: RemoteSocketRegistration,
+    fence_generation: u64,
+    lock: Arc<Mutex<()>>,
+    _guard: tokio::sync::OwnedMutexGuard<()>,
+}
+
+impl PhysicalResourceRegistrationGuard {
+    pub(crate) fn token(&self) -> PhysicalResourceAdmissionToken {
+        PhysicalResourceAdmissionToken {
+            registration_id: self.registration.registration_id,
+            admission_epoch: self.registration.admission_epoch,
+            socket_generation: self.registration.socket_generation,
+            socket_node: self.registration.socket_node.clone(),
+        }
+    }
+}
+
+struct RemoteOwnerOperationGuard {
+    inflight: Arc<StdMutex<HashSet<RemoteResourceRegistrationId>>>,
+    registration_id: RemoteResourceRegistrationId,
+}
+
+impl RemoteOwnerOperationGuard {
+    fn begin(
+        inflight: Arc<StdMutex<HashSet<RemoteResourceRegistrationId>>>,
+        registration_id: RemoteResourceRegistrationId,
+    ) -> Option<Self> {
+        let inserted = inflight
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(registration_id);
+        inserted.then_some(Self {
+            inflight,
+            registration_id,
+        })
+    }
+}
+
+impl Drop for RemoteOwnerOperationGuard {
+    fn drop(&mut self) {
+        self.inflight
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .remove(&self.registration_id);
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoteUserClaimValidationError {
+    Stale,
+    Unavailable,
 }
 
 struct RelayOriginSigner {
@@ -381,7 +483,7 @@ struct RemoteDeliverySeed {
     target_entity: Entity,
     previous_owner: NodeIdentity,
     channel: OrderedRelayChannel,
-    asserted_origin_node: NodeId,
+    asserted_origin_node: NodeIdentity,
     origin_inbound_sequence: OriginInboundSequence,
     origin_claim: OrderedRelayClaim,
     sender_claim: OrderedRelayClaim,
@@ -399,9 +501,15 @@ pub struct OrderedRelayDeliveryBridge {
     sender_state: Mutex<OrderedRelaySenderState>,
     channel_locks: Mutex<HashMap<OrderedRelayChannel, Arc<Mutex<()>>>>,
     remote_socket_resources: Mutex<HashMap<jid::FullJid, RemoteSocketRegistration>>,
-    remote_socket_generations: Mutex<HashMap<jid::FullJid, RemoteResourceSocketGeneration>>,
+    remote_socket_pending_cleanup:
+        Mutex<HashMap<RemoteResourceRegistrationId, (jid::FullJid, RemoteSocketRegistration)>>,
+    remote_socket_generation: AtomicU64,
     remote_owner_resources: Mutex<HashMap<jid::FullJid, RemoteOwnerRegistration>>,
+    remote_owner_pending_cleanup:
+        Mutex<HashMap<RemoteResourceRegistrationId, (jid::FullJid, RemoteOwnerRegistration)>>,
+    remote_owner_cleanup_inflight: Arc<StdMutex<HashSet<RemoteResourceRegistrationId>>>,
     remote_owner_registration_locks: Mutex<HashMap<jid::FullJid, Arc<Mutex<()>>>>,
+    remote_resource_fence_generation: AtomicU64,
     stop_token: CancellationToken,
     mailbox_timeout: Duration,
     reply_timeout: Duration,
@@ -424,9 +532,13 @@ impl OrderedRelayDeliveryBridge {
             sender_state: Mutex::new(OrderedRelaySenderState::default()),
             channel_locks: Mutex::new(HashMap::new()),
             remote_socket_resources: Mutex::new(HashMap::new()),
-            remote_socket_generations: Mutex::new(HashMap::new()),
+            remote_socket_pending_cleanup: Mutex::new(HashMap::new()),
+            remote_socket_generation: AtomicU64::new(0),
             remote_owner_resources: Mutex::new(HashMap::new()),
+            remote_owner_pending_cleanup: Mutex::new(HashMap::new()),
+            remote_owner_cleanup_inflight: Arc::new(StdMutex::new(HashSet::new())),
             remote_owner_registration_locks: Mutex::new(HashMap::new()),
+            remote_resource_fence_generation: AtomicU64::new(0),
             stop_token,
             // WebSocket stanza dispatch has a 15s wedge backstop. Full-JID
             // ordered delivery must resolve before that backstop can cancel
@@ -437,6 +549,235 @@ impl OrderedRelayDeliveryBridge {
                 .min(ORDERED_DELIVERY_MAILBOX_TIMEOUT),
             reply_timeout: messaging.reply_timeout.min(ORDERED_DELIVERY_REPLY_TIMEOUT),
         })
+    }
+
+    /// Drop every active remote-resource placement record after this node
+    /// self-fences. Connection/UserActor teardown owns the actual entry
+    /// retirement; this clears the bridge's routing indexes so a fresh node
+    /// epoch cannot inherit stale owner or socket registrations.
+    ///
+    /// Socket generations intentionally survive the fence. `node_id` is the
+    /// process-stable relay address, so a resource that reconnects after the
+    /// epoch rotates must publish a generation strictly newer than the one an
+    /// owner may still remember for that same socket node.
+    pub(crate) async fn clear_remote_resource_state_on_self_fence(&self) {
+        let socket_registrations = {
+            let mut registrations = self.remote_socket_resources.lock().await;
+            if self
+                .remote_resource_fence_generation
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |generation| {
+                    generation.checked_add(1)
+                })
+                .is_err()
+            {
+                tracing::error!(
+                    "remote-resource fence generation exhausted; bridge remains permanently fenced"
+                );
+            }
+            std::mem::take(&mut *registrations)
+        };
+        if !socket_registrations.is_empty() {
+            let mut pending = self.remote_socket_pending_cleanup.lock().await;
+            for (jid, registration) in socket_registrations {
+                pending.insert(registration.registration_id, (jid, registration));
+            }
+        }
+        let owner_registrations = {
+            let mut registrations = self.remote_owner_resources.lock().await;
+            std::mem::take(&mut *registrations)
+        };
+        if !owner_registrations.is_empty() {
+            let mut pending = self.remote_owner_pending_cleanup.lock().await;
+            for (jid, registration) in owner_registrations {
+                if !Self::insert_remote_owner_cleanup_reservation(&mut pending, &jid, &registration)
+                {
+                    tracing::error!(
+                        jid = %jid,
+                        registration_id = ?registration.registration_id,
+                        "self-fenced remote-owner registration lacked bounded cleanup capacity"
+                    );
+                }
+            }
+        }
+        if let Some(services) = self.services.get() {
+            let mut seen = HashSet::new();
+            let mut cancellations = Vec::new();
+            {
+                let pending = self.remote_socket_pending_cleanup.lock().await;
+                for (jid, registration) in pending.values() {
+                    if seen.insert(registration.registration_id) {
+                        cancellations.push((
+                            jid.clone(),
+                            registration.registration_id,
+                            registration.admission_epoch,
+                            registration.socket_node.clone(),
+                        ));
+                    }
+                }
+            }
+            {
+                let pending = self.remote_owner_pending_cleanup.lock().await;
+                for (jid, registration) in pending.values() {
+                    if seen.insert(registration.registration_id) {
+                        cancellations.push((
+                            jid.clone(),
+                            registration.registration_id,
+                            registration.admission_epoch,
+                            registration.socket_node.clone(),
+                        ));
+                    }
+                }
+            }
+            for batch in cancellations.chunks(REMOTE_SOCKET_GLOBAL_CLEANUP_RETRY_BATCH) {
+                let attempts = batch
+                    .iter()
+                    .map(|(jid, registration_id, epoch, socket_node)| {
+                        services.remote_resource_admission_store.cancel(
+                            jid,
+                            *registration_id,
+                            *epoch,
+                            socket_node,
+                        )
+                    });
+                for result in futures::future::join_all(attempts).await {
+                    if let Err(error) = result {
+                        tracing::warn!(
+                            %error,
+                            "self-fence could not revoke an exact remote-resource admission"
+                        );
+                    }
+                }
+            }
+        }
+        // Do not clear the per-JID lock index here: an old registration task
+        // may still hold a strong reference and guard. Fence-generation
+        // checks invalidate its work; normal strong-count cleanup retires the
+        // lock only after every overlapping guard is gone.
+    }
+
+    fn remote_resource_registration_allowed(
+        &self,
+        services: &OrderedRelayDeliveryServices,
+        fence_generation: u64,
+    ) -> bool {
+        if fence_generation == u64::MAX
+            || self.remote_resource_fence_generation.load(Ordering::SeqCst) != fence_generation
+        {
+            return false;
+        }
+        services
+            .web_socket_state
+            .upgrade()
+            .is_none_or(|state| state.deps.app_state.clustering_readiness.is_ready())
+    }
+
+    fn next_remote_socket_generation(&self) -> Option<RemoteResourceSocketGeneration> {
+        let previous = self
+            .remote_socket_generation
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                current.checked_add(1)
+            })
+            .ok()?;
+        previous.checked_add(1).map(RemoteResourceSocketGeneration)
+    }
+
+    pub(crate) async fn forget_remote_resource_state_if_owner(
+        &self,
+        jid: &jid::FullJid,
+        owner: &Arc<AtomicBool>,
+        placement: waddle_xmpp::registry::ConnectionPlacement,
+    ) {
+        match placement {
+            waddle_xmpp::registry::ConnectionPlacement::LocalSocket => {
+                let registration = {
+                    let mut registrations = self.remote_socket_resources.lock().await;
+                    if registrations
+                        .get(jid)
+                        .is_some_and(|registration| Arc::ptr_eq(&registration.owner, owner))
+                    {
+                        registrations.remove(jid)
+                    } else {
+                        None
+                    }
+                };
+                if let Some(registration) = registration {
+                    // Physical retirement is not proof that a remote owner
+                    // mirror was removed. Keep the exact tuple until the
+                    // unregister path receives a terminal owner reply.
+                    self.retain_remote_socket_cleanup(jid, &registration).await;
+                    if let Some(services) = self.services.get() {
+                        self.cancel_remote_resource_admission(services, jid, &registration)
+                            .await;
+                    }
+                }
+                let mut removed_owner = Vec::new();
+                {
+                    let mut registrations = self.remote_owner_resources.lock().await;
+                    if registrations.get(jid).is_some_and(|registration| {
+                        registration.placement == ConnectionPlacement::LocalSocket
+                            && Arc::ptr_eq(&registration.owner, owner)
+                    }) {
+                        if let Some(registration) = registrations.remove(jid) {
+                            removed_owner.push(registration);
+                        }
+                    }
+                }
+                self.remote_owner_pending_cleanup.lock().await.retain(
+                    |_, (pending_jid, registration)| {
+                        let keep = pending_jid != jid
+                            || registration.placement != ConnectionPlacement::LocalSocket
+                            || !Arc::ptr_eq(&registration.owner, owner);
+                        if !keep {
+                            removed_owner.push(registration.clone());
+                        }
+                        keep
+                    },
+                );
+                if let Some(services) = self.services.get() {
+                    for registration in removed_owner {
+                        if !self
+                            .cancel_remote_owner_admission(services, jid, &registration)
+                            .await
+                        {
+                            self.retain_remote_owner_cleanup(jid, &registration).await;
+                        }
+                    }
+                }
+            }
+            waddle_xmpp::registry::ConnectionPlacement::RemoteMirror => {
+                let mut removed = Vec::new();
+                {
+                    let mut registrations = self.remote_owner_resources.lock().await;
+                    if registrations
+                        .get(jid)
+                        .is_some_and(|registration| Arc::ptr_eq(&registration.owner, owner))
+                    {
+                        if let Some(registration) = registrations.remove(jid) {
+                            removed.push(registration);
+                        }
+                    }
+                }
+                self.remote_owner_pending_cleanup.lock().await.retain(
+                    |_, (pending_jid, registration)| {
+                        let keep = pending_jid != jid || !Arc::ptr_eq(&registration.owner, owner);
+                        if !keep {
+                            removed.push(registration.clone());
+                        }
+                        keep
+                    },
+                );
+                if let Some(services) = self.services.get() {
+                    for registration in removed {
+                        if !self
+                            .cancel_remote_owner_admission(services, jid, &registration)
+                            .await
+                        {
+                            self.retain_remote_owner_cleanup(jid, &registration).await;
+                        }
+                    }
+                }
+            }
+        }
     }
 
     pub fn wire(&self, services: Arc<OrderedRelayDeliveryServices>) {
@@ -473,16 +814,118 @@ impl OrderedRelayDeliveryBridge {
         jid: &jid::FullJid,
         owner: &Arc<AtomicBool>,
     ) -> Option<RemoteResourceOriginSnapshot> {
-        let registrations = self.remote_socket_resources.lock().await;
-        let registration = registrations
+        let registration = self
+            .remote_socket_resources
+            .lock()
+            .await
             .get(jid)
-            .filter(|registration| Arc::ptr_eq(&registration.owner, owner))?;
+            .filter(|registration| Arc::ptr_eq(&registration.owner, owner))?
+            .clone();
+        let services = self.services.get()?;
+        services.connection_registry.entry_if_owner(jid, owner)?;
         Some(RemoteResourceOriginSnapshot {
             jid: jid.clone(),
             registration_id: registration.registration_id,
+            admission_epoch: registration.admission_epoch,
             socket_generation: registration.socket_generation,
+            socket_node: registration.socket_node.clone(),
             user_owner: registration.user_owner.clone(),
+            user_claim_epoch: registration.user_claim_epoch,
         })
+    }
+
+    pub(crate) async fn physical_resource_origin_if_owner(
+        &self,
+        jid: &jid::FullJid,
+        owner: &Arc<AtomicBool>,
+        token: &PhysicalResourceAdmissionToken,
+    ) -> Option<PhysicalResourceRouteOrigin> {
+        let registration = self
+            .remote_socket_resources
+            .lock()
+            .await
+            .get(jid)
+            .filter(|registration| {
+                Arc::ptr_eq(&registration.owner, owner)
+                    && physical_token_matches_registration(token, registration)
+            })?
+            .clone();
+        let services = self.services.get()?;
+        if services.node_identity.current() != registration.socket_node
+            || services
+                .connection_registry
+                .entry_if_owner(jid, owner)
+                .is_none()
+            || services
+                .web_socket_state
+                .upgrade()
+                .is_some_and(|state| !state.deps.app_state.clustering_readiness.is_ready())
+        {
+            self.detach_stale_remote_socket_resource(jid, &registration)
+                .await;
+            return None;
+        }
+        match exact_remote_user_claim_is_current(
+            services,
+            jid,
+            &registration.user_owner,
+            registration.user_claim_epoch,
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(RemoteUserClaimValidationError::Stale) => {
+                self.detach_stale_remote_socket_resource(jid, &registration)
+                    .await;
+                return None;
+            }
+            Err(RemoteUserClaimValidationError::Unavailable) => return None,
+        }
+        match exact_remote_resource_admission_is_current(
+            services,
+            jid,
+            registration.registration_id,
+            registration.admission_epoch,
+            &registration.socket_node,
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(RemoteUserClaimValidationError::Stale) => {
+                self.detach_stale_remote_socket_resource(jid, &registration)
+                    .await;
+                return None;
+            }
+            Err(RemoteUserClaimValidationError::Unavailable) => return None,
+        }
+        if registration.user_owner == services.node_identity.current() {
+            match self
+                .local_owner_publication_is_current(services, jid, &registration)
+                .await
+            {
+                Ok(()) => {}
+                Err(RelayRemoteResourceRegistrationStatus::StaleRegistration) => {
+                    self.detach_stale_remote_socket_resource(jid, &registration)
+                        .await;
+                    return None;
+                }
+                Err(_) => return None,
+            }
+        }
+        let origin = RemoteResourceOriginSnapshot {
+            jid: jid.clone(),
+            registration_id: registration.registration_id,
+            admission_epoch: registration.admission_epoch,
+            socket_generation: registration.socket_generation,
+            socket_node: registration.socket_node,
+            user_owner: registration.user_owner,
+            user_claim_epoch: registration.user_claim_epoch,
+        };
+        if origin.user_owner == services.node_identity.current() {
+            Some(PhysicalResourceRouteOrigin::LocalSocket)
+        } else {
+            Some(PhysicalResourceRouteOrigin::RemoteMirror(origin))
+        }
     }
 
     pub(crate) async fn try_deliver_registered_remote_resource(
@@ -495,6 +938,36 @@ impl OrderedRelayDeliveryBridge {
             let registrations = self.remote_owner_resources.lock().await;
             registrations.get(target).cloned()
         }?;
+        let Some(services) = self.services.get().cloned() else {
+            return Some(FullJidDeliveryOutcome::Unavailable);
+        };
+        match remote_owner_registration_is_current(&services, target, &registration).await {
+            Ok(()) => {}
+            Err(RelayRemoteResourceRegistrationStatus::StaleRegistration) => {
+                let cleaned = self
+                    .cleanup_remote_owner_resource_if_registration(
+                        target,
+                        registration.registration_id,
+                    )
+                    .await;
+                if !cleaned
+                    || services
+                        .connection_registry
+                        .entry_if_owner(target, &registration.owner)
+                        .is_some()
+                {
+                    return Some(FullJidDeliveryOutcome::Unavailable);
+                }
+                return None;
+            }
+            Err(_) => return Some(FullJidDeliveryOutcome::Unavailable),
+        }
+        if registration.placement == ConnectionPlacement::LocalSocket {
+            // The exact durable admission was proved above. The ordinary local
+            // registry/actor path owns the actual enqueue, avoiding a needless
+            // relay loopback while preserving the shared ordering boundary.
+            return None;
+        }
         self.deliver_registered_remote_resource_with_registration(
             target,
             stanza,
@@ -573,7 +1046,7 @@ impl OrderedRelayDeliveryBridge {
                 target_entity: target_entity.clone(),
                 previous_owner: target_snapshot.owner.clone(),
                 channel,
-                asserted_origin_node: NodeId::new(me.node_id.clone()),
+                asserted_origin_node: me.clone(),
                 origin_inbound_sequence: OriginInboundSequence(origin.inbound_sequence),
                 origin_claim,
                 sender_claim,
@@ -680,7 +1153,7 @@ impl OrderedRelayDeliveryBridge {
                 target_entity,
                 previous_owner: target_snapshot.owner,
                 channel,
-                asserted_origin_node: NodeId::new(me.node_id.clone()),
+                asserted_origin_node: me.clone(),
                 origin_inbound_sequence: OriginInboundSequence(origin.inbound_sequence),
                 origin_claim,
                 sender_claim,
@@ -805,7 +1278,7 @@ impl OrderedRelayDeliveryBridge {
             target_entity: target_entity.clone(),
             previous_owner: previous_owner.clone(),
             channel,
-            asserted_origin_node: NodeId::new(me.node_id.clone()),
+            asserted_origin_node: me.clone(),
             origin_inbound_sequence: OriginInboundSequence(origin.inbound_sequence),
             origin_claim: origin_claim.clone(),
             sender_claim: sender_claim.clone(),
@@ -827,7 +1300,7 @@ impl OrderedRelayDeliveryBridge {
                             target_entity: target_entity.clone(),
                             previous_owner: previous_owner.clone(),
                             channel: retry_channel,
-                            asserted_origin_node: NodeId::new(me.node_id.clone()),
+                            asserted_origin_node: me.clone(),
                             origin_inbound_sequence: OriginInboundSequence(origin.inbound_sequence),
                             origin_claim: origin_claim.clone(),
                             sender_claim: sender_claim.clone(),
@@ -892,96 +1365,472 @@ impl OrderedRelayDeliveryBridge {
         })
     }
 
-    pub(crate) async fn try_register_remote_user_resource(
+    /// Reserve the one cluster-wide physical-socket epoch before either the
+    /// transport registry or the authoritative `UserActor` can observe this
+    /// full JID. The returned guard serializes owner-side publication for the
+    /// JID until [`Self::finalize_physical_user_resource`] or
+    /// [`Self::abort_physical_user_resource`] consumes it.
+    pub(crate) async fn begin_physical_user_resource(
         self: &Arc<Self>,
         jid: &jid::FullJid,
-        entry: ConnectionEntry,
         owner: Arc<AtomicBool>,
+    ) -> Result<PhysicalResourceRegistrationGuard, RemoteResourceRegisterOutcome> {
+        let Some(lock) = self.lock_for_remote_owner_registration(jid).await else {
+            return Err(RemoteResourceRegisterOutcome::Failed);
+        };
+        let guard = Arc::clone(&lock).lock_owned().await;
+        let Some(services) = self.services.get().cloned() else {
+            drop(guard);
+            self.remove_remote_owner_registration_lock_if_unused(jid, &lock)
+                .await;
+            return Err(RemoteResourceRegisterOutcome::Failed);
+        };
+        let fence_generation = self.remote_resource_fence_generation.load(Ordering::SeqCst);
+        if !self.remote_resource_registration_allowed(&services, fence_generation) {
+            drop(guard);
+            self.remove_remote_owner_registration_lock_if_unused(jid, &lock)
+                .await;
+            return Err(RemoteResourceRegisterOutcome::Failed);
+        }
+
+        // Locating or creating the authoritative actor does not publish this
+        // full-JID resource. The physical epoch below is still reserved before
+        // either ConnectionRegistry or UserActor resource registration.
+        let target_entity = user_entity(&jid.to_bare());
+        let mut target_snapshot = current_claim(&services, &target_entity).await;
+        if target_snapshot.is_none() {
+            let created = services
+                .user_registry
+                .ask(GetOrCreateUser {
+                    bare_jid: jid.to_bare(),
+                })
+                .mailbox_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+                .reply_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+                .await;
+            if created.is_err() {
+                drop(guard);
+                self.remove_remote_owner_registration_lock_if_unused(jid, &lock)
+                    .await;
+                return Err(RemoteResourceRegisterOutcome::Failed);
+            }
+            target_snapshot = current_claim(&services, &target_entity).await;
+        }
+        let Some(target_snapshot) = target_snapshot.filter(|snapshot| snapshot.owner_lease_fresh)
+        else {
+            drop(guard);
+            self.remove_remote_owner_registration_lock_if_unused(jid, &lock)
+                .await;
+            return Err(RemoteResourceRegisterOutcome::Failed);
+        };
+        if !self.remote_resource_registration_allowed(&services, fence_generation) {
+            drop(guard);
+            self.remove_remote_owner_registration_lock_if_unused(jid, &lock)
+                .await;
+            return Err(RemoteResourceRegisterOutcome::Failed);
+        }
+
+        let registration_id = RemoteResourceRegistrationId::fresh();
+        let Some(socket_generation) = self.next_remote_socket_generation() else {
+            tracing::error!(
+                "clustered physical-resource socket generation space exhausted; refusing registration"
+            );
+            drop(guard);
+            self.remove_remote_owner_registration_lock_if_unused(jid, &lock)
+                .await;
+            return Err(RemoteResourceRegisterOutcome::Failed);
+        };
+        let socket_node = services.node_identity.current();
+        if let Err(error) = services
+            .remote_resource_admission_store
+            .prune_stale(REMOTE_SOCKET_GLOBAL_CLEANUP_RETRY_BATCH)
+            .await
+        {
+            tracing::warn!(%error, "failed bounded stale physical-resource admission cleanup");
+        }
+        let admission_epoch = match services
+            .remote_resource_admission_store
+            .reserve(jid, registration_id, &socket_node)
+            .await
+        {
+            Ok(epoch) => epoch,
+            Err(error) => {
+                tracing::warn!(jid = %jid, %error, "failed to reserve physical-resource admission");
+                drop(guard);
+                self.remove_remote_owner_registration_lock_if_unused(jid, &lock)
+                    .await;
+                return Err(RemoteResourceRegisterOutcome::Failed);
+            }
+        };
+        let registration = RemoteSocketRegistration {
+            registration_id,
+            admission_epoch,
+            socket_generation,
+            socket_node,
+            owner,
+            user_owner: target_snapshot.owner,
+            user_claim_epoch: target_snapshot.claim_epoch,
+        };
+
+        // Reserving the newer durable epoch irrevocably superseded the previous
+        // physical socket. Retire that exact local placement before publishing
+        // the new map entry, even if a later capacity/publication step fails.
+        let displaced_socket = self.remote_socket_resources.lock().await.get(jid).cloned();
+        if let Some(displaced) = displaced_socket {
+            self.detach_remote_socket_resource(
+                jid,
+                &displaced,
+                ForceDetachReason::ResourceReplaced,
+            )
+            .await;
+        }
+
+        if !self
+            .reserve_remote_socket_cleanup_capacity(jid, &registration)
+            .await
+        {
+            if self.remote_socket_cleanup_global_capacity_exhausted().await {
+                self.retry_inactive_remote_socket_cleanups(
+                    REMOTE_SOCKET_GLOBAL_CLEANUP_RETRY_BATCH,
+                )
+                .await;
+            }
+            if !self
+                .reserve_remote_socket_cleanup_capacity(jid, &registration)
+                .await
+            {
+                self.cancel_remote_resource_admission(&services, jid, &registration)
+                    .await;
+                drop(guard);
+                self.remove_remote_owner_registration_lock_if_unused(jid, &lock)
+                    .await;
+                return Err(RemoteResourceRegisterOutcome::Failed);
+            }
+        }
+        if !self
+            .publish_pending_remote_socket_registration(jid, registration.clone())
+            .await
+        {
+            if self
+                .cancel_remote_resource_admission(&services, jid, &registration)
+                .await
+            {
+                self.remove_pending_remote_socket_cleanup_if_current(jid, &registration)
+                    .await;
+            }
+            drop(guard);
+            self.remove_remote_owner_registration_lock_if_unused(jid, &lock)
+                .await;
+            return Err(RemoteResourceRegisterOutcome::Failed);
+        }
+
+        Ok(PhysicalResourceRegistrationGuard {
+            jid: jid.clone(),
+            registration,
+            fence_generation,
+            lock,
+            _guard: guard,
+        })
+    }
+
+    /// Publish the already-reserved physical socket into its authoritative
+    /// owner. Local and remote placements share the exact same durable tuple;
+    /// only the final delivery adapter differs.
+    pub(crate) async fn publish_physical_user_resource(
+        self: &Arc<Self>,
+        guard: &PhysicalResourceRegistrationGuard,
+        entry: ConnectionEntry,
     ) -> RemoteResourceRegisterOutcome {
         let Some(services) = self.services.get().cloned() else {
             return RemoteResourceRegisterOutcome::Failed;
         };
-        let target_entity = user_entity(&jid.to_bare());
-        let Some(target_snapshot) = current_claim(&services, &target_entity).await else {
-            return RemoteResourceRegisterOutcome::NotRemote;
-        };
-        if !target_snapshot.owner_lease_fresh {
-            return RemoteResourceRegisterOutcome::NotRemote;
-        }
-        let me = services.node_identity.current();
-        if target_snapshot.owner == me {
-            return RemoteResourceRegisterOutcome::NotRemote;
-        }
-
-        let registration_id = RemoteResourceRegistrationId::fresh();
-        let socket_generation = {
-            let mut generations = self.remote_socket_generations.lock().await;
-            let next = RemoteResourceSocketGeneration::next(generations.get(jid).copied());
-            generations.insert(jid.clone(), next);
-            next
-        };
-        let socket_node = NodeId::new(me.node_id.clone());
-        let user_owner = NodeId::new(target_snapshot.owner.node_id.clone());
-        let state = RemoteResourceStateSnapshot::from_entry(
-            &entry,
-            services.connection_registry.get_presence_state(jid),
-        );
-        let mut handle = RelayHandle::new(user_owner.clone(), self.stop_token.clone())
-            .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
-        let reply = match handle
-            .register_remote_user_resource(RelayRegisterRemoteUserResource {
-                jid: jid.clone(),
-                registration_id,
-                socket_generation,
-                socket_node,
-                state,
-            })
+        if !self
+            .physical_registration_is_current(&services, guard, true)
             .await
         {
-            Ok(reply) => reply,
-            Err(error) => {
-                tracing::warn!(
-                    jid = %jid,
-                    owner_node = %user_owner.as_str(),
-                    %error,
-                    "clustered remote-resource register ask failed"
-                );
-                return RemoteResourceRegisterOutcome::Failed;
-            }
-        };
-        match reply.status {
-            RelayRemoteResourceRegistrationStatus::Registered => {
-                if services
-                    .connection_registry
-                    .entry_if_owner(jid, &owner)
-                    .is_none()
-                {
-                    let _ = handle
-                        .unregister_remote_user_resource(RelayUnregisterRemoteUserResource {
-                            jid: jid.clone(),
-                            registration_id,
-                            socket_generation,
-                        })
-                        .await;
-                    return RemoteResourceRegisterOutcome::Failed;
-                }
-                self.remote_socket_resources.lock().await.insert(
-                    jid.clone(),
-                    RemoteSocketRegistration {
-                        registration_id,
-                        socket_generation,
-                        owner,
-                        user_owner,
-                    },
-                );
+            return RemoteResourceRegisterOutcome::Failed;
+        }
+        let registration = &guard.registration;
+        if registration.user_owner == services.node_identity.current() {
+            return self
+                .publish_local_owner_physical_resource(&services, guard, entry)
+                .await;
+        }
+
+        let state = RemoteResourceStateSnapshot::from_entry(
+            &entry,
+            services.connection_registry.get_presence_state(&guard.jid),
+        );
+        let mut handle = RelayHandle::new(
+            NodeId::new(registration.user_owner.node_id.clone()),
+            self.stop_token.clone(),
+        )
+        .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        let reply = handle
+            .register_remote_user_resource(RelayRegisterRemoteUserResource {
+                jid: guard.jid.clone(),
+                registration_id: registration.registration_id,
+                admission_epoch: registration.admission_epoch,
+                socket_generation: registration.socket_generation,
+                socket_node: registration.socket_node.clone(),
+                expected_user_owner: registration.user_owner.clone(),
+                expected_user_claim_epoch: registration.user_claim_epoch,
+                state,
+            })
+            .await;
+        match reply {
+            Ok(RelayRemoteResourceRegistrationReply {
+                status: RelayRemoteResourceRegistrationStatus::Registered,
+            }) if self
+                .physical_registration_is_current(&services, guard, true)
+                .await =>
+            {
                 RemoteResourceRegisterOutcome::Registered
             }
-            RelayRemoteResourceRegistrationStatus::NotOwner => {
-                RemoteResourceRegisterOutcome::NotRemote
-            }
-            RelayRemoteResourceRegistrationStatus::StaleRegistration
-            | RelayRemoteResourceRegistrationStatus::Unavailable => {
+            Ok(RelayRemoteResourceRegistrationReply {
+                status: RelayRemoteResourceRegistrationStatus::NotOwner,
+            }) => RemoteResourceRegisterOutcome::NotRemote,
+            Ok(_) => RemoteResourceRegisterOutcome::Failed,
+            Err(error) => {
+                tracing::warn!(
+                    jid = %guard.jid,
+                    owner_node = %registration.user_owner.node_id,
+                    %error,
+                    "clustered physical-resource owner publication failed"
+                );
+                if matches!(
+                    error,
+                    RelayAskError::Send {
+                        effect: RelaySendEffect::MaybeCommitted,
+                        ..
+                    } | RelayAskError::Cancelled
+                ) {
+                    let _ = self
+                        .compensate_remote_socket_registration(
+                            &mut handle,
+                            &guard.jid,
+                            registration,
+                        )
+                        .await;
+                }
                 RemoteResourceRegisterOutcome::Failed
+            }
+        }
+    }
+
+    async fn publish_local_owner_physical_resource(
+        self: &Arc<Self>,
+        services: &OrderedRelayDeliveryServices,
+        guard: &PhysicalResourceRegistrationGuard,
+        entry: ConnectionEntry,
+    ) -> RemoteResourceRegisterOutcome {
+        let registration = &guard.registration;
+        if let Some(displaced) = self
+            .remote_owner_resources
+            .lock()
+            .await
+            .get(&guard.jid)
+            .cloned()
+        {
+            if !remote_socket_and_owner_registration_match(registration, &displaced)
+                && !self
+                    .retire_remote_owner_registration(services, &guard.jid, &displaced)
+                    .await
+            {
+                return RemoteResourceRegisterOutcome::Failed;
+            }
+            self.remove_remote_owner_registration_if_current(&guard.jid, &displaced)
+                .await;
+        }
+        let owner_registration = RemoteOwnerRegistration {
+            registration_id: registration.registration_id,
+            admission_epoch: registration.admission_epoch,
+            socket_node: registration.socket_node.clone(),
+            socket_generation: registration.socket_generation,
+            user_owner: registration.user_owner.clone(),
+            user_claim_epoch: registration.user_claim_epoch,
+            owner: registration.owner.clone(),
+            placement: ConnectionPlacement::LocalSocket,
+        };
+        let Some(_operation) = self
+            .reserve_remote_owner_cleanup_capacity(&guard.jid, &owner_registration)
+            .await
+        else {
+            return RemoteResourceRegisterOutcome::Failed;
+        };
+        if !self
+            .physical_registration_is_current(services, guard, true)
+            .await
+        {
+            self.remove_pending_remote_owner_cleanup_if_current(&guard.jid, &owner_registration)
+                .await;
+            return RemoteResourceRegisterOutcome::Failed;
+        }
+        let registered = services
+            .user_registry
+            .ask(RegisterUserResourceIfOwnerOrAbsent {
+                jid: guard.jid.clone(),
+                entry,
+                owner: registration.owner.clone(),
+            })
+            .mailbox_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+            .reply_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
+            .await;
+        if !matches!(registered, Ok(true))
+            || !self
+                .physical_registration_is_current(services, guard, true)
+                .await
+        {
+            self.retain_remote_owner_cleanup(&guard.jid, &owner_registration)
+                .await;
+            return RemoteResourceRegisterOutcome::Failed;
+        }
+        self.remote_owner_resources
+            .lock()
+            .await
+            .insert(guard.jid.clone(), owner_registration);
+        if self
+            .physical_registration_is_current(services, guard, true)
+            .await
+            && self
+                .local_owner_publication_is_current(services, &guard.jid, registration)
+                .await
+                .is_ok()
+        {
+            RemoteResourceRegisterOutcome::Registered
+        } else {
+            RemoteResourceRegisterOutcome::Failed
+        }
+    }
+
+    async fn physical_registration_is_current(
+        &self,
+        services: &OrderedRelayDeliveryServices,
+        guard: &PhysicalResourceRegistrationGuard,
+        require_registry: bool,
+    ) -> bool {
+        let registration = &guard.registration;
+        if !self.remote_resource_registration_allowed(services, guard.fence_generation)
+            || services.node_identity.current() != registration.socket_node
+            || !self
+                .remote_socket_registration_is_current(&guard.jid, registration)
+                .await
+        {
+            return false;
+        }
+        if require_registry
+            && services
+                .connection_registry
+                .entry_if_owner(&guard.jid, &registration.owner)
+                .is_none()
+        {
+            return false;
+        }
+        exact_remote_user_claim_is_current(
+            services,
+            &guard.jid,
+            &registration.user_owner,
+            registration.user_claim_epoch,
+        )
+        .await
+        .is_ok()
+            && exact_remote_resource_admission_is_current(
+                services,
+                &guard.jid,
+                registration.registration_id,
+                registration.admission_epoch,
+                &registration.socket_node,
+            )
+            .await
+            .is_ok()
+    }
+
+    async fn local_owner_publication_is_current(
+        &self,
+        services: &OrderedRelayDeliveryServices,
+        jid: &jid::FullJid,
+        socket: &RemoteSocketRegistration,
+    ) -> Result<(), RelayRemoteResourceRegistrationStatus> {
+        let owner_registration = self
+            .remote_owner_resources
+            .lock()
+            .await
+            .get(jid)
+            .filter(|registration| {
+                registration.placement == ConnectionPlacement::LocalSocket
+                    && remote_socket_and_owner_registration_match(socket, registration)
+            })
+            .cloned()
+            .ok_or(RelayRemoteResourceRegistrationStatus::StaleRegistration)?;
+        remote_owner_registration_is_current(services, jid, &owner_registration).await
+    }
+
+    pub(crate) async fn finalize_physical_user_resource(
+        self: &Arc<Self>,
+        guard: PhysicalResourceRegistrationGuard,
+    ) -> Option<PhysicalResourceAdmissionToken> {
+        let current = match self.services.get() {
+            Some(services) => {
+                let physical = self
+                    .physical_registration_is_current(services, &guard, true)
+                    .await;
+                physical
+                    && (guard.registration.user_owner != services.node_identity.current()
+                        || self
+                            .local_owner_publication_is_current(
+                                services,
+                                &guard.jid,
+                                &guard.registration,
+                            )
+                            .await
+                            .is_ok())
+            }
+            None => false,
+        };
+        if !current {
+            let jid = guard.jid.clone();
+            let owner = guard.registration.owner.clone();
+            drop(guard);
+            self.unregister_remote_user_resource_if_owner(&jid, &owner)
+                .await;
+            return None;
+        }
+        let token = Some(guard.token());
+        let jid = guard.jid.clone();
+        let lock = Arc::clone(&guard.lock);
+        drop(guard);
+        self.remove_remote_owner_registration_lock_if_unused(&jid, &lock)
+            .await;
+        token
+    }
+
+    pub(crate) async fn abort_physical_user_resource(
+        self: &Arc<Self>,
+        guard: PhysicalResourceRegistrationGuard,
+    ) {
+        let jid = guard.jid.clone();
+        let owner = guard.registration.owner.clone();
+        drop(guard);
+        self.unregister_remote_user_resource_if_owner(&jid, &owner)
+            .await;
+    }
+
+    async fn publish_pending_remote_socket_registration(
+        &self,
+        jid: &jid::FullJid,
+        registration: RemoteSocketRegistration,
+    ) -> bool {
+        let mut registrations = self.remote_socket_resources.lock().await;
+        match registrations.get(jid) {
+            Some(current) if current.socket_generation > registration.socket_generation => false,
+            Some(current)
+                if current.socket_generation == registration.socket_generation
+                    && !remote_socket_registration_matches(current, &registration) =>
+            {
+                false
+            }
+            _ => {
+                registrations.insert(jid.clone(), registration);
+                true
             }
         }
     }
@@ -991,34 +1840,173 @@ impl OrderedRelayDeliveryBridge {
         jid: &jid::FullJid,
         owner: &Arc<AtomicBool>,
     ) {
-        let registration = {
-            let mut registrations = self.remote_socket_resources.lock().await;
-            match registrations.get(jid) {
-                Some(registration) if Arc::ptr_eq(&registration.owner, owner) => {
-                    registrations.remove(jid)
-                }
-                _ => None,
-            }
-        };
-        let Some(registration) = registration else {
+        let Some(lock) = self.lock_for_remote_owner_registration(jid).await else {
             return;
         };
-        let mut handle = RelayHandle::new(registration.user_owner.clone(), self.stop_token.clone())
-            .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
-        if let Err(error) = handle
-            .unregister_remote_user_resource(RelayUnregisterRemoteUserResource {
-                jid: jid.clone(),
-                registration_id: registration.registration_id,
-                socket_generation: registration.socket_generation,
-            })
+        let guard = lock.lock().await;
+        self.unregister_remote_user_resource_if_owner_locked(jid, owner)
+            .await;
+        drop(guard);
+        self.remove_remote_owner_registration_lock_if_unused(jid, &lock)
+            .await;
+    }
+
+    async fn unregister_remote_user_resource_if_owner_locked(
+        &self,
+        jid: &jid::FullJid,
+        owner: &Arc<AtomicBool>,
+    ) {
+        let mut registrations_by_id = HashMap::new();
+        if let Some(registration) = self
+            .remote_socket_resources
+            .lock()
             .await
+            .get(jid)
+            .filter(|registration| Arc::ptr_eq(&registration.owner, owner))
+            .cloned()
         {
-            tracing::warn!(
-                jid = %jid,
-                %error,
-                "clustered remote-resource unregister ask failed; owner-side stale \
-                 entry will self-heal on closed-channel delivery"
-            );
+            registrations_by_id.insert(registration.registration_id, registration);
+        }
+        {
+            let pending = self.remote_socket_pending_cleanup.lock().await;
+            for (registration_id, (pending_jid, registration)) in pending.iter() {
+                if pending_jid == jid && Arc::ptr_eq(&registration.owner, owner) {
+                    registrations_by_id
+                        .entry(*registration_id)
+                        .or_insert_with(|| registration.clone());
+                }
+            }
+        }
+        if registrations_by_id.is_empty() {
+            return;
+        }
+
+        let Some(services) = self.services.get() else {
+            for registration in registrations_by_id.into_values() {
+                self.retain_remote_socket_cleanup(jid, &registration).await;
+                self.remove_remote_socket_registration_if_current(jid, &registration)
+                    .await;
+            }
+            return;
+        };
+
+        for registration in registrations_by_id.into_values() {
+            // Revoke the durable admission before asking the owner to remove
+            // its mirror. A delayed register message is then terminally stale
+            // even when unregister reaches the owner first.
+            if !self
+                .cancel_remote_resource_admission(services, jid, &registration)
+                .await
+            {
+                self.retain_remote_socket_cleanup(jid, &registration).await;
+                self.remove_remote_socket_registration_if_current(jid, &registration)
+                    .await;
+                continue;
+            }
+            self.remove_remote_socket_registration_if_current(jid, &registration)
+                .await;
+            if registration.user_owner == services.node_identity.current() {
+                let mut owner_registration = {
+                    let active = self.remote_owner_resources.lock().await;
+                    active
+                        .get(jid)
+                        .filter(|owner_registration| {
+                            remote_socket_and_owner_registration_match(
+                                &registration,
+                                owner_registration,
+                            )
+                        })
+                        .cloned()
+                };
+                if owner_registration.is_none() {
+                    owner_registration = self
+                        .remote_owner_pending_cleanup
+                        .lock()
+                        .await
+                        .get(&registration.registration_id)
+                        .filter(|(pending_jid, candidate)| {
+                            pending_jid == jid
+                                && remote_socket_and_owner_registration_match(
+                                    &registration,
+                                    candidate,
+                                )
+                        })
+                        .map(|(_, candidate)| candidate.clone());
+                }
+                if let Some(owner_registration) = owner_registration {
+                    if !unregister_remote_owner_actor_entry(
+                        services,
+                        jid,
+                        &owner_registration.owner,
+                    )
+                    .await
+                    {
+                        self.retain_remote_socket_cleanup(jid, &registration).await;
+                        self.retain_remote_owner_cleanup(jid, &owner_registration)
+                            .await;
+                        continue;
+                    }
+                    services
+                        .connection_registry
+                        .unregister_if_owner(jid, &owner_registration.owner);
+                    self.remove_remote_owner_registration_if_current(jid, &owner_registration)
+                        .await;
+                    self.remove_pending_remote_owner_cleanup_if_current(jid, &owner_registration)
+                        .await;
+                }
+                self.remove_pending_remote_socket_cleanup_if_current(jid, &registration)
+                    .await;
+                continue;
+            }
+            let mut handle = RelayHandle::new(
+                NodeId::new(registration.user_owner.node_id.clone()),
+                self.stop_token.clone(),
+            )
+            .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+            match handle
+                .unregister_remote_user_resource(RelayUnregisterRemoteUserResource {
+                    jid: jid.clone(),
+                    registration_id: registration.registration_id,
+                    admission_epoch: registration.admission_epoch,
+                    socket_generation: registration.socket_generation,
+                    socket_node: registration.socket_node.clone(),
+                    expected_user_owner: registration.user_owner.clone(),
+                    expected_user_claim_epoch: registration.user_claim_epoch,
+                })
+                .await
+            {
+                Ok(RelayRemoteResourceUnregisterReply {
+                    status: RelayRemoteResourceUnregisterStatus::Terminal,
+                }) => {
+                    self.remove_remote_socket_registration_if_current(jid, &registration)
+                        .await;
+                    self.remove_pending_remote_socket_cleanup_if_current(jid, &registration)
+                        .await;
+                }
+                Ok(RelayRemoteResourceUnregisterReply {
+                    status: RelayRemoteResourceUnregisterStatus::Retry,
+                }) => {
+                    self.retain_remote_socket_cleanup(jid, &registration).await;
+                    self.remove_remote_socket_registration_if_current(jid, &registration)
+                        .await;
+                    tracing::warn!(
+                        jid = %jid,
+                        registration_id = ?registration.registration_id,
+                        "clustered remote-resource owner could not prove unregister terminal; retaining exact metadata for retry"
+                    );
+                }
+                Err(error) => {
+                    self.retain_remote_socket_cleanup(jid, &registration).await;
+                    self.remove_remote_socket_registration_if_current(jid, &registration)
+                        .await;
+                    tracing::warn!(
+                        jid = %jid,
+                        registration_id = ?registration.registration_id,
+                        %error,
+                        "clustered remote-resource unregister remained uncertain; retaining exact metadata for retry"
+                    );
+                }
+            }
         }
     }
 
@@ -1038,13 +2026,30 @@ impl OrderedRelayDeliveryBridge {
         let Some(registration) = registration else {
             return;
         };
-        let mut handle = RelayHandle::new(registration.user_owner.clone(), self.stop_token.clone())
-            .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        let Some(services) = self.services.get() else {
+            return;
+        };
+        if registration.user_owner == services.node_identity.current() {
+            // LocalSocket registrations share the same `ConnectionEntry`
+            // with the authoritative actor, so the caller's local atomic
+            // update is already visible. Only RemoteMirror state crosses the
+            // relay boundary.
+            return;
+        }
+        let mut handle = RelayHandle::new(
+            NodeId::new(registration.user_owner.node_id.clone()),
+            self.stop_token.clone(),
+        )
+        .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
         match handle
             .update_remote_user_resource(RelayUpdateRemoteUserResource {
                 jid: jid.clone(),
                 registration_id: registration.registration_id,
+                admission_epoch: registration.admission_epoch,
                 socket_generation: registration.socket_generation,
+                socket_node: registration.socket_node.clone(),
+                expected_user_owner: registration.user_owner.clone(),
+                expected_user_claim_epoch: registration.user_claim_epoch,
                 update,
             })
             .await
@@ -1139,13 +2144,20 @@ impl OrderedRelayDeliveryBridge {
         else {
             return false;
         };
-        let mut handle = RelayHandle::new(registration.user_owner.clone(), self.stop_token.clone())
-            .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        let mut handle = RelayHandle::new(
+            NodeId::new(registration.user_owner.node_id.clone()),
+            self.stop_token.clone(),
+        )
+        .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
         match handle
             .remote_user_side_effect(RelayRemoteUserSideEffect {
                 source_jid: source_jid.clone(),
                 registration_id: registration.registration_id,
+                admission_epoch: registration.admission_epoch,
                 socket_generation: registration.socket_generation,
+                socket_node: registration.socket_node.clone(),
+                expected_user_owner: registration.user_owner.clone(),
+                expected_user_claim_epoch: registration.user_claim_epoch,
                 effect,
             })
             .await
@@ -1156,7 +2168,7 @@ impl OrderedRelayDeliveryBridge {
             Ok(RelayRemoteUserSideEffectReply {
                 status: RelayRemoteUserSideEffectStatus::StaleRegistration,
             }) => {
-                self.remove_remote_socket_registration_if_current(source_jid, &registration)
+                self.detach_stale_remote_socket_resource(source_jid, &registration)
                     .await;
                 false
             }
@@ -1203,19 +2215,311 @@ impl OrderedRelayDeliveryBridge {
             .map(|_| registration)
     }
 
+    async fn cancel_remote_resource_admission(
+        &self,
+        services: &OrderedRelayDeliveryServices,
+        jid: &jid::FullJid,
+        registration: &RemoteSocketRegistration,
+    ) -> bool {
+        self.cancel_exact_remote_resource_admission(
+            services,
+            jid,
+            registration.registration_id,
+            registration.admission_epoch,
+            &registration.socket_node,
+        )
+        .await
+    }
+
+    async fn cancel_exact_remote_resource_admission(
+        &self,
+        services: &OrderedRelayDeliveryServices,
+        jid: &jid::FullJid,
+        registration_id: RemoteResourceRegistrationId,
+        admission_epoch: RemoteResourceAdmissionEpoch,
+        socket_node: &NodeIdentity,
+    ) -> bool {
+        match services
+            .remote_resource_admission_store
+            .cancel(jid, registration_id, admission_epoch, socket_node)
+            .await
+        {
+            Ok(_) => true,
+            Err(error) => {
+                tracing::warn!(
+                    jid = %jid,
+                    registration_id = ?registration_id,
+                    %error,
+                    "exact remote-resource admission cancellation failed"
+                );
+                false
+            }
+        }
+    }
+
+    async fn cancel_remote_owner_admission(
+        &self,
+        services: &OrderedRelayDeliveryServices,
+        jid: &jid::FullJid,
+        registration: &RemoteOwnerRegistration,
+    ) -> bool {
+        match services
+            .remote_resource_admission_store
+            .cancel(
+                jid,
+                registration.registration_id,
+                registration.admission_epoch,
+                &registration.socket_node,
+            )
+            .await
+        {
+            Ok(_) => true,
+            Err(error) => {
+                tracing::warn!(
+                    jid = %jid,
+                    registration_id = ?registration.registration_id,
+                    %error,
+                    "exact remote-owner admission cancellation failed"
+                );
+                false
+            }
+        }
+    }
+
     async fn remove_remote_socket_registration_if_current(
         &self,
         jid: &jid::FullJid,
         registration: &RemoteSocketRegistration,
     ) {
         let mut registrations = self.remote_socket_resources.lock().await;
-        if registrations.get(jid).is_some_and(|current| {
-            current.registration_id == registration.registration_id
-                && current.socket_generation == registration.socket_generation
-                && current.user_owner == registration.user_owner
-                && Arc::ptr_eq(&current.owner, &registration.owner)
-        }) {
+        if registrations
+            .get(jid)
+            .is_some_and(|current| remote_socket_registration_matches(current, registration))
+        {
             registrations.remove(jid);
+        }
+    }
+
+    async fn remote_socket_registration_is_current(
+        &self,
+        jid: &jid::FullJid,
+        registration: &RemoteSocketRegistration,
+    ) -> bool {
+        self.remote_socket_resources
+            .lock()
+            .await
+            .get(jid)
+            .is_some_and(|current| remote_socket_registration_matches(current, registration))
+    }
+
+    async fn retain_remote_socket_cleanup(
+        &self,
+        jid: &jid::FullJid,
+        registration: &RemoteSocketRegistration,
+    ) {
+        self.remote_socket_pending_cleanup.lock().await.insert(
+            registration.registration_id,
+            (jid.clone(), registration.clone()),
+        );
+    }
+
+    async fn reserve_remote_socket_cleanup_capacity(
+        &self,
+        jid: &jid::FullJid,
+        registration: &RemoteSocketRegistration,
+    ) -> bool {
+        let mut pending = self.remote_socket_pending_cleanup.lock().await;
+        if pending
+            .get(&registration.registration_id)
+            .is_some_and(|(current_jid, current)| {
+                current_jid == jid && remote_socket_registration_matches(current, registration)
+            })
+        {
+            return true;
+        }
+        let same_jid = pending
+            .values()
+            .filter(|(pending_jid, _)| pending_jid == jid)
+            .count();
+        if same_jid >= MAX_PENDING_REMOTE_SOCKET_CLEANUPS_PER_JID {
+            tracing::error!(
+                jid = %jid,
+                limit = MAX_PENDING_REMOTE_SOCKET_CLEANUPS_PER_JID,
+                "clustered remote-resource per-JID cleanup capacity exhausted; refusing another registration"
+            );
+            return false;
+        }
+        if pending.len() >= MAX_REMOTE_SOCKET_CLEANUP_REGISTRATIONS {
+            tracing::error!(
+                jid = %jid,
+                limit = MAX_REMOTE_SOCKET_CLEANUP_REGISTRATIONS,
+                "clustered remote-resource global cleanup capacity exhausted; refusing another registration"
+            );
+            return false;
+        }
+        pending.insert(
+            registration.registration_id,
+            (jid.clone(), registration.clone()),
+        );
+        true
+    }
+
+    async fn remove_pending_remote_socket_cleanup_if_current(
+        &self,
+        jid: &jid::FullJid,
+        registration: &RemoteSocketRegistration,
+    ) {
+        let mut pending = self.remote_socket_pending_cleanup.lock().await;
+        if pending
+            .get(&registration.registration_id)
+            .is_some_and(|(current_jid, current)| {
+                current_jid == jid && remote_socket_registration_matches(current, registration)
+            })
+        {
+            pending.remove(&registration.registration_id);
+        }
+    }
+
+    async fn compensate_remote_socket_registration(
+        &self,
+        handle: &mut RelayHandle,
+        jid: &jid::FullJid,
+        registration: &RemoteSocketRegistration,
+    ) -> bool {
+        self.remove_remote_socket_registration_if_current(jid, registration)
+            .await;
+        let result = handle
+            .unregister_remote_user_resource(RelayUnregisterRemoteUserResource {
+                jid: jid.clone(),
+                registration_id: registration.registration_id,
+                admission_epoch: registration.admission_epoch,
+                socket_generation: registration.socket_generation,
+                socket_node: registration.socket_node.clone(),
+                expected_user_owner: registration.user_owner.clone(),
+                expected_user_claim_epoch: registration.user_claim_epoch,
+            })
+            .await;
+        let terminal = matches!(
+            result,
+            Ok(RelayRemoteResourceUnregisterReply {
+                status: RelayRemoteResourceUnregisterStatus::Terminal,
+            })
+        );
+        self.finish_remote_socket_cleanup_attempt(jid, registration, terminal)
+            .await
+    }
+
+    async fn finish_remote_socket_cleanup_attempt(
+        &self,
+        jid: &jid::FullJid,
+        registration: &RemoteSocketRegistration,
+        confirmed: bool,
+    ) -> bool {
+        if confirmed {
+            self.remove_remote_socket_registration_if_current(jid, registration)
+                .await;
+            self.remove_pending_remote_socket_cleanup_if_current(jid, registration)
+                .await;
+            true
+        } else {
+            self.retain_remote_socket_cleanup(jid, registration).await;
+            false
+        }
+    }
+
+    #[cfg(test)]
+    async fn pending_remote_socket_cleanups_for_jid(
+        &self,
+        jid: &jid::FullJid,
+    ) -> Vec<RemoteSocketRegistration> {
+        self.remote_socket_pending_cleanup
+            .lock()
+            .await
+            .values()
+            .filter(|(pending_jid, _)| pending_jid == jid)
+            .map(|(_, registration)| registration.clone())
+            .collect()
+    }
+
+    async fn remote_socket_cleanup_global_capacity_exhausted(&self) -> bool {
+        self.remote_socket_pending_cleanup.lock().await.len()
+            >= MAX_REMOTE_SOCKET_CLEANUP_REGISTRATIONS
+    }
+
+    async fn inactive_remote_socket_cleanups(
+        &self,
+        limit: usize,
+    ) -> Vec<(jid::FullJid, RemoteSocketRegistration)> {
+        let Some(services) = self.services.get() else {
+            return Vec::new();
+        };
+        let active = self.remote_socket_resources.lock().await;
+        self.remote_socket_pending_cleanup
+            .lock()
+            .await
+            .values()
+            .filter(|(jid, registration)| {
+                let exact_registration_is_active = active.get(jid).is_some_and(|current| {
+                    remote_socket_registration_matches(current, registration)
+                });
+                let exact_connection_is_live = services
+                    .connection_registry
+                    .entry_if_owner(jid, &registration.owner)
+                    .is_some();
+                !exact_registration_is_active || !exact_connection_is_live
+            })
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+
+    async fn retry_inactive_remote_socket_cleanups(&self, limit: usize) {
+        let pending = self.inactive_remote_socket_cleanups(limit).await;
+        self.retry_remote_socket_cleanups(pending).await;
+    }
+
+    async fn retry_remote_socket_cleanups(
+        &self,
+        pending: Vec<(jid::FullJid, RemoteSocketRegistration)>,
+    ) {
+        let attempts = pending.into_iter().map(|(jid, registration)| async move {
+            let admission_cancelled = if let Some(services) = self.services.get() {
+                self.cancel_remote_resource_admission(services, &jid, &registration)
+                    .await
+            } else {
+                false
+            };
+            if !admission_cancelled {
+                return (jid, registration, false);
+            }
+            self.remove_remote_socket_registration_if_current(&jid, &registration)
+                .await;
+            let mut handle = RelayHandle::new(
+                NodeId::new(registration.user_owner.node_id.clone()),
+                self.stop_token.clone(),
+            )
+            .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+            let terminal = matches!(
+                handle
+                    .unregister_remote_user_resource(RelayUnregisterRemoteUserResource {
+                        jid: jid.clone(),
+                        registration_id: registration.registration_id,
+                        admission_epoch: registration.admission_epoch,
+                        socket_generation: registration.socket_generation,
+                        socket_node: registration.socket_node.clone(),
+                        expected_user_owner: registration.user_owner.clone(),
+                        expected_user_claim_epoch: registration.user_claim_epoch,
+                    })
+                    .await,
+                Ok(RelayRemoteResourceUnregisterReply {
+                    status: RelayRemoteResourceUnregisterStatus::Terminal,
+                })
+            );
+            (jid, registration, terminal)
+        });
+        for (jid, registration, terminal) in futures::future::join_all(attempts).await {
+            self.finish_remote_socket_cleanup_attempt(&jid, &registration, terminal)
+                .await;
         }
     }
 
@@ -1231,6 +2535,190 @@ impl OrderedRelayDeliveryBridge {
         {
             registrations.remove(jid);
         }
+    }
+
+    async fn retain_remote_owner_cleanup(
+        &self,
+        jid: &jid::FullJid,
+        registration: &RemoteOwnerRegistration,
+    ) {
+        let retained = {
+            let mut pending = self.remote_owner_pending_cleanup.lock().await;
+            Self::insert_remote_owner_cleanup_reservation(&mut pending, jid, registration)
+        };
+        if !retained {
+            tracing::error!(
+                jid = %jid,
+                registration_id = ?registration.registration_id,
+                "remote-owner cleanup evidence was not pre-reserved; keeping the active registration"
+            );
+            return;
+        }
+        self.remove_remote_owner_registration_if_current(jid, registration)
+            .await;
+    }
+
+    fn insert_remote_owner_cleanup_reservation(
+        pending: &mut HashMap<
+            RemoteResourceRegistrationId,
+            (jid::FullJid, RemoteOwnerRegistration),
+        >,
+        jid: &jid::FullJid,
+        registration: &RemoteOwnerRegistration,
+    ) -> bool {
+        if let Some((current_jid, current)) = pending.get(&registration.registration_id) {
+            if current_jid == jid && remote_owner_registration_matches(current, registration) {
+                return true;
+            }
+            tracing::error!(
+                jid = %jid,
+                registration_id = ?registration.registration_id,
+                "remote-owner cleanup registration ID collision; preserving existing exact evidence"
+            );
+            return false;
+        }
+
+        let same_jid = pending
+            .values()
+            .filter(|(pending_jid, _)| pending_jid == jid)
+            .count();
+        if same_jid >= MAX_PENDING_REMOTE_OWNER_CLEANUPS_PER_JID {
+            tracing::error!(
+                jid = %jid,
+                limit = MAX_PENDING_REMOTE_OWNER_CLEANUPS_PER_JID,
+                "clustered remote-resource owner per-JID cleanup capacity exhausted"
+            );
+            return false;
+        }
+        if pending.len() >= MAX_REMOTE_OWNER_CLEANUP_REGISTRATIONS {
+            tracing::error!(
+                jid = %jid,
+                limit = MAX_REMOTE_OWNER_CLEANUP_REGISTRATIONS,
+                "clustered remote-resource owner global cleanup capacity exhausted"
+            );
+            return false;
+        }
+
+        pending.insert(
+            registration.registration_id,
+            (jid.clone(), registration.clone()),
+        );
+        true
+    }
+
+    async fn reserve_remote_owner_cleanup_capacity(
+        &self,
+        jid: &jid::FullJid,
+        registration: &RemoteOwnerRegistration,
+    ) -> Option<RemoteOwnerOperationGuard> {
+        let Some(operation) = RemoteOwnerOperationGuard::begin(
+            Arc::clone(&self.remote_owner_cleanup_inflight),
+            registration.registration_id,
+        ) else {
+            tracing::warn!(
+                jid = %jid,
+                registration_id = ?registration.registration_id,
+                "remote-owner registration already has an operation in flight"
+            );
+            return None;
+        };
+        let reserved = {
+            let mut pending = self.remote_owner_pending_cleanup.lock().await;
+            Self::insert_remote_owner_cleanup_reservation(&mut pending, jid, registration)
+        };
+        if reserved {
+            Some(operation)
+        } else {
+            None
+        }
+    }
+
+    async fn remote_owner_cleanup_global_capacity_exhausted(&self) -> bool {
+        self.remote_owner_pending_cleanup.lock().await.len()
+            >= MAX_REMOTE_OWNER_CLEANUP_REGISTRATIONS
+    }
+
+    async fn inactive_remote_owner_cleanup_ids(
+        &self,
+        limit: usize,
+    ) -> Vec<(jid::FullJid, RemoteResourceRegistrationId)> {
+        let active = self.remote_owner_resources.lock().await;
+        let inflight = self
+            .remote_owner_cleanup_inflight
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        self.remote_owner_pending_cleanup
+            .lock()
+            .await
+            .iter()
+            .filter(|(registration_id, (jid, registration))| {
+                !inflight.contains(registration_id)
+                    && !active.get(jid).is_some_and(|current| {
+                        remote_owner_registration_matches(current, registration)
+                    })
+            })
+            .take(limit)
+            .map(|(registration_id, (jid, _))| (jid.clone(), *registration_id))
+            .collect()
+    }
+
+    async fn retry_inactive_remote_owner_cleanups(&self, limit: usize) {
+        for (jid, registration_id) in self.inactive_remote_owner_cleanup_ids(limit).await {
+            let _ = self
+                .cleanup_remote_owner_resource_if_registration(&jid, registration_id)
+                .await;
+        }
+    }
+
+    async fn remove_pending_remote_owner_cleanup_if_current(
+        &self,
+        jid: &jid::FullJid,
+        registration: &RemoteOwnerRegistration,
+    ) {
+        let mut pending = self.remote_owner_pending_cleanup.lock().await;
+        if pending
+            .get(&registration.registration_id)
+            .is_some_and(|(current_jid, current)| {
+                current_jid == jid && remote_owner_registration_matches(current, registration)
+            })
+        {
+            pending.remove(&registration.registration_id);
+        }
+    }
+
+    async fn cleanup_pending_remote_owner_resources_for_jid(&self, jid: &jid::FullJid) -> bool {
+        let active = self.remote_owner_resources.lock().await;
+        let inflight = self
+            .remote_owner_cleanup_inflight
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone();
+        let pending_ids: Vec<_> = self
+            .remote_owner_pending_cleanup
+            .lock()
+            .await
+            .iter()
+            .filter(|(registration_id, (pending_jid, registration))| {
+                pending_jid == jid
+                    && !inflight.contains(registration_id)
+                    && !active.get(jid).is_some_and(|current| {
+                        remote_owner_registration_matches(current, registration)
+                    })
+            })
+            .map(|(registration_id, _)| *registration_id)
+            .collect();
+        drop(inflight);
+        drop(active);
+        for registration_id in pending_ids {
+            if !self
+                .cleanup_remote_owner_resource_if_registration(jid, registration_id)
+                .await
+            {
+                return false;
+            }
+        }
+        true
     }
 
     pub(crate) async fn register_remote_user_resource_on_owner(
@@ -1262,6 +2750,54 @@ impl OrderedRelayDeliveryBridge {
                 status: RelayRemoteResourceRegistrationStatus::Unavailable,
             };
         };
+        let fence_generation = self.remote_resource_fence_generation.load(Ordering::SeqCst);
+        if !self.remote_resource_registration_allowed(&services, fence_generation) {
+            return RelayRemoteResourceRegistrationReply {
+                status: RelayRemoteResourceRegistrationStatus::Unavailable,
+            };
+        }
+        if !self
+            .cleanup_pending_remote_owner_resources_for_jid(&msg.jid)
+            .await
+        {
+            return RelayRemoteResourceRegistrationReply {
+                status: RelayRemoteResourceRegistrationStatus::Unavailable,
+            };
+        }
+        match exact_remote_socket_node_is_current(&services, &msg.socket_node).await {
+            Ok(()) => {}
+            Err(RemoteUserClaimValidationError::Stale) => {
+                return RelayRemoteResourceRegistrationReply {
+                    status: RelayRemoteResourceRegistrationStatus::StaleRegistration,
+                };
+            }
+            Err(RemoteUserClaimValidationError::Unavailable) => {
+                return RelayRemoteResourceRegistrationReply {
+                    status: RelayRemoteResourceRegistrationStatus::Unavailable,
+                };
+            }
+        }
+        match exact_remote_resource_admission_is_current(
+            &services,
+            &msg.jid,
+            msg.registration_id,
+            msg.admission_epoch,
+            &msg.socket_node,
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(RemoteUserClaimValidationError::Stale) => {
+                return RelayRemoteResourceRegistrationReply {
+                    status: RelayRemoteResourceRegistrationStatus::StaleRegistration,
+                };
+            }
+            Err(RemoteUserClaimValidationError::Unavailable) => {
+                return RelayRemoteResourceRegistrationReply {
+                    status: RelayRemoteResourceRegistrationStatus::Unavailable,
+                };
+            }
+        }
         let target_entity = user_entity(&msg.jid.to_bare());
         let Some(snapshot) = current_claim(&services, &target_entity).await else {
             return RelayRemoteResourceRegistrationReply {
@@ -1269,75 +2805,59 @@ impl OrderedRelayDeliveryBridge {
             };
         };
         let me = services.node_identity.current();
-        if !snapshot.owner_lease_fresh || snapshot.owner != me {
+        if !snapshot.owner_lease_fresh
+            || snapshot.owner != msg.expected_user_owner
+            || snapshot.claim_epoch != msg.expected_user_claim_epoch
+            || me != msg.expected_user_owner
+        {
             return RelayRemoteResourceRegistrationReply {
                 status: RelayRemoteResourceRegistrationStatus::NotOwner,
             };
         }
+        if !self.remote_resource_registration_allowed(&services, fence_generation) {
+            return RelayRemoteResourceRegistrationReply {
+                status: RelayRemoteResourceRegistrationStatus::Unavailable,
+            };
+        }
 
-        if let Some(displaced) = self
-            .remote_owner_resources
-            .lock()
-            .await
-            .get(&msg.jid)
-            .cloned()
-        {
+        let displaced = {
+            let registrations = self.remote_owner_resources.lock().await;
+            registrations.get(&msg.jid).cloned()
+        };
+        if let Some(displaced) = displaced {
             if displaced.registration_id == msg.registration_id
+                && displaced.admission_epoch == msg.admission_epoch
                 && displaced.socket_node == msg.socket_node
                 && displaced.socket_generation == msg.socket_generation
+                && displaced.user_owner == msg.expected_user_owner
+                && displaced.user_claim_epoch == msg.expected_user_claim_epoch
             {
                 match remote_owner_registration_is_current(&services, &msg.jid, &displaced).await {
                     Ok(()) => {
-                        return RelayRemoteResourceRegistrationReply {
-                            status: RelayRemoteResourceRegistrationStatus::Registered,
-                        };
-                    }
-                    Err(RelayRemoteResourceRegistrationStatus::StaleRegistration) => {
-                        self.remove_remote_owner_registration_if_current(&msg.jid, &displaced)
-                            .await;
-                    }
-                    Err(status) => return RelayRemoteResourceRegistrationReply { status },
-                }
-            } else if displaced.socket_node == msg.socket_node
-                && displaced.socket_generation >= msg.socket_generation
-            {
-                return RelayRemoteResourceRegistrationReply {
-                    status: RelayRemoteResourceRegistrationStatus::StaleRegistration,
-                };
-            } else if displaced.socket_node != msg.socket_node {
-                match remote_owner_registration_is_current(&services, &msg.jid, &displaced).await {
-                    Ok(()) => {
-                        if !self
-                            .retire_remote_owner_registration(&services, &msg.jid, &displaced)
-                            .await
+                        let status = if self
+                            .remote_resource_registration_allowed(&services, fence_generation)
                         {
-                            return RelayRemoteResourceRegistrationReply {
-                                status: RelayRemoteResourceRegistrationStatus::Unavailable,
-                            };
-                        }
-                        let mut registrations = self.remote_owner_resources.lock().await;
-                        match registrations.get(&msg.jid) {
-                            Some(current)
-                                if remote_owner_registration_matches(current, &displaced) =>
-                            {
-                                registrations.remove(&msg.jid);
-                            }
-                            Some(_) => {
-                                return RelayRemoteResourceRegistrationReply {
-                                    status:
-                                        RelayRemoteResourceRegistrationStatus::StaleRegistration,
-                                };
-                            }
-                            None => {}
-                        }
+                            RelayRemoteResourceRegistrationStatus::Registered
+                        } else {
+                            RelayRemoteResourceRegistrationStatus::Unavailable
+                        };
+                        return RelayRemoteResourceRegistrationReply { status };
                     }
                     Err(RelayRemoteResourceRegistrationStatus::StaleRegistration) => {
-                        self.remove_remote_owner_registration_if_current(&msg.jid, &displaced)
-                            .await;
+                        self.cleanup_remote_owner_resource_if_registration(
+                            &msg.jid,
+                            displaced.registration_id,
+                        )
+                        .await;
                     }
                     Err(status) => return RelayRemoteResourceRegistrationReply { status },
                 }
             } else {
+                // The incoming durable admission was proven current above, so
+                // every different mirror is superseded even when its own
+                // admission has already become stale. Retire the exact old
+                // physical socket before publishing the new mirror; merely
+                // forgetting the stale mirror would leave that socket alive.
                 if !self
                     .retire_remote_owner_registration(&services, &msg.jid, &displaced)
                     .await
@@ -1371,11 +2891,65 @@ impl OrderedRelayDeliveryBridge {
             }
         }
 
+        if !self
+            .cleanup_pending_remote_owner_resources_for_jid(&msg.jid)
+            .await
+        {
+            return RelayRemoteResourceRegistrationReply {
+                status: RelayRemoteResourceRegistrationStatus::Unavailable,
+            };
+        }
+
+        if !self.remote_resource_registration_allowed(&services, fence_generation) {
+            return RelayRemoteResourceRegistrationReply {
+                status: RelayRemoteResourceRegistrationStatus::Unavailable,
+            };
+        }
+
         let (tx, rx) = mpsc::channel(REMOTE_RESOURCE_OUTBOUND_CHANNEL_SIZE);
-        let entry = ConnectionEntry::new(tx);
+        let entry = ConnectionEntry::new_remote_mirror(tx);
         apply_remote_resource_state(&entry, &msg.state);
         let owner = entry.carbons_handle();
         let force_detach_rx = entry.take_force_detach_rx();
+        let registration = RemoteOwnerRegistration {
+            registration_id: msg.registration_id,
+            admission_epoch: msg.admission_epoch,
+            socket_node: msg.socket_node.clone(),
+            socket_generation: msg.socket_generation,
+            user_owner: msg.expected_user_owner.clone(),
+            user_claim_epoch: msg.expected_user_claim_epoch,
+            owner: owner.clone(),
+            placement: ConnectionPlacement::RemoteMirror,
+        };
+        let _registration_operation = if let Some(operation) = self
+            .reserve_remote_owner_cleanup_capacity(&msg.jid, &registration)
+            .await
+        {
+            operation
+        } else {
+            if self.remote_owner_cleanup_global_capacity_exhausted().await {
+                self.retry_inactive_remote_owner_cleanups(REMOTE_OWNER_GLOBAL_CLEANUP_RETRY_BATCH)
+                    .await;
+            }
+            let Some(operation) = self
+                .reserve_remote_owner_cleanup_capacity(&msg.jid, &registration)
+                .await
+            else {
+                return RelayRemoteResourceRegistrationReply {
+                    status: RelayRemoteResourceRegistrationStatus::Unavailable,
+                };
+            };
+            operation
+        };
+        if let Err(error) =
+            exact_remote_owner_authority_is_current(&services, &msg.jid, &registration).await
+        {
+            self.remove_pending_remote_owner_cleanup_if_current(&msg.jid, &registration)
+                .await;
+            return RelayRemoteResourceRegistrationReply {
+                status: remote_registration_status_for_authority_error(error),
+            };
+        }
         match services
             .user_registry
             .ask(RegisterUserResourceIfOwnerOrAbsent {
@@ -1388,21 +2962,36 @@ impl OrderedRelayDeliveryBridge {
             .await
         {
             Ok(true) => {
-                let registration = RemoteOwnerRegistration {
-                    registration_id: msg.registration_id,
-                    socket_node: msg.socket_node.clone(),
-                    socket_generation: msg.socket_generation,
-                    owner: owner.clone(),
-                };
+                if let Err(error) =
+                    exact_remote_owner_authority_is_current(&services, &msg.jid, &registration)
+                        .await
+                {
+                    if !unregister_remote_owner_actor_entry(&services, &msg.jid, &owner).await {
+                        self.retain_remote_owner_cleanup(&msg.jid, &registration)
+                            .await;
+                        return RelayRemoteResourceRegistrationReply {
+                            status: RelayRemoteResourceRegistrationStatus::Unavailable,
+                        };
+                    }
+                    self.remove_pending_remote_owner_cleanup_if_current(&msg.jid, &registration)
+                        .await;
+                    return RelayRemoteResourceRegistrationReply {
+                        status: remote_registration_status_for_authority_error(error),
+                    };
+                }
                 if !services
                     .connection_registry
                     .register_entry_if_owner_or_absent(msg.jid.clone(), entry.clone(), &owner)
                 {
                     if !unregister_remote_owner_actor_entry(&services, &msg.jid, &owner).await {
+                        self.retain_remote_owner_cleanup(&msg.jid, &registration)
+                            .await;
                         return RelayRemoteResourceRegistrationReply {
                             status: RelayRemoteResourceRegistrationStatus::Unavailable,
                         };
                     }
+                    self.remove_pending_remote_owner_cleanup_if_current(&msg.jid, &registration)
+                        .await;
                     return RelayRemoteResourceRegistrationReply {
                         status: RelayRemoteResourceRegistrationStatus::StaleRegistration,
                     };
@@ -1412,6 +3001,8 @@ impl OrderedRelayDeliveryBridge {
                     Ok(()) => {}
                     Err(status) => {
                         if !unregister_remote_owner_actor_entry(&services, &msg.jid, &owner).await {
+                            self.retain_remote_owner_cleanup(&msg.jid, &registration)
+                                .await;
                             return RelayRemoteResourceRegistrationReply {
                                 status: RelayRemoteResourceRegistrationStatus::Unavailable,
                             };
@@ -1419,6 +3010,11 @@ impl OrderedRelayDeliveryBridge {
                         services
                             .connection_registry
                             .unregister_if_owner(&msg.jid, &owner);
+                        self.remove_pending_remote_owner_cleanup_if_current(
+                            &msg.jid,
+                            &registration,
+                        )
+                        .await;
                         return RelayRemoteResourceRegistrationReply { status };
                     }
                 }
@@ -1433,22 +3029,48 @@ impl OrderedRelayDeliveryBridge {
                 self.remote_owner_resources
                     .lock()
                     .await
-                    .insert(msg.jid.clone(), registration);
-                self.spawn_remote_resource_forwarder(
-                    msg.jid,
-                    msg.registration_id,
-                    msg.socket_node,
-                    rx,
-                    force_detach_rx,
-                );
+                    .insert(msg.jid.clone(), registration.clone());
+                // The pending exact entry is the lifetime reservation for this
+                // active mirror as well as its compensation evidence. Cleanup
+                // selection skips the matching active entry.
+                let post_publish_failure =
+                    if !self.remote_resource_registration_allowed(&services, fence_generation) {
+                        Some(RelayRemoteResourceRegistrationStatus::Unavailable)
+                    } else {
+                        remote_owner_registration_is_current(&services, &msg.jid, &registration)
+                            .await
+                            .err()
+                    };
+                if let Some(status) = post_publish_failure {
+                    self.retain_remote_owner_cleanup(&msg.jid, &registration)
+                        .await;
+                    if !unregister_remote_owner_actor_entry(&services, &msg.jid, &owner).await {
+                        return RelayRemoteResourceRegistrationReply {
+                            status: RelayRemoteResourceRegistrationStatus::Unavailable,
+                        };
+                    }
+                    services
+                        .connection_registry
+                        .unregister_if_owner(&msg.jid, &owner);
+                    self.remove_pending_remote_owner_cleanup_if_current(&msg.jid, &registration)
+                        .await;
+                    return RelayRemoteResourceRegistrationReply { status };
+                }
+                self.spawn_remote_resource_forwarder(msg.jid, registration, rx, force_detach_rx);
                 RelayRemoteResourceRegistrationReply {
                     status: RelayRemoteResourceRegistrationStatus::Registered,
                 }
             }
-            Ok(false) => RelayRemoteResourceRegistrationReply {
-                status: RelayRemoteResourceRegistrationStatus::StaleRegistration,
-            },
+            Ok(false) => {
+                self.remove_pending_remote_owner_cleanup_if_current(&msg.jid, &registration)
+                    .await;
+                RelayRemoteResourceRegistrationReply {
+                    status: RelayRemoteResourceRegistrationStatus::StaleRegistration,
+                }
+            }
             Err(error) => {
+                self.retain_remote_owner_cleanup(&msg.jid, &registration)
+                    .await;
                 tracing::warn!(
                     jid = %msg.jid,
                     %error,
@@ -1465,48 +3087,142 @@ impl OrderedRelayDeliveryBridge {
         &self,
         msg: RelayUnregisterRemoteUserResource,
     ) -> RelayRemoteResourceUnregisterReply {
+        let jid = msg.jid.clone();
+        let Some(lock) = self.lock_for_remote_owner_registration(&jid).await else {
+            return RelayRemoteResourceUnregisterReply {
+                status: RelayRemoteResourceUnregisterStatus::Retry,
+            };
+        };
+        let guard = lock.lock().await;
+        let reply = self
+            .unregister_remote_user_resource_on_owner_locked(msg)
+            .await;
+        drop(guard);
+        self.remove_remote_owner_registration_lock_if_unused(&jid, &lock)
+            .await;
+        reply
+    }
+
+    async fn unregister_remote_user_resource_on_owner_locked(
+        &self,
+        msg: RelayUnregisterRemoteUserResource,
+    ) -> RelayRemoteResourceUnregisterReply {
         let Some(services) = self.services.get().cloned() else {
-            return RelayRemoteResourceUnregisterReply { removed: false };
+            return RelayRemoteResourceUnregisterReply {
+                status: RelayRemoteResourceUnregisterStatus::Retry,
+            };
         };
-        let registration = self
-            .remote_owner_resources
-            .lock()
+        if let Err(error) = services
+            .remote_resource_admission_store
+            .cancel(
+                &msg.jid,
+                msg.registration_id,
+                msg.admission_epoch,
+                &msg.socket_node,
+            )
             .await
-            .get(&msg.jid)
-            .filter(|registration| {
-                registration.registration_id == msg.registration_id
-                    && registration.socket_generation == msg.socket_generation
-            })
-            .cloned();
+        {
+            tracing::warn!(
+                jid = %msg.jid,
+                registration_id = ?msg.registration_id,
+                %error,
+                "owner could not revoke exact remote-resource admission before unregister"
+            );
+            return RelayRemoteResourceUnregisterReply {
+                status: RelayRemoteResourceUnregisterStatus::Retry,
+            };
+        }
+        let active_registration = {
+            let registrations = self.remote_owner_resources.lock().await;
+            registrations
+                .get(&msg.jid)
+                .filter(|registration| {
+                    registration.registration_id == msg.registration_id
+                        && registration.admission_epoch == msg.admission_epoch
+                        && registration.socket_generation == msg.socket_generation
+                        && registration.socket_node == msg.socket_node
+                        && registration.user_owner == msg.expected_user_owner
+                        && registration.user_claim_epoch == msg.expected_user_claim_epoch
+                })
+                .cloned()
+        };
+        let registration = if let Some(registration) = active_registration {
+            Some(registration)
+        } else {
+            self.remote_owner_pending_cleanup
+                .lock()
+                .await
+                .get(&msg.registration_id)
+                .filter(|(pending_jid, registration)| {
+                    pending_jid == &msg.jid
+                        && registration.admission_epoch == msg.admission_epoch
+                        && registration.socket_generation == msg.socket_generation
+                        && registration.socket_node == msg.socket_node
+                        && registration.user_owner == msg.expected_user_owner
+                        && registration.user_claim_epoch == msg.expected_user_claim_epoch
+                })
+                .map(|(_, registration)| registration.clone())
+        };
         let Some(registration) = registration else {
-            return RelayRemoteResourceUnregisterReply { removed: false };
+            return RelayRemoteResourceUnregisterReply {
+                status: RelayRemoteResourceUnregisterStatus::Terminal,
+            };
         };
-        let actor_removed = services
-            .user_registry
-            .ask(UnregisterUserResource {
-                jid: msg.jid.clone(),
-                owner: Some(registration.owner.clone()),
-            })
-            .mailbox_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
-            .reply_timeout(ORDERED_DELIVERY_MAILBOX_TIMEOUT)
-            .await
-            .is_ok();
-        if !actor_removed {
-            return RelayRemoteResourceUnregisterReply { removed: false };
+        match remote_owner_registration_is_current(&services, &msg.jid, &registration).await {
+            Ok(()) => {}
+            Err(RelayRemoteResourceRegistrationStatus::StaleRegistration) => {
+                let terminal = self
+                    .cleanup_remote_owner_resource_if_registration(
+                        &msg.jid,
+                        registration.registration_id,
+                    )
+                    .await;
+                return RelayRemoteResourceUnregisterReply {
+                    status: if terminal {
+                        RelayRemoteResourceUnregisterStatus::Terminal
+                    } else {
+                        RelayRemoteResourceUnregisterStatus::Retry
+                    },
+                };
+            }
+            Err(_) => {
+                return RelayRemoteResourceUnregisterReply {
+                    status: RelayRemoteResourceUnregisterStatus::Retry,
+                };
+            }
         }
-        let registry_removed = services
-            .connection_registry
-            .unregister_if_owner(&msg.jid, &registration.owner)
-            .is_some();
-        let mut registrations = self.remote_owner_resources.lock().await;
-        if registrations.get(&msg.jid).is_some_and(|registration| {
-            registration.registration_id == msg.registration_id
-                && registration.socket_generation == msg.socket_generation
-        }) {
-            registrations.remove(&msg.jid);
+        match exact_remote_owner_authority_is_current(&services, &msg.jid, &registration).await {
+            Ok(()) => {}
+            Err(RemoteUserClaimValidationError::Stale) => {
+                let terminal = self
+                    .cleanup_remote_owner_resource_if_registration(
+                        &msg.jid,
+                        registration.registration_id,
+                    )
+                    .await;
+                return RelayRemoteResourceUnregisterReply {
+                    status: if terminal {
+                        RelayRemoteResourceUnregisterStatus::Terminal
+                    } else {
+                        RelayRemoteResourceUnregisterStatus::Retry
+                    },
+                };
+            }
+            Err(RemoteUserClaimValidationError::Unavailable) => {
+                return RelayRemoteResourceUnregisterReply {
+                    status: RelayRemoteResourceUnregisterStatus::Retry,
+                };
+            }
         }
+        let terminal = self
+            .cleanup_remote_owner_resource_if_registration(&msg.jid, registration.registration_id)
+            .await;
         RelayRemoteResourceUnregisterReply {
-            removed: registry_removed,
+            status: if terminal {
+                RelayRemoteResourceUnregisterStatus::Terminal
+            } else {
+                RelayRemoteResourceUnregisterStatus::Retry
+            },
         }
     }
 
@@ -1519,21 +3235,43 @@ impl OrderedRelayDeliveryBridge {
                 status: RelayRemoteResourceUpdateStatus::Unavailable,
             };
         };
-        let registration = self
-            .remote_owner_resources
-            .lock()
-            .await
-            .get(&msg.jid)
-            .filter(|registration| {
-                registration.registration_id == msg.registration_id
-                    && registration.socket_generation == msg.socket_generation
-            })
-            .cloned();
+        let registration = {
+            let registrations = self.remote_owner_resources.lock().await;
+            registrations
+                .get(&msg.jid)
+                .filter(|registration| {
+                    registration.registration_id == msg.registration_id
+                        && registration.admission_epoch == msg.admission_epoch
+                        && registration.socket_generation == msg.socket_generation
+                        && registration.socket_node == msg.socket_node
+                        && registration.user_owner == msg.expected_user_owner
+                        && registration.user_claim_epoch == msg.expected_user_claim_epoch
+                })
+                .cloned()
+        };
         let Some(registration) = registration else {
             return RelayRemoteResourceUpdateReply {
                 status: RelayRemoteResourceUpdateStatus::StaleRegistration,
             };
         };
+        match remote_owner_registration_is_current(&services, &msg.jid, &registration).await {
+            Ok(()) => {}
+            Err(RelayRemoteResourceRegistrationStatus::StaleRegistration) => {
+                self.cleanup_remote_owner_resource_if_registration(
+                    &msg.jid,
+                    registration.registration_id,
+                )
+                .await;
+                return RelayRemoteResourceUpdateReply {
+                    status: RelayRemoteResourceUpdateStatus::StaleRegistration,
+                };
+            }
+            Err(_) => {
+                return RelayRemoteResourceUpdateReply {
+                    status: RelayRemoteResourceUpdateStatus::Unavailable,
+                };
+            }
+        }
         let actor = match services
             .user_registry
             .ask(waddle_xmpp::registry::GetUser {
@@ -1561,82 +3299,61 @@ impl OrderedRelayDeliveryBridge {
             }
         };
         let jid = msg.jid;
+        let entry = match owner_remote_entry_if_current(
+            &actor,
+            &services.connection_registry,
+            &jid,
+            &registration.owner,
+        )
+        .await
+        {
+            Ok(entry) => entry,
+            Err(status) => return RelayRemoteResourceUpdateReply { status },
+        };
+        if let Err(error) =
+            exact_remote_owner_authority_is_current(&services, &jid, &registration).await
+        {
+            return RelayRemoteResourceUpdateReply {
+                status: match error {
+                    RemoteUserClaimValidationError::Stale => {
+                        RelayRemoteResourceUpdateStatus::StaleRegistration
+                    }
+                    RemoteUserClaimValidationError::Unavailable => {
+                        RelayRemoteResourceUpdateStatus::Unavailable
+                    }
+                },
+            };
+        }
         let status = match msg.update {
             RemoteResourceStateUpdate::Presence {
                 available,
                 priority,
                 state,
             } => {
-                match owner_remote_entry_if_current(
-                    &actor,
+                if apply_remote_resource_presence_to_registry(
                     &services.connection_registry,
                     &jid,
                     &registration.owner,
-                )
-                .await
-                {
-                    Ok(_) => {
-                        if apply_remote_resource_presence_to_registry(
-                            &services.connection_registry,
-                            &jid,
-                            &registration.owner,
-                            available,
-                            priority,
-                            state,
-                        ) {
-                            RelayRemoteResourceUpdateStatus::Updated
-                        } else {
-                            RelayRemoteResourceUpdateStatus::StaleRegistration
-                        }
-                    }
-                    Err(status) => status,
+                    available,
+                    priority,
+                    state,
+                ) {
+                    RelayRemoteResourceUpdateStatus::Updated
+                } else {
+                    RelayRemoteResourceUpdateStatus::StaleRegistration
                 }
             }
             RemoteResourceStateUpdate::Carbons { enabled } => {
-                match owner_remote_entry_if_current(
-                    &actor,
-                    &services.connection_registry,
-                    &jid,
-                    &registration.owner,
-                )
-                .await
-                {
-                    Ok(entry) => {
-                        entry.carbons_enabled.store(enabled, Ordering::Relaxed);
-                        RelayRemoteResourceUpdateStatus::Updated
-                    }
-                    Err(status) => status,
-                }
+                entry.carbons_enabled.store(enabled, Ordering::Relaxed);
+                RelayRemoteResourceUpdateStatus::Updated
             }
-            RemoteResourceStateUpdate::RosterInterested => match owner_remote_entry_if_current(
-                &actor,
-                &services.connection_registry,
-                &jid,
-                &registration.owner,
-            )
-            .await
-            {
-                Ok(entry) => {
-                    entry.roster_interested.store(true, Ordering::Relaxed);
-                    RelayRemoteResourceUpdateStatus::Updated
-                }
-                Err(status) => status,
-            },
+            RemoteResourceStateUpdate::RosterInterested => {
+                entry.roster_interested.store(true, Ordering::Relaxed);
+                RelayRemoteResourceUpdateStatus::Updated
+            }
             RemoteResourceStateUpdate::BlocklistInterested => {
-                match owner_remote_entry_if_current(
-                    &actor,
-                    &services.connection_registry,
-                    &jid,
-                    &registration.owner,
-                )
-                .await
-                {
-                    Ok(entry) => {
-                        entry.blocklist_interested.store(true, Ordering::Relaxed);
-                        RelayRemoteResourceUpdateStatus::Updated
-                    }
-                    Err(status) => status,
-                }
+                entry.blocklist_interested.store(true, Ordering::Relaxed);
+                RelayRemoteResourceUpdateStatus::Updated
             }
         };
         RelayRemoteResourceUpdateReply { status }
@@ -1651,21 +3368,44 @@ impl OrderedRelayDeliveryBridge {
                 status: RelayRemoteUserSideEffectStatus::Unavailable,
             };
         };
-        let registration = self
-            .remote_owner_resources
-            .lock()
-            .await
-            .get(&msg.source_jid)
-            .filter(|registration| {
-                registration.registration_id == msg.registration_id
-                    && registration.socket_generation == msg.socket_generation
-            })
-            .cloned();
+        let registration = {
+            let registrations = self.remote_owner_resources.lock().await;
+            registrations
+                .get(&msg.source_jid)
+                .filter(|registration| {
+                    registration.registration_id == msg.registration_id
+                        && registration.admission_epoch == msg.admission_epoch
+                        && registration.socket_generation == msg.socket_generation
+                        && registration.socket_node == msg.socket_node
+                        && registration.user_owner == msg.expected_user_owner
+                        && registration.user_claim_epoch == msg.expected_user_claim_epoch
+                })
+                .cloned()
+        };
         let Some(registration) = registration else {
             return RelayRemoteUserSideEffectReply {
                 status: RelayRemoteUserSideEffectStatus::StaleRegistration,
             };
         };
+        match remote_owner_registration_is_current(&services, &msg.source_jid, &registration).await
+        {
+            Ok(()) => {}
+            Err(RelayRemoteResourceRegistrationStatus::StaleRegistration) => {
+                self.cleanup_remote_owner_resource_if_registration(
+                    &msg.source_jid,
+                    registration.registration_id,
+                )
+                .await;
+                return RelayRemoteUserSideEffectReply {
+                    status: RelayRemoteUserSideEffectStatus::StaleRegistration,
+                };
+            }
+            Err(_) => {
+                return RelayRemoteUserSideEffectReply {
+                    status: RelayRemoteUserSideEffectStatus::Unavailable,
+                };
+            }
+        }
         let actor = match services
             .user_registry
             .ask(waddle_xmpp::registry::GetUser {
@@ -1709,6 +3449,20 @@ impl OrderedRelayDeliveryBridge {
                         RelayRemoteUserSideEffectStatus::StaleRegistration
                     }
                     RelayRemoteResourceUpdateStatus::Unavailable => {
+                        RelayRemoteUserSideEffectStatus::Unavailable
+                    }
+                },
+            };
+        }
+        if let Err(error) =
+            exact_remote_owner_authority_is_current(&services, &msg.source_jid, &registration).await
+        {
+            return RelayRemoteUserSideEffectReply {
+                status: match error {
+                    RemoteUserClaimValidationError::Stale => {
+                        RelayRemoteUserSideEffectStatus::StaleRegistration
+                    }
+                    RemoteUserClaimValidationError::Unavailable => {
                         RelayRemoteUserSideEffectStatus::Unavailable
                     }
                 },
@@ -1829,10 +3583,6 @@ impl OrderedRelayDeliveryBridge {
                             }
                         }
                     }
-                    RemoteResourceOriginRefresh::LocalOwner => {
-                        self.route_remote_resource_target_from_local_origin(&remote_origin, target)
-                            .await
-                    }
                     RemoteResourceOriginRefresh::Failed => {
                         Some(FullJidDeliveryOutcome::Unavailable)
                     }
@@ -1858,14 +3608,6 @@ impl OrderedRelayDeliveryBridge {
                                         .or(Some(FullJidDeliveryOutcome::Dropped))
                                 }
                             };
-                        }
-                        RemoteResourceOriginRefresh::LocalOwner => {
-                            return self
-                                .route_remote_resource_target_from_local_origin(
-                                    &remote_origin,
-                                    target,
-                                )
-                                .await;
                         }
                         RemoteResourceOriginRefresh::Failed => {}
                     }
@@ -1916,13 +3658,6 @@ impl OrderedRelayDeliveryBridge {
                             }
                         }
                     }
-                    RemoteResourceOriginRefresh::LocalOwner => {
-                        self.route_remote_resource_muc_target_from_local_origin(
-                            &remote_origin,
-                            target,
-                        )
-                        .await
-                    }
                     RemoteResourceOriginRefresh::Failed => {
                         Some(OrderedRelayMucProxyOutcome::Unavailable)
                     }
@@ -1951,14 +3686,6 @@ impl OrderedRelayDeliveryBridge {
                                 }
                             };
                         }
-                        RemoteResourceOriginRefresh::LocalOwner => {
-                            return self
-                                .route_remote_resource_muc_target_from_local_origin(
-                                    &remote_origin,
-                                    target,
-                                )
-                                .await;
-                        }
                         RemoteResourceOriginRefresh::Failed => {}
                     }
                 }
@@ -1972,85 +3699,23 @@ impl OrderedRelayDeliveryBridge {
         remote_origin: &RemoteResourceOriginSnapshot,
         target: RemoteResourceRouteTarget,
     ) -> Result<RelayRouteRemoteResourceStanzaReply, RelayAskError> {
-        let mut handle =
-            RelayHandle::new(remote_origin.user_owner.clone(), self.stop_token.clone())
-                .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        let mut handle = RelayHandle::new(
+            NodeId::new(remote_origin.user_owner.node_id.clone()),
+            self.stop_token.clone(),
+        )
+        .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
         handle
             .route_remote_resource_stanza(RelayRouteRemoteResourceStanza {
                 source_jid: remote_origin.jid.clone(),
                 registration_id: remote_origin.registration_id,
+                admission_epoch: remote_origin.admission_epoch,
                 socket_generation: remote_origin.socket_generation,
+                socket_node: remote_origin.socket_node.clone(),
+                expected_user_owner: remote_origin.user_owner.clone(),
+                expected_user_claim_epoch: remote_origin.user_claim_epoch,
                 target,
             })
             .await
-    }
-
-    async fn route_remote_resource_target_from_local_origin(
-        self: &Arc<Self>,
-        remote_origin: &RemoteResourceOriginSnapshot,
-        target: RemoteResourceRouteTarget,
-    ) -> Option<FullJidDeliveryOutcome> {
-        let services = self.services.get().cloned()?;
-        let origin = local_origin_for_remote_resource(remote_origin);
-        match target {
-            RemoteResourceRouteTarget::FullJid { target, stanza } => {
-                if let Some(remote) = self
-                    .try_deliver_full_jid_remote(&target, &stanza.0, &origin)
-                    .await
-                {
-                    Some(remote)
-                } else {
-                    Some(
-                        deliver_local_full_jid_after_target_refresh(&services, &target, &stanza.0)
-                            .await,
-                    )
-                }
-            }
-            RemoteResourceRouteTarget::BareJid { target, stanza } => {
-                match route_local_bare_jid_with_timeout(&services, &target, &stanza.0, Some(origin))
-                    .await
-                {
-                    Ok(replies) if replies.is_empty() => Some(FullJidDeliveryOutcome::Delivered),
-                    Ok(_) => Some(FullJidDeliveryOutcome::Unavailable),
-                    Err(OrderedRelayNackReason::TargetUnavailable) => {
-                        Some(FullJidDeliveryOutcome::Unavailable)
-                    }
-                    Err(_) => Some(FullJidDeliveryOutcome::Dropped),
-                }
-            }
-            RemoteResourceRouteTarget::MucProxy { .. } => Some(FullJidDeliveryOutcome::Dropped),
-        }
-    }
-
-    async fn route_remote_resource_muc_target_from_local_origin(
-        self: &Arc<Self>,
-        remote_origin: &RemoteResourceOriginSnapshot,
-        target: RemoteResourceRouteTarget,
-    ) -> Option<OrderedRelayMucProxyOutcome> {
-        let services = self.services.get().cloned()?;
-        let RemoteResourceRouteTarget::MucProxy {
-            room_jid,
-            kind,
-            stanza,
-        } = target
-        else {
-            return Some(OrderedRelayMucProxyOutcome::Dropped);
-        };
-        let origin = local_origin_for_remote_resource(remote_origin);
-        if let Some(remote) = self
-            .try_proxy_muc_remote_from_local_origin(&room_jid, &stanza.0, kind, &origin)
-            .await
-        {
-            Some(remote)
-        } else {
-            Some(muc_proxy_result_to_ordered_outcome(
-                kind,
-                Box::pin(deliver_reserved_muc_proxy(
-                    &services, &room_jid, kind, &stanza.0,
-                ))
-                .await,
-            ))
-        }
     }
 
     async fn refresh_remote_resource_origin(
@@ -2060,23 +3725,27 @@ impl OrderedRelayDeliveryBridge {
         let Some(services) = self.services.get().cloned() else {
             return RemoteResourceOriginRefresh::Failed;
         };
-        let owner = {
+        let registration = {
             let registrations = self.remote_socket_resources.lock().await;
-            let Some(owner) = registrations
+            let Some(registration) = registrations
                 .get(&remote_origin.jid)
                 .filter(|registration| {
                     registration.registration_id == remote_origin.registration_id
+                        && registration.admission_epoch == remote_origin.admission_epoch
                         && registration.socket_generation == remote_origin.socket_generation
+                        && registration.socket_node == remote_origin.socket_node
+                        && registration.user_owner == remote_origin.user_owner
+                        && registration.user_claim_epoch == remote_origin.user_claim_epoch
                 })
-                .map(|registration| registration.owner.clone())
+                .cloned()
             else {
                 return RemoteResourceOriginRefresh::Failed;
             };
-            owner
+            registration
         };
         let Some(entry) = services
             .connection_registry
-            .entry_if_owner(&remote_origin.jid, &owner)
+            .entry_if_owner(&remote_origin.jid, &registration.owner)
         else {
             return RemoteResourceOriginRefresh::Failed;
         };
@@ -2084,58 +3753,27 @@ impl OrderedRelayDeliveryBridge {
         let Some(snapshot) = current_claim(&services, &target_entity).await else {
             return RemoteResourceOriginRefresh::Failed;
         };
-        let me = services.node_identity.current();
-        if snapshot.owner_lease_fresh && snapshot.owner == me {
-            match crate::server::dual_registration::mirror_register_outcome(
-                &services.user_registry,
-                remote_origin.jid.clone(),
-                entry,
-            )
-            .await
-            {
-                crate::server::dual_registration::MirrorRegisterOutcome::Registered => {}
-                crate::server::dual_registration::MirrorRegisterOutcome::ForeignOwner
-                | crate::server::dual_registration::MirrorRegisterOutcome::Failed => {
-                    return RemoteResourceOriginRefresh::Failed;
-                }
-            }
-            self.remove_remote_socket_registration_if_snapshot(remote_origin, &owner)
-                .await;
-            return RemoteResourceOriginRefresh::LocalOwner;
-        }
+        let _ = entry;
         if !snapshot.owner_lease_fresh {
             return RemoteResourceOriginRefresh::Failed;
         }
-        match self
-            .try_register_remote_user_resource(&remote_origin.jid, entry, owner.clone())
-            .await
+        if snapshot.owner == registration.user_owner
+            && snapshot.claim_epoch == registration.user_claim_epoch
         {
-            RemoteResourceRegisterOutcome::Registered => self
-                .remote_resource_origin_if_owner(&remote_origin.jid, &owner)
-                .await
-                .map(RemoteResourceOriginRefresh::Remote)
-                .unwrap_or(RemoteResourceOriginRefresh::Failed),
-            RemoteResourceRegisterOutcome::NotRemote => RemoteResourceOriginRefresh::Failed,
-            RemoteResourceRegisterOutcome::Failed => RemoteResourceOriginRefresh::Failed,
+            return RemoteResourceOriginRefresh::Remote(remote_origin.clone());
         }
-    }
-
-    async fn remove_remote_socket_registration_if_snapshot(
-        &self,
-        remote_origin: &RemoteResourceOriginSnapshot,
-        owner: &Arc<AtomicBool>,
-    ) {
-        let mut registrations = self.remote_socket_resources.lock().await;
-        if registrations
-            .get(&remote_origin.jid)
-            .is_some_and(|registration| {
-                registration.registration_id == remote_origin.registration_id
-                    && registration.socket_generation == remote_origin.socket_generation
-                    && Arc::ptr_eq(&registration.owner, owner)
-            })
-        {
-            registrations.remove(&remote_origin.jid);
-        }
+        // The physical admission remains exact, but its authoritative actor
+        // claim changed. Reconnecting mints a fresh registration carrying the
+        // new claim epoch; allowing this connection to rewrite that lineage in
+        // place would let already-queued old-owner operations touch the new
+        // actor incarnation.
+        self.detach_remote_socket_resource(
+            &remote_origin.jid,
+            &registration,
+            ForceDetachReason::OwnershipLost,
+        )
+        .await;
+        RemoteResourceOriginRefresh::Failed
     }
 
     pub(crate) async fn route_remote_resource_stanza_on_owner(
@@ -2145,19 +3783,36 @@ impl OrderedRelayDeliveryBridge {
         let Some(services) = self.services.get().cloned() else {
             return remote_resource_route_reply(RemoteResourceRouteOutcome::Dropped);
         };
-        let Some(registration) = self
-            .remote_owner_resources
-            .lock()
-            .await
-            .get(&msg.source_jid)
-            .filter(|registration| {
-                registration.registration_id == msg.registration_id
-                    && registration.socket_generation == msg.socket_generation
-            })
-            .cloned()
-        else {
+        let registration = {
+            let registrations = self.remote_owner_resources.lock().await;
+            registrations
+                .get(&msg.source_jid)
+                .filter(|registration| {
+                    registration.registration_id == msg.registration_id
+                        && registration.admission_epoch == msg.admission_epoch
+                        && registration.socket_generation == msg.socket_generation
+                        && registration.socket_node == msg.socket_node
+                        && registration.user_owner == msg.expected_user_owner
+                        && registration.user_claim_epoch == msg.expected_user_claim_epoch
+                })
+                .cloned()
+        };
+        let Some(registration) = registration else {
             return remote_resource_route_reply(RemoteResourceRouteOutcome::StaleRegistration);
         };
+        match remote_owner_registration_is_current(&services, &msg.source_jid, &registration).await
+        {
+            Ok(()) => {}
+            Err(RelayRemoteResourceRegistrationStatus::StaleRegistration) => {
+                self.cleanup_remote_owner_resource_if_registration(
+                    &msg.source_jid,
+                    registration.registration_id,
+                )
+                .await;
+                return remote_resource_route_reply(RemoteResourceRouteOutcome::StaleRegistration);
+            }
+            Err(_) => return remote_resource_route_reply(RemoteResourceRouteOutcome::Dropped),
+        }
         let actor = match services
             .user_registry
             .ask(waddle_xmpp::registry::GetUser {
@@ -2194,6 +3849,16 @@ impl OrderedRelayDeliveryBridge {
                     RemoteResourceRouteOutcome::StaleRegistration
                 }
                 RelayRemoteResourceUpdateStatus::Unavailable => RemoteResourceRouteOutcome::Dropped,
+            });
+        }
+        if let Err(error) =
+            exact_remote_owner_authority_is_current(&services, &msg.source_jid, &registration).await
+        {
+            return remote_resource_route_reply(match error {
+                RemoteUserClaimValidationError::Stale => {
+                    RemoteResourceRouteOutcome::StaleRegistration
+                }
+                RemoteUserClaimValidationError::Unavailable => RemoteResourceRouteOutcome::Dropped,
             });
         }
 
@@ -2289,36 +3954,123 @@ impl OrderedRelayDeliveryBridge {
                 status: RelayRemoteResourceFrameStatus::Unavailable,
             };
         };
+        let fence_generation = self.remote_resource_fence_generation.load(Ordering::SeqCst);
+        if !self.remote_resource_registration_allowed(&services, fence_generation) {
+            return RelayRemoteResourceFrameReply {
+                status: RelayRemoteResourceFrameStatus::StaleRegistration,
+            };
+        }
         let registration = {
             let registrations = self.remote_socket_resources.lock().await;
             registrations
                 .get(&msg.frame.jid)
-                .filter(|registration| registration.registration_id == msg.frame.registration_id)
+                .filter(|registration| {
+                    registration.registration_id == msg.frame.registration_id
+                        && registration.admission_epoch == msg.frame.admission_epoch
+                        && registration.socket_generation == msg.frame.socket_generation
+                        && registration.socket_node == msg.frame.socket_node
+                        && registration.user_owner == msg.frame.expected_user_owner
+                        && registration.user_claim_epoch == msg.frame.expected_user_claim_epoch
+                })
                 .cloned()
         };
         let Some(registration) = registration else {
             return RelayRemoteResourceFrameReply {
-                status: RelayRemoteResourceFrameStatus::Unavailable,
+                status: RelayRemoteResourceFrameStatus::StaleRegistration,
             };
         };
+        if services.node_identity.current() != registration.socket_node {
+            self.detach_stale_remote_socket_resource(&msg.frame.jid, &registration)
+                .await;
+            return RelayRemoteResourceFrameReply {
+                status: RelayRemoteResourceFrameStatus::StaleRegistration,
+            };
+        }
+        match exact_remote_user_claim_is_current(
+            &services,
+            &msg.frame.jid,
+            &registration.user_owner,
+            registration.user_claim_epoch,
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(RemoteUserClaimValidationError::Stale) => {
+                self.detach_stale_remote_socket_resource(&msg.frame.jid, &registration)
+                    .await;
+                return RelayRemoteResourceFrameReply {
+                    status: RelayRemoteResourceFrameStatus::StaleRegistration,
+                };
+            }
+            Err(RemoteUserClaimValidationError::Unavailable) => {
+                return RelayRemoteResourceFrameReply {
+                    status: RelayRemoteResourceFrameStatus::Unavailable,
+                };
+            }
+        }
+        match exact_remote_resource_admission_is_current(
+            &services,
+            &msg.frame.jid,
+            registration.registration_id,
+            registration.admission_epoch,
+            &registration.socket_node,
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(RemoteUserClaimValidationError::Stale) => {
+                self.detach_stale_remote_socket_resource(&msg.frame.jid, &registration)
+                    .await;
+                return RelayRemoteResourceFrameReply {
+                    status: RelayRemoteResourceFrameStatus::StaleRegistration,
+                };
+            }
+            Err(RemoteUserClaimValidationError::Unavailable) => {
+                return RelayRemoteResourceFrameReply {
+                    status: RelayRemoteResourceFrameStatus::Unavailable,
+                };
+            }
+        }
         let outbound = OutboundStanza {
             stanza: msg.frame.stanza.0,
             kind: msg.frame.kind,
             pending_row_id: None,
             pending_row_original_receipt_at: None,
         };
-        let outcome = services.connection_registry.try_send_outbound_if_owner(
-            &msg.frame.jid,
-            &registration.owner,
-            outbound,
-        );
+        let outcome = {
+            let registrations = self.remote_socket_resources.lock().await;
+            let authority_is_current = self
+                .remote_resource_registration_allowed(&services, fence_generation)
+                && services.node_identity.current() == registration.socket_node
+                && registrations.get(&msg.frame.jid).is_some_and(|current| {
+                    remote_socket_registration_matches(current, &registration)
+                });
+            authority_is_current.then(|| {
+                services.connection_registry.try_send_outbound_if_owner(
+                    &msg.frame.jid,
+                    &registration.owner,
+                    outbound,
+                )
+            })
+        };
+        let Some(outcome) = outcome else {
+            self.detach_stale_remote_socket_resource(&msg.frame.jid, &registration)
+                .await;
+            return RelayRemoteResourceFrameReply {
+                status: RelayRemoteResourceFrameStatus::StaleRegistration,
+            };
+        };
         let status = match outcome {
             BroadcastOutcome::Delivered => RelayRemoteResourceFrameStatus::Delivered,
             BroadcastOutcome::DroppedFull => RelayRemoteResourceFrameStatus::Backpressure,
             BroadcastOutcome::NotConnected | BroadcastOutcome::DroppedClosed => {
-                RelayRemoteResourceFrameStatus::Unavailable
+                RelayRemoteResourceFrameStatus::StaleRegistration
             }
         };
+        if status == RelayRemoteResourceFrameStatus::StaleRegistration {
+            self.detach_stale_remote_socket_resource(&msg.frame.jid, &registration)
+                .await;
+        }
         RelayRemoteResourceFrameReply { status }
     }
 
@@ -2329,14 +4081,21 @@ impl OrderedRelayDeliveryBridge {
         kind: DeliveryKind,
         registration: &RemoteOwnerRegistration,
     ) -> Option<FullJidDeliveryOutcome> {
-        let mut handle =
-            RelayHandle::new(registration.socket_node.clone(), self.stop_token.clone())
-                .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        let mut handle = RelayHandle::new(
+            NodeId::new(registration.socket_node.node_id.clone()),
+            self.stop_token.clone(),
+        )
+        .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
         match handle
             .deliver_remote_resource_frame(RelayDeliverRemoteResourceFrame {
                 frame: RemoteResourceOutboundFrame {
                     jid: target.clone(),
                     registration_id: registration.registration_id,
+                    admission_epoch: registration.admission_epoch,
+                    socket_generation: registration.socket_generation,
+                    socket_node: registration.socket_node.clone(),
+                    expected_user_owner: registration.user_owner.clone(),
+                    expected_user_claim_epoch: registration.user_claim_epoch,
                     stanza: RemoteStanza(stanza.clone()),
                     kind,
                 },
@@ -2350,7 +4109,7 @@ impl OrderedRelayDeliveryBridge {
                 status: RelayRemoteResourceFrameStatus::Backpressure,
             }) => Some(FullJidDeliveryOutcome::Dropped),
             Ok(RelayRemoteResourceFrameReply {
-                status: RelayRemoteResourceFrameStatus::Unavailable,
+                status: RelayRemoteResourceFrameStatus::StaleRegistration,
             }) => {
                 self.cleanup_remote_owner_resource_if_registration(
                     target,
@@ -2359,6 +4118,9 @@ impl OrderedRelayDeliveryBridge {
                 .await;
                 None
             }
+            Ok(RelayRemoteResourceFrameReply {
+                status: RelayRemoteResourceFrameStatus::Unavailable,
+            }) => Some(FullJidDeliveryOutcome::Unavailable),
             Err(error) => {
                 tracing::warn!(
                     jid = %target,
@@ -2372,6 +4134,15 @@ impl OrderedRelayDeliveryBridge {
                     )
                     .await;
                     None
+                } else if matches!(
+                    error,
+                    RelayAskError::NotFound { .. }
+                        | RelayAskError::Send {
+                            effect: RelaySendEffect::NoEffect,
+                            ..
+                        }
+                ) {
+                    Some(FullJidDeliveryOutcome::Unavailable)
                 } else {
                     Some(FullJidDeliveryOutcome::MaybeCommitted)
                 }
@@ -2389,11 +4160,25 @@ impl OrderedRelayDeliveryBridge {
                 status: RelayRemoteResourceForceDetachStatus::Unknown,
             };
         };
+        let fence_generation = self.remote_resource_fence_generation.load(Ordering::SeqCst);
+        if !self.remote_resource_registration_allowed(&services, fence_generation) {
+            return RelayForceDetachRemoteUserResourceReply {
+                outcome: ForceDetachOutcome::NotPersisted,
+                status: RelayRemoteResourceForceDetachStatus::Unknown,
+            };
+        }
         let registration = {
             let registrations = self.remote_socket_resources.lock().await;
             registrations
                 .get(&msg.jid)
-                .filter(|registration| registration.registration_id == msg.registration_id)
+                .filter(|registration| {
+                    registration.registration_id == msg.registration_id
+                        && registration.admission_epoch == msg.admission_epoch
+                        && registration.socket_generation == msg.socket_generation
+                        && registration.socket_node == msg.socket_node
+                        && registration.user_owner == msg.expected_user_owner
+                        && registration.user_claim_epoch == msg.expected_user_claim_epoch
+                })
                 .cloned()
         };
         let Some(registration) = registration else {
@@ -2402,6 +4187,63 @@ impl OrderedRelayDeliveryBridge {
                 status: RelayRemoteResourceForceDetachStatus::NotLive,
             };
         };
+        if services.node_identity.current() != registration.socket_node {
+            self.detach_remote_socket_resource(&msg.jid, &registration, msg.reason)
+                .await;
+            return RelayForceDetachRemoteUserResourceReply {
+                outcome: ForceDetachOutcome::NotPersisted,
+                status: RelayRemoteResourceForceDetachStatus::Invalidated,
+            };
+        }
+        match exact_remote_user_claim_is_current(
+            &services,
+            &msg.jid,
+            &registration.user_owner,
+            registration.user_claim_epoch,
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(RemoteUserClaimValidationError::Stale) => {
+                self.detach_remote_socket_resource(&msg.jid, &registration, msg.reason)
+                    .await;
+                return RelayForceDetachRemoteUserResourceReply {
+                    outcome: ForceDetachOutcome::NotPersisted,
+                    status: RelayRemoteResourceForceDetachStatus::Invalidated,
+                };
+            }
+            Err(RemoteUserClaimValidationError::Unavailable) => {
+                return RelayForceDetachRemoteUserResourceReply {
+                    outcome: ForceDetachOutcome::NotPersisted,
+                    status: RelayRemoteResourceForceDetachStatus::Unknown,
+                };
+            }
+        }
+        match exact_remote_resource_admission_is_current(
+            &services,
+            &msg.jid,
+            registration.registration_id,
+            registration.admission_epoch,
+            &registration.socket_node,
+        )
+        .await
+        {
+            Ok(()) => {}
+            Err(RemoteUserClaimValidationError::Stale) => {
+                self.detach_remote_socket_resource(&msg.jid, &registration, msg.reason)
+                    .await;
+                return RelayForceDetachRemoteUserResourceReply {
+                    outcome: ForceDetachOutcome::NotPersisted,
+                    status: RelayRemoteResourceForceDetachStatus::Invalidated,
+                };
+            }
+            Err(RemoteUserClaimValidationError::Unavailable) => {
+                return RelayForceDetachRemoteUserResourceReply {
+                    outcome: ForceDetachOutcome::NotPersisted,
+                    status: RelayRemoteResourceForceDetachStatus::Unknown,
+                };
+            }
+        }
         let Some(entry) = services
             .connection_registry
             .entry_if_owner(&msg.jid, &registration.owner)
@@ -2414,9 +4256,28 @@ impl OrderedRelayDeliveryBridge {
         let (ack, ack_rx) = tokio::sync::oneshot::channel();
         let request = ForceDetachRequest {
             requester_bare_jid: msg.requester_bare_jid,
+            reason: msg.reason,
             ack,
         };
-        if entry.force_detach_sender().try_send(request).is_err() {
+        let queued = {
+            let registrations = self.remote_socket_resources.lock().await;
+            let authority_is_current = self
+                .remote_resource_registration_allowed(&services, fence_generation)
+                && services.node_identity.current() == registration.socket_node
+                && registrations.get(&msg.jid).is_some_and(|current| {
+                    remote_socket_registration_matches(current, &registration)
+                });
+            authority_is_current.then(|| entry.force_detach_sender().try_send(request))
+        };
+        let Some(queued) = queued else {
+            self.detach_remote_socket_resource(&msg.jid, &registration, msg.reason)
+                .await;
+            return RelayForceDetachRemoteUserResourceReply {
+                outcome: ForceDetachOutcome::NotPersisted,
+                status: RelayRemoteResourceForceDetachStatus::Invalidated,
+            };
+        };
+        if queued.is_err() {
             return RelayForceDetachRemoteUserResourceReply {
                 outcome: ForceDetachOutcome::NotPersisted,
                 status: RelayRemoteResourceForceDetachStatus::Unknown,
@@ -2449,29 +4310,88 @@ impl OrderedRelayDeliveryBridge {
         jid: &jid::FullJid,
         registration: &RemoteSocketRegistration,
     ) {
+        self.detach_remote_socket_resource(
+            jid,
+            registration,
+            ForceDetachReason::RemoteStateInvalidated,
+        )
+        .await;
+    }
+
+    async fn detach_remote_socket_resource(
+        &self,
+        jid: &jid::FullJid,
+        registration: &RemoteSocketRegistration,
+        reason: ForceDetachReason,
+    ) {
         let Some(services) = self.services.get().cloned() else {
             return;
         };
-        {
+        let removed = {
             let mut registrations = self.remote_socket_resources.lock().await;
-            if registrations.get(jid).is_some_and(|current| {
-                current.registration_id == registration.registration_id
-                    && current.socket_generation == registration.socket_generation
-            }) {
+            if registrations
+                .get(jid)
+                .is_some_and(|current| remote_socket_registration_matches(current, registration))
+            {
                 registrations.remove(jid);
+                true
+            } else {
+                false
             }
+        };
+        if !removed {
+            return;
         }
+        self.cancel_remote_resource_admission(&services, jid, registration)
+            .await;
+        self.retain_remote_socket_cleanup(jid, registration).await;
         let Some(entry) = services
             .connection_registry
             .entry_if_owner(jid, &registration.owner)
         else {
             return;
         };
-        let (ack, _ack_rx) = tokio::sync::oneshot::channel();
-        let _ = entry.force_detach_sender().try_send(ForceDetachRequest {
+        let retirement = entry.retirement_handle();
+        let (ack, ack_rx) = tokio::sync::oneshot::channel();
+        let queued = entry.force_detach_sender().try_send(ForceDetachRequest {
             requester_bare_jid: jid.to_bare(),
+            reason,
             ack,
         });
+        let cooperative = if queued.is_ok() {
+            matches!(
+                tokio::time::timeout(REMOTE_RESOURCE_STALE_DETACH_TIMEOUT, ack_rx).await,
+                Ok(Ok(
+                    ForceDetachOutcome::Detached | ForceDetachOutcome::NotPersisted
+                ))
+            )
+        } else {
+            false
+        };
+
+        let terminated = if cooperative {
+            match retirement.as_ref() {
+                Some(handle) => {
+                    tokio::time::timeout(REMOTE_RESOURCE_STALE_DETACH_TIMEOUT, handle.terminated())
+                        .await
+                        .is_ok()
+                }
+                None => true,
+            }
+        } else {
+            false
+        };
+        if !terminated {
+            if let Some(handle) = retirement {
+                handle.abort();
+                let _ =
+                    tokio::time::timeout(REMOTE_RESOURCE_STALE_DETACH_TIMEOUT, handle.terminated())
+                        .await;
+            }
+        }
+        services
+            .connection_registry
+            .unregister_if_owner(jid, &registration.owner);
     }
 
     async fn retire_remote_owner_registration(
@@ -2480,18 +4400,128 @@ impl OrderedRelayDeliveryBridge {
         jid: &jid::FullJid,
         registration: &RemoteOwnerRegistration,
     ) -> bool {
-        let mut handle =
-            RelayHandle::new(registration.socket_node.clone(), self.stop_token.clone())
-                .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        if registration.placement == ConnectionPlacement::LocalSocket {
+            self.detach_remote_socket_resource(
+                jid,
+                &RemoteSocketRegistration {
+                    registration_id: registration.registration_id,
+                    admission_epoch: registration.admission_epoch,
+                    socket_generation: registration.socket_generation,
+                    socket_node: registration.socket_node.clone(),
+                    owner: registration.owner.clone(),
+                    user_owner: registration.user_owner.clone(),
+                    user_claim_epoch: registration.user_claim_epoch,
+                },
+                ForceDetachReason::ResourceReplaced,
+            )
+            .await;
+            if !unregister_remote_owner_actor_entry(services, jid, &registration.owner).await {
+                self.retain_remote_owner_cleanup(jid, registration).await;
+                return false;
+            }
+            services
+                .connection_registry
+                .unregister_if_owner(jid, &registration.owner);
+            self.remove_pending_remote_owner_cleanup_if_current(jid, registration)
+                .await;
+            return true;
+        }
+        let mut handle = RelayHandle::new(
+            NodeId::new(registration.socket_node.node_id.clone()),
+            self.stop_token.clone(),
+        )
+        .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
         let detach = handle
             .force_detach_remote_user_resource(RelayForceDetachRemoteUserResource {
                 jid: jid.clone(),
                 registration_id: registration.registration_id,
+                admission_epoch: registration.admission_epoch,
+                socket_generation: registration.socket_generation,
+                socket_node: registration.socket_node.clone(),
+                expected_user_owner: registration.user_owner.clone(),
+                expected_user_claim_epoch: registration.user_claim_epoch,
                 requester_bare_jid: jid.to_bare(),
+                reason: ForceDetachReason::ResourceReplaced,
             })
             .await;
-        self.finish_remote_owner_registration_retire(services, jid, registration, detach)
+        let retired = self
+            .finish_remote_owner_registration_retire(services, jid, registration, detach)
+            .await;
+        if retired {
+            self.remove_pending_remote_owner_cleanup_if_current(jid, registration)
+                .await;
+        }
+        retired
+    }
+
+    /// Bounded direct compensation when the owner-mirror control queue is
+    /// full, closed, or wedged during ownership loss. The stored exact socket
+    /// incarnation and UserActor claim evidence remain sufficient for the
+    /// socket node to either perform the requested detach or recognize that
+    /// the authority is stale and terminally invalidate its own registration.
+    pub(crate) async fn terminally_force_detach_remote_mirror_if_owner(
+        &self,
+        jid: &jid::FullJid,
+        owner: &Arc<AtomicBool>,
+        reason: ForceDetachReason,
+    ) -> bool {
+        let active_registration = {
+            let registrations = self.remote_owner_resources.lock().await;
+            registrations
+                .get(jid)
+                .filter(|registration| Arc::ptr_eq(&registration.owner, owner))
+                .cloned()
+        };
+        let registration = if let Some(registration) = active_registration {
+            Some(registration)
+        } else {
+            self.remote_owner_pending_cleanup
+                .lock()
+                .await
+                .values()
+                .find(|(pending_jid, registration)| {
+                    pending_jid == jid && Arc::ptr_eq(&registration.owner, owner)
+                })
+                .map(|(_, registration)| registration.clone())
+        };
+        let Some(registration) = registration else {
+            return true;
+        };
+        let mut handle = RelayHandle::new(
+            NodeId::new(registration.socket_node.node_id.clone()),
+            self.stop_token.clone(),
+        )
+        .with_ask_timeouts(self.mailbox_timeout, self.reply_timeout);
+        match handle
+            .force_detach_remote_user_resource(RelayForceDetachRemoteUserResource {
+                jid: jid.clone(),
+                registration_id: registration.registration_id,
+                admission_epoch: registration.admission_epoch,
+                socket_generation: registration.socket_generation,
+                socket_node: registration.socket_node,
+                expected_user_owner: registration.user_owner,
+                expected_user_claim_epoch: registration.user_claim_epoch,
+                requester_bare_jid: jid.to_bare(),
+                reason,
+            })
             .await
+        {
+            Ok(reply) => matches!(
+                reply.status,
+                RelayRemoteResourceForceDetachStatus::Detached
+                    | RelayRemoteResourceForceDetachStatus::Invalidated
+                    | RelayRemoteResourceForceDetachStatus::NotLive
+            ),
+            Err(error) => {
+                tracing::warn!(
+                    jid = %jid,
+                    registration_id = ?registration.registration_id,
+                    %error,
+                    "direct remote-mirror force-detach ask failed; physical socket retirement remains uncertain"
+                );
+                false
+            }
+        }
     }
 
     async fn finish_remote_owner_registration_retire(
@@ -2510,6 +4540,7 @@ impl OrderedRelayDeliveryBridge {
                     "clustered remote-resource replacement cleaning stale old-socket mirror"
                 );
                 if !unregister_remote_owner_actor_entry(services, jid, &registration.owner).await {
+                    self.retain_remote_owner_cleanup(jid, registration).await;
                     return false;
                 }
                 services
@@ -2529,6 +4560,7 @@ impl OrderedRelayDeliveryBridge {
         if !matches!(
             reply.status,
             RelayRemoteResourceForceDetachStatus::Detached
+                | RelayRemoteResourceForceDetachStatus::Invalidated
                 | RelayRemoteResourceForceDetachStatus::NotLive
         ) {
             tracing::warn!(
@@ -2539,6 +4571,7 @@ impl OrderedRelayDeliveryBridge {
             return false;
         }
         if !unregister_remote_owner_actor_entry(services, jid, &registration.owner).await {
+            self.retain_remote_owner_cleanup(jid, registration).await;
             return false;
         }
         services
@@ -2551,19 +4584,44 @@ impl OrderedRelayDeliveryBridge {
         &self,
         jid: &jid::FullJid,
         registration_id: RemoteResourceRegistrationId,
-    ) {
-        let Some(services) = self.services.get().cloned() else {
-            return;
+    ) -> bool {
+        let Some(_cleanup_operation) = RemoteOwnerOperationGuard::begin(
+            Arc::clone(&self.remote_owner_cleanup_inflight),
+            registration_id,
+        ) else {
+            return false;
         };
-        let registration = self
-            .remote_owner_resources
-            .lock()
+        self.cleanup_remote_owner_resource_if_registration_inflight(jid, registration_id)
             .await
-            .get(jid)
-            .filter(|registration| registration.registration_id == registration_id)
-            .cloned();
+    }
+
+    async fn cleanup_remote_owner_resource_if_registration_inflight(
+        &self,
+        jid: &jid::FullJid,
+        registration_id: RemoteResourceRegistrationId,
+    ) -> bool {
+        let Some(services) = self.services.get().cloned() else {
+            return false;
+        };
+        let active_registration = {
+            let registrations = self.remote_owner_resources.lock().await;
+            registrations
+                .get(jid)
+                .filter(|registration| registration.registration_id == registration_id)
+                .cloned()
+        };
+        let registration = if let Some(registration) = active_registration {
+            Some(registration)
+        } else {
+            self.remote_owner_pending_cleanup
+                .lock()
+                .await
+                .get(&registration_id)
+                .filter(|(pending_jid, _)| pending_jid == jid)
+                .map(|(_, registration)| registration.clone())
+        };
         let Some(registration) = registration else {
-            return;
+            return true;
         };
         let actor_removed = services
             .user_registry
@@ -2576,38 +4634,35 @@ impl OrderedRelayDeliveryBridge {
             .await
             .is_ok();
         if !actor_removed {
-            return;
+            self.retain_remote_owner_cleanup(jid, &registration).await;
+            return false;
         }
         services
             .connection_registry
             .unregister_if_owner(jid, &registration.owner);
-        let mut registrations = self.remote_owner_resources.lock().await;
-        if registrations
-            .get(jid)
-            .is_some_and(|registration| registration.registration_id == registration_id)
-        {
-            registrations.remove(jid);
-        }
+        self.remove_remote_owner_registration_if_current(jid, &registration)
+            .await;
+        self.remove_pending_remote_owner_cleanup_if_current(jid, &registration)
+            .await;
+        true
     }
 
     fn spawn_remote_resource_forwarder(
         self: &Arc<Self>,
         jid: jid::FullJid,
-        registration_id: RemoteResourceRegistrationId,
-        socket_node: NodeId,
+        registration: RemoteOwnerRegistration,
         mut rx: mpsc::Receiver<OutboundStanza>,
         force_detach_rx: Option<mpsc::Receiver<ForceDetachRequest>>,
     ) {
         let outbound_bridge = Arc::clone(self);
         let outbound_jid = jid.clone();
-        let outbound_socket_node = socket_node.clone();
+        let outbound_registration = registration.clone();
         tokio::spawn(async move {
             while let Some(outbound) = rx.recv().await {
                 forward_remote_resource_outbound(
                     &outbound_bridge,
                     &outbound_jid,
-                    registration_id,
-                    &outbound_socket_node,
+                    &outbound_registration,
                     outbound,
                 )
                 .await;
@@ -2620,8 +4675,7 @@ impl OrderedRelayDeliveryBridge {
                     forward_remote_resource_force_detach(
                         &control_bridge,
                         &jid,
-                        registration_id,
-                        &socket_node,
+                        &registration,
                         request,
                     )
                     .await;
@@ -2695,7 +4749,7 @@ impl OrderedRelayDeliveryBridge {
             target_entity,
             previous_owner: target_snapshot.owner,
             channel,
-            asserted_origin_node: NodeId::new(me.node_id.clone()),
+            asserted_origin_node: me.clone(),
             origin_inbound_sequence: OriginInboundSequence(original_origin.inbound_sequence),
             origin_claim: OrderedRelayClaim {
                 entity: repair_origin_entity,
@@ -3212,11 +5266,134 @@ async fn owner_remote_entry_if_current(
     Ok(registry_entry)
 }
 
+async fn exact_remote_user_claim_is_current(
+    services: &OrderedRelayDeliveryServices,
+    jid: &jid::FullJid,
+    expected_owner: &NodeIdentity,
+    expected_claim_epoch: ClaimEpoch,
+) -> Result<(), RemoteUserClaimValidationError> {
+    let entity = user_entity(&jid.to_bare());
+    let snapshot = services
+        .claim_store
+        .current_claim(&entity)
+        .await
+        .map_err(|error| {
+            tracing::warn!(
+                %jid,
+                %error,
+                "clustered remote-resource exact UserActor claim lookup failed"
+            );
+            RemoteUserClaimValidationError::Unavailable
+        })?
+        .ok_or(RemoteUserClaimValidationError::Stale)?;
+    if !snapshot.owner_lease_fresh
+        || snapshot.owner != *expected_owner
+        || snapshot.claim_epoch != expected_claim_epoch
+    {
+        return Err(RemoteUserClaimValidationError::Stale);
+    }
+    Ok(())
+}
+
+async fn exact_remote_resource_admission_is_current(
+    services: &OrderedRelayDeliveryServices,
+    jid: &jid::FullJid,
+    registration_id: RemoteResourceRegistrationId,
+    admission_epoch: RemoteResourceAdmissionEpoch,
+    socket_node: &NodeIdentity,
+) -> Result<(), RemoteUserClaimValidationError> {
+    match services
+        .remote_resource_admission_store
+        .is_current(jid, registration_id, admission_epoch, socket_node)
+        .await
+    {
+        Ok(true) => Ok(()),
+        Ok(false) => Err(RemoteUserClaimValidationError::Stale),
+        Err(error) => {
+            tracing::warn!(
+                %jid,
+                registration_id = ?registration_id,
+                %error,
+                "clustered remote-resource exact admission lookup failed"
+            );
+            Err(RemoteUserClaimValidationError::Unavailable)
+        }
+    }
+}
+
+async fn exact_remote_socket_node_is_current(
+    services: &OrderedRelayDeliveryServices,
+    socket_node: &NodeIdentity,
+) -> Result<(), RemoteUserClaimValidationError> {
+    match services.node_lease.peer_id_for_node(socket_node).await {
+        Ok(Some(_)) => Ok(()),
+        Ok(None) => Err(RemoteUserClaimValidationError::Stale),
+        Err(error) => {
+            tracing::warn!(
+                socket_node_id = %socket_node.node_id,
+                socket_node_epoch = %socket_node.node_epoch,
+                %error,
+                "clustered remote-resource exact socket-node lookup failed"
+            );
+            Err(RemoteUserClaimValidationError::Unavailable)
+        }
+    }
+}
+
+async fn exact_remote_owner_authority_is_current(
+    services: &OrderedRelayDeliveryServices,
+    jid: &jid::FullJid,
+    registration: &RemoteOwnerRegistration,
+) -> Result<(), RemoteUserClaimValidationError> {
+    if services.node_identity.current() != registration.user_owner {
+        return Err(RemoteUserClaimValidationError::Stale);
+    }
+    exact_remote_user_claim_is_current(
+        services,
+        jid,
+        &registration.user_owner,
+        registration.user_claim_epoch,
+    )
+    .await?;
+    exact_remote_socket_node_is_current(services, &registration.socket_node).await?;
+    exact_remote_resource_admission_is_current(
+        services,
+        jid,
+        registration.registration_id,
+        registration.admission_epoch,
+        &registration.socket_node,
+    )
+    .await
+}
+
+fn remote_registration_status_for_authority_error(
+    error: RemoteUserClaimValidationError,
+) -> RelayRemoteResourceRegistrationStatus {
+    match error {
+        RemoteUserClaimValidationError::Stale => {
+            RelayRemoteResourceRegistrationStatus::StaleRegistration
+        }
+        RemoteUserClaimValidationError::Unavailable => {
+            RelayRemoteResourceRegistrationStatus::Unavailable
+        }
+    }
+}
+
 async fn remote_owner_registration_is_current(
     services: &OrderedRelayDeliveryServices,
     jid: &jid::FullJid,
     registration: &RemoteOwnerRegistration,
 ) -> Result<(), RelayRemoteResourceRegistrationStatus> {
+    exact_remote_owner_authority_is_current(services, jid, registration)
+        .await
+        .map_err(|error| match error {
+            RemoteUserClaimValidationError::Stale => {
+                RelayRemoteResourceRegistrationStatus::StaleRegistration
+            }
+            RemoteUserClaimValidationError::Unavailable => {
+                RelayRemoteResourceRegistrationStatus::Unavailable
+            }
+        })?;
     let actor = match services
         .user_registry
         .ask(waddle_xmpp::registry::GetUser {
@@ -3237,7 +5414,6 @@ async fn remote_owner_registration_is_current(
         &registration.owner,
     )
     .await
-    .map(|_| ())
     .map_err(|status| match status {
         RelayRemoteResourceUpdateStatus::Updated => {
             RelayRemoteResourceRegistrationStatus::Registered
@@ -3248,7 +5424,10 @@ async fn remote_owner_registration_is_current(
         RelayRemoteResourceUpdateStatus::Unavailable => {
             RelayRemoteResourceRegistrationStatus::Unavailable
         }
-    })
+    })?;
+    exact_remote_owner_authority_is_current(services, jid, registration)
+        .await
+        .map_err(remote_registration_status_for_authority_error)
 }
 
 async fn unregister_remote_owner_actor_entry(
@@ -3283,16 +5462,55 @@ fn remote_owner_registration_matches(
     right: &RemoteOwnerRegistration,
 ) -> bool {
     left.registration_id == right.registration_id
+        && left.admission_epoch == right.admission_epoch
         && left.socket_node == right.socket_node
         && left.socket_generation == right.socket_generation
+        && left.user_owner == right.user_owner
+        && left.user_claim_epoch == right.user_claim_epoch
         && Arc::ptr_eq(&left.owner, &right.owner)
+        && left.placement == right.placement
+}
+
+fn remote_socket_and_owner_registration_match(
+    socket: &RemoteSocketRegistration,
+    owner: &RemoteOwnerRegistration,
+) -> bool {
+    socket.registration_id == owner.registration_id
+        && socket.admission_epoch == owner.admission_epoch
+        && socket.socket_generation == owner.socket_generation
+        && socket.socket_node == owner.socket_node
+        && socket.user_owner == owner.user_owner
+        && socket.user_claim_epoch == owner.user_claim_epoch
+        && Arc::ptr_eq(&socket.owner, &owner.owner)
+}
+
+fn remote_socket_registration_matches(
+    left: &RemoteSocketRegistration,
+    right: &RemoteSocketRegistration,
+) -> bool {
+    left.registration_id == right.registration_id
+        && left.admission_epoch == right.admission_epoch
+        && left.socket_generation == right.socket_generation
+        && left.socket_node == right.socket_node
+        && left.user_owner == right.user_owner
+        && left.user_claim_epoch == right.user_claim_epoch
+        && Arc::ptr_eq(&left.owner, &right.owner)
+}
+
+fn physical_token_matches_registration(
+    token: &PhysicalResourceAdmissionToken,
+    registration: &RemoteSocketRegistration,
+) -> bool {
+    token.registration_id == registration.registration_id
+        && token.admission_epoch == registration.admission_epoch
+        && token.socket_generation == registration.socket_generation
+        && token.socket_node == registration.socket_node
 }
 
 async fn forward_remote_resource_outbound(
     bridge: &Arc<OrderedRelayDeliveryBridge>,
     jid: &jid::FullJid,
-    registration_id: RemoteResourceRegistrationId,
-    socket_node: &NodeId,
+    registration: &RemoteOwnerRegistration,
     outbound: OutboundStanza,
 ) {
     if outbound.pending_row_id.is_some() {
@@ -3306,12 +5524,20 @@ async fn forward_remote_resource_outbound(
     let kind = outbound.kind;
     let frame = RemoteResourceOutboundFrame {
         jid: jid.clone(),
-        registration_id,
+        registration_id: registration.registration_id,
+        admission_epoch: registration.admission_epoch,
+        socket_generation: registration.socket_generation,
+        socket_node: registration.socket_node.clone(),
+        expected_user_owner: registration.user_owner.clone(),
+        expected_user_claim_epoch: registration.user_claim_epoch,
         stanza: RemoteStanza(outbound.stanza),
         kind,
     };
-    let mut handle = RelayHandle::new(socket_node.clone(), bridge.stop_token.clone())
-        .with_ask_timeouts(bridge.mailbox_timeout, bridge.reply_timeout);
+    let mut handle = RelayHandle::new(
+        NodeId::new(registration.socket_node.node_id.clone()),
+        bridge.stop_token.clone(),
+    )
+    .with_ask_timeouts(bridge.mailbox_timeout, bridge.reply_timeout);
     match handle
         .deliver_remote_resource_frame(RelayDeliverRemoteResourceFrame { frame })
         .await
@@ -3320,15 +5546,23 @@ async fn forward_remote_resource_outbound(
             status: RelayRemoteResourceFrameStatus::Delivered,
         }) => {}
         Ok(RelayRemoteResourceFrameReply {
-            status: RelayRemoteResourceFrameStatus::Unavailable,
+            status: RelayRemoteResourceFrameStatus::StaleRegistration,
         }) => {
             tracing::debug!(
                 jid = %jid,
-                "clustered remote-resource socket registration unavailable; cleaning owner mirror"
+                "clustered remote-resource socket registration stale; cleaning owner mirror"
             );
             bridge
-                .cleanup_remote_owner_resource_if_registration(jid, registration_id)
+                .cleanup_remote_owner_resource_if_registration(jid, registration.registration_id)
                 .await;
+        }
+        Ok(RelayRemoteResourceFrameReply {
+            status: RelayRemoteResourceFrameStatus::Unavailable,
+        }) => {
+            tracing::warn!(
+                jid = %jid,
+                "clustered remote-resource delivery temporarily unavailable; retaining owner mirror"
+            );
         }
         Ok(reply) => {
             tracing::debug!(
@@ -3345,7 +5579,10 @@ async fn forward_remote_resource_outbound(
             );
             if ask_error_proves_remote_resource_ref_stale(&error) {
                 bridge
-                    .cleanup_remote_owner_resource_if_registration(jid, registration_id)
+                    .cleanup_remote_owner_resource_if_registration(
+                        jid,
+                        registration.registration_id,
+                    )
                     .await;
             }
         }
@@ -3355,31 +5592,53 @@ async fn forward_remote_resource_outbound(
 async fn forward_remote_resource_force_detach(
     bridge: &Arc<OrderedRelayDeliveryBridge>,
     jid: &jid::FullJid,
-    registration_id: RemoteResourceRegistrationId,
-    socket_node: &NodeId,
+    registration: &RemoteOwnerRegistration,
     request: ForceDetachRequest,
 ) {
-    let mut handle = RelayHandle::new(socket_node.clone(), bridge.stop_token.clone())
-        .with_ask_timeouts(bridge.mailbox_timeout, bridge.reply_timeout);
+    let mut handle = RelayHandle::new(
+        NodeId::new(registration.socket_node.node_id.clone()),
+        bridge.stop_token.clone(),
+    )
+    .with_ask_timeouts(bridge.mailbox_timeout, bridge.reply_timeout);
     let outcome = match handle
         .force_detach_remote_user_resource(RelayForceDetachRemoteUserResource {
             jid: jid.clone(),
-            registration_id,
+            registration_id: registration.registration_id,
+            admission_epoch: registration.admission_epoch,
+            socket_generation: registration.socket_generation,
+            socket_node: registration.socket_node.clone(),
+            expected_user_owner: registration.user_owner.clone(),
+            expected_user_claim_epoch: registration.user_claim_epoch,
             requester_bare_jid: request.requester_bare_jid,
+            reason: request.reason,
         })
         .await
     {
-        Ok(reply) => reply.outcome,
+        Ok(reply) => confirmed_remote_force_detach_outcome(reply),
         Err(error) => {
             tracing::warn!(
                 jid = %jid,
                 %error,
                 "clustered remote-resource force-detach relay ask failed"
             );
-            ForceDetachOutcome::NotPersisted
+            None
         }
     };
-    let _ = request.ack.send(outcome);
+    if let Some(outcome) = outcome {
+        let _ = request.ack.send(outcome);
+    }
+}
+
+fn confirmed_remote_force_detach_outcome(
+    reply: RelayForceDetachRemoteUserResourceReply,
+) -> Option<ForceDetachOutcome> {
+    match reply.status {
+        RelayRemoteResourceForceDetachStatus::Detached
+        | RelayRemoteResourceForceDetachStatus::Invalidated
+        | RelayRemoteResourceForceDetachStatus::NotLive => Some(reply.outcome),
+        RelayRemoteResourceForceDetachStatus::Refused => Some(ForceDetachOutcome::IdentityMismatch),
+        RelayRemoteResourceForceDetachStatus::Unknown => None,
+    }
 }
 
 impl OrderedRelayDeliveryBridge {
@@ -3838,18 +6097,6 @@ fn remote_resource_origin(
     }
 }
 
-fn local_origin_for_remote_resource(
-    remote_origin: &RemoteResourceOriginSnapshot,
-) -> OrderedRelayRouteOrigin {
-    let sender_entity = user_entity(&remote_origin.jid.to_bare());
-    OrderedRelayRouteOrigin {
-        kind: OrderedRelayRouteOriginKind::Entity(sender_entity.clone()),
-        sender_entity,
-        inbound_sequence: 0,
-        handoff: None,
-    }
-}
-
 async fn current_fresh_local_relay_claim(
     services: &OrderedRelayDeliveryServices,
     entity: &Entity,
@@ -4295,7 +6542,7 @@ async fn validate_claims(
         })?;
     if !origin.owner_lease_fresh
         || origin.claim_epoch != envelope.origin_claim.epoch
-        || origin.owner.node_id != envelope.asserted_origin_node.as_str()
+        || origin.owner != envelope.asserted_origin_node
     {
         return Err(OrderedRelayNackReason::NotOwner {
             role: OrderedRelayClaimRole::Origin,
@@ -4361,7 +6608,8 @@ async fn validate_origin_proof(
 ) -> Result<(), OrderedRelayNackReason> {
     let Some(proof) = &envelope.origin_proof else {
         tracing::warn!(
-            asserted_origin_node = %envelope.asserted_origin_node,
+            asserted_origin_node = %envelope.asserted_origin_node.node_id,
+            asserted_origin_epoch = %envelope.asserted_origin_node.node_epoch,
             "ordered relay: unsigned origin envelope rejected"
         );
         return Err(OrderedRelayNackReason::NotOwner {
@@ -4371,7 +6619,8 @@ async fn validate_origin_proof(
     let public_key = PublicKey::try_decode_protobuf(&proof.public_key).map_err(|error| {
         tracing::warn!(
             %error,
-            asserted_origin_node = %envelope.asserted_origin_node,
+            asserted_origin_node = %envelope.asserted_origin_node.node_id,
+            asserted_origin_epoch = %envelope.asserted_origin_node.node_epoch,
             "ordered relay: origin proof public key did not decode"
         );
         OrderedRelayNackReason::NotOwner {
@@ -4381,14 +6630,16 @@ async fn validate_origin_proof(
     let signing_bytes = envelope.signing_bytes().map_err(|error| {
         tracing::warn!(
             %error,
-            asserted_origin_node = %envelope.asserted_origin_node,
+            asserted_origin_node = %envelope.asserted_origin_node.node_id,
+            asserted_origin_epoch = %envelope.asserted_origin_node.node_epoch,
             "ordered relay: failed to serialize origin verification bytes"
         );
         OrderedRelayNackReason::ParseFailure
     })?;
     if !public_key.verify(&signing_bytes, &proof.signature) {
         tracing::warn!(
-            asserted_origin_node = %envelope.asserted_origin_node,
+            asserted_origin_node = %envelope.asserted_origin_node.node_id,
+            asserted_origin_epoch = %envelope.asserted_origin_node.node_epoch,
             "ordered relay: origin proof signature verification failed"
         );
         return Err(OrderedRelayNackReason::NotOwner {
@@ -4633,12 +6884,11 @@ fn ask_error_allows_target_refresh(error: &RelayAskError) -> bool {
 fn ask_error_proves_remote_resource_ref_stale(error: &RelayAskError) -> bool {
     matches!(
         error,
-        RelayAskError::NotFound { .. }
-            | RelayAskError::Send {
-                failure: RelaySendFailure::StaleRef,
-                effect: RelaySendEffect::NoEffect,
-                ..
-            }
+        RelayAskError::Send {
+            failure: RelaySendFailure::StaleRef,
+            effect: RelaySendEffect::NoEffect,
+            ..
+        }
     )
 }
 
@@ -4671,15 +6921,267 @@ fn ask_error_maybe_committed(error: &RelayAskError) -> bool {
 mod tests {
     use super::*;
     use crate::clustering::ordered_relay::OrderedRelaySequence;
+    use crate::clustering::remote_resource_admission::{
+        InMemoryRemoteResourceAdmissionStore, RemoteResourceAdmissionError,
+        RemoteResourceAdmissionStore,
+    };
     use kameo::actor::Spawn;
     use libp2p::PeerId;
     use std::collections::HashSet;
-    use waddle_xmpp::ownership::{ClaimEpoch, ClaimError, InProcessClaimStore, NodeIdentity};
+    use waddle_xmpp::ownership::{
+        ClaimEpoch, ClaimError, InProcessClaimStore, NodeIdentity, StalePredicate,
+    };
     use xmpp_parsers::message::{Lang, Message};
+
+    struct DelayedCurrentClaimStore {
+        inner: Arc<InProcessClaimStore>,
+        delay_next_read: AtomicBool,
+        read_started: tokio::sync::Notify,
+        release_read: tokio::sync::Notify,
+    }
+
+    impl DelayedCurrentClaimStore {
+        fn new(inner: Arc<InProcessClaimStore>) -> Arc<Self> {
+            Arc::new(Self {
+                inner,
+                delay_next_read: AtomicBool::new(false),
+                read_started: tokio::sync::Notify::new(),
+                release_read: tokio::sync::Notify::new(),
+            })
+        }
+
+        fn delay_next_read(&self) {
+            self.delay_next_read.store(true, Ordering::SeqCst);
+        }
+
+        async fn wait_until_read_started(&self) {
+            self.read_started.notified().await;
+        }
+
+        fn release_read(&self) {
+            self.release_read.notify_one();
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ClaimStore for DelayedCurrentClaimStore {
+        async fn ensure_schema(&self) -> Result<(), ClaimError> {
+            self.inner.ensure_schema().await
+        }
+
+        async fn acquire(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner.acquire(entity, me).await
+        }
+
+        async fn ensure_claimed(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner.ensure_claimed(entity, me).await
+        }
+
+        async fn steal_stale(
+            &self,
+            entity: &Entity,
+            observed: ClaimEpoch,
+            staleness: StalePredicate,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner
+                .steal_stale(entity, observed, staleness, me)
+                .await
+        }
+
+        async fn reclaim_after_self_fence(
+            &self,
+            entity: &Entity,
+            observed: ClaimEpoch,
+            expected_owner: &NodeIdentity,
+            me: &NodeIdentity,
+            lease_ttl: Duration,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner
+                .reclaim_after_self_fence(entity, observed, expected_owner, me, lease_ttl)
+                .await
+        }
+
+        async fn steal_for_resume(
+            &self,
+            entity: &Entity,
+            observed: ClaimEpoch,
+            witness: waddle_xmpp::ownership::ResumeIdentityProof,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner
+                .steal_for_resume(entity, observed, witness, me)
+                .await
+        }
+
+        async fn current_claim(
+            &self,
+            entity: &Entity,
+        ) -> Result<Option<waddle_xmpp::ownership::ClaimSnapshot>, ClaimError> {
+            let snapshot = self.inner.current_claim(entity).await?;
+            if self.delay_next_read.swap(false, Ordering::SeqCst) {
+                self.read_started.notify_one();
+                self.release_read.notified().await;
+            }
+            Ok(snapshot)
+        }
+
+        async fn fence(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<bool, ClaimError> {
+            self.inner.fence(entity, me, mine).await
+        }
+
+        async fn release(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<(), ClaimError> {
+            self.inner.release(entity, me, mine).await
+        }
+
+        async fn release_many(
+            &self,
+            grants: &[waddle_xmpp::ownership::ClaimGrant],
+        ) -> Result<(), ClaimError> {
+            self.inner.release_many(grants).await
+        }
+    }
+
+    #[derive(Default)]
+    struct PermissiveRemoteResourceAdmissionStore {
+        next_epoch: std::sync::atomic::AtomicI64,
+    }
+
+    #[async_trait::async_trait]
+    impl RemoteResourceAdmissionStore for PermissiveRemoteResourceAdmissionStore {
+        async fn ensure_schema(&self) -> Result<(), RemoteResourceAdmissionError> {
+            Ok(())
+        }
+
+        async fn reserve(
+            &self,
+            _jid: &jid::FullJid,
+            _registration_id: RemoteResourceRegistrationId,
+            _socket_node: &NodeIdentity,
+        ) -> Result<RemoteResourceAdmissionEpoch, RemoteResourceAdmissionError> {
+            let previous = self.next_epoch.fetch_add(1, Ordering::SeqCst);
+            Ok(RemoteResourceAdmissionEpoch(previous + 1))
+        }
+
+        async fn is_current(
+            &self,
+            _jid: &jid::FullJid,
+            _registration_id: RemoteResourceRegistrationId,
+            _admission_epoch: RemoteResourceAdmissionEpoch,
+            _socket_node: &NodeIdentity,
+        ) -> Result<bool, RemoteResourceAdmissionError> {
+            Ok(true)
+        }
+
+        async fn cancel(
+            &self,
+            _jid: &jid::FullJid,
+            _registration_id: RemoteResourceRegistrationId,
+            _admission_epoch: RemoteResourceAdmissionEpoch,
+            _socket_node: &NodeIdentity,
+        ) -> Result<bool, RemoteResourceAdmissionError> {
+            Ok(true)
+        }
+
+        async fn prune_stale(&self, _limit: usize) -> Result<u64, RemoteResourceAdmissionError> {
+            Ok(0)
+        }
+    }
+
+    struct FailFirstCancelAdmissionStore {
+        inner: InMemoryRemoteResourceAdmissionStore,
+        fail_next_cancel: AtomicBool,
+    }
+
+    impl FailFirstCancelAdmissionStore {
+        fn new() -> Self {
+            Self {
+                inner: InMemoryRemoteResourceAdmissionStore::default(),
+                fail_next_cancel: AtomicBool::new(true),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl RemoteResourceAdmissionStore for FailFirstCancelAdmissionStore {
+        async fn ensure_schema(&self) -> Result<(), RemoteResourceAdmissionError> {
+            Ok(())
+        }
+
+        async fn reserve(
+            &self,
+            jid: &jid::FullJid,
+            registration_id: RemoteResourceRegistrationId,
+            socket_node: &NodeIdentity,
+        ) -> Result<RemoteResourceAdmissionEpoch, RemoteResourceAdmissionError> {
+            self.inner.reserve(jid, registration_id, socket_node).await
+        }
+
+        async fn is_current(
+            &self,
+            jid: &jid::FullJid,
+            registration_id: RemoteResourceRegistrationId,
+            admission_epoch: RemoteResourceAdmissionEpoch,
+            socket_node: &NodeIdentity,
+        ) -> Result<bool, RemoteResourceAdmissionError> {
+            self.inner
+                .is_current(jid, registration_id, admission_epoch, socket_node)
+                .await
+        }
+
+        async fn cancel(
+            &self,
+            jid: &jid::FullJid,
+            registration_id: RemoteResourceRegistrationId,
+            admission_epoch: RemoteResourceAdmissionEpoch,
+            socket_node: &NodeIdentity,
+        ) -> Result<bool, RemoteResourceAdmissionError> {
+            if self.fail_next_cancel.swap(false, Ordering::SeqCst) {
+                return Err(RemoteResourceAdmissionError::Backend(
+                    "injected first cancellation failure".to_string(),
+                ));
+            }
+            self.inner
+                .cancel(jid, registration_id, admission_epoch, socket_node)
+                .await
+        }
+
+        async fn prune_stale(&self, limit: usize) -> Result<u64, RemoteResourceAdmissionError> {
+            self.inner.prune_stale(limit).await
+        }
+    }
 
     struct StaticNodeLease {
         origin: NodeIdentity,
         peer_id: String,
+        live_socket: std::sync::RwLock<NodeIdentity>,
+    }
+
+    impl StaticNodeLease {
+        fn rotate_socket(&self, identity: NodeIdentity) {
+            *self
+                .live_socket
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner) = identity;
+        }
     }
 
     #[async_trait::async_trait]
@@ -4696,7 +7198,11 @@ mod tests {
             &self,
             node: &NodeIdentity,
         ) -> Result<Option<String>, ClaimError> {
-            if node == &self.origin {
+            let live_socket = self
+                .live_socket
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if node == &self.origin || node == &*live_socket {
                 Ok(Some(self.peer_id.clone()))
             } else {
                 Ok(None)
@@ -4742,6 +7248,8 @@ mod tests {
         async fn report_steal_intent(
             &self,
             _entity: &Entity,
+            _target_owner: &NodeIdentity,
+            _target_epoch: ClaimEpoch,
             _reporter: &NodeIdentity,
         ) -> Result<(), ClaimError> {
             Ok(())
@@ -4803,6 +7311,10 @@ mod tests {
         NodeIdentity::new("other-node", "other-epoch")
     }
 
+    fn socket_identity() -> NodeIdentity {
+        NodeIdentity::new("socket-node", "socket-epoch")
+    }
+
     fn origin_entity() -> Entity {
         Entity::new(EntityType::SmSession, "stream-1")
     }
@@ -4827,6 +7339,53 @@ mod tests {
         user_entity(&target_bare())
     }
 
+    fn remote_resource_registration(
+        expected_user_owner: NodeIdentity,
+    ) -> RelayRegisterRemoteUserResource {
+        RelayRegisterRemoteUserResource {
+            jid: target_full(),
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_generation: RemoteResourceSocketGeneration::next(None),
+            socket_node: socket_identity(),
+            expected_user_owner,
+            expected_user_claim_epoch: ClaimEpoch(2),
+            state: RemoteResourceStateSnapshot {
+                carbons_enabled: false,
+                roster_interested: false,
+                blocklist_interested: false,
+                presence_available: false,
+                presence_priority: 0,
+                presence_state: None,
+            },
+        }
+    }
+
+    async fn steal_and_regrant_target_claim(
+        store: &InProcessClaimStore,
+        owner: &NodeIdentity,
+    ) -> ClaimEpoch {
+        let entity = target_entity();
+        let original = store
+            .current_claim(&entity)
+            .await
+            .expect("read original target claim")
+            .expect("target claim exists");
+        let stolen = store
+            .steal_stale(
+                &entity,
+                original.claim_epoch,
+                StalePredicate::OwnerStale,
+                &other_identity(),
+            )
+            .await
+            .expect("steal target claim");
+        store
+            .steal_stale(&entity, stolen, StalePredicate::OwnerStale, owner)
+            .await
+            .expect("regrant target claim to the original incarnation")
+    }
+
     fn envelope_claims(target_epoch: i64) -> OrderedRelayEnvelopeClaims {
         OrderedRelayEnvelopeClaims::new(
             OrderedRelayClaim {
@@ -4835,7 +7394,7 @@ mod tests {
             },
             OrderedRelayClaim {
                 entity: sender_entity(),
-                epoch: ClaimEpoch(0),
+                epoch: ClaimEpoch(1),
             },
             OrderedRelayClaim {
                 entity: target_entity(),
@@ -4880,13 +7439,13 @@ mod tests {
 
     fn envelope() -> RemoteStanzaEnvelope {
         RemoteStanzaEnvelope {
-            asserted_origin_node: NodeId::new(origin_identity().node_id),
+            asserted_origin_node: origin_identity(),
             channel: OrderedRelayChannel {
                 origin: OrderedRelayOrigin::SmSession(
                     waddle_xmpp::pending_delivery::SmSessionId::new("stream-1"),
                 ),
                 recipient: OrderedRelayRecipient::FullJid(target_full()),
-                target_epoch: waddle_xmpp::ownership::ClaimEpoch(0),
+                target_epoch: waddle_xmpp::ownership::ClaimEpoch(2),
             },
             sequence: OrderedRelaySequence::FIRST,
             origin_inbound_sequence: OriginInboundSequence(1),
@@ -4896,11 +7455,11 @@ mod tests {
             },
             sender_claim: OrderedRelayClaim {
                 entity: sender_entity(),
-                epoch: waddle_xmpp::ownership::ClaimEpoch(0),
+                epoch: waddle_xmpp::ownership::ClaimEpoch(1),
             },
             target_claim: OrderedRelayClaim {
                 entity: target_entity(),
-                epoch: waddle_xmpp::ownership::ClaimEpoch(0),
+                epoch: waddle_xmpp::ownership::ClaimEpoch(2),
             },
             payload: message_payload(),
             origin_proof: None,
@@ -4953,6 +7512,46 @@ mod tests {
         origin_peer_id: String,
         blocking_storage: Arc<dyn BlockingStorage>,
     ) -> OrderedRelayDeliveryServices {
+        services_with_claims_and_store(
+            origin_owner,
+            target_owner,
+            receiver,
+            origin_peer_id,
+            blocking_storage,
+        )
+        .await
+        .0
+    }
+
+    async fn services_with_claims_and_store(
+        origin_owner: NodeIdentity,
+        target_owner: NodeIdentity,
+        receiver: NodeIdentity,
+        origin_peer_id: String,
+        blocking_storage: Arc<dyn BlockingStorage>,
+    ) -> (OrderedRelayDeliveryServices, Arc<InProcessClaimStore>) {
+        let (services, store, _) = services_with_claims_and_controls(
+            origin_owner,
+            target_owner,
+            receiver,
+            origin_peer_id,
+            blocking_storage,
+        )
+        .await;
+        (services, store)
+    }
+
+    async fn services_with_claims_and_controls(
+        origin_owner: NodeIdentity,
+        target_owner: NodeIdentity,
+        receiver: NodeIdentity,
+        origin_peer_id: String,
+        blocking_storage: Arc<dyn BlockingStorage>,
+    ) -> (
+        OrderedRelayDeliveryServices,
+        Arc<InProcessClaimStore>,
+        Arc<StaticNodeLease>,
+    ) {
         let store = Arc::new(InProcessClaimStore::new());
         store
             .acquire(&origin_entity(), &origin_owner)
@@ -4966,22 +7565,1132 @@ mod tests {
             .acquire(&target_entity(), &target_owner)
             .await
             .expect("target claim");
-        OrderedRelayDeliveryServices {
-            claim_store: store,
+        let node_lease = Arc::new(StaticNodeLease {
+            origin: origin_owner,
+            peer_id: origin_peer_id.clone(),
+            live_socket: std::sync::RwLock::new(socket_identity()),
+        });
+        let services = OrderedRelayDeliveryServices {
+            claim_store: store.clone(),
             allowlist_store: Arc::new(StaticAllowlist {
                 peer_id: origin_peer_id.parse().expect("valid test peer id"),
             }),
-            node_lease: Arc::new(StaticNodeLease {
-                origin: origin_owner,
-                peer_id: origin_peer_id,
-            }),
+            node_lease: node_lease.clone(),
+            remote_resource_admission_store: Arc::new(
+                PermissiveRemoteResourceAdmissionStore::default(),
+            ),
             node_identity: SharedNodeIdentity::new(receiver),
             connection_registry: Arc::new(ConnectionRegistry::new()),
             user_registry: UserRegistryActor::spawn(UserRegistryActor::new()),
             sm_session_registry: Arc::new(InMemorySmSessionRegistry::new()),
             blocking_storage,
             web_socket_state: Weak::new(),
+        };
+        (services, store, node_lease)
+    }
+
+    #[tokio::test]
+    async fn newer_local_physical_admission_retires_old_and_falls_through_local_delivery() {
+        let me = receiver_identity();
+        let (mut services, _claims, _node_lease) = services_with_claims_and_controls(
+            me.clone(),
+            me.clone(),
+            me.clone(),
+            test_peer_id(),
+            Arc::new(waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new()),
+        )
+        .await;
+        let admissions = Arc::new(InMemoryRemoteResourceAdmissionStore::default());
+        services.remote_resource_admission_store = admissions.clone();
+        let services = Arc::new(services);
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let jid = target_full();
+
+        let (old_tx, _old_rx) = mpsc::channel(1);
+        let old_entry = ConnectionEntry::new(old_tx);
+        let old_owner = old_entry.carbons_handle();
+        let mut old_detach_rx = old_entry
+            .take_force_detach_rx()
+            .expect("old physical force-detach receiver");
+        services
+            .connection_registry
+            .register_entry(jid.clone(), old_entry);
+        let old_id = RemoteResourceRegistrationId::fresh();
+        let old_epoch = admissions
+            .reserve(&jid, old_id, &me)
+            .await
+            .expect("old durable admission");
+        let old_registration = RemoteSocketRegistration {
+            registration_id: old_id,
+            admission_epoch: old_epoch,
+            socket_generation: RemoteResourceSocketGeneration(1),
+            socket_node: me.clone(),
+            owner: Arc::clone(&old_owner),
+            user_owner: me.clone(),
+            user_claim_epoch: ClaimEpoch(2),
+        };
+        assert!(
+            bridge
+                .reserve_remote_socket_cleanup_capacity(&jid, &old_registration)
+                .await
+        );
+        assert!(
+            bridge
+                .publish_pending_remote_socket_registration(&jid, old_registration.clone())
+                .await
+        );
+        let old_token = PhysicalResourceAdmissionToken {
+            registration_id: old_id,
+            admission_epoch: old_epoch,
+            socket_generation: old_registration.socket_generation,
+            socket_node: me.clone(),
+        };
+
+        let (new_tx, _new_rx) = mpsc::channel(1);
+        let new_entry = ConnectionEntry::new(new_tx);
+        let new_owner = new_entry.carbons_handle();
+        let begin = tokio::spawn({
+            let bridge = Arc::clone(&bridge);
+            let jid = jid.clone();
+            let new_owner = Arc::clone(&new_owner);
+            async move { bridge.begin_physical_user_resource(&jid, new_owner).await }
+        });
+        let request = tokio::time::timeout(Duration::from_secs(1), old_detach_rx.recv())
+            .await
+            .expect("new admission promptly retires old socket")
+            .expect("old socket receives exact retirement");
+        assert_eq!(request.reason, ForceDetachReason::ResourceReplaced);
+        request
+            .ack
+            .send(ForceDetachOutcome::NotPersisted)
+            .expect("ack old retirement");
+        let guard = begin
+            .await
+            .expect("join begin")
+            .expect("new physical admission");
+        services
+            .connection_registry
+            .register_entry(jid.clone(), new_entry.clone());
+        assert_eq!(
+            bridge
+                .publish_physical_user_resource(&guard, new_entry)
+                .await,
+            RemoteResourceRegisterOutcome::Registered
+        );
+        let new_token = bridge
+            .finalize_physical_user_resource(guard)
+            .await
+            .expect("final exact admission");
+
+        assert!(
+            bridge
+                .physical_resource_origin_if_owner(&jid, &old_owner, &old_token)
+                .await
+                .is_none(),
+            "the old exact token must not observe or detach the winner"
+        );
+        bridge
+            .forget_remote_resource_state_if_owner(
+                &jid,
+                &old_owner,
+                ConnectionPlacement::LocalSocket,
+            )
+            .await;
+        assert!(
+            matches!(
+                bridge
+                    .physical_resource_origin_if_owner(&jid, &new_owner, &new_token)
+                    .await,
+                Some(PhysicalResourceRouteOrigin::LocalSocket)
+            ),
+            "the winner remains locally authorized after delayed old cleanup"
+        );
+        assert_eq!(
+            bridge
+                .remote_owner_resources
+                .lock()
+                .await
+                .get(&jid)
+                .map(|registration| registration.placement),
+            Some(ConnectionPlacement::LocalSocket)
+        );
+        assert_eq!(
+            bridge
+                .try_deliver_registered_remote_resource(
+                    &jid,
+                    &Stanza::Message(Message::new(Some(jid::Jid::from(jid.clone())))),
+                    DeliveryKind::DirectFrame,
+                )
+                .await,
+            None,
+            "an exact local-owner registration must fall through to local delivery"
+        );
+        assert!(services
+            .connection_registry
+            .entry_if_owner(&jid, &new_owner)
+            .is_some());
+        services
+            .connection_registry
+            .unregister_if_owner(&jid, &new_owner);
+        bridge
+            .unregister_remote_user_resource_if_owner(&jid, &new_owner)
+            .await;
+        assert!(!admissions
+            .is_current(
+                &jid,
+                new_token.registration_id,
+                new_token.admission_epoch,
+                &new_token.socket_node,
+            )
+            .await
+            .expect("read final admission cleanup"));
+        assert!(bridge
+            .remote_socket_resources
+            .lock()
+            .await
+            .get(&jid)
+            .is_none());
+        assert!(bridge
+            .remote_owner_resources
+            .lock()
+            .await
+            .get(&jid)
+            .is_none());
+        assert!(!bridge
+            .remote_socket_pending_cleanup
+            .lock()
+            .await
+            .contains_key(&new_token.registration_id));
+        assert!(!bridge
+            .remote_owner_pending_cleanup
+            .lock()
+            .await
+            .contains_key(&new_token.registration_id));
+    }
+
+    #[tokio::test]
+    async fn abort_before_registry_publication_cancels_exact_local_admission() {
+        let me = receiver_identity();
+        let (mut services, _claims, _node_lease) = services_with_claims_and_controls(
+            me.clone(),
+            me.clone(),
+            me,
+            test_peer_id(),
+            Arc::new(waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new()),
+        )
+        .await;
+        let admissions = Arc::new(InMemoryRemoteResourceAdmissionStore::default());
+        services.remote_resource_admission_store = admissions.clone();
+        let services = Arc::new(services);
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let jid = target_full();
+        let (tx, _rx) = mpsc::channel(1);
+        let owner = ConnectionEntry::new(tx).carbons_handle();
+
+        let guard = bridge
+            .begin_physical_user_resource(&jid, owner)
+            .await
+            .expect("reserve pre-publication physical admission");
+        let token = guard.token();
+        assert!(admissions
+            .is_current(
+                &jid,
+                token.registration_id,
+                token.admission_epoch,
+                &token.socket_node,
+            )
+            .await
+            .expect("read reserved admission"));
+
+        bridge.abort_physical_user_resource(guard).await;
+
+        assert!(!admissions
+            .is_current(
+                &jid,
+                token.registration_id,
+                token.admission_epoch,
+                &token.socket_node,
+            )
+            .await
+            .expect("read aborted admission"));
+        assert!(bridge
+            .remote_socket_resources
+            .lock()
+            .await
+            .get(&jid)
+            .is_none());
+        assert!(!bridge
+            .remote_socket_pending_cleanup
+            .lock()
+            .await
+            .contains_key(&token.registration_id));
+        assert!(bridge
+            .remote_owner_resources
+            .lock()
+            .await
+            .get(&jid)
+            .is_none());
+        assert!(!bridge
+            .remote_owner_pending_cleanup
+            .lock()
+            .await
+            .contains_key(&token.registration_id));
+    }
+
+    #[tokio::test]
+    async fn final_sm_rollback_releases_guard_before_exact_cleanup() {
+        let me = receiver_identity();
+        let (mut services, _claims, _node_lease) = services_with_claims_and_controls(
+            me.clone(),
+            me.clone(),
+            me,
+            test_peer_id(),
+            Arc::new(waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new()),
+        )
+        .await;
+        let admissions = Arc::new(InMemoryRemoteResourceAdmissionStore::default());
+        services.remote_resource_admission_store = admissions.clone();
+        let services = Arc::new(services);
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let jid = target_full();
+        let (tx, _rx) = mpsc::channel(1);
+        let entry = ConnectionEntry::new(tx);
+        let owner = entry.carbons_handle();
+        let guard = bridge
+            .begin_physical_user_resource(&jid, Arc::clone(&owner))
+            .await
+            .expect("reserve physical admission");
+        let token = guard.token();
+        services
+            .connection_registry
+            .register_entry(jid.clone(), entry.clone());
+        assert_eq!(
+            bridge.publish_physical_user_resource(&guard, entry).await,
+            RemoteResourceRegisterOutcome::Registered
+        );
+
+        // `complete_pending_resume_claim` rolls these views back while the
+        // physical guard is still held. The finalizer must observe that loss,
+        // drop the guard, and only then enter exact cleanup.
+        services
+            .connection_registry
+            .unregister_if_owner(&jid, &owner);
+        services
+            .user_registry
+            .ask(UnregisterUserResource {
+                jid: jid.clone(),
+                owner: Some(owner),
+            })
+            .await
+            .expect("simulate final SM actor rollback");
+        let finalized = tokio::time::timeout(
+            Duration::from_secs(1),
+            bridge.finalize_physical_user_resource(guard),
+        )
+        .await
+        .expect("final SM rollback must not deadlock on the per-JID guard");
+        assert!(finalized.is_none());
+        assert!(!admissions
+            .is_current(
+                &jid,
+                token.registration_id,
+                token.admission_epoch,
+                &token.socket_node,
+            )
+            .await
+            .expect("read final SM rollback admission"));
+        assert!(bridge
+            .remote_socket_resources
+            .lock()
+            .await
+            .get(&jid)
+            .is_none());
+        assert!(bridge
+            .remote_owner_resources
+            .lock()
+            .await
+            .get(&jid)
+            .is_none());
+        assert!(!bridge
+            .remote_socket_pending_cleanup
+            .lock()
+            .await
+            .contains_key(&token.registration_id));
+        assert!(!bridge
+            .remote_owner_pending_cleanup
+            .lock()
+            .await
+            .contains_key(&token.registration_id));
+    }
+
+    #[tokio::test]
+    async fn remote_resource_registration_rejects_pre_fence_owner_epoch() {
+        let expected_owner = NodeIdentity::new("receiver-node", "pre-fence-epoch");
+        let recovered_owner = NodeIdentity::new("receiver-node", "recovered-epoch");
+        let services = Arc::new(
+            services_with_claims(
+                origin_identity(),
+                recovered_owner.clone(),
+                recovered_owner,
+                test_peer_id(),
+            )
+            .await,
+        );
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+
+        let reply = bridge
+            .register_remote_user_resource_on_owner(remote_resource_registration(expected_owner))
+            .await;
+
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceRegistrationStatus::NotOwner
+        );
+        assert!(!services.connection_registry.is_connected(&target_full()));
+        assert!(bridge.remote_owner_resources.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn remote_resource_registration_rejects_non_local_expected_incarnation() {
+        let expected_owner = NodeIdentity::new("receiver-node", "pre-fence-epoch");
+        let recovered_identity = NodeIdentity::new("receiver-node", "recovered-epoch");
+        let services = Arc::new(
+            services_with_claims(
+                origin_identity(),
+                expected_owner.clone(),
+                recovered_identity,
+                test_peer_id(),
+            )
+            .await,
+        );
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+
+        let reply = bridge
+            .register_remote_user_resource_on_owner(remote_resource_registration(expected_owner))
+            .await;
+
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceRegistrationStatus::NotOwner
+        );
+        assert!(!services.connection_registry.is_connected(&target_full()));
+        assert!(bridge.remote_owner_resources.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn remote_resource_registration_rejects_old_claim_after_same_incarnation_regrant() {
+        let owner = receiver_identity();
+        let (services, store) = services_with_claims_and_store(
+            origin_identity(),
+            owner.clone(),
+            owner.clone(),
+            test_peer_id(),
+            Arc::new(waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new()),
+        )
+        .await;
+        let services = Arc::new(services);
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let current_epoch = steal_and_regrant_target_claim(&store, &owner).await;
+        assert_ne!(current_epoch, ClaimEpoch(2));
+
+        let reply = bridge
+            .register_remote_user_resource_on_owner(remote_resource_registration(owner))
+            .await;
+
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceRegistrationStatus::NotOwner
+        );
+        assert!(!services.connection_registry.is_connected(&target_full()));
+        assert!(bridge.remote_owner_resources.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delayed_remote_update_cannot_mutate_same_incarnation_after_claim_regrant() {
+        let owner = receiver_identity();
+        let (services, store) = services_with_claims_and_store(
+            origin_identity(),
+            owner.clone(),
+            owner.clone(),
+            test_peer_id(),
+            Arc::new(waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new()),
+        )
+        .await;
+        let services = Arc::new(services);
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let registration = remote_resource_registration(owner.clone());
+        let reply = bridge
+            .register_remote_user_resource_on_owner(registration.clone())
+            .await;
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceRegistrationStatus::Registered
+        );
+        let current_epoch = steal_and_regrant_target_claim(&store, &owner).await;
+        assert_ne!(current_epoch, registration.expected_user_claim_epoch);
+
+        let reply = bridge
+            .update_remote_user_resource_on_owner(RelayUpdateRemoteUserResource {
+                jid: registration.jid.clone(),
+                registration_id: registration.registration_id,
+                admission_epoch: registration.admission_epoch,
+                socket_generation: registration.socket_generation,
+                socket_node: registration.socket_node.clone(),
+                expected_user_owner: registration.expected_user_owner.clone(),
+                expected_user_claim_epoch: registration.expected_user_claim_epoch,
+                update: RemoteResourceStateUpdate::Carbons { enabled: true },
+            })
+            .await;
+
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceUpdateStatus::StaleRegistration
+        );
+        assert!(
+            !services.connection_registry.is_connected(&registration.jid),
+            "the stale owner mirror must be cleaned without mutating a new claim generation"
+        );
+        assert!(bridge.remote_owner_resources.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delayed_pre_fence_socket_epoch_cannot_update_owner_mirror() {
+        let owner = receiver_identity();
+        let (services, _store, node_lease) = services_with_claims_and_controls(
+            origin_identity(),
+            owner.clone(),
+            owner,
+            test_peer_id(),
+            Arc::new(waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new()),
+        )
+        .await;
+        let services = Arc::new(services);
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let registration = remote_resource_registration(receiver_identity());
+        let reply = bridge
+            .register_remote_user_resource_on_owner(registration.clone())
+            .await;
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceRegistrationStatus::Registered
+        );
+        let mirror = services
+            .connection_registry
+            .get_entry(&registration.jid)
+            .expect("owner mirror");
+        node_lease.rotate_socket(NodeIdentity::new(
+            registration.socket_node.node_id.clone(),
+            "post-fence-socket-epoch",
+        ));
+
+        let reply = bridge
+            .update_remote_user_resource_on_owner(RelayUpdateRemoteUserResource {
+                jid: registration.jid.clone(),
+                registration_id: registration.registration_id,
+                admission_epoch: registration.admission_epoch,
+                socket_generation: registration.socket_generation,
+                socket_node: registration.socket_node.clone(),
+                expected_user_owner: registration.expected_user_owner.clone(),
+                expected_user_claim_epoch: registration.expected_user_claim_epoch,
+                update: RemoteResourceStateUpdate::Carbons { enabled: true },
+            })
+            .await;
+
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceUpdateStatus::StaleRegistration
+        );
+        assert!(!mirror.carbons_enabled.load(Ordering::Relaxed));
+        assert!(!services.connection_registry.is_connected(&registration.jid));
+        assert!(bridge.remote_owner_resources.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn compensating_unregister_waits_for_delayed_register_and_is_idempotent() {
+        let owner = receiver_identity();
+        let services = Arc::new(
+            services_with_claims(origin_identity(), owner.clone(), owner, test_peer_id()).await,
+        );
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let registration = remote_resource_registration(receiver_identity());
+        let compensation = RelayUnregisterRemoteUserResource {
+            jid: registration.jid.clone(),
+            registration_id: registration.registration_id,
+            admission_epoch: registration.admission_epoch,
+            socket_generation: registration.socket_generation,
+            socket_node: registration.socket_node.clone(),
+            expected_user_owner: registration.expected_user_owner.clone(),
+            expected_user_claim_epoch: registration.expected_user_claim_epoch,
+        };
+        let lock = bridge
+            .lock_for_remote_owner_registration(&registration.jid)
+            .await
+            .expect("registration lock");
+        let guard = lock.lock().await;
+
+        let delayed_register = tokio::spawn({
+            let bridge = Arc::clone(&bridge);
+            let registration = registration.clone();
+            async move {
+                bridge
+                    .register_remote_user_resource_on_owner(registration)
+                    .await
+            }
+        });
+        tokio::task::yield_now().await;
+        let compensating_unregister = tokio::spawn({
+            let bridge = Arc::clone(&bridge);
+            let compensation = compensation.clone();
+            async move {
+                bridge
+                    .unregister_remote_user_resource_on_owner(compensation)
+                    .await
+            }
+        });
+        tokio::task::yield_now().await;
+        drop(guard);
+
+        let registered = delayed_register.await.expect("delayed register task");
+        assert_eq!(
+            registered.status,
+            RelayRemoteResourceRegistrationStatus::Registered
+        );
+        let removed = compensating_unregister
+            .await
+            .expect("compensating unregister task");
+        assert_eq!(
+            removed.status,
+            RelayRemoteResourceUnregisterStatus::Terminal
+        );
+        assert!(bridge.remote_owner_resources.lock().await.is_empty());
+        assert!(!services.connection_registry.is_connected(&registration.jid));
+
+        let duplicate = bridge
+            .unregister_remote_user_resource_on_owner(compensation)
+            .await;
+        assert_eq!(
+            duplicate.status,
+            RelayRemoteResourceUnregisterStatus::Terminal,
+            "a retried compensation must remain an idempotent terminal no-op"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_after_initial_admission_cancel_failure_prevents_delayed_register_revival() {
+        let owner = receiver_identity();
+        let (mut services, _claims, _node_lease) = services_with_claims_and_controls(
+            origin_identity(),
+            owner.clone(),
+            owner.clone(),
+            test_peer_id(),
+            Arc::new(waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new()),
+        )
+        .await;
+        let admission_store = Arc::new(FailFirstCancelAdmissionStore::new());
+        services.remote_resource_admission_store = admission_store.clone();
+        let services = Arc::new(services);
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+
+        let mut delayed_register = remote_resource_registration(owner);
+        delayed_register.admission_epoch = admission_store
+            .reserve(
+                &delayed_register.jid,
+                delayed_register.registration_id,
+                &delayed_register.socket_node,
+            )
+            .await
+            .expect("reserve admission for delayed register");
+        let local_registration = RemoteSocketRegistration {
+            registration_id: delayed_register.registration_id,
+            admission_epoch: delayed_register.admission_epoch,
+            socket_generation: delayed_register.socket_generation,
+            socket_node: delayed_register.socket_node.clone(),
+            owner: Arc::new(AtomicBool::new(true)),
+            user_owner: delayed_register.expected_user_owner.clone(),
+            user_claim_epoch: delayed_register.expected_user_claim_epoch,
+        };
+
+        assert!(
+            !bridge
+                .cancel_remote_resource_admission(
+                    &services,
+                    &delayed_register.jid,
+                    &local_registration,
+                )
+                .await,
+            "the injected first cancellation must remain retryable"
+        );
+        let retry = bridge
+            .unregister_remote_user_resource_on_owner(RelayUnregisterRemoteUserResource {
+                jid: delayed_register.jid.clone(),
+                registration_id: delayed_register.registration_id,
+                admission_epoch: delayed_register.admission_epoch,
+                socket_generation: delayed_register.socket_generation,
+                socket_node: delayed_register.socket_node.clone(),
+                expected_user_owner: delayed_register.expected_user_owner.clone(),
+                expected_user_claim_epoch: delayed_register.expected_user_claim_epoch,
+            })
+            .await;
+        assert_eq!(
+            retry.status,
+            RelayRemoteResourceUnregisterStatus::Terminal,
+            "the retry must revoke admission before reporting terminal"
+        );
+        assert!(!admission_store
+            .is_current(
+                &delayed_register.jid,
+                delayed_register.registration_id,
+                delayed_register.admission_epoch,
+                &delayed_register.socket_node,
+            )
+            .await
+            .expect("check revoked admission"));
+
+        let late_reply = bridge
+            .register_remote_user_resource_on_owner(delayed_register)
+            .await;
+        assert_eq!(
+            late_reply.status,
+            RelayRemoteResourceRegistrationStatus::StaleRegistration,
+            "a register delayed behind terminal cleanup must not recreate the owner mirror"
+        );
+        assert!(bridge.remote_owner_resources.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn terminal_unregister_from_pending_owner_cleanup_releases_exact_reservation() {
+        let owner = receiver_identity();
+        let services = Arc::new(
+            services_with_claims(origin_identity(), owner.clone(), owner, test_peer_id()).await,
+        );
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let registration = remote_resource_registration(receiver_identity());
+        let registered = bridge
+            .register_remote_user_resource_on_owner(registration.clone())
+            .await;
+        assert_eq!(
+            registered.status,
+            RelayRemoteResourceRegistrationStatus::Registered
+        );
+        let owner_registration = bridge
+            .remote_owner_resources
+            .lock()
+            .await
+            .remove(&registration.jid)
+            .expect("published owner registration");
+        assert!(bridge
+            .remote_owner_pending_cleanup
+            .lock()
+            .await
+            .contains_key(&owner_registration.registration_id));
+
+        let removed = bridge
+            .unregister_remote_user_resource_on_owner(RelayUnregisterRemoteUserResource {
+                jid: registration.jid.clone(),
+                registration_id: registration.registration_id,
+                admission_epoch: registration.admission_epoch,
+                socket_generation: registration.socket_generation,
+                socket_node: registration.socket_node,
+                expected_user_owner: registration.expected_user_owner,
+                expected_user_claim_epoch: registration.expected_user_claim_epoch,
+            })
+            .await;
+
+        assert_eq!(
+            removed.status,
+            RelayRemoteResourceUnregisterStatus::Terminal
+        );
+        assert!(bridge.remote_owner_resources.lock().await.is_empty());
+        assert!(bridge.remote_owner_pending_cleanup.lock().await.is_empty());
+        assert!(bridge
+            .remote_owner_cleanup_inflight
+            .lock()
+            .expect("owner operation lock")
+            .is_empty());
+        assert!(!services.connection_registry.is_connected(&registration.jid));
+    }
+
+    #[tokio::test]
+    async fn owner_cleanup_budget_bounds_active_and_uncertain_entries_per_full_jid() {
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let jid = target_full();
+        let other_jid: jid::FullJid = "juliet@example.test/tablet".parse().expect("full JID");
+        let mut reserved = Vec::new();
+        for generation in 1..=MAX_PENDING_REMOTE_OWNER_CLEANUPS_PER_JID {
+            let registration = RemoteOwnerRegistration {
+                registration_id: RemoteResourceRegistrationId::fresh(),
+                admission_epoch: RemoteResourceAdmissionEpoch(generation as i64),
+                socket_node: socket_identity(),
+                socket_generation: RemoteResourceSocketGeneration(generation as u64),
+                user_owner: receiver_identity(),
+                user_claim_epoch: ClaimEpoch(generation as i64),
+                owner: Arc::new(AtomicBool::new(true)),
+                placement: ConnectionPlacement::RemoteMirror,
+            };
+            let operation = bridge
+                .reserve_remote_owner_cleanup_capacity(&jid, &registration)
+                .await
+                .expect("bounded owner cleanup reservation");
+            drop(operation);
+            reserved.push(registration);
         }
+        let unrelated = RemoteOwnerRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_node: socket_identity(),
+            socket_generation: RemoteResourceSocketGeneration(1),
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(1),
+            owner: Arc::new(AtomicBool::new(true)),
+            placement: ConnectionPlacement::RemoteMirror,
+        };
+        let unrelated_operation = bridge
+            .reserve_remote_owner_cleanup_capacity(&other_jid, &unrelated)
+            .await
+            .expect("unrelated owner cleanup reservation");
+        drop(unrelated_operation);
+        let overflow = RemoteOwnerRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(9),
+            socket_node: socket_identity(),
+            socket_generation: RemoteResourceSocketGeneration(9),
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(9),
+            owner: Arc::new(AtomicBool::new(true)),
+            placement: ConnectionPlacement::RemoteMirror,
+        };
+
+        assert!(
+            bridge
+                .reserve_remote_owner_cleanup_capacity(&jid, &overflow)
+                .await
+                .is_none(),
+            "active plus uncertain owner registrations must share the same per-JID cap"
+        );
+        assert!(bridge
+            .remote_owner_cleanup_inflight
+            .lock()
+            .expect("owner operation lock")
+            .is_empty());
+        bridge
+            .remove_pending_remote_owner_cleanup_if_current(&jid, &reserved[0])
+            .await;
+        assert!(
+            bridge
+                .reserve_remote_owner_cleanup_capacity(&jid, &overflow)
+                .await
+                .is_some(),
+            "one terminal exact cleanup re-opens exactly one per-JID slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn owner_cleanup_global_budget_skips_active_entries_and_survives_self_fence() {
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let mut active_registration_id = None;
+        let mut first_inactive = None;
+        for index in 0..MAX_REMOTE_OWNER_CLEANUP_REGISTRATIONS {
+            let jid: jid::FullJid = format!("owner{index}@example.test/resource")
+                .parse()
+                .expect("generated full JID");
+            let registration = RemoteOwnerRegistration {
+                registration_id: RemoteResourceRegistrationId::fresh(),
+                admission_epoch: RemoteResourceAdmissionEpoch(index as i64 + 1),
+                socket_node: socket_identity(),
+                socket_generation: RemoteResourceSocketGeneration(1),
+                user_owner: receiver_identity(),
+                user_claim_epoch: ClaimEpoch(1),
+                owner: Arc::new(AtomicBool::new(true)),
+                placement: ConnectionPlacement::RemoteMirror,
+            };
+            let operation = bridge
+                .reserve_remote_owner_cleanup_capacity(&jid, &registration)
+                .await
+                .expect("bounded owner cleanup reservation");
+            drop(operation);
+            if index == 0 {
+                bridge
+                    .remote_owner_resources
+                    .lock()
+                    .await
+                    .insert(jid, registration.clone());
+                active_registration_id = Some(registration.registration_id);
+            } else if first_inactive.is_none() {
+                first_inactive = Some((jid, registration));
+            }
+        }
+        let overflow_jid: jid::FullJid = "owner-overflow@example.test/resource"
+            .parse()
+            .expect("overflow full JID");
+        let overflow = RemoteOwnerRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_node: socket_identity(),
+            socket_generation: RemoteResourceSocketGeneration(1),
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(1),
+            owner: Arc::new(AtomicBool::new(true)),
+            placement: ConnectionPlacement::RemoteMirror,
+        };
+
+        assert!(
+            bridge
+                .reserve_remote_owner_cleanup_capacity(&overflow_jid, &overflow)
+                .await
+                .is_none(),
+            "the owner-side global cap must reject before a register ask can maybe commit"
+        );
+        let retry_batch = bridge
+            .inactive_remote_owner_cleanup_ids(REMOTE_OWNER_GLOBAL_CLEANUP_RETRY_BATCH)
+            .await;
+        assert_eq!(retry_batch.len(), REMOTE_OWNER_GLOBAL_CLEANUP_RETRY_BATCH);
+        assert!(retry_batch
+            .iter()
+            .all(|(_, registration_id)| { Some(*registration_id) != active_registration_id }));
+
+        bridge.clear_remote_resource_state_on_self_fence().await;
+        assert!(bridge.remote_owner_resources.lock().await.is_empty());
+        assert_eq!(
+            bridge.remote_owner_pending_cleanup.lock().await.len(),
+            MAX_REMOTE_OWNER_CLEANUP_REGISTRATIONS,
+            "moving an already-reserved active entry on self-fence must not grow the map"
+        );
+
+        let (first_jid, first_registration) = first_inactive.expect("inactive reservation");
+        bridge
+            .remove_pending_remote_owner_cleanup_if_current(&first_jid, &first_registration)
+            .await;
+        assert!(
+            bridge
+                .reserve_remote_owner_cleanup_capacity(&overflow_jid, &overflow)
+                .await
+                .is_some(),
+            "one terminal exact cleanup re-opens one global owner slot"
+        );
+        assert_eq!(
+            bridge.remote_owner_pending_cleanup.lock().await.len(),
+            MAX_REMOTE_OWNER_CLEANUP_REGISTRATIONS
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_unregister_reply_preserves_maybe_committed_cleanup_evidence() {
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let jid = target_full();
+        let registration = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_generation: RemoteResourceSocketGeneration(1),
+            socket_node: origin_identity(),
+            owner: Arc::new(AtomicBool::new(true)),
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(2),
+        };
+        assert!(
+            bridge
+                .reserve_remote_socket_cleanup_capacity(&jid, &registration)
+                .await
+        );
+
+        // Model a register that may have committed followed by an unregister
+        // reaching an owner bridge that cannot currently access its services.
+        // A legacy `removed: false` reply was ambiguous here and the socket
+        // side incorrectly discarded its only rollback evidence.
+        let reply = bridge
+            .unregister_remote_user_resource_on_owner(RelayUnregisterRemoteUserResource {
+                jid: jid.clone(),
+                registration_id: registration.registration_id,
+                admission_epoch: registration.admission_epoch,
+                socket_generation: registration.socket_generation,
+                socket_node: registration.socket_node.clone(),
+                expected_user_owner: registration.user_owner.clone(),
+                expected_user_claim_epoch: registration.user_claim_epoch,
+            })
+            .await;
+        assert_eq!(reply.status, RelayRemoteResourceUnregisterStatus::Retry);
+        assert!(
+            !bridge
+                .finish_remote_socket_cleanup_attempt(
+                    &jid,
+                    &registration,
+                    reply.status == RelayRemoteResourceUnregisterStatus::Terminal,
+                )
+                .await
+        );
+        assert!(
+            bridge
+                .remote_socket_pending_cleanup
+                .lock()
+                .await
+                .contains_key(&registration.registration_id),
+            "retryable owner cleanup must retain exact maybe-committed evidence"
+        );
+    }
+
+    #[tokio::test]
+    async fn pre_publication_owner_register_failure_retains_non_routable_cleanup_evidence() {
+        let services = Arc::new(
+            services_with_claims(
+                origin_identity(),
+                receiver_identity(),
+                receiver_identity(),
+                test_peer_id(),
+            )
+            .await,
+        );
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        services.user_registry.kill();
+        tokio::task::yield_now().await;
+        let registration = remote_resource_registration(receiver_identity());
+
+        let reply = bridge
+            .register_remote_user_resource_on_owner(registration.clone())
+            .await;
+
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceRegistrationStatus::Unavailable
+        );
+        assert!(bridge.remote_owner_resources.lock().await.is_empty());
+        let pending = bridge.remote_owner_pending_cleanup.lock().await;
+        let (pending_jid, pending_registration) = pending
+            .get(&registration.registration_id)
+            .expect("maybe-committed pre-publication owner cleanup evidence");
+        assert_eq!(pending_jid, &registration.jid);
+        assert_eq!(pending_registration.socket_node, registration.socket_node);
+        assert_eq!(
+            pending_registration.user_claim_epoch,
+            registration.expected_user_claim_epoch
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_post_publication_owner_cleanup_remains_non_routable_and_retryable() {
+        let services = Arc::new(
+            services_with_claims(
+                origin_identity(),
+                receiver_identity(),
+                receiver_identity(),
+                test_peer_id(),
+            )
+            .await,
+        );
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let wire_registration = remote_resource_registration(receiver_identity());
+        let reply = bridge
+            .register_remote_user_resource_on_owner(wire_registration.clone())
+            .await;
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceRegistrationStatus::Registered
+        );
+        let owner_registration = bridge
+            .remote_owner_resources
+            .lock()
+            .await
+            .get(&wire_registration.jid)
+            .cloned()
+            .expect("published owner registration");
+
+        services.user_registry.kill();
+        tokio::task::yield_now().await;
+        bridge
+            .retain_remote_owner_cleanup(&wire_registration.jid, &owner_registration)
+            .await;
+        assert!(
+            !bridge
+                .cleanup_remote_owner_resource_if_registration(
+                    &wire_registration.jid,
+                    owner_registration.registration_id,
+                )
+                .await
+        );
+        assert!(bridge.remote_owner_resources.lock().await.is_empty());
+
+        let compensation = bridge
+            .unregister_remote_user_resource_on_owner(RelayUnregisterRemoteUserResource {
+                jid: wire_registration.jid.clone(),
+                registration_id: wire_registration.registration_id,
+                admission_epoch: wire_registration.admission_epoch,
+                socket_generation: wire_registration.socket_generation,
+                socket_node: wire_registration.socket_node,
+                expected_user_owner: wire_registration.expected_user_owner,
+                expected_user_claim_epoch: wire_registration.expected_user_claim_epoch,
+            })
+            .await;
+        assert_eq!(
+            compensation.status,
+            RelayRemoteResourceUnregisterStatus::Retry
+        );
+        assert!(
+            bridge
+                .remote_owner_pending_cleanup
+                .lock()
+                .await
+                .contains_key(&owner_registration.registration_id),
+            "failed actor cleanup must never become map-absent Terminal"
+        );
     }
 
     #[tokio::test]
@@ -5036,6 +8745,30 @@ mod tests {
         validate_claims(&services, &signed_envelope(&keypair))
             .await
             .expect("claims match origin and receiver");
+    }
+
+    #[tokio::test]
+    async fn receiver_rejects_pre_fence_origin_epoch_with_same_node_id_and_claim_epoch() {
+        let keypair = Keypair::generate_ed25519();
+        let recovered_origin = NodeIdentity::new("origin-node", "recovered-origin-epoch");
+        let services = services_with_claims(
+            recovered_origin,
+            receiver_identity(),
+            receiver_identity(),
+            keypair.public().to_peer_id().to_string(),
+        )
+        .await;
+
+        let err = validate_claims(&services, &signed_envelope(&keypair))
+            .await
+            .expect_err("a delayed envelope from the pre-fence epoch must be rejected");
+
+        assert_eq!(
+            err,
+            OrderedRelayNackReason::NotOwner {
+                role: OrderedRelayClaimRole::Origin
+            }
+        );
     }
 
     #[tokio::test]
@@ -5199,7 +8932,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stale_registered_remote_resource_cleans_mirror_and_allows_local_fallback() {
+    async fn absent_exact_socket_node_retires_registered_remote_resource() {
         let services = Arc::new(
             services_with_claims(
                 origin_identity(),
@@ -5236,9 +8969,13 @@ mod tests {
             target.clone(),
             RemoteOwnerRegistration {
                 registration_id,
-                socket_node: NodeId::new("missing-socket-node".to_string()),
+                admission_epoch: RemoteResourceAdmissionEpoch(1),
+                socket_node: NodeIdentity::new("missing-socket-node", "missing-socket-epoch"),
                 socket_generation: RemoteResourceSocketGeneration::next(None),
+                user_owner: receiver_identity(),
+                user_claim_epoch: ClaimEpoch(2),
                 owner: Arc::clone(&owner),
+                placement: ConnectionPlacement::RemoteMirror,
             },
         );
 
@@ -5252,24 +8989,1336 @@ mod tests {
 
         assert_eq!(outcome, None);
         assert!(
-            !bridge
+            bridge
                 .remote_owner_resources
                 .lock()
                 .await
-                .contains_key(&target),
-            "stale remote owner map entry must be removed"
+                .get(&target)
+                .is_none(),
+            "a proven-absent exact socket incarnation must retire the owner map entry"
         );
         assert!(
             services
                 .connection_registry
                 .entry_if_owner(&target, &owner)
                 .is_none(),
-            "stale remote connection mirror must be removed so local fallback can run"
+            "a proven-absent exact socket incarnation must retire the mirror"
         );
     }
 
     #[tokio::test]
-    async fn stale_force_detach_error_cleans_old_socket_mirror() {
+    async fn pending_socket_registration_is_detachable_before_owner_ack() {
+        let services = Arc::new(
+            services_with_claims(
+                origin_identity(),
+                receiver_identity(),
+                receiver_identity(),
+                test_peer_id(),
+            )
+            .await,
+        );
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+
+        let target = target_full();
+        let (outbound_tx, _outbound_rx) = mpsc::channel(1);
+        let owner = services
+            .connection_registry
+            .register(target.clone(), outbound_tx);
+        let entry = services
+            .connection_registry
+            .entry_if_owner(&target, &owner)
+            .expect("registered socket resource");
+        let mut force_detach_rx = entry
+            .take_force_detach_rx()
+            .expect("socket task owns force-detach receiver");
+        let registration_id = RemoteResourceRegistrationId::fresh();
+        let admission_epoch = RemoteResourceAdmissionEpoch(1);
+        let socket_generation = RemoteResourceSocketGeneration::next(None);
+        bridge
+            .publish_pending_remote_socket_registration(
+                &target,
+                RemoteSocketRegistration {
+                    registration_id,
+                    admission_epoch,
+                    socket_generation,
+                    socket_node: receiver_identity(),
+                    owner,
+                    user_owner: receiver_identity(),
+                    user_claim_epoch: ClaimEpoch(2),
+                },
+            )
+            .await;
+
+        // No owner registration ACK has arrived. A concurrent owner self-fence
+        // must nevertheless find this pending registration and reach the
+        // physical socket instead of concluding that it is already gone.
+        let detach = tokio::spawn({
+            let bridge = Arc::clone(&bridge);
+            let target = target.clone();
+            async move {
+                bridge
+                    .force_detach_remote_user_resource_on_socket(
+                        RelayForceDetachRemoteUserResource {
+                            requester_bare_jid: target.to_bare(),
+                            jid: target,
+                            registration_id,
+                            admission_epoch,
+                            socket_generation,
+                            socket_node: receiver_identity(),
+                            expected_user_owner: receiver_identity(),
+                            expected_user_claim_epoch: ClaimEpoch(2),
+                            reason: ForceDetachReason::NodeSelfFenced,
+                        },
+                    )
+                    .await
+            }
+        });
+
+        let request = force_detach_rx.recv().await.expect("force-detach request");
+        assert_eq!(request.reason, ForceDetachReason::NodeSelfFenced);
+        request
+            .ack
+            .send(ForceDetachOutcome::NotPersisted)
+            .expect("socket detach ack accepted");
+        let reply = detach.await.expect("relay detach task");
+        assert_eq!(reply.outcome, ForceDetachOutcome::NotPersisted);
+        assert_eq!(reply.status, RelayRemoteResourceForceDetachStatus::Detached);
+    }
+
+    #[tokio::test]
+    async fn hard_retired_local_socket_preserves_owner_mirror_cleanup_evidence() {
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let jid = target_full();
+        let owner = Arc::new(AtomicBool::new(true));
+        let registration = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_generation: RemoteResourceSocketGeneration(1),
+            socket_node: origin_identity(),
+            owner: Arc::clone(&owner),
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(2),
+        };
+        assert!(
+            bridge
+                .reserve_remote_socket_cleanup_capacity(&jid, &registration)
+                .await
+        );
+        assert!(
+            bridge
+                .publish_pending_remote_socket_registration(&jid, registration.clone())
+                .await
+        );
+
+        // UserLocalClaims invokes this after hard-aborting a non-cooperative
+        // physical socket. The local routing record is dead, but the remote
+        // owner mirror may still exist and therefore still needs exact
+        // compensation evidence.
+        bridge
+            .forget_remote_resource_state_if_owner(
+                &jid,
+                &owner,
+                waddle_xmpp::registry::ConnectionPlacement::LocalSocket,
+            )
+            .await;
+
+        assert!(bridge.remote_socket_resources.lock().await.is_empty());
+        assert!(
+            bridge
+                .remote_socket_pending_cleanup
+                .lock()
+                .await
+                .contains_key(&registration.registration_id),
+            "physical retirement must not imply owner-mirror cleanup"
+        );
+    }
+
+    #[tokio::test]
+    async fn delayed_old_owner_frame_is_rejected_after_claim_regrant() {
+        let user_owner = receiver_identity();
+        let (services, store) = services_with_claims_and_store(
+            origin_identity(),
+            user_owner.clone(),
+            origin_identity(),
+            test_peer_id(),
+            Arc::new(waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new()),
+        )
+        .await;
+        let services = Arc::new(services);
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let target = target_full();
+        let (outbound_tx, mut outbound_rx) = mpsc::channel(1);
+        let socket_owner = services
+            .connection_registry
+            .register(target.clone(), outbound_tx);
+        let entry = services
+            .connection_registry
+            .entry_if_owner(&target, &socket_owner)
+            .expect("registered physical socket");
+        let mut force_detach_rx = entry
+            .take_force_detach_rx()
+            .expect("socket owns force-detach receiver");
+        let registration = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_generation: RemoteResourceSocketGeneration::next(None),
+            socket_node: origin_identity(),
+            owner: socket_owner,
+            user_owner: user_owner.clone(),
+            user_claim_epoch: ClaimEpoch(2),
+        };
+        bridge
+            .publish_pending_remote_socket_registration(&target, registration.clone())
+            .await;
+        let current_epoch = steal_and_regrant_target_claim(&store, &user_owner).await;
+        assert_ne!(current_epoch, registration.user_claim_epoch);
+
+        let delivery = tokio::spawn({
+            let bridge = Arc::clone(&bridge);
+            let target = target.clone();
+            let registration = registration.clone();
+            async move {
+                bridge
+                    .deliver_remote_resource_frame_on_socket(RelayDeliverRemoteResourceFrame {
+                        frame: RemoteResourceOutboundFrame {
+                            jid: target.clone(),
+                            registration_id: registration.registration_id,
+                            admission_epoch: registration.admission_epoch,
+                            socket_generation: registration.socket_generation,
+                            socket_node: registration.socket_node,
+                            expected_user_owner: registration.user_owner,
+                            expected_user_claim_epoch: registration.user_claim_epoch,
+                            stanza: RemoteStanza(Stanza::Message(Message::new(Some(
+                                jid::Jid::from(target),
+                            )))),
+                            kind: DeliveryKind::PeerStanza,
+                        },
+                    })
+                    .await
+            }
+        });
+
+        assert!(
+            outbound_rx.try_recv().is_err(),
+            "stale frame must not reach socket"
+        );
+        let request = tokio::time::timeout(Duration::from_secs(1), force_detach_rx.recv())
+            .await
+            .expect("stale-registration detach must be prompt")
+            .expect("stale registration invalidates the physical socket");
+        assert_eq!(request.reason, ForceDetachReason::RemoteStateInvalidated);
+        request
+            .ack
+            .send(ForceDetachOutcome::NotPersisted)
+            .expect("cooperative stale detach accepts ack");
+        let reply = delivery.await.expect("stale frame handler");
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceFrameStatus::StaleRegistration
+        );
+        assert!(bridge.remote_socket_resources.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delayed_pre_fence_socket_epoch_frame_cannot_reach_recovered_process() {
+        let services = Arc::new(
+            services_with_claims(
+                origin_identity(),
+                receiver_identity(),
+                origin_identity(),
+                test_peer_id(),
+            )
+            .await,
+        );
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let target = target_full();
+        let (outbound_tx, mut outbound_rx) = mpsc::channel(1);
+        let socket_owner = services
+            .connection_registry
+            .register(target.clone(), outbound_tx);
+        let entry = services
+            .connection_registry
+            .entry_if_owner(&target, &socket_owner)
+            .expect("registered physical socket");
+        let mut force_detach_rx = entry
+            .take_force_detach_rx()
+            .expect("socket owns force-detach receiver");
+        let registration = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_generation: RemoteResourceSocketGeneration::next(None),
+            socket_node: origin_identity(),
+            owner: socket_owner,
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(2),
+        };
+        assert!(
+            bridge
+                .publish_pending_remote_socket_registration(&target, registration.clone())
+                .await
+        );
+        services.node_identity.set(NodeIdentity::new(
+            registration.socket_node.node_id.clone(),
+            "recovered-socket-epoch",
+        ));
+
+        let delivery = tokio::spawn({
+            let bridge = Arc::clone(&bridge);
+            let target = target.clone();
+            let registration = registration.clone();
+            async move {
+                bridge
+                    .deliver_remote_resource_frame_on_socket(RelayDeliverRemoteResourceFrame {
+                        frame: RemoteResourceOutboundFrame {
+                            jid: target.clone(),
+                            registration_id: registration.registration_id,
+                            admission_epoch: registration.admission_epoch,
+                            socket_generation: registration.socket_generation,
+                            socket_node: registration.socket_node,
+                            expected_user_owner: registration.user_owner,
+                            expected_user_claim_epoch: registration.user_claim_epoch,
+                            stanza: RemoteStanza(Stanza::Message(Message::new(Some(
+                                jid::Jid::from(target),
+                            )))),
+                            kind: DeliveryKind::PeerStanza,
+                        },
+                    })
+                    .await
+            }
+        });
+        let request = tokio::time::timeout(Duration::from_secs(1), force_detach_rx.recv())
+            .await
+            .expect("stale socket incarnation is retired promptly")
+            .expect("stale socket receives terminal invalidation");
+        assert_eq!(request.reason, ForceDetachReason::RemoteStateInvalidated);
+        request
+            .ack
+            .send(ForceDetachOutcome::NotPersisted)
+            .expect("cooperative stale detach accepts ack");
+        let reply = delivery.await.expect("stale socket frame handler");
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceFrameStatus::StaleRegistration
+        );
+        assert!(outbound_rx.try_recv().is_err());
+        assert!(!services.connection_registry.is_connected(&target));
+    }
+
+    #[tokio::test]
+    async fn self_fence_during_frame_claim_validation_prevents_post_fence_delivery() {
+        let (mut services, claim_store, _) = services_with_claims_and_controls(
+            origin_identity(),
+            receiver_identity(),
+            origin_identity(),
+            test_peer_id(),
+            Arc::new(waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new()),
+        )
+        .await;
+        let delayed_claim_store = DelayedCurrentClaimStore::new(claim_store);
+        services.claim_store = delayed_claim_store.clone();
+        let services = Arc::new(services);
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let target = target_full();
+        let (outbound_tx, mut outbound_rx) = mpsc::channel(1);
+        let socket_owner = services
+            .connection_registry
+            .register(target.clone(), outbound_tx);
+        let registration = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_generation: RemoteResourceSocketGeneration::next(None),
+            socket_node: origin_identity(),
+            owner: socket_owner,
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(2),
+        };
+        assert!(
+            bridge
+                .publish_pending_remote_socket_registration(&target, registration.clone())
+                .await
+        );
+        delayed_claim_store.delay_next_read();
+
+        let delivery = tokio::spawn({
+            let bridge = Arc::clone(&bridge);
+            let target = target.clone();
+            let registration = registration.clone();
+            async move {
+                bridge
+                    .deliver_remote_resource_frame_on_socket(RelayDeliverRemoteResourceFrame {
+                        frame: RemoteResourceOutboundFrame {
+                            jid: target.clone(),
+                            registration_id: registration.registration_id,
+                            admission_epoch: registration.admission_epoch,
+                            socket_generation: registration.socket_generation,
+                            socket_node: registration.socket_node,
+                            expected_user_owner: registration.user_owner,
+                            expected_user_claim_epoch: registration.user_claim_epoch,
+                            stanza: RemoteStanza(Stanza::Message(Message::new(Some(
+                                jid::Jid::from(target),
+                            )))),
+                            kind: DeliveryKind::PeerStanza,
+                        },
+                    })
+                    .await
+            }
+        });
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            delayed_claim_store.wait_until_read_started(),
+        )
+        .await
+        .expect("frame validation reaches delayed claim read");
+        bridge.clear_remote_resource_state_on_self_fence().await;
+        delayed_claim_store.release_read();
+
+        let reply = delivery.await.expect("delayed frame handler");
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceFrameStatus::StaleRegistration
+        );
+        assert!(
+            outbound_rx.try_recv().is_err(),
+            "a claim result read before the fence cannot authorize post-fence delivery"
+        );
+    }
+
+    #[tokio::test]
+    async fn delayed_old_frame_cannot_deliver_or_detach_a_superseding_registration() {
+        let user_owner = receiver_identity();
+        let (mut services, claim_store, _) = services_with_claims_and_controls(
+            origin_identity(),
+            user_owner.clone(),
+            origin_identity(),
+            test_peer_id(),
+            Arc::new(waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new()),
+        )
+        .await;
+        let delayed_claim_store = DelayedCurrentClaimStore::new(Arc::clone(&claim_store));
+        services.claim_store = delayed_claim_store.clone();
+        let services = Arc::new(services);
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let target = target_full();
+        let (outbound_tx, mut outbound_rx) = mpsc::channel(1);
+        let socket_owner = services
+            .connection_registry
+            .register(target.clone(), outbound_tx);
+        let entry = services
+            .connection_registry
+            .entry_if_owner(&target, &socket_owner)
+            .expect("registered physical socket");
+        let mut force_detach_rx = entry
+            .take_force_detach_rx()
+            .expect("socket owns force-detach receiver");
+        let older = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_generation: RemoteResourceSocketGeneration(1),
+            socket_node: origin_identity(),
+            owner: Arc::clone(&socket_owner),
+            user_owner: user_owner.clone(),
+            user_claim_epoch: ClaimEpoch(2),
+        };
+        assert!(
+            bridge
+                .publish_pending_remote_socket_registration(&target, older.clone())
+                .await
+        );
+        delayed_claim_store.delay_next_read();
+
+        let delivery = tokio::spawn({
+            let bridge = Arc::clone(&bridge);
+            let target = target.clone();
+            let older = older.clone();
+            async move {
+                bridge
+                    .deliver_remote_resource_frame_on_socket(RelayDeliverRemoteResourceFrame {
+                        frame: RemoteResourceOutboundFrame {
+                            jid: target.clone(),
+                            registration_id: older.registration_id,
+                            admission_epoch: older.admission_epoch,
+                            socket_generation: older.socket_generation,
+                            socket_node: older.socket_node,
+                            expected_user_owner: older.user_owner,
+                            expected_user_claim_epoch: older.user_claim_epoch,
+                            stanza: RemoteStanza(Stanza::Message(Message::new(Some(
+                                jid::Jid::from(target),
+                            )))),
+                            kind: DeliveryKind::PeerStanza,
+                        },
+                    })
+                    .await
+            }
+        });
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            delayed_claim_store.wait_until_read_started(),
+        )
+        .await
+        .expect("old frame reaches delayed claim read");
+
+        let current_epoch = steal_and_regrant_target_claim(&claim_store, &user_owner).await;
+        let newer = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(2),
+            socket_generation: RemoteResourceSocketGeneration(2),
+            socket_node: origin_identity(),
+            owner: socket_owner,
+            user_owner,
+            user_claim_epoch: current_epoch,
+        };
+        assert!(
+            bridge
+                .publish_pending_remote_socket_registration(&target, newer.clone())
+                .await
+        );
+        delayed_claim_store.release_read();
+
+        let reply = delivery.await.expect("delayed old frame handler");
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceFrameStatus::StaleRegistration
+        );
+        assert!(outbound_rx.try_recv().is_err());
+        assert!(force_detach_rx.try_recv().is_err());
+        assert!(services.connection_registry.is_connected(&target));
+        assert!(
+            bridge
+                .remote_socket_registration_is_current(&target, &newer)
+                .await,
+            "stale invalidation must not remove or hard-detach a superseding registration"
+        );
+    }
+
+    #[tokio::test]
+    async fn self_fence_during_force_detach_claim_validation_prevents_post_fence_control_effect() {
+        let (mut services, claim_store, _) = services_with_claims_and_controls(
+            origin_identity(),
+            receiver_identity(),
+            origin_identity(),
+            test_peer_id(),
+            Arc::new(waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new()),
+        )
+        .await;
+        let delayed_claim_store = DelayedCurrentClaimStore::new(claim_store);
+        services.claim_store = delayed_claim_store.clone();
+        let services = Arc::new(services);
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let target = target_full();
+        let (outbound_tx, _outbound_rx) = mpsc::channel(1);
+        let socket_owner = services
+            .connection_registry
+            .register(target.clone(), outbound_tx);
+        let entry = services
+            .connection_registry
+            .entry_if_owner(&target, &socket_owner)
+            .expect("registered physical socket");
+        let mut force_detach_rx = entry
+            .take_force_detach_rx()
+            .expect("socket owns force-detach receiver");
+        let registration = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_generation: RemoteResourceSocketGeneration::next(None),
+            socket_node: origin_identity(),
+            owner: socket_owner,
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(2),
+        };
+        assert!(
+            bridge
+                .publish_pending_remote_socket_registration(&target, registration.clone())
+                .await
+        );
+        delayed_claim_store.delay_next_read();
+
+        let detach = tokio::spawn({
+            let bridge = Arc::clone(&bridge);
+            let target = target.clone();
+            let registration = registration.clone();
+            async move {
+                bridge
+                    .force_detach_remote_user_resource_on_socket(
+                        RelayForceDetachRemoteUserResource {
+                            jid: target.clone(),
+                            registration_id: registration.registration_id,
+                            admission_epoch: registration.admission_epoch,
+                            socket_generation: registration.socket_generation,
+                            socket_node: registration.socket_node,
+                            expected_user_owner: registration.user_owner,
+                            expected_user_claim_epoch: registration.user_claim_epoch,
+                            requester_bare_jid: target.to_bare(),
+                            reason: ForceDetachReason::ResourceReplaced,
+                        },
+                    )
+                    .await
+            }
+        });
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            delayed_claim_store.wait_until_read_started(),
+        )
+        .await
+        .expect("force-detach validation reaches delayed claim read");
+        bridge.clear_remote_resource_state_on_self_fence().await;
+        delayed_claim_store.release_read();
+
+        let reply = detach.await.expect("delayed force-detach handler");
+        assert_eq!(reply.outcome, ForceDetachOutcome::NotPersisted);
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceForceDetachStatus::Invalidated
+        );
+        assert!(
+            force_detach_rx.try_recv().is_err(),
+            "a claim result read before the fence cannot enqueue post-fence control"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_socket_invalidation_hard_retires_full_and_wedged_control_channels() {
+        let services = Arc::new(
+            services_with_claims(
+                origin_identity(),
+                receiver_identity(),
+                origin_identity(),
+                test_peer_id(),
+            )
+            .await,
+        );
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+
+        for (resource, fill_channel) in [("full", true), ("wedged", false)] {
+            let jid: jid::FullJid = format!("juliet@example.test/{resource}")
+                .parse()
+                .expect("full jid");
+            let (outbound_tx, _outbound_rx) = mpsc::channel(1);
+            let owner = services
+                .connection_registry
+                .register(jid.clone(), outbound_tx);
+            let entry = services
+                .connection_registry
+                .entry_if_owner(&jid, &owner)
+                .expect("registered physical socket");
+            let held_rx = entry
+                .take_force_detach_rx()
+                .expect("socket owns force-detach receiver");
+            if fill_channel {
+                loop {
+                    let (ack, _ack_rx) = tokio::sync::oneshot::channel();
+                    if entry
+                        .force_detach_sender()
+                        .try_send(ForceDetachRequest {
+                            requester_bare_jid: jid.to_bare(),
+                            reason: ForceDetachReason::RemoteStateInvalidated,
+                            ack,
+                        })
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            }
+
+            let (abort, abort_registration) = futures::future::AbortHandle::new_pair();
+            let terminated = CancellationToken::new();
+            assert!(entry.install_retirement_handle(
+                waddle_xmpp::registry::ConnectionRetirementHandle::new(abort, terminated.clone(),),
+            ));
+            let task_terminated = terminated.clone();
+            let socket_task = tokio::spawn(async move {
+                let _ = futures::future::Abortable::new(
+                    std::future::pending::<()>(),
+                    abort_registration,
+                )
+                .await;
+                task_terminated.cancel();
+            });
+            let registration = RemoteSocketRegistration {
+                registration_id: RemoteResourceRegistrationId::fresh(),
+                admission_epoch: RemoteResourceAdmissionEpoch(1),
+                socket_generation: bridge
+                    .next_remote_socket_generation()
+                    .expect("socket generation"),
+                socket_node: origin_identity(),
+                owner: owner.clone(),
+                user_owner: receiver_identity(),
+                user_claim_epoch: ClaimEpoch(2),
+            };
+            assert!(
+                bridge
+                    .publish_pending_remote_socket_registration(&jid, registration.clone())
+                    .await
+            );
+
+            bridge
+                .detach_stale_remote_socket_resource(&jid, &registration)
+                .await;
+
+            tokio::time::timeout(Duration::from_secs(1), socket_task)
+                .await
+                .expect("hard-retired socket task terminates")
+                .expect("socket task join");
+            assert!(terminated.is_cancelled());
+            assert!(
+                services
+                    .connection_registry
+                    .entry_if_owner(&jid, &owner)
+                    .is_none(),
+                "terminal invalidation owner-gates registry cleanup"
+            );
+            assert!(
+                !bridge
+                    .remote_socket_resources
+                    .lock()
+                    .await
+                    .contains_key(&jid),
+                "terminal invalidation removes routing metadata"
+            );
+            drop(held_rx);
+        }
+    }
+
+    #[tokio::test]
+    async fn delayed_old_owner_force_detach_is_refused_after_claim_regrant() {
+        let user_owner = receiver_identity();
+        let (services, store) = services_with_claims_and_store(
+            origin_identity(),
+            user_owner.clone(),
+            origin_identity(),
+            test_peer_id(),
+            Arc::new(waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new()),
+        )
+        .await;
+        let services = Arc::new(services);
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        let target = target_full();
+        let (outbound_tx, _outbound_rx) = mpsc::channel(1);
+        let socket_owner = services
+            .connection_registry
+            .register(target.clone(), outbound_tx);
+        let entry = services
+            .connection_registry
+            .entry_if_owner(&target, &socket_owner)
+            .expect("registered physical socket");
+        let mut force_detach_rx = entry
+            .take_force_detach_rx()
+            .expect("socket owns force-detach receiver");
+        let registration = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_generation: RemoteResourceSocketGeneration::next(None),
+            socket_node: origin_identity(),
+            owner: socket_owner,
+            user_owner: user_owner.clone(),
+            user_claim_epoch: ClaimEpoch(2),
+        };
+        bridge
+            .publish_pending_remote_socket_registration(&target, registration.clone())
+            .await;
+        let current_epoch = steal_and_regrant_target_claim(&store, &user_owner).await;
+        assert_ne!(current_epoch, registration.user_claim_epoch);
+
+        let detach = tokio::spawn({
+            let bridge = Arc::clone(&bridge);
+            let target = target.clone();
+            let registration = registration.clone();
+            async move {
+                bridge
+                    .force_detach_remote_user_resource_on_socket(
+                        RelayForceDetachRemoteUserResource {
+                            jid: target.clone(),
+                            registration_id: registration.registration_id,
+                            admission_epoch: registration.admission_epoch,
+                            socket_generation: registration.socket_generation,
+                            socket_node: registration.socket_node,
+                            expected_user_owner: registration.user_owner,
+                            expected_user_claim_epoch: registration.user_claim_epoch,
+                            requester_bare_jid: target.to_bare(),
+                            reason: ForceDetachReason::ResourceReplaced,
+                        },
+                    )
+                    .await
+            }
+        });
+
+        let request = tokio::time::timeout(Duration::from_secs(1), force_detach_rx.recv())
+            .await
+            .expect("stale-registration detach must be prompt")
+            .expect("stale registration invalidates the physical socket");
+        assert_eq!(request.reason, ForceDetachReason::ResourceReplaced);
+        request
+            .ack
+            .send(ForceDetachOutcome::NotPersisted)
+            .expect("cooperative stale detach accepts ack");
+        let reply = detach.await.expect("stale force-detach handler");
+        assert_eq!(reply.outcome, ForceDetachOutcome::NotPersisted);
+        assert_eq!(
+            reply.status,
+            RelayRemoteResourceForceDetachStatus::Invalidated
+        );
+        assert!(bridge.remote_socket_resources.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn socket_generation_remains_monotonic_across_self_fence_cleanup() {
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let first = bridge
+            .next_remote_socket_generation()
+            .expect("first generation");
+
+        bridge.clear_remote_resource_state_on_self_fence().await;
+
+        let recovered = bridge
+            .next_remote_socket_generation()
+            .expect("post-fence generation");
+        assert!(
+            recovered > first,
+            "a stable socket-node relay address must never reuse a pre-fence generation"
+        );
+    }
+
+    #[tokio::test]
+    async fn self_fence_moves_unretired_owner_mirrors_to_non_routable_cleanup_evidence() {
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let jid = target_full();
+        let registration = RemoteOwnerRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_node: origin_identity(),
+            socket_generation: RemoteResourceSocketGeneration(1),
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(2),
+            owner: Arc::new(AtomicBool::new(true)),
+            placement: ConnectionPlacement::RemoteMirror,
+        };
+        bridge
+            .remote_owner_resources
+            .lock()
+            .await
+            .insert(jid.clone(), registration.clone());
+
+        bridge.clear_remote_resource_state_on_self_fence().await;
+
+        assert!(bridge.remote_owner_resources.lock().await.is_empty());
+        let pending = bridge.remote_owner_pending_cleanup.lock().await;
+        let (pending_jid, pending_registration) = pending
+            .get(&registration.registration_id)
+            .expect("self-fenced owner cleanup evidence");
+        assert_eq!(pending_jid, &jid);
+        assert!(remote_owner_registration_matches(
+            pending_registration,
+            &registration
+        ));
+    }
+
+    #[tokio::test]
+    async fn reverse_pending_publication_cannot_replace_newer_socket_generation() {
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let jid = target_full();
+        let newer = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(2),
+            socket_generation: RemoteResourceSocketGeneration(2),
+            socket_node: origin_identity(),
+            owner: Arc::new(AtomicBool::new(true)),
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(7),
+        };
+        let older = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_generation: RemoteResourceSocketGeneration(1),
+            socket_node: origin_identity(),
+            owner: Arc::new(AtomicBool::new(true)),
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(6),
+        };
+
+        assert!(
+            bridge
+                .publish_pending_remote_socket_registration(&jid, newer.clone())
+                .await
+        );
+        assert!(
+            !bridge
+                .publish_pending_remote_socket_registration(&jid, older)
+                .await,
+            "a delayed older publication must lose"
+        );
+        assert!(
+            bridge
+                .remote_socket_registration_is_current(&jid, &newer)
+                .await,
+            "the exact newer registration must survive reverse publication"
+        );
+    }
+
+    #[tokio::test]
+    async fn uncertain_old_compensation_survives_overlapping_newer_publication_failure() {
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let jid = target_full();
+        let owner = Arc::new(AtomicBool::new(true));
+        let older = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_generation: RemoteResourceSocketGeneration(1),
+            socket_node: origin_identity(),
+            owner: Arc::clone(&owner),
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(6),
+        };
+        let newer = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(2),
+            socket_generation: RemoteResourceSocketGeneration(2),
+            socket_node: origin_identity(),
+            owner,
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(7),
+        };
+
+        assert!(
+            bridge
+                .publish_pending_remote_socket_registration(&jid, older.clone())
+                .await
+        );
+        assert!(
+            bridge
+                .publish_pending_remote_socket_registration(&jid, newer.clone())
+                .await
+        );
+
+        // Model the older register committing while its reply is lost. Its
+        // compensating unregister is also uncertain, after a newer attempt
+        // has already replaced the JID-keyed publication slot.
+        bridge.retain_remote_socket_cleanup(&jid, &older).await;
+
+        // The newer attempt then fails before it can establish an owner
+        // mirror. Removing it must not discard the older exact compensation
+        // evidence just because both attempts used the same full JID.
+        bridge
+            .remove_remote_socket_registration_if_current(&jid, &newer)
+            .await;
+        assert!(bridge.remote_socket_resources.lock().await.is_empty());
+        let pending = bridge.remote_socket_pending_cleanup.lock().await;
+        let (pending_jid, pending_registration) = pending
+            .get(&older.registration_id)
+            .expect("uncertain older compensation metadata");
+        assert_eq!(pending_jid, &jid);
+        assert!(remote_socket_registration_matches(
+            pending_registration,
+            &older
+        ));
+        assert!(!pending.contains_key(&newer.registration_id));
+    }
+
+    #[tokio::test]
+    async fn confirmed_opportunistic_cleanup_removes_only_the_exact_pending_registration() {
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let jid = target_full();
+        let owner = Arc::new(AtomicBool::new(true));
+        let obsolete = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_generation: RemoteResourceSocketGeneration(1),
+            socket_node: origin_identity(),
+            owner: Arc::clone(&owner),
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(6),
+        };
+        let current = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(2),
+            socket_generation: RemoteResourceSocketGeneration(2),
+            socket_node: origin_identity(),
+            owner,
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(7),
+        };
+        assert!(
+            bridge
+                .reserve_remote_socket_cleanup_capacity(&jid, &obsolete)
+                .await
+        );
+        assert!(
+            bridge
+                .publish_pending_remote_socket_registration(&jid, current.clone())
+                .await
+        );
+
+        assert!(
+            !bridge
+                .finish_remote_socket_cleanup_attempt(&jid, &obsolete, false)
+                .await,
+            "an uncertain retry must retain exact compensation metadata"
+        );
+        assert!(bridge
+            .remote_socket_pending_cleanup
+            .lock()
+            .await
+            .contains_key(&obsolete.registration_id));
+        assert!(
+            bridge
+                .finish_remote_socket_cleanup_attempt(&jid, &obsolete, true)
+                .await,
+            "an acknowledged unregister retires the obsolete exact attempt"
+        );
+        assert!(bridge.remote_socket_pending_cleanup.lock().await.is_empty());
+        assert!(
+            bridge
+                .remote_socket_registration_is_current(&jid, &current)
+                .await,
+            "cleanup for generation N must not remove current generation N+1"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_cleanup_budget_bounds_reconnect_storms_per_full_jid() {
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let jid = target_full();
+        let other_jid: jid::FullJid = "juliet@example.test/tablet".parse().expect("full JID");
+        let owner = Arc::new(AtomicBool::new(true));
+        let mut pending = Vec::new();
+        for generation in 1..=MAX_PENDING_REMOTE_SOCKET_CLEANUPS_PER_JID {
+            let registration = RemoteSocketRegistration {
+                registration_id: RemoteResourceRegistrationId::fresh(),
+                admission_epoch: RemoteResourceAdmissionEpoch(generation as i64),
+                socket_generation: RemoteResourceSocketGeneration(generation as u64),
+                socket_node: origin_identity(),
+                owner: Arc::clone(&owner),
+                user_owner: receiver_identity(),
+                user_claim_epoch: ClaimEpoch(generation as i64),
+            };
+            assert!(
+                bridge
+                    .reserve_remote_socket_cleanup_capacity(&jid, &registration)
+                    .await
+            );
+            pending.push(registration);
+        }
+        let unrelated = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_generation: RemoteResourceSocketGeneration(1),
+            socket_node: origin_identity(),
+            owner,
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(1),
+        };
+        assert!(
+            bridge
+                .reserve_remote_socket_cleanup_capacity(&other_jid, &unrelated)
+                .await
+        );
+        let overflow = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(9),
+            socket_generation: RemoteResourceSocketGeneration(9),
+            socket_node: origin_identity(),
+            owner: Arc::new(AtomicBool::new(true)),
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(9),
+        };
+
+        assert!(
+            !bridge
+                .reserve_remote_socket_cleanup_capacity(&jid, &overflow)
+                .await,
+            "the next same-JID registration must fail closed at the uncertainty cap"
+        );
+        let selected = bridge.pending_remote_socket_cleanups_for_jid(&jid).await;
+        assert_eq!(selected.len(), MAX_PENDING_REMOTE_SOCKET_CLEANUPS_PER_JID);
+        assert!(selected
+            .iter()
+            .all(|registration| registration.registration_id != unrelated.registration_id));
+
+        assert!(
+            bridge
+                .finish_remote_socket_cleanup_attempt(&jid, &pending[0], true)
+                .await
+        );
+        assert!(
+            bridge
+                .reserve_remote_socket_cleanup_capacity(&jid, &overflow)
+                .await,
+            "one confirmed retry re-opens exactly one bounded registration slot"
+        );
+    }
+
+    #[tokio::test]
+    async fn global_cleanup_capacity_recovers_from_inactive_entries_without_touching_live_ones() {
+        let services = Arc::new(
+            services_with_claims(
+                origin_identity(),
+                receiver_identity(),
+                origin_identity(),
+                test_peer_id(),
+            )
+            .await,
+        );
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(services);
+        let owner = Arc::new(AtomicBool::new(true));
+        let mut first_cleanup = None;
+        let mut active_registration_id = None;
+        for index in 0..MAX_REMOTE_SOCKET_CLEANUP_REGISTRATIONS {
+            let jid: jid::FullJid = format!("user{index}@example.test/resource")
+                .parse()
+                .expect("generated full JID");
+            let registration = RemoteSocketRegistration {
+                registration_id: RemoteResourceRegistrationId::fresh(),
+                admission_epoch: RemoteResourceAdmissionEpoch(index as i64 + 1),
+                socket_generation: RemoteResourceSocketGeneration(1),
+                socket_node: origin_identity(),
+                owner: Arc::clone(&owner),
+                user_owner: receiver_identity(),
+                user_claim_epoch: ClaimEpoch(1),
+            };
+            assert!(
+                bridge
+                    .reserve_remote_socket_cleanup_capacity(&jid, &registration)
+                    .await
+            );
+            if index == 0 {
+                assert!(
+                    bridge
+                        .publish_pending_remote_socket_registration(&jid, registration.clone())
+                        .await
+                );
+                active_registration_id = Some(registration.registration_id);
+            } else if first_cleanup.is_none() {
+                first_cleanup = Some((jid, registration));
+            }
+        }
+        let overflow_jid: jid::FullJid = "overflow@example.test/resource"
+            .parse()
+            .expect("overflow full JID");
+        let overflow = RemoteSocketRegistration {
+            registration_id: RemoteResourceRegistrationId::fresh(),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_generation: RemoteResourceSocketGeneration(1),
+            socket_node: origin_identity(),
+            owner,
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(1),
+        };
+        assert!(
+            !bridge
+                .reserve_remote_socket_cleanup_capacity(&overflow_jid, &overflow)
+                .await,
+            "the global hard cap must reject a novel full JID without evicting uncertain evidence"
+        );
+        assert_eq!(
+            bridge.remote_socket_pending_cleanup.lock().await.len(),
+            MAX_REMOTE_SOCKET_CLEANUP_REGISTRATIONS
+        );
+        let retry_batch = bridge
+            .inactive_remote_socket_cleanups(REMOTE_SOCKET_GLOBAL_CLEANUP_RETRY_BATCH)
+            .await;
+        assert_eq!(retry_batch.len(), REMOTE_SOCKET_GLOBAL_CLEANUP_RETRY_BATCH);
+        assert!(retry_batch.iter().all(|(_, registration)| {
+            Some(registration.registration_id) != active_registration_id
+        }));
+
+        // A terminal result from that bounded opportunistic batch releases
+        // capacity; the active reservation remains protected from cleanup.
+        let (first_jid, first_registration) = first_cleanup.expect("first cleanup registration");
+        assert!(
+            bridge
+                .finish_remote_socket_cleanup_attempt(&first_jid, &first_registration, true)
+                .await
+        );
+        assert!(
+            bridge
+                .reserve_remote_socket_cleanup_capacity(&overflow_jid, &overflow)
+                .await,
+            "a confirmed exact cleanup re-opens one global slot"
+        );
+        assert_eq!(
+            bridge.remote_socket_pending_cleanup.lock().await.len(),
+            MAX_REMOTE_SOCKET_CLEANUP_REGISTRATIONS
+        );
+        assert!(bridge
+            .remote_socket_pending_cleanup
+            .lock()
+            .await
+            .contains_key(&active_registration_id.expect("active registration")));
+    }
+
+    #[tokio::test]
+    async fn exhausted_fence_generation_permanently_refuses_remote_registrations_without_panicking()
+    {
+        let services = Arc::new(
+            services_with_claims(
+                origin_identity(),
+                receiver_identity(),
+                origin_identity(),
+                test_peer_id(),
+            )
+            .await,
+        );
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        bridge.wire(Arc::clone(&services));
+        bridge
+            .remote_resource_fence_generation
+            .store(u64::MAX, Ordering::SeqCst);
+
+        bridge.clear_remote_resource_state_on_self_fence().await;
+        bridge.clear_remote_resource_state_on_self_fence().await;
+
+        assert_eq!(
+            bridge
+                .remote_resource_fence_generation
+                .load(Ordering::SeqCst),
+            u64::MAX
+        );
+        assert!(
+            !bridge.remote_resource_registration_allowed(&services, u64::MAX),
+            "generation exhaustion must fail closed forever"
+        );
+    }
+
+    #[tokio::test]
+    async fn self_fence_keeps_live_per_jid_registration_lock_until_guard_retires() {
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let jid = target_full();
+        let lock = bridge
+            .lock_for_remote_owner_registration(&jid)
+            .await
+            .expect("registration lock");
+        let guard = lock.lock().await;
+
+        bridge.clear_remote_resource_state_on_self_fence().await;
+        let overlapping = bridge
+            .lock_for_remote_owner_registration(&jid)
+            .await
+            .expect("overlapping registration lock");
+        assert!(
+            Arc::ptr_eq(&lock, &overlapping),
+            "self-fence must not create a second lock while an old guard lives"
+        );
+
+        drop(guard);
+        drop(overlapping);
+        bridge
+            .remove_remote_owner_registration_lock_if_unused(&jid, &lock)
+            .await;
+        assert!(
+            !bridge
+                .remote_owner_registration_locks
+                .lock()
+                .await
+                .contains_key(&jid),
+            "strong-count cleanup retires the lock after overlap ends"
+        );
+    }
+
+    #[tokio::test]
+    async fn self_fence_generation_increment_waits_for_the_socket_effect_critical_section() {
+        let bridge = OrderedRelayDeliveryBridge::new(
+            CancellationToken::new(),
+            &ClusteringMessagingConfig::default(),
+        );
+        let effect_guard = bridge.remote_socket_resources.lock().await;
+        let clear_started = Arc::new(tokio::sync::Notify::new());
+        let clear = tokio::spawn({
+            let bridge = Arc::clone(&bridge);
+            let clear_started = Arc::clone(&clear_started);
+            async move {
+                clear_started.notify_one();
+                bridge.clear_remote_resource_state_on_self_fence().await;
+            }
+        });
+        clear_started.notified().await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            bridge
+                .remote_resource_fence_generation
+                .load(Ordering::SeqCst),
+            0,
+            "self-fence cannot linearize while a validated socket effect holds the shared map guard"
+        );
+
+        // Frame delivery and force-detach perform their synchronous enqueue
+        // while holding this exact guard. Releasing it is therefore the
+        // latest point at which an old-generation effect can linearize.
+        drop(effect_guard);
+        clear.await.expect("self-fence clear task");
+        assert_eq!(
+            bridge
+                .remote_resource_fence_generation
+                .load(Ordering::SeqCst),
+            1,
+            "the fence increments immediately after the old effect critical section"
+        );
+    }
+
+    #[tokio::test]
+    async fn discovery_not_found_retains_old_socket_mirror() {
         let services = Arc::new(
             services_with_claims(
                 origin_identity(),
@@ -5304,30 +10353,34 @@ mod tests {
         let old_generation = RemoteResourceSocketGeneration::next(None);
         let registration = RemoteOwnerRegistration {
             registration_id: RemoteResourceRegistrationId::fresh(),
-            socket_node: NodeId::new("missing-old-socket-node".to_string()),
+            admission_epoch: RemoteResourceAdmissionEpoch(1),
+            socket_node: NodeIdentity::new("missing-old-socket-node", "missing-old-socket-epoch"),
             socket_generation: old_generation,
+            user_owner: receiver_identity(),
+            user_claim_epoch: ClaimEpoch(2),
             owner: Arc::clone(&old_owner),
+            placement: ConnectionPlacement::RemoteMirror,
         };
 
         assert!(
-            bridge
+            !bridge
                 .finish_remote_owner_registration_retire(
                     &services,
                     &target,
                     &registration,
                     Err(RelayAskError::NotFound {
-                        node_id: registration.socket_node.clone(),
+                        node_id: NodeId::new(registration.socket_node.node_id.clone()),
                     }),
                 )
                 .await,
-            "a missing old socket node proves no detach was committed and should permit cleanup"
+            "discovery NotFound is transient and cannot prove the exact socket registration stale"
         );
         assert!(
             services
                 .connection_registry
                 .entry_if_owner(&target, &old_owner)
-                .is_none(),
-            "stale old owner mirror must be removed before replacement"
+                .is_some(),
+            "transient discovery failure must retain the live owner mirror"
         );
         if let Some(actor) = services
             .user_registry
@@ -5344,8 +10397,8 @@ mod tests {
                     })
                     .await
                     .expect("get old actor mirror")
-                    .is_none(),
-                "stale old user-actor mirror must be removed before replacement"
+                    .is_some(),
+                "transient discovery failure must retain the live user-actor mirror"
             );
         }
     }
@@ -5436,6 +10489,26 @@ mod tests {
         );
     }
 
+    #[test]
+    fn uncertain_remote_force_detach_is_not_acknowledged_as_retired() {
+        assert_eq!(
+            confirmed_remote_force_detach_outcome(RelayForceDetachRemoteUserResourceReply {
+                outcome: ForceDetachOutcome::NotPersisted,
+                status: RelayRemoteResourceForceDetachStatus::Unknown,
+            }),
+            None,
+            "an unknown remote outcome must close the ack channel so terminal teardown stays incomplete"
+        );
+        assert_eq!(
+            confirmed_remote_force_detach_outcome(RelayForceDetachRemoteUserResourceReply {
+                outcome: ForceDetachOutcome::NotPersisted,
+                status: RelayRemoteResourceForceDetachStatus::NotLive,
+            }),
+            Some(ForceDetachOutcome::NotPersisted),
+            "a proven-absent remote socket is safe to retire locally"
+        );
+    }
+
     #[tokio::test]
     async fn maybe_committed_diversion_suppresses_iq_fallback_on_replay() {
         let services = services_with_claims(
@@ -5494,10 +10567,10 @@ mod tests {
             let mut sender = bridge.sender_state.lock().await;
             let first = sender
                 .next_envelope(
-                    NodeId::new(origin_identity().node_id),
+                    origin_identity(),
                     channel.clone(),
                     OriginInboundSequence(1),
-                    envelope_claims(0),
+                    envelope_claims(2),
                     message_payload(),
                 )
                 .expect("first envelope allocates");
@@ -5518,10 +10591,10 @@ mod tests {
             .lock()
             .await
             .next_envelope(
-                NodeId::new(origin_identity().node_id),
+                origin_identity(),
                 channel,
                 OriginInboundSequence(2),
-                envelope_claims(0),
+                envelope_claims(2),
                 message_payload(),
             )
             .expect_err("later sends must not restart at sequence one");
@@ -5539,10 +10612,10 @@ mod tests {
             let mut sender = bridge.sender_state.lock().await;
             let first = sender
                 .next_envelope(
-                    NodeId::new(origin_identity().node_id),
+                    origin_identity(),
                     channel.clone(),
                     OriginInboundSequence(1),
-                    envelope_claims(0),
+                    envelope_claims(2),
                     message_payload(),
                 )
                 .expect("first envelope allocates");
@@ -5562,7 +10635,7 @@ mod tests {
             .lock()
             .await
             .next_envelope(
-                NodeId::new(origin_identity().node_id),
+                origin_identity(),
                 refreshed_channel,
                 OriginInboundSequence(2),
                 envelope_claims(1),
@@ -5583,10 +10656,10 @@ mod tests {
             let mut sender = bridge.sender_state.lock().await;
             let first = sender
                 .next_envelope(
-                    NodeId::new(origin_identity().node_id),
+                    origin_identity(),
                     channel.clone(),
                     OriginInboundSequence(1),
-                    envelope_claims(0),
+                    envelope_claims(2),
                     message_payload(),
                 )
                 .expect("first envelope allocates");
@@ -5628,10 +10701,10 @@ mod tests {
             .lock()
             .await
             .next_envelope(
-                NodeId::new(origin_identity().node_id),
+                origin_identity(),
                 channel,
                 OriginInboundSequence(2),
-                envelope_claims(0),
+                envelope_claims(2),
                 message_payload(),
             )
             .expect("lookup miss must leave the ordered channel usable");
@@ -5651,10 +10724,10 @@ mod tests {
             .lock()
             .await
             .next_envelope(
-                NodeId::new(origin_identity().node_id),
+                origin_identity(),
                 channel.clone(),
                 OriginInboundSequence(1),
-                envelope_claims(0),
+                envelope_claims(2),
                 message_payload(),
             )
             .expect("first envelope allocates");
@@ -5672,10 +10745,10 @@ mod tests {
             .lock()
             .await
             .next_envelope(
-                NodeId::new(origin_identity().node_id),
+                origin_identity(),
                 channel.clone(),
                 OriginInboundSequence(2),
-                envelope_claims(0),
+                envelope_claims(2),
                 message_payload(),
             )
             .expect("second envelope allocates");
@@ -5713,10 +10786,10 @@ mod tests {
             .lock()
             .await
             .next_envelope(
-                NodeId::new(origin_identity().node_id),
+                origin_identity(),
                 channel,
                 OriginInboundSequence(3),
-                envelope_claims(0),
+                envelope_claims(2),
                 message_payload(),
             )
             .expect("lookup miss must retry at the missed sequence");
@@ -5816,7 +10889,7 @@ mod tests {
             .lock()
             .await
             .next_envelope(
-                NodeId::new(origin_identity().node_id),
+                origin_identity(),
                 channel,
                 OriginInboundSequence(6),
                 envelope_claims(1),

--- a/server/crates/waddle-server/src/clustering/self_fence.rs
+++ b/server/crates/waddle-server/src/clustering/self_fence.rs
@@ -19,6 +19,7 @@
 //! does not tear down the swarm — it works to re-register under a fresh
 //! node identity and resume serving.
 
+use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -27,14 +28,27 @@ use async_trait::async_trait;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 
-use waddle_xmpp::ownership::{
-    ClaimEpoch, ClaimError, ClaimStore, Entity, NodeIdentity, StalePredicate,
-};
+use waddle_xmpp::ownership::{ClaimEpoch, ClaimStore, Entity, NodeIdentity};
+#[cfg(test)]
+use waddle_xmpp::ownership::{ClaimError, EntityType};
 
 use super::claims::NodeLeaseStore;
 use super::metrics;
 use super::ClusteringReadiness;
 use crate::config::{ClusteringNodeLeaseConfig, ClusteringSelfFenceConfig};
+
+/// Strict per-entity result used by post-fence recovery's readiness gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReclaimedEntityHydration {
+    /// The exact candidate grant is represented in local state.
+    Local,
+    /// A current-claim read proved a different node now owns the entity.
+    Elsewhere,
+    /// The exact recovery grant was released or was already absent.
+    TerminallyReleased,
+    /// Ownership/storage/local initialization is uncertain; stay not-ready.
+    Retry,
+}
 
 /// Readable snapshot of the swarm's current connected-peer count (Phase 2
 /// Slice 1's connected-peer gauge, reused here rather than inventing a
@@ -92,9 +106,9 @@ impl ConnectedPeerCount {
     }
 }
 
-/// Supplies the local owned-entity set the demotion-reconciliation diff
-/// runs against, and demotes entities Postgres no longer attributes to
-/// this node.
+/// Supplies the authoritative local owned-entity set the
+/// demotion-reconciliation diff runs against, and demotes entities Postgres
+/// no longer attributes to this node.
 ///
 /// **No production implementor lands in Slice 2** — the mechanism and its
 /// tests land here, but no code acquires a Postgres-backed `sm_session`
@@ -104,13 +118,35 @@ impl ConnectedPeerCount {
 /// [`NoLocallyClaimedEntities`].
 #[async_trait]
 pub trait LocallyClaimedEntities: Send + Sync {
-    /// Every entity this process currently believes it owns, from local
-    /// bookkeeping only — never a Postgres read. `async` (ADR-0017 Phase 3
-    /// Slice 7 widening) because an actor-backed implementor (`RoomActor`'s
-    /// registry) can only be queried through its own mailbox — the
-    /// enumeration itself is still pure in-memory bookkeeping, never a
-    /// Postgres round-trip.
+    /// Every entity whose durable claim this process currently believes it
+    /// owns, from local authoritative bookkeeping only — never a Postgres
+    /// read. A socket or proxy physically hosted by this process but owned by
+    /// another node MUST NOT appear here: this list is compared directly with
+    /// Postgres and every absent entry is demoted.
+    ///
+    /// `async` (ADR-0017 Phase 3 Slice 7 widening) because an actor-backed
+    /// implementor (`RoomActor`'s registry) can only be queried through its
+    /// own mailbox — the enumeration itself is still pure in-memory
+    /// bookkeeping, never a Postgres round-trip.
     async fn owned(&self) -> Vec<Entity>;
+
+    /// Demote everything that must stop when this entire node loses its lease.
+    ///
+    /// Unlike [`Self::owned`], this terminal hook may include resources that
+    /// are only physically hosted here, such as clustered remote-user sockets
+    /// whose authoritative `UserActor` belongs to another node. The default is
+    /// correct for claim types whose hosted and authoritative ownership sets
+    /// are identical; implementations with proxy/remote resources override it.
+    /// Returns `true` only when terminal teardown completed. A `false` result
+    /// keeps the node not-ready and is retried before claim service resumes;
+    /// timing out a cooperative socket close must never let an old-generation
+    /// connection survive into a newly ready identity.
+    async fn demote_all_on_self_fence(&self) -> bool {
+        for entity in self.owned().await {
+            self.demote(&entity).await;
+        }
+        true
+    }
 
     /// Demote local state for an entity Postgres no longer attributes to
     /// this node (claim stolen, or this node's own claim row is gone).
@@ -156,7 +192,7 @@ pub trait LocallyClaimedEntities: Send + Sync {
     /// timed out (wedged — the caller proactively demotes rather than
     /// waiting to be stolen from at `intent_ttl`, per element 4's "an owner
     /// whose internal health ask fails ... kills the wedged actor and
-    /// conflict-closes its sockets" text).
+    /// retires its sockets" text).
     ///
     /// Never called against an entity absent from [`Self::owned`] — the
     /// veto-scan loop only health-asks entities `owner_steal_intents`
@@ -177,8 +213,16 @@ pub trait LocallyClaimedEntities: Send + Sync {
     /// by the time it runs. Default no-op, mirroring [`Self::demote`]'s
     /// own no-op default: correct for [`NoLocallyClaimedEntities`], which
     /// owns nothing to hydrate.
-    async fn hydrate_reclaimed(&self, entities: &[(Entity, ClaimEpoch)]) {
-        let _ = entities;
+    async fn hydrate_reclaimed(
+        &self,
+        owner: &NodeIdentity,
+        entity: &Entity,
+        epoch: ClaimEpoch,
+    ) -> ReclaimedEntityHydration {
+        let _ = owner;
+        let _ = entity;
+        let _ = epoch;
+        ReclaimedEntityHydration::Retry
     }
 
     /// ADR-0017 Phase 3 Slice 10: complete `entity`'s final fenced write —
@@ -350,18 +394,17 @@ pub struct NodeLeaseRunConfig {
     pub claim_store: Arc<dyn ClaimStore>,
     /// Live, shared view of this node's current identity (ADR-0017 Phase 3
     /// Slice 4 follow-up plumbing note): [`run_node_lease`] calls
-    /// [`waddle_xmpp::ownership::SharedNodeIdentity::set`] on it every
-    /// time it mints a fresh identity (initial value and every post-fence
-    /// re-registration), so any other holder of a clone — e.g. the
+    /// [`waddle_xmpp::ownership::SharedNodeIdentity::set`] on it after every
+    /// post-fence epoch rotation, so any other holder of a clone — e.g. the
     /// Postgres-fenced `SmPersistenceStorage`'s claim-acquire calls —
     /// always binds the identity currently in force, never a stale
     /// pre-fence snapshot.
     pub live_identity: waddle_xmpp::ownership::SharedNodeIdentity,
     /// The libp2p PeerId currently held by this process's leased swarm
     /// keypair, bound into every node-lease registration for the current
-    /// process. Re-registrations mint a fresh node identity, but they do not
-    /// mint a fresh swarm keypair, so the PeerId binding intentionally stays
-    /// stable across a self-fence.
+    /// process. Re-registrations rotate the node epoch, but they do not change
+    /// the process `node_id` or mint a fresh swarm keypair, so both the relay
+    /// address and PeerId binding stay stable across a self-fence.
     pub peer_id: Option<String>,
     /// ADR-0017 Phase 3 Slice 10: the graceful per-entity claim-release
     /// drain's time budget (`ClusteringNodeLeaseConfig::claim_release_budget`,
@@ -369,6 +412,10 @@ pub struct NodeLeaseRunConfig {
     /// [`crate::clustering::drain::run_shutdown_drain`], called from every
     /// ordinary-shutdown branch in [`run_node_lease`]'s `'tick` loop below.
     pub claim_release_budget: Duration,
+    /// Exact predecessor replaced during cold start. When present, the
+    /// current identity was registered draining and this task must run the
+    /// same strict reclaim/hydrate/activate state machine before serving.
+    pub startup_recovery_source: Option<NodeIdentity>,
 }
 
 /// Best-effort, time-bounded [`NodeLeaseStore::mark_draining`] — mirrors
@@ -448,70 +495,264 @@ where
 /// preserving the "backstop for other nodes" carried-risk boundary FIX 4's
 /// own doc note names honestly).
 ///
-/// Caller bounds this whole call against `config.lease_ttl` (mirroring
-/// every other control-plane call in [`run_node_lease`]); this function
-/// itself does not re-bound the individual `steal_stale`/hydrate calls —
-/// a slow-but-not-hung candidate set is expected to be small (this one
-/// node's own dropped claims only, not the cluster-wide set), so the
-/// outer deadline is sufficient.
+/// This sequence is deliberately not cancellation-raced or timeout-wrapped:
+/// once any `steal_stale` commits, dropping the future before targeted
+/// hydration would strand a fresh-owned durable session outside the local
+/// registry. The control-plane calls retain their database/pool bounds, but
+/// the mutation-plus-hydration sequence itself runs to a definite outcome.
+struct RecoveryState {
+    sources: HashSet<NodeIdentity>,
+    registration_source: NodeIdentity,
+    candidate: NodeIdentity,
+    candidate_registered: bool,
+    candidate_grants: HashMap<Entity, ClaimEpoch>,
+}
+
+impl RecoveryState {
+    fn new(identity: &NodeIdentity) -> Self {
+        let mut sources = HashSet::new();
+        sources.insert(identity.clone());
+        Self {
+            sources,
+            registration_source: identity.clone(),
+            candidate: NodeIdentity::new(
+                identity.node_id.clone(),
+                uuid::Uuid::new_v4().to_string(),
+            ),
+            candidate_registered: false,
+            candidate_grants: HashMap::new(),
+        }
+    }
+
+    fn from_registered_candidate(source: NodeIdentity, candidate: NodeIdentity) -> Self {
+        let mut sources = HashSet::new();
+        sources.insert(source.clone());
+        Self {
+            sources,
+            registration_source: source,
+            candidate,
+            candidate_registered: true,
+            candidate_grants: HashMap::new(),
+        }
+    }
+
+    fn rotate_candidate(&mut self) {
+        self.sources.insert(self.candidate.clone());
+        self.registration_source = self.candidate.clone();
+        self.candidate = NodeIdentity::new(
+            self.registration_source.node_id.clone(),
+            uuid::Uuid::new_v4().to_string(),
+        );
+        self.candidate_registered = false;
+        // Every grant in this map belongs to the candidate that just became
+        // a source. Once the replacement row is registered, the exact source
+        // scan will rediscover it and mint a new grant for the new candidate.
+        self.candidate_grants.clear();
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecoveryPass {
+    Complete,
+    Retry,
+    RotateCandidate,
+}
+
+async fn hydrate_pending_recovery_grants(
+    state: &mut RecoveryState,
+    local_claims: &dyn LocallyClaimedEntities,
+) -> bool {
+    let pending = state
+        .candidate_grants
+        .iter()
+        .map(|(entity, epoch)| (entity.clone(), *epoch))
+        .collect::<Vec<_>>();
+    let mut complete = true;
+    for (entity, epoch) in pending {
+        let outcome = local_claims
+            .hydrate_reclaimed(&state.candidate, &entity, epoch)
+            .await;
+        match outcome {
+            // Keep locally hydrated grants as recovery provenance. Every
+            // outer retry terminally demotes local state before entering the
+            // next pass, so the exact candidate-owned grant must be hydrated
+            // again on that later pass before readiness can be restored.
+            ReclaimedEntityHydration::Local => {}
+            ReclaimedEntityHydration::Elsewhere | ReclaimedEntityHydration::TerminallyReleased => {
+                state.candidate_grants.remove(&entity);
+            }
+            ReclaimedEntityHydration::Retry => complete = false,
+        }
+    }
+    complete
+}
+
 async fn reclaim_own_expired_claims<L>(
     lease: &L,
     claim_store: &dyn ClaimStore,
-    old_identity: &NodeIdentity,
-    fresh: &NodeIdentity,
+    state: &mut RecoveryState,
     local_claims: &dyn LocallyClaimedEntities,
-) where
+    lease_ttl: Duration,
+) -> RecoveryPass
+where
     L: NodeLeaseStore + Send + Sync,
 {
+    // Hydrate every candidate-owned grant at most once per recovery pass.
+    // A retry stays sticky for this pass and is attempted again only after
+    // the outer backoff/terminal-demotion boundary.
+    let mut complete = hydrate_pending_recovery_grants(state, local_claims).await;
     let candidates = match lease.list_orphaned_sm_session_claims().await {
         Ok(candidates) => candidates,
         Err(error) => {
             tracing::warn!(
                 %error,
-                node_id = %old_identity.node_id,
+                node_id = %state.candidate.node_id,
                 "clustering: inline post-fence reclaim: list_orphaned_sm_session_claims failed"
             );
-            return;
+            return RecoveryPass::Retry;
         }
     };
 
-    let mut reclaimed: Vec<(Entity, ClaimEpoch)> = Vec::new();
     for candidate in candidates {
-        if candidate.owner != *old_identity {
-            // Another node's genuinely dead claim — not this node's own
-            // just-superseded identity. Left for the general orphan
-            // reaper, exactly as element 9 describes; naming that
-            // boundary honestly (rather than silently widening this
-            // node's own inline reclaim to cover it) is the point of FIX
-            // 4's "residual window" carried-risk note.
+        if !state.sources.contains(&candidate.owner) {
             continue;
         }
-        match claim_store
-            .steal_stale(
+        let reclaimed = claim_store
+            .reclaim_after_self_fence(
                 &candidate.entity,
                 candidate.epoch,
-                StalePredicate::OwnerStale,
-                fresh,
+                &candidate.owner,
+                &state.candidate,
+                lease_ttl,
             )
-            .await
-        {
-            Ok(new_epoch) => reclaimed.push((candidate.entity, new_epoch)),
-            Err(ClaimError::Conflict) => {
-                // The general orphan reaper (or another node) already
-                // reclaimed it first — safe, no-op.
-            }
+            .await;
+        let grant = match reclaimed {
+            Ok(new_epoch) => Some(new_epoch),
             Err(error) => {
                 tracing::warn!(
                     entity_id = %candidate.entity.id,
                     %error,
-                    "clustering: inline post-fence reclaim: steal_stale(OwnerStale) failed"
+                    "clustering: inline post-fence exact reclaim did not return a grant"
                 );
+                // Conflict is not inherently benign: the source may still
+                // own the grant because the destination expired. Resolve
+                // every losing/ambiguous result against the current claim.
+                match claim_store.current_claim(&candidate.entity).await {
+                    Ok(Some(snapshot)) if snapshot.owner == state.candidate => {
+                        Some(snapshot.claim_epoch)
+                    }
+                    Ok(Some(snapshot)) if state.sources.contains(&snapshot.owner) => {
+                        complete = false;
+                        None
+                    }
+                    Ok(Some(snapshot)) if snapshot.owner.node_id != state.candidate.node_id => {
+                        // A different process won; this node must not hydrate
+                        // a second copy.
+                        None
+                    }
+                    Ok(None) => None,
+                    Ok(Some(_)) | Err(_) => return RecoveryPass::RotateCandidate,
+                }
+            }
+        };
+
+        if let Some(epoch) = grant {
+            state
+                .candidate_grants
+                .insert(candidate.entity.clone(), epoch);
+            let outcome = local_claims
+                .hydrate_reclaimed(&state.candidate, &candidate.entity, epoch)
+                .await;
+            match outcome {
+                // Retain the exact grant for any later recovery pass. If a
+                // subsequent completion check fails, the outer loop demotes
+                // this local state and the next pass must rehydrate it.
+                ReclaimedEntityHydration::Local => {}
+                ReclaimedEntityHydration::Elsewhere
+                | ReclaimedEntityHydration::TerminallyReleased => {
+                    state.candidate_grants.remove(&candidate.entity);
+                }
+                ReclaimedEntityHydration::Retry => complete = false,
             }
         }
     }
 
-    if !reclaimed.is_empty() {
-        local_claims.hydrate_reclaimed(&reclaimed).await;
+    // A second exact scan is the completion barrier. The first scan can race
+    // a final pre-teardown detach; readiness is forbidden while any durable
+    // SM claim still names any epoch superseded during this recovery.
+    let remaining_sources = match lease.list_orphaned_sm_session_claims().await {
+        Ok(candidates) => candidates
+            .into_iter()
+            .any(|candidate| state.sources.contains(&candidate.owner)),
+        Err(error) => {
+            tracing::warn!(%error, "clustering: recovery completion scan failed");
+            return RecoveryPass::Retry;
+        }
+    };
+    if complete && !remaining_sources {
+        // Every retained grant was hydrated exactly once in this pass, and
+        // no source claim remains. Consume recovery bookkeeping only at the
+        // completion barrier so an incomplete pass can survive the outer
+        // loop's terminal demotion and rehydrate on its next attempt.
+        state.candidate_grants.clear();
+        RecoveryPass::Complete
+    } else {
+        RecoveryPass::Retry
+    }
+}
+
+/// Poll a potentially long multi-session recovery pass while keeping the
+/// exact draining candidate's lease alive. A false heartbeat is remembered,
+/// but does not cancel the in-flight pass: a reclaim CAS may already have
+/// committed and must reach a definite hydration outcome before the
+/// candidate becomes a lineage source.
+async fn reclaim_with_candidate_heartbeat<L>(
+    lease: &L,
+    claim_store: &dyn ClaimStore,
+    state: &mut RecoveryState,
+    local_claims: &dyn LocallyClaimedEntities,
+    heartbeat_interval: Duration,
+    lease_ttl: Duration,
+) -> RecoveryPass
+where
+    L: NodeLeaseStore + Send + Sync,
+{
+    let candidate = state.candidate.clone();
+    let recovery = std::pin::pin!(reclaim_own_expired_claims(
+        lease,
+        claim_store,
+        state,
+        local_claims,
+        lease_ttl,
+    ));
+    let mut recovery = recovery;
+    let mut ticker = tokio::time::interval(heartbeat_interval);
+    ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    ticker.tick().await;
+    let mut candidate_lost = false;
+
+    loop {
+        tokio::select! {
+            biased;
+            result = &mut recovery => {
+                return if candidate_lost {
+                    RecoveryPass::RotateCandidate
+                } else {
+                    result
+                };
+            }
+            _ = ticker.tick(), if !candidate_lost => {
+                match lease.heartbeat(&candidate, lease_ttl).await {
+                    Ok(true) => {}
+                    Ok(false) => candidate_lost = true,
+                    Err(error) => tracing::warn!(
+                        %error,
+                        node_epoch = %candidate.node_epoch,
+                        "recovery candidate heartbeat failed during hydration"
+                    ),
+                }
+            }
+        }
     }
 }
 
@@ -651,36 +892,25 @@ pub(super) async fn run_shutdown_drain_with_heartbeat<L>(
 /// dropped per fence (never per-tick) — the deadline fires at most once
 /// before the loop exits to the self-fenced block below.
 ///
-/// On either trigger: locally demote every entity `local_claims.owned()`
-/// currently lists (a purely local action that must succeed even while
-/// Postgres is unreachable), flip `readiness` to not-ready, **mark the
-/// just-fenced identity's row draining (FIX 1(b), bounded best-effort)**,
-/// then loop re-registration attempts (exponential backoff) until one
-/// succeeds *and* the hysteresis gate ([`can_reacquire_claims`]) is
-/// satisfied — at which point readiness flips back to ready and normal
-/// heartbeat/reconciliation resumes under the freshly minted identity.
+/// On either trigger: flip `readiness` to not-ready, then concurrently run
+/// `local_claims.demote_all_on_self_fence()` (a purely local action that must
+/// stop every authoritative claim and hosted proxy even while Postgres is
+/// unreachable) and **mark the just-fenced identity's row draining (FIX 1(b),
+/// bounded best-effort)**, then
+/// loop re-registration attempts (exponential backoff) until one succeeds
+/// *and* the hysteresis gate ([`can_reacquire_claims`]) is satisfied — at which
+/// point readiness flips back to ready and normal heartbeat/reconciliation
+/// resumes under the process's stable `node_id` and freshly minted epoch.
 ///
-/// **FIX 1(a)**: the fresh `node_id`/`node_epoch` identity for
-/// re-registration is minted **once per fence**, before the retry loop —
-/// every retry within that fence's re-registration loop reuses the same
-/// identity. Minting a fresh random identity on every retry (including
-/// hysteresis-rejected ones, which do not indicate a registration
-/// failure) was a row-leak wedge: `register`'s `INSERT ... ON CONFLICT
-/// (node_id) DO UPDATE` only refreshes an existing row when called
-/// repeatedly with the *same* `node_id` — called with a fresh `node_id`
-/// every time, it INSERTs a new phantom row per retry instead, and — at the
-/// time this fix landed (Slice 2) — nothing in production ever expired node
-/// rows (`NodeLeaseStore::expire` had no production caller yet), so
-/// `clustering_nodes` would grow without bound across a single sustained
-/// fence and permanently inflate every node's `count_other_live_nodes` —
-/// eventually making [`can_reacquire_claims`] impossible to satisfy again (a
-/// permanent not-ready wedge) and polluting the cluster-wide isolation
-/// heuristic. (ADR-0017 Phase 3 Slice 5: `expire` now has its first two
-/// production callers — this function's own `expire_bounded` call below,
-/// and the orphan reaper — but this FIX 1(a) reasoning is unaffected: both
-/// callers only ever expire an identity this loop or the reaper has
-/// independently proven dead, never the identity a phantom-row retry would
-/// have minted.)
+/// **FIX 1(a)**: `node_id` is the process-stable clustering address used by
+/// both the node lease and the relay actor. A fresh `node_epoch` is minted
+/// **once per fence**, before the retry loop, and every retry within that
+/// fence reuses it. Rotating `node_id` would strand the relay actor under its
+/// original name and leak a new `clustering_nodes` row per fence; minting a
+/// new epoch on every retry would make each successful registration supersede
+/// the identity used by the previous retry. Keeping the address stable and
+/// rotating one epoch per fence gives Postgres a single bounded node row while
+/// still fencing all claims from the prior incarnation.
 pub async fn run_node_lease<L>(
     lease: L,
     mut identity: NodeIdentity,
@@ -700,6 +930,7 @@ pub async fn run_node_lease<L>(
         peer_id,
         claim_store,
         claim_release_budget,
+        startup_recovery_source,
     } = run_config;
     // Seed the shared handle with the identity this loop starts under —
     // see `live_identity`'s doc comment and the `identity = fresh;`
@@ -712,187 +943,178 @@ pub async fn run_node_lease<L>(
         self_fence_cfg.reregister_backoff_max,
     );
 
+    let mut startup_recovery_source = startup_recovery_source;
     'registered: loop {
-        let mut timer = tokio::time::interval_at(
-            tokio::time::Instant::now() + config.heartbeat_interval,
-            config.heartbeat_interval,
-        );
-        timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
-        let mut last_success = tokio::time::Instant::now();
-
-        // Runs until this identity self-fences (either trigger). Both
-        // trigger paths converge on identical handling below, so this
-        // block's exit is unconditional (never a plain `break`).
-        //
-        // FIX 2: labeled so the per-entity veto-scan loop below (which
-        // nests its own `for` loop over `owner_steal_intents`'s result) can
-        // `break 'tick` straight out to the self-fenced handling from
-        // inside that nested loop, exactly as if the heartbeat/count/
-        // reconcile calls above had blown the same deadline.
-        'tick: loop {
-            tokio::select! {
-                biased;
-                _ = stop_token.cancelled() => {
-                    run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
-                    return;
-                }
-                _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
-                    break;
-                }
-                _ = timer.tick() => {}
-            }
-
-            metrics::record_node_heartbeat_age_ms(last_success.elapsed().as_secs_f64() * 1000.0);
-
-            let write_started = tokio::time::Instant::now();
-            let renewal = std::pin::pin!(lease.heartbeat(&identity, config.lease_ttl));
-            let renewed = tokio::select! {
-                biased;
-                _ = stop_token.cancelled() => {
-                    run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
-                    return;
-                }
-                _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
-                    break;
-                }
-                result = renewal => result,
-            };
-            metrics::record_node_heartbeat_write_latency_ms(
-                write_started.elapsed().as_secs_f64() * 1000.0,
+        let startup_source = startup_recovery_source.take();
+        if startup_source.is_none() {
+            let mut timer = tokio::time::interval_at(
+                tokio::time::Instant::now() + config.heartbeat_interval,
+                config.heartbeat_interval,
             );
+            timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            let mut last_success = tokio::time::Instant::now();
 
-            match renewed {
-                Ok(true) => {
-                    last_success = tokio::time::Instant::now();
+            // Runs until this identity self-fences (either trigger). Both
+            // trigger paths converge on identical handling below, so this
+            // block's exit is unconditional (never a plain `break`).
+            //
+            // FIX 2: labeled so the per-entity veto-scan loop below (which
+            // nests its own `for` loop over `owner_steal_intents`'s result) can
+            // `break 'tick` straight out to the self-fenced handling from
+            // inside that nested loop, exactly as if the heartbeat/count/
+            // reconcile calls above had blown the same deadline.
+            'tick: loop {
+                tokio::select! {
+                    biased;
+                    _ = stop_token.cancelled() => {
+                        run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                        return;
+                    }
+                    _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
+                        break;
+                    }
+                    _ = timer.tick() => {}
                 }
-                Ok(false) => {
-                    tracing::error!(
-                        node_id = %identity.node_id,
-                        "clustering node-lease heartbeat lost (fencing): stopping local claims"
-                    );
-                    break;
-                }
-                Err(error) => {
-                    tracing::warn!(
-                        %error,
-                        node_id = %identity.node_id,
-                        "clustering node-lease heartbeat error; will retry next tick"
-                    );
-                    continue;
-                }
-            }
 
-            // Isolation check + demotion reconciliation, once per
-            // successful renewal — "each heartbeat interval, alongside the
-            // renewal CAS" (element 4). FIX 2: both control-plane calls
-            // below are deadline-armed identically to the heartbeat above
-            // — see this function's doc comment.
-            let count_future =
-                std::pin::pin!(lease.count_other_live_nodes(&identity, config.lease_ttl));
-            let other_live_result = tokio::select! {
-                biased;
-                _ = stop_token.cancelled() => {
-                    run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
-                    return;
-                }
-                _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
-                    break;
-                }
-                result = count_future => result,
-            };
-            let other_live = match other_live_result {
-                Ok(count) => count,
-                Err(error) => {
-                    tracing::warn!(%error, "clustering: failed to count other live nodes this interval");
-                    continue;
-                }
-            };
-            let reachable = usize::try_from(connected_peers.get().max(0)).unwrap_or(0);
-            if isolation.observe(other_live, reachable, self_fence_cfg.isolation_intervals) {
-                tracing::error!(
-                    node_id = %identity.node_id,
-                    other_live,
-                    "clustering node self-fencing: swarm-isolated from >= 2 live nodes for the \
-                     configured interval count"
+                metrics::record_node_heartbeat_age_ms(
+                    last_success.elapsed().as_secs_f64() * 1000.0,
                 );
-                break;
-            }
 
-            let owned = local_claims.owned().await;
-            let reconcile_future = std::pin::pin!(lease.reconcile(&identity, &owned));
-            let reconcile_result = tokio::select! {
-                biased;
-                _ = stop_token.cancelled() => {
-                    run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
-                    return;
-                }
-                _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
-                    break;
-                }
-                result = reconcile_future => result,
-            };
-            match reconcile_result {
-                Ok(lost) => {
-                    for entity in &lost {
-                        local_claims.demote(entity).await;
+                let write_started = tokio::time::Instant::now();
+                let renewal = std::pin::pin!(lease.heartbeat(&identity, config.lease_ttl));
+                let renewed = tokio::select! {
+                    biased;
+                    _ = stop_token.cancelled() => {
+                        run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                        return;
+                    }
+                    _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
+                        break;
+                    }
+                    result = renewal => result,
+                };
+                metrics::record_node_heartbeat_write_latency_ms(
+                    write_started.elapsed().as_secs_f64() * 1000.0,
+                );
+
+                match renewed {
+                    Ok(true) => {
+                        last_success = tokio::time::Instant::now();
+                    }
+                    Ok(false) => {
+                        tracing::error!(
+                            node_id = %identity.node_id,
+                            "clustering node-lease heartbeat lost (fencing): stopping local claims"
+                        );
+                        break;
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            %error,
+                            node_id = %identity.node_id,
+                            "clustering node-lease heartbeat error; will retry next tick"
+                        );
+                        continue;
                     }
                 }
-                Err(error) => {
-                    tracing::warn!(%error, "clustering demotion-reconciliation query failed; will retry next interval");
-                }
-            }
 
-            // ADR-0017 Phase 3 Slice 3: owner-side steal-intent veto scan,
-            // riding the same per-interval cadence and deadline-arm as the
-            // other control-plane calls above — "every owner's heartbeat
-            // loop reads intents against its own claims" (element 4).
-            // Vacuous in production this slice: `local_claims.owned()` is
-            // always empty (`NoLocallyClaimedEntities`, per Slice 2's own
-            // wiring — no code acquires a `UserActor`/`RoomActor` claim
-            // until Slices 5-7), so `owner_steal_intents` always returns an
-            // empty set and this block is a no-op every interval. It is
-            // exercised directly against `PostgresClaimStore` and a
-            // configurable `LocallyClaimedEntities` fake in this module's
-            // own tests.
-            let intents_future = std::pin::pin!(lease.owner_steal_intents(&identity));
-            let intents_result = tokio::select! {
-                biased;
-                _ = stop_token.cancelled() => {
-                    run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
-                    return;
-                }
-                _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
+                // Isolation check + demotion reconciliation, once per
+                // successful renewal — "each heartbeat interval, alongside the
+                // renewal CAS" (element 4). FIX 2: both control-plane calls
+                // below are deadline-armed identically to the heartbeat above
+                // — see this function's doc comment.
+                let count_future =
+                    std::pin::pin!(lease.count_other_live_nodes(&identity, config.lease_ttl));
+                let other_live_result = tokio::select! {
+                    biased;
+                    _ = stop_token.cancelled() => {
+                        run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                        return;
+                    }
+                    _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
+                        break;
+                    }
+                    result = count_future => result,
+                };
+                let other_live = match other_live_result {
+                    Ok(count) => count,
+                    Err(error) => {
+                        tracing::warn!(%error, "clustering: failed to count other live nodes this interval");
+                        continue;
+                    }
+                };
+                let reachable = usize::try_from(connected_peers.get().max(0)).unwrap_or(0);
+                if isolation.observe(other_live, reachable, self_fence_cfg.isolation_intervals) {
+                    tracing::error!(
+                        node_id = %identity.node_id,
+                        other_live,
+                        "clustering node self-fencing: swarm-isolated from >= 2 live nodes for the \
+                         configured interval count"
+                    );
                     break;
                 }
-                result = intents_future => result,
-            };
-            match intents_result {
-                Ok(intents) => {
-                    // FIX 2: each per-entity await below (`health_check`,
-                    // `clear_steal_intent`, `demote`) is deadline/
-                    // cancellation-armed exactly like every other
-                    // control-plane call above — a slow-but-not-hung
-                    // `health_check` across N owned entities must not blow
-                    // this node's own heartbeat deadline unobserved, and
-                    // shutdown must not block behind a hung ask.
-                    for (entity, epoch) in intents {
-                        let health_check_future =
-                            std::pin::pin!(local_claims.health_check(&entity));
-                        let healthy = tokio::select! {
-                            biased;
-                            _ = stop_token.cancelled() => {
-                                run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
-                                return;
-                            }
-                            _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
-                                break 'tick;
-                            }
-                            result = health_check_future => result,
-                        };
-                        if healthy {
-                            let clear_future =
-                                std::pin::pin!(lease.clear_steal_intent(&entity, &identity, epoch));
-                            let cleared = tokio::select! {
+
+                let owned = local_claims.owned().await;
+                let reconcile_future = std::pin::pin!(lease.reconcile(&identity, &owned));
+                let reconcile_result = tokio::select! {
+                    biased;
+                    _ = stop_token.cancelled() => {
+                        run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                        return;
+                    }
+                    _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
+                        break;
+                    }
+                    result = reconcile_future => result,
+                };
+                match reconcile_result {
+                    Ok(lost) => {
+                        for entity in &lost {
+                            local_claims.demote(entity).await;
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "clustering demotion-reconciliation query failed; will retry next interval");
+                    }
+                }
+
+                // ADR-0017 Phase 3 Slice 3: owner-side steal-intent veto scan,
+                // riding the same per-interval cadence and deadline-arm as the
+                // other control-plane calls above — "every owner's heartbeat
+                // loop reads intents against its own claims" (element 4).
+                // Vacuous in production this slice: `local_claims.owned()` is
+                // always empty (`NoLocallyClaimedEntities`, per Slice 2's own
+                // wiring — no code acquires a `UserActor`/`RoomActor` claim
+                // until Slices 5-7), so `owner_steal_intents` always returns an
+                // empty set and this block is a no-op every interval. It is
+                // exercised directly against `PostgresClaimStore` and a
+                // configurable `LocallyClaimedEntities` fake in this module's
+                // own tests.
+                let intents_future = std::pin::pin!(lease.owner_steal_intents(&identity));
+                let intents_result = tokio::select! {
+                    biased;
+                    _ = stop_token.cancelled() => {
+                        run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                        return;
+                    }
+                    _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
+                        break;
+                    }
+                    result = intents_future => result,
+                };
+                match intents_result {
+                    Ok(intents) => {
+                        // FIX 2: each per-entity await below (`health_check`,
+                        // `clear_steal_intent`, `demote`) is deadline/
+                        // cancellation-armed exactly like every other
+                        // control-plane call above — a slow-but-not-hung
+                        // `health_check` across N owned entities must not blow
+                        // this node's own heartbeat deadline unobserved, and
+                        // shutdown must not block behind a hung ask.
+                        for (entity, epoch) in intents {
+                            let health_check_future =
+                                std::pin::pin!(local_claims.health_check(&entity));
+                            let healthy = tokio::select! {
                                 biased;
                                 _ = stop_token.cancelled() => {
                                     run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
@@ -901,110 +1123,135 @@ pub async fn run_node_lease<L>(
                                 _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
                                     break 'tick;
                                 }
-                                result = clear_future => result,
+                                result = health_check_future => result,
                             };
-                            match cleared {
-                                Ok(rows) if rows > 0 => {}
-                                Ok(_) => {
-                                    // FIX 1(b): `owner_steal_intents` just
-                                    // reported this entity as ours with an
-                                    // outstanding intent, so zero rows
-                                    // affected by the epoch-fenced DELETE
-                                    // means the DELETE's own
-                                    // claims-ownership check failed — a
-                                    // steal already won the race (FIX 1(a)'s
-                                    // consume-CTE design) between our health
-                                    // check and this clear call. Treat this
-                                    // as "possibly deposed" and demote
-                                    // immediately rather than believing the
-                                    // veto succeeded.
-                                    tracing::warn!(
-                                        entity_id = %entity.id,
-                                        "clustering: clear_steal_intent affected zero rows; \
-                                         this node may already have been deposed for this \
-                                         entity — demoting locally"
-                                    );
-                                    let demote_future =
-                                        std::pin::pin!(local_claims.demote(&entity));
-                                    tokio::select! {
-                                        biased;
-                                        _ = stop_token.cancelled() => {
-                                            run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
-                                            return;
+                            if healthy {
+                                let clear_future = std::pin::pin!(
+                                    lease.clear_steal_intent(&entity, &identity, epoch)
+                                );
+                                let cleared = tokio::select! {
+                                    biased;
+                                    _ = stop_token.cancelled() => {
+                                        run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                                        return;
+                                    }
+                                    _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
+                                        break 'tick;
+                                    }
+                                    result = clear_future => result,
+                                };
+                                match cleared {
+                                    Ok(rows) if rows > 0 => {}
+                                    Ok(_) => {
+                                        // FIX 1(b): `owner_steal_intents` just
+                                        // reported this entity as ours with an
+                                        // outstanding intent, so zero rows
+                                        // affected by the epoch-fenced DELETE
+                                        // means the DELETE's own
+                                        // claims-ownership check failed — a
+                                        // steal already won the race (FIX 1(a)'s
+                                        // consume-CTE design) between our health
+                                        // check and this clear call. Treat this
+                                        // as "possibly deposed" and demote
+                                        // immediately rather than believing the
+                                        // veto succeeded.
+                                        tracing::warn!(
+                                            entity_id = %entity.id,
+                                            "clustering: clear_steal_intent affected zero rows; \
+                                             this node may already have been deposed for this \
+                                             entity — demoting locally"
+                                        );
+                                        let demote_future =
+                                            std::pin::pin!(local_claims.demote(&entity));
+                                        tokio::select! {
+                                            biased;
+                                            _ = stop_token.cancelled() => {
+                                                run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                                                return;
+                                            }
+                                            _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
+                                                break 'tick;
+                                            }
+                                            _ = demote_future => {}
                                         }
-                                        _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
-                                            break 'tick;
-                                        }
-                                        _ = demote_future => {}
+                                    }
+                                    Err(error) => {
+                                        tracing::warn!(
+                                            %error,
+                                            entity_id = %entity.id,
+                                            "clustering: failed to clear a vetoed steal intent; the \
+                                             reporter's next scan will re-observe it"
+                                        );
                                     }
                                 }
-                                Err(error) => {
-                                    tracing::warn!(
-                                        %error,
-                                        entity_id = %entity.id,
-                                        "clustering: failed to clear a vetoed steal intent; the \
-                                         reporter's next scan will re-observe it"
-                                    );
+                            } else {
+                                // Proactive wedge-kill (element 4): the health
+                                // ask failed, so this owner already knows the
+                                // steal will proceed at `intent_ttl` — demote
+                                // now rather than keep serving (or squatting on)
+                                // a wedged actor until then.
+                                tracing::error!(
+                                    entity_id = %entity.id,
+                                    "clustering: local actor failed its internal health ask during \
+                                     steal-intent processing; proactively demoting ahead of the \
+                                     pending steal"
+                                );
+                                let demote_future = std::pin::pin!(local_claims.demote(&entity));
+                                tokio::select! {
+                                    biased;
+                                    _ = stop_token.cancelled() => {
+                                        run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                                        return;
+                                    }
+                                    _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
+                                        break 'tick;
+                                    }
+                                    _ = demote_future => {}
                                 }
-                            }
-                        } else {
-                            // Proactive wedge-kill (element 4): the health
-                            // ask failed, so this owner already knows the
-                            // steal will proceed at `intent_ttl` — demote
-                            // now rather than keep serving (or squatting on)
-                            // a wedged actor until then.
-                            tracing::error!(
-                                entity_id = %entity.id,
-                                "clustering: local actor failed its internal health ask during \
-                                 steal-intent processing; proactively demoting ahead of the \
-                                 pending steal"
-                            );
-                            let demote_future = std::pin::pin!(local_claims.demote(&entity));
-                            tokio::select! {
-                                biased;
-                                _ = stop_token.cancelled() => {
-                                    run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
-                                    return;
-                                }
-                                _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
-                                    break 'tick;
-                                }
-                                _ = demote_future => {}
                             }
                         }
                     }
-                }
-                Err(error) => {
-                    tracing::warn!(%error, "clustering owner steal-intent scan failed; will retry next interval");
+                    Err(error) => {
+                        tracing::warn!(%error, "clustering owner steal-intent scan failed; will retry next interval");
+                    }
                 }
             }
         }
 
-        // Self-fenced (either trigger): stop serving before the lease
-        // becomes stealable, then flip client-facing readiness.
-        for entity in local_claims.owned().await {
-            local_claims.demote(&entity).await;
-        }
+        // Self-fenced (either trigger): refuse new sessions immediately,
+        // then stop every local claim/proxy while marking this identity
+        // draining. Both operations are independently bounded/best-effort;
+        // neither should serialize the other during a partition.
         readiness.set_ready(false);
+        let (teardown_complete, ()) = tokio::join!(
+            local_claims.demote_all_on_self_fence(),
+            mark_draining_bounded(&lease, &identity, config.heartbeat_interval),
+        );
+        if !teardown_complete {
+            tracing::error!(
+                node_id = %identity.node_id,
+                "clustering node self-fenced with incomplete local teardown; readiness will remain false until a pre-recovery retry succeeds"
+            );
+        }
         isolation.reset();
 
-        // FIX 1(b): best-effort mark the just-fenced identity's row
-        // draining, bounded — narrows how long other nodes keep counting
-        // it as live (FIX 1(c) already excludes draining rows regardless
-        // of heartbeat freshness).
-        mark_draining_bounded(&lease, &identity, config.heartbeat_interval).await;
-
-        // FIX 1(a): mint the fresh re-registration identity ONCE per
-        // fence — every retry below (including hysteresis-rejected ones)
-        // reuses it. See this function's doc comment for the row-leak
-        // wedge this closes.
-        let fresh = NodeIdentity::new(
-            uuid::Uuid::new_v4().to_string(),
-            uuid::Uuid::new_v4().to_string(),
-        );
+        // FIX 1(a): preserve the process-stable node_id/relay address and
+        // mint one fresh fencing epoch per fence. Every retry below
+        // (including hysteresis-rejected ones) reuses this incarnation.
+        let mut recovery = match startup_source {
+            Some(source) => RecoveryState::from_registered_candidate(source, identity.clone()),
+            None => RecoveryState::new(&identity),
+        };
 
         // Re-registration with hysteresis + exponential backoff.
         loop {
+            let mut delay = backoff.next_delay();
+            if recovery.candidate_registered {
+                // Once a draining candidate exists, keep its exact lease
+                // alive at the ordinary heartbeat cadence instead of letting
+                // exponential backoff exceed the node TTL.
+                delay = delay.min(config.heartbeat_interval);
+            }
             tokio::select! {
                 biased;
                 _ = stop_token.cancelled() => {
@@ -1014,25 +1261,72 @@ pub async fn run_node_lease<L>(
                     // all, in which case this is a harmless no-op) — mark
                     // it draining too before returning on ordinary
                     // shutdown.
-                    mark_draining_bounded(&lease, &fresh, config.heartbeat_interval).await;
+                    mark_draining_bounded(
+                        &lease,
+                        &recovery.candidate,
+                        config.heartbeat_interval,
+                    )
+                    .await;
                     return;
                 }
-                _ = tokio::time::sleep(backoff.next_delay()) => {}
+                _ = tokio::time::sleep(delay) => {}
             }
+
+            if recovery.candidate_registered {
+                match lease.heartbeat(&recovery.candidate, config.lease_ttl).await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        tracing::warn!(
+                            node_epoch = %recovery.candidate.node_epoch,
+                            "clustering recovery candidate lease elapsed; rotating epoch"
+                        );
+                        recovery.rotate_candidate();
+                        continue;
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            %error,
+                            node_epoch = %recovery.candidate.node_epoch,
+                            "clustering recovery candidate heartbeat failed"
+                        );
+                        continue;
+                    }
+                }
+            }
+
+            // Never supersede the old fencing epoch while a resource from
+            // that incarnation may still be alive. A failed terminal sweep
+            // means exactly that, so retry teardown before publishing the
+            // candidate epoch to Postgres.
+            if !local_claims.demote_all_on_self_fence().await {
+                tracing::error!(
+                    node_id = %identity.node_id,
+                    "clustering node terminal teardown remains incomplete; refusing to rotate the node epoch"
+                );
+                continue;
+            }
+
             match lease
-                .register_with_peer_id(&fresh, pod_template_hash.clone(), peer_id.clone())
+                .register_draining_with_peer_id(
+                    &recovery.registration_source,
+                    &recovery.candidate,
+                    pod_template_hash.clone(),
+                    peer_id.clone(),
+                    config.lease_ttl,
+                )
                 .await
             {
                 Ok(()) => {
+                    recovery.candidate_registered = true;
                     let other_live = lease
-                        .count_other_live_nodes(&fresh, config.lease_ttl)
+                        .count_other_live_nodes(&recovery.candidate, config.lease_ttl)
                         .await
                         .unwrap_or(usize::MAX);
                     let reachable = usize::try_from(connected_peers.get().max(0)).unwrap_or(0);
                     if can_reacquire_claims(other_live, reachable) {
                         // ADR-0017 Phase 3 Slice 5 (plan deviation #19,
                         // closed by FIX 4): the ADR's readiness gate is
-                        // "re-registration under a fresh node_id/node_epoch
+                        // "re-registration under a fresh node epoch
                         // **plus claim re-acquisition**." `local_claims` is
                         // no longer vacuous (Slice 5's
                         // `local_claims::SmSessionLocalClaims`), so the
@@ -1042,8 +1336,8 @@ pub async fn run_node_lease<L>(
                         // FIX 4(a): re-run the demote sweep ONE more time,
                         // right before flipping readiness. The self-fenced
                         // block's own sweep (above, at fence-entry) is a
-                        // one-shot snapshot of `local_claims.owned()` taken
-                        // BEFORE this retry loop even started — a session
+                        // one-shot terminal teardown taken BEFORE this retry
+                        // loop even started — a session
                         // that detached (and self-claimed, via
                         // `acquire_claim_store_entry_for_detach`) during
                         // the retry window did so under `live_identity`'s
@@ -1053,8 +1347,15 @@ pub async fn run_node_lease<L>(
                         // snapshot missed it entirely. Re-running the sweep
                         // here catches anything acquired during that window
                         // before this node ever claims to be ready again.
-                        for entity in local_claims.owned().await {
-                            local_claims.demote(&entity).await;
+                        if !local_claims.demote_all_on_self_fence().await {
+                            tracing::error!(
+                                node_id = %recovery.candidate.node_id,
+                                "clustering node re-registered but terminal local teardown is still incomplete; refusing to restore readiness"
+                            );
+                            // The candidate was atomically registered as
+                            // draining and stays that way across this retry;
+                            // it has never been advertised as serving.
+                            continue;
                         }
 
                         // What "claim re-acquisition" can mean AT THIS
@@ -1063,8 +1364,9 @@ pub async fn run_node_lease<L>(
                         // just above) is now demoted (forgotten locally,
                         // never released in Postgres — FIX 3's "must
                         // succeed even when Postgres is unreachable"
-                        // contract for `demote`), so `local_claims.owned()`
-                        // is empty and there is nothing left in THIS
+                        // contract for `demote`), so the authoritative
+                        // `local_claims.owned()` set is empty and there is
+                        // nothing left in THIS
                         // process's bookkeeping to "re-acquire" by name.
                         // What this node uniquely knows, that no other node
                         // can assert as confidently, is that its OWN
@@ -1072,47 +1374,152 @@ pub async fn run_node_lease<L>(
                         // reassignment below) is genuinely dead — so it
                         // commits that knowledge to Postgres immediately
                         // via `NodeLeaseStore::expire`.
-                        expire_bounded(&lease, &identity, config.lease_ttl).await;
+                        let sources = recovery.sources.iter().cloned().collect::<Vec<_>>();
+                        for source in sources {
+                            expire_bounded(&lease, &source, config.lease_ttl).await;
+                        }
 
                         // FIX 4(b), council-adjudicated: rather than
                         // leaving every one of this node's own dropped
                         // claims to wait out the general orphan reaper's
                         // independent 120s cadence, reclaim them inline,
                         // right here, under the freshly re-registered
-                        // identity — bounded/deadline-armed like every
-                        // sibling control-plane call in this function. The
+                        // identity. Once a claim-steal commits this sequence
+                        // is intentionally uncancellable through targeted
+                        // hydration; abandoning it midway would strand a
+                        // fresh-owned claim outside local state. The
                         // general reaper remains the backstop for every
                         // OTHER node's genuinely dead claims (never
                         // touched by this inline step — see
                         // `reclaim_own_expired_claims`'s owner filter).
-                        // Scoped in its own block: `std::pin::pin!` binds a
-                        // local that lives to the end of its enclosing
-                        // block, not just this statement, and that local
-                        // borrows `identity`/`fresh` — the block ensures
-                        // those borrows end before `identity = fresh` below
-                        // reassigns `identity` (and moves `fresh`).
-                        let reclaim_timed_out = {
-                            let reclaim_future = std::pin::pin!(reclaim_own_expired_claims(
+                        let recovery_pass = reclaim_with_candidate_heartbeat(
+                            &lease,
+                            claim_store.as_ref(),
+                            &mut recovery,
+                            local_claims.as_ref(),
+                            config.heartbeat_interval,
+                            config.lease_ttl,
+                        )
+                        .await;
+                        if stop_token.is_cancelled() {
+                            let _ = local_claims.demote_all_on_self_fence().await;
+                            mark_draining_bounded(
                                 &lease,
-                                claim_store.as_ref(),
-                                &identity,
-                                &fresh,
-                                local_claims.as_ref(),
-                            ));
-                            tokio::time::timeout(config.lease_ttl, reclaim_future)
-                                .await
-                                .is_err()
-                        };
-                        if reclaim_timed_out {
-                            tracing::warn!(
-                                node_id = %identity.node_id,
-                                "clustering: inline post-fence reclaim of this node's own \
-                                 just-expired identity's SM-session claims timed out; the \
-                                 general orphan reaper remains the backstop for these entities"
-                            );
+                                &recovery.candidate,
+                                config.heartbeat_interval,
+                            )
+                            .await;
+                            return;
+                        }
+                        match recovery_pass {
+                            RecoveryPass::Complete => {}
+                            RecoveryPass::Retry => continue,
+                            RecoveryPass::RotateCandidate => {
+                                mark_draining_bounded(
+                                    &lease,
+                                    &recovery.candidate,
+                                    config.heartbeat_interval,
+                                )
+                                .await;
+                                recovery.rotate_candidate();
+                                continue;
+                            }
                         }
 
-                        identity = fresh;
+                        // Recovery steals above are the sole acquisition
+                        // exception allowed while this exact candidate is
+                        // draining. Only after every moved session has been
+                        // hydrated do we activate the row. Thus ordinary
+                        // local admissions remain bound to the old (now
+                        // ineligible) SharedNodeIdentity, readiness stays
+                        // false, and the database never advertises this
+                        // candidate as generally acquisition-eligible during
+                        // reclaim.
+                        let activated = match lease
+                            .activate(&recovery.candidate, config.lease_ttl)
+                            .await
+                        {
+                            Ok(activated) => activated,
+                            Err(error) => {
+                                tracing::warn!(
+                                    node_id = %recovery.candidate.node_id,
+                                    %error,
+                                    "clustering node recovery activation failed after reclaim; rotating candidate"
+                                );
+                                false
+                            }
+                        };
+                        if stop_token.is_cancelled() {
+                            let _ = local_claims.demote_all_on_self_fence().await;
+                            mark_draining_bounded(
+                                &lease,
+                                &recovery.candidate,
+                                config.heartbeat_interval,
+                            )
+                            .await;
+                            return;
+                        }
+                        if !activated {
+                            mark_draining_bounded(
+                                &lease,
+                                &recovery.candidate,
+                                config.heartbeat_interval,
+                            )
+                            .await;
+                            recovery.rotate_candidate();
+                            continue;
+                        }
+
+                        // Reclaim may legitimately consume most of a lease
+                        // TTL. Renew and then prove the exact candidate row is
+                        // still active (non-draining), non-expired, and fresh
+                        // immediately before publishing its identity and
+                        // readiness. This also closes the window where a
+                        // watchdog expires the candidate while recovery is
+                        // hydrating durable SM state.
+                        let active_and_fresh = match lease
+                            .renew_active(&recovery.candidate, config.lease_ttl)
+                            .await
+                        {
+                            Ok(renewed) => renewed,
+                            Err(error) => {
+                                tracing::warn!(
+                                    node_id = %recovery.candidate.node_id,
+                                    %error,
+                                    "clustering node recovery lease revalidation failed after reclaim; retrying"
+                                );
+                                false
+                            }
+                        };
+                        if stop_token.is_cancelled() {
+                            let _ = local_claims.demote_all_on_self_fence().await;
+                            mark_draining_bounded(
+                                &lease,
+                                &recovery.candidate,
+                                config.heartbeat_interval,
+                            )
+                            .await;
+                            return;
+                        }
+                        if !active_and_fresh {
+                            mark_draining_bounded(
+                                &lease,
+                                &recovery.candidate,
+                                config.heartbeat_interval,
+                            )
+                            .await;
+                            // Claims may already have moved to `fresh` and
+                            // been hydrated before the final liveness proof
+                            // failed. Reusing the same candidate would make
+                            // the next terminal sweep forget them while the
+                            // old-owner filter found nothing to reclaim.
+                            // Rotate the recovery epoch and make this failed
+                            // candidate the next reclaim source instead.
+                            recovery.rotate_candidate();
+                            continue;
+                        }
+
+                        identity = recovery.candidate.clone();
                         live_identity.set(identity.clone());
                         backoff.reset();
                         readiness.set_ready(true);
@@ -1129,6 +1536,37 @@ pub async fn run_node_lease<L>(
                 }
                 Err(error) => {
                     tracing::warn!(%error, "clustering node re-registration failed; retrying with backoff");
+                    // A registration reply may be ambiguous. If the exact
+                    // candidate occupies the stable row, heartbeat is the
+                    // liveness proof; a false heartbeat means it is expired
+                    // or stale and must become a lineage source before a new
+                    // epoch is minted. If the row still contains an older
+                    // known source, retry the same candidate against that
+                    // exact predecessor.
+                    match lease.registered_identity(&recovery.candidate.node_id).await {
+                        Ok(Some(current)) if current == recovery.candidate => {
+                            match lease.heartbeat(&recovery.candidate, config.lease_ttl).await {
+                                Ok(true) => recovery.candidate_registered = true,
+                                Ok(false) => recovery.rotate_candidate(),
+                                Err(heartbeat_error) => tracing::warn!(
+                                    %heartbeat_error,
+                                    "failed to reconcile ambiguous recovery registration"
+                                ),
+                            }
+                        }
+                        Ok(Some(current)) if recovery.sources.contains(&current) => {
+                            recovery.registration_source = current;
+                        }
+                        Ok(Some(current)) => tracing::error!(
+                            node_epoch = %current.node_epoch,
+                            "stable node row contains an unknown recovery epoch; staying fenced"
+                        ),
+                        Ok(None) => {}
+                        Err(read_error) => tracing::warn!(
+                            %read_error,
+                            "failed to read exact node identity after registration error"
+                        ),
+                    }
                 }
             }
         }
@@ -1249,16 +1687,19 @@ mod tests {
     // `swarm.rs`'s own `PartitionedLease`-based heartbeat tests exactly,
     // one level up (node lease instead of keypair-slot lease).
 
-    use std::sync::atomic::{AtomicBool, AtomicU32};
+    use std::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize};
 
     struct FakeLease {
         heartbeat_result: std::sync::Mutex<Box<dyn FnMut() -> Result<bool, ClaimError> + Send>>,
         registrations: Arc<AtomicU32>,
         /// Every distinct `node_id` ever passed to `register` — lets tests
-        /// assert FIX 1(a)'s invariant directly: a single fence's
-        /// re-registration retries must all reuse the same identity, never
-        /// mint a fresh one per retry.
+        /// assert FIX 1(a)'s invariant directly: the process relay address
+        /// stays stable across every re-registration retry.
         registered_node_ids: Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+        /// Every distinct epoch passed to `register`; retries within one
+        /// fence must reuse the same incarnation rather than superseding one
+        /// another before readiness is restored.
+        registered_node_epochs: Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
         /// Count of `mark_draining` calls — lets tests assert FIX 1(b)/FIX 3
         /// actually fire (bounded best-effort call issued, not skipped).
         draining_calls: Arc<AtomicU32>,
@@ -1278,6 +1719,15 @@ mod tests {
         /// consume-CTE design between this node's health check and its
         /// clear call.
         clear_reports_zero_rows: Arc<AtomicBool>,
+        /// Scripted post-reclaim liveness proofs. Empty means success;
+        /// tests push `false` to force a recovery-candidate rotation after
+        /// claims have already moved and been hydrated.
+        renew_active_results: Arc<std::sync::Mutex<std::collections::VecDeque<bool>>>,
+        /// Optional dynamic orphan source for recovery-loop tests. The fake
+        /// reads the claim store on every scan so a claim moved from one
+        /// failed recovery epoch is surfaced under that exact new owner on
+        /// the next retry.
+        orphan_claim: Option<(Arc<dyn ClaimStore>, Entity)>,
     }
 
     impl FakeLease {
@@ -1288,12 +1738,24 @@ mod tests {
                 registered_node_ids: Arc::new(std::sync::Mutex::new(
                     std::collections::HashSet::new(),
                 )),
+                registered_node_epochs: Arc::new(std::sync::Mutex::new(
+                    std::collections::HashSet::new(),
+                )),
                 draining_calls: Arc::new(AtomicU32::new(0)),
                 other_live_nodes: Arc::new(AtomicU32::new(0)),
                 steal_intents: Arc::new(std::sync::Mutex::new(Vec::new())),
                 cleared_intents: Arc::new(std::sync::Mutex::new(Vec::new())),
                 clear_reports_zero_rows: Arc::new(AtomicBool::new(false)),
+                renew_active_results: Arc::new(std::sync::Mutex::new(
+                    std::collections::VecDeque::new(),
+                )),
+                orphan_claim: None,
             }
+        }
+
+        fn with_orphan_claim(mut self, store: Arc<dyn ClaimStore>, entity: Entity) -> Self {
+            self.orphan_claim = Some((store, entity));
+            self
         }
     }
 
@@ -1309,6 +1771,10 @@ mod tests {
                 .lock()
                 .expect("lock")
                 .insert(me.node_id.clone());
+            self.registered_node_epochs
+                .lock()
+                .expect("lock")
+                .insert(me.node_epoch.clone());
             Ok(())
         }
         async fn heartbeat(
@@ -1329,6 +1795,18 @@ mod tests {
             self.draining_calls.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
+        async fn renew_active(
+            &self,
+            _me: &NodeIdentity,
+            _lease_ttl: Duration,
+        ) -> Result<bool, ClaimError> {
+            Ok(self
+                .renew_active_results
+                .lock()
+                .expect("lock")
+                .pop_front()
+                .unwrap_or(true))
+        }
         async fn count_other_live_nodes(
             &self,
             _me: &NodeIdentity,
@@ -1346,6 +1824,8 @@ mod tests {
         async fn report_steal_intent(
             &self,
             entity: &Entity,
+            _target_owner: &NodeIdentity,
+            _target_epoch: ClaimEpoch,
             _reporter: &NodeIdentity,
         ) -> Result<(), ClaimError> {
             self.steal_intents
@@ -1382,11 +1862,20 @@ mod tests {
         async fn list_orphaned_sm_session_claims(
             &self,
         ) -> Result<Vec<crate::clustering::claims::OrphanedSmSessionClaim>, ClaimError> {
-            // Not exercised by this module's tests (the orphan reaper is
-            // tested against `PostgresClaimStore` directly, in
-            // `session_janitors.rs`/`claims.rs`); this fake never has
-            // orphaned candidates.
-            Ok(Vec::new())
+            let Some((store, entity)) = &self.orphan_claim else {
+                return Ok(Vec::new());
+            };
+            Ok(store
+                .current_claim(entity)
+                .await?
+                .map(|snapshot| {
+                    vec![crate::clustering::claims::OrphanedSmSessionClaim {
+                        entity: entity.clone(),
+                        epoch: snapshot.claim_epoch,
+                        owner: snapshot.owner,
+                    }]
+                })
+                .unwrap_or_default())
         }
         async fn current_generation(&self) -> Result<Option<String>, ClaimError> {
             // Not exercised by this module's tests (the rollout-aware
@@ -1455,6 +1944,7 @@ mod tests {
                 peer_id: None,
                 claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
                 claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
             },
         ));
 
@@ -1502,6 +1992,7 @@ mod tests {
                 peer_id: None,
                 claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
                 claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
             },
         ));
 
@@ -1553,6 +2044,7 @@ mod tests {
                 peer_id: None,
                 claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
                 claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
             },
         ));
 
@@ -1576,20 +2068,447 @@ mod tests {
         stop_token.cancel();
     }
 
-    // FIX 1(a): the row-leak wedge regression test. With `other_live_nodes`
+    #[tokio::test(start_paused = true)]
+    async fn cold_start_reclaims_the_exact_replaced_predecessor_before_readiness() {
+        let interval = Duration::from_millis(50);
+        let lease_ttl = Duration::from_millis(150);
+        let predecessor = identity();
+        let current = NodeIdentity::new(
+            predecessor.node_id.clone(),
+            uuid::Uuid::new_v4().to_string(),
+        );
+        let entity = Entity::new(EntityType::SmSession, "cold-start-predecessor");
+        let concrete_store = Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+        concrete_store
+            .acquire(&entity, &predecessor)
+            .await
+            .expect("seed predecessor claim");
+        let claim_store: Arc<dyn ClaimStore> = concrete_store.clone();
+        let lease = FakeLease::new(Box::new(|| Ok(true)))
+            .with_orphan_claim(Arc::clone(&claim_store), entity.clone());
+        let local_state = Arc::new(RecoveryLocalState::default());
+        let readiness = ClusteringReadiness::new();
+        readiness.set_ready(false);
+        let live_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(current.clone());
+        let stop_token = CancellationToken::new();
+        let task = tokio::spawn(run_node_lease(
+            lease,
+            current.clone(),
+            stop_token.clone(),
+            NodeLeaseRunConfig {
+                pod_template_hash: None,
+                lease_config: ClusteringNodeLeaseConfig {
+                    heartbeat_interval: interval,
+                    lease_ttl,
+                    claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                },
+                self_fence_config: ClusteringSelfFenceConfig {
+                    isolation_intervals: 3,
+                    reregister_backoff_base: Duration::from_millis(10),
+                    reregister_backoff_max: Duration::from_millis(20),
+                },
+                connected_peers: ConnectedPeerCount::new(),
+                local_claims: Arc::new(RecoveryLocalClaims {
+                    state: Arc::clone(&local_state),
+                }),
+                readiness: readiness.clone(),
+                live_identity: live_identity.clone(),
+                peer_id: None,
+                claim_store: Arc::clone(&claim_store),
+                claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: Some(predecessor),
+            },
+        ));
+
+        advance_until(Duration::from_millis(10), 30, || readiness.is_ready()).await;
+        assert!(readiness.is_ready());
+        assert_eq!(live_identity.current(), current);
+        let snapshot = claim_store
+            .current_claim(&entity)
+            .await
+            .expect("claim read")
+            .expect("claim present");
+        assert_eq!(snapshot.owner, current);
+        assert_eq!(
+            local_state.owned.lock().expect("lock").get(&entity),
+            Some(&current)
+        );
+
+        stop_token.cancel();
+        task.await.expect("node lease exits");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn post_reclaim_renewal_failure_rotates_and_rehydrates_before_readiness() {
+        let interval = Duration::from_millis(50);
+        let lease_ttl = Duration::from_millis(150);
+        let initial = identity();
+        let entity = Entity::new(EntityType::SmSession, "recovery-renew-retry");
+        let concrete_store = Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+        concrete_store
+            .acquire(&entity, &initial)
+            .await
+            .expect("seed pre-fence claim");
+        let claim_store: Arc<dyn ClaimStore> = concrete_store.clone();
+
+        let fenced_once = Arc::new(AtomicBool::new(false));
+        let fenced_once_writer = Arc::clone(&fenced_once);
+        let lease = FakeLease::new(Box::new(move || {
+            if fenced_once_writer.swap(true, Ordering::SeqCst) {
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }))
+        .with_orphan_claim(Arc::clone(&claim_store), entity.clone());
+        lease
+            .renew_active_results
+            .lock()
+            .expect("lock")
+            .push_back(false);
+        let registered_epochs = Arc::clone(&lease.registered_node_epochs);
+
+        let local_state = Arc::new(RecoveryLocalState::default());
+        let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(RecoveryLocalClaims {
+            state: Arc::clone(&local_state),
+        });
+        let readiness = ClusteringReadiness::new();
+        let live_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(initial.clone());
+        let stop_token = CancellationToken::new();
+        let task = tokio::spawn(run_node_lease(
+            lease,
+            initial,
+            stop_token.clone(),
+            NodeLeaseRunConfig {
+                pod_template_hash: None,
+                lease_config: ClusteringNodeLeaseConfig {
+                    heartbeat_interval: interval,
+                    lease_ttl,
+                    claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                },
+                self_fence_config: ClusteringSelfFenceConfig {
+                    isolation_intervals: 3,
+                    reregister_backoff_base: Duration::from_millis(10),
+                    reregister_backoff_max: Duration::from_millis(20),
+                },
+                connected_peers: ConnectedPeerCount::new(),
+                local_claims,
+                readiness: readiness.clone(),
+                live_identity: live_identity.clone(),
+                peer_id: None,
+                claim_store: Arc::clone(&claim_store),
+                claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
+            },
+        ));
+
+        advance_until(interval, 20, || !readiness.is_ready()).await;
+        assert!(
+            !readiness.is_ready(),
+            "the initial heartbeat miss self-fences"
+        );
+        advance_until(Duration::from_millis(10), 50, || readiness.is_ready()).await;
+        assert!(
+            readiness.is_ready(),
+            "a second recovery incarnation should eventually pass the final liveness proof"
+        );
+
+        let hydration_owners = local_state.hydration_owners.lock().expect("lock").clone();
+        let distinct_hydration_epochs = hydration_owners
+            .iter()
+            .map(|owner| owner.node_epoch.clone())
+            .collect::<std::collections::HashSet<_>>();
+        assert_eq!(
+            distinct_hydration_epochs.len(),
+            2,
+            "the claim must be verified under the failed candidate and again under its replacement"
+        );
+        assert_eq!(
+            registered_epochs.lock().expect("lock").len(),
+            2,
+            "the retry must publish two distinct candidate incarnations"
+        );
+        let live = live_identity.current();
+        let snapshot = claim_store
+            .current_claim(&entity)
+            .await
+            .expect("read final claim")
+            .expect("claim remains present");
+        assert_eq!(snapshot.owner, live);
+        assert_eq!(
+            local_state.owned.lock().expect("lock").get(&entity),
+            Some(&live),
+            "readiness requires the final claim owner to be hydrated locally under the same epoch"
+        );
+
+        stop_token.cancel();
+        task.await.expect("node lease exits cleanly");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn recovery_stays_not_ready_until_a_committed_grant_is_hydrated() {
+        let interval = Duration::from_millis(50);
+        let lease_ttl = Duration::from_millis(150);
+        let initial = identity();
+        let entity = Entity::new(EntityType::SmSession, "recovery-hydration-retry");
+        let concrete_store = Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+        concrete_store
+            .acquire(&entity, &initial)
+            .await
+            .expect("seed pre-fence claim");
+        let claim_store: Arc<dyn ClaimStore> = concrete_store.clone();
+
+        let fenced_once = Arc::new(AtomicBool::new(false));
+        let fenced_once_writer = Arc::clone(&fenced_once);
+        let lease = FakeLease::new(Box::new(move || {
+            if fenced_once_writer.swap(true, Ordering::SeqCst) {
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }))
+        .with_orphan_claim(Arc::clone(&claim_store), entity.clone());
+        let local_state = Arc::new(RecoveryLocalState::default());
+        local_state.hydration_failures.store(1, Ordering::SeqCst);
+        let readiness = ClusteringReadiness::new();
+        let stop_token = CancellationToken::new();
+        let task = tokio::spawn(run_node_lease(
+            lease,
+            initial,
+            stop_token.clone(),
+            NodeLeaseRunConfig {
+                pod_template_hash: None,
+                lease_config: ClusteringNodeLeaseConfig {
+                    heartbeat_interval: interval,
+                    lease_ttl,
+                    claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                },
+                self_fence_config: ClusteringSelfFenceConfig {
+                    isolation_intervals: 3,
+                    reregister_backoff_base: Duration::from_millis(10),
+                    reregister_backoff_max: Duration::from_millis(20),
+                },
+                connected_peers: ConnectedPeerCount::new(),
+                local_claims: Arc::new(RecoveryLocalClaims {
+                    state: Arc::clone(&local_state),
+                }),
+                readiness: readiness.clone(),
+                live_identity: waddle_xmpp::ownership::SharedNodeIdentity::new(identity()),
+                peer_id: None,
+                claim_store,
+                claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
+            },
+        ));
+
+        advance_until(interval, 20, || !readiness.is_ready()).await;
+        advance_until(Duration::from_millis(5), 20, || {
+            !local_state
+                .hydration_owners
+                .lock()
+                .expect("lock")
+                .is_empty()
+        })
+        .await;
+        assert!(
+            !readiness.is_ready(),
+            "a fresh-owned claim with failed local hydration must keep recovery fenced"
+        );
+
+        advance_until(Duration::from_millis(10), 30, || readiness.is_ready()).await;
+        assert!(
+            readiness.is_ready(),
+            "recovery may publish only after the pending exact grant hydrates"
+        );
+        assert!(local_state
+            .owned
+            .lock()
+            .expect("lock")
+            .contains_key(&entity));
+
+        stop_token.cancel();
+        task.await.expect("node lease exits cleanly");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn slow_recovery_keeps_the_draining_candidate_heartbeat_fresh() {
+        let interval = Duration::from_millis(40);
+        let lease_ttl = Duration::from_millis(120);
+        let initial = identity();
+        let entity = Entity::new(EntityType::SmSession, "slow-recovery-hydration");
+        let concrete_store = Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+        concrete_store
+            .acquire(&entity, &initial)
+            .await
+            .expect("seed pre-fence claim");
+        let claim_store: Arc<dyn ClaimStore> = concrete_store.clone();
+        let heartbeat_calls = Arc::new(AtomicUsize::new(0));
+        let heartbeat_calls_writer = Arc::clone(&heartbeat_calls);
+        let lease = FakeLease::new(Box::new(move || {
+            let call = heartbeat_calls_writer.fetch_add(1, Ordering::SeqCst);
+            Ok(call != 0)
+        }))
+        .with_orphan_claim(Arc::clone(&claim_store), entity.clone());
+        let local_state = Arc::new(RecoveryLocalState {
+            // One hydration must itself span the lease TTL. Before locally
+            // successful grants were consumed, the duplicate second
+            // hydration accidentally made two 80ms calls satisfy this test.
+            hydration_delay: Duration::from_millis(160),
+            ..RecoveryLocalState::default()
+        });
+        let readiness = ClusteringReadiness::new();
+        let stop_token = CancellationToken::new();
+        let task = tokio::spawn(run_node_lease(
+            lease,
+            initial,
+            stop_token.clone(),
+            NodeLeaseRunConfig {
+                pod_template_hash: None,
+                lease_config: ClusteringNodeLeaseConfig {
+                    heartbeat_interval: interval,
+                    lease_ttl,
+                    claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                },
+                self_fence_config: ClusteringSelfFenceConfig {
+                    isolation_intervals: 3,
+                    reregister_backoff_base: Duration::from_millis(10),
+                    reregister_backoff_max: Duration::from_millis(20),
+                },
+                connected_peers: ConnectedPeerCount::new(),
+                local_claims: Arc::new(RecoveryLocalClaims {
+                    state: Arc::clone(&local_state),
+                }),
+                readiness: readiness.clone(),
+                live_identity: waddle_xmpp::ownership::SharedNodeIdentity::new(identity()),
+                peer_id: None,
+                claim_store,
+                claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
+            },
+        ));
+
+        advance_until(interval, 20, || !readiness.is_ready()).await;
+        advance_until(Duration::from_millis(20), 40, || readiness.is_ready()).await;
+        assert!(readiness.is_ready());
+        assert!(
+            heartbeat_calls.load(Ordering::SeqCst) >= 3,
+            "a hydration pass longer than the TTL must renew the draining candidate"
+        );
+        assert!(local_state
+            .owned
+            .lock()
+            .expect("lock")
+            .contains_key(&entity));
+
+        stop_token.cancel();
+        task.await.expect("node lease exits cleanly");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cancellation_during_hydration_never_activates_or_restores_readiness() {
+        let interval = Duration::from_millis(50);
+        let lease_ttl = Duration::from_millis(150);
+        let initial = identity();
+        let entity = Entity::new(EntityType::SmSession, "cancelled-recovery-hydration");
+        let concrete_store = Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+        concrete_store
+            .acquire(&entity, &initial)
+            .await
+            .expect("seed pre-fence claim");
+        let claim_store: Arc<dyn ClaimStore> = concrete_store.clone();
+        let fenced_once = Arc::new(AtomicBool::new(false));
+        let fenced_once_writer = Arc::clone(&fenced_once);
+        let lease = FakeLease::new(Box::new(move || {
+            if fenced_once_writer.swap(true, Ordering::SeqCst) {
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }))
+        .with_orphan_claim(Arc::clone(&claim_store), entity.clone());
+        let started = Arc::new(AtomicBool::new(false));
+        let release = Arc::new(tokio::sync::Notify::new());
+        let local_state = Arc::new(RecoveryLocalState::default());
+        let readiness = ClusteringReadiness::new();
+        let stop_token = CancellationToken::new();
+        let task = tokio::spawn(run_node_lease(
+            lease,
+            initial,
+            stop_token.clone(),
+            NodeLeaseRunConfig {
+                pod_template_hash: None,
+                lease_config: ClusteringNodeLeaseConfig {
+                    heartbeat_interval: interval,
+                    lease_ttl,
+                    claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                },
+                self_fence_config: ClusteringSelfFenceConfig {
+                    isolation_intervals: 3,
+                    reregister_backoff_base: Duration::from_millis(10),
+                    reregister_backoff_max: Duration::from_millis(20),
+                },
+                connected_peers: ConnectedPeerCount::new(),
+                local_claims: Arc::new(BlockingHydrationClaims {
+                    state: Arc::clone(&local_state),
+                    started: Arc::clone(&started),
+                    release: Arc::clone(&release),
+                }),
+                readiness: readiness.clone(),
+                live_identity: waddle_xmpp::ownership::SharedNodeIdentity::new(identity()),
+                peer_id: None,
+                claim_store,
+                claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
+            },
+        ));
+
+        advance_until(interval, 20, || !readiness.is_ready()).await;
+        advance_until(Duration::from_millis(5), 30, || {
+            started.load(Ordering::SeqCst)
+        })
+        .await;
+        assert!(
+            started.load(Ordering::SeqCst),
+            "strict hydration must start"
+        );
+        stop_token.cancel();
+        release.notify_one();
+        task.await
+            .expect("recovery exits after finishing hydration");
+
+        assert!(
+            !readiness.is_ready(),
+            "shutdown cancellation must not publish the recovered candidate"
+        );
+        assert!(
+            local_state.owned.lock().expect("lock").is_empty(),
+            "the post-hydration cancellation path must terminally clear local state"
+        );
+    }
+
+    // FIX 1(a): the stable-address/row-leak regression test. With `other_live_nodes`
     // fixed at 1 and `connected_peers` at 0, `can_reacquire_claims(1, 0)` is
     // always false, so every re-registration attempt succeeds at
     // `register()` but is then rejected by the hysteresis gate — forcing
-    // several retries within a single fence. Before the fix, each retry
-    // minted a brand-new random identity (a phantom row per retry); after
-    // the fix, every retry within the same fence reuses one identity.
+    // several retries within a single fence. The process `node_id` must remain
+    // the relay actor's stable address while every retry reuses the one epoch
+    // minted for this fence.
     #[tokio::test(start_paused = true)]
     async fn re_registration_retries_within_one_fence_reuse_the_same_identity() {
         let interval = Duration::from_millis(50);
         let lease_ttl = Duration::from_millis(150);
-        let lease = FakeLease::new(Box::new(|| Ok(false)));
+        let fenced_once = Arc::new(AtomicBool::new(false));
+        let fenced_once_writer = Arc::clone(&fenced_once);
+        let lease = FakeLease::new(Box::new(move || {
+            if fenced_once_writer.swap(true, Ordering::SeqCst) {
+                Ok(true)
+            } else {
+                Ok(false)
+            }
+        }));
         lease.other_live_nodes.store(1, Ordering::SeqCst);
         let registered_node_ids = Arc::clone(&lease.registered_node_ids);
+        let registered_node_epochs = Arc::clone(&lease.registered_node_epochs);
         let registrations = Arc::clone(&lease.registrations);
         let readiness = ClusteringReadiness::new();
         let stop_token = CancellationToken::new();
@@ -1616,6 +2535,7 @@ mod tests {
                 peer_id: None,
                 claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
                 claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
             },
         ));
 
@@ -1640,8 +2560,12 @@ mod tests {
         assert_eq!(
             registered_node_ids.lock().expect("lock").len(),
             1,
-            "every retry within a single fence must reuse the same freshly-minted \
-             identity, never mint a new one per retry (the row-leak wedge)"
+            "every retry must preserve the process-stable node_id used by the relay actor"
+        );
+        assert_eq!(
+            registered_node_epochs.lock().expect("lock").len(),
+            1,
+            "every retry within one fence must reuse its single freshly minted epoch"
         );
         stop_token.cancel();
     }
@@ -1750,9 +2674,9 @@ mod tests {
         // A second, permanently-live node row: gives `count_other_live_nodes`
         // a nonzero count so the re-acquisition hysteresis gate genuinely
         // rejects re-registration attempts until `connected_peers` reports
-        // reachability — forcing several retries against the SAME
-        // freshly-minted identity within each fence, exactly the shape the
-        // row-leak bug manifested in.
+        // reachability — forcing several retries against the same freshly
+        // minted epoch within each fence while the process node_id remains
+        // stable.
         let other = NodeIdentity::new(
             uuid::Uuid::new_v4().to_string(),
             uuid::Uuid::new_v4().to_string(),
@@ -1803,6 +2727,7 @@ mod tests {
                 peer_id: None,
                 claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
                 claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
             },
         ));
 
@@ -1827,15 +2752,15 @@ mod tests {
         // (the hysteresis gate never clears: `other` keeps
         // `count_other_live_nodes` at 1, and `connected_peers` is still 0)
         // — sample the row count several times across that retry storm and
-        // assert it never exceeds "other + fenced-old + fresh-new", proving
-        // retries do not leak rows.
+        // assert the process row is updated in place rather than leaking a
+        // fresh row or relay address.
         for _ in 0..6 {
             tokio::time::sleep(Duration::from_millis(60)).await;
             let count = count_clustering_nodes_rows(&db).await;
-            assert!(
-                count <= 3,
-                "clustering_nodes must stay bounded across re-registration retries \
-                 within one fence, got {count} rows"
+            assert_eq!(
+                count, 2,
+                "clustering_nodes must remain other + the process-stable node row \
+                 across re-registration retries"
             );
         }
 
@@ -1850,31 +2775,14 @@ mod tests {
         .await;
         assert_eq!(
             count_clustering_nodes_rows(&db).await,
-            3,
-            "other + fenced-old (draining) + the one fresh identity from this fence"
+            2,
+            "other + the process-stable node row after its epoch rotates"
         );
 
-        // Identify cycle 1's fresh identity for the second fence below.
-        let cycle1_node_id = {
-            let conn = db.guard().await.expect("guard");
-            let mut rows = conn
-                .query(
-                    "SELECT node_id FROM clustering_nodes WHERE node_id != ? AND node_id != ?",
-                    crate::db_params![other.node_id.clone(), initial_identity.node_id.clone()],
-                )
-                .await
-                .expect("query cycle1 identity");
-            rows.next()
-                .await
-                .expect("row present")
-                .expect("exactly one row: cycle1's fresh identity")
-                .get::<String>(0)
-                .expect("column present")
-        };
-
-        // --- Fence cycle 2: repeat, forcing cycle 1's identity to expire.
+        // --- Fence cycle 2: repeat against the same process node row. Its
+        // epoch changed during cycle 1, but its relay-address node_id did not.
         connected_peers.set(0);
-        force_expire_row(&db, &cycle1_node_id).await;
+        force_expire_row(&db, &initial_identity.node_id).await;
         wait_until(
             || !readiness.is_ready(),
             Duration::from_millis(20),
@@ -1885,10 +2793,9 @@ mod tests {
         for _ in 0..6 {
             tokio::time::sleep(Duration::from_millis(60)).await;
             let count = count_clustering_nodes_rows(&db).await;
-            assert!(
-                count <= 4,
-                "clustering_nodes must stay bounded across the SECOND fence's \
-                 re-registration retries too, got {count} rows"
+            assert_eq!(
+                count, 2,
+                "the second fence must still update the process-stable node row in place"
             );
         }
 
@@ -1901,14 +2808,13 @@ mod tests {
         .await;
         assert_eq!(
             count_clustering_nodes_rows(&db).await,
-            4,
-            "other + 2 fenced-and-draining old identities + the current fresh identity"
+            2,
+            "repeated fences must retain exactly other + the process-stable node row"
         );
 
         // FIX 1(c): `count_other_live_nodes` must have recovered to the
         // truthful value from `other`'s perspective — exactly the current
-        // (cycle 2) identity, not an accumulation of every identity ever
-        // minted across both fences.
+        // process incarnation, not an accumulation of rows from old epochs.
         let truthful_count = store
             .count_other_live_nodes(&other, lease_ttl)
             .await
@@ -1971,11 +2877,251 @@ mod tests {
             self.healthy.load(Ordering::SeqCst)
         }
 
-        async fn hydrate_reclaimed(&self, entities: &[(Entity, ClaimEpoch)]) {
-            self.hydrated
+        async fn hydrate_reclaimed(
+            &self,
+            _owner: &NodeIdentity,
+            entity: &Entity,
+            _epoch: ClaimEpoch,
+        ) -> ReclaimedEntityHydration {
+            self.hydrated.lock().expect("lock").push(entity.clone());
+            ReclaimedEntityHydration::Local
+        }
+    }
+
+    #[tokio::test]
+    async fn successful_recovery_hydration_retains_grant_for_a_later_pass() {
+        let source = identity();
+        let entity = Entity::new(EntityType::SmSession, "pending-hydration-once");
+        let mut recovery = RecoveryState::new(&source);
+        recovery
+            .candidate_grants
+            .insert(entity.clone(), ClaimEpoch(41));
+        let hydrated = FakeLocalClaims::unhydrated();
+        let local_claims = FakeLocalClaims {
+            owned: Vec::new(),
+            healthy: Arc::new(AtomicBool::new(true)),
+            demoted: Arc::new(std::sync::Mutex::new(Vec::new())),
+            hydrated: Arc::clone(&hydrated),
+        };
+
+        assert!(hydrate_pending_recovery_grants(&mut recovery, &local_claims).await);
+        assert_eq!(
+            recovery.candidate_grants.get(&entity),
+            Some(&ClaimEpoch(41)),
+            "a successful hydration must retain the exact grant as recovery provenance"
+        );
+        assert!(hydrate_pending_recovery_grants(&mut recovery, &local_claims).await);
+        assert_eq!(
+            hydrated.lock().expect("lock").as_slice(),
+            &[entity.clone(), entity],
+            "a later recovery pass must rehydrate after the outer loop's terminal demotion"
+        );
+    }
+
+    #[tokio::test]
+    async fn completed_recovery_pass_hydrates_grant_once_and_consumes_bookkeeping() {
+        let source = identity();
+        let entity = Entity::new(EntityType::SmSession, "completed-hydration-once");
+        let mut recovery = RecoveryState::new(&source);
+        recovery
+            .candidate_grants
+            .insert(entity.clone(), ClaimEpoch(42));
+        let hydrated = FakeLocalClaims::unhydrated();
+        let local_claims = FakeLocalClaims {
+            owned: Vec::new(),
+            healthy: Arc::new(AtomicBool::new(true)),
+            demoted: Arc::new(std::sync::Mutex::new(Vec::new())),
+            hydrated: Arc::clone(&hydrated),
+        };
+        let lease = FakeLease::new(Box::new(|| Ok(true)));
+        let claim_store = waddle_xmpp::ownership::InProcessClaimStore::new();
+
+        assert_eq!(
+            reclaim_own_expired_claims(
+                &lease,
+                &claim_store,
+                &mut recovery,
+                &local_claims,
+                Duration::from_secs(1),
+            )
+            .await,
+            RecoveryPass::Complete
+        );
+        assert!(recovery.candidate_grants.is_empty());
+
+        assert_eq!(
+            reclaim_own_expired_claims(
+                &lease,
+                &claim_store,
+                &mut recovery,
+                &local_claims,
+                Duration::from_secs(1),
+            )
+            .await,
+            RecoveryPass::Complete
+        );
+        assert_eq!(
+            hydrated.lock().expect("lock").as_slice(),
+            std::slice::from_ref(&entity),
+            "a completed pass must consume its grant instead of hydrating it twice"
+        );
+    }
+
+    #[derive(Default)]
+    struct RecoveryLocalState {
+        owned: std::sync::Mutex<std::collections::HashMap<Entity, NodeIdentity>>,
+        hydration_owners: std::sync::Mutex<Vec<NodeIdentity>>,
+        hydration_failures: AtomicUsize,
+        hydration_delay: Duration,
+    }
+
+    struct RecoveryLocalClaims {
+        state: Arc<RecoveryLocalState>,
+    }
+
+    #[async_trait]
+    impl LocallyClaimedEntities for RecoveryLocalClaims {
+        async fn owned(&self) -> Vec<Entity> {
+            self.state
+                .owned
                 .lock()
                 .expect("lock")
-                .extend(entities.iter().map(|(entity, _epoch)| entity.clone()));
+                .keys()
+                .cloned()
+                .collect()
+        }
+
+        async fn demote(&self, entity: &Entity) {
+            self.state.owned.lock().expect("lock").remove(entity);
+        }
+
+        async fn health_check(&self, entity: &Entity) -> bool {
+            self.state.owned.lock().expect("lock").contains_key(entity)
+        }
+
+        async fn hydrate_reclaimed(
+            &self,
+            owner: &NodeIdentity,
+            entity: &Entity,
+            _epoch: ClaimEpoch,
+        ) -> ReclaimedEntityHydration {
+            if !self.state.hydration_delay.is_zero() {
+                tokio::time::sleep(self.state.hydration_delay).await;
+            }
+            self.state
+                .hydration_owners
+                .lock()
+                .expect("lock")
+                .push(owner.clone());
+            if self
+                .state
+                .hydration_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return ReclaimedEntityHydration::Retry;
+            }
+            self.state
+                .owned
+                .lock()
+                .expect("lock")
+                .insert(entity.clone(), owner.clone());
+            ReclaimedEntityHydration::Local
+        }
+    }
+
+    struct BlockingTerminalClaims {
+        started: Arc<AtomicBool>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    struct BlockingHydrationClaims {
+        state: Arc<RecoveryLocalState>,
+        started: Arc<AtomicBool>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait]
+    impl LocallyClaimedEntities for BlockingHydrationClaims {
+        async fn owned(&self) -> Vec<Entity> {
+            self.state
+                .owned
+                .lock()
+                .expect("lock")
+                .keys()
+                .cloned()
+                .collect()
+        }
+
+        async fn demote(&self, entity: &Entity) {
+            self.state.owned.lock().expect("lock").remove(entity);
+        }
+
+        async fn health_check(&self, entity: &Entity) -> bool {
+            self.state.owned.lock().expect("lock").contains_key(entity)
+        }
+
+        async fn hydrate_reclaimed(
+            &self,
+            owner: &NodeIdentity,
+            entity: &Entity,
+            _epoch: ClaimEpoch,
+        ) -> ReclaimedEntityHydration {
+            if !self.started.swap(true, Ordering::SeqCst) {
+                self.release.notified().await;
+            }
+            self.state
+                .owned
+                .lock()
+                .expect("lock")
+                .insert(entity.clone(), owner.clone());
+            ReclaimedEntityHydration::Local
+        }
+    }
+
+    #[async_trait]
+    impl LocallyClaimedEntities for BlockingTerminalClaims {
+        async fn owned(&self) -> Vec<Entity> {
+            Vec::new()
+        }
+
+        async fn demote_all_on_self_fence(&self) -> bool {
+            self.started.store(true, Ordering::SeqCst);
+            self.release.notified().await;
+            true
+        }
+
+        async fn demote(&self, _entity: &Entity) {
+            panic!("the terminal override, not per-entity demotion, must be used");
+        }
+
+        async fn health_check(&self, _entity: &Entity) -> bool {
+            true
+        }
+    }
+
+    struct RetriableTerminalClaims {
+        calls: Arc<AtomicUsize>,
+        allow_completion: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl LocallyClaimedEntities for RetriableTerminalClaims {
+        async fn owned(&self) -> Vec<Entity> {
+            Vec::new()
+        }
+
+        async fn demote_all_on_self_fence(&self) -> bool {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            self.allow_completion.load(Ordering::SeqCst)
+        }
+
+        async fn demote(&self, _entity: &Entity) {}
+
+        async fn health_check(&self, _entity: &Entity) -> bool {
+            true
         }
     }
 
@@ -2023,6 +3169,7 @@ mod tests {
                 peer_id: None,
                 claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
                 claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
             },
         ));
 
@@ -2089,6 +3236,7 @@ mod tests {
                 peer_id: None,
                 claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
                 claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
             },
         ));
 
@@ -2156,6 +3304,7 @@ mod tests {
                 peer_id: None,
                 claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
                 claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
             },
         ));
 
@@ -2175,9 +3324,8 @@ mod tests {
 
     // FIX A (ADR-0017 Phase 3 Slice 11 corrigenda, council-adjudicated,
     // deviation 109): the terminal "self-fenced (either trigger): demote
-    // ALL local claims" loop just above (`for entity in
-    // local_claims.owned().await { local_claims.demote(&entity).await }`,
-    // reached once the `'tick` loop breaks on either fencing trigger) was
+    // everything hosted here" hook just above (reached once the `'tick` loop
+    // breaks on either fencing trigger) was
     // previously exercised only with an EMPTY `owned()` set (the real-fence
     // tests above use `NoLocallyClaimedEntities`) or with a `FakeLease` that
     // never actually loses fencing (`Ok(true)` on every heartbeat, in every
@@ -2226,6 +3374,7 @@ mod tests {
                 peer_id: None,
                 claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
                 claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
             },
         ));
 
@@ -2245,6 +3394,135 @@ mod tests {
             "readiness must flip not-ready before the lease becomes stealable"
         );
         stop_token.cancel();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn node_lease_drops_readiness_before_terminal_teardown_with_no_owned_claims() {
+        let interval = Duration::from_millis(50);
+        let started = Arc::new(AtomicBool::new(false));
+        let release = Arc::new(tokio::sync::Notify::new());
+        let local_claims = Arc::new(BlockingTerminalClaims {
+            started: Arc::clone(&started),
+            release: Arc::clone(&release),
+        });
+        let readiness = ClusteringReadiness::new();
+        let stop_token = CancellationToken::new();
+        let task = tokio::spawn(run_node_lease(
+            FakeLease::new(Box::new(|| Ok(false))),
+            identity(),
+            stop_token.clone(),
+            NodeLeaseRunConfig {
+                pod_template_hash: None,
+                lease_config: ClusteringNodeLeaseConfig {
+                    heartbeat_interval: interval,
+                    lease_ttl: Duration::from_secs(10),
+                    claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                },
+                self_fence_config: ClusteringSelfFenceConfig {
+                    isolation_intervals: 1_000,
+                    reregister_backoff_base: Duration::from_millis(10),
+                    reregister_backoff_max: Duration::from_millis(20),
+                },
+                connected_peers: ConnectedPeerCount::new(),
+                local_claims,
+                readiness: readiness.clone(),
+                live_identity: waddle_xmpp::ownership::SharedNodeIdentity::new(identity()),
+                peer_id: None,
+                claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
+                claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
+            },
+        ));
+
+        advance_until(interval, 20, || started.load(Ordering::SeqCst)).await;
+        assert!(
+            started.load(Ordering::SeqCst),
+            "whole-node fencing must invoke the terminal hook even when owned() is empty"
+        );
+        assert!(
+            !readiness.is_ready(),
+            "readiness must be false while terminal teardown is still blocked"
+        );
+
+        stop_token.cancel();
+        release.notify_waiters();
+        task.await
+            .expect("node-lease task exits after cancellation");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn node_lease_retries_terminal_teardown_before_restoring_readiness() {
+        let interval = Duration::from_millis(50);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let allow_completion = Arc::new(AtomicBool::new(false));
+        let local_claims = Arc::new(RetriableTerminalClaims {
+            calls: Arc::clone(&calls),
+            allow_completion: Arc::clone(&allow_completion),
+        });
+        let lease = FakeLease::new(Box::new(|| Ok(false)));
+        let draining_calls = Arc::clone(&lease.draining_calls);
+        let registrations = Arc::clone(&lease.registrations);
+        let readiness = ClusteringReadiness::new();
+        let stop_token = CancellationToken::new();
+        let task = tokio::spawn(run_node_lease(
+            lease,
+            identity(),
+            stop_token.clone(),
+            NodeLeaseRunConfig {
+                pod_template_hash: None,
+                lease_config: ClusteringNodeLeaseConfig {
+                    heartbeat_interval: interval,
+                    lease_ttl: Duration::from_secs(10),
+                    claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                },
+                self_fence_config: ClusteringSelfFenceConfig {
+                    isolation_intervals: 1_000,
+                    reregister_backoff_base: Duration::from_millis(10),
+                    reregister_backoff_max: Duration::from_millis(20),
+                },
+                connected_peers: ConnectedPeerCount::new(),
+                local_claims,
+                readiness: readiness.clone(),
+                live_identity: waddle_xmpp::ownership::SharedNodeIdentity::new(identity()),
+                peer_id: None,
+                claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
+                claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
+            },
+        ));
+
+        advance_until(Duration::from_millis(10), 20, || {
+            calls.load(Ordering::SeqCst) >= 2
+        })
+        .await;
+        assert!(
+            calls.load(Ordering::SeqCst) >= 2,
+            "fencing must run an initial teardown and retry it before epoch rotation"
+        );
+        assert!(
+            !readiness.is_ready(),
+            "an incomplete teardown retry must keep the candidate identity not-ready"
+        );
+        assert_eq!(
+            registrations.load(Ordering::SeqCst),
+            0,
+            "an incomplete teardown must prevent the old epoch from being superseded"
+        );
+        assert!(
+            draining_calls.load(Ordering::SeqCst) >= 1,
+            "the fenced old identity must remain marked draining"
+        );
+
+        allow_completion.store(true, Ordering::SeqCst);
+        advance_until(Duration::from_millis(5), 20, || readiness.is_ready()).await;
+        assert!(
+            readiness.is_ready(),
+            "readiness may recover only after a later terminal teardown succeeds"
+        );
+
+        stop_token.cancel();
+        task.await
+            .expect("node-lease task exits after cancellation");
     }
 
     // --- FIX 4(b) (ADR-0017 Phase 3 Slice 5 corrigenda, council-
@@ -2351,6 +3629,7 @@ mod tests {
                 peer_id: None,
                 claim_store: task_claim_store,
                 claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                startup_recovery_source: None,
             },
         ));
 
@@ -2389,13 +3668,14 @@ mod tests {
              identity's sm_session claim, not leave it for the general reaper's slower cadence"
         );
 
-        // The claims row must now show the FRESH re-registered identity as
-        // owner — `steal_stale(OwnerStale)` actually won against the real
-        // CAS, not just a fake double.
+        // The claims row must now show the process's FRESH re-registered epoch
+        // as owner — `steal_stale(OwnerStale)` actually won against the real
+        // CAS, not just a fake double. The node_id remains stable because it
+        // is also the relay actor's address.
         let conn = db.guard().await.expect("guard");
         let mut rows = conn
             .query(
-                "SELECT node_id FROM clustering_claims WHERE entity = ?",
+                "SELECT node_id, node_epoch FROM clustering_claims WHERE entity = ?",
                 crate::db_params![format!(
                     "{}:{}",
                     EntityType::SmSession.as_db_str(),
@@ -2404,16 +3684,20 @@ mod tests {
             )
             .await
             .expect("query claims row");
-        let owner_node_id: String = rows
+        let row = rows
             .next()
             .await
             .expect("row present")
-            .expect("row present")
-            .get(0)
-            .expect("column present");
-        assert_ne!(
+            .expect("row present");
+        let owner_node_id: String = row.get(0).expect("column present");
+        let owner_node_epoch: String = row.get(1).expect("column present");
+        assert_eq!(
             owner_node_id, initial_identity.node_id,
-            "the claim must be owned by the FRESH re-registered identity, not the expired one"
+            "the process-stable node_id must remain the relay address"
+        );
+        assert_ne!(
+            owner_node_epoch, initial_identity.node_epoch,
+            "the claim must be owned by the fresh re-registered epoch, not the expired one"
         );
 
         stop_token.cancel();

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use std::{fmt, str::FromStr};
 use tracing::info;
 use waddle_extensions::ExtensionConfig;
+use waddle_xmpp::ownership::FENCED_TRANSACTION_BUDGET;
 use waddle_xmpp::xep::xep0421::{OccupantIdSecret, OCCUPANT_ID_SECRET_MIN_BYTES};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -824,6 +825,15 @@ impl ClusteringConfig {
                  WADDLE_CLUSTERING_NODE_LEASE_HEARTBEAT_INTERVAL_MS ({})",
                 node_lease_ttl.as_millis(),
                 node_lease_heartbeat_interval.as_millis()
+            ));
+        }
+        if node_lease_ttl <= FENCED_TRANSACTION_BUDGET.duration() {
+            return Err(format!(
+                "WADDLE_CLUSTERING_NODE_LEASE_TTL_MS ({}) must be strictly greater than the \
+                 fenced Postgres transaction budget ({}): no exact claim/node lock may survive \
+                 through the authority lease deadline",
+                node_lease_ttl.as_millis(),
+                FENCED_TRANSACTION_BUDGET.duration().as_millis(),
             ));
         }
         // ADR-0017 Phase 3 Slice 10: the per-entity claim-release drain
@@ -1888,6 +1898,22 @@ mod tests {
         .unwrap();
         assert_eq!(config.node_lease.heartbeat_interval.as_millis(), 5000);
         assert_eq!(config.node_lease.lease_ttl.as_millis(), 20000);
+    }
+
+    #[test]
+    fn clustering_rejects_node_lease_not_longer_than_fenced_transaction_budget() {
+        let budget_ms = FENCED_TRANSACTION_BUDGET.duration().as_millis().to_string();
+        let err = ClusteringConfig::from_vars([
+            ("WADDLE_CLUSTERING_NODE_LEASE_HEARTBEAT_INTERVAL_MS", "1000"),
+            ("WADDLE_CLUSTERING_NODE_LEASE_TTL_MS", budget_ms.as_str()),
+            ("WADDLE_CLUSTERING_CLAIM_RELEASE_BUDGET_MS", "1000"),
+            ("WADDLE_CLUSTERING_RESUME_HANDSHAKE_TIMEOUT_MS", "1000"),
+        ])
+        .unwrap_err();
+        assert!(
+            err.contains("strictly greater") && err.contains("fenced Postgres transaction budget"),
+            "unexpected validation error: {err}"
+        );
     }
 
     #[test]

--- a/server/crates/waddle-server/src/db/backend.rs
+++ b/server/crates/waddle-server/src/db/backend.rs
@@ -502,6 +502,35 @@ impl<'a> Transaction<'a> {
         Ok(Self { inner })
     }
 
+    /// Install Postgres 17's database-side deadlines before this transaction
+    /// takes any ownership lock. `transaction_timeout` is the hard outer
+    /// bound; the other settings release locks promptly for each individual
+    /// wait and for a task that becomes idle between statements.
+    pub(crate) async fn configure_fenced(
+        &mut self,
+        budget: waddle_xmpp::ownership::FencedTransactionBudget,
+    ) -> Result<(), DatabaseError> {
+        let TransactionInner::Postgres(tx) = &mut self.inner else {
+            return Err(DatabaseError::QueryFailed(
+                "fenced transactions require Postgres".to_string(),
+            ));
+        };
+        let timeout = budget.postgres_timeout();
+        sqlx::query(
+            r#"
+            SELECT
+                set_config('lock_timeout', $1, true),
+                set_config('statement_timeout', $1, true),
+                set_config('idle_in_transaction_session_timeout', $1, true),
+                set_config('transaction_timeout', $1, true)
+            "#,
+        )
+        .bind(timeout)
+        .execute(&mut **tx)
+        .await?;
+        Ok(())
+    }
+
     /// Execute a write statement inside the transaction.
     pub async fn execute(
         &mut self,
@@ -563,6 +592,15 @@ impl<'a> Transaction<'a> {
         match self.inner {
             TransactionInner::Sqlite(tx) => tx.commit().await?,
             TransactionInner::Postgres(tx) => tx.commit().await?,
+        }
+        Ok(())
+    }
+
+    /// Roll back this transaction explicitly.
+    pub async fn rollback(self) -> Result<(), DatabaseError> {
+        match self.inner {
+            TransactionInner::Sqlite(tx) => tx.rollback().await?,
+            TransactionInner::Postgres(tx) => tx.rollback().await?,
         }
         Ok(())
     }

--- a/server/crates/waddle-server/src/db/mod.rs
+++ b/server/crates/waddle-server/src/db/mod.rs
@@ -264,6 +264,29 @@ impl Database {
         }
     }
 
+    /// Begin a transaction on the dedicated clustering control-plane pool.
+    ///
+    /// Claim grants need more than one ordered locking step: first serialize
+    /// the entity claim, then prove the destination node lease at the actual
+    /// commit boundary. Keeping those steps on this pool preserves the
+    /// control-plane isolation guarantee while making the proof atomic.
+    pub async fn control_plane_begin(&self) -> Result<Transaction<'_>, DatabaseError> {
+        match &self.control_plane_backend {
+            Some(backend) => Transaction::begin(backend).await,
+            None => Err(DatabaseError::ControlPlanePoolUnavailable),
+        }
+    }
+
+    /// Begin a bounded transaction on the clustering control-plane pool.
+    /// Every transaction that can retain an exact claim/node lock must use
+    /// this instead of [`Self::control_plane_begin`].
+    pub async fn control_plane_begin_fenced(&self) -> Result<Transaction<'_>, DatabaseError> {
+        let mut tx = self.control_plane_begin().await?;
+        tx.configure_fenced(waddle_xmpp::ownership::FENCED_TRANSACTION_BUDGET)
+            .await?;
+        Ok(tx)
+    }
+
     /// Begin a database transaction.
     ///
     /// Multiple statements executed against the returned [`Transaction`]
@@ -274,6 +297,16 @@ impl Database {
     /// or not at all.
     pub async fn begin(&self) -> Result<Transaction<'_>, DatabaseError> {
         Transaction::begin(&self.backend).await
+    }
+
+    /// Begin a main-pool transaction with database-enforced lock, statement,
+    /// idle, and total transaction deadlines. This is the only supported
+    /// entrypoint for a transaction that holds an ownership fence.
+    pub async fn begin_fenced(&self) -> Result<Transaction<'_>, DatabaseError> {
+        let mut tx = self.begin().await?;
+        tx.configure_fenced(waddle_xmpp::ownership::FENCED_TRANSACTION_BUDGET)
+            .await?;
+        Ok(tx)
     }
 
     /// Begin a transaction that acquires the database write lock

--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -37,21 +37,13 @@
 //! successful claim acquire/steal — never re-derived here, mirroring
 //! `PostgresFencedSmPersistence`'s own "epoch side channel" design note.
 //!
-//! **Corrected code-research finding (this slice's own, not a plan
-//! misattribution)**: element 7's "the MAM archive insert doubles as the
-//! backstop when archiving is on" is not achievable within this slice's
-//! Files list. MAM storage (`waddle_xmpp::mam::storage::sqlx_store`) issues
-//! a plain `sqlx::QueryBuilder` insert directly against its own raw
-//! `sqlx::PgPool`/`SqlitePool`, in `waddle-xmpp` — it has no access to
-//! `waddle-server`'s `Database`/`Transaction` types (the crate-dependency
-//! direction only runs `waddle-server -> waddle-xmpp`) and making the MAM
-//! insert itself fenced would require restructuring the MAM storage
-//! boundary, out of scope here. [`Self::check_fenced_fanout`] is therefore
-//! the **sole** backstop, run unconditionally (both archiving-on and
-//! archiving-off), as a standalone autocommit statement — the ADR's own
-//! "otherwise the standalone autocommit fencing SELECT itself is the one
-//! write-adjacent statement" text for the non-archiving case, generalized
-//! to always apply. See the phase plan's deviation log for the full note.
+//! **Fan-out and archive fencing**: [`Self::check_fenced_fanout`] provides
+//! the standalone pre-effect proof used even when archiving is disabled.
+//! When a groupchat message is archived, `MamStorage::store_message_fenced`
+//! repeats the exact claim plus serving-eligible node-incarnation locks inside
+//! the same Postgres transaction as the MAM insert. Origin-id dedup hits are
+//! resolved inside that transaction too; a retry can never bypass the
+//! ownership proof merely because its archive row already exists.
 
 use dashmap::DashMap;
 use jid::BareJid;
@@ -61,7 +53,7 @@ use waddle_xmpp::muc::{
     DurableRoomState, MucDurableFuture, MucDurableStore, RoomClaimFenceContext, RoomConfig,
     SubjectState,
 };
-use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, SharedNodeIdentity};
+use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity, SharedNodeIdentity};
 use waddle_xmpp::{Affiliation, XmppError};
 
 use crate::clustering::relay::RelayHandle;
@@ -189,30 +181,69 @@ impl PostgresMucRoomStore {
         self.claim_epochs
             .get(room_jid)
             .map(|entry| *entry)
-            .ok_or_else(|| {
-                XmppError::internal(format!(
-                    "no claim epoch recorded for room {room_jid}; durable write skipped \
-                 (the room registry must call record_claim_epoch before any write)"
-                ))
-            })
+            .ok_or_else(|| XmppError::RoomOwnershipLost(room_jid.clone()))
     }
 
-    /// Take the fencing lock inside `tx` — the exact `SELECT ... FOR SHARE`
-    /// shape `sm_persistence_fenced::assert_fenced` already established —
-    /// for `room_jid` at `epoch`. See that function's doc comment for the
-    /// full contract this mirrors.
+    fn current_fence_for(&self, room_jid: &BareJid) -> Result<RoomClaimFenceContext, XmppError> {
+        Ok(RoomClaimFenceContext {
+            entity: Entity::new(EntityType::RoomActor, room_jid.to_string()),
+            epoch: self.epoch_for(room_jid)?,
+            owner: self.node_identity.current(),
+        })
+    }
+
+    fn validate_exact_fence(
+        room_jid: &BareJid,
+        fence: &RoomClaimFenceContext,
+    ) -> Result<(), XmppError> {
+        let expected = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        if fence.entity == expected {
+            Ok(())
+        } else {
+            Err(XmppError::RoomOwnershipLost(room_jid.clone()))
+        }
+    }
+
+    /// Take the fencing locks inside `tx` for both the exact claim and its
+    /// exact, non-expired, heartbeat-fresh node incarnation. A matching stale
+    /// claim row alone is not authority after the node lease has lapsed,
+    /// expired, or rotated. Draining
+    /// remains valid here: a draining owner serves its existing claims until
+    /// terminal teardown; only new acquisition is barred while draining.
     async fn assert_fenced(
         &self,
         tx: &mut Transaction<'_>,
         room_jid: &BareJid,
-        epoch: ClaimEpoch,
+        fence: &RoomClaimFenceContext,
     ) -> Result<(), XmppError> {
-        let identity = self.node_identity.current();
+        Self::validate_exact_fence(room_jid, fence)?;
         let key = room_entity_key(room_jid);
         let mut rows = tx
             .query(
-                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                crate::db_params![key, identity.node_id.clone(), epoch.0],
+                r#"
+                WITH locked AS MATERIALIZED (
+                    SELECT n.heartbeat, n.expired, n.lease_ttl_ms
+                    FROM clustering_claims AS c
+                    JOIN clustering_nodes AS n
+                      ON n.node_id = c.node_id
+                     AND n.node_epoch = c.node_epoch
+                    WHERE c.entity = ?
+                      AND c.node_id = ?
+                      AND c.node_epoch = ?
+                      AND c.claim_epoch = ?
+                    FOR SHARE OF c, n
+                )
+                SELECT 1 FROM locked
+                WHERE NOT expired
+                  AND heartbeat >= clock_timestamp()
+                      - (lease_ttl_ms::text || ' milliseconds')::interval
+                "#,
+                crate::db_params![
+                    key,
+                    fence.owner.node_id.clone(),
+                    fence.owner.node_epoch.clone(),
+                    fence.epoch.0,
+                ],
             )
             .await
             .map_err(db_err)?;
@@ -220,12 +251,162 @@ impl PostgresMucRoomStore {
         if held {
             Ok(())
         } else {
-            self.claim_epochs.remove(room_jid);
-            Err(XmppError::internal(format!(
-                "durable write for room {room_jid} aborted: this node no longer holds the \
-                 room's ownership claim (0 rows from the fencing SELECT)"
-            )))
+            // Never let an old actor's failed E1 proof erase a newer E2
+            // cache entry for the same room.
+            self.claim_epochs
+                .remove_if(room_jid, |_, cached| *cached == fence.epoch);
+            Err(XmppError::RoomOwnershipLost(room_jid.clone()))
         }
+    }
+
+    async fn save_config_at(
+        &self,
+        room_jid: &BareJid,
+        waddle_id: &str,
+        channel_id: &str,
+        config: &RoomConfig,
+        fence: &RoomClaimFenceContext,
+    ) -> Result<(), XmppError> {
+        let config_json = serde_json::to_string(config).map_err(|error| {
+            XmppError::internal(format!("durable room config encode failed: {error}"))
+        })?;
+        let mut tx = self.db.begin_fenced().await.map_err(db_err)?;
+        self.assert_fenced(&mut tx, room_jid, fence).await?;
+        tx.execute(
+            r#"
+            INSERT INTO clustering_muc_rooms (room_jid, waddle_id, channel_id, config_json, updated_at)
+            VALUES (?, ?, ?, ?, now())
+            ON CONFLICT (room_jid) DO UPDATE SET
+                waddle_id = excluded.waddle_id,
+                channel_id = excluded.channel_id,
+                config_json = excluded.config_json,
+                updated_at = excluded.updated_at
+            "#,
+            crate::db_params![
+                room_jid.to_string(),
+                waddle_id.to_string(),
+                channel_id.to_string(),
+                config_json,
+            ],
+        )
+        .await
+        .map_err(db_err)?;
+        tx.commit().await.map_err(db_err)?;
+        Ok(())
+    }
+
+    async fn save_subject_at(
+        &self,
+        room_jid: &BareJid,
+        subject: Option<&SubjectState>,
+        fence: &RoomClaimFenceContext,
+    ) -> Result<(), XmppError> {
+        let subject_json = subject
+            .map(serde_json::to_string)
+            .transpose()
+            .map_err(|error| {
+                XmppError::internal(format!("durable room subject encode failed: {error}"))
+            })?;
+        let mut tx = self.db.begin_fenced().await.map_err(db_err)?;
+        self.assert_fenced(&mut tx, room_jid, fence).await?;
+        let affected = tx
+            .execute(
+                "UPDATE clustering_muc_rooms SET subject_json = ?, updated_at = now() WHERE room_jid = ?",
+                crate::db_params![subject_json, room_jid.to_string()],
+            )
+            .await
+            .map_err(db_err)?;
+        if affected == 0 {
+            tracing::warn!(
+                room = %room_jid,
+                "durable subject persist skipped: no durable room row exists yet \
+                 (config has not been durably written for this room)"
+            );
+        }
+        tx.commit().await.map_err(db_err)?;
+        Ok(())
+    }
+
+    async fn save_affiliation_at(
+        &self,
+        room_jid: &BareJid,
+        entry: &AffiliationEntry,
+        fence: &RoomClaimFenceContext,
+    ) -> Result<(), XmppError> {
+        let mut tx = self.db.begin_fenced().await.map_err(db_err)?;
+        self.assert_fenced(&mut tx, room_jid, fence).await?;
+        if entry.affiliation == Affiliation::None {
+            tx.execute(
+                "DELETE FROM clustering_muc_room_affiliations WHERE room_jid = ? AND member_jid = ?",
+                crate::db_params![room_jid.to_string(), entry.jid.to_string()],
+            )
+            .await
+            .map_err(db_err)?;
+        } else {
+            tx.execute(
+                r#"
+                INSERT INTO clustering_muc_room_affiliations
+                    (room_jid, member_jid, affiliation, reason)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT (room_jid, member_jid) DO UPDATE SET
+                    affiliation = excluded.affiliation,
+                    reason = excluded.reason
+                "#,
+                crate::db_params![
+                    room_jid.to_string(),
+                    entry.jid.to_string(),
+                    affiliation_to_db_str(entry.affiliation).to_string(),
+                    entry.reason.clone(),
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        }
+        tx.commit().await.map_err(db_err)?;
+        Ok(())
+    }
+
+    async fn check_fence_at(
+        &self,
+        room_jid: &BareJid,
+        fence: &RoomClaimFenceContext,
+    ) -> Result<bool, XmppError> {
+        Self::validate_exact_fence(room_jid, fence)?;
+        let key = room_entity_key(room_jid);
+        let mut tx = self.db.begin_fenced().await.map_err(db_err)?;
+        let mut rows = tx
+            .query(
+                r#"
+                WITH locked AS MATERIALIZED (
+                    SELECT n.heartbeat, n.expired, n.lease_ttl_ms
+                    FROM clustering_claims AS c
+                    JOIN clustering_nodes AS n
+                      ON n.node_id = c.node_id
+                     AND n.node_epoch = c.node_epoch
+                    WHERE c.entity = ?
+                      AND c.node_id = ?
+                      AND c.node_epoch = ?
+                      AND c.claim_epoch = ?
+                    FOR SHARE OF c, n
+                )
+                SELECT 1 FROM locked
+                WHERE NOT expired
+                  AND heartbeat >= clock_timestamp()
+                      - (lease_ttl_ms::text || ' milliseconds')::interval
+                "#,
+                crate::db_params![
+                    key,
+                    fence.owner.node_id.clone(),
+                    fence.owner.node_epoch.clone(),
+                    fence.epoch.0,
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        let held = rows.next().await.map_err(db_err)?.is_some();
+        drop(rows);
+        tx.commit().await.map_err(db_err)?;
+        Ok(held)
     }
 }
 
@@ -316,33 +497,23 @@ impl MucDurableStore for PostgresMucRoomStore {
         config: &'a RoomConfig,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let epoch = self.epoch_for(room_jid)?;
-            let config_json = serde_json::to_string(config).map_err(|error| {
-                XmppError::internal(format!("durable room config encode failed: {error}"))
-            })?;
-            let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, epoch).await?;
-            tx.execute(
-                r#"
-                INSERT INTO clustering_muc_rooms (room_jid, waddle_id, channel_id, config_json, updated_at)
-                VALUES (?, ?, ?, ?, now())
-                ON CONFLICT (room_jid) DO UPDATE SET
-                    waddle_id = excluded.waddle_id,
-                    channel_id = excluded.channel_id,
-                    config_json = excluded.config_json,
-                    updated_at = excluded.updated_at
-                "#,
-                crate::db_params![
-                    room_jid.to_string(),
-                    waddle_id.to_string(),
-                    channel_id.to_string(),
-                    config_json,
-                ],
-            )
-            .await
-            .map_err(db_err)?;
-            tx.commit().await.map_err(db_err)?;
-            Ok(())
+            let fence = self.current_fence_for(room_jid)?;
+            self.save_config_at(room_jid, waddle_id, channel_id, config, &fence)
+                .await
+        })
+    }
+
+    fn save_config_exact<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        waddle_id: &'a str,
+        channel_id: &'a str,
+        config: &'a RoomConfig,
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, ()> {
+        Box::pin(async move {
+            self.save_config_at(room_jid, waddle_id, channel_id, config, fence)
+                .await
         })
     }
 
@@ -352,38 +523,18 @@ impl MucDurableStore for PostgresMucRoomStore {
         subject: Option<&'a SubjectState>,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let epoch = self.epoch_for(room_jid)?;
-            let subject_json = subject
-                .map(serde_json::to_string)
-                .transpose()
-                .map_err(|error| {
-                    XmppError::internal(format!("durable room subject encode failed: {error}"))
-                })?;
-            let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, epoch).await?;
-            // The room row must already exist (a subject can only be set on
-            // an already-spawned room, which always durably writes its
-            // config at spawn-adjacent points first) — an UPDATE-only
-            // statement here, not an upsert, so a missing row is a loud
-            // 0-rows-affected rather than a silently-incomplete insert
-            // missing `waddle_id`/`channel_id`.
-            let affected = tx
-                .execute(
-                    "UPDATE clustering_muc_rooms SET subject_json = ?, updated_at = now() WHERE room_jid = ?",
-                    crate::db_params![subject_json, room_jid.to_string()],
-                )
-                .await
-                .map_err(db_err)?;
-            if affected == 0 {
-                tracing::warn!(
-                    room = %room_jid,
-                    "durable subject persist skipped: no durable room row exists yet \
-                     (config has not been durably written for this room)"
-                );
-            }
-            tx.commit().await.map_err(db_err)?;
-            Ok(())
+            let fence = self.current_fence_for(room_jid)?;
+            self.save_subject_at(room_jid, subject, &fence).await
         })
+    }
+
+    fn save_subject_exact<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        subject: Option<&'a SubjectState>,
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, ()> {
+        Box::pin(async move { self.save_subject_at(room_jid, subject, fence).await })
     }
 
     fn save_affiliation<'a>(
@@ -392,39 +543,18 @@ impl MucDurableStore for PostgresMucRoomStore {
         entry: &'a AffiliationEntry,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let epoch = self.epoch_for(room_jid)?;
-            let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, epoch).await?;
-            if entry.affiliation == Affiliation::None {
-                tx.execute(
-                    "DELETE FROM clustering_muc_room_affiliations WHERE room_jid = ? AND member_jid = ?",
-                    crate::db_params![room_jid.to_string(), entry.jid.to_string()],
-                )
-                .await
-                .map_err(db_err)?;
-            } else {
-                tx.execute(
-                    r#"
-                    INSERT INTO clustering_muc_room_affiliations
-                        (room_jid, member_jid, affiliation, reason)
-                    VALUES (?, ?, ?, ?)
-                    ON CONFLICT (room_jid, member_jid) DO UPDATE SET
-                        affiliation = excluded.affiliation,
-                        reason = excluded.reason
-                    "#,
-                    crate::db_params![
-                        room_jid.to_string(),
-                        entry.jid.to_string(),
-                        affiliation_to_db_str(entry.affiliation).to_string(),
-                        entry.reason.clone(),
-                    ],
-                )
-                .await
-                .map_err(db_err)?;
-            }
-            tx.commit().await.map_err(db_err)?;
-            Ok(())
+            let fence = self.current_fence_for(room_jid)?;
+            self.save_affiliation_at(room_jid, entry, &fence).await
         })
+    }
+
+    fn save_affiliation_exact<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        entry: &'a AffiliationEntry,
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, ()> {
+        Box::pin(async move { self.save_affiliation_at(room_jid, entry, fence).await })
     }
 
     fn record_claim_epoch(&self, room_jid: &BareJid, epoch: ClaimEpoch) {
@@ -436,29 +566,28 @@ impl MucDurableStore for PostgresMucRoomStore {
     }
 
     /// The guaranteed demotion backstop (element 7): a fenced,
-    /// standalone-autocommit `SELECT ... FOR SHARE` on the main pool, run
-    /// before every local fan-out. See the module doc's MAM-backstop
-    /// correction for why this is the sole backstop mechanism this slice
-    /// lands, unconditionally (both archiving-on and archiving-off).
+    /// bounded read-only transaction with `SELECT ... FOR SHARE` on the main pool, run
+    /// before every local fan-out. It proves both the exact claim and the
+    /// exact, non-expired, heartbeat-fresh node incarnation at the check boundary. The later
+    /// MAM write repeats and holds the same locks inside its insert
+    /// transaction when archiving is active.
     fn check_fenced_fanout<'a>(&'a self, room_jid: &'a BareJid) -> MucDurableFuture<'a, bool> {
         Box::pin(async move {
-            let epoch = self.epoch_for(room_jid)?;
-            let identity = self.node_identity.current();
-            let key = room_entity_key(room_jid);
-            let conn = self.db.guard().await.map_err(db_err)?;
-            let mut rows = conn
-                .query(
-                    "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                    crate::db_params![key, identity.node_id.clone(), epoch.0],
-                )
-                .await
-                .map_err(db_err)?;
-            Ok(rows.next().await.map_err(db_err)?.is_some())
+            let fence = self.current_fence_for(room_jid)?;
+            self.check_fence_at(room_jid, &fence).await
         })
     }
 
+    fn check_fenced_fanout_exact<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, bool> {
+        Box::pin(async move { self.check_fence_at(room_jid, fence).await })
+    }
+
     /// ADR-0017 Phase 3 Slice 7 FIX 1: exposes the exact `(Entity,
-    /// ClaimEpoch, node_id)` triple [`Self::check_fenced_fanout`]/
+    /// ClaimEpoch, NodeIdentity)` triple [`Self::check_fenced_fanout`]/
     /// [`Self::assert_fenced`] already resolve from `self.claim_epochs`, so
     /// `groupchat_archive.rs`'s MAM fenced write can bind the identical
     /// typed context rather than re-deriving it from a second mechanism.
@@ -468,7 +597,7 @@ impl MucDurableStore for PostgresMucRoomStore {
         Some(RoomClaimFenceContext {
             entity: Entity::new(EntityType::RoomActor, room_jid.to_string()),
             epoch,
-            node_id: identity.node_id,
+            owner: identity,
         })
     }
 
@@ -476,7 +605,7 @@ impl MucDurableStore for PostgresMucRoomStore {
         &'a self,
         room_jid: &'a BareJid,
         previous_owner_node_id: &'a str,
-        _previous_owner_node_epoch: &'a str,
+        previous_owner_node_epoch: &'a str,
         new_epoch: ClaimEpoch,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
@@ -486,7 +615,11 @@ impl MucDurableStore for PostgresMucRoomStore {
                 self.stop_token.clone(),
             );
             relay_handle
-                .demote(entity, new_epoch)
+                .demote(
+                    entity,
+                    NodeIdentity::new(previous_owner_node_id, previous_owner_node_epoch),
+                    new_epoch,
+                )
                 .await
                 .map(|_reply| ())
                 .map_err(|error| {
@@ -501,7 +634,9 @@ impl MucDurableStore for PostgresMucRoomStore {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::clustering::claims::{clustering_control_plane_table_lock, PostgresClaimStore};
+    use crate::clustering::claims::{
+        clustering_control_plane_table_lock, NodeLeaseStore, PostgresClaimStore,
+    };
     use crate::db::{DatabaseConfig, DatabaseDriver, DEFAULT_CONTROL_PLANE_POOL_SIZE};
     use std::sync::Arc;
     use waddle_xmpp::muc::RoomSubjectTexts;
@@ -526,10 +661,139 @@ mod tests {
         stealer
     }
 
+    async fn expire_node(db: &crate::db::Database, identity: &NodeIdentity) {
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "UPDATE clustering_nodes SET expired = true \
+             WHERE node_id = ? AND node_epoch = ?",
+            crate::db_params![identity.node_id.clone(), identity.node_epoch.clone()],
+        )
+        .await
+        .expect("expire old owner incarnation");
+    }
+
+    async fn lapse_node_heartbeat(db: &crate::db::Database, identity: &NodeIdentity) {
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "UPDATE clustering_nodes SET heartbeat = now() - interval '1 hour', expired = false \
+             WHERE node_id = ? AND node_epoch = ?",
+            crate::db_params![identity.node_id.clone(), identity.node_epoch.clone()],
+        )
+        .await
+        .expect("lapse node heartbeat without committing expiry");
+    }
+
     fn room_jid(name: &str) -> BareJid {
         format!("{name}@muc.example.com")
             .parse()
             .expect("valid test room JID")
+    }
+
+    fn moderation_row(
+        room: &BareJid,
+        moderation_id: &str,
+        target_id: &str,
+    ) -> waddle_xmpp_core::mam::ArchivedMessage {
+        use waddle_xmpp_core::mam::{
+            ArchivedMessage, ArchivedModeration, ArchivedRichMessage, ArchivedRichPayload,
+            RichMessageId,
+        };
+        let room_jid = jid::Jid::from(room.clone());
+        let wire_id = format!("{moderation_id}-wire");
+        let stamp = chrono::Utc::now();
+        ArchivedMessage {
+            id: moderation_id.to_string(),
+            timestamp: stamp,
+            stanza_id: Some(waddle_xmpp_core::xep0359::StanzaId::new(
+                wire_id,
+                room_jid.clone(),
+            )),
+            message_type: xmpp_parsers::message::MessageType::Groupchat,
+            rich: Some(ArchivedRichMessage {
+                payload: Some(ArchivedRichPayload::Moderation(ArchivedModeration {
+                    target_id: RichMessageId::new(target_id).expect("target id"),
+                    moderated_by: format!("{room}/moderator").parse().expect("jid"),
+                    stamp: Some(stamp),
+                    reason: None,
+                })),
+                reply: None,
+                references: Vec::new(),
+                mentions: Vec::new(),
+                occupant_id: None,
+                muc_sender: None,
+            }),
+            ..ArchivedMessage::for_test(room_jid.clone(), room_jid)
+        }
+    }
+
+    fn retraction_tombstone(retraction_id: &str) -> waddle_xmpp_core::mam::ArchivedTombstone {
+        waddle_xmpp_core::mam::ArchivedTombstone {
+            retraction_id: waddle_xmpp_core::mam::RichMessageId::new(retraction_id),
+            stamp: chrono::Utc::now(),
+            moderation: None,
+        }
+    }
+
+    fn retraction_row(
+        room: &BareJid,
+        retraction_id: &str,
+        target_id: &str,
+        nickname_generation: u64,
+    ) -> waddle_xmpp_core::mam::ArchivedMessage {
+        use waddle_xmpp_core::mam::{
+            ArchivedMessage, ArchivedRetraction, ArchivedRichMessage, ArchivedRichPayload,
+            RichMessageId,
+        };
+        let room_jid = jid::Jid::from(room.clone());
+        let from: jid::Jid = format!("{room}/alice").parse().expect("occupant");
+        ArchivedMessage {
+            id: retraction_id.to_string(),
+            stanza_id: Some(waddle_xmpp_core::xep0359::StanzaId::new(
+                retraction_id,
+                room_jid.clone(),
+            )),
+            message_type: xmpp_parsers::message::MessageType::Groupchat,
+            rich: Some(ArchivedRichMessage {
+                payload: Some(ArchivedRichPayload::Retraction(ArchivedRetraction {
+                    target_id: RichMessageId::new(target_id).expect("target id"),
+                    stamp: None,
+                    retraction_id: RichMessageId::new(retraction_id),
+                })),
+                reply: None,
+                references: Vec::new(),
+                mentions: Vec::new(),
+                occupant_id: None,
+                muc_sender: None,
+            }),
+            nickname_generation: Some(nickname_generation),
+            ..ArchivedMessage::for_test(from, room_jid)
+        }
+    }
+
+    fn moderation_tombstone(
+        moderation: &waddle_xmpp_core::mam::ArchivedMessage,
+    ) -> waddle_xmpp_core::mam::ArchivedTombstone {
+        let payload = match moderation
+            .rich
+            .as_ref()
+            .and_then(|rich| rich.payload.as_ref())
+        {
+            Some(waddle_xmpp_core::mam::ArchivedRichPayload::Moderation(payload)) => {
+                payload.clone()
+            }
+            other => panic!("expected moderation payload, got {other:?}"),
+        };
+        let wire_id = moderation
+            .stanza_id
+            .as_ref()
+            .expect("moderation wire id")
+            .id
+            .clone();
+        waddle_xmpp_core::mam::ArchivedTombstone {
+            retraction_id: waddle_xmpp_core::mam::RichMessageId::new(wire_id),
+            stamp: moderation.timestamp,
+            moderation: Some(payload),
+        }
     }
 
     /// Open a clean `PostgresMucRoomStore` alongside a `PostgresClaimStore`
@@ -571,6 +835,11 @@ mod tests {
         conn.execute("DELETE FROM clustering_muc_room_affiliations", ())
             .await
             .expect("clean affiliations");
+        drop(conn);
+        claim_store
+            .register(&store.node_identity.current(), None)
+            .await
+            .expect("register live room owner");
         Some((store, claim_store, db))
     }
 
@@ -707,10 +976,10 @@ mod tests {
             "the current owner's own fenced check must pass"
         );
 
-        // Simulate another node stealing via steal_stale(OwnerStale): `me`
-        // has no `clustering_nodes` liveness row, so the owner-stale
-        // predicate is true, while the stealer has a fresh live row as
-        // required by Slice 1a's hardened steal CAS.
+        // Simulate another node stealing via steal_stale(OwnerStale): expire
+        // the exact old owner incarnation while the stealer has a fresh live
+        // row, matching Slice 1a's hardened steal CAS.
+        expire_node(&db, &me).await;
         let stealer = live_stealer(&db).await;
         claim_store
             .steal_stale(&entity, epoch, StalePredicate::OwnerStale, &stealer)
@@ -724,6 +993,567 @@ mod tests {
                 .expect("check_fenced_fanout"),
             "the deposed owner's very next fenced check must observe 0 rows"
         );
+    }
+
+    #[tokio::test]
+    async fn exact_claim_is_not_authority_after_its_node_incarnation_expires() {
+        use waddle_xmpp::mam::{MamStorage, MamStorageError, SqlxMamStorage};
+        use waddle_xmpp_core::mam::ArchivedMessage;
+
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, db)) = clean_store().await else {
+            return;
+        };
+        let jid = room_jid("expired-owner-row");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let me = store.node_identity.current();
+        let epoch = claim_store
+            .ensure_claimed(&entity, &me)
+            .await
+            .expect("claim room");
+        store.record_claim_epoch(&jid, epoch);
+        let fence = store
+            .current_claim_fence(&jid)
+            .expect("cached exact claim fence");
+
+        // Leave clustering_claims untouched. Only expire the exact node
+        // incarnation: a claim-only fence would incorrectly keep passing.
+        expire_node(&db, &me).await;
+
+        assert!(
+            !store
+                .check_fenced_fanout(&jid)
+                .await
+                .expect("fanout ownership check"),
+            "an exact claim row cannot outlive its owner node incarnation"
+        );
+        assert!(store
+            .save_config(&jid, "waddle", "channel", &RoomConfig::default())
+            .await
+            .is_err());
+
+        let mam_storage = SqlxMamStorage::open(db.database_url())
+            .await
+            .expect("open colocated MAM")
+            .with_cluster_fencing(true);
+        let archive_id = uuid::Uuid::new_v4().to_string();
+        let message = ArchivedMessage {
+            id: archive_id.clone(),
+            message_type: xmpp_parsers::message::MessageType::Groupchat,
+            ..ArchivedMessage::for_test(
+                format!("{jid}/alice").parse().expect("valid occupant JID"),
+                jid::Jid::from(jid.clone()),
+            )
+        };
+        assert!(matches!(
+            mam_storage
+                .store_message_fenced(&jid, &message, &fence)
+                .await,
+            Err(MamStorageError::NotOwner { .. })
+        ));
+        assert!(mam_storage
+            .get_message(&archive_id)
+            .await
+            .expect("read MAM row")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn lapsed_nonexpired_room_owner_cannot_fanout_or_write_muc_or_mam_state() {
+        use waddle_xmpp::mam::{MamStorage, MamStorageError, SqlxMamStorage};
+        use waddle_xmpp_core::mam::ArchivedMessage;
+
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, db)) = clean_store().await else {
+            return;
+        };
+        let jid = room_jid("lapsed-owner-row");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let me = store.node_identity.current();
+        let epoch = claim_store
+            .ensure_claimed(&entity, &me)
+            .await
+            .expect("claim room");
+        store.record_claim_epoch(&jid, epoch);
+        let fence = store
+            .current_claim_fence(&jid)
+            .expect("cached exact claim fence");
+        lapse_node_heartbeat(&db, &me).await;
+
+        assert!(
+            !store
+                .check_fenced_fanout(&jid)
+                .await
+                .expect("fanout ownership check"),
+            "raw deadline lapse must close fanout before a watchdog commits expiry"
+        );
+        assert!(store
+            .save_config(&jid, "waddle", "channel", &RoomConfig::default())
+            .await
+            .is_err());
+
+        let mam_storage = SqlxMamStorage::open(db.database_url())
+            .await
+            .expect("open colocated MAM")
+            .with_cluster_fencing(true);
+        let archive_id = uuid::Uuid::new_v4().to_string();
+        let message = ArchivedMessage {
+            id: archive_id.clone(),
+            message_type: xmpp_parsers::message::MessageType::Groupchat,
+            ..ArchivedMessage::for_test(
+                format!("{jid}/alice").parse().expect("valid occupant JID"),
+                jid::Jid::from(jid.clone()),
+            )
+        };
+        assert!(matches!(
+            mam_storage
+                .store_message_fenced(&jid, &message, &fence)
+                .await,
+            Err(MamStorageError::NotOwner { .. })
+        ));
+        assert!(mam_storage
+            .get_message(&archive_id)
+            .await
+            .expect("read MAM row")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn origin_id_dedup_retry_still_requires_a_live_exact_owner() {
+        use waddle_xmpp::mam::{MamStorage, MamStorageError, SqlxMamStorage};
+        use waddle_xmpp_core::mam::ArchivedMessage;
+        use waddle_xmpp_core::xep0359::OriginId;
+
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, db)) = clean_store().await else {
+            return;
+        };
+        let jid = room_jid("dedup-expired-owner");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let me = store.node_identity.current();
+        let epoch = claim_store
+            .ensure_claimed(&entity, &me)
+            .await
+            .expect("claim room");
+        store.record_claim_epoch(&jid, epoch);
+        let fence = store
+            .current_claim_fence(&jid)
+            .expect("cached exact claim fence");
+        let mam_storage = SqlxMamStorage::open(db.database_url())
+            .await
+            .expect("open colocated MAM")
+            .with_cluster_fencing(true);
+        let first_id = uuid::Uuid::new_v4().to_string();
+        let retry_id = uuid::Uuid::new_v4().to_string();
+        let origin_id = OriginId::new(uuid::Uuid::new_v4().to_string());
+        let first = ArchivedMessage {
+            id: first_id.clone(),
+            body: Some("deduplicated message".to_string()),
+            origin_id: Some(origin_id),
+            message_type: xmpp_parsers::message::MessageType::Groupchat,
+            ..ArchivedMessage::for_test(
+                format!("{jid}/alice").parse().expect("valid occupant JID"),
+                jid::Jid::from(jid.clone()),
+            )
+        };
+        mam_storage
+            .store_message_fenced(&jid, &first, &fence)
+            .await
+            .expect("live owner stores original");
+
+        expire_node(&db, &me).await;
+        let retry = ArchivedMessage {
+            id: retry_id.clone(),
+            ..first
+        };
+        assert!(matches!(
+            mam_storage.store_message_fenced(&jid, &retry, &fence).await,
+            Err(MamStorageError::NotOwner { .. })
+        ));
+        assert!(mam_storage
+            .get_message(&retry_id)
+            .await
+            .expect("read retry MAM row")
+            .is_none());
+        assert!(mam_storage
+            .get_message(&first_id)
+            .await
+            .expect("read original MAM row")
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn draining_owner_can_finish_existing_room_and_mam_writes() {
+        use waddle_xmpp::mam::{MamStorage, SqlxMamStorage};
+        use waddle_xmpp_core::mam::ArchivedMessage;
+
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, db)) = clean_store().await else {
+            return;
+        };
+        let jid = room_jid("draining-owner");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let me = store.node_identity.current();
+        let epoch = claim_store
+            .ensure_claimed(&entity, &me)
+            .await
+            .expect("claim room");
+        store.record_claim_epoch(&jid, epoch);
+        let fence = store
+            .current_claim_fence(&jid)
+            .expect("cached exact claim fence");
+        claim_store
+            .mark_draining(&me)
+            .await
+            .expect("mark owner draining");
+
+        assert!(
+            store
+                .check_fenced_fanout(&jid)
+                .await
+                .expect("fanout ownership check"),
+            "draining bars acquisition, not service of existing claims"
+        );
+        store
+            .save_config(&jid, "waddle", "channel", &RoomConfig::default())
+            .await
+            .expect("draining owner finishes durable room write");
+
+        let mam_storage = SqlxMamStorage::open(db.database_url())
+            .await
+            .expect("open colocated MAM")
+            .with_cluster_fencing(true);
+        let archive_id = uuid::Uuid::new_v4().to_string();
+        let message = ArchivedMessage {
+            id: archive_id.clone(),
+            message_type: xmpp_parsers::message::MessageType::Groupchat,
+            ..ArchivedMessage::for_test(
+                format!("{jid}/alice").parse().expect("valid occupant JID"),
+                jid::Jid::from(jid.clone()),
+            )
+        };
+        assert_eq!(
+            mam_storage
+                .store_message_fenced(&jid, &message, &fence)
+                .await
+                .expect("draining owner finishes fenced MAM write"),
+            archive_id
+        );
+    }
+
+    #[tokio::test]
+    async fn same_node_id_epoch_rotation_blocks_room_and_mam_writes() {
+        use waddle_xmpp::mam::{MamStorage, MamStorageError, SqlxMamStorage};
+        use waddle_xmpp_core::mam::ArchivedMessage;
+
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, db)) = clean_store().await else {
+            return;
+        };
+        let jid = room_jid("same-node-new-epoch");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let old = store.node_identity.current();
+        let epoch = claim_store
+            .ensure_claimed(&entity, &old)
+            .await
+            .expect("old incarnation claims room");
+        store.record_claim_epoch(&jid, epoch);
+        store
+            .save_config(&jid, "waddle-old", "channel-old", &RoomConfig::default())
+            .await
+            .expect("old incarnation writes initial room state");
+        let stale_mam_fence = store
+            .current_claim_fence(&jid)
+            .expect("room claim fence is available");
+
+        let recovered = NodeIdentity::new(old.node_id.clone(), uuid::Uuid::new_v4().to_string());
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "UPDATE clustering_nodes SET node_epoch = ? WHERE node_id = ?",
+            crate::db_params![recovered.node_epoch.clone(), recovered.node_id.clone()],
+        )
+        .await
+        .expect("rotate process node epoch");
+        conn.execute(
+            "UPDATE clustering_claims SET node_epoch = ? WHERE entity = ?",
+            crate::db_params![recovered.node_epoch.clone(), room_entity_key(&jid),],
+        )
+        .await
+        .expect("move claim without changing claim epoch");
+        drop(conn);
+
+        assert!(
+            !store
+                .check_fenced_fanout(&jid)
+                .await
+                .expect("fanout fence check"),
+            "the old node epoch must not fan out under the recovered incarnation"
+        );
+        assert!(
+            store
+                .save_config(
+                    &jid,
+                    "waddle-stale",
+                    "channel-stale",
+                    &RoomConfig::default(),
+                )
+                .await
+                .is_err(),
+            "the old node epoch must not mutate durable room state"
+        );
+
+        let mam_storage = SqlxMamStorage::open(db.database_url())
+            .await
+            .expect("open colocated mam storage")
+            .with_cluster_fencing(true);
+        let archive_id = uuid::Uuid::new_v4().to_string();
+        let message = ArchivedMessage {
+            id: archive_id.clone(),
+            body: Some("stale incarnation".to_string()),
+            message_type: xmpp_parsers::message::MessageType::Groupchat,
+            ..ArchivedMessage::for_test(
+                format!("{jid}/alice").parse().expect("valid full jid"),
+                jid::Jid::from(jid.clone()),
+            )
+        };
+        let result = mam_storage
+            .store_message_fenced(&jid, &message, &stale_mam_fence)
+            .await;
+        assert!(
+            matches!(result, Err(MamStorageError::NotOwner { .. })),
+            "MAM must reject an old node epoch even when node_id and claim_epoch match: {result:?}"
+        );
+        assert!(
+            mam_storage
+                .get_message(&archive_id)
+                .await
+                .expect("get message")
+                .is_none(),
+            "the rejected stale-epoch archive write must not land"
+        );
+    }
+
+    #[tokio::test]
+    async fn retained_e1_cannot_use_a_room_cache_that_has_advanced_to_e2() {
+        use waddle_xmpp::mam::{MamStorage, MamStorageError, SqlxMamStorage};
+        use waddle_xmpp_core::mam::ArchivedMessage;
+
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, db)) = clean_store().await else {
+            return;
+        };
+        let room = room_jid("retained-e1-new-e2");
+        let entity = Entity::new(EntityType::RoomActor, room.to_string());
+        let owner = store.node_identity.current();
+        let e1 = claim_store
+            .ensure_claimed(&entity, &owner)
+            .await
+            .expect("acquire E1");
+        store.record_claim_epoch(&room, e1);
+        let fence_e1 = store.current_claim_fence(&room).expect("E1 fence");
+
+        claim_store
+            .release(&entity, &owner, e1)
+            .await
+            .expect("release E1");
+        let e2 = claim_store
+            .ensure_claimed(&entity, &owner)
+            .await
+            .expect("acquire E2");
+        assert!(e2 > e1, "a replacement actor must receive a newer epoch");
+        store.record_claim_epoch(&room, e2);
+        let fence_e2 = store.current_claim_fence(&room).expect("E2 fence");
+
+        assert!(!store
+            .check_fenced_fanout_exact(&room, &fence_e1)
+            .await
+            .expect("stale E1 fanout check"));
+        assert!(store
+            .check_fenced_fanout_exact(&room, &fence_e2)
+            .await
+            .expect("live E2 fanout check"));
+
+        let stale_config = RoomConfig {
+            name: "must not persist from E1".to_string(),
+            ..RoomConfig::default()
+        };
+        let stale_save = store
+            .save_config_exact(&room, "waddle-e1", "channel-e1", &stale_config, &fence_e1)
+            .await;
+        assert!(matches!(
+            stale_save,
+            Err(XmppError::RoomOwnershipLost(ref lost_room)) if lost_room == &room
+        ));
+        assert_eq!(
+            store.current_claim_fence(&room),
+            Some(fence_e2.clone()),
+            "a failed E1 proof must not erase the newer cached E2"
+        );
+        assert!(store
+            .load_room_state(&room)
+            .await
+            .expect("load room")
+            .is_none());
+
+        let mam = SqlxMamStorage::open(db.database_url())
+            .await
+            .expect("MAM")
+            .with_cluster_fencing(true);
+        let archive_id = uuid::Uuid::new_v4().to_string();
+        let stale_message = ArchivedMessage {
+            id: archive_id.clone(),
+            body: Some("must not archive from E1".to_string()),
+            message_type: xmpp_parsers::message::MessageType::Groupchat,
+            ..ArchivedMessage::for_test(
+                format!("{room}/alice").parse().expect("occupant"),
+                jid::Jid::from(room.clone()),
+            )
+        };
+        let stale_archive = mam
+            .store_message_fenced(&room, &stale_message, &fence_e1)
+            .await;
+        assert!(matches!(
+            stale_archive,
+            Err(MamStorageError::NotOwner { .. })
+        ));
+        assert!(mam
+            .get_message(&archive_id)
+            .await
+            .expect("read rejected archive")
+            .is_none());
+        assert!(store
+            .check_fenced_fanout_exact(&room, &fence_e2)
+            .await
+            .expect("E2 remains authoritative"));
+    }
+
+    #[tokio::test]
+    async fn muc_fence_uses_wall_clock_when_lease_lapses_inside_an_open_transaction() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, db)) = clean_store().await else {
+            return;
+        };
+        let room = room_jid("muc-open-tx-lease-lapse");
+        let entity = Entity::new(EntityType::RoomActor, room.to_string());
+        let owner = store.node_identity.current();
+        let epoch = claim_store
+            .ensure_claimed(&entity, &owner)
+            .await
+            .expect("claim room");
+        store.record_claim_epoch(&room, epoch);
+        let fence = store.current_claim_fence(&room).expect("fence");
+        db.guard()
+            .await
+            .expect("guard")
+            .execute(
+                "UPDATE clustering_nodes SET heartbeat = clock_timestamp(), lease_ttl_ms = 50 WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![owner.node_id.clone(), owner.node_epoch.clone()],
+            )
+            .await
+            .expect("shorten lease");
+
+        let mut tx = db.begin().await.expect("begin before TTL lapse");
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        let result = store.assert_fenced(&mut tx, &room, &fence).await;
+        assert!(matches!(
+            result,
+            Err(XmppError::RoomOwnershipLost(ref lost_room)) if lost_room == &room
+        ));
+    }
+
+    #[tokio::test]
+    async fn blocked_muc_and_mam_fences_recheck_wall_clock_after_the_node_lock_releases() {
+        use waddle_xmpp::mam::{MamStorage, MamStorageError, SqlxMamStorage};
+        use waddle_xmpp_core::mam::ArchivedMessage;
+
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, db)) = clean_store().await else {
+            return;
+        };
+        let store = Arc::new(store);
+        let room = room_jid("blocked-fence-lease-lapse");
+        let entity = Entity::new(EntityType::RoomActor, room.to_string());
+        let owner = store.node_identity.current();
+        let epoch = claim_store
+            .ensure_claimed(&entity, &owner)
+            .await
+            .expect("claim room");
+        store.record_claim_epoch(&room, epoch);
+        let fence = store.current_claim_fence(&room).expect("fence");
+        let mam = SqlxMamStorage::open(db.database_url())
+            .await
+            .expect("MAM")
+            .with_cluster_fencing(true);
+        db.guard()
+            .await
+            .expect("guard")
+            .execute(
+                "UPDATE clustering_nodes SET heartbeat = clock_timestamp(), lease_ttl_ms = 100 WHERE node_id = ? AND node_epoch = ?",
+                crate::db_params![owner.node_id.clone(), owner.node_epoch.clone()],
+            )
+            .await
+            .expect("shorten lease");
+
+        let mut blocker = db.begin().await.expect("begin node-lock blocker");
+        let mut locked = blocker
+            .query(
+                "SELECT 1 FROM clustering_nodes WHERE node_id = ? AND node_epoch = ? FOR UPDATE",
+                crate::db_params![owner.node_id.clone(), owner.node_epoch.clone()],
+            )
+            .await
+            .expect("lock node row");
+        assert!(locked.next().await.expect("read lock row").is_some());
+        drop(locked);
+
+        let archive_id = uuid::Uuid::new_v4().to_string();
+        let message = ArchivedMessage {
+            id: archive_id.clone(),
+            body: Some("blocked until stale".to_string()),
+            message_type: xmpp_parsers::message::MessageType::Groupchat,
+            ..ArchivedMessage::for_test(
+                format!("{room}/alice").parse().expect("occupant"),
+                jid::Jid::from(room.clone()),
+            )
+        };
+
+        let muc_task = {
+            let store = Arc::clone(&store);
+            let room = room.clone();
+            let fence = fence.clone();
+            tokio::spawn(async move { store.check_fenced_fanout_exact(&room, &fence).await })
+        };
+        let mam_task = {
+            let room = room.clone();
+            let fence = fence.clone();
+            tokio::spawn(async move { mam.store_message_fenced(&room, &message, &fence).await })
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(175)).await;
+        assert!(
+            !muc_task.is_finished(),
+            "MUC fence must wait on the node lock"
+        );
+        assert!(
+            !mam_task.is_finished(),
+            "MAM fence must wait on the node lock"
+        );
+        blocker.commit().await.expect("release node lock");
+
+        assert!(!muc_task
+            .await
+            .expect("join MUC fence")
+            .expect("MUC fence result"));
+        assert!(matches!(
+            mam_task.await.expect("join MAM fence"),
+            Err(MamStorageError::NotOwner { .. })
+        ));
+        let mam = SqlxMamStorage::open(db.database_url())
+            .await
+            .expect("MAM readback");
+        assert!(mam
+            .get_message(&archive_id)
+            .await
+            .expect("read rejected message")
+            .is_none());
     }
 
     /// ADR-0017 Phase 3 Slice 7 FIX 1 (council-adjudicated): the MAM
@@ -771,7 +1601,7 @@ mod tests {
             .expect("current_claim_fence must resolve immediately after record_claim_epoch");
         assert_eq!(fence.entity, entity);
         assert_eq!(fence.epoch, epoch);
-        assert_eq!(fence.node_id, me.node_id);
+        assert_eq!(fence.owner, me);
 
         let message = ArchivedMessage {
             id: first_id.clone(),
@@ -794,9 +1624,10 @@ mod tests {
             .expect("row exists");
         assert_eq!(stored.body.as_deref(), Some("hello, fenced world"));
 
-        // Steal the claim exactly like `check_fenced_fanout`'s own test:
-        // the old owner is missing from `clustering_nodes`, and the stealer
-        // is explicitly live.
+        // Steal the claim exactly like `check_fenced_fanout`'s own test: the
+        // old owner incarnation is expired and the stealer is explicitly
+        // live.
+        expire_node(&db, &me).await;
         let stealer = live_stealer(&db).await;
         claim_store
             .steal_stale(&entity, epoch, StalePredicate::OwnerStale, &stealer)
@@ -830,6 +1661,293 @@ mod tests {
         assert!(
             should_be_absent.is_none(),
             "a rejected fenced write must not have committed any row"
+        );
+    }
+
+    #[tokio::test]
+    async fn xep0424_and_xep0425_fenced_writes_are_atomic_after_owner_expiry() {
+        use waddle_xmpp::mam::{MamStorage, MamStorageError, SqlxMamStorage};
+        use waddle_xmpp_core::mam::ArchivedMessage;
+
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, db)) = clean_store().await else {
+            return;
+        };
+        let room = room_jid("xep042x-expired-owner");
+        let entity = Entity::new(EntityType::RoomActor, room.to_string());
+        let owner = store.node_identity.current();
+        let epoch = claim_store
+            .ensure_claimed(&entity, &owner)
+            .await
+            .expect("claim room");
+        store.record_claim_epoch(&room, epoch);
+        let fence = store.current_claim_fence(&room).expect("fence");
+        let mam = SqlxMamStorage::open(db.database_url())
+            .await
+            .expect("MAM")
+            .with_cluster_fencing(true);
+
+        let target_id = uuid::Uuid::new_v4().to_string();
+        let target = ArchivedMessage {
+            id: target_id.clone(),
+            body: Some("secret".to_string()),
+            message_type: xmpp_parsers::message::MessageType::Groupchat,
+            nickname_generation: Some(1),
+            ..ArchivedMessage::for_test(
+                format!("{room}/alice").parse().expect("occupant"),
+                jid::Jid::from(room.clone()),
+            )
+        };
+        mam.store_message_fenced(&room, &target, &fence)
+            .await
+            .expect("seed target");
+        let retraction_id = uuid::Uuid::new_v4().to_string();
+        let retraction_from: jid::Jid = format!("{room}/alice").parse().expect("occupant");
+        let retraction = retraction_row(&room, &retraction_id, &target_id, 1);
+        mam.store_message_fenced(&room, &retraction, &fence)
+            .await
+            .expect("archive retraction event first");
+
+        expire_node(&db, &owner).await;
+        let xep0424 = mam
+            .replace_with_tombstone_fenced(
+                &room,
+                &target_id,
+                &retraction_id,
+                &retraction_from,
+                retraction_tombstone(&retraction_id),
+                &fence,
+            )
+            .await;
+        assert!(matches!(xep0424, Err(MamStorageError::NotOwner { .. })));
+
+        let moderation_id = uuid::Uuid::new_v4().to_string();
+        let moderation = moderation_row(&room, &moderation_id, &target_id);
+        let xep0425 = mam
+            .moderate_message_fenced(
+                &room,
+                &moderation,
+                &target_id,
+                moderation_tombstone(&moderation),
+                &fence,
+            )
+            .await;
+        assert!(matches!(xep0425, Err(MamStorageError::NotOwner { .. })));
+        assert!(mam
+            .get_message(&moderation_id)
+            .await
+            .expect("read moderation")
+            .is_none());
+        assert_eq!(
+            mam.get_message(&target_id)
+                .await
+                .expect("read target")
+                .expect("target exists")
+                .body
+                .as_deref(),
+            Some("secret"),
+            "neither failed transaction may tombstone the target"
+        );
+    }
+
+    #[tokio::test]
+    async fn xep0425_draining_exact_owner_commits_event_and_tombstone_together() {
+        use waddle_xmpp::mam::{MamStorage, SqlxMamStorage};
+        use waddle_xmpp_core::mam::ArchivedMessage;
+
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, db)) = clean_store().await else {
+            return;
+        };
+        let room = room_jid("xep0425-draining-owner");
+        let entity = Entity::new(EntityType::RoomActor, room.to_string());
+        let owner = store.node_identity.current();
+        let epoch = claim_store
+            .ensure_claimed(&entity, &owner)
+            .await
+            .expect("claim room");
+        store.record_claim_epoch(&room, epoch);
+        let fence = store.current_claim_fence(&room).expect("fence");
+        let mam = SqlxMamStorage::open(db.database_url())
+            .await
+            .expect("MAM")
+            .with_cluster_fencing(true);
+        let target_id = uuid::Uuid::new_v4().to_string();
+        let target = ArchivedMessage {
+            id: target_id.clone(),
+            body: Some("moderate me".to_string()),
+            message_type: xmpp_parsers::message::MessageType::Groupchat,
+            ..ArchivedMessage::for_test(
+                format!("{room}/alice").parse().expect("occupant"),
+                jid::Jid::from(room.clone()),
+            )
+        };
+        mam.store_message_fenced(&room, &target, &fence)
+            .await
+            .expect("seed target");
+        claim_store
+            .mark_draining(&owner)
+            .await
+            .expect("mark draining");
+
+        let moderation_id = uuid::Uuid::new_v4().to_string();
+        let moderation = moderation_row(&room, &moderation_id, &target_id);
+        assert!(mam
+            .moderate_message_fenced(
+                &room,
+                &moderation,
+                &target_id,
+                moderation_tombstone(&moderation),
+                &fence,
+            )
+            .await
+            .expect("draining exact owner may finish"));
+        assert!(mam
+            .get_message(&moderation_id)
+            .await
+            .expect("read moderation")
+            .is_some());
+        assert!(mam
+            .get_message(&target_id)
+            .await
+            .expect("read target")
+            .expect("target")
+            .body
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn xep0424_and_xep0425_atomic_boundaries_reject_mismatched_typed_proofs() {
+        use waddle_xmpp::mam::{MamStorage, MamStorageError, SqlxMamStorage};
+        use waddle_xmpp_core::mam::ArchivedMessage;
+
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, db)) = clean_store().await else {
+            return;
+        };
+        let room = room_jid("xep042x-proof-binding");
+        let owner = store.node_identity.current();
+        let epoch = claim_store
+            .ensure_claimed(
+                &Entity::new(EntityType::RoomActor, room.to_string()),
+                &owner,
+            )
+            .await
+            .expect("claim room");
+        store.record_claim_epoch(&room, epoch);
+        let fence = store.current_claim_fence(&room).expect("fence");
+        let mam = SqlxMamStorage::open(db.database_url())
+            .await
+            .expect("MAM")
+            .with_cluster_fencing(true);
+        let target_id = uuid::Uuid::new_v4().to_string();
+        let target = ArchivedMessage {
+            id: target_id.clone(),
+            body: Some("must remain".to_string()),
+            message_type: xmpp_parsers::message::MessageType::Groupchat,
+            nickname_generation: Some(7),
+            ..ArchivedMessage::for_test(
+                format!("{room}/alice").parse().expect("occupant"),
+                jid::Jid::from(room.clone()),
+            )
+        };
+        mam.store_message_fenced(&room, &target, &fence)
+            .await
+            .expect("seed target");
+
+        let mismatched_retraction_id = uuid::Uuid::new_v4().to_string();
+        let mismatched_retraction = retraction_row(
+            &room,
+            &mismatched_retraction_id,
+            &uuid::Uuid::new_v4().to_string(),
+            7,
+        );
+        mam.store_message_fenced(&room, &mismatched_retraction, &fence)
+            .await
+            .expect("store mismatched retraction");
+        let from: jid::Jid = format!("{room}/alice").parse().expect("occupant");
+        assert!(!mam
+            .replace_with_tombstone_fenced(
+                &room,
+                &target_id,
+                &mismatched_retraction_id,
+                &from,
+                retraction_tombstone(&mismatched_retraction_id),
+                &fence,
+            )
+            .await
+            .expect("typed mismatch is a rejected proof"));
+
+        let reused_nick_retraction_id = uuid::Uuid::new_v4().to_string();
+        let reused_nick_retraction =
+            retraction_row(&room, &reused_nick_retraction_id, &target_id, 8);
+        mam.store_message_fenced(&room, &reused_nick_retraction, &fence)
+            .await
+            .expect("store later nickname generation");
+        assert!(!mam
+            .replace_with_tombstone_fenced(
+                &room,
+                &target_id,
+                &reused_nick_retraction_id,
+                &from,
+                retraction_tombstone(&reused_nick_retraction_id),
+                &fence,
+            )
+            .await
+            .expect("generation mismatch is a rejected proof"));
+
+        let moderation_id = uuid::Uuid::new_v4().to_string();
+        let moderation = moderation_row(&room, &moderation_id, &target_id);
+        let mut archive_id_as_wire_id = moderation_tombstone(&moderation);
+        archive_id_as_wire_id.retraction_id =
+            waddle_xmpp_core::mam::RichMessageId::new(moderation.id.clone());
+        let wrong_wire_result = mam
+            .moderate_message_fenced(
+                &room,
+                &moderation,
+                &target_id,
+                archive_id_as_wire_id,
+                &fence,
+            )
+            .await;
+        assert!(matches!(
+            wrong_wire_result,
+            Err(MamStorageError::Serialization(_))
+        ));
+        assert!(mam
+            .get_message(&moderation_id)
+            .await
+            .expect("wrong-wire moderation lookup")
+            .is_none());
+
+        let mut mismatched_tombstone = moderation_tombstone(&moderation);
+        mismatched_tombstone
+            .moderation
+            .as_mut()
+            .expect("moderation")
+            .target_id =
+            waddle_xmpp_core::mam::RichMessageId::new(uuid::Uuid::new_v4().to_string())
+                .expect("id");
+        let moderation_result = mam
+            .moderate_message_fenced(&room, &moderation, &target_id, mismatched_tombstone, &fence)
+            .await;
+        assert!(matches!(
+            moderation_result,
+            Err(MamStorageError::Serialization(_))
+        ));
+        assert!(mam
+            .get_message(&moderation_id)
+            .await
+            .expect("moderation lookup")
+            .is_none());
+        assert_eq!(
+            mam.get_message(&target_id)
+                .await
+                .expect("target lookup")
+                .expect("target")
+                .body
+                .as_deref(),
+            Some("must remain")
         );
     }
 }

--- a/server/crates/waddle-server/src/pending_delivery/database.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database.rs
@@ -135,7 +135,7 @@ fn claim_error_to_pending_storage_error(error: ClaimError, entity: Entity) -> Pe
         ClaimError::AlreadyClaimed | ClaimError::Conflict | ClaimError::Draining => {
             PendingStorageError::NotOwner { entity }
         }
-        ClaimError::Backend(_) | ClaimError::Poisoned => {
+        ClaimError::Backend(_) | ClaimError::Poisoned | ClaimError::EpochExhausted => {
             PendingStorageError::Other(error.to_string())
         }
         // Defensive only: `ensure_claimed` never actually returns this
@@ -414,7 +414,7 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
 
         let mut tx = self
             .db
-            .begin()
+            .begin_fenced()
             .await
             .map_err(|e| PendingStorageError::Other(e.to_string()))?;
 
@@ -427,8 +427,21 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         let entity_key = format!("{}:{}", EntityType::SmSession.as_db_str(), origin_stream_id);
         let mut fence_rows = tx
             .query(
-                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                crate::db_params![entity_key, identity.node_id.clone(), epoch.0],
+                "WITH locked AS MATERIALIZED ( \
+                     SELECT n.heartbeat, n.expired, n.lease_ttl_ms \
+                     FROM clustering_claims c \
+                     JOIN clustering_nodes n ON n.node_id = c.node_id AND n.node_epoch = c.node_epoch \
+                     WHERE c.entity = ? AND c.node_id = ? AND c.node_epoch = ? AND c.claim_epoch = ? \
+                     FOR SHARE OF c, n \
+                 ) \
+                 SELECT 1 FROM locked WHERE NOT expired \
+                   AND heartbeat >= clock_timestamp() - (lease_ttl_ms::text || ' milliseconds')::interval",
+                crate::db_params![
+                    entity_key,
+                    identity.node_id.clone(),
+                    identity.node_epoch.clone(),
+                    epoch.0,
+                ],
             )
             .await
             .map_err(|e| PendingStorageError::Other(e.to_string()))?;

--- a/server/crates/waddle-server/src/pending_delivery/flush.rs
+++ b/server/crates/waddle-server/src/pending_delivery/flush.rs
@@ -503,7 +503,8 @@ impl ArchiveResolver for MamArchiveResolver {
             // rest of the claimed batch) for retry instead of
             // destroying queued mail during a MAM outage.
             //
-            // `NotOwner`/`ClusterColocationMismatch` (ADR-0017 Phase 3
+            // `NotOwner`/`FencingUnavailable`/`ClusterColocationMismatch`
+            // (ADR-0017 Phase 3
             // Slice 7 FIX 1) are defensive-only here: both are only ever
             // returned by `store_message_fenced` (a write path), never by
             // this read lookup. Matched exhaustively so a future
@@ -515,6 +516,7 @@ impl ArchiveResolver for MamArchiveResolver {
             Err(
                 error @ (waddle_xmpp::mam::storage::MamStorageError::Database(_)
                 | waddle_xmpp::mam::storage::MamStorageError::NotOwner { .. }
+                | waddle_xmpp::mam::storage::MamStorageError::FencingUnavailable { .. }
                 | waddle_xmpp::mam::storage::MamStorageError::ClusterColocationMismatch {
                     ..
                 }),

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -2258,19 +2258,20 @@ async fn db_storage_postgres_handles_i32_overflow_receipt_ms() {
 }
 
 // ── ADR-0017 Phase 3 Slice 5 FIX 3 (council-adjudicated): fenced Q6
-// promotion insert — duplicate-promotion (double-janitor) prevention ──
+// promotion insert — exact node-incarnation fencing ──
 //
 // Element 9's locked text: "promotion executes under the row-locked
 // fenced epoch." This proves `insert_fenced`'s wiring end-to-end against
-// real Postgres: two nodes attempting to promote the SAME SM session's
-// unacked queue under different claim states — one holds a now-stale
-// (deposed) claim, the other holds the current one — must have exactly
-// one succeed; the deposed node's attempt aborts fenced
+// real Postgres: two epochs of the same process-stable node_id attempting to
+// promote the SAME SM session's unacked queue under one unchanged claim epoch
+// must have exactly one succeed; the pre-fence incarnation aborts fenced
 // (`PendingStorageError::NotOwner`) before writing anything.
 #[cfg(feature = "clustering")]
 #[tokio::test]
-async fn insert_fenced_prevents_duplicate_promotion_across_claim_states() {
-    use crate::clustering::claims::{clustering_control_plane_table_lock, PostgresClaimStore};
+async fn insert_fenced_rejects_old_epoch_after_same_node_id_recovery() {
+    use crate::clustering::claims::{
+        clustering_control_plane_table_lock, NodeLeaseStore, PostgresClaimStore,
+    };
     use crate::db::{Database, DatabaseConfig, DatabaseDriver, DEFAULT_CONTROL_PLANE_POOL_SIZE};
     use waddle_xmpp::ownership::{
         ClaimStore, Entity, EntityType, NodeIdentity, SharedNodeIdentity,
@@ -2307,46 +2308,38 @@ async fn insert_fenced_prevents_duplicate_promotion_across_claim_states() {
         uuid::Uuid::new_v4().to_string(),
         uuid::Uuid::new_v4().to_string(),
     );
-    let node_b = NodeIdentity::new(
-        uuid::Uuid::new_v4().to_string(),
-        uuid::Uuid::new_v4().to_string(),
-    );
+    let node_b = NodeIdentity::new(node_a.node_id.clone(), uuid::Uuid::new_v4().to_string());
 
-    // Node A originally holds the claim — the ordinary "self-claimed
-    // session" state a Q6 promotion runs under.
     schema_store
+        .register(&node_a, None)
+        .await
+        .expect("register original node incarnation");
+    // The original epoch holds the claim before this process self-fences.
+    let old_claim_epoch = schema_store
         .acquire(&entity, &node_a)
         .await
         .expect("node A acquires");
 
-    // Simulate a concurrent double-janitor: another node's own
-    // `steal_stale`/orphan-reaper sweep won this exact entity's claim out
-    // from under node A between node A's own claim and this promotion
-    // attempt (element 9's "any node may steal such claims" text) — bump
-    // the row directly to node B's identity/epoch, the same observable
-    // end state a real concurrent steal would leave, without depending on
-    // real-time interleaving for a deterministic test.
-    {
-        let conn = db.guard().await.expect("guard");
-        conn.execute(
-            "UPDATE clustering_claims SET node_id = ?, node_epoch = ?, \
-             claim_epoch = claim_epoch + 1 WHERE entity = ?",
-            crate::db_params![
-                node_b.node_id.clone(),
-                node_b.node_epoch.clone(),
-                entity_key.clone(),
-            ],
+    // Recover under the same relay-address node_id but a new fencing epoch.
+    // Keep the entity claim epoch unchanged so only node_epoch can reject the
+    // stale pending-delivery writer.
+    schema_store
+        .register_draining_with_peer_id(
+            &node_a,
+            &node_b,
+            None,
+            None,
+            std::time::Duration::from_secs(30),
         )
         .await
-        .expect("simulate concurrent steal to node B");
-    }
+        .expect("register recovered node incarnation as draining");
 
     let recipient_str = format!("dup-promo-{}@example.com", uuid::Uuid::new_v4());
     let recipient = bare(&recipient_str);
     let row_for_a = transient_row(&recipient_str, "node A's promotion attempt");
     let row_for_b = transient_row(&recipient_str, "node B's promotion attempt");
 
-    // Node A's storage: fenced against its own (now-stale/deposed) identity.
+    // The pre-fence storage still reads the old process incarnation.
     let storage_a = crate::pending_delivery::open_for_cluster_mode(
         Some(&database_url),
         QuotaPolicy::Unlimited,
@@ -2361,8 +2354,7 @@ async fn insert_fenced_prevents_duplicate_promotion_across_claim_states() {
     .await
     .expect("open node A's fenced pending_delivery storage");
 
-    // Node B's storage: fenced against the identity that actually won the
-    // claim.
+    // The recovered storage reads the new epoch under the same node_id.
     let storage_b = crate::pending_delivery::open_for_cluster_mode(
         Some(&database_url),
         QuotaPolicy::Unlimited,
@@ -2377,16 +2369,31 @@ async fn insert_fenced_prevents_duplicate_promotion_across_claim_states() {
     .await
     .expect("open node B's fenced pending_delivery storage");
 
-    // Node A's promotion aborts fenced — its own `ensure_claimed` observes
-    // a genuinely different node/epoch now on the row and refuses before
-    // any write.
+    // The old epoch aborts before writing even though both node_id and
+    // claim_epoch still match the recovered owner.
     let outcome_a = storage_a.insert_fenced(row_for_a, &stream_id).await;
     assert!(
         matches!(outcome_a, Err(PendingStorageError::NotOwner { .. })),
-        "the deposed node's promotion attempt must abort fenced (NotOwner), got {outcome_a:?}"
+        "the old node epoch must abort fenced (NotOwner), got {outcome_a:?}"
     );
 
-    // Node B's promotion succeeds — it is the current, genuine owner.
+    let recovered_epoch = schema_store
+        .reclaim_after_self_fence(
+            &entity,
+            old_claim_epoch,
+            &node_a,
+            &node_b,
+            std::time::Duration::from_secs(30),
+        )
+        .await
+        .expect("reclaim old exact grant into draining recovery candidate");
+    assert_ne!(recovered_epoch, old_claim_epoch);
+    assert!(schema_store
+        .activate(&node_b, std::time::Duration::from_secs(30))
+        .await
+        .expect("activate recovered node"));
+
+    // The recovered epoch succeeds under the exact same node_id.
     let outcome_b = storage_b
         .insert_fenced(row_for_b, &stream_id)
         .await
@@ -2411,6 +2418,46 @@ async fn insert_fenced_prevents_duplicate_promotion_across_claim_states() {
         Some("node B's promotion attempt"),
         "the landed row must be the current owner's, never the deposed node's"
     );
+
+    db.guard()
+        .await
+        .expect("guard")
+        .execute(
+            "UPDATE clustering_nodes SET heartbeat = clock_timestamp(), lease_ttl_ms = 50 WHERE node_id = ? AND node_epoch = ?",
+            crate::db_params![node_b.node_id.clone(), node_b.node_epoch.clone()],
+        )
+        .await
+        .expect("install short lease");
+    let mut blocker = db.begin().await.expect("begin node blocker");
+    let mut lock_rows = blocker
+        .query(
+            "SELECT 1 FROM clustering_nodes WHERE node_id = ? AND node_epoch = ? FOR UPDATE",
+            crate::db_params![node_b.node_id.clone(), node_b.node_epoch.clone()],
+        )
+        .await
+        .expect("lock destination node");
+    assert!(lock_rows.next().await.expect("read lock row").is_some());
+    drop(lock_rows);
+    let delayed_storage = storage_b.clone();
+    let delayed_stream = stream_id.clone();
+    let delayed_row = transient_row(&recipient_str, "post-TTL promotion must not land");
+    let delayed = tokio::spawn(async move {
+        delayed_storage
+            .insert_fenced(delayed_row, &delayed_stream)
+            .await
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    assert!(
+        !delayed.is_finished(),
+        "pending insert must wait on the held node row"
+    );
+    tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+    blocker.commit().await.expect("release node blocker");
+    assert!(matches!(
+        delayed.await.expect("join delayed insert"),
+        Err(PendingStorageError::NotOwner { .. })
+    ));
+    assert_eq!(storage_b.list(&recipient).await.expect("list").len(), 1);
 
     // Cleanup — scoped to this test's own unique stream id/recipient, never
     // a global cutoff (see the i32-overflow test above for why).

--- a/server/crates/waddle-server/src/server/extension_host_adapter.rs
+++ b/server/crates/waddle-server/src/server/extension_host_adapter.rs
@@ -121,7 +121,7 @@ impl ExtensionHostAdapter {
                 let room_sender = self.plugin_actor_jid(&invocation.plugin_id)?;
                 let result = interpret::dispatch_extension_bot_groupchat_response(
                     &deps,
-                    room,
+                    room.clone(),
                     room_sender,
                     response,
                 )
@@ -131,6 +131,9 @@ impl ExtensionHostAdapter {
                     return Err(ExtensionHostAdapterError::Protocol(
                         "bot groupchat dispatch requested transport close".to_string(),
                     ));
+                }
+                if result.outcome.room_ownership_uncertain {
+                    return Err(ExtensionHostAdapterError::RoomOwnershipUncertain(room));
                 }
                 Ok(result.stanza_id)
             }
@@ -265,6 +268,25 @@ impl ExtensionHostAdapter {
             inbox_storage: Some(&self.state.deps.protocol.inbox_storage),
             extension_manager: Some(&self.state.deps.protocol.extension_manager),
             room_registry: Some(&self.state.deps.protocol.room_registry),
+            room_actor_incarnation: None,
+            #[cfg(feature = "clustering")]
+            muc_durable_store: self
+                .state
+                .deps
+                .app_state
+                .clustering_claims
+                .muc_durable_store
+                .as_ref(),
+            #[cfg(feature = "clustering")]
+            clustered_muc_ownership_required: self
+                .state
+                .deps
+                .app_state
+                .clustering_claims
+                .claim_store
+                .is_some(),
+            #[cfg(feature = "clustering")]
+            room_claim_fence: None,
             web_socket_state: Some(&self.state),
             authenticated_session: session,
             local_domain: self.state.deps.auth_state.xmpp_domain.as_str(),

--- a/server/crates/waddle-server/src/server/extension_host_adapter/conversions.rs
+++ b/server/crates/waddle-server/src/server/extension_host_adapter/conversions.rs
@@ -18,6 +18,7 @@ pub(super) fn host_tool_error(error: ExtensionHostAdapterError) -> ext_host::Hos
         ExtensionHostAdapterError::RoomNotFound(_) => ext_host::HostToolErrorCode::NotFound,
         ExtensionHostAdapterError::Unsupported(_) => ext_host::HostToolErrorCode::Unsupported,
         ExtensionHostAdapterError::RoomActor(_)
+        | ExtensionHostAdapterError::RoomOwnershipUncertain(_)
         | ExtensionHostAdapterError::Storage(_)
         | ExtensionHostAdapterError::Protocol(_) => ext_host::HostToolErrorCode::TemporaryFailure,
     };

--- a/server/crates/waddle-server/src/server/extension_host_adapter/types.rs
+++ b/server/crates/waddle-server/src/server/extension_host_adapter/types.rs
@@ -116,6 +116,8 @@ pub enum ExtensionHostAdapterError {
     RoomNotFound(BareJid),
     #[error("room actor failed: {0}")]
     RoomActor(String),
+    #[error("room ownership cannot currently be verified: {0}")]
+    RoomOwnershipUncertain(BareJid),
     #[error("storage failed: {0}")]
     Storage(String),
     #[error("protocol failed: {0}")]

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -463,6 +463,13 @@ async fn create_websocket_state(
     if let Some(user_local_claims) = &state.clustering_claims.user_local_claims {
         user_local_claims.wire(user_registry.clone());
         user_local_claims.wire_connection_registry(Arc::clone(&connection_registry));
+        if let Some(bridge) = state
+            .clustering_claims
+            .ordered_relay_delivery_bridge
+            .as_ref()
+        {
+            user_local_claims.wire_remote_resource_bridge(Arc::clone(bridge));
+        }
     }
 
     // Read the MUC room registry and PubSub storage off the shared
@@ -768,10 +775,14 @@ async fn create_websocket_state(
         &state.clustering_claims.ordered_relay_delivery_bridge,
         state.clustering_claims.claim_pair(),
     ) {
-        if let Some(node_lease) = &state.clustering_claims.node_lease {
+        if let (Some(node_lease), Some(remote_resource_admission_store)) = (
+            &state.clustering_claims.node_lease,
+            &state.clustering_claims.remote_resource_admission_store,
+        ) {
             bridge.wire(Arc::new(
                 crate::clustering::route_bridge::OrderedRelayDeliveryServices {
                     claim_store,
+                    remote_resource_admission_store: Arc::clone(remote_resource_admission_store),
                     allowlist_store: Arc::new(
                         crate::clustering::allowlist::PostgresAllowlistStore::new(
                             state.db_pool.global().clone(),
@@ -791,7 +802,9 @@ async fn create_websocket_state(
                 },
             ));
         } else {
-            warn!("ordered relay delivery bridge not wired: clustering node lease handle missing");
+            warn!(
+                "ordered relay delivery bridge not wired: clustering control-plane handle missing"
+            );
         }
     }
     deferred_extension_host_tools.set(Arc::new(extension_host_adapter::ExtensionHostAdapter::new(

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -100,18 +100,20 @@ use waddle_xmpp::mam::{
     ArchivedReply, ArchivedRetraction, ArchivedRichMessage, ArchivedRichPayload, ArchivedTombstone,
     RichMessageId, RichText, STANZA_ID_NS,
 };
+#[cfg(feature = "clustering")]
+use waddle_xmpp::muc::room_actor::GetRoomClaimFence;
 use waddle_xmpp::muc::room_actor::{
     ApplyPin, GetAffiliation, GetNicknameGeneration, GetRoomSnapshot, JoinAffiliationGrant,
     JoinWithAffiliation, RoomActor, SetSubject,
 };
-// ADR-0017 Phase 3 Slice 7: `DestroyRoom` is used by `dispatch_to_room`'s
+// ADR-0017 Phase 3 Slice 7: exact destroy is used by the fenced room paths'
 // fenced pre-fan-out backstop, which only exists on `clustering`-feature
 // builds (the check itself is a no-op — `ClusteringHandles::
 // muc_durable_store` is `None` — whenever clustering is disabled, but the
 // import must still be feature-gated to avoid an unused-import warning on
 // a build that lacks the `clustering` feature entirely).
 #[cfg(feature = "clustering")]
-use waddle_xmpp::muc::room_registry_actor::DestroyRoom;
+use waddle_xmpp::muc::room_registry_actor::DestroyRoomExact;
 use waddle_xmpp::muc::room_registry_actor::{GetRoom, RoomRegistryActor};
 use waddle_xmpp::parse_managed_room_jid;
 use waddle_xmpp::parser::{message_to_string, stanza_to_string};
@@ -164,13 +166,16 @@ mod handoff;
 mod notification_activity_ingest;
 mod offline_delivery;
 mod room_dispatch;
+mod room_effect_authority;
 mod room_pin;
 mod room_subject;
 mod room_system_message;
 mod route_to_connection;
 mod routing;
 
-use archive_groupchat_event::{archive_groupchat_event, ArchiveGroupchatEventOutcome};
+use archive_groupchat_event::{
+    archive_groupchat_event, exact_room_effect_authorized, ArchiveGroupchatEventOutcome,
+};
 use archive_lookup::{
     build_carbon_envelope, lookup_archived_message, waddle_id_for_room_jid, ToElementString,
 };
@@ -184,7 +189,7 @@ use direct_retraction::apply_retraction_tombstone;
 use displayed_marker::mark_inbox_read_from_displayed;
 use groupchat_archive::{
     apply_groupchat_retraction_tombstone, archive_groupchat_message, project_groupchat_inbox,
-    resolve_room_claim_fence, ArchiveGroupchatOutcome,
+    resolve_room_claim_fence, scrub_unacked_for_tombstone, ArchiveGroupchatOutcome,
 };
 pub(crate) use groupchat_inbox::reconcile_groupchat_notification_candidates;
 use groupchat_inbox::{project_groupchat_inbox_event, ProjectGroupchatInboxEvent};
@@ -200,8 +205,9 @@ pub use handoff::{
 use offline_delivery::queue_offline_delivery;
 pub(crate) use offline_delivery::reconcile_xep0357_notification_candidates;
 use room_dispatch::dispatch_to_room;
-use room_pin::apply_pin_change_event;
-use room_subject::persist_room_subject_event;
+use room_effect_authority::{exact_room_actor_for_effect, RoomEffectAuthorityError};
+use room_pin::{apply_pin_change_event, PinChangeOutcome};
+use room_subject::{persist_room_subject_event, PersistRoomSubjectOutcome};
 pub(crate) use route_to_connection::{fallback_reply_for_undeliverable_iq, route_to_connection};
 pub(crate) use routing::{deliver_direct_to_full, deliver_peer_to_full, FullJidDeliveryOutcome};
 use routing::{run_fanout_recipient_pass, run_headless_recipient_pass, FanoutPassResult};
@@ -380,10 +386,15 @@ async fn interpret_with_depth(
     // per-occupant `RouteToConnection` fan-out for the same message, which
     // always follows the archive handler in the locked Q7 chain order) is
     // suppressed — "the message is NOT archived and NOT fanned out."
-    let mut ownership_lost = false;
+    let mut ownership_uncertain = false;
+    // A successful exact DB-backed check immediately before the room
+    // projection/fan-out tail. Later per-recipient routes still compare the
+    // registry's actor ref so same-claim E1/E2 replacement cannot inherit
+    // the old batch without paying a Postgres round trip per occupant.
+    let mut room_fanout_authorized = false;
 
     for mut event in events {
-        if ownership_lost {
+        if ownership_uncertain {
             continue;
         }
         apply_archive_id_rewrites(&mut event, &archive_id_rewrites);
@@ -422,6 +433,32 @@ async fn interpret_with_depth(
             // content into logs.
             // -------------------------------------------------------
             OutboundEvent::RouteToConnection { jid, stanza } => {
+                let nested_room = if deps.room_actor_incarnation.is_some() {
+                    match stanza.as_ref() {
+                        Stanza::Message(message) => message.from.as_ref().map(Jid::to_bare),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+                if deps.room_actor_incarnation.is_some() {
+                    let Some(room) = nested_room.as_ref() else {
+                        ownership_uncertain = true;
+                        outcome.room_ownership_uncertain = true;
+                        continue;
+                    };
+                    let authorized = if room_fanout_authorized {
+                        exact_room_actor_for_effect(deps, room).await.is_ok()
+                    } else {
+                        exact_room_effect_authorized(deps, room).await
+                    };
+                    if !authorized {
+                        ownership_uncertain = true;
+                        outcome.room_ownership_uncertain = true;
+                        continue;
+                    }
+                    room_fanout_authorized = true;
+                }
                 for stanza in route_to_connection(deps, jid, stanza, recursion_depth).await {
                     match stanza.to_element_string() {
                         Ok(xml) => outcome.frames.push(xml),
@@ -431,6 +468,12 @@ async fn interpret_with_depth(
                                 "failed to serialize route fallback stanza; dropping frame"
                             );
                         }
+                    }
+                }
+                if let Some(room) = nested_room.as_ref() {
+                    if exact_room_actor_for_effect(deps, room).await.is_err() {
+                        ownership_uncertain = true;
+                        outcome.room_ownership_uncertain = true;
                     }
                 }
             }
@@ -455,6 +498,7 @@ async fn interpret_with_depth(
                     keepalive_probes: nested_probes,
                     timer_commands: nested_timer_commands,
                     archive_id_rewrites: nested_rewrites,
+                    room_ownership_uncertain: nested_ownership_uncertain,
                 } = nested;
                 outcome.frames.extend(nested_frames);
                 if nested_close {
@@ -466,6 +510,9 @@ async fn interpret_with_depth(
                 // Carry nested rewrites forward so later events in THIS
                 // batch see them too.
                 archive_id_rewrites.extend(nested_rewrites);
+                if nested_ownership_uncertain {
+                    ownership_uncertain = true;
+                }
             }
             OutboundEvent::ProjectInbox {
                 owner,
@@ -552,9 +599,12 @@ async fn interpret_with_depth(
                 {
                     ArchiveGroupchatEventOutcome::Rewrite(Some(rewrite)) => {
                         archive_id_rewrites.push(rewrite);
+                        room_fanout_authorized = true;
                     }
-                    ArchiveGroupchatEventOutcome::Rewrite(None) => {}
-                    ArchiveGroupchatEventOutcome::OwnershipLost(bounce) => {
+                    ArchiveGroupchatEventOutcome::Rewrite(None) => {
+                        room_fanout_authorized = true;
+                    }
+                    ArchiveGroupchatEventOutcome::OwnershipUncertain(bounce) => {
                         // FIX 1: not archived, not fanned out — suppress
                         // every remaining event in this batch (the
                         // reflector's fan-out for this same message) and
@@ -570,66 +620,180 @@ async fn interpret_with_depth(
                                 );
                             }
                         }
-                        ownership_lost = true;
+                        ownership_uncertain = true;
+                        outcome.room_ownership_uncertain = true;
                     }
                 }
             }
             OutboundEvent::ApplyPinChange { room, request } => {
-                apply_pin_change_event(deps, room, request, recursion_depth).await;
+                let pin_outcome =
+                    apply_pin_change_event(deps, room.clone(), request, recursion_depth).await;
+                if pin_outcome != PinChangeOutcome::Applied {
+                    // The retained-incarnation gate already exact-demotes E1
+                    // on `NotOwner`. A room-key demotion here could kill a
+                    // replacement E2.
+                    ownership_uncertain = true;
+                    outcome.room_ownership_uncertain = true;
+                }
             }
             OutboundEvent::ApplyGroupchatRetractionTombstone {
                 room,
                 target_message_id,
                 retraction_message,
             } => {
+                if !exact_room_effect_authorized(deps, &room).await {
+                    ownership_uncertain = true;
+                    outcome.room_ownership_uncertain = true;
+                    continue;
+                }
                 let Some(mam_storage) = deps.mam_storage else {
                     debug!(
                         room = %room,
                         target = %target_message_id,
                         "ApplyGroupchatRetractionTombstone: no mam_storage in Deps; skipping"
                     );
+                    ownership_uncertain = true;
+                    outcome.room_ownership_uncertain = true;
                     continue;
                 };
-                let tombstoned = apply_groupchat_retraction_tombstone(
+                let fence = resolve_room_claim_fence(deps, &room);
+                let tombstone_outcome = apply_groupchat_retraction_tombstone(
                     mam_storage,
-                    deps.sm_session_registry,
-                    deps.pending_delivery_storage,
                     &room,
                     &target_message_id,
                     &retraction_message,
+                    &fence,
                 )
                 .await;
-                if tombstoned {
-                    if let Some(state) = deps.web_socket_state {
-                        crate::server::routes::websocket::link_preview_refs::clear_current_message_preview_refs(
-                            state.deps.app_state.db_pool.global_actor(),
-                            &room,
-                            &target_message_id,
-                        )
-                        .await;
-                    }
+                if tombstone_outcome
+                    != groupchat_archive::GroupchatRetractionTombstoneOutcome::Applied
+                {
+                    // Re-resolve through the exact actor helper so a retained
+                    // E1 is killed without ever applying a room-key demotion
+                    // to a replacement E2.
+                    let _ = exact_room_effect_authorized(deps, &room).await;
+                    warn!(
+                        room = %room,
+                        target = %target_message_id,
+                        ?tombstone_outcome,
+                        "groupchat retraction did not commit; suppressing remaining effects"
+                    );
+                    ownership_uncertain = true;
+                    outcome.room_ownership_uncertain = true;
+                    continue;
+                }
+                if !exact_room_effect_authorized(deps, &room).await {
+                    ownership_uncertain = true;
+                    outcome.room_ownership_uncertain = true;
+                    continue;
+                }
+                let scrub_target = waddle_xmpp::tombstone::TombstoneTarget::Groupchat {
+                    stanza_id: target_message_id.clone(),
+                    room: room.clone(),
+                };
+                scrub_unacked_for_tombstone(
+                    deps.sm_session_registry,
+                    deps.pending_delivery_storage,
+                    &scrub_target,
+                    "ApplyGroupchatRetractionTombstone",
+                )
+                .await;
+                if !exact_room_effect_authorized(deps, &room).await {
+                    ownership_uncertain = true;
+                    outcome.room_ownership_uncertain = true;
+                    continue;
+                }
+                if let Some(state) = deps.web_socket_state {
+                    crate::server::routes::websocket::link_preview_refs::clear_current_message_preview_refs(
+                        state.deps.app_state.db_pool.global_actor(),
+                        &room,
+                        &target_message_id,
+                    )
+                    .await;
+                }
+                if !exact_room_effect_authorized(deps, &room).await {
+                    ownership_uncertain = true;
+                    outcome.room_ownership_uncertain = true;
+                    continue;
                 }
                 // #414: cascade XEP-0424 retraction to the room's pin
                 // list. If the retracted stanza-id is currently pinned,
                 // remove it from the projection and broadcast a
                 // synthetic unpin system message so live clients see the
                 // tab update without a separate poll.
-                room_pin::cascade_retraction_to_pin_list(
+                let pin_outcome = room_pin::cascade_retraction_to_pin_list(
                     deps,
-                    room,
-                    target_message_id,
+                    room.clone(),
+                    target_message_id.clone(),
                     recursion_depth,
                 )
                 .await;
+                if matches!(
+                    pin_outcome,
+                    PinChangeOutcome::NotOwner
+                        | PinChangeOutcome::OwnershipUncertain
+                        | PinChangeOutcome::PersistFailed
+                ) {
+                    // The cascade shares the batch's retained incarnation and
+                    // exact-demotes it on `NotOwner`; never demote by room JID.
+                    ownership_uncertain = true;
+                    outcome.room_ownership_uncertain = true;
+                }
+                if !exact_room_effect_authorized(deps, &room).await {
+                    ownership_uncertain = true;
+                    outcome.room_ownership_uncertain = true;
+                } else {
+                    room_fanout_authorized = true;
+                }
             }
             OutboundEvent::PersistRoomSubject {
                 room,
                 texts,
                 setter,
                 setter_nick,
+                sender_full,
+                message,
                 set_at,
             } => {
-                persist_room_subject_event(deps, room, texts, setter, setter_nick, set_at).await;
+                let persist_outcome = persist_room_subject_event(
+                    deps,
+                    room.clone(),
+                    texts,
+                    setter,
+                    setter_nick,
+                    set_at,
+                )
+                .await;
+                if persist_outcome != PersistRoomSubjectOutcome::Applied {
+                    // Subject persistence is bound to the retained actor and
+                    // exact-demotes E1 itself. A JID-only demotion can race
+                    // with recreation and destroy E2.
+                    let stanza_error = match persist_outcome {
+                        PersistRoomSubjectOutcome::PersistFailed => StanzaError::new(
+                            ErrorType::Wait,
+                            DefinedCondition::InternalServerError,
+                            "en",
+                            "The subject could not be persisted; please retry.",
+                        ),
+                        PersistRoomSubjectOutcome::NotOwner
+                        | PersistRoomSubjectOutcome::OwnershipUncertain => {
+                            resource_constraint_error(
+                                "This room's ownership cannot currently be verified; please retry.",
+                            )
+                        }
+                        PersistRoomSubjectOutcome::Applied => unreachable!(),
+                    };
+                    let bounce =
+                        build_message_error_reply(&message, &room, &sender_full, stanza_error);
+                    match Stanza::Message(bounce).to_element_string() {
+                        Ok(xml) => outcome.frames.push(xml),
+                        Err(error) => {
+                            warn!(%error, "PersistRoomSubject: failed to serialize retryable error")
+                        }
+                    }
+                    ownership_uncertain = true;
+                    outcome.room_ownership_uncertain = true;
+                }
             }
             OutboundEvent::ProjectGroupchatInbox {
                 owner,
@@ -643,10 +807,15 @@ async fn interpret_with_depth(
                 thread,
                 dispatch_timestamp,
             } => {
+                if !exact_room_effect_authorized(deps, &room).await {
+                    ownership_uncertain = true;
+                    outcome.room_ownership_uncertain = true;
+                    continue;
+                }
                 project_groupchat_inbox_event(ProjectGroupchatInboxEvent {
                     deps,
                     owner,
-                    room,
+                    room: room.clone(),
                     message,
                     is_recipient,
                     is_durable_recipient,
@@ -657,6 +826,12 @@ async fn interpret_with_depth(
                     dispatch_timestamp,
                 })
                 .await;
+                if !exact_room_effect_authorized(deps, &room).await {
+                    ownership_uncertain = true;
+                    outcome.room_ownership_uncertain = true;
+                } else {
+                    room_fanout_authorized = true;
+                }
             }
             OutboundEvent::ArchiveDirect {
                 archive_jid,
@@ -737,6 +912,7 @@ async fn interpret_with_depth(
     }
 
     outcome.archive_id_rewrites = archive_id_rewrites;
+    outcome.room_ownership_uncertain |= ownership_uncertain;
     outcome
 }
 

--- a/server/crates/waddle-server/src/server/routes/interpret/archive_groupchat_event.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/archive_groupchat_event.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 /// Outcome of the [`OutboundEvent::ArchiveGroupchat`] interpreter arm
-/// (ADR-0017 Phase 3 Slice 7 FIX 1, council-adjudicated). `OwnershipLost`
+/// (ADR-0017 Phase 3 Slice 7 FIX 1, council-adjudicated). `OwnershipUncertain`
 /// carries the pre-built bounce reply the caller pushes to `outcome.frames`
 /// AND uses as the signal to suppress every remaining event in this same
 /// dispatch batch (the archive handler always runs before the reflector
@@ -9,7 +9,67 @@ use super::*;
 /// any `RouteToConnection` fan-out for the same message).
 pub(super) enum ArchiveGroupchatEventOutcome {
     Rewrite(Option<ArchiveIdRewrite>),
-    OwnershipLost(Box<Message>),
+    OwnershipUncertain(Box<Message>),
+}
+
+/// Prove that a nested room batch still belongs to the exact actor
+/// incarnation that produced it and that actor's immutable claim is live.
+/// The actor-ref comparison closes same-claim E1/E2 replacement; the actor's
+/// mutation gate closes ordinary claim/node-lease loss.
+pub(super) async fn exact_room_effect_authorized(deps: &Deps<'_>, room: &BareJid) -> bool {
+    #[cfg(feature = "clustering")]
+    let actor_bound = deps.room_actor_incarnation.is_some()
+        || deps.clustered_muc_ownership_required
+        || deps.muc_durable_store.is_some();
+    #[cfg(not(feature = "clustering"))]
+    let actor_bound = deps.room_actor_incarnation.is_some();
+    if !actor_bound {
+        // Portable direct interpreter fixtures and genuinely single-node
+        // server-authored events have no clustered actor incarnation to
+        // protect. Nested room dispatch always supplies one.
+        return true;
+    }
+    let actor = match exact_room_actor_for_effect(deps, room).await {
+        Ok(actor) => actor,
+        Err(_) => return false,
+    };
+    let checked = actor
+        .ask(waddle_xmpp::muc::room_actor::CheckMutationOwnership)
+        .await;
+    match checked {
+        Ok(()) => true,
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+        )) => {
+            if let Some(registry) = deps.room_registry {
+                let _ = registry
+                    .ask(waddle_xmpp::muc::room_registry_actor::DestroyRoomExact {
+                        room_jid: room.clone(),
+                        expected_actor: actor.clone(),
+                    })
+                    .await;
+            }
+            actor.kill();
+            false
+        }
+        Err(_) => false,
+    }
+}
+
+fn ownership_uncertain_bounce(
+    room: &BareJid,
+    sender: &FullJid,
+    message: &Message,
+) -> ArchiveGroupchatEventOutcome {
+    let bounce = build_message_error_reply(
+        message,
+        room,
+        sender,
+        resource_constraint_error(
+            "This room's ownership cannot currently be verified; please retry.",
+        ),
+    );
+    ArchiveGroupchatEventOutcome::OwnershipUncertain(Box::new(bounce))
 }
 
 pub(super) async fn archive_groupchat_event(
@@ -20,7 +80,20 @@ pub(super) async fn archive_groupchat_event(
     sender_nickname_generation: u64,
     sender_item: Option<waddle_xmpp_core::mam::ArchivedMucSender>,
 ) -> ArchiveGroupchatEventOutcome {
+    if !exact_room_effect_authorized(deps, &room).await {
+        return ownership_uncertain_bounce(&room, &sender, &message);
+    }
+    // Resolve clustered ownership before the optional archive backend. A
+    // missing MAM fixture is a benign archive-policy skip only when MUC
+    // ownership itself is not uncertain.
+    let fence = resolve_room_claim_fence(deps, &room);
+    if fence.is_ownership_uncertain() {
+        return ownership_uncertain_bounce(&room, &sender, &message);
+    }
     let Some(mam_storage) = deps.mam_storage else {
+        if fence.is_fenced() {
+            return ownership_uncertain_bounce(&room, &sender, &message);
+        }
         debug!(
             room = %room,
             sender = %sender,
@@ -42,37 +115,40 @@ pub(super) async fn archive_groupchat_event(
     // ADR-0017 Phase 3 Slice 7 FIX 1: resolve the SAME typed fencing
     // context `dispatch_to_room`'s own pre-fan-out check reads, so the
     // fenced archive write below agrees with it by construction.
-    let fence = resolve_room_claim_fence(deps, &room);
     let archive_id = match archive_groupchat_message(
         mam_storage,
         &room,
         &message,
         sender_nickname_generation,
-        fence.as_ref(),
+        &fence,
         sender_item.as_ref(),
     )
     .await
     {
         ArchiveGroupchatOutcome::Stored(result) => result,
-        ArchiveGroupchatOutcome::Skipped => return ArchiveGroupchatEventOutcome::Rewrite(None),
-        ArchiveGroupchatOutcome::OwnershipLost => {
-            let bounce = build_message_error_reply(
-                &message,
-                &room,
-                &sender,
-                resource_constraint_error(
-                    "This room's ownership recently moved to another node; please retry.",
-                ),
-            );
-            return ArchiveGroupchatEventOutcome::OwnershipLost(Box::new(bounce));
+        ArchiveGroupchatOutcome::Skipped => {
+            return if exact_room_effect_authorized(deps, &room).await {
+                ArchiveGroupchatEventOutcome::Rewrite(None)
+            } else {
+                ownership_uncertain_bounce(&room, &sender, &message)
+            };
+        }
+        ArchiveGroupchatOutcome::OwnershipUncertain => {
+            return ownership_uncertain_bounce(&room, &sender, &message);
         }
     };
+    if !exact_room_effect_authorized(deps, &room).await {
+        return ownership_uncertain_bounce(&room, &sender, &message);
+    }
     debug!(
         room = %room,
         archive_id = %archive_id.stored_id,
         "ArchiveGroupchat: persisted"
     );
     update_groupchat_link_preview_refs(deps, &room, &archive_id.stored_id, &message).await;
+    if !exact_room_effect_authorized(deps, &room).await {
+        return ownership_uncertain_bounce(&room, &sender, &message);
+    }
     // Notification activity ingest (slice 2b): committing the sender's
     // groupchat message into the room archive is the strongest
     // "currently active" signal we have for `(sender, room)`. Unlike
@@ -86,7 +162,11 @@ pub(super) async fn archive_groupchat_event(
         &message,
     )
     .await;
-    ArchiveGroupchatEventOutcome::Rewrite(archive_id.rewrite)
+    if exact_room_effect_authorized(deps, &room).await {
+        ArchiveGroupchatEventOutcome::Rewrite(archive_id.rewrite)
+    } else {
+        ownership_uncertain_bounce(&room, &sender, &message)
+    }
 }
 
 async fn update_groupchat_link_preview_refs(

--- a/server/crates/waddle-server/src/server/routes/interpret/bot.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/bot.rs
@@ -135,6 +135,12 @@ pub(super) async fn dispatch_bot_groupchat_response(
     outcome.frames.extend(nested.frames);
     outcome.close = nested.close;
     outcome.feedback.extend(nested.feedback);
+    outcome.keepalive_probes += nested.keepalive_probes;
+    outcome.timer_commands.extend(nested.timer_commands);
+    outcome
+        .archive_id_rewrites
+        .extend(nested.archive_id_rewrites);
+    outcome.room_ownership_uncertain |= nested.room_ownership_uncertain;
     Ok(ExtensionRoomDispatchResult { outcome, stanza_id })
 }
 
@@ -412,6 +418,12 @@ pub(crate) async fn dispatch_extension_bot_groupchat_response(
     outcome.frames.extend(nested.outcome.frames);
     outcome.close = outcome.close || nested.outcome.close;
     outcome.feedback.extend(nested.outcome.feedback);
+    outcome.keepalive_probes += nested.outcome.keepalive_probes;
+    outcome.timer_commands.extend(nested.outcome.timer_commands);
+    outcome
+        .archive_id_rewrites
+        .extend(nested.outcome.archive_id_rewrites);
+    outcome.room_ownership_uncertain |= nested.outcome.room_ownership_uncertain;
     Ok(ExtensionRoomDispatchResult {
         outcome,
         stanza_id: nested.stanza_id,

--- a/server/crates/waddle-server/src/server/routes/interpret/deps.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/deps.rs
@@ -63,6 +63,11 @@ pub struct InterpretOutcome {
     /// wire stanza it extracts BEFORE interpreting, so live/MAM id
     /// parity holds under origin-id retries.
     pub(super) archive_id_rewrites: Vec<ArchiveIdRewrite>,
+    /// A clustered MUC effect could not prove the exact current room
+    /// ownership fence. Nested interpreters propagate this bit so callers
+    /// can suppress post-dispatch observers and later enclosing effects
+    /// while retaining the retryable bounce frame.
+    pub(crate) room_ownership_uncertain: bool,
 }
 
 /// Typed timer instruction relayed from the state machine to the
@@ -121,6 +126,27 @@ pub struct Deps<'a> {
     /// actor and ask it for a frozen
     /// [`waddle_xmpp::muc::room_actor::RoomChainSnapshot`].
     pub room_registry: Option<&'a ActorRef<RoomRegistryActor>>,
+    /// Exact `RoomActor` incarnation whose frozen snapshot authorized the
+    /// current nested room-event batch. Room mutations after async work must
+    /// compare the registry's current actor with this ref immediately before
+    /// applying the effect, so retained E1 authority never transfers to E2.
+    pub room_actor_incarnation: Option<ActorRef<waddle_xmpp::muc::room_actor::RoomActor>>,
+    /// Explicit clustered MUC ownership boundary. Keeping this separate
+    /// from `web_socket_state` prevents a missing transport context from
+    /// being mistaken for single-node operation. `None` means clustered
+    /// durable MUC ownership is genuinely not configured.
+    #[cfg(feature = "clustering")]
+    pub muc_durable_store: Option<&'a Arc<dyn waddle_xmpp::muc::MucDurableStore>>,
+    /// True when the clustering claim plane is active. The pair
+    /// `(true, None)` is an unavailable ownership proof and fails closed;
+    /// only `(false, None)` selects portable single-node behavior.
+    #[cfg(feature = "clustering")]
+    pub clustered_muc_ownership_required: bool,
+    /// Exact immutable claim carried by the `RoomActor` whose snapshot is
+    /// being interpreted. Nested room effects must use this rather than a
+    /// newer room-scoped cache entry.
+    #[cfg(feature = "clustering")]
+    pub room_claim_fence: Option<waddle_xmpp::muc::RoomClaimFenceContext>,
     /// WebSocket route state. Used by the
     /// [`OutboundEvent::DispatchToRoom`] arm for the managed-room
     /// owner check (announcements room) and by
@@ -188,6 +214,13 @@ impl<'a> Deps<'a> {
             inbox_storage: None,
             extension_manager: None,
             room_registry: None,
+            room_actor_incarnation: None,
+            #[cfg(feature = "clustering")]
+            muc_durable_store: None,
+            #[cfg(feature = "clustering")]
+            clustered_muc_ownership_required: false,
+            #[cfg(feature = "clustering")]
+            room_claim_fence: None,
             web_socket_state: None,
             authenticated_session: None,
             local_domain: "example.com",
@@ -217,6 +250,13 @@ impl<'a> Deps<'a> {
             inbox_storage: None,
             extension_manager: None,
             room_registry: None,
+            room_actor_incarnation: None,
+            #[cfg(feature = "clustering")]
+            muc_durable_store: None,
+            #[cfg(feature = "clustering")]
+            clustered_muc_ownership_required: false,
+            #[cfg(feature = "clustering")]
+            room_claim_fence: None,
             web_socket_state: None,
             authenticated_session: None,
             local_domain: "example.com",
@@ -244,6 +284,13 @@ impl<'a> Deps<'a> {
             inbox_storage: Some(inbox_storage),
             extension_manager: None,
             room_registry: None,
+            room_actor_incarnation: None,
+            #[cfg(feature = "clustering")]
+            muc_durable_store: None,
+            #[cfg(feature = "clustering")]
+            clustered_muc_ownership_required: false,
+            #[cfg(feature = "clustering")]
+            room_claim_fence: None,
             web_socket_state: None,
             authenticated_session: None,
             local_domain: "example.com",
@@ -269,6 +316,13 @@ impl<'a> Deps<'a> {
             inbox_storage: None,
             extension_manager: Some(extension_manager),
             room_registry: None,
+            room_actor_incarnation: None,
+            #[cfg(feature = "clustering")]
+            muc_durable_store: None,
+            #[cfg(feature = "clustering")]
+            clustered_muc_ownership_required: false,
+            #[cfg(feature = "clustering")]
+            room_claim_fence: None,
             web_socket_state: None,
             authenticated_session: None,
             local_domain: "example.com",

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -1,54 +1,104 @@
 use super::*;
 use waddle_xmpp::mam::MamStorageError;
+#[cfg(any(feature = "clustering", test))]
 use waddle_xmpp::muc::RoomClaimFenceContext;
 
 /// Outcome of a groupchat archive write attempt (ADR-0017 Phase 3 Slice 7
-/// FIX 1, council-adjudicated). `OwnershipLost` is the fenced backstop
-/// firing: the caller MUST neither treat the message as archived NOR fan
-/// it out to occupants — mirroring `dispatch_to_room`'s own
-/// `check_fenced_fanout` `Ok(false)` handling one layer closer to the
-/// actual write.
+/// FIX 1, council-adjudicated). `OwnershipUncertain` means the fenced
+/// backstop either disproved ownership or could not prove it. The caller
+/// MUST neither treat the message as archived NOR fan it out to occupants.
 pub(super) enum ArchiveGroupchatOutcome {
     Stored(ArchiveStoreResult),
     /// Not an error: a chain-bug guard or a non-fencing storage failure
     /// declined the write. The reflection still goes out (today's
     /// pre-existing behavior, unchanged).
     Skipped,
-    /// The fenced write observed that this node no longer holds the
-    /// room's ownership claim. The message was NOT archived; the caller
-    /// must also suppress fan-out and bounce the sender.
-    OwnershipLost,
+    /// Exact ownership could not be proved. This covers a definitive claim
+    /// mismatch, a missing cached claim fence, and a backend failure while
+    /// checking or applying a fenced write. The message was NOT archived;
+    /// the caller must also suppress fan-out and other effects.
+    OwnershipUncertain,
+}
+
+/// Resolution of the room-ownership fence for a groupchat archive write.
+///
+/// `Unfenced` is reserved for deployments where clustered MUC ownership is
+/// not configured at all. Once a clustered durable room store exists, a
+/// missing cached epoch is not equivalent to single-node operation: it is
+/// an inability to prove ownership and must fail closed.
+pub(super) enum RoomClaimFenceResolution {
+    Unfenced,
+    #[cfg(any(feature = "clustering", test))]
+    Fenced(RoomClaimFenceContext),
+    #[cfg(any(feature = "clustering", test))]
+    OwnershipUncertain,
+}
+
+impl RoomClaimFenceResolution {
+    pub(super) fn is_fenced(&self) -> bool {
+        #[cfg(any(feature = "clustering", test))]
+        {
+            matches!(self, Self::Fenced(_))
+        }
+        #[cfg(not(any(feature = "clustering", test)))]
+        {
+            false
+        }
+    }
+
+    pub(super) fn is_ownership_uncertain(&self) -> bool {
+        #[cfg(any(feature = "clustering", test))]
+        {
+            matches!(self, Self::OwnershipUncertain)
+        }
+        #[cfg(not(any(feature = "clustering", test)))]
+        {
+            false
+        }
+    }
 }
 
 /// ADR-0017 Phase 3 Slice 7 FIX 1: resolve the typed `(Entity, ClaimEpoch,
-/// node_id)` fencing context for `room`, the SAME mechanism
+/// NodeIdentity)` fencing context for `room`, the SAME mechanism
 /// `dispatch_to_room`'s own `check_fenced_fanout` pre-fan-out check reads
 /// from — threaded here rather than re-derived from a second, independent
-/// source. `None` whenever clustering is disabled, this binary lacks the
-/// `clustering` Cargo feature, or no durable store is configured for this
-/// room (matches `check_fenced_fanout`'s own `None`-means-unfenced
-/// contract): callers fall back to the portable, unfenced
-/// `MamStorage::store_message` path, byte-identical to pre-Slice-7
-/// behavior.
+/// source. `Unfenced` is returned only when clustering/durable MUC ownership
+/// is not configured. A configured store with no cached exact claim returns
+/// `OwnershipUncertain`; it must never degrade into an unfenced write.
 pub(super) fn resolve_room_claim_fence(
     deps: &Deps<'_>,
     room: &BareJid,
-) -> Option<RoomClaimFenceContext> {
+) -> RoomClaimFenceResolution {
     #[cfg(feature = "clustering")]
     {
-        let state = deps.web_socket_state?;
-        let store = state
-            .deps
-            .app_state
-            .clustering_claims
-            .muc_durable_store
-            .as_ref()?;
-        store.current_claim_fence(room)
+        let Some(_store) = deps.muc_durable_store else {
+            return if deps.clustered_muc_ownership_required {
+                RoomClaimFenceResolution::OwnershipUncertain
+            } else {
+                RoomClaimFenceResolution::Unfenced
+            };
+        };
+        if let Some(fence) = deps.room_claim_fence.as_ref() {
+            let expected = waddle_xmpp::ownership::Entity::new(
+                waddle_xmpp::ownership::EntityType::RoomActor,
+                room.to_string(),
+            );
+            return if fence.entity == expected {
+                RoomClaimFenceResolution::Fenced(fence.clone())
+            } else {
+                RoomClaimFenceResolution::OwnershipUncertain
+            };
+        }
+        // A configured durable MUC store means this archive belongs to a
+        // claim-bound RoomActor incarnation. Never recover a missing actor
+        // proof from the store's room-scoped "latest epoch" cache: after an
+        // E1 actor is retained and E2 is acquired, that would revive the ABA.
+        RoomClaimFenceResolution::OwnershipUncertain
     }
     #[cfg(not(feature = "clustering"))]
     {
         let _ = (deps, room);
-        None
+        RoomClaimFenceResolution::Unfenced
     }
 }
 
@@ -57,9 +107,17 @@ pub(super) async fn archive_groupchat_message(
     room: &BareJid,
     message: &Message,
     sender_nickname_generation: u64,
-    fence: Option<&RoomClaimFenceContext>,
+    fence: &RoomClaimFenceResolution,
     sender_item: Option<&waddle_xmpp_core::mam::ArchivedMucSender>,
 ) -> ArchiveGroupchatOutcome {
+    if fence.is_ownership_uncertain() {
+        warn!(
+            room = %room,
+            "ArchiveGroupchat: clustered room has no provable claim fence; failing closed"
+        );
+        return ArchiveGroupchatOutcome::OwnershipUncertain;
+    }
+
     // XEP-0313 §MUC Archives: for non-anonymous rooms the *archived*
     // copy carries a room-authored `<x xmlns='muc#user'><item
     // jid='real-jid' affiliation role/></x>` disclosing the sender's
@@ -94,7 +152,15 @@ pub(super) async fn archive_groupchat_message(
                  skipping archive write because persisting an archive-only id would \
                  break the wire/archive stanza-id invariant (chain bug)"
             );
-            return ArchiveGroupchatOutcome::Skipped;
+            return if fence.is_fenced() {
+                // In clustered mode an emitted archive effect without its
+                // canonical room stanza-id is not a benign policy skip. The
+                // chain cannot prove a safe archive/fan-out identity, so the
+                // whole batch must fail closed.
+                ArchiveGroupchatOutcome::OwnershipUncertain
+            } else {
+                ArchiveGroupchatOutcome::Skipped
+            };
         }
     };
 
@@ -126,7 +192,7 @@ pub(super) async fn finish_archive_groupchat_message(
     archive_clone: Message,
     archive_id: String,
     sender_nickname_generation: u64,
-    fence: Option<&RoomClaimFenceContext>,
+    fence: &RoomClaimFenceResolution,
     sender_item: Option<&waddle_xmpp_core::mam::ArchivedMucSender>,
 ) -> ArchiveGroupchatOutcome {
     // RFC 6121 §5.2.3: `<body>` is optional. Preserve the
@@ -192,13 +258,26 @@ pub(super) async fn finish_archive_groupchat_message(
     // `pending_delivery::insert_fenced` establishes one table over,
     // running the `SELECT ... FOR SHARE` INSIDE the same transaction as
     // this insert.
-    let store_result = match fence {
-        Some(fence) => {
+    let (store_result, fenced) = match fence {
+        #[cfg(any(feature = "clustering", test))]
+        RoomClaimFenceResolution::Fenced(fence) => (
             mam_storage
                 .store_message_fenced(room, &archived, fence)
-                .await
+                .await,
+            true,
+        ),
+        RoomClaimFenceResolution::Unfenced => {
+            (mam_storage.store_message(room, &archived).await, false)
         }
-        None => mam_storage.store_message(room, &archived).await,
+        #[cfg(any(feature = "clustering", test))]
+        RoomClaimFenceResolution::OwnershipUncertain => {
+            warn!(
+                room = %room,
+                "ArchiveGroupchat: clustered room ownership became uncertain before store; \
+                 failing closed"
+            );
+            return ArchiveGroupchatOutcome::OwnershipUncertain;
+        }
     };
     match store_result {
         Ok(stored_id) => ArchiveGroupchatOutcome::Stored(ArchiveStoreResult {
@@ -216,7 +295,16 @@ pub(super) async fn finish_archive_groupchat_message(
                 "ArchiveGroupchat: fenced store failed — this node has been deposed; \
                  not archiving, caller must also suppress fan-out"
             );
-            ArchiveGroupchatOutcome::OwnershipLost
+            ArchiveGroupchatOutcome::OwnershipUncertain
+        }
+        Err(error) if fenced => {
+            warn!(
+                room = %room,
+                %error,
+                "ArchiveGroupchat: fenced store could not prove and commit under exact room \
+                 ownership; failing closed"
+            );
+            ArchiveGroupchatOutcome::OwnershipUncertain
         }
         Err(error) => {
             warn!(
@@ -234,16 +322,25 @@ pub(super) struct ArchiveStoreResult {
     pub rewrite: Option<ArchiveIdRewrite>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum GroupchatRetractionTombstoneOutcome {
+    Applied,
+    Skipped,
+    NotOwner,
+    OwnershipUncertain,
+    PersistFailed,
+}
+
 pub(super) async fn apply_groupchat_retraction_tombstone(
     mam_storage: &Arc<dyn MamStorage>,
-    sm_session_registry: Option<&Arc<InMemorySmSessionRegistry>>,
-    pending_storage: Option<
-        &Arc<dyn waddle_xmpp::pending_delivery::storage::PendingDeliveryStorage>,
-    >,
     room: &BareJid,
     target_message_id: &str,
     retraction_message: &Message,
-) -> bool {
+    fence: &RoomClaimFenceResolution,
+) -> GroupchatRetractionTombstoneOutcome {
+    if fence.is_ownership_uncertain() {
+        return GroupchatRetractionTombstoneOutcome::OwnershipUncertain;
+    }
     // XEP-0424 §3 (xep-0424.xml lines 158, 230-232): a groupchat
     // retraction names the target by the room-assigned XEP-0359
     // stanza-id, which is persisted as the archive primary key. Resolve
@@ -251,14 +348,11 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
     // room (the archived `to` is the room JID) — never by the wire `id`
     // attribute or the origin-id. Keyed identically to the
     // validation-time `lookup_groupchat_retraction_target` so both sites
-    // agree. The scrub target mirrors this: cached reflections match
-    // ONLY on `<stanza-id by=room id=target/>`, never on the
-    // client-chosen wire id (which any occupant could mint to collide).
-    let scrub_target = waddle_xmpp::tombstone::TombstoneTarget::Groupchat {
-        stanza_id: target_message_id.to_string(),
-        room: room.clone(),
-    };
-    let original = match mam_storage.get_message(target_message_id).await {
+    // agree.
+    let original = match mam_storage
+        .get_message_by_archive_or_stanza_id(room, target_message_id)
+        .await
+    {
         Ok(Some(row)) if row.to.to_bare() == *room => row,
         Ok(_) => {
             debug!(
@@ -266,7 +360,7 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
                 target = target_message_id,
                 "ApplyGroupchatRetractionTombstone: target not found in room archive; skipping"
             );
-            return false;
+            return GroupchatRetractionTombstoneOutcome::Skipped;
         }
         Err(error) => {
             warn!(
@@ -275,31 +369,89 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
                 %error,
                 "ApplyGroupchatRetractionTombstone: archive lookup failed; skipping"
             );
-            return false;
+            return if fence.is_fenced() {
+                GroupchatRetractionTombstoneOutcome::OwnershipUncertain
+            } else {
+                GroupchatRetractionTombstoneOutcome::PersistFailed
+            };
         }
     };
+    let Some(retraction_archive_id) = extract_room_stanza_id(retraction_message, room) else {
+        warn!(
+            archive = %room,
+            target = target_message_id,
+            "ApplyGroupchatRetractionTombstone: retraction stanza missing canonical room stanza-id"
+        );
+        return if fence.is_fenced() {
+            GroupchatRetractionTombstoneOutcome::OwnershipUncertain
+        } else {
+            GroupchatRetractionTombstoneOutcome::Skipped
+        };
+    };
+    // XEP-0424 tombstones cite the retraction message's wire `id`, while
+    // the fenced storage proof above/below uses its room-assigned canonical
+    // stanza-id. Keep those two identities deliberately distinct.
     let Some(retraction_id) = retraction_message
         .id
         .as_ref()
         .map(|id| id.0.clone())
         .and_then(RichMessageId::new)
     else {
-        warn!(
-            archive = %room,
-            target = target_message_id,
-            "ApplyGroupchatRetractionTombstone: retraction stanza missing valid message id; skipping"
-        );
-        return false;
+        return if fence.is_fenced() {
+            GroupchatRetractionTombstoneOutcome::OwnershipUncertain
+        } else {
+            GroupchatRetractionTombstoneOutcome::Skipped
+        };
+    };
+    let Some(retraction_from) = retraction_message.from.as_ref() else {
+        return if fence.is_fenced() {
+            GroupchatRetractionTombstoneOutcome::OwnershipUncertain
+        } else {
+            GroupchatRetractionTombstoneOutcome::Skipped
+        };
     };
     let tombstone = ArchivedTombstone {
         retraction_id: Some(retraction_id),
         stamp: chrono::Utc::now(),
         moderation: None,
     };
-    match mam_storage
-        .replace_with_tombstone(&original.id, tombstone)
-        .await
-    {
+    let replace_result = match fence {
+        #[cfg(any(feature = "clustering", test))]
+        RoomClaimFenceResolution::Fenced(fence) => {
+            mam_storage
+                .replace_with_tombstone_fenced(
+                    room,
+                    &original.id,
+                    &retraction_archive_id,
+                    retraction_from,
+                    tombstone,
+                    fence,
+                )
+                .await
+        }
+        RoomClaimFenceResolution::Unfenced => {
+            // XEP-0424 requires the retraction message itself to be stored.
+            // Prove it belongs to this room and exact occupant before
+            // replacing the target even in a single-node deployment.
+            let archived_retraction = mam_storage
+                .get_message_by_archive_or_stanza_id(room, &retraction_archive_id)
+                .await;
+            match archived_retraction {
+                Ok(Some(row)) if row.to.to_bare() == *room && row.from == *retraction_from => {
+                    mam_storage
+                        .replace_with_tombstone(&original.id, tombstone)
+                        .await
+                }
+                Ok(_) => Ok(false),
+                Err(error) => Err(error),
+            }
+        }
+        #[cfg(any(feature = "clustering", test))]
+        RoomClaimFenceResolution::OwnershipUncertain => {
+            unreachable!("ownership-uncertain fence returned before archive access")
+        }
+    };
+    match replace_result {
         Ok(true) => {
             debug!(
                 archive = %room,
@@ -313,14 +465,10 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
                 original_id = %original.id,
                 "ApplyGroupchatRetractionTombstone: target row not found at replace time"
             );
-            scrub_unacked_for_tombstone(
-                sm_session_registry,
-                pending_storage,
-                &scrub_target,
-                "ApplyGroupchatRetractionTombstone",
-            )
-            .await;
-            return false;
+            return GroupchatRetractionTombstoneOutcome::PersistFailed;
+        }
+        Err(MamStorageError::NotOwner { .. }) => {
+            return GroupchatRetractionTombstoneOutcome::NotOwner;
         }
         Err(error) => {
             warn!(
@@ -329,32 +477,14 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
                 %error,
                 "ApplyGroupchatRetractionTombstone: replace_with_tombstone failed"
             );
-            scrub_unacked_for_tombstone(
-                sm_session_registry,
-                pending_storage,
-                &scrub_target,
-                "ApplyGroupchatRetractionTombstone",
-            )
-            .await;
-            return false;
+            return if fence.is_fenced() {
+                GroupchatRetractionTombstoneOutcome::OwnershipUncertain
+            } else {
+                GroupchatRetractionTombstoneOutcome::PersistFailed
+            };
         }
     }
-    // Drop matching unacked groupchat reflections from detached
-    // XEP-0198 session queues. The reflection is what occupants see;
-    // scrubbing here closes the resume-side replay leak for groupchat
-    // retractions identically to the 1:1 case. Scope by the room JID
-    // so the matcher's stanza-id branch can find groupchat reflections
-    // that key by the room's XEP-0359 stamp, and so a colliding wire
-    // id in another conversation is not accidentally scrubbed
-    // (Codex P1, Copilot review on PR #305).
-    scrub_unacked_for_tombstone(
-        sm_session_registry,
-        pending_storage,
-        &scrub_target,
-        "ApplyGroupchatRetractionTombstone",
-    )
-    .await;
-    true
+    GroupchatRetractionTombstoneOutcome::Applied
 }
 
 /// Walk the SM session registry AND the pending-delivery store and
@@ -731,5 +861,287 @@ pub(super) fn rich_archive_payload(
             occupant_id,
             muc_sender,
         })
+    }
+}
+
+#[cfg(test)]
+mod ownership_tests {
+    use super::*;
+    use waddle_xmpp::mam::SqlxMamStorage;
+    #[cfg(feature = "clustering")]
+    use waddle_xmpp::muc::{DurableRoomState, MucDurableFuture, MucDurableStore, RoomConfig};
+    use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
+    use waddle_xmpp_core::xep0359::{add_stanza_id, StanzaId};
+
+    fn room() -> BareJid {
+        "archive-fence@muc.example.com"
+            .parse()
+            .expect("valid room JID")
+    }
+
+    fn fence(room: &BareJid) -> RoomClaimFenceResolution {
+        RoomClaimFenceResolution::Fenced(RoomClaimFenceContext {
+            entity: Entity::new(EntityType::RoomActor, room.to_string()),
+            epoch: ClaimEpoch(7),
+            owner: NodeIdentity::new("node-a", "epoch-a"),
+        })
+    }
+
+    fn groupchat_message(room: &BareJid, with_stanza_id: bool) -> Message {
+        let mut message = Message::new(Some(Jid::from(room.clone())));
+        message.from = Some(
+            format!("{room}/alice")
+                .parse::<Jid>()
+                .expect("valid room occupant JID"),
+        );
+        message.type_ = XmppMessageType::Groupchat;
+        message.id = Some(xmpp_parsers::message::Id("wire-id".to_string()));
+        message
+            .bodies
+            .insert(xmpp_parsers::message::Lang::new(), "hello".to_string());
+        if with_stanza_id {
+            add_stanza_id(
+                &mut message,
+                &StanzaId::new("archive-id", Jid::from(room.clone())),
+            );
+        }
+        message
+    }
+
+    #[cfg(feature = "clustering")]
+    struct MissingCachedFenceStore;
+
+    #[cfg(feature = "clustering")]
+    impl MucDurableStore for MissingCachedFenceStore {
+        fn load_room_state<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+        ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn save_config<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _waddle_id: &'a str,
+            _channel_id: &'a str,
+            _config: &'a RoomConfig,
+        ) -> MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn save_subject<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _subject: Option<&'a waddle_xmpp::muc::SubjectState>,
+        ) -> MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn save_affiliation<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _entry: &'a waddle_xmpp::muc::affiliation::AffiliationEntry,
+        ) -> MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[cfg(feature = "clustering")]
+    #[test]
+    fn active_cluster_without_muc_store_is_not_treated_as_unfenced() {
+        let registry = ConnectionRegistry::new();
+        let mut deps = Deps::registry_only(&registry);
+        deps.clustered_muc_ownership_required = true;
+
+        assert!(matches!(
+            resolve_room_claim_fence(&deps, &room()),
+            RoomClaimFenceResolution::OwnershipUncertain
+        ));
+    }
+
+    #[cfg(feature = "clustering")]
+    #[test]
+    fn clustered_store_without_cached_claim_is_ownership_uncertain() {
+        let registry = ConnectionRegistry::new();
+        let store: Arc<dyn MucDurableStore> = Arc::new(MissingCachedFenceStore);
+        let mut deps = Deps::registry_only(&registry);
+        deps.clustered_muc_ownership_required = true;
+        deps.muc_durable_store = Some(&store);
+
+        assert!(matches!(
+            resolve_room_claim_fence(&deps, &room()),
+            RoomClaimFenceResolution::OwnershipUncertain
+        ));
+    }
+
+    #[cfg(feature = "clustering")]
+    #[test]
+    fn durable_archive_without_actor_fence_never_uses_a_room_scoped_latest_claim() {
+        use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
+
+        let registry = ConnectionRegistry::new();
+        let room = room();
+        let latest = RoomClaimFenceContext {
+            entity: Entity::new(EntityType::RoomActor, room.to_string()),
+            epoch: ClaimEpoch(2),
+            owner: NodeIdentity::new("node-a", "node-epoch-a"),
+        };
+        struct LatestClaimStore(RoomClaimFenceContext);
+        impl MucDurableStore for LatestClaimStore {
+            fn load_room_state<'a>(
+                &'a self,
+                _room_jid: &'a BareJid,
+            ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+                Box::pin(async { Ok(None) })
+            }
+
+            fn save_config<'a>(
+                &'a self,
+                _room_jid: &'a BareJid,
+                _waddle_id: &'a str,
+                _channel_id: &'a str,
+                _config: &'a RoomConfig,
+            ) -> MucDurableFuture<'a, ()> {
+                Box::pin(async { Ok(()) })
+            }
+
+            fn save_subject<'a>(
+                &'a self,
+                _room_jid: &'a BareJid,
+                _subject: Option<&'a waddle_xmpp::muc::SubjectState>,
+            ) -> MucDurableFuture<'a, ()> {
+                Box::pin(async { Ok(()) })
+            }
+
+            fn save_affiliation<'a>(
+                &'a self,
+                _room_jid: &'a BareJid,
+                _entry: &'a waddle_xmpp::muc::affiliation::AffiliationEntry,
+            ) -> MucDurableFuture<'a, ()> {
+                Box::pin(async { Ok(()) })
+            }
+
+            fn current_claim_fence(&self, _room_jid: &BareJid) -> Option<RoomClaimFenceContext> {
+                Some(self.0.clone())
+            }
+        }
+
+        let latest_store: Arc<dyn MucDurableStore> = Arc::new(LatestClaimStore(latest));
+        let mut deps = Deps::registry_only(&registry);
+        deps.muc_durable_store = Some(&latest_store);
+
+        assert!(matches!(
+            resolve_room_claim_fence(&deps, &room),
+            RoomClaimFenceResolution::OwnershipUncertain
+        ));
+    }
+
+    #[tokio::test]
+    async fn ownership_uncertainty_overrides_archive_policy_skip() {
+        let room = room();
+        let storage: Arc<dyn MamStorage> = Arc::new(
+            SqlxMamStorage::open_in_memory()
+                .await
+                .expect("open in-memory MAM"),
+        );
+        let outcome = archive_groupchat_message(
+            &storage,
+            &room,
+            &groupchat_message(&room, false),
+            0,
+            &RoomClaimFenceResolution::OwnershipUncertain,
+            None,
+        )
+        .await;
+
+        assert!(matches!(
+            outcome,
+            ArchiveGroupchatOutcome::OwnershipUncertain
+        ));
+    }
+
+    #[tokio::test]
+    async fn fenced_malformed_archive_event_is_ownership_uncertain() {
+        let room = room();
+        let storage: Arc<dyn MamStorage> = Arc::new(
+            SqlxMamStorage::open_in_memory()
+                .await
+                .expect("open in-memory MAM"),
+        );
+        let outcome = archive_groupchat_message(
+            &storage,
+            &room,
+            &groupchat_message(&room, false),
+            0,
+            &fence(&room),
+            None,
+        )
+        .await;
+
+        assert!(matches!(
+            outcome,
+            ArchiveGroupchatOutcome::OwnershipUncertain
+        ));
+    }
+
+    #[tokio::test]
+    async fn fenced_archive_without_fencing_backend_fails_closed() {
+        let room = room();
+        let storage: Arc<dyn MamStorage> = Arc::new(
+            SqlxMamStorage::open_in_memory()
+                .await
+                .expect("open in-memory MAM"),
+        );
+        let outcome = archive_groupchat_message(
+            &storage,
+            &room,
+            &groupchat_message(&room, true),
+            0,
+            &fence(&room),
+            None,
+        )
+        .await;
+
+        assert!(matches!(
+            outcome,
+            ArchiveGroupchatOutcome::OwnershipUncertain
+        ));
+        assert!(storage
+            .query_messages(&room, &Default::default())
+            .await
+            .expect("query archive")
+            .messages
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn unfenced_single_node_archive_uses_portable_store() {
+        let room = room();
+        let storage: Arc<dyn MamStorage> = Arc::new(
+            SqlxMamStorage::open_in_memory()
+                .await
+                .expect("open in-memory MAM"),
+        );
+        let outcome = archive_groupchat_message(
+            &storage,
+            &room,
+            &groupchat_message(&room, true),
+            0,
+            &RoomClaimFenceResolution::Unfenced,
+            None,
+        )
+        .await;
+
+        assert!(matches!(outcome, ArchiveGroupchatOutcome::Stored(_)));
+        assert_eq!(
+            storage
+                .query_messages(&room, &Default::default())
+                .await
+                .expect("query archive")
+                .messages
+                .len(),
+            1
+        );
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_validation.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_validation.rs
@@ -83,6 +83,13 @@ pub(super) async fn validate_groupchat_rich_targets(
                 "Only the original sender may retract a message.",
             ));
         }
+        verify_groupchat_occupancy_generation(
+            sender_archive_view,
+            &original,
+            room_actor,
+            sender_nickname_generation,
+        )
+        .await?;
     }
     Ok(())
 }
@@ -126,9 +133,9 @@ pub(super) fn sender_matches_groupchat_from(sender: &Jid, original_from: &Jid) -
     sender == original_from
 }
 
-/// XEP-0308 §3 occupancy continuity check: a full-JID that left the
-/// room and rejoined under the same nickname MUST NOT be allowed to
-/// correct messages from the previous occupancy. Compares the
+/// Occupancy continuity check for rich-target mutations: a full-JID that
+/// left the room and rejoined under the same nickname MUST NOT be allowed
+/// to correct or retract messages from the previous occupancy. Compares the
 /// per-nickname generation captured on the archive row at write time
 /// against the room actor's current generation for the sender's
 /// nickname.
@@ -140,12 +147,12 @@ pub(super) async fn verify_groupchat_occupancy_generation(
 ) -> Result<(), StanzaError> {
     let Some(nick) = sender.resource().map(|r| r.to_string()) else {
         return Err(forbidden_error(
-            "Correction sender has no MUC nickname for occupancy check.",
+            "Rich-target sender has no MUC nickname for occupancy check.",
         ));
     };
     let Some(archived_generation) = original.nickname_generation else {
         return Err(forbidden_error(
-            "Original message predates occupancy tracking; correction window has closed.",
+            "Original message predates occupancy tracking; rich-target mutation window has closed.",
         ));
     };
     // Prefer the generation snapshot already captured by `dispatch_to_room`
@@ -165,7 +172,7 @@ pub(super) async fn verify_groupchat_occupancy_generation(
     };
     if current_generation != archived_generation {
         return Err(forbidden_error(
-            "Occupancy generation has advanced; correction is no longer permitted across the leave/rejoin boundary.",
+            "Occupancy generation has advanced; this rich-target mutation is no longer permitted across the leave/rejoin boundary.",
         ));
     }
     Ok(())

--- a/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
@@ -158,6 +158,15 @@ pub(super) async fn dispatch_to_room(
         }
     };
 
+    #[cfg(feature = "clustering")]
+    let exact_fence = match room_actor.ask(GetRoomClaimFence).await {
+        Ok(fence) => fence,
+        Err(error) => {
+            warn!(room = %room_jid, ?error, "DispatchToRoom: exact actor fence lookup failed");
+            None
+        }
+    };
+
     // ADR-0017 Phase 3 Slice 7: the two-part demotion protocol's
     // guaranteed backstop — a fenced `SELECT ... FOR SHARE` against this
     // room's Postgres claim, run before any local fan-out (this is the
@@ -167,22 +176,43 @@ pub(super) async fn dispatch_to_room(
     // `GetRoomSnapshot`-based sans-I/O chain and carries no live
     // production caller). `None` (clustering disabled, non-Postgres, or a
     // build without the `clustering` feature) skips this entirely —
-    // single-node behavior, unchanged. A transient backend error fails
-    // open (logged, not blocking); only a definitive 0-rows result
-    // demotes.
+    // single-node behavior, unchanged. Both a definitive 0-rows result and
+    // an inability to check the database fail closed: neither case may
+    // emit local fan-out or other message effects. Only definitive
+    // ownership loss demotes the actor; a transient check error bounces
+    // this message without destroying still-potentially-owned state.
     #[cfg(feature = "clustering")]
     if let Some(store) = &state.deps.app_state.clustering_claims.muc_durable_store {
-        match store.check_fenced_fanout(&room_jid).await {
+        let Some(exact_fence) = exact_fence.as_ref() else {
+            let reply = build_message_error_reply(
+                &incoming,
+                &room_jid,
+                &sender_full,
+                resource_constraint_error(
+                    "This room's ownership cannot currently be verified; please retry.",
+                ),
+            );
+            if let Ok(xml) = Stanza::Message(reply).to_element_string() {
+                outcome.frames.push(xml);
+            }
+            outcome.room_ownership_uncertain = true;
+            return outcome;
+        };
+        match store
+            .check_fenced_fanout_exact(&room_jid, exact_fence)
+            .await
+        {
             Ok(true) => {}
-            Ok(false) => {
+            Ok(false) | Err(waddle_xmpp::XmppError::RoomOwnershipLost(_)) => {
                 warn!(
                     room = %room_jid,
-                    "DispatchToRoom: fenced ownership check observed 0 rows; this node has \
-                     been deposed — evicting the local room actor and bouncing the sender"
+                    "DispatchToRoom: fenced ownership check proved this node is no longer \
+                     authoritative — evicting the local room actor and bouncing the sender"
                 );
                 let _ = room_registry
-                    .ask(DestroyRoom {
+                    .ask(DestroyRoomExact {
                         room_jid: room_jid.clone(),
+                        expected_actor: room_actor.clone(),
                     })
                     .await;
                 let reply = build_message_error_reply(
@@ -203,6 +233,7 @@ pub(super) async fn dispatch_to_room(
                         );
                     }
                 }
+                outcome.room_ownership_uncertain = true;
                 return outcome;
             }
             Err(error) => {
@@ -210,8 +241,28 @@ pub(super) async fn dispatch_to_room(
                     room = %room_jid,
                     %error,
                     "DispatchToRoom: fenced ownership check failed (transient backend \
-                     error); failing open, not demoting"
+                     error); failing closed for this message without demoting"
                 );
+                let reply = build_message_error_reply(
+                    &incoming,
+                    &room_jid,
+                    &sender_full,
+                    resource_constraint_error(
+                        "This room's ownership cannot currently be verified; please retry.",
+                    ),
+                );
+                match Stanza::Message(reply).to_element_string() {
+                    Ok(xml) => outcome.frames.push(xml),
+                    Err(serialize_error) => {
+                        warn!(
+                            room = %room_jid,
+                            error = %serialize_error,
+                            "DispatchToRoom: failed to serialize ownership-uncertainty bounce reply"
+                        );
+                    }
+                }
+                outcome.room_ownership_uncertain = true;
+                return outcome;
             }
         }
     }
@@ -284,27 +335,12 @@ pub(super) async fn dispatch_to_room(
         // pending callback completions if a future gate handler ever
         // emits them.
         let nested = Box::pin(interpret_with_depth(gate_events, deps, recursion_depth)).await;
+        outcome.room_ownership_uncertain = nested.room_ownership_uncertain;
         outcome.frames.extend(nested.frames);
         outcome.close = outcome.close || nested.close;
         outcome.feedback.extend(nested.feedback);
         return outcome;
     }
-
-    // Notification activity ingest (slice 2b): a XEP-0085 chat-state on
-    // an inbound MUC stanza represents the sender being currently
-    // active in the room. Record `(sender_bare, room)` only AFTER the
-    // occupancy / managed-room gate has admitted the sender — otherwise
-    // a non-occupant or managed-room-forbidden sender whose stanza is
-    // rejected could still bump their activity projection and appear
-    // "recently active" for the XEP-0513 `<active/>` filter (Codex
-    // review on PR #731).
-    super::notification_activity_ingest::record_chat_state_activity(
-        deps,
-        &sender_full.to_bare(),
-        &room_jid,
-        &incoming,
-    )
-    .await;
 
     if message_has_framework_envelope(&prototype) {
         let mut sanitized = incoming.clone();
@@ -428,17 +464,48 @@ pub(super) async fn dispatch_to_room(
     //    promotes to a headless recipient pass (depth bumped there).
     //    Bumping here would break that path for every offline
     //    occupant.
+    let nested_deps = {
+        let mut nested = deps.clone();
+        nested.room_actor_incarnation = Some(room_actor.clone());
+        #[cfg(feature = "clustering")]
+        {
+            nested.room_claim_fence = exact_fence.clone();
+        }
+        nested
+    };
     let nested = Box::pin(interpret_with_depth(
         dispatch_outcome.events,
-        deps,
+        &nested_deps,
         recursion_depth,
     ))
     .await;
+    let nested_ownership_uncertain = nested.room_ownership_uncertain;
     outcome.frames.extend(nested.frames);
     if nested.close {
         outcome.close = true;
     }
     outcome.feedback.extend(nested.feedback);
+
+    if nested_ownership_uncertain {
+        // The nested archive fence has already suppressed the remaining
+        // batch and emitted a retryable bounce. Do not leave activity or
+        // extension-observer side effects behind for a message whose exact
+        // room owner could not be proved.
+        outcome.room_ownership_uncertain = true;
+        return outcome;
+    }
+
+    // Notification activity ingest (slice 2b): a XEP-0085 chat-state on
+    // an admitted inbound MUC stanza represents the sender being currently
+    // active in the room. This runs only after the archive/fan-out batch has
+    // completed without ownership uncertainty.
+    super::notification_activity_ingest::record_chat_state_activity(
+        deps,
+        &sender_full.to_bare(),
+        &room_jid,
+        &incoming,
+    )
+    .await;
 
     let mut observer_message = observer_message;
     let observer_outcome = state

--- a/server/crates/waddle-server/src/server/routes/interpret/room_effect_authority.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_effect_authority.rs
@@ -1,0 +1,197 @@
+use super::*;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RoomEffectAuthorityError {
+    NotOwner,
+    OwnershipUncertain,
+}
+
+async fn demote_expected_actor(
+    room_registry: &ActorRef<RoomRegistryActor>,
+    room: &BareJid,
+    expected_actor: &ActorRef<RoomActor>,
+) {
+    let _ = room_registry
+        .ask(waddle_xmpp::muc::room_registry_actor::DestroyRoomExact {
+            room_jid: room.clone(),
+            expected_actor: expected_actor.clone(),
+        })
+        .await;
+    expected_actor.kill();
+}
+
+/// Resolve the exact actor incarnation that authorized this nested room
+/// event. A room-only `GetRoom` is used solely as a CAS comparison; its
+/// returned actor is never adopted as fresh authority for the old event.
+pub(super) async fn exact_room_actor_for_effect(
+    deps: &Deps<'_>,
+    room: &BareJid,
+) -> Result<ActorRef<RoomActor>, RoomEffectAuthorityError> {
+    let Some(room_registry) = deps.room_registry else {
+        return Err(RoomEffectAuthorityError::OwnershipUncertain);
+    };
+    let Some(expected_actor) = deps.room_actor_incarnation.as_ref() else {
+        return Err(RoomEffectAuthorityError::OwnershipUncertain);
+    };
+    let current_actor = match room_registry
+        .ask(GetRoom {
+            room_jid: room.clone(),
+        })
+        .await
+    {
+        Ok(Some(actor)) => actor,
+        Ok(None) => {
+            demote_expected_actor(room_registry, room, expected_actor).await;
+            return Err(RoomEffectAuthorityError::NotOwner);
+        }
+        Err(_) => return Err(RoomEffectAuthorityError::OwnershipUncertain),
+    };
+    if current_actor != *expected_actor {
+        demote_expected_actor(room_registry, room, expected_actor).await;
+        return Err(RoomEffectAuthorityError::NotOwner);
+    }
+
+    #[cfg(feature = "clustering")]
+    if deps.clustered_muc_ownership_required || deps.muc_durable_store.is_some() {
+        let Some(expected_fence) = deps.room_claim_fence.as_ref() else {
+            return Err(RoomEffectAuthorityError::OwnershipUncertain);
+        };
+        match expected_actor.ask(GetRoomClaimFence).await {
+            Ok(Some(bound_fence)) if bound_fence == *expected_fence => {}
+            Ok(Some(_)) => {
+                demote_expected_actor(room_registry, room, expected_actor).await;
+                return Err(RoomEffectAuthorityError::NotOwner);
+            }
+            Ok(None) | Err(_) => return Err(RoomEffectAuthorityError::OwnershipUncertain),
+        }
+    }
+
+    Ok(expected_actor.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kameo::actor::Spawn;
+    use waddle_xmpp::muc::room_registry_actor::{CreateRoom, DestroyRoom};
+    use waddle_xmpp::muc::RoomConfig;
+    use waddle_xmpp::xep::xep0421::OccupantIdSecret;
+
+    async fn replaced_room(
+        name: &str,
+    ) -> (
+        ActorRef<RoomRegistryActor>,
+        BareJid,
+        ActorRef<RoomActor>,
+        ActorRef<RoomActor>,
+    ) {
+        let registry = RoomRegistryActor::spawn(RoomRegistryActor::new(
+            "muc.example.com".to_string(),
+            OccupantIdSecret::new(vec![b'e'; 32]).expect("test secret"),
+        ));
+        let room: BareJid = format!("{name}@muc.example.com").parse().expect("room JID");
+        let original = registry
+            .ask(CreateRoom {
+                room_jid: room.clone(),
+                waddle_id: "original".to_string(),
+                channel_id: format!("{name}-original"),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create E1");
+        registry
+            .ask(DestroyRoom {
+                room_jid: room.clone(),
+            })
+            .await
+            .expect("remove E1");
+        let replacement = registry
+            .ask(CreateRoom {
+                room_jid: room.clone(),
+                waddle_id: "replacement".to_string(),
+                channel_id: format!("{name}-replacement"),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create E2");
+        (registry, room, original, replacement)
+    }
+
+    #[tokio::test]
+    async fn retained_archive_effect_cannot_adopt_replacement_actor() {
+        let connections = ConnectionRegistry::new();
+        let (room_registry, room, original, replacement) = replaced_room("archive-authority").await;
+        let mut deps = Deps::registry_only(&connections);
+        deps.room_registry = Some(&room_registry);
+        deps.room_actor_incarnation = Some(original);
+
+        let sender: FullJid = "alice@example.com/web".parse().expect("sender JID");
+        let mut message = Message::new(Some(Jid::from(room.clone())));
+        message.from = Some(
+            room.clone()
+                .with_resource_str("alice")
+                .map(Jid::from)
+                .expect("room occupant JID"),
+        );
+        message.type_ = XmppMessageType::Groupchat;
+        let archive_outcome = super::super::archive_groupchat_event::archive_groupchat_event(
+            &deps,
+            room,
+            sender,
+            Box::new(message),
+            0,
+            None,
+        )
+        .await;
+
+        assert!(matches!(
+            archive_outcome,
+            super::super::archive_groupchat_event::ArchiveGroupchatEventOutcome::OwnershipUncertain(
+                _
+            )
+        ));
+        assert!(
+            replacement.is_alive(),
+            "exact E1 rejection must preserve E2"
+        );
+    }
+
+    #[tokio::test]
+    async fn retained_fanout_effect_cannot_deliver_after_actor_replacement() {
+        let connections = ConnectionRegistry::new();
+        let (room_registry, room, original, replacement) = replaced_room("fanout-authority").await;
+        let recipient: FullJid = "bob@example.com/web".parse().expect("recipient JID");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        connections.register_with_carbons(recipient.clone(), tx, false);
+        let mut deps = Deps::registry_only(&connections);
+        deps.room_registry = Some(&room_registry);
+        deps.room_actor_incarnation = Some(original);
+
+        let mut message = Message::new(Some(Jid::from(recipient.clone())));
+        message.from = Some(
+            room.clone()
+                .with_resource_str("alice")
+                .map(Jid::from)
+                .expect("room occupant JID"),
+        );
+        message.type_ = XmppMessageType::Groupchat;
+        let outcome = interpret(
+            vec![OutboundEvent::RouteToConnection {
+                jid: Jid::from(recipient),
+                stanza: Box::new(Stanza::Message(message)),
+            }],
+            &deps,
+        )
+        .await;
+
+        assert!(outcome.room_ownership_uncertain);
+        assert!(
+            rx.try_recv().is_err(),
+            "stale E1 fanout reached a recipient"
+        );
+        assert!(
+            replacement.is_alive(),
+            "exact E1 rejection must preserve E2"
+        );
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/interpret/room_pin.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_pin.rs
@@ -23,19 +23,28 @@ use jid::BareJid;
 use waddle_xmpp::muc::pin::{
     PinChangeRequest, PinPreview, PinStateChange, PinnedEntry, MAX_PREVIEW_LEN,
 };
-use waddle_xmpp::muc::room_actor::{GetPinList, GetRoomSnapshot};
+use waddle_xmpp::muc::room_actor::{GetPinList, GetRoomSnapshot, RollbackPinIfRevision};
 use waddle_xmpp::protocol::room::pin::{
     build_pinned_system_message, build_unpinned_system_message,
 };
 use waddle_xmpp::xep::xep_waddle_pin::MAX_TARGET_STANZA_ID_LEN;
 use waddle_xmpp_core::xep0359::StanzaId;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PinChangeOutcome {
+    Applied,
+    Skipped,
+    NotOwner,
+    OwnershipUncertain,
+    PersistFailed,
+}
+
 pub(super) async fn apply_pin_change_event(
     deps: &Deps<'_>,
     room: BareJid,
     request: PinChangeRequest,
     recursion_depth: u8,
-) {
+) -> PinChangeOutcome {
     if request.target_stanza_id().id.is_empty()
         || request.target_stanza_id().id.len() > MAX_TARGET_STANZA_ID_LEN
     {
@@ -44,19 +53,20 @@ pub(super) async fn apply_pin_change_event(
             target = %request.target_stanza_id().id,
             "ApplyPinChange: target stanza-id failed length validation; dropping"
         );
-        return;
+        return PinChangeOutcome::Skipped;
     }
     match request {
-        PinChangeRequest::Pin { .. } => {
-            apply_pin(deps, room, request, recursion_depth).await;
-        }
-        PinChangeRequest::Unpin { .. } => {
-            apply_unpin(deps, room, request, recursion_depth).await;
-        }
+        PinChangeRequest::Pin { .. } => apply_pin(deps, room, request, recursion_depth).await,
+        PinChangeRequest::Unpin { .. } => apply_unpin(deps, room, request, recursion_depth).await,
     }
 }
 
-async fn apply_pin(deps: &Deps<'_>, room: BareJid, request: PinChangeRequest, recursion_depth: u8) {
+async fn apply_pin(
+    deps: &Deps<'_>,
+    room: BareJid,
+    request: PinChangeRequest,
+    recursion_depth: u8,
+) -> PinChangeOutcome {
     let PinChangeRequest::Pin {
         target_stanza_id,
         pinner_jid,
@@ -64,10 +74,11 @@ async fn apply_pin(deps: &Deps<'_>, room: BareJid, request: PinChangeRequest, re
         pinned_at,
     } = request
     else {
-        return;
+        return PinChangeOutcome::Skipped;
     };
-    let Some(room_actor) = lookup_room_actor(deps, &room, "ApplyPinChange::Pin").await else {
-        return;
+    let room_actor = match exact_room_actor_for_effect(deps, &room).await {
+        Ok(actor) => actor,
+        Err(error) => return map_room_effect_authority_error(error),
     };
 
     // Pull the room snapshot once: we need its occupant list to map
@@ -81,7 +92,7 @@ async fn apply_pin(deps: &Deps<'_>, room: BareJid, request: PinChangeRequest, re
                 ?error,
                 "ApplyPinChange::Pin: failed to build resolver sender; dropping"
             );
-            return;
+            return PinChangeOutcome::PersistFailed;
         }
     };
     let snapshot = match room_actor
@@ -97,7 +108,7 @@ async fn apply_pin(deps: &Deps<'_>, room: BareJid, request: PinChangeRequest, re
                 error = ?error,
                 "ApplyPinChange::Pin: GetRoomSnapshot failed; dropping"
             );
-            return;
+            return PinChangeOutcome::OwnershipUncertain;
         }
     };
 
@@ -123,20 +134,21 @@ async fn apply_pin(deps: &Deps<'_>, room: BareJid, request: PinChangeRequest, re
         pinned_at,
         preview: preview.clone(),
     };
+    let previous = match room_actor.ask(GetPinList).await {
+        Ok(entries) => entries
+            .into_iter()
+            .find(|entry| entry.target_stanza_id.id == target_stanza_id.id),
+        Err(error) => {
+            warn!(room = %room, ?error, "ApplyPinChange::Pin: failed to snapshot pin state");
+            return PinChangeOutcome::OwnershipUncertain;
+        }
+    };
 
-    if let Err(error) = room_actor
-        .ask(ApplyPin {
-            change: PinStateChange::Pin(entry),
-        })
-        .await
-    {
-        warn!(
-            room = %room,
-            error = ?error,
-            "ApplyPinChange::Pin: ApplyPin ask failed; pin not stored or broadcast"
-        );
-        return;
-    }
+    let (room_actor, applied_revision) =
+        match apply_pin_state_change_exact(deps, &room, PinStateChange::Pin(entry)).await {
+            Ok(applied) => applied,
+            Err(outcome) => return outcome,
+        };
 
     let system_message = build_pinned_system_message(
         &room,
@@ -146,13 +158,25 @@ async fn apply_pin(deps: &Deps<'_>, room: BareJid, request: PinChangeRequest, re
         Some(&preview),
         None,
     );
-    super::room_system_message::broadcast_room_system_message_event(
+    let broadcast = super::room_system_message::broadcast_room_system_message_event(
         deps,
-        room,
+        room.clone(),
         Box::new(system_message),
         recursion_depth,
     )
     .await;
+    if broadcast.is_none() {
+        rollback_pin_change(
+            &room_actor,
+            &room,
+            &target_stanza_id,
+            previous,
+            applied_revision,
+        )
+        .await;
+        return PinChangeOutcome::OwnershipUncertain;
+    }
+    PinChangeOutcome::Applied
 }
 
 async fn apply_unpin(
@@ -160,7 +184,7 @@ async fn apply_unpin(
     room: BareJid,
     request: PinChangeRequest,
     recursion_depth: u8,
-) {
+) -> PinChangeOutcome {
     let PinChangeRequest::Unpin {
         target_stanza_id,
         pinner_jid,
@@ -168,27 +192,35 @@ async fn apply_unpin(
         reason,
     } = request
     else {
-        return;
+        return PinChangeOutcome::Skipped;
     };
-    let Some(room_actor) = lookup_room_actor(deps, &room, "ApplyPinChange::Unpin").await else {
-        return;
+    let room_actor = match exact_room_actor_for_effect(deps, &room).await {
+        Ok(actor) => actor,
+        Err(error) => return map_room_effect_authority_error(error),
     };
 
-    if let Err(error) = room_actor
-        .ask(ApplyPin {
-            change: PinStateChange::Unpin {
-                target_stanza_id: target_stanza_id.clone(),
-            },
-        })
-        .await
+    let previous = match room_actor.ask(GetPinList).await {
+        Ok(entries) => entries
+            .into_iter()
+            .find(|entry| entry.target_stanza_id.id == target_stanza_id.id),
+        Err(error) => {
+            warn!(room = %room, ?error, "ApplyPinChange::Unpin: failed to snapshot pin state");
+            return PinChangeOutcome::OwnershipUncertain;
+        }
+    };
+
+    let (room_actor, applied_revision) = match apply_pin_state_change_exact(
+        deps,
+        &room,
+        PinStateChange::Unpin {
+            target_stanza_id: target_stanza_id.clone(),
+        },
+    )
+    .await
     {
-        warn!(
-            room = %room,
-            error = ?error,
-            "ApplyPinChange::Unpin: ApplyPin ask failed; pin still in list, no broadcast"
-        );
-        return;
-    }
+        Ok(applied) => applied,
+        Err(outcome) => return outcome,
+    };
 
     let system_message = build_unpinned_system_message(
         &room,
@@ -197,51 +229,107 @@ async fn apply_unpin(
         &target_stanza_id,
         reason.as_deref(),
     );
-    super::room_system_message::broadcast_room_system_message_event(
+    let broadcast = super::room_system_message::broadcast_room_system_message_event(
         deps,
-        room,
+        room.clone(),
         Box::new(system_message),
         recursion_depth,
     )
     .await;
+    if broadcast.is_none() {
+        rollback_pin_change(
+            &room_actor,
+            &room,
+            &target_stanza_id,
+            previous,
+            applied_revision,
+        )
+        .await;
+        return PinChangeOutcome::OwnershipUncertain;
+    }
+    PinChangeOutcome::Applied
 }
 
-async fn lookup_room_actor(
+fn map_apply_pin_error(
+    error: kameo::error::SendError<ApplyPin, waddle_xmpp::muc::room_actor::RoomMutationError>,
+) -> PinChangeOutcome {
+    match error {
+        kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+        ) => PinChangeOutcome::NotOwner,
+        kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::OwnershipUncertain,
+        ) => PinChangeOutcome::OwnershipUncertain,
+        kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::PersistFailed(_),
+        ) => PinChangeOutcome::PersistFailed,
+        _ => PinChangeOutcome::OwnershipUncertain,
+    }
+}
+
+/// Final, write-adjacent gate for a resolved pin change. Preview lookup and
+/// prior-state reads may await; this helper deliberately resolves the retained
+/// actor incarnation again immediately before the mutation ask.
+pub(super) async fn apply_pin_state_change_exact(
     deps: &Deps<'_>,
     room: &BareJid,
-    op: &'static str,
-) -> Option<kameo::actor::ActorRef<RoomActor>> {
-    let Some(room_registry) = deps.room_registry else {
-        debug!(
+    change: PinStateChange,
+) -> Result<(kameo::actor::ActorRef<RoomActor>, u64), PinChangeOutcome> {
+    let room_actor = exact_room_actor_for_effect(deps, room)
+        .await
+        .map_err(map_room_effect_authority_error)?;
+    let revision = room_actor.ask(ApplyPin { change }).await.map_err(|error| {
+        warn!(
             room = %room,
-            op,
-            "no room_registry in Deps; skipping"
+            error = ?error,
+            "ApplyPinChange: ApplyPin ask failed; state not broadcast"
         );
-        return None;
-    };
-    match room_registry
-        .ask(GetRoom {
-            room_jid: room.clone(),
+        map_apply_pin_error(error)
+    })?;
+    Ok((room_actor, revision))
+}
+
+fn map_room_effect_authority_error(error: RoomEffectAuthorityError) -> PinChangeOutcome {
+    match error {
+        RoomEffectAuthorityError::NotOwner => PinChangeOutcome::NotOwner,
+        RoomEffectAuthorityError::OwnershipUncertain => PinChangeOutcome::OwnershipUncertain,
+    }
+}
+
+async fn rollback_pin_change(
+    room_actor: &kameo::actor::ActorRef<RoomActor>,
+    room: &BareJid,
+    target: &StanzaId,
+    previous: Option<PinnedEntry>,
+    expected_revision: u64,
+) {
+    let change = previous.map_or_else(
+        || PinStateChange::Unpin {
+            target_stanza_id: target.clone(),
+        },
+        PinStateChange::Pin,
+    );
+    match room_actor
+        .ask(RollbackPinIfRevision {
+            expected_revision,
+            change,
         })
         .await
     {
-        Ok(Some(actor)) => Some(actor),
-        Ok(None) => {
-            debug!(
-                room = %room,
-                op,
-                "room not registered; skipping"
-            );
-            None
-        }
+        Ok(true) => {}
+        Ok(false) => debug!(
+            room = %room,
+            target = %target.id,
+            expected_revision,
+            "ApplyPinChange: skipped rollback because a later pin mutation won"
+        ),
         Err(error) => {
             warn!(
                 room = %room,
-                op,
-                error = ?error,
-                "room registry lookup failed; skipping"
+                target = %target.id,
+                ?error,
+                "ApplyPinChange: system broadcast failed and guarded rollback could not apply"
             );
-            None
         }
     }
 }
@@ -321,12 +409,13 @@ pub(super) async fn cascade_retraction_to_pin_list(
     room: BareJid,
     target_message_id: String,
     recursion_depth: u8,
-) {
+) -> PinChangeOutcome {
     if target_message_id.is_empty() || target_message_id.len() > MAX_TARGET_STANZA_ID_LEN {
-        return;
+        return PinChangeOutcome::Skipped;
     }
-    let Some(room_actor) = lookup_room_actor(deps, &room, "PinRetractionCascade").await else {
-        return;
+    let room_actor = match exact_room_actor_for_effect(deps, &room).await {
+        Ok(actor) => actor,
+        Err(error) => return map_room_effect_authority_error(error),
     };
     let entries = match room_actor.ask(GetPinList).await {
         Ok(entries) => entries,
@@ -336,7 +425,7 @@ pub(super) async fn cascade_retraction_to_pin_list(
                 error = ?error,
                 "Pin retraction cascade: GetPinList ask failed"
             );
-            return;
+            return PinChangeOutcome::OwnershipUncertain;
         }
     };
     let Some(entry) = entries
@@ -344,7 +433,7 @@ pub(super) async fn cascade_retraction_to_pin_list(
         .find(|e| e.target_stanza_id.id == target_message_id)
         .cloned()
     else {
-        return;
+        return PinChangeOutcome::Skipped;
     };
 
     apply_pin_change_event(
@@ -358,5 +447,192 @@ pub(super) async fn cascade_retraction_to_pin_list(
         },
         recursion_depth,
     )
-    .await;
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kameo::actor::Spawn;
+    use waddle_xmpp::muc::room_actor::{JoinAffiliationGrant, JoinWithAffiliation};
+    use waddle_xmpp::muc::room_registry_actor::{CreateRoom, DestroyRoom};
+    use waddle_xmpp::muc::RoomConfig;
+    use waddle_xmpp::registry::UserRegistryActor;
+    use waddle_xmpp::xep::xep0421::OccupantIdSecret;
+
+    fn pin_entry(room: &BareJid, target: &str) -> PinnedEntry {
+        let pinner: BareJid = "alice@example.com".parse().expect("pinner JID");
+        let pinned_at = chrono::Utc::now();
+        PinnedEntry {
+            target_stanza_id: StanzaId::new(target, Jid::from(room.clone())),
+            pinner_jid: pinner.clone(),
+            pinned_at,
+            preview: PinPreview::new(pinner, Some("alice".to_string()), "preview", pinned_at),
+        }
+    }
+
+    async fn replaced_room(
+        name: &str,
+    ) -> (
+        ActorRef<RoomRegistryActor>,
+        BareJid,
+        ActorRef<RoomActor>,
+        ActorRef<RoomActor>,
+    ) {
+        let room_registry = RoomRegistryActor::spawn(RoomRegistryActor::new(
+            "muc.example.com".to_string(),
+            OccupantIdSecret::new(vec![b'p'; 32]).expect("test secret"),
+        ));
+        let room: BareJid = format!("{name}@muc.example.com").parse().expect("room JID");
+        let original = room_registry
+            .ask(CreateRoom {
+                room_jid: room.clone(),
+                waddle_id: "original".to_string(),
+                channel_id: format!("{name}-original"),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create original actor");
+        room_registry
+            .ask(DestroyRoom {
+                room_jid: room.clone(),
+            })
+            .await
+            .expect("remove original actor");
+        let replacement = room_registry
+            .ask(CreateRoom {
+                room_jid: room.clone(),
+                waddle_id: "replacement".to_string(),
+                channel_id: format!("{name}-replacement"),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create replacement actor");
+        (room_registry, room, original, replacement)
+    }
+
+    #[tokio::test]
+    async fn replacement_after_preview_cannot_receive_resolved_pin_mutation() {
+        let connections = ConnectionRegistry::new();
+        let (room_registry, room, original, replacement) = replaced_room("pin-final-gate").await;
+        let mut deps = Deps::registry_only(&connections);
+        deps.room_registry = Some(&room_registry);
+        deps.room_actor_incarnation = Some(original);
+
+        // `apply_pin` calls this seam only after preview enrichment and the
+        // prior-state read have completed. Replacing E1 before this call
+        // deterministically models that exact delayed continuation.
+        let outcome = apply_pin_state_change_exact(
+            &deps,
+            &room,
+            PinStateChange::Pin(pin_entry(&room, "stale-pin")),
+        )
+        .await;
+
+        assert_eq!(outcome, Err(PinChangeOutcome::NotOwner));
+        assert!(replacement
+            .ask(GetPinList)
+            .await
+            .expect("replacement pin list")
+            .is_empty());
+        assert!(replacement.is_alive(), "exact E1 demotion must preserve E2");
+    }
+
+    #[tokio::test]
+    async fn replacement_between_pin_apply_and_broadcast_gets_no_stale_system_message() {
+        let connections = ConnectionRegistry::new();
+        let user_registry = UserRegistryActor::spawn(UserRegistryActor::new());
+        let room_registry = RoomRegistryActor::spawn(RoomRegistryActor::new(
+            "muc.example.com".to_string(),
+            OccupantIdSecret::new(vec![b'b'; 32]).expect("test secret"),
+        ));
+        let room: BareJid = "pin-broadcast@muc.example.com".parse().expect("room JID");
+        let original = room_registry
+            .ask(CreateRoom {
+                room_jid: room.clone(),
+                waddle_id: "original".to_string(),
+                channel_id: "pin-broadcast-original".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create original actor");
+        let entry = pin_entry(&room, "applied-on-e1");
+        original
+            .ask(ApplyPin {
+                change: PinStateChange::Pin(entry.clone()),
+            })
+            .await
+            .expect("apply pin to E1");
+
+        room_registry
+            .ask(DestroyRoom {
+                room_jid: room.clone(),
+            })
+            .await
+            .expect("remove E1 after pin apply");
+        let replacement = room_registry
+            .ask(CreateRoom {
+                room_jid: room.clone(),
+                waddle_id: "replacement".to_string(),
+                channel_id: "pin-broadcast-replacement".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create E2");
+        let occupant: FullJid = "bob@example.com/web".parse().expect("occupant JID");
+        replacement
+            .ask(JoinWithAffiliation {
+                sender_jid: occupant.clone(),
+                nick: "bob".to_string(),
+                affiliation_grant: JoinAffiliationGrant::Resolver(waddle_xmpp::Affiliation::Member),
+                local_domain: "example.com".to_string(),
+                admission_revision: 0,
+            })
+            .await
+            .expect("join E2 occupant");
+        let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+        connections.register_with_carbons(occupant.clone(), tx, false);
+        let connection_entry = connections
+            .get_entry(&occupant)
+            .expect("registered connection entry");
+        assert!(
+            crate::server::dual_registration::mirror_register(
+                &user_registry,
+                occupant,
+                connection_entry,
+            )
+            .await
+        );
+
+        let mut deps = Deps::registry_with_user_registry(&connections, &user_registry);
+        deps.room_registry = Some(&room_registry);
+        deps.room_actor_incarnation = Some(original);
+        let system_message = build_pinned_system_message(
+            &room,
+            &entry.pinner_jid,
+            "alice",
+            &entry.target_stanza_id,
+            Some(&entry.preview),
+            None,
+        );
+        let broadcast = super::super::room_system_message::broadcast_room_system_message_event(
+            &deps,
+            room,
+            Box::new(system_message),
+            0,
+        )
+        .await;
+
+        assert!(broadcast.is_none());
+        assert!(
+            rx.try_recv().is_err(),
+            "E2 occupant received stale E1 pin event"
+        );
+        assert!(replacement
+            .ask(GetPinList)
+            .await
+            .expect("replacement pin list")
+            .is_empty());
+        assert!(replacement.is_alive(), "exact E1 demotion must preserve E2");
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/room_subject.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_subject.rs
@@ -1,6 +1,14 @@
 use super::*;
 use waddle_xmpp::muc::RoomSubjectTexts;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum PersistRoomSubjectOutcome {
+    Applied,
+    NotOwner,
+    OwnershipUncertain,
+    PersistFailed,
+}
+
 pub(super) async fn persist_room_subject_event(
     deps: &Deps<'_>,
     room: BareJid,
@@ -8,38 +16,17 @@ pub(super) async fn persist_room_subject_event(
     setter: BareJid,
     setter_nick: String,
     set_at: chrono::DateTime<chrono::Utc>,
-) {
-    let Some(room_registry) = deps.room_registry else {
-        debug!(
-            room = %room,
-            "PersistRoomSubject: no room_registry in Deps; skipping"
-        );
-        return;
-    };
-    let room_actor = match room_registry
-        .ask(GetRoom {
-            room_jid: room.clone(),
-        })
-        .await
-    {
-        Ok(Some(actor)) => actor,
-        Ok(None) => {
-            debug!(
-                room = %room,
-                "PersistRoomSubject: room not registered; skipping"
-            );
-            return;
+) -> PersistRoomSubjectOutcome {
+    let room_actor = match exact_room_actor_for_effect(deps, &room).await {
+        Ok(actor) => actor,
+        Err(RoomEffectAuthorityError::NotOwner) => {
+            return PersistRoomSubjectOutcome::NotOwner;
         }
-        Err(error) => {
-            warn!(
-                room = %room,
-                error = ?error,
-                "PersistRoomSubject: room registry lookup failed; skipping"
-            );
-            return;
+        Err(RoomEffectAuthorityError::OwnershipUncertain) => {
+            return PersistRoomSubjectOutcome::OwnershipUncertain;
         }
     };
-    if let Err(error) = room_actor
+    match room_actor
         .ask(SetSubject {
             texts,
             setter: setter.clone(),
@@ -48,11 +35,89 @@ pub(super) async fn persist_room_subject_event(
         })
         .await
     {
-        warn!(
-            room = %room,
-            setter = %setter,
-            error = ?error,
-            "PersistRoomSubject: SetSubject ask failed; subject left at previous state"
-        );
+        Ok(()) => PersistRoomSubjectOutcome::Applied,
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+        )) => PersistRoomSubjectOutcome::NotOwner,
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::OwnershipUncertain,
+        )) => PersistRoomSubjectOutcome::OwnershipUncertain,
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::PersistFailed(_),
+        )) => PersistRoomSubjectOutcome::PersistFailed,
+        Err(error) => {
+            warn!(
+                room = %room,
+                setter = %setter,
+                error = ?error,
+                "PersistRoomSubject: SetSubject ask failed; subject left at previous state"
+            );
+            PersistRoomSubjectOutcome::OwnershipUncertain
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kameo::actor::Spawn;
+    use waddle_xmpp::muc::room_actor::GetSnapshot;
+    use waddle_xmpp::muc::room_registry_actor::{CreateRoom, DestroyRoom};
+    use waddle_xmpp::muc::RoomConfig;
+    use waddle_xmpp::xep::xep0421::OccupantIdSecret;
+
+    #[tokio::test]
+    async fn retained_subject_event_cannot_mutate_replacement_room_actor() {
+        let connections = ConnectionRegistry::new();
+        let room_registry = RoomRegistryActor::spawn(RoomRegistryActor::new(
+            "muc.example.com".to_string(),
+            OccupantIdSecret::new(vec![b's'; 32]).expect("test secret"),
+        ));
+        let room: BareJid = "subject@muc.example.com".parse().expect("room JID");
+        let original = room_registry
+            .ask(CreateRoom {
+                room_jid: room.clone(),
+                waddle_id: "original".to_string(),
+                channel_id: "subject-original".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create original actor");
+        room_registry
+            .ask(DestroyRoom {
+                room_jid: room.clone(),
+            })
+            .await
+            .expect("remove original actor");
+        let replacement = room_registry
+            .ask(CreateRoom {
+                room_jid: room.clone(),
+                waddle_id: "replacement".to_string(),
+                channel_id: "subject-replacement".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create replacement actor");
+
+        let mut deps = Deps::registry_only(&connections);
+        deps.room_registry = Some(&room_registry);
+        deps.room_actor_incarnation = Some(original);
+        let outcome = persist_room_subject_event(
+            &deps,
+            room,
+            RoomSubjectTexts::from_iter([(String::new(), "stale subject".to_string())]),
+            "alice@example.com".parse().expect("setter JID"),
+            "alice".to_string(),
+            chrono::Utc::now(),
+        )
+        .await;
+
+        assert_eq!(outcome, PersistRoomSubjectOutcome::NotOwner);
+        let snapshot = replacement
+            .ask(GetSnapshot)
+            .await
+            .expect("replacement snapshot");
+        assert!(snapshot.room.subject.is_none());
+        assert!(replacement.is_alive(), "exact E1 demotion must preserve E2");
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
@@ -16,6 +16,16 @@
 use super::*;
 use waddle_xmpp_core::xep0359::{add_stanza_id, StanzaId};
 
+fn bind_room_system_actor<'a>(deps: &Deps<'a>, room_actor: &ActorRef<RoomActor>) -> Deps<'a> {
+    let mut exact_deps = deps.clone();
+    exact_deps.room_actor_incarnation = Some(room_actor.clone());
+    exact_deps
+}
+
+async fn room_system_fanout_authorized(deps: &Deps<'_>, room: &BareJid) -> bool {
+    exact_room_actor_for_effect(deps, room).await.is_ok()
+}
+
 pub(super) async fn broadcast_room_system_message_event(
     deps: &Deps<'_>,
     room: BareJid,
@@ -29,29 +39,51 @@ pub(super) async fn broadcast_room_system_message_event(
         );
         return None;
     };
-    let room_actor = match room_registry
-        .ask(GetRoom {
-            room_jid: room.clone(),
-        })
-        .await
-    {
-        Ok(Some(actor)) => actor,
-        Ok(None) => {
-            debug!(
-                room = %room,
-                "BroadcastRoomSystemMessage: room not registered; dropping"
-            );
-            return None;
+    let room_actor = if deps.room_actor_incarnation.is_some() {
+        match exact_room_actor_for_effect(deps, &room).await {
+            Ok(actor) => actor,
+            Err(error) => {
+                warn!(
+                    room = %room,
+                    ?error,
+                    "BroadcastRoomSystemMessage: authorizing room incarnation was replaced; \
+                     dropping"
+                );
+                return None;
+            }
         }
-        Err(error) => {
-            warn!(
-                room = %room,
-                error = ?error,
-                "BroadcastRoomSystemMessage: room registry lookup failed; dropping"
-            );
-            return None;
+    } else {
+        // Direct server-originated notifications are logical-room operations,
+        // so they may resolve the current incarnation. Nested pin events carry
+        // `room_actor_incarnation` and must never adopt a replacement actor.
+        match room_registry
+            .ask(GetRoom {
+                room_jid: room.clone(),
+            })
+            .await
+        {
+            Ok(Some(actor)) => actor,
+            Ok(None) => {
+                debug!(
+                    room = %room,
+                    "BroadcastRoomSystemMessage: room not registered; dropping"
+                );
+                return None;
+            }
+            Err(error) => {
+                warn!(
+                    room = %room,
+                    error = ?error,
+                    "BroadcastRoomSystemMessage: room registry lookup failed; dropping"
+                );
+                return None;
+            }
         }
     };
+    // From this point on, even a direct logical-room event is bound to the
+    // exact actor selected above. It may resolve fresh authority once, at
+    // entry, but it must not transfer that authority to a later E2.
+    let exact_deps = bind_room_system_actor(deps, &room_actor);
 
     // The system message has `from = room@conf` (bare). The room
     // snapshot query is keyed by a full JID for the sender-occupancy
@@ -86,6 +118,57 @@ pub(super) async fn broadcast_room_system_message_event(
         }
     };
 
+    #[cfg(feature = "clustering")]
+    let exact_fence = match room_actor.ask(GetRoomClaimFence).await {
+        Ok(Some(fence)) => Some(fence),
+        Ok(None) => None,
+        Err(error) => {
+            warn!(room = %room, ?error, "BroadcastRoomSystemMessage: exact fence lookup failed");
+            None
+        }
+    };
+    #[cfg(feature = "clustering")]
+    let exact_deps = {
+        let mut exact_deps = exact_deps;
+        exact_deps.room_claim_fence = exact_fence.clone();
+        exact_deps
+    };
+
+    // System messages do not pass through `dispatch_to_room`, so perform
+    // the same exact ownership proof here even when MAM is disabled. A
+    // cached fence is only an input to the transactional archive check; it
+    // is not by itself proof that the claim/node rows are still live.
+    #[cfg(feature = "clustering")]
+    if let Some(store) = deps.muc_durable_store {
+        let exact_fence = exact_fence.as_ref()?;
+        match store.check_fenced_fanout_exact(&room, exact_fence).await {
+            Ok(true) => {}
+            Ok(false) | Err(waddle_xmpp::XmppError::RoomOwnershipLost(_)) => {
+                warn!(
+                    room = %room,
+                    "BroadcastRoomSystemMessage: exact room ownership was lost; demoting the \
+                     local actor and dropping"
+                );
+                let _ = room_registry
+                    .ask(DestroyRoomExact {
+                        room_jid: room.clone(),
+                        expected_actor: room_actor.clone(),
+                    })
+                    .await;
+                return None;
+            }
+            Err(error) => {
+                warn!(
+                    room = %room,
+                    %error,
+                    "BroadcastRoomSystemMessage: exact room ownership could not be checked; \
+                     failing closed"
+                );
+                return None;
+            }
+        }
+    }
+
     // Stamp a canonical XEP-0359 `<stanza-id by='room'/>` so the
     // message is uniquely addressable in MAM and from clients.
     let stanza_id = uuid::Uuid::new_v4().to_string();
@@ -106,12 +189,19 @@ pub(super) async fn broadcast_room_system_message_event(
     // (there is no separate batch to suppress, unlike the interpreter's
     // `ArchiveGroupchat` event arm), so an early return here is the exact
     // "not archived, not fanned out" contract.
+    let fence = resolve_room_claim_fence(&exact_deps, &room);
+    if fence.is_ownership_uncertain() {
+        warn!(
+            room = %room,
+            "BroadcastRoomSystemMessage: clustered room ownership cannot be resolved; \
+             dropping system message entirely"
+        );
+        return None;
+    }
     if let Some(mam_storage) = deps.mam_storage {
-        let fence = resolve_room_claim_fence(deps, &room);
         // Room-authored system messages have no occupant sender, so
         // there is no real-JID `<x xmlns='muc#user'/>` to disclose.
-        match archive_groupchat_message(mam_storage, &room, &message, 0, fence.as_ref(), None).await
-        {
+        match archive_groupchat_message(mam_storage, &room, &message, 0, &fence, None).await {
             ArchiveGroupchatOutcome::Stored(result) => debug!(
                 room = %room,
                 stanza_id = %result.stored_id,
@@ -121,15 +211,28 @@ pub(super) async fn broadcast_room_system_message_event(
                 room = %room,
                 "BroadcastRoomSystemMessage: archive helper declined (chain bug?)"
             ),
-            ArchiveGroupchatOutcome::OwnershipLost => {
+            ArchiveGroupchatOutcome::OwnershipUncertain => {
                 warn!(
                     room = %room,
-                    "BroadcastRoomSystemMessage: fenced archive write observed ownership \
-                     loss; dropping system message entirely (not archived, not fanned out)"
+                    "BroadcastRoomSystemMessage: exact room ownership could not be proved; \
+                     dropping system message entirely (not archived, not fanned out)"
                 );
                 return None;
             }
         }
+    }
+
+    // Archiving is asynchronous. Bind even a direct logical-room event to the
+    // actor chosen at entry, then re-check that exact incarnation before the
+    // first externally visible fan-out. A direct E1 snapshot must not escape
+    // under E2 merely because the caller arrived without nested batch context.
+    if !room_system_fanout_authorized(&exact_deps, &room).await {
+        warn!(
+            room = %room,
+            "BroadcastRoomSystemMessage: selected room incarnation changed while archiving; \
+             suppressing fan-out"
+        );
+        return None;
     }
 
     // Fan out to every joined occupant. One `RouteToConnection`
@@ -139,15 +242,214 @@ pub(super) async fn broadcast_room_system_message_event(
     // recipient-pass logic (incoming-blocking, archive, inbox) sees
     // a stanza addressed to the room bare JID and may misroute.
     for occupant in &snapshot.occupants {
+        // Routing one recipient can await actor/storage work. Re-prove E1
+        // before every subsequent enqueue and stop immediately if E2 replaced
+        // it between recipients.
+        if !room_system_fanout_authorized(&exact_deps, &room).await {
+            warn!(
+                room = %room,
+                recipient = %occupant.full_jid,
+                "BroadcastRoomSystemMessage: selected room incarnation changed during fan-out; \
+                 stopping remaining recipients"
+            );
+            return None;
+        }
         let mut copy = (*message).clone();
         copy.to = Some(Jid::from(occupant.full_jid.clone()));
         route_to_connection(
-            deps,
+            &exact_deps,
             Jid::from(occupant.full_jid.clone()),
             Box::new(Stanza::Message(copy)),
             recursion_depth,
         )
         .await;
     }
+    // Catch replacement during the final recipient's awaited routing step;
+    // earlier replacements are caught by the next loop iteration.
+    if !room_system_fanout_authorized(&exact_deps, &room).await {
+        warn!(
+            room = %room,
+            "BroadcastRoomSystemMessage: selected room incarnation changed before fan-out \
+             completion"
+        );
+        return None;
+    }
     Some(stanza_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kameo::actor::Spawn;
+    #[cfg(feature = "clustering")]
+    use waddle_xmpp::muc::room_actor::BindRoomClaimFence;
+    use waddle_xmpp::muc::room_registry_actor::{CreateRoom, DestroyRoom};
+    use waddle_xmpp::muc::RoomConfig;
+    use waddle_xmpp::xep::xep0421::OccupantIdSecret;
+
+    #[cfg(feature = "clustering")]
+    struct AlwaysOwnedStore;
+
+    #[cfg(feature = "clustering")]
+    impl waddle_xmpp::muc::MucDurableStore for AlwaysOwnedStore {
+        fn load_room_state<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+        ) -> waddle_xmpp::muc::MucDurableFuture<'a, Option<waddle_xmpp::muc::DurableRoomState>>
+        {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn save_config<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _waddle_id: &'a str,
+            _channel_id: &'a str,
+            _config: &'a RoomConfig,
+        ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn save_subject<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _subject: Option<&'a waddle_xmpp::muc::SubjectState>,
+        ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn save_affiliation<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _entry: &'a waddle_xmpp::muc::affiliation::AffiliationEntry,
+        ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[cfg(feature = "clustering")]
+    fn claim_fence(room: &BareJid, epoch: i64) -> waddle_xmpp::muc::RoomClaimFenceContext {
+        waddle_xmpp::muc::RoomClaimFenceContext {
+            entity: waddle_xmpp::ownership::Entity::new(
+                waddle_xmpp::ownership::EntityType::RoomActor,
+                room.to_string(),
+            ),
+            epoch: waddle_xmpp::ownership::ClaimEpoch(epoch),
+            owner: waddle_xmpp::ownership::NodeIdentity::new("node-a", "node-a-epoch"),
+        }
+    }
+
+    #[cfg(feature = "clustering")]
+    #[tokio::test]
+    async fn clustered_direct_system_event_with_exact_e1_fence_remains_authorized() {
+        let connections = ConnectionRegistry::new();
+        let room_registry = RoomRegistryActor::spawn(RoomRegistryActor::new(
+            "muc.example.com".to_string(),
+            OccupantIdSecret::new(vec![b'c'; 32]).expect("test secret"),
+        ));
+        let room: BareJid = "clustered-system@muc.example.com"
+            .parse()
+            .expect("room JID");
+        let actor = room_registry
+            .ask(CreateRoom {
+                room_jid: room.clone(),
+                waddle_id: "clustered".to_string(),
+                channel_id: "clustered-system".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create room");
+        let fence = claim_fence(&room, 1);
+        actor
+            .ask(BindRoomClaimFence {
+                fence: fence.clone(),
+            })
+            .await
+            .expect("bind exact fence");
+        let durable_store: std::sync::Arc<dyn waddle_xmpp::muc::MucDurableStore> =
+            std::sync::Arc::new(AlwaysOwnedStore);
+        let mut deps = Deps::registry_only(&connections);
+        deps.room_registry = Some(&room_registry);
+        deps.muc_durable_store = Some(&durable_store);
+        deps.clustered_muc_ownership_required = true;
+
+        let mut message = Message::new(Some(Jid::from(room.clone())));
+        message.from = Some(Jid::from(room.clone()));
+        message.type_ = XmppMessageType::Groupchat;
+        let result = broadcast_room_system_message_event(&deps, room, Box::new(message), 0).await;
+
+        assert!(result.is_some());
+        assert!(actor.is_alive());
+    }
+
+    #[tokio::test]
+    async fn direct_system_event_snapshot_cannot_fan_out_after_actor_replacement() {
+        let connections = ConnectionRegistry::new();
+        let room_registry = RoomRegistryActor::spawn(RoomRegistryActor::new(
+            "muc.example.com".to_string(),
+            OccupantIdSecret::new(vec![b'd'; 32]).expect("test secret"),
+        ));
+        let room: BareJid = "direct-system@muc.example.com".parse().expect("room JID");
+        let original = room_registry
+            .ask(CreateRoom {
+                room_jid: room.clone(),
+                waddle_id: "original".to_string(),
+                channel_id: "direct-system-original".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create E1");
+        #[cfg(feature = "clustering")]
+        let original_fence = claim_fence(&room, 1);
+        #[cfg(feature = "clustering")]
+        original
+            .ask(BindRoomClaimFence {
+                fence: original_fence.clone(),
+            })
+            .await
+            .expect("bind E1 fence");
+        #[cfg(feature = "clustering")]
+        let durable_store: std::sync::Arc<dyn waddle_xmpp::muc::MucDurableStore> =
+            std::sync::Arc::new(AlwaysOwnedStore);
+        let mut deps = Deps::registry_only(&connections);
+        deps.room_registry = Some(&room_registry);
+        #[cfg(feature = "clustering")]
+        {
+            deps.muc_durable_store = Some(&durable_store);
+            deps.clustered_muc_ownership_required = true;
+        }
+        let exact_deps = bind_room_system_actor(&deps, &original);
+        #[cfg(feature = "clustering")]
+        let exact_deps = {
+            let mut exact_deps = exact_deps;
+            exact_deps.room_claim_fence = Some(original_fence);
+            exact_deps
+        };
+        // The first recipient's per-enqueue proof succeeds under E1.
+        assert!(room_system_fanout_authorized(&exact_deps, &room).await);
+
+        // Model a direct event after it resolved E1 and captured its snapshot,
+        // while its asynchronous archive write was still pending.
+        room_registry
+            .ask(DestroyRoom {
+                room_jid: room.clone(),
+            })
+            .await
+            .expect("remove E1");
+        let replacement = room_registry
+            .ask(CreateRoom {
+                room_jid: room.clone(),
+                waddle_id: "replacement".to_string(),
+                channel_id: "direct-system-replacement".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create E2");
+        // Re-entry before recipient two observes replacement and stops the
+        // remaining fan-out rather than adopting E2.
+        let authorized = room_system_fanout_authorized(&exact_deps, &room).await;
+
+        assert!(!authorized);
+        assert!(replacement.is_alive(), "exact E1 check must preserve E2");
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/routing.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/routing.rs
@@ -83,6 +83,7 @@ pub(super) async fn run_headless_recipient_pass(
         // Headless pass emits no wire copy, so there is nothing to
         // rewrite.
         archive_id_rewrites: _,
+        room_ownership_uncertain: _,
     } = nested;
     debug!(
         bare_jid = %recipient_bare,
@@ -245,6 +246,7 @@ pub(super) async fn run_fanout_recipient_pass(
         keepalive_probes: _,
         timer_commands: _,
         archive_id_rewrites,
+        room_ownership_uncertain: _,
     } = nested;
     debug!(
         bare_jid = %recipient_bare,

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -281,6 +281,13 @@ async fn xep_0280_send_carbons_queues_for_detached_xep_0198_resources() {
         inbox_storage: None,
         extension_manager: None,
         room_registry: None,
+        room_actor_incarnation: None,
+        #[cfg(feature = "clustering")]
+        muc_durable_store: None,
+        #[cfg(feature = "clustering")]
+        clustered_muc_ownership_required: false,
+        #[cfg(feature = "clustering")]
+        room_claim_fence: None,
         web_socket_state: None,
         authenticated_session: None,
         local_domain: "example.com",
@@ -2062,6 +2069,191 @@ async fn send_stanza_preserves_xep_0201_thread_on_wire() {
 // the chain wiring against the lightweight in-process `Deps` shape.
 // -----------------------------------------------------------------
 
+#[cfg(feature = "clustering")]
+struct ResolvedRoomFenceStore {
+    fence: waddle_xmpp::muc::RoomClaimFenceContext,
+}
+
+#[cfg(feature = "clustering")]
+impl waddle_xmpp::muc::MucDurableStore for ResolvedRoomFenceStore {
+    fn load_room_state<'a>(
+        &'a self,
+        _room_jid: &'a BareJid,
+    ) -> waddle_xmpp::muc::MucDurableFuture<'a, Option<waddle_xmpp::muc::DurableRoomState>> {
+        Box::pin(async { Ok(None) })
+    }
+
+    fn save_config<'a>(
+        &'a self,
+        _room_jid: &'a BareJid,
+        _waddle_id: &'a str,
+        _channel_id: &'a str,
+        _config: &'a waddle_xmpp::muc::RoomConfig,
+    ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn save_subject<'a>(
+        &'a self,
+        _room_jid: &'a BareJid,
+        _subject: Option<&'a waddle_xmpp::muc::SubjectState>,
+    ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn save_affiliation<'a>(
+        &'a self,
+        _room_jid: &'a BareJid,
+        _entry: &'a waddle_xmpp::muc::affiliation::AffiliationEntry,
+    ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn current_claim_fence(
+        &self,
+        _room_jid: &BareJid,
+    ) -> Option<waddle_xmpp::muc::RoomClaimFenceContext> {
+        Some(self.fence.clone())
+    }
+}
+
+#[cfg(feature = "clustering")]
+fn archive_groupchat_event_message(room: &BareJid, with_stanza_id: bool) -> Message {
+    use waddle_xmpp_core::xep0359::{add_stanza_id, StanzaId};
+
+    let mut message = Message::new(Some(Jid::from(room.clone())));
+    message.from = Some(
+        format!("{room}/alice")
+            .parse::<Jid>()
+            .expect("valid room occupant JID"),
+    );
+    message.type_ = XmppMessageType::Groupchat;
+    message.id = Some(xmpp_parsers::message::Id("wire-id".to_string()));
+    message
+        .bodies
+        .insert(xmpp_parsers::message::Lang::new(), "hello".to_string());
+    if with_stanza_id {
+        add_stanza_id(
+            &mut message,
+            &StanzaId::new("archive-id", Jid::from(room.clone())),
+        );
+    }
+    message
+}
+
+#[cfg(feature = "clustering")]
+fn clustered_archive_test_deps<'a>(
+    registry: &'a ConnectionRegistry,
+    mam: &'a Arc<dyn MamStorage>,
+    inbox: &'a Arc<dyn InboxStorage>,
+    store: &'a Arc<dyn waddle_xmpp::muc::MucDurableStore>,
+) -> Deps<'a> {
+    let mut deps = Deps::test_with_storage(registry, mam, inbox);
+    deps.muc_durable_store = Some(store);
+    deps.clustered_muc_ownership_required = true;
+    deps
+}
+
+#[cfg(feature = "clustering")]
+#[tokio::test]
+async fn clustered_archive_fence_failure_suppresses_later_batch_effects() {
+    use waddle_xmpp::mam::SqlxMamStorage;
+    use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
+
+    let registry = ConnectionRegistry::new();
+    let mam: Arc<dyn MamStorage> = Arc::new(
+        SqlxMamStorage::open_in_memory()
+            .await
+            .expect("open in-memory MAM"),
+    );
+    let inbox: Arc<dyn InboxStorage> =
+        Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
+    let room: BareJid = "batch-fence@muc.example.com".parse().expect("room");
+    let store: Arc<dyn waddle_xmpp::muc::MucDurableStore> = Arc::new(ResolvedRoomFenceStore {
+        fence: waddle_xmpp::muc::RoomClaimFenceContext {
+            entity: Entity::new(EntityType::RoomActor, room.to_string()),
+            epoch: ClaimEpoch(3),
+            owner: NodeIdentity::new("node-a", "epoch-a"),
+        },
+    });
+    let deps = clustered_archive_test_deps(&registry, &mam, &inbox, &store);
+    let sender: jid::FullJid = "alice@example.com/web".parse().expect("sender");
+    let outcome = interpret(
+        vec![
+            OutboundEvent::ArchiveGroupchat {
+                room: room.clone(),
+                sender,
+                message: Box::new(archive_groupchat_event_message(&room, true)),
+                sender_nickname_generation: 0,
+                sender_item: None,
+            },
+            OutboundEvent::SendStanza(Box::new(Stanza::Iq(Box::new(result_iq("must-not-run"))))),
+        ],
+        &deps,
+    )
+    .await;
+
+    assert!(outcome.room_ownership_uncertain);
+    assert!(outcome
+        .frames
+        .iter()
+        .any(|frame| frame.contains("resource-constraint")));
+    assert!(!outcome
+        .frames
+        .iter()
+        .any(|frame| frame.contains("must-not-run")));
+}
+
+#[cfg(feature = "clustering")]
+#[tokio::test]
+async fn malformed_fenced_archive_event_suppresses_later_batch_effects() {
+    use waddle_xmpp::mam::SqlxMamStorage;
+    use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
+
+    let registry = ConnectionRegistry::new();
+    let mam: Arc<dyn MamStorage> = Arc::new(
+        SqlxMamStorage::open_in_memory()
+            .await
+            .expect("open in-memory MAM"),
+    );
+    let inbox: Arc<dyn InboxStorage> =
+        Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
+    let room: BareJid = "batch-skip@muc.example.com".parse().expect("room");
+    let store: Arc<dyn waddle_xmpp::muc::MucDurableStore> = Arc::new(ResolvedRoomFenceStore {
+        fence: waddle_xmpp::muc::RoomClaimFenceContext {
+            entity: Entity::new(EntityType::RoomActor, room.to_string()),
+            epoch: ClaimEpoch(4),
+            owner: NodeIdentity::new("node-a", "epoch-a"),
+        },
+    });
+    let deps = clustered_archive_test_deps(&registry, &mam, &inbox, &store);
+    let sender: jid::FullJid = "alice@example.com/web".parse().expect("sender");
+    let outcome = interpret(
+        vec![
+            OutboundEvent::ArchiveGroupchat {
+                room: room.clone(),
+                sender,
+                message: Box::new(archive_groupchat_event_message(&room, false)),
+                sender_nickname_generation: 0,
+                sender_item: None,
+            },
+            OutboundEvent::SendStanza(Box::new(Stanza::Iq(Box::new(result_iq("must-not-run"))))),
+        ],
+        &deps,
+    )
+    .await;
+
+    assert!(outcome.room_ownership_uncertain);
+    assert!(outcome
+        .frames
+        .iter()
+        .any(|frame| frame.contains("resource-constraint")));
+    assert!(!outcome
+        .frames
+        .iter()
+        .any(|frame| frame.contains("must-not-run")));
+}
+
 /// Without `web_socket_state` the arm logs a warn and drops the
 /// event without panicking — production must wire `web_socket_state`
 /// via [`super::super::websocket::build_interpret_deps`].
@@ -2344,6 +2536,13 @@ fn offline_pass_deps<'a>(
         inbox_storage: Some(inbox),
         extension_manager: None,
         room_registry: None,
+        room_actor_incarnation: None,
+        #[cfg(feature = "clustering")]
+        muc_durable_store: None,
+        #[cfg(feature = "clustering")]
+        clustered_muc_ownership_required: false,
+        #[cfg(feature = "clustering")]
+        room_claim_fence: None,
         web_socket_state: None,
         authenticated_session: None,
         local_domain: "example.com",
@@ -2835,7 +3034,7 @@ async fn xep_0045_persist_room_subject_writes_state_via_room_actor() {
             .expect("test secret meets length floor"),
     ));
     let room_jid: jid::BareJid = "channel@muc.example.com".parse().expect("bare jid");
-    let _room_actor = room_registry
+    let room_actor = room_registry
         .ask(CreateRoom {
             room_jid: room_jid.clone(),
             waddle_id: "w-1".to_string(),
@@ -2853,6 +3052,13 @@ async fn xep_0045_persist_room_subject_writes_state_via_room_actor() {
         inbox_storage: None,
         extension_manager: None,
         room_registry: Some(&room_registry),
+        room_actor_incarnation: Some(room_actor),
+        #[cfg(feature = "clustering")]
+        muc_durable_store: None,
+        #[cfg(feature = "clustering")]
+        clustered_muc_ownership_required: false,
+        #[cfg(feature = "clustering")]
+        room_claim_fence: None,
         web_socket_state: None,
         authenticated_session: None,
         local_domain: "example.com",
@@ -2874,6 +3080,8 @@ async fn xep_0045_persist_room_subject_writes_state_via_room_actor() {
         texts: texts.clone(),
         setter: setter.clone(),
         setter_nick: "alice-nick".to_string(),
+        sender_full: "alice@example.com/desktop".parse().expect("full jid"),
+        message: Box::new(Message::new(Some(jid::Jid::from(room_jid.clone())))),
         set_at,
     }];
     let _outcome = interpret(events, &deps).await;
@@ -2912,14 +3120,17 @@ async fn xep_0045_persist_room_subject_with_no_registry_is_noop() {
     let texts =
         waddle_xmpp::muc::RoomSubjectTexts::from_iter([(String::new(), "ignored".to_string())]);
     let events = vec![OutboundEvent::PersistRoomSubject {
-        room: room_jid,
+        room: room_jid.clone(),
         texts,
         setter,
         setter_nick: "alice-nick".to_string(),
+        sender_full: "alice@example.com/desktop".parse().expect("full jid"),
+        message: Box::new(Message::new(Some(jid::Jid::from(room_jid)))),
         set_at: chrono::Utc.with_ymd_and_hms(2026, 5, 2, 12, 0, 0).unwrap(),
     }];
     let outcome = interpret(events, &deps).await;
-    assert!(outcome.frames.is_empty());
+    assert_eq!(outcome.frames.len(), 1, "the sender gets a retryable error");
+    assert!(outcome.room_ownership_uncertain);
     assert!(!outcome.close);
 }
 
@@ -3110,15 +3321,31 @@ async fn xep_0424_apply_groupchat_retraction_tombstone_keys_off_room_stanza_id()
     retraction.id = Some(xmpp_parsers::message::Id("retract-stanza-1".to_string()));
     retraction.from = Some(format!("{room}/alice").parse().expect("room/nick"));
     retraction.type_ = XmppMessageType::Groupchat;
+    waddle_xmpp_core::xep0359::add_stanza_id(
+        &mut retraction,
+        &waddle_xmpp_core::xep0359::StanzaId::new(
+            "retract-room-stamp-1",
+            jid::Jid::from(room.clone()),
+        ),
+    );
     retraction
         .payloads
         .push(waddle_xmpp::xep::xep0424::build_retract_element(archive_pk));
 
-    let events = vec![OutboundEvent::ApplyGroupchatRetractionTombstone {
-        room: room.clone(),
-        target_message_id: archive_pk.to_string(),
-        retraction_message: Box::new(retraction),
-    }];
+    let events = vec![
+        OutboundEvent::ArchiveGroupchat {
+            room: room.clone(),
+            sender: "alice@example.com/web".parse().expect("full jid"),
+            message: Box::new(retraction.clone()),
+            sender_nickname_generation: 0,
+            sender_item: None,
+        },
+        OutboundEvent::ApplyGroupchatRetractionTombstone {
+            room: room.clone(),
+            target_message_id: archive_pk.to_string(),
+            retraction_message: Box::new(retraction),
+        },
+    ];
     let _outcome = interpret(events, &deps).await;
 
     // The seeded row's body must now be scrubbed and a
@@ -3213,15 +3440,31 @@ async fn xep_0424_groupchat_retraction_scrubs_pending_delivery_rows() {
     retraction.id = Some(xmpp_parsers::message::Id("retract-stanza-2".to_string()));
     retraction.from = Some(format!("{room}/alice").parse().expect("room/nick"));
     retraction.type_ = XmppMessageType::Groupchat;
+    waddle_xmpp_core::xep0359::add_stanza_id(
+        &mut retraction,
+        &waddle_xmpp_core::xep0359::StanzaId::new(
+            "retract-room-stamp-2",
+            jid::Jid::from(room.clone()),
+        ),
+    );
     retraction
         .payloads
         .push(waddle_xmpp::xep::xep0424::build_retract_element(archive_pk));
 
-    let events = vec![OutboundEvent::ApplyGroupchatRetractionTombstone {
-        room: room.clone(),
-        target_message_id: archive_pk.to_string(),
-        retraction_message: Box::new(retraction),
-    }];
+    let events = vec![
+        OutboundEvent::ArchiveGroupchat {
+            room: room.clone(),
+            sender: "alice@example.com/web".parse().expect("full jid"),
+            message: Box::new(retraction.clone()),
+            sender_nickname_generation: 0,
+            sender_item: None,
+        },
+        OutboundEvent::ApplyGroupchatRetractionTombstone {
+            room: room.clone(),
+            target_message_id: archive_pk.to_string(),
+            retraction_message: Box::new(retraction),
+        },
+    ];
     let _outcome = interpret(events, &deps).await;
 
     let rows = pending.list(&recipient).await.expect("list");
@@ -3308,6 +3551,13 @@ async fn fanout_pass_blocklist_failure_falls_back_to_legacy_per_resource_deliver
         inbox_storage: None,
         extension_manager: None,
         room_registry: None,
+        room_actor_incarnation: None,
+        #[cfg(feature = "clustering")]
+        muc_durable_store: None,
+        #[cfg(feature = "clustering")]
+        clustered_muc_ownership_required: false,
+        #[cfg(feature = "clustering")]
+        room_claim_fence: None,
         web_socket_state: None,
         authenticated_session: None,
         local_domain: "example.com",

--- a/server/crates/waddle-server/src/server/routes/muc_muji_clear.rs
+++ b/server/crates/waddle-server/src/server/routes/muc_muji_clear.rs
@@ -60,14 +60,20 @@ pub(crate) async fn clear_muji_presence_for_departure(
             note_participant_left_from_webhook(state, room_jid, full_jid);
             return;
         }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+        )) => {
+            super::websocket::handlers::iq::demote_exact_room_actor(state, room_jid, &actor).await;
+            warn!(room = %room_jid, identity = %full_jid, "Room ownership moved; suppressing Muji clear side effects");
+            return;
+        }
         Err(error) => {
             warn!(
                 room = %room_jid,
                 identity = %full_jid,
                 error = ?error,
-                "Room actor rejected Muji clear; falling through to SFU unregister"
+                "Room actor rejected Muji clear; suppressing SFU and fanout side effects"
             );
-            note_participant_left_from_webhook(state, room_jid, full_jid);
             return;
         }
     };

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -9,7 +9,7 @@ use waddle_xmpp::xep::xep0272::Muji;
 use waddle_xmpp::xep::xep0421::OccupantIdentity;
 
 #[cfg(feature = "clustering")]
-async fn unregister_remote_user_resource_if_owner(
+pub(super) async fn unregister_remote_user_resource_if_owner(
     state: &WebSocketState,
     jid: &FullJid,
     owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
@@ -28,7 +28,7 @@ async fn unregister_remote_user_resource_if_owner(
 }
 
 #[cfg(not(feature = "clustering"))]
-async fn unregister_remote_user_resource_if_owner(
+pub(super) async fn unregister_remote_user_resource_if_owner(
     _state: &WebSocketState,
     _jid: &FullJid,
     _owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
@@ -670,20 +670,11 @@ async fn cleanup_muc_presence_with_origin(
                 sender_jid: jid.clone(),
             })
             .await;
-        // SFU teardown runs *after* the room actor has dropped the
-        // session so the MUC's view of the world is the leading edge
-        // (the membership gate immediately reports the user as a
-        // non-occupant) and the SFU's view is the trailing edge —
-        // matches `handle_muc_leave`'s "XMPP says they left, then
-        // notify SFU" semantics. Tab close / SM-expiry: the client
-        // never sends a graceful `request-leave` on
-        // `urn:waddle:muc-call:0`, so without this call the SFU
-        // would otherwise hold the participant slot until its own
-        // (long) timeout. Idempotent on the SFU side — calling for
-        // rooms where the user was never in a call is a no-op.
-        super::muc_call_sfu::unregister_participant_from_room(state, &room_jid, jid);
         match leave_result {
             Ok(Some(outcome)) => {
+                // The actor mutation linearizes first; only then may SFU
+                // cleanup and occupant fan-out observe the leave.
+                super::muc_call_sfu::unregister_participant_from_room(state, &room_jid, jid);
                 debug!(
                     room = %room_jid,
                     nick = %outcome.nick,
@@ -703,7 +694,14 @@ async fn cleanup_muc_presence_with_origin(
                 broadcast_muc_muji_clear_to_remaining(state, &room_jid, jid, &outcome).await;
                 maybe_evict_empty_room(state, &room_jid, &outcome).await;
             }
-            Ok(None) => {}
+            Ok(None) => {
+                super::muc_call_sfu::unregister_participant_from_room(state, &room_jid, jid);
+            }
+            Err(kameo::error::SendError::HandlerError(
+                waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+            )) => {
+                super::handlers::iq::demote_exact_room_actor(state, &room_jid, &room_actor).await;
+            }
             Err(error) => {
                 warn!(
                     room = %room_jid,
@@ -1129,19 +1127,6 @@ pub(crate) async fn is_muc_room_jid(state: &WebSocketState, room_jid: &BareJid) 
         Ok(is_muc_jid) => is_muc_jid,
         Err(error) => {
             warn!(room = %room_jid, error = %error, "Failed to validate MUC JID");
-            false
-        }
-    }
-}
-
-pub(crate) async fn destroy_room_actor(state: &WebSocketState, room_jid: &BareJid) -> bool {
-    match RoomRegistry::wrap(state.deps.protocol.room_registry.clone())
-        .destroy_room(room_jid.clone())
-        .await
-    {
-        Ok(destroyed) => destroyed,
-        Err(error) => {
-            warn!(room = %room_jid, error = %error, "Failed to destroy room actor");
             false
         }
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -19,7 +19,11 @@ use super::{
 };
 use axum::response::IntoResponse;
 use futures::stream::{SplitSink, SplitStream};
+use waddle_xmpp::registry::ForceDetachReason;
 use waddle_xmpp::stream_management::SmRequest;
+
+const FORCE_DETACH_RECONNECT_TEXT: &str =
+    "This stream can no longer be served here; please reconnect.";
 
 /// Create the WebSocket router
 pub fn router(state: Arc<WebSocketState>) -> Router {
@@ -108,7 +112,28 @@ async fn handle_xmpp_websocket(
     // drain (issue #1091) only completes once every live session has
     // been closed AND its SM state handed to the session registry for
     // Q6 promotion.
+    connection_guard: waddle_ecdysis::ConnectionGuard,
+) {
+    let (abort, registration) = futures::future::AbortHandle::new_pair();
+    let terminated = tokio_util::sync::CancellationToken::new();
+    let retirement_handle =
+        waddle_xmpp::registry::ConnectionRetirementHandle::new(abort, terminated.clone());
+    let result = futures::future::Abortable::new(
+        handle_xmpp_websocket_inner(socket, state, connection_guard, retirement_handle),
+        registration,
+    )
+    .await;
+    terminated.cancel();
+    if result.is_err() {
+        warn!("XMPP WebSocket connection hard-retired after force-detach timeout");
+    }
+}
+
+async fn handle_xmpp_websocket_inner(
+    socket: WebSocket,
+    state: Arc<WebSocketState>,
     _connection_guard: waddle_ecdysis::ConnectionGuard,
+    retirement_handle: waddle_xmpp::registry::ConnectionRetirementHandle,
 ) {
     let domain = state.deps.auth_state.xmpp_domain.clone();
     let shutdown_token = state.deps.shutdown.stop_token();
@@ -145,6 +170,12 @@ async fn handle_xmpp_websocket(
 
     // Track connection state
     let mut conn = WsConnState::new();
+    conn.clustering_admission = state
+        .deps
+        .app_state
+        .clustering_readiness
+        .capture_admission();
+    conn.retirement_handle = Some(retirement_handle);
     let (handoff_tx, mut handoff_rx) = mpsc::unbounded_channel::<
         crate::server::routes::interpret::OrderedRelayHandoffCompletion,
     >();
@@ -367,14 +398,15 @@ async fn handle_xmpp_websocket(
                 }
             }
 
-            // ADR-0017 Phase 3 Slice 6: a cross-node XEP-0198 resume
-            // live-steal handshake ask for this connection's own stream id.
+            // A typed request to retire this connection on its own task.
+            // Cross-node XEP-0198 resume and same-resource replacement use
+            // <conflict/>; whole-node fencing uses <system-shutdown/>; and
+            // per-resource ownership/remote-state loss uses recoverable
+            // <internal-server-error/> so the client reconnects.
             // The identity check gates the destructive close itself (defense
             // in depth against a wrong-identity `previd` forcing a disconnect
-            // before rejection) — a mismatch answers inline and this
-            // connection keeps serving normally; a match sends `<conflict/>`
-            // (XEP-0198 "Resumption" SHOULD) and closes, falling through to
-            // the SAME detach-for-resume cleanup a graceful/keepalive close
+            // before rejection). A matching request closes and falls through
+            // to the same detach-for-resume cleanup a graceful/keepalive close
             // uses (never transitions `phase` to `Closing`).
             request = recv_optional(&mut force_detach_rx) => {
                 match request {
@@ -384,27 +416,32 @@ async fn handle_xmpp_websocket(
                             warn!(
                                 requester = %request.requester_bare_jid,
                                 bound = ?bound_bare,
-                                "Cross-node resume force-detach rejected: identity mismatch"
+                                reason = ?request.reason,
+                                "Force-detach rejected: identity mismatch"
                             );
                             let _ = request
                                 .ack
                                 .send(waddle_xmpp::registry::ForceDetachOutcome::IdentityMismatch);
                         } else {
+                            let (stream_error, condition) =
+                                force_detach_stream_error(request.reason);
                             info!(
                                 jid = ?conn.phase.bound_jid(),
-                                "Cross-node resume: force-detaching this session (<conflict/> close)"
+                                reason = ?request.reason,
+                                condition,
+                                "Force-detaching this session"
                             );
                             if conn.stream_open_sent {
                                 let _ = send_ws_text_frames(
                                     &mut ws_sender,
-                                    [build_conflict_stream_error(), websocket_stream_close_xml()],
-                                    "Failed to send conflict stream error",
+                                    [stream_error, websocket_stream_close_xml()],
+                                    "Failed to send force-detach stream error",
                                 )
                                 .await;
                             }
                             let _ = close_ws_connection(
                                 &mut ws_sender,
-                                "Failed to send WebSocket close frame after conflict",
+                                "Failed to send WebSocket close frame after force-detach",
                             )
                             .await;
                             // Deferred: acked only after this connection's own
@@ -889,6 +926,21 @@ fn response_batch_ends_with_websocket_stream_close(responses: &[String]) -> bool
         .is_some_and(|frame| frame == &websocket_close)
 }
 
+fn force_detach_stream_error(reason: ForceDetachReason) -> (String, &'static str) {
+    match reason {
+        ForceDetachReason::SessionResumed | ForceDetachReason::ResourceReplaced => {
+            (build_conflict_stream_error(), "conflict")
+        }
+        ForceDetachReason::NodeSelfFenced => {
+            (build_system_shutdown_stream_error(), "system-shutdown")
+        }
+        ForceDetachReason::OwnershipLost | ForceDetachReason::RemoteStateInvalidated => (
+            build_internal_server_error_stream_error(FORCE_DETACH_RECONNECT_TEXT),
+            "internal-server-error",
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -919,5 +971,36 @@ mod tests {
         ensure_websocket_stream_close_for_closing_phase(&conn, &mut responses);
 
         assert_eq!(responses.len(), 1);
+    }
+
+    #[test]
+    fn force_detach_reason_selects_terminal_or_recoverable_stream_error() {
+        for reason in [
+            ForceDetachReason::SessionResumed,
+            ForceDetachReason::ResourceReplaced,
+        ] {
+            let (xml, condition) = force_detach_stream_error(reason);
+            assert_eq!(condition, "conflict");
+            assert!(xml.contains("<conflict "));
+        }
+
+        let (xml, condition) = force_detach_stream_error(ForceDetachReason::NodeSelfFenced);
+        assert_eq!(condition, "system-shutdown");
+        assert!(xml.contains("<system-shutdown "));
+
+        for reason in [
+            ForceDetachReason::OwnershipLost,
+            ForceDetachReason::RemoteStateInvalidated,
+        ] {
+            let (xml, condition) = force_detach_stream_error(reason);
+            assert_eq!(condition, "internal-server-error");
+            assert_eq!(
+                xml,
+                build_internal_server_error_stream_error(FORCE_DETACH_RECONNECT_TEXT)
+            );
+            assert!(xml.contains(
+                "<internal-server-error xmlns=\"urn:ietf:params:xml:ns:xmpp-streams\"/>"
+            ));
+        }
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -55,6 +55,8 @@ async fn handle_xmpp_frame_impl(
         state_machine,
         stream_open_sent,
         registry_owner,
+        #[cfg(feature = "clustering")]
+        physical_resource_admission,
         ..
     } = conn;
     let muc_domain = state.deps.service_domains.muc.clone();
@@ -229,10 +231,20 @@ async fn handle_xmpp_frame_impl(
                 sm_state,
                 phase.bound_jid(),
                 registry_owner.as_ref(),
+                #[cfg(feature = "clustering")]
+                physical_resource_admission.as_ref(),
                 reserved_inbound_for_sm,
                 ordered_relay_handoff_tx.as_ref(),
             )
             .await;
+            #[cfg(feature = "clustering")]
+            if physical_resource_admission.is_some() && ordered_relay_origin.is_none() {
+                warn!(
+                    jid = ?phase.bound_jid(),
+                    "Dropping stanza whose exact physical-resource admission is no longer current"
+                );
+                return Vec::new();
+            }
 
             // Resource binding is stream setup, not request processing: handle
             // it inline and return BEFORE the wedge backstop (#808 ADR-008 scope
@@ -329,6 +341,9 @@ async fn ordered_relay_origin_for_inbound_stanza(
     sm_state: &waddle_xmpp::stream_management::StreamManagementState,
     bound_jid: Option<&jid::FullJid>,
     registry_owner: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    physical_resource_admission: Option<
+        &crate::clustering::route_bridge::PhysicalResourceAdmissionToken,
+    >,
     inbound_sequence: Option<crate::server::routes::interpret::OrderedRelayInboundSequence>,
     handoff_tx: Option<
         &tokio::sync::mpsc::UnboundedSender<
@@ -342,16 +357,40 @@ async fn ordered_relay_origin_for_inbound_stanza(
             jid.to_bare().to_string(),
         )
     })?;
-    if let (Some(jid), Some(owner), Some(bridge)) = (
-        bound_jid,
-        registry_owner,
-        state
-            .deps
-            .app_state
-            .clustering_claims
-            .ordered_relay_delivery_bridge
-            .as_ref(),
-    ) {
+    let bridge = state
+        .deps
+        .app_state
+        .clustering_claims
+        .ordered_relay_delivery_bridge
+        .as_ref();
+    if let Some(token) = physical_resource_admission {
+        let physical_origin = bridge?
+            .physical_resource_origin_if_owner(bound_jid?, registry_owner?, token)
+            .await?;
+        if let crate::clustering::route_bridge::PhysicalResourceRouteOrigin::RemoteMirror(remote) =
+            physical_origin
+        {
+            return Some(crate::server::routes::interpret::OrderedRelayRouteOrigin {
+                kind: crate::server::routes::interpret::OrderedRelayRouteOriginKind::RemoteResource(
+                    remote,
+                ),
+                sender_entity,
+                inbound_sequence: inbound_sequence.map(|sequence| sequence.0).unwrap_or(0),
+                handoff: if sm_state.enabled {
+                    inbound_sequence.and_then(|sequence| {
+                        handoff_tx.map(|tx| {
+                            crate::server::routes::interpret::OrderedRelayHandoffHandle::new(
+                                sequence,
+                                tx.clone(),
+                            )
+                        })
+                    })
+                } else {
+                    None
+                },
+            });
+        }
+    } else if let (Some(jid), Some(owner), Some(bridge)) = (bound_jid, registry_owner, bridge) {
         if let Some(remote) = bridge.remote_resource_origin_if_owner(jid, owner).await {
             return Some(crate::server::routes::interpret::OrderedRelayRouteOrigin {
                 kind: crate::server::routes::interpret::OrderedRelayRouteOriginKind::RemoteResource(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -1,7 +1,10 @@
 use chrono;
 use jid::{BareJid, FullJid, Jid};
+use kameo::actor::ActorRef;
 use std::{collections::HashSet, sync::Arc};
 use tracing::{debug, info, warn};
+#[cfg(feature = "clustering")]
+use waddle_xmpp::muc::room_actor::GetRoomClaimFence;
 use waddle_xmpp::{
     carbons::CARBONS_NS,
     commands::{CommandContext, CommandResult},
@@ -24,8 +27,9 @@ use waddle_xmpp::{
         },
         owner::build_config_form,
         room_actor::{
-            ApplyAdminItems, ChangeAffiliation, EnforceMembersOnly, EnforceMembersOnlyAffiliations,
-            GetAdminContext, GetOccupantByJid, GetSnapshot, PingSelfCheck, UpdateConfig,
+            ApplyAdminItems, ChangeAffiliation, CheckMutationOwnership, EnforceMembersOnly,
+            EnforceMembersOnlyAffiliations, GetAdminContext, GetOccupantByJid, GetSnapshot,
+            PingSelfCheck, RoomActor, UpdateConfig,
         },
         DATA_FORMS_NS,
     },
@@ -171,6 +175,296 @@ pub(super) use errors::{
     service_unavailable_iq_error,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum FencedRoomEffectsOutcome {
+    Authorized,
+    NotOwner,
+    OwnershipUncertain,
+}
+
+/// Demote only the actor incarnation that produced the failed exact proof.
+/// If E2 has already replaced retained E1 in the registry, the registry CAS
+/// refuses to touch E2 and the direct kill still terminates the retained E1.
+pub(crate) async fn demote_exact_room_actor(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    room_actor: &ActorRef<RoomActor>,
+) {
+    let _ = state
+        .deps
+        .protocol
+        .room_registry
+        .ask(waddle_xmpp::muc::room_registry_actor::DestroyRoomExact {
+            room_jid: room_jid.clone(),
+            expected_actor: room_actor.clone(),
+        })
+        .await;
+    room_actor.kill();
+}
+
+/// Final local-incarnation half of an exact room-effects proof. Run this
+/// after any backend claim check so a retained E1 cannot borrow E2's current
+/// room-scoped authority merely because both use the same logical JID.
+async fn fence_current_room_actor(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    room_actor: &ActorRef<RoomActor>,
+) -> FencedRoomEffectsOutcome {
+    match state
+        .deps
+        .protocol
+        .room_registry
+        .ask(waddle_xmpp::muc::room_registry_actor::GetRoom {
+            room_jid: room_jid.clone(),
+        })
+        .await
+    {
+        Ok(Some(current_actor)) if current_actor == *room_actor => {
+            FencedRoomEffectsOutcome::Authorized
+        }
+        Ok(Some(_)) | Ok(None) => {
+            demote_exact_room_actor(state, room_jid, room_actor).await;
+            FencedRoomEffectsOutcome::NotOwner
+        }
+        Err(_) => FencedRoomEffectsOutcome::OwnershipUncertain,
+    }
+}
+
+/// Final exact-incarnation proof for direct room effects that bypass the
+/// sans-I/O room dispatcher (admin/config presence, moderation, destroy).
+pub(super) async fn fence_room_effects(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+    room_actor: &ActorRef<RoomActor>,
+) -> FencedRoomEffectsOutcome {
+    #[cfg(feature = "clustering")]
+    {
+        let clustering = &state.deps.app_state.clustering_claims;
+        if clustering.claim_store.is_none() {
+            return fence_current_room_actor(state, room_jid, room_actor).await;
+        }
+        let Some(store) = clustering.muc_durable_store.as_ref() else {
+            return FencedRoomEffectsOutcome::OwnershipUncertain;
+        };
+        let fence = match room_actor.ask(GetRoomClaimFence).await {
+            Ok(Some(fence)) => fence,
+            Ok(None) | Err(_) => return FencedRoomEffectsOutcome::OwnershipUncertain,
+        };
+        match store.check_fenced_fanout_exact(room_jid, &fence).await {
+            Ok(true) => fence_current_room_actor(state, room_jid, room_actor).await,
+            Ok(false) | Err(waddle_xmpp::XmppError::RoomOwnershipLost(_)) => {
+                demote_exact_room_actor(state, room_jid, room_actor).await;
+                FencedRoomEffectsOutcome::NotOwner
+            }
+            Err(_) => FencedRoomEffectsOutcome::OwnershipUncertain,
+        }
+    }
+    #[cfg(not(feature = "clustering"))]
+    {
+        fence_current_room_actor(state, room_jid, room_actor).await
+    }
+}
+
+#[cfg(all(test, feature = "clustering"))]
+mod fenced_effect_tests {
+    use super::*;
+    use kameo::actor::Spawn;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use waddle_xmpp::muc::room_actor::{BindRoomClaimFence, GetSnapshot, Join};
+    use waddle_xmpp::muc::room_registry_actor::CreateRoom;
+    use waddle_xmpp::muc::{DurableRoomState, MucDurableFuture, MucDurableStore, RoomConfig};
+    use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
+    use waddle_xmpp_core::{Affiliation, Role};
+
+    struct SwitchableFenceStore {
+        owned: AtomicBool,
+    }
+
+    impl MucDurableStore for SwitchableFenceStore {
+        fn load_room_state<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+        ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn save_config<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _waddle_id: &'a str,
+            _channel_id: &'a str,
+            _config: &'a RoomConfig,
+        ) -> MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn save_subject<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _subject: Option<&'a waddle_xmpp::muc::SubjectState>,
+        ) -> MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn save_affiliation<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _entry: &'a waddle_xmpp::muc::affiliation::AffiliationEntry,
+        ) -> MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn check_fenced_fanout_exact<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _fence: &'a waddle_xmpp::muc::RoomClaimFenceContext,
+        ) -> MucDurableFuture<'a, bool> {
+            let owned = self.owned.load(Ordering::SeqCst);
+            Box::pin(async move { Ok(owned) })
+        }
+    }
+
+    #[tokio::test]
+    async fn ownership_loss_during_snapshot_and_scrub_window_suppresses_live_fanout() {
+        use crate::server::routes::websocket::tests::{
+            create_test_websocket_state_with_clustering, register_test_connection,
+        };
+
+        let store = Arc::new(SwitchableFenceStore {
+            owned: AtomicBool::new(true),
+        });
+        let clustering = crate::clustering::ClusteringHandles {
+            claim_store: Some(Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new())),
+            muc_durable_store: Some(store.clone()),
+            ..Default::default()
+        };
+        let sm_registry =
+            Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new());
+        let state = create_test_websocket_state_with_clustering(clustering, sm_registry).await;
+        let room: BareJid = "late-fence@muc.example.com".parse().expect("room");
+        let actor = state
+            .deps
+            .protocol
+            .room_registry
+            .ask(CreateRoom {
+                room_jid: room.clone(),
+                waddle_id: "waddle".to_string(),
+                channel_id: "channel".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create room");
+        actor
+            .ask(BindRoomClaimFence {
+                fence: waddle_xmpp::muc::RoomClaimFenceContext {
+                    entity: Entity::new(EntityType::RoomActor, room.to_string()),
+                    epoch: ClaimEpoch(1),
+                    owner: NodeIdentity::new("node-a", "node-epoch-a"),
+                },
+            })
+            .await
+            .expect("bind E1");
+        let occupant: jid::FullJid = "alice@example.com/web".parse().expect("occupant");
+        actor
+            .ask(Join {
+                nick: "alice".to_string(),
+                real_jid: occupant.clone(),
+                role: Role::Moderator,
+                affiliation: Affiliation::Owner,
+            })
+            .await
+            .expect("join occupant");
+
+        // The moderation path takes this snapshot and then awaits preview,
+        // SM, and pending-delivery scrubs. Model the claim moving during
+        // that window before the production final-effects helper runs.
+        let snapshot = actor.ask(GetSnapshot).await.expect("snapshot");
+        tokio::task::yield_now().await;
+        store.owned.store(false, Ordering::SeqCst);
+
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        let _owner = register_test_connection(&state, &occupant, sender).await;
+        if fence_room_effects(&state, &room, &actor).await == FencedRoomEffectsOutcome::Authorized {
+            let presence =
+                xmpp_parsers::presence::Presence::new(xmpp_parsers::presence::Type::None);
+            let _ = state.deps.protocol.connection_registry.try_send_to(
+                &snapshot.room.occupants["alice"].real_jid,
+                Stanza::Presence(presence),
+            );
+        }
+        assert!(matches!(
+            receiver.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn retained_actor_cannot_borrow_current_registry_incarnation_authority() {
+        use crate::server::routes::websocket::tests::create_test_websocket_state_with_clustering;
+
+        let store = Arc::new(SwitchableFenceStore {
+            owned: AtomicBool::new(true),
+        });
+        let clustering = crate::clustering::ClusteringHandles {
+            claim_store: Some(Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new())),
+            muc_durable_store: Some(store),
+            ..Default::default()
+        };
+        let sm_registry =
+            Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new());
+        let state = create_test_websocket_state_with_clustering(clustering, sm_registry).await;
+        let room: BareJid = "actor-ref-fence@muc.example.com".parse().expect("room");
+        let current = state
+            .deps
+            .protocol
+            .room_registry
+            .ask(CreateRoom {
+                room_jid: room.clone(),
+                waddle_id: "current".to_string(),
+                channel_id: "current".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create current actor");
+        let retained = RoomActor::spawn(RoomActor::new(
+            waddle_xmpp::muc::MucRoom::new(
+                room.clone(),
+                "retained".to_string(),
+                "retained".to_string(),
+                RoomConfig::default(),
+            ),
+            state.deps.occupant_id_secret.clone(),
+        ));
+        retained
+            .ask(BindRoomClaimFence {
+                fence: waddle_xmpp::muc::RoomClaimFenceContext {
+                    entity: Entity::new(EntityType::RoomActor, room.to_string()),
+                    epoch: ClaimEpoch(1),
+                    owner: NodeIdentity::new("node-a", "node-epoch-a"),
+                },
+            })
+            .await
+            .expect("bind retained fence");
+
+        assert_eq!(
+            fence_room_effects(&state, &room, &retained).await,
+            FencedRoomEffectsOutcome::NotOwner
+        );
+        tokio::task::yield_now().await;
+        assert!(!retained.is_alive());
+        let still_current = state
+            .deps
+            .protocol
+            .room_registry
+            .ask(waddle_xmpp::muc::room_registry_actor::GetRoom { room_jid: room })
+            .await
+            .expect("get current actor")
+            .expect("current actor remains");
+        assert_eq!(still_current, current);
+        assert!(current.is_alive());
+    }
+}
+
 fn push_service_stanza_error(error: XmppError) -> xmpp_parsers::stanza_error::StanzaError {
     match error {
         XmppError::Stanza {
@@ -201,8 +495,8 @@ use vcard_private::{handle_private_storage_iq, handle_vcard_iq};
 pub(super) use super::super::build_iq_error_xml_typed;
 
 use super::super::{
-    build_iq_result_xml, destroy_room_actor, element_to_xml, get_room_actor, iq_to_xml,
-    is_muc_room_jid, stanza_to_xml, WebSocketState,
+    build_iq_result_xml, element_to_xml, get_room_actor, iq_to_xml, is_muc_room_jid, stanza_to_xml,
+    WebSocketState,
 };
 use super::presence::{
     get_managed_channel_for_room, resolve_muc_room_archive_access,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_admin.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_admin.rs
@@ -1,3 +1,4 @@
+use super::errors::resource_constraint_iq_error;
 use super::*;
 use crate::admin::channels::{acquire_room_config_lock, explicit_channel_affiliations_for_jids};
 
@@ -401,6 +402,45 @@ pub(super) async fn handle_muc_admin_iq(
         Vec::new()
     };
     if let Some(channel_id) = managed_channel_id.as_deref() {
+        match room_actor
+            .ask(CheckMutationOwnership)
+            .reply_timeout(ADMIN_ROOM_ASK_TIMEOUT)
+            .await
+        {
+            Ok(()) => {}
+            Err(kameo::error::SendError::HandlerError(
+                waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+            )) => {
+                demote_exact_room_actor(state, &room_jid, &room_actor).await;
+                return vec![build_iq_error_xml_typed(
+                    iq.id(),
+                    response_from,
+                    response_to,
+                    resource_constraint_iq_error("Room ownership recently moved; please retry."),
+                )];
+            }
+            Err(kameo::error::SendError::HandlerError(
+                waddle_xmpp::muc::room_actor::RoomMutationError::OwnershipUncertain,
+            )) => {
+                return vec![build_iq_error_xml_typed(
+                    iq.id(),
+                    response_from,
+                    response_to,
+                    resource_constraint_iq_error(
+                        "Room ownership cannot currently be verified; please retry.",
+                    ),
+                )];
+            }
+            Err(error) => {
+                warn!(room = %room_jid, ?error, "MUC admin ownership admission failed");
+                return vec![build_iq_error_xml_typed(
+                    iq.id(),
+                    response_from,
+                    response_to,
+                    internal_server_error_iq_error("Internal server error."),
+                )];
+            }
+        }
         for (jid, affiliation) in &affiliation_updates {
             if let Err(error) =
                 persist_managed_channel_affiliation(state, channel_id, jid, *affiliation).await
@@ -440,6 +480,41 @@ pub(super) async fn handle_muc_admin_iq(
         .await
     {
         Ok(applied) => applied,
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::NotOwner,
+        )) => {
+            demote_exact_room_actor(state, &room_jid, &room_actor).await;
+            return vec![build_iq_error_xml_typed(
+                iq.id(),
+                response_from,
+                response_to,
+                resource_constraint_iq_error("Room ownership recently moved; please retry."),
+            )];
+        }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::OwnershipUncertain,
+        )) => {
+            return vec![build_iq_error_xml_typed(
+                iq.id(),
+                response_from,
+                response_to,
+                resource_constraint_iq_error(
+                    "Room ownership cannot currently be verified; please retry.",
+                ),
+            )];
+        }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::AdminApplyError::PersistFailed(_),
+        )) => {
+            return vec![build_iq_error_xml_typed(
+                iq.id(),
+                response_from,
+                response_to,
+                internal_server_error_iq_error(
+                    "Moderation effects could not converge durably; please retry.",
+                ),
+            )];
+        }
         Err(kameo::error::SendError::HandlerError(
             waddle_xmpp::muc::room_actor::AdminApplyError::CannotRemoveLastOwner,
         )) => {
@@ -592,6 +667,28 @@ pub(super) async fn handle_muc_admin_iq(
             )];
         }
     };
+    match fence_room_effects(state, &room_jid, &room_actor).await {
+        FencedRoomEffectsOutcome::Authorized => {}
+        FencedRoomEffectsOutcome::NotOwner => {
+            return vec![build_iq_error_xml_typed(
+                iq.id(),
+                response_from,
+                response_to,
+                resource_constraint_iq_error("Room ownership recently moved; please retry."),
+            )];
+        }
+        FencedRoomEffectsOutcome::OwnershipUncertain => {
+            return vec![build_iq_error_xml_typed(
+                iq.id(),
+                response_from,
+                response_to,
+                resource_constraint_iq_error(
+                    "Room ownership cannot currently be verified; please retry.",
+                ),
+            )];
+        }
+    }
+    let persist_failure = applied.persist_failure.clone();
     for (recipient, presence) in applied.presence_updates {
         let _ = state
             .deps
@@ -610,6 +707,17 @@ pub(super) async fn handle_muc_admin_iq(
         super::super::super::muc_call_sfu::unregister_participant_from_room(
             state, &room_jid, removed,
         );
+    }
+    if let Some(error) = persist_failure {
+        warn!(room = %room_jid, %error, "MUC admin effects applied but durable convergence failed");
+        return vec![build_iq_error_xml_typed(
+            iq.id(),
+            response_from,
+            response_to,
+            internal_server_error_iq_error(
+                "Moderation effects were applied but durable convergence failed; please retry.",
+            ),
+        )];
     }
     vec![iq_to_xml(build_admin_set_result(
         iq.id(),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_config.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_config.rs
@@ -2,6 +2,24 @@ use super::permissions::write_tuple_if_absent;
 use super::*;
 use crate::admin::channels::{acquire_room_config_lock, explicit_channel_affiliations_for_jids};
 
+#[derive(Debug, thiserror::Error)]
+pub(super) enum MucOwnerConfigError {
+    #[error("room ownership moved")]
+    NotOwner,
+    #[error("room ownership cannot currently be verified")]
+    OwnershipUncertain,
+    #[error("room mutation did not converge durably: {0}")]
+    PersistFailed(String),
+    #[error("{0}")]
+    Other(String),
+}
+
+impl From<String> for MucOwnerConfigError {
+    fn from(error: String) -> Self {
+        Self::Other(error)
+    }
+}
+
 fn data_form_value(form: &Element, var: &str) -> Option<String> {
     form.children()
         .filter(|child| child.name() == "field" && child.ns() == DATA_FORMS_NS)
@@ -76,7 +94,7 @@ pub(super) async fn apply_muc_owner_config(
     room_jid: &BareJid,
     iq: &xmpp_parsers::iq::Iq,
     session: Option<&Session>,
-) -> Result<(), String> {
+) -> Result<(), MucOwnerConfigError> {
     let room_actor = get_room_actor(state, room_jid)
         .await
         .ok_or_else(|| "room actor not found".to_string())?;
@@ -145,6 +163,28 @@ pub(super) async fn apply_muc_owner_config(
     if let Some(channel_type) = existing_channel_type {
         project_channel_type_to_config(&mut config, channel_type);
     }
+    if channel_id.is_some() {
+        match room_actor.ask(CheckMutationOwnership).await {
+            Ok(()) => {}
+            Err(kameo::error::SendError::HandlerError(
+                waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+            )) => {
+                demote_exact_room_actor(state, room_jid, &room_actor).await;
+                return Err(MucOwnerConfigError::NotOwner);
+            }
+            Err(kameo::error::SendError::HandlerError(
+                waddle_xmpp::muc::room_actor::RoomMutationError::OwnershipUncertain,
+            )) => return Err(MucOwnerConfigError::OwnershipUncertain),
+            Err(kameo::error::SendError::HandlerError(
+                waddle_xmpp::muc::room_actor::RoomMutationError::PersistFailed(detail),
+            )) => return Err(MucOwnerConfigError::PersistFailed(detail)),
+            Err(error) => {
+                return Err(MucOwnerConfigError::Other(format!(
+                    "ownership admission failed: {error}"
+                )));
+            }
+        }
+    }
     if let (Some(channel_id), Some(session)) = (channel_id.as_deref(), session) {
         write_tuple_if_absent(
             state,
@@ -174,21 +214,61 @@ pub(super) async fn apply_muc_owner_config(
         None
     };
 
-    let expected_revision = room_actor
+    let expected_revision = match room_actor
         .ask(UpdateConfig {
             config: config.clone(),
         })
         .await
-        .map_err(|error| format!("config update failed: {error:?}"))?;
+    {
+        Ok(revision) => revision,
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+        )) => {
+            demote_exact_room_actor(state, room_jid, &room_actor).await;
+            return Err(MucOwnerConfigError::NotOwner);
+        }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::OwnershipUncertain,
+        )) => return Err(MucOwnerConfigError::OwnershipUncertain),
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::PersistFailed(detail),
+        )) => return Err(MucOwnerConfigError::PersistFailed(detail)),
+        Err(error) => {
+            return Err(MucOwnerConfigError::Other(format!(
+                "config update failed: {error:?}"
+            )));
+        }
+    };
     let config_status_codes =
         waddle_xmpp::muc::config_change_status_codes(&previous_config, &config);
 
     let Some(channel_id) = channel_id else {
         if !previous_members_only && config.members_only {
-            let updates = room_actor
-                .ask(EnforceMembersOnly)
-                .await
-                .map_err(|error| format!("members-only enforcement failed: {error:?}"))?;
+            let updates =
+                room_actor
+                    .ask(EnforceMembersOnly)
+                    .await
+                    .map_err(|error| match error {
+                        kameo::error::SendError::HandlerError(
+                            waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+                        ) => MucOwnerConfigError::NotOwner,
+                        kameo::error::SendError::HandlerError(
+                            waddle_xmpp::muc::room_actor::RoomMutationError::OwnershipUncertain,
+                        ) => MucOwnerConfigError::OwnershipUncertain,
+                        kameo::error::SendError::HandlerError(
+                            waddle_xmpp::muc::room_actor::RoomMutationError::PersistFailed(detail),
+                        ) => MucOwnerConfigError::PersistFailed(detail),
+                        error => MucOwnerConfigError::Other(format!(
+                            "members-only enforcement failed: {error:?}"
+                        )),
+                    })?;
+            match fence_room_effects(state, room_jid, &room_actor).await {
+                FencedRoomEffectsOutcome::Authorized => {}
+                FencedRoomEffectsOutcome::NotOwner => return Err(MucOwnerConfigError::NotOwner),
+                FencedRoomEffectsOutcome::OwnershipUncertain => {
+                    return Err(MucOwnerConfigError::OwnershipUncertain)
+                }
+            }
             for (recipient, presence) in updates {
                 let _ = state
                     .deps
@@ -201,6 +281,13 @@ pub(super) async fn apply_muc_owner_config(
             .ask(GetSnapshot)
             .await
             .map_err(|error| format!("post-config snapshot failed: {error:?}"))?;
+        match fence_room_effects(state, room_jid, &room_actor).await {
+            FencedRoomEffectsOutcome::Authorized => {}
+            FencedRoomEffectsOutcome::NotOwner => return Err(MucOwnerConfigError::NotOwner),
+            FencedRoomEffectsOutcome::OwnershipUncertain => {
+                return Err(MucOwnerConfigError::OwnershipUncertain)
+            }
+        }
         broadcast_muc_config_change(
             state,
             room_jid,
@@ -248,7 +335,9 @@ pub(super) async fn apply_muc_owner_config(
                 config: previous_config,
             })
             .await;
-        return Err(format!("channel upsert failed: {error}"));
+        return Err(MucOwnerConfigError::Other(format!(
+            "channel upsert failed: {error}"
+        )));
     }
 
     // The channel#owner tuple was written before the config update/upsert so the
@@ -267,13 +356,46 @@ pub(super) async fn apply_muc_owner_config(
             room_actor
                 .ask(EnforceMembersOnlyAffiliations { affiliations })
                 .await
-                .map_err(|error| format!("members-only enforcement failed: {error:?}"))?
+                .map_err(|error| match error {
+                    kameo::error::SendError::HandlerError(
+                        waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+                    ) => MucOwnerConfigError::NotOwner,
+                    kameo::error::SendError::HandlerError(
+                        waddle_xmpp::muc::room_actor::RoomMutationError::OwnershipUncertain,
+                    ) => MucOwnerConfigError::OwnershipUncertain,
+                    kameo::error::SendError::HandlerError(
+                        waddle_xmpp::muc::room_actor::RoomMutationError::PersistFailed(detail),
+                    ) => MucOwnerConfigError::PersistFailed(detail),
+                    error => MucOwnerConfigError::Other(format!(
+                        "members-only enforcement failed: {error:?}"
+                    )),
+                })?
         } else {
             room_actor
                 .ask(EnforceMembersOnly)
                 .await
-                .map_err(|error| format!("members-only enforcement failed: {error:?}"))?
+                .map_err(|error| match error {
+                    kameo::error::SendError::HandlerError(
+                        waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+                    ) => MucOwnerConfigError::NotOwner,
+                    kameo::error::SendError::HandlerError(
+                        waddle_xmpp::muc::room_actor::RoomMutationError::OwnershipUncertain,
+                    ) => MucOwnerConfigError::OwnershipUncertain,
+                    kameo::error::SendError::HandlerError(
+                        waddle_xmpp::muc::room_actor::RoomMutationError::PersistFailed(detail),
+                    ) => MucOwnerConfigError::PersistFailed(detail),
+                    error => MucOwnerConfigError::Other(format!(
+                        "members-only enforcement failed: {error:?}"
+                    )),
+                })?
         };
+        match fence_room_effects(state, room_jid, &room_actor).await {
+            FencedRoomEffectsOutcome::Authorized => {}
+            FencedRoomEffectsOutcome::NotOwner => return Err(MucOwnerConfigError::NotOwner),
+            FencedRoomEffectsOutcome::OwnershipUncertain => {
+                return Err(MucOwnerConfigError::OwnershipUncertain)
+            }
+        }
         for (recipient, presence) in updates {
             let _ = state
                 .deps
@@ -287,6 +409,13 @@ pub(super) async fn apply_muc_owner_config(
         .ask(GetSnapshot)
         .await
         .map_err(|error| format!("post-config snapshot failed: {error:?}"))?;
+    match fence_room_effects(state, room_jid, &room_actor).await {
+        FencedRoomEffectsOutcome::Authorized => {}
+        FencedRoomEffectsOutcome::NotOwner => return Err(MucOwnerConfigError::NotOwner),
+        FencedRoomEffectsOutcome::OwnershipUncertain => {
+            return Err(MucOwnerConfigError::OwnershipUncertain)
+        }
+    }
     broadcast_muc_config_change(
         state,
         room_jid,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
@@ -1,4 +1,8 @@
+use super::errors::resource_constraint_iq_error;
 use super::*;
+use waddle_xmpp::muc::room_registry_actor::{
+    DestroyRoomExactAfterEffects, RoomDestroyEffectsDone, RoomDestroyEffectsReserved,
+};
 use waddle_xmpp::muc::{build_destroy_notification, DestroyRequest, NS_MUC_OWNER};
 
 /// Extract the optional alternate venue, reason, and password from a
@@ -127,70 +131,166 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
             // others are routed via the connection registry.
             let destroy_request = parse_destroy_request(iq).unwrap_or_default();
             let mut frames = Vec::new();
-            if let Some(room_actor) = get_room_actor(state, &room_jid).await {
-                if let Ok(snapshot) = room_actor.ask(GetSnapshot).await {
-                    for occupant in snapshot.room.occupants.values() {
-                        let is_self_occupant = occupant.real_jid == *sender_jid;
-                        // XEP-0421: the destroy notification is the
-                        // occupant's final unavailable presence from
-                        // the room and MUST carry their occupant-id
-                        // (#1268).
-                        let occupant_bare = occupant.real_jid.to_bare();
-                        let identity = waddle_xmpp::xep::xep0421::OccupantIdentity {
-                            bare_jid: &occupant_bare,
-                            real_jid: Some(&occupant.real_jid),
-                            secret: &state.deps.occupant_id_secret,
-                        };
-                        let presence = build_destroy_notification(
-                            &room_jid,
-                            &occupant.nick,
-                            &occupant.real_jid,
-                            &destroy_request,
-                            is_self_occupant,
-                            &identity,
-                        );
-                        if is_self_occupant {
-                            frames.push(stanza_to_xml(&Stanza::Presence(presence)));
-                        } else {
-                            let _ = state
-                                .deps
-                                .protocol
-                                .connection_registry
-                                .try_send_to(&occupant.real_jid, Stanza::Presence(presence));
-                        }
-                        // XEP-0045 §10.9 destroy ends every occupant's
-                        // session in the room — their LiveKit
-                        // participant must end with it. Without this
-                        // the SFU keeps the room populated until its
-                        // own timeout even though the XMPP room is
-                        // gone. Idempotent for non-call participants.
-                        super::super::super::muc_call_sfu::unregister_participant_from_room(
-                            state,
-                            &room_jid,
-                            &occupant.real_jid,
-                        );
-                    }
+            let Some(room_actor) = get_room_actor(state, &room_jid).await else {
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    response_from,
+                    response_to,
+                    resource_constraint_iq_error(
+                        "Room ownership cannot currently be verified; please retry.",
+                    ),
+                )];
+            };
+            // Prove this exact actor incarnation before asking the registry
+            // to seal its admission mailbox and return the final snapshot.
+            match fence_room_effects(state, &room_jid, &room_actor).await {
+                FencedRoomEffectsOutcome::Authorized => {}
+                FencedRoomEffectsOutcome::NotOwner => {
+                    return vec![build_iq_error_xml_typed(
+                        id,
+                        response_from,
+                        response_to,
+                        resource_constraint_iq_error(
+                            "Room ownership recently moved; please retry.",
+                        ),
+                    )];
+                }
+                FencedRoomEffectsOutcome::OwnershipUncertain => {
+                    return vec![build_iq_error_xml_typed(
+                        id,
+                        response_from,
+                        response_to,
+                        resource_constraint_iq_error(
+                            "Room ownership cannot currently be verified; please retry.",
+                        ),
+                    )];
                 }
             }
 
-            if destroy_room_actor(state, &room_jid).await {
-                debug!(room = %room_jid, "Destroyed MUC room via owner IQ");
-                let room_jid_string = room_jid.to_string();
-                frames.push(build_iq_result_xml(
-                    id,
-                    Some(room_jid_string.as_str()),
-                    response_to,
-                    None,
-                ));
-                return frames;
+            // The registry performs the final exact claim + actor-ref proof,
+            // removes E1, and then holds its serialized mailbox (and E1's
+            // exact claim grant) until this caller completes the irreversible
+            // presence/SFU batch. A queued E2 create cannot run in the gap.
+            let (effects_reserved_sender, mut effects_reserved_receiver) =
+                tokio::sync::oneshot::channel();
+            let (effects_done_sender, effects_done_receiver) = tokio::sync::oneshot::channel();
+            let room_registry = state.deps.protocol.room_registry.clone();
+            let destroy_room_jid = room_jid.clone();
+            let destroy_expected_actor = room_actor.clone();
+            let destroy_barrier = async move {
+                room_registry
+                    .ask(DestroyRoomExactAfterEffects {
+                        room_jid: destroy_room_jid,
+                        expected_actor: destroy_expected_actor,
+                        effects_reserved: effects_reserved_sender,
+                        effects_done: effects_done_receiver,
+                    })
+                    .await
+            };
+            tokio::pin!(destroy_barrier);
+
+            let reservation = tokio::select! {
+                reservation = &mut effects_reserved_receiver => reservation,
+                result = &mut destroy_barrier => {
+                    warn!(
+                        room = %room_jid,
+                        result = ?result,
+                        "Exact room destroy ended before reserving its external effects"
+                    );
+                    return vec![build_iq_error_xml_typed(
+                        id,
+                        response_from,
+                        response_to,
+                        resource_constraint_iq_error(
+                            "Room ownership changed before destruction committed; please retry.",
+                        ),
+                    )];
+                }
+            };
+            let snapshot = match reservation {
+                Ok(RoomDestroyEffectsReserved { snapshot }) => snapshot,
+                Err(_) => {
+                    let result = destroy_barrier.await;
+                    warn!(
+                        room = %room_jid,
+                        result = ?result,
+                        "Exact room destroy refused its external-effect reservation"
+                    );
+                    return vec![build_iq_error_xml_typed(
+                        id,
+                        response_from,
+                        response_to,
+                        resource_constraint_iq_error(
+                            "Room ownership changed before destruction committed; please retry.",
+                        ),
+                    )];
+                }
+            };
+
+            for occupant in snapshot.room.occupants.values() {
+                let is_self_occupant = occupant.real_jid == *sender_jid;
+                // XEP-0421: the destroy notification is the
+                // occupant's final unavailable presence from
+                // the room and MUST carry their occupant-id
+                // (#1268).
+                let occupant_bare = occupant.real_jid.to_bare();
+                let identity = waddle_xmpp::xep::xep0421::OccupantIdentity {
+                    bare_jid: &occupant_bare,
+                    real_jid: Some(&occupant.real_jid),
+                    secret: &state.deps.occupant_id_secret,
+                };
+                let presence = build_destroy_notification(
+                    &room_jid,
+                    &occupant.nick,
+                    &occupant.real_jid,
+                    &destroy_request,
+                    is_self_occupant,
+                    &identity,
+                );
+                if is_self_occupant {
+                    frames.push(stanza_to_xml(&Stanza::Presence(presence)));
+                } else {
+                    let _ = state
+                        .deps
+                        .protocol
+                        .connection_registry
+                        .try_send_to(&occupant.real_jid, Stanza::Presence(presence));
+                }
+                // XEP-0045 §10.9 destroy ends every occupant's
+                // session in the room — their LiveKit
+                // participant must end with it. Without this
+                // the SFU keeps the room populated until its
+                // own timeout even though the XMPP room is
+                // gone. Idempotent for non-call participants.
+                super::super::super::muc_call_sfu::unregister_participant_from_room(
+                    state,
+                    &room_jid,
+                    &occupant.real_jid,
+                );
             }
 
-            return vec![build_iq_error_xml_typed(
+            let _ = effects_done_sender.send(RoomDestroyEffectsDone);
+            let destroy_result = destroy_barrier.await;
+            if !matches!(destroy_result, Ok(true)) {
+                // The exact actor was already removed and its effects were
+                // committed once the reservation was granted. A lost cleanup
+                // reply cannot roll them back and must not turn success into a
+                // contradictory IQ error.
+                warn!(
+                    room = %room_jid,
+                    result = ?destroy_result,
+                    "Exact room destroy committed effects but cleanup acknowledgement was unavailable"
+                );
+            }
+            debug!(room = %room_jid, "Destroyed MUC room via owner IQ");
+            let room_jid_string = room_jid.to_string();
+            frames.push(build_iq_result_xml(
                 id,
-                response_from,
+                Some(room_jid_string.as_str()),
                 response_to,
-                item_not_found_iq_error("Requested item not found."),
-            )];
+                None,
+            ));
+            return frames;
         }
 
         if matches!(iq, xmpp_parsers::iq::Iq::Get { .. }) {
@@ -212,20 +312,46 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
             }
         }
 
-        if let Err(error) =
-            apply_muc_owner_config(state, &room_jid, iq, authenticated_session.as_ref()).await
-        {
-            warn!(
-                room = %room_jid,
-                error = %error,
-                "Failed to apply MUC owner config"
-            );
-            return vec![build_iq_error_xml_typed(
-                id,
-                response_from,
-                response_to,
-                internal_server_error_iq_error("Internal server error."),
-            )];
+        match apply_muc_owner_config(state, &room_jid, iq, authenticated_session.as_ref()).await {
+            Ok(()) => {}
+            Err(super::muc_owner_config::MucOwnerConfigError::NotOwner) => {
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    response_from,
+                    response_to,
+                    resource_constraint_iq_error("Room ownership recently moved; please retry."),
+                )];
+            }
+            Err(super::muc_owner_config::MucOwnerConfigError::OwnershipUncertain) => {
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    response_from,
+                    response_to,
+                    resource_constraint_iq_error(
+                        "Room ownership cannot currently be verified; please retry.",
+                    ),
+                )];
+            }
+            Err(super::muc_owner_config::MucOwnerConfigError::PersistFailed(error)) => {
+                warn!(room = %room_jid, %error, "MUC owner config durable persist failed");
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    response_from,
+                    response_to,
+                    internal_server_error_iq_error(
+                        "The room change could not converge durably; please retry.",
+                    ),
+                )];
+            }
+            Err(error) => {
+                warn!(room = %room_jid, %error, "Failed to apply MUC owner config");
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    response_from,
+                    response_to,
+                    internal_server_error_iq_error("Internal server error."),
+                )];
+            }
         }
 
         // Treat all other owner IQ sets as successful config submit for instant rooms.
@@ -293,14 +419,14 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                 forbidden_iq_error("Operation not permitted."),
             )];
         }
-        match state
+        let original = match state
             .deps
             .protocol
             .mam_storage
             .get_message(&request.target_id)
             .await
         {
-            Ok(Some(message)) if message.to.to_string() == room_jid.to_string() => {}
+            Ok(Some(message)) if message.to.to_bare() == room_jid => message,
             Ok(Some(_)) => {
                 return vec![build_iq_error_xml_typed(
                     id,
@@ -326,7 +452,55 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                     internal_server_error_iq_error("Internal server error."),
                 )];
             }
-        }
+        };
+
+        #[cfg(feature = "clustering")]
+        let room_fence = {
+            let clustering = &state.deps.app_state.clustering_claims;
+            if clustering.claim_store.is_some() {
+                if clustering.muc_durable_store.is_none() {
+                    return vec![build_iq_error_xml_typed(
+                        id,
+                        response_from,
+                        response_to,
+                        resource_constraint_iq_error(
+                            "Room ownership cannot currently be verified; please retry.",
+                        ),
+                    )];
+                }
+                let fence = match room_actor.ask(GetRoomClaimFence).await {
+                    Ok(Some(fence)) => fence,
+                    Ok(None) | Err(_) => {
+                        return vec![build_iq_error_xml_typed(
+                            id,
+                            response_from,
+                            response_to,
+                            resource_constraint_iq_error(
+                                "Room ownership cannot currently be verified; please retry.",
+                            ),
+                        )];
+                    }
+                };
+                if fence.entity
+                    != waddle_xmpp::ownership::Entity::new(
+                        waddle_xmpp::ownership::EntityType::RoomActor,
+                        room_jid.to_string(),
+                    )
+                {
+                    return vec![build_iq_error_xml_typed(
+                        id,
+                        response_from,
+                        response_to,
+                        resource_constraint_iq_error(
+                            "Room ownership cannot currently be verified; please retry.",
+                        ),
+                    )];
+                }
+                Some(fence)
+            } else {
+                None
+            }
+        };
 
         let moderator_nick = context
             .nick
@@ -349,6 +523,14 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
             Some(moderator_occupant_id.as_str()),
             request.reason.as_deref(),
         );
+        let Some(moderation_wire_id) = moderation.id.as_ref().map(|id| id.0.clone()) else {
+            return vec![build_iq_error_xml_typed(
+                id,
+                response_from,
+                response_to,
+                internal_server_error_iq_error("Internal server error."),
+            )];
+        };
         let archive_id = uuid::Uuid::now_v7().to_string();
         let room_jid_full = jid::Jid::from(room_jid.clone());
         add_stanza_id_xep0359(
@@ -356,205 +538,222 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
             &Xep0359StanzaId::new(archive_id.as_str(), room_jid_full.clone()),
         );
 
-        if let (Some(target_id), Ok(moderator_jid)) = (
-            RichMessageId::new(request.target_id.clone()),
-            moderated_by.parse::<Jid>(),
-        ) {
-            let archived = ArchivedMessage {
-                id: archive_id.clone(),
-                timestamp: chrono::Utc::now(),
-                from: jid::Jid::from(room_jid.clone()),
-                to: jid::Jid::from(room_jid.clone()),
-                // XEP-0425 moderation tombstone has no `<body>` — `None`
-                // is the wire-faithful "no body element" form.
-                body: None,
-                stanza_id: moderation
-                    .id
-                    .as_ref()
-                    .map(|id| Xep0359StanzaId::new(id.0.clone(), room_jid_full.clone())),
-                // XEP-0425 moderation tombstone: leak-prone fields are
-                // already cleared by construction (this row is a fresh
-                // tombstone, not a scrub of an existing message).
-                thread: None,
+        let Some(target_id) = RichMessageId::new(original.id.clone()) else {
+            return vec![build_iq_error_xml_typed(
+                id,
+                response_from,
+                response_to,
+                bad_request_iq_error("Malformed moderation target."),
+            )];
+        };
+        let Ok(moderator_jid) = moderated_by.parse::<Jid>() else {
+            return vec![build_iq_error_xml_typed(
+                id,
+                response_from,
+                response_to,
+                internal_server_error_iq_error("Internal server error."),
+            )];
+        };
+        let archived = ArchivedMessage {
+            id: archive_id.clone(),
+            timestamp: stamp_time,
+            from: room_jid_full.clone(),
+            to: room_jid_full.clone(),
+            body: None,
+            // `ArchivedMessage.id` is the room-assigned archive/stanza ID;
+            // `stanza_id` carries the live moderation message's wire `id` so
+            // MAM replay preserves it and the tombstone can cite it exactly.
+            stanza_id: Some(Xep0359StanzaId::new(
+                moderation_wire_id.clone(),
+                room_jid_full.clone(),
+            )),
+            thread: None,
+            reply: None,
+            origin_id: None,
+            message_type: xmpp_parsers::message::MessageType::Groupchat,
+            stanza_xml: None,
+            rich: Some(ArchivedRichMessage {
+                payload: Some(ArchivedRichPayload::Moderation(ArchivedModeration {
+                    target_id: target_id.clone(),
+                    moderated_by: moderator_jid.clone(),
+                    stamp: Some(stamp_time),
+                    reason: request.reason.as_deref().and_then(RichText::new),
+                })),
                 reply: None,
-                origin_id: None,
-                message_type: xmpp_parsers::message::MessageType::Groupchat,
-                stanza_xml: None,
-                rich: Some(ArchivedRichMessage {
-                    payload: Some(ArchivedRichPayload::Moderation(ArchivedModeration {
-                        target_id,
-                        moderated_by: moderator_jid,
-                        stamp: Some(stamp_time),
-                        reason: request.reason.as_deref().and_then(RichText::new),
-                    })),
-                    reply: None,
-                    references: Vec::new(),
-                    mentions: Vec::new(),
-                    // Room-authored moderation event row: no occupant
-                    // sender to identify.
-                    occupant_id: None,
-                    muc_sender: None,
-                }),
-                nickname_generation: None,
-            };
-            if let Err(error) = state
+                references: Vec::new(),
+                mentions: Vec::new(),
+                // Room-authored moderation event row: no occupant
+                // sender to identify.
+                occupant_id: None,
+                muc_sender: None,
+            }),
+            nickname_generation: None,
+        };
+        let tombstone = waddle_xmpp::mam::ArchivedTombstone {
+            retraction_id: RichMessageId::new(moderation_wire_id),
+            stamp: stamp_time,
+            moderation: Some(ArchivedModeration {
+                target_id,
+                moderated_by: moderator_jid,
+                stamp: Some(stamp_time),
+                reason: request.reason.as_deref().and_then(RichText::new),
+            }),
+        };
+
+        #[cfg(feature = "clustering")]
+        let persistence_result = if let Some(fence) = room_fence.as_ref() {
+            state
+                .deps
+                .protocol
+                .mam_storage
+                .moderate_message_fenced(
+                    &room_jid,
+                    &archived,
+                    &original.id,
+                    tombstone.clone(),
+                    fence,
+                )
+                .await
+        } else {
+            match state
                 .deps
                 .protocol
                 .mam_storage
                 .store_message(&room_jid, &archived)
                 .await
             {
-                warn!(room = %room_jid, target = %request.target_id, error = %error, "Failed to archive moderation event");
-            }
-
-            // XEP-0425 §"the archiving service MAY replace the
-            // retracted message with a tombstone": replace the
-            // original room archive row with a moderation tombstone
-            // whose `<retracted/>` carries `<moderated by/>` and the
-            // optional reason.
-            let original_lookup = state
-                .deps
-                .protocol
-                .mam_storage
-                .get_message(&request.target_id)
-                .await;
-            match original_lookup {
-                Ok(Some(original)) if original.to.to_string() == room_jid.to_string() => {
-                    // Use the moderation message's server-assigned
-                    // archive id (XEP-0359 stanza-id stamped via
-                    // `add_stanza_id_xep0359` above). That's the id
-                    // clients see on the live moderation broadcast
-                    // and need to correlate against the tombstone —
-                    // `moderation.id` is the client message-id
-                    // attribute, which would not match the archive
-                    // entry clients can resolve.
-                    let tombstone = waddle_xmpp::mam::ArchivedTombstone {
-                        retraction_id: waddle_xmpp::mam::RichMessageId::new(archive_id.clone()),
-                        stamp: stamp_time,
-                        moderation: Some(ArchivedModeration {
-                            target_id: waddle_xmpp::mam::RichMessageId::new(
-                                request.target_id.clone(),
-                            )
-                            .expect("target id is non-empty here"),
-                            moderated_by: moderated_by
-                                .parse::<Jid>()
-                                .expect("moderated_by parsed earlier"),
-                            stamp: Some(stamp_time),
-                            reason: request.reason.as_deref().and_then(RichText::new),
-                        }),
-                    };
-                    match state
+                Ok(_) => {
+                    state
                         .deps
                         .protocol
                         .mam_storage
-                        .replace_with_tombstone(&original.id, tombstone)
+                        .replace_with_tombstone(&original.id, tombstone.clone())
                         .await
-                    {
-                        Ok(true) => {
-                            if let Some(stanza_id) = original.stanza_id.as_ref() {
-                                crate::server::routes::websocket::link_preview_refs::clear_current_message_preview_refs(
-                                    state.deps.app_state.db_pool.global_actor(),
-                                    &room_jid,
-                                    &stanza_id.id,
-                                )
-                                .await;
-                            }
-                        }
-                        Ok(false) => warn!(
-                            room = %room_jid,
-                            target = %request.target_id,
-                            "Moderation tombstone target disappeared before replacement"
-                        ),
-                        Err(error) => {
-                            warn!(
-                                room = %room_jid,
-                                target = %request.target_id,
-                                error = %error,
-                                "Failed to replace original with moderation tombstone"
-                            );
-                        }
-                    }
-                    // XEP-0425 §Tombstones / XEP-0198: scrub the
-                    // pre-tombstone groupchat reflection from any
-                    // detached resume queues so a recipient mid-resume
-                    // does not replay the moderated content. Best
-                    // effort — tombstone is already applied to the
-                    // archive. Scope by the room JID so the matcher's
-                    // stanza-id branch finds groupchat reflections
-                    // that key by the room's XEP-0359 stamp, and so a
-                    // colliding wire id in another conversation is not
-                    // accidentally scrubbed (Codex P1, Copilot review
-                    // on PR #305).
-                    use waddle_xmpp::stream_management::SmSessionRegistry as _;
-                    let target_id = request.target_id.as_str();
-                    // XEP-0425 moderation targets the room-assigned
-                    // XEP-0359 stanza-id: cached reflections are
-                    // matched ONLY on `<stanza-id by=room/>`, never on
-                    // the client-chosen wire id (which any occupant
-                    // could mint to collide with another reflection).
-                    let scrub_target = waddle_xmpp::tombstone::TombstoneTarget::Groupchat {
-                        stanza_id: request.target_id.clone(),
-                        room: room_jid.clone(),
-                    };
-                    match state
-                        .deps
-                        .protocol
-                        .sm_session_registry
-                        .scrub_unacked_for_tombstone(&scrub_target)
-                        .await
-                    {
-                        Ok(removed) if removed > 0 => debug!(
-                            room = %room_jid,
-                            target = target_id,
-                            removed,
-                            "XEP-0425 moderation: scrubbed unacked SM queue entries"
-                        ),
-                        Ok(_) => {}
-                        Err(error) => warn!(
-                            room = %room_jid,
-                            target = target_id,
-                            %error,
-                            "XEP-0425 moderation: scrub_unacked_for_tombstone failed; pre-scrub stanza may still replay on resume"
-                        ),
-                    }
-                    // F2: promotion (#1097/#1098) parks unacked copies
-                    // in pending_delivery — scrub that layer with the
-                    // same keys or the moderated content delivers
-                    // verbatim at the recipient's next login.
-                    match state
-                        .deps
-                        .protocol
-                        .pending_delivery_storage
-                        .scrub_for_tombstone(&scrub_target)
-                        .await
-                    {
-                        Ok(removed) if removed > 0 => debug!(
-                            room = %room_jid,
-                            target = target_id,
-                            removed,
-                            "XEP-0425 moderation: scrubbed pending_delivery rows"
-                        ),
-                        Ok(_) => {}
-                        Err(error) => warn!(
-                            room = %room_jid,
-                            target = target_id,
-                            %error,
-                            "XEP-0425 moderation: pending_delivery scrub_for_tombstone failed; moderated content may still deliver at next login"
-                        ),
-                    }
                 }
-                Ok(_) => {}
-                Err(error) => warn!(
-                    room = %room_jid,
-                    target = %request.target_id,
-                    error = %error,
-                    "Failed to look up moderation target for tombstone"
-                ),
+                Err(error) => Err(error),
+            }
+        };
+        #[cfg(not(feature = "clustering"))]
+        let persistence_result = match state
+            .deps
+            .protocol
+            .mam_storage
+            .store_message(&room_jid, &archived)
+            .await
+        {
+            Ok(_) => {
+                state
+                    .deps
+                    .protocol
+                    .mam_storage
+                    .replace_with_tombstone(&original.id, tombstone)
+                    .await
+            }
+            Err(error) => Err(error),
+        };
+
+        match persistence_result {
+            Ok(true) => {}
+            Ok(false) => {
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    response_from,
+                    response_to,
+                    item_not_found_iq_error("Requested item not found."),
+                )];
+            }
+            Err(waddle_xmpp::mam::MamStorageError::NotOwner { .. }) => {
+                demote_exact_room_actor(state, &room_jid, &room_actor).await;
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    response_from,
+                    response_to,
+                    resource_constraint_iq_error("Room ownership recently moved; please retry."),
+                )];
+            }
+            Err(waddle_xmpp::mam::MamStorageError::FencingUnavailable { .. }) => {
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    response_from,
+                    response_to,
+                    resource_constraint_iq_error(
+                        "Room ownership cannot currently be verified; please retry.",
+                    ),
+                )];
+            }
+            Err(error) => {
+                warn!(room = %room_jid, target = %request.target_id, %error, "Failed to commit moderation event and tombstone");
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    response_from,
+                    response_to,
+                    internal_server_error_iq_error("Internal server error."),
+                )];
+            }
+        }
+
+        if let Some(stanza_id) = original.stanza_id.as_ref() {
+            crate::server::routes::websocket::link_preview_refs::clear_current_message_preview_refs(
+                state.deps.app_state.db_pool.global_actor(),
+                &room_jid,
+                &stanza_id.id,
+            )
+            .await;
+        }
+
+        use waddle_xmpp::stream_management::SmSessionRegistry as _;
+        let scrub_target = waddle_xmpp::tombstone::TombstoneTarget::Groupchat {
+            stanza_id: request.target_id.clone(),
+            room: room_jid.clone(),
+        };
+        if let Err(error) = state
+            .deps
+            .protocol
+            .sm_session_registry
+            .scrub_unacked_for_tombstone(&scrub_target)
+            .await
+        {
+            warn!(room = %room_jid, target = %request.target_id, %error, "XEP-0425 moderation: SM scrub failed after commit");
+        }
+        if let Err(error) = state
+            .deps
+            .protocol
+            .pending_delivery_storage
+            .scrub_for_tombstone(&scrub_target)
+            .await
+        {
+            warn!(room = %room_jid, target = %request.target_id, %error, "XEP-0425 moderation: pending-delivery scrub failed after commit");
+        }
+
+        let snapshot = room_actor.ask(GetSnapshot).await.ok();
+        // The archive commit and every scrub above can yield long enough for
+        // E1 to be replaced. Re-prove the actor's immutable fence only after
+        // all of them and after the final snapshot await, immediately before
+        // live fanout.
+        match fence_room_effects(state, &room_jid, &room_actor).await {
+            FencedRoomEffectsOutcome::Authorized => {}
+            FencedRoomEffectsOutcome::NotOwner => {
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    response_from,
+                    response_to,
+                    resource_constraint_iq_error("Room ownership recently moved; please retry."),
+                )];
+            }
+            FencedRoomEffectsOutcome::OwnershipUncertain => {
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    response_from,
+                    response_to,
+                    resource_constraint_iq_error(
+                        "Room ownership cannot currently be verified; please retry.",
+                    ),
+                )];
             }
         }
 
         let mut frames = Vec::new();
-        if let Ok(snapshot) = room_actor.ask(GetSnapshot).await {
+        if let Some(snapshot) = snapshot {
             for occupant in snapshot.room.occupants.values() {
                 for occupant_jid in snapshot.room.get_occupant_sessions(&occupant.nick) {
                     let mut outbound = moderation.clone();

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/sans_io.rs
@@ -154,6 +154,23 @@ pub(super) async fn handle_sans_io_iq(
             inbox_storage: Some(&state.deps.protocol.inbox_storage),
             extension_manager: Some(&state.deps.protocol.extension_manager),
             room_registry: Some(&state.deps.protocol.room_registry),
+            room_actor_incarnation: None,
+            #[cfg(feature = "clustering")]
+            muc_durable_store: state
+                .deps
+                .app_state
+                .clustering_claims
+                .muc_durable_store
+                .as_ref(),
+            #[cfg(feature = "clustering")]
+            clustered_muc_ownership_required: state
+                .deps
+                .app_state
+                .clustering_claims
+                .claim_store
+                .is_some(),
+            #[cfg(feature = "clustering")]
+            room_claim_fence: None,
             web_socket_state: Some(state),
             authenticated_session: authenticated_session.as_ref(),
             local_domain: state.deps.auth_state.xmpp_domain.as_str(),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -11,9 +11,9 @@ pub use access::{
 use access::{resolve_managed_channel_affiliation, server_permission_allowed};
 use waddle_xmpp::muc::room_actor::GetSnapshot;
 use waddle_xmpp::muc::RoomRegistry;
+pub(super) use xml::build_muc_presence_error_xml;
 use xml::{
-    build_muc_conflict_presence_xml, build_muc_join_presence_stanza, build_muc_presence_error_xml,
-    build_muc_self_unavailable_xml,
+    build_muc_conflict_presence_xml, build_muc_join_presence_stanza, build_muc_self_unavailable_xml,
 };
 pub(super) use xml::{build_muc_join_presence_xml, MucJoinPresence};
 
@@ -96,6 +96,7 @@ pub async fn handle_muc_join_with_ordered_relay(
 /// between, so a delayed sync can never clear a live occupant's fresh
 /// affiliation.
 async fn sync_resolver_affiliation_on_rejection(
+    state: &WebSocketState,
     existing_room_actor: Option<&kameo::actor::ActorRef<waddle_xmpp::muc::room_actor::RoomActor>>,
     room_jid: &BareJid,
     jid: BareJid,
@@ -123,6 +124,14 @@ async fn sync_resolver_affiliation_on_rejection(
                 outcome = ?outcome,
                 "Skipped resolver affiliation sync on rejected join"
             );
+        }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+        )) => {
+            crate::server::routes::websocket::handlers::iq::demote_exact_room_actor(
+                state, room_jid, actor,
+            )
+            .await;
         }
         Err(error) => {
             warn!(
@@ -509,6 +518,7 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                     // until eviction. Explicit bans are untouched by the
                     // provenance-aware sync.
                     sync_resolver_affiliation_on_rejection(
+                        state,
                         existing_room_actor.as_ref(),
                         room_jid,
                         // Room affiliations are keyed by the joiner's
@@ -541,6 +551,7 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                         // actor — clear any stale resolver-derived
                         // affiliation from before the revocation here.
                         sync_resolver_affiliation_on_rejection(
+                            state,
                             existing_room_actor.as_ref(),
                             room_jid,
                             // Same key as `JoinWithAffiliation`:
@@ -940,6 +951,48 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                 if matches!(
                     &error,
                     kameo::error::SendError::HandlerError(
+                        waddle_xmpp::muc::room_actor::RoomActorError::NotOwner
+                    )
+                ) {
+                    crate::server::routes::websocket::handlers::iq::demote_exact_room_actor(
+                        state,
+                        room_jid,
+                        &room_actor,
+                    )
+                    .await;
+                    return vec![build_muc_presence_error_xml(
+                        room_jid,
+                        &nick,
+                        sender_jid,
+                        StanzaError::new(
+                            ErrorType::Wait,
+                            DefinedCondition::ResourceConstraint,
+                            "en",
+                            "This room's ownership recently moved; please retry.",
+                        ),
+                    )];
+                }
+                if matches!(
+                    &error,
+                    kameo::error::SendError::HandlerError(
+                        waddle_xmpp::muc::room_actor::RoomActorError::OwnershipUncertain
+                    )
+                ) {
+                    return vec![build_muc_presence_error_xml(
+                        room_jid,
+                        &nick,
+                        sender_jid,
+                        StanzaError::new(
+                            ErrorType::Wait,
+                            DefinedCondition::ResourceConstraint,
+                            "en",
+                            "This room's ownership cannot currently be verified; please retry.",
+                        ),
+                    )];
+                }
+                if matches!(
+                    &error,
+                    kameo::error::SendError::HandlerError(
                         waddle_xmpp::muc::room_actor::RoomActorError::RoomFull
                     )
                 ) {
@@ -1318,10 +1371,54 @@ pub async fn handle_muc_leave(
                 state, room_jid, nick, sender_jid, true,
             )];
         }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+        )) => {
+            crate::server::routes::websocket::handlers::iq::demote_exact_room_actor(
+                state,
+                room_jid,
+                &room_actor,
+            )
+            .await;
+            return vec![build_muc_presence_error_xml(
+                room_jid,
+                nick,
+                sender_jid,
+                StanzaError::new(
+                    ErrorType::Wait,
+                    DefinedCondition::ResourceConstraint,
+                    "en",
+                    "This room's ownership recently moved; please retry.",
+                ),
+            )];
+        }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::OwnershipUncertain,
+        )) => {
+            return vec![build_muc_presence_error_xml(
+                room_jid,
+                nick,
+                sender_jid,
+                StanzaError::new(
+                    ErrorType::Wait,
+                    DefinedCondition::ResourceConstraint,
+                    "en",
+                    "This room's ownership cannot currently be verified; please retry.",
+                ),
+            )];
+        }
         Err(error) => {
             warn!(room = %room_jid, nick = %nick, sender = %sender_jid, error = ?error, "Failed to leave MUC room");
-            return vec![build_muc_self_unavailable_xml(
-                state, room_jid, nick, sender_jid, true,
+            return vec![build_muc_presence_error_xml(
+                room_jid,
+                nick,
+                sender_jid,
+                StanzaError::new(
+                    ErrorType::Wait,
+                    DefinedCondition::InternalServerError,
+                    "en",
+                    "Failed to leave the room; please retry.",
+                ),
             )];
         }
     };

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/xml.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc/xml.rs
@@ -115,7 +115,7 @@ pub(super) fn build_muc_conflict_presence_xml(
 /// `<error/>` element is serialised via the upstream
 /// `From<StanzaError> for Element` impl so the wire shape is identical
 /// to the legacy `Element::builder("error", …)` literal.
-pub(super) fn build_muc_presence_error_xml(
+pub(crate) fn build_muc_presence_error_xml(
     room_jid: &BareJid,
     nick: &str,
     to_jid: &FullJid,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc_update.rs
@@ -54,11 +54,31 @@ use waddle_xmpp_core::xep0359::{build_origin_id_element, NS_SID};
 use xmpp_parsers::jingle::SessionId;
 use xmpp_parsers::message::{Lang, Message, MessageType};
 use xmpp_parsers::presence::Presence;
+use xmpp_parsers::stanza_error::{DefinedCondition, ErrorType, StanzaError};
 
 use super::super::super::{get_room_actor, stanza_to_xml};
 use crate::server::routes::websocket::{
     interpret_loop::build_interpret_deps, ActiveCallThread, WebSocketState,
 };
+
+fn retryable_room_error(
+    room: &BareJid,
+    nick: &str,
+    sender: &FullJid,
+    text: &'static str,
+) -> Vec<String> {
+    vec![super::muc::build_muc_presence_error_xml(
+        room,
+        nick,
+        sender,
+        StanzaError::new(
+            ErrorType::Wait,
+            DefinedCondition::ResourceConstraint,
+            "en",
+            text,
+        ),
+    )]
+}
 
 /// Pull out the typed [`Muji`] element from an inbound presence's
 /// payloads if it carries one. Returns `None` when the namespace
@@ -177,6 +197,30 @@ pub(crate) async fn try_handle_muc_presence_update(
         {
             Ok(Some(outcome)) => outcome,
             Ok(None) => return None,
+            Err(kameo::error::SendError::HandlerError(
+                waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+            )) => {
+                crate::server::routes::websocket::handlers::iq::demote_exact_room_actor(
+                    state, room_jid, &actor,
+                )
+                .await;
+                return Some(retryable_room_error(
+                    room_jid,
+                    nick,
+                    sender_jid,
+                    "This room's ownership recently moved; please retry.",
+                ));
+            }
+            Err(kameo::error::SendError::HandlerError(
+                waddle_xmpp::muc::room_actor::RoomMutationError::OwnershipUncertain,
+            )) => {
+                return Some(retryable_room_error(
+                    room_jid,
+                    nick,
+                    sender_jid,
+                    "This room's ownership cannot currently be verified; please retry.",
+                ));
+            }
             Err(error) => {
                 warn!(
                     room = %room_jid,
@@ -185,7 +229,12 @@ pub(crate) async fn try_handle_muc_presence_update(
                     error = ?error,
                     "Failed to upsert MUC Muji presence; falling back to join path"
                 );
-                return None;
+                return Some(retryable_room_error(
+                    room_jid,
+                    nick,
+                    sender_jid,
+                    "The room could not apply this presence update; please retry.",
+                ));
             }
         },
         None => match actor
@@ -196,6 +245,30 @@ pub(crate) async fn try_handle_muc_presence_update(
         {
             Ok(Some(outcome)) => outcome,
             Ok(None) => return None,
+            Err(kameo::error::SendError::HandlerError(
+                waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+            )) => {
+                crate::server::routes::websocket::handlers::iq::demote_exact_room_actor(
+                    state, room_jid, &actor,
+                )
+                .await;
+                return Some(retryable_room_error(
+                    room_jid,
+                    nick,
+                    sender_jid,
+                    "This room's ownership recently moved; please retry.",
+                ));
+            }
+            Err(kameo::error::SendError::HandlerError(
+                waddle_xmpp::muc::room_actor::RoomMutationError::OwnershipUncertain,
+            )) => {
+                return Some(retryable_room_error(
+                    room_jid,
+                    nick,
+                    sender_jid,
+                    "This room's ownership cannot currently be verified; please retry.",
+                ));
+            }
             Err(error) => {
                 warn!(
                     room = %room_jid,
@@ -204,7 +277,12 @@ pub(crate) async fn try_handle_muc_presence_update(
                     error = ?error,
                     "Failed to clear MUC Muji presence; falling back to join path"
                 );
-                return None;
+                return Some(retryable_room_error(
+                    room_jid,
+                    nick,
+                    sender_jid,
+                    "The room could not apply this presence update; please retry.",
+                ));
             }
         },
     };
@@ -272,7 +350,40 @@ pub(crate) async fn try_handle_muc_presence_update(
         .await
     {
         Ok(Some(in_call_outcome)) => in_call_outcome.in_call_sessions,
-        Ok(None) | Err(_) => Vec::new(),
+        Ok(None) => Vec::new(),
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::NotOwner,
+        )) => {
+            crate::server::routes::websocket::handlers::iq::demote_exact_room_actor(
+                state, room_jid, &actor,
+            )
+            .await;
+            return Some(retryable_room_error(
+                room_jid,
+                nick,
+                sender_jid,
+                "This room's ownership recently moved; please retry.",
+            ));
+        }
+        Err(kameo::error::SendError::HandlerError(
+            waddle_xmpp::muc::room_actor::RoomMutationError::OwnershipUncertain,
+        )) => {
+            return Some(retryable_room_error(
+                room_jid,
+                nick,
+                sender_jid,
+                "This room's ownership cannot currently be verified; please retry.",
+            ));
+        }
+        Err(error) => {
+            warn!(room = %room_jid, ?error, "Failed to apply in-call state; suppressing presence fanout");
+            return Some(retryable_room_error(
+                room_jid,
+                nick,
+                sender_jid,
+                "The room could not apply this presence update; please retry.",
+            ));
+        }
     };
 
     let from_room_jid = room_jid

--- a/server/crates/waddle-server/src/server/routes/websocket/interpret_loop.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/interpret_loop.rs
@@ -23,6 +23,23 @@ pub(crate) fn build_interpret_deps<'a>(
         inbox_storage: Some(&state.deps.protocol.inbox_storage),
         extension_manager: Some(&state.deps.protocol.extension_manager),
         room_registry: Some(&state.deps.protocol.room_registry),
+        room_actor_incarnation: None,
+        #[cfg(feature = "clustering")]
+        muc_durable_store: state
+            .deps
+            .app_state
+            .clustering_claims
+            .muc_durable_store
+            .as_ref(),
+        #[cfg(feature = "clustering")]
+        clustered_muc_ownership_required: state
+            .deps
+            .app_state
+            .clustering_claims
+            .claim_store
+            .is_some(),
+        #[cfg(feature = "clustering")]
+        room_claim_fence: None,
         web_socket_state: Some(state),
         authenticated_session,
         local_domain: state.deps.auth_state.xmpp_domain.as_str(),

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -103,9 +103,7 @@ pub use state::{
     RemoteMucMemberships, WebSocketDeps, WebSocketState, XmppServiceDomains,
 };
 
-pub(crate) use cleanup::{
-    destroy_room_actor, get_or_create_room_actor, get_room_actor, is_muc_room_jid,
-};
+pub(crate) use cleanup::{get_or_create_room_actor, get_room_actor, is_muc_room_jid};
 pub(crate) use muc_call_sfu::{
     note_participant_left_by_call_id, note_participant_left_from_webhook,
 };

--- a/server/crates/waddle-server/src/server/routes/websocket/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/registration.rs
@@ -79,6 +79,48 @@ pub(super) fn publish_stream_id_and_presence(
     }
 }
 
+pub(super) fn rollback_registration_if_self_fenced(
+    state: &WebSocketState,
+    jid: &FullJid,
+    owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+    admission: Option<crate::clustering::ClusteringAdmissionToken>,
+) -> bool {
+    if admission.is_some_and(|token| state.deps.app_state.clustering_readiness.admits(token)) {
+        return false;
+    }
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .unregister_if_owner(jid, owner);
+    true
+}
+
+fn clustering_admission_is_current(state: &WebSocketState, conn: &WsConnState) -> bool {
+    conn.clustering_admission
+        .is_some_and(|token| state.deps.app_state.clustering_readiness.admits(token))
+}
+
+pub(super) async fn rollback_authoritative_registration(
+    state: &WebSocketState,
+    jid: &FullJid,
+    owner: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .unregister_if_owner(jid, owner);
+    tokio::join!(
+        crate::server::dual_registration::mirror_unregister(
+            &state.deps.protocol.user_registry,
+            jid,
+            Some(owner.clone()),
+        ),
+        super::cleanup::unregister_remote_user_resource_if_owner(state, jid, owner),
+    );
+}
+
 pub(super) async fn register_bound_connection_after_frame(
     state: &WebSocketState,
     domain: &str,
@@ -88,6 +130,13 @@ pub(super) async fn register_bound_connection_after_frame(
     let Some(jid) = conn.phase.bound_jid().cloned() else {
         return RegistrationAfterFrame::Unchanged;
     };
+    if !clustering_admission_is_current(state, conn) {
+        warn!(
+            jid = %jid,
+            "Refusing XMPP resource registration while the cluster node is self-fenced"
+        );
+        return RegistrationAfterFrame::SessionInitializationFailed;
+    }
     let Some(tx) = pending_tx.take() else {
         return RegistrationAfterFrame::Unchanged;
     };
@@ -130,18 +179,71 @@ pub(super) async fn register_bound_connection_after_frame(
         blocklist,
     );
 
-    let owner = state
+    // Construct the physical entry before publishing it. In cluster mode the
+    // bridge first reserves the one durable admission epoch shared by local-
+    // owner and remote-owner sockets; only then may either registry observe
+    // this full JID.
+    let entry = waddle_xmpp::registry::ConnectionEntry::new(tx);
+    entry
+        .carbons_enabled
+        .store(conn.carbons_enabled, std::sync::atomic::Ordering::Relaxed);
+    entry
+        .roster_interested
+        .store(conn.roster_interested, std::sync::atomic::Ordering::Relaxed);
+    entry.blocklist_interested.store(
+        conn.blocklist_interested,
+        std::sync::atomic::Ordering::Relaxed,
+    );
+    let owner = entry.carbons_handle();
+    if let Some(retirement_handle) = conn.retirement_handle.clone() {
+        if !entry.install_retirement_handle(retirement_handle) {
+            error!(jid = %jid, "Connection retirement handle was already installed");
+            return RegistrationAfterFrame::SessionInitializationFailed;
+        }
+    }
+
+    #[cfg(feature = "clustering")]
+    let mut physical_guard = {
+        let bridge = state
+            .deps
+            .app_state
+            .clustering_claims
+            .ordered_relay_delivery_bridge
+            .as_ref();
+        match bridge {
+            Some(bridge) => match bridge
+                .begin_physical_user_resource(&jid, owner.clone())
+                .await
+            {
+                Ok(guard) => Some(guard),
+                Err(_) => return RegistrationAfterFrame::SessionInitializationFailed,
+            },
+            None => None,
+        }
+    };
+
+    let published_owner = state
         .deps
         .protocol
         .connection_registry
-        .register_with_stream_state(
-            jid.clone(),
-            tx,
-            conn.carbons_enabled,
-            conn.roster_interested,
-            conn.blocklist_interested,
-        );
+        .register_entry(jid.clone(), entry.clone());
+    debug_assert!(std::sync::Arc::ptr_eq(&published_owner, &owner));
     conn.registry_owner = Some(owner.clone());
+
+    // Close the race where fencing begins after the pre-registration check
+    // but before publication. Since readiness flips before the terminal
+    // ConnectionRegistry snapshot, either that snapshot sees this entry or
+    // this owner-gated rollback removes it here.
+    if rollback_registration_if_self_fenced(state, &jid, &owner, conn.clustering_admission) {
+        #[cfg(feature = "clustering")]
+        abort_physical_registration(state, &mut physical_guard).await;
+        conn.registry_owner = None;
+        warn!(
+            jid = %jid,
+            "Rolled back XMPP resource registration because the cluster node self-fenced"
+        );
+        return RegistrationAfterFrame::SessionInitializationFailed;
+    }
 
     // Publish the SM stream id + restored presence onto the
     // freshly-registered entry, owner-gated against a racing same-JID
@@ -196,44 +298,83 @@ pub(super) async fn register_bound_connection_after_frame(
         .connection_registry
         .entry_if_owner(&jid, &owner)
     {
-        let mirror_outcome = crate::server::dual_registration::mirror_register_outcome(
-            &state.deps.protocol.user_registry,
-            jid.clone(),
-            entry.clone(),
-        )
-        .await;
-        let registered = match mirror_outcome {
-            crate::server::dual_registration::MirrorRegisterOutcome::Registered => true,
-            crate::server::dual_registration::MirrorRegisterOutcome::ForeignOwner => {
-                register_remote_clustered_resource(state, &jid, entry, owner.clone()).await
-            }
-            crate::server::dual_registration::MirrorRegisterOutcome::Failed => false,
+        #[cfg(feature = "clustering")]
+        let registered = if physical_guard.is_some() {
+            publish_clustered_physical_resource(state, physical_guard.as_ref(), entry.clone()).await
+        } else {
+            matches!(
+                crate::server::dual_registration::mirror_register_outcome(
+                    &state.deps.protocol.user_registry,
+                    jid.clone(),
+                    entry.clone(),
+                )
+                .await,
+                crate::server::dual_registration::MirrorRegisterOutcome::Registered
+            )
         };
+        #[cfg(not(feature = "clustering"))]
+        let registered = matches!(
+            crate::server::dual_registration::mirror_register_outcome(
+                &state.deps.protocol.user_registry,
+                jid.clone(),
+                entry.clone(),
+            )
+            .await,
+            crate::server::dual_registration::MirrorRegisterOutcome::Registered
+        );
         if !registered {
-            // Rollback also clears the presence_states published above.
-            state
-                .deps
-                .protocol
-                .connection_registry
-                .unregister_if_owner(&jid, &owner);
             // kameo's reply_timeout does not cancel an already-enqueued
             // handler, so a register that *timed out* may still land in the
             // actor tree after this rollback. Reap it with an owner-gated
             // unregister: the `UserRegistryActor` mailbox is FIFO, so this is
             // ordered after the register ask and prunes the phantom if it ran
             // late; owner-gating leaves a racing replacement untouched.
-            crate::server::dual_registration::mirror_unregister(
-                &state.deps.protocol.user_registry,
-                &jid,
-                Some(owner.clone()),
-            )
-            .await;
+            #[cfg(feature = "clustering")]
+            abort_physical_registration(state, &mut physical_guard).await;
+            rollback_authoritative_registration(state, &jid, &owner).await;
             conn.registry_owner = None;
             return RegistrationAfterFrame::SessionInitializationFailed;
         }
     }
 
+    if !clustering_admission_is_current(state, conn) {
+        #[cfg(feature = "clustering")]
+        abort_physical_registration(state, &mut physical_guard).await;
+        rollback_authoritative_registration(state, &jid, &owner).await;
+        conn.registry_owner = None;
+        warn!(jid = %jid, "Rolled back authoritative registration after node self-fence");
+        return RegistrationAfterFrame::SessionInitializationFailed;
+    }
+
     let sm_finalization = finalize_sm_after_registry_registration(state, conn, &jid, &owner).await;
+    if !clustering_admission_is_current(state, conn) {
+        #[cfg(feature = "clustering")]
+        abort_physical_registration(state, &mut physical_guard).await;
+        rollback_authoritative_registration(state, &jid, &owner).await;
+        conn.registry_owner = None;
+        warn!(jid = %jid, "Rolled back finalized session after node self-fence");
+        return RegistrationAfterFrame::SessionInitializationFailed;
+    }
+    #[cfg(feature = "clustering")]
+    if let Some(guard) = physical_guard.take() {
+        let Some(bridge) = state
+            .deps
+            .app_state
+            .clustering_claims
+            .ordered_relay_delivery_bridge
+            .as_ref()
+        else {
+            rollback_authoritative_registration(state, &jid, &owner).await;
+            conn.registry_owner = None;
+            return RegistrationAfterFrame::SessionInitializationFailed;
+        };
+        let Some(token) = bridge.finalize_physical_user_resource(guard).await else {
+            rollback_authoritative_registration(state, &jid, &owner).await;
+            conn.registry_owner = None;
+            return RegistrationAfterFrame::SessionInitializationFailed;
+        };
+        conn.physical_resource_admission = Some(token);
+    }
     info!(
         jid = %jid,
         resumed = conn.phase.is_resumed(),
@@ -245,11 +386,10 @@ pub(super) async fn register_bound_connection_after_frame(
 }
 
 #[cfg(feature = "clustering")]
-async fn register_remote_clustered_resource(
+async fn publish_clustered_physical_resource(
     state: &WebSocketState,
-    jid: &FullJid,
+    guard: Option<&crate::clustering::route_bridge::PhysicalResourceRegistrationGuard>,
     entry: waddle_xmpp::registry::ConnectionEntry,
-    owner: std::sync::Arc<std::sync::atomic::AtomicBool>,
 ) -> bool {
     let Some(bridge) = state
         .deps
@@ -260,22 +400,31 @@ async fn register_remote_clustered_resource(
     else {
         return false;
     };
-    match bridge
-        .try_register_remote_user_resource(jid, entry, owner)
-        .await
-    {
+    let Some(guard) = guard else {
+        return false;
+    };
+    match bridge.publish_physical_user_resource(guard, entry).await {
         crate::clustering::route_bridge::RemoteResourceRegisterOutcome::Registered => true,
         crate::clustering::route_bridge::RemoteResourceRegisterOutcome::NotRemote
         | crate::clustering::route_bridge::RemoteResourceRegisterOutcome::Failed => false,
     }
 }
 
-#[cfg(not(feature = "clustering"))]
-async fn register_remote_clustered_resource(
-    _state: &WebSocketState,
-    _jid: &FullJid,
-    _entry: waddle_xmpp::registry::ConnectionEntry,
-    _owner: std::sync::Arc<std::sync::atomic::AtomicBool>,
-) -> bool {
-    false
+#[cfg(feature = "clustering")]
+async fn abort_physical_registration(
+    state: &WebSocketState,
+    guard: &mut Option<crate::clustering::route_bridge::PhysicalResourceRegistrationGuard>,
+) {
+    let Some(guard) = guard.take() else {
+        return;
+    };
+    if let Some(bridge) = state
+        .deps
+        .app_state
+        .clustering_claims
+        .ordered_relay_delivery_bridge
+        .as_ref()
+    {
+        bridge.abort_physical_user_resource(guard).await;
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -639,6 +639,20 @@ pub(super) struct WsConnState {
     pub(super) pending_resume_h: Option<u32>,
     /// Ownership handle for the current connection-registry entry.
     pub(super) registry_owner: Option<Arc<std::sync::atomic::AtomicBool>>,
+    /// Exact clustering admission generation captured when this physical
+    /// WebSocket task started. Registration fails closed if the node fences
+    /// and recovers while this connection is suspended before publication.
+    pub(super) clustering_admission: Option<crate::clustering::ClusteringAdmissionToken>,
+    /// Exact cluster-wide physical full-JID admission. Unlike the node-level
+    /// admission above, this orders same-resource binds across every socket
+    /// node and remains attached to the connection through final SM setup and
+    /// owner-gated cleanup.
+    #[cfg(feature = "clustering")]
+    pub(super) physical_resource_admission:
+        Option<crate::clustering::route_bridge::PhysicalResourceAdmissionToken>,
+    /// Hard-retirement backstop for whole-node fencing. Installed onto the
+    /// local ConnectionEntry at bind; never used for owner-side remote mirrors.
+    pub(super) retirement_handle: Option<waddle_xmpp::registry::ConnectionRetirementHandle>,
     /// One-shot flag: when set, the main loop must NOT push the current
     /// frame's responses into `sm_state.record_outbound`. The flag is
     /// raised by `handle_sm_resume` because the responses it returns are
@@ -718,6 +732,10 @@ impl WsConnState {
             pending_resume_stream_id: None,
             pending_resume_h: None,
             registry_owner: None,
+            clustering_admission: None,
+            #[cfg(feature = "clustering")]
+            physical_resource_admission: None,
+            retirement_handle: None,
             suppress_sm_record_next_batch: false,
             deferred_inbound: std::collections::VecDeque::new(),
             send_window_pause_deadline: None,

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -246,8 +246,6 @@ async fn handle_sm_enable(
         Some(m) => m,
         None => max_resume_secs,
     };
-    sm_state.enable(stream_id.clone(), enable.resume, Some(max));
-
     // ADR-0017 Phase 3 Slice 6, element 8: ensure this node's `ClaimStore`
     // claim on this SM session at `<enable/>` time — not only at detach
     // time (Slice 5's `acquire_claim_store_entry_for_detach`). Without a
@@ -259,12 +257,24 @@ async fn handle_sm_enable(
     // with the detach-time call for the same stream id later in this
     // session's lifetime. No-op in practice for single-node deployments
     // (`InProcessClaimStore`'s bookkeeping, never a foreign conflict).
-    state
+    let claim_grant = match state
         .deps
         .protocol
         .sm_session_registry
         .ensure_session_claim(&stream_id)
-        .await;
+        .await
+    {
+        Ok(grant) => grant,
+        Err(error) => {
+            warn!(
+                stream_id = %stream_id,
+                %error,
+                "SM enable rejected: authoritative session claim admission failed"
+            );
+            return vec![SmFailed::with_condition("internal-server-error").to_xml()];
+        }
+    };
+    sm_state.enable(stream_id.clone(), enable.resume, Some(max));
 
     // Publish the stream id onto the registry's ConnectionEntry so
     // the offline-flush path can claim `pending_delivery` rows under
@@ -310,7 +320,10 @@ async fn handle_sm_enable(
             Some(mechanism) if mechanism == waddle_xmpp::isr::ISR_PINNED_MECHANISM => {
                 match state.deps.app_state.clustering_claims.isr_token_store() {
                     Some(isr_token_store) => {
-                        match isr_token_store.issue(&stream_id, mechanism).await {
+                        match isr_token_store
+                            .issue(&stream_id, mechanism, &claim_grant)
+                            .await
+                        {
                             Ok(issued) => Some(issued.token),
                             Err(error) => {
                                 warn!(stream_id = %stream_id, %error, "ISR token issuance failed");

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management/registration.rs
@@ -10,33 +10,6 @@ use super::super::{
     cleanup::cleanup_invalidated_detached_session, state::WsConnState, WebSocketState,
 };
 
-#[cfg(feature = "clustering")]
-async fn unregister_remote_user_resource_if_owner(
-    state: &WebSocketState,
-    jid: &FullJid,
-    owner: &Arc<std::sync::atomic::AtomicBool>,
-) {
-    if let Some(bridge) = state
-        .deps
-        .app_state
-        .clustering_claims
-        .ordered_relay_delivery_bridge
-        .as_ref()
-    {
-        bridge
-            .unregister_remote_user_resource_if_owner(jid, owner)
-            .await;
-    }
-}
-
-#[cfg(not(feature = "clustering"))]
-async fn unregister_remote_user_resource_if_owner(
-    _state: &WebSocketState,
-    _jid: &FullJid,
-    _owner: &Arc<std::sync::atomic::AtomicBool>,
-) {
-}
-
 /// Finish the XEP-0198 side effects that become safe only after the resumed
 /// or freshly-bound resource has been published to the connection registry.
 ///
@@ -275,7 +248,10 @@ async fn reset_registered_resume_attempt(
             Some(Arc::clone(owner)),
         )
         .await;
-        unregister_remote_user_resource_if_owner(state, jid, owner).await;
+        // Clustered physical-admission cleanup is deliberately left to
+        // `register_bound_connection_after_frame`: it still holds the per-JID
+        // publication guard across this final SM step and must drop that guard
+        // before performing the exact bridge unregister.
     }
     conn.registry_owner = None;
     conn.phase = ConnectionPhase::authenticated(jid);
@@ -321,7 +297,9 @@ async fn close_registered_resume_attempt(
             Some(Arc::clone(owner)),
         )
         .await;
-        unregister_remote_user_resource_if_owner(state, jid, owner).await;
+        // See `reset_registered_resume_attempt`: the outer registration
+        // boundary owns exact clustered physical-admission rollback after it
+        // releases the publication guard.
     }
     conn.registry_owner = None;
     conn.phase = ConnectionPhase::closing(Some(jid.clone()));

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
@@ -20,7 +20,9 @@
 use super::super::isr_resume::handle_isr_resume_authenticate;
 use super::super::stream_management::SmCtx;
 use super::*;
-use crate::clustering::claims::{clustering_control_plane_table_lock, PostgresClaimStore};
+use crate::clustering::claims::{
+    clustering_control_plane_table_lock, NodeLeaseStore, PostgresClaimStore,
+};
 use crate::clustering::isr::PostgresIsrTokenStore;
 use crate::clustering::ClusteringHandles;
 use crate::db::{Database, DatabaseConfig, DatabaseDriver};
@@ -64,6 +66,10 @@ async fn isr_fixture() -> Option<IsrFixture> {
         uuid::Uuid::new_v4().to_string(),
         uuid::Uuid::new_v4().to_string(),
     ));
+    PostgresClaimStore::new(db.clone())
+        .register(&node_identity.current(), None)
+        .await
+        .expect("register ISR fixture node incarnation");
 
     let sm_session_registry = Arc::new(
         InMemorySmSessionRegistry::new()
@@ -79,6 +85,7 @@ async fn isr_fixture() -> Option<IsrFixture> {
         muc_durable_store: None,
         isr_token_store: Some(isr_token_store.clone()),
         node_lease: None,
+        remote_resource_admission_store: None,
         lease_ttl: None,
         pod_template_hash: None,
         resume_bridge: None,
@@ -273,9 +280,17 @@ async fn isr_resume_succeeds_matches_token_rotates_and_replays() {
         .store_session(seeded_detached_session(&stream_id, &jid))
         .await
         .expect("seed detached session");
+    let grant = fixture
+        .state
+        .deps
+        .protocol
+        .sm_session_registry
+        .ensure_session_claim(&stream_id)
+        .await
+        .expect("read exact session grant");
     let issued = fixture
         .isr_token_store
-        .issue(&stream_id, ISR_PINNED_MECHANISM)
+        .issue(&stream_id, ISR_PINNED_MECHANISM, &grant)
         .await
         .expect("issue token");
 
@@ -356,9 +371,17 @@ async fn isr_resume_rejects_wrong_token_with_bare_failure_and_destroys_session()
         .store_session(seeded_detached_session(&stream_id, &jid))
         .await
         .expect("seed detached session");
+    let grant = fixture
+        .state
+        .deps
+        .protocol
+        .sm_session_registry
+        .ensure_session_claim(&stream_id)
+        .await
+        .expect("read exact session grant");
     fixture
         .isr_token_store
-        .issue(&stream_id, ISR_PINNED_MECHANISM)
+        .issue(&stream_id, ISR_PINNED_MECHANISM, &grant)
         .await
         .expect("issue token");
 
@@ -473,9 +496,17 @@ async fn isr_resume_rejects_identity_mismatch_without_destroying_session() {
         .store_session(seeded_detached_session(&stream_id, &jid))
         .await
         .expect("seed detached session");
+    let grant = fixture
+        .state
+        .deps
+        .protocol
+        .sm_session_registry
+        .ensure_session_claim(&stream_id)
+        .await
+        .expect("read exact session grant");
     let issued = fixture
         .isr_token_store
-        .issue(&stream_id, ISR_PINNED_MECHANISM)
+        .issue(&stream_id, ISR_PINNED_MECHANISM, &grant)
         .await
         .expect("issue token");
 
@@ -523,9 +554,17 @@ async fn isr_resume_authenticated_but_impossible_wraps_failed_in_success() {
         .store_session(seeded_detached_session(&stream_id, &jid))
         .await
         .expect("seed detached session");
+    let grant = fixture
+        .state
+        .deps
+        .protocol
+        .sm_session_registry
+        .ensure_session_claim(&stream_id)
+        .await
+        .expect("read exact session grant");
     let issued = fixture
         .isr_token_store
-        .issue(&stream_id, ISR_PINNED_MECHANISM)
+        .issue(&stream_id, ISR_PINNED_MECHANISM, &grant)
         .await
         .expect("issue token");
 
@@ -627,6 +666,10 @@ async fn isr_resume_wins_a_cross_node_steal_and_consumes_the_token() {
         uuid::Uuid::new_v4().to_string(),
         uuid::Uuid::new_v4().to_string(),
     ));
+    PostgresClaimStore::new(db.clone())
+        .register(&identity_a.current(), None)
+        .await
+        .expect("register ISR owner incarnation");
     let persistence_a = crate::sm_persistence_fenced::PostgresFencedSmPersistence::open(
         db.clone(),
         std::sync::Arc::clone(&claim_store_a),
@@ -646,13 +689,17 @@ async fn isr_resume_wins_a_cross_node_steal_and_consumes_the_token() {
         .store_session(seeded_detached_session_for_persistence(&stream_id, &jid))
         .await
         .expect("node A stores + claims + persists the detached session");
+    let grant = registry_a
+        .ensure_session_claim(&stream_id)
+        .await
+        .expect("read node A exact session grant");
 
     // ---- The ISR token: issued against the shared Postgres, before node
     // ---- B ever sees this stream, exactly as <isr-enable/> would mint it.
     let isr_store = PostgresIsrTokenStore::new(db.clone());
     isr_store.ensure_schema().await.expect("ensure isr schema");
     let issued = isr_store
-        .issue(&stream_id, ISR_PINNED_MECHANISM)
+        .issue(&stream_id, ISR_PINNED_MECHANISM, &grant)
         .await
         .expect("issue token");
 
@@ -665,6 +712,10 @@ async fn isr_resume_wins_a_cross_node_steal_and_consumes_the_token() {
         uuid::Uuid::new_v4().to_string(),
         uuid::Uuid::new_v4().to_string(),
     ));
+    PostgresClaimStore::new(db.clone())
+        .register(&identity_b.current(), None)
+        .await
+        .expect("register ISR resume destination incarnation");
     let persistence_b = crate::sm_persistence_fenced::PostgresFencedSmPersistence::open(
         db.clone(),
         std::sync::Arc::clone(&claim_store_b),
@@ -687,6 +738,7 @@ async fn isr_resume_wins_a_cross_node_steal_and_consumes_the_token() {
         muc_durable_store: None,
         isr_token_store: Some(std::sync::Arc::new(isr_store) as std::sync::Arc<dyn IsrTokenStore>),
         node_lease: None,
+        remote_resource_admission_store: None,
         lease_ttl: None,
         pod_template_hash: None,
         ordered_relay_delivery_bridge: None,

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -2866,6 +2866,122 @@ async fn standard_muc_owner_config_rejects_non_owner() {
     assert!(responses[0].contains("forbidden"));
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_owner_destroy_emits_unavailable_and_sfu_effects_once() {
+    let gate = std::sync::Arc::new(FirstUnregisterGate::default());
+    let recorder = std::sync::Arc::new(RecordingSfu::blocking_first_unregister(gate.clone()));
+    let state = state_with_recording_sfu(recorder.clone()).await;
+    let session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "destroy-once@muc.example.com".parse().expect("room jid");
+    let alice_jid: FullJid = "alice@example.com/web".parse().expect("alice jid");
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(session.clone()),
+    )
+    .await;
+
+    let destroy_iq = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), "destroy-once")
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "set")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_OWNER)
+                    .append(Element::builder("destroy", waddle_xmpp::muc::NS_MUC_OWNER).build())
+                    .build(),
+            )
+            .build(),
+    );
+
+    let first_state = state.clone();
+    let first_iq = destroy_iq.clone();
+    let first_session = session.clone();
+    let first_jid = alice_jid.clone();
+    let first = tokio::spawn(async move {
+        handle_iq(
+            &first_iq,
+            "example.com",
+            "muc.example.com",
+            first_state.as_ref(),
+            &Some(first_session),
+            &ready_phase(&first_jid),
+        )
+        .await
+    });
+
+    let wait_gate = gate.clone();
+    let first_effect_started = tokio::task::spawn_blocking(move || wait_gate.wait_until_entered())
+        .await
+        .expect("first destroy reaches SFU effect");
+    if !first_effect_started {
+        gate.release();
+        panic!("first destroy never reached SFU effect");
+    }
+
+    let second_state = state.clone();
+    let second_session = session;
+    let second_jid = alice_jid;
+    let second = tokio::spawn(async move {
+        handle_iq(
+            &destroy_iq,
+            "example.com",
+            "muc.example.com",
+            second_state.as_ref(),
+            &Some(second_session),
+            &ready_phase(&second_jid),
+        )
+        .await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    let pre_release_count = recorder.snapshot().len();
+    gate.release();
+    assert_eq!(
+        pre_release_count, 1,
+        "the losing destroy must not enter the irreversible SFU batch"
+    );
+
+    let first_responses = first.await.expect("first destroy task");
+    let second_responses = second.await.expect("second destroy task");
+    assert_eq!(
+        recorder.snapshot().len(),
+        1,
+        "the exact room incarnation emits SFU teardown exactly once"
+    );
+    let successes = [&first_responses, &second_responses]
+        .into_iter()
+        .filter(|responses| {
+            responses
+                .iter()
+                .any(|frame| frame.contains("type='result'"))
+        })
+        .count();
+    let failures = [&first_responses, &second_responses]
+        .into_iter()
+        .filter(|responses| responses.iter().any(|frame| frame.contains("type='error'")))
+        .count();
+    assert_eq!(successes, 1, "only the reservation winner succeeds");
+    assert_eq!(failures, 1, "the stale destroy fails without effects");
+    let destroy_unavailable = [&first_responses, &second_responses]
+        .into_iter()
+        .flat_map(|responses| responses.iter())
+        .filter(|frame| frame.contains("type='unavailable'") && frame.contains("<destroy"))
+        .count();
+    assert_eq!(
+        destroy_unavailable, 1,
+        "XEP-0045 §10.9 destroy-unavailable presence is emitted exactly once"
+    );
+}
+
 #[tokio::test]
 async fn room_disco_info_advertises_parent_space_metadata_for_linked_channel() {
     let state = create_test_websocket_state().await;
@@ -3767,11 +3883,57 @@ fn empty_muji() -> waddle_xmpp::xep::xep0272::Muji {
 struct RecordingSfu {
     calls: std::sync::Mutex<Vec<(waddle_sfu::CallId, waddle_sfu::Identity)>>,
     note_calls: std::sync::Mutex<Vec<(waddle_sfu::CallId, waddle_sfu::Identity)>>,
+    first_unregister_gate: Option<std::sync::Arc<FirstUnregisterGate>>,
 }
 
 impl RecordingSfu {
     fn snapshot(&self) -> Vec<(waddle_sfu::CallId, waddle_sfu::Identity)> {
         self.calls.lock().expect("recording lock").clone()
+    }
+
+    fn blocking_first_unregister(gate: std::sync::Arc<FirstUnregisterGate>) -> Self {
+        Self {
+            first_unregister_gate: Some(gate),
+            ..Self::default()
+        }
+    }
+}
+
+#[derive(Default)]
+struct FirstUnregisterGate {
+    entered: std::sync::Mutex<bool>,
+    entered_signal: std::sync::Condvar,
+    released: std::sync::Mutex<bool>,
+    release_signal: std::sync::Condvar,
+}
+
+impl FirstUnregisterGate {
+    fn enter_and_wait(&self) {
+        *self.entered.lock().expect("entered lock") = true;
+        self.entered_signal.notify_all();
+        let mut released = self.released.lock().expect("release lock");
+        while !*released {
+            released = self
+                .release_signal
+                .wait(released)
+                .expect("release wait lock");
+        }
+    }
+
+    fn wait_until_entered(&self) -> bool {
+        let entered = self.entered.lock().expect("entered lock");
+        let (entered, _) = self
+            .entered_signal
+            .wait_timeout_while(entered, std::time::Duration::from_secs(2), |entered| {
+                !*entered
+            })
+            .expect("entered wait lock");
+        *entered
+    }
+
+    fn release(&self) {
+        *self.released.lock().expect("release lock") = true;
+        self.release_signal.notify_all();
     }
 }
 
@@ -3803,10 +3965,16 @@ impl waddle_sfu::SfuService for RecordingSfu {
         call_id: &waddle_sfu::CallId,
         identity: &waddle_sfu::Identity,
     ) -> waddle_sfu::CallState {
-        self.calls
-            .lock()
-            .expect("recording lock")
-            .push((call_id.clone(), identity.clone()));
+        let call_number = {
+            let mut calls = self.calls.lock().expect("recording lock");
+            calls.push((call_id.clone(), identity.clone()));
+            calls.len()
+        };
+        if call_number == 1 {
+            if let Some(gate) = &self.first_unregister_gate {
+                gate.enter_and_wait();
+            }
+        }
         waddle_sfu::CallState::Ended
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/registration.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/registration.rs
@@ -2,10 +2,11 @@ use super::super::{
     frame::handle_xmpp_frame,
     registration::{
         publish_stream_id_and_presence, register_bound_connection_after_frame,
+        rollback_authoritative_registration, rollback_registration_if_self_fenced,
         RegistrationAfterFrame,
     },
     session_init::load_blocklist_for_bind,
-    state::WsConnState,
+    state::{WebSocketState, WsConnState},
     stream_management::SmRegistrationFinalization,
     transport_xml::element_to_xml,
 };
@@ -21,6 +22,15 @@ use waddle_xmpp::{
 };
 use xmpp_parsers::message::MessageType as XmppMessageType;
 use xmpp_parsers::minidom::Element;
+
+fn capture_clustering_admission(state: &WebSocketState, conn: &mut WsConnState) {
+    conn.clustering_admission = state
+        .deps
+        .app_state
+        .clustering_readiness
+        .capture_admission();
+    assert!(conn.clustering_admission.is_some());
+}
 
 #[tokio::test]
 async fn ensure_state_machine_initializes_sm_in_ready_phase() {
@@ -50,6 +60,7 @@ async fn ensure_state_machine_initializes_sm_in_ready_phase() {
 async fn register_bound_connection_after_frame_registers_ready_connection_once() {
     let state = create_test_websocket_state().await;
     let mut conn = WsConnState::new();
+    capture_clustering_admission(state.as_ref(), &mut conn);
     let jid: FullJid = "alice@example.com/web".parse().expect("jid");
     let (tx, _rx) = mpsc::channel::<OutboundStanza>(1);
     let mut pending_tx = Some(tx);
@@ -128,6 +139,150 @@ async fn register_bound_connection_after_frame_registers_ready_connection_once()
 }
 
 #[tokio::test]
+async fn register_bound_connection_after_frame_rejects_self_fenced_node() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    capture_clustering_admission(state.as_ref(), &mut conn);
+    state.deps.app_state.clustering_readiness.set_ready(false);
+    let jid: FullJid = "alice@example.com/fenced".parse().expect("jid");
+    let (tx, _rx) = mpsc::channel::<OutboundStanza>(1);
+    let mut pending_tx = Some(tx);
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+
+    let result = register_bound_connection_after_frame(
+        state.as_ref(),
+        "example.com",
+        &mut conn,
+        &mut pending_tx,
+    )
+    .await;
+
+    assert!(matches!(
+        result,
+        RegistrationAfterFrame::SessionInitializationFailed
+    ));
+    assert!(
+        pending_tx.is_some(),
+        "the readiness gate must reject before consuming registration state"
+    );
+    assert!(!state.deps.protocol.connection_registry.is_connected(&jid));
+}
+
+#[tokio::test]
+async fn registration_rejects_pre_fence_connection_after_false_true_readiness_aba() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    capture_clustering_admission(state.as_ref(), &mut conn);
+    let jid: FullJid = "alice@example.com/readiness-aba".parse().expect("jid");
+    let (tx, _rx) = mpsc::channel::<OutboundStanza>(1);
+    let mut pending_tx = Some(tx);
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+
+    state.deps.app_state.clustering_readiness.set_ready(false);
+    state.deps.app_state.clustering_readiness.set_ready(true);
+    assert!(state.deps.app_state.clustering_readiness.is_ready());
+
+    let result = register_bound_connection_after_frame(
+        state.as_ref(),
+        "example.com",
+        &mut conn,
+        &mut pending_tx,
+    )
+    .await;
+
+    assert!(matches!(
+        result,
+        RegistrationAfterFrame::SessionInitializationFailed
+    ));
+    assert!(pending_tx.is_some());
+    assert!(
+        !state.deps.protocol.connection_registry.is_connected(&jid),
+        "a socket from the pre-fence generation must not publish after recovery"
+    );
+}
+
+#[tokio::test]
+async fn post_publication_readiness_check_rolls_back_racing_registration() {
+    let state = create_test_websocket_state().await;
+    let admission = state
+        .deps
+        .app_state
+        .clustering_readiness
+        .capture_admission();
+    let jid: FullJid = "alice@example.com/racing-fence".parse().expect("jid");
+    let (tx, _rx) = mpsc::channel::<OutboundStanza>(1);
+    let owner = state
+        .deps
+        .protocol
+        .connection_registry
+        .register(jid.clone(), tx);
+    assert!(state.deps.protocol.connection_registry.is_connected(&jid));
+
+    state.deps.app_state.clustering_readiness.set_ready(false);
+
+    assert!(rollback_registration_if_self_fenced(
+        state.as_ref(),
+        &jid,
+        &owner,
+        admission,
+    ));
+    assert!(
+        !state.deps.protocol.connection_registry.is_connected(&jid),
+        "a fence racing after publication must remove the just-registered owner"
+    );
+}
+
+#[tokio::test]
+async fn authoritative_rollback_removes_connection_and_actor_views() {
+    let state = create_test_websocket_state().await;
+    let jid: FullJid = "alice@example.com/authoritative-race".parse().expect("jid");
+    let (tx, _rx) = mpsc::channel::<OutboundStanza>(1);
+    let owner = state
+        .deps
+        .protocol
+        .connection_registry
+        .register(jid.clone(), tx);
+    let entry = state
+        .deps
+        .protocol
+        .connection_registry
+        .entry_if_owner(&jid, &owner)
+        .expect("registered entry");
+    assert!(
+        crate::server::dual_registration::mirror_register(
+            &state.deps.protocol.user_registry,
+            jid.clone(),
+            entry,
+        )
+        .await
+    );
+
+    rollback_authoritative_registration(state.as_ref(), &jid, &owner).await;
+    tokio::task::yield_now().await;
+
+    assert!(!state.deps.protocol.connection_registry.is_connected(&jid));
+    let actor = state
+        .deps
+        .protocol
+        .user_registry
+        .ask(waddle_xmpp::registry::GetUser {
+            bare_jid: jid.to_bare(),
+        })
+        .await
+        .expect("user lookup after rollback");
+    if let Some(actor) = actor {
+        assert!(
+            actor
+                .ask(waddle_xmpp::registry::GetConnectionEntry { jid })
+                .await
+                .expect("resource lookup after rollback")
+                .is_none(),
+            "owner-gated rollback must remove the actor mirror too"
+        );
+    }
+}
+
+#[tokio::test]
 async fn register_bound_connection_after_frame_completes_pending_resume_claim() {
     use waddle_xmpp::stream_management::{
         DetachedSession, DetachedUnackedStanza, SmSessionRegistry,
@@ -135,6 +290,7 @@ async fn register_bound_connection_after_frame_completes_pending_resume_claim() 
 
     let state = create_test_websocket_state().await;
     let mut conn = WsConnState::new();
+    capture_clustering_admission(state.as_ref(), &mut conn);
     let jid: FullJid = "alice@example.com/web".parse().expect("jid");
     let stream_id = "registration-resume-stream".to_string();
     let session = create_test_session(state.as_ref(), "alice").await;
@@ -283,6 +439,7 @@ async fn replay_gap_during_resume_finalization_clears_blocklist_interest_for_fre
 
     let state = create_test_websocket_state().await;
     let mut conn = WsConnState::new();
+    capture_clustering_admission(state.as_ref(), &mut conn);
     let jid: FullJid = "alice@example.com/web".parse().expect("jid");
     let stream_id = "registration-resume-gap-stream".to_string();
     let session = create_test_session(state.as_ref(), "alice").await;
@@ -599,6 +756,7 @@ async fn stale_owner_publication_does_not_stamp_replacement_entry() {
 async fn cleanup_connection_shutdown_mirrors_unregister_into_actor_tree() {
     let state = create_test_websocket_state().await;
     let mut conn = WsConnState::new();
+    capture_clustering_admission(state.as_ref(), &mut conn);
     let jid: FullJid = "alice@example.com/web".parse().expect("jid");
     let (tx, mut rx) = mpsc::channel::<OutboundStanza>(1);
     let mut pending_tx = Some(tx);

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -4,7 +4,7 @@ use super::super::{
     handlers::{self, presence::handle_muc_join},
     interpret_loop::build_interpret_deps,
     replay::drive_interpret_loop,
-    state::WsConnState,
+    state::{WebSocketState, WsConnState},
     stream_management::is_countable_stanza,
     transport_xml::{build_stream_features_xml, element_to_xml, sasl_success_xml, stanza_to_xml},
 };
@@ -25,6 +25,15 @@ use waddle_xmpp::{
     Stanza,
 };
 use xmpp_parsers::minidom::Element;
+
+fn capture_clustering_admission(state: &WebSocketState, conn: &mut WsConnState) {
+    conn.clustering_admission = state
+        .deps
+        .app_state
+        .clustering_readiness
+        .capture_admission();
+    assert!(conn.clustering_admission.is_some());
+}
 
 fn resume_frame_xml(stream_id: &str, handled_count: u32) -> String {
     element_to_xml(
@@ -635,6 +644,153 @@ async fn sm_enable_after_bind_returns_enabled_and_tracks_counters() {
     .await;
     let ack2_el = Element::from_str(&ack2[0]).expect("xml");
     assert_eq!(ack2_el.attr("h"), Some("1"));
+}
+
+#[cfg(feature = "clustering")]
+mod sm_enable_claim_admission {
+    use super::*;
+    use crate::clustering::{ClusteringHandles, ClusteringReadiness};
+    use crate::server::routes::websocket::tests::create_test_websocket_state_with_clustering;
+    use std::sync::Arc;
+    use waddle_xmpp::ownership::{
+        ClaimEpoch, ClaimError, ClaimGrant, ClaimSnapshot, ClaimStore, Entity, NodeIdentity,
+        ResumeIdentityProof, SharedNodeIdentity, StalePredicate,
+    };
+    use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
+
+    /// Deterministic control-plane outage: the only operation the enable
+    /// path should reach is `ensure_claimed`, and that operation always
+    /// fails. The remaining methods make this a complete typed ClaimStore
+    /// rather than relying on a database or scheduling-dependent race.
+    struct RejectingClaimStore;
+
+    #[async_trait::async_trait]
+    impl ClaimStore for RejectingClaimStore {
+        async fn ensure_schema(&self) -> Result<(), ClaimError> {
+            Ok(())
+        }
+
+        async fn acquire(
+            &self,
+            _entity: &Entity,
+            _me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            Err(ClaimError::Backend("test control-plane outage".to_string()))
+        }
+
+        async fn ensure_claimed(
+            &self,
+            _entity: &Entity,
+            _me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            Err(ClaimError::Backend("test control-plane outage".to_string()))
+        }
+
+        async fn steal_stale(
+            &self,
+            _entity: &Entity,
+            _observed: ClaimEpoch,
+            _staleness: StalePredicate,
+            _me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            Err(ClaimError::Conflict)
+        }
+
+        async fn steal_for_resume(
+            &self,
+            _entity: &Entity,
+            _observed: ClaimEpoch,
+            _witness: ResumeIdentityProof,
+            _me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            Err(ClaimError::Conflict)
+        }
+
+        async fn current_claim(
+            &self,
+            _entity: &Entity,
+        ) -> Result<Option<ClaimSnapshot>, ClaimError> {
+            Ok(None)
+        }
+
+        async fn fence(
+            &self,
+            _entity: &Entity,
+            _me: &NodeIdentity,
+            _mine: ClaimEpoch,
+        ) -> Result<bool, ClaimError> {
+            Ok(false)
+        }
+
+        async fn release(
+            &self,
+            _entity: &Entity,
+            _me: &NodeIdentity,
+            _mine: ClaimEpoch,
+        ) -> Result<(), ClaimError> {
+            Ok(())
+        }
+
+        async fn release_many(&self, _grants: &[ClaimGrant]) -> Result<(), ClaimError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn sm_enable_fails_closed_when_the_authoritative_claim_cannot_be_acquired() {
+        let claim_store: Arc<dyn ClaimStore> = Arc::new(RejectingClaimStore);
+        let identity = SharedNodeIdentity::new(NodeIdentity::new("node-a", "epoch-a"));
+        let sm_session_registry = Arc::new(
+            InMemorySmSessionRegistry::new()
+                .with_claim_store(Arc::clone(&claim_store), identity.clone()),
+        );
+        let clustering = ClusteringHandles {
+            claim_store: Some(claim_store),
+            node_identity: Some(identity),
+            ..ClusteringHandles::default()
+        };
+        let state =
+            create_test_websocket_state_with_clustering(clustering, sm_session_registry).await;
+        // The fixture is clustering-enabled but has no lease task. Mark it
+        // ready explicitly so this test isolates claim admission failure.
+        let readiness: &ClusteringReadiness = &state.deps.app_state.clustering_readiness;
+        readiness.set_ready(true);
+
+        let mut conn = WsConnState::new();
+        capture_clustering_admission(state.as_ref(), &mut conn);
+        conn.phase = ConnectionPhase::ready(
+            "alice@example.com/web"
+                .parse::<FullJid>()
+                .expect("valid jid"),
+            false,
+        );
+
+        let responses = handle_xmpp_frame(
+            "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
+            "example.com",
+            state.as_ref(),
+            &mut conn,
+        )
+        .await;
+
+        assert_eq!(responses.len(), 1);
+        let failed = Element::from_str(&responses[0]).expect("failed xml");
+        assert_eq!(failed.name(), "failed");
+        assert!(
+            failed
+                .get_child(
+                    "internal-server-error",
+                    "urn:ietf:params:xml:ns:xmpp-stanzas"
+                )
+                .is_some(),
+            "claim admission failure must be an explicit retryable SM failure: {responses:?}"
+        );
+        assert!(
+            !conn.sm_state.enabled,
+            "a stream without an authoritative claim must never enter the enabled state"
+        );
+        assert!(conn.sm_state.stream_id.is_none());
+    }
 }
 
 /// Enable SM on a fresh ready connection and return the negotiated
@@ -3220,7 +3376,9 @@ async fn sm_detach_on_transport_drop_does_not_evict_sfu_call_session() {
 #[cfg(feature = "clustering")]
 mod fix3_shutdown_race {
     use super::*;
-    use crate::clustering::claims::{clustering_control_plane_table_lock, PostgresClaimStore};
+    use crate::clustering::claims::{
+        clustering_control_plane_table_lock, NodeLeaseStore, PostgresClaimStore,
+    };
     use crate::clustering::ClusteringHandles;
     use crate::db::{Database, DatabaseConfig, DatabaseDriver, DEFAULT_CONTROL_PLANE_POOL_SIZE};
     use crate::server::routes::websocket::tests::create_test_websocket_state_with_clustering;
@@ -3250,7 +3408,8 @@ mod fix3_shutdown_race {
     impl RemoteResumeAsker for HangingAsker {
         async fn ask_remote_detach(
             &self,
-            _node_id: &str,
+            _expected_owner: &waddle_xmpp::ownership::NodeIdentity,
+            _observed: waddle_xmpp::ownership::ClaimEpoch,
             _stream_id: &str,
             _requester_bare_jid: &BareJid,
         ) -> RemoteResumeAskOutcome {
@@ -3292,6 +3451,10 @@ mod fix3_shutdown_race {
         // actually dispatches into branch 2/3 (live handshake) instead of
         // short-circuiting.
         let owner = node_identity();
+        claim_store
+            .register(&owner, None)
+            .await
+            .expect("register foreign owner incarnation");
         let entity = Entity::new(EntityType::SmSession, "stream-shutdown-race".to_string());
         claim_store
             .acquire(&entity, &owner)
@@ -3299,6 +3462,10 @@ mod fix3_shutdown_race {
             .expect("owner claims the entity");
 
         let resuming_identity = node_identity();
+        claim_store
+            .register(&resuming_identity, None)
+            .await
+            .expect("register resuming node incarnation");
         let resuming_identity_handle = SharedNodeIdentity::new(resuming_identity.clone());
         let resuming_claim_store: Arc<dyn ClaimStore> =
             Arc::new(PostgresClaimStore::new(db.clone()));
@@ -3325,6 +3492,7 @@ mod fix3_shutdown_race {
             muc_durable_store: None,
             isr_token_store: None,
             node_lease: None,
+            remote_resource_admission_store: None,
             lease_ttl: None,
             pod_template_hash: None,
             resume_bridge: None,
@@ -3393,7 +3561,9 @@ mod fix3_shutdown_race {
 #[cfg(feature = "clustering")]
 mod fix_a_post_cas_shutdown {
     use super::*;
-    use crate::clustering::claims::{clustering_control_plane_table_lock, PostgresClaimStore};
+    use crate::clustering::claims::{
+        clustering_control_plane_table_lock, NodeLeaseStore, PostgresClaimStore,
+    };
     use crate::clustering::ClusteringHandles;
     use crate::db::{Database, DatabaseConfig, DatabaseDriver, DEFAULT_CONTROL_PLANE_POOL_SIZE};
     use crate::server::routes::websocket::tests::create_test_websocket_state_with_clustering;
@@ -3513,10 +3683,9 @@ mod fix_a_post_cas_shutdown {
 
         async fn release_many(
             &self,
-            entities: &[Entity],
-            me: &NodeIdentity,
+            grants: &[waddle_xmpp::ownership::ClaimGrant],
         ) -> Result<(), ClaimError> {
-            self.inner.release_many(entities, me).await
+            self.inner.release_many(grants).await
         }
     }
 
@@ -3574,6 +3743,10 @@ mod fix_a_post_cas_shutdown {
         // a genuine persisted row (branch 1's fast path) rather than
         // needing a live-handshake asker at all.
         let owner_identity = SharedNodeIdentity::new(node_identity());
+        PostgresClaimStore::new(db.clone())
+            .register(&owner_identity.current(), None)
+            .await
+            .expect("register owner node incarnation");
         let owner_claim_store: Arc<dyn ClaimStore> = Arc::new(PostgresClaimStore::new(db.clone()));
         let owner_persistence = PostgresFencedSmPersistence::open(
             db.clone(),
@@ -3616,6 +3789,10 @@ mod fix_a_post_cas_shutdown {
         // test. Its `ClaimStore` is gated on `ensure_claimed` — the call
         // `hydrate_reclaimed` issues right after `steal_for_resume` wins.
         let resuming_identity = node_identity();
+        PostgresClaimStore::new(db.clone())
+            .register(&resuming_identity, None)
+            .await
+            .expect("register resuming node incarnation");
         let resuming_identity_handle = SharedNodeIdentity::new(resuming_identity.clone());
         let real_claim_store: Arc<dyn ClaimStore> = Arc::new(PostgresClaimStore::new(db.clone()));
         let arrived = Arc::new(tokio::sync::Notify::new());
@@ -3656,6 +3833,7 @@ mod fix_a_post_cas_shutdown {
             muc_durable_store: None,
             isr_token_store: None,
             node_lease: None,
+            remote_resource_admission_store: None,
             lease_ttl: None,
             pod_template_hash: None,
             resume_bridge: None,
@@ -3841,6 +4019,7 @@ async fn sm_resume_restores_presence_payloads_to_the_live_registry() {
         .expect("store");
 
     let mut conn = WsConnState::new();
+    capture_clustering_admission(state.as_ref(), &mut conn);
     conn.phase = ConnectionPhase::authenticated(&jid);
     let responses = handle_xmpp_frame(
         &resume_frame_xml("stream-idle", 0),
@@ -3919,6 +4098,7 @@ async fn sm_resume_preserves_the_pending_subscribe_once_per_session_claim() {
         .expect("store");
 
     let mut conn = WsConnState::new();
+    capture_clustering_admission(state.as_ref(), &mut conn);
     conn.phase = ConnectionPhase::authenticated(&jid);
     let responses = handle_xmpp_frame(
         &resume_frame_xml("stream-claimed", 0),
@@ -3999,6 +4179,7 @@ async fn sm_resume_preserves_consumed_claim_when_detached_unavailable() {
         .expect("store");
 
     let mut conn = WsConnState::new();
+    capture_clustering_admission(state.as_ref(), &mut conn);
     conn.phase = ConnectionPhase::authenticated(&jid);
     let responses = handle_xmpp_frame(
         &resume_frame_xml("stream-claimed-unavail", 0),
@@ -4074,6 +4255,7 @@ async fn sm_resume_keeps_unconsumed_claim_armed() {
         .expect("store");
 
     let mut conn = WsConnState::new();
+    capture_clustering_admission(state.as_ref(), &mut conn);
     conn.phase = ConnectionPhase::authenticated(&jid);
     let responses = handle_xmpp_frame(
         &resume_frame_xml("stream-unclaimed", 0),

--- a/server/crates/waddle-server/src/server/routes/websocket/transport_xml.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/transport_xml.rs
@@ -208,7 +208,7 @@ pub(super) fn build_system_shutdown_stream_error() -> String {
     String::from_utf8(writer.into_inner()).expect("quick-xml serializes valid UTF-8")
 }
 
-/// Build the RFC 6120 §4.9.3.1 `<stream:error><conflict/>` frame sent to a
+/// Build the RFC 6120 §4.9.3.3 `<stream:error><conflict/>` frame sent to a
 /// live stream that has just lost cross-node XEP-0198 resume claim-steal
 /// arbitration (ADR-0017 Phase 3 Slice 6): "If the former stream is resumed
 /// and the server still has the stream for the previously-identified

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -808,7 +808,7 @@ mod orphan_reaper_sweep_tests {
     use crate::sm_persistence_fenced::PostgresFencedSmPersistence;
     use chrono::{TimeZone, Utc};
     use waddle_xmpp::ownership::{
-        ClaimEpoch, ClaimStore, Entity, EntityType, NodeIdentity, SharedNodeIdentity,
+        ClaimStore, Entity, EntityType, NodeIdentity, SharedNodeIdentity,
     };
     use waddle_xmpp::pending_delivery::SmSessionId;
     use waddle_xmpp::stream_management::persistence::{PersistedSession, SmPersistenceStorage};
@@ -917,11 +917,11 @@ mod orphan_reaper_sweep_tests {
             .expect("seed persisted session as its current claim-holding owner");
     }
 
-    /// Register `dead_owner`, then backdate its heartbeat while leaving
-    /// `expired = false`. The sweep's stale-node watchdog must discover
-    /// this row, commit `NodeLeaseStore::expire`, and only then make its
-    /// SM-session claims visible to `list_orphaned_sm_session_claims`.
-    async fn register_and_backdate_dead_owner(
+    /// Register `dead_owner` while it is still serving-eligible. Callers seed
+    /// its claim and persisted session before backdating the heartbeat: a real
+    /// node acquires/persists while live, then becomes stale. Acquiring after
+    /// the backdate is correctly rejected as `ClaimError::Draining`.
+    async fn register_dead_owner(
         claim_store: &PostgresClaimStore,
         db: &Database,
         dead_owner: &NodeIdentity,
@@ -934,6 +934,12 @@ mod orphan_reaper_sweep_tests {
             !expired_flag(db, &dead_owner.node_id).await,
             "freshly registered node must start non-expired"
         );
+    }
+
+    /// Make an already-seeded owner heartbeat-stale while leaving
+    /// `expired = false`. The sweep's watchdog must commit expiry before the
+    /// orphan claim becomes eligible for stealing.
+    async fn backdate_dead_owner(db: &Database, dead_owner: &NodeIdentity) {
         backdate_heartbeat(db, &dead_owner.node_id).await;
         assert!(
             !expired_flag(db, &dead_owner.node_id).await,
@@ -1026,6 +1032,7 @@ mod orphan_reaper_sweep_tests {
             muc_durable_store: None,
             isr_token_store: None,
             node_lease: Some(sweeper_node_lease),
+            remote_resource_admission_store: None,
             lease_ttl: Some(lease_ttl),
             pod_template_hash: None,
             resume_bridge: None,
@@ -1042,7 +1049,7 @@ mod orphan_reaper_sweep_tests {
 
         // ============ Leg 1: single-sweep steal + targeted hydrate ============
         let dead_owner = node_identity();
-        register_and_backdate_dead_owner(&claim_store, &db, &dead_owner).await;
+        register_dead_owner(&claim_store, &db, &dead_owner).await;
 
         let stream_id = "orphan-reaper-stream-1";
         let entity = sm_entity(stream_id);
@@ -1051,6 +1058,7 @@ mod orphan_reaper_sweep_tests {
             .await
             .expect("acquire claim under dead owner");
         seed_persisted_session_as_owner(&db, &dead_owner, stream_id).await;
+        backdate_dead_owner(&db, &dead_owner).await;
 
         run_orphan_reaper_sweep(&state).await;
 
@@ -1058,14 +1066,18 @@ mod orphan_reaper_sweep_tests {
             expired_flag(&db, &dead_owner.node_id).await,
             "the stale-node watchdog must commit dead owner's clustering_nodes row expired"
         );
-        let steal_landed = claim_store
-            .fence(&entity, &sweeper_identity, ClaimEpoch(orphan_epoch.0 + 1))
+        let reclaimed = claim_store
+            .current_claim(&entity)
             .await
-            .expect("fence call");
+            .expect("read reclaimed claim")
+            .expect("reclaimed claim remains present");
+        assert_eq!(
+            reclaimed.owner, sweeper_identity,
+            "steal must land under the sweeping node"
+        );
         assert!(
-            steal_landed,
-            "steal must land: the sweeping node must now own the entity at the \
-             bumped epoch"
+            reclaimed.claim_epoch > orphan_epoch,
+            "steal must advance the global claim epoch"
         );
         let hydrated = sm_session_registry
             .peek_session(stream_id)
@@ -1078,7 +1090,7 @@ mod orphan_reaper_sweep_tests {
 
         // ============ Leg 2: two concurrent sweeps, exactly-once steal ============
         let dead_owner_2 = node_identity();
-        register_and_backdate_dead_owner(&claim_store, &db, &dead_owner_2).await;
+        register_dead_owner(&claim_store, &db, &dead_owner_2).await;
 
         let stream_id_2 = "orphan-reaper-stream-2";
         let entity_2 = sm_entity(stream_id_2);
@@ -1087,6 +1099,7 @@ mod orphan_reaper_sweep_tests {
             .await
             .expect("acquire claim under dead owner 2");
         seed_persisted_session_as_owner(&db, &dead_owner_2, stream_id_2).await;
+        backdate_dead_owner(&db, &dead_owner_2).await;
 
         let state_a = Arc::clone(&state);
         let state_b = Arc::clone(&state);
@@ -1100,19 +1113,18 @@ mod orphan_reaper_sweep_tests {
             expired_flag(&db, &dead_owner_2.node_id).await,
             "dead owner 2's clustering_nodes row must be committed-expired"
         );
-        let steal_landed_exactly_once = claim_store
-            .fence(
-                &entity_2,
-                &sweeper_identity,
-                ClaimEpoch(orphan_epoch_2.0 + 1),
-            )
+        let reclaimed_2 = claim_store
+            .current_claim(&entity_2)
             .await
-            .expect("fence call");
+            .expect("read concurrently reclaimed claim")
+            .expect("concurrently reclaimed claim remains present");
+        assert_eq!(
+            reclaimed_2.owner, sweeper_identity,
+            "exactly one concurrent sweep must reclaim under the sweeping node"
+        );
         assert!(
-            steal_landed_exactly_once,
-            "exactly one of the two concurrent sweeps must have won the steal — the \
-             epoch must be bumped by exactly 1, not 2 (a double-steal would fence at \
-             +1 as false, since the epoch would actually be +2)"
+            reclaimed_2.claim_epoch > orphan_epoch_2,
+            "the winning concurrent sweep must advance the global claim epoch"
         );
         let hydrated_2 = sm_session_registry
             .peek_session(stream_id_2)
@@ -1146,7 +1158,7 @@ mod orphan_reaper_sweep_tests {
         }
 
         let dead_owner_3 = node_identity();
-        register_and_backdate_dead_owner(&claim_store, &db, &dead_owner_3).await;
+        register_dead_owner(&claim_store, &db, &dead_owner_3).await;
         let stream_id_3 = "orphan-reaper-stream-stale-sweeper";
         let entity_3 = sm_entity(stream_id_3);
         let orphan_epoch_3 = claim_store
@@ -1154,26 +1166,22 @@ mod orphan_reaper_sweep_tests {
             .await
             .expect("acquire claim under dead owner 3");
         seed_persisted_session_as_owner(&db, &dead_owner_3, stream_id_3).await;
+        backdate_dead_owner(&db, &dead_owner_3).await;
 
         run_orphan_reaper_sweep(&state).await;
 
-        assert!(
-            claim_store
-                .fence(&entity_3, &dead_owner_3, orphan_epoch_3)
-                .await
-                .expect("fence dead-owner claim after heartbeat-stale sweeper"),
+        let unchanged = claim_store
+            .current_claim(&entity_3)
+            .await
+            .expect("read claim after heartbeat-stale sweep")
+            .expect("dead-owner claim remains present");
+        assert_eq!(
+            unchanged.owner, dead_owner_3,
             "a heartbeat-stale sweeping node must not steal the orphaned claim"
         );
-        assert!(
-            !claim_store
-                .fence(
-                    &entity_3,
-                    &sweeper_identity,
-                    ClaimEpoch(orphan_epoch_3.0 + 1)
-                )
-                .await
-                .expect("fence heartbeat-stale sweeper after failed steal"),
-            "the heartbeat-stale sweeping node must not own the bumped claim epoch"
+        assert_eq!(
+            unchanged.claim_epoch, orphan_epoch_3,
+            "a rejected sweep must not advance the global claim epoch"
         );
         let not_hydrated = sm_session_registry
             .peek_session(stream_id_3)

--- a/server/crates/waddle-server/src/sm_persistence_fenced.rs
+++ b/server/crates/waddle-server/src/sm_persistence_fenced.rs
@@ -12,8 +12,8 @@
 //! `record_promotion_failure`) each need the fencing SELECT inside one
 //! `Transaction`. Two trait-shape divergences from the portable impl are
 //! explicit and accepted: (a) detach writes ignore the caller-supplied
-//! `detached_at` and stamp/re-read Postgres `now()`... (b) expiry listing
-//! evaluates the window in SQL against Postgres `now()`, treating the
+//! `detached_at` and stamp/re-read Postgres `clock_timestamp()`... (b) expiry listing
+//! evaluates the window in SQL against Postgres `clock_timestamp()`, treating the
 //! trait's `now` parameter as advisory in the fenced impl. The portable
 //! impl and schema remain byte-identical for SQLite."*
 //!
@@ -31,7 +31,8 @@
 //!
 //! Every method that writes `sm_sessions`/`sm_unacked` on behalf of an
 //! SM-session entity runs its own `SELECT 1 FROM clustering_claims WHERE
-//! entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE` — the exact
+//! entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR
+//! SHARE` — the exact
 //! fencing-transaction SQL shape ADR-0017 Phase 3 Slice 1 locks — as the
 //! first statement inside the *same* [`crate::db::Transaction`] as the
 //! write(s) it guards, all on the **main pool**
@@ -164,7 +165,7 @@ fn claim_error_to_sm_persistence_error(error: ClaimError, entity: Entity) -> SmP
         ClaimError::AlreadyClaimed | ClaimError::Conflict | ClaimError::Draining => {
             SmPersistenceError::NotOwner { entity }
         }
-        ClaimError::Backend(_) | ClaimError::Poisoned => {
+        ClaimError::Backend(_) | ClaimError::Poisoned | ClaimError::EpochExhausted => {
             SmPersistenceError::Other(error.to_string())
         }
         // Defensive only: `ensure_claimed`/`acquire` never actually return
@@ -220,6 +221,45 @@ pub struct PostgresFencedSmPersistence {
     /// an already-populated, now-stale cell from the map entirely so a
     /// later call builds a brand-new one.
     claim_epochs: Arc<DashMap<SmSessionId, Arc<OnceCell<ClaimEpoch>>>>,
+    /// Unit-test-only rendezvous used to hold a real multi-statement write
+    /// immediately after its fencing SELECT has acquired the claim/node row
+    /// locks. This field and every call site compile out of production.
+    #[cfg(test)]
+    fenced_write_test_barrier: Option<FencedWriteTestBarrier>,
+}
+
+/// Two-phase test rendezvous for deterministic expiry-vs-write interleavings.
+/// The first barrier proves the real fencing SELECT returned `Ok`; the second
+/// keeps that transaction open until the test has launched the exact expiry
+/// CAS that must block on its node-row lock.
+#[cfg(test)]
+#[derive(Clone)]
+struct FencedWriteTestBarrier {
+    fenced: Arc<tokio::sync::Barrier>,
+    resume: Arc<tokio::sync::Barrier>,
+}
+
+#[cfg(test)]
+impl FencedWriteTestBarrier {
+    fn new() -> Self {
+        Self {
+            fenced: Arc::new(tokio::sync::Barrier::new(2)),
+            resume: Arc::new(tokio::sync::Barrier::new(2)),
+        }
+    }
+
+    async fn pause_writer(&self) {
+        self.fenced.wait().await;
+        self.resume.wait().await;
+    }
+
+    async fn wait_until_fenced(&self) {
+        self.fenced.wait().await;
+    }
+
+    async fn resume_writer(&self) {
+        self.resume.wait().await;
+    }
 }
 
 impl PostgresFencedSmPersistence {
@@ -257,12 +297,28 @@ impl PostgresFencedSmPersistence {
             claim_store,
             node_identity,
             claim_epochs: Arc::new(DashMap::new()),
+            #[cfg(test)]
+            fenced_write_test_barrier: None,
         };
         storage.ensure_schema().await?;
         tracing::info!(
             "Postgres-fenced SM persistence storage initialized (ADR-0017 Phase 3 Slice 4)"
         );
         Ok(storage)
+    }
+
+    #[cfg(test)]
+    fn install_fenced_write_test_barrier(&mut self) -> FencedWriteTestBarrier {
+        let barrier = FencedWriteTestBarrier::new();
+        self.fenced_write_test_barrier = Some(barrier.clone());
+        barrier
+    }
+
+    #[cfg(test)]
+    async fn pause_fenced_write_for_test(&self) {
+        if let Some(barrier) = &self.fenced_write_test_barrier {
+            barrier.pause_writer().await;
+        }
     }
 
     async fn ensure_schema(&self) -> Result<(), SmPersistenceError> {
@@ -425,8 +481,22 @@ impl PostgresFencedSmPersistence {
         let key = sm_session_entity_key(stream_id);
         let mut rows = tx
             .query(
-                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                crate::db_params![key, identity.node_id.clone(), epoch.0],
+                "WITH locked AS MATERIALIZED ( \
+                     SELECT n.heartbeat, n.expired, n.lease_ttl_ms \
+                     FROM clustering_claims c \
+                     JOIN clustering_nodes n ON n.node_id = c.node_id AND n.node_epoch = c.node_epoch \
+                     WHERE c.entity = ? AND c.node_id = ? AND c.node_epoch = ? AND c.claim_epoch = ? \
+                     FOR SHARE OF c, n \
+                 ) \
+                 SELECT 1 FROM locked \
+                 WHERE NOT expired \
+                   AND heartbeat >= clock_timestamp() - (lease_ttl_ms::text || ' milliseconds')::interval",
+                crate::db_params![
+                    key,
+                    identity.node_id.clone(),
+                    identity.node_epoch.clone(),
+                    epoch.0,
+                ],
             )
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
@@ -443,6 +513,36 @@ impl PostgresFencedSmPersistence {
                 entity: sm_session_entity(stream_id),
             })
         }
+    }
+
+    /// Serialize an absent session row and wait out any existing row writer
+    /// before computing the database-owned detach timestamp. Evaluating
+    /// `clock_timestamp()` directly in an `INSERT .. ON CONFLICT` is not
+    /// enough: Postgres may evaluate the VALUES expression before waiting on
+    /// the conflicting row lock.
+    async fn lock_session_effect_row(
+        &self,
+        tx: &mut Transaction<'_>,
+        stream_id: &SmSessionId,
+    ) -> Result<(), SmPersistenceError> {
+        tx.execute(
+            "SELECT pg_advisory_xact_lock(hashtextextended(?, 8720))",
+            crate::db_params![stream_id.as_str().to_string()],
+        )
+        .await
+        .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let mut rows = tx
+            .query(
+                "SELECT 1 FROM sm_sessions WHERE stream_id = ? FOR UPDATE",
+                crate::db_params![stream_id.as_str().to_string()],
+            )
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        let _ = rows
+            .next()
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        Ok(())
     }
 
     async fn guard_query(
@@ -473,13 +573,14 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
 
         let mut tx = self
             .db
-            .begin()
+            .begin_fenced()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
         self.assert_fenced(&mut tx, &stream_id, epoch).await?;
+        self.lock_session_effect_row(&mut tx, &stream_id).await?;
 
         // Divergence (a): ignore `session.detached_at`; stamp Postgres
-        // `now()` in SQL instead (both the fresh-insert VALUES and the
+        // `clock_timestamp()` in SQL instead (both the fresh-insert VALUES and the
         // ON CONFLICT UPDATE's `excluded.detached_at_ms` read the same
         // server-computed literal, so both paths agree).
         tx.execute(
@@ -490,7 +591,7 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
                 carbons_enabled, roster_interested, blocklist_interested, presence_available,
                 presence_show, presence_status, presence_priority, replay_gap_through,
                 presence_payloads
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, (EXTRACT(EPOCH FROM now()) * 1000)::bigint, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::bigint, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (stream_id) DO UPDATE SET
                 user_id = excluded.user_id,
                 full_jid = excluded.full_jid,
@@ -572,10 +673,12 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
         let epoch = self.claim_epoch_for(stream_id).await?;
         let mut tx = self
             .db
-            .begin()
+            .begin_fenced()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
         self.assert_fenced(&mut tx, stream_id, epoch).await?;
+        #[cfg(test)]
+        self.pause_fenced_write_for_test().await;
 
         // Two statements rather than ON DELETE CASCADE, matching the
         // portable impl's observable lifecycle exactly.
@@ -610,7 +713,7 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
 
         let mut tx = self
             .db
-            .begin()
+            .begin_fenced()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
         self.assert_fenced(&mut tx, &stream_id, epoch).await?;
@@ -640,7 +743,7 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
         let epoch = self.claim_epoch_for(stream_id).await?;
         let mut tx = self
             .db
-            .begin()
+            .begin_fenced()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
         self.assert_fenced(&mut tx, stream_id, epoch).await?;
@@ -665,7 +768,7 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
         let epoch = self.claim_epoch_for(stream_id).await?;
         let mut tx = self
             .db
-            .begin()
+            .begin_fenced()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
         self.assert_fenced(&mut tx, stream_id, epoch).await?;
@@ -791,15 +894,18 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
 
         let mut tx = self
             .db
-            .begin()
+            .begin_fenced()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
         self.assert_fenced(&mut tx, &stream_id, epoch).await?;
+        #[cfg(test)]
+        self.pause_fenced_write_for_test().await;
+        self.lock_session_effect_row(&mut tx, &stream_id).await?;
 
         // Drop any pre-existing unacked rows first (see the portable
         // impl's identical comment on this statement's ordering
         // rationale), then upsert the session row (divergence (a):
-        // Postgres `now()`, not `session.detached_at`), then append every
+        // Postgres `clock_timestamp()`, not `session.detached_at`), then append every
         // supplied unacked stanza.
         tx.execute(
             "DELETE FROM sm_unacked WHERE stream_id = ?",
@@ -816,7 +922,7 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
                 carbons_enabled, roster_interested, blocklist_interested, presence_available,
                 presence_show, presence_status, presence_priority, replay_gap_through,
                 presence_payloads
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, (EXTRACT(EPOCH FROM now()) * 1000)::bigint, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::bigint, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT (stream_id) DO UPDATE SET
                 user_id = excluded.user_id,
                 full_jid = excluded.full_jid,
@@ -889,10 +995,12 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
         let epoch = self.claim_epoch_for(stream_id).await?;
         let mut tx = self
             .db
-            .begin()
+            .begin_fenced()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
         self.assert_fenced(&mut tx, stream_id, epoch).await?;
+        #[cfg(test)]
+        self.pause_fenced_write_for_test().await;
         let mut rows = tx
             .query(
                 "UPDATE sm_sessions SET promotion_attempts = promotion_attempts + 1 \

--- a/server/crates/waddle-server/src/sm_persistence_fenced/tests.rs
+++ b/server/crates/waddle-server/src/sm_persistence_fenced/tests.rs
@@ -3,7 +3,7 @@
 //! unset, mirroring `clustering::claims`'s own test style exactly.
 
 use super::*;
-use crate::clustering::claims::PostgresClaimStore;
+use crate::clustering::claims::{NodeLeaseStore, PostgresClaimStore};
 use crate::db::DatabaseConfig;
 use chrono::TimeZone;
 use std::time::Duration as StdDuration;
@@ -65,15 +65,23 @@ fn node_identity() -> NodeIdentity {
     )
 }
 
-/// Mirrors `clustering::claims::tests::seed_node` exactly (duplicated
-/// rather than exposed cross-module for a test-only helper — see that
-/// function's own doc comment for why `expired` is spliced as a literal).
+/// Mirrors `clustering::claims::tests::seed_node`'s direct-SQL purpose
+/// (duplicated rather than exposed cross-module for a test-only helper).
+/// This variant upserts because [`fixture`] now registers its exact live
+/// identity before each test; see the original helper's doc comment for why
+/// `expired` is spliced as a literal.
 async fn seed_node(db: &Database, identity: &NodeIdentity, expired: bool) {
     let conn = db.guard().await.expect("guard");
     let expired_literal = if expired { "true" } else { "false" };
     conn.execute(
         &format!(
-            "INSERT INTO clustering_nodes (node_id, node_epoch, expired) VALUES (?, ?, {expired_literal})"
+            "INSERT INTO clustering_nodes (node_id, node_epoch, heartbeat, expired, draining) \
+             VALUES (?, ?, now(), {expired_literal}, false) \
+             ON CONFLICT (node_id) DO UPDATE SET \
+                 node_epoch = EXCLUDED.node_epoch, \
+                 heartbeat = now(), \
+                 expired = EXCLUDED.expired, \
+                 draining = false"
         ),
         crate::db_params![identity.node_id.clone(), identity.node_epoch.clone()],
     )
@@ -85,6 +93,95 @@ async fn live_stealer(db: &Database) -> NodeIdentity {
     let stealer = node_identity();
     seed_node(db, &stealer, false).await;
     stealer
+}
+
+async fn current_claim_epoch(claims: &PostgresClaimStore, entity: &Entity) -> ClaimEpoch {
+    claims
+        .current_claim(entity)
+        .await
+        .expect("read current claim")
+        .expect("fixture claim exists")
+        .claim_epoch
+}
+
+const FENCED_WRITE_RACE_LEASE_TTL_MS: i64 = 1_000;
+
+/// Give the owner a short but comfortably-live lease. The writer is started
+/// immediately and must reach the test barrier while this lease is fresh;
+/// once fenced, the test can let database time make the same owner stale
+/// without updating the node row that the writer has locked `FOR SHARE`.
+async fn arm_short_live_owner_lease(db: &Database, owner: &NodeIdentity) {
+    let conn = db.guard().await.expect("guard");
+    let updated = conn
+        .execute(
+            "UPDATE clustering_nodes \
+             SET heartbeat = clock_timestamp(), lease_ttl_ms = ?, expired = false, draining = false \
+             WHERE node_id = ? AND node_epoch = ?",
+            crate::db_params![
+                FENCED_WRITE_RACE_LEASE_TTL_MS,
+                owner.node_id.clone(),
+                owner.node_epoch.clone(),
+            ],
+        )
+        .await
+        .expect("arm short live owner lease");
+    assert_eq!(updated, 1, "fixture owner row must exist");
+}
+
+/// Wait until a real public persistence method has passed `assert_fenced`
+/// and is holding the claim/node rows, let the short owner lease lapse, then
+/// launch the exact `expire` CAS on another connection. The early timeout
+/// proves expiry is blocked by the writer's node-row lock. Once the writer
+/// commits, expiry must commit first; only that committed `expired = true`
+/// transition makes the following `OwnerStale` steal eligible.
+async fn expire_then_steal_behind_fenced_write(
+    db: Database,
+    barrier: FencedWriteTestBarrier,
+    entity: Entity,
+    observed: ClaimEpoch,
+    owner: NodeIdentity,
+    stealer: NodeIdentity,
+) -> ClaimEpoch {
+    tokio::time::timeout(StdDuration::from_secs(5), barrier.wait_until_fenced())
+        .await
+        .expect("writer must acquire its fencing lock while the owner lease is fresh");
+
+    tokio::time::sleep(StdDuration::from_millis(
+        u64::try_from(FENCED_WRITE_RACE_LEASE_TTL_MS).expect("positive fixture TTL") + 200,
+    ))
+    .await;
+
+    let expire_db = db.clone();
+    let mut expire_task = tokio::spawn(async move {
+        PostgresClaimStore::new(expire_db)
+            .expire(
+                &owner,
+                StdDuration::from_millis(
+                    u64::try_from(FENCED_WRITE_RACE_LEASE_TTL_MS).expect("positive fixture TTL"),
+                ),
+            )
+            .await
+    });
+    if let Ok(early) = tokio::time::timeout(StdDuration::from_millis(200), &mut expire_task).await {
+        barrier.resume_writer().await;
+        panic!("expiry completed before the fenced writer released its node-row lock: {early:?}");
+    }
+
+    barrier.resume_writer().await;
+    let expired = tokio::time::timeout(StdDuration::from_secs(5), expire_task)
+        .await
+        .expect("expiry must unblock after the fenced writer commits")
+        .expect("expiry task must not panic")
+        .expect("expiry CAS must execute cleanly");
+    assert!(
+        expired,
+        "the lapsed exact owner must commit expired=true after the writer releases its lock"
+    );
+
+    PostgresClaimStore::new(db)
+        .steal_stale(&entity, observed, StalePredicate::OwnerStale, &stealer)
+        .await
+        .expect("steal must succeed after the exact owner commits expired=true")
 }
 
 struct Fixture {
@@ -156,6 +253,11 @@ async fn fixture() -> Option<Fixture> {
     ] {
         conn.execute(stmt, ()).await.expect("clean table");
     }
+    drop(conn);
+    claims
+        .register(&identity, None)
+        .await
+        .expect("register live fixture node");
 
     Some(Fixture {
         fenced,
@@ -206,6 +308,51 @@ async fn upsert_and_get_session_round_trip_except_divergent_detached_at() {
     assert!(
         loaded.detached_at >= before,
         "detached_at must be stamped from Postgres now() at write time"
+    );
+}
+
+#[tokio::test]
+async fn upsert_stamps_detached_at_after_session_row_lock_wait() {
+    let Some(f) = fixture().await else { return };
+    let stream_id = "stream-detached-post-lock";
+    f.fenced
+        .upsert_session(fixture_session(stream_id))
+        .await
+        .unwrap();
+
+    let db = f.claims_db.clone();
+    let mut blocker = db.begin().await.unwrap();
+    let mut rows = blocker
+        .query(
+            "SELECT 1 FROM sm_sessions WHERE stream_id = ? FOR UPDATE",
+            crate::db_params![stream_id.to_string()],
+        )
+        .await
+        .unwrap();
+    assert!(rows.next().await.unwrap().is_some());
+    drop(rows);
+
+    let fenced = Arc::new(f.fenced);
+    let task_fenced = fenced.clone();
+    let task =
+        tokio::spawn(async move { task_fenced.upsert_session(fixture_session(stream_id)).await });
+    tokio::time::sleep(StdDuration::from_millis(40)).await;
+    assert!(!task.is_finished(), "upsert must wait on the session row");
+    tokio::time::sleep(StdDuration::from_millis(360)).await;
+    let release_started_at = Utc::now() - chrono::Duration::milliseconds(5);
+    blocker.commit().await.unwrap();
+    task.await.unwrap().unwrap();
+
+    let loaded = fenced
+        .get_session(&SmSessionId::new(stream_id))
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        loaded.detached_at >= release_started_at,
+        "detached_at must be computed after the 400ms session-row wait: {} < {}",
+        loaded.detached_at,
+        release_started_at,
     );
 }
 
@@ -434,15 +581,18 @@ async fn delete_session_aborts_before_any_write_once_the_claim_is_stolen() {
     f.fenced
         .upsert_session(fixture_session("stream-stolen"))
         .await
-        .expect("upsert_session establishes the claim at epoch 0");
+        .expect("upsert_session establishes the claim");
 
     // Make the current owner's node row stale, then steal the entity to a
-    // different node — the fenced impl's cached epoch (0) is now invalid.
-    seed_node(&f.claims_db, &f.identity, true).await;
+    // different node — the fenced impl's cached epoch is now invalid. Claim
+    // epochs come from a global monotonic sequence, so read the exact grant
+    // rather than assuming a freshly-cleaned table resets it to zero.
     let entity = Entity::new(EntityType::SmSession, "stream-stolen".to_string());
+    let observed = current_claim_epoch(&f.claims, &entity).await;
+    seed_node(&f.claims_db, &f.identity, true).await;
     let stealer = live_stealer(&f.claims_db).await;
     f.claims
-        .steal_stale(&entity, ClaimEpoch(0), StalePredicate::OwnerStale, &stealer)
+        .steal_stale(&entity, observed, StalePredicate::OwnerStale, &stealer)
         .await
         .expect("steal succeeds against a stale owner");
 
@@ -470,13 +620,14 @@ async fn record_promotion_failure_aborts_before_any_write_once_the_claim_is_stol
     f.fenced
         .upsert_session(fixture_session("stream-promo-stolen"))
         .await
-        .expect("upsert_session establishes the claim at epoch 0");
+        .expect("upsert_session establishes the claim");
 
-    seed_node(&f.claims_db, &f.identity, true).await;
     let entity = Entity::new(EntityType::SmSession, "stream-promo-stolen".to_string());
+    let observed = current_claim_epoch(&f.claims, &entity).await;
+    seed_node(&f.claims_db, &f.identity, true).await;
     let stealer = live_stealer(&f.claims_db).await;
     f.claims
-        .steal_stale(&entity, ClaimEpoch(0), StalePredicate::OwnerStale, &stealer)
+        .steal_stale(&entity, observed, StalePredicate::OwnerStale, &stealer)
         .await
         .expect("steal succeeds against a stale owner");
 
@@ -501,12 +652,151 @@ async fn record_promotion_failure_aborts_before_any_write_once_the_claim_is_stol
 }
 
 #[tokio::test]
+async fn durable_write_rejects_a_lapsed_owner_before_expiry_is_committed() {
+    let Some(f) = fixture().await else { return };
+    let stream_id = SmSessionId::new("stream-lapsed-owner");
+    f.fenced
+        .upsert_session(fixture_session(stream_id.as_str()))
+        .await
+        .expect("live owner establishes session and claim");
+
+    let conn = f.claims_db.guard().await.expect("guard");
+    conn.execute(
+        "UPDATE clustering_nodes SET heartbeat = now() - interval '1 hour' \
+         WHERE node_id = ? AND node_epoch = ?",
+        crate::db_params![f.identity.node_id.clone(), f.identity.node_epoch.clone()],
+    )
+    .await
+    .expect("lapse heartbeat without committing expiry");
+    let mut rows = conn
+        .query(
+            "SELECT expired FROM clustering_nodes WHERE node_id = ? AND node_epoch = ?",
+            crate::db_params![f.identity.node_id.clone(), f.identity.node_epoch.clone()],
+        )
+        .await
+        .expect("read expiry bit");
+    assert!(!rows
+        .next()
+        .await
+        .expect("row read")
+        .expect("node row")
+        .get::<bool>(0)
+        .expect("expired"));
+    drop(rows);
+    drop(conn);
+
+    let result = f.fenced.record_promotion_failure(&stream_id).await;
+    assert!(
+        matches!(result, Err(SmPersistenceError::NotOwner { .. })),
+        "a lapsed-but-not-expired owner must fail the in-transaction fence: {result:?}"
+    );
+    let conn = f.claims_db.guard().await.expect("guard");
+    let mut rows = conn
+        .query(
+            "SELECT promotion_attempts FROM sm_sessions WHERE stream_id = ?",
+            crate::db_params![stream_id.as_str().to_owned()],
+        )
+        .await
+        .expect("query untouched session");
+    assert_eq!(
+        rows.next()
+            .await
+            .expect("row read")
+            .expect("session row")
+            .get::<i64>(0)
+            .expect("promotion_attempts"),
+        0
+    );
+}
+
+#[tokio::test]
+async fn fence_uses_wall_clock_after_transaction_begin() {
+    let Some(f) = fixture().await else { return };
+    let stream_id = SmSessionId::new("stream-transaction-clock");
+    f.fenced
+        .upsert_session(fixture_session(stream_id.as_str()))
+        .await
+        .expect("establish claim");
+    let entity = Entity::new(EntityType::SmSession, stream_id.as_str().to_string());
+    let epoch = f
+        .claims
+        .current_claim(&entity)
+        .await
+        .unwrap()
+        .unwrap()
+        .claim_epoch;
+    f.claims_db
+        .guard()
+        .await
+        .unwrap()
+        .execute(
+            "UPDATE clustering_nodes SET heartbeat = clock_timestamp(), lease_ttl_ms = 50 WHERE node_id = ? AND node_epoch = ?",
+            crate::db_params![f.identity.node_id.clone(), f.identity.node_epoch.clone()],
+        )
+        .await
+        .unwrap();
+
+    let mut tx = f.claims_db.begin().await.unwrap();
+    tokio::time::sleep(StdDuration::from_millis(150)).await;
+    let result = f.fenced.assert_fenced(&mut tx, &stream_id, epoch).await;
+    assert!(matches!(result, Err(SmPersistenceError::NotOwner { .. })));
+}
+
+#[tokio::test]
+async fn fenced_write_rejects_the_old_epoch_after_same_node_id_recovery() {
+    let Some(f) = fixture().await else { return };
+    let stream_id = SmSessionId::new("stream-same-node-new-epoch");
+    seed_node(&f.claims_db, &f.identity, false).await;
+    f.fenced
+        .upsert_session(fixture_session(stream_id.as_str()))
+        .await
+        .expect("old incarnation establishes the session and claim");
+
+    let recovered = NodeIdentity::new(f.identity.node_id.clone(), uuid::Uuid::new_v4().to_string());
+    let conn = f.claims_db.guard().await.expect("guard");
+    conn.execute(
+        "UPDATE clustering_nodes SET node_epoch = ? WHERE node_id = ?",
+        crate::db_params![recovered.node_epoch.clone(), recovered.node_id.clone()],
+    )
+    .await
+    .expect("rotate process node epoch");
+    drop(conn);
+
+    let result = f.fenced.record_promotion_failure(&stream_id).await;
+    assert!(
+        matches!(result, Err(SmPersistenceError::NotOwner { .. })),
+        "the old node epoch must not pass a same-node-id write fence: {result:?}"
+    );
+
+    let conn = f.claims_db.guard().await.expect("guard");
+    let mut rows = conn
+        .query(
+            "SELECT promotion_attempts FROM sm_sessions WHERE stream_id = ?",
+            crate::db_params![stream_id.as_str().to_string()],
+        )
+        .await
+        .expect("query promotion attempts");
+    let attempts: i64 = rows
+        .next()
+        .await
+        .expect("row")
+        .expect("session remains")
+        .get(0)
+        .expect("promotion_attempts column");
+    assert_eq!(attempts, 0, "the stale incarnation must not mutate the row");
+}
+
+#[tokio::test]
 async fn upsert_session_fails_closed_when_entity_already_claimed_by_another_node() {
     let Some(f) = fixture().await else { return };
     // A different node claims the entity first (simulating this SM-ID
     // already being owned elsewhere before this node ever saw it).
     let entity = Entity::new(EntityType::SmSession, "stream-preclaimed".to_string());
     let other = node_identity();
+    f.claims
+        .register(&other, None)
+        .await
+        .expect("register foreign claimant");
     f.claims.acquire(&entity, &other).await.expect("acquire");
 
     let result = f
@@ -528,36 +818,50 @@ async fn upsert_session_fails_closed_when_entity_already_claimed_by_another_node
 }
 
 /// Proves `delete_session`'s fencing check and its subsequent DELETEs are
-/// genuinely atomic — not merely "usually fine": a concurrent steal can
-/// never land in the window between the `FOR SHARE` SELECT succeeding and
-/// the DELETEs committing, because both contend for the same
-/// `clustering_claims` row. Modeled on
+/// genuinely atomic — not merely "usually fine": this deterministically
+/// pauses after the `FOR SHARE` SELECT succeeds, launches the exact expiry
+/// CAS, proves it is blocked, then lets both DELETEs commit before expiry
+/// makes the later steal eligible. Modeled on
 /// `clustering::claims::tests::steal_commit_interleaved_inside_a_fenced_transaction`.
 #[tokio::test]
-async fn concurrent_steal_vs_delete_session_never_produces_torn_state() {
-    let Some(f) = fixture().await else { return };
+async fn fenced_delete_serializes_concurrent_owner_expiry_before_steal() {
+    let Some(mut f) = fixture().await else {
+        return;
+    };
     let stream_id = SmSessionId::new("stream-race");
     f.fenced
         .upsert_session(fixture_session("stream-race"))
         .await
         .expect("upsert_session");
-    seed_node(&f.claims_db, &f.identity, true).await;
+    f.fenced
+        .append_unacked(fixture_unacked("stream-race", 1))
+        .await
+        .expect("append_unacked establishes a row for the first DELETE");
 
     let entity = Entity::new(EntityType::SmSession, "stream-race".to_string());
+    let observed = current_claim_epoch(&f.claims, &entity).await;
     let stealer = live_stealer(&f.claims_db).await;
+    arm_short_live_owner_lease(&f.claims_db, &f.identity).await;
+    let barrier = f.fenced.install_fenced_write_test_barrier();
 
     let delete_result = f.fenced.delete_session(&stream_id);
-    let steal_result =
-        f.claims
-            .steal_stale(&entity, ClaimEpoch(0), StalePredicate::OwnerStale, &stealer);
-    let (delete_outcome, _steal_outcome) = tokio::join!(delete_result, steal_result);
+    let steal_result = expire_then_steal_behind_fenced_write(
+        f.claims_db.clone(),
+        barrier,
+        entity,
+        observed,
+        f.identity.clone(),
+        stealer,
+    );
+    let (delete_outcome, stolen_epoch) = tokio::join!(delete_result, steal_result);
+    delete_outcome.expect("fenced delete must commit before the blocked expiry CAS");
+    assert!(
+        stolen_epoch > observed,
+        "the steal must advance the claim after the delete commits"
+    );
 
-    // Whichever statement's transaction actually committed first, the
-    // session row must be in a *consistent* state: either fully deleted
-    // (delete_session won the race before the steal changed the epoch) or
-    // fully intact (the steal's epoch bump landed first, so
-    // delete_session's FOR SHARE SELECT saw zero rows and rolled back
-    // before deleting anything) — never partially deleted.
+    // Both rows must be gone: the writer committed its complete transaction
+    // before the blocked expiry CAS made the later steal eligible.
     let session_present = f
         .fenced
         .get_session(&stream_id)
@@ -570,23 +874,8 @@ async fn concurrent_steal_vs_delete_session_never_produces_torn_state() {
         .await
         .expect("list_unacked")
         .is_empty();
-
-    match delete_outcome {
-        Ok(()) => {
-            assert!(
-                !session_present,
-                "delete_session Ok(()) must mean the row is gone"
-            );
-            assert!(!unacked_present);
-        }
-        Err(SmPersistenceError::NotOwner { .. }) => {
-            assert!(
-                session_present,
-                "delete_session NotOwner must mean the row was never touched"
-            );
-        }
-        Err(other) => panic!("unexpected delete_session error: {other:?}"),
-    }
+    assert!(!session_present, "the session row must be deleted");
+    assert!(!unacked_present, "the unacked row must be deleted");
 }
 
 /// FIX 6: `store_session_atomic`'s own fencing check must abort the
@@ -600,17 +889,18 @@ async fn store_session_atomic_aborts_before_any_write_once_the_claim_is_stolen()
     f.fenced
         .upsert_session(fixture_session("stream-atomic-stolen"))
         .await
-        .expect("upsert_session establishes the claim at epoch 0");
+        .expect("upsert_session establishes the claim");
     f.fenced
         .append_unacked(fixture_unacked("stream-atomic-stolen", 1))
         .await
         .expect("append_unacked establishes an original unacked row");
 
-    seed_node(&f.claims_db, &f.identity, true).await;
     let entity = Entity::new(EntityType::SmSession, "stream-atomic-stolen".to_string());
+    let observed = current_claim_epoch(&f.claims, &entity).await;
+    seed_node(&f.claims_db, &f.identity, true).await;
     let stealer = live_stealer(&f.claims_db).await;
     f.claims
-        .steal_stale(&entity, ClaimEpoch(0), StalePredicate::OwnerStale, &stealer)
+        .steal_stale(&entity, observed, StalePredicate::OwnerStale, &stealer)
         .await
         .expect("steal succeeds against a stale owner");
 
@@ -648,13 +938,15 @@ async fn store_session_atomic_aborts_before_any_write_once_the_claim_is_stolen()
 }
 
 /// FIX 6: the same steal-vs-write race as
-/// `concurrent_steal_vs_delete_session_never_produces_torn_state`, exercised
+/// `fenced_delete_serializes_concurrent_owner_expiry_before_steal`, exercised
 /// against `store_session_atomic`'s own DELETE-then-INSERT-then-append
-/// sequence: whichever side commits first, the durable state must never end
-/// up torn between the old and new session/unacked rows.
+/// sequence. Expiry must wait for the complete durable replacement before it
+/// can commit and make the subsequent steal eligible.
 #[tokio::test]
-async fn concurrent_steal_vs_store_session_atomic_never_produces_torn_state() {
-    let Some(f) = fixture().await else { return };
+async fn fenced_atomic_store_serializes_concurrent_owner_expiry_before_steal() {
+    let Some(mut f) = fixture().await else {
+        return;
+    };
     let stream_id = SmSessionId::new("stream-atomic-race");
     f.fenced
         .upsert_session(fixture_session("stream-atomic-race"))
@@ -664,20 +956,32 @@ async fn concurrent_steal_vs_store_session_atomic_never_produces_torn_state() {
         .append_unacked(fixture_unacked("stream-atomic-race", 1))
         .await
         .expect("append_unacked establishes an original unacked row");
-    seed_node(&f.claims_db, &f.identity, true).await;
 
     let entity = Entity::new(EntityType::SmSession, "stream-atomic-race".to_string());
+    let observed = current_claim_epoch(&f.claims, &entity).await;
     let stealer = live_stealer(&f.claims_db).await;
+    arm_short_live_owner_lease(&f.claims_db, &f.identity).await;
+    let barrier = f.fenced.install_fenced_write_test_barrier();
 
     let mut new_session = fixture_session("stream-atomic-race");
     new_session.inbound_count = 999;
     let new_unacked = vec![fixture_unacked("stream-atomic-race", 2)];
 
     let store_result = f.fenced.store_session_atomic(new_session, new_unacked);
-    let steal_result =
-        f.claims
-            .steal_stale(&entity, ClaimEpoch(0), StalePredicate::OwnerStale, &stealer);
-    let (store_outcome, _steal_outcome) = tokio::join!(store_result, steal_result);
+    let steal_result = expire_then_steal_behind_fenced_write(
+        f.claims_db.clone(),
+        barrier,
+        entity,
+        observed,
+        f.identity.clone(),
+        stealer,
+    );
+    let (store_outcome, stolen_epoch) = tokio::join!(store_result, steal_result);
+    store_outcome.expect("fenced atomic store must commit before the blocked expiry CAS");
+    assert!(
+        stolen_epoch > observed,
+        "the steal must advance the claim after the atomic store commits"
+    );
 
     let loaded = f
         .fenced
@@ -691,50 +995,51 @@ async fn concurrent_steal_vs_store_session_atomic_never_produces_torn_state() {
         .await
         .expect("list_unacked");
 
-    match store_outcome {
-        Ok(()) => {
-            assert_eq!(
-                loaded.inbound_count, 999,
-                "store_session_atomic Ok(()) must mean the new session landed"
-            );
-            assert_eq!(queue.len(), 1);
-            assert_eq!(queue[0].sequence, 2);
-        }
-        Err(SmPersistenceError::NotOwner { .. }) => {
-            assert_eq!(
-                loaded.inbound_count, 7,
-                "store_session_atomic NotOwner must mean the original row survived untouched"
-            );
-            assert_eq!(queue.len(), 1);
-            assert_eq!(
-                queue[0].sequence, 1,
-                "the original unacked row must survive untouched"
-            );
-        }
-        Err(other) => panic!("unexpected store_session_atomic error: {other:?}"),
-    }
+    assert_eq!(
+        loaded.inbound_count, 999,
+        "the complete replacement session must land before the steal"
+    );
+    assert_eq!(queue.len(), 1);
+    assert_eq!(queue[0].sequence, 2);
 }
 
-/// FIX 6: the same steal-vs-write race, exercised against
+/// FIX 6: the same expiry-then-steal ordering, exercised against
 /// `record_promotion_failure`'s fenced `UPDATE ... RETURNING`.
 #[tokio::test]
-async fn concurrent_steal_vs_record_promotion_failure_never_produces_torn_state() {
-    let Some(f) = fixture().await else { return };
+async fn fenced_promotion_update_serializes_concurrent_owner_expiry_before_steal() {
+    let Some(mut f) = fixture().await else {
+        return;
+    };
     let stream_id = SmSessionId::new("stream-promo-race");
     f.fenced
         .upsert_session(fixture_session("stream-promo-race"))
         .await
         .expect("upsert_session");
-    seed_node(&f.claims_db, &f.identity, true).await;
 
     let entity = Entity::new(EntityType::SmSession, "stream-promo-race".to_string());
+    let observed = current_claim_epoch(&f.claims, &entity).await;
     let stealer = live_stealer(&f.claims_db).await;
+    arm_short_live_owner_lease(&f.claims_db, &f.identity).await;
+    let barrier = f.fenced.install_fenced_write_test_barrier();
 
     let promo_result = f.fenced.record_promotion_failure(&stream_id);
-    let steal_result =
-        f.claims
-            .steal_stale(&entity, ClaimEpoch(0), StalePredicate::OwnerStale, &stealer);
-    let (promo_outcome, _steal_outcome) = tokio::join!(promo_result, steal_result);
+    let steal_result = expire_then_steal_behind_fenced_write(
+        f.claims_db.clone(),
+        barrier,
+        entity,
+        observed,
+        f.identity.clone(),
+        stealer,
+    );
+    let (promo_outcome, stolen_epoch) = tokio::join!(promo_result, steal_result);
+    assert_eq!(
+        promo_outcome.expect("fenced promotion update must commit before the blocked expiry CAS"),
+        1
+    );
+    assert!(
+        stolen_epoch > observed,
+        "the steal must advance the claim after the promotion update commits"
+    );
 
     let conn = f.claims_db.guard().await.expect("guard");
     let mut rows = conn
@@ -747,22 +1052,7 @@ async fn concurrent_steal_vs_record_promotion_failure_never_produces_torn_state(
     let row = rows.next().await.expect("row").expect("row present");
     let attempts: i64 = row.get(0).expect("promotion_attempts column");
 
-    match promo_outcome {
-        Ok(count) => {
-            assert_eq!(
-                count, 1,
-                "record_promotion_failure Ok(1) must mean the UPDATE committed"
-            );
-            assert_eq!(attempts, 1);
-        }
-        Err(SmPersistenceError::NotOwner { .. }) => {
-            assert_eq!(
-                attempts, 0,
-                "record_promotion_failure NotOwner must mean the UPDATE never ran"
-            );
-        }
-        Err(other) => panic!("unexpected record_promotion_failure error: {other:?}"),
-    }
+    assert_eq!(attempts, 1, "the fenced UPDATE must commit exactly once");
 }
 
 /// FIX 6: `list_all_sessions` round-trips every persisted session under the
@@ -859,6 +1149,10 @@ struct SecondNode {
 
 async fn second_node(f: &Fixture) -> SecondNode {
     let identity = node_identity();
+    PostgresClaimStore::new(f.claims_db.clone())
+        .register(&identity, None)
+        .await
+        .expect("register second node incarnation");
     let shared_identity = SharedNodeIdentity::new(identity.clone());
     let claim_store: Arc<dyn ClaimStore> = Arc::new(PostgresClaimStore::new(f.claims_db.clone()));
     let fenced = PostgresFencedSmPersistence::open(

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -70,11 +70,16 @@ use waddle_server::config::{ClusteringBootstrapConfig, ClusteringConfig, Cluster
 use waddle_server::db::{Database, DatabaseConfig, DatabaseDriver};
 use waddle_ws_test_support::{extract_attr_after, TestServer, WsXmppClient};
 use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
+use waddle_xmpp::protocol::CarbonKind;
 use waddle_xmpp::Stanza;
+use waddle_xmpp_core::carbons::{CARBONS_NS, FORWARDED_NS};
 
 const POOL_SIZE: usize = 4;
 const CLUSTER_PEER_USERNAME: &str = "cluster-peer";
 const CLUSTER_PEER_PASSWORD: &str = "cluster-peer-password";
+const NODE_LEASE_HEARTBEAT_INTERVAL_MS: u64 = 300;
+const REMOTE_RESOURCE_REQUIRED_HEARTBEAT_ADVANCES: usize = 3;
+const CARBON_DUPLICATE_QUIET_WINDOW: Duration = Duration::from_secs(1);
 
 struct EnrolledPool {
     /// base64-encoded 32-byte ed25519 seeds (the WADDLE_CLUSTERING_KEYPAIR_POOL value).
@@ -140,6 +145,21 @@ async fn open_control_db(url: &str) -> Database {
     )
     .await
     .expect("open harness postgres")
+}
+
+async fn node_heartbeat(db: &Database, node_id: &str) -> Option<String> {
+    let conn = db.guard().await.expect("guard");
+    let mut rows = conn
+        .query(
+            "SELECT heartbeat::text FROM clustering_nodes WHERE node_id = ?",
+            waddle_server::db_params![node_id.to_string()],
+        )
+        .await
+        .expect("query node heartbeat");
+    rows.next()
+        .await
+        .expect("node heartbeat row")
+        .map(|row| row.get::<String>(0).expect("heartbeat column"))
 }
 
 /// Reset the clustering control-plane tables and enroll every pool PeerId.
@@ -268,6 +288,283 @@ fn frame_attr_starts_with(frame: &str, name: &str, prefix: &str) -> bool {
     frame.contains(&format!("{name}='{prefix}")) || frame.contains(&format!("{name}=\"{prefix}"))
 }
 
+async fn enable_carbons(client: &mut WsXmppClient, id: &str) {
+    let iq = xmpp_parsers::iq::Iq::Set {
+        from: None,
+        to: None,
+        id: id.to_string(),
+        payload: minidom::Element::builder("enable", CARBONS_NS).build(),
+    };
+    client
+        .send(&stanza_xml(Stanza::Iq(Box::new(iq))))
+        .await
+        .expect("send XEP-0280 enable IQ");
+    let response = client
+        .recv_matching(|frame| frame_has_attr(frame, "id", id))
+        .await
+        .expect("receive XEP-0280 enable result");
+    let response = response
+        .parse::<minidom::Element>()
+        .unwrap_or_else(|error| panic!("carbons enable result must be XML: {error}: {response}"));
+    assert_eq!(response.name(), "iq", "carbons enable response stanza");
+    assert_eq!(
+        response.ns(),
+        waddle_xmpp::ns::JABBER_CLIENT,
+        "carbons enable IQ namespace"
+    );
+    assert_eq!(
+        response.attr("type"),
+        Some("result"),
+        "carbons enable result"
+    );
+}
+
+struct CarbonWireExpectation<'a> {
+    kind: CarbonKind,
+    owner: &'a jid::BareJid,
+    target: &'a jid::FullJid,
+    original_id: &'a str,
+    original_from: &'a jid::FullJid,
+    original_to: &'a jid::FullJid,
+    original_body: &'a str,
+}
+
+fn carbon_element_name(kind: CarbonKind) -> &'static str {
+    match kind {
+        CarbonKind::Sent => "sent",
+        CarbonKind::Received => "received",
+    }
+}
+
+fn assert_carbon_wire_shape(frame: &str, expected: CarbonWireExpectation<'_>) {
+    let envelope = frame
+        .parse::<minidom::Element>()
+        .unwrap_or_else(|error| panic!("carbon envelope must be XML: {error}: {frame}"));
+    assert_eq!(envelope.name(), "message", "carbon envelope stanza");
+    assert_eq!(
+        envelope.ns(),
+        waddle_xmpp::ns::JABBER_CLIENT,
+        "carbon envelope namespace"
+    );
+    assert_eq!(
+        envelope.attr("type"),
+        Some("chat"),
+        "XEP-0280 carbon envelope must preserve the original message type"
+    );
+    assert_eq!(
+        envelope.attr("from"),
+        Some(expected.owner.as_str()),
+        "XEP-0280 carbon envelope must originate from the user's bare JID"
+    );
+    assert_eq!(
+        envelope.attr("to"),
+        Some(expected.target.as_str()),
+        "XEP-0280 carbon envelope must target the opted-in full JID"
+    );
+
+    let kind = carbon_element_name(expected.kind);
+    let carbon_elements = envelope
+        .children()
+        .filter(|child| child.ns() == CARBONS_NS && matches!(child.name(), "sent" | "received"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        carbon_elements.len(),
+        1,
+        "carbon envelope must contain exactly one <sent/> or <received/> child: {frame}"
+    );
+    let carbon = carbon_elements[0];
+    assert_eq!(
+        carbon.name(),
+        kind,
+        "carbon envelope contained the opposite carbon kind: {frame}"
+    );
+    let forwarded = carbon
+        .get_child("forwarded", FORWARDED_NS)
+        .unwrap_or_else(|| panic!("<{}> missing XEP-0297 <forwarded/> child: {frame}", kind));
+    let original = forwarded
+        .get_child("message", waddle_xmpp::ns::JABBER_CLIENT)
+        .unwrap_or_else(|| panic!("<forwarded/> missing original <message/>: {frame}"));
+    assert_eq!(
+        original.attr("id"),
+        Some(expected.original_id),
+        "forwarded message id"
+    );
+    assert_eq!(
+        original.attr("from"),
+        Some(expected.original_from.as_str()),
+        "forwarded original sender"
+    );
+    assert_eq!(
+        original.attr("to"),
+        Some(expected.original_to.as_str()),
+        "forwarded original recipient"
+    );
+    assert_eq!(
+        original.attr("type"),
+        Some("chat"),
+        "forwarded original message type"
+    );
+    assert_eq!(
+        original
+            .get_child("body", waddle_xmpp::ns::JABBER_CLIENT)
+            .map(minidom::Element::text)
+            .as_deref(),
+        Some(expected.original_body),
+        "forwarded original body"
+    );
+}
+
+fn assert_original_message_wire_shape(
+    frame: &str,
+    id: &str,
+    from: &jid::FullJid,
+    to: &jid::FullJid,
+    body: &str,
+) {
+    let message = frame
+        .parse::<minidom::Element>()
+        .unwrap_or_else(|error| panic!("original message must be XML: {error}: {frame}"));
+    assert_eq!(message.name(), "message", "original delivery stanza");
+    assert_eq!(
+        message.ns(),
+        waddle_xmpp::ns::JABBER_CLIENT,
+        "original delivery namespace"
+    );
+    assert_eq!(message.attr("id"), Some(id), "original delivery id");
+    assert_eq!(
+        message.attr("from"),
+        Some(from.as_str()),
+        "original delivery sender"
+    );
+    assert_eq!(
+        message.attr("to"),
+        Some(to.as_str()),
+        "original delivery recipient"
+    );
+    assert_eq!(message.attr("type"), Some("chat"), "original delivery type");
+    assert_eq!(
+        message
+            .get_child("body", waddle_xmpp::ns::JABBER_CLIENT)
+            .map(minidom::Element::text)
+            .as_deref(),
+        Some(body),
+        "original delivery body"
+    );
+    assert!(
+        message.children().all(|child| {
+            child.ns() != CARBONS_NS || !matches!(child.name(), "sent" | "received")
+        }),
+        "the original delivery must not be substituted with a carbon: {frame}"
+    );
+}
+
+fn assert_stream_error_wire_shape(frame: &str, expected_condition: &str, label: &str) {
+    let stream_error = frame
+        .parse::<minidom::Element>()
+        .unwrap_or_else(|error| panic!("{label}: stream error must be XML: {error}: {frame}"));
+    assert_eq!(
+        stream_error.name(),
+        "error",
+        "{label}: terminal frame must be <stream:error>: {frame}"
+    );
+    assert_eq!(
+        stream_error.ns(),
+        waddle_xmpp::ns::STREAM,
+        "{label}: <stream:error> must use the streams namespace: {frame}"
+    );
+
+    let conditions = stream_error
+        .children()
+        .filter(|child| child.ns() == waddle_xmpp::ns::STREAMS && child.name() != "text")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        conditions.len(),
+        1,
+        "{label}: <stream:error> must contain exactly one streams-namespaced condition: {frame}"
+    );
+    assert_eq!(
+        conditions[0].name(),
+        expected_condition,
+        "{label}: unexpected stream-error condition: {frame}"
+    );
+}
+
+async fn assert_stream_error_then_framing_close(
+    client: &mut WsXmppClient,
+    expected_condition: &str,
+    label: &str,
+) {
+    let stream_error = client
+        .recv_matching(|frame| frame.contains("<stream:error"))
+        .await
+        .unwrap_or_else(|error| panic!("{label}: did not receive <stream:error>: {error}"));
+    assert_stream_error_wire_shape(&stream_error, expected_condition, label);
+
+    let close = client.recv().await.unwrap_or_else(|error| {
+        panic!("{label}: stream error was not followed by RFC 7395 <close/>: {error}")
+    });
+    let close = close
+        .parse::<minidom::Element>()
+        .unwrap_or_else(|error| panic!("{label}: framing close must be XML: {error}: {close}"));
+    assert_eq!(close.name(), "close", "{label}: framing close element");
+    assert_eq!(
+        close.ns(),
+        "urn:ietf:params:xml:ns:xmpp-framing",
+        "{label}: framing close namespace"
+    );
+}
+
+async fn drain_frames_with_id(
+    client: &mut WsXmppClient,
+    id: &str,
+    window: Duration,
+    label: &str,
+) -> Vec<String> {
+    let deadline = Instant::now() + window;
+    let mut matching = Vec::new();
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match client.recv_timeout(remaining).await {
+            Ok(frame) => {
+                if frame_has_attr(&frame, "id", id) {
+                    matching.push(frame);
+                }
+            }
+            Err(error) if error == "Timeout waiting for message" => break,
+            Err(error) => panic!("{label}: failed while draining frames for {id}: {error}"),
+        }
+    }
+    matching
+}
+
+async fn recv_exactly_one_frame_with_id(
+    client: &mut WsXmppClient,
+    id: &str,
+    label: &str,
+) -> String {
+    let first = client
+        .recv_matching(|frame| frame_has_attr(frame, "id", id))
+        .await
+        .unwrap_or_else(|error| panic!("{label}: did not receive {id}: {error}"));
+    let duplicates = drain_frames_with_id(client, id, CARBON_DUPLICATE_QUIET_WINDOW, label).await;
+    assert!(
+        duplicates.is_empty(),
+        "{label}: expected exactly one frame for {id}, received duplicates: {duplicates:?}"
+    );
+    first
+}
+
+async fn assert_no_frame_with_id(client: &mut WsXmppClient, id: &str, label: &str) {
+    let unexpected = drain_frames_with_id(client, id, CARBON_DUPLICATE_QUIET_WINDOW, label).await;
+    assert!(
+        unexpected.is_empty(),
+        "{label}: expected no frame for {id}, received: {unexpected:?}"
+    );
+}
+
 async fn send_roster_get(client: &mut WsXmppClient, id: &str) -> String {
     let iq = xmpp_parsers::iq::Iq::Get {
         from: None,
@@ -331,6 +628,7 @@ async fn spawn_cluster_server(
             .map(|port| format!("localhost:{port}"))
             .collect::<Vec<_>>()
             .join(",");
+        let node_lease_heartbeat_interval_ms = NODE_LEASE_HEARTBEAT_INTERVAL_MS.to_string();
 
         let mut envs: Vec<(&str, &str)> = vec![
             ("WADDLE_DB_DRIVER", "postgres"),
@@ -371,7 +669,10 @@ async fn spawn_cluster_server(
             // self-fence loop unconditionally, so these envs simply make that
             // already-running production loop observable on a modest wall
             // clock instead of introducing a second harness-only code path.
-            ("WADDLE_CLUSTERING_NODE_LEASE_HEARTBEAT_INTERVAL_MS", "300"),
+            (
+                "WADDLE_CLUSTERING_NODE_LEASE_HEARTBEAT_INTERVAL_MS",
+                &node_lease_heartbeat_interval_ms,
+            ),
             ("WADDLE_CLUSTERING_NODE_LEASE_TTL_MS", "1200"),
             ("WADDLE_CLUSTERING_ISOLATION_INTERVALS", "2"),
             ("WADDLE_CLUSTERING_REREGISTER_BACKOFF_BASE_MS", "200"),
@@ -856,6 +1157,53 @@ async fn cluster_exit_criteria_end_to_end() {
         "same-bare remote bind must not advance the UserActor claim epoch"
     );
 
+    // The node-lease loop renews the heartbeat, performs reconciliation, then
+    // starts the next tick. Observe three heartbeat advances after this bind:
+    // reaching the third proves at least the first two post-bind reconciliation
+    // passes completed. A wall-clock sleep alone would not prove that under a
+    // loaded CI scheduler. The old bug included this remote socket in node B's
+    // authoritative UserActor set and conflict-closed it on the first pass.
+    let initial_heartbeat = node_heartbeat(&db, &node_b)
+        .await
+        .expect("node B heartbeat row after remote bind");
+    let mut last_heartbeat = initial_heartbeat.clone();
+    let mut heartbeat_advances = 0usize;
+    let heartbeat_deadline = Instant::now() + Duration::from_secs(15);
+    while heartbeat_advances < REMOTE_RESOURCE_REQUIRED_HEARTBEAT_ADVANCES {
+        assert!(
+            Instant::now() < heartbeat_deadline,
+            "node B heartbeat did not advance {} times after remote bind; observed \
+             {heartbeat_advances} advances from {initial_heartbeat} to {last_heartbeat}",
+            REMOTE_RESOURCE_REQUIRED_HEARTBEAT_ADVANCES
+        );
+        tokio::time::sleep(Duration::from_millis(NODE_LEASE_HEARTBEAT_INTERVAL_MS / 4)).await;
+        let observed = node_heartbeat(&db, &node_b)
+            .await
+            .expect("node B heartbeat row remains present");
+        if observed != last_heartbeat {
+            heartbeat_advances += 1;
+            last_heartbeat = observed;
+        }
+    }
+
+    let after_reconciliation = claim_store
+        .current_claim(&target_entity)
+        .await
+        .expect("target claim lookup after node-B reconciliation")
+        .expect("target claim remains present after node-B reconciliation");
+    assert_eq!(
+        after_reconciliation.owner.node_id, node_a,
+        "node-B reconciliation must not steal the authoritative UserActor claim"
+    );
+    assert_eq!(
+        after_reconciliation.claim_epoch, target_snapshot.claim_epoch,
+        "node-B reconciliation must not advance the UserActor claim epoch"
+    );
+
+    // This IQ round-trip is the post-reconciliation socket usability proof and
+    // mirrors the remote resource's XEP-0280 state onto its node-A owner.
+    enable_carbons(&mut remote_target_client, "cluster-remote-carbons-enable").await;
+
     let mut same_bare_message =
         xmpp_parsers::message::Message::new(Some(jid::Jid::from(remote_target_full.clone())));
     same_bare_message.thread = Some(xmpp_parsers::message::Thread {
@@ -913,9 +1261,275 @@ async fn cluster_exit_criteria_end_to_end() {
         "remote-origin frame should remain addressed to the owner-node full JID: \
          {remote_origin_delivered}"
     );
-    let _ = remote_target_client.close().await;
 
-    let ordered_origin_node = NodeId::new(handle.node_id.as_str().to_string());
+    // XEP-0280 sent carbon: the node-A owner resource sends an eligible
+    // message. The carbons-enabled sibling is the remote resource whose
+    // socket lives on node B, so the owner must use the registered remote
+    // resource route for the conformant <sent><forwarded><message/> copy.
+    let ordered_origin_full: jid::FullJid = ordered_origin_client
+        .full_jid
+        .as_ref()
+        .expect("ordered origin bind full JID")
+        .parse()
+        .expect("ordered origin full JID");
+    let sent_carbon_id = "cluster-remote-carbon-sent";
+    let sent_carbon_body = "cross-node remote-resource sent carbon";
+    let mut sent_carbon_message =
+        xmpp_parsers::message::Message::new(Some(jid::Jid::from(ordered_origin_full.clone())));
+    sent_carbon_message.id = Some(xmpp_parsers::message::Id(sent_carbon_id.to_string()));
+    sent_carbon_message.type_ = xmpp_parsers::message::MessageType::Chat;
+    sent_carbon_message.bodies.insert(
+        xmpp_parsers::message::Lang::new(),
+        sent_carbon_body.to_string(),
+    );
+    let sent_carbon_xml = waddle_xmpp::parser::message_to_string(&sent_carbon_message)
+        .expect("serialize sent-carbon source message");
+    ordered_target_client
+        .send(&sent_carbon_xml)
+        .await
+        .expect("owner-node resource sends sent-carbon source message");
+    let (sent_original, sent_carbon) = tokio::join!(
+        recv_exactly_one_frame_with_id(
+            &mut ordered_origin_client,
+            sent_carbon_id,
+            "sent-carbon original recipient",
+        ),
+        recv_exactly_one_frame_with_id(
+            &mut remote_target_client,
+            sent_carbon_id,
+            "sent-carbon remote sibling",
+        ),
+    );
+    assert_original_message_wire_shape(
+        &sent_original,
+        sent_carbon_id,
+        &ordered_target_full,
+        &ordered_origin_full,
+        sent_carbon_body,
+    );
+    assert_carbon_wire_shape(
+        &sent_carbon,
+        CarbonWireExpectation {
+            kind: CarbonKind::Sent,
+            owner: &ordered_target_full.to_bare(),
+            target: &remote_target_full,
+            original_id: sent_carbon_id,
+            original_from: &ordered_target_full,
+            original_to: &ordered_origin_full,
+            original_body: sent_carbon_body,
+        },
+    );
+    assert_no_frame_with_id(
+        &mut ordered_target_client,
+        sent_carbon_id,
+        "sent-carbon originating resource",
+    )
+    .await;
+
+    // XEP-0280 received carbon: a node-B resource for another account sends
+    // to the node-A owner resource. That resource receives the original; its
+    // carbons-enabled remote sibling on node B receives only the conformant
+    // <received><forwarded><message/> copy.
+    let received_carbon_id = "cluster-remote-carbon-received";
+    let received_carbon_body = "cross-node remote-resource received carbon";
+    let mut received_carbon_message =
+        xmpp_parsers::message::Message::new(Some(jid::Jid::from(ordered_target_full.clone())));
+    received_carbon_message.id = Some(xmpp_parsers::message::Id(received_carbon_id.to_string()));
+    received_carbon_message.type_ = xmpp_parsers::message::MessageType::Chat;
+    received_carbon_message.bodies.insert(
+        xmpp_parsers::message::Lang::new(),
+        received_carbon_body.to_string(),
+    );
+    let received_carbon_xml = waddle_xmpp::parser::message_to_string(&received_carbon_message)
+        .expect("serialize received-carbon source message");
+    ordered_origin_client
+        .send(&received_carbon_xml)
+        .await
+        .expect("cross-node peer sends received-carbon source message");
+    let (received_original, received_carbon) = tokio::join!(
+        recv_exactly_one_frame_with_id(
+            &mut ordered_target_client,
+            received_carbon_id,
+            "received-carbon original recipient",
+        ),
+        recv_exactly_one_frame_with_id(
+            &mut remote_target_client,
+            received_carbon_id,
+            "received-carbon remote sibling",
+        ),
+    );
+    assert_original_message_wire_shape(
+        &received_original,
+        received_carbon_id,
+        &ordered_origin_full,
+        &ordered_target_full,
+        received_carbon_body,
+    );
+    assert_carbon_wire_shape(
+        &received_carbon,
+        CarbonWireExpectation {
+            kind: CarbonKind::Received,
+            owner: &ordered_target_full.to_bare(),
+            target: &remote_target_full,
+            original_id: received_carbon_id,
+            original_from: &ordered_origin_full,
+            original_to: &ordered_target_full,
+            original_body: received_carbon_body,
+        },
+    );
+    assert_no_frame_with_id(
+        &mut ordered_origin_client,
+        received_carbon_id,
+        "received-carbon originating resource",
+    )
+    .await;
+
+    // A single full JID has one physical-admission lineage across every
+    // cluster placement. Move the exact resource from its node-B socket to a
+    // node-A socket. The newcomer must conflict-close the former socket, and
+    // the owner-side registration must become a LocalSocket without taking a
+    // second UserActor claim.
+    let mut local_replacement = WsXmppClient::connect_and_auth(
+        &server_a.ws_url(),
+        "localhost",
+        CLUSTER_PEER_USERNAME,
+        CLUSTER_PEER_PASSWORD,
+        &remote_resource,
+    )
+    .await
+    .expect("same full JID moves from its remote socket to the owner node");
+    assert_eq!(
+        local_replacement.full_jid.as_deref(),
+        Some(remote_target_full.as_str()),
+        "remote-to-local replacement must preserve the exact full JID"
+    );
+    assert_stream_error_then_framing_close(
+        &mut remote_target_client,
+        "conflict",
+        "remote socket displaced by exact local replacement",
+    )
+    .await;
+
+    let after_local_replacement = claim_store
+        .current_claim(&target_entity)
+        .await
+        .expect("target claim lookup after remote-to-local replacement")
+        .expect("target claim remains present after remote-to-local replacement");
+    assert_eq!(after_local_replacement.owner.node_id, node_a);
+    assert_eq!(
+        after_local_replacement.claim_epoch, target_snapshot.claim_epoch,
+        "physical replacement must not advance the UserActor claim epoch"
+    );
+
+    // The LocalSocket placement must still participate in the ordinary
+    // owner-local XEP-0280 path. This catches an accidental attempt to relay
+    // a local physical socket through the RemoteMirror transport.
+    enable_carbons(
+        &mut local_replacement,
+        "cluster-local-replacement-carbons-enable",
+    )
+    .await;
+    let local_carbon_id = "cluster-local-replacement-carbon-received";
+    let local_carbon_body = "local replacement received carbon";
+    let mut local_carbon_message =
+        xmpp_parsers::message::Message::new(Some(jid::Jid::from(ordered_target_full.clone())));
+    local_carbon_message.id = Some(xmpp_parsers::message::Id(local_carbon_id.to_string()));
+    local_carbon_message.type_ = xmpp_parsers::message::MessageType::Chat;
+    local_carbon_message.bodies.insert(
+        xmpp_parsers::message::Lang::new(),
+        local_carbon_body.to_string(),
+    );
+    ordered_origin_client
+        .send(
+            &waddle_xmpp::parser::message_to_string(&local_carbon_message)
+                .expect("serialize local-replacement carbon source message"),
+        )
+        .await
+        .expect("cross-node peer sends local-replacement carbon source message");
+    let (local_original, local_carbon) = tokio::join!(
+        recv_exactly_one_frame_with_id(
+            &mut ordered_target_client,
+            local_carbon_id,
+            "local-replacement carbon original recipient",
+        ),
+        recv_exactly_one_frame_with_id(
+            &mut local_replacement,
+            local_carbon_id,
+            "local-replacement carbon sibling",
+        ),
+    );
+    assert_original_message_wire_shape(
+        &local_original,
+        local_carbon_id,
+        &ordered_origin_full,
+        &ordered_target_full,
+        local_carbon_body,
+    );
+    assert_carbon_wire_shape(
+        &local_carbon,
+        CarbonWireExpectation {
+            kind: CarbonKind::Received,
+            owner: &ordered_target_full.to_bare(),
+            target: &remote_target_full,
+            original_id: local_carbon_id,
+            original_from: &ordered_origin_full,
+            original_to: &ordered_target_full,
+            original_body: local_carbon_body,
+        },
+    );
+
+    // Move the same full JID back to node B. The exact local socket must now
+    // be conflict-closed, and the new RemoteMirror must be the only route that
+    // accepts a full-JID delivery.
+    let mut remote_replacement = WsXmppClient::connect_and_auth(
+        &server_b.ws_url(),
+        "localhost",
+        CLUSTER_PEER_USERNAME,
+        CLUSTER_PEER_PASSWORD,
+        &remote_resource,
+    )
+    .await
+    .expect("same full JID moves back from the owner node to a remote socket");
+    assert_eq!(
+        remote_replacement.full_jid.as_deref(),
+        Some(remote_target_full.as_str()),
+        "local-to-remote replacement must preserve the exact full JID"
+    );
+    assert_stream_error_then_framing_close(
+        &mut local_replacement,
+        "conflict",
+        "local socket displaced by exact remote replacement",
+    )
+    .await;
+
+    let replacement_delivery_id = "cluster-remote-replacement-delivery";
+    let replacement_delivery_body = "remote replacement owns the full JID";
+    let mut replacement_delivery =
+        xmpp_parsers::message::Message::new(Some(jid::Jid::from(remote_target_full.clone())));
+    replacement_delivery.id = Some(xmpp_parsers::message::Id(
+        replacement_delivery_id.to_string(),
+    ));
+    replacement_delivery.type_ = xmpp_parsers::message::MessageType::Chat;
+    replacement_delivery.bodies.insert(
+        xmpp_parsers::message::Lang::new(),
+        replacement_delivery_body.to_string(),
+    );
+    ordered_origin_client
+        .send(
+            &waddle_xmpp::parser::message_to_string(&replacement_delivery)
+                .expect("serialize remote-replacement delivery"),
+        )
+        .await
+        .expect("origin sends to the remote replacement");
+    remote_replacement
+        .recv_matching(|frame| {
+            frame.contains(replacement_delivery_id) && frame.contains(replacement_delivery_body)
+        })
+        .await
+        .expect("remote replacement receives the exact full-JID delivery");
+    let _ = remote_replacement.close().await;
+
+    let ordered_origin_node = origin_identity.clone();
     let ordered_channel = ordered_channel(
         ordered_stream_id,
         &ordered_target_full,
@@ -1272,6 +1886,24 @@ async fn node_expired_flag(db: &Database, node_id: &str) -> Option<bool> {
         .map(|row| row.get::<bool>(0).expect("expired column"))
 }
 
+async fn node_lease_state(db: &Database, node_id: &str) -> Option<(String, bool, bool)> {
+    let conn = db.guard().await.expect("guard");
+    let mut rows = conn
+        .query(
+            "SELECT node_epoch, expired, draining FROM clustering_nodes WHERE node_id = ?",
+            waddle_server::db_params![node_id.to_string()],
+        )
+        .await
+        .expect("query node lease state");
+    rows.next().await.expect("row").map(|row| {
+        (
+            row.get::<String>(0).expect("node_epoch column"),
+            row.get::<bool>(1).expect("expired column"),
+            row.get::<bool>(2).expect("draining column"),
+        )
+    })
+}
+
 async fn seed_detached_sm_session_row(
     db: &Database,
     stream_id: &str,
@@ -1356,6 +1988,8 @@ async fn sm_session_claim_owner(db: &Database, stream_id: &str) -> Option<(Strin
 /// below complete in single-digit seconds of real time.
 #[tokio::test(flavor = "multi_thread")]
 async fn lone_survivor_and_isolation_fencing() {
+    use waddle_xmpp::ownership::ClaimStore as _;
+
     let Ok(postgres_url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
         eprintln!("skipping: WADDLE_TEST_POSTGRES_URL not set");
         return;
@@ -1427,16 +2061,103 @@ async fn lone_survivor_and_isolation_fencing() {
         let port_a = free_tcp_port();
         let port_b = free_tcp_port();
         let port_d = free_tcp_port();
-        let (server_a, _node_a, _peer_a) =
+        let (server_a, node_a, _peer_a) =
             spawn_cluster_server(&postgres_url, &pool.pool_env, port_a, &[port_b, port_d]).await;
         let (server_b, _node_b, _peer_b) =
             spawn_cluster_server(&postgres_url, &pool.pool_env, port_b, &[port_a, port_d]).await;
-        let (server_d, _node_d, peer_d) =
+        let (server_d, node_d, peer_d) =
             spawn_cluster_server(&postgres_url, &pool.pool_env, port_d, &[port_a, port_b]).await;
 
         wait_for_readiness(&server_a, true, Duration::from_secs(15)).await;
         wait_for_readiness(&server_b, true, Duration::from_secs(15)).await;
         wait_for_readiness(&server_d, true, Duration::from_secs(15)).await;
+        let (node_d_epoch_before, node_d_expired_before, node_d_draining_before) =
+            node_lease_state(&db, &node_d)
+                .await
+                .expect("D node lease exists before isolation");
+        assert!(
+            !node_d_expired_before && !node_d_draining_before,
+            "D must begin the remote-resource scenario as an active node"
+        );
+
+        // Give isolated node D a real remote resource to tear down. Node A
+        // owns the authoritative UserActor; the same account's second socket
+        // is physically hosted by D and mirrored back to A.
+        let password = server_d.fixed_account_password().to_string();
+        let owner_resource = format!("isolation-owner-{}", uuid::Uuid::new_v4());
+        let remote_resource = format!("isolation-remote-{}", uuid::Uuid::new_v4());
+        let mut owner_client = WsXmppClient::connect_and_auth(
+            &server_a.ws_url(),
+            "localhost",
+            "admin",
+            &password,
+            &owner_resource,
+        )
+        .await
+        .expect("authoritative owner resource connects to node A");
+        let owner_full: jid::FullJid = owner_client
+            .full_jid
+            .as_ref()
+            .expect("owner full JID")
+            .parse()
+            .expect("valid owner full JID");
+        let mut remote_client = WsXmppClient::connect_and_auth(
+            &server_d.ws_url(),
+            "localhost",
+            "admin",
+            &password,
+            &remote_resource,
+        )
+        .await
+        .expect("same-account remote resource connects to node D");
+        let remote_full: jid::FullJid = remote_client
+            .full_jid
+            .as_ref()
+            .expect("remote full JID")
+            .parse()
+            .expect("valid remote full JID");
+        let claim_store = PostgresClaimStore::new(db.clone());
+        let user_entity = Entity::new(EntityType::UserActor, owner_full.to_bare().to_string());
+        let user_claim = {
+            let deadline = Instant::now() + Duration::from_secs(10);
+            loop {
+                if let Some(snapshot) = claim_store
+                    .current_claim(&user_entity)
+                    .await
+                    .expect("isolation user claim lookup")
+                {
+                    if snapshot.owner.node_id == node_a {
+                        break snapshot;
+                    }
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "node A did not retain the authoritative UserActor claim"
+                );
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+        };
+
+        let before_id = "isolation-remote-before-fence";
+        let before_body = "remote socket works before isolation";
+        let mut before =
+            xmpp_parsers::message::Message::new(Some(jid::Jid::from(remote_full.clone())));
+        before.id = Some(xmpp_parsers::message::Id(before_id.to_string()));
+        before.type_ = xmpp_parsers::message::MessageType::Chat;
+        before
+            .bodies
+            .insert(xmpp_parsers::message::Lang::new(), before_body.to_string());
+        owner_client
+            .send(
+                &waddle_xmpp::parser::message_to_string(&before)
+                    .expect("serialize pre-fence message"),
+            )
+            .await
+            .expect("send pre-fence remote message");
+        remote_client
+            .recv_matching(|frame| frame.contains(before_id) && frame.contains(before_body))
+            .await
+            .expect("remote resource receives pre-fence message through owner mirror");
 
         let conn = db.guard().await.expect("guard");
         conn.execute(
@@ -1448,7 +2169,25 @@ async fn lone_survivor_and_isolation_fencing() {
 
         // D must self-fence: readiness flips not-ready within a modest
         // deadline (a few allowlist-refresh + isolation-interval windows).
+        // This is infrastructure teardown, not XEP-0198 replacement of an
+        // open former stream: it must therefore be recoverable
+        // <system-shutdown/>, never the resumption-only <conflict/> condition,
+        // followed immediately by RFC 7395 framing <close/>.
         wait_for_readiness(&server_d, false, Duration::from_secs(15)).await;
+        assert_stream_error_then_framing_close(
+            &mut remote_client,
+            "system-shutdown",
+            "isolated node remote socket",
+        )
+        .await;
+
+        let claim_after_fence = claim_store
+            .current_claim(&user_entity)
+            .await
+            .expect("claim lookup after D fence")
+            .expect("authoritative claim remains present");
+        assert_eq!(claim_after_fence.owner.node_id, node_a);
+        assert_eq!(claim_after_fence.claim_epoch, user_claim.claim_epoch);
 
         // A and B were never isolated from each other — they must stay
         // ready throughout, proving this is a targeted fence of the
@@ -1463,6 +2202,100 @@ async fn lone_survivor_and_isolation_fencing() {
             Some(true),
             "uninvolved peer B must stay ready"
         );
+
+        // Re-enroll D and reuse the exact resource. Recovery must clear both
+        // D's physical registration and A's old owner-side mirror; otherwise
+        // this same-JID registration or the post-recovery delivery fails.
+        conn.execute(
+            "INSERT INTO clustering_peer_allowlist (peer_id) VALUES (?) ON CONFLICT DO NOTHING",
+            waddle_server::db_params![peer_d.clone()],
+        )
+        .await
+        .expect("re-enroll D after isolation fence");
+        wait_for_readiness(&server_d, true, Duration::from_secs(30)).await;
+        let mut recovered_remote = WsXmppClient::connect_and_auth(
+            &server_d.ws_url(),
+            "localhost",
+            "admin",
+            &password,
+            &remote_resource,
+        )
+        .await
+        .expect("same remote resource reconnects after D recovers");
+        assert_eq!(
+            recovered_remote.full_jid.as_deref(),
+            Some(remote_full.as_str()),
+            "recovery must bind the exact same full JID on the re-enrolled node"
+        );
+
+        // Recovery must be a fresh fencing incarnation on the same stable
+        // node_id. Repeated isolation/re-registration must update that row in
+        // place instead of leaking one clustering_nodes row per epoch.
+        let (node_d_epoch_after, node_d_expired_after, node_d_draining_after) =
+            node_lease_state(&db, &node_d)
+                .await
+                .expect("D node lease exists after recovery");
+        assert_ne!(
+            node_d_epoch_after, node_d_epoch_before,
+            "D must rotate its fencing epoch before accepting the recovered resource"
+        );
+        assert!(
+            !node_d_expired_after && !node_d_draining_after,
+            "D's recovered stable node row must be active"
+        );
+        let mut node_rows = conn
+            .query(
+                "SELECT COUNT(*), COUNT(*) FILTER (WHERE NOT expired AND NOT draining) \
+                 FROM clustering_nodes",
+                (),
+            )
+            .await
+            .expect("count clustering node rows after D recovery");
+        let node_counts = node_rows
+            .next()
+            .await
+            .expect("node count row")
+            .expect("node count row present");
+        let total_node_count: i64 = node_counts.get(0).expect("total node count");
+        let active_node_count: i64 = node_counts.get(1).expect("active node count");
+        assert_eq!(
+            total_node_count, 3,
+            "D recovery must keep clustering_nodes bounded to stable A, B, and D rows"
+        );
+        assert_eq!(
+            active_node_count, 3,
+            "A, B, and recovered D must be the only active node rows"
+        );
+
+        let claim_after_reconnect = claim_store
+            .current_claim(&user_entity)
+            .await
+            .expect("claim lookup after D reconnect")
+            .expect("authoritative claim remains present after D reconnect");
+        assert_eq!(claim_after_reconnect.owner.node_id, node_a);
+        assert_eq!(claim_after_reconnect.claim_epoch, user_claim.claim_epoch);
+
+        let after_id = "isolation-remote-after-recovery";
+        let after_body = "remote socket works after isolation recovery";
+        let mut after = xmpp_parsers::message::Message::new(Some(jid::Jid::from(remote_full)));
+        after.id = Some(xmpp_parsers::message::Id(after_id.to_string()));
+        after.type_ = xmpp_parsers::message::MessageType::Chat;
+        after
+            .bodies
+            .insert(xmpp_parsers::message::Lang::new(), after_body.to_string());
+        owner_client
+            .send(
+                &waddle_xmpp::parser::message_to_string(&after)
+                    .expect("serialize post-recovery message"),
+            )
+            .await
+            .expect("send post-recovery remote message");
+        recovered_remote
+            .recv_matching(|frame| frame.contains(after_id) && frame.contains(after_body))
+            .await
+            .expect("recovered remote resource receives through fresh owner mirror");
+        let _ = owner_client.close().await;
+        let _ = recovered_remote.close().await;
 
         drop(server_a);
         drop(server_b);
@@ -1575,14 +2408,12 @@ async fn cross_node_resume_live_steal_handshake() {
 
     // Client A's live socket must have been force-detached: XEP-0198
     // "Resumption"'s `<conflict/>` stream error, then the transport close.
-    let conflict_or_close = client_a
-        .recv_matching(|frame| frame.contains("conflict") || frame.contains("<close"))
-        .await
-        .expect("client A observes the force-detach close");
-    assert!(
-        conflict_or_close.contains("conflict") || conflict_or_close.contains("<close"),
-        "client A must see the <conflict/> stream error (or the framing close that follows): {conflict_or_close}"
-    );
+    assert_stream_error_then_framing_close(
+        &mut client_a,
+        "conflict",
+        "cross-node resumed former stream",
+    )
+    .await;
 
     drop(server_a);
     drop(server_b);
@@ -1986,7 +2817,16 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
         uuid::Uuid::new_v4().to_string(),
     );
     node_lease_store
-        .report_steal_intent(&entity, &reporter)
+        .register(&reporter, None)
+        .await
+        .expect("register reporter lease");
+    let snapshot = claim_store
+        .current_claim(&entity)
+        .await
+        .expect("read room claim")
+        .expect("room claim exists");
+    node_lease_store
+        .report_steal_intent(&entity, &snapshot.owner, snapshot.claim_epoch, &reporter)
         .await
         .expect("report steal intent");
 
@@ -2015,6 +2855,7 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
             peer_id: None,
             claim_store,
             claim_release_budget: Duration::from_secs(5),
+            startup_recovery_source: None,
         },
     ));
 
@@ -2456,7 +3297,7 @@ async fn subscription_presence_and_probe_route_to_foreign_user_owner() {
 /// symmetric isolation of ONE of three nodes (the same primitive
 /// `lone_survivor_and_isolation_fencing`'s Part 2 uses), extended with an
 /// assertion Part 2 does NOT make — genuine, unattended SELF-RECOVERY
-/// (re-registration under a fresh identity, `self_fence.rs`'s
+/// (re-registration under a fresh fencing epoch, `self_fence.rs`'s
 /// `readiness.set_ready(true)` re-arm path) once connectivity returns, with
 /// no process restart. This is the most faithful available proof that a
 /// connectivity degradation "degrades... without [permanently] fencing"
@@ -2521,6 +3362,11 @@ async fn whole_node_isolation_fences_then_self_heals_without_operator_interventi
     wait_for_readiness(&server_a, true, Duration::from_secs(15)).await;
     wait_for_readiness(&server_b, true, Duration::from_secs(15)).await;
     wait_for_readiness(&server_c, true, Duration::from_secs(15)).await;
+    let (node_c_epoch_before, node_c_expired_before, node_c_draining_before) =
+        node_lease_state(&db, &node_c)
+            .await
+            .expect("C node lease exists before isolation");
+    assert!(!node_c_expired_before && !node_c_draining_before);
 
     // --- Induce (closest available primitive, see deviation 107): revoke
     // C's peer_id cluster-wide.
@@ -2559,7 +3405,7 @@ async fn whole_node_isolation_fences_then_self_heals_without_operator_interventi
 
     // --- Degrades WITHOUT [permanently] fencing: re-enroll C and assert
     // genuine, unattended SELF-RECOVERY — no process restart, a fresh
-    // internal identity re-registers and readiness re-arms once swarm
+    // fencing epoch re-registers and readiness re-arms once swarm
     // connectivity actually returns (`self_fence.rs`'s
     // `can_reacquire_claims`/`readiness.set_ready(true)` path).
     conn.execute(
@@ -2571,36 +3417,39 @@ async fn whole_node_isolation_fences_then_self_heals_without_operator_interventi
 
     wait_for_readiness(&server_c, true, Duration::from_secs(30)).await;
 
-    // Prove the recovery is REAL re-registration (a fresh `NodeIdentity`),
-    // not a stale readiness flag: C's ORIGINAL `clustering_nodes` row must
-    // now be committed-expired (`self_fence.rs`'s successful-recovery path
-    // explicitly calls `expire_bounded` on the just-superseded identity),
-    // and exactly three live (not expired, not draining) rows must exist
-    // cluster-wide — A, B, and C's fresh post-recovery identity.
-    assert_eq!(
-        node_expired_flag(&db, &node_c).await,
-        Some(true),
-        "C's ORIGINAL clustering_nodes row must be committed-expired after self-healing \
-         re-registration under a fresh identity"
+    // Prove recovery is a real fencing-incarnation change, not a stale
+    // readiness flag. The process-stable node_id is also C's relay address,
+    // so recovery updates that one row in place with a fresh node_epoch.
+    let (node_c_epoch_after, node_c_expired_after, node_c_draining_after) =
+        node_lease_state(&db, &node_c)
+            .await
+            .expect("C node lease exists after recovery");
+    assert_ne!(
+        node_c_epoch_after, node_c_epoch_before,
+        "C must rotate its fencing epoch during unattended recovery"
+    );
+    assert!(
+        !node_c_expired_after && !node_c_draining_after,
+        "C's recovered stable node row must be active"
     );
     let mut rows = conn
         .query(
-            "SELECT COUNT(*) FROM clustering_nodes WHERE NOT expired AND NOT draining",
+            "SELECT COUNT(*), COUNT(*) FILTER (WHERE NOT expired AND NOT draining) \
+             FROM clustering_nodes",
             (),
         )
         .await
         .expect("count live nodes");
-    let live_count: i64 = rows
-        .next()
-        .await
-        .expect("row")
-        .expect("row present")
-        .get(0)
-        .expect("count column");
+    let row = rows.next().await.expect("row").expect("row present");
+    let total_count: i64 = row.get(0).expect("total count column");
+    let live_count: i64 = row.get(1).expect("live count column");
+    assert_eq!(
+        total_count, 3,
+        "stable node ids must keep clustering_nodes bounded to A, B, and C"
+    );
     assert_eq!(
         live_count, 3,
-        "exactly three live node rows must exist post-recovery: A, B, and C's fresh \
-         re-registered identity (C's original row is expired, not deleted)"
+        "exactly three active node rows must exist post-recovery: A, B, and C"
     );
 
     // A and B must still be ready too — full-mesh recovery, not just C's

--- a/server/crates/waddle-server/tests/clustering_ordered_relay.rs
+++ b/server/crates/waddle-server/tests/clustering_ordered_relay.rs
@@ -10,8 +10,7 @@ use waddle_server::clustering::ordered_relay::{
     OrderedRelayRecipient, OrderedRelayReply, OrderedRelayReservation, OrderedRelaySenderState,
     OrderedRelaySequence, OriginInboundSequence, RemoteStanzaEnvelope,
 };
-use waddle_server::clustering::NodeId;
-use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType};
+use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
 use waddle_xmpp::pending_delivery::SmSessionId;
 use xmpp_parsers::message::{Lang, Message};
 
@@ -30,8 +29,8 @@ fn channel_for_bare(bare: &str) -> OrderedRelayChannel {
     }
 }
 
-fn origin_node() -> NodeId {
-    NodeId::new("origin-node".to_string())
+fn origin_node() -> NodeIdentity {
+    NodeIdentity::new("origin-node", "origin-epoch")
 }
 
 fn room_jid() -> jid::BareJid {
@@ -177,7 +176,7 @@ fn sender_sequence_is_stable_across_asserted_origin_node_changes() {
 
     let first = state
         .next_envelope(
-            NodeId::new("old-node".to_string()),
+            NodeIdentity::new("old-node", "old-epoch"),
             channel.clone(),
             inbound(1),
             claims(),
@@ -186,7 +185,7 @@ fn sender_sequence_is_stable_across_asserted_origin_node_changes() {
         .expect("first");
     let second = state
         .next_envelope(
-            NodeId::new("new-node".to_string()),
+            NodeIdentity::new("new-node", "new-epoch"),
             channel,
             inbound(2),
             claims(),
@@ -363,7 +362,7 @@ fn receiver_replays_duplicate_ack_across_mutable_provenance_changes() {
     let mut receiver =
         waddle_server::clustering::ordered_relay::OrderedRelayReceiverState::default();
     let envelope = RemoteStanzaEnvelope {
-        asserted_origin_node: NodeId::new("old-node".to_string()),
+        asserted_origin_node: NodeIdentity::new("old-node", "old-epoch"),
         channel: channel(),
         sequence: OrderedRelaySequence(1),
         origin_inbound_sequence: inbound(1),
@@ -382,7 +381,7 @@ fn receiver_replays_duplicate_ack_across_mutable_provenance_changes() {
     ));
 
     let retry_after_move = RemoteStanzaEnvelope {
-        asserted_origin_node: NodeId::new("new-node".to_string()),
+        asserted_origin_node: NodeIdentity::new("new-node", "new-epoch"),
         origin_claim: OrderedRelayClaim {
             epoch: ClaimEpoch(99),
             ..origin_claim()

--- a/server/crates/waddle-server/tests/xep0198_cross_node_resume.rs
+++ b/server/crates/waddle-server/tests/xep0198_cross_node_resume.rs
@@ -123,6 +123,10 @@ async fn node_registry_with_claim_store(
     claim_store: Arc<dyn ClaimStore>,
     asker: Option<Arc<dyn RemoteResumeAsker>>,
 ) -> (Arc<InMemorySmSessionRegistry>, SharedNodeIdentity) {
+    PostgresClaimStore::new(db.clone())
+        .register(&identity, None)
+        .await
+        .expect("register simulated node incarnation");
     let shared_identity = SharedNodeIdentity::new(identity);
     let persistence = PostgresFencedSmPersistence::open(
         db.clone(),
@@ -206,7 +210,8 @@ impl FakeAsker {
 impl RemoteResumeAsker for FakeAsker {
     async fn ask_remote_detach(
         &self,
-        _node_id: &str,
+        _expected_owner: &NodeIdentity,
+        _observed: ClaimEpoch,
         _stream_id: &str,
         requester_bare_jid: &BareJid,
     ) -> RemoteResumeAskOutcome {
@@ -236,7 +241,8 @@ struct UnreachableAsker;
 impl RemoteResumeAsker for UnreachableAsker {
     async fn ask_remote_detach(
         &self,
-        _node_id: &str,
+        _expected_owner: &NodeIdentity,
+        _observed: ClaimEpoch,
         _stream_id: &str,
         _requester_bare_jid: &BareJid,
     ) -> RemoteResumeAskOutcome {
@@ -1055,8 +1061,11 @@ impl ClaimStore for EnsureClaimedFailsOnceClaimStore {
         self.inner.release(entity, me, mine).await
     }
 
-    async fn release_many(&self, entities: &[Entity], me: &NodeIdentity) -> Result<(), ClaimError> {
-        self.inner.release_many(entities, me).await
+    async fn release_many(
+        &self,
+        grants: &[waddle_xmpp::ownership::ClaimGrant],
+    ) -> Result<(), ClaimError> {
+        self.inner.release_many(grants).await
     }
 }
 

--- a/server/crates/waddle-server/tests/xep0424_message_retraction_ws.rs
+++ b/server/crates/waddle-server/tests/xep0424_message_retraction_ws.rs
@@ -109,10 +109,19 @@ async fn xep_0424_groupchat_retraction_round_trip_succeeds() {
     // The retraction message itself is archived as its own row with a
     // live `<retract>` payload — that's the "I retracted X" timeline
     // entry clients render.
-    assert!(
-        frames.iter().any(|frame| frame.contains("<retract ")
-            && frame.contains(&format!("id='{room_stanza_id}'"))),
-        "MAM did not replay retraction event citing the room stanza-id: {frames:?}"
+    let retraction_event = frames
+        .iter()
+        .find(|frame| {
+            frame.contains("<retract ") && frame.contains(&format!("id='{room_stanza_id}'"))
+        })
+        .unwrap_or_else(|| {
+            panic!("MAM did not replay retraction event citing the room stanza-id: {frames:?}")
+        });
+    let retraction_archive_id = extract_attr_after(retraction_event, "stanza-id", "id")
+        .expect("archived retraction event has a canonical room stanza-id");
+    assert_ne!(
+        retraction_archive_id, "retract-1",
+        "the fenced archive proof uses the room stanza-id, while the tombstone cites wire id"
     );
 
     // XEP-0424 §"prevent further distribution… by replacing the
@@ -136,6 +145,75 @@ async fn xep_0424_groupchat_retraction_round_trip_succeeds() {
             .iter()
             .all(|frame| !frame.contains("<body>remove me</body>")),
         "original body must not appear in any MAM result after retraction: {frames:?}"
+    );
+
+    let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn groupchat_retraction_rejects_reused_nickname_generation() {
+    let _guard = TEST_SERIAL.lock().await;
+    let (_server, mut client) = setup().await;
+    let room = format!("retract-generation-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="old-generation"><body>old occupancy</body></message>"#
+        ))
+        .await
+        .expect("send original");
+    let original_echo = client
+        .recv_matching(|frame| frame.contains("old occupancy"))
+        .await
+        .expect("original echo");
+    let target = extract_attr_after(&original_echo, "stanza-id", "id").expect("room stanza-id");
+
+    client
+        .send(&format!(
+            r#"<presence type="unavailable" to="{room}/{USERNAME}"/>"#
+        ))
+        .await
+        .expect("leave old occupancy");
+    client
+        .recv_matching(|frame| frame.contains("type='unavailable'") && frame.contains(&room))
+        .await
+        .expect("self unavailable");
+    join_room(&mut client, &room).await;
+
+    client
+        .send(&format!(
+            r#"<message type="groupchat" to="{room}" id="cross-generation-retract">
+                <retract xmlns="urn:xmpp:message-retract:1" id="{target}"/>
+                <body>/me tried to retract a previous occupancy</body>
+            </message>"#
+        ))
+        .await
+        .expect("send stale-generation retraction");
+    let error = client
+        .recv_matching(|frame| {
+            frame.contains("cross-generation-retract") && frame.contains("<error")
+        })
+        .await
+        .expect("retraction error");
+    assert!(
+        error.contains("<forbidden"),
+        "nick reuse must not authorize a prior occupancy's message: {error}"
+    );
+
+    client
+        .send(&format!(
+            r#"<iq type="set" id="mam-generation" to="{room}"><query xmlns="urn:xmpp:mam:2"/></iq>"#
+        ))
+        .await
+        .expect("query MAM");
+    let frames = client
+        .recv_until(|frame| frame.contains("mam-generation") && frame.contains("<fin"))
+        .await
+        .expect("MAM frames");
+    assert!(
+        frames.iter().any(|frame| frame.contains("old occupancy")),
+        "rejected cross-generation retraction must leave the original intact: {frames:?}"
     );
 
     let _ = client.close().await;

--- a/server/crates/waddle-server/tests/xep0425_message_moderation_ws.rs
+++ b/server/crates/waddle-server/tests/xep0425_message_moderation_ws.rs
@@ -100,6 +100,14 @@ fn assert_moderation_shape(frame: &str, target: &str) {
     assert_eq!(reason.text(), "cleanup");
 }
 
+fn moderation_wire_id(frame: &str) -> String {
+    let element = frame.parse::<Element>().expect("valid XML frame");
+    find_moderation_message(&element)
+        .and_then(|message| message.attr("id"))
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| panic!("moderation message missing wire id: {frame}"))
+}
+
 #[tokio::test]
 async fn moderation_broadcasts_and_replays_from_mam() {
     let _guard = TEST_SERIAL.lock().await;
@@ -122,6 +130,23 @@ async fn moderation_broadcasts_and_replays_from_mam() {
 
     client
         .send(&format!(
+            r#"<iq type="set" id="moderate-wire-id" to="{room}">
+                <moderate xmlns="urn:xmpp:message-moderate:1" id="orig-1">
+                    <retract xmlns="urn:xmpp:message-retract:1"/>
+                </moderate>
+            </iq>"#
+        ))
+        .await
+        .expect("send non-canonical moderation target");
+    client
+        .recv_matching(|frame| {
+            frame.contains("moderate-wire-id") && frame.contains("<item-not-found")
+        })
+        .await
+        .expect("client wire id must not resolve as a room moderation target");
+
+    client
+        .send(&format!(
             r#"<iq type="set" id="moderate-1" to="{room}">
                 <moderate xmlns="urn:xmpp:message-moderate:1" id="{target}">
                     <retract xmlns="urn:xmpp:message-retract:1"/>
@@ -140,6 +165,12 @@ async fn moderation_broadcasts_and_replays_from_mam() {
         .find(|frame| frame.contains("urn:xmpp:message-moderate:1"))
         .unwrap_or_else(|| panic!("missing moderation broadcast: {frames:?}"));
     assert_moderation_shape(broadcast, &target);
+    let live_moderation_wire_id = moderation_wire_id(broadcast);
+    let live_moderation_stanza_id = stanza_id(broadcast);
+    assert_ne!(
+        live_moderation_wire_id, live_moderation_stanza_id,
+        "wire message id and room-assigned stanza id are distinct identities"
+    );
 
     client
         .send(&format!(
@@ -167,6 +198,16 @@ async fn moderation_broadcasts_and_replays_from_mam() {
         })
         .unwrap_or_else(|| panic!("MAM did not replay live moderation event: {frames:?}"));
     assert_moderation_shape(live, &target);
+    assert_eq!(
+        moderation_wire_id(live),
+        live_moderation_wire_id,
+        "MAM replay must preserve the live moderation message id"
+    );
+    assert_eq!(
+        stanza_id(live),
+        live_moderation_stanza_id,
+        "MAM replay must preserve the room-assigned stanza id"
+    );
 
     let tombstone = frames
         .iter()
@@ -191,6 +232,11 @@ async fn moderation_broadcasts_and_replays_from_mam() {
     assert!(
         retracted.attr("stamp").is_some(),
         "tombstone must include stamp: {tombstone}"
+    );
+    assert_eq!(
+        retracted.attr("id"),
+        Some(live_moderation_wire_id.as_str()),
+        "moderation tombstone must cite the live retraction message wire id"
     );
     assert!(
         !tombstone.contains("<body>moderate me</body>"),

--- a/server/crates/waddle-xmpp/src/error.rs
+++ b/server/crates/waddle-xmpp/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for the XMPP server.
 
+use jid::BareJid;
 use thiserror::Error;
 use waddle_xmpp_core::CoreError;
 
@@ -49,6 +50,12 @@ pub enum XmppError {
     /// Internal server error
     #[error("Internal error: {0}")]
     Internal(String),
+
+    /// A room-scoped durable write reached its transaction fence after the
+    /// node had lost the exact room claim. Kept distinct from backend errors
+    /// so callers can demote the stale actor and suppress old-owner effects.
+    #[error("room ownership lost before durable write: {0}")]
+    RoomOwnershipLost(BareJid),
 
     /// Stanza error (for IQ error responses)
     #[error("Stanza error: {condition}")]

--- a/server/crates/waddle-xmpp/src/isr/store.rs
+++ b/server/crates/waddle-xmpp/src/isr/store.rs
@@ -21,7 +21,7 @@ use std::sync::RwLock;
 use async_trait::async_trait;
 use subtle::ConstantTimeEq;
 
-use crate::ownership::{ClaimEpoch, NodeIdentity};
+use crate::ownership::{ClaimEpoch, ClaimGrant, NodeIdentity};
 
 /// A freshly issued or rotated ISR token (ADR-0017 Phase 3 Slice 8,
 /// XEP-0397). The token string itself is a secret credential — never
@@ -115,6 +115,7 @@ pub trait IsrTokenStore: Send + Sync {
         &self,
         sm_id: &str,
         mechanism: &str,
+        grant: &ClaimGrant,
     ) -> Result<IssuedIsrToken, IsrTokenStoreError>;
 
     /// Fenced, single-use, constant-time consume. See the trait-level doc
@@ -169,6 +170,7 @@ impl IsrTokenStore for InMemoryIsrTokenStore {
         &self,
         sm_id: &str,
         mechanism: &str,
+        _grant: &ClaimGrant,
     ) -> Result<IssuedIsrToken, IsrTokenStoreError> {
         let issued = IssuedIsrToken {
             token: super::generate_isr_token(),
@@ -236,15 +238,27 @@ impl IsrTokenStore for InMemoryIsrTokenStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ownership::{Entity, EntityType};
 
     fn identity() -> NodeIdentity {
         NodeIdentity::local()
     }
 
+    fn grant(sm_id: &str) -> ClaimGrant {
+        ClaimGrant::new(
+            Entity::new(EntityType::SmSession, sm_id),
+            identity(),
+            ClaimEpoch(0),
+        )
+    }
+
     #[tokio::test]
     async fn issue_then_consume_with_matching_token_rotates() {
         let store = InMemoryIsrTokenStore::new();
-        let issued = store.issue("sm-1", "PLAIN").await.expect("issue");
+        let issued = store
+            .issue("sm-1", "PLAIN", &grant("sm-1"))
+            .await
+            .expect("issue");
         let outcome = store
             .consume(
                 "sm-1",
@@ -264,7 +278,10 @@ mod tests {
     #[tokio::test]
     async fn consume_with_wrong_token_is_mismatched_and_destroys_the_row() {
         let store = InMemoryIsrTokenStore::new();
-        let issued = store.issue("sm-1", "PLAIN").await.expect("issue");
+        let issued = store
+            .issue("sm-1", "PLAIN", &grant("sm-1"))
+            .await
+            .expect("issue");
         let outcome = store
             .consume(
                 "sm-1",
@@ -296,7 +313,10 @@ mod tests {
     #[tokio::test]
     async fn consume_is_single_use() {
         let store = InMemoryIsrTokenStore::new();
-        let issued = store.issue("sm-1", "PLAIN").await.expect("issue");
+        let issued = store
+            .issue("sm-1", "PLAIN", &grant("sm-1"))
+            .await
+            .expect("issue");
         let first = store
             .consume(
                 "sm-1",
@@ -344,7 +364,10 @@ mod tests {
     #[tokio::test]
     async fn consume_pins_the_mechanism() {
         let store = InMemoryIsrTokenStore::new();
-        let issued = store.issue("sm-1", "PLAIN").await.expect("issue");
+        let issued = store
+            .issue("sm-1", "PLAIN", &grant("sm-1"))
+            .await
+            .expect("issue");
         let outcome = store
             .consume(
                 "sm-1",

--- a/server/crates/waddle-xmpp/src/mam/storage/error.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/error.rs
@@ -32,6 +32,13 @@ pub enum MamStorageError {
     )]
     NotOwner { entity: Entity },
 
+    /// A caller requested a clustered, ownership-fenced archive write from
+    /// a storage implementation that cannot execute the fence. Falling back
+    /// to an unfenced insert would let a stale room owner fan out messages,
+    /// so this is a hard failure for the clustered groupchat path.
+    #[error("clustered MAM fencing is unavailable for entity '{entity}'")]
+    FencingUnavailable { entity: Entity },
+
     /// ADR-0017 Phase 3 Slice 7 FIX 1: clustered MAM fencing requires this
     /// storage's own database to be co-located with the clustering global
     /// database (the fencing `SELECT ... FOR SHARE` targets

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/decode.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/decode.rs
@@ -209,7 +209,7 @@ pub(super) fn encode_rich_payload(
         .map_err(|error| MamStorageError::Serialization(error.to_string()))
 }
 
-fn decode_rich_payload(
+pub(super) fn decode_rich_payload(
     value: Option<&str>,
 ) -> Result<Option<waddle_xmpp_core::mam::ArchivedRichMessage>, MamStorageError> {
     value

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/impls.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/impls.rs
@@ -1,11 +1,11 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use jid::BareJid;
+use jid::{BareJid, Jid};
 use sqlx::postgres::PgRow;
 use sqlx::sqlite::SqliteRow;
 use sqlx::{Postgres, QueryBuilder, Sqlite};
 use tracing::{debug, instrument};
-use waddle_xmpp_core::mam::{ArchivedMessage, MamQuery, MamResult};
+use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedTombstone, MamQuery, MamResult};
 
 use crate::mam::storage::query_semantics::{finalize_result, uses_backward_pagination};
 use crate::mam::storage::{MamStorage, MamStorageError};
@@ -38,7 +38,9 @@ impl MamStorage for SqlxMamStorage {
         fence: &RoomClaimFenceContext,
     ) -> Result<String, MamStorageError> {
         if !self.fencing_enabled {
-            return self.store_message(archive_jid, message).await;
+            return Err(MamStorageError::FencingUnavailable {
+                entity: fence.entity.clone(),
+            });
         }
         super::write::store_message_fenced(&self.backend, archive_jid, message, fence).await
     }
@@ -413,5 +415,57 @@ impl MamStorage for SqlxMamStorage {
         tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
     ) -> Result<bool, MamStorageError> {
         super::write::replace_with_tombstone(&self.backend, archive_id, tombstone).await
+    }
+
+    #[instrument(skip(self, moderation, tombstone, fence), fields(archive = %archive_jid))]
+    async fn moderate_message_fenced(
+        &self,
+        archive_jid: &BareJid,
+        moderation: &ArchivedMessage,
+        target_archive_id: &str,
+        tombstone: ArchivedTombstone,
+        fence: &RoomClaimFenceContext,
+    ) -> Result<bool, MamStorageError> {
+        if !self.fencing_enabled {
+            return Err(MamStorageError::FencingUnavailable {
+                entity: fence.entity.clone(),
+            });
+        }
+        super::write::moderate_message_fenced(
+            &self.backend,
+            archive_jid,
+            moderation,
+            target_archive_id,
+            tombstone,
+            fence,
+        )
+        .await
+    }
+
+    #[instrument(skip(self, retraction_from, tombstone, fence), fields(archive = %archive_jid))]
+    async fn replace_with_tombstone_fenced(
+        &self,
+        archive_jid: &BareJid,
+        target_archive_id: &str,
+        retraction_archive_id: &str,
+        retraction_from: &Jid,
+        tombstone: ArchivedTombstone,
+        fence: &RoomClaimFenceContext,
+    ) -> Result<bool, MamStorageError> {
+        if !self.fencing_enabled {
+            return Err(MamStorageError::FencingUnavailable {
+                entity: fence.entity.clone(),
+            });
+        }
+        super::write::replace_with_tombstone_fenced(
+            &self.backend,
+            archive_jid,
+            target_archive_id,
+            retraction_archive_id,
+            retraction_from,
+            tombstone,
+            fence,
+        )
+        .await
     }
 }

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/mod.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/mod.rs
@@ -11,6 +11,7 @@ use std::str::FromStr;
 
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions};
+use sqlx::{Postgres, Transaction};
 use tracing::info;
 
 use super::MamStorageError;
@@ -33,12 +34,35 @@ pub struct SqlxMamStorage {
     /// the caller has verified (via [`Self::with_cluster_fencing`]) that
     /// clustering is enabled AND this storage's own database is co-located
     /// with the clustering global database. [`super::MamStorage::store_message_fenced`]
-    /// uses this to decide whether to run the fenced groupchat-archive
-    /// insert or fall back to the portable, unfenced [`super::MamStorage::store_message`]
-    /// path. `false` for every non-clustered deployment (and, defensively,
-    /// for a SQLite backend even if requested — see that method's doc
-    /// comment).
+    /// uses this to decide whether it can run the fenced groupchat-archive
+    /// insert. A fenced call while this is false returns
+    /// [`super::MamStorageError::FencingUnavailable`]; non-clustered callers
+    /// use the ordinary [`super::MamStorage::store_message`] method instead.
     pub(super) fencing_enabled: bool,
+}
+
+/// Begin a Postgres transaction that cannot retain an exact room/node fence
+/// past the cluster-wide fenced-transaction budget. PostgreSQL 17's total
+/// `transaction_timeout` is the hard outer bound; the other local settings
+/// cover an individual lock/statement wait and an idle task between awaits.
+pub(super) async fn begin_fenced(
+    pool: &PgPool,
+) -> Result<Transaction<'_, Postgres>, MamStorageError> {
+    let mut tx = pool.begin().await?;
+    let timeout = crate::ownership::FENCED_TRANSACTION_BUDGET.postgres_timeout();
+    sqlx::query(
+        r#"
+        SELECT
+            set_config('lock_timeout', $1, true),
+            set_config('statement_timeout', $1, true),
+            set_config('idle_in_transaction_session_timeout', $1, true),
+            set_config('transaction_timeout', $1, true)
+        "#,
+    )
+    .bind(timeout)
+    .execute(&mut *tx)
+    .await?;
+    Ok(tx)
 }
 
 impl SqlxMamStorage {

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -7,14 +7,16 @@ use sqlx::sqlite::SqliteRow;
 use sqlx::{Postgres, QueryBuilder, Row, Sqlite};
 use tracing::{debug, warn};
 use uuid::Uuid;
-use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedRichMessage, ArchivedRichPayload};
+use waddle_xmpp_core::mam::{
+    ArchivedMessage, ArchivedRichMessage, ArchivedRichPayload, ArchivedTombstone,
+};
 use xmpp_parsers::message::MessageType;
 
 use crate::mam::storage::MamStorageError;
 use crate::muc::RoomClaimFenceContext;
 
-use super::decode::{encode_nickname_generation, encode_rich_payload};
-use super::MamDatabaseBackend;
+use super::decode::{decode_rich_payload, encode_nickname_generation, encode_rich_payload};
+use super::{begin_fenced, MamDatabaseBackend};
 
 pub(super) async fn store_message(
     backend: &MamDatabaseBackend,
@@ -164,23 +166,31 @@ pub(super) async fn store_message(
 /// standalone pre-fan-out check and this write can never land a phantom
 /// archived row under a claim this node no longer holds.
 ///
-/// The origin-id dedup pre-check (idempotency for retried sends) runs
-/// against the plain pool, exactly as [`store_message`] already does it —
-/// it only ever reads already-committed rows, so it needs no transactional
-/// isolation from this write; only the fencing-check-then-insert pair needs
-/// one-transaction atomicity, which this function provides. Postgres-only:
-/// fencing is never enabled for a SQLite backend (clustering is
-/// Postgres-only per ADR-0017 element 1 — see
-/// `SqlxMamStorage::with_cluster_fencing`), so the non-Postgres arm here is
-/// defensive only.
+/// Origin-id deduplication runs only after the fence is locked, inside that
+/// same transaction. A dedup hit is still a message effect: returning it
+/// before proving current ownership would let a stale room actor fan out a
+/// retry without ever touching the fenced insert. Postgres-only: fencing is
+/// never enabled for a SQLite backend (clustering is Postgres-only per
+/// ADR-0017 element 1 — see `SqlxMamStorage::with_cluster_fencing`).
 pub(super) async fn store_message_fenced(
     backend: &MamDatabaseBackend,
     archive_jid: &BareJid,
     message: &ArchivedMessage,
     fence: &RoomClaimFenceContext,
 ) -> Result<String, MamStorageError> {
+    let expected_entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::RoomActor,
+        archive_jid.to_string(),
+    );
+    if fence.entity != expected_entity {
+        return Err(MamStorageError::NotOwner {
+            entity: expected_entity,
+        });
+    }
     let MamDatabaseBackend::Postgres(pool) = backend else {
-        return store_message(backend, archive_jid, message).await;
+        return Err(MamStorageError::FencingUnavailable {
+            entity: fence.entity.clone(),
+        });
     };
 
     let rich_payload = encode_rich_payload(message)?;
@@ -188,18 +198,6 @@ pub(super) async fn store_message_fenced(
         .origin_id
         .as_ref()
         .map(|_| origin_dedup_fingerprint(message));
-
-    if let Some(existing_archive_id) = find_existing_origin_id_match(
-        backend,
-        archive_jid,
-        message,
-        rich_payload.as_deref(),
-        origin_dedup_fingerprint.as_deref(),
-    )
-    .await?
-    {
-        return Ok(existing_archive_id);
-    }
 
     let archive_id = if message.id.is_empty() {
         Uuid::now_v7().to_string()
@@ -218,36 +216,23 @@ pub(super) async fn store_message_fenced(
         .and_then(|r| r.to.as_ref())
         .map(|jid| jid.to_string());
 
-    let mut tx = pool.begin().await?;
+    let mut tx = begin_fenced(pool).await?;
 
-    // Fencing check: the exact `SELECT ... FOR SHARE` shape
-    // `muc_durable::PostgresMucRoomStore::assert_fenced`/
-    // `sm_persistence_fenced::assert_fenced`/`pending_delivery`'s
-    // `insert_fenced` already establish — the first statement inside this
-    // transaction, on the SAME connection as the write it guards. A failed
-    // check rolls back BEFORE any write.
-    let entity_key = format!(
-        "{}:{}",
-        fence.entity.entity_type.as_db_str(),
-        fence.entity.id
-    );
-    let held = sqlx::query(
-        "SELECT 1 FROM clustering_claims WHERE entity = $1 AND node_id = $2 AND claim_epoch = $3 FOR SHARE",
-    )
-    .bind(&entity_key)
-    .bind(&fence.node_id)
-    .bind(fence.epoch.0)
-    .fetch_optional(&mut *tx)
-    .await?
-    .is_some();
-    if !held {
-        // Roll back explicitly rather than relying on drop — the fencing
-        // failure is the expected, correctness-critical path here, not an
-        // error worth masking behind an implicit rollback-on-drop.
+    if let Err(error) = assert_room_fence(&mut tx, fence).await {
         let _ = tx.rollback().await;
-        return Err(MamStorageError::NotOwner {
-            entity: fence.entity.clone(),
-        });
+        return Err(error);
+    }
+    if let Some(existing_archive_id) = find_existing_origin_id_match_postgres_in_tx(
+        &mut tx,
+        archive_jid,
+        message,
+        rich_payload.as_deref(),
+        origin_dedup_fingerprint.as_deref(),
+    )
+    .await?
+    {
+        tx.commit().await?;
+        return Ok(existing_archive_id);
     }
 
     let mut query = QueryBuilder::<Postgres>::new(
@@ -281,10 +266,12 @@ pub(super) async fn store_message_fenced(
     });
     if let Err(error) = query.build().execute(&mut *tx).await {
         let _ = tx.rollback().await;
-        if let Some(existing_archive_id) = find_existing_origin_id_match(
-            backend,
+        let insert_error = MamStorageError::from(error);
+        if let Some(existing_archive_id) = find_existing_origin_id_match_fenced(
+            pool,
             archive_jid,
             message,
+            fence,
             rich_payload.as_deref(),
             origin_dedup_fingerprint.as_deref(),
         )
@@ -292,12 +279,122 @@ pub(super) async fn store_message_fenced(
         {
             return Ok(existing_archive_id);
         }
-        return Err(error.into());
+        return Err(insert_error);
     }
     tx.commit().await?;
 
     debug!(archive_id = %archive_id, "Message stored in MAM archive (fenced)");
     Ok(archive_id)
+}
+
+/// Lock both halves of the ownership proof in the archive transaction.
+/// Locking only `clustering_claims` is insufficient: a self-fence can rotate
+/// or expire the matching `clustering_nodes` incarnation while leaving the
+/// old claim row intact. Existing owners remain allowed to finish work while
+/// draining only while their registered heartbeat deadline remains fresh;
+/// deadline lapse fails closed before the watchdog commits terminal expiry.
+async fn assert_room_fence(
+    tx: &mut sqlx::Transaction<'_, Postgres>,
+    fence: &RoomClaimFenceContext,
+) -> Result<(), MamStorageError> {
+    let entity_key = format!(
+        "{}:{}",
+        fence.entity.entity_type.as_db_str(),
+        fence.entity.id
+    );
+    let held = sqlx::query(
+        r#"
+        WITH locked AS MATERIALIZED (
+            SELECT n.heartbeat, n.expired, n.lease_ttl_ms
+            FROM clustering_claims AS c
+            JOIN clustering_nodes AS n
+              ON n.node_id = c.node_id
+             AND n.node_epoch = c.node_epoch
+            WHERE c.entity = $1
+              AND c.node_id = $2
+              AND c.node_epoch = $3
+              AND c.claim_epoch = $4
+            FOR SHARE OF c, n
+        )
+        SELECT 1 FROM locked
+        WHERE NOT expired
+          AND heartbeat >= clock_timestamp()
+              - (lease_ttl_ms::text || ' milliseconds')::interval
+        "#,
+    )
+    .bind(&entity_key)
+    .bind(&fence.owner.node_id)
+    .bind(&fence.owner.node_epoch)
+    .bind(fence.epoch.0)
+    .fetch_optional(&mut **tx)
+    .await?
+    .is_some();
+    if held {
+        Ok(())
+    } else {
+        Err(MamStorageError::NotOwner {
+            entity: fence.entity.clone(),
+        })
+    }
+}
+
+async fn find_existing_origin_id_match_fenced(
+    pool: &sqlx::PgPool,
+    archive_jid: &BareJid,
+    message: &ArchivedMessage,
+    fence: &RoomClaimFenceContext,
+    incoming_rich_payload: Option<&str>,
+    origin_dedup_fingerprint: Option<&str>,
+) -> Result<Option<String>, MamStorageError> {
+    let mut tx = begin_fenced(pool).await?;
+    if let Err(error) = assert_room_fence(&mut tx, fence).await {
+        let _ = tx.rollback().await;
+        return Err(error);
+    }
+    let result = find_existing_origin_id_match_postgres_in_tx(
+        &mut tx,
+        archive_jid,
+        message,
+        incoming_rich_payload,
+        origin_dedup_fingerprint,
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(result)
+}
+
+async fn find_existing_origin_id_match_postgres_in_tx(
+    tx: &mut sqlx::Transaction<'_, Postgres>,
+    archive_jid: &BareJid,
+    message: &ArchivedMessage,
+    incoming_rich_payload: Option<&str>,
+    origin_dedup_fingerprint: Option<&str>,
+) -> Result<Option<String>, MamStorageError> {
+    let Some(origin_id) = message.origin_id.as_ref() else {
+        return Ok(None);
+    };
+    let archive_jid_str = archive_jid.to_string();
+    let mut builder = QueryBuilder::<Postgres>::new(
+        "SELECT id, from_jid, to_jid, body, thread_id, parent_thread_id, \
+         reply_to_id, reply_to_jid, message_type, rich_payload, nickname_generation \
+         FROM mam_messages WHERE room_jid = ",
+    );
+    push_origin_dedup_filter(
+        &mut builder,
+        archive_jid_str.as_str(),
+        origin_id.as_str(),
+        origin_dedup_fingerprint,
+    );
+    let rows: Vec<PgRow> = builder.build().fetch_all(&mut **tx).await?;
+    for row in rows {
+        let Some(existing) = OriginDedupRow::from_postgres(&row) else {
+            continue;
+        };
+        if existing.matches(message, incoming_rich_payload) {
+            return Ok(Some(existing.id));
+        }
+    }
+    Ok(None)
 }
 
 async fn find_existing_origin_id_match(
@@ -672,19 +769,7 @@ pub(super) async fn replace_with_tombstone(
     archive_id: &str,
     tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
 ) -> Result<bool, MamStorageError> {
-    let payload = ArchivedRichMessage {
-        payload: Some(ArchivedRichPayload::Tombstone(tombstone)),
-        reply: None,
-        references: Vec::new(),
-        mentions: Vec::new(),
-        // XEP-0424 §Tombstones: the occupant-id and real-JID item
-        // identify the original sender and MUST NOT survive the
-        // tombstone replacement.
-        occupant_id: None,
-        muc_sender: None,
-    };
-    let encoded = serde_json::to_string(&payload)
-        .map_err(|error| MamStorageError::Serialization(error.to_string()))?;
+    let encoded = encode_tombstone(tombstone)?;
 
     // XEP-0424 §Tombstones / XEP-0425 §Tombstones: drop the body
     // entirely on tombstone. With wire-fidelity body semantics, SQL NULL
@@ -718,4 +803,279 @@ pub(super) async fn replace_with_tombstone(
         "Replaced archived message with tombstone"
     );
     Ok(rows > 0)
+}
+
+fn encode_tombstone(tombstone: ArchivedTombstone) -> Result<String, MamStorageError> {
+    let payload = ArchivedRichMessage {
+        payload: Some(ArchivedRichPayload::Tombstone(tombstone)),
+        reply: None,
+        references: Vec::new(),
+        mentions: Vec::new(),
+        // XEP-0424 §Tombstones: the occupant-id and real-JID item
+        // identify the original sender and MUST NOT survive the
+        // tombstone replacement.
+        occupant_id: None,
+        muc_sender: None,
+    };
+    serde_json::to_string(&payload)
+        .map_err(|error| MamStorageError::Serialization(error.to_string()))
+}
+
+fn validate_room_fence(
+    archive_jid: &BareJid,
+    fence: &RoomClaimFenceContext,
+) -> Result<(), MamStorageError> {
+    let expected_entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::RoomActor,
+        archive_jid.to_string(),
+    );
+    if fence.entity == expected_entity {
+        Ok(())
+    } else {
+        Err(MamStorageError::NotOwner {
+            entity: expected_entity,
+        })
+    }
+}
+
+async fn insert_postgres_message(
+    tx: &mut sqlx::Transaction<'_, Postgres>,
+    archive_jid: &BareJid,
+    message: &ArchivedMessage,
+) -> Result<(), MamStorageError> {
+    let rich_payload = encode_rich_payload(message)?;
+    let origin_dedup_fingerprint = message
+        .origin_id
+        .as_ref()
+        .map(|_| origin_dedup_fingerprint(message));
+    let message_type = waddle_xmpp_core::mam::message_type_wire_str(&message.message_type);
+    let nickname_generation = encode_nickname_generation(message.nickname_generation)?;
+    let archive_jid_str = archive_jid.to_string();
+    let from_jid_str = message.from.to_string();
+    let to_jid_str = message.to.to_string();
+    let reply_to_jid = message
+        .reply
+        .as_ref()
+        .and_then(|reply| reply.to.as_ref())
+        .map(ToString::to_string);
+
+    let mut query = QueryBuilder::<Postgres>::new(
+        "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation, parent_thread_id, origin_dedup_fingerprint) ",
+    );
+    query.push_values(std::iter::once(()), |mut builder, _| {
+        builder
+            .push_bind(&message.id)
+            .push_bind(archive_jid_str.as_str())
+            .push_bind(message.timestamp)
+            .push_bind(from_jid_str.as_str())
+            .push_bind(to_jid_str.as_str())
+            .push_bind(message.body.as_deref())
+            .push_bind(message.stanza_id.as_ref().map(|id| id.id.as_str()))
+            .push_bind(message.thread.as_ref().map(|thread| thread.id.as_str()))
+            .push_bind(message.reply.as_ref().map(|reply| reply.id.as_str()))
+            .push_bind(reply_to_jid.as_deref())
+            .push_bind(message.origin_id.as_ref().map(|id| id.id.as_str()))
+            .push_bind(message_type)
+            .push_bind(message.stanza_xml.as_deref())
+            .push_bind(rich_payload.as_deref())
+            .push_bind(nickname_generation)
+            .push_bind(
+                message
+                    .thread
+                    .as_ref()
+                    .and_then(|thread| thread.parent.as_ref())
+                    .map(|parent| parent.as_str()),
+            )
+            .push_bind(origin_dedup_fingerprint.as_deref());
+    });
+    query.build().execute(&mut **tx).await?;
+    Ok(())
+}
+
+/// XEP-0425 moderation is one room effect: the canonical moderation event
+/// and target tombstone either both commit beneath the exact claim lock or
+/// neither exists.
+pub(super) async fn moderate_message_fenced(
+    backend: &MamDatabaseBackend,
+    archive_jid: &BareJid,
+    moderation: &ArchivedMessage,
+    target_archive_id: &str,
+    tombstone: ArchivedTombstone,
+    fence: &RoomClaimFenceContext,
+) -> Result<bool, MamStorageError> {
+    validate_room_fence(archive_jid, fence)?;
+    let MamDatabaseBackend::Postgres(pool) = backend else {
+        return Err(MamStorageError::FencingUnavailable {
+            entity: fence.entity.clone(),
+        });
+    };
+    let canonical_by = Jid::from(archive_jid.clone());
+    let moderation_payload = moderation
+        .rich
+        .as_ref()
+        .and_then(|rich| rich.payload.as_ref())
+        .and_then(|payload| match payload {
+            ArchivedRichPayload::Moderation(moderation) => Some(moderation),
+            _ => None,
+        });
+    let moderation_wire_id = moderation.stanza_id.as_ref().and_then(|stanza_id| {
+        (stanza_id.by == canonical_by && !stanza_id.id.trim().is_empty())
+            .then_some(stanza_id.id.as_str())
+    });
+    let canonical = !moderation.id.trim().is_empty()
+        && moderation.id != target_archive_id
+        && moderation_wire_id.is_some()
+        && moderation.to == canonical_by
+        && moderation.from == canonical_by
+        && moderation.message_type == MessageType::Groupchat
+        && moderation_payload.is_some_and(|payload| {
+            payload.target_id.as_str() == target_archive_id
+                && payload.stamp == Some(moderation.timestamp)
+                && tombstone
+                    .retraction_id
+                    .as_ref()
+                    .is_some_and(|retraction_id| Some(retraction_id.as_str()) == moderation_wire_id)
+                && tombstone.moderation.as_ref() == Some(payload)
+                && tombstone.stamp == moderation.timestamp
+        });
+    if !canonical {
+        return Err(MamStorageError::Serialization(
+            "moderation archive row and tombstone are not canonically bound to the target"
+                .to_owned(),
+        ));
+    }
+    let encoded_tombstone = encode_tombstone(tombstone.clone())?;
+    let room = archive_jid.to_string();
+    let mut tx = begin_fenced(pool).await?;
+    if let Err(error) = assert_room_fence(&mut tx, fence).await {
+        let _ = tx.rollback().await;
+        return Err(error);
+    }
+    let target_exists = sqlx::query_scalar::<_, i32>(
+        "SELECT 1 FROM mam_messages WHERE id = $1 AND room_jid = $2 AND to_jid = $2 AND message_type = 'groupchat' FOR UPDATE",
+    )
+    .bind(target_archive_id)
+    .bind(room.as_str())
+    .fetch_optional(&mut *tx)
+    .await?
+    .is_some();
+    if !target_exists {
+        let _ = tx.rollback().await;
+        return Ok(false);
+    }
+    if let Err(error) = insert_postgres_message(&mut tx, archive_jid, moderation).await {
+        let _ = tx.rollback().await;
+        return Err(error);
+    }
+    let updated = sqlx::query(
+        "UPDATE mam_messages SET body = NULL, stanza_xml = NULL, thread_id = NULL, parent_thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, origin_dedup_fingerprint = NULL, rich_payload = $1 WHERE id = $2 AND room_jid = $3",
+    )
+    .bind(encoded_tombstone)
+    .bind(target_archive_id)
+    .bind(room.as_str())
+    .execute(&mut *tx)
+    .await?
+    .rows_affected();
+    if updated != 1 {
+        let _ = tx.rollback().await;
+        return Ok(false);
+    }
+    tx.commit().await?;
+    Ok(true)
+}
+
+/// XEP-0424 tombstoning is fenced and can only follow the exact retraction
+/// event archived by the authenticated room occupant in the same archive.
+pub(super) async fn replace_with_tombstone_fenced(
+    backend: &MamDatabaseBackend,
+    archive_jid: &BareJid,
+    target_archive_id: &str,
+    retraction_archive_id: &str,
+    retraction_from: &Jid,
+    tombstone: ArchivedTombstone,
+    fence: &RoomClaimFenceContext,
+) -> Result<bool, MamStorageError> {
+    validate_room_fence(archive_jid, fence)?;
+    let MamDatabaseBackend::Postgres(pool) = backend else {
+        return Err(MamStorageError::FencingUnavailable {
+            entity: fence.entity.clone(),
+        });
+    };
+    if target_archive_id == retraction_archive_id {
+        return Ok(false);
+    }
+    let encoded_tombstone = encode_tombstone(tombstone.clone())?;
+    let room = archive_jid.to_string();
+    let retraction_from = retraction_from.to_string();
+    let mut tx = begin_fenced(pool).await?;
+    if let Err(error) = assert_room_fence(&mut tx, fence).await {
+        let _ = tx.rollback().await;
+        return Err(error);
+    }
+    let target = sqlx::query(
+        "SELECT from_jid, nickname_generation FROM mam_messages WHERE id = $1 AND room_jid = $2 AND to_jid = $2 AND message_type = 'groupchat' FOR UPDATE",
+    )
+    .bind(target_archive_id)
+    .bind(room.as_str())
+    .fetch_optional(&mut *tx)
+    .await?;
+    let Some(target) = target else {
+        let _ = tx.rollback().await;
+        return Ok(false);
+    };
+    let target_from: String = target.try_get("from_jid")?;
+    let target_generation: Option<i64> = target.try_get("nickname_generation")?;
+
+    let retraction = sqlx::query(
+        "SELECT from_jid, stanza_id, rich_payload, nickname_generation FROM mam_messages WHERE id = $1 AND room_jid = $2 AND to_jid = $2 AND from_jid = $3 AND message_type = 'groupchat' FOR SHARE",
+    )
+    .bind(retraction_archive_id)
+    .bind(room.as_str())
+    .bind(retraction_from.as_str())
+    .fetch_optional(&mut *tx)
+    .await?;
+    let Some(retraction) = retraction else {
+        let _ = tx.rollback().await;
+        return Ok(false);
+    };
+    let retraction_row_from: String = retraction.try_get("from_jid")?;
+    let retraction_wire_id: Option<String> = retraction.try_get("stanza_id")?;
+    let retraction_rich: Option<String> = retraction.try_get("rich_payload")?;
+    let retraction_generation: Option<i64> = retraction.try_get("nickname_generation")?;
+    let typed_retraction = decode_rich_payload(retraction_rich.as_deref())?
+        .and_then(|rich| rich.payload)
+        .and_then(|payload| match payload {
+            ArchivedRichPayload::Retraction(retraction) => Some(retraction),
+            _ => None,
+        });
+    let proof_matches = target_from == retraction_from
+        && retraction_row_from == retraction_from
+        && target_generation.is_some()
+        && target_generation == retraction_generation
+        && tombstone.moderation.is_none()
+        && typed_retraction.is_some_and(|retraction| {
+            retraction.target_id.as_str() == target_archive_id
+                && retraction.retraction_id == tombstone.retraction_id
+                && retraction_wire_id.as_deref()
+                    == retraction.retraction_id.as_ref().map(|id| id.as_str())
+        });
+    if !proof_matches {
+        let _ = tx.rollback().await;
+        return Ok(false);
+    }
+    let updated = sqlx::query(
+        "UPDATE mam_messages SET body = NULL, stanza_xml = NULL, thread_id = NULL, parent_thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, origin_dedup_fingerprint = NULL, rich_payload = $1 WHERE id = $2 AND room_jid = $3",
+    )
+    .bind(encoded_tombstone)
+    .bind(target_archive_id)
+    .bind(room.as_str())
+    .execute(&mut *tx)
+    .await?
+    .rows_affected();
+    if updated != 1 {
+        let _ = tx.rollback().await;
+        return Ok(false);
+    }
+    tx.commit().await?;
+    Ok(true)
 }

--- a/server/crates/waddle-xmpp/src/mam/storage/traits.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/traits.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use jid::BareJid;
-use waddle_xmpp_core::mam::{ArchivedMessage, MamQuery, MamResult};
+use jid::{BareJid, Jid};
+use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedTombstone, MamQuery, MamResult};
 
 use crate::muc::RoomClaimFenceContext;
 
@@ -44,18 +44,20 @@ pub trait MamStorage: Send + Sync {
     /// otherwise still commit a phantom archived row under a claim this
     /// node no longer holds.
     ///
-    /// `fence` carries the SAME typed `(Entity, ClaimEpoch, node_id)`
+    /// `fence` carries the SAME typed `(Entity, ClaimEpoch, NodeIdentity)`
     /// context [`crate::muc::MucDurableStore::current_claim_fence`]
     /// resolves from `dispatch_to_room`'s own fencing mechanism — threaded
     /// through rather than re-derived, so both fencing checks (the
     /// standalone pre-fan-out one and this write-adjacent one) agree by
     /// construction.
     ///
-    /// Default impl ignores `fence` and falls back to [`Self::store_message`]
-    /// — correct for every implementation with no clustering/fencing
-    /// concept (the portable, single-node backend, and the in-memory test
-    /// double). A cluster-aware implementation overrides this to run the
-    /// fencing check and the insert in one transaction, mirroring
+    /// The default implementation fails with
+    /// [`MamStorageError::FencingUnavailable`]. Single-node callers use
+    /// [`Self::store_message`] directly and never enter this method; once a
+    /// clustered caller supplies a fence, silently falling back to an
+    /// unfenced insert would violate the ownership boundary. A
+    /// cluster-aware implementation overrides this to run the fencing
+    /// check and the insert in one transaction, mirroring
     /// `pending_delivery::storage::PendingDeliveryStorage::insert_fenced`'s
     /// identical pattern one table over. On a failed fence, returns
     /// [`MamStorageError::NotOwner`] and the write never touches
@@ -66,8 +68,10 @@ pub trait MamStorage: Send + Sync {
         message: &ArchivedMessage,
         fence: &RoomClaimFenceContext,
     ) -> Result<String, MamStorageError> {
-        let _ = fence;
-        self.store_message(archive_jid, message).await
+        let _ = (archive_jid, message);
+        Err(MamStorageError::FencingUnavailable {
+            entity: fence.entity.clone(),
+        })
     }
 
     /// Query messages from the archive.
@@ -103,8 +107,50 @@ pub trait MamStorage: Send + Sync {
     async fn replace_with_tombstone(
         &self,
         archive_id: &str,
-        tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+        tombstone: ArchivedTombstone,
     ) -> Result<bool, MamStorageError>;
+
+    /// Atomically archive a canonical XEP-0425 moderation event and replace
+    /// its exact room-scoped target with a tombstone under the same room
+    /// ownership fence. `Ok(false)` means the target did not exist in this
+    /// room; neither write is committed.
+    async fn moderate_message_fenced(
+        &self,
+        archive_jid: &BareJid,
+        moderation: &ArchivedMessage,
+        target_archive_id: &str,
+        tombstone: ArchivedTombstone,
+        fence: &RoomClaimFenceContext,
+    ) -> Result<bool, MamStorageError> {
+        let _ = (archive_jid, moderation, target_archive_id, tombstone);
+        Err(MamStorageError::FencingUnavailable {
+            entity: fence.entity.clone(),
+        })
+    }
+
+    /// Replace an exact room-scoped XEP-0424 target only while the exact
+    /// room claim is still held and the matching retraction event has already
+    /// been archived in that room by the authenticated occupant sender.
+    async fn replace_with_tombstone_fenced(
+        &self,
+        archive_jid: &BareJid,
+        target_archive_id: &str,
+        retraction_archive_id: &str,
+        retraction_from: &Jid,
+        tombstone: ArchivedTombstone,
+        fence: &RoomClaimFenceContext,
+    ) -> Result<bool, MamStorageError> {
+        let _ = (
+            archive_jid,
+            target_archive_id,
+            retraction_archive_id,
+            retraction_from,
+            tombstone,
+        );
+        Err(MamStorageError::FencingUnavailable {
+            entity: fence.entity.clone(),
+        })
+    }
 
     /// Get a single message by its original message/stanza id inside an archive.
     async fn get_message_by_stanza_id(

--- a/server/crates/waddle-xmpp/src/muc/durable.rs
+++ b/server/crates/waddle-xmpp/src/muc/durable.rs
@@ -36,7 +36,7 @@ use jid::BareJid;
 
 use super::affiliation::AffiliationEntry;
 use super::{RoomConfig, SubjectState};
-use crate::ownership::{ClaimEpoch, Entity};
+use crate::ownership::{ClaimEpoch, Entity, NodeIdentity};
 use crate::XmppError;
 
 /// Boxed future returned by every [`MucDurableStore`] method, mirroring
@@ -46,18 +46,18 @@ pub type MucDurableFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, XmppErr
 
 /// Typed fencing context for a room's currently-recorded Postgres claim
 /// (ADR-0017 Phase 3 Slice 7 FIX 1, council-adjudicated): the same
-/// `(Entity, ClaimEpoch, node_id)` triple [`MucDurableStore::check_fenced_fanout`]
+/// `(Entity, ClaimEpoch, NodeIdentity)` triple [`MucDurableStore::check_fenced_fanout`]
 /// resolves internally via [`MucDurableStore::record_claim_epoch`]'s cache,
 /// exposed here so a caller that needs to run its OWN fenced write against a
 /// DIFFERENT store (MAM's `store_message_fenced`, which cannot share a SQL
 /// transaction with this store's own `assert_fenced`) can bind the identical
 /// typed values into its own `SELECT ... FOR SHARE` check, rather than
 /// re-deriving them from a second, independent source of truth.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RoomClaimFenceContext {
     pub entity: Entity,
     pub epoch: ClaimEpoch,
-    pub node_id: String,
+    pub owner: NodeIdentity,
 }
 
 /// Full durable snapshot of a room's long-lived state: configuration,
@@ -79,8 +79,8 @@ pub struct DurableRoomState {
 /// on the room's `RoomActor` entity (see [`Self::record_claim_epoch`]) —
 /// "epoch-fenced like all claimed-entity writes" per element 7.
 ///
-/// **Fail-open contract, revised (ADR-0017 Phase 3 Slice 7 FIX 2,
-/// council-adjudicated).** This trait's `save_*` methods themselves are
+/// **Fail-closed ownership contract (ADR-0017 Phase 3 Slice 7 FIX 2).**
+/// This trait's `save_*` methods themselves are
 /// still fire-and-forget from a Rust-signature perspective (`Result<(),
 /// XmppError>`, not surfaced up through every intermediate layer) — a
 /// fenced write that fails still just returns `Err` to its immediate
@@ -94,9 +94,10 @@ pub struct DurableRoomState {
 /// 1. **Before mutating**: the handler runs
 ///    [`super::room_actor::RoomActor::gate_mutation`] — a `SELECT ... FOR
 ///    SHARE`-fenced [`Self::check_fenced_fanout`] pre-check — and refuses
-///    to mutate at all on a definitive ownership-loss result. This is new:
-///    previously every mutation applied in-memory unconditionally,
-///    regardless of whether this node's claim was still current.
+///    to mutate on either definitive ownership loss or a backend error that
+///    prevents proving exact ownership. The uncertain case does not demote
+///    the actor; neither case applies the requested in-memory or durable
+///    effect.
 /// 2. **After mutating**: a `save_*` failure that is NOT ownership loss
 ///    (a transient backend outage) is no longer silently logged and
 ///    swallowed — it now surfaces as a typed error
@@ -130,6 +131,21 @@ pub trait MucDurableStore: Send + Sync {
         config: &'a RoomConfig,
     ) -> MucDurableFuture<'a, ()>;
 
+    /// Persist configuration under the exact claim captured by one
+    /// `RoomActor` incarnation. Clustered implementations override this;
+    /// portable stores retain their existing room-scoped behavior.
+    fn save_config_exact<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        waddle_id: &'a str,
+        channel_id: &'a str,
+        config: &'a RoomConfig,
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, ()> {
+        let _ = fence;
+        self.save_config(room_jid, waddle_id, channel_id, config)
+    }
+
     /// Durably upsert (or, when `subject` is `None`, clear) the room's
     /// current subject.
     fn save_subject<'a>(
@@ -137,6 +153,17 @@ pub trait MucDurableStore: Send + Sync {
         room_jid: &'a BareJid,
         subject: Option<&'a SubjectState>,
     ) -> MucDurableFuture<'a, ()>;
+
+    /// Exact-incarnation variant of [`Self::save_subject`].
+    fn save_subject_exact<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        subject: Option<&'a SubjectState>,
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, ()> {
+        let _ = fence;
+        self.save_subject(room_jid, subject)
+    }
 
     /// Durably upsert one affiliation-list entry. `Affiliation::None`
     /// removes the row, mirroring `AffiliationList::set`'s in-memory
@@ -146,6 +173,17 @@ pub trait MucDurableStore: Send + Sync {
         room_jid: &'a BareJid,
         entry: &'a AffiliationEntry,
     ) -> MucDurableFuture<'a, ()>;
+
+    /// Exact-incarnation variant of [`Self::save_affiliation`].
+    fn save_affiliation_exact<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        entry: &'a AffiliationEntry,
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, ()> {
+        let _ = fence;
+        self.save_affiliation(room_jid, entry)
+    }
 
     /// Record the claim epoch this node most recently won for `room_jid`
     /// (called by the room registry immediately after a successful
@@ -170,7 +208,9 @@ pub trait MucDurableStore: Send + Sync {
     /// epoch [`Self::record_claim_epoch`] last recorded), run before every
     /// local fan-out. `Ok(true)` iff this node still holds the claim;
     /// `Ok(false)` means a steal has committed and the caller must demote
-    /// locally and not deliver. Default `Ok(true)` (never demotes):
+    /// locally and not deliver. `Err` means exact ownership could not be
+    /// proved; callers must suppress the current fan-out/mutation without
+    /// demoting solely from that uncertainty. Default `Ok(true)` (never demotes):
     /// single-node/non-clustering deployments never configure a
     /// `MucDurableStore` at all, so this default only matters for tests
     /// exercising the trait directly.
@@ -179,7 +219,19 @@ pub trait MucDurableStore: Send + Sync {
         Box::pin(async { Ok(true) })
     }
 
-    /// The typed `(Entity, ClaimEpoch, node_id)` context this room is
+    /// Prove the exact claim captured by a particular room-actor
+    /// incarnation. Unlike [`Self::check_fenced_fanout`], this must never
+    /// substitute a newer epoch cached for the same room.
+    fn check_fenced_fanout_exact<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, bool> {
+        let _ = fence;
+        self.check_fenced_fanout(room_jid)
+    }
+
+    /// The typed `(Entity, ClaimEpoch, NodeIdentity)` context this room is
     /// currently cached under (ADR-0017 Phase 3 Slice 7 FIX 1) — the exact
     /// same values [`Self::check_fenced_fanout`] resolves internally, handed
     /// out here so a caller needing its OWN fenced write (MAM's

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -24,8 +24,8 @@ mod snapshot_handlers;
 mod tests;
 
 pub use admin_handlers::{
-    ApplyAdminItems, ApplyAffiliationChange, EnforceMembersOnly, EnforceMembersOnlyAffiliations,
-    GetAdminContext, IsOwner,
+    ApplyAdminItems, ApplyAffiliationChange, CheckMutationOwnership, EnforceMembersOnly,
+    EnforceMembersOnlyAffiliations, GetAdminContext, IsOwner,
 };
 pub use occupancy_handlers::{
     ClearMujiPresence, InCallPresenceUpdateOutcome, JoinAffiliationGrant, JoinWithAffiliation,
@@ -162,6 +162,11 @@ pub enum AdminApplyError {
     /// `<resource-constraint/>` bounce).
     #[error("this room's ownership has moved to another node")]
     NotOwner,
+    /// The ownership store could not prove or disprove the exact claim.
+    /// The mutation was never applied. Unlike `NotOwner`, callers must not
+    /// demote the actor solely from this transient uncertainty.
+    #[error("this room's ownership cannot currently be verified")]
+    OwnershipUncertain,
     /// FIX 2: the fenced gate passed (or was skipped, single-node), the
     /// in-memory mutation was applied, but the best-effort durable
     /// persist afterwards failed for a reason OTHER than ownership loss
@@ -177,6 +182,7 @@ impl From<RoomMutationError> for AdminApplyError {
     fn from(error: RoomMutationError) -> Self {
         match error {
             RoomMutationError::NotOwner => AdminApplyError::NotOwner,
+            RoomMutationError::OwnershipUncertain => AdminApplyError::OwnershipUncertain,
             RoomMutationError::PersistFailed(detail) => AdminApplyError::PersistFailed(detail),
         }
     }
@@ -185,6 +191,8 @@ impl From<RoomMutationError> for AdminApplyError {
 impl From<DurablePersistError> for AdminApplyError {
     fn from(error: DurablePersistError) -> Self {
         match error {
+            DurablePersistError::NotOwner => AdminApplyError::NotOwner,
+            DurablePersistError::OwnershipUncertain => AdminApplyError::OwnershipUncertain,
             DurablePersistError::Failed(detail) => AdminApplyError::PersistFailed(detail),
         }
     }
@@ -219,6 +227,8 @@ impl From<DurablePersistError> for AdminApplyError {
 pub enum RoomMutationError {
     #[error("this room's ownership has moved to another node")]
     NotOwner,
+    #[error("this room's ownership cannot currently be verified")]
+    OwnershipUncertain,
     #[error("durable persist failed after the in-memory mutation committed: {0}")]
     PersistFailed(String),
 }
@@ -232,6 +242,10 @@ pub enum RoomMutationError {
 /// named variant (`PendingStorageError::Other`, `MamStorageError::Database`).
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum DurablePersistError {
+    #[error("this room's ownership moved before the durable write committed")]
+    NotOwner,
+    #[error("this room's exact-incarnation ownership cannot currently be verified")]
+    OwnershipUncertain,
     #[error("durable persist failed: {0}")]
     Failed(String),
 }
@@ -239,6 +253,8 @@ pub enum DurablePersistError {
 impl From<DurablePersistError> for RoomMutationError {
     fn from(error: DurablePersistError) -> Self {
         match error {
+            DurablePersistError::NotOwner => RoomMutationError::NotOwner,
+            DurablePersistError::OwnershipUncertain => RoomMutationError::OwnershipUncertain,
             DurablePersistError::Failed(detail) => RoomMutationError::PersistFailed(detail),
         }
     }
@@ -276,6 +292,9 @@ pub struct RoomActor {
     /// makes the probe's revision stale, closing the probe→destroy
     /// TOCTOU that orphaned freshly-admitted occupants.
     occupancy_revision: u64,
+    /// Monotonic token for pin-list mutations. Failed system-message
+    /// broadcasts use it for ABA-safe conditional rollback.
+    pin_revision: u64,
     /// Set by [`SealIfInactive`] immediately before the registry
     /// removes this actor from its map (#1108). A sealed actor refuses
     /// further admissions with [`RoomActorError::RoomSealed`] so a
@@ -309,6 +328,10 @@ pub struct RoomActor {
     /// Every config/subject/affiliation-mutating handler best-effort
     /// persists through this handle when it is `Some`.
     durable_store: Option<std::sync::Arc<dyn super::durable::MucDurableStore>>,
+    /// Exact claim won for this actor incarnation. This never follows a
+    /// later room-scoped cache update, preventing an E1 actor from borrowing
+    /// a same-node E2 reacquisition after destroy/recreate.
+    claim_fence: Option<super::durable::RoomClaimFenceContext>,
     /// ADR-0017 Phase 3 Slice 7 FIX 4 (council-adjudicated): whether this
     /// actor incarnation's durable restore genuinely completed. See
     /// [`DurableRestoreState`]'s own doc comment.
@@ -389,6 +412,25 @@ pub enum RoomActorError {
     /// ownership-gap bounce.
     #[error("durable room-state restore has not yet completed; retry")]
     RestorePending,
+    /// The exact room claim no longer belongs to this actor's node/epoch.
+    /// No join mutation was applied.
+    #[error("this room's ownership has moved to another node")]
+    NotOwner,
+    /// The ownership store could not verify the exact room claim. No join
+    /// mutation was applied.
+    #[error("this room's ownership cannot currently be verified")]
+    OwnershipUncertain,
+}
+
+impl From<RoomMutationError> for RoomActorError {
+    fn from(error: RoomMutationError) -> Self {
+        match error {
+            RoomMutationError::NotOwner => Self::NotOwner,
+            RoomMutationError::OwnershipUncertain | RoomMutationError::PersistFailed(_) => {
+                Self::OwnershipUncertain
+            }
+        }
+    }
 }
 
 impl RoomActor {
@@ -399,11 +441,13 @@ impl RoomActor {
             config_revision: 0,
             admission_revision: 0,
             occupancy_revision: 0,
+            pin_revision: 0,
             sealed: false,
             occupant_id_secret,
             durable_member_recipients: Vec::new(),
             membership_source: None,
             durable_store: None,
+            claim_fence: None,
             restore_state: DurableRestoreState::Ready,
         }
     }
@@ -416,17 +460,25 @@ impl RoomActor {
     /// still holds the claim. `Err(RoomMutationError::NotOwner)` when the
     /// fenced check observes 0 rows — the caller MUST NOT mutate.
     ///
-    /// A transient backend failure fails OPEN for the gate itself
-    /// (mirroring `dispatch_to_room`'s identical "a transient fencing
-    /// -check failure never demotes, only a definitive 0-rows result
-    /// does" rule) — only a definitive fencing failure blocks the
-    /// mutation; an unreachable Postgres must not itself wedge every
-    /// mutating admin action.
+    /// A backend failure returns `OwnershipUncertain` and fails this
+    /// mutation closed. It does not demote the actor (only a definitive
+    /// zero-row result does), but an unreachable ownership store cannot
+    /// authorize an in-memory state change.
     async fn gate_mutation(&self) -> Result<(), RoomMutationError> {
         let Some(store) = self.durable_store.clone() else {
             return Ok(());
         };
-        match store.check_fenced_fanout(&self.room.room_jid).await {
+        let Some(fence) = self.claim_fence.as_ref() else {
+            tracing::warn!(
+                room = %self.room.room_jid,
+                "durable room actor has no exact-incarnation claim fence; failing mutation closed"
+            );
+            return Err(RoomMutationError::OwnershipUncertain);
+        };
+        let checked = store
+            .check_fenced_fanout_exact(&self.room.room_jid, fence)
+            .await;
+        match checked {
             Ok(true) => Ok(()),
             Ok(false) => {
                 tracing::warn!(
@@ -435,14 +487,20 @@ impl RoomActor {
                 );
                 Err(RoomMutationError::NotOwner)
             }
+            Err(crate::XmppError::RoomOwnershipLost(_)) => {
+                tracing::warn!(
+                    room = %self.room.room_jid,
+                    "mutation gate has no live cached room claim; refusing as not-owner"
+                );
+                Err(RoomMutationError::NotOwner)
+            }
             Err(error) => {
                 tracing::warn!(
                     room = %self.room.room_jid,
                     %error,
-                    "mutation gate fencing check failed transiently; failing open \
-                     (not blocking the mutation)"
+                    "mutation gate fencing check failed; failing closed without demoting"
                 );
-                Ok(())
+                Err(RoomMutationError::OwnershipUncertain)
             }
         }
     }
@@ -509,23 +567,30 @@ impl RoomActor {
         let Some(store) = self.durable_store.clone() else {
             return Ok(());
         };
-        store
-            .save_config(
+        let Some(fence) = self.claim_fence.as_ref() else {
+            return Err(DurablePersistError::OwnershipUncertain);
+        };
+        let saved = store
+            .save_config_exact(
                 &self.room.room_jid,
                 &self.room.waddle_id,
                 &self.room.channel_id,
                 &self.room.config,
+                fence,
             )
-            .await
-            .map_err(|error| {
-                tracing::warn!(
-                    room = %self.room.room_jid,
-                    %error,
-                    "durable room-config persist failed (in-memory config remains \
-                     authoritative for this actor incarnation; surfaced typed to caller)"
-                );
-                DurablePersistError::Failed(error.to_string())
-            })
+            .await;
+        saved.map_err(|error| {
+            tracing::warn!(
+                room = %self.room.room_jid,
+                %error,
+                "durable room-config persist failed (in-memory config remains \
+                 authoritative for this actor incarnation; surfaced typed to caller)"
+            );
+            match error {
+                crate::XmppError::RoomOwnershipLost(_) => DurablePersistError::NotOwner,
+                other => DurablePersistError::Failed(other.to_string()),
+            }
+        })
     }
 
     /// Best-effort durable persist of the current subject. See
@@ -534,17 +599,23 @@ impl RoomActor {
         let Some(store) = self.durable_store.clone() else {
             return Ok(());
         };
-        store
-            .save_subject(&self.room.room_jid, self.room.subject.as_ref())
-            .await
-            .map_err(|error| {
-                tracing::warn!(
-                    room = %self.room.room_jid,
-                    %error,
-                    "durable room-subject persist failed (surfaced typed to caller)"
-                );
-                DurablePersistError::Failed(error.to_string())
-            })
+        let Some(fence) = self.claim_fence.as_ref() else {
+            return Err(DurablePersistError::OwnershipUncertain);
+        };
+        let saved = store
+            .save_subject_exact(&self.room.room_jid, self.room.subject.as_ref(), fence)
+            .await;
+        saved.map_err(|error| {
+            tracing::warn!(
+                room = %self.room.room_jid,
+                %error,
+                "durable room-subject persist failed (surfaced typed to caller)"
+            );
+            match error {
+                crate::XmppError::RoomOwnershipLost(_) => DurablePersistError::NotOwner,
+                other => DurablePersistError::Failed(other.to_string()),
+            }
+        })
     }
 
     /// Best-effort durable persist of one affiliation-list entry. See
@@ -558,18 +629,24 @@ impl RoomActor {
             return Ok(());
         };
         let entry = super::affiliation::AffiliationEntry::new(jid.clone(), affiliation);
-        store
-            .save_affiliation(&self.room.room_jid, &entry)
-            .await
-            .map_err(|error| {
-                tracing::warn!(
-                    room = %self.room.room_jid,
-                    jid = %jid,
-                    %error,
-                    "durable room-affiliation persist failed (surfaced typed to caller)"
-                );
-                DurablePersistError::Failed(error.to_string())
-            })
+        let Some(fence) = self.claim_fence.as_ref() else {
+            return Err(DurablePersistError::OwnershipUncertain);
+        };
+        let saved = store
+            .save_affiliation_exact(&self.room.room_jid, &entry, fence)
+            .await;
+        saved.map_err(|error| {
+            tracing::warn!(
+                room = %self.room.room_jid,
+                jid = %jid,
+                %error,
+                "durable room-affiliation persist failed (surfaced typed to caller)"
+            );
+            match error {
+                crate::XmppError::RoomOwnershipLost(_) => DurablePersistError::NotOwner,
+                other => DurablePersistError::Failed(other.to_string()),
+            }
+        })
     }
 
     /// Drop a JID from the spawn-time hydrated durable-recipient
@@ -735,6 +812,69 @@ pub struct RestoreDurableRoomState {
     pub store: std::sync::Arc<dyn super::durable::MucDurableStore>,
 }
 
+/// Bind the immutable claim proof won for this exact actor incarnation.
+/// The registry enqueues this before restore and before exposing the actor.
+pub struct BindRoomClaimFence {
+    pub fence: super::durable::RoomClaimFenceContext,
+}
+
+/// An actor incarnation may carry exactly one claim proof. Re-sending the
+/// identical proof is idempotent, but attempting to transplant a newer (or
+/// otherwise different) proof into the retained actor is an ABA violation.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum BindRoomClaimFenceError {
+    #[error("room actor already carries a different exact-incarnation claim fence")]
+    ConflictingFence {
+        bound: super::durable::RoomClaimFenceContext,
+        attempted: super::durable::RoomClaimFenceContext,
+    },
+}
+
+impl kameo::message::Message<BindRoomClaimFence> for RoomActor {
+    type Reply = Result<(), BindRoomClaimFenceError>;
+
+    async fn handle(
+        &mut self,
+        msg: BindRoomClaimFence,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        match self.claim_fence.as_ref() {
+            None => {
+                self.claim_fence = Some(msg.fence);
+                Ok(())
+            }
+            Some(bound) if bound == &msg.fence => Ok(()),
+            Some(bound) => {
+                let error = BindRoomClaimFenceError::ConflictingFence {
+                    bound: bound.clone(),
+                    attempted: msg.fence,
+                };
+                tracing::error!(
+                    room = %self.room.room_jid,
+                    "room actor claim fence rebind rejected; stopping retained actor"
+                );
+                ctx.stop();
+                Err(error)
+            }
+        }
+    }
+}
+
+/// Return the immutable exact-incarnation claim carried by this actor.
+pub struct GetRoomClaimFence;
+
+impl kameo::message::Message<GetRoomClaimFence> for RoomActor {
+    type Reply = Option<super::durable::RoomClaimFenceContext>;
+
+    async fn handle(
+        &mut self,
+        _msg: GetRoomClaimFence,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.claim_fence.clone()
+    }
+}
+
 impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
     type Reply = ();
 
@@ -801,6 +941,7 @@ impl kameo::message::Message<Join> for RoomActor {
         if self.sealed {
             return Err(RoomActorError::RoomSealed);
         }
+        self.gate_mutation().await?;
         if self.room.is_full() && !affiliation_overflows_full_room(msg.affiliation) {
             return Err(RoomActorError::RoomFull);
         }
@@ -829,6 +970,7 @@ impl kameo::message::Message<Leave> for RoomActor {
     type Reply = Result<(), RoomActorError>;
 
     async fn handle(&mut self, msg: Leave, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        self.gate_mutation().await?;
         self.room
             .remove_occupant(&msg.nick)
             .map(|_| ())
@@ -977,6 +1119,8 @@ pub enum UpdateGroupDmConfigByMemberError {
     /// doc comment — identical contract, one message type over.
     #[error("this room's ownership has moved to another node")]
     NotOwner,
+    #[error("this room's ownership cannot currently be verified")]
+    OwnershipUncertain,
     /// FIX 2: see [`AdminApplyError::PersistFailed`]'s doc comment.
     #[error("durable persist failed after the in-memory mutation committed: {0}")]
     PersistFailed(String),
@@ -986,6 +1130,9 @@ impl From<RoomMutationError> for UpdateGroupDmConfigByMemberError {
     fn from(error: RoomMutationError) -> Self {
         match error {
             RoomMutationError::NotOwner => UpdateGroupDmConfigByMemberError::NotOwner,
+            RoomMutationError::OwnershipUncertain => {
+                UpdateGroupDmConfigByMemberError::OwnershipUncertain
+            }
             RoomMutationError::PersistFailed(detail) => {
                 UpdateGroupDmConfigByMemberError::PersistFailed(detail)
             }
@@ -996,6 +1143,10 @@ impl From<RoomMutationError> for UpdateGroupDmConfigByMemberError {
 impl From<DurablePersistError> for UpdateGroupDmConfigByMemberError {
     fn from(error: DurablePersistError) -> Self {
         match error {
+            DurablePersistError::NotOwner => UpdateGroupDmConfigByMemberError::NotOwner,
+            DurablePersistError::OwnershipUncertain => {
+                UpdateGroupDmConfigByMemberError::OwnershipUncertain
+            }
             DurablePersistError::Failed(detail) => {
                 UpdateGroupDmConfigByMemberError::PersistFailed(detail)
             }
@@ -1064,9 +1215,13 @@ impl kameo::message::Message<SetSubject> for RoomActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         self.gate_mutation().await?;
+        let previous_subject = self.room.subject.clone();
         self.room
             .set_subject(msg.texts, msg.setter, msg.setter_nick, msg.set_at);
-        self.persist_subject().await?;
+        if let Err(error) = self.persist_subject().await {
+            self.room.subject = previous_subject;
+            return Err(error.into());
+        }
         Ok(())
     }
 }
@@ -1081,13 +1236,14 @@ pub struct ApplyPin {
 }
 
 impl kameo::message::Message<ApplyPin> for RoomActor {
-    type Reply = ();
+    type Reply = Result<u64, RoomMutationError>;
 
     async fn handle(
         &mut self,
         msg: ApplyPin,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_mutation().await?;
         match msg.change {
             PinStateChange::Pin(entry) => {
                 self.room.upsert_pin(entry);
@@ -1096,6 +1252,40 @@ impl kameo::message::Message<ApplyPin> for RoomActor {
                 self.room.remove_pin_by_target(&target_stanza_id);
             }
         }
+        self.pin_revision = self.pin_revision.saturating_add(1);
+        Ok(self.pin_revision)
+    }
+}
+
+/// Restore a pin target after a failed system-message broadcast, but only
+/// when no later pin mutation was processed while that broadcast awaited.
+pub struct RollbackPinIfRevision {
+    pub expected_revision: u64,
+    pub change: PinStateChange,
+}
+
+impl kameo::message::Message<RollbackPinIfRevision> for RoomActor {
+    type Reply = Result<bool, RoomMutationError>;
+
+    async fn handle(
+        &mut self,
+        msg: RollbackPinIfRevision,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self.pin_revision != msg.expected_revision {
+            return Ok(false);
+        }
+        self.gate_mutation().await?;
+        match msg.change {
+            PinStateChange::Pin(entry) => {
+                self.room.upsert_pin(entry);
+            }
+            PinStateChange::Unpin { target_stanza_id } => {
+                self.room.remove_pin_by_target(&target_stanza_id);
+            }
+        }
+        self.pin_revision = self.pin_revision.saturating_add(1);
+        Ok(true)
     }
 }
 
@@ -1315,6 +1505,34 @@ pub enum SealGuard {
     /// eviction of instant rooms (XEP-0045 §10.1.3), which may still
     /// hold a subject or the creator's Owner grant.
     EmptyNonPersistent,
+}
+
+/// Seal this exact actor for an owner-requested XEP-0045 room destruction and
+/// return the final occupant snapshot covered by that seal.
+///
+/// The actor mailbox is the admission barrier: every join queued before this
+/// message commits before the snapshot, while every join processed after it
+/// observes [`RoomActorError::RoomSealed`]. The ownership mutation gate runs
+/// before changing `sealed`, so claim loss or backend uncertainty never
+/// authorizes destruction from a deposed actor.
+pub struct SealForOwnerDestroy;
+
+impl kameo::message::Message<SealForOwnerDestroy> for RoomActor {
+    type Reply = Result<RoomSnapshot, RoomActorError>;
+
+    async fn handle(
+        &mut self,
+        _msg: SealForOwnerDestroy,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.gate_mutation().await?;
+        self.sealed = true;
+        Ok(RoomSnapshot {
+            room: self.room.clone(),
+            config_revision: self.config_revision,
+            admission_revision: self.admission_revision,
+        })
+    }
 }
 
 /// Seal this room actor for destruction if it is still inactive at the

--- a/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
@@ -4,7 +4,7 @@ use jid::{BareJid, FullJid};
 use kameo::message::Context;
 use xmpp_parsers::presence::Presence;
 
-use super::{AdminApplyError, AdminContext, RoomActor};
+use super::{AdminApplyError, AdminContext, RoomActor, RoomMutationError};
 use crate::muc::admin::{is_role_change_query, AdminItem};
 use crate::muc::{
     build_affiliation_change_presence, build_ban_presence, build_kick_presence,
@@ -138,6 +138,7 @@ fn apply_affiliation_change(
         return Ok(AdminItemsApplied {
             presence_updates: updates,
             removed_by_moderation,
+            persist_failure: None,
         });
     }
 
@@ -161,6 +162,7 @@ fn apply_affiliation_change(
         return Ok(AdminItemsApplied {
             presence_updates: updates,
             removed_by_moderation: Vec::new(),
+            persist_failure: None,
         });
     }
 
@@ -193,6 +195,7 @@ fn apply_affiliation_change(
     Ok(AdminItemsApplied {
         presence_updates: updates,
         removed_by_moderation: Vec::new(),
+        persist_failure: None,
     })
 }
 
@@ -295,6 +298,11 @@ pub struct ApplyAdminItems {
 pub struct AdminItemsApplied {
     pub presence_updates: Vec<(FullJid, Presence)>,
     pub removed_by_moderation: Vec<FullJid>,
+    /// A durable convergence failure discovered after one or more effects
+    /// had already mutated room state. Callers must deliver those effects
+    /// before returning a retryable error; dropping this outcome would leave
+    /// clients and SFU state inconsistent with the actor.
+    pub persist_failure: Option<super::DurablePersistError>,
 }
 
 impl kameo::message::Message<ApplyAdminItems> for RoomActor {
@@ -549,6 +557,15 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                     self.admission_revision = self.admission_revision.saturating_add(1);
                     if let Err(error) = self.persist_affiliation(&target_jid, new_affiliation).await
                     {
+                        match &error {
+                            super::DurablePersistError::NotOwner => {
+                                return Err(AdminApplyError::NotOwner);
+                            }
+                            super::DurablePersistError::OwnershipUncertain => {
+                                return Err(AdminApplyError::OwnershipUncertain);
+                            }
+                            super::DurablePersistError::Failed(_) => {}
+                        }
                         persist_failure.get_or_insert(error);
                     }
                 }
@@ -566,12 +583,10 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
             // `RoomActor::refresh_durable_recipients_from_source`).
             self.refresh_durable_recipients_from_source().await;
         }
-        if let Some(error) = persist_failure {
-            return Err(error.into());
-        }
         Ok(AdminItemsApplied {
             presence_updates,
             removed_by_moderation,
+            persist_failure,
         })
     }
 }
@@ -602,9 +617,24 @@ impl kameo::message::Message<ApplyAffiliationChange> for RoomActor {
             None,
         )?;
         let needs_rehydration = self.prune_durable_recipient_if_removed(&msg.jid, msg.affiliation);
+        let mut updates = updates;
         if previous_affiliation != msg.affiliation {
             self.admission_revision = self.admission_revision.saturating_add(1);
-            self.persist_affiliation(&msg.jid, msg.affiliation).await?;
+            if let Err(error) = self.persist_affiliation(&msg.jid, msg.affiliation).await {
+                match &error {
+                    super::DurablePersistError::NotOwner => {
+                        return Err(AdminApplyError::NotOwner);
+                    }
+                    super::DurablePersistError::OwnershipUncertain => {
+                        return Err(AdminApplyError::OwnershipUncertain);
+                    }
+                    super::DurablePersistError::Failed(_) => {}
+                }
+                // The affiliation/removal effects have already committed in
+                // memory. Return them with the convergence error so callers
+                // notify occupants and evict calls before reporting failure.
+                updates.persist_failure = Some(error);
+            }
         }
         if needs_rehydration {
             self.refresh_durable_recipients_from_source().await;
@@ -616,14 +646,34 @@ impl kameo::message::Message<ApplyAffiliationChange> for RoomActor {
 pub struct EnforceMembersOnly;
 
 impl kameo::message::Message<EnforceMembersOnly> for RoomActor {
-    type Reply = Vec<(FullJid, Presence)>;
+    type Reply = Result<Vec<(FullJid, Presence)>, RoomMutationError>;
 
     async fn handle(
         &mut self,
         _msg: EnforceMembersOnly,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        enforce_members_only(&mut self.room, &self.occupant_id_secret)
+        self.gate_mutation().await?;
+        Ok(enforce_members_only(
+            &mut self.room,
+            &self.occupant_id_secret,
+        ))
+    }
+}
+
+/// Admit a server-side managed-channel mutation against this exact actor
+/// incarnation before touching external channel/bookmark state.
+pub struct CheckMutationOwnership;
+
+impl kameo::message::Message<CheckMutationOwnership> for RoomActor {
+    type Reply = Result<(), RoomMutationError>;
+
+    async fn handle(
+        &mut self,
+        _msg: CheckMutationOwnership,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.gate_mutation().await
     }
 }
 
@@ -665,6 +715,15 @@ impl kameo::message::Message<EnforceMembersOnlyAffiliations> for RoomActor {
             {
                 self.admission_revision = self.admission_revision.saturating_add(1);
                 if let Err(error) = self.persist_affiliation(&jid, affiliation).await {
+                    match &error {
+                        super::DurablePersistError::NotOwner => {
+                            return Err(super::RoomMutationError::NotOwner);
+                        }
+                        super::DurablePersistError::OwnershipUncertain => {
+                            return Err(super::RoomMutationError::OwnershipUncertain);
+                        }
+                        super::DurablePersistError::Failed(_) => {}
+                    }
                     persist_failure.get_or_insert(error);
                 }
             }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -1,11 +1,9 @@
-use std::convert::Infallible;
-
 use jid::{BareJid, FullJid};
 use kameo::message::Context;
 
 use super::{
     affiliation_overflows_full_room, JoinExistingOccupant, JoinOutcome, LeaveOutcome,
-    PresenceUpdateOutcome, RoomActor, RoomActorError,
+    PresenceUpdateOutcome, RoomActor, RoomActorError, RoomMutationError,
 };
 use crate::muc::RoomConfig;
 use crate::types::Affiliation;
@@ -57,6 +55,10 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
         // unresolved (a genuine backend failure, not a legitimate brand
         // -new room) — see `RoomActor::ensure_restored_before_join`.
         self.ensure_restored_before_join().await?;
+        // A live actor may outlast its exact clustered claim. Fence before
+        // applying resolver affiliation, creator ownership, occupancy, or
+        // producing any recipient fan-out snapshot.
+        self.gate_mutation().await?;
         if msg.admission_revision != self.admission_revision {
             return Err(RoomActorError::StaleAdmissionRevision);
         }
@@ -200,13 +202,14 @@ pub struct LeaveByRealJid {
 }
 
 impl kameo::message::Message<LeaveByRealJid> for RoomActor {
-    type Reply = Result<Option<LeaveOutcome>, Infallible>;
+    type Reply = Result<Option<LeaveOutcome>, RoomMutationError>;
 
     async fn handle(
         &mut self,
         msg: LeaveByRealJid,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_mutation().await?;
         // #1107: collect EVERY nick this full JID occupies. Post-#1107
         // the join path refuses a second nick for the same full JID, so
         // this is normally a single entry — but pre-existing ghost
@@ -308,13 +311,14 @@ pub struct PresenceUpdateData {
 }
 
 impl kameo::message::Message<PresenceUpdateData> for RoomActor {
-    type Reply = Result<Option<PresenceUpdateOutcome>, Infallible>;
+    type Reply = Result<Option<PresenceUpdateOutcome>, RoomMutationError>;
 
     async fn handle(
         &mut self,
         msg: PresenceUpdateData,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_mutation().await?;
         let Some(sender_occupant) = self.room.find_occupant_by_real_jid(&msg.sender_jid) else {
             return Ok(None);
         };
@@ -379,13 +383,14 @@ pub struct MujiPresenceUpdateOutcome {
 }
 
 impl kameo::message::Message<UpsertMujiPresence> for RoomActor {
-    type Reply = Result<Option<MujiPresenceUpdateOutcome>, Infallible>;
+    type Reply = Result<Option<MujiPresenceUpdateOutcome>, RoomMutationError>;
 
     async fn handle(
         &mut self,
         msg: UpsertMujiPresence,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_mutation().await?;
         let Some(sender_occupant) = self.room.find_occupant_by_real_jid(&msg.sender_jid) else {
             return Ok(None);
         };
@@ -425,13 +430,14 @@ impl kameo::message::Message<UpsertMujiPresence> for RoomActor {
 }
 
 impl kameo::message::Message<ClearMujiPresence> for RoomActor {
-    type Reply = Result<Option<MujiPresenceUpdateOutcome>, Infallible>;
+    type Reply = Result<Option<MujiPresenceUpdateOutcome>, RoomMutationError>;
 
     async fn handle(
         &mut self,
         msg: ClearMujiPresence,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_mutation().await?;
         let Some(sender_occupant) = self.room.find_occupant_by_real_jid(&msg.sender_jid) else {
             return Ok(None);
         };
@@ -488,13 +494,14 @@ pub struct InCallPresenceUpdateOutcome {
 }
 
 impl kameo::message::Message<UpsertInCallState> for RoomActor {
-    type Reply = Result<Option<InCallPresenceUpdateOutcome>, Infallible>;
+    type Reply = Result<Option<InCallPresenceUpdateOutcome>, RoomMutationError>;
 
     async fn handle(
         &mut self,
         msg: UpsertInCallState,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        self.gate_mutation().await?;
         let Some(sender_occupant) = self.room.find_occupant_by_real_jid(&msg.sender_jid) else {
             return Ok(None);
         };
@@ -604,7 +611,7 @@ pub enum ResolverAffiliationSyncOutcome {
 }
 
 impl kameo::message::Message<SyncResolverAffiliation> for RoomActor {
-    type Reply = ResolverAffiliationSyncOutcome;
+    type Reply = Result<ResolverAffiliationSyncOutcome, RoomMutationError>;
 
     async fn handle(
         &mut self,
@@ -612,11 +619,12 @@ impl kameo::message::Message<SyncResolverAffiliation> for RoomActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         if self.sealed {
-            return ResolverAffiliationSyncOutcome::RoomSealed;
+            return Ok(ResolverAffiliationSyncOutcome::RoomSealed);
         }
         if msg.expected_admission_revision != self.admission_revision {
-            return ResolverAffiliationSyncOutcome::StaleAdmissionRevision;
+            return Ok(ResolverAffiliationSyncOutcome::StaleAdmissionRevision);
         }
+        self.gate_mutation().await?;
         // An applied change is itself an admission-relevant affiliation
         // change, so it bumps the revision like `ChangeAffiliation` —
         // any join admitted against the pre-sync snapshot retries.
@@ -627,6 +635,6 @@ impl kameo::message::Message<SyncResolverAffiliation> for RoomActor {
         {
             self.admission_revision = self.admission_revision.saturating_add(1);
         }
-        ResolverAffiliationSyncOutcome::Applied
+        Ok(ResolverAffiliationSyncOutcome::Applied)
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 use crate::muc::admin::AdminItem;
+use crate::muc::durable::MucDurableStore as _;
 use crate::xep::xep0421::OccupantIdSecret;
 use kameo::actor::{ActorRef, Spawn};
 use kameo::error::SendError;
@@ -34,6 +35,26 @@ fn test_full_jid_resource(user: &str, resource: &str) -> FullJid {
 
 async fn spawn_room_actor() -> ActorRef<RoomActor> {
     RoomActor::spawn(RoomActor::new(test_room(), test_secret()))
+}
+
+fn test_room_claim_fence(epoch: i64) -> crate::muc::RoomClaimFenceContext {
+    crate::muc::RoomClaimFenceContext {
+        entity: crate::ownership::Entity::new(
+            crate::ownership::EntityType::RoomActor,
+            "testroom@muc.example.com",
+        ),
+        epoch: crate::ownership::ClaimEpoch(epoch),
+        owner: crate::ownership::NodeIdentity::new("test-node", "test-node-epoch"),
+    }
+}
+
+async fn bind_test_room_claim_fence(actor: &ActorRef<RoomActor>) {
+    actor
+        .ask(BindRoomClaimFence {
+            fence: test_room_claim_fence(1),
+        })
+        .await
+        .expect("bind test room claim fence");
 }
 
 async fn current_admission_revision(actor: &ActorRef<RoomActor>) -> u64 {
@@ -1238,6 +1259,54 @@ async fn apply_unpin_for_unknown_target_is_idempotent() {
         .expect("apply unpin no-op");
     let entries = actor.ask(GetPinList).await.expect("get pin list");
     assert!(entries.is_empty());
+}
+
+#[tokio::test]
+async fn pin_rollback_revision_does_not_clobber_a_later_same_target_update() {
+    use crate::muc::pin::{PinPreview, PinStateChange, PinnedEntry};
+    use chrono::Utc;
+    use waddle_xmpp_core::xep0359::StanzaId;
+
+    let actor = spawn_room_actor().await;
+    let room_jid: BareJid = "testroom@muc.example.com".parse().expect("valid jid");
+    let target = StanzaId::new("stanza-aba", jid::Jid::from(room_jid));
+    let entry = |text: &str| PinnedEntry {
+        target_stanza_id: target.clone(),
+        pinner_jid: "admin@example.com".parse().expect("valid jid"),
+        pinned_at: Utc::now(),
+        preview: PinPreview::new(
+            "alice@example.com".parse().expect("valid jid"),
+            Some("alice".to_string()),
+            text,
+            Utc::now(),
+        ),
+    };
+    let first = entry("first");
+    let first_revision = actor
+        .ask(ApplyPin {
+            change: PinStateChange::Pin(first),
+        })
+        .await
+        .expect("first pin");
+    let later = entry("later");
+    actor
+        .ask(ApplyPin {
+            change: PinStateChange::Pin(later.clone()),
+        })
+        .await
+        .expect("later pin");
+
+    let rolled_back = actor
+        .ask(RollbackPinIfRevision {
+            expected_revision: first_revision,
+            change: PinStateChange::Unpin {
+                target_stanza_id: target,
+            },
+        })
+        .await
+        .expect("conditional rollback");
+    assert!(!rolled_back, "the stale rollback token must be refused");
+    assert_eq!(actor.ask(GetPinList).await.expect("pin list"), vec![later]);
 }
 
 #[tokio::test]
@@ -3369,9 +3438,11 @@ async fn health_check_replies_when_the_room_actor_is_idle() {
 struct FakeDurableStore {
     /// `check_fenced_fanout`'s result: `Some(true)` = owned, `Some(false)`
     /// = deposed, `None` = simulate a transient backend error (fails
-    /// open, per `gate_mutation`'s own contract).
+    /// closed as typed ownership uncertainty).
     fenced: std::sync::Mutex<Option<bool>>,
     fail_persist: bool,
+    persist_not_owner: bool,
+    ownership_lost: std::sync::atomic::AtomicBool,
     save_calls: std::sync::atomic::AtomicUsize,
 }
 
@@ -3401,6 +3472,18 @@ impl FakeDurableStore {
         std::sync::Arc::new(Self {
             fenced: std::sync::Mutex::new(Some(true)),
             fail_persist: true,
+            persist_not_owner: false,
+            ownership_lost: std::sync::atomic::AtomicBool::new(false),
+            save_calls: std::sync::atomic::AtomicUsize::new(0),
+        })
+    }
+
+    fn owned_but_loses_fence_during_persist() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self {
+            fenced: std::sync::Mutex::new(Some(true)),
+            fail_persist: false,
+            persist_not_owner: true,
+            ownership_lost: std::sync::atomic::AtomicBool::new(false),
             save_calls: std::sync::atomic::AtomicUsize::new(0),
         })
     }
@@ -3429,8 +3512,16 @@ impl crate::muc::durable::MucDurableStore for FakeDurableStore {
         self.save_calls
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let fail = self.fail_persist;
+        let not_owner = self.persist_not_owner;
+        if not_owner {
+            self.ownership_lost
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+        let room_jid = _room_jid.clone();
         Box::pin(async move {
-            if fail {
+            if not_owner {
+                Err(crate::XmppError::RoomOwnershipLost(room_jid))
+            } else if fail {
                 Err(crate::XmppError::internal(
                     "simulated transient persist failure",
                 ))
@@ -3448,8 +3539,16 @@ impl crate::muc::durable::MucDurableStore for FakeDurableStore {
         self.save_calls
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let fail = self.fail_persist;
+        let not_owner = self.persist_not_owner;
+        if not_owner {
+            self.ownership_lost
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+        let room_jid = _room_jid.clone();
         Box::pin(async move {
-            if fail {
+            if not_owner {
+                Err(crate::XmppError::RoomOwnershipLost(room_jid))
+            } else if fail {
                 Err(crate::XmppError::internal(
                     "simulated transient persist failure",
                 ))
@@ -3467,8 +3566,16 @@ impl crate::muc::durable::MucDurableStore for FakeDurableStore {
         self.save_calls
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let fail = self.fail_persist;
+        let not_owner = self.persist_not_owner;
+        if not_owner {
+            self.ownership_lost
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+        let room_jid = _room_jid.clone();
         Box::pin(async move {
-            if fail {
+            if not_owner {
+                Err(crate::XmppError::RoomOwnershipLost(room_jid))
+            } else if fail {
                 Err(crate::XmppError::internal(
                     "simulated transient persist failure",
                 ))
@@ -3482,6 +3589,13 @@ impl crate::muc::durable::MucDurableStore for FakeDurableStore {
         &'a self,
         _room_jid: &'a BareJid,
     ) -> crate::muc::durable::MucDurableFuture<'a, bool> {
+        if self
+            .ownership_lost
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            let room_jid = _room_jid.clone();
+            return Box::pin(async move { Err(crate::XmppError::RoomOwnershipLost(room_jid)) });
+        }
         let fenced = *self.fenced.lock().expect("lock");
         Box::pin(async move {
             match fenced {
@@ -3494,15 +3608,257 @@ impl crate::muc::durable::MucDurableStore for FakeDurableStore {
     }
 }
 
+/// Deliberately reports the newest room-scoped claim as owned while proving
+/// only one exact actor incarnation. This models the retained-E1/new-E2 ABA:
+/// any accidental legacy fallback would authorize the stale actor.
+struct ExactIncarnationStore {
+    live_fence: crate::muc::RoomClaimFenceContext,
+    legacy_calls: std::sync::atomic::AtomicUsize,
+    exact_calls: std::sync::atomic::AtomicUsize,
+}
+
+impl ExactIncarnationStore {
+    fn new(live_fence: crate::muc::RoomClaimFenceContext) -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self {
+            live_fence,
+            legacy_calls: std::sync::atomic::AtomicUsize::new(0),
+            exact_calls: std::sync::atomic::AtomicUsize::new(0),
+        })
+    }
+
+    fn legacy_call_count(&self) -> usize {
+        self.legacy_calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    fn exact_call_count(&self) -> usize {
+        self.exact_calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+impl crate::muc::durable::MucDurableStore for ExactIncarnationStore {
+    fn load_room_state<'a>(
+        &'a self,
+        _room_jid: &'a BareJid,
+    ) -> crate::muc::durable::MucDurableFuture<'a, Option<crate::muc::durable::DurableRoomState>>
+    {
+        Box::pin(async { Ok(None) })
+    }
+
+    fn save_config<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        _waddle_id: &'a str,
+        _channel_id: &'a str,
+        _config: &'a RoomConfig,
+    ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
+        self.legacy_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let room_jid = room_jid.clone();
+        Box::pin(async move { Err(crate::XmppError::RoomOwnershipLost(room_jid)) })
+    }
+
+    fn save_subject<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        _subject: Option<&'a SubjectState>,
+    ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
+        self.legacy_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let room_jid = room_jid.clone();
+        Box::pin(async move { Err(crate::XmppError::RoomOwnershipLost(room_jid)) })
+    }
+
+    fn save_affiliation<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        _entry: &'a crate::muc::affiliation::AffiliationEntry,
+    ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
+        self.legacy_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let room_jid = room_jid.clone();
+        Box::pin(async move { Err(crate::XmppError::RoomOwnershipLost(room_jid)) })
+    }
+
+    fn check_fenced_fanout<'a>(
+        &'a self,
+        _room_jid: &'a BareJid,
+    ) -> crate::muc::durable::MucDurableFuture<'a, bool> {
+        self.legacy_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Box::pin(async { Ok(true) })
+    }
+
+    fn check_fenced_fanout_exact<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        fence: &'a crate::muc::RoomClaimFenceContext,
+    ) -> crate::muc::durable::MucDurableFuture<'a, bool> {
+        self.exact_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let owned = fence == &self.live_fence
+            && fence.entity.id == room_jid.to_string()
+            && fence.entity.entity_type == crate::ownership::EntityType::RoomActor;
+        Box::pin(async move { Ok(owned) })
+    }
+}
+
 async fn spawn_room_actor_with_store(
     store: std::sync::Arc<dyn crate::muc::durable::MucDurableStore>,
 ) -> ActorRef<RoomActor> {
     let actor = spawn_room_actor().await;
+    bind_test_room_claim_fence(&actor).await;
     actor
         .ask(RestoreDurableRoomState { store })
         .await
         .expect("restore");
     actor
+}
+
+#[tokio::test]
+async fn claim_fence_binding_is_idempotent_but_a_different_epoch_stops_the_actor() {
+    let actor = spawn_room_actor().await;
+    let e1 = test_room_claim_fence(1);
+    let e2 = test_room_claim_fence(2);
+
+    actor
+        .ask(BindRoomClaimFence { fence: e1.clone() })
+        .await
+        .expect("first E1 bind");
+    actor
+        .ask(BindRoomClaimFence { fence: e1.clone() })
+        .await
+        .expect("identical E1 retry is idempotent");
+    assert_eq!(
+        actor.ask(GetRoomClaimFence).await.expect("bound fence"),
+        Some(e1.clone())
+    );
+
+    let rebound = actor.ask(BindRoomClaimFence { fence: e2.clone() }).await;
+    assert!(matches!(
+        rebound,
+        Err(SendError::HandlerError(
+            BindRoomClaimFenceError::ConflictingFence { bound, attempted }
+        )) if bound == e1 && attempted == e2
+    ));
+    tokio::task::yield_now().await;
+    assert!(
+        !actor.is_alive(),
+        "a retained actor that receives a different incarnation must stop"
+    );
+}
+
+#[tokio::test]
+async fn durable_actor_without_an_exact_fence_never_uses_the_latest_room_claim() {
+    let store = ExactIncarnationStore::new(test_room_claim_fence(2));
+    let actor = spawn_room_actor().await;
+    actor
+        .ask(RestoreDurableRoomState {
+            store: store.clone(),
+        })
+        .await
+        .expect("restore");
+
+    let mut config = actor.ask(GetConfig).await.expect("config");
+    config.members_only = !config.members_only;
+    assert!(matches!(
+        actor.ask(UpdateConfig { config }).await,
+        Err(SendError::HandlerError(
+            RoomMutationError::OwnershipUncertain
+        ))
+    ));
+    assert_eq!(store.legacy_call_count(), 0);
+    assert_eq!(store.exact_call_count(), 0);
+}
+
+#[tokio::test]
+async fn retained_e1_actor_cannot_mutate_pin_join_or_fanout_after_e2_is_live() {
+    use crate::muc::pin::PinStateChange;
+    use waddle_xmpp_core::xep0359::StanzaId;
+
+    let e1 = test_room_claim_fence(1);
+    let e2 = test_room_claim_fence(2);
+    let store = ExactIncarnationStore::new(e2.clone());
+    let actor = spawn_room_actor().await;
+    actor
+        .ask(BindRoomClaimFence { fence: e1.clone() })
+        .await
+        .expect("bind retained E1");
+    actor
+        .ask(RestoreDurableRoomState {
+            store: store.clone(),
+        })
+        .await
+        .expect("restore against E2-backed store");
+
+    assert_eq!(
+        actor.ask(GetRoomClaimFence).await.expect("actor fence"),
+        Some(e1.clone()),
+        "the retained actor must never adopt the newest room-scoped E2"
+    );
+    assert!(matches!(
+        actor
+            .ask(Join {
+                nick: "alice".to_string(),
+                real_jid: test_full_jid("alice"),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await,
+        Err(SendError::HandlerError(RoomActorError::NotOwner))
+    ));
+    assert_eq!(actor.ask(OccupantCount).await.expect("count"), 0);
+
+    let original_config = actor.ask(GetConfig).await.expect("config");
+    let mut changed_config = original_config.clone();
+    changed_config.members_only = !changed_config.members_only;
+    assert!(matches!(
+        actor
+            .ask(UpdateConfig {
+                config: changed_config
+            })
+            .await,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert_eq!(
+        actor
+            .ask(GetConfig)
+            .await
+            .expect("unchanged config")
+            .members_only,
+        original_config.members_only
+    );
+
+    let target = StanzaId::new(
+        "pin-target",
+        "testroom@muc.example.com"
+            .parse::<jid::Jid>()
+            .expect("room jid"),
+    );
+    assert!(matches!(
+        actor
+            .ask(ApplyPin {
+                change: PinStateChange::Unpin {
+                    target_stanza_id: target,
+                },
+            })
+            .await,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert!(actor.ask(GetPinList).await.expect("pins").is_empty());
+
+    assert!(!store
+        .check_fenced_fanout_exact(&test_room().room_jid, &e1)
+        .await
+        .expect("E1 fanout proof"));
+    assert!(store
+        .check_fenced_fanout_exact(&test_room().room_jid, &e2)
+        .await
+        .expect("E2 fanout proof"));
+    assert_eq!(
+        store.legacy_call_count(),
+        0,
+        "no retained-E1 path may fall back to the latest room-scoped claim"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -3611,6 +3967,7 @@ async fn join_is_refused_while_restore_is_pending_then_succeeds_once_recovered_w
     // in-line retry (calls 0 and 1); the SECOND retry (call 2) succeeds.
     let store = FlakyThenRecoveringStore::new(2, banned.clone());
     let actor = spawn_room_actor().await;
+    bind_test_room_claim_fence(&actor).await;
     actor
         .ask(RestoreDurableRoomState {
             store: store.clone(),
@@ -3659,7 +4016,8 @@ async fn join_is_refused_while_restore_is_pending_then_succeeds_once_recovered_w
 
 #[tokio::test]
 async fn update_config_gate_blocks_the_mutation_when_deposed() {
-    let actor = spawn_room_actor_with_store(FakeDurableStore::deposed()).await;
+    let store = FakeDurableStore::deposed();
+    let actor = spawn_room_actor_with_store(store.clone()).await;
     let original = actor.ask(GetConfig).await.expect("ask").members_only;
 
     let mut new_config = actor.ask(GetConfig).await.expect("ask");
@@ -3677,6 +4035,11 @@ async fn update_config_gate_blocks_the_mutation_when_deposed() {
     assert_eq!(
         after, original,
         "a gated-out mutation must never have applied in-memory"
+    );
+    assert_eq!(
+        store.save_call_count(),
+        0,
+        "a proven ownership loss must not attempt the durable mutation"
     );
 }
 
@@ -3698,21 +4061,33 @@ async fn update_config_gate_allows_the_mutation_when_owned() {
 }
 
 #[tokio::test]
-async fn update_config_gate_fails_open_on_a_transient_fencing_error() {
-    let actor = spawn_room_actor_with_store(FakeDurableStore::transient_failure()).await;
+async fn update_config_gate_fails_closed_on_ownership_uncertainty() {
+    let store = FakeDurableStore::transient_failure();
+    let actor = spawn_room_actor_with_store(store.clone()).await;
     let original = actor.ask(GetConfig).await.expect("ask").members_only;
 
     let mut new_config = actor.ask(GetConfig).await.expect("ask");
     new_config.members_only = !original;
-    actor
-        .ask(UpdateConfig { config: new_config })
-        .await
-        .expect("a transient fencing failure must fail OPEN, not block the mutation");
+    let result = actor.ask(UpdateConfig { config: new_config }).await;
+    assert!(
+        matches!(
+            result,
+            Err(SendError::HandlerError(
+                RoomMutationError::OwnershipUncertain
+            ))
+        ),
+        "expected typed OwnershipUncertain, got: {result:?}"
+    );
 
     let after = actor.ask(GetConfig).await.expect("ask").members_only;
-    assert_ne!(
+    assert_eq!(
         after, original,
-        "fail-open means the mutation still applies despite the transient error"
+        "ownership uncertainty must not mutate in-memory state"
+    );
+    assert_eq!(
+        store.save_call_count(),
+        0,
+        "ownership uncertainty must not attempt the durable mutation"
     );
 }
 
@@ -3739,6 +4114,35 @@ async fn update_config_surfaces_a_typed_persist_failure_after_mutating() {
     // only the caller's visibility into durable convergence changed.
     let after = actor.ask(GetConfig).await.expect("ask").members_only;
     assert_ne!(after, original, "the in-memory mutation still applies");
+}
+
+#[tokio::test]
+async fn gate_pass_then_durable_fence_loss_surfaces_not_owner() {
+    let store = FakeDurableStore::owned_but_loses_fence_during_persist();
+    let actor = spawn_room_actor_with_store(store.clone()).await;
+    let mut config = actor.ask(GetConfig).await.expect("config");
+    config.members_only = !config.members_only;
+
+    let result = actor.ask(UpdateConfig { config }).await;
+
+    assert!(matches!(
+        result,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert_eq!(store.save_call_count(), 1);
+
+    let mut retry = actor.ask(GetConfig).await.expect("config after loss");
+    retry.members_only = !retry.members_only;
+    let retry_result = actor.ask(UpdateConfig { config: retry }).await;
+    assert!(matches!(
+        retry_result,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert_eq!(
+        store.save_call_count(),
+        1,
+        "the removed cached epoch must fail at the gate without another save"
+    );
 }
 
 #[tokio::test]
@@ -3788,6 +4192,283 @@ async fn set_subject_gate_blocks_the_mutation_when_deposed() {
         ),
         "expected NotOwner, got: {result:?}"
     );
+}
+
+#[tokio::test]
+async fn legacy_join_gate_blocks_stale_and_uncertain_actors_without_occupancy_mutation() {
+    for (store, expected) in [
+        (FakeDurableStore::deposed(), RoomActorError::NotOwner),
+        (
+            FakeDurableStore::transient_failure(),
+            RoomActorError::OwnershipUncertain,
+        ),
+    ] {
+        let actor = spawn_room_actor_with_store(store).await;
+        let result = actor
+            .ask(Join {
+                nick: "alice".to_string(),
+                real_jid: test_full_jid("alice"),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await;
+        let Err(SendError::HandlerError(actual)) = result else {
+            panic!("legacy Join must return a typed ownership failure");
+        };
+        assert_eq!(actual, expected);
+        assert_eq!(actor.ask(OccupantCount).await.expect("count"), 0);
+    }
+}
+
+#[tokio::test]
+async fn legacy_leave_gate_does_not_remove_an_occupant_after_claim_loss() {
+    let actor = spawn_room_actor().await;
+    actor
+        .ask(Join {
+            nick: "alice".to_string(),
+            real_jid: test_full_jid("alice"),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("seed occupant before fencing");
+    bind_test_room_claim_fence(&actor).await;
+    actor
+        .ask(RestoreDurableRoomState {
+            store: FakeDurableStore::deposed(),
+        })
+        .await
+        .expect("wire deposed store");
+
+    let result = actor
+        .ask(Leave {
+            nick: "alice".to_string(),
+        })
+        .await;
+    assert!(matches!(
+        result,
+        Err(SendError::HandlerError(RoomActorError::NotOwner))
+    ));
+    assert_eq!(actor.ask(OccupantCount).await.expect("count"), 1);
+}
+
+#[tokio::test]
+async fn set_subject_rolls_back_when_durable_persist_fails() {
+    let actor = spawn_room_actor_with_store(FakeDurableStore::owned_but_persist_fails()).await;
+    let before = actor.ask(GetSnapshot).await.expect("snapshot").room.subject;
+    let result = actor
+        .ask(SetSubject {
+            texts: RoomSubjectTexts::from_iter([(String::new(), "new subject".to_string())]),
+            setter: "alice@example.com".parse().expect("bare jid"),
+            setter_nick: "alice".to_string(),
+            set_at: chrono::Utc::now(),
+        })
+        .await;
+    assert!(matches!(
+        result,
+        Err(SendError::HandlerError(RoomMutationError::PersistFailed(_)))
+    ));
+    assert_eq!(
+        actor.ask(GetSnapshot).await.expect("snapshot").room.subject,
+        before,
+        "subject must not remain locally changed when its durable write fails"
+    );
+}
+
+#[tokio::test]
+async fn apply_admin_items_returns_applied_effects_with_persist_failure() {
+    let actor = spawn_room_actor().await;
+    let owner: BareJid = "owner@example.com".parse().expect("bare jid");
+    actor
+        .ask(ChangeAffiliation {
+            jid: owner.clone(),
+            affiliation: Affiliation::Owner,
+        })
+        .await
+        .expect("seed owner");
+    bind_test_room_claim_fence(&actor).await;
+    actor
+        .ask(RestoreDurableRoomState {
+            store: FakeDurableStore::owned_but_persist_fails(),
+        })
+        .await
+        .expect("wire failing durable store");
+    let member: BareJid = "member@example.com".parse().expect("bare jid");
+    let applied = actor
+        .ask(ApplyAdminItems {
+            sender_jid: "owner@example.com/web".parse().expect("full jid"),
+            sender_affiliation: Affiliation::Owner,
+            sender_role: Role::Moderator,
+            items: vec![AdminItem {
+                jid: Some(member.clone()),
+                nick: None,
+                affiliation: Some(Affiliation::Member),
+                role: None,
+                reason: None,
+            }],
+        })
+        .await
+        .expect("already-applied outcome must not be discarded");
+    assert!(applied.persist_failure.is_some());
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid: member })
+            .await
+            .expect("affiliation"),
+        Affiliation::Member,
+        "the outcome reports convergence failure alongside the committed actor mutation"
+    );
+}
+
+#[tokio::test]
+async fn apply_admin_items_drops_old_owner_fanout_after_save_fence_loss() {
+    let actor = spawn_room_actor().await;
+    let owner: BareJid = "owner@example.com".parse().expect("bare jid");
+    actor
+        .ask(ChangeAffiliation {
+            jid: owner,
+            affiliation: Affiliation::Owner,
+        })
+        .await
+        .expect("seed owner");
+    bind_test_room_claim_fence(&actor).await;
+    actor
+        .ask(RestoreDurableRoomState {
+            store: FakeDurableStore::owned_but_loses_fence_during_persist(),
+        })
+        .await
+        .expect("wire fence-loss store");
+
+    let result = actor
+        .ask(ApplyAdminItems {
+            sender_jid: "owner@example.com/web".parse().expect("full jid"),
+            sender_affiliation: Affiliation::Owner,
+            sender_role: Role::Moderator,
+            items: vec![AdminItem {
+                jid: Some("member@example.com".parse().expect("bare jid")),
+                nick: None,
+                affiliation: Some(Affiliation::Member),
+                role: None,
+                reason: None,
+            }],
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(SendError::HandlerError(AdminApplyError::NotOwner))
+    ));
+}
+
+#[tokio::test]
+async fn live_occupancy_pin_and_presence_handlers_refuse_a_stolen_actor() {
+    use crate::muc::pin::PinStateChange;
+    use waddle_xmpp_core::xep0359::StanzaId;
+
+    let actor = spawn_room_actor().await;
+    let alice = test_full_jid("alice");
+    actor
+        .ask(Join {
+            nick: "alice".to_string(),
+            real_jid: alice.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("seed occupant");
+    let admission_revision = actor
+        .ask(GetSnapshot)
+        .await
+        .expect("snapshot")
+        .admission_revision;
+    bind_test_room_claim_fence(&actor).await;
+    actor
+        .ask(RestoreDurableRoomState {
+            store: FakeDurableStore::deposed(),
+        })
+        .await
+        .expect("wire deposed store");
+
+    assert!(matches!(
+        actor
+            .ask(JoinWithAffiliation {
+                sender_jid: test_full_jid("bob"),
+                nick: "bob".to_string(),
+                affiliation_grant: JoinAffiliationGrant::Resolver(Affiliation::Member),
+                local_domain: "example.com".to_string(),
+                admission_revision,
+            })
+            .await,
+        Err(SendError::HandlerError(RoomActorError::NotOwner))
+    ));
+    assert!(matches!(
+        actor
+            .ask(PresenceUpdateData {
+                sender_jid: alice.clone()
+            })
+            .await,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert!(matches!(
+        actor
+            .ask(UpsertMujiPresence {
+                sender_jid: alice.clone(),
+                muji: audio_muji(),
+            })
+            .await,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert!(matches!(
+        actor
+            .ask(ClearMujiPresence {
+                sender_jid: alice.clone()
+            })
+            .await,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert!(matches!(
+        actor
+            .ask(UpsertInCallState {
+                sender_jid: alice.clone(),
+                state: crate::xep::InCallPresenceState::default(),
+            })
+            .await,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert!(matches!(
+        actor
+            .ask(SyncResolverAffiliation {
+                jid: "bob@example.com".parse().expect("bare jid"),
+                affiliation: Affiliation::Member,
+                expected_admission_revision: admission_revision,
+            })
+            .await,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    let target = StanzaId::new(
+        "pin-target",
+        "testroom@muc.example.com".parse::<jid::Jid>().expect("jid"),
+    );
+    assert!(matches!(
+        actor
+            .ask(ApplyPin {
+                change: PinStateChange::Unpin {
+                    target_stanza_id: target,
+                },
+            })
+            .await,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert!(matches!(
+        actor.ask(EnforceMembersOnly).await,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert!(matches!(
+        actor.ask(LeaveByRealJid { sender_jid: alice }).await,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert_eq!(actor.ask(OccupantCount).await.expect("count"), 1);
+    assert!(actor.ask(GetPinList).await.expect("pins").is_empty());
 }
 
 /// A resolver-derived affiliation must never replace an explicit grant
@@ -4100,6 +4781,72 @@ async fn stale_sync_resolver_affiliation_does_not_clear_readmitted_member() {
         Affiliation::Member,
         "a stale rejection sync must not clear the live occupant's re-derived Member"
     );
+}
+
+/// The owner-destroy seal is ordered in the actor mailbox: it includes every
+/// previously committed join in its final snapshot and refuses later joins.
+#[tokio::test]
+async fn owner_destroy_seal_snapshots_prior_joins_and_refuses_later_joins() {
+    let actor = spawn_room_actor().await;
+    let alice = test_full_jid("alice");
+    let bob = test_full_jid("bob");
+    actor
+        .tell(Join {
+            nick: "alice".to_string(),
+            real_jid: alice.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("queue Alice before owner-destroy seal");
+
+    let snapshot = actor
+        .ask(SealForOwnerDestroy)
+        .await
+        .expect("seal and snapshot");
+    assert_eq!(snapshot.room.occupant_count(), 1);
+    assert_eq!(snapshot.room.find_nick_by_real_jid(&alice), Some("alice"));
+
+    let later_join = actor
+        .ask(Join {
+            nick: "bob".to_string(),
+            real_jid: bob.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await;
+    assert!(matches!(
+        later_join,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert!(
+        snapshot.room.find_nick_by_real_jid(&bob).is_none(),
+        "the reserved snapshot excludes joins attempted after its seal"
+    );
+}
+
+#[tokio::test]
+async fn owner_destroy_seal_uncertainty_leaves_actor_unsealed_and_joinable() {
+    let store = FakeDurableStore::transient_failure();
+    let actor = spawn_room_actor_with_store(store.clone()).await;
+
+    let seal = actor.ask(SealForOwnerDestroy).await;
+    assert!(matches!(
+        seal,
+        Err(SendError::HandlerError(RoomActorError::OwnershipUncertain))
+    ));
+    assert!(!actor.ask(IsSealed).await.expect("sealed state"));
+
+    *store.fenced.lock().expect("fence lock") = Some(true);
+    actor
+        .ask(Join {
+            nick: "alice".to_string(),
+            real_jid: test_full_jid("alice"),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("a failed seal must not leave the actor closed to joins");
 }
 
 /// A sealed actor (#1108) is pending destruction; a delayed rejection

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -12,30 +12,31 @@ use kameo::actor::{ActorRef, Spawn};
 use kameo::message::Context;
 use kameo::Actor;
 use thiserror::Error;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::affiliation::DurableMembershipSource;
 use super::durable::MucDurableStore;
 use super::room_actor::{
-    HydrateDurableRecipients, IsSealed, RestoreDurableRoomState, RoomActor, SealGuard,
-    SealIfInactive,
+    BindRoomClaimFence, HydrateDurableRecipients, IsSealed, RestoreDurableRoomState, RoomActor,
+    RoomSnapshot, SealForOwnerDestroy, SealGuard, SealIfInactive,
 };
-use super::{MucRoom, RoomConfig};
+use super::{MucRoom, RoomClaimFenceContext, RoomConfig};
 use crate::metrics;
 use crate::ownership::{
-    ClaimEpoch, ClaimError, ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity,
-    RolloutBackoff, SharedNodeIdentity, StalePredicate,
+    ClaimEpoch, ClaimError, ClaimGrant, ClaimStore, Entity, EntityType, InProcessClaimStore,
+    NodeIdentity, RolloutBackoff, SharedNodeIdentity, StalePredicate,
 };
 use crate::xep::xep0421::OccupantIdSecret;
 
-/// A locally-spawned room's actor ref plus the Postgres claim epoch this
-/// node acquired/won it under (ADR-0017 Phase 3 Slice 7). The epoch
-/// travels with the actor ref so [`RoomRegistryActor::DestroyRoom`] can
-/// release the exact claim this incarnation holds.
+/// A locally-spawned room's actor ref plus the exact Postgres claim grant
+/// this actor incarnation was spawned under. The owner identity must travel
+/// with the epoch: [`SharedNodeIdentity`] can rotate after self-fencing, and
+/// using its later value to release this actor's claim would turn an intended
+/// release into a silent epoch-gated no-op.
 #[derive(Clone)]
 struct RoomEntry {
     actor_ref: ActorRef<RoomActor>,
-    claim_epoch: ClaimEpoch,
+    claim_grant: ClaimGrant,
 }
 
 /// Actor that owns the mapping from room JIDs to per-room actors.
@@ -46,6 +47,11 @@ struct RoomEntry {
 pub struct RoomRegistryActor {
     rooms: HashMap<BareJid, RoomEntry>,
     poisoned_rooms: HashSet<BareJid>,
+    /// Exact grants whose terminal release returned backend uncertainty.
+    /// A room cannot be acquired or respawned while an entry remains here:
+    /// otherwise `ensure_claimed` could self-reacquire the surviving claim
+    /// and spawn E2 under E1's fencing epoch.
+    pending_claim_releases: HashMap<BareJid, ClaimGrant>,
     muc_domain: String,
     /// Per-deployment XEP-0421 occupant-id HMAC key. Forwarded to every
     /// `RoomActor` at spawn so all rooms in this deployment share the
@@ -88,6 +94,8 @@ pub enum RoomRegistryError {
     RoomAlreadyExists(BareJid),
     #[error("room actor state for {0} was lost; explicit destroy/recreate is required")]
     RoomActorStateLost(BareJid),
+    #[error("room {0}'s previous ownership claim release is still unresolved")]
+    ClaimReleasePending(BareJid),
     /// A request to the registry actor exceeded
     /// [`ROOM_REGISTRY_REPLY_TIMEOUT`](crate::muc::room_registry_handle::ROOM_REGISTRY_REPLY_TIMEOUT)
     /// without a reply. Surfaced (instead of hanging the caller indefinitely)
@@ -119,6 +127,7 @@ impl RoomRegistryActor {
         Self {
             rooms: HashMap::new(),
             poisoned_rooms: HashSet::new(),
+            pending_claim_releases: HashMap::new(),
             muc_domain,
             occupant_id_secret,
             membership_source: None,
@@ -139,8 +148,9 @@ impl RoomRegistryActor {
 
     /// Acquire this room's Postgres claim (ADR-0017 Phase 3 Slice 7),
     /// stealing from a dead owner (re-election) when the current owner's
-    /// own node lease is no longer fresh. Returns the epoch this node now
-    /// holds the claim under.
+    /// own node lease is no longer fresh. Returns the exact entity, owner
+    /// incarnation, and epoch this actor must remain bound to across every
+    /// later identity rotation.
     ///
     /// A live foreign owner (steal not applicable) is reported as
     /// [`RoomRegistryError::ClaimHeldByAnotherNode`] rather than
@@ -149,20 +159,21 @@ impl RoomRegistryActor {
     async fn acquire_room_claim(
         &self,
         room_jid: &BareJid,
-    ) -> Result<ClaimEpoch, RoomRegistryError> {
+    ) -> Result<ClaimGrant, RoomRegistryError> {
         let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
         let identity = self.node_identity.current();
-        match self.claim_store.ensure_claimed(&entity, &identity).await {
-            Ok(epoch) => Ok(epoch),
+        let epoch = match self.claim_store.ensure_claimed(&entity, &identity).await {
+            Ok(epoch) => epoch,
             Err(ClaimError::AlreadyClaimed) => {
                 self.steal_from_dead_owner(&entity, room_jid, &identity)
-                    .await
+                    .await?
             }
             Err(error) => {
                 warn!(room = %room_jid, %error, "room claim acquisition failed");
-                Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()))
+                return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()));
             }
-        }
+        };
+        Ok(ClaimGrant::new(entity, identity, epoch))
     }
 
     /// The re-election path: `entity`'s claim is held by another node —
@@ -272,12 +283,28 @@ impl RoomRegistryActor {
         waddle_id: String,
         channel_id: String,
         config: RoomConfig,
-        claim_epoch: ClaimEpoch,
+        claim_grant: ClaimGrant,
     ) -> ActorRef<RoomActor> {
+        debug_assert_eq!(
+            claim_grant.entity,
+            Entity::new(EntityType::RoomActor, room_jid.to_string())
+        );
         let room = MucRoom::new(room_jid.clone(), waddle_id, channel_id, config);
         let actor_ref = RoomActor::spawn(RoomActor::new(room, self.occupant_id_secret.clone()));
         if let Some(store) = &self.durable_store {
-            store.record_claim_epoch(&room_jid, claim_epoch);
+            store.record_claim_epoch(&room_jid, claim_grant.epoch);
+            let fence = RoomClaimFenceContext {
+                entity: claim_grant.entity.clone(),
+                epoch: claim_grant.epoch,
+                owner: claim_grant.owner.clone(),
+            };
+            if let Err(error) = actor_ref.tell(BindRoomClaimFence { fence }).await {
+                warn!(
+                    room = %room_jid,
+                    %error,
+                    "failed to bind exact room-actor claim fence"
+                );
+            }
             if let Err(error) = actor_ref
                 .tell(RestoreDurableRoomState {
                     store: Arc::clone(store),
@@ -311,7 +338,7 @@ impl RoomRegistryActor {
             room_jid,
             RoomEntry {
                 actor_ref: actor_ref.clone(),
-                claim_epoch,
+                claim_grant,
             },
         );
         actor_ref
@@ -326,14 +353,15 @@ impl RoomRegistryActor {
     /// epoch needed to release it, once `self.rooms.remove` ran) until
     /// this node's own liveness lease eventually looked stale to another
     /// node's `OwnerStale` steal. This capture-then-release closes that
-    /// gap: the claim epoch is read BEFORE the entry is removed, and
-    /// [`Self::release_room_claim`] runs on it — the exact same
-    /// best-effort, epoch-gated release [`DestroyRoom`]'s handler already
-    /// uses for the graceful-destroy path.
+    /// gap: the full claim grant is captured BEFORE the entry is removed,
+    /// and [`Self::release_room_claim`] retains it across backend failure —
+    /// the exact same fail-closed release [`DestroyRoom`]'s handler uses for
+    /// the graceful-destroy path.
     async fn live_room(
         &mut self,
         room_jid: &BareJid,
     ) -> Result<Option<ActorRef<RoomActor>>, RoomRegistryError> {
+        self.retry_pending_claim_release(room_jid).await?;
         if self.poisoned_rooms.contains(room_jid) {
             return Err(RoomRegistryError::RoomActorStateLost(room_jid.clone()));
         }
@@ -341,7 +369,7 @@ impl RoomRegistryActor {
             if entry.actor_ref.is_alive() {
                 return Ok(Some(entry.actor_ref.clone()));
             }
-            let claim_epoch = entry.claim_epoch;
+            let claim_grant = entry.claim_grant.clone();
             self.rooms.remove(room_jid);
             self.poisoned_rooms.insert(room_jid.clone());
             warn!(
@@ -354,29 +382,77 @@ impl RoomRegistryActor {
             // claim (this node holds it in Postgres but has no way left
             // to act on it), not merely a "fail fast and let the caller
             // retry" situation.
-            self.release_room_claim(room_jid, claim_epoch).await;
+            self.release_room_claim(room_jid, claim_grant).await;
             return Err(RoomRegistryError::RoomActorStateLost(room_jid.clone()));
         }
         Ok(None)
     }
 
-    /// Best-effort release of `room_jid`'s Postgres claim (dormancy
-    /// eviction / explicit destroy, element 7's "graceful release").
-    /// Epoch-gated and best-effort per [`ClaimStore::release`]'s own
-    /// contract — a claim already stolen out from under this node is a
-    /// no-op, not an error.
-    async fn release_room_claim(&self, room_jid: &BareJid, claim_epoch: ClaimEpoch) {
-        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
-        let identity = self.node_identity.current();
-        if let Err(error) = self
+    /// Queue and attempt an exact room-claim release. A backend error is
+    /// uncertainty, not permission to forget the grant: the surviving row
+    /// may still belong to the removed actor incarnation. Keeping it blocks
+    /// replacement until a retry proves the exact release completed (or was
+    /// already made irrelevant by a newer exact grant).
+    async fn release_room_claim(&mut self, room_jid: &BareJid, claim_grant: ClaimGrant) {
+        debug_assert_eq!(
+            claim_grant.entity,
+            Entity::new(EntityType::RoomActor, room_jid.to_string())
+        );
+        if let Some(existing) = self.pending_claim_releases.get(room_jid) {
+            if existing != &claim_grant {
+                error!(
+                    room = %room_jid,
+                    pending_owner = %existing.owner.node_id,
+                    pending_owner_epoch = %existing.owner.node_epoch,
+                    pending_claim_epoch = existing.epoch.0,
+                    rejected_owner = %claim_grant.owner.node_id,
+                    rejected_owner_epoch = %claim_grant.owner.node_epoch,
+                    rejected_claim_epoch = claim_grant.epoch.0,
+                    "refused to overwrite unresolved room-claim release evidence"
+                );
+            }
+        } else {
+            self.pending_claim_releases
+                .insert(room_jid.clone(), claim_grant);
+        }
+        let _ = self.retry_pending_claim_release(room_jid).await;
+    }
+
+    /// Retry the exact unresolved release before any room lookup can proceed
+    /// to acquisition. The captured owner is deliberate: the registry's
+    /// shared current identity may have rotated since E1 acquired the claim.
+    async fn retry_pending_claim_release(
+        &mut self,
+        room_jid: &BareJid,
+    ) -> Result<(), RoomRegistryError> {
+        let Some(claim_grant) = self.pending_claim_releases.get(room_jid).cloned() else {
+            return Ok(());
+        };
+        match self
             .claim_store
-            .release(&entity, &identity, claim_epoch)
+            .release(&claim_grant.entity, &claim_grant.owner, claim_grant.epoch)
             .await
         {
-            warn!(room = %room_jid, %error, "failed to release room ownership claim");
-        }
-        if let Some(store) = &self.durable_store {
-            store.forget_claim_epoch(room_jid);
+            Ok(()) => {
+                self.pending_claim_releases.remove(room_jid);
+                if !self.rooms.contains_key(room_jid) {
+                    if let Some(store) = &self.durable_store {
+                        store.forget_claim_epoch(room_jid);
+                    }
+                }
+                Ok(())
+            }
+            Err(error) => {
+                warn!(
+                    room = %room_jid,
+                    owner = %claim_grant.owner.node_id,
+                    owner_epoch = %claim_grant.owner.node_epoch,
+                    claim_epoch = claim_grant.epoch.0,
+                    %error,
+                    "room ownership claim release remains unresolved; replacement is fenced"
+                );
+                Err(RoomRegistryError::ClaimReleasePending(room_jid.clone()))
+            }
         }
     }
 }
@@ -481,7 +557,7 @@ impl kameo::message::Message<GetOrCreateRoom> for RoomRegistryActor {
             });
         }
 
-        let claim_epoch = self.acquire_room_claim(&msg.room_jid).await?;
+        let claim_grant = self.acquire_room_claim(&msg.room_jid).await?;
         info!(room = %msg.room_jid, "Creating new room via GetOrCreateRoom");
         self.poisoned_rooms.remove(&msg.room_jid);
         let actor_ref = self
@@ -490,7 +566,7 @@ impl kameo::message::Message<GetOrCreateRoom> for RoomRegistryActor {
                 msg.waddle_id,
                 msg.channel_id,
                 msg.config,
-                claim_epoch,
+                claim_grant,
             )
             .await;
         Ok(RoomAcquisition {
@@ -534,10 +610,10 @@ impl kameo::message::Message<CreateInstantRoom> for RoomRegistryActor {
             ..RoomConfig::default()
         };
 
-        let claim_epoch = self.acquire_room_claim(&msg.room_jid).await?;
+        let claim_grant = self.acquire_room_claim(&msg.room_jid).await?;
         self.poisoned_rooms.remove(&msg.room_jid);
         let actor_ref = self
-            .spawn_room(msg.room_jid, waddle_id, channel_id, config, claim_epoch)
+            .spawn_room(msg.room_jid, waddle_id, channel_id, config, claim_grant)
             .await;
         Ok(RoomAcquisition {
             actor_ref,
@@ -566,7 +642,7 @@ impl kameo::message::Message<CreateRoom> for RoomRegistryActor {
             return Err(RoomRegistryError::RoomAlreadyExists(msg.room_jid));
         }
 
-        let claim_epoch = self.acquire_room_claim(&msg.room_jid).await?;
+        let claim_grant = self.acquire_room_claim(&msg.room_jid).await?;
         info!(room = %msg.room_jid, "Creating new room");
         self.poisoned_rooms.remove(&msg.room_jid);
         let actor_ref = self
@@ -575,7 +651,7 @@ impl kameo::message::Message<CreateRoom> for RoomRegistryActor {
                 msg.waddle_id,
                 msg.channel_id,
                 msg.config,
-                claim_epoch,
+                claim_grant,
             )
             .await;
         Ok(actor_ref)
@@ -600,16 +676,12 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
         let removed_entry = self.rooms.remove(&msg.room_jid);
         let removed_room = removed_entry.is_some();
         let removed_poison = self.poisoned_rooms.remove(&msg.room_jid);
-        // ADR-0017 Phase 3 Slice 7: release the Postgres claim on every
-        // terminal path (explicit destroy, dormancy-eviction sweep) —
-        // "graceful release" per element 7. A poisoned-only removal (the
-        // actor died and was already detected by `live_room`) has no
-        // known epoch to release; the claim is instead reclaimed by
-        // another node's `OwnerStale` steal once this node's own liveness
-        // lease is what it takes to look stale (bounded residual gap,
-        // same class as FIX 6e's fail-open-detach gap).
+        // Release the exact grant on every terminal path. A poisoned-only
+        // removal keeps any unresolved grant in `pending_claim_releases`;
+        // clearing the poison is not allowed to discard that evidence.
         if let Some(entry) = removed_entry {
-            self.release_room_claim(&msg.room_jid, entry.claim_epoch)
+            entry.actor_ref.kill();
+            self.release_room_claim(&msg.room_jid, entry.claim_grant)
                 .await;
         }
         if removed_room || removed_poison {
@@ -619,6 +691,211 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
             warn!(room = %msg.room_jid, "Attempted to destroy non-existent room");
             false
         }
+    }
+}
+
+/// Destroy only the exact actor incarnation observed by the caller.
+///
+/// Long-running owner/moderation flows may retain E1 across snapshot or
+/// storage awaits while the registry advances the same room to E2. This
+/// actor-ref CAS prevents the stale flow from removing E2 or releasing E2's
+/// claim when it eventually reaches its destroy step.
+pub struct DestroyRoomExact {
+    pub room_jid: BareJid,
+    pub expected_actor: ActorRef<RoomActor>,
+}
+
+impl kameo::message::Message<DestroyRoomExact> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: DestroyRoomExact,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let is_expected_incarnation = self
+            .rooms
+            .get(&msg.room_jid)
+            .is_some_and(|entry| entry.actor_ref == msg.expected_actor);
+        if !is_expected_incarnation {
+            warn!(
+                room = %msg.room_jid,
+                "Refused exact room destroy because the registry now holds a different actor incarnation"
+            );
+            return false;
+        }
+
+        let Some(entry) = self.rooms.remove(&msg.room_jid) else {
+            return false;
+        };
+        entry.actor_ref.kill();
+        self.poisoned_rooms.remove(&msg.room_jid);
+        self.release_room_claim(&msg.room_jid, entry.claim_grant)
+            .await;
+        info!(room = %msg.room_jid, "Destroyed exact room actor incarnation");
+        true
+    }
+}
+
+/// Typed signal that the registry removed and killed the exact actor named by
+/// an owner-destroy flow while retaining its claim grant.
+///
+/// The registry does not process another room message until it receives
+/// [`RoomDestroyEffectsDone`] (or observes that signal's sender was dropped),
+/// so no replacement actor can appear while the caller emits the final
+/// XEP-0045 unavailable-presence and SFU effects.
+#[derive(Debug, Clone)]
+pub struct RoomDestroyEffectsReserved {
+    pub snapshot: RoomSnapshot,
+}
+
+/// Typed acknowledgement that the exact owner-destroy effects were emitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RoomDestroyEffectsDone;
+
+/// Destroy one exact room actor while serializing its external effects with
+/// replacement admission.
+///
+/// A plain check-then-destroy leaves a gap: E1 can pass its ownership check,
+/// another request can replace it with E2, and E1 can still emit unavailable
+/// presence or tear down E2's SFU participant before its final actor-ref CAS
+/// loses. This message makes the registry itself the barrier:
+///
+/// 1. actor-ref-CAS and re-prove E1's exact claim;
+/// 2. seal E1's admission mailbox and capture its final occupant snapshot;
+/// 3. remove and kill E1 while retaining its exact claim grant;
+/// 4. notify the caller that it alone may emit the snapshot's effects;
+/// 5. keep the registry mailbox blocked until the caller acknowledges the
+///    effects (dropping the acknowledgement sender also unblocks it);
+/// 6. release E1's exact claim before serving any queued E2 admission.
+pub struct DestroyRoomExactAfterEffects {
+    pub room_jid: BareJid,
+    pub expected_actor: ActorRef<RoomActor>,
+    pub effects_reserved: tokio::sync::oneshot::Sender<RoomDestroyEffectsReserved>,
+    pub effects_done: tokio::sync::oneshot::Receiver<RoomDestroyEffectsDone>,
+}
+
+impl kameo::message::Message<DestroyRoomExactAfterEffects> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: DestroyRoomExactAfterEffects,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let Some(entry) = self.rooms.get(&msg.room_jid).cloned() else {
+            return false;
+        };
+        if entry.actor_ref != msg.expected_actor {
+            warn!(
+                room = %msg.room_jid,
+                "Refused effect-serialized room destroy because the registry now holds a different actor incarnation"
+            );
+            return false;
+        }
+
+        // First re-prove the registry entry's exact grant against the claim
+        // store. Backend uncertainty leaves E1 untouched and unsealed; a
+        // definitive loss demotes it without effects.
+        match self
+            .claim_store
+            .fence(
+                &entry.claim_grant.entity,
+                &entry.claim_grant.owner,
+                entry.claim_grant.epoch,
+            )
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                warn!(
+                    room = %msg.room_jid,
+                    "Refused effect-serialized room destroy because its exact claim is no longer authoritative; demoting E1 without effects"
+                );
+                let Some(entry) = self.rooms.remove(&msg.room_jid) else {
+                    return false;
+                };
+                entry.actor_ref.kill();
+                self.poisoned_rooms.remove(&msg.room_jid);
+                self.release_room_claim(&msg.room_jid, entry.claim_grant)
+                    .await;
+                return false;
+            }
+            Err(error) => {
+                warn!(
+                    room = %msg.room_jid,
+                    %error,
+                    "Refused effect-serialized room destroy because exact claim authority could not be verified"
+                );
+                return false;
+            }
+        }
+
+        // The actor's mutation gate is the final cross-node proof and its
+        // mailbox is the final admission boundary. Joins queued before this
+        // message are included in the returned snapshot; later joins fail
+        // with RoomSealed. After this succeeds there is no fallible authority
+        // check before E1 is removed and the effect reservation is granted.
+        let snapshot = match entry.actor_ref.ask(SealForOwnerDestroy).await {
+            Ok(snapshot) => snapshot,
+            Err(kameo::error::SendError::HandlerError(
+                super::room_actor::RoomActorError::NotOwner,
+            )) => {
+                warn!(
+                    room = %msg.room_jid,
+                    "Owner-destroy seal proved E1 lost ownership; demoting without effects"
+                );
+                let Some(entry) = self.rooms.remove(&msg.room_jid) else {
+                    return false;
+                };
+                entry.actor_ref.kill();
+                self.poisoned_rooms.remove(&msg.room_jid);
+                self.release_room_claim(&msg.room_jid, entry.claim_grant)
+                    .await;
+                return false;
+            }
+            Err(error) => {
+                warn!(
+                    room = %msg.room_jid,
+                    ?error,
+                    "Owner-destroy could not seal E1 and capture its final occupant snapshot"
+                );
+                return false;
+            }
+        };
+
+        let Some(entry) = self.rooms.remove(&msg.room_jid) else {
+            return false;
+        };
+        entry.actor_ref.kill();
+        self.poisoned_rooms.remove(&msg.room_jid);
+
+        if msg
+            .effects_reserved
+            .send(RoomDestroyEffectsReserved { snapshot })
+            .is_ok()
+        {
+            match msg.effects_done.await {
+                Ok(RoomDestroyEffectsDone) => {}
+                Err(_) => debug!(
+                    room = %msg.room_jid,
+                    "Owner-destroy caller ended before acknowledging effects; completing exact claim release"
+                ),
+            }
+        } else {
+            debug!(
+                room = %msg.room_jid,
+                "Owner-destroy caller ended before accepting its effect reservation"
+            );
+        }
+
+        self.release_room_claim(&msg.room_jid, entry.claim_grant)
+            .await;
+        info!(
+            room = %msg.room_jid,
+            "Destroyed exact room actor after serialized owner-destroy effects"
+        );
+        true
     }
 }
 
@@ -671,12 +948,13 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
             Ok(true) => {
                 self.rooms.remove(&msg.room_jid);
                 self.poisoned_rooms.remove(&msg.room_jid);
+                entry.actor_ref.kill();
                 // ADR-0017 Phase 3 Slice 7: this is a terminal removal from
                 // `self.rooms` exactly like `DestroyRoom` — release the
                 // Postgres claim here too, or every guarded dormancy-evicted
                 // room leaks its claim until this node's own liveness lease
                 // looks stale to another node's `OwnerStale` steal.
-                self.release_room_claim(&msg.room_jid, entry.claim_epoch)
+                self.release_room_claim(&msg.room_jid, entry.claim_grant)
                     .await;
                 info!(room = %msg.room_jid, "Destroyed inactive room (guarded)");
                 true
@@ -734,7 +1012,7 @@ impl kameo::message::Message<ReapSealedRoom> for RoomRegistryActor {
             self.poisoned_rooms.remove(&msg.room_jid);
             // ADR-0017 Phase 3 Slice 7: same terminal-removal claim release
             // as the `live_room` dead-actor path and `DestroyRoom`.
-            self.release_room_claim(&msg.room_jid, entry.claim_epoch)
+            self.release_room_claim(&msg.room_jid, entry.claim_grant)
                 .await;
             info!(room = %msg.room_jid, "Reaped dead room actor during sealed-room purge");
             return true;
@@ -749,9 +1027,10 @@ impl kameo::message::Message<ReapSealedRoom> for RoomRegistryActor {
             Ok(true) => {
                 self.rooms.remove(&msg.room_jid);
                 self.poisoned_rooms.remove(&msg.room_jid);
+                entry.actor_ref.kill();
                 // ADR-0017 Phase 3 Slice 7: same terminal-removal claim
                 // release as the guarded-destroy path above.
-                self.release_room_claim(&msg.room_jid, entry.claim_epoch)
+                self.release_room_claim(&msg.room_jid, entry.claim_grant)
                     .await;
                 info!(
                     room = %msg.room_jid,
@@ -830,6 +1109,70 @@ impl kameo::message::Message<ListRooms> for RoomRegistryActor {
             }
         }
         Ok(live_rooms)
+    }
+}
+
+/// Forget and hard-kill every locally held room actor after this entire node
+/// loses its cluster lease. The registry map is drained atomically in one
+/// mailbox message so terminal fencing is not serialized into one bounded ask
+/// per room. Claims are intentionally not released under the fenced identity.
+pub struct DemoteAllRooms;
+
+impl kameo::message::Message<DemoteAllRooms> for RoomRegistryActor {
+    type Reply = usize;
+
+    async fn handle(
+        &mut self,
+        _msg: DemoteAllRooms,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let rooms = std::mem::take(&mut self.rooms);
+        let count = rooms.len();
+        self.poisoned_rooms.clear();
+        // Do not clear `pending_claim_releases`: those grants already belong
+        // to removed actors and retain the exact pre-rotation owner needed
+        // for a safe retry after this self-fence changes node identity.
+        for entry in rooms.into_values() {
+            entry.actor_ref.kill();
+        }
+        debug!(count, "Demoted every local RoomActor after node self-fence");
+        count
+    }
+}
+
+/// Demote one room only when the relay request names the exact local node
+/// incarnation that held the superseded claim and the local actor has not
+/// already advanced to the carried winning claim epoch (or beyond).
+pub struct DemoteRoomIfSuperseded {
+    pub room_jid: BareJid,
+    pub expected_owner: NodeIdentity,
+    pub new_epoch: ClaimEpoch,
+}
+
+impl kameo::message::Message<DemoteRoomIfSuperseded> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: DemoteRoomIfSuperseded,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let should_demote = self.rooms.get(&msg.room_jid).is_some_and(|entry| {
+            entry.claim_grant.owner == msg.expected_owner && entry.claim_grant.epoch < msg.new_epoch
+        });
+        if !should_demote {
+            return false;
+        }
+        let Some(entry) = self.rooms.remove(&msg.room_jid) else {
+            return false;
+        };
+        entry.actor_ref.kill();
+        debug!(
+            room = %msg.room_jid,
+            winning_epoch = msg.new_epoch.0,
+            "Demoted superseded local RoomActor"
+        );
+        true
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use kameo::actor::Spawn;
 use kameo::error::SendError;
+use waddle_xmpp_core::{Affiliation, Role};
 
 fn test_room_jid(name: &str) -> BareJid {
     format!("{}@muc.example.com", name)
@@ -150,7 +151,7 @@ async fn test_destroy_room() {
     let registry = spawn_registry().await;
     let jid = test_room_jid("doomed");
 
-    registry
+    let actor = registry
         .ask(CreateRoom {
             room_jid: jid.clone(),
             waddle_id: "w-1".to_string(),
@@ -167,12 +168,265 @@ async fn test_destroy_room() {
         .await
         .expect("destroy");
     assert!(removed);
+    tokio::task::yield_now().await;
+    assert!(
+        !actor.is_alive(),
+        "registry removal must hard-kill retained actor refs"
+    );
 
     let exists: bool = registry
         .ask(RoomExists { room_jid: jid })
         .await
         .expect("exists");
     assert!(!exists);
+}
+
+#[tokio::test]
+async fn stale_exact_destroy_cannot_remove_a_replacement_actor() {
+    let registry = spawn_registry().await;
+    let jid = test_room_jid("destroy-aba");
+    let e1 = registry
+        .ask(CreateRoom {
+            room_jid: jid.clone(),
+            waddle_id: "w-1".to_string(),
+            channel_id: "c-1".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("create E1");
+    assert!(registry
+        .ask(DestroyRoomExact {
+            room_jid: jid.clone(),
+            expected_actor: e1.clone(),
+        })
+        .await
+        .expect("destroy E1"));
+
+    let e2 = registry
+        .ask(CreateRoom {
+            room_jid: jid.clone(),
+            waddle_id: "w-2".to_string(),
+            channel_id: "c-2".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("create E2");
+
+    assert!(
+        !registry
+            .ask(DestroyRoomExact {
+                room_jid: jid.clone(),
+                expected_actor: e1,
+            })
+            .await
+            .expect("stale E1 destroy CAS"),
+        "retained E1 must not remove or release the replacement E2"
+    );
+    let current = registry
+        .ask(GetRoom { room_jid: jid })
+        .await
+        .expect("get E2")
+        .expect("E2 remains registered");
+    assert_eq!(current, e2);
+    assert!(e2.is_alive());
+}
+
+#[tokio::test]
+async fn exact_effect_barrier_blocks_replacement_until_effects_finish() {
+    let registry = spawn_registry().await;
+    let jid = test_room_jid("destroy-effect-barrier");
+    let e1 = registry
+        .ask(CreateRoom {
+            room_jid: jid.clone(),
+            waddle_id: "w-1".to_string(),
+            channel_id: "c-1".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("create E1");
+    let alice: jid::FullJid = "alice@example.com/web".parse().expect("Alice JID");
+    e1.tell(crate::muc::room_actor::Join {
+        nick: "alice".to_string(),
+        real_jid: alice.clone(),
+        role: Role::Moderator,
+        affiliation: Affiliation::Owner,
+    })
+    .await
+    .expect("queue Alice before owner-destroy seal");
+
+    let (reserved_sender, reserved_receiver) = tokio::sync::oneshot::channel();
+    let (done_sender, done_receiver) = tokio::sync::oneshot::channel();
+    let destroy_registry = registry.clone();
+    let destroy_jid = jid.clone();
+    let destroy_e1 = e1.clone();
+    let destroy = tokio::spawn(async move {
+        destroy_registry
+            .ask(DestroyRoomExactAfterEffects {
+                room_jid: destroy_jid,
+                expected_actor: destroy_e1,
+                effects_reserved: reserved_sender,
+                effects_done: done_receiver,
+            })
+            .await
+    });
+
+    let RoomDestroyEffectsReserved { snapshot } =
+        reserved_receiver.await.expect("E1 effect reservation");
+    assert_eq!(
+        snapshot.room.find_nick_by_real_jid(&alice),
+        Some("alice"),
+        "the reserved final snapshot includes joins committed before the seal"
+    );
+    tokio::task::yield_now().await;
+    assert!(!e1.is_alive(), "the reserved E1 must already be stopped");
+
+    let create_registry = registry.clone();
+    let create_jid = jid.clone();
+    let mut create_e2 = tokio::spawn(async move {
+        create_registry
+            .ask(CreateRoom {
+                room_jid: create_jid,
+                waddle_id: "w-2".to_string(),
+                channel_id: "c-2".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+    });
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_millis(25), &mut create_e2)
+            .await
+            .is_err(),
+        "the serialized registry must not process E2 while E1 effects are reserved"
+    );
+
+    done_sender
+        .send(RoomDestroyEffectsDone)
+        .expect("acknowledge E1 effects");
+    assert!(destroy.await.expect("destroy task").expect("destroy E1"));
+    let e2 = create_e2
+        .await
+        .expect("create task")
+        .expect("create E2 after E1 effects");
+    assert!(e2.is_alive());
+}
+
+#[tokio::test]
+async fn dropping_effect_acknowledgement_unblocks_exact_destroy() {
+    let registry = spawn_registry().await;
+    let jid = test_room_jid("destroy-effect-cancel");
+    let e1 = registry
+        .ask(CreateRoom {
+            room_jid: jid.clone(),
+            waddle_id: "w-1".to_string(),
+            channel_id: "c-1".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("create E1");
+
+    let (reserved_sender, reserved_receiver) = tokio::sync::oneshot::channel();
+    let (done_sender, done_receiver) = tokio::sync::oneshot::channel();
+    let destroy_registry = registry.clone();
+    let destroy_jid = jid.clone();
+    let destroy = tokio::spawn(async move {
+        destroy_registry
+            .ask(DestroyRoomExactAfterEffects {
+                room_jid: destroy_jid,
+                expected_actor: e1,
+                effects_reserved: reserved_sender,
+                effects_done: done_receiver,
+            })
+            .await
+    });
+
+    let RoomDestroyEffectsReserved { snapshot } =
+        reserved_receiver.await.expect("E1 effect reservation");
+    assert!(snapshot.room.occupants.is_empty());
+    drop(done_sender);
+    assert!(
+        tokio::time::timeout(std::time::Duration::from_secs(1), destroy)
+            .await
+            .expect("destroy must unblock when caller is cancelled")
+            .expect("destroy task")
+            .expect("destroy E1")
+    );
+
+    let e2 = registry
+        .ask(CreateRoom {
+            room_jid: jid,
+            waddle_id: "w-2".to_string(),
+            channel_id: "c-2".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("replacement after cancelled effect caller");
+    assert!(e2.is_alive());
+}
+
+#[tokio::test]
+async fn concurrent_exact_effect_barriers_reserve_effects_once() {
+    let registry = spawn_registry().await;
+    let jid = test_room_jid("destroy-effect-single-winner");
+    let e1 = registry
+        .ask(CreateRoom {
+            room_jid: jid.clone(),
+            waddle_id: "w-1".to_string(),
+            channel_id: "c-1".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("create E1");
+
+    let (reserved_one_sender, reserved_one_receiver) = tokio::sync::oneshot::channel();
+    let (done_one_sender, done_one_receiver) = tokio::sync::oneshot::channel();
+    let first_registry = registry.clone();
+    let first_jid = jid.clone();
+    let first_e1 = e1.clone();
+    let first = tokio::spawn(async move {
+        first_registry
+            .ask(DestroyRoomExactAfterEffects {
+                room_jid: first_jid,
+                expected_actor: first_e1,
+                effects_reserved: reserved_one_sender,
+                effects_done: done_one_receiver,
+            })
+            .await
+    });
+    let RoomDestroyEffectsReserved { snapshot } = reserved_one_receiver
+        .await
+        .expect("first effect reservation");
+    assert!(snapshot.room.occupants.is_empty());
+
+    let (reserved_two_sender, reserved_two_receiver) = tokio::sync::oneshot::channel();
+    let (done_two_sender, done_two_receiver) = tokio::sync::oneshot::channel();
+    let second_registry = registry.clone();
+    let second = tokio::spawn(async move {
+        second_registry
+            .ask(DestroyRoomExactAfterEffects {
+                room_jid: jid,
+                expected_actor: e1,
+                effects_reserved: reserved_two_sender,
+                effects_done: done_two_receiver,
+            })
+            .await
+    });
+
+    done_one_sender
+        .send(RoomDestroyEffectsDone)
+        .expect("complete first effects");
+    assert!(first.await.expect("first task").expect("first destroy"));
+    drop(done_two_sender);
+    assert!(
+        !second
+            .await
+            .expect("second task")
+            .expect("second destroy reply"),
+        "only the exact first barrier may win"
+    );
+    assert!(
+        reserved_two_receiver.await.is_err(),
+        "the losing barrier must never receive effect authority"
+    );
 }
 
 /// #1134: the "did this call create the room?" bit must come from the
@@ -321,15 +575,12 @@ async fn guarded_destroy_refuses_when_join_landed_after_dormancy_probe() {
 }
 
 /// #1108 second half: a caller that grabbed the ActorRef before the
-/// guarded destroy and sends its join afterwards must get a typed,
-/// retryable refusal (the sealed actor never silently admits an
-/// occupant into a destroyed room), so the join handler can re-run
-/// the registry lookup and respawn the room.
+/// guarded destroy cannot send a join afterwards. Registry removal now
+/// hard-kills every actor incarnation, so the stale ref is stopped rather
+/// than remaining alive merely to return `RoomSealed`.
 #[tokio::test]
-async fn sealed_room_refuses_late_join_with_retryable_error() {
-    use crate::muc::room_actor::{
-        IsDormant, JoinAffiliationGrant, JoinWithAffiliation, RoomActorError, SealGuard,
-    };
+async fn removed_room_hard_kills_stale_actor_ref() {
+    use crate::muc::room_actor::{IsDormant, JoinAffiliationGrant, JoinWithAffiliation, SealGuard};
     use crate::types::Affiliation;
 
     let registry = spawn_registry().await;
@@ -370,10 +621,10 @@ async fn sealed_room_refuses_late_join_with_retryable_error() {
     assert!(
         matches!(
             result,
-            Err(SendError::HandlerError(RoomActorError::RoomSealed))
+            Err(SendError::ActorNotRunning(_)) | Err(SendError::ActorStopped)
         ),
-        "a sealed room actor refuses late joins with the typed retryable \
-         error instead of admitting an occupant into a destroyed room; \
+        "a removed room actor must be stopped instead of admitting an \
+         occupant through a retained ref; \
          got: {result:?}"
     );
 }
@@ -834,12 +1085,12 @@ mod ownership_claims_tests {
     use crate::muc::room_actor::{GetAffiliation, GetConfig};
     use crate::muc::subject::SubjectState;
     use crate::ownership::{
-        ClaimEpoch, ClaimError, ClaimSnapshot, ClaimStore, Entity, EntityType, InProcessClaimStore,
-        NodeIdentity, ResumeIdentityProof, SharedNodeIdentity, StalePredicate,
+        ClaimEpoch, ClaimError, ClaimGrant, ClaimSnapshot, ClaimStore, Entity, EntityType,
+        InProcessClaimStore, NodeIdentity, ResumeIdentityProof, SharedNodeIdentity, StalePredicate,
     };
     use crate::types::Affiliation;
     use async_trait::async_trait;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Mutex;
 
     fn foreign_identity() -> NodeIdentity {
@@ -848,6 +1099,162 @@ mod ownership_claims_tests {
 
     fn this_identity() -> NodeIdentity {
         NodeIdentity::new("this-node", "this-epoch")
+    }
+
+    /// Delegates to the production single-node store but injects a bounded
+    /// sequence of release backend failures. This preserves the real global
+    /// epoch allocator, so the regression can prove E2 receives a fresh
+    /// generation after the unresolved E1 release is finally retried.
+    struct ReleaseFailingClaimStore {
+        inner: InProcessClaimStore,
+        fence_allowed: AtomicBool,
+        fence_backend_error: AtomicBool,
+        release_failures_remaining: AtomicUsize,
+        release_calls: AtomicUsize,
+        ensure_claimed_calls: AtomicUsize,
+    }
+
+    impl ReleaseFailingClaimStore {
+        fn new(release_failures: usize) -> Self {
+            Self {
+                inner: InProcessClaimStore::new(),
+                fence_allowed: AtomicBool::new(true),
+                fence_backend_error: AtomicBool::new(false),
+                release_failures_remaining: AtomicUsize::new(release_failures),
+                release_calls: AtomicUsize::new(0),
+                ensure_claimed_calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn should_fail_release(&self) -> bool {
+            self.release_failures_remaining
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+        }
+
+        fn set_fence_allowed(&self, allowed: bool) {
+            self.fence_allowed.store(allowed, Ordering::SeqCst);
+        }
+
+        fn set_fence_backend_error(&self, fail: bool) {
+            self.fence_backend_error.store(fail, Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait]
+    impl ClaimStore for ReleaseFailingClaimStore {
+        async fn ensure_schema(&self) -> Result<(), ClaimError> {
+            self.inner.ensure_schema().await
+        }
+
+        async fn acquire(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner.acquire(entity, me).await
+        }
+
+        async fn ensure_claimed(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.ensure_claimed_calls.fetch_add(1, Ordering::SeqCst);
+            self.inner.ensure_claimed(entity, me).await
+        }
+
+        async fn steal_stale(
+            &self,
+            entity: &Entity,
+            observed: ClaimEpoch,
+            staleness: StalePredicate,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner
+                .steal_stale(entity, observed, staleness, me)
+                .await
+        }
+
+        async fn steal_for_resume(
+            &self,
+            entity: &Entity,
+            observed: ClaimEpoch,
+            witness: ResumeIdentityProof,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner
+                .steal_for_resume(entity, observed, witness, me)
+                .await
+        }
+
+        async fn current_claim(
+            &self,
+            entity: &Entity,
+        ) -> Result<Option<ClaimSnapshot>, ClaimError> {
+            self.inner.current_claim(entity).await
+        }
+
+        async fn fence(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<bool, ClaimError> {
+            if self.fence_backend_error.load(Ordering::SeqCst) {
+                return Err(ClaimError::Backend(
+                    "injected room-claim fence failure".to_string(),
+                ));
+            }
+            if !self.fence_allowed.load(Ordering::SeqCst) {
+                return Ok(false);
+            }
+            self.inner.fence(entity, me, mine).await
+        }
+
+        async fn release(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<(), ClaimError> {
+            self.release_calls.fetch_add(1, Ordering::SeqCst);
+            if self.should_fail_release() {
+                return Err(ClaimError::Backend(
+                    "injected room-claim release failure".to_string(),
+                ));
+            }
+            self.inner.release(entity, me, mine).await
+        }
+
+        async fn release_many(&self, grants: &[ClaimGrant]) -> Result<(), ClaimError> {
+            self.inner.release_many(grants).await
+        }
+    }
+
+    #[tokio::test]
+    async fn a_second_grant_cannot_overwrite_pending_exact_release_evidence() {
+        let mut registry = RoomRegistryActor::new(
+            "rooms.test".to_string(),
+            OccupantIdSecret::new(vec![0x42; 32]).expect("valid test secret"),
+        );
+        let failing_store = Arc::new(ReleaseFailingClaimStore::new(1));
+        registry.claim_store = failing_store.clone();
+
+        let jid = test_room_jid("pending-release-invariant");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let pending = ClaimGrant::new(entity.clone(), this_identity(), ClaimEpoch(7));
+        let unexpected = ClaimGrant::new(entity, foreign_identity(), ClaimEpoch(8));
+        registry
+            .pending_claim_releases
+            .insert(jid.clone(), pending.clone());
+
+        registry.release_room_claim(&jid, unexpected).await;
+
+        assert_eq!(registry.pending_claim_releases.get(&jid), Some(&pending));
+        assert_eq!(failing_store.release_calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]
@@ -901,6 +1308,239 @@ mod ownership_claims_tests {
             "DestroyRoom must release the Postgres claim (element 7's \
              'graceful release')"
         );
+    }
+
+    #[tokio::test]
+    async fn exact_effect_barrier_demotes_room_without_effects_when_final_claim_is_lost() {
+        let registry = spawn_registry().await;
+        let store = Arc::new(ReleaseFailingClaimStore::new(0));
+        let claim_store: Arc<dyn ClaimStore> = store.clone();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire claim store");
+
+        let jid = test_room_jid("destroy-final-fence-refusal");
+        let e1 = registry
+            .ask(CreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-1".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create E1");
+        store.set_fence_allowed(false);
+
+        let (reserved_sender, reserved_receiver) = tokio::sync::oneshot::channel();
+        let (_done_sender, done_receiver) = tokio::sync::oneshot::channel();
+        assert!(!registry
+            .ask(DestroyRoomExactAfterEffects {
+                room_jid: jid.clone(),
+                expected_actor: e1.clone(),
+                effects_reserved: reserved_sender,
+                effects_done: done_receiver,
+            })
+            .await
+            .expect("barrier refusal"));
+        assert!(
+            reserved_receiver.await.is_err(),
+            "a failed final claim proof must not authorize any effect"
+        );
+        let current = registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("get after E1 demotion");
+        assert!(current.is_none(), "the definitively deposed E1 is removed");
+        tokio::task::yield_now().await;
+        assert!(!e1.is_alive());
+    }
+
+    #[tokio::test]
+    async fn exact_effect_barrier_retains_room_on_final_claim_backend_uncertainty() {
+        let registry = spawn_registry().await;
+        let store = Arc::new(ReleaseFailingClaimStore::new(0));
+        let claim_store: Arc<dyn ClaimStore> = store.clone();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire claim store");
+
+        let jid = test_room_jid("destroy-final-fence-error");
+        let e1 = registry
+            .ask(CreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-1".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create E1");
+        store.set_fence_backend_error(true);
+
+        let (reserved_sender, reserved_receiver) = tokio::sync::oneshot::channel();
+        let (_done_sender, done_receiver) = tokio::sync::oneshot::channel();
+        assert!(!registry
+            .ask(DestroyRoomExactAfterEffects {
+                room_jid: jid.clone(),
+                expected_actor: e1.clone(),
+                effects_reserved: reserved_sender,
+                effects_done: done_receiver,
+            })
+            .await
+            .expect("barrier uncertainty"));
+        assert!(
+            reserved_receiver.await.is_err(),
+            "backend uncertainty must not authorize any effect"
+        );
+        let current = registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("get retained E1")
+            .expect("uncertain E1 remains registered");
+        assert_eq!(current, e1);
+        assert!(e1.is_alive());
+        e1.ask(crate::muc::room_actor::Join {
+            nick: "alice".to_string(),
+            real_jid: "alice@example.com/web".parse().expect("Alice JID"),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("backend uncertainty must retain E1 unsealed and joinable");
+    }
+
+    #[tokio::test]
+    async fn unresolved_exact_release_blocks_replacement_until_old_grant_is_released() {
+        let registry = spawn_registry().await;
+        // The first failure occurs during DestroyRoom; the second occurs on
+        // the first replacement attempt. Only the following retry succeeds.
+        let failing_store = Arc::new(ReleaseFailingClaimStore::new(2));
+        let claim_store: Arc<dyn ClaimStore> = failing_store.clone();
+        let first_identity = this_identity();
+        let replacement_identity = NodeIdentity::new("this-node", "replacement-epoch");
+        let shared_identity = SharedNodeIdentity::new(first_identity.clone());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store),
+                node_identity: shared_identity.clone(),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let jid = test_room_jid("release-failure");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let first_actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-1".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create E1")
+            .actor_ref;
+        let first_claim = claim_store
+            .current_claim(&entity)
+            .await
+            .expect("read E1 claim")
+            .expect("E1 claim exists");
+
+        assert!(registry
+            .ask(DestroyRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("destroy E1"));
+        assert_eq!(failing_store.release_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            claim_store
+                .current_claim(&entity)
+                .await
+                .expect("read unresolved E1 claim")
+                .expect("failed release must leave E1 claim"),
+            first_claim
+        );
+
+        // With the same current identity, the old implementation would call
+        // ensure_claimed here, self-reacquire E1's surviving row, and spawn
+        // E2 under the exact same epoch. A second release failure must stop
+        // before acquisition instead.
+        let blocked = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-1".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await;
+        assert!(matches!(
+            blocked,
+            Err(SendError::HandlerError(
+                RoomRegistryError::ClaimReleasePending(ref room)
+            )) if *room == jid
+        ));
+        assert_eq!(
+            failing_store.ensure_claimed_calls.load(Ordering::SeqCst),
+            1,
+            "a replacement must not call ensure_claimed while E1's release is unresolved"
+        );
+        assert_eq!(
+            claim_store
+                .current_claim(&entity)
+                .await
+                .expect("read still-unresolved E1 claim")
+                .expect("E1 claim must still exist after failed retry"),
+            first_claim
+        );
+
+        // Now rotate the registry identity and run terminal self-fence
+        // demotion. Demotion must retain already-pending release evidence,
+        // and the successful retry must still carry E1's captured owner
+        // rather than using this newer identity for an epoch-gated no-op.
+        shared_identity.set(replacement_identity.clone());
+        assert_eq!(
+            registry
+                .ask(DemoteAllRooms)
+                .await
+                .expect("demote after identity rotation"),
+            0
+        );
+        let replacement = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-1".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("release E1 and create E2");
+        let replacement_claim = claim_store
+            .current_claim(&entity)
+            .await
+            .expect("read E2 claim")
+            .expect("E2 claim exists");
+
+        assert_ne!(replacement.actor_ref, first_actor);
+        assert_eq!(replacement_claim.owner, replacement_identity);
+        assert!(
+            replacement_claim.claim_epoch > first_claim.claim_epoch,
+            "E2 must receive a globally fresh epoch rather than self-reacquiring E1's epoch"
+        );
+        assert_eq!(failing_store.release_calls.load(Ordering::SeqCst), 3);
+        assert_eq!(failing_store.ensure_claimed_calls.load(Ordering::SeqCst), 2);
     }
 
     /// ADR-0017 Phase 3 Slice 7 FIX 3 (council-adjudicated): `live_room`'s
@@ -1150,12 +1790,16 @@ mod ownership_claims_tests {
 
         async fn release_many(
             &self,
-            _entities: &[Entity],
-            me: &NodeIdentity,
+            grants: &[crate::ownership::ClaimGrant],
         ) -> Result<(), ClaimError> {
             let mut state = self.state.lock().expect("lock");
-            if matches!(&*state, Some((owner, _)) if owner == me) {
-                *state = None;
+            if let Some((owner, epoch)) = &*state {
+                if grants
+                    .iter()
+                    .any(|grant| grant.owner == *owner && grant.epoch == *epoch)
+                {
+                    *state = None;
+                }
             }
             Ok(())
         }

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -36,13 +36,14 @@ use super::affiliation::DurableMembershipSource;
 use super::durable::MucDurableStore;
 use super::room_actor::{RoomActor, SealGuard};
 use super::room_registry_actor::{
-    CreateInstantRoom, CreateRoom, DestroyRoom, DestroyRoomIfInactive, GetOrCreateRoom, GetRoom,
-    IsMucJid, ListRooms, ReapSealedRoom, RoomAcquisition, RoomCount, RoomExists, RoomRegistryActor,
-    RoomRegistryError, WireClusteringClaims,
+    CreateInstantRoom, CreateRoom, DemoteAllRooms, DemoteRoomIfSuperseded, DestroyRoom,
+    DestroyRoomExact, DestroyRoomIfInactive, GetOrCreateRoom, GetRoom, IsMucJid, ListRooms,
+    ReapSealedRoom, RoomAcquisition, RoomCount, RoomExists, RoomRegistryActor, RoomRegistryError,
+    WireClusteringClaims,
 };
 use super::RoomConfig;
 use crate::metrics;
-use crate::ownership::{ClaimStore, SharedNodeIdentity};
+use crate::ownership::{ClaimEpoch, ClaimStore, NodeIdentity, SharedNodeIdentity};
 use crate::xep::xep0421::OccupantIdSecret;
 
 /// Explicit bounded mailbox capacity for the `RoomRegistryActor`.
@@ -314,10 +315,23 @@ impl RoomRegistry {
     );
 
     registry_method!(
-        /// Destroy a room, returning whether it existed.
+        /// Destroy the current room for a logical JID, returning whether it
+        /// existed. This unconditional form is for explicit administrator
+        /// intent; delayed rollback paths must use [`Self::destroy_room_exact`].
         destroy_room(room_jid: BareJid) -> bool,
         "destroy_room",
         DestroyRoom { room_jid }
+    );
+
+    registry_method!(
+        /// Destroy only the exact actor incarnation previously observed by
+        /// the caller, refusing a retained-E1/new-E2 ABA.
+        destroy_room_exact(
+            room_jid: BareJid,
+            expected_actor: ActorRef<RoomActor>
+        ) -> bool,
+        "destroy_room_exact",
+        DestroyRoomExact { room_jid, expected_actor }
     );
 
     registry_method!(
@@ -360,6 +374,26 @@ impl RoomRegistry {
         list_rooms() -> Vec<BareJid>,
         "list_rooms",
         ListRooms
+    );
+
+    registry_method!(
+        /// Atomically forget and hard-kill every room after node self-fence.
+        /// Claims are not released under the fenced identity.
+        demote_all_rooms() -> usize,
+        "demote_all_rooms",
+        DemoteAllRooms
+    );
+
+    registry_method!(
+        /// Hard-kill a room only when a delayed cluster Demote still names
+        /// this exact node incarnation and a strictly newer claim epoch.
+        demote_room_if_superseded(
+            room_jid: BareJid,
+            expected_owner: NodeIdentity,
+            new_epoch: ClaimEpoch
+        ) -> bool,
+        "demote_room_if_superseded",
+        DemoteRoomIfSuperseded { room_jid, expected_owner, new_epoch }
     );
 
     registry_method!(

--- a/server/crates/waddle-xmpp/src/ownership/in_process.rs
+++ b/server/crates/waddle-xmpp/src/ownership/in_process.rs
@@ -21,12 +21,15 @@
 //! enforce.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Mutex;
+use std::time::Duration;
 
 use async_trait::async_trait;
 
 use super::{
-    ClaimEpoch, ClaimError, ClaimStore, Entity, NodeIdentity, ResumeIdentityProof, StalePredicate,
+    ClaimEpoch, ClaimError, ClaimGrant, ClaimStore, Entity, NodeIdentity, ResumeIdentityProof,
+    StalePredicate,
 };
 
 /// A held claim's owner + current fencing epoch. `owner` is needed so
@@ -43,6 +46,10 @@ struct ClaimRecord {
 #[derive(Default)]
 pub struct InProcessClaimStore {
     claims: Mutex<HashMap<Entity, ClaimRecord>>,
+    /// Process-global monotonically increasing generation allocator. Claim
+    /// rows may be deleted on release, but generations are never reset or
+    /// reused while this store lives.
+    next_epoch: AtomicI64,
 }
 
 impl InProcessClaimStore {
@@ -52,6 +59,15 @@ impl InProcessClaimStore {
 
     fn lock(&self) -> Result<std::sync::MutexGuard<'_, HashMap<Entity, ClaimRecord>>, ClaimError> {
         self.claims.lock().map_err(|_| ClaimError::Poisoned)
+    }
+
+    fn allocate_epoch(&self) -> Result<ClaimEpoch, ClaimError> {
+        self.next_epoch
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+                current.checked_add(1)
+            })
+            .map(ClaimEpoch)
+            .map_err(|_| ClaimError::EpochExhausted)
     }
 }
 
@@ -74,14 +90,15 @@ impl ClaimStore for InProcessClaimStore {
         if claims.contains_key(entity) {
             return Err(ClaimError::AlreadyClaimed);
         }
+        let epoch = self.allocate_epoch()?;
         claims.insert(
             entity.clone(),
             ClaimRecord {
                 owner: me.clone(),
-                epoch: ClaimEpoch(0),
+                epoch,
             },
         );
-        Ok(ClaimEpoch(0))
+        Ok(epoch)
     }
 
     async fn ensure_claimed(
@@ -98,14 +115,15 @@ impl ClaimStore for InProcessClaimStore {
         let mut claims = self.lock()?;
         match claims.get(entity) {
             None => {
+                let epoch = self.allocate_epoch()?;
                 claims.insert(
                     entity.clone(),
                     ClaimRecord {
                         owner: me.clone(),
-                        epoch: ClaimEpoch(0),
+                        epoch,
                     },
                 );
-                Ok(ClaimEpoch(0))
+                Ok(epoch)
             }
             Some(record) if record.owner == *me => Ok(record.epoch),
             Some(_) => Err(ClaimError::AlreadyClaimed),
@@ -134,7 +152,7 @@ impl ClaimStore for InProcessClaimStore {
         let mut claims = self.lock()?;
         match claims.get(entity) {
             Some(record) if record.epoch == observed => {
-                let new_epoch = ClaimEpoch(record.epoch.0 + 1);
+                let new_epoch = self.allocate_epoch()?;
                 claims.insert(
                     entity.clone(),
                     ClaimRecord {
@@ -167,6 +185,34 @@ impl ClaimStore for InProcessClaimStore {
             .await
     }
 
+    async fn reclaim_after_self_fence(
+        &self,
+        entity: &Entity,
+        observed: ClaimEpoch,
+        expected_owner: &NodeIdentity,
+        me: &NodeIdentity,
+        _lease_ttl: Duration,
+    ) -> Result<ClaimEpoch, ClaimError> {
+        if expected_owner.node_id != me.node_id {
+            return Err(ClaimError::Conflict);
+        }
+        let mut claims = self.lock()?;
+        match claims.get(entity) {
+            Some(record) if record.owner == *expected_owner && record.epoch == observed => {
+                let epoch = self.allocate_epoch()?;
+                claims.insert(
+                    entity.clone(),
+                    ClaimRecord {
+                        owner: me.clone(),
+                        epoch,
+                    },
+                );
+                Ok(epoch)
+            }
+            _ => Err(ClaimError::Conflict),
+        }
+    }
+
     async fn current_claim(
         &self,
         entity: &Entity,
@@ -181,42 +227,64 @@ impl ClaimStore for InProcessClaimStore {
         }))
     }
 
+    async fn owned_claims(
+        &self,
+        entities: &[Entity],
+        me: &NodeIdentity,
+    ) -> Result<Vec<ClaimGrant>, ClaimError> {
+        let claims = self.lock()?;
+        Ok(entities
+            .iter()
+            .filter_map(|entity| {
+                let record = claims.get(entity)?;
+                (record.owner == *me)
+                    .then(|| ClaimGrant::new(entity.clone(), record.owner.clone(), record.epoch))
+            })
+            .collect())
+    }
+
     async fn fence(
         &self,
         entity: &Entity,
-        _me: &NodeIdentity,
+        me: &NodeIdentity,
         mine: ClaimEpoch,
     ) -> Result<bool, ClaimError> {
         let claims = self.lock()?;
-        Ok(claims.get(entity).map(|record| record.epoch) == Some(mine))
+        Ok(matches!(
+            claims.get(entity),
+            Some(record) if record.owner == *me && record.epoch == mine
+        ))
     }
 
     async fn release(
         &self,
         entity: &Entity,
-        _me: &NodeIdentity,
+        me: &NodeIdentity,
         mine: ClaimEpoch,
     ) -> Result<(), ClaimError> {
         let mut claims = self.lock()?;
         // Epoch-gated exactly like `PostgresClaimStore`'s CAS: a losing
         // epoch is a no-op (the claim was re-issued since the caller
         // observed `mine`), and releasing an absent claim is idempotent.
-        if claims.get(entity).map(|record| record.epoch) == Some(mine) {
+        if matches!(
+            claims.get(entity),
+            Some(record) if record.owner == *me && record.epoch == mine
+        ) {
             claims.remove(entity);
         }
         Ok(())
     }
 
-    async fn release_many(
-        &self,
-        entities: &[Entity],
-        _me: &NodeIdentity,
-    ) -> Result<(), ClaimError> {
-        // Claim-epoch-blind by the trait contract (the node-identity gate
-        // is trivially satisfied here: this store *is* the one node).
+    async fn release_many(&self, grants: &[ClaimGrant]) -> Result<(), ClaimError> {
         let mut claims = self.lock()?;
-        for entity in entities {
-            claims.remove(entity);
+        for grant in grants {
+            if matches!(
+                claims.get(&grant.entity),
+                Some(record)
+                    if record.owner == grant.owner && record.epoch == grant.epoch
+            ) {
+                claims.remove(&grant.entity);
+            }
         }
         Ok(())
     }
@@ -253,14 +321,25 @@ mod tests {
             .expect_err("second acquire against a still-held entity loses the race");
         assert!(matches!(err, ClaimError::AlreadyClaimed));
 
-        // Once released, the entity is claimable again from epoch 0 —
-        // mirroring a fresh Postgres `INSERT` after the row is deleted.
+        // Once released, the entity is claimable again, but the global
+        // generation allocator must never reuse the old epoch.
         store.release(&e, &me(), first).await.expect("release");
         let reacquired = store
             .acquire(&e, &me())
             .await
             .expect("re-acquire after release");
-        assert_eq!(reacquired, ClaimEpoch(0));
+        assert_eq!(reacquired, ClaimEpoch(1));
+
+        // A delayed cleanup from the old grant cannot remove or fence the
+        // replacement even though entity and owner identity are unchanged.
+        store
+            .release(&e, &me(), first)
+            .await
+            .expect("delayed release");
+        assert!(store
+            .fence(&e, &me(), reacquired)
+            .await
+            .expect("new grant survives delayed old release"));
     }
 
     #[tokio::test]
@@ -484,21 +563,19 @@ mod tests {
         let store = InProcessClaimStore::new();
         let a = entity("stream-a");
         let b = entity("stream-b");
-        store.acquire(&a, &me()).await.expect("acquire a");
-        store.acquire(&b, &me()).await.expect("acquire b");
+        let owner = me();
+        let a_epoch = store.acquire(&a, &owner).await.expect("acquire a");
+        let b_epoch = store.acquire(&b, &owner).await.expect("acquire b");
 
         store
-            .release_many(&[a.clone(), b.clone()], &me())
+            .release_many(&[
+                ClaimGrant::new(a.clone(), owner.clone(), a_epoch),
+                ClaimGrant::new(b.clone(), owner.clone(), b_epoch),
+            ])
             .await
             .expect("release_many");
 
-        assert!(!store
-            .fence(&a, &me(), ClaimEpoch(0))
-            .await
-            .expect("fence a"));
-        assert!(!store
-            .fence(&b, &me(), ClaimEpoch(0))
-            .await
-            .expect("fence b"));
+        assert!(!store.fence(&a, &owner, a_epoch).await.expect("fence a"));
+        assert!(!store.fence(&b, &owner, b_epoch).await.expect("fence b"));
     }
 }

--- a/server/crates/waddle-xmpp/src/ownership/mod.rs
+++ b/server/crates/waddle-xmpp/src/ownership/mod.rs
@@ -46,6 +46,39 @@ pub use resume::{verify_resume_identity, ResumeIdentityProof};
 use async_trait::async_trait;
 use std::time::Duration;
 
+/// Hard wall-clock budget for a Postgres transaction that holds an exact
+/// claim or node-incarnation fence.
+///
+/// Fenced transactions deliberately keep row locks until commit so an
+/// ownership transfer cannot pass a durable write. Without a database-side
+/// bound, however, one stalled transaction can retain both the entity claim
+/// and the shared node row forever, preventing heartbeat renewal and cluster
+/// recovery past the nominal lease TTL. Both `waddle-server`'s database
+/// adapter and this crate's direct SQLx MAM path consume this one typed value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FencedTransactionBudget(Duration);
+
+impl FencedTransactionBudget {
+    pub const fn from_millis(milliseconds: u64) -> Self {
+        Self(Duration::from_millis(milliseconds))
+    }
+
+    pub const fn duration(self) -> Duration {
+        self.0
+    }
+
+    pub fn postgres_timeout(self) -> String {
+        format!("{}ms", self.0.as_millis())
+    }
+}
+
+/// Five seconds is comfortably below the shipped 30-second node lease while
+/// leaving ordinary fenced SM/MUC/MAM writes ample time to finish. Cluster
+/// configuration rejects any node lease that is not strictly longer than
+/// this budget.
+pub const FENCED_TRANSACTION_BUDGET: FencedTransactionBudget =
+    FencedTransactionBudget::from_millis(5_000);
+
 /// Closed set of claimable entity kinds (element 4). Serialized to `TEXT`
 /// only at the SQL boundary (`entity_type` column) — never compared or
 /// branched on as a bare string at call sites. Also `Serialize`/
@@ -177,11 +210,13 @@ impl std::fmt::Display for Entity {
 /// typed-payloads hard rule.
 ///
 /// `owner_lease_fresh` (council-adjudicated fix, Slice 6): whether `owner`'s
-/// own node-liveness row is currently fresh (not committed-`expired`, and its
-/// `node_epoch` still matches) — the exact same owner-stale predicate
-/// [`StalePredicate::OwnerStale`] realizes for `steal_stale`, read here
-/// advisory-only (no write attached, same "never itself an authority"
-/// caveat as the rest of this snapshot). This is what lets a cross-node
+/// own node-liveness row is currently serving-eligible (exact `node_epoch`,
+/// not committed-`expired`, and heartbeat still within that incarnation's
+/// registered lease TTL), read advisory-only (no write attached, same
+/// "never itself an authority" caveat as the rest of this snapshot). This
+/// freshness read never authorizes stealing: [`StalePredicate::OwnerStale`]
+/// continues to require the serialized committed-expiry transition. This is
+/// what lets a cross-node
 /// resume attempt distinguish, once its held-response window closes,
 /// between "the owner is still alive, just unreachable over the swarm right
 /// now" (XEP-0198's `resource-constraint`) and "the owner's own lease has
@@ -207,13 +242,37 @@ pub struct ClaimSnapshot {
 )]
 pub struct ClaimEpoch(pub i64);
 
+/// Exact authority returned by a successful claim grant. Carrying the
+/// entity, owner incarnation, and globally unique claim generation together
+/// prevents callers from accidentally pairing an epoch with a different
+/// entity or a later node incarnation across an `.await` boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClaimGrant {
+    pub entity: Entity,
+    pub owner: NodeIdentity,
+    pub epoch: ClaimEpoch,
+}
+
+impl ClaimGrant {
+    pub fn new(entity: Entity, owner: NodeIdentity, epoch: ClaimEpoch) -> Self {
+        Self {
+            entity,
+            owner,
+            epoch,
+        }
+    }
+}
+
 /// A node's cluster identity, as seen by the claims CAS. Distinct from
 /// `waddle-server::clustering::NodeId` (which is `clustering`-feature gated
 /// and libp2p-flavored): this type is unconditionally compiled, so it is
-/// plain data with no dependency on the swarm subsystem. `node_epoch` is
-/// freshly generated on every process start and never reused, mirroring the
-/// keypair-slot lease's `LeaseIdentity` (ADR-0017 element 3/4).
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// plain data with no dependency on the swarm subsystem. `node_id` is the
+/// process-stable relay address; `node_epoch` is freshly generated on every
+/// process start and after every self-fence recovery, and is never reused.
+/// Both fields are serialized together on cluster relay messages whose
+/// correctness depends on the exact owner incarnation, rather than only its
+/// routable process address.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct NodeIdentity {
     pub node_id: String,
     pub node_epoch: String,
@@ -238,9 +297,10 @@ impl NodeIdentity {
 /// A live, shared view of this process's current [`NodeIdentity`].
 ///
 /// Node identity is not fixed for the life of a process: ADR-0017 Phase 3
-/// Slice 2's `self_fence::run_node_lease` mints a fresh `node_id`/
-/// `node_epoch` pair every time this node re-registers after a self-fence,
-/// reassigning its loop-local identity in place. Any call site that binds
+/// Slice 2's `self_fence::run_node_lease` retains the process-stable
+/// `node_id` relay address while minting a fresh `node_epoch` every time this
+/// node re-registers after a self-fence, reassigning its loop-local identity
+/// in place. Any call site that binds
 /// an identity into a claim acquire/fence CAS on this node's behalf must
 /// observe whatever identity is *currently* in force, not a snapshot
 /// captured once at startup — a caller holding a stale, pre-fence identity
@@ -346,6 +406,12 @@ pub enum ClaimError {
     #[error("claim store internal lock poisoned")]
     Poisoned,
 
+    /// The monotonic claim-generation allocator reached `i64::MAX`.
+    /// Reusing an epoch would make delayed fences/releases valid again, so
+    /// exhaustion is a hard typed failure rather than wrapping.
+    #[error("claim epoch allocator exhausted")]
+    EpochExhausted,
+
     /// A steal-intent operation (`report_steal_intent`/`owner_steal_intents`/
     /// `clear_steal_intent`, ADR-0017 Phase 3 Slice 3) was asked to operate
     /// on an `EntityType::SmSession` claim. Per the three-rule steal-variant
@@ -362,16 +428,17 @@ pub enum ClaimError {
     SmSessionExcludedFromStealIntent,
 
     /// `acquire`/`ensure_claimed`/`steal_stale` refused to grant a NEW
-    /// claim because the calling node has marked itself draining
-    /// (ADR-0017 Phase 3 Slice 10: `NodeLeaseStore::mark_draining` — "stop
-    /// acquiring new claims, keep serving already-owned ones"). Distinct
+    /// claim because the calling node's exact lease incarnation is missing,
+    /// expired, or marked draining (ADR-0017 Phase 3 Slice 10:
+    /// `NodeLeaseStore::mark_draining` — "stop acquiring new claims, keep
+    /// serving already-owned ones"). Distinct
     /// from [`ClaimError::AlreadyClaimed`]: the entity may well be
     /// unclaimed — this node simply refuses to be the one to claim it while
     /// on its way out. A caller already holding this exact claim is
     /// unaffected (`ensure_claimed`'s self-reacquire fallback still
     /// succeeds while draining); only a genuinely NEW acquisition is
     /// refused.
-    #[error("this node is draining and refuses to acquire a new claim")]
+    #[error("this node lease is unavailable or draining and refuses to acquire a new claim")]
     Draining,
 }
 
@@ -459,6 +526,24 @@ pub trait ClaimStore: Send + Sync {
         me: &NodeIdentity,
     ) -> Result<ClaimEpoch, ClaimError>;
 
+    /// Self-fence recovery-only reclaim from `expected_owner` into a
+    /// registered-but-draining replacement incarnation. Unlike ordinary
+    /// acquisition, the destination may be draining because readiness and
+    /// all general admissions remain closed until hydration completes and
+    /// the node is activated. The exact source identity prevents this
+    /// narrow exception from becoming a generic stale-claim steal.
+    async fn reclaim_after_self_fence(
+        &self,
+        entity: &Entity,
+        observed: ClaimEpoch,
+        expected_owner: &NodeIdentity,
+        me: &NodeIdentity,
+        lease_ttl: Duration,
+    ) -> Result<ClaimEpoch, ClaimError> {
+        let _ = (entity, observed, expected_owner, me, lease_ttl);
+        Err(ClaimError::Conflict)
+    }
+
     /// Steal `entity` via the consent/epoch-only CAS (element 4's third CAS
     /// variant), authorized exclusively by an identity-checked resume
     /// (element 8). Requires a [`ResumeIdentityProof`], which only
@@ -485,6 +570,30 @@ pub trait ClaimStore: Send + Sync {
     /// call.
     async fn current_claim(&self, entity: &Entity) -> Result<Option<ClaimSnapshot>, ClaimError>;
 
+    /// Bulk snapshot the exact grants among `entities` currently held by
+    /// `me`. Graceful drain uses this once before sealing, then carries each
+    /// exact grant through the final write into [`Self::release_many`]
+    /// without issuing one point read per entity.
+    async fn owned_claims(
+        &self,
+        entities: &[Entity],
+        me: &NodeIdentity,
+    ) -> Result<Vec<ClaimGrant>, ClaimError> {
+        let mut grants = Vec::new();
+        for entity in entities {
+            if let Some(snapshot) = self.current_claim(entity).await? {
+                if snapshot.owner == *me && snapshot.owner_lease_fresh {
+                    grants.push(ClaimGrant::new(
+                        entity.clone(),
+                        snapshot.owner,
+                        snapshot.claim_epoch,
+                    ));
+                }
+            }
+        }
+        Ok(grants)
+    }
+
     /// Advisory, own-transaction check: does `me` still hold `entity` under
     /// epoch `mine` right now? See the trait-level doc for why this is
     /// never the write-path fencing mechanism.
@@ -506,27 +615,12 @@ pub trait ClaimStore: Send + Sync {
 
     /// Batched release for graceful drain (~18k modeled claims, ADR-0017
     /// Phase 3 Slice 10) — one round-trip, not one-at-a-time. Releases every
-    /// entity in `entities` currently held by `me`, regardless of each
-    /// entity's individual epoch (drain does not need per-entity epoch
-    /// pinning — only "still owned by me, whatever the epoch").
-    ///
-    /// **Plan-sanctioned ABA window**: this release is blind to `entity`'s
-    /// individual `claim_epoch`, matching only on `(node_id, node_epoch)` —
-    /// so if an entity queued into `entities` (because its final write
-    /// already committed) is *re-claimed by this same node* at a higher
-    /// epoch before the batched DELETE actually runs (e.g. a resumed
-    /// XEP-0198 session legitimately steals back onto this node via
-    /// `steal_for_resume` — no staleness required — while this node is
-    /// still draining but not yet gone), the stale batch entry deletes that
-    /// brand-new, genuinely-live claim too. Slice 2's draining-node marker
-    /// (`NodeLeaseStore::mark_draining` stops this node from *acquiring*
-    /// new claims once draining, narrowing but not eliminating the window)
-    /// and Slice 10's batch-construction ordering (an entity enters the
-    /// batch only after its final fenced write's transaction has committed,
-    /// keeping the window as short as possible) are the mitigations — not a
-    /// full closure of the race. See Slice 10's Tests paragraph for the
-    /// interleaving this implies for the drain test suite.
-    async fn release_many(&self, entities: &[Entity], me: &NodeIdentity) -> Result<(), ClaimError>;
+    /// grant in `grants` only while its exact `(entity, owner node/epoch,
+    /// claim_epoch)` tuple remains current. The epoch is mandatory: an
+    /// owner-only batch can delete a claim that was stolen away and then
+    /// legitimately granted back to the same node before the delayed batch
+    /// executes.
+    async fn release_many(&self, grants: &[ClaimGrant]) -> Result<(), ClaimError>;
 }
 
 /// Rollout-aware claim-acquisition placement (ADR-0017 Phase 3 Slice 10,
@@ -606,6 +700,16 @@ mod tests {
     #[test]
     fn node_identity_local_is_stable() {
         assert_eq!(NodeIdentity::local(), NodeIdentity::local());
+    }
+
+    #[test]
+    fn node_identity_serde_round_trips_both_incarnation_fields() {
+        let identity = NodeIdentity::new("relay-address", "post-fence-epoch");
+        let encoded = serde_json::to_string(&identity).expect("serialize node identity");
+        let decoded: NodeIdentity =
+            serde_json::from_str(&encoded).expect("deserialize node identity");
+
+        assert_eq!(decoded, identity);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
@@ -211,6 +211,11 @@ pub enum OutboundEvent {
         /// emissions stay stable across nick changes and after the
         /// setter has left the room.
         setter_nick: String,
+        /// Exact sending session, retained so an interpreter-side ownership
+        /// failure can return a retryable message error to the requester.
+        sender_full: FullJid,
+        /// Canonicalized subject-change message used to correlate that error.
+        message: Box<Message>,
         /// Wall-clock time of the change (UTC). Becomes the XEP-0203
         /// `<delay/>` `stamp` attribute on the next join's emission.
         set_at: DateTime<Utc>,

--- a/server/crates/waddle-xmpp/src/protocol/room/subject.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/subject.rs
@@ -130,6 +130,8 @@ impl RoomHandler for MucSubjectHandler {
             texts,
             setter: sender.bare_jid(),
             setter_nick: sender.nick.clone(),
+            sender_full: sender.full_jid.clone(),
+            message: Box::new(message.clone()),
             set_at,
         };
         RoomHandlerOutcome::Continue(vec![event])

--- a/server/crates/waddle-xmpp/src/registry/connection_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry.rs
@@ -24,8 +24,9 @@ mod state;
 mod subscriptions;
 
 pub use outbound::{
-    BroadcastOutcome, ConnectionEntry, DeliveryKind, ForceDetachOutcome, ForceDetachRequest,
-    OutboundStanza, SendResult,
+    BroadcastOutcome, ConnectionEntry, ConnectionPlacement, ConnectionRetirementHandle,
+    DeliveryKind, ForceDetachOutcome, ForceDetachReason, ForceDetachRequest, OutboundStanza,
+    SendResult,
 };
 pub use state::{LastActivityState, PresenceState};
 

--- a/server/crates/waddle-xmpp/src/registry/connection_registry/outbound.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry/outbound.rs
@@ -127,28 +127,83 @@ impl OutboundStanza {
 /// element 8's "live, owned elsewhere" branch) and also used by clustered
 /// `UserActor` owner demotion/retirement before a stale user claim is reused.
 /// Delivered through [`ConnectionEntry::force_detach_tx`] into the owning
-/// connection's own select loop, so the destructive detach-flush +
-/// `<conflict/>` close runs on the connection's own task (never from an
-/// external task reaching into its state directly).
+/// connection's own select loop, so the destructive detach-flush and typed
+/// stream close run on the connection's own task (never from an external task
+/// reaching into its state directly).
 #[derive(Debug)]
 pub struct ForceDetachRequest {
-    /// The bare JID the cross-node resume requester authenticated as.
-    /// Compared against this connection's own bound JID (defense in depth:
-    /// the caller — `ResumeStealBridge` — already checked this against the
-    /// registry's reverse index before sending, but the identity check must
-    /// gate the destructive close itself, not just an earlier lookup).
+    /// The bare JID authorized to retire this connection. Compared against
+    /// this connection's own bound JID as a final defense in depth; callers
+    /// already locate the resource through an identity-scoped registry or
+    /// relay route, but the destructive close itself must still be gated.
     pub requester_bare_jid: jid::BareJid,
+    /// Why the connection is being retired. The transport adapter uses this
+    /// typed reason to distinguish XEP-0198/same-resource replacement
+    /// (`<conflict/>`) from recoverable cluster infrastructure errors.
+    pub reason: ForceDetachReason,
     /// Answered exactly once, after the connection either force-detaches
     /// (identity matched) or declines (identity mismatch).
     pub ack: tokio::sync::oneshot::Sender<ForceDetachOutcome>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum ForceDetachReason {
+    /// XEP-0198 resumed this still-open former stream elsewhere.
+    SessionResumed,
+    /// A newer registration displaced this same full JID.
+    ResourceReplaced,
+    /// This node lost the authoritative claim that allowed it to serve the
+    /// resource. The client should reconnect through the surviving cluster.
+    OwnershipLost,
+    /// This entire node self-fenced after losing its cluster lease.
+    NodeSelfFenced,
+    /// The owner-side mirror rejected or lost this remote resource state.
+    RemoteStateInvalidated,
+}
+
+/// Where a registry entry executes. A local socket can be hard-aborted by
+/// this process; a remote mirror is only proxy state and must never pin this
+/// node's readiness while another node owns the physical transport.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectionPlacement {
+    LocalSocket,
+    RemoteMirror,
+}
+
+/// Non-cooperative retirement backstop installed by a local WebSocket task.
+/// Cooperative force-detach remains the normal path so clients receive a
+/// native stream error and SM cleanup runs; terminal fencing uses this handle
+/// only after that bounded grace window expires.
+#[derive(Debug, Clone)]
+pub struct ConnectionRetirementHandle {
+    abort: futures::future::AbortHandle,
+    terminated: tokio_util::sync::CancellationToken,
+}
+
+impl ConnectionRetirementHandle {
+    pub fn new(
+        abort: futures::future::AbortHandle,
+        terminated: tokio_util::sync::CancellationToken,
+    ) -> Self {
+        Self { abort, terminated }
+    }
+
+    pub fn abort(&self) {
+        self.abort.abort();
+    }
+
+    pub async fn terminated(&self) {
+        self.terminated.cancelled().await;
+    }
+}
+
 /// Outcome of a [`ForceDetachRequest`], reported back to the asker.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum ForceDetachOutcome {
-    /// Identity matched, the connection sent `<conflict/>` and closed, AND
-    /// its subsequent XEP-0198 detach-for-resume cleanup actually persisted
-    /// a resumable snapshot (council-adjudicated fix: this is the ONLY
+    /// Identity matched, the connection sent the stream error appropriate to
+    /// [`ForceDetachRequest::reason`] and closed, AND its subsequent XEP-0198
+    /// detach-for-resume cleanup actually persisted a resumable snapshot
+    /// (council-adjudicated fix: this is the ONLY
     /// variant that authorizes the asker to proceed with
     /// `steal_for_resume` — see [`Self::NotPersisted`] for every other
     /// outcome of that same cleanup pass).
@@ -228,8 +283,9 @@ pub struct ConnectionEntry {
     /// **Council-adjudicated fix (updating this comment to match reality,
     /// not the original design intent)**: the capacity here is
     /// belt-and-suspenders, not the load-bearing bound it once was.
-    /// `ResumeStealBridge::request_forced_detach` (the sole production
-    /// sender) uses `try_send`, not a blocking `send().await` — a full or
+    /// Every production sender (resume, ownership reconciliation, and
+    /// remote-resource retirement) uses `try_send`, not a blocking
+    /// `send().await` — a full or
     /// closed channel answers `NotLiveLocally` immediately rather than
     /// waiting for capacity that may never free up. This is belt-and
     /// -suspenders alongside (not a replacement for) the
@@ -244,6 +300,8 @@ pub struct ConnectionEntry {
     /// own asker-side ack timeout instead (a bounded, not indefinite, wait).
     force_detach_tx: mpsc::Sender<ForceDetachRequest>,
     force_detach_rx: Arc<std::sync::Mutex<Option<mpsc::Receiver<ForceDetachRequest>>>>,
+    placement: ConnectionPlacement,
+    retirement: Arc<std::sync::OnceLock<ConnectionRetirementHandle>>,
 }
 
 /// See [`ConnectionEntry::force_detach_tx`]'s doc comment for why this is
@@ -253,6 +311,18 @@ const FORCE_DETACH_CHANNEL_CAPACITY: usize = 8;
 impl ConnectionEntry {
     /// Create a new connection entry with carbons disabled by default.
     pub fn new(sender: mpsc::Sender<OutboundStanza>) -> Self {
+        Self::with_placement(sender, ConnectionPlacement::LocalSocket)
+    }
+
+    /// Create owner-side proxy state for a socket hosted by another node.
+    pub fn new_remote_mirror(sender: mpsc::Sender<OutboundStanza>) -> Self {
+        Self::with_placement(sender, ConnectionPlacement::RemoteMirror)
+    }
+
+    fn with_placement(
+        sender: mpsc::Sender<OutboundStanza>,
+        placement: ConnectionPlacement,
+    ) -> Self {
         let (force_detach_tx, force_detach_rx) = mpsc::channel(FORCE_DETACH_CHANNEL_CAPACITY);
         Self {
             sender,
@@ -266,7 +336,21 @@ impl ConnectionEntry {
             sm_stream_id: Arc::new(std::sync::Mutex::new(None)),
             force_detach_tx,
             force_detach_rx: Arc::new(std::sync::Mutex::new(Some(force_detach_rx))),
+            placement,
+            retirement: Arc::new(std::sync::OnceLock::new()),
         }
+    }
+
+    pub fn placement(&self) -> ConnectionPlacement {
+        self.placement
+    }
+
+    pub fn install_retirement_handle(&self, handle: ConnectionRetirementHandle) -> bool {
+        self.retirement.set(handle).is_ok()
+    }
+
+    pub fn retirement_handle(&self) -> Option<ConnectionRetirementHandle> {
+        self.retirement.get().cloned()
     }
 
     /// Clone of this entry's force-detach sender, for a caller (the

--- a/server/crates/waddle-xmpp/src/registry/mod.rs
+++ b/server/crates/waddle-xmpp/src/registry/mod.rs
@@ -22,7 +22,8 @@ pub mod user_actor;
 pub mod user_registry;
 
 pub use connection_registry::{
-    BroadcastOutcome, ConnectionEntry, ConnectionRegistry, DeliveryKind, ForceDetachOutcome,
+    BroadcastOutcome, ConnectionEntry, ConnectionPlacement, ConnectionRegistry,
+    ConnectionRetirementHandle, DeliveryKind, ForceDetachOutcome, ForceDetachReason,
     ForceDetachRequest, OutboundStanza, PresenceState, SendResult,
 };
 pub use selection::{
@@ -33,7 +34,8 @@ pub use user_actor::delivery::{
 };
 pub use user_actor::GetResources;
 pub use user_registry::{
-    DemoteUserActor, GetOrCreateUser, GetUser, GetUserForLocalClaim, ListUsers, ReapUserIfEmpty,
-    RegisterUserResource, RegisterUserResourceIfOwnerOrAbsent, RemoveUser, UnregisterUserResource,
-    UserCount, UserRegistryActor, UserRegistryError, WireUserClusteringClaims,
+    DemoteAllUserActors, DemoteUserActor, GetOrCreateUser, GetUser, GetUserForLocalClaim,
+    ListUsers, ReapUserIfEmpty, RegisterUserResource, RegisterUserResourceIfOwnerOrAbsent,
+    RemoveUser, UnregisterUserResource, UserCount, UserRegistryActor, UserRegistryError,
+    WireUserClusteringClaims,
 };

--- a/server/crates/waddle-xmpp/src/registry/user_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_registry.rs
@@ -19,10 +19,11 @@ use kameo::Actor;
 use thiserror::Error;
 use tracing::{debug, info, warn};
 
-use super::connection_registry::{ConnectionEntry, ForceDetachOutcome, ForceDetachRequest};
-use super::user_actor::delivery::GetConnectionEntry;
+use super::connection_registry::{
+    ConnectionEntry, ForceDetachOutcome, ForceDetachReason, ForceDetachRequest,
+};
 use super::user_actor::{
-    GetResources, RegisterConnection, RegisterConnectionIfOwnerOrAbsent, ResourceCount,
+    RegisterConnection, RegisterConnectionIfOwnerOrAbsent, ResourceCount,
     UnregisterConnectionAndReportEmpty, UserActor,
 };
 use crate::metrics;
@@ -45,10 +46,13 @@ struct UserClaimLease {
 
 /// A locally-spawned user's actor ref plus the ownership lease this node holds
 /// for that bare JID.
-#[derive(Clone)]
 struct UserEntry {
     actor_ref: ActorRef<UserActor>,
     claim: UserClaimLease,
+    /// Exact owner-token-bearing entries registered into this actor. Keeping
+    /// this mirror at the registry boundary lets demotion retire only the
+    /// stale actor incarnation's resources, never a newer same-JID slot.
+    resources: HashMap<FullJid, ConnectionEntry>,
 }
 
 enum UserEntryClaimStatus {
@@ -171,6 +175,7 @@ impl UserRegistryActor {
             UserEntry {
                 actor_ref: actor_ref.clone(),
                 claim,
+                resources: HashMap::new(),
             },
         );
         actor_ref
@@ -196,13 +201,13 @@ impl UserRegistryActor {
     async fn validate_existing_user_entry_claim(
         &self,
         bare_jid: &BareJid,
-        entry: &UserEntry,
+        claim: &UserClaimLease,
     ) -> UserEntryClaimStatus {
         let current_identity = self.node_identity.current();
-        if entry.claim.owner != current_identity {
+        if claim.owner != current_identity {
             warn!(
                 jid = %bare_jid,
-                claim_owner = %entry.claim.owner.node_id,
+                claim_owner = %claim.owner.node_id,
                 current_owner = %current_identity.node_id,
                 "existing UserActor claim identity is stale; demoting before reuse"
             );
@@ -211,14 +216,14 @@ impl UserRegistryActor {
         let entity = Entity::new(EntityType::UserActor, bare_jid.to_string());
         match self
             .claim_store
-            .fence(&entity, &entry.claim.owner, entry.claim.epoch)
+            .fence(&entity, &claim.owner, claim.epoch)
             .await
         {
             Ok(true) => UserEntryClaimStatus::Current,
             Ok(false) => {
                 warn!(
                     jid = %bare_jid,
-                    epoch = entry.claim.epoch.0,
+                    epoch = claim.epoch.0,
                     "existing UserActor no longer owns its fenced claim; demoting before reuse"
                 );
                 UserEntryClaimStatus::ProvenStale
@@ -226,7 +231,7 @@ impl UserRegistryActor {
             Err(error) => {
                 warn!(
                     jid = %bare_jid,
-                    epoch = entry.claim.epoch.0,
+                    epoch = claim.epoch.0,
                     %error,
                     "failed to validate existing UserActor claim; refusing reuse without mutating actor state"
                 );
@@ -239,25 +244,33 @@ impl UserRegistryActor {
         &mut self,
         bare_jid: &BareJid,
     ) -> Result<Option<ActorRef<UserActor>>, UserRegistryError> {
-        let Some(entry) = self.users.get(bare_jid).cloned() else {
-            return Ok(None);
+        let (actor_ref, claim) = {
+            let Some(entry) = self.users.get(bare_jid) else {
+                return Ok(None);
+            };
+            (entry.actor_ref.clone(), entry.claim.clone())
         };
-        if !entry.actor_ref.is_alive() {
+        if !actor_ref.is_alive() {
             debug!(jid = %bare_jid, "Detected dead UserActor; failing fast");
             return Err(self.mark_actor_state_lost(bare_jid).await);
         }
         match self
-            .validate_existing_user_entry_claim(bare_jid, &entry)
+            .validate_existing_user_entry_claim(bare_jid, &claim)
             .await
         {
-            UserEntryClaimStatus::Current => return Ok(Some(entry.actor_ref)),
+            UserEntryClaimStatus::Current => return Ok(Some(actor_ref)),
             UserEntryClaimStatus::ValidationUnavailable => {
                 return Err(UserRegistryError::ClaimUnavailable(bare_jid.clone()));
             }
             UserEntryClaimStatus::ProvenStale => {}
         }
+        let resources = self
+            .users
+            .get(bare_jid)
+            .map(|entry| entry.resources.clone())
+            .unwrap_or_default();
         if !self
-            .force_detach_stale_actor_resources(bare_jid, &entry.actor_ref)
+            .force_detach_stale_actor_resources(bare_jid, &resources)
             .await
         {
             return Err(UserRegistryError::StaleUserActorRetirementFailed(
@@ -265,53 +278,21 @@ impl UserRegistryActor {
             ));
         }
         self.users.remove(bare_jid);
-        entry.actor_ref.kill();
+        actor_ref.kill();
         Ok(None)
     }
 
     async fn force_detach_stale_actor_resources(
         &self,
         bare_jid: &BareJid,
-        actor_ref: &ActorRef<UserActor>,
+        resources: &HashMap<FullJid, ConnectionEntry>,
     ) -> bool {
-        let resources = match actor_ref
-            .ask(GetResources)
-            .mailbox_timeout(CHILD_ACTOR_TIMEOUT)
-            .reply_timeout(CHILD_ACTOR_TIMEOUT)
-            .await
-        {
-            Ok(resources) => resources,
-            Err(error) => {
-                warn!(
-                    jid = %bare_jid,
-                    ?error,
-                    "failed to enumerate stale UserActor resources; refusing claim reuse"
-                );
-                return false;
-            }
-        };
         let mut ack_receivers = Vec::new();
-        for jid in resources {
-            let entry = match actor_ref
-                .ask(GetConnectionEntry { jid: jid.clone() })
-                .mailbox_timeout(CHILD_ACTOR_TIMEOUT)
-                .reply_timeout(CHILD_ACTOR_TIMEOUT)
-                .await
-            {
-                Ok(Some(entry)) => entry,
-                Ok(None) => continue,
-                Err(error) => {
-                    warn!(
-                        jid = %jid,
-                        ?error,
-                        "failed to read stale UserActor resource entry; refusing claim reuse"
-                    );
-                    return false;
-                }
-            };
+        for (jid, entry) in resources {
             let (ack, ack_rx) = tokio::sync::oneshot::channel();
             let request = ForceDetachRequest {
                 requester_bare_jid: bare_jid.clone(),
+                reason: ForceDetachReason::OwnershipLost,
                 ack,
             };
             if let Err(error) = entry.force_detach_sender().try_send(request) {
@@ -322,7 +303,7 @@ impl UserRegistryActor {
                 );
                 return false;
             }
-            ack_receivers.push((jid, ack_rx));
+            ack_receivers.push((jid.clone(), ack_rx));
         }
         let ack_waits = ack_receivers.into_iter().map(|(jid, ack_rx)| async move {
             (jid, tokio::time::timeout(CHILD_ACTOR_TIMEOUT, ack_rx).await)
@@ -515,6 +496,8 @@ impl kameo::message::Message<RegisterUserResource> for UserRegistryActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let bare_jid = msg.jid.to_bare();
+        let jid = msg.jid;
+        let registry_entry = msg.entry.clone();
         if self.poisoned_users.contains(&bare_jid) {
             return Err(UserRegistryError::UserActorStateLost(bare_jid));
         }
@@ -531,14 +514,18 @@ impl kameo::message::Message<RegisterUserResource> for UserRegistryActor {
 
         match user_actor
             .ask(RegisterConnection {
-                jid: msg.jid.clone(),
+                jid: jid.clone(),
                 entry: msg.entry,
             })
             .mailbox_timeout(CHILD_ACTOR_TIMEOUT)
             .reply_timeout(CHILD_ACTOR_TIMEOUT)
             .await
         {
-            Ok(()) => {}
+            Ok(()) => {
+                if let Some(user_entry) = self.users.get_mut(&bare_jid) {
+                    user_entry.resources.insert(jid, registry_entry);
+                }
+            }
             Err(SendError::MailboxFull(_) | SendError::Timeout(_)) => {
                 return Err(UserRegistryError::UserActorBusy(bare_jid));
             }
@@ -570,6 +557,8 @@ impl kameo::message::Message<RegisterUserResourceIfOwnerOrAbsent> for UserRegist
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let bare_jid = msg.jid.to_bare();
+        let jid = msg.jid;
+        let registry_entry = msg.entry.clone();
         if self.poisoned_users.contains(&bare_jid) {
             return Err(UserRegistryError::UserActorStateLost(bare_jid));
         }
@@ -586,7 +575,7 @@ impl kameo::message::Message<RegisterUserResourceIfOwnerOrAbsent> for UserRegist
 
         match user_actor
             .ask(RegisterConnectionIfOwnerOrAbsent {
-                jid: msg.jid.clone(),
+                jid: jid.clone(),
                 entry: msg.entry,
                 owner: msg.owner,
             })
@@ -594,7 +583,14 @@ impl kameo::message::Message<RegisterUserResourceIfOwnerOrAbsent> for UserRegist
             .reply_timeout(CHILD_ACTOR_TIMEOUT)
             .await
         {
-            Ok(registered) => Ok(registered),
+            Ok(registered) => {
+                if registered {
+                    if let Some(user_entry) = self.users.get_mut(&bare_jid) {
+                        user_entry.resources.insert(jid, registry_entry);
+                    }
+                }
+                Ok(registered)
+            }
             Err(SendError::MailboxFull(_) | SendError::Timeout(_)) => {
                 Err(UserRegistryError::UserActorBusy(bare_jid))
             }
@@ -622,22 +618,26 @@ impl kameo::message::Message<UnregisterUserResource> for UserRegistryActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let bare_jid = msg.jid.to_bare();
+        let jid = msg.jid;
+        let owner = msg.owner;
         if self.poisoned_users.contains(&bare_jid) {
             return Err(UserRegistryError::UserActorStateLost(bare_jid));
         }
 
-        let Some(entry) = self.users.get(&bare_jid).cloned() else {
-            return Ok(());
+        let actor_ref = {
+            let Some(entry) = self.users.get(&bare_jid) else {
+                return Ok(());
+            };
+            entry.actor_ref.clone()
         };
-        if !entry.actor_ref.is_alive() {
+        if !actor_ref.is_alive() {
             return Err(self.mark_actor_state_lost(&bare_jid).await);
         }
 
-        let is_empty = match entry
-            .actor_ref
+        let is_empty = match actor_ref
             .ask(UnregisterConnectionAndReportEmpty {
-                jid: msg.jid,
-                owner: msg.owner,
+                jid: jid.clone(),
+                owner: owner.clone(),
             })
             .mailbox_timeout(CHILD_ACTOR_TIMEOUT)
             .reply_timeout(CHILD_ACTOR_TIMEOUT)
@@ -649,6 +649,17 @@ impl kameo::message::Message<UnregisterUserResource> for UserRegistryActor {
             }
             Err(_) => return Err(self.mark_actor_state_lost(&bare_jid).await),
         };
+
+        if let Some(user_entry) = self.users.get_mut(&bare_jid) {
+            let remove = user_entry.resources.get(&jid).is_some_and(|entry| {
+                owner
+                    .as_ref()
+                    .is_none_or(|owner| Arc::ptr_eq(&entry.carbons_handle(), owner))
+            });
+            if remove {
+                user_entry.resources.remove(&jid);
+            }
+        }
 
         if is_empty {
             if let Some(entry) = self.users.remove(&bare_jid) {
@@ -699,7 +710,7 @@ pub struct DemoteUserActor {
 }
 
 impl kameo::message::Message<DemoteUserActor> for UserRegistryActor {
-    type Reply = bool;
+    type Reply = Vec<(FullJid, ConnectionEntry)>;
 
     async fn handle(
         &mut self,
@@ -707,11 +718,39 @@ impl kameo::message::Message<DemoteUserActor> for UserRegistryActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let Some(entry) = self.users.remove(&msg.bare_jid) else {
-            return false;
+            return Vec::new();
         };
         entry.actor_ref.kill();
         debug!(jid = %msg.bare_jid, "Demoted local UserActor");
-        true
+        entry.resources.into_iter().collect()
+    }
+}
+
+/// Forget and hard-kill every locally held user actor after this entire node
+/// loses its lease. This is deliberately one registry message rather than one
+/// mailbox ask per user: the registry drains its map atomically, so terminal
+/// fencing remains bounded even with thousands of active users. Claims are not
+/// released because the old node identity is already fenced.
+pub struct DemoteAllUserActors;
+
+impl kameo::message::Message<DemoteAllUserActors> for UserRegistryActor {
+    type Reply = Vec<(FullJid, ConnectionEntry)>;
+
+    async fn handle(
+        &mut self,
+        _msg: DemoteAllUserActors,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let users = std::mem::take(&mut self.users);
+        let count = users.len();
+        self.poisoned_users.clear();
+        let mut resources = Vec::new();
+        for entry in users.into_values() {
+            entry.actor_ref.kill();
+            resources.extend(entry.resources);
+        }
+        debug!(count, "Demoted every local UserActor after node self-fence");
+        resources
     }
 }
 

--- a/server/crates/waddle-xmpp/src/registry/user_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_registry/tests.rs
@@ -207,13 +207,20 @@ impl ClaimStore for RecordingClaimStore {
 
     async fn release_many(
         &self,
-        _entities: &[Entity],
-        me: &NodeIdentity,
+        grants: &[crate::ownership::ClaimGrant],
     ) -> Result<(), ClaimError> {
-        self.release_owners.lock().expect("lock").push(me.clone());
+        self.release_owners
+            .lock()
+            .expect("lock")
+            .extend(grants.iter().map(|grant| grant.owner.clone()));
         let mut state = self.state.lock().expect("lock");
-        if matches!(&*state, Some((owner, _, _)) if owner == me) {
-            *state = None;
+        if let Some((owner, epoch, _)) = &*state {
+            if grants
+                .iter()
+                .any(|grant| grant.owner == *owner && grant.epoch == *epoch)
+            {
+                *state = None;
+            }
         }
         Ok(())
     }
@@ -784,7 +791,10 @@ async fn test_demote_user_actor_hard_kills_without_releasing_the_claim() {
         })
         .await
         .expect("demote");
-    assert!(demoted);
+    assert!(
+        demoted.is_empty(),
+        "an actor with no resources returns no detach targets"
+    );
     actor.wait_for_shutdown().await;
 
     let lookup = registry

--- a/server/crates/waddle-xmpp/src/stream_management/mod.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/mod.rs
@@ -37,8 +37,8 @@ pub use replay::{stamp_replay_delay, ReplayStanza};
 pub use session_registry::{
     CrossNodeResumeOutcome, CrossNodeResumeStage, DetachedPresenceState, DetachedSession,
     DetachedUnackedStanza, InMemorySmSessionRegistry, RecentTombstoneRecord,
-    RemoteResumeAskOutcome, RemoteResumeAsker, SmClaimCompletion, SmRegistryError,
-    SmSessionRegistry, StealTicket, DEFAULT_MAX_SESSIONS,
+    ReclaimedSessionHydration, RemoteResumeAskOutcome, RemoteResumeAsker, SmClaimCompletion,
+    SmRegistryError, SmSessionRegistry, StealTicket, DEFAULT_MAX_SESSIONS,
 };
 pub use stanzas::{SmAck, SmEnable, SmEnabled, SmFailed, SmRequest, SmResume, SmResumed, SmStanza};
 pub use state::{DetachedSessionSnapshot, StreamManagementState};

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -18,7 +18,7 @@ mod tombstones;
 mod trait_impl;
 mod traits;
 
-pub use core::InMemorySmSessionRegistry;
+pub use core::{InMemorySmSessionRegistry, ReclaimedSessionHydration};
 pub use cross_node_resume::{
     CrossNodeResumeOutcome, CrossNodeResumeStage, RemoteResumeAskOutcome, RemoteResumeAsker,
     StealTicket,

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -1,7 +1,7 @@
 use jid::FullJid;
 use tracing::debug;
 
-use crate::ownership::{ClaimError, Entity, EntityType};
+use crate::ownership::{ClaimError, ClaimGrant, Entity, EntityType};
 
 use super::core::{InMemorySmSessionRegistry, CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT};
 use super::{DetachedSession, SmClaimCompletion, SmRegistryError};
@@ -91,24 +91,28 @@ impl InMemorySmSessionRegistry {
     /// `demote`'s own contract, must not be REQUIRED to succeed while
     /// Postgres is unreachable (the self-fencing trigger this method
     /// exists to serve).
-    pub async fn forget_claim_locally(&self, stream_id: &str) {
+    pub async fn forget_claim_locally(&self, stream_id: &str) -> bool {
         let Ok(stream_lock) = self.stream_lock(stream_id) else {
-            return;
+            return false;
         };
         let _stream_guard = stream_lock.lock().await;
-        if let Ok(mut sessions) = self.sessions.write() {
-            sessions.remove(stream_id);
-        }
-        if let Ok(mut claimed) = self.claimed_sessions.write() {
-            claimed.remove(stream_id);
-        }
-        if let Ok(mut epochs) = self.claim_epochs.write() {
-            epochs.remove(stream_id);
-        }
+        let Ok(mut sessions) = self.sessions.write() else {
+            return false;
+        };
+        let Ok(mut claimed) = self.claimed_sessions.write() else {
+            return false;
+        };
+        let Ok(mut epochs) = self.claim_epochs.write() else {
+            return false;
+        };
+        sessions.remove(stream_id);
+        claimed.remove(stream_id);
+        epochs.remove(stream_id);
         if let Some(storage) = &self.persistence {
             let session_id = crate::pending_delivery::SmSessionId::new(stream_id.to_string());
             storage.evict_claim_cache(&session_id);
         }
+        true
     }
 
     /// Confirm that a drained session has been fully promoted —
@@ -345,29 +349,18 @@ impl InMemorySmSessionRegistry {
     /// them precisely because both go through the same idempotent-for-self
     /// primitive.
     ///
-    /// Best-effort by design, exactly like
-    /// [`Self::acquire_claim_store_entry_for_detach`]: `stream_id` is a
-    /// freshly minted UUID (element 8), so a genuine collision with
-    /// another node's claim is not expected in practice, and a failure
-    /// here must not fail the `<enable/>` handshake itself — the session
-    /// simply proceeds without a durable claim record until the detach
-    /// -time call retries. Logged at `warn` so a persistently failing
-    /// `ClaimStore` backend stays visible. Called with no stream-shard
-    /// lock held: `stream_id` is freshly minted and cannot yet appear in
-    /// `sessions`/`claimed_sessions`, so there is nothing else to
-    /// coordinate with under that lock.
-    pub async fn ensure_session_claim(&self, stream_id: &str) {
+    /// This admission is authoritative, not best-effort: clustered
+    /// `<enable/>` must fail closed when the exact live node incarnation
+    /// cannot acquire/fence the claim. Returning the exact grant also lets
+    /// ISR issuance bind its UPSERT to the same claim generation in one
+    /// transaction. Called with no stream-shard lock held: `stream_id` is
+    /// freshly minted and cannot yet appear in `sessions` or
+    /// `claimed_sessions`.
+    pub async fn ensure_session_claim(&self, stream_id: &str) -> Result<ClaimGrant, ClaimError> {
         let entity = sm_session_entity(stream_id);
         let identity = self.node_identity.current();
-        if let Err(error) = self.claim_store.ensure_claimed(&entity, &identity).await {
-            tracing::warn!(
-                stream_id = %stream_id,
-                %error,
-                "handle_sm_enable: ClaimStore ensure_claimed failed for a freshly enabled \
-                 session; proceeding without a durable claim record until the detach-time \
-                 retry (best-effort, see this method's doc comment)"
-            );
-        }
+        let epoch = self.claim_store.ensure_claimed(&entity, &identity).await?;
+        Ok(ClaimGrant::new(entity, identity, epoch))
     }
 
     /// Atomically claim a resumable session for a single resume attempt.

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
@@ -37,6 +37,31 @@ const STREAM_LOCK_SHARDS: usize = 256;
 /// lease call).
 pub(super) const CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Exact per-entity outcome of post-reclaim hydration.
+///
+/// Recovery callers must distinguish a locally usable session from a claim
+/// that moved elsewhere, a claim that was terminally released, and a
+/// transient failure that must keep the node not-ready. A count alone cannot
+/// express those states: `Ok(0)` used to collapse all three and could publish
+/// a fresh live claim with no corresponding in-memory session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReclaimedSessionHydration {
+    /// The exact current claim is represented in this registry and its epoch
+    /// cache is bound to the supplied owner incarnation.
+    Hydrated,
+    /// The exact current claim was already represented locally; no durable
+    /// row was reloaded or overwritten.
+    AlreadyLocal,
+    /// A read after the reclaim attempt proves a different node owns it.
+    Elsewhere,
+    /// The exact claim was released (or was already absent) after the durable
+    /// session proved absent or unusable.
+    TerminallyReleased,
+    /// Ownership or storage is uncertain; recovery must retry or rotate the
+    /// candidate and must not restore readiness.
+    Retry,
+}
+
 /// In-memory implementation of the SM session registry, optionally
 /// backed by a [`SmPersistenceStorage`] so detached sessions survive
 /// process restarts (issue #209 slice (d) phase 3, locked Q8 = B).
@@ -488,132 +513,231 @@ impl InMemorySmSessionRegistry {
         &self,
         entities: &[(Entity, ClaimEpoch)],
     ) -> Result<usize, SmRegistryError> {
-        let Some(storage) = &self.persistence else {
-            return Ok(0);
-        };
+        let identity = self.node_identity.current();
+        self.hydrate_reclaimed_as(entities, &identity).await
+    }
+
+    /// Targeted hydration under an explicitly proven node incarnation.
+    ///
+    /// Post-self-fence recovery uses this variant while the process-wide
+    /// [`SharedNodeIdentity`] deliberately still points at the fenced epoch:
+    /// publishing the new identity before terminal recovery completes would
+    /// reopen unrelated claim admission. The caller has already won each
+    /// supplied claim for `identity`; this method still performs the same
+    /// bounded `ensure_claimed` recheck before hydrating any durable row.
+    pub async fn hydrate_reclaimed_as(
+        &self,
+        entities: &[(Entity, ClaimEpoch)],
+        identity: &NodeIdentity,
+    ) -> Result<usize, SmRegistryError> {
         let mut hydrated = 0usize;
-        for (entity, _caller_epoch) in entities {
-            if entity.entity_type != EntityType::SmSession {
-                debug!(
-                    entity = %entity,
-                    "hydrate_reclaimed: skipping a non-SmSession entity"
-                );
-                continue;
-            }
-            let stream_id = entity.id.clone();
-            let stream_lock = self.stream_lock(&stream_id)?;
-            let _stream_guard = stream_lock.lock().await;
-
-            let present = {
-                let sessions = self
-                    .sessions
-                    .read()
-                    .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-                let claimed = self
-                    .claimed_sessions
-                    .read()
-                    .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-                sessions.contains_key(&stream_id) || claimed.contains_key(&stream_id)
-            };
-            if present {
-                debug!(
-                    stream_id = %stream_id,
-                    "hydrate_reclaimed: already present in-memory (live session, or already \
-                     hydrated by an overlapping sweep); skipping"
-                );
-                continue;
-            }
-
-            // FIX 5: bounded — see `CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT`'s
-            // doc comment. On timeout or a lost self-reacquire, skip this
-            // entity for this pass rather than insert a session this node
-            // can no longer prove it owns; the entity remains eligible for
-            // a future sweep.
-            let identity = self.node_identity.current();
-            let epoch = match tokio::time::timeout(
-                CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
-                self.claim_store.ensure_claimed(entity, &identity),
-            )
-            .await
+        for (entity, caller_epoch) in entities {
+            if self
+                .hydrate_reclaimed_one_as(entity, *caller_epoch, identity)
+                .await?
+                == ReclaimedSessionHydration::Hydrated
             {
-                Ok(Ok(epoch)) => epoch,
-                Ok(Err(error)) => {
-                    debug!(
-                        stream_id = %stream_id,
-                        %error,
-                        "hydrate_reclaimed: ClaimStore ensure_claimed self-reacquire failed \
-                         (claim lost again since the caller's steal_stale); skipping"
-                    );
-                    continue;
-                }
-                Err(_timeout) => {
-                    tracing::warn!(
-                        stream_id = %stream_id,
-                        timeout = ?CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
-                        "hydrate_reclaimed: ClaimStore ensure_claimed timed out while holding \
-                         this stream's shard lock; skipping this entity for this pass"
-                    );
-                    continue;
-                }
-            };
-
-            let session_id = crate::pending_delivery::SmSessionId::new(stream_id.clone());
-            let persisted = match storage.get_session(&session_id).await {
-                Ok(Some(row)) => row,
-                Ok(None) => {
-                    debug!(
-                        stream_id = %stream_id,
-                        "hydrate_reclaimed: no durable row (already promoted/deleted by a \
-                         concurrent sweep); skipping"
-                    );
-                    continue;
-                }
-                Err(error) => {
-                    debug!(
-                        stream_id = %stream_id,
-                        %error,
-                        "hydrate_reclaimed: get_session failed; skipping this entity for this pass"
-                    );
-                    continue;
-                }
-            };
-            let unacked = match storage.list_unacked(&session_id).await {
-                Ok(rows) => rows,
-                Err(error) => {
-                    debug!(
-                        stream_id = %stream_id,
-                        %error,
-                        "hydrate_reclaimed: list_unacked failed; skipping this entity for this pass"
-                    );
-                    continue;
-                }
-            };
-            let session = match persisted_to_detached(&persisted, &unacked) {
-                Ok(session) => session,
-                Err(error) => {
-                    debug!(
-                        stream_id = %stream_id,
-                        %error,
-                        "hydrate_reclaimed: row decode failed (poison pill); skipping"
-                    );
-                    self.release_claim_store_entry_under(&stream_id, epoch)
-                        .await;
-                    continue;
-                }
-            };
-            {
-                let mut sessions = self
-                    .sessions
-                    .write()
-                    .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-                sessions.insert(stream_id.clone(), session);
+                hydrated += 1;
             }
-            if let Ok(mut claim_epochs) = self.claim_epochs.write() {
-                claim_epochs.insert(stream_id, epoch);
-            }
-            hydrated += 1;
         }
         Ok(hydrated)
+    }
+
+    /// Strict, typed hydration of one exact recovery grant.
+    ///
+    /// Unlike [`Self::hydrate_reclaimed_as`]'s historical aggregate count,
+    /// this method never hides a transient failure inside `Ok(0)`. It is the
+    /// recovery state machine's readiness gate: a caller may proceed only on
+    /// `Hydrated`, `AlreadyLocal`, `Elsewhere`, or `TerminallyReleased`.
+    pub async fn hydrate_reclaimed_one_as(
+        &self,
+        entity: &Entity,
+        caller_epoch: ClaimEpoch,
+        identity: &NodeIdentity,
+    ) -> Result<ReclaimedSessionHydration, SmRegistryError> {
+        if entity.entity_type != EntityType::SmSession {
+            debug!(entity = %entity, "hydrate_reclaimed: non-SmSession entity");
+            return Ok(ReclaimedSessionHydration::Retry);
+        }
+        let Some(storage) = &self.persistence else {
+            return Ok(ReclaimedSessionHydration::Retry);
+        };
+        let stream_id = entity.id.clone();
+        let stream_lock = self.stream_lock(&stream_id)?;
+        let _stream_guard = stream_lock.lock().await;
+
+        // Re-prove the exact owner after the caller's reclaim CAS. If the
+        // bounded self-reacquire has an ambiguous outcome, an unlocked
+        // current-claim read classifies it without trusting the caller's
+        // stale observation.
+        let epoch = match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            self.claim_store.ensure_claimed(entity, identity),
+        )
+        .await
+        {
+            Ok(Ok(epoch)) => epoch,
+            Ok(Err(error)) => {
+                debug!(stream_id = %stream_id, %error, "strict hydration claim recheck failed");
+                return Ok(self
+                    .classify_reclaimed_owner(entity, identity, caller_epoch)
+                    .await);
+            }
+            Err(_) => {
+                tracing::warn!(
+                    stream_id = %stream_id,
+                    timeout = ?CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+                    "strict hydration claim recheck timed out"
+                );
+                return Ok(self
+                    .classify_reclaimed_owner(entity, identity, caller_epoch)
+                    .await);
+            }
+        };
+
+        let present = {
+            let sessions = self
+                .sessions
+                .read()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            let claimed = self
+                .claimed_sessions
+                .read()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            sessions.contains_key(&stream_id) || claimed.contains_key(&stream_id)
+        };
+        if present {
+            self.claim_epochs
+                .write()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?
+                .insert(stream_id, epoch);
+            return Ok(ReclaimedSessionHydration::AlreadyLocal);
+        }
+
+        let session_id = crate::pending_delivery::SmSessionId::new(stream_id.clone());
+        let persisted = match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            storage.get_session(&session_id),
+        )
+        .await
+        {
+            Ok(Ok(Some(row))) => row,
+            Ok(Ok(None)) => {
+                debug!(stream_id = %stream_id, "strict hydration found no durable session");
+                return Ok(self.release_reclaimed_claim(entity, identity, epoch).await);
+            }
+            Ok(Err(error)) => {
+                debug!(stream_id = %stream_id, %error, "strict hydration durable load failed");
+                return Ok(ReclaimedSessionHydration::Retry);
+            }
+            Err(_) => return Ok(ReclaimedSessionHydration::Retry),
+        };
+        let unacked = match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            storage.list_unacked(&session_id),
+        )
+        .await
+        {
+            Ok(Ok(rows)) => rows,
+            Ok(Err(error)) => {
+                debug!(stream_id = %stream_id, %error, "strict hydration unacked load failed");
+                return Ok(ReclaimedSessionHydration::Retry);
+            }
+            Err(_) => return Ok(ReclaimedSessionHydration::Retry),
+        };
+        let session = match persisted_to_detached(&persisted, &unacked) {
+            Ok(session) => session,
+            Err(error) => {
+                debug!(stream_id = %stream_id, %error, "strict hydration found a poison row");
+                return Ok(self.release_reclaimed_claim(entity, identity, epoch).await);
+            }
+        };
+
+        // Durable reads can span a lease transition. Re-prove the exact
+        // owner and grant generation immediately before the synchronous
+        // local insert; a session stolen while storage was loading must
+        // never be hydrated here under stale authority.
+        match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            self.claim_store.current_claim(entity),
+        )
+        .await
+        {
+            Ok(Ok(Some(snapshot)))
+                if snapshot.owner == *identity
+                    && snapshot.claim_epoch == epoch
+                    && snapshot.owner_lease_fresh => {}
+            Ok(Ok(Some(snapshot))) if snapshot.owner != *identity => {
+                return Ok(ReclaimedSessionHydration::Elsewhere);
+            }
+            Ok(Ok(None)) => return Ok(ReclaimedSessionHydration::TerminallyReleased),
+            _ => return Ok(ReclaimedSessionHydration::Retry),
+        }
+
+        let mut sessions = self
+            .sessions
+            .write()
+            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+        let mut claim_epochs = self
+            .claim_epochs
+            .write()
+            .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+        sessions.insert(stream_id.clone(), session);
+        claim_epochs.insert(stream_id, epoch);
+        Ok(ReclaimedSessionHydration::Hydrated)
+    }
+
+    async fn classify_reclaimed_owner(
+        &self,
+        entity: &Entity,
+        identity: &NodeIdentity,
+        expected_epoch: ClaimEpoch,
+    ) -> ReclaimedSessionHydration {
+        match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            self.claim_store.current_claim(entity),
+        )
+        .await
+        {
+            Ok(Ok(Some(snapshot)))
+                if snapshot.owner == *identity && snapshot.claim_epoch == expected_epoch =>
+            {
+                // The ownership proof survived but the full hydration path
+                // has not run yet. Keep it pending rather than accepting the
+                // claim without local state.
+                ReclaimedSessionHydration::Retry
+            }
+            Ok(Ok(Some(snapshot))) if snapshot.owner != *identity => {
+                ReclaimedSessionHydration::Elsewhere
+            }
+            Ok(Ok(None)) => ReclaimedSessionHydration::TerminallyReleased,
+            _ => ReclaimedSessionHydration::Retry,
+        }
+    }
+
+    async fn release_reclaimed_claim(
+        &self,
+        entity: &Entity,
+        identity: &NodeIdentity,
+        epoch: ClaimEpoch,
+    ) -> ReclaimedSessionHydration {
+        let _ = tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            self.claim_store.release(entity, identity, epoch),
+        )
+        .await;
+        match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            self.claim_store.current_claim(entity),
+        )
+        .await
+        {
+            Ok(Ok(None)) => ReclaimedSessionHydration::TerminallyReleased,
+            Ok(Ok(Some(snapshot))) if snapshot.owner != *identity => {
+                ReclaimedSessionHydration::Elsewhere
+            }
+            _ => ReclaimedSessionHydration::Retry,
+        }
     }
 }
 

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/cross_node_resume.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/cross_node_resume.rs
@@ -118,7 +118,8 @@ use jid::BareJid;
 use tokio::time::Instant;
 
 use crate::ownership::{
-    verify_resume_identity, ClaimEpoch, ClaimError, Entity, EntityType, ResumeIdentityProof,
+    verify_resume_identity, ClaimEpoch, ClaimError, Entity, EntityType, NodeIdentity,
+    ResumeIdentityProof,
 };
 use crate::stream_management::persistence::PersistedSession;
 
@@ -172,9 +173,10 @@ const REPAIR_RELEASE_MAX_ATTEMPTS: u32 = 3;
 /// Delay between [`REPAIR_RELEASE_MAX_ATTEMPTS`] repair-release retries.
 const REPAIR_RELEASE_RETRY_DELAY: Duration = Duration::from_millis(200);
 
-/// Ask a remote node (identified by its `node_id`) to release a live SM
-/// session for cross-node resume (element 8's "live, owned elsewhere"
-/// branch — XEP-0198's "Resumption" section `<conflict/>`-close SHOULD).
+/// Ask the exact remote owner incarnation observed in the claims table to
+/// release a live SM session for cross-node resume (element 8's "live,
+/// owned elsewhere" branch — XEP-0198's "Resumption" section
+/// `<conflict/>`-close SHOULD).
 ///
 /// Implemented in `waddle-server` via `RelayHandle` (the swarm's cross-node
 /// ask); this trait keeps `waddle-xmpp` free of any clustering/swarm/libp2p
@@ -182,14 +184,16 @@ const REPAIR_RELEASE_RETRY_DELAY: Duration = Duration::from_millis(200);
 /// already uses for the Postgres CAS implementation.
 #[async_trait::async_trait]
 pub trait RemoteResumeAsker: Send + Sync {
-    /// Ask node `node_id` to force-detach its live SM session `stream_id`
-    /// on behalf of `requester_bare_jid`. The remote node performs its own
-    /// defense-in-depth identity check before doing anything destructive
-    /// (ADR-0017 Phase 3 plan, Slice 6: "the identity check gates the
-    /// destructive close itself, not just the subsequent CAS").
+    /// Ask `expected_owner` to force-detach its live SM session `stream_id`
+    /// only while the claim is still held under `observed`. The remote node
+    /// performs both exact-owner/claim-epoch validation and the requester's
+    /// JID identity check before doing anything destructive (ADR-0017 Phase
+    /// 3 plan, Slice 6: "the identity check gates the destructive close
+    /// itself, not just the subsequent CAS").
     async fn ask_remote_detach(
         &self,
-        node_id: &str,
+        expected_owner: &NodeIdentity,
+        observed: ClaimEpoch,
         stream_id: &str,
         requester_bare_jid: &BareJid,
     ) -> RemoteResumeAskOutcome;
@@ -359,7 +363,7 @@ impl InMemorySmSessionRegistry {
         // The eventual `steal_for_resume` call binds this exact value,
         // never a freshly re-read one.
         let observed_epoch = snapshot.claim_epoch;
-        let owner_node_id = snapshot.owner.node_id;
+        let expected_owner = snapshot.owner;
 
         let deadline = Instant::now() + handshake_budget;
         let mut backoff = INITIAL_HANDSHAKE_BACKOFF;
@@ -452,7 +456,12 @@ impl InMemorySmSessionRegistry {
             // same bounded backoff-and-retry below.
             let ask_outcome = match tokio::time::timeout(
                 remaining,
-                asker.ask_remote_detach(&owner_node_id, stream_id, requester_bare_jid),
+                asker.ask_remote_detach(
+                    &expected_owner,
+                    observed_epoch,
+                    stream_id,
+                    requester_bare_jid,
+                ),
             )
             .await
             {
@@ -917,7 +926,8 @@ mod tests {
     impl RemoteResumeAsker for SlowAsker {
         async fn ask_remote_detach(
             &self,
-            _node_id: &str,
+            _expected_owner: &NodeIdentity,
+            _observed: ClaimEpoch,
             _stream_id: &str,
             _requester_bare_jid: &BareJid,
         ) -> RemoteResumeAskOutcome {
@@ -1016,7 +1026,8 @@ mod tests {
     impl RemoteResumeAsker for FlakyAsker {
         async fn ask_remote_detach(
             &self,
-            _node_id: &str,
+            _expected_owner: &NodeIdentity,
+            _observed: ClaimEpoch,
             stream_id: &str,
             _requester_bare_jid: &BareJid,
         ) -> RemoteResumeAskOutcome {
@@ -1123,7 +1134,8 @@ mod tests {
         impl RemoteResumeAsker for ReleasingAsker {
             async fn ask_remote_detach(
                 &self,
-                _node_id: &str,
+                _expected_owner: &NodeIdentity,
+                _observed: ClaimEpoch,
                 _stream_id: &str,
                 _requester_bare_jid: &BareJid,
             ) -> RemoteResumeAskOutcome {
@@ -1550,10 +1562,9 @@ mod tests {
         }
         async fn release_many(
             &self,
-            entities: &[Entity],
-            me: &crate::ownership::NodeIdentity,
+            grants: &[crate::ownership::ClaimGrant],
         ) -> Result<(), ClaimError> {
-            self.inner.release_many(entities, me).await
+            self.inner.release_many(grants).await
         }
     }
 

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -2717,6 +2717,87 @@ impl super::super::persistence::SmPersistenceStorage for GatedGetSessionPersiste
 }
 
 #[tokio::test]
+async fn strict_hydration_rechecks_the_exact_grant_after_durable_reads() {
+    let storage = std::sync::Arc::new(GatedGetSessionPersistence::new("stream-stolen-mid-load"));
+    let claim_store = std::sync::Arc::new(crate::ownership::InProcessClaimStore::new());
+    let me = crate::ownership::NodeIdentity::new("recovery", "candidate");
+    let other = crate::ownership::NodeIdentity::new("other", "winner");
+    let entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        "stream-stolen-mid-load",
+    );
+    storage
+        .inner
+        .upsert_session(super::super::persistence::PersistedSession {
+            stream_id: crate::pending_delivery::SmSessionId::new("stream-stolen-mid-load"),
+            user_id: "race@example.com".to_string(),
+            jid: "race@example.com/recovery".parse().expect("jid"),
+            inbound_count: 0,
+            outbound_count: 0,
+            last_acked: 0,
+            replay_gap_through: None,
+            max_resume_time: Some(300),
+            detached_at: chrono::Utc::now(),
+            max_resume_duration: Duration::from_secs(300),
+            carbons_enabled: false,
+            roster_interested: false,
+            blocklist_interested: false,
+            presence_available: false,
+            presence_show: None,
+            presence_status: None,
+            presence_priority: 0,
+            presence_payloads: Vec::new(),
+        })
+        .await
+        .expect("seed durable row");
+    let epoch = claim_store.acquire(&entity, &me).await.expect("seed claim");
+    let registry = std::sync::Arc::new(
+        InMemorySmSessionRegistry::new()
+            .with_persistence(storage.clone())
+            .with_claim_store(
+                claim_store.clone(),
+                crate::ownership::SharedNodeIdentity::new(me.clone()),
+            ),
+    );
+
+    storage
+        .armed
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    let hydrate_registry = std::sync::Arc::clone(&registry);
+    let hydrate_entity = entity.clone();
+    let hydrate_owner = me.clone();
+    let hydrate = tokio::spawn(async move {
+        hydrate_registry
+            .hydrate_reclaimed_one_as(&hydrate_entity, epoch, &hydrate_owner)
+            .await
+    });
+    storage.reached.notified().await;
+    claim_store
+        .steal_stale(
+            &entity,
+            epoch,
+            crate::ownership::StalePredicate::OwnerStale,
+            &other,
+        )
+        .await
+        .expect("move claim during durable load");
+    storage
+        .armed
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+    storage.proceed.notify_one();
+
+    assert_eq!(
+        hydrate.await.expect("task").expect("hydrate"),
+        ReclaimedSessionHydration::Elsewhere
+    );
+    assert!(registry
+        .peek_session("stream-stolen-mid-load")
+        .await
+        .expect("peek")
+        .is_none());
+}
+
+#[tokio::test]
 async fn hydrate_reclaimed_serializes_against_a_concurrent_live_mutator_for_the_same_stream() {
     // FIX 2's mid-flight race: the orphan reaper's `hydrate_reclaimed` must
     // never overlap a live session's own store/claim/take mutation of the

--- a/server/docs/adrs/0017-phase4-plan-cross-node-routing-ga.md
+++ b/server/docs/adrs/0017-phase4-plan-cross-node-routing-ga.md
@@ -393,12 +393,14 @@ changes slice scope, XEP behavior, or operational requirements.
    only after the connection task acknowledges cleanup. A final correctness
    pass closed three edge cases: UserActor health checks are now
    non-destructive so a failed health probe cannot release the claim before
-   demotion; `owned()` falls back to `ConnectionRegistry` bare-JID enumeration
-   if the user registry cannot answer during terminal self-fence; and a queued
-   force-detach timeout leaves the registry entry in place so the connection
-   task can still consume the request and run non-superseded cleanup. XMPP wire
-   behavior remains unchanged except for the intended native `<conflict/>`
-   close on a deposed live stream. A later XEP/lifecycle review found the
+   demotion; terminal self-fence teardown includes `ConnectionRegistry`
+   bare-JID enumeration even if the user registry cannot answer, without
+   treating those sockets as authoritative claims during ordinary
+   reconciliation; and a queued force-detach timeout leaves the registry entry
+   in place so the connection task can still consume the request and run
+   non-superseded cleanup. At that stage, XMPP wire behavior remained
+   unchanged except for the intended native `<conflict/>` close on a deposed
+   live stream. A later XEP/lifecycle review found the
    registry reuse fast path still needed the same discipline: a stale
    `UserEntry` whose stored owner/epoch no longer matches the current shared
    identity/fence is now retired only after its live resources acknowledge
@@ -808,3 +810,192 @@ changes slice scope, XEP behavior, or operational requirements.
     keypair pool or an external secret source whenever `clustering.enabled=true`,
     and Postgres-backed keypair-slot tests share the cluster test lock to keep
     the real multi-process harness deterministic.
+49. Remote-resource rollout exposed an ownership-enumeration ambiguity in
+    `UserLocalClaims`: the ordinary Postgres reconciliation set unconditionally
+    included every socket in the local `ConnectionRegistry`, including sockets
+    whose authoritative `UserActor` claim belongs to another node. The
+    10-second reconciliation loop therefore classified valid remote resources
+    as deposed local claims and conflict-closed them. Authoritative claim
+    enumeration and terminal whole-node teardown are now separate surfaces:
+    routine reconciliation reads only locally owned actors, while an actual
+    node self-fence still demotes all authoritative actors, every socket
+    physically hosted on that node, and owner-side mirrors for remote sockets.
+    Force-detach now carries a typed reason through the relay: real session
+    resume or resource replacement retains the terminal `<conflict/>`; whole
+    node self-fence uses `<system-shutdown/>`; and per-resource ownership or
+    remote-state loss uses recoverable `<internal-server-error/>`. This
+    preserves the Phase 4 safety boundary without treating cross-node resource
+    placement as ownership loss or suppressing client reconnection during
+    infrastructure failure. Per-user reconciliation also carries the exact
+    `ConnectionEntry` owner tokens recorded by the deposed `UserActor`; it
+    never broad-scans the bare JID and therefore cannot detach a newer
+    same-JID incarnation.
+
+    Whole-node teardown is bulk and fail-closed: UserActor and RoomActor
+    registries atomically drain in one mailbox operation; socket retirements
+    run concurrently; a timed-out local socket is hard-aborted through its
+    per-connection retirement handle; and remote mirrors are classified as
+    proxy state rather than local transports. Readiness is cleared before any
+    await and is not restored until terminal teardown succeeds. Incomplete
+    retries re-mark the fresh node row draining, while successful teardown
+    purges both socket-side and owner-side remote-resource bridge indexes.
+    Bind/resume registration checks readiness before publication, immediately
+    after publication, after actor/remote mirroring, and after SM finalization,
+    with owner-gated rollback of every published view.
+
+    Self-fence recovery preserves the process `node_id`, which is also the
+    supervised relay actor's registered address, and rotates only
+    `node_epoch`. Re-registration therefore updates one bounded node row and
+    does not publish claims or routes for a relay name that was never spawned.
+    The replacement epoch is first registered atomically as `draining`; the
+    old epoch is not superseded until terminal teardown succeeds, and an
+    exact-epoch activation CAS runs only after teardown and hysteresis pass.
+    New-claim, resume, and idempotent-reacquire paths require an eligible exact
+    node incarnation, while every durable write fence now matches
+    `(node_id, node_epoch, claim_epoch)` so a recovered process cannot revive
+    a stale incarnation through the stable relay address.
+
+    Claim epochs now come from one never-reset Postgres sequence, and release,
+    bulk release, and recovery operations match the full claim grant rather
+    than a resource key alone. A cold process start uses the same recovery
+    state machine as a live self-fence: it registers the replacement
+    incarnation as draining, keeps readiness false, reclaims only the exact
+    predecessor lineage, strictly hydrates its typed SM, ISR, pending-delivery,
+    UserActor, and RoomActor state, and re-proves every current claim after the
+    durable reads. Recovery heartbeats while that work is in progress; an
+    initialization latch prevents new traffic from observing half-restored SM
+    state; and cancellation or any failed re-proof leaves the candidate
+    draining instead of activating partial state.
+
+    Each node incarnation persists its configured lease TTL beside its
+    heartbeat. Destination-side claim grants, current-ownership proofs, relay
+    authority, reconciliation vetoes, and all SM, ISR, pending-delivery, MUC,
+    and MAM durable-write fences atomically require that row-local heartbeat to
+    remain within the recorded TTL, even if the watchdog has not yet committed
+    `expired=true`. Takeover of another node remains stricter: source ownership
+    is stealable only after its expiry is durably committed. This prevents a
+    paused process from waking after its lease window and winning a new claim
+    or committing a stale durable write during the watchdog scheduling gap.
+
+    Those deadline checks run after the contested claim or node row has been
+    locked, using Postgres `clock_timestamp()` rather than transaction-stable
+    `now()`. Claim grants mutate inside a control-plane transaction, then lock
+    and validate the destination incarnation immediately before commit; a
+    failed proof rolls the mutation and any consumed steal intent back.
+    Absent-row acquisition and stable-node registration use transaction-scoped
+    advisory locks so a uniqueness wait cannot preserve an early liveness
+    decision. Durable stores materialize the exact claim and node locks before
+    evaluating the wall clock. A task that begins while fresh but waits beyond
+    the TTL therefore cannot renew, acquire, or commit a fenced write.
+
+    Every transaction that can retain one of those exact claim or node locks
+    installs a five-second database-side deadline before taking the lock. On
+    PostgreSQL 17 this sets local lock, statement, idle-in-transaction, and
+    total transaction timeouts from one typed budget; cluster configuration
+    rejects a node lease TTL that is not strictly longer. The same bounded
+    transaction entry point is used by the control plane and the SM, ISR,
+    pending-delivery, MUC, and MAM durable stores, so a stalled task cannot pin
+    heartbeat or takeover locks indefinitely past the nominal lease.
+
+    Before publishing either a local-owner resource or a remote-owner mirror,
+    a socket reserves one durable full-JID admission row under a never-reset
+    Postgres sequence. The row binds a typed admission epoch and registration
+    id to the exact physical socket `NodeIdentity`; a later reservation on any
+    node atomically supersedes it. Both placements pass through the same
+    per-full-JID publication guard and owner-side registration map, so a newer
+    local socket displaces an older remote socket and a newer remote socket
+    displaces an older local socket in one total order. Owner handlers prove
+    that exact row before displacement and again after every await and before
+    publication, while exact cancellation can delete only the matching
+    admission. Inbound stanzas, full-JID delivery, and Carbon fanout also prove
+    the stored token; a cancellation that arrives before its delayed register
+    therefore makes the register terminally stale, and an old node cannot
+    deliver to or detach a newer bind. Normal and whole-node cleanup cancel the
+    exact row; a bounded indexed janitor removes only rows whose socket
+    incarnation is absent or committed expired.
+
+    The socket also publishes its exact pending registration before asking the
+    owner to create a mirror, ensuring concurrent owner teardown can always
+    reach the physical connection even if the registration ACK is still in
+    flight. Process-local socket generations survive epoch rotation and remain
+    an additional same-node ordering proof. Registration, update, route,
+    delivery, force-detach, unregister, and compensation messages carry both
+    generations plus the expected authoritative owner incarnation.
+
+    Both sides retain typed, exact-generation compensation evidence for an
+    owner registration whose reply is uncertain. Cleanup distinguishes a
+    terminal exact unregister from a retryable maybe-committed outcome, never
+    makes cleanup-only evidence routable, and is bounded globally and per JID
+    before the owner ask is admitted. Whole-node fencing transfers active
+    registrations into that same bounded cleanup path, while cooperative
+    detach and the physical socket's abort handle provide a terminal fallback.
+    All registration, forwarding, detach, and compensation messages carry the
+    exact socket `NodeIdentity`, resource generation, and registration id, so
+    a delayed operation cannot retire a newer same-resource incarnation.
+
+    Remote delivery replies also distinguish positively stale registration
+    evidence from temporary unavailability. A missing exact connection,
+    superseded admission, or changed socket incarnation permits cleanup; a
+    claim-store failure, relay discovery miss, or other ambiguous outage keeps
+    the owner mirror and returns a retryable unavailable outcome. Pending
+    socket cleanup becomes globally retryable as soon as either its exact
+    active metadata or exact physical connection is gone, preventing uncertain
+    disconnects from permanently consuming the bounded cleanup budget.
+
+    Each RoomActor now binds the exact claim context won for that actor
+    incarnation before restore; it never resolves a later room-scoped epoch.
+    Binding is one-shot, every registry removal kills the old actor, and
+    destroy is an exact actor-reference CAS, so a retained E1 reference cannot
+    borrow E2 authority or remove the replacement. Room mutations pass that
+    exact gate before touching actor state, durable MUC/MAM writes return typed
+    ownership loss when their in-transaction fence fails, and direct admin,
+    config, destroy, moderation, and system-message effects re-prove the same
+    context immediately after their final await and before fanout. Definitive
+    loss demotes; backend uncertainty fails closed without guessing.
+
+    Owner-driven room destruction uses a registry-serialized exact-effect
+    barrier rather than a check followed by an ordinary destroy CAS. CAS-first
+    alone is insufficient: once E1 is removed and its claim released, the
+    registry can install E2 before the caller emits E1's final unavailable
+    presence and room/full-JID-keyed SFU teardown. The barrier revalidates E1's
+    exact claim and live node inside the registry handler, then asks E1's own
+    mailbox to run its mutation gate, seal admission, and return the final
+    occupant snapshot. Joins committed before the seal are therefore included;
+    later joins receive `RoomSealed`. No fallible authority check follows that
+    seal. The actor-ref CAS removes and kills E1 while retaining its full
+    `ClaimGrant`, then grants the caller one typed reservation carrying that
+    snapshot. The registry mailbox remains blocked until a typed `effects_done`
+    acknowledgement arrives; dropping the acknowledgement sender on
+    cancellation also unblocks cleanup. Only that reservation winner emits
+    XEP-0045 destroy effects, after which the registry exact-releases E1's grant
+    before admitting E2. Definitive claim loss demotes E1 without effects,
+    while claim-backend or actor-gate uncertainty retains E1 unsealed and fails
+    closed.
+
+    Terminal registry removal retains the actor's full typed `ClaimGrant`
+    until its exact release succeeds. A transient release failure therefore
+    blocks replacement instead of allowing `ensure_claimed` to self-reacquire
+    E1's orphaned epoch for E2; the pending evidence survives whole-node
+    demotion and identity rotation and is retried with E1's captured owner.
+    Duplicate release evidence cannot overwrite the first unresolved grant.
+    Nested room effects also carry the authorizing actor reference alongside
+    the claim fence: archive, tombstone, inbox projection, and normal or system
+    fanout re-prove that exact actor around awaited work and at each recipient
+    boundary. A stale E1 result can exact-demote only E1 and can never adopt,
+    remove, mutate, or fan out through the room-key-current E2.
+
+    XEP-0424 retraction validates the canonical target, wire retraction id,
+    sender, room, and non-null occupancy generation in the same transaction.
+    XEP-0425 accepts only the room-assigned stanza/archive id as its target,
+    preserves the moderation message's distinct wire `id` during MAM replay,
+    and uses that wire id for the XEP-0424 tombstone `<retracted id>`, while the
+    canonical event and tombstone remain atomically bound to the exact target
+    and moderator. Subject, affiliation, role, occupant, moderation, destroy,
+    and pin effects therefore fail closed across claim rotation instead of
+    publishing from a deposed room owner.
+
+    The multi-process regression now holds a non-owner resource across
+    multiple observed heartbeat/reconciliation advances, proves exact XEP-0280
+    sent/received carbon shapes, and drives a live remote socket through
+    isolation fencing (`<system-shutdown/>`), re-enrollment, same-resource
+    reconnection, and fresh owner-mirror delivery.


### PR DESCRIPTION
## Problem

Clustered WebSocket resources are physically hosted in a node-local `ConnectionRegistry`, but their authoritative `UserActor` can live on another node. Routine `UserLocalClaims` reconciliation treated every physical socket as a locally owned actor claim, so the 10-second reconciliation loop conflict-closed valid remote resources. Clients surfaced that as “this session was replaced by a newer sign-in”; XEP-0280 Carbon fanout exposed the stale routing, but Carbon serialization was not the root cause.

The same audit found two adjacent correctness gaps that could recreate the symptom under failure:

- local-owner and remote-owner binds for the same full JID did not share one cluster-wide replacement order;
- a stalled fenced transaction, stale node epoch, or retained MUC actor could keep acting after ownership moved.

## Implementation

- Separate authoritative actor enumeration from physical socket placement. Routine reconciliation considers only locally owned actors; terminal whole-node fencing still retires every locally hosted socket and remote mirror.
- Give every local or remote full-JID bind one durable, never-reset admission epoch. Publication, inbound traffic, full-JID delivery, Carbons, state updates, detach, compensation, and cleanup all prove the exact registration, admission, socket node/epoch, and actor claim.
- Serialize same-full-JID replacement across placements: newer local displaces older remote, and newer remote displaces older local. Delayed E1 frames, cleanup, or unregister operations cannot affect E2.
- Carry typed detach reasons end to end: real resource replacement remains `<conflict/>`; node shutdown uses `<system-shutdown/>`; ownership/infrastructure loss uses recoverable `<internal-server-error/>`.
- Make node recovery exact: stable `node_id`, rotating `node_epoch`, draining cold-start predecessor recovery, strict hydration/re-proof before readiness, globally monotonic claim epochs, and exact-grant release.
- Evaluate node freshness after contested rows are locked with `clock_timestamp()`. Every transaction that retains a claim/node fence installs PostgreSQL 17 lock, statement, idle, and total transaction deadlines from one five-second typed budget; configuration requires the node lease to be longer.
- Apply the same exact claim/node fences to SM, ISR, pending delivery, MUC, and MAM writes.
- Bind MUC effects to the exact `RoomActor` plus claim grant. Subject, pin, archive, tombstone, projection, admin rollback, and per-recipient fanout cannot adopt a replacement actor. Failed exact claim release retains typed evidence and blocks same-epoch respawn until release succeeds.
- Linearize XEP-0045 owner destruction across the actor mailbox, registry, claim, XMPP presence, and SFU teardown: E1 is claim-fenced and admission-sealed, the seal returns the final occupant snapshot, the registry retains E1's grant and blocks E2 until the sole winning synchronous effect batch completes, and cancellation still finalizes the exact release.
- Preserve XEP-0424/0425 wire semantics: moderation targets the room-assigned stanza/archive ID, while the distinct live wire message ID is retained for the retraction tombstone.

The full design and failure-ordering rationale are recorded in ADR-0017 item 49.

## Protocol review

Reviewed against the local XEP corpus for XEP-0045, XEP-0198, XEP-0280, XEP-0424, and XEP-0425. The implementation remains XMPP-native and adds no out-of-band control API or custom official-namespace shape.

## Validation

- `cargo fmt --manifest-path server/Cargo.toml --all -- --check`
- `cargo check --manifest-path server/Cargo.toml -p waddle-server --all-features --tests`
- strict all-target/all-feature clippy for `waddle-server` and `waddle-xmpp`
- rebased onto `origin/main` at `13598844`; all five MUC/MAM conflicts were resolved by retaining both upstream XEP-0421/MUC archive identity semantics and this change's exact ownership fences
- post-rebase self-fence suite: 28 passed; MUC durable suite: 15 passed; groupchat interpretation suite: 117 passed
- exact owner-destroy seal/barrier/final-claim/cancellation/concurrency and actor-ref regressions: all focused tests passed
- clustering library: 292 passed
- ordered-relay integration: 23 passed
- XEP-0198 cross-node resume: 12 passed
- RoomActor: 108 passed; RoomRegistryActor: 26 passed
- XEP-0280: 7 passed; XEP-0424: 12 passed; XEP-0425: 14 passed
- unified resource-admission/route bridge: 60 passed
- multiprocess clustered remote → local → remote same-full-JID and Carbon scenario compiled with `--no-run`
- repeated lease/recovery, resource-routing, MUC/XEP, and final cross-domain adversarial reviews: no actionable issues remain
- `git diff --check`

The first PR `nixTest` completed 1,826 tests and exposed 20 clustered-Postgres fixture/recovery failures. Those are now corrected with exact-incarnation fixture setup, persisted lease TTLs, global claim-epoch reads, cross-pass recovery grant provenance, canonical moderation timestamps, and deterministic fenced expiry/write tests. Full local library sweeps are otherwise limited only by the workspace sandbox denying OS-port binds for mock HTTP servers; CI remains the authoritative live PostgreSQL/network proof.
