### PR TITLE
fix(server): MUC-MAM 'from' + muc#user anti-spoofing + XEP-0421 occupant-id gaps (#1250 #1251 #1268)

### DIFF
--- a/TODO-ISSUES.md
+++ b/TODO-ISSUES.md
@@ -133,9 +133,9 @@ in parallel; within a bundle, top-to-bottom.
 5. #1262 — owner bypasses §8.4/§9.7 role-change target protections.
 
 **J4 — MUC-MAM + occupant-id + spoofing `[bundle]`**
-1. #1250 — **High**: MUC-MAM result envelopes missing `from` → strict clients discard all room history.
-2. #1251 — **High (security)**: client `muc#user <x>` not stripped from groupchat messages before reflect/archive (persisted spoofing).
-3. #1268 — XEP-0421 occupant-id gaps (PM, destroy presence, MAM real-JID for non-anon rooms).
+1. ✅ #1250 — **High**: MUC-MAM result envelopes missing `from` → strict clients discard all room history. DONE (PR #1274)
+2. ✅ #1251 — **High (security)**: client `muc#user <x>` not stripped from groupchat messages before reflect/archive (persisted spoofing). DONE (PR #1274)
+3. ✅ #1268 — XEP-0421 occupant-id gaps (PM, destroy presence, MAM real-JID for non-anon rooms). DONE (PR #1274)
 
 **J5 — MUC delivery / self-ping reliability `[bundle]`**
 1. #1249 — **High**: cross-node disconnect cleanup ghosts occupants — root cause of the recurring prod `failed to relay remote MUC unavailable during disconnect cleanup`. Relates #1195.

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -538,6 +538,7 @@ async fn interpret_with_depth(
                 sender,
                 message,
                 sender_nickname_generation,
+                sender_item,
             } => {
                 match archive_groupchat_event(
                     deps,
@@ -545,6 +546,7 @@ async fn interpret_with_depth(
                     sender,
                     message,
                     sender_nickname_generation,
+                    sender_item,
                 )
                 .await
                 {

--- a/server/crates/waddle-server/src/server/routes/interpret/archive_groupchat_event.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/archive_groupchat_event.rs
@@ -18,6 +18,7 @@ pub(super) async fn archive_groupchat_event(
     sender: FullJid,
     message: Box<Message>,
     sender_nickname_generation: u64,
+    sender_item: Option<waddle_xmpp_core::mam::ArchivedMucSender>,
 ) -> ArchiveGroupchatEventOutcome {
     let Some(mam_storage) = deps.mam_storage else {
         debug!(
@@ -48,6 +49,7 @@ pub(super) async fn archive_groupchat_event(
         &message,
         sender_nickname_generation,
         fence.as_ref(),
+        sender_item.as_ref(),
     )
     .await
     {

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -58,8 +58,23 @@ pub(super) async fn archive_groupchat_message(
     message: &Message,
     sender_nickname_generation: u64,
     fence: Option<&RoomClaimFenceContext>,
+    sender_item: Option<&waddle_xmpp_core::mam::ArchivedMucSender>,
 ) -> ArchiveGroupchatOutcome {
-    let archive_clone = message.clone();
+    // XEP-0313 §MUC Archives: for non-anonymous rooms the *archived*
+    // copy carries a room-authored `<x xmlns='muc#user'><item
+    // jid='real-jid' affiliation role/></x>` disclosing the sender's
+    // real JID (#1268). The live reflection never carries it — this
+    // append happens on the archive clone only, after
+    // `MucCanonicalizeHandler` has already stripped any
+    // client-supplied muc#user forgery (#1251).
+    let mut archive_clone = message.clone();
+    if let Some(sender_item) = sender_item {
+        archive_clone
+            .payloads
+            .push(waddle_xmpp_core::mam::build_archived_muc_sender_x(
+                sender_item,
+            ));
+    }
     let archive_id = match extract_room_stanza_id(&archive_clone, room) {
         Some(id) => id,
         None => {
@@ -90,6 +105,7 @@ pub(super) async fn archive_groupchat_message(
         archive_id,
         sender_nickname_generation,
         fence,
+        sender_item,
     )
     .await
 }
@@ -111,6 +127,7 @@ pub(super) async fn finish_archive_groupchat_message(
     archive_id: String,
     sender_nickname_generation: u64,
     fence: Option<&RoomClaimFenceContext>,
+    sender_item: Option<&waddle_xmpp_core::mam::ArchivedMucSender>,
 ) -> ArchiveGroupchatOutcome {
     // RFC 6121 §5.2.3: `<body>` is optional. Preserve the
     // None-vs-empty distinction so subject-only / reaction-only
@@ -119,7 +136,7 @@ pub(super) async fn finish_archive_groupchat_message(
     let body = super::prototype_body(&archive_clone);
     let reply = extract_groupchat_reply_reference(&archive_clone, room);
     let origin_id = extract_origin_id(&archive_clone);
-    let rich = rich_archive_payload(&archive_clone);
+    let rich = rich_archive_payload(&archive_clone, sender_item);
     let stanza_xml = serialize_groupchat_stanza_xml(&archive_clone);
 
     // XEP-0201: read the typed thread info (id + optional parent) from the
@@ -599,7 +616,10 @@ pub(super) fn serialize_groupchat_stanza_xml(message: &Message) -> Option<String
     }
 }
 
-pub(super) fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMessage> {
+pub(super) fn rich_archive_payload(
+    message: &Message,
+    muc_sender: Option<&waddle_xmpp_core::mam::ArchivedMucSender>,
+) -> Option<ArchivedRichMessage> {
     let payload = extract_correction_from_message(message)
         .and_then(|correction| {
             RichMessageId::new(correction.replaces_id)
@@ -686,7 +706,21 @@ pub(super) fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMess
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
-    if payload.is_none() && reply.is_none() && references.is_empty() && mentions.is_empty() {
+    // XEP-0421: capture the server-stamped occupant-id into the typed
+    // projection so the non-`stanza_xml` fallback reconstruction can
+    // re-emit it (#1268). `MucCanonicalizeHandler` stamped it (and
+    // stripped any client-supplied one) before the archive event was
+    // emitted, so this value is server-authored.
+    let occupant_id = waddle_xmpp::xep::xep0421::extract_occupant_id_from_message(message)
+        .and_then(|id| waddle_xmpp_core::mam::ArchivedOccupantId::new(id.as_str()));
+    let muc_sender = muc_sender.cloned();
+    if payload.is_none()
+        && reply.is_none()
+        && references.is_empty()
+        && mentions.is_empty()
+        && occupant_id.is_none()
+        && muc_sender.is_none()
+    {
         None
     } else {
         Some(ArchivedRichMessage {
@@ -694,6 +728,8 @@ pub(super) fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMess
             reply,
             references,
             mentions,
+            occupant_id,
+            muc_sender,
         })
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
@@ -108,7 +108,10 @@ pub(super) async fn broadcast_room_system_message_event(
     // "not archived, not fanned out" contract.
     if let Some(mam_storage) = deps.mam_storage {
         let fence = resolve_room_claim_fence(deps, &room);
-        match archive_groupchat_message(mam_storage, &room, &message, 0, fence.as_ref()).await {
+        // Room-authored system messages have no occupant sender, so
+        // there is no real-JID `<x xmlns='muc#user'/>` to disclose.
+        match archive_groupchat_message(mam_storage, &room, &message, 0, fence.as_ref(), None).await
+        {
             ArchiveGroupchatOutcome::Stored(result) => debug!(
                 room = %room,
                 stanza_id = %result.stored_id,

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -1253,6 +1253,8 @@ async fn xep_0424_lookup_archived_message_propagates_tombstone_state() {
             reply: None,
             references: Vec::new(),
             mentions: Vec::new(),
+            occupant_id: None,
+            muc_sender: None,
         }),
         nickname_generation: None,
     };

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
@@ -210,8 +210,14 @@ pub(super) async fn handle_archive_inbox_upload_iq(
             )];
         };
 
+        // XEP-0313 §Security "Sender Impersonation": result envelopes
+        // MUST come from the queried archive JID — the room bare JID
+        // for MUC archives, the user's own bare JID for personal
+        // archives (#1250). `target_bare` is exactly that queried
+        // archive address for both cases.
+        let archive_jid = jid::Jid::from(target_bare.clone());
         let mut responses: Vec<String> =
-            build_result_messages(&query_id, &recipient_jid, &result.messages)
+            build_result_messages(&query_id, &archive_jid, &recipient_jid, &result.messages)
                 .into_iter()
                 .map(|message| stanza_to_xml(&Stanza::Message(message)))
                 .collect();

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
@@ -131,12 +131,23 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                 if let Ok(snapshot) = room_actor.ask(GetSnapshot).await {
                     for occupant in snapshot.room.occupants.values() {
                         let is_self_occupant = occupant.real_jid == *sender_jid;
+                        // XEP-0421: the destroy notification is the
+                        // occupant's final unavailable presence from
+                        // the room and MUST carry their occupant-id
+                        // (#1268).
+                        let occupant_bare = occupant.real_jid.to_bare();
+                        let identity = waddle_xmpp::xep::xep0421::OccupantIdentity {
+                            bare_jid: &occupant_bare,
+                            real_jid: Some(&occupant.real_jid),
+                            secret: &state.deps.occupant_id_secret,
+                        };
                         let presence = build_destroy_notification(
                             &room_jid,
                             &occupant.nick,
                             &occupant.real_jid,
                             &destroy_request,
                             is_self_occupant,
+                            &identity,
                         );
                         if is_self_occupant {
                             frames.push(stanza_to_xml(&Stanza::Presence(presence)));
@@ -379,6 +390,10 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                     reply: None,
                     references: Vec::new(),
                     mentions: Vec::new(),
+                    // Room-authored moderation event row: no occupant
+                    // sender to identify.
+                    occupant_id: None,
+                    muc_sender: None,
                 }),
                 nickname_generation: None,
             };

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message/muc_direct.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message/muc_direct.rs
@@ -104,11 +104,20 @@ async fn handle_muc_private_message(
             )]);
         }
     };
+    // XEP-0421 §Business Rules: "The <occupant-id/> element MUST be
+    // attached to every message ... sent by a MUC" — private messages
+    // included. Derive the sender's stable occupant-id the same way
+    // the groupchat canonicalize handler does (#1268).
+    let sender_occupant_id = waddle_xmpp::xep::xep0421::generate_occupant_id(
+        &bound_jid.to_bare(),
+        &room_jid,
+        &state.deps.occupant_id_secret,
+    );
     for recipient in snapshot.room.get_occupant_sessions(&target_nick) {
         let mut routed = incoming.clone();
         routed.from = Some(jid::Jid::from(from_room_jid.clone()));
         routed.to = Some(jid::Jid::from(recipient.clone()));
-        canonicalize_muc_private_payloads(&mut routed);
+        canonicalize_muc_private_payloads(&mut routed, &sender_occupant_id);
         let _ = state
             .deps
             .protocol
@@ -252,7 +261,10 @@ fn build_mediated_decline_payload(
         .build()
 }
 
-fn canonicalize_muc_private_payloads(message: &mut Message) {
+fn canonicalize_muc_private_payloads(
+    message: &mut Message,
+    sender_occupant_id: &waddle_xmpp::xep::xep0421::OccupantId,
+) {
     message.payloads.retain(|payload| {
         if payload.is("x", waddle_xmpp::muc::presence::NS_MUC_USER)
             || payload.is("occupant-id", waddle_xmpp::xep::xep0421::NS_OCCUPANT_ID)
@@ -271,6 +283,9 @@ fn canonicalize_muc_private_payloads(message: &mut Message) {
     message
         .payloads
         .push(minidom::Element::builder("x", waddle_xmpp::muc::presence::NS_MUC_USER).build());
+    // XEP-0421: re-stamp the server-derived occupant-id after stripping
+    // any client-supplied one (#1268).
+    waddle_xmpp::xep::xep0421::set_occupant_id_on_message(message, sender_occupant_id);
 }
 
 fn message_error_frame(
@@ -287,4 +302,98 @@ fn message_error_frame(
         StanzaError::new(error_type, condition, "en", text),
     );
     stanza_to_string(reply).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use waddle_xmpp::xep::xep0421::{
+        extract_occupant_id_from_message, generate_occupant_id, OccupantId, OccupantIdSecret,
+        NS_OCCUPANT_ID, OCCUPANT_ID_SECRET_MIN_BYTES,
+    };
+
+    fn secret() -> OccupantIdSecret {
+        OccupantIdSecret::new(vec![3u8; OCCUPANT_ID_SECRET_MIN_BYTES]).expect("valid secret")
+    }
+
+    fn pm() -> Message {
+        let mut m = Message::new(Some(
+            "room@muc.example.com/bob".parse::<jid::Jid>().expect("jid"),
+        ));
+        m.type_ = MessageType::Chat;
+        m.bodies
+            .insert(xmpp_parsers::message::Lang::new(), "psst".to_string());
+        m
+    }
+
+    /// XEP-0421 Business Rules (#1268): MUC private messages MUST carry
+    /// the server-derived occupant-id — stripping the client's forgery
+    /// and re-stamping the canonical value.
+    #[test]
+    fn xep0421_pm_carries_server_stamped_occupant_id() {
+        let room: jid::BareJid = "room@muc.example.com".parse().expect("room");
+        let sender_bare: jid::BareJid = "alice@example.com".parse().expect("sender");
+        let secret = secret();
+        let server_id = generate_occupant_id(&sender_bare, &room, &secret);
+
+        let mut msg = pm();
+        // Client tries to spoof someone else's occupant-id.
+        msg.payloads
+            .push(waddle_xmpp::xep::xep0421::build_occupant_id_element(
+                &OccupantId::new("forged-id"),
+            ));
+
+        canonicalize_muc_private_payloads(&mut msg, &server_id);
+
+        let stamped = extract_occupant_id_from_message(&msg).expect("occupant-id stamped on PM");
+        assert_eq!(stamped, server_id);
+        assert_ne!(stamped, OccupantId::new("forged-id"));
+        // Exactly one occupant-id element.
+        let count = msg
+            .payloads
+            .iter()
+            .filter(|p| p.is("occupant-id", NS_OCCUPANT_ID))
+            .count();
+        assert_eq!(count, 1);
+    }
+
+    /// XEP-0045 §7.5: the PM keeps exactly one empty muc#user `<x/>`
+    /// marker (client-supplied ones are stripped) alongside the
+    /// occupant-id.
+    #[test]
+    fn xep0421_pm_keeps_single_empty_muc_user_marker() {
+        let room: jid::BareJid = "room@muc.example.com".parse().expect("room");
+        let sender_bare: jid::BareJid = "alice@example.com".parse().expect("sender");
+        let secret = secret();
+        let server_id = generate_occupant_id(&sender_bare, &room, &secret);
+
+        let mut msg = pm();
+        // Forged muc#user x with an item claiming an affiliation.
+        msg.payloads.push(
+            minidom::Element::builder("x", waddle_xmpp::muc::presence::NS_MUC_USER)
+                .append(
+                    minidom::Element::builder("item", waddle_xmpp::muc::presence::NS_MUC_USER)
+                        .attr(
+                            minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                            "owner",
+                        )
+                        .build(),
+                )
+                .build(),
+        );
+
+        canonicalize_muc_private_payloads(&mut msg, &server_id);
+
+        let markers: Vec<_> = msg
+            .payloads
+            .iter()
+            .filter(|p| p.is("x", waddle_xmpp::muc::presence::NS_MUC_USER))
+            .collect();
+        assert_eq!(markers.len(), 1, "exactly one muc#user marker");
+        assert_eq!(
+            markers[0].children().count(),
+            0,
+            "the PM marker is empty — forged items must not survive"
+        );
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message/muc_direct.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message/muc_direct.rs
@@ -266,7 +266,14 @@ fn canonicalize_muc_private_payloads(
     sender_occupant_id: &waddle_xmpp::xep::xep0421::OccupantId,
 ) {
     message.payloads.retain(|payload| {
-        if payload.is("x", waddle_xmpp::muc::presence::NS_MUC_USER)
+        // XEP-0313 §Security "MUC message spoofing" + XEP-0045
+        // anti-spoofing: strip every client-supplied payload in a MUC
+        // *service* namespace (muc / muc#user / muc#admin / muc#owner)
+        // so an occupant cannot forge affiliation/role/status/invite
+        // signalling on a PM that the server then relays from
+        // `room/nick`. Namespace-only, sharing the exact set with the
+        // groupchat canonicalizer (#1251, #1268).
+        if waddle_xmpp::muc::is_muc_service_namespace(payload.ns().as_str())
             || payload.is("occupant-id", waddle_xmpp::xep::xep0421::NS_OCCUPANT_ID)
         {
             return false;
@@ -395,5 +402,59 @@ mod tests {
             0,
             "the PM marker is empty — forged items must not survive"
         );
+    }
+
+    /// XEP-0313 §Security / XEP-0045 anti-spoofing (#1251): a PM must
+    /// not launder client-supplied payloads in ANY MUC service
+    /// namespace (muc / muc#admin / muc#owner), not just muc#user —
+    /// including non-`<x>` element names.
+    #[test]
+    fn xep0045_pm_strips_all_muc_service_namespaces() {
+        let room: jid::BareJid = "room@muc.example.com".parse().expect("room");
+        let sender_bare: jid::BareJid = "alice@example.com".parse().expect("sender");
+        let secret = secret();
+        let server_id = generate_occupant_id(&sender_bare, &room, &secret);
+
+        let mut msg = pm();
+        // A non-`<x>` element in muc#user (status code), plus payloads
+        // in muc / muc#admin / muc#owner.
+        msg.payloads.push(
+            minidom::Element::builder("status", waddle_xmpp::muc::presence::NS_MUC_USER)
+                .attr(minidom::rxml::xml_ncname!("code").to_owned(), "110")
+                .build(),
+        );
+        msg.payloads
+            .push(minidom::Element::builder("x", waddle_xmpp::muc::presence::NS_MUC).build());
+        msg.payloads
+            .push(minidom::Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN).build());
+        msg.payloads
+            .push(minidom::Element::builder("query", waddle_xmpp::muc::NS_MUC_OWNER).build());
+
+        canonicalize_muc_private_payloads(&mut msg, &server_id);
+
+        // Only the single server-authored empty muc#user marker remains
+        // in MUC service namespaces; nothing else.
+        for ns in [
+            waddle_xmpp::muc::presence::NS_MUC,
+            waddle_xmpp::muc::NS_MUC_ADMIN,
+            waddle_xmpp::muc::NS_MUC_OWNER,
+        ] {
+            assert!(
+                !msg.payloads.iter().any(|p| p.ns() == ns),
+                "client payloads in `{ns}` must be stripped from a MUC PM"
+            );
+        }
+        let muc_user: Vec<_> = msg
+            .payloads
+            .iter()
+            .filter(|p| p.ns() == waddle_xmpp::muc::presence::NS_MUC_USER)
+            .collect();
+        assert_eq!(
+            muc_user.len(),
+            1,
+            "only the server-authored empty muc#user marker survives"
+        );
+        assert_eq!(muc_user[0].name(), "x");
+        assert_eq!(muc_user[0].children().count(), 0);
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -3780,10 +3780,25 @@ async fn muc_private_message_routes_from_sender_room_nick_to_target_session() {
             .is_none(),
         "routed MUC PM must not preserve caller-supplied muc#user metadata: {xml}"
     );
-    assert!(
-        routed
-            .get_child("occupant-id", waddle_xmpp::xep::xep0421::NS_OCCUPANT_ID)
-            .is_none(),
+    // XEP-0421 Business Rules (#1268): the caller-supplied occupant-id
+    // is stripped and the server stamps its own stable value derived
+    // from the SENDER's bare JID.
+    let stamped_occupant_id = routed
+        .get_child("occupant-id", waddle_xmpp::xep::xep0421::NS_OCCUPANT_ID)
+        .expect("routed MUC PM must carry the server-stamped occupant-id");
+    let expected_occupant_id = waddle_xmpp::xep::xep0421::generate_occupant_id(
+        &alice_jid.to_bare(),
+        &room_jid,
+        &state.deps.occupant_id_secret,
+    );
+    assert_eq!(
+        stamped_occupant_id.attr("id"),
+        Some(expected_occupant_id.as_str()),
+        "routed MUC PM occupant-id must be the server-derived sender id: {xml}"
+    );
+    assert_ne!(
+        stamped_occupant_id.attr("id"),
+        Some("spoofed-occupant"),
         "routed MUC PM must not preserve caller-supplied occupant-id: {xml}"
     );
     // Strongest invariant: the server strips ALL client-supplied stanza-ids

--- a/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
+++ b/server/crates/waddle-server/tests/xep0513_mentions_ws.rs
@@ -142,14 +142,35 @@ async fn explicit_mentions_route_and_replay_from_mam() {
         .recv_until(|frame| frame.contains("mam-mention") && frame.contains("<fin"))
         .await
         .expect("MAM frames");
+    // XEP-0513: the replayed mention MUST still identify its target by
+    // occupant-id, never by a raw JID inside the `<mention/>` element.
+    let mention_frame = frames
+        .iter()
+        .find(|frame| frame.contains("urn:xmpp:mentions:0") && frame.contains(&occupant_id))
+        .unwrap_or_else(|| panic!("MAM did not replay mention: {frames:?}"));
+    // XEP-0313 §MUC Archives: for a non-anonymous room the *archived*
+    // result additionally discloses the sender's real JID via a
+    // room-authored `<x xmlns='muc#user'><item jid=…/></x>` (#1268).
+    // The disclosure lives in that item, NOT in the `<mention/>`
+    // element — assert the mention element itself stays JID-free while
+    // the muc#user item carries the real JID.
+    let mention_element_start = mention_frame
+        .find("<mention ")
+        .expect("mention element present in replay");
+    let mention_element_end = mention_frame[mention_element_start..]
+        .find("/>")
+        .map(|offset| mention_element_start + offset)
+        .expect("mention element is self-closing");
+    let mention_element = &mention_frame[mention_element_start..mention_element_end];
     assert!(
-        frames
-            .iter()
-            .any(|frame| frame.contains("urn:xmpp:mentions:0")
-                && frame.contains(&occupant_id)
-                && !frame.contains("jid='admin@localhost")
-                && !frame.contains("jid='admin@localhost")),
-        "MAM did not replay mention: {frames:?}"
+        !mention_element.contains("jid="),
+        "MUC mention element leaked a JID despite occupant-id support: {mention_element}"
+    );
+    assert!(
+        mention_frame.contains("http://jabber.org/protocol/muc#user")
+            && mention_frame.contains("jid='admin@localhost"),
+        "XEP-0313 §MUC Archives: non-anonymous MAM replay must disclose the real JID \
+         via the muc#user item: {mention_frame}"
     );
 
     let _ = client.close().await;

--- a/server/crates/waddle-xmpp-core/src/mam.rs
+++ b/server/crates/waddle-xmpp-core/src/mam.rs
@@ -11,15 +11,16 @@ mod types;
 
 pub use query::{build_query_form_iq, is_mam_query, is_mam_query_form_request, parse_mam_query};
 pub use response::{
-    archived_inner_message, build_fin_iq, build_result_messages, message_type_wire_str,
+    archived_inner_message, build_archived_muc_sender_x, build_archived_occupant_id_element,
+    build_fin_iq, build_result_messages, message_type_wire_str,
 };
 pub use stanza_id_filter::{
     MamFilterStanzaId, MAX_FILTER_STANZA_IDS, MAX_FILTER_STANZA_ID_LEN, STANZA_ID_FILTER_FIELD,
 };
 pub use types::{
-    ArchivedMention, ArchivedMessage, ArchivedModeration, ArchivedReactionSet, ArchivedReference,
-    ArchivedReply, ArchivedRetraction, ArchivedRichMessage, ArchivedRichPayload, ArchivedTombstone,
-    MamQuery, MamResult, RichMessageId, RichText, ThreadId,
+    ArchivedMention, ArchivedMessage, ArchivedModeration, ArchivedMucSender, ArchivedOccupantId,
+    ArchivedReactionSet, ArchivedReference, ArchivedReply, ArchivedRetraction, ArchivedRichMessage,
+    ArchivedRichPayload, ArchivedTombstone, MamQuery, MamResult, RichMessageId, RichText, ThreadId,
 };
 
 /// MAM XML namespace (XEP-0313 v2).
@@ -88,6 +89,13 @@ pub const FORWARD_NS: &str = "urn:xmpp:forward:0";
 
 /// Delay namespace (XEP-0203).
 pub const DELAY_NS: &str = "urn:xmpp:delay";
+
+/// XEP-0421 occupant-id namespace.
+pub const OCCUPANT_ID_NS: &str = "urn:xmpp:occupant-id:0";
+
+/// XEP-0045 `muc#user` namespace (extended presence / archived
+/// real-JID disclosure per XEP-0313 §MUC Archives).
+pub const MUC_USER_NS: &str = "http://jabber.org/protocol/muc#user";
 
 const CLIENT_NS: &str = "jabber:client";
 const REPLY_NS: &str = "urn:xmpp:reply:0";

--- a/server/crates/waddle-xmpp-core/src/mam/response.rs
+++ b/server/crates/waddle-xmpp-core/src/mam/response.rs
@@ -5,13 +5,25 @@ use uuid::Uuid;
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::message::{Message, MessageType};
 
-use super::types::{ArchivedMessage, ArchivedRichMessage, ArchivedRichPayload, MamResult};
+use super::types::{
+    ArchivedMessage, ArchivedMucSender, ArchivedOccupantId, ArchivedRichMessage,
+    ArchivedRichPayload, MamResult,
+};
 use super::{
     CLIENT_NS, DELAY_NS, FORWARD_NS, MAM_NS, MENTIONS_NS, MESSAGE_CORRECT_NS, MESSAGE_MODERATE_NS,
-    MESSAGE_RETRACT_NS, REACTIONS_NS, REFERENCE_NS, REPLY_NS, RSM_NS, STANZA_ID_NS,
+    MESSAGE_RETRACT_NS, MUC_USER_NS, OCCUPANT_ID_NS, REACTIONS_NS, REFERENCE_NS, REPLY_NS, RSM_NS,
+    STANZA_ID_NS,
 };
 
 /// Build MAM result messages for each archived message.
+///
+/// `archive_jid` is the queried archive's address (room bare JID for
+/// MUC archives, user bare JID for personal archives) and is stamped
+/// as the result envelope's `from`. XEP-0313 §Security "Sender
+/// Impersonation" requires clients to verify that result messages come
+/// from the entity they queried and to discard unsolicited results —
+/// an envelope without `from` (or with the wrong `from`) is dropped by
+/// conformant clients, silently emptying room history (#1250).
 ///
 /// `to_jid` is typed as `&jid::Jid` so the recipient address is a
 /// validated value flowing in from the IQ wire-parse boundary; the
@@ -20,12 +32,13 @@ use super::{
 /// fallback (a hot-path data-loss bug).
 pub fn build_result_messages(
     query_id: &str,
+    archive_jid: &Jid,
     to_jid: &Jid,
     messages: &[ArchivedMessage],
 ) -> Vec<Message> {
     messages
         .iter()
-        .map(|archived| build_result_message(query_id, to_jid, archived))
+        .map(|archived| build_result_message(query_id, archive_jid, to_jid, archived))
         .collect()
 }
 
@@ -47,7 +60,12 @@ pub fn build_fin_iq(original_iq: &Iq, result: &MamResult) -> Iq {
     }
 }
 
-fn build_result_message(query_id: &str, to_jid: &Jid, archived: &ArchivedMessage) -> Message {
+fn build_result_message(
+    query_id: &str,
+    archive_jid: &Jid,
+    to_jid: &Jid,
+    archived: &ArchivedMessage,
+) -> Message {
     let inner_msg = archived_inner_message(archived);
     let delay = Element::builder("delay", DELAY_NS)
         .attr(
@@ -66,6 +84,10 @@ fn build_result_message(query_id: &str, to_jid: &Jid, archived: &ArchivedMessage
         .build();
 
     let mut msg = Message::new(Some(to_jid.clone()));
+    // XEP-0313 §Security "Sender Impersonation": the result envelope
+    // MUST come from the queried archive JID so clients can match it
+    // against their open query instead of discarding it as unsolicited.
+    msg.from = Some(archive_jid.clone());
     msg.id = Some(xmpp_parsers::message::Id(Uuid::now_v7().to_string()));
     msg.type_ = MessageType::Normal;
     msg.payloads.push(result);
@@ -125,6 +147,40 @@ pub fn message_type_wire_str(message_type: &MessageType) -> &'static str {
         MessageType::Headline => "headline",
         MessageType::Normal => "normal",
     }
+}
+
+/// Build the room-authored XEP-0313 §MUC Archives real-JID disclosure:
+/// `<x xmlns='http://jabber.org/protocol/muc#user'><item affiliation
+/// role jid='real-jid'/></x>`. Used by the archive write path (baked
+/// into `stanza_xml`) and by the typed fallback reconstruction below,
+/// so both replay paths agree on the wire shape.
+pub fn build_archived_muc_sender_x(sender: &ArchivedMucSender) -> Element {
+    Element::builder("x", MUC_USER_NS)
+        .append(
+            Element::builder("item", MUC_USER_NS)
+                .attr(
+                    minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                    sender.affiliation.to_string(),
+                )
+                .attr(
+                    minidom::rxml::xml_ncname!("role").to_owned(),
+                    sender.role.to_string(),
+                )
+                .attr(
+                    minidom::rxml::xml_ncname!("jid").to_owned(),
+                    sender.jid.to_string(),
+                )
+                .build(),
+        )
+        .build()
+}
+
+/// Build a XEP-0421 `<occupant-id xmlns='urn:xmpp:occupant-id:0'
+/// id='…'/>` element from the archived projection value.
+pub fn build_archived_occupant_id_element(id: &ArchivedOccupantId) -> Element {
+    Element::builder("occupant-id", OCCUPANT_ID_NS)
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id.as_str())
+        .build()
 }
 
 fn normalize_archived_inner_message(element: Element, archived: &ArchivedMessage) -> Element {
@@ -219,6 +275,20 @@ fn build_typed_inner_message(archived: &ArchivedMessage, rich: &ArchivedRichMess
                 )
                 .build(),
         );
+    }
+    if msg_type == MessageType::Groupchat {
+        // XEP-0421 Business Rules: occupant-id MUST be attached to
+        // every message sent by a MUC, including MAM history — the
+        // typed fallback must not drop it just because the row lacks
+        // `stanza_xml` (#1268).
+        if let Some(occupant_id) = rich.occupant_id.as_ref() {
+            builder = builder.append(build_archived_occupant_id_element(occupant_id));
+        }
+        // XEP-0313 §MUC Archives: non-anonymous rooms disclose the
+        // sender's real JID via a room-authored muc#user `<x/>`.
+        if let Some(sender) = rich.muc_sender.as_ref() {
+            builder = builder.append(build_archived_muc_sender_x(sender));
+        }
     }
     if let Some(reply) = rich.reply.as_ref() {
         let mut reply_builder = Element::builder("reply", REPLY_NS).attr(

--- a/server/crates/waddle-xmpp-core/src/mam/tests.rs
+++ b/server/crates/waddle-xmpp-core/src/mam/tests.rs
@@ -457,7 +457,12 @@ fn builds_result_message_from_legacy_fields() {
         )
     };
 
-    let msg = build_result_messages("query-1", &jid("user@example.com"), &[archived]);
+    let msg = build_result_messages(
+        "query-1",
+        &jid("archive@example.com"),
+        &jid("user@example.com"),
+        &[archived],
+    );
     let result = msg[0]
         .payloads
         .iter()
@@ -529,6 +534,8 @@ fn xep_0201_typed_replay_emits_thread_parent() {
     // own `<thread/>`.
     let archived = ArchivedMessage {
         rich: Some(ArchivedRichMessage {
+            occupant_id: None,
+            muc_sender: None,
             payload: None,
             reply: None,
             references: vec![],
@@ -536,7 +543,12 @@ fn xep_0201_typed_replay_emits_thread_parent() {
         }),
         ..nested_thread_archived_for_replay(None)
     };
-    let msgs = build_result_messages("q1", &jid("user@example.com"), &[archived]);
+    let msgs = build_result_messages(
+        "q1",
+        &jid("archive@example.com"),
+        &jid("user@example.com"),
+        &[archived],
+    );
     let thread = replay_inner_thread(&msgs[0]);
     assert_eq!(thread.text().trim(), "child-thread");
     assert_eq!(thread.attr("parent"), Some("root-thread"));
@@ -548,7 +560,12 @@ fn xep_0201_legacy_replay_emits_thread_parent() {
     // None — `build_legacy_inner_message` rebuilds purely from
     // scalar columns.
     let archived = nested_thread_archived_for_replay(None);
-    let msgs = build_result_messages("q2", &jid("user@example.com"), &[archived]);
+    let msgs = build_result_messages(
+        "q2",
+        &jid("archive@example.com"),
+        &jid("user@example.com"),
+        &[archived],
+    );
     let thread = replay_inner_thread(&msgs[0]);
     assert_eq!(thread.text().trim(), "child-thread");
     assert_eq!(thread.attr("parent"), Some("root-thread"));
@@ -580,7 +597,12 @@ fn xep_0201_groupchat_stanza_xml_replay_reinstalls_thread_and_strips_to() {
         )
     };
 
-    let msgs = build_result_messages("q-stanza-xml", &jid("bob@example.com/web"), &[archived]);
+    let msgs = build_result_messages(
+        "q-stanza-xml",
+        &jid("archive@example.com"),
+        &jid("bob@example.com/web"),
+        &[archived],
+    );
     let result = msgs[0]
         .payloads
         .iter()
@@ -628,7 +650,12 @@ fn xep_0201_replay_omits_thread_when_id_missing_even_with_parent() {
         rich: None,
         ..ArchivedMessage::for_test(jid("alice@example.com/web"), jid("bob@example.com"))
     };
-    let msgs = build_result_messages("q3", &jid("user@example.com"), &[archived]);
+    let msgs = build_result_messages(
+        "q3",
+        &jid("archive@example.com"),
+        &jid("user@example.com"),
+        &[archived],
+    );
     let result = msgs[0]
         .payloads
         .iter()
@@ -663,7 +690,12 @@ fn preserves_archived_stanza_payload() {
         )
     };
 
-    let msg = build_result_messages("query-2", &jid("user@example.com"), &[archived]);
+    let msg = build_result_messages(
+        "query-2",
+        &jid("archive@example.com"),
+        &jid("user@example.com"),
+        &[archived],
+    );
     let result = msg[0]
         .payloads
         .iter()
@@ -740,6 +772,8 @@ fn stanza_xml_preferred_over_rich_payload() {
             "<message xmlns='jabber:client' from='room@conference.example.com/alice' type='groupchat' id='live-1'><body>live body with extension payload</body><item xmlns='urn:example:task-widget:1' id='task-123' status='open'/></message>".to_string(),
         ),
         rich: Some(ArchivedRichMessage {
+            occupant_id: None,
+            muc_sender: None,
             payload: None,
             reply: None,
             references: vec![],
@@ -751,7 +785,12 @@ fn stanza_xml_preferred_over_rich_payload() {
         )
     };
 
-    let msg = build_result_messages("query-priority", &jid("user@example.com"), &[archived]);
+    let msg = build_result_messages(
+        "query-priority",
+        &jid("archive@example.com"),
+        &jid("user@example.com"),
+        &[archived],
+    );
     let result = msg[0]
         .payloads
         .iter()
@@ -792,6 +831,8 @@ fn stanza_xml_preserves_reply_fallback() {
             to: Some(jid("room@conference.example.com/alice")),
         }),
         rich: Some(ArchivedRichMessage {
+            occupant_id: None,
+            muc_sender: None,
             payload: None,
             reply: Some(ArchivedReply {
                 id: RichMessageId("orig-1".to_string()),
@@ -806,7 +847,12 @@ fn stanza_xml_preserves_reply_fallback() {
         )
     };
 
-    let msg = build_result_messages("query-fallback", &jid("user@example.com"), &[archived]);
+    let msg = build_result_messages(
+        "query-fallback",
+        &jid("archive@example.com"),
+        &jid("user@example.com"),
+        &[archived],
+    );
     let result = msg[0]
         .payloads
         .iter()
@@ -854,7 +900,12 @@ fn stanza_xml_strips_to_for_groupchat() {
         )
     };
 
-    let msg = build_result_messages("query-strip-to", &jid("user@example.com"), &[archived]);
+    let msg = build_result_messages(
+        "query-strip-to",
+        &jid("archive@example.com"),
+        &jid("user@example.com"),
+        &[archived],
+    );
     let result = msg[0]
         .payloads
         .iter()
@@ -890,7 +941,12 @@ fn stanza_xml_strips_to_for_groupchat_on_raw_element_fallback() {
         )
     };
 
-    let msg = build_result_messages("query-strip-raw", &jid("user@example.com"), &[archived]);
+    let msg = build_result_messages(
+        "query-strip-raw",
+        &jid("archive@example.com"),
+        &jid("user@example.com"),
+        &[archived],
+    );
     let result = msg[0]
         .payloads
         .iter()
@@ -977,4 +1033,116 @@ fn rejects_too_many_stanza_ids() {
     let iq = build_mam_iq_with_form_fields(&[(STANZA_ID_FILTER_FIELD, refs)]);
     let err = parse_mam_query(&iq).expect_err("must reject");
     assert!(matches!(err, CoreError::BadRequest(_)));
+}
+
+/// XEP-0313 §Security "Sender Impersonation" (#1250): the result
+/// envelope MUST carry `from` = the queried archive JID so conformant
+/// clients can match it against their open query instead of discarding
+/// it as unsolicited. For a MUC archive that is the room bare JID.
+#[test]
+fn result_envelope_from_is_the_queried_archive_jid() {
+    let archived = ArchivedMessage {
+        id: "row-1".to_string(),
+        body: Some("hi".to_string()),
+        message_type: MessageType::Groupchat,
+        ..ArchivedMessage::for_test(
+            jid("room@conference.example.com/alice"),
+            jid("room@conference.example.com"),
+        )
+    };
+
+    let msgs = build_result_messages(
+        "q-from",
+        &jid("room@conference.example.com"),
+        &jid("hag66@shakespeare.lit/pda"),
+        &[archived],
+    );
+
+    assert_eq!(msgs.len(), 1);
+    assert_eq!(
+        msgs[0].from.as_ref().map(|j| j.to_string()),
+        Some("room@conference.example.com".to_string()),
+        "result envelope `from` must be the queried archive JID"
+    );
+    assert_eq!(
+        msgs[0].to.as_ref().map(|j| j.to_string()),
+        Some("hag66@shakespeare.lit/pda".to_string())
+    );
+}
+
+/// XEP-0421 Business Rules + XEP-0313 §MUC Archives (#1268): the typed
+/// fallback reconstruction (row without `stanza_xml`) must re-emit the
+/// sender's `<occupant-id/>` and the room-authored non-anonymous
+/// real-JID `<x xmlns='muc#user'><item jid=…/></x>` captured in the
+/// rich projection.
+#[test]
+fn typed_fallback_emits_occupant_id_and_muc_user_item() {
+    let rich = ArchivedRichMessage {
+        occupant_id: ArchivedOccupantId::new("stable-occupant-id"),
+        muc_sender: Some(ArchivedMucSender {
+            jid: jid("crone1@shakespeare.lit/desktop"),
+            affiliation: crate::types::Affiliation::Owner,
+            role: crate::types::Role::Participant,
+        }),
+        ..ArchivedRichMessage::default()
+    };
+    let archived = ArchivedMessage {
+        id: "row-2".to_string(),
+        body: Some("Thrice the brinded cat hath mew'd.".to_string()),
+        message_type: MessageType::Groupchat,
+        rich: Some(rich),
+        ..ArchivedMessage::for_test(
+            jid("coven@chat.shakespeare.lit/firstwitch"),
+            jid("coven@chat.shakespeare.lit"),
+        )
+    };
+
+    let inner = archived_inner_message(&archived);
+
+    let occupant_id = inner
+        .children()
+        .find(|c| c.name() == "occupant-id" && c.ns() == OCCUPANT_ID_NS)
+        .expect("typed fallback must emit <occupant-id/>");
+    assert_eq!(occupant_id.attr("id"), Some("stable-occupant-id"));
+
+    let x = inner
+        .children()
+        .find(|c| c.name() == "x" && c.ns() == MUC_USER_NS)
+        .expect("typed fallback must emit muc#user <x/>");
+    let item = x.get_child("item", MUC_USER_NS).expect("item child");
+    assert_eq!(item.attr("jid"), Some("crone1@shakespeare.lit/desktop"));
+    assert_eq!(item.attr("affiliation"), Some("owner"));
+    assert_eq!(item.attr("role"), Some("participant"));
+}
+
+/// The MUC identity payloads are groupchat-only: a 1:1 chat row whose
+/// rich projection somehow carried them must NOT leak occupant-id /
+/// muc#user into the reconstructed 1:1 message.
+#[test]
+fn typed_fallback_omits_muc_identity_for_non_groupchat_rows() {
+    let rich = ArchivedRichMessage {
+        occupant_id: ArchivedOccupantId::new("stray-id"),
+        muc_sender: Some(ArchivedMucSender {
+            jid: jid("alice@example.com/web"),
+            affiliation: crate::types::Affiliation::Member,
+            role: crate::types::Role::Participant,
+        }),
+        ..ArchivedRichMessage::default()
+    };
+    let archived = ArchivedMessage {
+        id: "row-3".to_string(),
+        body: Some("hi".to_string()),
+        message_type: MessageType::Chat,
+        rich: Some(rich),
+        ..ArchivedMessage::for_test(jid("alice@example.com"), jid("bob@example.com"))
+    };
+
+    let inner = archived_inner_message(&archived);
+
+    assert!(
+        !inner
+            .children()
+            .any(|c| c.ns() == OCCUPANT_ID_NS || c.ns() == MUC_USER_NS),
+        "1:1 rows must not emit MUC identity payloads"
+    );
 }

--- a/server/crates/waddle-xmpp-core/src/mam/types.rs
+++ b/server/crates/waddle-xmpp-core/src/mam/types.rs
@@ -200,6 +200,29 @@ impl ArchivedRichMessage {
             ..self.clone()
         }
     }
+
+    /// True when this payload carries no client-authored content
+    /// (`payload` / `reply` / `references` / `mentions`) and no
+    /// server-derived MUC identity (`occupant_id` / `muc_sender`).
+    pub fn is_empty(&self) -> bool {
+        self.payload.is_none()
+            && self.reply.is_none()
+            && self.references.is_empty()
+            && self.mentions.is_empty()
+            && self.occupant_id.is_none()
+            && self.muc_sender.is_none()
+    }
+
+    /// The content-only projection used for XEP-0359 origin-id retry
+    /// dedup, normalized so an *empty* projection is `None` rather than
+    /// `Some(default)`. This makes "a row whose only rich content was
+    /// the server-stamped occupant-id / real-JID" compare equal to a
+    /// row that carried no `rich_payload` at all — the two are the same
+    /// logical message for dedup purposes.
+    pub fn dedup_content(&self) -> Option<Self> {
+        let content = self.content_only();
+        (!content.is_empty()).then_some(content)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/server/crates/waddle-xmpp-core/src/mam/types.rs
+++ b/server/crates/waddle-xmpp-core/src/mam/types.rs
@@ -181,6 +181,27 @@ pub struct ArchivedRichMessage {
     pub muc_sender: Option<ArchivedMucSender>,
 }
 
+impl ArchivedRichMessage {
+    /// Return a clone with the server-derived MUC identity fields
+    /// cleared. These fields ([`Self::occupant_id`],
+    /// [`Self::muc_sender`]) are stamped by the room service per
+    /// dispatch, not authored by the client — in particular
+    /// `muc_sender.jid` carries the sender's *per-session* full JID
+    /// (a fresh random resource each reconnect). They MUST be excluded
+    /// from XEP-0359 origin-id retry-dedup comparisons: a client that
+    /// resends the same origin-id from a fresh session is the same
+    /// logical message even though its resource (and possibly its
+    /// affiliation/role) changed. Comparing the identity fields would
+    /// break dedup and duplicate the row in the archive.
+    pub fn content_only(&self) -> Self {
+        Self {
+            occupant_id: None,
+            muc_sender: None,
+            ..self.clone()
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ThreadId(String);
 

--- a/server/crates/waddle-xmpp-core/src/mam/types.rs
+++ b/server/crates/waddle-xmpp-core/src/mam/types.rs
@@ -123,12 +123,62 @@ pub enum ArchivedRichPayload {
     Tombstone(ArchivedTombstone),
 }
 
+/// XEP-0421 occupant-id captured for an archived groupchat row.
+///
+/// Typed newtype (not a raw `String` field) per the typed-payloads
+/// hard rule. Carried in the `rich_payload` projection so the
+/// non-`stanza_xml` fallback reconstruction can re-emit the
+/// `<occupant-id/>` element XEP-0421 Business Rules require on every
+/// message sent by a MUC — including MAM history (#1268).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArchivedOccupantId(String);
+
+impl ArchivedOccupantId {
+    pub fn new(value: impl Into<String>) -> Option<Self> {
+        let value = value.into();
+        (!value.trim().is_empty()).then_some(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+/// XEP-0313 §MUC Archives real-JID disclosure for an archived
+/// groupchat row: "In the case of non-anonymous rooms … the archive
+/// message will use extended message information in an `<x/>` element
+/// qualified by the 'http://jabber.org/protocol/muc#user' namespace
+/// and containing an `<item/>` child with a 'jid' attribute
+/// specifying the occupant's full JID."
+///
+/// The room chain captures the sender's authority at dispatch time so
+/// MAM replay (both the `stanza_xml` path and the typed fallback) can
+/// reproduce the room-authored `<x/>` without re-resolving room state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArchivedMucSender {
+    /// The sender's real JID (full JID for live occupants).
+    pub jid: Jid,
+    /// XEP-0045 affiliation at message time.
+    pub affiliation: crate::types::Affiliation,
+    /// XEP-0045 role at message time.
+    pub role: crate::types::Role,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct ArchivedRichMessage {
     pub payload: Option<ArchivedRichPayload>,
     pub reply: Option<ArchivedReply>,
     pub references: Vec<ArchivedReference>,
     pub mentions: Vec<ArchivedMention>,
+    /// XEP-0421 occupant-id of the sender (groupchat rows only).
+    /// `#[serde(default)]` keeps previously-serialized rich payloads
+    /// decodable.
+    #[serde(default)]
+    pub occupant_id: Option<ArchivedOccupantId>,
+    /// XEP-0313 §MUC Archives non-anonymous real-JID item
+    /// (groupchat rows only).
+    #[serde(default)]
+    pub muc_sender: Option<ArchivedMucSender>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/server/crates/waddle-xmpp/src/mam/projection.rs
+++ b/server/crates/waddle-xmpp/src/mam/projection.rs
@@ -287,6 +287,11 @@ fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMessage> {
             reply,
             references,
             mentions,
+            // 1:1 archive rows have no MUC occupant identity; the
+            // groupchat projection (`rich_archive_payload` in the
+            // interpreter) is the path that captures these.
+            occupant_id: None,
+            muc_sender: None,
         })
     }
 }

--- a/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
@@ -53,7 +53,10 @@ fn archived_content_matches(existing: &ArchivedMessage, incoming: &ArchivedMessa
 }
 
 fn rich_content_matches(existing: &ArchivedMessage, incoming: &ArchivedMessage) -> bool {
-    let existing = existing.rich.as_ref().map(|rich| rich.content_only());
-    let incoming = incoming.rich.as_ref().map(|rich| rich.content_only());
+    // `dedup_content` normalizes an identity-only projection to `None`
+    // so a row whose only rich content was the server-stamped
+    // occupant-id / real-JID compares equal to a `rich: None` row.
+    let existing = existing.rich.as_ref().and_then(|rich| rich.dedup_content());
+    let incoming = incoming.rich.as_ref().and_then(|rich| rich.dedup_content());
     existing == incoming
 }

--- a/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
@@ -38,9 +38,22 @@ fn archived_content_matches(existing: &ArchivedMessage, incoming: &ArchivedMessa
     // MAM content must still match before origin-id is accepted as a
     // retry key; a reused origin-id with new content is a distinct
     // message and must be archived separately.
+    //
+    // The server-derived MUC identity fields (`occupant_id`,
+    // `muc_sender`) are ALSO excluded via `content_only()`:
+    // `muc_sender.jid` carries the sender's per-session full JID (a
+    // fresh random resource each reconnect), so comparing it would
+    // make every fresh-session retry look like new content and
+    // duplicate the archive row.
     existing.body == incoming.body
         && existing.thread == incoming.thread
         && existing.reply == incoming.reply
         && existing.message_type == incoming.message_type
-        && existing.rich == incoming.rich
+        && rich_content_matches(existing, incoming)
+}
+
+fn rich_content_matches(existing: &ArchivedMessage, incoming: &ArchivedMessage) -> bool {
+    let existing = existing.rich.as_ref().map(|rich| rich.content_only());
+    let incoming = incoming.rich.as_ref().map(|rich| rich.content_only());
+    existing == incoming
 }

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -573,17 +573,25 @@ fn parse_dedup_jid(archive_id: &str, column: &'static str, value: &str) -> Optio
 /// fails to decode falls back to raw-string equality (defensive:
 /// corrupt/foreign JSON should never spuriously dedup two rows).
 fn rich_payload_content_matches(existing: Option<&str>, incoming: Option<&str>) -> bool {
-    fn decode_content(value: Option<&str>) -> Option<ArchivedRichMessage> {
-        value
-            .filter(|value| !value.trim().is_empty())
-            .and_then(|value| serde_json::from_str::<ArchivedRichMessage>(value).ok())
-            .map(|rich| rich.content_only())
+    // `Ok(Some(_))` decoded to a non-empty content projection;
+    // `Ok(None)` is "absent, empty, or identity-only" (all normalize to
+    // no dedup-relevant content); `Err(())` is present-but-undecodable.
+    fn normalized(value: Option<&str>) -> Result<Option<ArchivedRichMessage>, ()> {
+        match value {
+            None => Ok(None),
+            Some(value) if value.trim().is_empty() => Ok(None),
+            Some(value) => match serde_json::from_str::<ArchivedRichMessage>(value) {
+                Ok(rich) => Ok(rich.dedup_content()),
+                Err(_) => Err(()),
+            },
+        }
     }
 
-    match (decode_content(existing), decode_content(incoming)) {
-        (Some(existing), Some(incoming)) => existing == incoming,
-        // At least one side is absent or undecodable — fall back to
-        // exact string equality (both `None` ⇒ trivially equal).
+    match (normalized(existing), normalized(incoming)) {
+        (Ok(existing), Ok(incoming)) => existing == incoming,
+        // At least one side is present-but-undecodable — fall back to
+        // conservative exact string equality (never spuriously merge
+        // two rows whose payloads we could not parse).
         _ => existing == incoming,
     }
 }
@@ -633,7 +641,7 @@ fn origin_dedup_fingerprint(message: &ArchivedMessage) -> String {
     let dedup_rich = message
         .rich
         .as_ref()
-        .map(|rich| rich.content_only())
+        .and_then(|rich| rich.dedup_content())
         .as_ref()
         .and_then(|rich| serde_json::to_string(rich).ok());
     update_hash_part(&mut hasher, "rich_payload", dedup_rich.as_deref());

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -25,7 +25,7 @@ pub(super) async fn store_message(
     let origin_dedup_fingerprint = message
         .origin_id
         .as_ref()
-        .map(|_| origin_dedup_fingerprint(message, rich_payload.as_deref()));
+        .map(|_| origin_dedup_fingerprint(message));
 
     if let Some(existing_archive_id) = find_existing_origin_id_match(
         backend,
@@ -187,7 +187,7 @@ pub(super) async fn store_message_fenced(
     let origin_dedup_fingerprint = message
         .origin_id
         .as_ref()
-        .map(|_| origin_dedup_fingerprint(message, rich_payload.as_deref()));
+        .map(|_| origin_dedup_fingerprint(message));
 
     if let Some(existing_archive_id) = find_existing_origin_id_match(
         backend,
@@ -506,7 +506,7 @@ impl OriginDedupRow {
             && self.reply_to_jid.as_ref()
                 == incoming.reply.as_ref().and_then(|reply| reply.to.as_ref())
             && self.message_type == incoming.message_type
-            && self.rich_payload.as_deref() == incoming_rich_payload
+            && rich_payload_content_matches(self.rich_payload.as_deref(), incoming_rich_payload)
     }
 
     fn sender_scope_matches(&self, incoming: &ArchivedMessage) -> bool {
@@ -567,7 +567,28 @@ fn parse_dedup_jid(archive_id: &str, column: &'static str, value: &str) -> Optio
     }
 }
 
-fn origin_dedup_fingerprint(message: &ArchivedMessage, rich_payload: Option<&str>) -> String {
+/// Compare two encoded `rich_payload` JSON blobs for origin-id retry
+/// dedup, ignoring the server-derived MUC identity fields
+/// (`occupant_id`, `muc_sender`) that vary per session. A blob that
+/// fails to decode falls back to raw-string equality (defensive:
+/// corrupt/foreign JSON should never spuriously dedup two rows).
+fn rich_payload_content_matches(existing: Option<&str>, incoming: Option<&str>) -> bool {
+    fn decode_content(value: Option<&str>) -> Option<ArchivedRichMessage> {
+        value
+            .filter(|value| !value.trim().is_empty())
+            .and_then(|value| serde_json::from_str::<ArchivedRichMessage>(value).ok())
+            .map(|rich| rich.content_only())
+    }
+
+    match (decode_content(existing), decode_content(incoming)) {
+        (Some(existing), Some(incoming)) => existing == incoming,
+        // At least one side is absent or undecodable — fall back to
+        // exact string equality (both `None` ⇒ trivially equal).
+        _ => existing == incoming,
+    }
+}
+
+fn origin_dedup_fingerprint(message: &ArchivedMessage) -> String {
     let mut hasher = Sha256::new();
     update_hash_part(
         &mut hasher,
@@ -602,7 +623,20 @@ fn origin_dedup_fingerprint(message: &ArchivedMessage, rich_payload: Option<&str
         .and_then(|reply| reply.to.as_ref())
         .map(|jid| jid.to_string());
     update_hash_part(&mut hasher, "reply_to_jid", reply_to_jid.as_deref());
-    update_hash_part(&mut hasher, "rich_payload", rich_payload);
+    // Hash the CONTENT-ONLY rich payload, not the full one bound to the
+    // `rich_payload` column: the server-derived MUC identity fields
+    // (`occupant_id`, `muc_sender`) carry per-session data
+    // (`muc_sender.jid` is a fresh random resource each reconnect), so
+    // including them would make every fresh-session origin-id retry
+    // fingerprint differently and defeat dedup. `content_only()` clears
+    // them, matching the in-memory `origin_id_dedup_match` check.
+    let dedup_rich = message
+        .rich
+        .as_ref()
+        .map(|rich| rich.content_only())
+        .as_ref()
+        .and_then(|rich| serde_json::to_string(rich).ok());
+    update_hash_part(&mut hasher, "rich_payload", dedup_rich.as_deref());
     let digest = hasher.finalize();
     let mut hex = String::with_capacity(digest.len() * 2);
     for byte in digest {

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -635,6 +635,11 @@ pub(super) async fn replace_with_tombstone(
         reply: None,
         references: Vec::new(),
         mentions: Vec::new(),
+        // XEP-0424 §Tombstones: the occupant-id and real-JID item
+        // identify the original sender and MUST NOT survive the
+        // tombstone replacement.
+        occupant_id: None,
+        muc_sender: None,
     };
     let encoded = serde_json::to_string(&payload)
         .map_err(|error| MamStorageError::Serialization(error.to_string()))?;

--- a/server/crates/waddle-xmpp/src/mam/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tests.rs
@@ -250,9 +250,29 @@ async fn assert_origin_id_dedup_ignores_per_session_muc_sender(storage: &dyn Mam
         ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
     };
 
+    // A retry whose rich projection is entirely absent (`None`) — e.g.
+    // a legacy row or a path that didn't capture identity — must STILL
+    // dedup against an identity-only stored row: the identity-only
+    // projection normalizes to "no dedup-relevant content", same as
+    // `None` (codex second-pass finding).
+    let retry_no_rich = ArchivedMessage {
+        id: "archive-session-retry-no-rich".to_string(),
+        timestamp: base_timestamp,
+        body: Some("resent across sessions".to_string()),
+        origin_id: Some(origin_id.clone()),
+        message_type: xmpp_parsers::message::MessageType::Groupchat,
+        nickname_generation: Some(3),
+        rich: None,
+        ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
+    };
+
     let first_id = storage.store_message(&archive, &first).await.unwrap();
     let retry_id = storage
         .store_message(&archive, &retry_fresh_session)
+        .await
+        .unwrap();
+    let retry_no_rich_id = storage
+        .store_message(&archive, &retry_no_rich)
         .await
         .unwrap();
 
@@ -260,6 +280,10 @@ async fn assert_origin_id_dedup_ignores_per_session_muc_sender(storage: &dyn Mam
     assert_eq!(
         retry_id, first_id,
         "fresh-session retry must dedup despite a differing per-session muc_sender"
+    );
+    assert_eq!(
+        retry_no_rich_id, first_id,
+        "a rich=None retry must dedup against an identity-only stored row"
     );
 
     let result = storage

--- a/server/crates/waddle-xmpp/src/mam/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tests.rs
@@ -180,6 +180,100 @@ async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn
 }
 
 #[tokio::test]
+async fn test_sqlite_origin_id_dedup_ignores_per_session_muc_sender() {
+    let storage = create_test_storage().await;
+    assert_origin_id_dedup_ignores_per_session_muc_sender(&storage).await;
+}
+
+#[tokio::test]
+async fn test_inmemory_origin_id_dedup_ignores_per_session_muc_sender() {
+    let storage = InMemoryMamStorage::new();
+    assert_origin_id_dedup_ignores_per_session_muc_sender(&storage).await;
+}
+
+/// Regression (#1268 follow-up): the XEP-0313 §MUC Archives real-JID
+/// disclosure (`muc_sender`) carries the sender's *per-session* full
+/// JID (a fresh random resource each reconnect). A fresh-session
+/// origin-id retry MUST still dedup — the identity fields are excluded
+/// from the dedup fingerprint / content comparison — otherwise the
+/// same logical message is archived twice and duplicated in history.
+async fn assert_origin_id_dedup_ignores_per_session_muc_sender(storage: &dyn MamStorage) {
+    use waddle_xmpp_core::mam::{ArchivedMucSender, ArchivedOccupantId, ArchivedRichMessage};
+    use waddle_xmpp_core::types::{Affiliation, Role};
+
+    let archive = bare("room@conference.example.com");
+    let archive_jid = jid("room@conference.example.com");
+    let origin_id = waddle_xmpp_core::xep0359::OriginId::new("client-origin-session");
+    let base_timestamp = DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+        .expect("valid timestamp")
+        .with_timezone(&Utc);
+
+    // Occupant-id is a stable HMAC of (bare, room, secret) — identical
+    // across sessions. muc_sender.jid is the per-session full JID.
+    let stable_occupant_id = ArchivedOccupantId::new("stable-occupant-id");
+    let first = ArchivedMessage {
+        id: "archive-session-first".to_string(),
+        timestamp: base_timestamp,
+        body: Some("resent across sessions".to_string()),
+        origin_id: Some(origin_id.clone()),
+        message_type: xmpp_parsers::message::MessageType::Groupchat,
+        nickname_generation: Some(3),
+        rich: Some(ArchivedRichMessage {
+            occupant_id: stable_occupant_id.clone(),
+            muc_sender: Some(ArchivedMucSender {
+                jid: jid("alice@example.com/session-A"),
+                affiliation: Affiliation::Member,
+                role: Role::Participant,
+            }),
+            ..ArchivedRichMessage::default()
+        }),
+        ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
+    };
+    let retry_fresh_session = ArchivedMessage {
+        id: "archive-session-retry".to_string(),
+        timestamp: base_timestamp,
+        body: Some("resent across sessions".to_string()),
+        origin_id: Some(origin_id.clone()),
+        message_type: xmpp_parsers::message::MessageType::Groupchat,
+        nickname_generation: Some(3),
+        rich: Some(ArchivedRichMessage {
+            occupant_id: stable_occupant_id,
+            muc_sender: Some(ArchivedMucSender {
+                // Fresh session ⇒ different resource, and the
+                // affiliation happens to have changed too.
+                jid: jid("alice@example.com/session-B"),
+                affiliation: Affiliation::Admin,
+                role: Role::Moderator,
+            }),
+            ..ArchivedRichMessage::default()
+        }),
+        ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
+    };
+
+    let first_id = storage.store_message(&archive, &first).await.unwrap();
+    let retry_id = storage
+        .store_message(&archive, &retry_fresh_session)
+        .await
+        .unwrap();
+
+    assert_eq!(first_id, "archive-session-first");
+    assert_eq!(
+        retry_id, first_id,
+        "fresh-session retry must dedup despite a differing per-session muc_sender"
+    );
+
+    let result = storage
+        .query_messages(&archive, &MamQuery::default())
+        .await
+        .unwrap();
+    assert_eq!(
+        result.messages.len(),
+        1,
+        "the message must be archived exactly once"
+    );
+}
+
+#[tokio::test]
 async fn test_sqlite_origin_id_dedup_uses_bare_sender_for_direct_messages() {
     let storage = create_test_storage().await;
     assert_origin_id_dedup_uses_bare_sender_for_direct_messages(&storage).await;

--- a/server/crates/waddle-xmpp/src/mam/storage/tombstone.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tombstone.rs
@@ -26,5 +26,10 @@ pub(super) fn apply_tombstone(
         reply: None,
         references: Vec::new(),
         mentions: Vec::new(),
+        // XEP-0424 §Tombstones: the occupant-id and real-JID item
+        // identify the original sender and MUST NOT survive the
+        // tombstone replacement.
+        occupant_id: None,
+        muc_sender: None,
     });
 }

--- a/server/crates/waddle-xmpp/src/muc/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/mod.rs
@@ -58,3 +58,23 @@ pub use room_registry_handle::{
     ROOM_REGISTRY_REPLY_TIMEOUT, ROOM_REGISTRY_SLOW_ASK_WARN,
 };
 pub use subject::{RoomSubjectTexts, SubjectState};
+
+/// True when `ns` is a MUC *service* namespace whose payloads are
+/// authored by the room service, never by an occupant client:
+/// `http://jabber.org/protocol/muc` and its `#user` / `#admin` /
+/// `#owner` fragments.
+///
+/// XEP-0313 §Security "MUC message spoofing" and XEP-0045
+/// anti-spoofing require the service to strip any occupant-supplied
+/// payload in these namespaces from both groupchat messages (before
+/// reflect/archive) and private messages (before routing), so an
+/// occupant cannot forge affiliation/role/status/invite signalling
+/// that appears to come from `room/nick` (#1251, #1268). Shared by the
+/// groupchat canonicalizer and the MUC-PM canonicalizer so both agree
+/// on the exact namespace set.
+pub fn is_muc_service_namespace(ns: &str) -> bool {
+    matches!(
+        ns,
+        presence::NS_MUC | presence::NS_MUC_USER | NS_MUC_ADMIN | NS_MUC_OWNER
+    )
+}

--- a/server/crates/waddle-xmpp/src/muc/presence.rs
+++ b/server/crates/waddle-xmpp/src/muc/presence.rs
@@ -541,12 +541,17 @@ pub struct DestroyRequest {
 ///
 /// `is_self` adds XEP-0045 status code 110 so the recipient
 /// recognizes the presence as their own.
+///
+/// `identity` stamps the XEP-0421 `<occupant-id/>` — the Business
+/// Rules require it on *every* presence sent by a MUC, and the destroy
+/// notification is the occupant's final unavailable presence (#1268).
 pub fn build_destroy_notification(
     room_jid: &BareJid,
     occupant_nick: &str,
     occupant_jid: &FullJid,
     destroy_request: &DestroyRequest,
     is_self: bool,
+    identity: &OccupantIdentity<'_>,
 ) -> Presence {
     let from_room_jid = room_jid
         .with_resource_str(occupant_nick)
@@ -557,7 +562,7 @@ pub fn build_destroy_notification(
         });
 
     let mut presence = Presence::new(PresenceType::Unavailable);
-    presence.from = Some(Jid::from(from_room_jid));
+    presence.from = Some(Jid::from(from_room_jid.clone()));
     presence.to = Some(Jid::from(occupant_jid.clone()));
 
     // The typed MucUser serializer omits affiliation='none' / role='none'
@@ -604,5 +609,6 @@ pub fn build_destroy_notification(
     }
 
     presence.payloads.push(x_elem.build());
+    add_presence_identity_payloads(&mut presence, &from_room_jid, identity);
     presence
 }

--- a/server/crates/waddle-xmpp/src/muc/presence/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/presence/tests.rs
@@ -568,7 +568,20 @@ fn test_build_destroy_notification() {
         password: None,
     };
 
-    let presence = build_destroy_notification(&room_jid, "user", &occupant_jid, &request, true);
+    let secret = test_secret();
+    let occupant_bare = occupant_jid.to_bare();
+    let presence = build_destroy_notification(
+        &room_jid,
+        "user",
+        &occupant_jid,
+        &request,
+        true,
+        &OccupantIdentity {
+            bare_jid: &occupant_bare,
+            real_jid: Some(&occupant_jid),
+            secret: &secret,
+        },
+    );
 
     assert!(matches!(presence.type_, PresenceType::Unavailable));
     assert!(presence.from.is_some());
@@ -602,6 +615,14 @@ fn test_build_destroy_notification() {
         status_110.is_some(),
         "self-presence must carry status code 110"
     );
+
+    // XEP-0421 Business Rules: occupant-id MUST be on every presence
+    // sent by a MUC — the destroy notification included (#1268).
+    let occupant_id = crate::xep::xep0421::extract_occupant_id_from_presence(&presence)
+        .expect("destroy presence carries occupant-id");
+    let expected =
+        crate::xep::xep0421::generate_occupant_id(&occupant_jid.to_bare(), &room_jid, &secret);
+    assert_eq!(occupant_id, expected);
 }
 
 /// XEP-0045 §10.9: a destroy notification addressed to a different
@@ -612,12 +633,19 @@ fn test_build_destroy_notification_not_self_minimal() {
     use jid::BareJid;
     let room_jid: BareJid = "room@muc.example.com".parse().unwrap();
     let occupant_jid: FullJid = "bob@example.com/desk".parse().unwrap();
+    let secret = test_secret();
+    let occupant_bare = occupant_jid.to_bare();
     let presence = build_destroy_notification(
         &room_jid,
         "alice",
         &occupant_jid,
         &DestroyRequest::default(),
         false,
+        &OccupantIdentity {
+            bare_jid: &occupant_bare,
+            real_jid: Some(&occupant_jid),
+            secret: &secret,
+        },
     );
     let x_elem = presence
         .payloads

--- a/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
@@ -111,11 +111,21 @@ pub enum OutboundEvent {
     /// chain via `RoomContext`) so the archive arm can stamp the
     /// archive row without a second `RoomActor::GetRoomSnapshot`
     /// round-trip (Copilot review on PR #279).
+    ///
+    /// `sender_item` is the sender's typed authority snapshot
+    /// (real JID + affiliation + role) captured at dispatch time.
+    /// XEP-0313 §MUC Archives requires non-anonymous rooms to
+    /// disclose the sender's real JID in archived messages via a
+    /// room-authored `<x xmlns='muc#user'><item jid=…/></x>`; the
+    /// interpreter bakes it into the archived copy only — the live
+    /// reflection never carries it (#1268). `None` for synthetic
+    /// dispatches with no occupant snapshot.
     ArchiveGroupchat {
         room: BareJid,
         sender: FullJid,
         message: Box<Message>,
         sender_nickname_generation: u64,
+        sender_item: Option<waddle_xmpp_core::mam::ArchivedMucSender>,
     },
     /// Persist a one-to-one direct message to the MAM archive.
     ///

--- a/server/crates/waddle-xmpp/src/protocol/room/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/archive.rs
@@ -54,11 +54,24 @@ impl RoomHandler for MucArchiveHandler {
     fn handle(&self, message: &mut Message, ctx: &RoomContext<'_>) -> RoomHandlerOutcome {
         let mut events = Vec::new();
         if is_archivable(message) {
+            // XEP-0313 §MUC Archives: capture the sender's typed
+            // authority (real JID + affiliation + role) so the
+            // interpreter can bake the non-anonymous real-JID
+            // disclosure `<x xmlns='muc#user'>` into the archived
+            // copy (#1268). Waddle rooms are all `muc_nonanonymous`.
+            let sender_item =
+                ctx.sender_snapshot()
+                    .map(|snapshot| waddle_xmpp_core::mam::ArchivedMucSender {
+                        jid: jid::Jid::from(snapshot.full_jid.clone()),
+                        affiliation: snapshot.affiliation,
+                        role: snapshot.role,
+                    });
             events.push(OutboundEvent::ArchiveGroupchat {
                 room: ctx.room.clone(),
                 sender: ctx.sender_full.clone(),
                 message: Box::new(message.clone()),
                 sender_nickname_generation: ctx.sender_nickname_generation,
+                sender_item,
             });
         }
         if let Some(RetractionKind::Request(retraction)) = extract_retraction_from_message(message)

--- a/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
@@ -96,10 +96,15 @@ impl RoomHandler for MucCanonicalizeHandler {
         //    anti-spoofing rewrite is unconditional: the invariant
         //    "nothing client-forgeable in a MUC service namespace ever
         //    reaches archive or reflection" must not depend on the
-        //    occupancy gate having run (defense-in-depth).
-        message
-            .payloads
-            .retain(|p| !crate::muc::is_muc_service_namespace(p.ns().as_str()));
+        //    occupancy gate having run (defense-in-depth). The
+        //    client-supplied XEP-0421 `<occupant-id/>` is stripped here
+        //    too: the snapshot-less early return below skips step 4's
+        //    strip-and-re-stamp, so without this a forged occupant-id
+        //    could otherwise survive on that defensive path.
+        message.payloads.retain(|p| {
+            !crate::muc::is_muc_service_namespace(p.ns().as_str())
+                && !crate::xep::xep0421::is_occupant_id_element(p)
+        });
 
         let Some(sender) = ctx.sender_snapshot() else {
             // OccupancyValidationHandler should have halted before us.
@@ -236,6 +241,73 @@ mod tests {
             RoomHandlerOutcome::Continue(e) => e,
             RoomHandlerOutcome::Halt(_) => panic!("canonicalize never halts"),
         }
+    }
+
+    /// Defense-in-depth (#1251 / Greptile P1): even on the snapshot-less
+    /// early-return path — where step 4's occupant-id strip-and-re-stamp
+    /// never runs — a client-forged MUC service payload AND a forged
+    /// XEP-0421 `<occupant-id/>` MUST be stripped before archive/reflection.
+    #[test]
+    fn anti_spoof_strip_runs_without_sender_snapshot() {
+        let room = bare("team@conf.example.com");
+        let sender = full("mallory@example.com/web");
+        let mut msg = groupchat(&room, &sender, "hi");
+        msg.payloads.push(
+            minidom::Element::builder("x", crate::muc::presence::NS_MUC_USER)
+                .append(
+                    minidom::Element::builder("item", crate::muc::presence::NS_MUC_USER)
+                        .attr(
+                            minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                            "owner",
+                        )
+                        .build(),
+                )
+                .build(),
+        );
+        msg.payloads
+            .push(crate::xep::xep0421::build_occupant_id_element(
+                &crate::xep::xep0421::OccupantId::new("forged-id"),
+            ));
+
+        // Empty occupant list ⇒ `sender_snapshot()` is None ⇒ the
+        // handler takes the defensive early return after the strip.
+        let occupants: Vec<OccupantSnapshot> = Vec::new();
+        let id_gen = FixedIdGenerator("ignored".to_string());
+        let secret = OccupantIdSecret::for_testing(b"test-secret".to_vec());
+        let ctx = RoomContext {
+            room: &room,
+            sender_full: &sender,
+            occupants: &occupants,
+            durable_recipient_bare_jids: &[],
+            managed_room_forbidden: false,
+            room_moderated: false,
+            room_members_only: false,
+            pin_permission: crate::muc::PinPermission::default(),
+            id_gen: &id_gen,
+            occupant_id_secret: &secret,
+            sender_nickname_generation: 0,
+            project_sender_inbox: true,
+            synthetic_sender_authority: None,
+            dispatch_timestamp: 0,
+        };
+        assert!(ctx.sender_snapshot().is_none(), "test requires no snapshot");
+        match MucCanonicalizeHandler.handle(&mut msg, &ctx) {
+            RoomHandlerOutcome::Continue(_) => {}
+            RoomHandlerOutcome::Halt(_) => panic!("canonicalize never halts"),
+        }
+
+        assert!(
+            !msg.payloads
+                .iter()
+                .any(|p| p.ns() == crate::muc::presence::NS_MUC_USER),
+            "forged muc#user must be stripped even without a sender snapshot"
+        );
+        assert!(
+            !msg.payloads
+                .iter()
+                .any(crate::xep::xep0421::is_occupant_id_element),
+            "forged occupant-id must be stripped even without a sender snapshot"
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
@@ -48,23 +48,6 @@ use xmpp_parsers::message::Message;
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MucCanonicalizeHandler;
 
-/// True when `payload` lives in a MUC service namespace a client must
-/// not inject into a groupchat message: `http://jabber.org/protocol/muc`
-/// and its `#user` / `#admin` / `#owner` fragments. These namespaces
-/// carry service-authored room signalling (affiliation/role items,
-/// status codes, invites, admin/owner payloads); XEP-0313 §Security
-/// "MUC message spoofing" requires stripping them from occupant
-/// messages before reflection/archiving.
-fn is_client_forgeable_muc_payload(payload: &minidom::Element) -> bool {
-    matches!(
-        payload.ns().as_str(),
-        crate::muc::presence::NS_MUC
-            | crate::muc::presence::NS_MUC_USER
-            | crate::muc::NS_MUC_ADMIN
-            | crate::muc::NS_MUC_OWNER
-    )
-}
-
 fn replace_stanza_thread(message: &mut Message, thread_id: impl Into<String>) {
     let thread_id = thread_id.into();
     // An empty `thread_id` would emit a malformed `<thread></thread>`
@@ -98,12 +81,6 @@ impl RoomHandler for MucCanonicalizeHandler {
     }
 
     fn handle(&self, message: &mut Message, ctx: &RoomContext<'_>) -> RoomHandlerOutcome {
-        let Some(sender) = ctx.sender_snapshot() else {
-            // OccupancyValidationHandler should have halted before us.
-            // Be defensive: skip canonicalization if somehow not.
-            return RoomHandlerOutcome::Continue(Vec::new());
-        };
-
         // 0. Strip client-supplied MUC-namespace payloads. XEP-0313
         //    §Security "MUC message spoofing": "the archiving entity
         //    MUST strip any existing <x> element in the
@@ -114,9 +91,22 @@ impl RoomHandler for MucCanonicalizeHandler {
         //    service. The presence path (`muc_update.rs`) and the PM
         //    path (`muc_direct.rs`) already strip these — this closes
         //    the groupchat-message gap (#1251).
+        //
+        //    Done BEFORE the `sender_snapshot()` guard so the
+        //    anti-spoofing rewrite is unconditional: the invariant
+        //    "nothing client-forgeable in a MUC service namespace ever
+        //    reaches archive or reflection" must not depend on the
+        //    occupancy gate having run (defense-in-depth).
         message
             .payloads
-            .retain(|p| !is_client_forgeable_muc_payload(p));
+            .retain(|p| !crate::muc::is_muc_service_namespace(p.ns().as_str()));
+
+        let Some(sender) = ctx.sender_snapshot() else {
+            // OccupancyValidationHandler should have halted before us.
+            // Be defensive: skip the rest of canonicalization if
+            // somehow not — the anti-spoofing strip above already ran.
+            return RoomHandlerOutcome::Continue(Vec::new());
+        };
 
         // 1. Strip same-`by=room` stanza-id siblings (typed BareJid
         //    equality so case-folded variants strip; mirrors the 1:1

--- a/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/canonicalize.rs
@@ -4,8 +4,16 @@
 //! Mutates the in-flight message so subsequent room handlers (archive,
 //! reflector) and the eventual wire write see the canonicalized form.
 //!
-//! Four rewrites in order:
+//! Five rewrites in order:
 //!
+//! 0. **Strip client-supplied MUC-namespace payloads** (`muc`,
+//!    `muc#user`, `muc#admin`, `muc#owner`). XEP-0313 §Security "MUC
+//!    message spoofing" + XEP-0045 anti-spoofing: an occupant could
+//!    otherwise forge `<x xmlns='muc#user'>` affiliation/role/status
+//!    signalling that appears to come from `room/nick`, and the
+//!    forgery would be reflected live AND persisted into the room
+//!    archive (#1251). Canonicalize runs before the archive and
+//!    reflector handlers, so this single strip covers both paths.
 //! 1. **Strip same-`by=room`** XEP-0359 `<stanza-id>` siblings (XEP-0359
 //!    §5 strip rule, room scope). Defends against client spoofing of a
 //!    stamp claiming to come from the room archive.
@@ -39,6 +47,23 @@ use xmpp_parsers::message::Message;
 /// chain.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct MucCanonicalizeHandler;
+
+/// True when `payload` lives in a MUC service namespace a client must
+/// not inject into a groupchat message: `http://jabber.org/protocol/muc`
+/// and its `#user` / `#admin` / `#owner` fragments. These namespaces
+/// carry service-authored room signalling (affiliation/role items,
+/// status codes, invites, admin/owner payloads); XEP-0313 §Security
+/// "MUC message spoofing" requires stripping them from occupant
+/// messages before reflection/archiving.
+fn is_client_forgeable_muc_payload(payload: &minidom::Element) -> bool {
+    matches!(
+        payload.ns().as_str(),
+        crate::muc::presence::NS_MUC
+            | crate::muc::presence::NS_MUC_USER
+            | crate::muc::NS_MUC_ADMIN
+            | crate::muc::NS_MUC_OWNER
+    )
+}
 
 fn replace_stanza_thread(message: &mut Message, thread_id: impl Into<String>) {
     let thread_id = thread_id.into();
@@ -78,6 +103,20 @@ impl RoomHandler for MucCanonicalizeHandler {
             // Be defensive: skip canonicalization if somehow not.
             return RoomHandlerOutcome::Continue(Vec::new());
         };
+
+        // 0. Strip client-supplied MUC-namespace payloads. XEP-0313
+        //    §Security "MUC message spoofing": "the archiving entity
+        //    MUST strip any existing <x> element in the
+        //    'http://jabber.org/protocol/muc#user' namespace from
+        //    messages before archiving them"; XEP-0045 likewise
+        //    reserves room signalling (`muc#user` items/statuses/
+        //    invites, `muc#admin`/`muc#owner` payloads) to the
+        //    service. The presence path (`muc_update.rs`) and the PM
+        //    path (`muc_direct.rs`) already strip these — this closes
+        //    the groupchat-message gap (#1251).
+        message
+            .payloads
+            .retain(|p| !is_client_forgeable_muc_payload(p));
 
         // 1. Strip same-`by=room` stanza-id siblings (typed BareJid
         //    equality so case-folded variants strip; mirrors the 1:1
@@ -426,5 +465,104 @@ mod tests {
         let from = msg.from.as_ref().expect("from set");
         assert_eq!(from.to_string(), "team@conf.example.com/alice-nick");
         assert!(msg.to.is_none(), "to is dropped for fan-out");
+    }
+
+    /// XEP-0313 §Security "MUC message spoofing" + XEP-0045
+    /// anti-spoofing (#1251): a client-supplied
+    /// `<x xmlns='http://jabber.org/protocol/muc#user'>` carrying
+    /// forged `<item/>` / `<status/>` room signalling MUST be
+    /// stripped before the message is reflected or archived.
+    #[test]
+    fn xep_0045_strips_client_supplied_muc_user_x() {
+        let room = bare("team@conf.example.com");
+        let sender = full("mallory@example.com/web");
+        let mut msg = groupchat(&room, &sender, "hi");
+        let ns_user = crate::muc::presence::NS_MUC_USER;
+        msg.payloads.push(
+            minidom::Element::builder("x", ns_user)
+                .append(
+                    minidom::Element::builder("item", ns_user)
+                        .attr(
+                            minidom::rxml::xml_ncname!("jid").to_owned(),
+                            "victim@example.com",
+                        )
+                        .attr(
+                            minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                            "owner",
+                        )
+                        .attr(minidom::rxml::xml_ncname!("role").to_owned(), "moderator")
+                        .build(),
+                )
+                .append(
+                    minidom::Element::builder("status", ns_user)
+                        .attr(minidom::rxml::xml_ncname!("code").to_owned(), "110")
+                        .build(),
+                )
+                .build(),
+        );
+
+        run(&room, &sender, "mallory", &mut msg, "stamp-1");
+
+        assert!(
+            !msg.payloads.iter().any(|p| p.ns() == ns_user),
+            "client-supplied muc#user <x> must be stripped before reflect/archive"
+        );
+        // The legitimate body survives.
+        assert!(!msg.bodies.is_empty());
+    }
+
+    /// The other MUC service namespaces (`muc`, `muc#admin`,
+    /// `muc#owner`) are equally service-authored; a client must not be
+    /// able to smuggle payloads in them through a groupchat message.
+    #[test]
+    fn xep_0045_strips_all_client_supplied_muc_service_namespaces() {
+        let room = bare("team@conf.example.com");
+        let sender = full("mallory@example.com/web");
+        let mut msg = groupchat(&room, &sender, "hi");
+        for ns in [
+            crate::muc::presence::NS_MUC,
+            crate::muc::NS_MUC_ADMIN,
+            crate::muc::NS_MUC_OWNER,
+        ] {
+            msg.payloads
+                .push(minidom::Element::builder("x", ns).build());
+        }
+
+        run(&room, &sender, "mallory", &mut msg, "stamp-1");
+
+        for ns in [
+            crate::muc::presence::NS_MUC,
+            crate::muc::presence::NS_MUC_USER,
+            crate::muc::NS_MUC_ADMIN,
+            crate::muc::NS_MUC_OWNER,
+        ] {
+            assert!(
+                !msg.payloads.iter().any(|p| p.ns() == ns),
+                "payloads in `{ns}` must be stripped from occupant groupchat messages"
+            );
+        }
+    }
+
+    /// Non-MUC payloads (the message's own extensions) must survive
+    /// the anti-spoofing strip untouched.
+    #[test]
+    fn xep_0045_strip_preserves_non_muc_payloads() {
+        let room = bare("team@conf.example.com");
+        let sender = full("alice@example.com/web");
+        let mut msg = groupchat(&room, &sender, "hi");
+        msg.payloads
+            .push(minidom::Element::builder("x", crate::muc::presence::NS_MUC_USER).build());
+        msg.payloads.push(
+            minidom::Element::builder("active", "http://jabber.org/protocol/chatstates").build(),
+        );
+
+        run(&room, &sender, "alice-nick", &mut msg, "stamp-1");
+
+        assert!(
+            msg.payloads
+                .iter()
+                .any(|p| p.name() == "active" && p.ns() == "http://jabber.org/protocol/chatstates"),
+            "non-MUC payloads must survive the anti-spoofing strip"
+        );
     }
 }

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_mam_stanza_id_tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_mam_stanza_id_tests.rs
@@ -332,7 +332,8 @@ async fn stanza_id_filter_preserves_rich_payload_roundtrip() {
 
     // Run through the wire serializer used by the MAM IQ handler.
     let requester = jid("alice@example.com/device");
-    let wire_messages = build_result_messages("qid-1", &requester, &result.messages);
+    let archive = jid("alice@example.com");
+    let wire_messages = build_result_messages("qid-1", &archive, &requester, &result.messages);
     assert_eq!(wire_messages.len(), 1, "one wire message produced");
 
     // Extract the inner forwarded stanza from the MAM result element and

--- a/server/crates/waddle-xmpp/tests/xep0201_thread_parent.rs
+++ b/server/crates/waddle-xmpp/tests/xep0201_thread_parent.rs
@@ -114,6 +114,7 @@ async fn xep_0201_nested_thread_round_trips_through_mam() {
     // carries `<thread parent='root-thread'>child-thread</thread>`.
     let envelopes = waddle_xmpp_core::mam::build_result_messages(
         "q1",
+        &jid_lit("room@conference.example.com"),
         &jid_lit("alice@example.com"),
         &result.messages,
     );
@@ -209,8 +210,12 @@ fn xep_0201_groupchat_stanza_xml_replay_preserves_thread_metadata() {
         nickname_generation: Some(0),
     };
 
-    let envelopes =
-        waddle_xmpp_core::mam::build_result_messages("q-xml", &jid_lit("bob@example.com"), &[row]);
+    let envelopes = waddle_xmpp_core::mam::build_result_messages(
+        "q-xml",
+        &jid_lit("room@conference.example.com"),
+        &jid_lit("bob@example.com"),
+        &[row],
+    );
     let result_payload = envelopes[0]
         .payloads
         .iter()

--- a/server/crates/waddle-xmpp/tests/xep0313_mam.rs
+++ b/server/crates/waddle-xmpp/tests/xep0313_mam.rs
@@ -15,3 +15,194 @@ fn muc_room_disco_advertises_mam_extended_for_supported_id_filters() {
     assert!(features.contains(&Feature::mam()));
     assert!(features.contains(&Feature::mam_extended()));
 }
+
+// ── §Security "Sender Impersonation" + "MUC message spoofing" +
+//    §MUC Archives (PR for #1250 / #1251 / #1268) ────────────────────
+
+use jid::{BareJid, FullJid, Jid};
+use waddle_xmpp::protocol::event::OutboundEvent;
+use waddle_xmpp::protocol::id_gen::FixedIdGenerator;
+use waddle_xmpp::protocol::room::archive::MucArchiveHandler;
+use waddle_xmpp::protocol::room::canonicalize::MucCanonicalizeHandler;
+use waddle_xmpp::protocol::room::context::{OccupantSnapshot, RoomContext};
+use waddle_xmpp::protocol::room::traits::{RoomHandler, RoomHandlerOutcome};
+use waddle_xmpp::xep::xep0421::{OccupantIdSecret, OCCUPANT_ID_SECRET_MIN_BYTES};
+use waddle_xmpp_core::types::{Affiliation, Role};
+use xmpp_parsers::message::{Message, MessageType};
+
+const MUC_USER_NS: &str = "http://jabber.org/protocol/muc#user";
+
+fn secret() -> OccupantIdSecret {
+    OccupantIdSecret::new(vec![7u8; OCCUPANT_ID_SECRET_MIN_BYTES]).expect("valid secret")
+}
+
+fn groupchat(room: &BareJid, sender: &FullJid, body: &str) -> Message {
+    let mut m = Message::new(Some(Jid::from(room.clone())));
+    m.from = Some(Jid::from(sender.clone()));
+    m.type_ = MessageType::Groupchat;
+    m.bodies
+        .insert(xmpp_parsers::message::Lang::new(), body.to_string());
+    m
+}
+
+fn run_chain(
+    room: &BareJid,
+    sender: &FullJid,
+    nick: &str,
+    msg: &mut Message,
+) -> Vec<OutboundEvent> {
+    let occupants = vec![OccupantSnapshot {
+        full_jid: sender.clone(),
+        nick: nick.to_string(),
+        affiliation: Affiliation::Member,
+        role: Role::Participant,
+    }];
+    let id_gen = FixedIdGenerator("fixed-stanza-id".to_string());
+    let secret = secret();
+    let ctx = RoomContext {
+        room,
+        sender_full: sender,
+        occupants: &occupants,
+        durable_recipient_bare_jids: &[],
+        managed_room_forbidden: false,
+        room_moderated: false,
+        room_members_only: false,
+        pin_permission: waddle_xmpp::muc::PinPermission::default(),
+        id_gen: &id_gen,
+        occupant_id_secret: &secret,
+        sender_nickname_generation: 0,
+        project_sender_inbox: true,
+        synthetic_sender_authority: None,
+        dispatch_timestamp: 0,
+    };
+    let mut events = Vec::new();
+    for handler in [
+        &MucCanonicalizeHandler as &dyn RoomHandler,
+        &MucArchiveHandler as &dyn RoomHandler,
+    ] {
+        match handler.handle(msg, &ctx) {
+            RoomHandlerOutcome::Continue(e) => events.extend(e),
+            RoomHandlerOutcome::Halt(_) => panic!("chain must not halt"),
+        }
+    }
+    events
+}
+
+/// XEP-0313 §Security "MUC message spoofing" (#1251): a forged
+/// occupant-supplied `<x xmlns='muc#user'>` never reaches the archive
+/// event or the reflected message.
+#[test]
+fn xep0313_forged_muc_user_x_never_reaches_archive_or_reflection() {
+    let room: BareJid = "coven@chat.shakespeare.lit".parse().unwrap();
+    let sender: FullJid = "mallory@shakespeare.lit/web".parse().unwrap();
+    let mut msg = groupchat(&room, &sender, "innocent-looking message");
+    msg.payloads.push(
+        minidom::Element::builder("x", MUC_USER_NS)
+            .append(
+                minidom::Element::builder("item", MUC_USER_NS)
+                    .attr(
+                        minidom::rxml::xml_ncname!("jid").to_owned(),
+                        "victim@shakespeare.lit",
+                    )
+                    .attr(
+                        minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                        "owner",
+                    )
+                    .build(),
+            )
+            .build(),
+    );
+
+    let events = run_chain(&room, &sender, "mallory", &mut msg);
+
+    // Reflected (in-flight) message is clean.
+    assert!(
+        !msg.payloads.iter().any(|p| p.ns() == MUC_USER_NS),
+        "reflection must not carry the forged muc#user <x>"
+    );
+    // Archived copy is clean of the forgery too; the only muc#user
+    // content the interpreter may add later is the room-authored
+    // real-JID item derived from `sender_item`.
+    let archived = events
+        .iter()
+        .find_map(|e| match e {
+            OutboundEvent::ArchiveGroupchat {
+                message,
+                sender_item,
+                ..
+            } => Some((message, sender_item)),
+            _ => None,
+        })
+        .expect("archive event emitted");
+    assert!(
+        !archived.0.payloads.iter().any(|p| p.ns() == MUC_USER_NS),
+        "archive event message must not carry the forged muc#user <x>"
+    );
+    let sender_item = archived.1.as_ref().expect("sender_item captured");
+    assert_eq!(
+        sender_item.jid.to_string(),
+        "mallory@shakespeare.lit/web",
+        "sender_item must carry the real sender, not the forged victim"
+    );
+}
+
+/// XEP-0313 §MUC Archives (#1268): the archive event carries the
+/// sender's typed authority snapshot (real full JID + affiliation +
+/// role) so the interpreter can bake the non-anonymous real-JID
+/// disclosure into the archived copy.
+#[test]
+fn xep0313_archive_event_captures_sender_real_jid_item() {
+    let room: BareJid = "coven@chat.shakespeare.lit".parse().unwrap();
+    let sender: FullJid = "crone1@shakespeare.lit/desktop".parse().unwrap();
+    let mut msg = groupchat(&room, &sender, "Thrice the brinded cat hath mew'd.");
+
+    let events = run_chain(&room, &sender, "firstwitch", &mut msg);
+
+    let sender_item = events
+        .iter()
+        .find_map(|e| match e {
+            OutboundEvent::ArchiveGroupchat { sender_item, .. } => sender_item.as_ref(),
+            _ => None,
+        })
+        .expect("sender_item captured");
+    assert_eq!(
+        sender_item.jid.to_string(),
+        "crone1@shakespeare.lit/desktop"
+    );
+    assert_eq!(sender_item.affiliation, Affiliation::Member);
+    assert_eq!(sender_item.role, Role::Participant);
+
+    // And the wire builder produces the XEP-0313 §MUC Archives shape.
+    let x = waddle_xmpp_core::mam::build_archived_muc_sender_x(sender_item);
+    assert_eq!(x.name(), "x");
+    assert_eq!(x.ns(), MUC_USER_NS);
+    let item = x.get_child("item", MUC_USER_NS).expect("item child");
+    assert_eq!(item.attr("jid"), Some("crone1@shakespeare.lit/desktop"));
+    assert_eq!(item.attr("affiliation"), Some("member"));
+    assert_eq!(item.attr("role"), Some("participant"));
+}
+
+/// XEP-0313 §Security "Sender Impersonation" (#1250): result envelopes
+/// carry `from` = the queried archive JID (the room bare JID for MUC
+/// archives) so strict clients accept them against their open query.
+#[test]
+fn xep0313_result_envelope_from_is_the_room_jid() {
+    let archive: Jid = "coven@chat.shakespeare.lit".parse().unwrap();
+    let requester: Jid = "hag66@shakespeare.lit/pda".parse().unwrap();
+    let row = waddle_xmpp_core::mam::ArchivedMessage {
+        id: "row-1".to_string(),
+        body: Some("hello".to_string()),
+        message_type: MessageType::Groupchat,
+        ..waddle_xmpp_core::mam::ArchivedMessage::for_test(
+            "coven@chat.shakespeare.lit/firstwitch".parse().unwrap(),
+            archive.clone(),
+        )
+    };
+
+    let envelopes =
+        waddle_xmpp_core::mam::build_result_messages("q1", &archive, &requester, &[row]);
+
+    assert_eq!(envelopes.len(), 1);
+    assert_eq!(envelopes[0].from.as_ref(), Some(&archive));
+    assert_eq!(envelopes[0].to.as_ref(), Some(&requester));
+}

--- a/server/crates/waddle-xmpp/tests/xep0421_occupant_id.rs
+++ b/server/crates/waddle-xmpp/tests/xep0421_occupant_id.rs
@@ -343,3 +343,39 @@ fn xep0421_carrier_trait_is_a_typed_extraction_path() {
         Some("P-TRAIT")
     );
 }
+
+// ── §"Business Rules": occupant-id on EVERY presence sent by a MUC —
+//    including the XEP-0045 §10.9 destroy notification (#1268) ───────
+
+#[test]
+fn xep0421_destroy_notification_carries_occupant_id() {
+    use waddle_xmpp::muc::{build_destroy_notification, DestroyRequest};
+    use waddle_xmpp::xep::xep0421::{OccupantIdentity, OCCUPANT_ID_SECRET_MIN_BYTES};
+
+    let room: jid::BareJid = "room@muc.example.com".parse().expect("room jid");
+    let occupant: jid::FullJid = "user@example.com/res".parse().expect("occupant jid");
+    let occupant_bare = occupant.to_bare();
+    let secret =
+        OccupantIdSecret::new(vec![9u8; OCCUPANT_ID_SECRET_MIN_BYTES]).expect("valid secret");
+
+    let presence = build_destroy_notification(
+        &room,
+        "user",
+        &occupant,
+        &DestroyRequest::default(),
+        true,
+        &OccupantIdentity {
+            bare_jid: &occupant_bare,
+            real_jid: Some(&occupant),
+            secret: &secret,
+        },
+    );
+
+    let stamped = extract_occupant_id_from_presence(&presence)
+        .expect("destroy notification must carry <occupant-id/> per XEP-0421 Business Rules");
+    let expected = generate_occupant_id(&occupant_bare, &room, &secret);
+    assert_eq!(
+        stamped, expected,
+        "destroy presence occupant-id must be the stable HMAC id"
+    );
+}


### PR DESCRIPTION
# Lane J4 — MUC-MAM `from` + muc#user anti-spoofing + XEP-0421 occupant-id gaps

Fixes #1250
Fixes #1251
Fixes #1268

Bundle 4 of the 2026-07-10 1:1/MUC conformance audit (epic #1269). Verified against the XEP texts in `./xeps` (XEP-0313, XEP-0045, XEP-0421).

## #1250 — MUC-MAM result envelopes missing `from` (High)

XEP-0313 §Security "Sender Impersonation": a client MUST verify that MAM result messages come from the queried archive and discard unsolicited ones. `build_result_message` never set `from`, so strict clients dropped all room history.

- `build_result_messages` / `build_result_message` gain an `archive_jid: &Jid` parameter and stamp it as the **outer** result envelope's `from`.
- The MAM IQ handler passes the queried archive JID (`target_bare`) — the room bare JID for MUC archives, the user bare JID for personal archives.

## #1251 — client `muc#user <x>` not stripped before reflect/archive (High, security)

XEP-0313 §Security "MUC message spoofing" + XEP-0045 anti-spoofing: the service MUST strip any client-supplied `<x>` in the `muc#user` namespace before archiving; occupant-forged room signalling must never be relayed.

- `MucCanonicalizeHandler` strips every payload in the `muc` / `muc#user` / `muc#admin` / `muc#owner` namespaces from inbound groupchat messages. Runs **before** the archive and reflector handlers, so both the live reflection and the archived `stanza_xml` are clean. The strip is unconditional (above the `sender_snapshot` guard) as defense-in-depth.
- The MUC private-message path (`muc_direct.rs`) was strengthened to strip the **same** namespace set (previously only `muc#user`), via the shared `waddle_xmpp::muc::is_muc_service_namespace` predicate.

## #1268 — XEP-0421 occupant-id gaps

XEP-0421 Business Rules: the `<occupant-id/>` MUST be attached to every message and presence sent by a MUC, including MAM history.

1. **MUC PMs** now carry the server-derived occupant-id (`generate_occupant_id(sender_bare, room, secret)`), replacing any client-supplied one.
2. **Destroy presence** (`build_destroy_notification`) gains an `OccupantIdentity` and stamps the occupant-id like every other unavailable-presence builder.
3. **MAM real-JID for non-anonymous rooms** (XEP-0313 §MUC Archives): the `ArchiveGroupchat` event carries a typed `sender_item` (real full JID + affiliation + role); the interpreter bakes a room-authored `<x xmlns='muc#user'><item jid=… affiliation role/></x>` into the **archived copy only** (never the live reflection).
4. **Typed MAM fallback**: the non-`stanza_xml` reconstruction re-emits both the occupant-id and the real-JID item from a new typed `ArchivedRichMessage` projection (`occupant_id` + `muc_sender`, `#[serde(default)]`, no SQL schema change).

### Dedup safety

`muc_sender.jid` is a per-session full JID (fresh resource each reconnect). The XEP-0359 origin-id retry dedup now excludes the server-derived identity fields (`occupant_id`, `muc_sender`) via `ArchivedRichMessage::dedup_content()` — applied in the in-memory compare, the SQL fingerprint, and the SQL row re-check — so a fresh-session retry still deduplicates instead of duplicating the archive row. An identity-only projection normalizes to `None` so it matches a `rich: None` row.

## Tests

- XEP-0313 suite: result-envelope `from` = room JID; forged `muc#user <x>` never reaches archive event or reflection; archive event captures the sender real-JID item.
- XEP-0421 suite: destroy presence carries the stable occupant-id.
- MUC-PM: server-stamped occupant-id, single empty `muc#user` marker, all MUC service namespaces stripped.
- canonicalize: strips all four MUC service namespaces, preserves non-MUC payloads.
- core MAM: envelope `from`, typed fallback emits occupant-id + real-JID item (groupchat-only, not 1:1).
- MAM storage: fresh-session `muc_sender` and `rich=None` retries still dedup (sqlite + in-memory).

## Process

Typed builders only (no `format!` XML); clippy `-D warnings` clean; dedicated per-XEP Rust suites updated in this PR; TODO-ISSUES.md Lane J4 marked done. Reviewed by adversarial security / XEP-pedant / regression subagents plus two independent gpt-5.5 (codex) passes; all findings addressed.
