### PR TITLE
feat(server): XEP-0357/0050 polish — strict publish-options FORM_TYPE, §4.3 command errors, session lifecycle, single-tx register, typed composer errors (#774 #772 #773 #776 #777)

### DIFF
--- a/TODO-ISSUES.md
+++ b/TODO-ISSUES.md
@@ -50,7 +50,7 @@ _Residual (tracked, not #945-gating): survivor-check TOCTOU needs per-call locki
 ### Lane C — Push server reliability + conformance
 1. ✅ **#1123 + #1124 + #1126 `[one PR]` — duplicate/spurious push trio: per-device idempotent retry (delivered-device filter + all-delivered→published), janitor claim-recency floor (`claimed_at_ms` + 3-interval floor), unread-0 suppression (typed `Suppressed` outcome + `unread_zero_at_publish` audit reason) + ±25% retry jitter on all three backoff paths. DONE (PR #1236).**
 2. ✅ **#779 + #780 `[one PR]` — stanza-id rides a typed `stanza-id` attribute on `urn:waddle:push:context:0` → `PushEnvelope.item` (item id stays job id for coalesce/idempotency; SW dedupe now live for DM + MUC); reaction-only messages suppressed at T1 with typed `xep0444_reaction` reason (archived, never pushed). DONE (PR #1239).**
-3. #774 + #772 + #773 + #776 + #777 `[one PR]` — XEP-0357/0050 polish: strict publish-options FORM_TYPE validation, emit SessionExpired, session-lifecycle robustness, single-tx register-device, typed composer errors.
+3. ✅ **#774 + #772 + #773 + #776 + #777 `[one PR]` — XEP-0357/0050 polish: tri-state publish-options FORM_TYPE (`bad-request` on mismatch), typed `<session-expired/>` vs `<bad-sessionid/>` (bounded recently-expired cache), minted sessionid on single-shot Completed, single-tx register-device (+XEP-0060 compensation), typed `PushRegistrationError` + `StanzaError.application_condition` + structured WASM rejection + chat session-expired retry. DONE (PR #1240).**
 4. #775 — finish §6 forward cleanup on 410 GONE (device half done; user-server invalidation + client notify remain).
 5. #1125 — dead-letter permanently-unresolvable notification candidates.
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -100,7 +100,11 @@ import { discoverChannels, discoverTopology } from "./discovery";
 import { discoverUploadService, uploadFile, type UploadProgress } from "./file-upload";
 import { createGroupDm, type CreateGroupDmResult } from "./group-dm";
 import { ReconnectCatchup } from "./reconnect-catchup";
-import { parseRegisterDeviceResult, type RegisterDeviceResult } from "./push-register-result";
+import {
+  parseRegisterDeviceResult,
+  parseRegisterPushDeviceRejection,
+  type RegisterDeviceResult,
+} from "./push-register-result";
 import {
   createLocalStorageResumePersistence,
   type ResumePersistence,
@@ -1976,6 +1980,10 @@ export class BrowserXmppClient {
       }
       return parsed;
     } catch (error) {
+      const rejection = parseRegisterPushDeviceRejection(error);
+      if (rejection?.code === "session-expired") {
+        throw error;
+      }
       console.warn("[xmpp] XEP-0050 register-device rejected:", error);
       return null;
     }

--- a/chat/src/lib/xmpp/push-register-result.ts
+++ b/chat/src/lib/xmpp/push-register-result.ts
@@ -7,6 +7,37 @@ export interface RegisterDeviceResult {
   deviceId: string;
 }
 
+export interface RegisterPushDeviceRejection {
+  code: string;
+  message: string;
+}
+
+export function parseRegisterPushDeviceRejection(error: unknown): RegisterPushDeviceRejection | null {
+  if (!error || typeof error !== "object") return null;
+  const candidate = error as { code?: unknown; message?: unknown };
+  if (typeof candidate.code !== "string" || typeof candidate.message !== "string") {
+    return null;
+  }
+  return { code: candidate.code, message: candidate.message };
+}
+
+export async function retryRegisterPushDeviceAfterSessionExpired<T>(
+  register: () => Promise<T | null>,
+): Promise<T | null> {
+  try {
+    return await register();
+  } catch (error) {
+    const rejection = parseRegisterPushDeviceRejection(error);
+    if (rejection?.code !== "session-expired") return null;
+  }
+
+  try {
+    return await register();
+  } catch {
+    return null;
+  }
+}
+
 /// Parse the raw `register_push_device` result into the typed
 /// `(node, deviceId)` pair the chat persists.
 ///

--- a/chat/src/lib/xmpp/push-register-result.ts
+++ b/chat/src/lib/xmpp/push-register-result.ts
@@ -27,14 +27,25 @@ export async function retryRegisterPushDeviceAfterSessionExpired<T>(
   try {
     return await register();
   } catch (error) {
+    // Only the structured session-expired rejection is retryable —
+    // any other exception (e.g. a transient connection failure BEFORE
+    // the WASM call) must keep propagating exactly as it did before
+    // this helper existed, so the caller's persisted node/deviceId
+    // are not cleared over a blip.
     const rejection = parseRegisterPushDeviceRejection(error);
-    if (rejection?.code !== "session-expired") return null;
+    if (rejection?.code !== "session-expired") throw error;
   }
 
+  // Single retry from stage 1 with a fresh XEP-0050 session. A SECOND
+  // session-expired is a terminal registration failure (the caller's
+  // null-path clears the persisted ids, matching the pre-retry
+  // behavior for terminal failures); anything else propagates.
   try {
     return await register();
-  } catch {
-    return null;
+  } catch (error) {
+    const rejection = parseRegisterPushDeviceRejection(error);
+    if (rejection?.code === "session-expired") return null;
+    throw error;
   }
 }
 

--- a/chat/src/shell/notifications.ts
+++ b/chat/src/shell/notifications.ts
@@ -1,5 +1,6 @@
 import { computed, ref, watch } from "vue";
 import { barePeerJid, jidDomainOrEmpty, type BrowserXmppClient, type NotifyMode } from "@/lib/xmpp-client";
+import { retryRegisterPushDeviceAfterSessionExpired } from "@/lib/xmpp/push-register-result";
 import { getOrRegisterServiceWorker, registerServiceWorker as registerChatServiceWorker } from "@/lib/service-worker-registration";
 import { createPushFlowLock } from "./push-flow-lock";
 import {
@@ -465,14 +466,17 @@ export function usePushNotifications() {
     // app-id) push node, binds the browser's PushSubscription, and
     // returns BOTH the assigned XEP-0357 node id and the Push
     // Service-assigned device id in the stage-4 result form.
-    const registered = await xmppClient.registerPushDevice({
+    const registerOptions = {
       serviceJid,
       appId: APP_ID_WEB,
       environment: PUSH_ENVIRONMENT,
       endpoint,
       p256dh,
       auth,
-    });
+    } as const;
+    const registered = await retryRegisterPushDeviceAfterSessionExpired(() =>
+      xmppClient.registerPushDevice(registerOptions),
+    );
     if (!registered) {
       console.warn(
         "[notifications] XEP-0050 register-device failed; push subscription will not be delivered",

--- a/chat/tests/push-register-result.test.ts
+++ b/chat/tests/push-register-result.test.ts
@@ -6,7 +6,11 @@
 // down sibling devices on the same XEP-0357 node.
 
 import { describe, expect, test } from "bun:test";
-import { parseRegisterDeviceResult } from "../src/lib/xmpp/push-register-result";
+import {
+  parseRegisterDeviceResult,
+  parseRegisterPushDeviceRejection,
+  retryRegisterPushDeviceAfterSessionExpired,
+} from "../src/lib/xmpp/push-register-result";
 
 describe("parseRegisterDeviceResult", () => {
   test("accepts a well-formed (node, deviceId) pair", () => {
@@ -46,5 +50,56 @@ describe("parseRegisterDeviceResult", () => {
     expect(
       parseRegisterDeviceResult({ node: "node-1", deviceId: "device-1", leaked: "secret" }),
     ).toEqual({ node: "node-1", deviceId: "device-1" });
+  });
+});
+
+describe("registerPushDevice session-expired retry", () => {
+  test("parses structured wasm rejection objects", () => {
+    expect(
+      parseRegisterPushDeviceRejection({
+        code: "session-expired",
+        message: "XEP-0050 command session expired",
+      }),
+    ).toEqual({
+      code: "session-expired",
+      message: "XEP-0050 command session expired",
+    });
+    expect(parseRegisterPushDeviceRejection("session expired")).toBeNull();
+  });
+
+  test("retries exactly once after session-expired", async () => {
+    let calls = 0;
+    const result = await retryRegisterPushDeviceAfterSessionExpired(async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw { code: "session-expired", message: "expired" };
+      }
+      return { node: "node-1", deviceId: "device-1" };
+    });
+
+    expect(result).toEqual({ node: "node-1", deviceId: "device-1" });
+    expect(calls).toBe(2);
+  });
+
+  test("does not retry non-session failures", async () => {
+    let calls = 0;
+    const result = await retryRegisterPushDeviceAfterSessionExpired(async () => {
+      calls += 1;
+      throw { code: "stanza-error", message: "forbidden" };
+    });
+
+    expect(result).toBeNull();
+    expect(calls).toBe(1);
+  });
+
+  test("gives up after one failed session-expired retry", async () => {
+    let calls = 0;
+    const result = await retryRegisterPushDeviceAfterSessionExpired(async () => {
+      calls += 1;
+      throw { code: "session-expired", message: "expired" };
+    });
+
+    expect(result).toBeNull();
+    expect(calls).toBe(2);
   });
 });

--- a/chat/tests/push-register-result.test.ts
+++ b/chat/tests/push-register-result.test.ts
@@ -83,23 +83,61 @@ describe("registerPushDevice session-expired retry", () => {
 
   test("does not retry non-session failures", async () => {
     let calls = 0;
-    const result = await retryRegisterPushDeviceAfterSessionExpired(async () => {
-      calls += 1;
-      throw { code: "stanza-error", message: "forbidden" };
-    });
+    let thrown: unknown = null;
+    try {
+      await retryRegisterPushDeviceAfterSessionExpired(async () => {
+        calls += 1;
+        throw { code: "stanza-error", message: "forbidden" };
+      });
+    } catch (error) {
+      thrown = error;
+    }
 
-    expect(result).toBeNull();
+    // Non-session failures PROPAGATE (they are not retryable and the
+    // caller's error handling must see them unchanged — swallowing
+    // into null would wrongly clear persisted push ids over a blip).
+    expect(thrown).toEqual({ code: "stanza-error", message: "forbidden" });
     expect(calls).toBe(1);
   });
 
-  test("gives up after one failed session-expired retry", async () => {
+  test("a transient pre-WASM exception propagates untouched", async () => {
+    let thrown: unknown = null;
+    try {
+      await retryRegisterPushDeviceAfterSessionExpired(async () => {
+        throw new Error("xmpp not connected");
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+  });
+
+  test("second session-expired is terminal: null after the single retry", async () => {
     let calls = 0;
     const result = await retryRegisterPushDeviceAfterSessionExpired(async () => {
       calls += 1;
       throw { code: "session-expired", message: "expired" };
     });
 
+    // Terminal registration failure → the caller's null-path clears
+    // the persisted ids (same as any terminal register failure).
     expect(result).toBeNull();
+    expect(calls).toBe(2);
+  });
+
+  test("a non-session failure on the retry attempt propagates", async () => {
+    let calls = 0;
+    let thrown: unknown = null;
+    try {
+      await retryRegisterPushDeviceAfterSessionExpired(async () => {
+        calls += 1;
+        if (calls === 1) throw { code: "session-expired", message: "expired" };
+        throw new Error("network dropped mid-retry");
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
     expect(calls).toBe(2);
   });
 });

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -526,6 +526,7 @@ async fn handle_list(ctx: CommandContext, state: Arc<AppState>) -> CommandResult
     };
     match run_list(&state, &args).await {
         Ok(result) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_list_form(&result)),
             notes: vec![],
         },
@@ -543,6 +544,7 @@ async fn handle_create(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
     };
     match run_create(&state, &args).await {
         Ok(channel) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_channel_form(&channel)),
             notes: vec![],
         },
@@ -557,6 +559,7 @@ async fn handle_group_dm_create(ctx: CommandContext, state: Arc<AppState>) -> Co
     };
     match run_group_dm_create(&state, &ctx.from.to_bare(), &args).await {
         Ok(group_dm) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_group_dm_form(&group_dm)),
             notes: vec![],
         },
@@ -598,6 +601,7 @@ async fn handle_group_dm_leave(
     .await
     {
         Ok(result) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_group_dm_leave_form(&result)),
             notes: vec![],
         },
@@ -627,6 +631,7 @@ async fn handle_group_dm_rename(
     }
     match run_group_dm_rename(&state, &connections, &caller_full, &args).await {
         Ok(result) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_group_dm_rename_form(&result)),
             notes: vec![],
         },
@@ -648,6 +653,7 @@ async fn handle_update(
     };
     match run_update(&state, &connections, &args).await {
         Ok(channel) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_channel_form(&channel)),
             notes: vec![],
         },
@@ -665,6 +671,7 @@ async fn handle_delete(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
     };
     match run_delete(&state, &args).await {
         Ok(()) => CommandResult::Completed {
+            session_id: None,
             form: None,
             notes: vec![],
         },
@@ -682,6 +689,7 @@ async fn handle_occupants(ctx: CommandContext, state: Arc<AppState>) -> CommandR
     };
     match run_occupants(&state, &args).await {
         Ok(result) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_occupants_form(&result)),
             notes: vec![],
         },
@@ -699,6 +707,7 @@ async fn handle_affiliations(ctx: CommandContext, state: Arc<AppState>) -> Comma
     };
     match run_affiliations(&state, &args).await {
         Ok(result) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_affiliations_form(&result)),
             notes: vec![],
         },
@@ -722,6 +731,7 @@ async fn handle_set_affiliation(
     };
     match run_set_affiliation(&state, &connections, &caller_bare, &args, sfu.as_ref()).await {
         Ok(result) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_set_affiliation_form(&result)),
             notes: vec![],
         },
@@ -763,6 +773,7 @@ async fn handle_kick(
     };
     match run_kick(&state, &connections, &caller_full, &args, sfu.as_ref()).await {
         Ok(result) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_kick_form(&result)),
             notes: vec![],
         },

--- a/server/crates/waddle-server/src/admin/spaces.rs
+++ b/server/crates/waddle-server/src/admin/spaces.rs
@@ -341,6 +341,7 @@ async fn handle_list(ctx: CommandContext, state: Arc<AppState>) -> CommandResult
     };
     match run_list(&state, &args).await {
         Ok(result) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_list_form(&result)),
             notes: vec![],
         },
@@ -358,6 +359,7 @@ async fn handle_create(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
     };
     match run_create(&state, &args).await {
         Ok(space) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_space_form(NODE_CREATE, &space)),
             notes: vec![],
         },
@@ -375,6 +377,7 @@ async fn handle_update(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
     };
     match run_update(&state, &args).await {
         Ok(space) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_space_form(NODE_UPDATE, &space)),
             notes: vec![],
         },
@@ -392,6 +395,7 @@ async fn handle_delete(ctx: CommandContext, state: Arc<AppState>) -> CommandResu
     };
     match run_delete(&state, &args).await {
         Ok(()) => CommandResult::Completed {
+            session_id: None,
             form: None,
             notes: vec![],
         },
@@ -409,6 +413,7 @@ async fn handle_members(ctx: CommandContext, state: Arc<AppState>) -> CommandRes
     };
     match run_members(&state, &args).await {
         Ok(result) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_members_form(&result)),
             notes: vec![],
         },
