### PR TITLE
feat(server): XEP-0359 stanza-id through push publish + XEP-0444 reaction-only suppression (#779 #780)

### DIFF
--- a/TODO-ISSUES.md
+++ b/TODO-ISSUES.md
@@ -49,7 +49,7 @@ _Residual (tracked, not #945-gating): survivor-check TOCTOU needs per-call locki
 
 ### Lane C — Push server reliability + conformance
 1. ✅ **#1123 + #1124 + #1126 `[one PR]` — duplicate/spurious push trio: per-device idempotent retry (delivered-device filter + all-delivered→published), janitor claim-recency floor (`claimed_at_ms` + 3-interval floor), unread-0 suppression (typed `Suppressed` outcome + `unread_zero_at_publish` audit reason) + ±25% retry jitter on all three backoff paths. DONE (PR #1236).**
-2. #779 + #780 `[one PR]` — preserve XEP-0359 stanza-id through XEP-0357 publish (SW dedupe is dead by construction); suppress push for XEP-0444 reaction-only messages.
+2. ✅ **#779 + #780 `[one PR]` — stanza-id rides a typed `stanza-id` attribute on `urn:waddle:push:context:0` → `PushEnvelope.item` (item id stays job id for coalesce/idempotency; SW dedupe now live for DM + MUC); reaction-only messages suppressed at T1 with typed `xep0444_reaction` reason (archived, never pushed). DONE (PR #1239).**
 3. #774 + #772 + #773 + #776 + #777 `[one PR]` — XEP-0357/0050 polish: strict publish-options FORM_TYPE validation, emit SessionExpired, session-lifecycle robustness, single-tx register-device, typed composer errors.
 4. #775 — finish §6 forward cleanup on 410 GONE (device half done; user-server invalidation + client notify remain).
 5. #1125 — dead-letter permanently-unresolvable notification candidates.

--- a/cuenv.lock
+++ b/cuenv.lock
@@ -18,18 +18,6 @@ flake = "../.."
 digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
 lockfile = "infrastructure/waddle.cloud/../../flake.lock"
 
-[runtimes.server]
-type = "nix"
-flake = ".."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
-lockfile = "server/../flake.lock"
-
-[runtimes.website]
-type = "nix"
-flake = ".."
-digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
-lockfile = "website/../flake.lock"
-
 [vcs.cuenv-skills]
 url = "https://github.com/cuenv/cuenv.git"
 reference = "main"

--- a/cuenv.lock
+++ b/cuenv.lock
@@ -18,6 +18,18 @@ flake = "../.."
 digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
 lockfile = "infrastructure/waddle.cloud/../../flake.lock"
 
+[runtimes.server]
+type = "nix"
+flake = ".."
+digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+lockfile = "server/../flake.lock"
+
+[runtimes.website]
+type = "nix"
+flake = ".."
+digest = "sha256:22c72a3faea22e798923cadadad88c625122228e05204cc052fc74d5f2d8d883"
+lockfile = "website/../flake.lock"
+
 [vcs.cuenv-skills]
 url = "https://github.com/cuenv/cuenv.git"
 reference = "main"

--- a/server/crates/waddle-server/src/notification_outbox/candidate.rs
+++ b/server/crates/waddle-server/src/notification_outbox/candidate.rs
@@ -32,6 +32,12 @@ pub struct NotificationCandidate {
     /// hint applies — an off-the-record body is never persisted onto the
     /// candidate row, even temporarily (XEP-0334 §3 storage conformance).
     pub(super) last_message_body: Option<String>,
+    /// XEP-0444 reaction-only hint, message-frozen at T0 (#780).
+    /// `true` when the originating message carried `<reactions/>` and
+    /// no substantive body — the T1 evaluator suppresses with
+    /// [`SuppressedReason::Xep0444Reaction`]; "Alice reacted 👍" is
+    /// archived (MAM is untouched) but never fires an OS push.
+    pub(super) reaction: bool,
 }
 
 /// Message-frozen suppression hints carried on a
@@ -48,6 +54,9 @@ pub struct NotificationMessageHints {
     pub noping: bool,
     pub no_store: bool,
     pub no_permanent_store: bool,
+    /// XEP-0444 reaction-only message (#780) — reactions payload with
+    /// no substantive body.
+    pub reaction: bool,
 }
 
 impl NotificationMessageHints {
@@ -63,6 +72,11 @@ impl NotificationMessageHints {
     pub fn with_xep0334(mut self, no_store: bool, no_permanent_store: bool) -> Self {
         self.no_store = no_store;
         self.no_permanent_store = no_permanent_store;
+        self
+    }
+
+    pub fn with_reaction(mut self, reaction: bool) -> Self {
+        self.reaction = reaction;
         self
     }
 }
@@ -138,6 +152,7 @@ impl NotificationCandidate {
             no_store: hints.no_store,
             no_permanent_store: hints.no_permanent_store,
             last_message_body: None,
+            reaction: hints.reaction,
         })
     }
 
@@ -204,6 +219,7 @@ impl NotificationCandidate {
             no_store: hints.no_store,
             no_permanent_store: hints.no_permanent_store,
             last_message_body: None,
+            reaction: hints.reaction,
         })
     }
 
@@ -267,6 +283,10 @@ impl NotificationCandidate {
 
     pub fn no_permanent_store(&self) -> bool {
         self.no_permanent_store
+    }
+
+    pub fn reaction(&self) -> bool {
+        self.reaction
     }
 }
 

--- a/server/crates/waddle-server/src/notification_outbox/codec.rs
+++ b/server/crates/waddle-server/src/notification_outbox/codec.rs
@@ -58,6 +58,7 @@ pub(super) fn decode_candidate(
         no_store: row.get::<i64>(10)? != 0,
         no_permanent_store: row.get::<i64>(11)? != 0,
         last_message_body: row.get::<Option<String>>(12)?,
+        reaction: row.get::<i64>(13)? != 0,
     })
 }
 

--- a/server/crates/waddle-server/src/notification_outbox/drain.rs
+++ b/server/crates/waddle-server/src/notification_outbox/drain.rs
@@ -254,7 +254,8 @@ impl NotificationOutboxStore {
                        noping,
                        no_store,
                        no_permanent_store,
-                       last_message_body
+                       last_message_body,
+                       reaction
                 FROM notification_candidates
                 WHERE outboxed_at_ms IS NULL
                   AND (next_attempt_at_ms IS NULL OR next_attempt_at_ms <= ?)

--- a/server/crates/waddle-server/src/notification_outbox/enqueue.rs
+++ b/server/crates/waddle-server/src/notification_outbox/enqueue.rs
@@ -28,8 +28,9 @@ impl NotificationOutboxStore {
                     noping,
                     no_store,
                     no_permanent_store,
-                    last_message_body
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?, ?)
+                    last_message_body,
+                    reaction
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?, ?, ?, ?)
                 ON CONFLICT DO NOTHING
                 "#,
                 crate::db_params![
@@ -47,6 +48,7 @@ impl NotificationOutboxStore {
                     i64::from(candidate.no_store),
                     i64::from(candidate.no_permanent_store),
                     candidate.last_message_body.clone(),
+                    i64::from(candidate.reaction),
                 ],
             )
             .await?;

