### PR TITLE
fix(server): preserve XEP-0198 sender responsibility after handler timeout

### DIFF
--- a/TODO-ISSUES.md
+++ b/TODO-ISSUES.md
@@ -105,12 +105,13 @@ _Residual (tracked, not #945-gating): survivor-check TOCTOU needs per-call locki
 
 ### Lane J — 1:1 chat + MUC conformance (2026-07-10 audit; epic #1269) — ✅ **COMPLETE**
 
-**Lane J COMPLETE (2026-07-11):** all six bundles merged — J1 client chat (PR #1273,
-+#1275 server stanza-id strip), J2 server 1:1 routing (PR #1272), J3 MUC invites/
+**Lane J COMPLETE (2026-07-11):** all six original bundles merged — J1 client chat
+(PR #1273, #1275 server stanza-id strip), J2 server 1:1 routing (PR #1272), J3 MUC invites/
 lifecycle (PR #1276), J4 MUC-MAM/spoofing (PR #1274), J5 MUC delivery/self-ping
 (PR #1277), J6 disco truthfulness (PR #1271). 27 issues closed (#1243–#1268 + #1275);
-epic **#1269** closed. Each merged only after CI green + Qodo + Greptile approval on
-the final SHA with zero unresolved threads.
+epic **#1269** closed. Each implementation bundle merged after CI green, a successful
+final-SHA Greptile check, the Qodo report's actionable findings were addressed, and
+zero unresolved review threads remained. Post-completion residuals are tracked below.
 
 Second deep audit (6 lanes incl. independent gpt-5.5) of private + group chat vs
 main @ `c35afb9d`; all findings verified in code. #1243–#1268 filed, indexed by
@@ -134,7 +135,7 @@ in parallel; within a bundle, top-to-bottom.
 
 **J3 — MUC invites / lifecycle `[bundle]`**
 1. ✅ #1248 — **High**: mediated invitations (§7.8) unimplemented for non-group-DM rooms → "invite" silently no-ops. Relates #945. DONE (PR #1276)
-2. ✅ #1252 — **High**: nick change silently dropped after tearing down MUJI + SFU (no 303/210 anywhere). DONE (PR #1276)
+2. ✅ #1252 — **High**: nick-change attempts no longer tear down MUJI/SFU state; Waddle's identity-locked nickname policy rejects them conformantly with `not-acceptable` rather than emitting a 303 rename. DONE (PR #1276)
 3. ✅ #1261 — destroy doesn't wipe durable state (resurrection) + misses sibling same-nick sessions. DONE (PR #1276)
 4. ✅ #1264 — mediated decline spoofable (no invite ledger) + dropped for offline/remote inviter. DONE (PR #1276)
 5. ✅ #1262 — owner bypasses §8.4/§9.7 role-change target protections. DONE (PR #1276)
@@ -157,6 +158,29 @@ in parallel; within a bundle, top-to-bottom.
 3. ✅ #1265 — XEP-0045 MUC minor conformance cluster (16 items, incl. `muc#stable_id` advertise, history-knob, member-list access). Relates Lane D #1170 (extended-MAM), #1258. DONE (PR #1271; items 3 → #232 and 5 deferred with justification in the PR)
 
 _Cross-refs (already-lane'd, referenced not re-filed): #1173/#1171/#1170 (Lane D), #1118 (Lane E), #984 (Lane G), #466 (Tier 0 close — residual → #1267)._
+
+### Lane J follow-up — adversarial residual audit (2026-07-11; epic #1279) — 🚧 **IN PROGRESS**
+
+The original Lane J scope above remains historical completion. A subsequent adversarial
+audit found residual loss, isolation, concurrency, and conformance defects. Work the
+unblocked frontier; #1287 is natively blocked by #1281.
+
+1. 🚧 **#1280 — XEP-0198 handler-timeout false ack: cancelled message/presence dispatch remains sender-owned, `h` cannot cross the hole, and cleanup detaches without hanging. IN REVIEW (PR #1292).**
+2. #1281 — scope MUC-PM MAM history to the full occupant JID.
+3. #1287 — scope MUC-PM displayed state to the full occupant JID. Blocked by #1281.
+4. #1282 — reject untrusted delay timestamps on ordinary MUC messages while preserving conformant foreign-authority stanza IDs.
+5. #1288 — prevent cross-occupant MUC message-ID collision merges.
+6. #1289 — make mediated-invite grants and rollback atomic.
+7. #1283 — seal room destruction and purge the destroyed MAM epoch.
+8. #1290 — implement XEP-0313 `with=self` intersection semantics.
+9. #1286 — advertise XEP-0085 chat-state support in entity capabilities.
+10. #1291 — reject duplicate `FORM_TYPE` values across capability forms.
+11. #1284 — reconcile `RoomActor` claims left by dead nodes.
+12. #1285 — send MUC status 332 on non-resumable service shutdown.
+
+_Shared completion work: #1136 proves the handler-timeout metric end to end; its completion
+unblocks #1163's timeout alert. #1174 removes the post-#1247 dead XEP-0184 surface and
+stale receipt comments._
 
 ## Tier 3 — Performance / scale prep (parallel with Tier 2 tail)
 

--- a/server/crates/waddle-server/src/server/routes/interpret/handoff.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/handoff.rs
@@ -62,6 +62,11 @@ pub struct SmInboundCompletionTracker {
     next_reserved: Option<u32>,
     pending: BTreeSet<u32>,
     completed: BTreeSet<u32>,
+    /// First stanza whose dispatch was cancelled before the server accepted
+    /// XEP-0198 responsibility. The connection terminates after creating this
+    /// hole; retaining it here prevents late or later completions from
+    /// advancing `h` across the sender-owned stanza.
+    first_unhandled: Option<u32>,
 }
 
 impl SmInboundCompletionTracker {
@@ -87,6 +92,9 @@ impl SmInboundCompletionTracker {
         self.completed.insert(sequence.0);
         loop {
             let next = sm_state.get_inbound_count().wrapping_add(1);
+            if self.first_unhandled == Some(next) {
+                break;
+            }
             if !self.completed.remove(&next) {
                 break;
             }
@@ -94,14 +102,29 @@ impl SmInboundCompletionTracker {
         }
     }
 
+    pub fn abandon(&mut self, sequence: OrderedRelayInboundSequence) {
+        if !self.pending.remove(&sequence.0) {
+            return;
+        }
+        self.completed.remove(&sequence.0);
+        if self.first_unhandled.is_none() {
+            self.first_unhandled = Some(sequence.0);
+        }
+    }
+
     pub fn has_pending(&self) -> bool {
         !self.pending.is_empty()
+    }
+
+    pub fn has_unhandled_hole(&self) -> bool {
+        self.first_unhandled.is_some()
     }
 
     pub fn reset(&mut self) {
         self.next_reserved = None;
         self.pending.clear();
         self.completed.clear();
+        self.first_unhandled = None;
     }
 }
 
@@ -142,6 +165,41 @@ mod tests {
         assert!(tracker.has_pending());
 
         tracker.reset();
+        assert!(!tracker.has_pending());
+    }
+
+    #[test]
+    fn abandoned_sequence_never_advances_handled_count_or_waits_for_completion() {
+        let mut sm_state = enabled_sm_state();
+        let mut tracker = SmInboundCompletionTracker::default();
+
+        let abandoned = tracker.reserve(&sm_state);
+        tracker.abandon(abandoned);
+
+        assert_eq!(sm_state.get_inbound_count(), 0);
+        assert!(!tracker.has_pending());
+        assert!(tracker.has_unhandled_hole());
+
+        let later = tracker.reserve(&sm_state);
+        tracker.complete(later, &mut sm_state);
+        tracker.complete(abandoned, &mut sm_state);
+
+        assert_eq!(sm_state.get_inbound_count(), 0);
+        assert!(!tracker.has_pending());
+    }
+
+    #[test]
+    fn completion_before_abandoned_sequence_still_advances_to_the_hole() {
+        let mut sm_state = enabled_sm_state();
+        let mut tracker = SmInboundCompletionTracker::default();
+
+        let first = tracker.reserve(&sm_state);
+        let abandoned = tracker.reserve(&sm_state);
+        tracker.abandon(abandoned);
+        tracker.complete(first, &mut sm_state);
+
+        assert_eq!(sm_state.get_inbound_count(), 1);
+        assert!(tracker.has_unhandled_hole());
         assert!(!tracker.has_pending());
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/handoff.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/handoff.rs
@@ -116,6 +116,10 @@ impl SmInboundCompletionTracker {
         !self.pending.is_empty()
     }
 
+    pub fn pending_count(&self) -> usize {
+        self.pending.len()
+    }
+
     pub fn has_unhandled_hole(&self) -> bool {
         self.first_unhandled.is_some()
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -764,6 +764,19 @@ async fn handle_inbound_text(
         BatchWriteOutcome::TransportClosed => return false,
     }
 
+    // A timed-out message/presence dispatch was cancelled before the server
+    // accepted XEP-0198 responsibility. End this transport without moving to
+    // `Closing`: normal cleanup must persist the resumable session with the
+    // pre-hole inbound `h`, prompting the sender to replay the stanza.
+    if conn.sm_inbound_completion.has_unhandled_hole() {
+        warn!(
+            jid = ?conn.phase.bound_jid(),
+            inbound_h = conn.sm_state.get_inbound_count(),
+            "Closing stream after unhandled stanza dispatch timeout; preserving sender responsibility"
+        );
+        return false;
+    }
+
     if matches!(conn.phase, ConnectionPhase::Closing { .. }) {
         let _ = close_ws_connection(
             ws_sender,
@@ -812,6 +825,25 @@ async fn drain_ordered_relay_handoffs_before_cleanup(
     if !conn.sm_inbound_completion.has_pending() {
         return;
     }
+    if conn.sm_inbound_completion.has_unhandled_hole() {
+        // The stream is already terminal and the sender will replay from the
+        // hole. Consume only completions that are ready now; waiting for an
+        // earlier ordered relay would make disconnect/shutdown cleanup
+        // unbounded. Under-acknowledging that earlier stanza is safe because
+        // XEP-0198 deliberately leaves it in the sender's replay queue.
+        while let Ok(completion) = handoff_rx.try_recv() {
+            conn.sm_inbound_completion
+                .complete(completion.inbound_sequence, &mut conn.sm_state);
+            let replies = serialize_ordered_relay_handoff_replies(completion.replies);
+            batch_write::record_remaining_for_replay(
+                conn,
+                replies.into_iter(),
+                BatchSmPolicy::Record,
+            );
+        }
+        conn.sm_inbound_completion.reset();
+        return;
+    }
     while conn.sm_inbound_completion.has_pending() {
         let Some(completion) = handoff_rx.recv().await else {
             break;
@@ -856,6 +888,16 @@ async fn process_deferred_inbound_after_transport_loss(
     state: &WebSocketState,
     conn: &mut WsConnState,
 ) {
+    if conn.sm_inbound_completion.has_unhandled_hole() {
+        let dropped = discard_deferred_inbound_after_unhandled_hole(conn);
+        if dropped > 0 {
+            warn!(
+                dropped,
+                "Dropping deferred inbound frames after XEP-0198 handled-count hole; sender will replay"
+            );
+        }
+        return;
+    }
     while let Some(text) = conn.deferred_inbound.pop_front() {
         let responses = handle_xmpp_frame(&text, domain, state, conn).await;
         conn.sync_state_machine_phase();
@@ -866,7 +908,23 @@ async fn process_deferred_inbound_after_transport_loss(
             BatchSmPolicy::Record
         };
         batch_write::record_remaining_for_replay(conn, responses.into_iter(), policy);
+        if conn.sm_inbound_completion.has_unhandled_hole() {
+            let dropped = discard_deferred_inbound_after_unhandled_hole(conn);
+            if dropped > 0 {
+                warn!(
+                    dropped,
+                    "Dropping later deferred inbound frames after XEP-0198 handled-count hole; sender will replay"
+                );
+            }
+            break;
+        }
     }
+}
+
+fn discard_deferred_inbound_after_unhandled_hole(conn: &mut WsConnState) -> usize {
+    let dropped = conn.deferred_inbound.len();
+    conn.deferred_inbound.clear();
+    dropped
 }
 
 fn ensure_websocket_stream_close_for_closing_phase(
@@ -893,6 +951,47 @@ fn response_batch_ends_with_websocket_stream_close(responses: &[String]) -> bool
 mod tests {
     use super::*;
     use std::str::FromStr;
+
+    #[tokio::test]
+    async fn abandoned_inbound_slot_does_not_block_handoff_cleanup() {
+        let mut conn = WsConnState::new();
+        conn.sm_state
+            .enable("stream-timeout".to_string(), true, Some(300));
+        let _earlier_pending = conn.sm_inbound_completion.reserve(&conn.sm_state);
+        let abandoned = conn.sm_inbound_completion.reserve(&conn.sm_state);
+        conn.sm_inbound_completion.abandon(abandoned);
+
+        // Keep the sender alive: a naive cleanup that still considers the
+        // terminal hole pending would wait forever for the earlier ordered
+        // relay. Under-acknowledging that earlier stanza is safe; hanging
+        // detach is not.
+        let (_tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            drain_ordered_relay_handoffs_before_cleanup(&mut rx, &mut conn),
+        )
+        .await
+        .expect("abandoned sequence must not block cleanup");
+
+        assert_eq!(conn.sm_state.get_inbound_count(), 0);
+    }
+
+    #[test]
+    fn later_deferred_frames_are_discarded_after_unhandled_hole() {
+        let mut conn = WsConnState::new();
+        conn.sm_state
+            .enable("stream-timeout".to_string(), true, Some(300));
+        let sequence = conn.sm_inbound_completion.reserve(&conn.sm_state);
+        conn.sm_inbound_completion.abandon(sequence);
+        conn.deferred_inbound.extend([
+            axum::extract::ws::Utf8Bytes::from_static("<message id='later-1'/>"),
+            axum::extract::ws::Utf8Bytes::from_static("<presence/>"),
+        ]);
+
+        assert_eq!(discard_deferred_inbound_after_unhandled_hole(&mut conn), 2);
+        assert!(conn.deferred_inbound.is_empty());
+        assert_eq!(conn.sm_state.get_inbound_count(), 0);
+    }
 
     #[test]
     fn closing_phase_appends_websocket_stream_close_frame() {

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -776,13 +776,15 @@ async fn handle_inbound_text(
 
     // A timed-out message/presence dispatch was cancelled before the server
     // accepted XEP-0198 responsibility. End this transport without moving to
-    // `Closing`: normal cleanup must persist the resumable session with the
-    // pre-hole inbound `h`, prompting the sender to replay the stanza.
+    // `Closing`: resumable sessions persist the pre-hole `h`; non-resumable
+    // sessions leave their unacknowledged suffix to the sender's stream-end
+    // policy. In both cases the server must not falsely acknowledge the hole.
     if conn.sm_inbound_completion.has_unhandled_hole() {
         warn!(
             jid = ?conn.phase.bound_jid(),
             inbound_h = conn.sm_state.get_inbound_count(),
-            "Closing stream after unhandled stanza dispatch timeout; preserving sender responsibility"
+            resumable = conn.sm_state.is_resumable(),
+            "Ending transport after unhandled stanza dispatch timeout; preserving sender responsibility"
         );
         return false;
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -75,6 +75,16 @@ const SEND_WINDOW_LOOP_PAUSE_DEADLINE: std::time::Duration = std::time::Duration
 /// that follows the break is what actually preserves the session.
 const SHUTDOWN_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
+/// Aggregate grace period for ordered-relay completions that precede a
+/// terminal XEP-0198 handled-count hole. Those tasks have already spent the
+/// later stanza's 15-second wedge budget running, so this window primarily
+/// closes the scheduler/channel race at detach. It is deliberately aggregate:
+/// an unbounded relay backlog or a panicked spawned task must not strand
+/// connection/shutdown cleanup forever.
+const ORDERED_RELAY_HANDOFF_CLEANUP_DEADLINE: std::time::Duration =
+    std::time::Duration::from_secs(2);
+const ORDERED_RELAY_HANDOFF_CLEANUP_MAX_COMPLETIONS: usize = 1_024;
+
 /// The two channel halves handed over to the `ConnectionRegistry` at
 /// registration time (`register_bound_connection_after_frame`, then
 /// ADR-0017 Phase 3 Slice 6's force-detach receiver take-over). Bundled so
@@ -825,35 +835,55 @@ async fn drain_ordered_relay_handoffs_before_cleanup(
     if !conn.sm_inbound_completion.has_pending() {
         return;
     }
-    if conn.sm_inbound_completion.has_unhandled_hole() {
-        // The stream is already terminal and the sender will replay from the
-        // hole. Consume only completions that are ready now; waiting for an
-        // earlier ordered relay would make disconnect/shutdown cleanup
-        // unbounded. Under-acknowledging that earlier stanza is safe because
-        // XEP-0198 deliberately leaves it in the sender's replay queue.
-        while let Ok(completion) = handoff_rx.try_recv() {
-            conn.sm_inbound_completion
-                .complete(completion.inbound_sequence, &mut conn.sm_state);
-            let replies = serialize_ordered_relay_handoff_replies(completion.replies);
-            batch_write::record_remaining_for_replay(
-                conn,
-                replies.into_iter(),
-                BatchSmPolicy::Record,
-            );
+    if !conn.sm_inbound_completion.has_unhandled_hole() {
+        while conn.sm_inbound_completion.has_pending() {
+            let Some(completion) = handoff_rx.recv().await else {
+                break;
+            };
+            apply_ordered_relay_handoff_completion(conn, completion);
         }
         conn.sm_inbound_completion.reset();
         return;
     }
-    while conn.sm_inbound_completion.has_pending() {
-        let Some(completion) = handoff_rx.recv().await else {
+
+    let deadline = tokio::time::Instant::now() + ORDERED_RELAY_HANDOFF_CLEANUP_DEADLINE;
+    let mut drained = 0usize;
+    while conn.sm_inbound_completion.has_pending()
+        && drained < ORDERED_RELAY_HANDOFF_CLEANUP_MAX_COMPLETIONS
+    {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let Ok(Some(completion)) = tokio::time::timeout(remaining, handoff_rx.recv()).await else {
             break;
         };
-        conn.sm_inbound_completion
-            .complete(completion.inbound_sequence, &mut conn.sm_state);
-        let replies = serialize_ordered_relay_handoff_replies(completion.replies);
-        batch_write::record_remaining_for_replay(conn, replies.into_iter(), BatchSmPolicy::Record);
+        apply_ordered_relay_handoff_completion(conn, completion);
+        drained += 1;
+        // Tokio timeouts cannot preempt a future that continuously consumes a
+        // ready unbounded-channel backlog. Yield so the deadline is observable
+        // even under adversarial queued completion volume.
+        tokio::task::yield_now().await;
+    }
+    if conn.sm_inbound_completion.has_pending() {
+        warn!(
+            pending = conn.sm_inbound_completion.pending_count(),
+            drained,
+            timeout_ms = ORDERED_RELAY_HANDOFF_CLEANUP_DEADLINE.as_millis(),
+            "Stopped bounded pre-hole ordered-relay drain; preserving conservative sender replay"
+        );
     }
     conn.sm_inbound_completion.reset();
+}
+
+fn apply_ordered_relay_handoff_completion(
+    conn: &mut WsConnState,
+    completion: crate::server::routes::interpret::OrderedRelayHandoffCompletion,
+) {
+    conn.sm_inbound_completion
+        .complete(completion.inbound_sequence, &mut conn.sm_state);
+    let replies = serialize_ordered_relay_handoff_replies(completion.replies);
+    batch_write::record_remaining_for_replay(conn, replies.into_iter(), BatchSmPolicy::Record);
 }
 
 fn serialize_ordered_relay_handoff_replies(replies: Vec<Stanza>) -> Vec<String> {
@@ -957,14 +987,11 @@ mod tests {
         let mut conn = WsConnState::new();
         conn.sm_state
             .enable("stream-timeout".to_string(), true, Some(300));
-        let _earlier_pending = conn.sm_inbound_completion.reserve(&conn.sm_state);
         let abandoned = conn.sm_inbound_completion.reserve(&conn.sm_state);
         conn.sm_inbound_completion.abandon(abandoned);
 
-        // Keep the sender alive: a naive cleanup that still considers the
-        // terminal hole pending would wait forever for the earlier ordered
-        // relay. Under-acknowledging that earlier stanza is safe; hanging
-        // detach is not.
+        // Keep the sender alive: the abandoned sequence itself must not remain
+        // pending and make cleanup wait for a completion that cannot arrive.
         let (_tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         tokio::time::timeout(
             std::time::Duration::from_millis(50),
@@ -974,6 +1001,89 @@ mod tests {
         .expect("abandoned sequence must not block cleanup");
 
         assert_eq!(conn.sm_state.get_inbound_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_waits_for_pre_hole_ordered_relay_completion() {
+        let mut conn = WsConnState::new();
+        conn.sm_state
+            .enable("stream-timeout".to_string(), true, Some(300));
+        let earlier = conn.sm_inbound_completion.reserve(&conn.sm_state);
+        let abandoned = conn.sm_inbound_completion.reserve(&conn.sm_state);
+        conn.sm_inbound_completion.abandon(abandoned);
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let completion = crate::server::routes::interpret::OrderedRelayHandoffCompletion {
+            inbound_sequence: earlier,
+            replies: Vec::new(),
+        };
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            tx.send(completion).expect("cleanup receiver remains open");
+        });
+
+        drain_ordered_relay_handoffs_before_cleanup(&mut rx, &mut conn).await;
+
+        assert_eq!(
+            conn.sm_state.get_inbound_count(),
+            1,
+            "the contiguous pre-hole stanza must be acknowledged before detach"
+        );
+        assert!(!conn.sm_inbound_completion.has_pending());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn cleanup_deadline_bounds_missing_pre_hole_completion() {
+        let mut conn = WsConnState::new();
+        conn.sm_state
+            .enable("stream-timeout".to_string(), true, Some(300));
+        let _missing = conn.sm_inbound_completion.reserve(&conn.sm_state);
+        let abandoned = conn.sm_inbound_completion.reserve(&conn.sm_state);
+        conn.sm_inbound_completion.abandon(abandoned);
+
+        // The connection itself still owns a sender in production, so keep
+        // this one alive to prove cleanup cannot rely on channel closure.
+        let (_tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut drain = Box::pin(drain_ordered_relay_handoffs_before_cleanup(
+            &mut rx, &mut conn,
+        ));
+        assert!(futures::poll!(drain.as_mut()).is_pending());
+
+        tokio::time::advance(ORDERED_RELAY_HANDOFF_CLEANUP_DEADLINE).await;
+        drain.await;
+
+        assert_eq!(conn.sm_state.get_inbound_count(), 0);
+        assert!(!conn.sm_inbound_completion.has_pending());
+    }
+
+    #[tokio::test]
+    async fn cleanup_work_cap_bounds_ready_pre_hole_backlog() {
+        let mut conn = WsConnState::new();
+        conn.sm_state
+            .enable("stream-timeout".to_string(), true, Some(300));
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+
+        for _ in 0..=ORDERED_RELAY_HANDOFF_CLEANUP_MAX_COMPLETIONS {
+            let sequence = conn.sm_inbound_completion.reserve(&conn.sm_state);
+            tx.send(
+                crate::server::routes::interpret::OrderedRelayHandoffCompletion {
+                    inbound_sequence: sequence,
+                    replies: Vec::new(),
+                },
+            )
+            .expect("cleanup receiver remains open");
+        }
+        let abandoned = conn.sm_inbound_completion.reserve(&conn.sm_state);
+        conn.sm_inbound_completion.abandon(abandoned);
+
+        drain_ordered_relay_handoffs_before_cleanup(&mut rx, &mut conn).await;
+
+        assert_eq!(
+            conn.sm_state.get_inbound_count(),
+            ORDERED_RELAY_HANDOFF_CLEANUP_MAX_COMPLETIONS as u32,
+            "cleanup must cap ready backlog work before detaching"
+        );
+        assert!(!conn.sm_inbound_completion.has_pending());
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -1,6 +1,6 @@
 use super::*;
 use super::{
-    frame_backstop::{run_with_backstop, StanzaBackstop},
+    frame_backstop::{run_with_backstop, InboundDisposition, StanzaBackstop},
     isr_resume::handle_isr_resume_authenticate,
     parse_errors::{is_sasl_parse_failure, parse_error_responses},
     resource_binding::handle_resource_binding,
@@ -312,14 +312,82 @@ async fn handle_xmpp_frame_impl(
                     }
                 }
             };
-            let responses = run_with_backstop(backstop, dispatch).await;
-            if let Some(inbound_sequence) = reserved_inbound_for_sm {
-                if !ordered_relay_origin_was_deferred(&ordered_relay_origin) {
-                    sm_inbound_completion.complete(inbound_sequence, sm_state);
-                }
-            }
-            responses
+            let outcome = run_with_backstop(backstop, dispatch).await;
+            settle_inbound_dispatch(
+                outcome.disposition,
+                ordered_relay_origin_was_deferred(&ordered_relay_origin),
+                reserved_inbound_for_sm,
+                sm_inbound_completion,
+                sm_state,
+            );
+            outcome.responses
         }
+    }
+}
+
+pub(super) fn settle_inbound_dispatch(
+    disposition: InboundDisposition,
+    ordered_relay_deferred: bool,
+    inbound_sequence: Option<crate::server::routes::interpret::OrderedRelayInboundSequence>,
+    completion: &mut crate::server::routes::interpret::SmInboundCompletionTracker,
+    sm_state: &mut waddle_xmpp::stream_management::StreamManagementState,
+) {
+    let Some(inbound_sequence) = inbound_sequence else {
+        return;
+    };
+    match disposition {
+        InboundDisposition::Handled => {
+            if !ordered_relay_deferred {
+                completion.complete(inbound_sequence, sm_state);
+            }
+        }
+        InboundDisposition::Unhandled => {
+            // A timeout cancels dispatch. Remove the slot from the set cleanup
+            // waits for, but preserve a permanent `h` hole so responsibility
+            // stays with the sender. This overrides ordered-relay deferral: a
+            // late handoff must not convert a cancelled dispatch into an ack.
+            completion.abandon(inbound_sequence);
+        }
+    }
+}
+
+#[cfg(test)]
+mod inbound_dispatch_tests {
+    use super::*;
+
+    fn enabled_sm() -> waddle_xmpp::stream_management::StreamManagementState {
+        let mut state = waddle_xmpp::stream_management::StreamManagementState::new();
+        state.enable("dispatch-test".to_string(), true, Some(300));
+        state
+    }
+
+    #[test]
+    fn handled_dispatch_advances_h_unless_ordered_relay_owns_completion() {
+        let mut state = enabled_sm();
+        let mut completion =
+            crate::server::routes::interpret::SmInboundCompletionTracker::default();
+        let sequence = completion.reserve(&state);
+
+        settle_inbound_dispatch(
+            InboundDisposition::Handled,
+            false,
+            Some(sequence),
+            &mut completion,
+            &mut state,
+        );
+
+        assert_eq!(state.get_inbound_count(), 1);
+
+        let deferred = completion.reserve(&state);
+        settle_inbound_dispatch(
+            InboundDisposition::Handled,
+            true,
+            Some(deferred),
+            &mut completion,
+            &mut state,
+        );
+        assert_eq!(state.get_inbound_count(), 1);
+        assert!(completion.has_pending());
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -1,6 +1,6 @@
 use super::*;
 use super::{
-    frame_backstop::{run_with_backstop, InboundDisposition, StanzaBackstop},
+    frame_backstop::{run_with_backstop, InboundDisposition, StanzaBackstop, StanzaTimeout},
     isr_resume::handle_isr_resume_authenticate,
     parse_errors::{is_sasl_parse_failure, parse_error_responses},
     resource_binding::handle_resource_binding,
@@ -312,15 +312,21 @@ async fn handle_xmpp_frame_impl(
                     }
                 }
             };
-            let outcome = run_with_backstop(backstop, dispatch).await;
+            let (responses, disposition) = match run_with_backstop(backstop, dispatch).await {
+                Ok(responses) => (responses, InboundDisposition::Handled),
+                Err(StanzaTimeout::HandledIq(reply)) => {
+                    (vec![element_to_xml(reply)], InboundDisposition::Handled)
+                }
+                Err(StanzaTimeout::Unhandled) => (Vec::new(), InboundDisposition::Unhandled),
+            };
             settle_inbound_dispatch(
-                outcome.disposition,
+                disposition,
                 ordered_relay_origin_was_deferred(&ordered_relay_origin),
                 reserved_inbound_for_sm,
                 sm_inbound_completion,
                 sm_state,
             );
-            outcome.responses
+            responses
         }
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
@@ -12,8 +12,9 @@
 //! On elapse the response is **conformant** (RFC 6120 §8.2.3 / §8.3): a timed-out
 //! IQ `get`/`set` still owes exactly one reply, so we synthesize
 //! `<iq type='error'><resource-constraint/></iq>` with error type `wait` (a
-//! temporary, retryable condition). Message/Presence owe no reply, so they are
-//! dropped (logged + metered) on elapse.
+//! temporary, retryable condition). Message/Presence owe no reply; when stream
+//! management is active they remain explicitly unhandled and the transport is
+//! ended for replay/resumption instead of falsely advancing XEP-0198 `h`.
 //!
 //! Observability (all OTEL-native via the existing providers): a per-dispatch
 //! `info_span!` (→ OTEL span), a `warn!` with stable fields (→ OTLP log), and
@@ -27,6 +28,22 @@ use waddle_xmpp::metrics;
 use waddle_xmpp::Stanza;
 
 use super::handlers::iq::errors::resource_constraint_iq_error;
+
+/// Whether dispatch accepted XEP-0198 responsibility for the inbound stanza.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum InboundDisposition {
+    Handled,
+    Unhandled,
+}
+
+/// Dispatch responses plus the XEP-0198 handled-state decision that produced
+/// them. An empty response set is not enough to infer this: successful message
+/// and presence handlers normally return no response too.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct StanzaDispatchResult {
+    pub(super) responses: Vec<String>,
+    pub(super) disposition: InboundDisposition,
+}
 
 /// Maximum wall-clock a single stanza's dispatch may take before the backstop
 /// fires. This is a coarse *wedge* backstop, not a latency SLO: it sits above
@@ -106,13 +123,14 @@ impl StanzaBackstop {
 
     /// Build the conformant response set for a dispatch that exceeded
     /// [`STANZA_HANDLER_WEDGE_TIMEOUT`]: a `resource-constraint`/`wait` IQ error
-    /// for get/set, nothing for everything else. Records the timeout metric and
-    /// a `warn!`, and marks the span errored.
-    fn on_timeout(self) -> Vec<String> {
+    /// for get/set, nothing for everything else. The typed disposition keeps an
+    /// empty successful response distinct from a cancelled, unhandled stanza.
+    /// Records the timeout metric and a `warn!`, and marks the span errored.
+    fn on_timeout(self) -> StanzaDispatchResult {
         metrics::record_stanza_handler_timeout(self.kind, &self.payload_ns);
         self.span.record("otel.status_code", "ERROR");
         let _enter = self.span.enter();
-        match &self.iq_reply {
+        let (responses, disposition) = match &self.iq_reply {
             Some(reply) => {
                 warn!(
                     stanza_kind = self.kind,
@@ -126,24 +144,35 @@ impl StanzaBackstop {
                     timeout_secs = STANZA_HANDLER_WEDGE_TIMEOUT.as_secs(),
                     "stanza handler exceeded wedge backstop; returning resource-constraint"
                 );
-                vec![super::build_iq_error_xml_typed(
-                    &reply.id,
-                    reply.from.as_deref(),
-                    reply.to.as_deref(),
-                    resource_constraint_iq_error(
-                        "The server could not process this request in time; please retry.",
-                    ),
-                )]
+                (
+                    vec![super::build_iq_error_xml_typed(
+                        &reply.id,
+                        reply.from.as_deref(),
+                        reply.to.as_deref(),
+                        resource_constraint_iq_error(
+                            "The server could not process this request in time; please retry.",
+                        ),
+                    )],
+                    // Producing the required retryable IQ error accepts
+                    // responsibility for the request.
+                    InboundDisposition::Handled,
+                )
             }
             None => {
                 warn!(
                     stanza_kind = self.kind,
                     payload_ns = %self.payload_ns,
                     timeout_secs = STANZA_HANDLER_WEDGE_TIMEOUT.as_secs(),
-                    "stanza handler exceeded wedge backstop; dropping (no reply owed)"
+                    "stanza handler exceeded wedge backstop; leaving stanza unhandled (no reply owed)"
                 );
-                Vec::new()
+                // Dispatch was cancelled without a protocol response. XEP-0198
+                // leaves responsibility with the sender.
+                (Vec::new(), InboundDisposition::Unhandled)
             }
+        };
+        StanzaDispatchResult {
+            responses,
+            disposition,
         }
     }
 }
@@ -151,13 +180,19 @@ impl StanzaBackstop {
 /// Drive a stanza's dispatch under the wedge backstop: run `dispatch` within the
 /// backstop span and the [`STANZA_HANDLER_WEDGE_TIMEOUT`]; on elapse, return the
 /// conformant timeout response instead of letting the connection hang.
-pub(super) async fn run_with_backstop<F>(backstop: StanzaBackstop, dispatch: F) -> Vec<String>
+pub(super) async fn run_with_backstop<F>(
+    backstop: StanzaBackstop,
+    dispatch: F,
+) -> StanzaDispatchResult
 where
     F: Future<Output = Vec<String>> + Send,
 {
     let span = backstop.span.clone();
     match tokio::time::timeout(STANZA_HANDLER_WEDGE_TIMEOUT, dispatch.instrument(span)).await {
-        Ok(responses) => responses,
+        Ok(responses) => StanzaDispatchResult {
+            responses,
+            disposition: InboundDisposition::Handled,
+        },
         Err(_elapsed) => backstop.on_timeout(),
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop.rs
@@ -36,13 +36,15 @@ pub(super) enum InboundDisposition {
     Unhandled,
 }
 
-/// Dispatch responses plus the XEP-0198 handled-state decision that produced
-/// them. An empty response set is not enough to infer this: successful message
-/// and presence handlers normally return no response too.
 #[derive(Debug, PartialEq, Eq)]
-pub(super) struct StanzaDispatchResult {
-    pub(super) responses: Vec<String>,
-    pub(super) disposition: InboundDisposition,
+pub(super) enum StanzaTimeout {
+    /// The retryable IQ error accepts responsibility for the request. Keep the
+    /// response typed until `frame.rs` reaches the existing transport XML
+    /// boundary.
+    HandledIq(xmpp_parsers::minidom::Element),
+    /// Dispatch was cancelled without accepting responsibility or owing a
+    /// protocol response.
+    Unhandled,
 }
 
 /// Maximum wall-clock a single stanza's dispatch may take before the backstop
@@ -126,11 +128,11 @@ impl StanzaBackstop {
     /// for get/set, nothing for everything else. The typed disposition keeps an
     /// empty successful response distinct from a cancelled, unhandled stanza.
     /// Records the timeout metric and a `warn!`, and marks the span errored.
-    fn on_timeout(self) -> StanzaDispatchResult {
+    fn on_timeout(self) -> StanzaTimeout {
         metrics::record_stanza_handler_timeout(self.kind, &self.payload_ns);
         self.span.record("otel.status_code", "ERROR");
         let _enter = self.span.enter();
-        let (responses, disposition) = match &self.iq_reply {
+        match &self.iq_reply {
             Some(reply) => {
                 warn!(
                     stanza_kind = self.kind,
@@ -144,19 +146,14 @@ impl StanzaBackstop {
                     timeout_secs = STANZA_HANDLER_WEDGE_TIMEOUT.as_secs(),
                     "stanza handler exceeded wedge backstop; returning resource-constraint"
                 );
-                (
-                    vec![super::build_iq_error_xml_typed(
-                        &reply.id,
-                        reply.from.as_deref(),
-                        reply.to.as_deref(),
-                        resource_constraint_iq_error(
-                            "The server could not process this request in time; please retry.",
-                        ),
-                    )],
-                    // Producing the required retryable IQ error accepts
-                    // responsibility for the request.
-                    InboundDisposition::Handled,
-                )
+                StanzaTimeout::HandledIq(super::transport_xml::build_iq_error_element_typed(
+                    &reply.id,
+                    reply.from.as_deref(),
+                    reply.to.as_deref(),
+                    resource_constraint_iq_error(
+                        "The server could not process this request in time; please retry.",
+                    ),
+                ))
             }
             None => {
                 warn!(
@@ -167,12 +164,8 @@ impl StanzaBackstop {
                 );
                 // Dispatch was cancelled without a protocol response. XEP-0198
                 // leaves responsibility with the sender.
-                (Vec::new(), InboundDisposition::Unhandled)
+                StanzaTimeout::Unhandled
             }
-        };
-        StanzaDispatchResult {
-            responses,
-            disposition,
         }
     }
 }
@@ -183,17 +176,14 @@ impl StanzaBackstop {
 pub(super) async fn run_with_backstop<F>(
     backstop: StanzaBackstop,
     dispatch: F,
-) -> StanzaDispatchResult
+) -> Result<Vec<String>, StanzaTimeout>
 where
     F: Future<Output = Vec<String>> + Send,
 {
     let span = backstop.span.clone();
     match tokio::time::timeout(STANZA_HANDLER_WEDGE_TIMEOUT, dispatch.instrument(span)).await {
-        Ok(responses) => StanzaDispatchResult {
-            responses,
-            disposition: InboundDisposition::Handled,
-        },
-        Err(_elapsed) => backstop.on_timeout(),
+        Ok(responses) => Ok(responses),
+        Err(_elapsed) => Err(backstop.on_timeout()),
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
@@ -50,14 +50,31 @@ async fn iq_get_timeout_yields_conformant_resource_constraint() {
         "must not resolve before the wedge budget elapses"
     );
     tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
-    let responses = fut.await;
+    let outcome = fut.await;
 
     assert_eq!(
-        responses.len(),
+        outcome.responses.len(),
         1,
         "a timed-out IQ get owes exactly one reply"
     );
-    let reply = &responses[0];
+    assert_eq!(outcome.disposition, InboundDisposition::Handled);
+    let mut sm_state = waddle_xmpp::stream_management::StreamManagementState::new();
+    sm_state.enable("iq-timeout".to_string(), true, Some(300));
+    let mut completion = crate::server::routes::interpret::SmInboundCompletionTracker::default();
+    let sequence = completion.reserve(&sm_state);
+    crate::server::routes::websocket::frame::settle_inbound_dispatch(
+        outcome.disposition,
+        false,
+        Some(sequence),
+        &mut completion,
+        &mut sm_state,
+    );
+    assert_eq!(
+        sm_state.get_inbound_count(),
+        1,
+        "the retryable IQ error accepts responsibility for the request"
+    );
+    let reply = &outcome.responses[0];
     // minidom serializes attributes with single quotes (house style; see the
     // existing iq.rs assertions).
     assert!(
@@ -94,12 +111,14 @@ async fn message_timeout_yields_no_response() {
 
     let fut = run_with_backstop(backstop, pending::<Vec<String>>());
     tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
-    let responses = fut.await;
+    let outcome = fut.await;
 
     assert!(
-        responses.is_empty(),
-        "a timed-out message owes no reply: {responses:?}"
+        outcome.responses.is_empty(),
+        "a timed-out message owes no reply: {:?}",
+        outcome.responses
     );
+    assert_eq!(outcome.disposition, InboundDisposition::Unhandled);
 }
 
 #[tokio::test(start_paused = true)]
@@ -109,9 +128,13 @@ async fn presence_timeout_yields_no_response() {
 
     let fut = run_with_backstop(backstop, pending::<Vec<String>>());
     tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
-    let responses = fut.await;
+    let outcome = fut.await;
 
-    assert!(responses.is_empty(), "a timed-out presence owes no reply");
+    assert!(
+        outcome.responses.is_empty(),
+        "a timed-out presence owes no reply"
+    );
+    assert_eq!(outcome.disposition, InboundDisposition::Unhandled);
 }
 
 #[tokio::test(start_paused = true)]
@@ -124,12 +147,14 @@ async fn iq_result_timeout_yields_no_response() {
 
     let fut = run_with_backstop(backstop, pending::<Vec<String>>());
     tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
-    let responses = fut.await;
+    let outcome = fut.await;
 
     assert!(
-        responses.is_empty(),
-        "a timed-out IQ result owes no reply: {responses:?}"
+        outcome.responses.is_empty(),
+        "a timed-out IQ result owes no reply: {:?}",
+        outcome.responses
     );
+    assert_eq!(outcome.disposition, InboundDisposition::Unhandled);
 }
 
 #[tokio::test(start_paused = true)]
@@ -139,13 +164,14 @@ async fn fast_dispatch_passes_through_untouched() {
 
     // A handler that completes immediately must pass its response through
     // unchanged, with no timeout reply.
-    let responses = run_with_backstop(backstop, async {
+    let outcome = run_with_backstop(backstop, async {
         vec!["<iq id=\"disco-2\" type=\"result\"/>".to_string()]
     })
     .await;
 
     assert_eq!(
-        responses,
+        outcome.responses,
         vec!["<iq id=\"disco-2\" type=\"result\"/>".to_string()]
     );
+    assert_eq!(outcome.disposition, InboundDisposition::Handled);
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame_backstop/tests.rs
@@ -39,6 +39,19 @@ fn presence_stanza() -> Stanza {
     Stanza::Presence(Presence::new(xmpp_parsers::presence::Type::None))
 }
 
+fn responses_and_disposition(
+    result: Result<Vec<String>, StanzaTimeout>,
+) -> (Vec<String>, InboundDisposition) {
+    match result {
+        Ok(responses) => (responses, InboundDisposition::Handled),
+        Err(StanzaTimeout::HandledIq(reply)) => (
+            vec![crate::server::routes::websocket::element_to_xml(reply)],
+            InboundDisposition::Handled,
+        ),
+        Err(StanzaTimeout::Unhandled) => (Vec::new(), InboundDisposition::Unhandled),
+    }
+}
+
 #[tokio::test(start_paused = true)]
 async fn iq_get_timeout_yields_conformant_resource_constraint() {
     let stanza = iq_get_stanza("disco-1", "alice@example.com/web", "upload.example.com");
@@ -50,20 +63,20 @@ async fn iq_get_timeout_yields_conformant_resource_constraint() {
         "must not resolve before the wedge budget elapses"
     );
     tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
-    let outcome = fut.await;
+    let (responses, disposition) = responses_and_disposition(fut.await);
 
     assert_eq!(
-        outcome.responses.len(),
+        responses.len(),
         1,
         "a timed-out IQ get owes exactly one reply"
     );
-    assert_eq!(outcome.disposition, InboundDisposition::Handled);
+    assert_eq!(disposition, InboundDisposition::Handled);
     let mut sm_state = waddle_xmpp::stream_management::StreamManagementState::new();
     sm_state.enable("iq-timeout".to_string(), true, Some(300));
     let mut completion = crate::server::routes::interpret::SmInboundCompletionTracker::default();
     let sequence = completion.reserve(&sm_state);
     crate::server::routes::websocket::frame::settle_inbound_dispatch(
-        outcome.disposition,
+        disposition,
         false,
         Some(sequence),
         &mut completion,
@@ -74,7 +87,7 @@ async fn iq_get_timeout_yields_conformant_resource_constraint() {
         1,
         "the retryable IQ error accepts responsibility for the request"
     );
-    let reply = &outcome.responses[0];
+    let reply = &responses[0];
     // minidom serializes attributes with single quotes (house style; see the
     // existing iq.rs assertions).
     assert!(
@@ -111,14 +124,14 @@ async fn message_timeout_yields_no_response() {
 
     let fut = run_with_backstop(backstop, pending::<Vec<String>>());
     tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
-    let outcome = fut.await;
+    let (responses, disposition) = responses_and_disposition(fut.await);
 
     assert!(
-        outcome.responses.is_empty(),
+        responses.is_empty(),
         "a timed-out message owes no reply: {:?}",
-        outcome.responses
+        responses
     );
-    assert_eq!(outcome.disposition, InboundDisposition::Unhandled);
+    assert_eq!(disposition, InboundDisposition::Unhandled);
 }
 
 #[tokio::test(start_paused = true)]
@@ -128,13 +141,10 @@ async fn presence_timeout_yields_no_response() {
 
     let fut = run_with_backstop(backstop, pending::<Vec<String>>());
     tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
-    let outcome = fut.await;
+    let (responses, disposition) = responses_and_disposition(fut.await);
 
-    assert!(
-        outcome.responses.is_empty(),
-        "a timed-out presence owes no reply"
-    );
-    assert_eq!(outcome.disposition, InboundDisposition::Unhandled);
+    assert!(responses.is_empty(), "a timed-out presence owes no reply");
+    assert_eq!(disposition, InboundDisposition::Unhandled);
 }
 
 #[tokio::test(start_paused = true)]
@@ -147,14 +157,14 @@ async fn iq_result_timeout_yields_no_response() {
 
     let fut = run_with_backstop(backstop, pending::<Vec<String>>());
     tokio::time::advance(STANZA_HANDLER_WEDGE_TIMEOUT + Duration::from_millis(1)).await;
-    let outcome = fut.await;
+    let (responses, disposition) = responses_and_disposition(fut.await);
 
     assert!(
-        outcome.responses.is_empty(),
+        responses.is_empty(),
         "a timed-out IQ result owes no reply: {:?}",
-        outcome.responses
+        responses
     );
-    assert_eq!(outcome.disposition, InboundDisposition::Unhandled);
+    assert_eq!(disposition, InboundDisposition::Unhandled);
 }
 
 #[tokio::test(start_paused = true)]
@@ -164,14 +174,15 @@ async fn fast_dispatch_passes_through_untouched() {
 
     // A handler that completes immediately must pass its response through
     // unchanged, with no timeout reply.
-    let outcome = run_with_backstop(backstop, async {
+    let result = run_with_backstop(backstop, async {
         vec!["<iq id=\"disco-2\" type=\"result\"/>".to_string()]
     })
     .await;
+    let (responses, disposition) = responses_and_disposition(result);
 
     assert_eq!(
-        outcome.responses,
+        responses,
         vec!["<iq id=\"disco-2\" type=\"result\"/>".to_string()]
     );
-    assert_eq!(outcome.disposition, InboundDisposition::Handled);
+    assert_eq!(disposition, InboundDisposition::Handled);
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -1,6 +1,7 @@
 use super::super::{
     cleanup::{cleanup_connection_shutdown, cleanup_muc_presence_for_jid},
-    frame::handle_xmpp_frame,
+    frame::{handle_xmpp_frame, settle_inbound_dispatch},
+    frame_backstop::InboundDisposition,
     handlers::{self, presence::handle_muc_join},
     interpret_loop::build_interpret_deps,
     replay::drive_interpret_loop,
@@ -39,6 +40,108 @@ fn resume_frame_xml(stream_id: &str, handled_count: u32) -> String {
 }
 
 // ---- XEP-0198 stream management --------------------------------
+
+#[test]
+fn timed_out_inbound_stanza_preserves_sender_responsibility() {
+    let mut state = waddle_xmpp::stream_management::StreamManagementState::new();
+    state.enable("timeout-regression".to_string(), true, Some(300));
+    let mut completion = crate::server::routes::interpret::SmInboundCompletionTracker::default();
+    let sequence = completion.reserve(&state);
+
+    settle_inbound_dispatch(
+        InboundDisposition::Unhandled,
+        true,
+        Some(sequence),
+        &mut completion,
+        &mut state,
+    );
+
+    assert_eq!(state.get_inbound_count(), 0);
+    assert!(!completion.has_pending());
+    assert!(completion.has_unhandled_hole());
+
+    // A late ordered-relay completion cannot turn the cancelled dispatch into
+    // an acknowledgement: the sender must retain and replay this stanza.
+    completion.complete(sequence, &mut state);
+    assert_eq!(state.get_inbound_count(), 0);
+}
+
+#[tokio::test]
+async fn timed_out_inbound_stanza_detaches_and_resumes_before_the_hole() {
+    let state = create_test_websocket_state().await;
+    let jid: FullJid = "alice@example.com/web".parse().expect("jid");
+    let (tx, mut rx) = mpsc::channel::<OutboundStanza>(4);
+    let owner = state
+        .deps
+        .protocol
+        .connection_registry
+        .register(jid.clone(), tx);
+
+    let mut conn = WsConnState::new();
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    conn.registry_owner = Some(owner);
+    conn.sm_state
+        .enable("timeout-detach".to_string(), true, Some(300));
+
+    let handled = conn.sm_inbound_completion.reserve(&conn.sm_state);
+    settle_inbound_dispatch(
+        InboundDisposition::Handled,
+        false,
+        Some(handled),
+        &mut conn.sm_inbound_completion,
+        &mut conn.sm_state,
+    );
+    let timed_out = conn.sm_inbound_completion.reserve(&conn.sm_state);
+    settle_inbound_dispatch(
+        InboundDisposition::Unhandled,
+        false,
+        Some(timed_out),
+        &mut conn.sm_inbound_completion,
+        &mut conn.sm_state,
+    );
+
+    assert_eq!(conn.sm_state.get_inbound_count(), 1);
+    assert!(conn.sm_inbound_completion.has_unhandled_hole());
+    assert!(
+        !conn.phase.is_closing(),
+        "timeout must use resumable transport termination, not a clean stream close"
+    );
+
+    let outcome = cleanup_connection_shutdown(state.as_ref(), &mut rx, &mut conn, false).await;
+    assert_eq!(
+        outcome,
+        super::super::cleanup::ConnectionShutdownOutcome::Detached
+    );
+    let detached = state
+        .deps
+        .protocol
+        .sm_session_registry
+        .peek_session("timeout-detach")
+        .await
+        .expect("registry lookup")
+        .expect("resumable snapshot");
+    assert_eq!(detached.inbound_count, 1);
+
+    let mut resumed = WsConnState::new();
+    resumed.phase = ConnectionPhase::authenticated(&jid);
+    let responses = handle_xmpp_frame(
+        &resume_frame_xml("timeout-detach", 0),
+        "example.com",
+        state.as_ref(),
+        &mut resumed,
+    )
+    .await;
+    let resumed_frame = responses
+        .iter()
+        .map(|xml| Element::from_str(xml).expect("response xml"))
+        .find(|element| element.name() == "resumed")
+        .expect("resume succeeds");
+    assert_eq!(
+        resumed_frame.attr("h"),
+        Some("1"),
+        "the timed-out second stanza must remain outside the server acknowledgement"
+    );
+}
 
 #[tokio::test]
 async fn sm_features_advertise_sm_namespace() {

--- a/server/crates/waddle-server/src/server/routes/websocket/transport_xml.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/transport_xml.rs
@@ -147,6 +147,15 @@ pub(crate) fn build_iq_error_xml_typed(
     to: Option<&str>,
     error: xmpp_parsers::stanza_error::StanzaError,
 ) -> String {
+    element_to_xml(build_iq_error_element_typed(id, from, to, error))
+}
+
+pub(crate) fn build_iq_error_element_typed(
+    id: &str,
+    from: Option<&str>,
+    to: Option<&str>,
+    error: xmpp_parsers::stanza_error::StanzaError,
+) -> xmpp_parsers::minidom::Element {
     let mut iq = xmpp_parsers::minidom::Element::builder("iq", "jabber:client")
         .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
         .attr(minidom::rxml::xml_ncname!("type").to_owned(), "error");
@@ -157,11 +166,8 @@ pub(crate) fn build_iq_error_xml_typed(
         iq = iq.attr(minidom::rxml::xml_ncname!("to").to_owned(), to);
     }
 
-    let iq = iq
-        .append(xmpp_parsers::minidom::Element::from(error))
-        .build();
-
-    element_to_xml(iq)
+    iq.append(xmpp_parsers::minidom::Element::from(error))
+        .build()
 }
 
 pub(super) fn build_handled_count_too_high_stream_error(

--- a/server/crates/waddle-xmpp-client/src/stream_management.rs
+++ b/server/crates/waddle-xmpp-client/src/stream_management.rs
@@ -663,6 +663,28 @@ mod tests {
     }
 
     #[test]
+    fn unchanged_server_h_replays_a_timed_out_outbound_stanza() {
+        let mut state = SmState::new();
+        state.start_outbound();
+        state.previd = Some("timed-out-stream".to_string());
+        let timed_out = Element::builder("message", "jabber:client")
+            .attr(
+                minidom::rxml::xml_ncname!("id").to_owned(),
+                "timed-out-message",
+            )
+            .build();
+        state.record_sent_stanza(&timed_out);
+
+        // The server ended the transport without advancing h, so processing
+        // its last acknowledgement must leave the stanza sender-owned.
+        assert!(state.process_ack(0).is_empty());
+        let resume_state = state.resume_state().expect("resume state");
+        let mut resumed = SmState::from_resume_state(&resume_state);
+
+        assert_eq!(resumed.mark_unhandled_for_replay(), vec![timed_out]);
+    }
+
+    #[test]
     fn resume_state_carries_advertised_max_resume_window() {
         let mut state = SmState::new();
         state.previd = Some("previous-stream".to_string());


### PR DESCRIPTION
## Summary

Preserve XEP-0198 sender responsibility when the stanza-handler wedge backstop cancels a message or presence before the server has accepted responsibility for it.

Closes #1280. Child of #1279.

## What changed

- Return a typed handled/unhandled dispatch outcome from the wedge backstop.
- Keep timed-out message, presence, and IQ result/error stanzas outside the handled prefix; timed-out IQ get/set requests remain handled after their retryable error is produced.
- Track a terminal inbound sequence hole so late and later completions cannot advance `h` past the sender-owned stanza.
- End the affected transport without a clean-stream closing transition, allowing normal cleanup to persist the pre-hole resumable snapshot.
- Discard later deferred inbound frames so they remain sender-owned for replay.
- Before detach, drain delayed ordered-relay completions that precede the hole so committed delivery and replies enter the accurate handled prefix.
- Bound that exceptional drain by an aggregate deadline, cooperative polling, and a completion cap; ordinary disconnect draining remains unchanged.
- Add dedicated XEP-0198 coverage for classification, handled counts, detach, resume, cleanup, relay races, and sender replay.
- Record the follow-up lane in `TODO-ISSUES.md` as in review; metric export and alerting remain tracked by #1136 and #1163.

## XEP review

- XEP-0198 §4: an acknowledgement transfers responsibility only after the receiving entity has handled the stanza.
- XEP-0198 §5: `<resumed h='N'/>` reports the last handled client stanza and leaves the unhandled suffix queued for retransmission.
- Timed-out message/presence dispatch is cancelled and therefore remains sender-owned.
- A timed-out IQ get/set that receives the retryable stanza error is handled.

## Verification

- `cargo test -p waddle-server --lib` — 1,530 passed before the review follow-up; all revised cleanup/timeout regressions pass afterward.
- Focused coverage includes delayed, never-completing, and oversized ready ordered-relay backlogs; detach/resume; IQ handling; late completion; and client replay.
- `cargo clippy -p waddle-server -p waddle-xmpp-client --all-targets --all-features -- -D warnings` passed; revised server-only clippy also passed after the review fix.
- `cargo fmt --all -- --check` passed.
- `git diff --check` passed.
- Three independent adversarial reviews covered XEP conformance, async/concurrency invariants, and test/operations completeness.
- A final-SHA inline review found a pre-hole relay scheduling race. It was fixed on `a870da1e`; the delayed-completion and bounded-liveness regressions were added, the thread was resolved, and concurrency re-review found no remaining actionable issue.

## Residual risk

If cancellation occurs after an irreversible handler side effect, sender replay can produce a duplicate. The bounded cleanup path reduces this for pre-hole relay work but conservatively under-acknowledges if its deadline or work cap is exhausted. XEP-0198 explicitly permits duplicate ambiguity for unacknowledged stanzas; preserving replay is preferable to permanent silent loss or unbounded shutdown.

## Merge gate

Keep this PR unmerged until CI is green, Greptile succeeds on the final SHA, Qodo has no actionable findings on the final revision, and no review thread remains unresolved.