@@ -426,6 +431,7 @@ async fn handle_set_role(ctx: CommandContext, state: Arc<AppState>) -> CommandRe
     };
     match run_set_role(&state, &args).await {
         Ok(result) => CommandResult::Completed {
+            session_id: None,
             form: Some(build_set_role_form(&result)),
             notes: vec![],
         },

--- a/server/crates/waddle-server/src/admin/users_list.rs
+++ b/server/crates/waddle-server/src/admin/users_list.rs
@@ -140,6 +140,7 @@ async fn handle(
     };
 
     CommandResult::Completed {
+        session_id: None,
         form: Some(build_result_form(&page)),
         notes: vec![],
     }

--- a/server/crates/waddle-server/src/push_service/commands.rs
+++ b/server/crates/waddle-server/src/push_service/commands.rs
@@ -267,20 +267,20 @@ async fn handle_register_device(
     let owner = ctx.from.to_bare();
 
     // Allocate (or reuse) the XEP-0357 push node bound to (owner,
-    // app_id). The custom-namespace handler used a separate
-    // `ensure-node` round-trip; the XEP-0050 dance folds that step
-    // into stage 3 so the chat client never sees the node id until
-    // the result form returns it. Storage layout is unchanged.
+    // app_id), then register the device in the same write transaction.
+    // The custom-namespace handler used a separate `ensure-node`
+    // round-trip; the XEP-0050 dance folds that step into stage 3 so
+    // the chat client never sees the node id until the result form
+    // returns it. Storage layout is unchanged.
     let app_id = request.app_id().to_string();
-    let push_node = match push_service.ensure_node(&owner, &app_id).await {
-        Ok(node) => node,
-        Err(error) => return CommandResult::Error(error),
-    };
-
     let device_id = generate_device_id();
-    let registration = build_registration(&request, &device_id, push_node.node());
-    let device = match push_service.upsert_device(&owner, registration).await {
-        Ok(device) => device,
+    let (_push_node, device) = match push_service
+        .register_device_for_owner(&owner, &app_id, |node| {
+            build_registration(&request, &device_id, node)
+        })
+        .await
+    {
+        Ok(registered) => registered,
         Err(error) => return CommandResult::Error(error),
     };
 

--- a/server/crates/waddle-server/src/push_service/commands.rs
+++ b/server/crates/waddle-server/src/push_service/commands.rs
@@ -285,6 +285,7 @@ async fn handle_register_device(
     };
 
     CommandResult::Completed {
+        session_id: None,
         form: Some(build_register_device_result_form(
             device.node(),
             device.device_id(),
@@ -348,6 +349,7 @@ async fn handle_disable_device(
         // typed IQ stanza error — so a stale/typo'd device-id is reported
         // honestly instead of as a false success.
         Ok(()) => CommandResult::Completed {
+            session_id: None,
             form: None,
             notes: vec![],
         },

--- a/server/crates/waddle-server/src/push_service/devices.rs
+++ b/server/crates/waddle-server/src/push_service/devices.rs
@@ -6,7 +6,7 @@ use jid::BareJid;
 use waddle_xmpp::XmppError;
 
 use super::dispatch;
-use super::nodes::{get_node_tx, MAX_NODE_ID_LEN};
+use super::nodes::{ensure_node_tx, get_node_tx, MAX_NODE_ID_LEN};
 use super::publish_jobs::wake_queued_publish_jobs_for_node_tx;
 use super::secrets::PushSecretCipher;
 use super::store::{lock_node_tx, DatabasePushServiceStore};
@@ -379,128 +379,163 @@ fn decode_device(
     })
 }
 
+pub(super) async fn upsert_device_tx(
+    tx: &mut crate::db::Transaction<'_>,
+    owner_bare_jid: &BareJid,
+    registration: PushDeviceRegistration,
+    secrets: &PushSecretCipher,
+    now_ms: i64,
+) -> Result<PushServiceDevice, XmppError> {
+    if registration.device_id.is_empty()
+        || registration.node.is_empty()
+        || registration.environment.is_empty()
+    {
+        return Err(XmppError::bad_request(Some(
+            "Push Service device-id, node, and environment are required".to_string(),
+        )));
+    }
+    validate_device_registration(&registration)?;
+    if get_node_tx(tx, &registration.node).await?.is_none() {
+        return Err(XmppError::item_not_found(Some(
+            "Push node not found".to_string(),
+        )));
+    }
+    lock_node_tx(tx, &registration.node, now_ms).await?;
+    let push_node = get_node_tx(tx, &registration.node)
+        .await?
+        .ok_or_else(|| XmppError::internal("Push Service node was not persisted"))?;
+    if push_node.owner_bare_jid != *owner_bare_jid {
+        return Err(XmppError::forbidden(Some(
+            "Push node belongs to another user".to_string(),
+        )));
+    }
+    if push_node.status != PushNodeStatus::Active {
+        return Err(XmppError::item_not_found(Some(
+            "Push node not active".to_string(),
+        )));
+    }
+    prune_disabled_devices_for_node_tx(
+        tx,
+        &registration.node,
+        MAX_RETAINED_DISABLED_DEVICES_PER_NODE,
+    )
+    .await?;
+    if !active_device_exists_on_node_tx(tx, &registration.node, &registration.device_id).await?
+        && count_active_devices_for_node_tx(tx, &registration.node).await?
+            >= MAX_PUSH_DEVICES_PER_NODE
+    {
+        return Err(XmppError::bad_request(Some(format!(
+            "Push Service active device quota exceeded; max {MAX_PUSH_DEVICES_PER_NODE} active devices per node"
+        ))));
+    }
+
+    let sealed_provider_endpoint = secrets.seal_optional(registration.provider_endpoint.clone())?;
+    let sealed_provider_token = secrets.seal_optional(registration.provider_token.clone())?;
+    let sealed_provider_key_material =
+        secrets.seal_optional(registration.provider_key_material.clone())?;
+    let device_id = registration.device_id.clone();
+    tx.execute(
+        r#"
+        INSERT INTO push_devices (
+            device_id,
+            node,
+            platform,
+            environment,
+            provider_endpoint,
+            provider_token,
+            provider_key_material,
+            status,
+            failure_count,
+            last_error,
+            created_at_ms,
+            updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?, ?)
+        ON CONFLICT(node, device_id) DO UPDATE SET
+            platform = excluded.platform,
+            environment = excluded.environment,
+            provider_endpoint = excluded.provider_endpoint,
+            provider_token = excluded.provider_token,
+            provider_key_material = excluded.provider_key_material,
+            status = excluded.status,
+            failure_count = 0,
+            last_error = NULL,
+            updated_at_ms = excluded.updated_at_ms
+        "#,
+        crate::db_params![
+            device_id.clone(),
+            registration.node.clone(),
+            registration.platform.to_string(),
+            registration.environment.clone(),
+            sealed_provider_endpoint,
+            sealed_provider_token,
+            sealed_provider_key_material,
+            DEVICE_STATUS_ACTIVE,
+            now_ms,
+            now_ms,
+        ],
+    )
+    .await
+    .map_err(|error| XmppError::internal(error.to_string()))?;
+    wake_queued_publish_jobs_for_node_tx(tx, &registration.node, now_ms).await?;
+    get_device_for_owner_on_node_tx(tx, owner_bare_jid, &registration.node, &device_id, secrets)
+        .await?
+        .ok_or_else(|| XmppError::internal("Push Service device was not persisted"))
+}
+
 impl DatabasePushServiceStore {
     pub async fn upsert_device(
         &self,
         owner_bare_jid: &BareJid,
         registration: PushDeviceRegistration,
     ) -> Result<PushServiceDevice, XmppError> {
-        if registration.device_id.is_empty()
-            || registration.node.is_empty()
-            || registration.environment.is_empty()
-        {
-            return Err(XmppError::bad_request(Some(
-                "Push Service device-id, node, and environment are required".to_string(),
-            )));
-        }
-        validate_device_registration(&registration)?;
         let now_ms = crate::time::now_ms();
         let mut tx = self
             .db
             .begin_immediate()
             .await
             .map_err(|error| XmppError::internal(error.to_string()))?;
-        if get_node_tx(&mut tx, &registration.node).await?.is_none() {
-            return Err(XmppError::item_not_found(Some(
-                "Push node not found".to_string(),
-            )));
-        }
-        lock_node_tx(&mut tx, &registration.node, now_ms).await?;
-        let push_node = get_node_tx(&mut tx, &registration.node)
-            .await?
-            .ok_or_else(|| XmppError::internal("Push Service node was not persisted"))?;
-        if push_node.owner_bare_jid != *owner_bare_jid {
-            return Err(XmppError::forbidden(Some(
-                "Push node belongs to another user".to_string(),
-            )));
-        }
-        if push_node.status != PushNodeStatus::Active {
-            return Err(XmppError::item_not_found(Some(
-                "Push node not active".to_string(),
-            )));
-        }
-        prune_disabled_devices_for_node_tx(
-            &mut tx,
-            &registration.node,
-            MAX_RETAINED_DISABLED_DEVICES_PER_NODE,
-        )
-        .await?;
-        if !active_device_exists_on_node_tx(&mut tx, &registration.node, &registration.device_id)
-            .await?
-            && count_active_devices_for_node_tx(&mut tx, &registration.node).await?
-                >= MAX_PUSH_DEVICES_PER_NODE
-        {
-            return Err(XmppError::bad_request(Some(format!(
-                "Push Service active device quota exceeded; max {MAX_PUSH_DEVICES_PER_NODE} active devices per node"
-            ))));
-        }
-
-        let sealed_provider_endpoint = self
-            .secrets
-            .seal_optional(registration.provider_endpoint.clone())?;
-        let sealed_provider_token = self
-            .secrets
-            .seal_optional(registration.provider_token.clone())?;
-        let sealed_provider_key_material = self
-            .secrets
-            .seal_optional(registration.provider_key_material.clone())?;
-        let device_id = registration.device_id.clone();
-        tx.execute(
-            r#"
-            INSERT INTO push_devices (
-                device_id,
-                node,
-                platform,
-                environment,
-                provider_endpoint,
-                provider_token,
-                provider_key_material,
-                status,
-                failure_count,
-                last_error,
-                created_at_ms,
-                updated_at_ms
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?, ?)
-            ON CONFLICT(node, device_id) DO UPDATE SET
-                platform = excluded.platform,
-                environment = excluded.environment,
-                provider_endpoint = excluded.provider_endpoint,
-                provider_token = excluded.provider_token,
-                provider_key_material = excluded.provider_key_material,
-                status = excluded.status,
-                failure_count = 0,
-                last_error = NULL,
-                updated_at_ms = excluded.updated_at_ms
-            "#,
-            crate::db_params![
-                device_id.clone(),
-                registration.node.clone(),
-                registration.platform.to_string(),
-                registration.environment.clone(),
-                sealed_provider_endpoint,
-                sealed_provider_token,
-                sealed_provider_key_material,
-                DEVICE_STATUS_ACTIVE,
-                now_ms,
-                now_ms,
-            ],
-        )
-        .await
-        .map_err(|error| XmppError::internal(error.to_string()))?;
-        wake_queued_publish_jobs_for_node_tx(&mut tx, &registration.node, now_ms).await?;
-        let device = get_device_for_owner_on_node_tx(
-            &mut tx,
-            owner_bare_jid,
-            &registration.node,
-            &device_id,
-            &self.secrets,
-        )
-        .await?
-        .ok_or_else(|| XmppError::internal("Push Service device was not persisted"))?;
+        let device =
+            upsert_device_tx(&mut tx, owner_bare_jid, registration, &self.secrets, now_ms).await?;
         tx.commit()
             .await
             .map_err(|error| XmppError::internal(error.to_string()))?;
         Ok(device)
+    }
+
+    pub async fn register_device_for_owner(
+        &self,
+        owner_bare_jid: &BareJid,
+        app_id: &str,
+        registration_for_node: impl FnOnce(&str) -> PushDeviceRegistration,
+    ) -> Result<(super::types::PushServiceNode, PushServiceDevice), XmppError> {
+        let now_ms = crate::time::now_ms();
+        let mut tx = self
+            .db
+            .begin_immediate()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        let node = ensure_node_tx(&mut tx, owner_bare_jid, app_id, now_ms).await?;
+        let registration = registration_for_node(node.node());
+        let device =
+            upsert_device_tx(&mut tx, owner_bare_jid, registration, &self.secrets, now_ms).await?;
+        tx.commit()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        if let Err(error) = self
+            .ensure_xep0060_push_node_for_owner(owner_bare_jid, node.node())
+            .await
+        {
+            let _ = self
+                .disable_device_for_owner(
+                    owner_bare_jid,
+                    node.node(),
+                    device.device_id(),
+                    Some("failed to provision XEP-0060 Push Service node"),
+                )
+                .await;
+            return Err(error);
+        }
+        Ok((node, device))
     }
 
     /// Disable a single device on an owner's push node, clearing its
@@ -686,11 +721,238 @@ impl DatabasePushServiceStore {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
+    use async_trait::async_trait;
+    use jid::Jid;
+    use waddle_xmpp::pubsub::{
+        Affiliation, InMemoryPubSubStorage, NodeConfig, PubSubItem, PubSubNode, PubSubStorage,
+        PublishResult, StoredItem, SubId, Subscription,
+    };
     use waddle_xmpp::push::{PushSubscription, PushSubscriptionStore};
 
+    use crate::db::Database;
     use crate::push_service::secrets::SEALED_PROVIDER_VALUE_PREFIX;
-    use crate::push_service::test_support::{notification_item, owner, store};
+    use crate::push_service::test_support::{
+        assert_item_not_found, notification_item, owner, store,
+    };
+
+    struct FailingNodeConfigPubSubStorage {
+        inner: InMemoryPubSubStorage,
+    }
+
+    impl FailingNodeConfigPubSubStorage {
+        fn new() -> Self {
+            Self {
+                inner: InMemoryPubSubStorage::new(),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl PubSubStorage for FailingNodeConfigPubSubStorage {
+        async fn get_or_create_node(
+            &self,
+            owner: &BareJid,
+            node_name: &str,
+        ) -> Result<(PubSubNode, bool), XmppError> {
+            self.inner.get_or_create_node(owner, node_name).await
+        }
+
+        async fn get_node(
+            &self,
+            owner: &BareJid,
+            node_name: &str,
+        ) -> Result<Option<PubSubNode>, XmppError> {
+            self.inner.get_node(owner, node_name).await
+        }
+
+        async fn delete_node(&self, owner: &BareJid, node_name: &str) -> Result<bool, XmppError> {
+            self.inner.delete_node(owner, node_name).await
+        }
+
+        async fn publish_item(
+            &self,
+            owner: &BareJid,
+            node_name: &str,
+            item: &PubSubItem,
+            publisher: Option<&BareJid>,
+            auto_create: bool,
+        ) -> Result<PublishResult, XmppError> {
+            self.inner
+                .publish_item(owner, node_name, item, publisher, auto_create)
+                .await
+        }
+
+        async fn publish_item_if_missing_or_publisher(
+            &self,
+            owner: &BareJid,
+            node_name: &str,
+            item: &PubSubItem,
+            publisher: &BareJid,
+            auto_create: bool,
+        ) -> Result<PublishResult, XmppError> {
+            self.inner
+                .publish_item_if_missing_or_publisher(
+                    owner,
+                    node_name,
+                    item,
+                    publisher,
+                    auto_create,
+                )
+                .await
+        }
+
+        async fn get_items(
+            &self,
+            owner: &BareJid,
+            node_name: &str,
+            max_items: Option<u32>,
+            item_ids: &[String],
+        ) -> Result<Vec<StoredItem>, XmppError> {
+            self.inner
+                .get_items(owner, node_name, max_items, item_ids)
+                .await
+        }
+
+        async fn retract_item(
+            &self,
+            owner: &BareJid,
+            node_name: &str,
+            item_id: &str,
+        ) -> Result<bool, XmppError> {
+            self.inner.retract_item(owner, node_name, item_id).await
+        }
+
+        async fn list_nodes(&self, owner: &BareJid) -> Result<Vec<String>, XmppError> {
+            self.inner.list_nodes(owner).await
+        }
+
+        async fn find_node_for_item(
+            &self,
+            owner: &BareJid,
+            item_id: &str,
+        ) -> Result<Option<PubSubNode>, XmppError> {
+            self.inner.find_node_for_item(owner, item_id).await
+        }
+
+        async fn list_node_names_for_item(
+            &self,
+            owner: &BareJid,
+            item_id: &str,
+        ) -> Result<Vec<String>, XmppError> {
+            self.inner.list_node_names_for_item(owner, item_id).await
+        }
+
+        async fn update_node_config(
+            &self,
+            _owner: &BareJid,
+            _node_name: &str,
+            _config: &NodeConfig,
+        ) -> Result<(), XmppError> {
+            Err(XmppError::internal("forced XEP-0060 node config failure"))
+        }
+
+        async fn purge_node(&self, owner: &BareJid, node_name: &str) -> Result<u64, XmppError> {
+            self.inner.purge_node(owner, node_name).await
+        }
+
+        async fn subscribe(
+            &self,
+            owner: &BareJid,
+            node_name: &str,
+            subscriber: &Jid,
+        ) -> Result<Subscription, XmppError> {
+            self.inner.subscribe(owner, node_name, subscriber).await
+        }
+
+        async fn unsubscribe(
+            &self,
+            owner: &BareJid,
+            node_name: &str,
+            subscriber: &Jid,
+            subid: Option<&SubId>,
+        ) -> Result<bool, XmppError> {
+            self.inner
+                .unsubscribe(owner, node_name, subscriber, subid)
+                .await
+        }
+
+        async fn list_node_subscriptions(
+            &self,
+            owner: &BareJid,
+            node_name: &str,
+        ) -> Result<Vec<Subscription>, XmppError> {
+            self.inner.list_node_subscriptions(owner, node_name).await
+        }
+
+        async fn list_subscriber_subscriptions(
+            &self,
+            owner: &BareJid,
+            subscriber: &Jid,
+        ) -> Result<Vec<(String, Subscription)>, XmppError> {
+            self.inner
+                .list_subscriber_subscriptions(owner, subscriber)
+                .await
+        }
+
+        async fn get_subscription(
+            &self,
+            owner: &BareJid,
+            node_name: &str,
+            subid: &SubId,
+        ) -> Result<Option<Subscription>, XmppError> {
+            self.inner.get_subscription(owner, node_name, subid).await
+        }
+
+        async fn list_deliverable_subscribers(
+            &self,
+            owner: &BareJid,
+            node_name: &str,
+        ) -> Result<Vec<Subscription>, XmppError> {
+            self.inner
+                .list_deliverable_subscribers(owner, node_name)
+                .await
+        }
+
+        async fn set_affiliation(
+            &self,
+            owner: &BareJid,
+            node_name: &str,
+            entity: &BareJid,
+            affiliation: Affiliation,
+        ) -> Result<Affiliation, XmppError> {
+            self.inner
+                .set_affiliation(owner, node_name, entity, affiliation)
+                .await
+        }
+
+        async fn get_affiliation(
+            &self,
+            owner: &BareJid,
+            node_name: &str,
+            entity: &BareJid,
+        ) -> Result<Affiliation, XmppError> {
+            self.inner.get_affiliation(owner, node_name, entity).await
+        }
+
+        async fn list_node_affiliations(
+            &self,
+            owner: &BareJid,
+            node_name: &str,
+        ) -> Result<Vec<(BareJid, Affiliation)>, XmppError> {
+            self.inner.list_node_affiliations(owner, node_name).await
+        }
+
+        async fn list_entity_affiliations(
+            &self,
+            owner: &BareJid,
+            entity: &BareJid,
+        ) -> Result<Vec<(String, Affiliation)>, XmppError> {
+            self.inner.list_entity_affiliations(owner, entity).await
+        }
+    }
 
     #[tokio::test]
     async fn provider_credentials_live_in_push_service_not_xep0357_registration_store() {
@@ -767,6 +1029,125 @@ mod tests {
         assert!(registrations[0].endpoint.is_none());
         assert!(registrations[0].p256dh.is_none());
         assert!(registrations[0].auth_key.is_none());
+    }
+
+    #[tokio::test]
+    async fn register_device_for_owner_rolls_back_node_when_device_insert_fails() {
+        let store = store().await;
+        let owner = owner();
+        store
+            .execute(
+                r#"
+                CREATE TRIGGER fail_push_device_insert
+                BEFORE INSERT ON push_devices
+                BEGIN
+                    SELECT RAISE(ABORT, 'forced push device insert failure');
+                END
+                "#,
+                (),
+            )
+            .await
+            .expect("failure trigger");
+
+        store
+            .register_device_for_owner(&owner, "web", |node| {
+                PushDeviceRegistration::new("web-1", node, PushDevicePlatform::Web, "test")
+            })
+            .await
+            .expect_err("device insert trigger aborts registration");
+
+        assert!(
+            store
+                .list_node_names_for_owner(&owner)
+                .await
+                .expect("node list")
+                .is_empty(),
+            "node insert must roll back with the failed device insert"
+        );
+        assert!(
+            store
+                .get_device_for_owner(&owner, "web-1")
+                .await
+                .expect("device lookup")
+                .is_none(),
+            "device insert failed, so no device row should exist"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_device_for_owner_allows_disable_after_combined_commit() {
+        let store = store().await;
+        let owner = owner();
+        let (node, device) = store
+            .register_device_for_owner(&owner, "web", |node| {
+                PushDeviceRegistration::new("web-1", node, PushDevicePlatform::Web, "test")
+                    .with_provider_token(Some("provider-secret".to_string()))
+            })
+            .await
+            .expect("register device");
+
+        assert_eq!(device.node(), node.node());
+        store
+            .disable_nodes_for_owner(&owner, Some(node.node()))
+            .await
+            .expect("disable node after combined registration commit");
+        assert_item_not_found(
+            store
+                .upsert_device(
+                    &owner,
+                    PushDeviceRegistration::new(
+                        "web-2",
+                        node.node(),
+                        PushDevicePlatform::Web,
+                        "test",
+                    ),
+                )
+                .await
+                .expect_err("disabled node rejects later device registration"),
+        );
+    }
+
+    #[tokio::test]
+    async fn register_device_for_owner_compensates_device_when_pubsub_backing_fails() {
+        let owner = owner();
+        let store = DatabasePushServiceStore::new_with_secret_key_and_pubsub(
+            Database::in_memory("push-service-failing-pubsub")
+                .await
+                .expect("push service db"),
+            b"waddle-push-service-test-secret-key",
+            "push.example.com".parse().expect("push service jid"),
+            Arc::new(FailingNodeConfigPubSubStorage::new()),
+        )
+        .await
+        .expect("push service store");
+
+        store
+            .register_device_for_owner(&owner, "web", |node| {
+                PushDeviceRegistration::new("web-1", node, PushDevicePlatform::Web, "test")
+                    .with_provider_token(Some("provider-secret".to_string()))
+            })
+            .await
+            .expect_err("post-commit XEP-0060 provisioning fails");
+
+        let nodes = store
+            .list_node_names_for_owner(&owner)
+            .await
+            .expect("node list");
+        assert_eq!(nodes.len(), 1, "node commit should match ensure_node shape");
+        assert!(
+            store
+                .test_only_active_devices_for_owner_node(&owner, &nodes[0])
+                .await
+                .expect("active device list")
+                .is_empty(),
+            "failed post-commit provisioning must not leave an active device"
+        );
+        let compensated_device = store
+            .get_device_for_owner_on_node(&owner, &nodes[0], "web-1")
+            .await
+            .expect("compensated device lookup")
+            .expect("compensated disabled device");
+        assert_eq!(compensated_device.provider_token(), None);
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/push_service/devices.rs
+++ b/server/crates/waddle-server/src/push_service/devices.rs
@@ -525,14 +525,35 @@ impl DatabasePushServiceStore {
             .ensure_xep0060_push_node_for_owner(owner_bare_jid, node.node())
             .await
         {
-            let _ = self
+            // Compensation: the node+device commit above must not
+            // leave an active device whose XEP-0060 backing node was
+            // never provisioned — retries mint fresh device ids, and
+            // active orphans are never reaped by the disabled-device
+            // pruner, so they would permanently eat into
+            // MAX_PUSH_DEVICES_PER_NODE. If the compensating disable
+            // ITSELF fails (double DB failure), log loudly so an
+            // operator can reap the orphan; swallowing it silently
+            // would make the quota leak undiagnosable.
+            if let Err(compensation_error) = self
                 .disable_device_for_owner(
                     owner_bare_jid,
                     node.node(),
                     device.device_id(),
                     Some("failed to provision XEP-0060 Push Service node"),
                 )
-                .await;
+                .await
+            {
+                tracing::warn!(
+                    owner = %owner_bare_jid,
+                    node = %node.node(),
+                    device_id = %device.device_id(),
+                    provisioning_error = %error,
+                    %compensation_error,
+                    "register-device compensation failed; an ACTIVE push device \
+                     without a XEP-0060 backing node was left behind and counts \
+                     against the per-node device quota until manually disabled"
+                );
+            }
             return Err(error);
         }
         Ok((node, device))

--- a/server/crates/waddle-server/src/push_service/devices.rs
+++ b/server/crates/waddle-server/src/push_service/devices.rs
@@ -379,12 +379,25 @@ fn decode_device(
     })
 }
 
+/// Whether [`upsert_device_tx`] wakes queued publish jobs for the node
+/// inside the same transaction. The combined register path defers the
+/// wake until AFTER the post-commit XEP-0060 backing-node provisioning
+/// succeeds — waking earlier lets a worker claim a job whose phase-1
+/// backing validation is guaranteed to fail, burning a retry cycle at
+/// the exact moment a device (re)registers (Qodo review).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum WakeQueuedJobs {
+    InTx,
+    Deferred,
+}
+
 pub(super) async fn upsert_device_tx(
     tx: &mut crate::db::Transaction<'_>,
     owner_bare_jid: &BareJid,
     registration: PushDeviceRegistration,
     secrets: &PushSecretCipher,
     now_ms: i64,
+    wake: WakeQueuedJobs,
 ) -> Result<PushServiceDevice, XmppError> {
     if registration.device_id.is_empty()
         || registration.node.is_empty()
@@ -476,7 +489,9 @@ pub(super) async fn upsert_device_tx(
     )
     .await
     .map_err(|error| XmppError::internal(error.to_string()))?;
-    wake_queued_publish_jobs_for_node_tx(tx, &registration.node, now_ms).await?;
+    if wake == WakeQueuedJobs::InTx {
+        wake_queued_publish_jobs_for_node_tx(tx, &registration.node, now_ms).await?;
+    }
     get_device_for_owner_on_node_tx(tx, owner_bare_jid, &registration.node, &device_id, secrets)
         .await?
         .ok_or_else(|| XmppError::internal("Push Service device was not persisted"))
@@ -494,8 +509,15 @@ impl DatabasePushServiceStore {
             .begin_immediate()
             .await
             .map_err(|error| XmppError::internal(error.to_string()))?;
-        let device =
-            upsert_device_tx(&mut tx, owner_bare_jid, registration, &self.secrets, now_ms).await?;
+        let device = upsert_device_tx(
+            &mut tx,
+            owner_bare_jid,
+            registration,
+            &self.secrets,
+            now_ms,
+            WakeQueuedJobs::InTx,
+        )
+        .await?;
         tx.commit()
             .await
             .map_err(|error| XmppError::internal(error.to_string()))?;
@@ -516,8 +538,18 @@ impl DatabasePushServiceStore {
             .map_err(|error| XmppError::internal(error.to_string()))?;
         let node = ensure_node_tx(&mut tx, owner_bare_jid, app_id, now_ms).await?;
         let registration = registration_for_node(node.node());
-        let device =
-            upsert_device_tx(&mut tx, owner_bare_jid, registration, &self.secrets, now_ms).await?;
+        let device = upsert_device_tx(
+            &mut tx,
+            owner_bare_jid,
+            registration,
+            &self.secrets,
+            now_ms,
+            // The wake happens after the XEP-0060 provisioning below —
+            // a job woken here could be claimed before the backing
+            // node exists and would burn a retry cycle.
+            WakeQueuedJobs::Deferred,
+        )
+        .await?;
         tx.commit()
             .await
             .map_err(|error| XmppError::internal(error.to_string()))?;
@@ -556,6 +588,18 @@ impl DatabasePushServiceStore {
             }
             return Err(error);
         }
+        // Backing node is provisioned — NOW queued publish jobs for
+        // this node can run without failing phase-1 validation.
+        let mut wake_tx = self
+            .db
+            .begin_immediate()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?;
+        wake_queued_publish_jobs_for_node_tx(&mut wake_tx, node.node(), now_ms).await?;
+        wake_tx
+            .commit()
+            .await
+            .map_err(|error| XmppError::internal(error.to_string()))?;
         Ok((node, device))
     }
 

--- a/server/crates/waddle-server/src/push_service/nodes.rs
+++ b/server/crates/waddle-server/src/push_service/nodes.rs
@@ -178,6 +178,84 @@ async fn prune_disabled_nodes_for_owner_tx(
     Ok(())
 }
 
+fn validate_app_id(app_id: &str) -> Result<(), XmppError> {
+    if app_id.is_empty() {
+        return Err(XmppError::bad_request(Some(
+            "Push Service app-id is required".to_string(),
+        )));
+    }
+    validate_len("Push Service app-id", app_id, MAX_APP_ID_LEN)
+}
+
+pub(super) async fn ensure_node_tx(
+    tx: &mut crate::db::Transaction<'_>,
+    owner_bare_jid: &BareJid,
+    app_id: &str,
+    now_ms: i64,
+) -> Result<PushServiceNode, XmppError> {
+    validate_app_id(app_id)?;
+    lock_owner_tx(tx, owner_bare_jid, now_ms).await?;
+    if let Some(node) = find_node_by_owner_app_tx(tx, owner_bare_jid, app_id).await? {
+        if node.status == PushNodeStatus::Active {
+            return Ok(node);
+        }
+        if count_active_nodes_for_owner_tx(tx, owner_bare_jid).await? >= MAX_PUSH_NODES_PER_OWNER {
+            return Err(XmppError::bad_request(Some(format!(
+                "Push Service active node quota exceeded; max {MAX_PUSH_NODES_PER_OWNER} active nodes per owner"
+            ))));
+        }
+        tx.execute(
+            r#"
+            UPDATE push_nodes
+            SET status = ?, updated_at_ms = ?
+            WHERE node = ?
+            "#,
+            crate::db_params![PushNodeStatus::Active.as_str(), now_ms, node.node()],
+        )
+        .await
+        .map_err(|error| XmppError::internal(error.to_string()))?;
+        return get_node_tx(tx, node.node())
+            .await?
+            .ok_or_else(|| XmppError::internal("Push Service node was not persisted"));
+    }
+    prune_disabled_nodes_for_owner_tx(tx, owner_bare_jid, MAX_RETAINED_DISABLED_NODES_PER_OWNER)
+        .await?;
+    if count_active_nodes_for_owner_tx(tx, owner_bare_jid).await? >= MAX_PUSH_NODES_PER_OWNER {
+        return Err(XmppError::bad_request(Some(format!(
+            "Push Service active node quota exceeded; max {MAX_PUSH_NODES_PER_OWNER} active nodes per owner"
+        ))));
+    }
+
+    let node_name = format!("urn:waddle:push-node:{}", uuid::Uuid::new_v4());
+    tx.execute(
+        r#"
+        INSERT INTO push_nodes (
+            node,
+            owner_bare_jid,
+            app_id,
+            status,
+            created_at_ms,
+            updated_at_ms
+        ) VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(owner_bare_jid, app_id) DO NOTHING
+        "#,
+        crate::db_params![
+            node_name,
+            owner_bare_jid.to_string(),
+            app_id,
+            PushNodeStatus::Active.as_str(),
+            now_ms,
+            now_ms,
+        ],
+    )
+    .await
+    .map_err(|error| XmppError::internal(error.to_string()))?;
+
+    find_node_by_owner_app_tx(tx, owner_bare_jid, app_id)
+        .await?
+        .ok_or_else(|| XmppError::internal("Push Service node was not persisted"))
+}
+
 fn decode_node(row: &crate::db::Row) -> Result<PushServiceNode, XmppError> {
     let owner_bare_jid: String = row
         .get(1)
@@ -211,105 +289,13 @@ impl DatabasePushServiceStore {
         owner_bare_jid: &BareJid,
         app_id: &str,
     ) -> Result<PushServiceNode, XmppError> {
-        if app_id.is_empty() {
-            return Err(XmppError::bad_request(Some(
-                "Push Service app-id is required".to_string(),
-            )));
-        }
-        validate_len("Push Service app-id", app_id, MAX_APP_ID_LEN)?;
-        if let Some(node) = self.find_node_by_owner_app(owner_bare_jid, app_id).await? {
-            if node.status == PushNodeStatus::Active {
-                self.ensure_xep0060_push_node_for_owner(owner_bare_jid, node.node())
-                    .await?;
-                return Ok(node);
-            }
-        }
-
         let now_ms = crate::time::now_ms();
         let mut tx = self
             .db
             .begin_immediate()
             .await
             .map_err(|error| XmppError::internal(error.to_string()))?;
-        lock_owner_tx(&mut tx, owner_bare_jid, now_ms).await?;
-        if let Some(node) = find_node_by_owner_app_tx(&mut tx, owner_bare_jid, app_id).await? {
-            if node.status == PushNodeStatus::Active {
-                tx.commit()
-                    .await
-                    .map_err(|error| XmppError::internal(error.to_string()))?;
-                self.ensure_xep0060_push_node_for_owner(owner_bare_jid, node.node())
-                    .await?;
-                return Ok(node);
-            }
-            if count_active_nodes_for_owner_tx(&mut tx, owner_bare_jid).await?
-                >= MAX_PUSH_NODES_PER_OWNER
-            {
-                return Err(XmppError::bad_request(Some(format!(
-                    "Push Service active node quota exceeded; max {MAX_PUSH_NODES_PER_OWNER} active nodes per owner"
-                ))));
-            }
-            tx.execute(
-                r#"
-                UPDATE push_nodes
-                SET status = ?, updated_at_ms = ?
-                WHERE node = ?
-                "#,
-                crate::db_params![PushNodeStatus::Active.as_str(), now_ms, node.node()],
-            )
-            .await
-            .map_err(|error| XmppError::internal(error.to_string()))?;
-            let node = get_node_tx(&mut tx, node.node())
-                .await?
-                .ok_or_else(|| XmppError::internal("Push Service node was not persisted"))?;
-            tx.commit()
-                .await
-                .map_err(|error| XmppError::internal(error.to_string()))?;
-            self.ensure_xep0060_push_node_for_owner(owner_bare_jid, node.node())
-                .await?;
-            return Ok(node);
-        }
-        prune_disabled_nodes_for_owner_tx(
-            &mut tx,
-            owner_bare_jid,
-            MAX_RETAINED_DISABLED_NODES_PER_OWNER,
-        )
-        .await?;
-        if count_active_nodes_for_owner_tx(&mut tx, owner_bare_jid).await?
-            >= MAX_PUSH_NODES_PER_OWNER
-        {
-            return Err(XmppError::bad_request(Some(format!(
-                "Push Service active node quota exceeded; max {MAX_PUSH_NODES_PER_OWNER} active nodes per owner"
-            ))));
-        }
-
-        let node_name = format!("urn:waddle:push-node:{}", uuid::Uuid::new_v4());
-        tx.execute(
-            r#"
-            INSERT INTO push_nodes (
-                node,
-                owner_bare_jid,
-                app_id,
-                status,
-                created_at_ms,
-                updated_at_ms
-            ) VALUES (?, ?, ?, ?, ?, ?)
-            ON CONFLICT(owner_bare_jid, app_id) DO NOTHING
-            "#,
-            crate::db_params![
-                node_name,
-                owner_bare_jid.to_string(),
-                app_id,
-                PushNodeStatus::Active.as_str(),
-                now_ms,
-                now_ms,
-            ],
-        )
-        .await
-        .map_err(|error| XmppError::internal(error.to_string()))?;
-
-        let node = find_node_by_owner_app_tx(&mut tx, owner_bare_jid, app_id)
-            .await?
-            .ok_or_else(|| XmppError::internal("Push Service node was not persisted"))?;
+        let node = ensure_node_tx(&mut tx, owner_bare_jid, app_id, now_ms).await?;
         tx.commit()
             .await
             .map_err(|error| XmppError::internal(error.to_string()))?;
@@ -466,31 +452,6 @@ impl DatabasePushServiceStore {
             .await
             .map_err(|error| XmppError::internal(error.to_string()))?;
         Ok(affected_devices)
-    }
-
-    async fn find_node_by_owner_app(
-        &self,
-        owner_bare_jid: &BareJid,
-        app_id: &str,
-    ) -> Result<Option<PushServiceNode>, XmppError> {
-        let mut rows = self
-            .query(
-                r#"
-                SELECT node, owner_bare_jid, app_id, status, created_at_ms, updated_at_ms
-                FROM push_nodes
-                WHERE owner_bare_jid = ? AND app_id = ?
-                "#,
-                crate::db_params![owner_bare_jid.to_string(), app_id],
-            )
-            .await?;
-        let Some(row) = rows
-            .next()
-            .await
-            .map_err(|error| XmppError::internal(error.to_string()))?
-        else {
-            return Ok(None);
-        };
-        Ok(Some(decode_node(&row)?))
     }
 }
 

--- a/server/crates/waddle-server/src/server/extension_commands/mod.rs
+++ b/server/crates/waddle-server/src/server/extension_commands/mod.rs
@@ -149,6 +149,7 @@ pub(crate) async fn register_extension_commands(
                         Ok(value) => value,
                         Err(error) => {
                             return waddle_xmpp::commands::CommandResult::Completed {
+                                session_id: None,
                                 form: None,
                                 notes: vec![waddle_xmpp::commands::Note::error(format!(
                                     "Invalid requester JID: {error}"
@@ -173,6 +174,7 @@ pub(crate) async fn register_extension_commands(
                                 Ok(value) => value,
                                 Err(error) => {
                                     return waddle_xmpp::commands::CommandResult::Completed {
+                                        session_id: None,
                                         form: None,
                                         notes: vec![waddle_xmpp::commands::Note::error(format!(
                                             "Invalid requester JID: {error}"
@@ -256,6 +258,7 @@ fn extension_field_value(
 
 fn extension_warning_result(message: &str) -> waddle_xmpp::commands::CommandResult {
     waddle_xmpp::commands::CommandResult::Completed {
+        session_id: None,
         form: None,
         notes: vec![waddle_xmpp::commands::Note::error(message.to_string())],
     }

--- a/server/crates/waddle-server/src/server/extension_commands/pubsub.rs
+++ b/server/crates/waddle-server/src/server/extension_commands/pubsub.rs
@@ -238,6 +238,7 @@ pub(crate) async fn extension_command_result(
     }
 
     waddle_xmpp::commands::CommandResult::Completed {
+        session_id: None,
         form: result_form,
         notes,
     }
@@ -301,6 +302,7 @@ mod tests {
                 .await;
 
         let CommandResult::Completed {
+            session_id: None,
             form: Some(_),
             notes,
         } = result

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/commands.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/commands.rs
@@ -100,18 +100,25 @@ pub(super) async fn handle_command_iq(
             command.actions = actions;
             command
         }
-        CommandResult::Completed { form, notes } => {
+        CommandResult::Completed {
+            session_id: response_session_id,
+            form,
+            notes,
+        } => {
             let mut command = Command::new(node.clone());
             command.status = Some(CommandStatus::Completed);
-            command.session_id = session_id;
+            command.session_id = response_session_id.or(session_id);
             command.form = form;
             command.notes = notes;
             command
         }
-        CommandResult::Canceled { notes } => {
+        CommandResult::Canceled {
+            session_id: response_session_id,
+            notes,
+        } => {
             let mut command = Command::new(node.clone());
             command.status = Some(CommandStatus::Canceled);
-            command.session_id = session_id;
+            command.session_id = response_session_id.or(session_id);
             command.notes = notes;
             command
         }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/push.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/push.rs
@@ -28,6 +28,16 @@ pub(super) async fn handle_push_iq(
                 bad_request_iq_error("Malformed IQ payload."),
             )];
         };
+        if enable.publish_options.is_invalid() {
+            return vec![build_iq_error_xml_typed(
+                iq.id(),
+                response_from,
+                response_to,
+                bad_request_iq_error(
+                    "XEP-0357 publish-options form requires FORM_TYPE='http://jabber.org/protocol/pubsub#publish-options'.",
+                ),
+            )];
+        }
         let service_jid = enable.jid.to_string();
         if service_jid == push_domain {
             let Some(node) = enable.node.as_deref() else {
@@ -46,7 +56,7 @@ pub(super) async fn handle_push_iq(
                     &bare_jid,
                     &service_jid,
                     node,
-                    enable.publish_options.as_ref(),
+                    enable.publish_options.as_element(),
                 )
                 .await
             {

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/iq.rs
@@ -643,6 +643,55 @@ async fn handle_iq_command_request_routes_to_registry() {
 }
 
 #[tokio::test]
+async fn handle_iq_single_shot_completed_command_carries_generated_sessionid() {
+    let state = create_test_websocket_state().await;
+    state
+        .deps
+        .protocol
+        .command_registry
+        .register(
+            "test:single-shot-command",
+            "Single Shot Command",
+            |_ctx: CommandContext| async move {
+                CommandResult::Completed {
+                    session_id: None,
+                    form: None,
+                    notes: vec![],
+                }
+            },
+        )
+        .await;
+
+    let session = create_test_session(state.as_ref(), "alice").await;
+    let sender_jid: FullJid = "alice@example.com/web".parse().expect("sender jid");
+    let frame = r#"<iq xmlns="jabber:client" id="cmd-complete-1" type="set" to="example.com"><command xmlns="http://jabber.org/protocol/commands" node="test:single-shot-command" action="execute"/></iq>"#;
+    let responses = handle_iq(
+        frame,
+        "example.com",
+        "muc.example.com",
+        state.as_ref(),
+        &Some(session),
+        &ready_phase(&sender_jid),
+    )
+    .await;
+
+    assert_eq!(responses.len(), 1);
+    let response = responses.first().expect("command response");
+    let element = Element::from_str(response).expect("parse command response");
+    assert_eq!(element.attr("type"), Some("result"));
+    let command = element
+        .children()
+        .find(|child| child.name() == "command")
+        .expect("command payload");
+    assert_eq!(command.attr("status"), Some("completed"));
+    let session_id = command.attr("sessionid").expect("completed sessionid");
+    assert!(
+        !session_id.is_empty(),
+        "completed command sessionid must be non-empty: {response}"
+    );
+}
+
+#[tokio::test]
 async fn handle_iq_command_request_requires_ready_phase() {
     let state = create_test_websocket_state().await;
     state

--- a/server/crates/waddle-server/tests/xep0357_push_service_ws.rs
+++ b/server/crates/waddle-server/tests/xep0357_push_service_ws.rs
@@ -886,6 +886,35 @@ async fn xep0357_first_party_enable_requires_owned_active_node_with_device() {
     let disable_iq = parse_iq_element(&disable_response, "push-disable-first-party", "result");
     assert!(disable_iq.children().next().is_none());
 
+    let enable_with_wrong_publish_options_form_type = Element::builder("enable", NS_PUSH)
+        .attr(
+            minidom::rxml::xml_ncname!("jid").to_owned(),
+            PUSH_SERVICE_JID,
+        )
+        .attr(minidom::rxml::xml_ncname!("node").to_owned(), node.as_str())
+        .append(submit_form("jabber:x:oob", &[]))
+        .build();
+    let wrong_form_type_response = send_iq(
+        &mut client,
+        iq_frame(
+            "set",
+            "push-enable-wrong-publish-options-form-type",
+            DOMAIN,
+            enable_with_wrong_publish_options_form_type,
+        ),
+        "push-enable-wrong-publish-options-form-type",
+    )
+    .await;
+    assert_iq_error_condition(
+        &wrong_form_type_response,
+        "push-enable-wrong-publish-options-form-type",
+        "bad-request",
+    );
+    assert!(
+        wrong_form_type_response.contains("FORM_TYPE"),
+        "bad-request text should name the FORM_TYPE requirement: {wrong_form_type_response}"
+    );
+
     let enable_with_publish_options = Element::builder("enable", NS_PUSH)
         .attr(
             minidom::rxml::xml_ncname!("jid").to_owned(),

--- a/server/crates/waddle-xmpp-client-ffi/src/push.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/push.rs
@@ -66,6 +66,23 @@ impl WaddleClient {
         let handle = self.clone_handle().await?;
         let env: waddle_xmpp_client::push::PushEnvironment = environment.into();
         let creds: waddle_xmpp_client::push::PushDeviceCredentials = credentials.into();
+        let push_service_jid =
+            match waddle_xmpp_client::push::PushServiceJid::new(&push_service_jid) {
+                Ok(value) => value,
+                Err(e) => {
+                    self.listener
+                        .on_error(format!("register_push_device failed: {e}"));
+                    return None;
+                }
+            };
+        let app_id = match waddle_xmpp_client::push::PushAppId::new(&app_id) {
+            Ok(value) => value,
+            Err(e) => {
+                self.listener
+                    .on_error(format!("register_push_device failed: {e}"));
+                return None;
+            }
+        };
         match waddle_xmpp_client::push::register_push_device(
             &handle,
             &push_service_jid,

--- a/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_account.rs
@@ -59,11 +59,15 @@ impl WaddleClient {
         let inner = self.inner.clone();
         future_to_promise(async move {
             let opts: RegisterPushDeviceOptions = serde_wasm_bindgen::from_value(options)
-                .map_err(|err| JsValue::from_str(&err.to_string()))?;
-            let service_jid = opts.service_jid.clone();
-            let app_id = opts.app_id.clone();
+                .map_err(|err| push_registration_js_error("protocol-shape", err.to_string()))?;
+            let service_jid = waddle_xmpp_client::push::PushServiceJid::new(&opts.service_jid)
+                .map_err(push_registration_client_js_error)?;
+            let app_id = waddle_xmpp_client::push::PushAppId::new(&opts.app_id)
+                .map_err(push_registration_client_js_error)?;
             let environment = opts.environment;
-            let credentials = opts.into_credentials().map_err(js_error)?;
+            let credentials = opts
+                .into_credentials()
+                .map_err(|err| push_registration_js_error("protocol-shape", err))?;
             let driver = WasmCommandDriver { inner };
             let outcome = waddle_xmpp_client::push::register_push_device(
                 &driver,
@@ -73,7 +77,7 @@ impl WaddleClient {
                 &credentials,
             )
             .await
-            .map_err(|err| JsValue::from_str(&err.to_string()))?;
+            .map_err(push_registration_client_js_error)?;
             to_js_value(&WaddleRegisterDeviceResult {
                 node: outcome.node.into_string(),
                 device_id: outcome.device_id.into_string(),
@@ -749,6 +753,36 @@ impl WaddleClient {
             to_js_value(&profile)
         })
     }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RegisterPushDeviceError {
+    code: &'static str,
+    message: String,
+}
+
+fn push_registration_js_error(code: &'static str, message: impl ToString) -> JsValue {
+    to_js_value(&RegisterPushDeviceError {
+        code,
+        message: message.to_string(),
+    })
+    .unwrap_or_else(|_| JsValue::from_str(&message.to_string()))
+}
+
+fn push_registration_client_js_error(error: impl Into<ClientError>) -> JsValue {
+    let error = error.into();
+    let code = match &error {
+        ClientError::PushRegistration(
+            waddle_xmpp_client::push::PushRegistrationError::SessionExpired,
+        ) => "session-expired",
+        ClientError::PushRegistration(_) => "protocol-shape",
+        ClientError::StanzaError(_) => "stanza-error",
+        ClientError::Disconnected => "disconnected",
+        ClientError::TransportClosed | ClientError::RequestCancelled => "disconnected",
+        _ => "error",
+    };
+    push_registration_js_error(code, error.to_string())
 }
 
 /// Build the `<extensions xmlns='urn:xmpp:bookmarks:1'>…</extensions>`

--- a/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_calls.rs
@@ -492,6 +492,7 @@ mod tests {
             error_type: waddle_xmpp_client::StanzaErrorType::Auth,
             condition: "forbidden".to_string(),
             text: Some("Jingle terminator is not a participant in this call".to_string()),
+            application_condition: None,
         };
         assert!(is_orphaned_dm_call_terminate(&orphaned));
 
@@ -499,6 +500,7 @@ mod tests {
             error_type: waddle_xmpp_client::StanzaErrorType::Auth,
             condition: "forbidden".to_string(),
             text: Some("Jingle responder was not invited to this call party".to_string()),
+            application_condition: None,
         };
         assert!(!is_orphaned_dm_call_terminate(&generic_forbidden));
 
@@ -506,6 +508,7 @@ mod tests {
             error_type: waddle_xmpp_client::StanzaErrorType::Cancel,
             condition: "remote-server-timeout".to_string(),
             text: None,
+            application_condition: None,
         };
         assert!(!is_orphaned_dm_call_terminate(&transportish));
     }

--- a/server/crates/waddle-xmpp-client/src/discovery/ext.rs
+++ b/server/crates/waddle-xmpp-client/src/discovery/ext.rs
@@ -24,6 +24,7 @@ fn parse_error() -> ClientError {
         error_type: StanzaErrorType::Cancel,
         condition: "bad-request".to_string(),
         text: Some("response could not be parsed".to_string()),
+        application_condition: None,
     })
 }
 
@@ -257,6 +258,7 @@ impl DiscoveryExt for ClientHandle {
                         error_type: StanzaErrorType::Cancel,
                         condition: "bad-request".to_string(),
                         text: Some(format!("invalid MUC fallback JID: {e}")),
+                        application_condition: None,
                     })
                 })?;
         let fallback_spaces: BareJid =
@@ -267,6 +269,7 @@ impl DiscoveryExt for ClientHandle {
                         error_type: StanzaErrorType::Cancel,
                         condition: "bad-request".to_string(),
                         text: Some(format!("invalid Spaces fallback JID: {e}")),
+                        application_condition: None,
                     })
                 })?;
 

--- a/server/crates/waddle-xmpp-client/src/error.rs
+++ b/server/crates/waddle-xmpp-client/src/error.rs
@@ -4,6 +4,7 @@ use minidom::Element;
 use thiserror::Error;
 
 use crate::bootstrap::{RequiredStreamFeature, SaslFailureCondition};
+use crate::push::PushRegistrationError;
 use crate::request::{RequestId, StanzaId};
 use crate::state::{ClientState, SessionPhase};
 
@@ -13,6 +14,7 @@ pub type ClientResult<T> = Result<T, ClientError>;
 /// protocol flows.
 pub const STANZA_CONDITION_ITEM_NOT_FOUND: &str = "item-not-found";
 pub const STANZA_CONDITION_PRECONDITION_NOT_MET: &str = "precondition-not-met";
+pub const STANZA_CONDITION_SESSION_EXPIRED: &str = "session-expired";
 
 #[derive(Debug, Error)]
 pub enum ClientError {
@@ -81,6 +83,8 @@ pub enum ClientError {
     RequestCancelled,
     #[error("the XMPP session is disconnected")]
     Disconnected,
+    #[error(transparent)]
+    PushRegistration(#[from] PushRegistrationError),
     #[error("server returned a stanza error: {0}")]
     StanzaError(#[from] StanzaError),
 }
@@ -102,6 +106,21 @@ pub struct StanzaError {
     pub condition: String,
     /// Optional human-readable `<text/>` content.
     pub text: Option<String>,
+    /// Optional application-specific error condition (RFC 6120 §8.3.4):
+    /// the first `<error/>` child outside the stanzas namespace, e.g.
+    /// XEP-0050 `<session-expired xmlns='http://jabber.org/protocol/commands'/>`.
+    /// Carried ALONGSIDE the defined `condition` — a conformant server
+    /// always includes both, so consumers branching on an application
+    /// condition must read this field, not `condition`.
+    pub application_condition: Option<ApplicationCondition>,
+}
+
+/// Application-specific error condition child (RFC 6120 §8.3.4),
+/// identified by its element name and namespace.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplicationCondition {
+    pub namespace: String,
+    pub name: String,
 }
 
 /// Values of the `type` attribute on an XMPP `<error/>` element (RFC 6120 §8.3.2).
@@ -143,8 +162,8 @@ pub fn parse_stanza_error(element: &Element) -> StanzaError {
         })
         .unwrap_or(StanzaErrorType::Unknown);
 
-    let (condition, text) = match error_el {
-        None => ("unknown".to_string(), None),
+    let (condition, text, application_condition) = match error_el {
+        None => ("unknown".to_string(), None, None),
         Some(err) => {
             let condition = err
                 .children()
@@ -154,7 +173,20 @@ pub fn parse_stanza_error(element: &Element) -> StanzaError {
 
             let text = err.get_child("text", NS_STANZAS).map(|t| t.text());
 
-            (condition, text)
+            // RFC 6120 §8.3.4: an application MAY include its own
+            // condition child alongside the defined condition. Capture
+            // the first non-stanzas child so consumers (e.g. the
+            // XEP-0050 `<session-expired/>` retry surface) can branch
+            // on it without re-parsing XML.
+            let application_condition =
+                err.children()
+                    .find(|c| c.ns() != NS_STANZAS)
+                    .map(|c| ApplicationCondition {
+                        namespace: c.ns().to_string(),
+                        name: c.name().to_string(),
+                    });
+
+            (condition, text, application_condition)
         }
     };
 
@@ -162,6 +194,7 @@ pub fn parse_stanza_error(element: &Element) -> StanzaError {
         error_type,
         condition,
         text,
+        application_condition,
     }
 }
 

--- a/server/crates/waddle-xmpp-client/src/notification_settings.rs
+++ b/server/crates/waddle-xmpp-client/src/notification_settings.rs
@@ -249,6 +249,7 @@ mod tests {
             error_type: StanzaErrorType::Cancel,
             condition: condition.to_string(),
             text: None,
+            application_condition: None,
         })
     }
 

--- a/server/crates/waddle-xmpp-client/src/push/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/push/mod.rs
@@ -18,10 +18,14 @@
 //! `waddle-server`) is unchanged by the XEP-0050 cutover — only the
 //! wire shape changes.
 
+use std::str::FromStr;
+
+use jid::BareJid;
 use minidom::Element;
+use thiserror::Error;
 use xmpp_parsers::data_forms::{DataForm, DataFormType, Field, FieldType};
 
-use crate::error::{ClientError, ClientResult, StanzaError, StanzaErrorType};
+use crate::error::{ClientError, ClientResult, StanzaError};
 use crate::xep::xep0050::{
     build_xep0050_command_request, build_xep0050_command_request_with_session,
     parse_command_response, AdHocAction, AdHocStatus,
@@ -82,6 +86,78 @@ pub enum PushEnvironment {
     Production,
     #[serde(rename = "sandbox")]
     Sandbox,
+}
+
+/// Validated Push Service component JID used by the XEP-0050
+/// `register-device` composer. The public FFI/WASM boundaries still
+/// accept strings and construct this value at the edge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushServiceJid(BareJid);
+
+impl PushServiceJid {
+    pub fn new(value: impl AsRef<str>) -> Result<Self, PushRegistrationError> {
+        let value = value.as_ref().trim();
+        if value.is_empty() {
+            return Err(PushRegistrationError::MalformedResultForm {
+                reason: "push service JID must not be empty".to_string(),
+            });
+        }
+        let jid =
+            BareJid::from_str(value).map_err(|_| PushRegistrationError::MalformedResultForm {
+                reason: "push service JID must be a parseable bare JID".to_string(),
+            })?;
+        Ok(Self(jid))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+/// Application identifier submitted to the Push Service. It scopes the
+/// stable per-(user, app-id) node, so an empty value is rejected before
+/// any IQ is sent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushAppId(String);
+
+impl PushAppId {
+    pub fn new(value: impl AsRef<str>) -> Result<Self, PushRegistrationError> {
+        let value = value.as_ref().trim();
+        if value.is_empty() {
+            return Err(PushRegistrationError::MalformedResultForm {
+                reason: "push app id must not be empty".to_string(),
+            });
+        }
+        Ok(Self(value.to_string()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Typed failures raised by the XEP-0050 `register-device` composer
+/// when the Push Service response shape violates the expected
+/// protocol choreography.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PushRegistrationError {
+    #[error("missing <command/> response during {stage}")]
+    MissingCommandResponse { stage: &'static str },
+    #[error("unexpected command status during {stage}; expected {expected}")]
+    UnexpectedStatus {
+        stage: &'static str,
+        expected: &'static str,
+    },
+    #[error("missing sessionid in stage 2")]
+    MissingSessionId,
+    #[error("stage 4 sessionid did not match the session opened in stage 2")]
+    SessionIdMismatch,
+    #[error("missing result form in stage 4")]
+    MissingResultForm,
+    #[error("malformed register-device result form: {reason}")]
+    MalformedResultForm { reason: String },
+    #[error("XEP-0050 command session expired")]
+    SessionExpired,
 }
 
 impl PushEnvironment {
@@ -309,12 +385,37 @@ fn text_single(var: &str, value: &str) -> Field {
     }
 }
 
-fn protocol_error(text: &str) -> ClientError {
-    ClientError::StanzaError(StanzaError {
-        error_type: StanzaErrorType::Cancel,
-        condition: "bad-request".to_string(),
-        text: Some(text.to_string()),
+fn push_registration_error(error: PushRegistrationError) -> ClientError {
+    ClientError::PushRegistration(error)
+}
+
+fn malformed_response(reason: impl Into<String>) -> ClientError {
+    push_registration_error(PushRegistrationError::MalformedResultForm {
+        reason: reason.into(),
     })
+}
+
+fn map_submit_error(error: ClientError) -> ClientError {
+    match error {
+        ClientError::StanzaError(stanza) if is_xep0050_session_expired(&stanza) => {
+            PushRegistrationError::SessionExpired.into()
+        }
+        other => other,
+    }
+}
+
+fn is_xep0050_session_expired(stanza: &StanzaError) -> bool {
+    // XEP-0050 §4.3 ships `<session-expired/>` as an APPLICATION
+    // condition in the commands namespace, alongside the RFC 6120
+    // defined condition (`not-allowed` on our server) — so the check
+    // must read the application condition, never `condition`.
+    stanza
+        .application_condition
+        .as_ref()
+        .is_some_and(|application| {
+            application.namespace == "http://jabber.org/protocol/commands"
+                && application.name == "session-expired"
+        })
 }
 
 /// Defense-in-depth check against an IQ response whose `from` doesn't
@@ -331,17 +432,17 @@ fn protocol_error(text: &str) -> ClientError {
 /// Push Service JIDs are pure-domain XEP-0114 components, so a
 /// `service_jid/resource` form is rejected even via case-insensitive
 /// equality.
-fn verify_iq_from_matches(iq: &Element, push_service_jid: &str) -> ClientResult<()> {
+fn verify_iq_from_matches(iq: &Element, push_service_jid: &PushServiceJid) -> ClientResult<()> {
     let from = iq.attr("from").ok_or_else(|| {
-        protocol_error(
+        malformed_response(
             "Push Service IQ response carries no `from`; RFC 6120 §8.1.2.1 \
              requires components to stamp `from`. Refusing to trust the response.",
         )
     })?;
-    if from.eq_ignore_ascii_case(push_service_jid) {
+    if from.eq_ignore_ascii_case(push_service_jid.as_str()) {
         Ok(())
     } else {
-        Err(protocol_error(
+        Err(malformed_response(
             "Push Service IQ response `from` does not match the addressed Push \
              Service JID; refusing to trust the response.",
         ))
@@ -360,14 +461,14 @@ fn verify_iq_from_matches(iq: &Element, push_service_jid: &str) -> ClientResult<
 /// never stringly-typed payloads (CLAUDE.md typed-payloads hard rule).
 pub async fn register_push_device<D: CommandDriver>(
     driver: &D,
-    push_service_jid: &str,
-    app_id: &str,
+    push_service_jid: &PushServiceJid,
+    app_id: &PushAppId,
     environment: PushEnvironment,
     credentials: &PushDeviceCredentials,
 ) -> ClientResult<RegisterDeviceResult> {
     // Stage 1 → 2: execute, expect executing + form back + sessionid.
     let initial = build_xep0050_command_request(
-        push_service_jid,
+        push_service_jid.as_str(),
         REGISTER_DEVICE_NODE,
         AdHocAction::Execute,
         None,
@@ -375,31 +476,39 @@ pub async fn register_push_device<D: CommandDriver>(
     let executing_iq = driver.send_iq(initial).await?;
     verify_iq_from_matches(&executing_iq, push_service_jid)?;
     let executing = parse_command_response(&executing_iq)
-        .ok_or_else(|| protocol_error("expected <command/> response in stage 2"))?;
+        .ok_or(PushRegistrationError::MissingCommandResponse { stage: "stage 2" })?;
     if executing.status != AdHocStatus::Executing {
-        return Err(protocol_error("expected status='executing' in stage 2"));
+        return Err(PushRegistrationError::UnexpectedStatus {
+            stage: "stage 2",
+            expected: "executing",
+        }
+        .into());
     }
     let session_id = executing
         .session_id
         .clone()
-        .ok_or_else(|| protocol_error("missing sessionid in stage 2"))?;
+        .ok_or(PushRegistrationError::MissingSessionId)?;
 
     // Stage 3 → 4: submit the platform-specific form, expect
     // completed + result form with the assigned node id.
-    let submit_form = build_register_device_submit_form(app_id, environment, credentials);
+    let submit_form = build_register_device_submit_form(app_id.as_str(), environment, credentials);
     let complete = build_xep0050_command_request_with_session(
-        push_service_jid,
+        push_service_jid.as_str(),
         REGISTER_DEVICE_NODE,
         &session_id,
         AdHocAction::Complete,
         Some(submit_form),
     );
-    let completed_iq = driver.send_iq(complete).await?;
+    let completed_iq = driver.send_iq(complete).await.map_err(map_submit_error)?;
     verify_iq_from_matches(&completed_iq, push_service_jid)?;
     let completed = parse_command_response(&completed_iq)
-        .ok_or_else(|| protocol_error("expected <command/> response in stage 4"))?;
+        .ok_or(PushRegistrationError::MissingCommandResponse { stage: "stage 4" })?;
     if completed.status != AdHocStatus::Completed {
-        return Err(protocol_error("expected status='completed' in stage 4"));
+        return Err(PushRegistrationError::UnexpectedStatus {
+            stage: "stage 4",
+            expected: "completed",
+        }
+        .into());
     }
     // XEP-0050 §3.4: the responder echoes the sessionid so the requester
     // can correlate the response to the session it opened in stage 2.
@@ -410,19 +519,19 @@ pub async fn register_push_device<D: CommandDriver>(
     match completed.session_id.as_deref() {
         Some(returned) if returned == session_id => {}
         _ => {
-            return Err(protocol_error(
-                "stage 4 sessionid did not match the session opened in stage 2",
-            ));
+            return Err(PushRegistrationError::SessionIdMismatch.into());
         }
     }
     let result_form = completed
         .form
-        .ok_or_else(|| protocol_error("missing result form in stage 4"))?;
+        .ok_or(PushRegistrationError::MissingResultForm)?;
     parse_register_device_result(&result_form).ok_or_else(|| {
-        protocol_error(
-            "stage 4 result form is malformed: wrong FORM_TYPE, wrong type='result', \
-             or missing/empty 'node' / 'device-id' field",
-        )
+        PushRegistrationError::MalformedResultForm {
+            reason: "wrong FORM_TYPE, wrong type='result', or missing/empty 'node' / \
+                     'device-id' field"
+                .to_string(),
+        }
+        .into()
     })
 }
 
@@ -634,30 +743,31 @@ mod tests {
 
     #[test]
     fn verify_iq_from_accepts_exact_match() {
-        assert!(verify_iq_from_matches(
-            &iq_with_from(Some("push.example.com")),
-            "push.example.com"
-        )
-        .is_ok());
+        let service_jid = PushServiceJid::new("push.example.com").expect("valid service jid");
+        assert!(
+            verify_iq_from_matches(&iq_with_from(Some("push.example.com")), &service_jid).is_ok()
+        );
     }
 
     #[test]
     fn verify_iq_from_accepts_case_variation_on_domain() {
         // RFC 6122 §2.4: domainpart comparison is case-insensitive.
-        assert!(verify_iq_from_matches(
-            &iq_with_from(Some("Push.Example.COM")),
-            "push.example.com"
-        )
-        .is_ok());
+        let service_jid = PushServiceJid::new("push.example.com").expect("valid service jid");
+        assert!(
+            verify_iq_from_matches(&iq_with_from(Some("Push.Example.COM")), &service_jid).is_ok()
+        );
     }
 
     #[test]
     fn verify_iq_from_rejects_absent_from() {
-        let err = verify_iq_from_matches(&iq_with_from(None), "push.example.com")
+        let service_jid = PushServiceJid::new("push.example.com").expect("valid service jid");
+        let err = verify_iq_from_matches(&iq_with_from(None), &service_jid)
             .expect_err("missing `from` must reject");
         match err {
-            ClientError::StanzaError(stanza) => {
-                assert!(stanza.text.as_deref().unwrap_or("").contains("no `from`"));
+            ClientError::PushRegistration(PushRegistrationError::MalformedResultForm {
+                reason,
+            }) => {
+                assert!(reason.contains("no `from`"));
             }
             other => panic!("unexpected error: {other:?}"),
         }
@@ -665,26 +775,29 @@ mod tests {
 
     #[test]
     fn verify_iq_from_rejects_unrelated_jid() {
-        let err = verify_iq_from_matches(&iq_with_from(Some("attacker.tld")), "push.example.com")
+        let service_jid = PushServiceJid::new("push.example.com").expect("valid service jid");
+        let err = verify_iq_from_matches(&iq_with_from(Some("attacker.tld")), &service_jid)
             .expect_err("unrelated `from` must reject");
-        assert!(matches!(err, ClientError::StanzaError(_)));
+        assert!(matches!(err, ClientError::PushRegistration(_)));
     }
 
     #[test]
     fn verify_iq_from_rejects_prefix_substring_collision() {
         // `push.example.com` MUST NOT match `push.example.com.attacker.tld`.
+        let service_jid = PushServiceJid::new("push.example.com").expect("valid service jid");
         let err = verify_iq_from_matches(
             &iq_with_from(Some("push.example.com.attacker.tld")),
-            "push.example.com",
+            &service_jid,
         )
         .expect_err("substring collision must reject");
-        assert!(matches!(err, ClientError::StanzaError(_)));
+        assert!(matches!(err, ClientError::PushRegistration(_)));
     }
 
     #[test]
     fn verify_iq_from_rejects_empty_from() {
-        let err = verify_iq_from_matches(&iq_with_from(Some("")), "push.example.com")
+        let service_jid = PushServiceJid::new("push.example.com").expect("valid service jid");
+        let err = verify_iq_from_matches(&iq_with_from(Some("")), &service_jid)
             .expect_err("empty `from` must reject");
-        assert!(matches!(err, ClientError::StanzaError(_)));
+        assert!(matches!(err, ClientError::PushRegistration(_)));
     }
 }

--- a/server/crates/waddle-xmpp-client/src/push/mod.rs
+++ b/server/crates/waddle-xmpp-client/src/push/mod.rs
@@ -106,6 +106,15 @@ impl PushServiceJid {
             BareJid::from_str(value).map_err(|_| PushRegistrationError::MalformedResultForm {
                 reason: "push service JID must be a parseable bare JID".to_string(),
             })?;
+        // A Push Service is a pure-domain XEP-0114 component
+        // (`push.<domain>`); a localpart means the caller swapped the
+        // arguments or addressed a user — reject at the type boundary
+        // so the misaddressed IQ never reaches the wire.
+        if jid.node().is_some() {
+            return Err(PushRegistrationError::MalformedResultForm {
+                reason: "push service JID must be a domain-only component JID".to_string(),
+            });
+        }
         Ok(Self(jid))
     }
 

--- a/server/crates/waddle-xmpp-client/tests/register_push_device_against_fake_service.rs
+++ b/server/crates/waddle-xmpp-client/tests/register_push_device_against_fake_service.rs
@@ -7,10 +7,13 @@
 use std::cell::RefCell;
 
 use minidom::Element;
-use waddle_xmpp_client::error::{ClientError, ClientResult, StanzaError, StanzaErrorType};
+use waddle_xmpp_client::error::{
+    parse_stanza_error, ClientError, ClientResult, StanzaError, StanzaErrorType,
+};
 use waddle_xmpp_client::push::{
-    register_push_device, CommandDriver, PushDeviceCredentials, PushEnvironment,
-    REGISTER_DEVICE_FORM_TYPE, REGISTER_DEVICE_NODE,
+    register_push_device, CommandDriver, PushAppId, PushDeviceCredentials, PushEnvironment,
+    PushRegistrationError, PushServiceJid, RegisterDeviceResult, REGISTER_DEVICE_FORM_TYPE,
+    REGISTER_DEVICE_NODE,
 };
 use waddle_xmpp_client::xep::xep0050::NS_COMMANDS;
 
@@ -52,7 +55,19 @@ fn protocol_error(text: &str) -> ClientError {
         error_type: StanzaErrorType::Cancel,
         condition: "bad-request".to_string(),
         text: Some(text.to_string()),
+        application_condition: None,
     })
+}
+
+async fn register_test_device(
+    driver: &ScriptedDriver,
+    app_id: &str,
+    environment: PushEnvironment,
+    credentials: &PushDeviceCredentials,
+) -> ClientResult<RegisterDeviceResult> {
+    let push_service_jid = PushServiceJid::new("push.example.com")?;
+    let app_id = PushAppId::new(app_id)?;
+    register_push_device(driver, &push_service_jid, &app_id, environment, credentials).await
 }
 
 fn iq_with_command(command: Element) -> Element {
@@ -148,6 +163,29 @@ fn completed_response_with_outcome(session_id: &str, node_id: &str, device_id: &
     iq_with_command(command)
 }
 
+fn session_expired_iq_error() -> Element {
+    Element::builder("iq", NS_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "error")
+        .attr(
+            minidom::rxml::xml_ncname!("from").to_owned(),
+            "push.example.com",
+        )
+        .append(
+            Element::builder("error", NS_CLIENT)
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "cancel")
+                // Conformant RFC 6120 §8.3 shape: the defined condition
+                // (`not-allowed`, what the real server renders for
+                // session-expired) PLUS the XEP-0050 application
+                // condition. The client must key on the latter.
+                .append(
+                    Element::builder("not-allowed", "urn:ietf:params:xml:ns:xmpp-stanzas").build(),
+                )
+                .append(Element::builder("session-expired", NS_COMMANDS).build())
+                .build(),
+        )
+        .build()
+}
+
 #[tokio::test]
 async fn register_push_device_completes_multi_step_dance() {
     let driver = ScriptedDriver::new(vec![
@@ -163,9 +201,8 @@ async fn register_push_device_completes_multi_step_dance() {
         p256dh: "p256-key".to_string(),
         auth: "auth-secret".to_string(),
     };
-    let outcome = register_push_device(
+    let outcome = register_test_device(
         &driver,
-        "push.example.com",
         "app-web",
         PushEnvironment::Production,
         &credentials,
@@ -256,28 +293,13 @@ async fn register_push_device_rejects_completed_with_mismatched_sessionid() {
     let credentials = PushDeviceCredentials::Apns {
         device_token: "t".to_string(),
     };
-    let err = register_push_device(
-        &driver,
-        "push.example.com",
-        "app-ios",
-        PushEnvironment::Sandbox,
-        &credentials,
-    )
-    .await
-    .expect_err("mismatched sessionid rejected");
-    match err {
-        ClientError::StanzaError(stanza_err) => {
-            assert!(
-                stanza_err
-                    .text
-                    .as_deref()
-                    .unwrap_or("")
-                    .contains("sessionid"),
-                "diagnostic must name the sessionid mismatch; got: {stanza_err:?}"
-            );
-        }
-        other => panic!("unexpected error: {other:?}"),
-    }
+    let err = register_test_device(&driver, "app-ios", PushEnvironment::Sandbox, &credentials)
+        .await
+        .expect_err("mismatched sessionid rejected");
+    assert!(matches!(
+        err,
+        ClientError::PushRegistration(PushRegistrationError::SessionIdMismatch)
+    ));
     // Both IQs went out, but the attacker's outcome was NOT persisted —
     // the composer returned an error instead of a RegisterDeviceResult.
     assert_eq!(driver.transcript().len(), 2);
@@ -289,18 +311,41 @@ async fn register_push_device_propagates_transport_error_from_stage_1() {
     let credentials = PushDeviceCredentials::Apns {
         device_token: "apns-token".to_string(),
     };
-    let err = register_push_device(
-        &driver,
-        "push.example.com",
-        "app-ios",
-        PushEnvironment::Sandbox,
-        &credentials,
-    )
-    .await
-    .expect_err("transport error propagates");
+    let err = register_test_device(&driver, "app-ios", PushEnvironment::Sandbox, &credentials)
+        .await
+        .expect_err("transport error propagates");
     assert!(matches!(err, ClientError::Disconnected));
     // We MUST NOT have sent stage 3 after stage 1 failed.
     assert_eq!(driver.transcript().len(), 1);
+}
+
+#[tokio::test]
+async fn register_push_device_maps_stage_4_session_expired_stanza_error() {
+    let session_expired = session_expired_iq_error();
+    let driver = ScriptedDriver::new(vec![
+        Ok(executing_response_with_form("session-1")),
+        Err(ClientError::StanzaError(parse_stanza_error(
+            &session_expired,
+        ))),
+    ]);
+    let credentials = PushDeviceCredentials::WebPush {
+        endpoint: "e".to_string(),
+        p256dh: "p".to_string(),
+        auth: "a".to_string(),
+    };
+    let err = register_test_device(
+        &driver,
+        "app-web",
+        PushEnvironment::Production,
+        &credentials,
+    )
+    .await
+    .expect_err("session-expired stanza error rejected");
+    assert!(matches!(
+        err,
+        ClientError::PushRegistration(PushRegistrationError::SessionExpired)
+    ));
+    assert_eq!(driver.transcript().len(), 2);
 }
 
 #[tokio::test]
@@ -321,28 +366,18 @@ async fn register_push_device_rejects_stage_2_without_session_id() {
     let credentials = PushDeviceCredentials::Fcm {
         registration_token: "t".to_string(),
     };
-    let err = register_push_device(
+    let err = register_test_device(
         &driver,
-        "push.example.com",
         "app-android",
         PushEnvironment::Production,
         &credentials,
     )
     .await
     .expect_err("missing sessionid rejected");
-    match err {
-        ClientError::StanzaError(stanza_err) => {
-            assert!(
-                stanza_err
-                    .text
-                    .as_deref()
-                    .unwrap_or("")
-                    .contains("sessionid"),
-                "diagnostic text must name the missing sessionid; got: {stanza_err:?}"
-            );
-        }
-        other => panic!("unexpected error: {other:?}"),
-    }
+    assert!(matches!(
+        err,
+        ClientError::PushRegistration(PushRegistrationError::MissingSessionId)
+    ));
 }
 
 #[tokio::test]
@@ -387,16 +422,13 @@ async fn register_push_device_rejects_completed_without_device_id_field() {
     let credentials = PushDeviceCredentials::Apns {
         device_token: "t".to_string(),
     };
-    let err = register_push_device(
-        &driver,
-        "push.example.com",
-        "app-ios",
-        PushEnvironment::Sandbox,
-        &credentials,
-    )
-    .await
-    .expect_err("missing device-id field rejected");
-    assert!(matches!(err, ClientError::StanzaError(_)));
+    let err = register_test_device(&driver, "app-ios", PushEnvironment::Sandbox, &credentials)
+        .await
+        .expect_err("missing device-id field rejected");
+    assert!(matches!(
+        err,
+        ClientError::PushRegistration(PushRegistrationError::MalformedResultForm { .. })
+    ));
 }
 
 #[tokio::test]
@@ -429,9 +461,8 @@ async fn register_push_device_rejects_completed_without_node_field() {
         p256dh: "p".to_string(),
         auth: "a".to_string(),
     };
-    let err = register_push_device(
+    let err = register_test_device(
         &driver,
-        "push.example.com",
         "app-web",
         PushEnvironment::Production,
         &credentials,
@@ -439,8 +470,8 @@ async fn register_push_device_rejects_completed_without_node_field() {
     .await
     .expect_err("missing node field rejected");
     match err {
-        ClientError::StanzaError(stanza_err) => {
-            assert!(stanza_err.text.as_deref().unwrap_or("").contains("'node'"));
+        ClientError::PushRegistration(PushRegistrationError::MalformedResultForm { reason }) => {
+            assert!(reason.contains("'node'"));
         }
         other => panic!("unexpected error: {other:?}"),
     }
@@ -470,16 +501,21 @@ async fn register_push_device_rejects_stage_4_canceled_status() {
         p256dh: "p".to_string(),
         auth: "a".to_string(),
     };
-    let err = register_push_device(
+    let err = register_test_device(
         &driver,
-        "push.example.com",
         "app-web",
         PushEnvironment::Production,
         &credentials,
     )
     .await
     .expect_err("stage 4 canceled rejected");
-    assert!(matches!(err, ClientError::StanzaError(_)));
+    assert!(matches!(
+        err,
+        ClientError::PushRegistration(PushRegistrationError::UnexpectedStatus {
+            stage: "stage 4",
+            expected: "completed",
+        })
+    ));
 }
 
 #[tokio::test]
@@ -508,16 +544,16 @@ async fn register_push_device_rejects_stage_4_still_executing() {
     let credentials = PushDeviceCredentials::Apns {
         device_token: "t".to_string(),
     };
-    let err = register_push_device(
-        &driver,
-        "push.example.com",
-        "app-ios",
-        PushEnvironment::Sandbox,
-        &credentials,
-    )
-    .await
-    .expect_err("stage 4 still-executing rejected");
-    assert!(matches!(err, ClientError::StanzaError(_)));
+    let err = register_test_device(&driver, "app-ios", PushEnvironment::Sandbox, &credentials)
+        .await
+        .expect_err("stage 4 still-executing rejected");
+    assert!(matches!(
+        err,
+        ClientError::PushRegistration(PushRegistrationError::UnexpectedStatus {
+            stage: "stage 4",
+            expected: "completed",
+        })
+    ));
 }
 
 #[tokio::test]
@@ -556,16 +592,18 @@ async fn register_push_device_rejects_response_with_spoofed_from() {
         p256dh: "p".to_string(),
         auth: "a".to_string(),
     };
-    let err = register_push_device(
+    let err = register_test_device(
         &driver,
-        "push.example.com",
         "app-web",
         PushEnvironment::Production,
         &credentials,
     )
     .await
     .expect_err("spoofed `from=` must reject");
-    assert!(matches!(err, ClientError::StanzaError(_)));
+    assert!(matches!(
+        err,
+        ClientError::PushRegistration(PushRegistrationError::MalformedResultForm { .. })
+    ));
     // We MUST NOT have proceeded to stage 3 after the spoofed stage 2.
     assert_eq!(
         driver.transcript().len(),
@@ -603,9 +641,8 @@ async fn register_push_device_rejects_response_without_from_attr() {
     let credentials = PushDeviceCredentials::Fcm {
         registration_token: "fcm".to_string(),
     };
-    let err = register_push_device(
+    let err = register_test_device(
         &driver,
-        "push.example.com",
         "app-android",
         PushEnvironment::Production,
         &credentials,
@@ -613,8 +650,8 @@ async fn register_push_device_rejects_response_without_from_attr() {
     .await
     .expect_err("absent `from=` must reject");
     match err {
-        ClientError::StanzaError(stanza) => {
-            assert!(stanza.text.as_deref().unwrap_or("").contains("no `from`"));
+        ClientError::PushRegistration(PushRegistrationError::MalformedResultForm { reason }) => {
+            assert!(reason.contains("no `from`"));
         }
         other => panic!("unexpected error: {other:?}"),
     }

--- a/server/crates/waddle-xmpp/src/commands/registry.rs
+++ b/server/crates/waddle-xmpp/src/commands/registry.rs
@@ -18,6 +18,10 @@ use crate::XmppError;
 
 /// Time-to-live for command sessions (5 minutes)
 const SESSION_TTL: Duration = Duration::from_secs(300);
+/// How long to remember timed-out session ids after cleanup.
+const EXPIRED_SESSION_GRACE: Duration = Duration::from_secs(300);
+/// Upper bound for the recently-expired session cache.
+const MAX_RECENTLY_EXPIRED_SESSIONS: usize = 1024;
 
 /// Result of executing a command handler.
 pub enum CommandResult {
@@ -38,11 +42,15 @@ pub enum CommandResult {
     },
     /// Command completed successfully.
     Completed {
+        session_id: Option<String>,
         form: Option<DataForm>,
         notes: Vec<Note>,
     },
     /// Command was canceled.
-    Canceled { notes: Vec<Note> },
+    Canceled {
+        session_id: Option<String>,
+        notes: Vec<Note>,
+    },
     /// Command failed with an error.
     Error(XmppError),
 }
@@ -124,12 +132,21 @@ impl CommandSession {
     }
 }
 
+struct ExpiredCommandSession {
+    expired_at: Instant,
+    node: String,
+    from: Jid,
+}
+
 /// Registry for ad-hoc commands.
 pub struct CommandRegistry {
     /// Registered command metadata by node
     commands: RwLock<HashMap<String, CommandMetadata>>,
     /// Active command sessions
     sessions: RwLock<HashMap<String, CommandSession>>,
+    /// Recently timed-out sessions retained to distinguish
+    /// `<session-expired/>` from unknown or foreign session ids.
+    recently_expired_sessions: RwLock<HashMap<String, ExpiredCommandSession>>,
 }
 
 impl CommandRegistry {
@@ -138,6 +155,7 @@ impl CommandRegistry {
         Self {
             commands: RwLock::new(HashMap::new()),
             sessions: RwLock::new(HashMap::new()),
+            recently_expired_sessions: RwLock::new(HashMap::new()),
         }
     }
 
@@ -257,18 +275,9 @@ impl CommandRegistry {
                 if let Some(ref session_id) = ctx.command.session_id {
                     let session = self.sessions.read().await.get(session_id).cloned();
                     if !session_matches_request(session.as_ref(), node, from) {
-                        // §4.4 bad-sessionid: the sessionid is not valid
-                        // for this requester/node (unknown, expired, or
-                        // owned by someone else — indistinguishable once
-                        // the session has been evicted, so we report the
-                        // honest "cannot accept this sessionid").
-                        return CommandResult::Error(XmppError::ad_hoc_command(
-                            AdHocCommandCondition::BadSessionId,
-                            Some(
-                                "Session not found, expired, or owned by another requester"
-                                    .to_string(),
-                            ),
-                        ));
+                        return CommandResult::Error(
+                            self.session_id_error(session_id, node, from).await,
+                        );
                     }
                     self.sessions.write().await.remove(session_id);
                     debug!(
@@ -277,7 +286,10 @@ impl CommandRegistry {
                         "Canceled command session"
                     );
                 }
-                return CommandResult::Canceled { notes: vec![] };
+                return CommandResult::Canceled {
+                    session_id: ctx.command.session_id,
+                    notes: vec![],
+                };
             }
             Action::Complete | Action::Next | Action::Prev => {
                 if ctx.command.session_id.is_none() {
@@ -293,24 +305,21 @@ impl CommandRegistry {
                 }
                 // Touch the session to update last_accessed
                 if let Some(ref session_id) = ctx.command.session_id {
-                    if let Some(session) = self.sessions.write().await.get_mut(session_id) {
-                        if !session_matches_request(Some(session), node, from) {
-                            // §4.4 bad-sessionid (see Cancel arm).
-                            return CommandResult::Error(XmppError::ad_hoc_command(
-                                AdHocCommandCondition::BadSessionId,
-                                Some(
-                                    "Session not found, expired, or owned by another requester"
-                                        .to_string(),
-                                ),
-                            ));
+                    let session_matches = {
+                        let mut sessions = self.sessions.write().await;
+                        match sessions.get_mut(session_id) {
+                            Some(session) if session_matches_request(Some(session), node, from) => {
+                                session.touch();
+                                true
+                            }
+                            Some(_) => false,
+                            None => false,
                         }
-                        session.touch();
-                    } else {
-                        // §4.4 bad-sessionid: no such active session.
-                        return CommandResult::Error(XmppError::ad_hoc_command(
-                            AdHocCommandCondition::BadSessionId,
-                            Some("Session not found or expired".to_string()),
-                        ));
+                    };
+                    if !session_matches {
+                        return CommandResult::Error(
+                            self.session_id_error(session_id, node, from).await,
+                        );
                     }
                 }
             }
@@ -333,6 +342,28 @@ impl CommandRegistry {
                 session_id,
                 notes,
                 actions,
+            },
+            (
+                Some(session_id),
+                CommandResult::Completed {
+                    session_id: None,
+                    form,
+                    notes,
+                },
+            ) => CommandResult::Completed {
+                session_id: Some(session_id),
+                form,
+                notes,
+            },
+            (
+                Some(session_id),
+                CommandResult::Canceled {
+                    session_id: None,
+                    notes,
+                },
+            ) => CommandResult::Canceled {
+                session_id: Some(session_id),
+                notes,
             },
             (_, result) => result,
         };
@@ -386,10 +417,98 @@ impl CommandRegistry {
             .map(|(id, _)| id.clone())
             .collect();
 
+        let mut expired_sessions = Vec::with_capacity(expired.len());
         for id in expired {
-            sessions.remove(&id);
+            if let Some(session) = sessions.remove(&id) {
+                expired_sessions.push(session);
+            }
             debug!(session_id = %id, "Cleaned up expired command session");
         }
+        drop(sessions);
+
+        self.record_expired_sessions(expired_sessions).await;
+    }
+
+    async fn record_expired_sessions(&self, sessions: Vec<CommandSession>) {
+        if sessions.is_empty() {
+            return;
+        }
+
+        let now = Instant::now();
+        let mut recently_expired = self.recently_expired_sessions.write().await;
+        prune_recently_expired_sessions(&mut recently_expired, now);
+
+        for session in sessions {
+            recently_expired.insert(
+                session.id,
+                ExpiredCommandSession {
+                    expired_at: now,
+                    node: session.node,
+                    from: session.from,
+                },
+            );
+        }
+
+        cap_recently_expired_sessions(&mut recently_expired);
+    }
+
+    async fn recently_expired_session_matches_request(
+        &self,
+        session_id: &str,
+        node: &str,
+        from: &Jid,
+    ) -> bool {
+        let now = Instant::now();
+        let mut recently_expired = self.recently_expired_sessions.write().await;
+        prune_recently_expired_sessions(&mut recently_expired, now);
+
+        recently_expired
+            .get(session_id)
+            .is_some_and(|session| session.node == node && session.from == *from)
+    }
+
+    async fn session_id_error(&self, session_id: &str, node: &str, from: &Jid) -> XmppError {
+        if self
+            .recently_expired_session_matches_request(session_id, node, from)
+            .await
+        {
+            XmppError::ad_hoc_command(
+                AdHocCommandCondition::SessionExpired,
+                Some("Command session has expired".to_string()),
+            )
+        } else {
+            XmppError::ad_hoc_command(
+                AdHocCommandCondition::BadSessionId,
+                Some("Session not found or owned by another requester".to_string()),
+            )
+        }
+    }
+}
+
+fn prune_recently_expired_sessions(
+    recently_expired: &mut HashMap<String, ExpiredCommandSession>,
+    now: Instant,
+) {
+    recently_expired
+        .retain(|_, session| now.duration_since(session.expired_at) <= EXPIRED_SESSION_GRACE);
+}
+
+fn cap_recently_expired_sessions(recently_expired: &mut HashMap<String, ExpiredCommandSession>) {
+    let excess = recently_expired
+        .len()
+        .saturating_sub(MAX_RECENTLY_EXPIRED_SESSIONS);
+    if excess == 0 {
+        return;
+    }
+
+    let mut oldest: Vec<(String, Instant)> = recently_expired
+        .iter()
+        .map(|(id, session)| (id.clone(), session.expired_at))
+        .collect();
+    oldest.sort_by_key(|(_, expired_at)| *expired_at);
+
+    for (id, _) in oldest.into_iter().take(excess) {
+        recently_expired.remove(&id);
     }
 }
 
@@ -417,7 +536,12 @@ mod tests {
             .register(
                 "test:command",
                 "Test Command",
-                |_ctx: CommandContext| async { CommandResult::Canceled { notes: vec![] } },
+                |_ctx: CommandContext| async {
+                    CommandResult::Canceled {
+                        session_id: None,
+                        notes: vec![],
+                    }
+                },
             )
             .await;
 
@@ -477,5 +601,106 @@ mod tests {
 
         assert!(!session_id.is_empty());
         assert!(registry.get_session(&session_id).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_expired_session_returns_session_expired() {
+        let registry = CommandRegistry::new();
+
+        registry
+            .register(
+                "test:command",
+                "Test Command",
+                |ctx: CommandContext| async move {
+                    CommandResult::Executing {
+                        form: DataForm::new(crate::xep::xep0004::FormType::Form),
+                        session_id: ctx.command.session_id.unwrap_or_default(),
+                        notes: vec![],
+                        actions: None,
+                    }
+                },
+            )
+            .await;
+
+        let result = registry
+            .dispatch(test_context(
+                Command::new("test:command").with_action(Action::Execute),
+            ))
+            .await;
+        let session_id = match result {
+            CommandResult::Executing { session_id, .. } => session_id,
+            _ => panic!("expected executing result"),
+        };
+
+        {
+            let mut sessions = registry.sessions.write().await;
+            let session = sessions
+                .get_mut(&session_id)
+                .expect("execute created a session");
+            session.last_accessed = Instant::now() - SESSION_TTL - Duration::from_secs(1);
+        }
+
+        let result = registry
+            .dispatch(test_context(
+                Command::new("test:command")
+                    .with_action(Action::Next)
+                    .with_session_id(session_id),
+            ))
+            .await;
+
+        match result {
+            CommandResult::Error(XmppError::AdHocCommand { condition, .. }) => {
+                assert_eq!(condition, AdHocCommandCondition::SessionExpired);
+            }
+            _ => panic!("expected session-expired error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_unknown_session_returns_bad_sessionid() {
+        let registry = CommandRegistry::new();
+
+        registry
+            .register(
+                "test:command",
+                "Test Command",
+                |_ctx: CommandContext| async {
+                    CommandResult::Completed {
+                        session_id: None,
+                        form: None,
+                        notes: vec![],
+                    }
+                },
+            )
+            .await;
+
+        let result = registry
+            .dispatch(test_context(
+                Command::new("test:command")
+                    .with_action(Action::Complete)
+                    .with_session_id("unknown-session"),
+            ))
+            .await;
+
+        match result {
+            CommandResult::Error(XmppError::AdHocCommand { condition, .. }) => {
+                assert_eq!(condition, AdHocCommandCondition::BadSessionId);
+            }
+            _ => panic!("expected bad-sessionid error"),
+        }
+    }
+
+    fn test_context(command: Command) -> CommandContext {
+        CommandContext {
+            from: "user@localhost".parse().expect("test jid"),
+            authenticated_user_id: Some("user-123".to_string()),
+            iq: Iq::Set {
+                from: None,
+                to: None,
+                id: "test-iq".to_string(),
+                payload: "<query xmlns='urn:test'/>".parse().expect("test payload"),
+            },
+            command,
+        }
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/exports.rs
+++ b/server/crates/waddle-xmpp/src/xep/exports.rs
@@ -192,8 +192,8 @@ pub use waddle_xmpp_core::xep0359::{
 
 pub use super::xep0357::{
     build_push_disable_result, build_push_enable_result, is_push_disable, is_push_enable,
-    parse_push_disable, parse_push_enable, PushDisable, PushEnable, NS_PUBSUB_PUBLISH_OPTIONS,
-    NS_PUSH,
+    parse_push_disable, parse_push_enable, PublishOptionsParse, PushDisable, PushEnable,
+    NS_PUBSUB_PUBLISH_OPTIONS, NS_PUSH,
 };
 
 pub use super::xep0410::{

--- a/server/crates/waddle-xmpp/src/xep/xep0357.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0357.rs
@@ -54,7 +54,33 @@ pub struct PushEnable {
     /// Key-value pairs from the XEP-0060 publish-options form.
     pub options: Vec<(String, String)>,
     /// The original XEP-0004 publish-options form for later PubSub publish.
-    pub publish_options: Option<Element>,
+    pub publish_options: PublishOptionsParse,
+}
+
+/// Parsed state for an optional XEP-0060 publish-options data form.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PublishOptionsParse {
+    /// No submitted XEP-0004 form was present.
+    Absent,
+    /// A submitted XEP-0004 form was present, but its FORM_TYPE was missing or wrong.
+    Invalid,
+    /// A submitted XEP-0004 form with the required publish-options FORM_TYPE.
+    Valid(Element),
+}
+
+impl PublishOptionsParse {
+    /// Return the valid publish-options form, if present.
+    pub fn as_element(&self) -> Option<&Element> {
+        match self {
+            Self::Valid(form) => Some(form),
+            Self::Absent | Self::Invalid => None,
+        }
+    }
+
+    /// Whether the client submitted a malformed publish-options form.
+    pub fn is_invalid(&self) -> bool {
+        matches!(self, Self::Invalid)
+    }
 }
 
 /// A parsed push disable request.
@@ -103,7 +129,7 @@ pub fn parse_push_enable(iq: &Iq) -> Option<PushEnable> {
 
     let publish_options = parse_publish_options_form(elem);
     let options = publish_options
-        .as_ref()
+        .as_element()
         .map(parse_data_form_options)
         .unwrap_or_default();
 
@@ -155,16 +181,17 @@ fn parse_push_service_jid(raw: &str) -> Option<BareJid> {
     raw.parse::<BareJid>().ok()
 }
 
-fn parse_publish_options_form(parent: &Element) -> Option<Element> {
-    parent
-        .children()
-        .find(|child| {
-            child.name() == "x"
-                && child.ns() == NS_DATA_FORMS
-                && child.attr("type") == Some("submit")
-                && data_form_type(child).as_deref() == Some(NS_PUBSUB_PUBLISH_OPTIONS)
-        })
-        .cloned()
+fn parse_publish_options_form(parent: &Element) -> PublishOptionsParse {
+    let Some(form) = parent.children().find(|child| {
+        child.name() == "x" && child.ns() == NS_DATA_FORMS && child.attr("type") == Some("submit")
+    }) else {
+        return PublishOptionsParse::Absent;
+    };
+
+    match data_form_type(form).as_deref() {
+        Some(NS_PUBSUB_PUBLISH_OPTIONS) => PublishOptionsParse::Valid(form.clone()),
+        Some(_) | None => PublishOptionsParse::Invalid,
+    }
 }
 
 fn data_form_type(form: &Element) -> Option<String> {

--- a/server/crates/waddle-xmpp/src/xep/xep0357.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0357.rs
@@ -182,11 +182,23 @@ fn parse_push_service_jid(raw: &str) -> Option<BareJid> {
 }
 
 fn parse_publish_options_form(parent: &Element) -> PublishOptionsParse {
-    let Some(form) = parent.children().find(|child| {
+    // Strict shape: EXACTLY ONE submitted form, carrying the
+    // publish-options FORM_TYPE. Multiple submit forms are ambiguous
+    // (which one would the server honor?), and a wrong/missing
+    // FORM_TYPE on any submit form means the client asked for
+    // something we would otherwise silently drop — both are Invalid
+    // (XEP-0068 §4.1 → bad-request), never silently degraded.
+    // (Greptile review: a valid form followed by an invalid one must
+    // not slip through on first-match.)
+    let mut submit_forms = parent.children().filter(|child| {
         child.name() == "x" && child.ns() == NS_DATA_FORMS && child.attr("type") == Some("submit")
-    }) else {
+    });
+    let Some(form) = submit_forms.next() else {
         return PublishOptionsParse::Absent;
     };
+    if submit_forms.next().is_some() {
+        return PublishOptionsParse::Invalid;
+    }
 
     match data_form_type(form).as_deref() {
         Some(NS_PUBSUB_PUBLISH_OPTIONS) => PublishOptionsParse::Valid(form.clone()),

--- a/server/crates/waddle-xmpp/src/xep/xep0357/tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0357/tests.rs
@@ -64,6 +64,24 @@ fn bare_jid(value: &str) -> jid::BareJid {
     value.parse().expect("valid bare jid")
 }
 
+fn submit_form_with_form_type(form_type: Option<&str>) -> Element {
+    let mut form = Element::builder("x", NS_DATA_FORMS)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "submit");
+    if let Some(form_type) = form_type {
+        form = form.append(
+            Element::builder("field", NS_DATA_FORMS)
+                .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+                .append(
+                    Element::builder("value", NS_DATA_FORMS)
+                        .append(form_type)
+                        .build(),
+                )
+                .build(),
+        );
+    }
+    form.build()
+}
+
 #[test]
 fn test_ns_push_constant() {
     assert_eq!(NS_PUSH, "urn:xmpp:push:0");
@@ -170,7 +188,10 @@ fn test_parse_push_enable_with_options() {
     assert_eq!(enable.jid, bare_jid("push-service.example.com"));
     assert_eq!(enable.node.as_deref(), Some("web-push"));
     assert_eq!(enable.options.len(), 2);
-    assert!(enable.publish_options.is_some());
+    assert!(matches!(
+        enable.publish_options,
+        PublishOptionsParse::Valid(_)
+    ));
 
     assert!(enable
         .options
@@ -190,7 +211,7 @@ fn test_parse_push_enable_without_options() {
     assert_eq!(enable.jid, bare_jid("push-service.example.com"));
     assert_eq!(enable.node.as_deref(), Some("web-push"));
     assert!(enable.options.is_empty());
-    assert!(enable.publish_options.is_none());
+    assert_eq!(enable.publish_options, PublishOptionsParse::Absent);
 }
 
 #[test]
@@ -219,7 +240,7 @@ fn test_parse_push_enable_ignores_provider_attribute_options() {
     assert_eq!(enable.jid, bare_jid("push-service.example.com"));
     assert_eq!(enable.node.as_deref(), Some("web-push"));
     assert!(enable.options.is_empty());
-    assert!(enable.publish_options.is_none());
+    assert_eq!(enable.publish_options, PublishOptionsParse::Absent);
 }
 
 #[test]
@@ -229,7 +250,49 @@ fn test_parse_push_enable_without_node() {
 
     assert_eq!(enable.jid, bare_jid("push-service.example.com"));
     assert!(enable.node.is_none());
-    assert!(enable.publish_options.is_none());
+    assert_eq!(enable.publish_options, PublishOptionsParse::Absent);
+}
+
+#[test]
+fn test_parse_push_enable_wrong_publish_options_form_type_is_invalid() {
+    let mut enable_elem = Element::builder("enable", NS_PUSH)
+        .attr(
+            minidom::rxml::xml_ncname!("jid").to_owned(),
+            "push.example.com",
+        )
+        .build();
+    enable_elem.append_child(submit_form_with_form_type(Some("jabber:x:oob")));
+    let iq = Iq::Set {
+        from: None,
+        to: None,
+        id: "test".to_string(),
+        payload: enable_elem,
+    };
+
+    let enable = parse_push_enable(&iq).expect("enable");
+    assert!(enable.options.is_empty());
+    assert_eq!(enable.publish_options, PublishOptionsParse::Invalid);
+}
+
+#[test]
+fn test_parse_push_enable_missing_publish_options_form_type_is_invalid() {
+    let mut enable_elem = Element::builder("enable", NS_PUSH)
+        .attr(
+            minidom::rxml::xml_ncname!("jid").to_owned(),
+            "push.example.com",
+        )
+        .build();
+    enable_elem.append_child(submit_form_with_form_type(None));
+    let iq = Iq::Set {
+        from: None,
+        to: None,
+        id: "test".to_string(),
+        payload: enable_elem,
+    };
+
+    let enable = parse_push_enable(&iq).expect("enable");
+    assert!(enable.options.is_empty());
+    assert_eq!(enable.publish_options, PublishOptionsParse::Invalid);
 }
 
 #[test]
@@ -483,24 +546,13 @@ fn test_parse_data_form_with_missing_var() {
 
 #[test]
 fn test_non_publish_options_form_is_not_registration_publish_options() {
-    let value = Element::builder("value", NS_DATA_FORMS)
-        .append("not-publish-options")
-        .build();
-    let field = Element::builder("field", NS_DATA_FORMS)
-        .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
-        .append(value)
-        .build();
-    let form = Element::builder("x", NS_DATA_FORMS)
-        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "submit")
-        .append(field)
-        .build();
     let mut enable_elem = Element::builder("enable", NS_PUSH)
         .attr(
             minidom::rxml::xml_ncname!("jid").to_owned(),
             "push.example.com",
         )
         .build();
-    enable_elem.append_child(form);
+    enable_elem.append_child(submit_form_with_form_type(Some("not-publish-options")));
     let iq = Iq::Set {
         from: None,
         to: None,
@@ -510,7 +562,7 @@ fn test_non_publish_options_form_is_not_registration_publish_options() {
 
     let enable = parse_push_enable(&iq).expect("enable");
     assert!(enable.options.is_empty());
-    assert!(enable.publish_options.is_none());
+    assert_eq!(enable.publish_options, PublishOptionsParse::Invalid);
 }
 
 #[test]
@@ -519,7 +571,7 @@ fn test_push_enable_struct_debug() {
         jid: bare_jid("push.example.com"),
         node: Some("web-push".to_string()),
         options: vec![("key".to_string(), "val".to_string())],
-        publish_options: None,
+        publish_options: PublishOptionsParse::Absent,
     };
     let debug = format!("{:?}", enable);
     assert!(debug.contains("push.example.com"));
@@ -542,7 +594,7 @@ fn test_push_enable_clone_eq() {
         jid: bare_jid("push.example.com"),
         node: Some("node1".to_string()),
         options: vec![("k".to_string(), "v".to_string())],
-        publish_options: None,
+        publish_options: PublishOptionsParse::Absent,
     };
     let cloned = enable.clone();
     assert_eq!(enable, cloned);

--- a/server/crates/waddle-xmpp/src/xep/xep0357/tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0357/tests.rs
@@ -295,6 +295,33 @@ fn test_parse_push_enable_missing_publish_options_form_type_is_invalid() {
     assert_eq!(enable.publish_options, PublishOptionsParse::Invalid);
 }
 
+// Greptile review: a VALID publish-options form followed by a second
+// submit form (wrong FORM_TYPE or even another valid one) must not
+// slip through on first-match — multiple submit forms are ambiguous
+// and therefore Invalid.
+#[test]
+fn test_parse_push_enable_multiple_submit_forms_are_invalid() {
+    let mut enable_elem = Element::builder("enable", NS_PUSH)
+        .attr(
+            minidom::rxml::xml_ncname!("jid").to_owned(),
+            "push.example.com",
+        )
+        .build();
+    enable_elem.append_child(submit_form_with_form_type(Some(
+        "http://jabber.org/protocol/pubsub#publish-options",
+    )));
+    enable_elem.append_child(submit_form_with_form_type(Some("jabber:x:oob")));
+    let iq = Iq::Set {
+        from: None,
+        to: None,
+        id: "test".to_string(),
+        payload: enable_elem,
+    };
+
+    let enable = parse_push_enable(&iq).expect("enable");
+    assert_eq!(enable.publish_options, PublishOptionsParse::Invalid);
+}
+
 #[test]
 fn test_parse_push_enable_missing_jid() {
     let elem = Element::builder("enable", NS_PUSH).build();


### PR DESCRIPTION
Fixes #774.
Fixes #772.
Fixes #773.
Fixes #776.
Fixes #777.

Lane C item 3 — XEP-0357 / XEP-0050 polish bundle (one PR, five issues, ordered from safest refactor to riskiest boundary).

## What shipped (four slices, safest→riskiest)

### #776 — register-device single transaction (safe refactor, first)

`handle_register_device` runs `ensure_node` + `upsert_device` as two separate transactions; a concurrent `disable_nodes_for_owner` landing between them surfaces a confusing mid-flow stage-4 error. Extract `ensure_node_tx` / `upsert_device_tx` cores (the existing `_tx` free-function pattern) and compose them under one `begin_immediate()`; the XEP-0060 backing-node side effect moves after the combined commit.

### #772 + #773 (server half) — XEP-0050 §4.3/§4.4 application errors + session lifecycle

The typed `AdHocCommandCondition` enum and the `<error/>` rendering path already exist; two conditions are defined but never emitted:

- Split `session-expired` out of the `bad-session-id` conflation in the command registry: an expired-but-known session gets `<session-expired/>` (Cancel/not-allowed), an unknown/foreign session keeps `<bad-sessionid/>`.
- Thread the registry-minted `sessionid` through `CommandResult::Completed` so a single-shot `execute` that completes immediately stamps the minted sessionid on the result IQ (XEP-0050 "the responder SHOULD initialize … or maintain this attribute").
- (`<bad-locale/>` stays unemitted — no locale negotiation exists to violate; advertising an error for a feature we don't parse would be noise.)

### #774 — strict publish-options FORM_TYPE on `<enable/>`

`parse_publish_options_form` currently folds "form present with wrong/missing FORM_TYPE" into "no form" and accepts the enable with `publish_options=None` — not what the client asked for. Make the parse tri-state and have the enable handler answer `<bad-request/>` (XEP-0068 §4.1) when a submit form is present but its FORM_TYPE is not `http://jabber.org/protocol/pubsub#publish-options`.

### #777 + #773 (client half) — typed composer errors + retry surface

- New typed `PushRegistrationError` (thiserror) + `ClientError` variant replacing the eight stringly `protocol_error("bad-request")` sites in `register_push_device`; typed `PushServiceJid`/`PushAppId` value objects for the two remaining `&str` args.
- The WASM boundary surfaces a structured error code (string enum) instead of a flat `Display` string so `syncPushSubscriptionImpl` can distinguish `session-expired` (retry from stage 1) from terminal failures (clear persisted ids). **The UniFFI-exported signatures stay byte-identical** so `checkXmppClientFfiBindings` and the Apple bindings are untouched.

## XEP conformance

XEP-0050 §4.3 error extensions and sessionid maintenance are MUST/SHOULD-level conformance gaps being closed; XEP-0357 §5 mandates the publish-options FORM_TYPE; XEP-0068 §4.1 prescribes `<bad-request/>` for FORM_TYPE mismatches. Dedicated Rust tests per XEP surface in the same PR.

## Review rounds

Adversarial review (opus agent) ran on the full branch before push: lock ordering (owner→node everywhere), expired-cache bounds + spoof-resistance, sessionid stamping arms, tri-state leniency for non-submit forms, and the full server→WASM→chat session-expired retry chain all verified; one real finding (silently swallowed compensation failure could leak an active quota-eating device on a double DB failure) fixed with a loud warn. Implementation slices were produced by gpt-5.5 (codex) under tight specs, each reviewed and re-verified by Claude outside the codex sandbox — including one caught-and-fixed codex bug: session-expired detection originally keyed on `StanzaError.condition`, which the real server never sets to the application condition; fixed via a typed `application_condition` field + conformant two-condition test fixture.

Verification: full cargo workspace tests, clippy `-D warnings`, chat `bun test` (3306 pass, only the known startup-loading build-precondition flake), `knip` clean, and `check-xmpp-client-ffi-bindings.sh` green (Apple bindings byte-identical).

Also marks Lane C item 3 done in TODO-ISSUES.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