--- a/server/crates/waddle-server/src/notification_outbox/gate.rs
+++ b/server/crates/waddle-server/src/notification_outbox/gate.rs
@@ -229,6 +229,17 @@ pub(crate) async fn evaluate_push_gate_at_dispatch(
         });
     }
 
+    // #780: XEP-0444 reaction-only messages are archived (MAM is the
+    // right place for them) but never fire an OS push — matching the
+    // wider XMPP client ecosystem (Conversations, Snikket, Movim).
+    // Message-frozen like `<noping/>`, so it runs ONLY at T1Drain for
+    // the same audit-row reason documented above.
+    if stage == PushEvalStage::T1Drain && candidate.reaction() {
+        return Ok(T1PushDispatchOutcome::Suppressed {
+            reason: SuppressedReason::Xep0444Reaction,
+        });
+    }
+
     let (conversation_kind, is_mention) = match candidate.class() {
         NotificationClass::DirectMessage => (
             crate::notification_settings_projection::ConversationKind::Direct,
@@ -677,6 +688,46 @@ mod tests {
                 }
             ),
             "T1Drain must suppress noping with the typed Xep0513Noping reason; got {t1:?}"
+        );
+
+        // #780: XEP-0444 reaction-only follows the same stage split —
+        // T0 persists the row, T1 suppresses with the typed reason.
+        let reaction_candidate = NotificationCandidate::direct_message_with_hints(
+            recipient.clone(),
+            "bob@example.com/web".parse().expect("full sender"),
+            StanzaId::new("stage-split-reaction", Jid::from(recipient.clone())),
+            false,
+            NotificationMessageHints::none().with_reaction(true),
+        )
+        .expect("candidate");
+        let t0 = evaluate_push_gate_at_dispatch(
+            PushEvalStage::T0Emit,
+            eval_deps,
+            &reaction_candidate,
+            &mut eval_caches,
+        )
+        .await
+        .expect("t0 eval");
+        assert!(
+            matches!(t0, T1PushDispatchOutcome::Deliver { .. }),
+            "T0Emit must NOT suppress on message-frozen reaction-only so the candidate persists; got {t0:?}"
+        );
+        let t1 = evaluate_push_gate_at_dispatch(
+            PushEvalStage::T1Drain,
+            eval_deps,
+            &reaction_candidate,
+            &mut eval_caches,
+        )
+        .await
+        .expect("t1 eval");
+        assert!(
+            matches!(
+                t1,
+                T1PushDispatchOutcome::Suppressed {
+                    reason: SuppressedReason::Xep0444Reaction
+                }
+            ),
+            "T1Drain must suppress reaction-only with the typed Xep0444Reaction reason; got {t1:?}"
         );
 
         // Contrast: XEP-0334 storage hints are NOT push suppressors.

--- a/server/crates/waddle-server/src/notification_outbox/payload.rs
+++ b/server/crates/waddle-server/src/notification_outbox/payload.rs
@@ -19,6 +19,20 @@ pub(super) fn build_waddle_context(candidate: &NotificationCandidate) -> Element
             minidom::rxml::xml_ncname!("class").to_owned(),
             candidate.class.as_db_value(),
         )
+        // #779: the originating message's XEP-0359 stanza-id, typed
+        // onto the context so the push service can source
+        // `PushEnvelope.item` from it — the SW's in-band-vs-Web-Push
+        // dedupe compares against the stanza-id the foreground tab
+        // posts, never the pubsub item id (which stays the job id for
+        // coalesce/idempotency stability). Coalescing keeps this
+        // fresh: `merge_outbox_job_tx` overwrites `context_xml` with
+        // the latest candidate's context, so a coalesced job names
+        // the newest message — the one the foreground most recently
+        // rendered.
+        .attr(
+            minidom::rxml::xml_ncname!("stanza-id").to_owned(),
+            candidate.archive_stanza_id.id.as_str(),
+        )
         .build()
 }
 

--- a/server/crates/waddle-server/src/notification_outbox/schema.rs
+++ b/server/crates/waddle-server/src/notification_outbox/schema.rs
@@ -642,6 +642,13 @@ impl NotificationOutboxStore {
         .await?;
         tx.execute(&notification_candidates_table_sql(i64_type, false), ())
             .await?;
+        // This rebuild runs AFTER every add_column_if_missing in
+        // `initialize` (unlike the legacy reason/class rebuilds), so
+        // the copy list must carry the FULL current column set — a
+        // pre-existing DB forced through this rebuild by a new
+        // suppressed_reason value must not lose in-flight candidates'
+        // `last_message_body` / `reaction` bits (Codex review on the
+        // #780 PR).
         tx.execute(
             r#"
             INSERT INTO notification_candidates (
@@ -660,7 +667,9 @@ impl NotificationOutboxStore {
                 suppressed_reason,
                 noping,
                 no_store,
-                no_permanent_store
+                no_permanent_store,
+                last_message_body,
+                reaction
             )
             SELECT
                 recipient_bare_jid,
@@ -678,7 +687,9 @@ impl NotificationOutboxStore {
                 suppressed_reason,
                 noping,
                 no_store,
-                no_permanent_store
+                no_permanent_store,
+                last_message_body,
+                reaction
             FROM notification_candidates_old_suppressed_reason_check
             "#,
             (),
@@ -1390,6 +1401,82 @@ mod tests {
             insert_result.is_err(),
             "CHECK constraint must reject nonsense suppressed_reason"
         );
+    }
+
+    /// #780 Codex review regression: when a NEW suppressed_reason value
+    /// forces the SQLite CHECK rebuild on a pre-existing DB, the
+    /// rename→create→copy MUST carry the FULL current column set —
+    /// in-flight candidates must not lose `last_message_body` or
+    /// `reaction` mid-migration.
+    #[tokio::test]
+    async fn suppressed_reason_rebuild_preserves_body_and_reaction() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir
+            .path()
+            .join("outbox-rebuild.sqlite")
+            .to_str()
+            .expect("utf-8 path")
+            .to_string();
+        let url = format!("sqlite://{path}");
+        {
+            // Simulate the pre-#780 schema: full column set, but a
+            // 13-value CHECK missing `xep0444_reaction` → stale.
+            let db = crate::db::Database::from_config(
+                "outbox-rebuild-legacy",
+                &crate::db::DatabaseConfig::new(crate::db::DatabaseDriver::Sqlite, url.clone()),
+            )
+            .await
+            .expect("legacy db");
+            let conn = db.guard().await.expect("guard");
+            conn.execute(
+                "CREATE TABLE notification_candidates (                     recipient_bare_jid TEXT NOT NULL,                     conversation_jid TEXT NOT NULL,                     sender_jid TEXT NOT NULL,                     thread_id TEXT NOT NULL DEFAULT '',                     stanza_id_by TEXT NOT NULL,                     stanza_id TEXT NOT NULL,                     class TEXT NOT NULL CONSTRAINT notification_candidates_class_check CHECK (class IN ('dm', 'dm_mention', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')),                     reason TEXT NOT NULL CONSTRAINT notification_candidates_reason_check CHECK (reason IN ('offline_dm', 'offline_dm_mention', 'groupchat_personal_mention', 'groupchat_channel_mention', 'groupchat_active_channel_mention', 'groupchat_notify_all')),                     created_at_ms INTEGER NOT NULL,                     policy_error_count INTEGER NOT NULL DEFAULT 0,                     next_attempt_at_ms INTEGER,                     outboxed_at_ms INTEGER,                     suppressed_reason TEXT CONSTRAINT notification_candidates_suppressed_reason_check CHECK (suppressed_reason IS NULL OR suppressed_reason IN ('xep0357_self', 'xep0357_no_registration', 'xep0357_registration_disabled', 'xep0492_never', 'xep0492_on_mention_miss', 'xep0191_blocked', 'xep0513_noping', 'xep0513_active_miss', 'waddle_dnd', 'provider_rejected', 'provider_token_expired', 'xep0357_push_service_degraded', 'unread_zero_at_publish')),                     noping INTEGER NOT NULL DEFAULT 0,                     no_store INTEGER NOT NULL DEFAULT 0,                     no_permanent_store INTEGER NOT NULL DEFAULT 0,                     last_message_body TEXT,                     reaction INTEGER NOT NULL DEFAULT 0,                     PRIMARY KEY (recipient_bare_jid, conversation_jid, thread_id, stanza_id_by, stanza_id, class)                 )",
+                (),
+            )
+            .await
+            .expect("legacy table");
+            conn.execute(
+                "INSERT INTO notification_candidates (                     recipient_bare_jid, conversation_jid, sender_jid, thread_id,                     stanza_id_by, stanza_id, class, reason, created_at_ms,                     policy_error_count, suppressed_reason, noping, no_store,                     no_permanent_store, last_message_body, reaction                 ) VALUES (?, ?, ?, '', ?, ?, 'dm', 'offline_dm', 1, 0, NULL, 1, 0, 0, ?, 1)",
+                crate::db_params![
+                    "alice@example.com",
+                    "bob@example.com",
+                    "bob@example.com/web",
+                    "alice@example.com",
+                    "rebuild-probe",
+                    "the in-flight body",
+                ],
+            )
+            .await
+            .expect("legacy row");
+        }
+
+        // Opening the store runs initialize() → the stale CHECK forces
+        // the rebuild.
+        let db = crate::db::Database::from_config(
+            "outbox-rebuild-current",
+            &crate::db::DatabaseConfig::new(crate::db::DatabaseDriver::Sqlite, url.clone()),
+        )
+        .await
+        .expect("current db");
+        let store = NotificationOutboxStore::new(db).await.expect("store");
+        let mut rows = store
+            .query(
+                "SELECT last_message_body, reaction, noping FROM notification_candidates                  WHERE stanza_id = ?",
+                crate::db_params!["rebuild-probe"],
+            )
+            .await
+            .expect("query");
+        let row = rows.next().await.expect("row").expect("row survives");
+        assert_eq!(
+            row.get::<Option<String>>(0).expect("body").as_deref(),
+            Some("the in-flight body"),
+            "rebuild must carry last_message_body"
+        );
+        assert_eq!(
+            row.get::<i64>(1).expect("reaction"),
+            1,
+            "rebuild must carry reaction"
+        );
+        assert_eq!(row.get::<i64>(2).expect("noping"), 1);
     }
 
     /// Schema regression: cold-init MUST produce a

--- a/server/crates/waddle-server/src/notification_outbox/schema.rs
+++ b/server/crates/waddle-server/src/notification_outbox/schema.rs
@@ -35,7 +35,7 @@ const NOTIFICATION_OUTBOX_CLASS_VALUES: [&str; 6] = [
 const NOTIFICATION_OUTBOX_CLASS_CHECK_SQL: &str = "class IN ('dm', 'dm_mention', 'personal_mention', 'channel_mention', 'active_channel_mention', 'notify_all')";
 const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_NAME: &str =
     "notification_candidates_suppressed_reason_check";
-pub(super) const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES: [&str; 13] = [
+pub(super) const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES: [&str; 14] = [
     "xep0357_self",
     "xep0357_no_registration",
     "xep0357_registration_disabled",
@@ -49,8 +49,9 @@ pub(super) const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_VALUES: [&str; 13] = 
     "provider_token_expired",
     "xep0357_push_service_degraded",
     "unread_zero_at_publish",
+    "xep0444_reaction",
 ];
-const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_SQL: &str = "suppressed_reason IS NULL OR suppressed_reason IN ('xep0357_self', 'xep0357_no_registration', 'xep0357_registration_disabled', 'xep0492_never', 'xep0492_on_mention_miss', 'xep0191_blocked', 'xep0513_noping', 'xep0513_active_miss', 'waddle_dnd', 'provider_rejected', 'provider_token_expired', 'xep0357_push_service_degraded', 'unread_zero_at_publish')";
+const NOTIFICATION_CANDIDATES_SUPPRESSED_REASON_CHECK_SQL: &str = "suppressed_reason IS NULL OR suppressed_reason IN ('xep0357_self', 'xep0357_no_registration', 'xep0357_registration_disabled', 'xep0492_never', 'xep0492_on_mention_miss', 'xep0191_blocked', 'xep0513_noping', 'xep0513_active_miss', 'waddle_dnd', 'provider_rejected', 'provider_token_expired', 'xep0357_push_service_degraded', 'unread_zero_at_publish', 'xep0444_reaction')";
 const NOTIFICATION_CANDIDATES_INDEXES: [&str; 4] = [
     "idx_notification_candidates_recipient_created",
     "idx_notification_candidates_identity",
@@ -86,6 +87,7 @@ fn notification_candidates_table_sql(i64_type: &str, if_not_exists: bool) -> Str
             no_store INTEGER NOT NULL DEFAULT 0,
             no_permanent_store INTEGER NOT NULL DEFAULT 0,
             last_message_body TEXT,
+            reaction INTEGER NOT NULL DEFAULT 0,
             PRIMARY KEY (recipient_bare_jid, conversation_jid, thread_id, stanza_id_by, stanza_id, class)
         )
         "#
@@ -259,6 +261,13 @@ impl NotificationOutboxStore {
         // storage hint applies.
         self.add_column_if_missing("notification_candidates", "last_message_body TEXT")
             .await?;
+        // #780: XEP-0444 reaction-only hint, message-frozen at T0 like
+        // `noping`; T1 suppresses with `xep0444_reaction`.
+        self.add_column_if_missing(
+            "notification_candidates",
+            "reaction INTEGER NOT NULL DEFAULT 0",
+        )
+        .await?;
         self.migrate_notification_candidates_suppressed_reason_constraint(i64_type)
             .await?;
         self.execute(
@@ -1280,7 +1289,7 @@ mod tests {
 
     #[test]
     fn postgres_suppressed_reason_constraint_match_accepts_current_definition() {
-        let postgres_definition = "CHECK (((suppressed_reason IS NULL) OR ((suppressed_reason)::text = ANY ((ARRAY['xep0357_self'::character varying, 'xep0357_no_registration'::character varying, 'xep0357_registration_disabled'::character varying, 'xep0492_never'::character varying, 'xep0492_on_mention_miss'::character varying, 'xep0191_blocked'::character varying, 'xep0513_noping'::character varying, 'xep0513_active_miss'::character varying, 'waddle_dnd'::character varying, 'provider_rejected'::character varying, 'provider_token_expired'::character varying, 'xep0357_push_service_degraded'::character varying, 'unread_zero_at_publish'::character varying])::text[]))))";
+        let postgres_definition = "CHECK (((suppressed_reason IS NULL) OR ((suppressed_reason)::text = ANY ((ARRAY['xep0357_self'::character varying, 'xep0357_no_registration'::character varying, 'xep0357_registration_disabled'::character varying, 'xep0492_never'::character varying, 'xep0492_on_mention_miss'::character varying, 'xep0191_blocked'::character varying, 'xep0513_noping'::character varying, 'xep0513_active_miss'::character varying, 'waddle_dnd'::character varying, 'provider_rejected'::character varying, 'provider_token_expired'::character varying, 'xep0357_push_service_degraded'::character varying, 'unread_zero_at_publish'::character varying, 'xep0444_reaction'::character varying])::text[]))))";
         assert!(
             notification_candidates_suppressed_reason_constraint_matches_expected(
                 postgres_definition

--- a/server/crates/waddle-server/src/notification_outbox/types.rs
+++ b/server/crates/waddle-server/src/notification_outbox/types.rs
@@ -199,6 +199,11 @@ pub(crate) enum SuppressedReason {
     /// push would be spurious (#1126). Emitted at publish time;
     /// the job is dropped terminally instead of published.
     UnreadZeroAtPublish,
+    /// The originating message was XEP-0444 reaction-only (reactions
+    /// payload, no substantive body) — "Alice reacted 👍" is archived
+    /// but never fires an OS push (#780). Message-frozen at T0,
+    /// suppressed by the T1 evaluator like `<noping/>`.
+    Xep0444Reaction,
 }
 
 impl SuppressedReason {
@@ -224,6 +229,7 @@ impl SuppressedReason {
         Self::ProviderTokenExpired,
         Self::Xep0357PushServiceDegraded,
         Self::UnreadZeroAtPublish,
+        Self::Xep0444Reaction,
     ];
 
     pub(crate) fn as_db_value(self) -> &'static str {
@@ -241,6 +247,7 @@ impl SuppressedReason {
             Self::ProviderTokenExpired => "provider_token_expired",
             Self::Xep0357PushServiceDegraded => "xep0357_push_service_degraded",
             Self::UnreadZeroAtPublish => "unread_zero_at_publish",
+            Self::Xep0444Reaction => "xep0444_reaction",
         }
     }
 

--- a/server/crates/waddle-server/src/push_service/dispatch.rs
+++ b/server/crates/waddle-server/src/push_service/dispatch.rs
@@ -60,6 +60,21 @@ pub(crate) struct ParsedPushPayload {
     /// values are rejected at this boundary, not silently folded to
     /// `Mention`.
     pub class: NotificationClass,
+    /// `<context stanza-id='...'/>` — the originating message's
+    /// XEP-0359 stanza-id (#779). Sourced into `PushEnvelope.item`
+    /// so the service worker's in-band-vs-Web-Push dedupe key matches
+    /// what the foreground tab posts. `None` when the publisher
+    /// omitted it (the envelope falls back to the pubsub item id).
+    pub stanza_id: Option<String>,
+}
+
+/// The dedup key shipped as `PushEnvelope.item` (#779): the
+/// originating message's XEP-0359 stanza-id when the context carries
+/// it, else the pubsub item id (the outbox job id) — the pre-#779
+/// behavior, kept as the fallback so a payload without the typed
+/// attribute still produces a usable (if non-matching) key.
+pub(crate) fn envelope_item<'a>(parsed: &'a ParsedPushPayload, pubsub_item_id: &'a str) -> &'a str {
+    parsed.stanza_id.as_deref().unwrap_or(pubsub_item_id)
 }
 
 /// Parse the serialized `<notification>` element. Strictly validates
@@ -105,12 +120,17 @@ pub(crate) fn parse_publish_payload(payload_xml: &str) -> Result<ParsedPushPaylo
         .attr("thread")
         .filter(|t| !t.is_empty())
         .map(str::to_owned);
+    let stanza_id = context
+        .attr("stanza-id")
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned);
     let message_count = parse_summary_message_count(&payload);
     Ok(ParsedPushPayload {
         message_count,
         conversation,
         thread,
         class,
+        stanza_id,
     })
 }
 
@@ -238,7 +258,7 @@ pub(crate) async fn dispatch_one_web_push(
         parsed.class.as_db_value(),
         &conversation_str,
         parsed.thread.as_deref(),
-        item_id,
+        envelope_item(parsed, item_id),
         parsed.message_count,
     );
     let plaintext = envelope.to_plaintext();
@@ -381,6 +401,46 @@ mod tests {
             ctx = ctx.attr(minidom::rxml::xml_ncname!("thread").to_owned(), t);
         }
         ctx.build()
+    }
+
+    /// Fixture with the #779 typed `stanza-id` context attribute.
+    fn build_notification_xml_with_stanza_id(stanza_id: &str) -> String {
+        let summary = build_summary_form(Some(1));
+        let context = Element::builder("context", NS_WADDLE_PUSH_CONTEXT)
+            .attr(
+                minidom::rxml::xml_ncname!("conversation").to_owned(),
+                "alice@example.com",
+            )
+            .attr(minidom::rxml::xml_ncname!("class").to_owned(), "dm")
+            .attr(
+                minidom::rxml::xml_ncname!("stanza-id").to_owned(),
+                stanza_id,
+            )
+            .build();
+        let notification = Element::builder("notification", NS_PUSH)
+            .append(summary)
+            .append(context)
+            .build();
+        String::from(&notification)
+    }
+
+    // #779: the XEP-0359 stanza-id rides the typed context attribute
+    // and becomes the SW dedup key; the pubsub item id (job id) stays
+    // the fallback when absent.
+    #[test]
+    fn parse_publish_payload_extracts_stanza_id() {
+        let xml = build_notification_xml_with_stanza_id("stanza-abc-123");
+        let parsed = parse_publish_payload(&xml).expect("valid payload");
+        assert_eq!(parsed.stanza_id.as_deref(), Some("stanza-abc-123"));
+        assert_eq!(envelope_item(&parsed, "job-uuid"), "stanza-abc-123");
+    }
+
+    #[test]
+    fn parse_publish_payload_missing_stanza_id_falls_back_to_item_id() {
+        let xml = build_notification_xml("dm", "alice@example.com", None, Some(1));
+        let parsed = parse_publish_payload(&xml).expect("valid payload");
+        assert!(parsed.stanza_id.is_none());
+        assert_eq!(envelope_item(&parsed, "job-uuid"), "job-uuid");
     }
 
     #[test]

--- a/server/crates/waddle-server/src/push_service/dispatch.rs
+++ b/server/crates/waddle-server/src/push_service/dispatch.rs
@@ -65,7 +65,32 @@ pub(crate) struct ParsedPushPayload {
     /// so the service worker's in-band-vs-Web-Push dedupe key matches
     /// what the foreground tab posts. `None` when the publisher
     /// omitted it (the envelope falls back to the pubsub item id).
-    pub stanza_id: Option<String>,
+    pub stanza_id: Option<ContextStanzaId>,
+}
+
+/// Non-empty XEP-0359 stanza-id lifted off the typed context at the
+/// parse boundary (#779). Downstream it is an opaque equality token —
+/// the SW only ever compares it against the id the foreground tab
+/// posted — so the newtype's invariant is exactly "non-empty",
+/// enforced by the only constructor. (The full
+/// `waddle_xmpp_core::xep0359::StanzaId` pairs the id with its `by`
+/// archive JID; the context attribute deliberately carries only the
+/// id, since the SW dedup key is unscoped.)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ContextStanzaId(String);
+
+impl ContextStanzaId {
+    fn parse(value: &str) -> Option<Self> {
+        if value.is_empty() {
+            None
+        } else {
+            Some(Self(value.to_owned()))
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 /// The dedup key shipped as `PushEnvelope.item` (#779): the
@@ -74,7 +99,11 @@ pub(crate) struct ParsedPushPayload {
 /// behavior, kept as the fallback so a payload without the typed
 /// attribute still produces a usable (if non-matching) key.
 pub(crate) fn envelope_item<'a>(parsed: &'a ParsedPushPayload, pubsub_item_id: &'a str) -> &'a str {
-    parsed.stanza_id.as_deref().unwrap_or(pubsub_item_id)
+    parsed
+        .stanza_id
+        .as_ref()
+        .map(ContextStanzaId::as_str)
+        .unwrap_or(pubsub_item_id)
 }
 
 /// Parse the serialized `<notification>` element. Strictly validates
@@ -120,10 +149,7 @@ pub(crate) fn parse_publish_payload(payload_xml: &str) -> Result<ParsedPushPaylo
         .attr("thread")
         .filter(|t| !t.is_empty())
         .map(str::to_owned);
-    let stanza_id = context
-        .attr("stanza-id")
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned);
+    let stanza_id = context.attr("stanza-id").and_then(ContextStanzaId::parse);
     let message_count = parse_summary_message_count(&payload);
     Ok(ParsedPushPayload {
         message_count,
@@ -431,7 +457,10 @@ mod tests {
     fn parse_publish_payload_extracts_stanza_id() {
         let xml = build_notification_xml_with_stanza_id("stanza-abc-123");
         let parsed = parse_publish_payload(&xml).expect("valid payload");
-        assert_eq!(parsed.stanza_id.as_deref(), Some("stanza-abc-123"));
+        assert_eq!(
+            parsed.stanza_id.as_ref().map(ContextStanzaId::as_str),
+            Some("stanza-abc-123")
+        );
         assert_eq!(envelope_item(&parsed, "job-uuid"), "stanza-abc-123");
     }
 

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_inbox.rs
@@ -349,7 +349,8 @@ async fn insert_groupchat_notification_candidate(
                 message,
                 waddle_xmpp::xep::xep0334::Hint::NoPermanentStore,
             ),
-        );
+        )
+        .with_reaction(waddle_xmpp::xep::xep0444::is_reaction_only_message(message));
     let candidate = match crate::notification_outbox::NotificationCandidate::groupchat_with_hints(
         owner.clone(),
         room.clone(),

--- a/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/offline_delivery.rs
@@ -327,7 +327,10 @@ async fn enqueue_xep0357_notification_candidate_for_message(
                 original_message,
                 waddle_xmpp::xep::xep0334::Hint::NoPermanentStore,
             ),
-        );
+        )
+        .with_reaction(waddle_xmpp::xep::xep0444::is_reaction_only_message(
+            original_message,
+        ));
     let candidate = match crate::notification_outbox::NotificationCandidate::direct_message_with_hints(
         recipient.clone(),
         sender_jid.clone(),

--- a/server/crates/waddle-server/tests/notification_outbox/publish.rs
+++ b/server/crates/waddle-server/tests/notification_outbox/publish.rs
@@ -100,6 +100,44 @@ async fn claimed_outbox_job_builds_stable_xep0357_pubsub_item() {
     assert_eq!(item.id.as_deref(), Some(jobs[0].job_id().as_str()));
     let payload = item.payload.expect("payload");
     assert!(payload.is("notification", waddle_xmpp::xep::xep0357::NS_PUSH));
+    // #779: the context carries the originating message's XEP-0359
+    // stanza-id (the SW dedup key) while the pubsub item id above
+    // stays the job id (coalesce/idempotency stability).
+    let context = payload
+        .children()
+        .find(|child| child.is("context", WADDLE_PUSH_CONTEXT_NS))
+        .expect("waddle context");
+    assert_eq!(context.attr("stanza-id"), Some("archive-1"));
+}
+
+// #779: coalescing must keep the context's stanza-id pointing at the
+// LATEST message merged into the job — that is the id the foreground
+// tab most recently posted to the SW dedup store.
+#[tokio::test]
+async fn coalesced_job_context_names_latest_stanza_id() {
+    let store = store().await;
+    let target = target();
+    enqueue_jobs_for_test(
+        &store,
+        &candidate("archive-first"),
+        std::slice::from_ref(&target),
+    )
+    .await;
+    enqueue_jobs_for_test(&store, &candidate("archive-second"), &[target]).await;
+
+    let jobs = store.claim_due_outbox_jobs(16).await.expect("claim");
+    assert_eq!(jobs.len(), 1);
+    assert_eq!(jobs[0].message_count(), 2, "coalesced into one job");
+    let payload = jobs[0].to_xep0357_pubsub_item().payload.expect("payload");
+    let context = payload
+        .children()
+        .find(|child| child.is("context", WADDLE_PUSH_CONTEXT_NS))
+        .expect("waddle context");
+    assert_eq!(
+        context.attr("stanza-id"),
+        Some("archive-second"),
+        "merge must overwrite the context with the newest candidate's stanza-id"
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/tests/notification_outbox/suppression.rs
+++ b/server/crates/waddle-server/tests/notification_outbox/suppression.rs
@@ -367,6 +367,73 @@ async fn t1_noping_records_typed_suppressed_reason() {
     assert!(rendered.contains("waddle_push_suppressed_total{reason=\"xep0513_noping\"} 1"),);
 }
 
+// #780: a reaction-only message's candidate persists at T0 and is
+// suppressed at T1 with the typed `xep0444_reaction` reason + labeled
+// metric — no outbox job is created.
+#[tokio::test]
+async fn t1_xep0444_reaction_records_typed_suppressed_reason() {
+    let _guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+    waddle_xmpp::prometheus::reset_metrics_for_test();
+    let store = store().await;
+    let push_store = waddle_xmpp::push::InMemoryPushStore::new();
+    let blocking = waddle_xmpp::xep::xep0191::InMemoryBlockingStorage::new();
+    let projection = settings_projection().await;
+    let room_policy = StubRoomPolicy::new();
+    let dnd_reader = NoopDndReader;
+    let recipient = bare("alice@example.com");
+    let sender_jid: Jid = "bob@example.com/web".parse().expect("full sender");
+    let candidate = NotificationCandidate::direct_message_with_hints(
+        recipient.clone(),
+        sender_jid,
+        StanzaId::new("t1-reaction", Jid::from(recipient.clone())),
+        false,
+        NotificationMessageHints::none().with_reaction(true),
+    )
+    .expect("candidate");
+    assert!(candidate.reaction());
+    store
+        .insert_candidate(&candidate)
+        .await
+        .expect("insert candidate");
+
+    let deps = drain_deps_with_noop_activity(&room_policy, &dnd_reader, noop_activity_reader());
+    store
+        .drain_pending_candidates_into_outbox(
+            &push_store,
+            &blocking,
+            &projection,
+            deps,
+            &bare("push.example.com"),
+            16,
+        )
+        .await
+        .expect("drain candidates");
+
+    let mut rows = store
+        .query(
+            "SELECT suppressed_reason, reaction FROM notification_candidates WHERE stanza_id = ?",
+            waddle_server::db_params!["t1-reaction"],
+        )
+        .await
+        .expect("query");
+    let row = rows.next().await.expect("row").expect("row exists");
+    assert_eq!(
+        row.get::<Option<String>>(0).expect("reason").as_deref(),
+        Some("xep0444_reaction")
+    );
+    assert_eq!(row.get::<i64>(1).expect("reaction"), 1);
+    assert!(
+        store
+            .pending_outbox_jobs()
+            .await
+            .expect("pending jobs")
+            .is_empty(),
+        "a reaction-only candidate must not produce an outbox job"
+    );
+    let rendered = waddle_xmpp::prometheus::render_metrics();
+    assert!(rendered.contains("waddle_push_suppressed_total{reason=\"xep0444_reaction\"} 1"),);
+}
+
 /// #719: with the rich-payload opt-in set and no XEP-0334 storage
 /// hint, the drained push carries the full XEP-0357 §5.4 summary —
 /// both `last-message-sender` and `last-message-body`.

--- a/server/crates/waddle-server/tests/xep0357_push_service_ws.rs
+++ b/server/crates/waddle-server/tests/xep0357_push_service_ws.rs
@@ -651,6 +651,15 @@ async fn xep0357_offline_dm_emits_durable_summary_pubsub_publish_job() {
         .expect("Waddle push context");
     assert_eq!(context.attr("conversation"), Some("admin@localhost"));
     assert_eq!(context.attr("class"), Some("dm"));
+    // #779: the context carries the originating message's XEP-0359
+    // stanza-id so the SW's in-band-vs-Web-Push dedupe key matches
+    // what the foreground tab posts.
+    assert!(
+        context
+            .attr("stanza-id")
+            .is_some_and(|stanza_id| !stanza_id.is_empty()),
+        "context must carry the XEP-0359 stanza-id"
+    );
     assert!(
         !payload_xml.contains("durable notification body"),
         "minimal XEP-0357 payload must not leak the message body"
@@ -658,6 +667,141 @@ async fn xep0357_offline_dm_emits_durable_summary_pubsub_publish_job() {
     assert_eq!(
         notification_candidate_count(&database_url, "bob@localhost").await,
         1
+    );
+
+    let _ = admin.close().await;
+}
+
+/// Poll until the recipient's candidate row records a
+/// `suppressed_reason`, returning it. Panics after ~10s.
+async fn wait_for_candidate_suppressed_reason(database_url: &str, recipient: &str) -> String {
+    for _ in 0..100 {
+        let db = waddle_server::db::Database::from_config(
+            "xep0357-test-observer",
+            &waddle_server::db::DatabaseConfig::new(
+                waddle_server::db::DatabaseDriver::Sqlite,
+                database_url.to_string(),
+            ),
+        )
+        .await
+        .expect("observer db");
+        let conn = db.guard().await.expect("db guard");
+        let mut rows = conn
+            .query(
+                "SELECT suppressed_reason FROM notification_candidates \
+                 WHERE recipient_bare_jid = ? AND suppressed_reason IS NOT NULL",
+                waddle_server::db_params![recipient],
+            )
+            .await
+            .expect("query");
+        if let Some(row) = rows.next().await.expect("row") {
+            return row.get::<String>(0).expect("reason");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+    panic!("candidate for {recipient} never recorded a suppressed_reason");
+}
+
+// #780: a XEP-0444 reaction-only DM to an offline recipient is
+// archived and produces a candidate, but the T1 evaluator suppresses
+// it with the typed `xep0444_reaction` reason — no publish job, no
+// OS push for "Alice reacted 👍".
+#[tokio::test]
+async fn xep0444_reaction_only_dm_is_suppressed_not_published() {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let db_path = temp_dir.path().join("xep0444-reaction-push.sqlite3");
+    let database_url = format!("sqlite://{}?mode=rwc", db_path.display());
+    let server =
+        TestServer::start_persistent_with_extra_accounts(&database_url, &[("bob", "bob-password")]);
+    let ws_url = server.ws_url();
+    let mut bob = WsXmppClient::connect_and_auth(
+        &ws_url,
+        DOMAIN,
+        "bob",
+        "bob-password",
+        &format!("xep0444-bob-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("bob connection");
+    let node = register_web_push_device_via_xep0050(
+        &mut bob,
+        "bob-reaction-push",
+        "web",
+        "https://push.example.com/endpoint/bob-reaction",
+        "bob-p256-key",
+        "bob-provider-secret",
+    )
+    .await;
+    let enable = Element::builder("enable", NS_PUSH)
+        .attr(
+            minidom::rxml::xml_ncname!("jid").to_owned(),
+            PUSH_SERVICE_JID,
+        )
+        .attr(minidom::rxml::xml_ncname!("node").to_owned(), node.as_str())
+        .build();
+    let enable_response = send_iq(
+        &mut bob,
+        iq_frame("set", "bob-reaction-enable", DOMAIN, enable),
+        "bob-reaction-enable",
+    )
+    .await;
+    parse_iq_element(&enable_response, "bob-reaction-enable", "result");
+    let _ = bob.close().await;
+
+    let mut admin = WsXmppClient::connect_and_auth(
+        &ws_url,
+        DOMAIN,
+        USERNAME,
+        server.fixed_account_password(),
+        &format!("xep0444-admin-{}", uuid::Uuid::new_v4()),
+    )
+    .await
+    .expect("admin connection");
+    let reaction_message = element_to_xml(
+        Element::builder("message", CLIENT_NS)
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+            .attr(minidom::rxml::xml_ncname!("to").to_owned(), "bob@localhost")
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "reaction-only-dm-1",
+            )
+            .append(waddle_xmpp::xep::xep0444::build_reactions_element(
+                "some-earlier-message-id",
+                &["👍"],
+            ))
+            .build(),
+    );
+    admin
+        .send(&reaction_message)
+        .await
+        .expect("send reaction-only dm");
+
+    let reason = wait_for_candidate_suppressed_reason(&database_url, "bob@localhost").await;
+    assert_eq!(reason, "xep0444_reaction");
+    // The suppression is terminal at T1: no durable publish job for
+    // the node may exist.
+    let db = waddle_server::db::Database::from_config(
+        "xep0357-test-observer-jobs",
+        &waddle_server::db::DatabaseConfig::new(
+            waddle_server::db::DatabaseDriver::Sqlite,
+            database_url.clone(),
+        ),
+    )
+    .await
+    .expect("observer db");
+    let conn = db.guard().await.expect("db guard");
+    let mut rows = conn
+        .query(
+            "SELECT COUNT(*) FROM push_publish_jobs WHERE node = ?",
+            waddle_server::db_params![node.as_str()],
+        )
+        .await
+        .expect("job count query");
+    let row = rows.next().await.expect("row").expect("count row");
+    assert_eq!(
+        row.get::<i64>(0).expect("count"),
+        0,
+        "a reaction-only message must not enqueue a push publish job"
     );
 
     let _ = admin.close().await;

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -264,6 +264,7 @@ pub(crate) const PUSH_SUPPRESSED_REASONS: &[&str] = &[
     "provider_token_expired",
     "xep0357_push_service_degraded",
     "unread_zero_at_publish",
+    "xep0444_reaction",
 ];
 
 const PUSH_SUPPRESSED_COUNTERS_LEN: usize = PUSH_SUPPRESSED_REASONS.len();
@@ -275,6 +276,7 @@ static PUSH_SUPPRESSED_COUNTERS: [AtomicU64; PUSH_SUPPRESSED_COUNTERS_LEN] = {
     // below, so a future reason addition that forgets a slot fails to
     // compile.
     [
+        AtomicU64::new(0),
         AtomicU64::new(0),
         AtomicU64::new(0),
         AtomicU64::new(0),

--- a/server/crates/waddle-xmpp/src/xep/xep0444.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0444.rs
@@ -109,14 +109,26 @@ pub fn is_reaction_message(msg: &Message) -> bool {
     msg.payloads.iter().any(is_reactions_element)
 }
 
-/// A reaction-ONLY message: carries `<reactions/>` and no substantive
-/// body (#780). This is the push-suppression predicate — "Alice
-/// reacted 👍" should not fire an OS push, but a message that adjusts
-/// reactions AND carries a real body still notifies. Whitespace-only
-/// bodies do not count as substantive, matching the archive layer's
-/// body test.
+/// A reaction-ONLY message: carries `<reactions/>` and NOTHING else
+/// actionable (#780). This is the push-suppression predicate —
+/// "Alice reacted 👍" should not fire an OS push, but any other
+/// actionable content riding the same stanza keeps the notification:
+///
+/// - a substantive (non-whitespace) body,
+/// - an XEP-0308 correction (an edit is actionable even body-less),
+/// - an XEP-0424 retraction,
+/// - XEP-0513 explicit mentions (a body-less mention still pings).
+///
+/// (Greptile review on the #780 PR: without the payload checks, a
+/// body-less but actionable stanza that happened to also carry
+/// reactions would be silently suppressed before mention/class policy
+/// ran.)
 pub fn is_reaction_only_message(msg: &Message) -> bool {
-    is_reaction_message(msg) && !msg.bodies.values().any(|text| !text.trim().is_empty())
+    is_reaction_message(msg)
+        && !msg.bodies.values().any(|text| !text.trim().is_empty())
+        && !super::xep0308::is_correction_message(msg)
+        && super::xep0424::extract_retraction_from_message(msg).is_none()
+        && super::xep0513::extract_explicit_mentions(msg).is_none()
 }
 
 // ── Extraction ───────────────────────────────────────────────────────
@@ -279,6 +291,29 @@ mod tests {
             .bodies
             .insert(xmpp_parsers::message::Lang::new(), "hello".to_string());
         assert!(!is_reaction_only_message(&plain));
+
+        // Body-less reactions + XEP-0308 correction → NOT reaction-only
+        // (an edit is actionable and must still notify).
+        let mut with_correction = reaction_only.clone();
+        with_correction.payloads.push(
+            Element::builder("replace", super::super::xep0308::NS_MESSAGE_CORRECT)
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "orig-1")
+                .build(),
+        );
+        assert!(!is_reaction_only_message(&with_correction));
+
+        // Body-less reactions + XEP-0513 explicit mention → NOT
+        // reaction-only (a body-less mention still pings).
+        let mut with_mention = reaction_only.clone();
+        with_mention.payloads.push(
+            Element::builder("mention", super::super::xep0513::NS_EXPLICIT_MENTIONS)
+                .attr(
+                    minidom::rxml::xml_ncname!("jid").to_owned(),
+                    "carol@example.com",
+                )
+                .build(),
+        );
+        assert!(!is_reaction_only_message(&with_mention));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0444.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0444.rs
@@ -109,26 +109,39 @@ pub fn is_reaction_message(msg: &Message) -> bool {
     msg.payloads.iter().any(is_reactions_element)
 }
 
+/// Routing/transport metadata namespaces that never make a stanza
+/// actionable on their own: XEP-0359 stanza/origin ids, XEP-0334
+/// storage hints, XEP-0203 delayed-delivery stamps, and XEP-0421
+/// occupant ids. Everything OUTSIDE this list defeats the
+/// reaction-only predicate — the safe failure mode for a payload we
+/// don't recognize is to notify, never to suppress.
+const NON_ACTIONABLE_PAYLOAD_NAMESPACES: &[&str] = &[
+    "urn:xmpp:sid:0",
+    "urn:xmpp:hints",
+    "urn:xmpp:delay",
+    "urn:xmpp:occupant-id:0",
+];
+
 /// A reaction-ONLY message: carries `<reactions/>` and NOTHING else
 /// actionable (#780). This is the push-suppression predicate —
 /// "Alice reacted 👍" should not fire an OS push, but any other
-/// actionable content riding the same stanza keeps the notification:
+/// actionable content riding the same stanza keeps the notification.
 ///
-/// - a substantive (non-whitespace) body,
-/// - an XEP-0308 correction (an edit is actionable even body-less),
-/// - an XEP-0424 retraction,
-/// - XEP-0513 explicit mentions (a body-less mention still pings).
-///
-/// (Greptile review on the #780 PR: without the payload checks, a
-/// body-less but actionable stanza that happened to also carry
-/// reactions would be silently suppressed before mention/class policy
-/// ran.)
+/// The check is an ALLOW-list, not an enumeration of known actionable
+/// payloads (Greptile review on the #780 PR, twice): besides requiring
+/// no substantive body, every payload element must be either the
+/// `<reactions/>` element itself or pure routing/transport metadata
+/// ([`NON_ACTIONABLE_PAYLOAD_NAMESPACES`]). A correction, retraction,
+/// mention, invite, file share, or any future payload we have not
+/// modeled therefore fails open to "still notify" instead of being
+/// silently suppressed.
 pub fn is_reaction_only_message(msg: &Message) -> bool {
     is_reaction_message(msg)
         && !msg.bodies.values().any(|text| !text.trim().is_empty())
-        && !super::xep0308::is_correction_message(msg)
-        && super::xep0424::extract_retraction_from_message(msg).is_none()
-        && super::xep0513::extract_explicit_mentions(msg).is_none()
+        && msg.payloads.iter().all(|elem| {
+            is_reactions_element(elem)
+                || NON_ACTIONABLE_PAYLOAD_NAMESPACES.contains(&elem.ns().as_str())
+        })
 }
 
 // ── Extraction ───────────────────────────────────────────────────────
@@ -314,6 +327,34 @@ mod tests {
                 .build(),
         );
         assert!(!is_reaction_only_message(&with_mention));
+
+        // Pure routing/transport metadata riding the reaction does NOT
+        // defeat the predicate: stanza ids, hints, delay stamps, and
+        // occupant ids are never actionable on their own.
+        let mut with_metadata = reaction_only.clone();
+        with_metadata.payloads.push(
+            Element::builder("stanza-id", "urn:xmpp:sid:0")
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "sid-1")
+                .attr(
+                    minidom::rxml::xml_ncname!("by").to_owned(),
+                    "alice@example.com",
+                )
+                .build(),
+        );
+        with_metadata
+            .payloads
+            .push(Element::builder("store", "urn:xmpp:hints").build());
+        assert!(is_reaction_only_message(&with_metadata));
+
+        // ANY unmodeled payload fails open to "still notify" — the
+        // allow-list, not an actionable-payload enumeration, is the
+        // safety property (e.g. a body-less file share or invite that
+        // also carries reactions must not be suppressed).
+        let mut with_unknown = reaction_only.clone();
+        with_unknown
+            .payloads
+            .push(Element::builder("file-sharing", "urn:xmpp:sfs:0").build());
+        assert!(!is_reaction_only_message(&with_unknown));
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0444.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0444.rs
@@ -109,6 +109,16 @@ pub fn is_reaction_message(msg: &Message) -> bool {
     msg.payloads.iter().any(is_reactions_element)
 }
 
+/// A reaction-ONLY message: carries `<reactions/>` and no substantive
+/// body (#780). This is the push-suppression predicate — "Alice
+/// reacted 👍" should not fire an OS push, but a message that adjusts
+/// reactions AND carries a real body still notifies. Whitespace-only
+/// bodies do not count as substantive, matching the archive layer's
+/// body test.
+pub fn is_reaction_only_message(msg: &Message) -> bool {
+    is_reaction_message(msg) && !msg.bodies.values().any(|text| !text.trim().is_empty())
+}
+
 // ── Extraction ───────────────────────────────────────────────────────
 
 /// Extract the reaction set from a message.
@@ -236,6 +246,39 @@ mod tests {
 
         let wrong_name = Element::builder("reaction", NS_REACTIONS).build();
         assert!(!is_reactions_element(&wrong_name));
+    }
+
+    #[test]
+    fn reaction_only_requires_reactions_and_no_substantive_body() {
+        // Reaction with no body → reaction-only (#780 push suppression).
+        let mut reaction_only = Message::new(None::<jid::Jid>);
+        reaction_only
+            .payloads
+            .push(build_reactions_element("msg-1", &["👍"]));
+        assert!(is_reaction_only_message(&reaction_only));
+
+        // Whitespace-only body still counts as reaction-only.
+        let mut whitespace_body = reaction_only.clone();
+        whitespace_body
+            .bodies
+            .insert(xmpp_parsers::message::Lang::new(), "  ".to_string());
+        assert!(is_reaction_only_message(&whitespace_body));
+
+        // Reaction + substantive body → NOT reaction-only (an edit
+        // that also adjusts reactions must still notify).
+        let mut with_body = reaction_only.clone();
+        with_body.bodies.insert(
+            xmpp_parsers::message::Lang::new(),
+            "also saying something".to_string(),
+        );
+        assert!(!is_reaction_only_message(&with_body));
+
+        // Plain body message → not reaction-only.
+        let mut plain = Message::new(None::<jid::Jid>);
+        plain
+            .bodies
+            .insert(xmpp_parsers::message::Lang::new(), "hello".to_string());
+        assert!(!is_reaction_only_message(&plain));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #779.
Fixes #780.

Lane C item 2 — XEP-0359 stanza-id through XEP-0357 publish + XEP-0444 reaction-only push suppression (one PR).

## Plan

### #779 — preserve the XEP-0359 stanza-id through push publish

The published pubsub `<item id>` is the outbox `job_id` (a fresh UUID), while the chat service worker's in-band-vs-Web-Push dedupe compares against the original XEP-0359 stanza-id posted by the foreground tab — the two never match by construction, so the documented SW dedupe is inoperative on every push.

Taking the **typed context attribute** acceptance option, NOT the item-id swap: outbox jobs coalesce multiple messages (no single stanza-id per item), and both the `ON CONFLICT(node, item_id)` upsert and #1123's delivered-device retry filter rely on the item id staying the stable job id.

- Carry `candidate.archive_stanza_id.id` onto `NotificationOutboxJob` (new `notification_outbox.stanza_id` column; populated on insert, overwritten on coalesce-merge so the job always names the **latest** message — matching what the foreground most recently rendered).
- Emit it as a typed `stanza-id` attribute on `<context xmlns='urn:waddle:push:context:0'/>` (`payload.rs`).
- Parse it in `ParsedPushPayload` and source `PushEnvelope.item` from it (falling back to the pubsub item id when absent). `PushEnvelope.item`'s doc-comment already claims stanza-id semantics; the SW (`sw-template.js`) and foreground (`notifications.ts`) already agree on the stanza-id key, so no chat-side change is needed — the SW dedupe starts working as documented.
- Tests: context attribute round-trip, envelope sourcing (stanza-id present/absent), coalesce-merge updates the id, SW-side dedupe simulation (foreground posts stanza-id X → push with X suppressed).

### #780 — suppress push for reaction-only messages

`has_archivable_payload` treats a message carrying only `<reactions xmlns='urn:xmpp:reactions:0'/>` as archivable (correct for MAM), and the push pipeline gates candidate creation on archivability — so every reaction emoji fires an OS push. Every mainstream XMPP client suppresses these.

- Reaction-only = carries reactions AND no substantive body (an edit that also adjusts reactions still notifies).
- Snapshot the boolean onto `NotificationMessageHints` at both candidate-construction sites (DM `offline_delivery.rs`, groupchat `groupchat_inbox.rs`), persisted like `noping`.
- T1 gate suppresses with a typed `SuppressedReason::Xep0444Reaction` (full 5-way lockstep: enum, schema CHECK, postgres fixture, prometheus label + counter slot), recording the candidate audit row + metric.
- Tests: gate-level T0-delivers/T1-suppresses; T1 integration asserting the typed `suppressed_reason`, the labeled metric, and no publish job; reaction→MAM archival stays green.

## XEP conformance

XEP-0357 leaves publish policy to the server; the stanza-id rides the existing custom `urn:waddle:push:context:0` element (no official-namespace changes). XEP-0444 §6 doesn't speak to push; suppression is the ecosystem convention (Conversations, Snikket, Movim). XEP-0359 ids are used exactly for their designed purpose: a stable server-assigned id surviving forwarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
