### PR TITLE
fix(chat): isolate MUC-PM history by full occupant JID

### DIFF
--- a/TODO-ISSUES.md
+++ b/TODO-ISSUES.md
@@ -165,8 +165,8 @@ The original Lane J scope above remains historical completion. A subsequent adve
 audit found residual loss, isolation, concurrency, and conformance defects. Work the
 unblocked frontier; #1287 is natively blocked by #1281.
 
-1. 🚧 **#1280 — XEP-0198 handler-timeout false ack: cancelled message/presence dispatch remains sender-owned, `h` cannot cross the hole, and cleanup detaches without hanging. IN REVIEW (PR #1292).**
-2. #1281 — scope MUC-PM MAM history to the full occupant JID.
+1. ✅ **#1280 — XEP-0198 handler-timeout false ack: cancelled message/presence dispatch remains sender-owned, `h` cannot cross the hole, and cleanup detaches without hanging. DONE (PR #1292, merged).**
+2. 🚧 **#1281 — scope MUC-PM MAM history to the full occupant JID. IN REVIEW (PR #1293).**
 3. #1287 — scope MUC-PM displayed state to the full occupant JID. Blocked by #1281.
 4. #1282 — reject untrusted delay timestamps on ordinary MUC messages while preserving conformant foreign-authority stanza IDs.
 5. #1288 — prevent cross-occupant MUC message-ID collision merges.

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -8,7 +8,7 @@ import type {
   LiveDmMessage,
   SessionLifecycleEvent,
 } from "@/lib/xmpp-client";
-import { bareJidKey, barePeerJid, jidLocalpart } from "@/lib/xmpp-client";
+import { barePeerJid, dmConversationIdentityKey, jidLocalpart } from "@/lib/xmpp-client";
 import type { CatchupConversationFailure } from "@/lib/xmpp-client";
 import type { WaddleSession } from "@/lib/server-auth";
 import {
@@ -299,7 +299,10 @@ export function useDirectMessages(
     if (event.type !== "fresh") return;
     const peerJid = activePeerJid.value;
     if (!peerJid) return;
-    if (event.catchup.dmJids.some((jid) => bareJidKey(jid) === bareJidKey(peerJid))) return;
+    const scopedOccupants = new Set(event.catchup.dmOccupantJids ?? []);
+    const isMucPmPeer = (jid: string) => scopedOccupants.has(jid) || (xmppClient.value?.isMucPmPeer?.(jid) ?? false);
+    const peerKey = dmConversationIdentityKey(peerJid, isMucPmPeer);
+    if (event.catchup.dmJids.some((jid) => dmConversationIdentityKey(jid, isMucPmPeer) === peerKey)) return;
     refetchTimelineToCloseGap();
   }
 
@@ -309,7 +312,13 @@ export function useDirectMessages(
   function onCatchupFailed(failure: CatchupConversationFailure) {
     if (failure.kind !== "dm") return;
     const peerJid = activePeerJid.value;
-    if (!peerJid || bareJidKey(peerJid) !== bareJidKey(failure.key)) return;
+    const isMucPmPeer = (jid: string) =>
+      (failure.dmScope === "muc-occupant" && jid === failure.key)
+      || (xmppClient.value?.isMucPmPeer?.(jid) ?? false);
+    if (
+      !peerJid
+      || dmConversationIdentityKey(peerJid, isMucPmPeer) !== dmConversationIdentityKey(failure.key, isMucPmPeer)
+    ) return;
     refetchTimelineToCloseGap();
   }
 

--- a/chat/src/lib/xmpp/client-events.ts
+++ b/chat/src/lib/xmpp/client-events.ts
@@ -67,7 +67,7 @@ type CatchupOutcome = "completed" | "aborted" | "failed";
  * fallback signal to run that reload after the failed attempt
  * (serialized, so the two fetches can no longer race).
  */
-export type CatchupConversationFailure = { kind: "dm" | "room"; key: string };
+export type CatchupConversationFailure = { kind: "dm" | "room"; key: string; dmScope?: "account" | "muc-occupant" };
 
 export type CatchupHookInfo = {
   conversations: number;

--- a/chat/src/lib/xmpp/client-mam.ts
+++ b/chat/src/lib/xmpp/client-mam.ts
@@ -242,7 +242,7 @@ export class MamPager {
   constructor(private readonly deps: MamPagerDeps) {}
 
   private isMucPmPeer(peerJid: string, scope?: DmConversationScope): boolean {
-    return scope ? scope === "muc-occupant" : this.deps.isMucPmPeer(peerJid);
+    return scope === "muc-occupant" || this.deps.isMucPmPeer(peerJid);
   }
 
   private selfBare(): string {

--- a/chat/src/lib/xmpp/client-mam.ts
+++ b/chat/src/lib/xmpp/client-mam.ts
@@ -12,10 +12,10 @@ import {
 } from "@/lib/calls/dm-call-activity";
 import { buildDmCallOutcomeAnchor, type DmCallOutcomeAnchor } from "@/lib/calls/dm-call-anchor";
 import { compareTimelineTimestamps } from "../timeline-timestamps";
-import { barePeerJid, jidDomain } from "./jid";
+import { bareJidKey, barePeerJid, fullJidIdentityKey, jidDomain, resourceOf } from "./jid";
 import type { ClientEvents, TypedEventBus } from "./client-events";
 import { classifyMamError, isMamCursorNotFound } from "./mam";
-import type { ReconnectCatchup } from "./reconnect-catchup";
+import type { DmConversationScope, ReconnectCatchup, ReconnectCatchupEntry } from "./reconnect-catchup";
 import type {
   LiveDmMessage,
   LiveRoomMessage,
@@ -44,8 +44,6 @@ export type DmCallActivityHydrationOptions = { since?: string; pageSize?: number
 
 type CatchupRunStats = { pages: number; messages: number };
 type CatchupOutcome = "completed" | "aborted" | "failed";
-
-type ReconnectCatchupEntry = { kind: "dm" | "room"; key: string; after?: string; since?: string; seenIds?: string[] };
 
 /**
  * #1267 item 4: typed marker for catch-up page-budget exhaustion. Unlike
@@ -236,10 +234,16 @@ type MamPagerDeps = {
    * the live path. Optional so bare unit-test pagers keep working.
    */
   classifyMucPm?: (message: WasmMessage) => { occupantJid: string; nick: string } | undefined;
+  /** Session-authoritative occupant scope derived from the configured MUC service. */
+  isMucPmPeer: (peerJid: string) => boolean;
 };
 
 export class MamPager {
   constructor(private readonly deps: MamPagerDeps) {}
+
+  private isMucPmPeer(peerJid: string, scope?: DmConversationScope): boolean {
+    return scope ? scope === "muc-occupant" : this.deps.isMucPmPeer(peerJid);
+  }
 
   private selfBare(): string {
     return barePeerJid(this.deps.sessionJid());
@@ -266,18 +270,28 @@ export class MamPager {
 
   private dmPageToMessages(
     page: WasmMamPage,
-    options: { applyCallEvents?: boolean } = {},
+    options: { applyCallEvents?: boolean; peerJid?: string; dmScope?: DmConversationScope } = {},
   ): MamHistoryPage<LiveDmMessage> {
     const selfBare = this.selfBare();
-    const outcomeAnchors = options.applyCallEvents === false
+    const outcomeAnchors = options.applyCallEvents === false || this.isMucPmPeer(options.peerJid ?? "", options.dmScope)
       ? []
-      : this.applyDmCallEventsFromMamPage(page, selfBare, { publishOutcome: false });
-    const messages = page.messages
+      : this.applyDmCallEventsFromMamPage(page, selfBare, {
+          publishOutcome: false,
+          ...(options.peerJid ? { peerJid: options.peerJid } : {}),
+          ...(options.dmScope ? { dmScope: options.dmScope } : {}),
+        });
+    const requestedPeerJid = options.peerJid;
+    const rawMessages = requestedPeerJid
+      ? page.messages.filter((message) => this.rawDmMessageMatchesPeer(message, requestedPeerJid, options.dmScope))
+      : page.messages;
+    const messages = rawMessages
       .map((message) => {
         const converted = dmMessageFromArchived(message, selfBare, { trustedMediaOrigin: this.deps.trustedMediaOrigin() });
-        return converted ? this.applyMucPmClassification(message, converted) : null;
+        return converted ? this.applyMucPmClassification(message, converted, options.peerJid, options.dmScope) : null;
       })
-      .filter((message): message is LiveDmMessage => !!message);
+      .filter((message): message is LiveDmMessage =>
+        !!message && (!options.peerJid || this.dmMessageMatchesPeer(message, options.peerJid, options.dmScope))
+      );
     const outcomeMessages = outcomeAnchors.map((outcome) =>
       this.dmCallOutcomeAnchorToLiveMessage(outcome),
     );
@@ -312,11 +326,25 @@ export class MamPager {
   private applyDmCallEventsFromMamPage(
     page: WasmMamPage | null | undefined,
     selfBare = this.selfBare(),
-    options: { since?: string; seenIds?: ReadonlyArray<string>; publishOutcome?: boolean } = {},
+    options: { since?: string; seenIds?: ReadonlyArray<string>; publishOutcome?: boolean; peerJid?: string; dmScope?: DmConversationScope } = {},
   ): ArchivedDmCallOutcome[] {
+    // DM call state is bare-peer scoped. Until it is occupant scoped end to
+    // end, replaying MUC-PM call events would alias every nick in the room.
+    if (this.isMucPmPeer(options.peerJid ?? "", options.dmScope)) return [];
     const outcomeAnchors: ArchivedDmCallOutcome[] = [];
     for (const message of page?.messages ?? []) {
       if (!message.call_event) continue;
+      const rawCounterpart = this.rawDmCounterpart(message);
+      // The account archive tuple is authoritative before service discovery:
+      // ordinary server DM rows use a bare remote endpoint; a full remote
+      // endpoint is a MUC-PM occupant. Global hydration has no requested peer
+      // or persisted scope, so fail closed on every resource-qualified row.
+      if (!options.peerJid && !options.dmScope && resourceOf(rawCounterpart)) continue;
+      // Global personal-history hydration has no requested peer context. The
+      // raw remote endpoint still identifies MUC-PM rows, which DM call state
+      // cannot safely represent until it is keyed by full occupant JID.
+      if (this.isMucPmPeer(rawCounterpart)) continue;
+      if (options.peerJid && !this.rawDmMessageMatchesPeer(message, options.peerJid, options.dmScope)) continue;
       if (shouldSkipRawCatchupMessage(message, this.dmStanzaIdAuthorities(), options.since, options.seenIds)) continue;
       const outcomeAnchor = applyDmCallEvent({
         event: message.call_event,
@@ -332,8 +360,18 @@ export class MamPager {
   }
 
   /** Apply the #1256 occupant re-keying to a converted DM message. */
-  private applyMucPmClassification(raw: WasmMessage, converted: LiveDmMessage): LiveDmMessage {
-    const occupant = this.deps.classifyMucPm?.(raw);
+  private applyMucPmClassification(
+    raw: WasmMessage,
+    converted: LiveDmMessage,
+    requestedPeerJid?: string,
+    dmScope?: DmConversationScope,
+  ): LiveDmMessage {
+    const requestedOccupant = requestedPeerJid
+      && this.isMucPmPeer(requestedPeerJid, dmScope)
+      && fullJidIdentityKey(this.rawDmCounterpart(raw)) === fullJidIdentityKey(requestedPeerJid)
+      ? { occupantJid: requestedPeerJid, nick: resourceOf(requestedPeerJid) }
+      : undefined;
+    const occupant = requestedOccupant ?? this.deps.classifyMucPm?.(raw);
     if (!occupant) return converted;
     const isSelf = barePeerJid(raw.from ?? "") === this.selfBare();
     return {
@@ -344,6 +382,37 @@ export class MamPager {
     };
   }
 
+  private dmMessageMatchesPeer(message: LiveDmMessage, peerJid: string, dmScope?: DmConversationScope): boolean {
+    // #1281: a MUC-PM conversation is the full occupant JID. Bare matching
+    // would alias every nick in the room; conversely, ordinary DMs retain
+    // their established bare-JID conversation identity.
+    if (this.isMucPmPeer(peerJid, dmScope)) {
+      return message.mucPm === true
+        && fullJidIdentityKey(message.peerJid) === fullJidIdentityKey(peerJid);
+    }
+    return message.mucPm !== true && bareJidKey(message.peerJid) === bareJidKey(peerJid);
+  }
+
+  private rawDmMessageMatchesPeer(message: WasmMessage, peerJid: string, dmScope?: DmConversationScope): boolean {
+    if (this.isMucPmPeer(peerJid, dmScope)) {
+      return fullJidIdentityKey(this.rawDmCounterpart(message)) === fullJidIdentityKey(peerJid);
+    }
+    const occupant = this.deps.classifyMucPm?.(message);
+    if (occupant) return false;
+    const rawPeer = this.rawDmCounterpart(message);
+    if (this.isMucPmPeer(rawPeer, dmScope) && bareJidKey(rawPeer) === bareJidKey(peerJid)) return false;
+    return bareJidKey(rawPeer) === bareJidKey(peerJid);
+  }
+
+  private rawDmCounterpart(message: WasmMessage): string {
+    const from = message.from ?? "";
+    return bareJidKey(from) === bareJidKey(this.selfBare()) ? (message.to ?? "") : from;
+  }
+
+  private dmArchivePeerJid(peerJid: string, dmScope?: DmConversationScope): string {
+    return this.isMucPmPeer(peerJid, dmScope) ? peerJid : barePeerJid(peerJid);
+  }
+
   private recordRoomWatermarks(messages: ReadonlyArray<LiveRoomMessage>) {
     for (const message of messages) {
       this.deps.catchup.recordRoomSeen(message.roomJid, message.createdAt, message.archiveId, messageSeenIds(message));
@@ -352,7 +421,7 @@ export class MamPager {
 
   private recordDmWatermarks(messages: ReadonlyArray<LiveDmMessage>) {
     for (const message of messages) {
-      this.deps.catchup.recordDmSeen(message.peerJid, message.createdAt, message.archiveId, messageSeenIds(message));
+      this.deps.catchup.recordDmSeen(message.peerJid, message.createdAt, message.archiveId, messageSeenIds(message), message.mucPm ? "muc-occupant" : "account");
     }
   }
 
@@ -407,9 +476,10 @@ export class MamPager {
 
   async queryPersonalMamPage(peerJid: string, max = 100, pageParam: MamPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveDmMessage>> {
     const xmpp = await this.deps.requireConnectedXmpp();
-    const page = await xmpp.fetch_dm_history_page?.(barePeerJid(peerJid), max, pageParam);
+    const archivePeerJid = this.dmArchivePeerJid(peerJid);
+    const page = await xmpp.fetch_dm_history_page?.(archivePeerJid, max, pageParam);
     if (!page) return { messages: [], complete: true };
-    const result = this.dmPageToMessages(page);
+    const result = this.dmPageToMessages(page, { peerJid: archivePeerJid });
     this.recordDmWatermarks(result.messages);
     return result;
   }
@@ -417,9 +487,10 @@ export class MamPager {
   async queryPersonalMamThreadPage(peerJid: string, threadId: string, max = 100, pageParam: MamThreadPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveDmMessage>> {
     if (!threadId) return { messages: [], complete: true };
     const xmpp = await this.deps.requireConnectedXmpp();
-    const page = await xmpp.fetch_dm_history_by_thread?.(barePeerJid(peerJid), threadId, max, pageParam.type === "before" ? pageParam.before : null);
+    const archivePeerJid = this.dmArchivePeerJid(peerJid);
+    const page = await xmpp.fetch_dm_history_by_thread?.(archivePeerJid, threadId, max, pageParam.type === "before" ? pageParam.before : null);
     if (!page) return { messages: [], complete: true };
-    const result = this.dmPageToMessages(page, { applyCallEvents: false });
+    const result = this.dmPageToMessages(page, { applyCallEvents: false, peerJid: archivePeerJid });
     this.recordDmWatermarks(result.messages);
     return result;
   }
@@ -430,6 +501,10 @@ export class MamPager {
   ): Promise<void> {
     const xmpp = await this.deps.requireConnectedXmpp();
     if (!xmpp.fetch_dm_history_page) return;
+    if (
+      this.deps.isMucPmPeer(peerJid)
+      || this.deps.catchup.getDmScope(peerJid) === "muc-occupant"
+    ) return;
     const peer = barePeerJid(peerJid);
     if (!peer) return;
     const sessionJid = this.deps.sessionJid();
@@ -468,14 +543,21 @@ export class MamPager {
   async searchDmMessages(peerJid: string, query: string, max = 20): Promise<MessageSearchResult[]> {
     if (!query.trim()) return [];
     const xmpp = await this.deps.requireConnectedXmpp();
-    const page = await xmpp.search_dm_history?.(barePeerJid(peerJid), query, max);
+    const archivePeerJid = this.dmArchivePeerJid(peerJid);
+    const page = await xmpp.search_dm_history?.(archivePeerJid, query, max);
     const selfBare = this.selfBare();
     const parsed = page?.messages
-      .map((archived) => ({
-        archived,
-        message: dmMessageFromArchived(archived, selfBare, { trustedMediaOrigin: this.deps.trustedMediaOrigin() }),
-      }))
-      .filter((entry): entry is { archived: WasmArchivedMessage; message: LiveDmMessage } => !!entry.message) ?? [];
+      .filter((archived) => this.rawDmMessageMatchesPeer(archived, archivePeerJid))
+      .map((archived) => {
+        const decoded = dmMessageFromArchived(archived, selfBare, { trustedMediaOrigin: this.deps.trustedMediaOrigin() });
+        return {
+          archived,
+          message: decoded ? this.applyMucPmClassification(archived, decoded, archivePeerJid) : null,
+        };
+      })
+      .filter((entry): entry is { archived: WasmArchivedMessage; message: LiveDmMessage } =>
+        !!entry.message && this.dmMessageMatchesPeer(entry.message, archivePeerJid)
+      ) ?? [];
     return parsed.filter(({ message }) => !!message.body).map(({ archived, message }) => ({ id: message.id, ...(archived.mam_id ? { archiveId: archived.mam_id } : {}), nick: message.nick, body: message.body, createdAt: message.createdAt, ...(message.threadId ? { threadId: message.threadId } : {}), ...(message.parentThreadId ? { parentThreadId: message.parentThreadId } : {}), peerJid: message.peerJid }));
   }
 
@@ -541,7 +623,11 @@ export class MamPager {
             // telemetry-hook failure — this handler is the reload
             // fallback, so surface a failure on the typed error channel.
             try {
-              this.deps.events.emit("catchupFailure", { kind: entry.kind, key: entry.key });
+              this.deps.events.emit("catchupFailure", {
+                kind: entry.kind,
+                key: entry.key,
+                ...(entry.kind === "dm" && entry.scope === "muc-occupant" ? { dmScope: entry.scope } : {}),
+              });
             } catch (handlerError) {
               this.deps.emitError({
                 kind: "history",
@@ -567,11 +653,12 @@ export class MamPager {
 
   private async runDmReconnectCatchup(
     xmpp: MamWasmClient,
-    entry: { key: string; after?: string; since?: string; seenIds?: string[] },
+    entry: Extract<ReconnectCatchupEntry, { kind: "dm" }>,
     sessionJid: string,
     stats: CatchupRunStats,
   ) {
     if (!xmpp.fetch_dm_history_page) return;
+    const archivePeerJid = this.dmArchivePeerJid(entry.key, entry.scope);
     if (entry.after) {
       let after: string | undefined = entry.after;
       const seenAfter = new Set<string>();
@@ -584,11 +671,11 @@ export class MamPager {
         }
         let page: WasmMamPage | null | undefined;
         try {
-          page = await xmpp.fetch_dm_history_page(entry.key, 100, { type: "after", after });
+          page = await xmpp.fetch_dm_history_page(archivePeerJid, 100, { type: "after", after });
         } catch (error) {
           if (isMamCursorNotFound(classifyMamError(error))) {
             const since = entry.since ?? this.deps.catchup.getDmLastSeen(entry.key);
-            if (since) await this.runDmTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds, stats);
+            if (since) await this.runDmTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds, stats, entry.scope);
             return;
           }
           throw error;
@@ -596,7 +683,7 @@ export class MamPager {
         pageCount += 1;
         if (!this.deps.isCurrentConnected(xmpp, sessionJid)) return;
         if (pageContainsArchiveId(page, after)) throw new Error(`Reconnect catch-up received non-advancing archive cursor for ${entry.key}`);
-        const nextAfter = this.applyDmCatchupPage(page, undefined, entry.seenIds, { stats });
+        const nextAfter = this.applyDmCatchupPage(page, entry.key, undefined, entry.seenIds, { stats, dmScope: entry.scope });
         if (isMamPageComplete(page)) return;
         if (!nextAfter || nextAfter === after) throw new Error(`Reconnect catch-up could not advance archive cursor for ${entry.key}`);
         after = nextAfter;
@@ -605,7 +692,7 @@ export class MamPager {
     }
     const since = entry.since ?? this.deps.catchup.getDmLastSeen(entry.key);
     if (!since) return;
-    await this.runDmTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds, stats);
+    await this.runDmTimestampCatchup(xmpp, entry.key, since, sessionJid, entry.seenIds, stats, entry.scope);
   }
 
   private async runRoomReconnectCatchup(
@@ -658,7 +745,9 @@ export class MamPager {
     sessionJid: string,
     seenIds?: ReadonlyArray<string>,
     stats?: CatchupRunStats,
+    dmScope?: DmConversationScope,
   ) {
+    const archivePeerJid = this.dmArchivePeerJid(peerJid, dmScope);
     let pageParam: MamPageParam = { type: "latest" };
     const seenBefore = new Set<string>();
     const pages: WasmMamPage[] = [];
@@ -670,14 +759,14 @@ export class MamPager {
     const applyCollected = () => {
       const selfBare = this.selfBare();
       for (const page of [...pages].reverse()) {
-        this.applyDmCatchupPage(page, since, seenIds, { applyCallEvents: false, stats });
+        this.applyDmCatchupPage(page, peerJid, since, seenIds, { applyCallEvents: false, stats, dmScope });
       }
       for (const page of [...pages].reverse()) {
-        this.applyDmCallEventsFromMamPage(page, selfBare, { since, seenIds });
+        this.applyDmCallEventsFromMamPage(page, selfBare, { since, seenIds, peerJid, dmScope });
       }
     };
     while (true) {
-      const page = await xmpp.fetch_dm_history_page?.(peerJid, 100, pageParam);
+      const page = await xmpp.fetch_dm_history_page?.(archivePeerJid, 100, pageParam);
       if (!this.deps.isCurrentConnected(xmpp, sessionJid)) return;
       if (page) pages.push(page);
       if (isMamPageComplete(page) || pageCrossesSince(page, since)) break;
@@ -733,25 +822,39 @@ export class MamPager {
 
   private applyDmCatchupPage(
     page: WasmMamPage | null | undefined,
+    peerJid: string,
     since?: string,
     seenIds?: ReadonlyArray<string>,
-    options: { applyCallEvents?: boolean; stats?: CatchupRunStats } = {},
+    options: { applyCallEvents?: boolean; stats?: CatchupRunStats; dmScope?: DmConversationScope } = {},
   ): string | undefined {
+    // Keep the server page boundary even when every decoded row is rejected.
+    // RSM cursors describe the raw result set; deriving this from accepted
+    // rows would strand paging on an all-sibling legacy/foreign page.
     let lastArchiveId = pageLastArchiveId(page);
     const selfBare = this.selfBare();
     if (options.stats) options.stats.pages += 1;
-    if (options.applyCallEvents !== false) {
-      this.applyDmCallEventsFromMamPage(page, selfBare, { since, seenIds });
-    }
-    for (const message of page?.messages ?? []) {
+    const acceptedRaw = (page?.messages ?? []).filter((message) =>
+      this.rawDmMessageMatchesPeer(message, peerJid, options.dmScope)
+    );
+    const accepted = acceptedRaw.flatMap((message) => {
       const decoded = dmMessageFromArchived(message, selfBare, { trustedMediaOrigin: this.deps.trustedMediaOrigin() });
-      if (!decoded) continue;
-      const converted = this.applyMucPmClassification(message, decoded);
+      if (!decoded) return [];
+      const converted = this.applyMucPmClassification(message, decoded, peerJid, options.dmScope);
+      return this.dmMessageMatchesPeer(converted, peerJid, options.dmScope) ? [{ converted }] : [];
+    });
+    if (options.applyCallEvents !== false) {
+      this.applyDmCallEventsFromMamPage(
+        page ? { ...page, messages: acceptedRaw } : page,
+        selfBare,
+        { since, seenIds, peerJid, dmScope: options.dmScope },
+      );
+    }
+    for (const { converted } of accepted) {
       if (shouldSkipCatchupMessage(converted, since, seenIds)) continue;
-      this.deps.catchup.recordDmSeen(converted.peerJid, converted.createdAt, converted.archiveId, messageSeenIds(converted));
+      this.deps.catchup.recordDmSeen(converted.peerJid, converted.createdAt, converted.archiveId, messageSeenIds(converted), converted.mucPm ? "muc-occupant" : "account");
       this.deps.events.emit("directMessage", converted);
       if (options.stats) options.stats.messages += 1;
-      lastArchiveId = converted.archiveId ?? lastArchiveId;
+      lastArchiveId ??= converted.archiveId;
     }
     return lastArchiveId;
   }

--- a/chat/src/lib/xmpp/client-mam.ts
+++ b/chat/src/lib/xmpp/client-mam.ts
@@ -480,10 +480,11 @@ export class MamPager {
 
   async queryPersonalMamPage(peerJid: string, max = 100, pageParam: MamPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveDmMessage>> {
     const xmpp = await this.deps.requireConnectedXmpp();
-    const archivePeerJid = this.dmArchivePeerJid(peerJid);
+    const dmScope = this.deps.catchup.getDmScope(peerJid);
+    const archivePeerJid = this.dmArchivePeerJid(peerJid, dmScope);
     const page = await xmpp.fetch_dm_history_page?.(archivePeerJid, max, pageParam);
     if (!page) return { messages: [], complete: true };
-    const result = this.dmPageToMessages(page, { peerJid: archivePeerJid });
+    const result = this.dmPageToMessages(page, { peerJid: archivePeerJid, dmScope });
     this.recordDmWatermarks(result.messages);
     return result;
   }
@@ -491,10 +492,11 @@ export class MamPager {
   async queryPersonalMamThreadPage(peerJid: string, threadId: string, max = 100, pageParam: MamThreadPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveDmMessage>> {
     if (!threadId) return { messages: [], complete: true };
     const xmpp = await this.deps.requireConnectedXmpp();
-    const archivePeerJid = this.dmArchivePeerJid(peerJid);
+    const dmScope = this.deps.catchup.getDmScope(peerJid);
+    const archivePeerJid = this.dmArchivePeerJid(peerJid, dmScope);
     const page = await xmpp.fetch_dm_history_by_thread?.(archivePeerJid, threadId, max, pageParam.type === "before" ? pageParam.before : null);
     if (!page) return { messages: [], complete: true };
-    const result = this.dmPageToMessages(page, { applyCallEvents: false, peerJid: archivePeerJid });
+    const result = this.dmPageToMessages(page, { applyCallEvents: false, peerJid: archivePeerJid, dmScope });
     this.recordDmWatermarks(result.messages);
     return result;
   }
@@ -547,20 +549,21 @@ export class MamPager {
   async searchDmMessages(peerJid: string, query: string, max = 20): Promise<MessageSearchResult[]> {
     if (!query.trim()) return [];
     const xmpp = await this.deps.requireConnectedXmpp();
-    const archivePeerJid = this.dmArchivePeerJid(peerJid);
+    const dmScope = this.deps.catchup.getDmScope(peerJid);
+    const archivePeerJid = this.dmArchivePeerJid(peerJid, dmScope);
     const page = await xmpp.search_dm_history?.(archivePeerJid, query, max);
     const selfBare = this.selfBare();
     const parsed = page?.messages
-      .filter((archived) => this.rawDmMessageMatchesPeer(archived, archivePeerJid))
+      .filter((archived) => this.rawDmMessageMatchesPeer(archived, archivePeerJid, dmScope))
       .map((archived) => {
         const decoded = dmMessageFromArchived(archived, selfBare, { trustedMediaOrigin: this.deps.trustedMediaOrigin() });
         return {
           archived,
-          message: decoded ? this.applyMucPmClassification(archived, decoded, archivePeerJid) : null,
+          message: decoded ? this.applyMucPmClassification(archived, decoded, archivePeerJid, dmScope) : null,
         };
       })
       .filter((entry): entry is { archived: WasmArchivedMessage; message: LiveDmMessage } =>
-        !!entry.message && this.dmMessageMatchesPeer(entry.message, archivePeerJid)
+        !!entry.message && this.dmMessageMatchesPeer(entry.message, archivePeerJid, dmScope)
       ) ?? [];
     return parsed.filter(({ message }) => !!message.body).map(({ archived, message }) => ({ id: message.id, ...(archived.mam_id ? { archiveId: archived.mam_id } : {}), nick: message.nick, body: message.body, createdAt: message.createdAt, ...(message.threadId ? { threadId: message.threadId } : {}), ...(message.parentThreadId ? { parentThreadId: message.parentThreadId } : {}), peerJid: message.peerJid }));
   }

--- a/chat/src/lib/xmpp/client-mam.ts
+++ b/chat/src/lib/xmpp/client-mam.ts
@@ -400,7 +400,11 @@ export class MamPager {
     const occupant = this.deps.classifyMucPm?.(message);
     if (occupant) return false;
     const rawPeer = this.rawDmCounterpart(message);
-    if (this.isMucPmPeer(rawPeer, dmScope) && bareJidKey(rawPeer) === bareJidKey(peerJid)) return false;
+    // The persisted scope describes the requested conversation, not the raw
+    // archive endpoint. Keep authoritative endpoint classification independent
+    // so a legacy bare-room cursor cannot admit full occupant rows merely
+    // because its old cursor defaulted to account scope.
+    if (this.isMucPmPeer(rawPeer) && bareJidKey(rawPeer) === bareJidKey(peerJid)) return false;
     return bareJidKey(rawPeer) === bareJidKey(peerJid);
   }
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1466,6 +1466,7 @@ export class BrowserXmppClient {
     return hasResource && (
       this.isMucServiceOccupant(peerJid)
       || this.isKnownMucRoomBare(barePeerJid(peerJid))
+      || this.catchup.getDmScope(peerJid) === "muc-occupant"
     )
       ? peerJid
       : barePeerJid(peerJid);

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1463,7 +1463,10 @@ export class BrowserXmppClient {
    * bare peer JID. */
   private directMessageAddress(peerJid: string): string {
     const hasResource = peerJid.includes("/");
-    return hasResource && this.isKnownMucRoomBare(barePeerJid(peerJid))
+    return hasResource && (
+      this.isMucServiceOccupant(peerJid)
+      || this.isKnownMucRoomBare(barePeerJid(peerJid))
+    )
       ? peerJid
       : barePeerJid(peerJid);
   }

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -29,7 +29,7 @@ import {
   isInCallReactionForActiveCall,
   receiveInCallReaction,
 } from "@/lib/calls/in-call-reactions";
-import { bareJidKey, barePeerJid, fullJidIdentityKey, jidDomain, jidLocalpart, roomBareJidFor } from "./jid";
+import { bareJidKey, barePeerJid, fullJidIdentityKey, jidDomain, jidLocalpart, resourceOf, roomBareJidFor } from "./jid";
 import { TypedEventBus } from "./client-events";
 import type {
   CatchupConversationFailure,
@@ -99,7 +99,7 @@ import { prepareEncryptedAttachmentUpload } from "./encrypted-attachments";
 import { discoverChannels, discoverTopology } from "./discovery";
 import { discoverUploadService, uploadFile, type UploadProgress } from "./file-upload";
 import { createGroupDm, type CreateGroupDmResult } from "./group-dm";
-import { ReconnectCatchup } from "./reconnect-catchup";
+import { ReconnectCatchup, type ReconnectCatchupEntry } from "./reconnect-catchup";
 import {
   parseRegisterDeviceResult,
   parseRegisterPushDeviceRejection,
@@ -421,6 +421,7 @@ export class BrowserXmppClient {
   // Cleared on disconnect so a genuine fresh cycle rejoins.
   private readonly autoJoinAttemptedRoomKeys = new Set<string>();
   private uploadServiceJid: string | null = null;
+  private mucServiceJid = "";
   private discoveredRoomJids = new Map<string, string>();
   private readonly reconnect: ReconnectScheduler;
   private readonly resume: ResumeStateStore;
@@ -510,6 +511,7 @@ export class BrowserXmppClient {
 
   constructor(session: WaddleSession, persistence?: ResumePersistence) {
     this.session = session;
+    this.mucServiceJid = `muc.${jidDomain(session.jid)}`;
     // Per-account so a logout/login on the same browser doesn't mix
     // cursors. `session.jid` is the bare JID — already unique per
     // identity — and matches the `accountKey` used by the outbound
@@ -556,6 +558,7 @@ export class BrowserXmppClient {
       // same occupant classification as the live path, so a MUC PM never
       // re-files under the room bare JID after a reconnect.
       classifyMucPm: (message) => this.mucPmOccupant(message),
+      isMucPmPeer: (peerJid) => this.isMucServiceOccupant(peerJid),
     });
     this.mucAdmin = new MucAdmin({
       requireConnectedXmpp: () => this.requireConnectedXmpp(),
@@ -2173,6 +2176,7 @@ export class BrowserXmppClient {
   async discoverTopology(): Promise<DiscoveredTopology> {
     const xmpp = await this.requireConnectedXmpp();
     const topology = await discoverTopology(xmpp as WasmClient, this.session.jid);
+    if (topology.services?.muc) this.mucServiceJid = barePeerJid(topology.services.muc);
     this.discoveredRoomJids = new Map(topology.rooms.flatMap((room) => room.jid ? [[room.id, room.jid] as const] : []));
     const autoJoinRoomJids = topology.rooms
       .filter((room) => room.autojoin !== false && !!room.jid)
@@ -2276,6 +2280,9 @@ export class BrowserXmppClient {
           type: "fresh",
           catchup: {
             dmJids: catchupEntries.filter((e) => e.kind === "dm").map((e) => e.key),
+            ...(catchupEntries.some((e) => e.kind === "dm" && e.scope === "muc-occupant")
+              ? { dmOccupantJids: catchupEntries.filter((e) => e.kind === "dm" && e.scope === "muc-occupant").map((e) => e.key) }
+              : {}),
             roomJids: catchupEntries.filter((e) => e.kind === "room").map((e) => e.key),
           },
         }
@@ -2646,7 +2653,13 @@ export class BrowserXmppClient {
       // XEP-0359: the DM authorities mirror the decode path
       // (`assignedStanzaIdBy`): account bare + server domain. Seen-ids
       // and row wireIds must never diverge (see dmStanzaIdAuthorities).
-      this.catchup.recordDmSeen(converted.peerJid, converted.createdAt, undefined, rawMessageSeenIds(message, [selfBare, jidDomain(selfBare)]));
+      this.catchup.recordDmSeen(
+        converted.peerJid,
+        converted.createdAt,
+        undefined,
+        rawMessageSeenIds(message, [selfBare, jidDomain(selfBare)]),
+        converted.mucPm ? "muc-occupant" : "account",
+      );
       this.events.emit("directMessage", converted);
     }
   }
@@ -2709,6 +2722,11 @@ export class BrowserXmppClient {
     return false;
   }
 
+  private isMucServiceOccupant(peerJid: string): boolean {
+    return Boolean(resourceOf(peerJid))
+      && jidDomain(peerJid).toLowerCase() === this.mucServiceJid.trim().toLowerCase();
+  }
+
   /**
    * XEP-0045 §7.5 (#1256): detect a MUC private message — a non-groupchat
    * message whose conversation counterpart is `room@service/nick` for a
@@ -2737,14 +2755,14 @@ export class BrowserXmppClient {
     return this.isKnownMucRoomBare(barePeerJid(bareJid));
   }
 
-  /** Public: whether `peerJid` is a MUC occupant JID (`room@service/nick`)
-   * of a known room — i.e. a MUC-PM conversation identity. */
+  /** Public: whether `peerJid` is a full occupant JID on the session's
+   * authoritative MUC service (fallback or service discovery result). */
   isMucPmPeer(peerJid: string): boolean {
-    return peerJid.includes("/") && this.isKnownMucRoomBare(barePeerJid(peerJid));
+    return this.isMucServiceOccupant(peerJid);
   }
   private runReconnectCatchup(
     xmpp: XmppClientInstance,
-    entries: Array<{ kind: "dm" | "room"; key: string; after?: string; since?: string; seenIds?: string[] }>,
+    entries: ReadonlyArray<ReconnectCatchupEntry>,
     lifecycle: SessionLifecycleEvent["type"],
   ) {
     return this.mam.runReconnectCatchup(xmpp, entries, lifecycle);

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -28,6 +28,7 @@ export type {
 export {
   bareJidKey,
   barePeerJid,
+  dmConversationIdentityKey,
   jidDomain,
   jidDomainOrEmpty,
   jidLocalpart,

--- a/chat/src/lib/xmpp/jid.ts
+++ b/chat/src/lib/xmpp/jid.ts
@@ -48,6 +48,18 @@ export function bareJidKey(jid: string): string {
   return barePeerJid(jid).trim().toLowerCase();
 }
 
+/**
+ * Conversation identity for direct-message coordination. The caller supplies
+ * session-authoritative MUC service context; syntax alone cannot distinguish
+ * an occupant from an ordinary account resource.
+ */
+export function dmConversationIdentityKey(
+  jid: string,
+  isMucPmPeer: (peerJid: string) => boolean,
+): string {
+  return isMucPmPeer(jid) ? fullJidIdentityKey(jid) : bareJidKey(jid);
+}
+
 export function parseManagedRoomBareJid(
   roomJid: string,
 ): { channelId: string } | null {

--- a/chat/src/lib/xmpp/reconnect-catchup.ts
+++ b/chat/src/lib/xmpp/reconnect-catchup.ts
@@ -71,9 +71,28 @@ export class ReconnectCatchup {
     if (!snapshot) return;
     for (const [key, cursor] of snapshot.dmLastSeen) {
       const scope = cursor.scope ?? "account";
-      this.dmLastSeen.set(dmCursorKey(key, scope), { ...cursor, scope });
+      advance(
+        this.dmLastSeen,
+        dmCursorKey(key, scope),
+        cursor.timestamp,
+        cursor.archiveId,
+        cursor.seenIds,
+        cursor.archiveTimestamp,
+        cursor.archiveSeenIds,
+        scope,
+      );
     }
-    for (const [key, cursor] of snapshot.roomLastSeen) this.roomLastSeen.set(key, { ...cursor });
+    for (const [key, cursor] of snapshot.roomLastSeen) {
+      advance(
+        this.roomLastSeen,
+        key,
+        cursor.timestamp,
+        cursor.archiveId,
+        cursor.seenIds,
+        cursor.archiveTimestamp,
+        cursor.archiveSeenIds,
+      );
+    }
     // A hydrated instance is by definition *not* a first-ever login —
     // it represents a prior tab session that left cursors behind. The
     // next `onSessionStarted()` must return those cursors so MAM
@@ -90,15 +109,11 @@ export class ReconnectCatchup {
     this.persistScheduled = true;
     queueMicrotask(() => {
       this.persistScheduled = false;
-      // Read-merge-write so two tabs of the same account don't
-      // clobber each other's cursor advances. Pre-fix each tab held
-      // its own in-memory map and serialized the whole thing on
-      // every write — the last writer won, and the other tab's
-      // progress was silently lost. Now we merge any remote state
-      // that landed since our last write back into our in-memory
-      // maps before persisting, so both tabs converge to the union
-      // (per-key: higher timestamp wins, equal timestamps merge
-      // `seenIds` — exactly the rule `advance()` already uses).
+      // Each tab writes its own persistence shard, so concurrent
+      // localStorage writes cannot replace another tab's cursor set.
+      // Merge every shard before saving this tab's snapshot so live
+      // tabs converge eagerly as well; hydrate applies the same
+      // higher-timestamp/equal-seenIds `advance()` rule on reload.
       const remote = this.persistence.loadCatchup();
       if (remote) this.absorbRemoteSnapshot(remote);
       const snapshot: PersistedReconnectCatchup = {

--- a/chat/src/lib/xmpp/reconnect-catchup.ts
+++ b/chat/src/lib/xmpp/reconnect-catchup.ts
@@ -1,4 +1,5 @@
 import { compareTimelineTimestamps } from "@/lib/timeline-timestamps";
+import { bareJidKey, fullJidIdentityKey } from "@/lib/xmpp/jid";
 
 import {
   nullResumePersistence,
@@ -45,6 +46,12 @@ type SeenCursor = {
 
 export type DmConversationScope = "account" | "muc-occupant";
 
+function dmCursorKey(peerJid: string, scope: DmConversationScope): string {
+  return scope === "muc-occupant"
+    ? fullJidIdentityKey(peerJid)
+    : bareJidKey(peerJid);
+}
+
 export class ReconnectCatchup {
   private readonly dmLastSeen = new Map<string, SeenCursor>();
   private readonly roomLastSeen = new Map<string, SeenCursor>();
@@ -62,7 +69,10 @@ export class ReconnectCatchup {
   private hydrate(): void {
     const snapshot = this.persistence.loadCatchup();
     if (!snapshot) return;
-    for (const [key, cursor] of snapshot.dmLastSeen) this.dmLastSeen.set(key, { ...cursor });
+    for (const [key, cursor] of snapshot.dmLastSeen) {
+      const scope = cursor.scope ?? "account";
+      this.dmLastSeen.set(dmCursorKey(key, scope), { ...cursor, scope });
+    }
     for (const [key, cursor] of snapshot.roomLastSeen) this.roomLastSeen.set(key, { ...cursor });
     // A hydrated instance is by definition *not* a first-ever login —
     // it represents a prior tab session that left cursors behind. The
@@ -101,7 +111,8 @@ export class ReconnectCatchup {
 
   private absorbRemoteSnapshot(remote: PersistedReconnectCatchup): void {
     for (const [key, cursor] of remote.dmLastSeen) {
-      advance(this.dmLastSeen, key, cursor.timestamp, cursor.archiveId, cursor.seenIds, cursor.archiveTimestamp, cursor.archiveSeenIds, cursor.scope);
+      const scope = cursor.scope ?? "account";
+      advance(this.dmLastSeen, dmCursorKey(key, scope), cursor.timestamp, cursor.archiveId, cursor.seenIds, cursor.archiveTimestamp, cursor.archiveSeenIds, scope);
     }
     for (const [key, cursor] of remote.roomLastSeen) {
       advance(this.roomLastSeen, key, cursor.timestamp, cursor.archiveId, cursor.seenIds, cursor.archiveTimestamp, cursor.archiveSeenIds);
@@ -114,7 +125,7 @@ export class ReconnectCatchup {
    * next catch-up can't re-pull already-applied messages.
    */
   recordDmSeen(peerBareJid: string, timestamp: string, archiveId?: string, seenIds?: ReadonlyArray<string>, scope: DmConversationScope = "account"): void {
-    advance(this.dmLastSeen, peerBareJid, timestamp, archiveId, seenIds, undefined, undefined, scope);
+    advance(this.dmLastSeen, dmCursorKey(peerBareJid, scope), timestamp, archiveId, seenIds, undefined, undefined, scope);
     this.schedulePersist();
   }
 
@@ -125,11 +136,15 @@ export class ReconnectCatchup {
   }
 
   getDmLastSeen(peerBareJid: string): string | undefined {
-    return this.dmLastSeen.get(peerBareJid)?.timestamp;
+    const occupantCursor = this.dmLastSeen.get(dmCursorKey(peerBareJid, "muc-occupant"));
+    if (occupantCursor?.scope === "muc-occupant") return occupantCursor.timestamp;
+    return this.dmLastSeen.get(dmCursorKey(peerBareJid, "account"))?.timestamp;
   }
 
   getDmScope(peerJid: string): DmConversationScope | undefined {
-    return this.dmLastSeen.get(peerJid)?.scope;
+    const occupantCursor = this.dmLastSeen.get(dmCursorKey(peerJid, "muc-occupant"));
+    if (occupantCursor?.scope === "muc-occupant") return occupantCursor.scope;
+    return this.dmLastSeen.get(dmCursorKey(peerJid, "account"))?.scope;
   }
 
   getRoomLastSeen(roomBareJid: string): string | undefined {

--- a/chat/src/lib/xmpp/reconnect-catchup.ts
+++ b/chat/src/lib/xmpp/reconnect-catchup.ts
@@ -30,17 +30,20 @@ import {
  * any messages received while the tab was gone unrecovered until the user
  * manually scrolls back (PR3 in the tab-restore plan).
  */
-type CatchupEntry =
-  | { kind: "dm"; key: string; after?: string; since?: string; seenIds?: string[] }
+export type ReconnectCatchupEntry =
+  | { kind: "dm"; key: string; scope: DmConversationScope; after?: string; since?: string; seenIds?: string[] }
   | { kind: "room"; key: string; after?: string; since?: string; seenIds?: string[] };
 
 type SeenCursor = {
   timestamp: string;
+  scope?: DmConversationScope;
   archiveId?: string;
   archiveTimestamp?: string;
   archiveSeenIds?: string[];
   seenIds?: string[];
 };
+
+export type DmConversationScope = "account" | "muc-occupant";
 
 export class ReconnectCatchup {
   private readonly dmLastSeen = new Map<string, SeenCursor>();
@@ -98,7 +101,7 @@ export class ReconnectCatchup {
 
   private absorbRemoteSnapshot(remote: PersistedReconnectCatchup): void {
     for (const [key, cursor] of remote.dmLastSeen) {
-      advance(this.dmLastSeen, key, cursor.timestamp, cursor.archiveId, cursor.seenIds, cursor.archiveTimestamp, cursor.archiveSeenIds);
+      advance(this.dmLastSeen, key, cursor.timestamp, cursor.archiveId, cursor.seenIds, cursor.archiveTimestamp, cursor.archiveSeenIds, cursor.scope);
     }
     for (const [key, cursor] of remote.roomLastSeen) {
       advance(this.roomLastSeen, key, cursor.timestamp, cursor.archiveId, cursor.seenIds, cursor.archiveTimestamp, cursor.archiveSeenIds);
@@ -110,8 +113,8 @@ export class ReconnectCatchup {
    * advances the cursor — out-of-order or older arrivals are ignored so the
    * next catch-up can't re-pull already-applied messages.
    */
-  recordDmSeen(peerBareJid: string, timestamp: string, archiveId?: string, seenIds?: ReadonlyArray<string>): void {
-    advance(this.dmLastSeen, peerBareJid, timestamp, archiveId, seenIds);
+  recordDmSeen(peerBareJid: string, timestamp: string, archiveId?: string, seenIds?: ReadonlyArray<string>, scope: DmConversationScope = "account"): void {
+    advance(this.dmLastSeen, peerBareJid, timestamp, archiveId, seenIds, undefined, undefined, scope);
     this.schedulePersist();
   }
 
@@ -125,6 +128,10 @@ export class ReconnectCatchup {
     return this.dmLastSeen.get(peerBareJid)?.timestamp;
   }
 
+  getDmScope(peerJid: string): DmConversationScope | undefined {
+    return this.dmLastSeen.get(peerJid)?.scope;
+  }
+
   getRoomLastSeen(roomBareJid: string): string | undefined {
     return this.roomLastSeen.get(roomBareJid)?.timestamp;
   }
@@ -135,12 +142,12 @@ export class ReconnectCatchup {
    * result is empty (initial login has no missed history); on subsequent
    * calls it contains every tracked DM peer and room.
    */
-  onSessionStarted(): CatchupEntry[] {
+  onSessionStarted(): ReconnectCatchupEntry[] {
     if (!this.sessionStartedOnce) {
       this.sessionStartedOnce = true;
       return [];
     }
-    const entries: CatchupEntry[] = [];
+    const entries: ReconnectCatchupEntry[] = [];
     for (const [key, cursor] of this.dmLastSeen) {
       entries.push(catchupEntry("dm", key, cursor));
     }
@@ -159,25 +166,27 @@ export class ReconnectCatchup {
   }
 }
 
-function catchupEntry(kind: "dm", key: string, cursor: SeenCursor): CatchupEntry;
-function catchupEntry(kind: "room", key: string, cursor: SeenCursor): CatchupEntry;
-function catchupEntry(kind: "dm" | "room", key: string, cursor: SeenCursor): CatchupEntry {
+function catchupEntry(kind: "dm", key: string, cursor: SeenCursor): ReconnectCatchupEntry;
+function catchupEntry(kind: "room", key: string, cursor: SeenCursor): ReconnectCatchupEntry;
+function catchupEntry(kind: "dm" | "room", key: string, cursor: SeenCursor): ReconnectCatchupEntry {
   if (!cursor.archiveId) {
-    return {
-      kind,
-      key,
+    const rest = {
       since: cursor.timestamp,
       ...(cursor.seenIds?.length ? { seenIds: cursor.seenIds } : {}),
     };
+    return kind === "dm"
+      ? { kind, key, scope: cursor.scope ?? "account", ...rest }
+      : { kind, key, ...rest };
   }
   const seenIds = mergeSeenIds(cursor.archiveSeenIds, cursor.seenIds);
-  return {
-    kind,
-    key,
+  const rest = {
     after: cursor.archiveId,
     since: cursor.archiveTimestamp ?? cursor.timestamp,
     ...(seenIds.length ? { seenIds } : {}),
   };
+  return kind === "dm"
+    ? { kind, key, scope: cursor.scope ?? "account", ...rest }
+    : { kind, key, ...rest };
 }
 
 function advance(
@@ -188,6 +197,7 @@ function advance(
   seenIds?: ReadonlyArray<string>,
   archiveTimestamp?: string,
   archiveSeenIds?: ReadonlyArray<string>,
+  scope?: DmConversationScope,
 ): void {
   const normalizedTimestamp = normalizeTimestamp(timestamp);
   const normalizedArchiveTimestamp = archiveTimestamp ? normalizeTimestamp(archiveTimestamp) : undefined;
@@ -205,6 +215,7 @@ function advance(
       : mergeSeenIds(undefined, seenIds);
     map.set(key, {
       timestamp: normalizedTimestamp,
+      ...(scope ? { scope } : current?.scope ? { scope: current.scope } : {}),
       ...(nextArchiveId ? { archiveId: nextArchiveId } : {}),
       ...(nextArchiveTimestamp ? { archiveTimestamp: nextArchiveTimestamp } : {}),
       ...nonEmptyArchiveSeenIds(nextArchiveSeenIds),
@@ -219,6 +230,7 @@ function advance(
       : mergeSeenIds(current.archiveSeenIds, archiveSeenIds);
     map.set(key, {
       ...current,
+      ...(scope ? { scope } : {}),
       ...(archiveId ? { archiveId } : {}),
       ...(archiveId ? { archiveTimestamp: normalizedArchiveTimestamp ?? normalizedTimestamp } : {}),
       ...nonEmptyArchiveSeenIds(nextArchiveSeenIds),

--- a/chat/src/lib/xmpp/resume-persistence.ts
+++ b/chat/src/lib/xmpp/resume-persistence.ts
@@ -38,6 +38,7 @@ const OWNER_HANDOFF_PREFIX = `${SM_PREFIX}.owner-handoff`;
 
 type PersistedSeenCursor = {
   timestamp: string;
+  scope?: "account" | "muc-occupant";
   archiveId?: string;
   archiveTimestamp?: string;
   archiveSeenIds?: string[];
@@ -438,6 +439,7 @@ function isPersistedSeenCursor(value: unknown): value is PersistedSeenCursor {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Record<string, unknown>;
   if (typeof candidate.timestamp !== "string") return false;
+  if (candidate.scope !== undefined && candidate.scope !== "account" && candidate.scope !== "muc-occupant") return false;
   if (candidate.archiveId !== undefined && typeof candidate.archiveId !== "string") return false;
   if (candidate.archiveTimestamp !== undefined && typeof candidate.archiveTimestamp !== "string") return false;
   if (candidate.archiveSeenIds !== undefined) {

--- a/chat/src/lib/xmpp/resume-persistence.ts
+++ b/chat/src/lib/xmpp/resume-persistence.ts
@@ -133,7 +133,9 @@ export const nullResumePersistence: ResumePersistence = {
 
 export function createLocalStorageResumePersistence(accountKey: string, ownerId?: string): ResumePersistence {
   const owner = ownerId ? explicitResumeOwner(ownerId) : resumeOwner();
-  const catchupKeyPrefix = `${CATCHUP_PREFIX}.${accountKey}`;
+  // Length-prefix the account segment so prefix enumeration cannot make
+  // `alice@example.com` consume `alice@example.com.evil` shards.
+  const catchupKeyPrefix = `${CATCHUP_PREFIX}.${accountKey.length}:${accountKey}`;
   const catchupKey = `${catchupKeyPrefix}.${owner.ownerId}`;
   const smKey = `${SM_PREFIX}.${accountKey}`;
   const joinedRoomsKey = `${JOINED_ROOMS_PREFIX}.${accountKey}.${owner.ownerId}`;

--- a/chat/src/lib/xmpp/resume-persistence.ts
+++ b/chat/src/lib/xmpp/resume-persistence.ts
@@ -133,19 +133,20 @@ export const nullResumePersistence: ResumePersistence = {
 
 export function createLocalStorageResumePersistence(accountKey: string, ownerId?: string): ResumePersistence {
   const owner = ownerId ? explicitResumeOwner(ownerId) : resumeOwner();
-  const catchupKey = `${CATCHUP_PREFIX}.${accountKey}`;
+  const catchupKeyPrefix = `${CATCHUP_PREFIX}.${accountKey}`;
+  const catchupKey = `${catchupKeyPrefix}.${owner.ownerId}`;
   const smKey = `${SM_PREFIX}.${accountKey}`;
   const joinedRoomsKey = `${JOINED_ROOMS_PREFIX}.${accountKey}.${owner.ownerId}`;
 
   return {
     loadCatchup() {
-      return readJson<PersistedReconnectCatchup>(catchupKey, isPersistedReconnectCatchup, "catchup");
+      return readCatchupShards(catchupKeyPrefix);
     },
     saveCatchup(snapshot) {
       writeJson(catchupKey, snapshot, "catchup");
     },
     clearCatchup() {
-      removeKey(catchupKey, "catchup");
+      removeKeysWithPrefix(`${catchupKeyPrefix}.`, "catchup");
     },
     loadSm() {
       const envelope = readJson<PersistedSmEnvelope>(smKey, isPersistedSmEnvelope, "sm");
@@ -403,6 +404,40 @@ function readJson<T>(key: string, validate: (value: unknown) => value is T, kind
     });
     return null;
   }
+}
+
+function storageKeysWithPrefix(prefix: string): string[] {
+  const s = storage();
+  if (!s) return [];
+  const keys: string[] = [];
+  try {
+    for (let index = 0; index < s.length; index += 1) {
+      const key = s.key(index);
+      if (key?.startsWith(prefix)) keys.push(key);
+    }
+  } catch (err) {
+    reportError("storage.read", err, {
+      recoverable: true,
+      detail: "resume-persistence shard enumeration failed (catchup)",
+      storage_area: "catchup",
+    });
+  }
+  return keys;
+}
+
+function readCatchupShards(prefix: string): PersistedReconnectCatchup | null {
+  const snapshots = storageKeysWithPrefix(`${prefix}.`)
+    .map((key) => readJson<PersistedReconnectCatchup>(key, isPersistedReconnectCatchup, "catchup"))
+    .filter((snapshot): snapshot is PersistedReconnectCatchup => !!snapshot);
+  if (snapshots.length === 0) return null;
+  return {
+    dmLastSeen: snapshots.flatMap((snapshot) => snapshot.dmLastSeen),
+    roomLastSeen: snapshots.flatMap((snapshot) => snapshot.roomLastSeen),
+  };
+}
+
+function removeKeysWithPrefix(prefix: string, kind: string): void {
+  for (const key of storageKeysWithPrefix(prefix)) removeKey(key, kind);
 }
 
 function writeJson(key: string, value: unknown, kind: string): void {

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -20,6 +20,8 @@ export interface XmppStatusSnapshot {
  */
 type SessionCatchupCoverage = {
   dmJids: readonly string[];
+  /** DM cursor keys authoritatively scoped as full MUC occupant JIDs. */
+  dmOccupantJids?: readonly string[];
   roomJids: readonly string[];
 };
 

--- a/chat/tests/client-mam.test.ts
+++ b/chat/tests/client-mam.test.ts
@@ -313,6 +313,41 @@ describe("MUC-PM classification and archive isolation (#1256, #1281)", () => {
     expect(delivered.map((message) => message.body)).toEqual(["matching alice"]);
   });
 
+  test("persisted custom occupant scope keeps page, thread, and search full before topology discovery", async () => {
+    const catchup = new ReconnectCatchup();
+    catchup.recordDmSeen(
+      CUSTOM_MUC_PM_ALICE,
+      "2026-07-01T09:00:00.000Z",
+      "custom-persisted-cursor",
+      [],
+      "muc-occupant",
+    );
+    const mixed = page([
+      archivedMucPm("persisted-bob", CUSTOM_MUC_PM_BOB, "matching bob", "2026-07-01T10:00:00.000Z"),
+      archivedMucPm("persisted-alice", CUSTOM_MUC_PM_ALICE, "matching alice", "2026-07-01T10:00:01.000Z"),
+    ], { complete: true });
+    const requestedPeers: string[] = [];
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async (peerJid) => { requestedPeers.push(peerJid); return mixed; },
+      fetch_dm_history_by_thread: async (peerJid) => { requestedPeers.push(peerJid); return mixed; },
+      search_dm_history: async (peerJid) => { requestedPeers.push(peerJid); return mixed; },
+    };
+    const { pager } = createPager(xmpp, {
+      catchup,
+      classifyMucPm: () => undefined,
+      isMucPmPeer: () => false,
+    });
+
+    const history = await pager.queryPersonalMamPage(CUSTOM_MUC_PM_ALICE);
+    const thread = await pager.queryPersonalMamThreadPage(CUSTOM_MUC_PM_ALICE, "thread-1");
+    const search = await pager.searchDmMessages(CUSTOM_MUC_PM_ALICE, "matching");
+
+    expect(requestedPeers).toEqual(Array(3).fill(CUSTOM_MUC_PM_ALICE));
+    expect(history.messages.map((message) => message.body)).toEqual(["matching alice"]);
+    expect(thread.messages.map((message) => message.body)).toEqual(["matching alice"]);
+    expect(search.map((message) => message.body)).toEqual(["matching alice"]);
+  });
+
   test("cold-reload catch-up retains custom MUC occupant scope before topology discovery", async () => {
     const catchup = new ReconnectCatchup();
     catchup.onSessionStarted();

--- a/chat/tests/client-mam.test.ts
+++ b/chat/tests/client-mam.test.ts
@@ -10,11 +10,16 @@ import { describe, expect, test } from "bun:test";
 import { TypedEventBus, type ClientEvents } from "../src/lib/xmpp/client-events";
 import { MamPager, rawMessageSeenIds, type MamWasmClient } from "../src/lib/xmpp/client-mam";
 import { ReconnectCatchup } from "../src/lib/xmpp/reconnect-catchup";
+import { clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
 import type { LiveDmMessage, XmppErrorEvent } from "../src/lib/xmpp/types";
 import type { WasmArchivedMessage, WasmMamPage } from "../src/lib/xmpp/wasm-types";
 
 const SELF = "alice@example.com";
 const PEER = "bob@example.com";
+const MUC_PM_ALICE = "room@muc.example.com/alice";
+const MUC_PM_BOB = "room@muc.example.com/bob";
+const CUSTOM_MUC_PM_ALICE = "room@rooms.waddle.example/alice";
+const CUSTOM_MUC_PM_BOB = "room@rooms.waddle.example/bob";
 
 function archivedDm(mamId: string, body: string, timestamp: string, from = PEER): WasmArchivedMessage {
   return {
@@ -22,6 +27,23 @@ function archivedDm(mamId: string, body: string, timestamp: string, from = PEER)
     id: `msg-${mamId}`,
     from,
     to: from === PEER ? SELF : PEER,
+    body,
+    message_type: "chat",
+    timestamp,
+  };
+}
+
+function archivedMucPm(
+  mamId: string,
+  occupantJid: string,
+  body: string,
+  timestamp: string,
+): WasmArchivedMessage {
+  return {
+    mam_id: mamId,
+    id: `msg-${mamId}`,
+    from: occupantJid,
+    to: SELF,
     body,
     message_type: "chat",
     timestamp,
@@ -36,9 +58,17 @@ function page(messages: WasmArchivedMessage[], opts: { complete?: boolean } = {}
   };
 }
 
-function createPager(xmpp: MamWasmClient, overrides: { currentXmpp?: () => MamWasmClient | null } = {}) {
+function createPager(
+  xmpp: MamWasmClient,
+  overrides: {
+    currentXmpp?: () => MamWasmClient | null;
+    classifyMucPm?: (message: WasmArchivedMessage) => { occupantJid: string; nick: string } | undefined;
+    isMucPmPeer?: (peerJid: string) => boolean;
+    catchup?: ReconnectCatchup;
+  } = {},
+) {
   const events = new TypedEventBus<ClientEvents>();
-  const catchup = new ReconnectCatchup();
+  const catchup = overrides.catchup ?? new ReconnectCatchup();
   const errors: XmppErrorEvent[] = [];
   const pager = new MamPager({
     sessionJid: () => SELF,
@@ -54,12 +84,13 @@ function createPager(xmpp: MamWasmClient, overrides: { currentXmpp?: () => MamWa
     isCurrentConnected: (candidate) =>
       overrides.currentXmpp ? overrides.currentXmpp() === candidate : xmpp === candidate,
     // Mirrors BrowserXmppClient.mucPmOccupant for a known test room.
-    classifyMucPm: (message) => {
+    classifyMucPm: overrides.classifyMucPm ?? ((message) => {
       const counterpart = (message.from ?? "").startsWith(SELF) ? (message.to ?? "") : (message.from ?? "");
       const [bare, nick] = [counterpart.split("/")[0], counterpart.split("/").slice(1).join("/")];
       if (!nick || bare !== "room@muc.example.com") return undefined;
       return { occupantJid: counterpart, nick };
-    },
+    }),
+    isMucPmPeer: overrides.isMucPmPeer ?? ((peerJid) => peerJid.includes("@muc.example.com/")),
   });
   return { pager, events, catchup, errors };
 }
@@ -98,6 +129,60 @@ describe("MamPager page conversion", () => {
 
     expect(calls).toEqual([{ roomJid: "general@muc.example.com", max: 25 }]);
     expect(result).toEqual({ messages: [], complete: true });
+  });
+
+  test("ordinary full-resource DM pages retain bare conversation behavior", async () => {
+    const requestedPeers: string[] = [];
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async (peerJid) => {
+        requestedPeers.push(peerJid);
+        return page([
+          archivedDm("resource-page", "hello", "2024-01-01T00:00:01Z", `${PEER}/phone`),
+        ], { complete: true });
+      },
+    };
+    const { pager } = createPager(xmpp);
+
+    const result = await pager.queryPersonalMamPage(`${PEER}/phone`);
+
+    expect(requestedPeers).toEqual([PEER]);
+    expect(result.messages.map((message) => message.body)).toEqual(["hello"]);
+  });
+
+  test("ordinary full-resource DM thread pages retain bare conversation behavior", async () => {
+    const requestedPeers: string[] = [];
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_by_thread: async (peerJid) => {
+        requestedPeers.push(peerJid);
+        return page([
+          archivedDm("resource-thread", "thread reply", "2024-01-01T00:00:01Z", `${PEER}/phone`),
+        ], { complete: true });
+      },
+    };
+    const { pager } = createPager(xmpp);
+
+    const result = await pager.queryPersonalMamThreadPage(`${PEER}/phone`, "thread-1");
+
+    expect(requestedPeers).toEqual([PEER]);
+    expect(result.messages.map((message) => message.body)).toEqual(["thread reply"]);
+  });
+
+  test("ordinary full-resource DM search retains bare conversation behavior", async () => {
+    const requestedPeers: string[] = [];
+    const xmpp: MamWasmClient = {
+      search_dm_history: async (peerJid) => {
+        requestedPeers.push(peerJid);
+        return page([
+          archivedDm("resource-search", "matching", "2024-01-01T00:00:01Z", `${PEER}/phone`),
+        ], { complete: true });
+      },
+    };
+    const { pager } = createPager(xmpp);
+
+    const result = await pager.searchDmMessages(`${PEER}/phone`, "matching");
+
+    expect(requestedPeers).toEqual([PEER]);
+    expect(result.map((message) => message.body)).toEqual(["matching"]);
   });
 });
 
@@ -193,7 +278,572 @@ describe("MamPager reconnect catch-up cursor handling", () => {
   });
 });
 
-describe("MUC-PM classification on the archive path (#1256)", () => {
+describe("MUC-PM classification and archive isolation (#1256, #1281)", () => {
+  test("custom MUC service scopes page, thread, search, and reconnect by full occupant", async () => {
+    const mixed = page([
+      archivedMucPm("custom-bob", CUSTOM_MUC_PM_BOB, "matching bob", "2026-07-01T10:00:00.000Z"),
+      archivedMucPm("custom-alice", CUSTOM_MUC_PM_ALICE, "matching alice", "2026-07-01T10:00:01.000Z"),
+    ], { complete: true });
+    const requestedPeers: string[] = [];
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async (peerJid) => { requestedPeers.push(peerJid); return mixed; },
+      fetch_dm_history_by_thread: async (peerJid) => { requestedPeers.push(peerJid); return mixed; },
+      search_dm_history: async (peerJid) => { requestedPeers.push(peerJid); return mixed; },
+    };
+    const { pager, events } = createPager(xmpp, {
+      classifyMucPm: () => undefined,
+      isMucPmPeer: (peerJid) => peerJid.includes("@rooms.waddle.example/"),
+    });
+    const delivered: LiveDmMessage[] = [];
+    events.on("directMessage", (message) => delivered.push(message));
+
+    const history = await pager.queryPersonalMamPage(CUSTOM_MUC_PM_ALICE);
+    const thread = await pager.queryPersonalMamThreadPage(CUSTOM_MUC_PM_ALICE, "thread-1");
+    const search = await pager.searchDmMessages(CUSTOM_MUC_PM_ALICE, "matching");
+    await pager.runReconnectCatchup(
+      xmpp,
+      [{ kind: "dm", key: CUSTOM_MUC_PM_ALICE, after: "before-gap" }],
+      "fresh",
+    );
+
+    expect(requestedPeers).toEqual(Array(4).fill(CUSTOM_MUC_PM_ALICE));
+    expect(history.messages.map((message) => message.body)).toEqual(["matching alice"]);
+    expect(thread.messages.map((message) => message.body)).toEqual(["matching alice"]);
+    expect(search.map((message) => message.body)).toEqual(["matching alice"]);
+    expect(delivered.map((message) => message.body)).toEqual(["matching alice"]);
+  });
+
+  test("cold-reload catch-up retains custom MUC occupant scope before topology discovery", async () => {
+    const catchup = new ReconnectCatchup();
+    catchup.onSessionStarted();
+    catchup.recordDmSeen(
+      CUSTOM_MUC_PM_ALICE,
+      "2026-07-01T10:00:00.000Z",
+      "custom-before-gap",
+      [],
+      "muc-occupant",
+    );
+    const requestedPeers: string[] = [];
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async (peerJid) => {
+        requestedPeers.push(peerJid);
+        return page([
+          archivedMucPm("custom-cold-bob", CUSTOM_MUC_PM_BOB, "bob secret", "2026-07-01T10:00:01.000Z"),
+          archivedMucPm("custom-cold-alice", CUSTOM_MUC_PM_ALICE, "alice message", "2026-07-01T10:00:02.000Z"),
+        ], { complete: true });
+      },
+    };
+    const { pager, events } = createPager(xmpp, {
+      catchup,
+      classifyMucPm: () => undefined,
+      isMucPmPeer: () => false,
+    });
+    const delivered: LiveDmMessage[] = [];
+    events.on("directMessage", (message) => delivered.push(message));
+
+    await pager.runReconnectCatchup(xmpp, catchup.onSessionStarted(), "fresh");
+
+    expect(requestedPeers).toEqual([CUSTOM_MUC_PM_ALICE]);
+    expect(delivered.map((message) => message.body)).toEqual(["alice message"]);
+  });
+
+  test("overlapping handles keep custom occupant scope request-local when the old run resolves first", async () => {
+    let resolveOld: ((page: WasmMamPage) => void) | undefined;
+    let resolveCurrent: ((page: WasmMamPage) => void) | undefined;
+    const oldXmpp: MamWasmClient = {
+      fetch_dm_history_page: async () => new Promise<WasmMamPage>((resolve) => { resolveOld = resolve; }),
+    };
+    const currentXmpp: MamWasmClient = {
+      fetch_dm_history_page: async () => new Promise<WasmMamPage>((resolve) => { resolveCurrent = resolve; }),
+    };
+    let current: MamWasmClient | null = oldXmpp;
+    const { pager, events } = createPager(oldXmpp, {
+      currentXmpp: () => current,
+      classifyMucPm: () => undefined,
+      isMucPmPeer: () => false,
+    });
+    const delivered: LiveDmMessage[] = [];
+    events.on("directMessage", (message) => delivered.push(message));
+    clearDmCallActivities();
+    const entry = {
+      kind: "dm" as const,
+      key: CUSTOM_MUC_PM_ALICE,
+      scope: "muc-occupant" as const,
+      after: "before-gap",
+    };
+
+    const oldRun = pager.runReconnectCatchup(oldXmpp, [entry], "fresh");
+    await Promise.resolve();
+    current = currentXmpp;
+    const currentRun = pager.runReconnectCatchup(currentXmpp, [entry], "fresh");
+    await Promise.resolve();
+    resolveOld?.(page([], { complete: true }));
+    await oldRun;
+    const targetCall = archivedMucPm("overlap-call", CUSTOM_MUC_PM_ALICE, "", new Date().toISOString());
+    targetCall.call_event = {
+      kind: "propose",
+      from: CUSTOM_MUC_PM_ALICE,
+      to: `${SELF}/web-test`,
+      sid: "overlap-call",
+      media: { audio: true, video: false },
+    };
+    resolveCurrent?.(page([
+      archivedMucPm("overlap-bob", CUSTOM_MUC_PM_BOB, "bob secret", "2026-07-01T10:00:01.000Z"),
+      targetCall,
+      archivedMucPm("overlap-alice", CUSTOM_MUC_PM_ALICE, "alice message", "2026-07-01T10:00:02.000Z"),
+    ], { complete: true }));
+    await currentRun;
+
+    expect(delivered.map((message) => message.body)).toEqual(["alice message"]);
+    expect(readDmCallActivity("room@rooms.waddle.example")).toBeNull();
+    clearDmCallActivities();
+  });
+
+  test("muc-looking ordinary account resource stays a bare DM when service authority differs", async () => {
+    const requestedPeers: string[] = [];
+    const ordinaryPeer = "user@muc.example.com/phone";
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async (peerJid) => {
+        requestedPeers.push(peerJid);
+        return page([archivedDm("muc-looking-user", "hello", "2026-07-01T10:00:00.000Z", ordinaryPeer)], { complete: true });
+      },
+    };
+    const { pager } = createPager(xmpp, {
+      isMucPmPeer: (peerJid) => peerJid.includes("@rooms.waddle.example/"),
+    });
+
+    const result = await pager.queryPersonalMamPage(ordinaryPeer);
+
+    expect(requestedPeers).toEqual(["user@muc.example.com"]);
+    expect(result.messages.map((message) => message.body)).toEqual(["hello"]);
+  });
+  test("full-peer pages isolate and re-key incoming and outgoing rows without room discovery", async () => {
+    const outgoingTarget = archivedMucPm(
+      "pm-alice-outgoing",
+      `${SELF}/web-test`,
+      "outgoing alice",
+      "2026-07-01T10:00:02.000Z",
+    );
+    outgoingTarget.to = MUC_PM_ALICE;
+    const outgoingSibling = archivedMucPm(
+      "pm-bob-outgoing",
+      `${SELF}/web-test`,
+      "outgoing bob",
+      "2026-07-01T10:00:03.000Z",
+    );
+    outgoingSibling.to = MUC_PM_BOB;
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async () => page([
+        archivedMucPm("pm-bob", MUC_PM_BOB, "incoming bob", "2026-07-01T10:00:00.000Z"),
+        archivedMucPm("pm-alice", MUC_PM_ALICE, "incoming alice", "2026-07-01T10:00:01.000Z"),
+        outgoingSibling,
+        outgoingTarget,
+      ], { complete: true }),
+    };
+    const { pager, catchup } = createPager(xmpp, { classifyMucPm: () => undefined });
+
+    const result = await pager.queryPersonalMamPage(MUC_PM_ALICE);
+
+    expect(result.messages.map(({ body, peerJid, mucPm }) => ({ body, peerJid, mucPm }))).toEqual([
+      { body: "incoming alice", peerJid: MUC_PM_ALICE, mucPm: true },
+      { body: "outgoing alice", peerJid: MUC_PM_ALICE, mucPm: true },
+    ]);
+    expect(catchup.getDmLastSeen(MUC_PM_ALICE)).toBe("2026-07-01T10:00:02.000Z");
+    expect(catchup.getDmLastSeen(MUC_PM_BOB)).toBeUndefined();
+  });
+
+  test("full-peer thread and search results isolate rows without room discovery", async () => {
+    const mixed = page([
+      archivedMucPm("result-bob", MUC_PM_BOB, "matching bob", "2026-07-01T10:00:00.000Z"),
+      archivedMucPm("result-alice", MUC_PM_ALICE, "matching alice", "2026-07-01T10:00:01.000Z"),
+    ], { complete: true });
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_by_thread: async () => mixed,
+      search_dm_history: async () => mixed,
+    };
+    const { pager } = createPager(xmpp, { classifyMucPm: () => undefined });
+
+    const thread = await pager.queryPersonalMamThreadPage(MUC_PM_ALICE, "thread-1");
+    const search = await pager.searchDmMessages(MUC_PM_ALICE, "matching");
+
+    expect(thread.messages.map((message) => message.body)).toEqual(["matching alice"]);
+    expect(search.map((message) => message.body)).toEqual(["matching alice"]);
+    expect(thread.messages[0]?.peerJid).toBe(MUC_PM_ALICE);
+    expect(search[0]?.peerJid).toBe(MUC_PM_ALICE);
+  });
+
+  test("full-peer reconnect emits incoming and outgoing target rows without room discovery", async () => {
+    const outgoingTarget = archivedMucPm(
+      "catchup-alice-outgoing",
+      `${SELF}/web-test`,
+      "outgoing alice",
+      "2026-07-01T10:00:02.000Z",
+    );
+    outgoingTarget.to = MUC_PM_ALICE;
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async () => page([
+        archivedMucPm("catchup-bob", MUC_PM_BOB, "incoming bob", "2026-07-01T10:00:00.000Z"),
+        archivedMucPm("catchup-alice", MUC_PM_ALICE, "incoming alice", "2026-07-01T10:00:01.000Z"),
+        outgoingTarget,
+      ], { complete: true }),
+    };
+    const { pager, events, catchup } = createPager(xmpp, { classifyMucPm: () => undefined });
+    const delivered: LiveDmMessage[] = [];
+    events.on("directMessage", (message) => delivered.push(message));
+
+    await pager.runReconnectCatchup(
+      xmpp,
+      [{ kind: "dm", key: MUC_PM_ALICE, after: "before-gap" }],
+      "fresh",
+    );
+
+    expect(delivered.map(({ body, peerJid, mucPm }) => ({ body, peerJid, mucPm }))).toEqual([
+      { body: "incoming alice", peerJid: MUC_PM_ALICE, mucPm: true },
+      { body: "outgoing alice", peerJid: MUC_PM_ALICE, mucPm: true },
+    ]);
+    expect(catchup.getDmLastSeen(MUC_PM_ALICE)).toBe("2026-07-01T10:00:02.000Z");
+    expect(catchup.getDmLastSeen(MUC_PM_BOB)).toBeUndefined();
+  });
+
+  test("legacy bare-room catch-up rejects occupant rows when room discovery is unavailable", async () => {
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async () => page([
+        archivedMucPm("legacy-bob", MUC_PM_BOB, "bob secret", "2026-07-01T10:00:00.000Z"),
+        archivedMucPm("legacy-alice", MUC_PM_ALICE, "alice secret", "2026-07-01T10:00:01.000Z"),
+      ], { complete: true }),
+    };
+    const { pager, events, catchup } = createPager(xmpp, { classifyMucPm: () => undefined });
+    const delivered: LiveDmMessage[] = [];
+    events.on("directMessage", (message) => delivered.push(message));
+
+    await pager.runReconnectCatchup(
+      xmpp,
+      [{ kind: "dm", key: "room@muc.example.com", after: "legacy-boundary" }],
+      "fresh",
+    );
+
+    expect(delivered).toEqual([]);
+    expect(catchup.getDmLastSeen("room@muc.example.com")).toBeUndefined();
+  });
+
+  test("legacy bare-room pages reject occupant rows before conversion", async () => {
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async () => page([
+        archivedMucPm("legacy-page-bob", MUC_PM_BOB, "bob secret", "2026-07-01T10:00:00.000Z"),
+        archivedMucPm("legacy-page-alice", MUC_PM_ALICE, "alice secret", "2026-07-01T10:00:01.000Z"),
+      ], { complete: false }),
+    };
+    const { pager, catchup } = createPager(xmpp, { classifyMucPm: () => undefined });
+
+    const result = await pager.queryPersonalMamPage("room@muc.example.com");
+
+    expect(result.messages).toEqual([]);
+    expect(result.firstArchiveId).toBe("legacy-page-bob");
+    expect(result.lastArchiveId).toBe("legacy-page-alice");
+    expect(catchup.getDmLastSeen("room@muc.example.com")).toBeUndefined();
+  });
+
+  test("legacy bare-room thread pages reject occupant rows before conversion", async () => {
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_by_thread: async () => page([
+        archivedMucPm("legacy-thread-bob", MUC_PM_BOB, "bob secret", "2026-07-01T10:00:00.000Z"),
+        archivedMucPm("legacy-thread-alice", MUC_PM_ALICE, "alice secret", "2026-07-01T10:00:01.000Z"),
+      ], { complete: false }),
+    };
+    const { pager, catchup } = createPager(xmpp, { classifyMucPm: () => undefined });
+
+    const result = await pager.queryPersonalMamThreadPage("room@muc.example.com", "thread-1");
+
+    expect(result.messages).toEqual([]);
+    expect(result.firstArchiveId).toBe("legacy-thread-bob");
+    expect(result.lastArchiveId).toBe("legacy-thread-alice");
+    expect(catchup.getDmLastSeen("room@muc.example.com")).toBeUndefined();
+  });
+
+  test("legacy bare-room search rejects occupant rows before conversion", async () => {
+    const xmpp: MamWasmClient = {
+      search_dm_history: async () => page([
+        archivedMucPm("legacy-search-bob", MUC_PM_BOB, "matching bob", "2026-07-01T10:00:00.000Z"),
+        archivedMucPm("legacy-search-alice", MUC_PM_ALICE, "matching alice", "2026-07-01T10:00:01.000Z"),
+      ], { complete: true }),
+    };
+    const { pager } = createPager(xmpp, { classifyMucPm: () => undefined });
+
+    const result = await pager.searchDmMessages("room@muc.example.com", "matching");
+
+    expect(result).toEqual([]);
+  });
+
+  test("full-peer pages ignore target call events and do not create bare-room watermarks", async () => {
+    clearDmCallActivities();
+    const targetCall = archivedMucPm(
+      "target-call",
+      MUC_PM_ALICE,
+      "",
+      new Date().toISOString(),
+    );
+    targetCall.call_event = {
+      kind: "propose",
+      from: MUC_PM_ALICE,
+      to: `${SELF}/web-test`,
+      sid: "target-call",
+      media: { audio: true, video: false },
+    };
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async () => page([targetCall], { complete: true }),
+    };
+    const { pager, catchup } = createPager(xmpp);
+
+    const result = await pager.queryPersonalMamPage(MUC_PM_ALICE);
+
+    expect(result.messages).toEqual([]);
+    expect(readDmCallActivity("room@muc.example.com")).toBeNull();
+    expect(catchup.getDmLastSeen("room@muc.example.com")).toBeUndefined();
+    clearDmCallActivities();
+  });
+
+  test("cold global personal-history call hydration ignores custom-service MUC-PM call events", async () => {
+    clearDmCallActivities();
+    const targetCall = archivedMucPm(
+      "hydration-target-call",
+      CUSTOM_MUC_PM_ALICE,
+      "",
+      new Date().toISOString(),
+    );
+    targetCall.call_event = {
+      kind: "propose",
+      from: CUSTOM_MUC_PM_ALICE,
+      to: `${SELF}/web-test`,
+      sid: "hydration-target-call",
+      media: { audio: true, video: false },
+    };
+    const xmpp: MamWasmClient = {
+      fetch_personal_history_page: async () => page([targetCall], { complete: true }),
+    };
+    const { pager } = createPager(xmpp, { isMucPmPeer: () => false });
+
+    await pager.hydrateRecentDmCallActivities();
+
+    expect(readDmCallActivity("room@rooms.waddle.example")).toBeNull();
+    clearDmCallActivities();
+  });
+
+  test("global personal-history call hydration preserves ordinary bare DM calls", async () => {
+    clearDmCallActivities();
+    const ordinaryCall = archivedDm("ordinary-hydration-call", "", new Date().toISOString(), PEER);
+    ordinaryCall.call_event = {
+      kind: "propose",
+      from: PEER,
+      to: SELF,
+      sid: "ordinary-hydration-call",
+      media: { audio: true, video: false },
+    };
+    const xmpp: MamWasmClient = {
+      fetch_personal_history_page: async () => page([ordinaryCall], { complete: true }),
+    };
+    const { pager } = createPager(xmpp, { isMucPmPeer: () => false });
+
+    await pager.hydrateRecentDmCallActivities();
+
+    expect(readDmCallActivity(PEER)?.sid).toBe("ordinary-hydration-call");
+    clearDmCallActivities();
+  });
+
+  test("selected call hydration skips a peer with persisted MUC occupant scope", async () => {
+    const catchup = new ReconnectCatchup();
+    catchup.recordDmSeen(CUSTOM_MUC_PM_ALICE, new Date().toISOString(), undefined, [], "muc-occupant");
+    const requestedPeers: string[] = [];
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async (peerJid) => {
+        requestedPeers.push(peerJid);
+        return page([], { complete: true });
+      },
+    };
+    const { pager } = createPager(xmpp, {
+      catchup,
+      isMucPmPeer: () => false,
+    });
+
+    await pager.hydrateRecentDmCallActivity(CUSTOM_MUC_PM_ALICE);
+
+    expect(requestedPeers).toEqual([]);
+  });
+
+  test("latest pages keep the full requested occupant and reject sibling occupants before watermarking", async () => {
+    const requestedPeers: string[] = [];
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async (peerJid) => {
+        requestedPeers.push(peerJid);
+        return page([
+          archivedMucPm("pm-bob", MUC_PM_BOB, "bob secret", "2026-07-01T10:00:00.000Z"),
+          archivedMucPm("pm-alice", MUC_PM_ALICE, "alice secret", "2026-07-01T10:00:01.000Z"),
+        ], { complete: false });
+      },
+    };
+    const { pager, catchup } = createPager(xmpp);
+
+    const result = await pager.queryPersonalMamPage(MUC_PM_ALICE, 50, { type: "latest" });
+
+    expect(requestedPeers).toEqual([MUC_PM_ALICE]);
+    expect(result.messages.map((message) => message.body)).toEqual(["alice secret"]);
+    expect(result.firstArchiveId).toBe("pm-bob");
+    expect(result.lastArchiveId).toBe("pm-alice");
+    expect(result.complete).toBe(false);
+    expect(catchup.getDmLastSeen(MUC_PM_ALICE)).toBe("2026-07-01T10:00:01.000Z");
+    expect(catchup.getDmLastSeen(MUC_PM_BOB)).toBeUndefined();
+  });
+
+  test("before pages preserve their raw cursor while filtering sibling occupants", async () => {
+    const calls: Array<{ peerJid: string; before?: string }> = [];
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async (peerJid, _max, pageParam) => {
+        calls.push({
+          peerJid,
+          ...(pageParam.type === "before" ? { before: pageParam.before } : {}),
+        });
+        return page([
+          archivedMucPm("older-bob", MUC_PM_BOB, "older bob", "2026-07-01T09:00:00.000Z"),
+        ], { complete: false });
+      },
+    };
+    const { pager } = createPager(xmpp);
+
+    const result = await pager.queryPersonalMamPage(MUC_PM_ALICE, 50, {
+      type: "before",
+      before: "newer-boundary",
+    });
+
+    expect(calls).toEqual([{ peerJid: MUC_PM_ALICE, before: "newer-boundary" }]);
+    expect(result.messages).toEqual([]);
+    expect(result.firstArchiveId).toBe("older-bob");
+    expect(result.lastArchiveId).toBe("older-bob");
+    expect(result.complete).toBe(false);
+  });
+
+  test("thread pages keep the full requested occupant and reject sibling occupants", async () => {
+    const requestedPeers: string[] = [];
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_by_thread: async (peerJid) => {
+        requestedPeers.push(peerJid);
+        return page([
+          archivedMucPm("thread-bob", MUC_PM_BOB, "bob reply", "2026-07-01T10:00:00.000Z"),
+          archivedMucPm("thread-alice", MUC_PM_ALICE, "alice reply", "2026-07-01T10:00:01.000Z"),
+        ], { complete: true });
+      },
+    };
+    const { pager, catchup } = createPager(xmpp);
+
+    const result = await pager.queryPersonalMamThreadPage(MUC_PM_ALICE, "thread-1", 50);
+
+    expect(requestedPeers).toEqual([MUC_PM_ALICE]);
+    expect(result.messages.map((message) => message.body)).toEqual(["alice reply"]);
+    expect(catchup.getDmLastSeen(MUC_PM_ALICE)).toBe("2026-07-01T10:00:01.000Z");
+    expect(catchup.getDmLastSeen(MUC_PM_BOB)).toBeUndefined();
+  });
+
+  test("search keeps the full requested occupant and rejects sibling results", async () => {
+    const requestedPeers: string[] = [];
+    const xmpp: MamWasmClient = {
+      search_dm_history: async (peerJid) => {
+        requestedPeers.push(peerJid);
+        return page([
+          archivedMucPm("search-bob", MUC_PM_BOB, "matching bob", "2026-07-01T10:00:00.000Z"),
+          archivedMucPm("search-alice", MUC_PM_ALICE, "matching alice", "2026-07-01T10:00:01.000Z"),
+        ], { complete: true });
+      },
+    };
+    const { pager } = createPager(xmpp);
+
+    const result = await pager.searchDmMessages(MUC_PM_ALICE, "matching", 20);
+
+    expect(requestedPeers).toEqual([MUC_PM_ALICE]);
+    expect(result.map((message) => ({ body: message.body, peerJid: message.peerJid }))).toEqual([
+      { body: "matching alice", peerJid: MUC_PM_ALICE },
+    ]);
+  });
+
+  test("forward reconnect catch-up emits and watermarks only the requested occupant", async () => {
+    const requestedPeers: string[] = [];
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async (peerJid) => {
+        requestedPeers.push(peerJid);
+        return page([
+          archivedMucPm("catchup-bob", MUC_PM_BOB, "missed bob", "2026-07-01T10:00:00.000Z"),
+          archivedMucPm("catchup-alice", MUC_PM_ALICE, "missed alice", "2026-07-01T10:00:01.000Z"),
+        ], { complete: true });
+      },
+    };
+    const { pager, events, catchup } = createPager(xmpp);
+    const delivered: LiveDmMessage[] = [];
+    events.on("directMessage", (message) => delivered.push(message));
+
+    await pager.runReconnectCatchup(
+      xmpp,
+      [{ kind: "dm", key: MUC_PM_ALICE, after: "before-gap" }],
+      "fresh",
+    );
+
+    expect(requestedPeers).toEqual([MUC_PM_ALICE]);
+    expect(delivered.map((message) => message.body)).toEqual(["missed alice"]);
+    expect(catchup.getDmLastSeen(MUC_PM_ALICE)).toBe("2026-07-01T10:00:01.000Z");
+    expect(catchup.getDmLastSeen(MUC_PM_BOB)).toBeUndefined();
+  });
+
+  test("timestamp reconnect fallback rejects sibling messages and all MUC-PM call-event side effects", async () => {
+    clearDmCallActivities();
+    const now = Date.now();
+    const siblingTimestamp = new Date(now - 1_000).toISOString();
+    const targetTimestamp = new Date(now).toISOString();
+    const since = new Date(now - 2_000).toISOString();
+    const siblingCall = archivedMucPm(
+      "timestamp-bob-call",
+      MUC_PM_BOB,
+      "",
+      siblingTimestamp,
+    );
+    siblingCall.call_event = {
+      kind: "propose",
+      from: MUC_PM_BOB,
+      to: `${SELF}/web-test`,
+      sid: "sibling-call",
+      media: { audio: true, video: false },
+    };
+    const targetCall = archivedMucPm(
+      "timestamp-alice-call",
+      MUC_PM_ALICE,
+      "",
+      targetTimestamp,
+    );
+    targetCall.call_event = {
+      kind: "propose",
+      from: MUC_PM_ALICE,
+      to: `${SELF}/web-test`,
+      sid: "target-call",
+      media: { audio: true, video: false },
+    };
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async () => page([
+        siblingCall,
+        targetCall,
+        archivedMucPm("timestamp-alice", MUC_PM_ALICE, "recent alice", targetTimestamp),
+      ], { complete: true }),
+    };
+    const { pager, events, catchup } = createPager(xmpp);
+    const delivered: LiveDmMessage[] = [];
+    events.on("directMessage", (message) => delivered.push(message));
+
+    await pager.runReconnectCatchup(
+      xmpp,
+      [{ kind: "dm", key: MUC_PM_ALICE, since }],
+      "fresh",
+    );
+
+    expect(delivered.map((message) => message.body)).toEqual(["recent alice"]);
+    expect(catchup.getDmLastSeen(MUC_PM_BOB)).toBeUndefined();
+    expect(readDmCallActivity("room@muc.example.com")).toBeNull();
+    clearDmCallActivities();
+  });
+
   test("catch-up re-emissions re-key MUC PMs by the occupant JID", async () => {
     const pmFromOccupant: WasmArchivedMessage = {
       mam_id: "pm-1",

--- a/chat/tests/client-mam.test.ts
+++ b/chat/tests/client-mam.test.ts
@@ -149,6 +149,21 @@ describe("MamPager page conversion", () => {
     expect(result.messages.map((message) => message.body)).toEqual(["hello"]);
   });
 
+  test("known MUC authority overrides a stale bare account cursor", async () => {
+    const requestedPeers: string[] = [];
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async (peerJid) => {
+        requestedPeers.push(peerJid);
+        return page([], { complete: true });
+      },
+    };
+    const { pager, catchup } = createPager(xmpp);
+    catchup.recordDmSeen("room@muc.example.com/mobile", "2026-07-01T09:00:00.000Z");
+    await pager.queryPersonalMamPage(MUC_PM_ALICE);
+
+    expect(requestedPeers).toEqual([MUC_PM_ALICE]);
+  });
+
   test("ordinary full-resource DM thread pages retain bare conversation behavior", async () => {
     const requestedPeers: string[] = [];
     const xmpp: MamWasmClient = {

--- a/chat/tests/client-mam.test.ts
+++ b/chat/tests/client-mam.test.ts
@@ -204,7 +204,7 @@ describe("MamPager reconnect catch-up cursor handling", () => {
     const delivered: LiveDmMessage[] = [];
     events.on("directMessage", (message) => delivered.push(message));
 
-    await pager.runReconnectCatchup(xmpp, [{ kind: "dm", key: PEER, after: "a0" }]);
+    await pager.runReconnectCatchup(xmpp, [{ kind: "dm", key: PEER, scope: "account", after: "a0" }]);
 
     expect(cursors).toEqual(["a0", "a1"]);
     expect(delivered.map((message) => message.body)).toEqual(["one", "two"]);
@@ -218,7 +218,7 @@ describe("MamPager reconnect catch-up cursor handling", () => {
     };
     const { pager, errors } = createPager(xmpp);
 
-    await pager.runReconnectCatchup(xmpp, [{ kind: "dm", key: PEER, after: "a0" }]);
+    await pager.runReconnectCatchup(xmpp, [{ kind: "dm", key: PEER, scope: "account", after: "a0" }]);
 
     expect(errors).toHaveLength(1);
     expect(errors[0].kind).toBe("history");
@@ -247,7 +247,7 @@ describe("MamPager reconnect catch-up cursor handling", () => {
     events.on("directMessage", (message) => delivered.push(message));
 
     await pager.runReconnectCatchup(xmpp, [
-      { kind: "dm", key: PEER, after: "gone", since: "2024-01-01T00:00:01Z" },
+      { kind: "dm", key: PEER, scope: "account", after: "gone", since: "2024-01-01T00:00:01Z" },
     ]);
 
     expect(afterAttempts).toBe(1);
@@ -271,7 +271,7 @@ describe("MamPager reconnect catch-up cursor handling", () => {
     const catchupInfos: Array<{ outcome: string }> = [];
     events.on("catchup", (info) => catchupInfos.push({ outcome: info.outcome }));
 
-    await pager.runReconnectCatchup(xmpp, [{ kind: "dm", key: PEER, after: "a0" }]);
+    await pager.runReconnectCatchup(xmpp, [{ kind: "dm", key: PEER, scope: "account", after: "a0" }]);
 
     expect(delivered).toEqual([]);
     expect(catchupInfos).toEqual([{ outcome: "aborted" }]);
@@ -302,7 +302,7 @@ describe("MUC-PM classification and archive isolation (#1256, #1281)", () => {
     const search = await pager.searchDmMessages(CUSTOM_MUC_PM_ALICE, "matching");
     await pager.runReconnectCatchup(
       xmpp,
-      [{ kind: "dm", key: CUSTOM_MUC_PM_ALICE, after: "before-gap" }],
+      [{ kind: "dm", key: CUSTOM_MUC_PM_ALICE, scope: "muc-occupant", after: "before-gap" }],
       "fresh",
     );
 
@@ -493,7 +493,7 @@ describe("MUC-PM classification and archive isolation (#1256, #1281)", () => {
 
     await pager.runReconnectCatchup(
       xmpp,
-      [{ kind: "dm", key: MUC_PM_ALICE, after: "before-gap" }],
+      [{ kind: "dm", key: MUC_PM_ALICE, scope: "muc-occupant", after: "before-gap" }],
       "fresh",
     );
 
@@ -518,7 +518,7 @@ describe("MUC-PM classification and archive isolation (#1256, #1281)", () => {
 
     await pager.runReconnectCatchup(
       xmpp,
-      [{ kind: "dm", key: "room@muc.example.com", after: "legacy-boundary" }],
+      [{ kind: "dm", key: "room@muc.example.com", scope: "account", after: "legacy-boundary" }],
       "fresh",
     );
 
@@ -779,7 +779,7 @@ describe("MUC-PM classification and archive isolation (#1256, #1281)", () => {
 
     await pager.runReconnectCatchup(
       xmpp,
-      [{ kind: "dm", key: MUC_PM_ALICE, after: "before-gap" }],
+      [{ kind: "dm", key: MUC_PM_ALICE, scope: "muc-occupant", after: "before-gap" }],
       "fresh",
     );
 
@@ -834,7 +834,7 @@ describe("MUC-PM classification and archive isolation (#1256, #1281)", () => {
 
     await pager.runReconnectCatchup(
       xmpp,
-      [{ kind: "dm", key: MUC_PM_ALICE, since }],
+      [{ kind: "dm", key: MUC_PM_ALICE, scope: "muc-occupant", since }],
       "fresh",
     );
 
@@ -863,7 +863,7 @@ describe("MUC-PM classification and archive isolation (#1256, #1281)", () => {
 
     await pager.runReconnectCatchup(
       xmpp,
-      [{ kind: "dm", key: "room@muc.example.com/juliet", since: "2026-07-01T09:00:00.000Z" }],
+      [{ kind: "dm", key: "room@muc.example.com/juliet", scope: "muc-occupant", since: "2026-07-01T09:00:00.000Z" }],
       "fresh",
     );
 

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -1106,6 +1106,44 @@ describe("client send readiness", () => {
     expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toEqual([]);
   });
 
+  test("custom-service MUC-PM sends preserve the occupant resource before room discovery", async () => {
+    const sentTargets: string[] = [];
+    const captureTarget = async (target: string) => { sentTargets.push(target); };
+    const xmpp = {
+      send_chat_message: mock(async (target: string) => { sentTargets.push(target); return "muc-pm-send"; }),
+      send_chat_state: mock(captureTarget),
+      send_displayed: mock(captureTarget),
+      send_retraction: mock(captureTarget),
+      send_correction: mock(async (target: string) => { sentTargets.push(target); return "muc-pm-correction"; }),
+      send_reaction: mock(captureTarget),
+    };
+    const client = new BrowserXmppClient(session());
+    const occupant = "room@rooms.waddle.example/alice";
+    (client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      mucServiceJid: string;
+      connect: ReturnType<typeof mock>;
+    }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { mucServiceJid: string }).mucServiceJid = "rooms.waddle.example";
+    (client as unknown as { connect: ReturnType<typeof mock> }).connect = mock(async () => undefined);
+
+    await client.sendDirectMessage(occupant, "hello", { id: "muc-pm-send" });
+    await client.sendDmChatState(occupant, "composing");
+    await client.sendDmDisplayed(occupant, "message-1");
+    await client.sendDmRetraction(occupant, "message-1");
+    await client.sendDmCorrection(occupant, "edited", "message-1");
+    await client.sendDmReaction(occupant, "message-1", ["👍"]);
+
+    expect(sentTargets).toEqual(Array(6).fill(occupant));
+    expect((xmpp.send_chat_message.mock.calls[0]?.[2] as { muc_pm?: boolean }).muc_pm).toBe(true);
+    expect(
+      (client as unknown as { directMessageAddress: (peerJid: string) => string })
+        .directMessageAddress("user@accounts.example/phone"),
+    ).toBe("user@accounts.example");
+  });
+
   test("native failed-resume fallback owns resend for live unacked DM sends", async () => {
     const xmpp = {
       send_chat_message: mock(async (_peer: string, _body: string, opts: { stanza_id?: string }) => opts.stanza_id),

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -1127,7 +1127,7 @@ describe("client send readiness", () => {
     (client as unknown as { connected: boolean }).connected = true;
     (client as unknown as { connect: ReturnType<typeof mock> }).connect = mock(async () => undefined);
     client.catchup.recordDmSeen(
-      occupant,
+      " Room@Rooms.Waddle.Example/alice ",
       "2026-07-11T17:00:00.000Z",
       undefined,
       undefined,

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -1330,7 +1330,7 @@ describe("client keepalive lifecycle", () => {
       peerJid: "bob@example.com",
     }));
     expect(catchup.onSessionStarted()).toEqual([
-      { kind: "dm", key: "bob@example.com", after: "mam-newer", since: "2024-01-01T00:00:01.000Z", seenIds: ["dm-newer"] },
+      { kind: "dm", scope: "account", key: "bob@example.com", after: "mam-newer", since: "2024-01-01T00:00:01.000Z", seenIds: ["dm-newer"] },
     ]);
   });
 
@@ -1996,7 +1996,7 @@ describe("client keepalive lifecycle", () => {
     await client.queryPersonalMamPage("bob@example.com", 100, { type: "latest" });
 
     expect((client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted()).toEqual([
-      { kind: "dm", key: "bob@example.com", after: "mam-loaded-1", since: "2024-01-01T00:00:01.000Z", seenIds: ["dm-loaded-1"] },
+      { kind: "dm", scope: "account", key: "bob@example.com", after: "mam-loaded-1", since: "2024-01-01T00:00:01.000Z", seenIds: ["dm-loaded-1"] },
     ]);
   });
 
@@ -2070,6 +2070,7 @@ describe("client keepalive lifecycle", () => {
     expect((client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted()).toEqual([
       {
         kind: "dm",
+        scope: "account",
         key: "bob@example.com",
         after: "mam-retract-video",
         since: retractedAt,

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -1122,12 +1122,17 @@ describe("client send readiness", () => {
     (client as unknown as {
       xmpp: typeof xmpp;
       connected: boolean;
-      mucServiceJid: string;
       connect: ReturnType<typeof mock>;
     }).xmpp = xmpp;
     (client as unknown as { connected: boolean }).connected = true;
-    (client as unknown as { mucServiceJid: string }).mucServiceJid = "rooms.waddle.example";
     (client as unknown as { connect: ReturnType<typeof mock> }).connect = mock(async () => undefined);
+    client.catchup.recordDmSeen(
+      occupant,
+      "2026-07-11T17:00:00.000Z",
+      undefined,
+      undefined,
+      "muc-occupant",
+    );
 
     await client.sendDirectMessage(occupant, "hello", { id: "muc-pm-send" });
     await client.sendDmChatState(occupant, "composing");

--- a/chat/tests/dm-call-activity-hydration.test.ts
+++ b/chat/tests/dm-call-activity-hydration.test.ts
@@ -157,8 +157,8 @@ describe("DM call activity hydration", () => {
       messages: [
         {
           mam_id: "mam-proceed",
-          from: "alice@example.com/web",
-          to: "bob@example.com/phone",
+          from: "alice@example.com",
+          to: "bob@example.com",
           timestamp: timestamp(-60_000),
           call_event: {
             kind: "proceed",
@@ -176,8 +176,8 @@ describe("DM call activity hydration", () => {
       messages: [
         {
           mam_id: "mam-propose",
-          from: "bob@example.com/phone",
-          to: "alice@example.com/web",
+          from: "bob@example.com",
+          to: "alice@example.com",
           timestamp: timestamp(-300_000),
           call_event: {
             kind: "propose",
@@ -224,8 +224,8 @@ describe("DM call activity hydration", () => {
       messages: [
         {
           mam_id: "mam-finish",
-          from: "bob@example.com/phone",
-          to: "alice@example.com/web",
+          from: "bob@example.com",
+          to: "alice@example.com",
           timestamp: finishedAt,
           call_event: {
             kind: "finish",
@@ -242,8 +242,8 @@ describe("DM call activity hydration", () => {
       messages: [
         {
           mam_id: "mam-accepted",
-          from: "bob@example.com/phone",
-          to: "alice@example.com/web",
+          from: "bob@example.com",
+          to: "alice@example.com",
           timestamp: acceptedAt,
           call_event: {
             kind: "session-accept",
@@ -296,8 +296,8 @@ describe("DM call activity hydration", () => {
     const page = {
       messages: [{
         mam_id: "mam-propose",
-        from: "bob@example.com/phone",
-        to: "alice@example.com/web",
+        from: "bob@example.com",
+        to: "alice@example.com",
         timestamp,
         call_event: {
           kind: "propose",
@@ -343,8 +343,8 @@ describe("DM call activity hydration", () => {
     const page = {
       messages: [{
         mam_id: "mam-propose",
-        from: "bob@example.com/phone",
-        to: "alice@example.com/web",
+        from: "bob@example.com",
+        to: "alice@example.com",
         timestamp: new Date(now - 60_000).toISOString(),
         call_event: {
           kind: "propose",

--- a/chat/tests/reconnect-catchup.test.ts
+++ b/chat/tests/reconnect-catchup.test.ts
@@ -50,6 +50,28 @@ describe("ReconnectCatchup", () => {
     expect(c.getDmLastSeen("bob@example.com")).toBe("2024-01-02T00:00:00.000Z");
   });
 
+  test("MUC occupant scope uses a canonical full-JID key", () => {
+    const c = new ReconnectCatchup();
+    c.recordDmSeen(
+      " Room@Rooms.Example/Alice ",
+      "2024-01-02T00:00:00Z",
+      "mam-occupant-1",
+      [],
+      "muc-occupant",
+    );
+
+    expect(c.getDmScope("room@rooms.example/Alice")).toBe("muc-occupant");
+    expect(c.getDmLastSeen("ROOM@ROOMS.EXAMPLE/Alice")).toBe("2024-01-02T00:00:00.000Z");
+    expect(c.onSessionStarted()).toEqual([]);
+    expect(c.onSessionStarted()).toEqual([{
+      kind: "dm",
+      key: "room@rooms.example/Alice",
+      scope: "muc-occupant",
+      after: "mam-occupant-1",
+      since: "2024-01-02T00:00:00.000Z",
+    }]);
+  });
+
   test("subsequent onSessionStarted falls back to timestamp when no archive id is known", () => {
     const c = new ReconnectCatchup();
     c.recordDmSeen("bob@example.com", "2024-01-01T00:00:00Z");

--- a/chat/tests/reconnect-catchup.test.ts
+++ b/chat/tests/reconnect-catchup.test.ts
@@ -29,6 +29,7 @@ describe("ReconnectCatchup", () => {
     expect(entries).toHaveLength(2);
     expect(entries).toContainEqual({
       kind: "dm",
+      scope: "account",
       key: "bob@example.com",
       after: "dm-arch-1",
       since: "2024-01-01T00:00:00.000Z",
@@ -56,7 +57,7 @@ describe("ReconnectCatchup", () => {
     c.onSessionStarted();
 
     expect(c.onSessionStarted()).toEqual([
-      { kind: "dm", key: "bob@example.com", since: "2024-01-01T00:00:00.000Z" },
+      { kind: "dm", scope: "account", key: "bob@example.com", since: "2024-01-01T00:00:00.000Z" },
     ]);
   });
 
@@ -70,6 +71,7 @@ describe("ReconnectCatchup", () => {
     expect(c.onSessionStarted()).toEqual([
       {
         kind: "dm",
+        scope: "account",
         key: "bob@example.com",
         since: "2024-01-01T00:00:00.000Z",
         seenIds: ["dm-1", "dm-2"],
@@ -87,6 +89,7 @@ describe("ReconnectCatchup", () => {
     expect(c.onSessionStarted()).toEqual([
       {
         kind: "dm",
+        scope: "account",
         key: "bob@example.com",
         since: "2024-01-01T00:00:00.000Z",
         seenIds: ["dm-1", "dm-2"],
@@ -102,7 +105,7 @@ describe("ReconnectCatchup", () => {
     c.onSessionStarted();
 
     expect(c.onSessionStarted()).toEqual([
-      { kind: "dm", key: "bob@example.com", after: "dm-arch-2", since: "2024-01-02T00:00:00.000Z" },
+      { kind: "dm", scope: "account", key: "bob@example.com", after: "dm-arch-2", since: "2024-01-02T00:00:00.000Z" },
     ]);
   });
 
@@ -114,7 +117,7 @@ describe("ReconnectCatchup", () => {
     c.onSessionStarted();
 
     expect(c.onSessionStarted()).toEqual([
-      { kind: "dm", key: "bob@example.com", after: "dm-arch-2", since: "2024-01-02T00:00:00.000Z" },
+      { kind: "dm", scope: "account", key: "bob@example.com", after: "dm-arch-2", since: "2024-01-02T00:00:00.000Z" },
     ]);
   });
 
@@ -129,6 +132,7 @@ describe("ReconnectCatchup", () => {
     expect(c.onSessionStarted()).toEqual([
       {
         kind: "dm",
+        scope: "account",
         key: "bob@example.com",
         after: "dm-arch-2",
         since: "2024-01-02T00:00:00.000Z",
@@ -147,6 +151,7 @@ describe("ReconnectCatchup", () => {
     expect(c.onSessionStarted()).toEqual([
       {
         kind: "dm",
+        scope: "account",
         key: "bob@example.com",
         after: "dm-arch-2",
         since: "2024-01-02T00:00:00.000Z",

--- a/chat/tests/reconnect-state-machine.test.ts
+++ b/chat/tests/reconnect-state-machine.test.ts
@@ -14,6 +14,7 @@
 import { describe, expect, test } from "bun:test";
 import type { WaddleSession } from "../src/lib/server-auth";
 import { BrowserXmppClient } from "../src/lib/xmpp-client";
+import type { ReconnectCatchupEntry } from "../src/lib/xmpp/reconnect-catchup";
 import type { XmppStatusSnapshot } from "../src/lib/xmpp/types";
 
 type StreamErrorPayload = { detail?: string | null; condition?: string | null };
@@ -38,7 +39,7 @@ type PrivateState = {
   loadModule: () => Promise<unknown>;
   runSessionReady: (xmpp: unknown, lifecycle: { type: "fresh" | "resumed" }) => Promise<void>;
   runReconnectCatchup: (...args: unknown[]) => Promise<void>;
-  catchup: { onSessionStarted: () => Array<{ kind: "dm" | "room"; key: string }> };
+  catchup: { onSessionStarted: () => ReconnectCatchupEntry[] };
 };
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -159,7 +160,7 @@ describe("connect budget measures to session-ready, not catch-up completion (C1)
     state.connectTimeoutMs = 20;
     // Catch-up (behind the resume barrier) outlives the connect budget.
     state.runReconnectCatchup = () => sleep(60);
-    state.catchup.onSessionStarted = () => [{ kind: "dm", key: "bob@example.com" }];
+    state.catchup.onSessionStarted = () => [{ kind: "dm", key: "bob@example.com", scope: "account" }];
     let stalledHandleDisconnects = 0;
     const handle = { disconnect: async () => { stalledHandleDisconnects += 1; } };
     state.doConnect = async () => {

--- a/chat/tests/resume-persistence.test.ts
+++ b/chat/tests/resume-persistence.test.ts
@@ -147,14 +147,14 @@ describe("ReconnectCatchup persistence — hydrate from snapshot on construct", 
     // dead weight (writes on every advance, never consumed).
     const persistence = inMemoryPersistence();
     persistence.saveCatchup({
-      dmLastSeen: [["bob@example.com", { timestamp: "2026-05-20T10:00:00.000Z", archiveId: "dm-arch-1" }]],
+      dmLastSeen: [["bob@example.com", { timestamp: "2026-05-20T10:00:00.000Z", scope: "account", archiveId: "dm-arch-1" }]],
       roomLastSeen: [],
     });
 
     const c = new ReconnectCatchup(persistence);
     const entries = c.onSessionStarted();
     expect(entries).toEqual([
-      { kind: "dm", key: "bob@example.com", after: "dm-arch-1", since: "2026-05-20T10:00:00.000Z" },
+      { kind: "dm", key: "bob@example.com", scope: "account", after: "dm-arch-1", since: "2026-05-20T10:00:00.000Z" },
     ]);
   });
 
@@ -187,10 +187,34 @@ describe("ReconnectCatchup persistence — writes back on advance", () => {
       "bob@example.com",
       {
         timestamp: "2026-05-20T10:00:00.000Z",
+        scope: "account",
         archiveId: "dm-arch-1",
         archiveTimestamp: "2026-05-20T10:00:00.000Z",
       },
     ]);
+  });
+
+  test("persists and hydrates custom MUC occupant scope", async () => {
+    const persistence = inMemoryPersistence();
+    const writer = new ReconnectCatchup(persistence);
+    writer.recordDmSeen(
+      "room@rooms.waddle.example/alice",
+      "2026-05-20T10:00:00Z",
+      "pm-arch-1",
+      [],
+      "muc-occupant",
+    );
+    await flushMicrotasks();
+
+    const reader = new ReconnectCatchup(persistence);
+
+    expect(reader.onSessionStarted()).toEqual([{
+      kind: "dm",
+      key: "room@rooms.waddle.example/alice",
+      scope: "muc-occupant",
+      after: "pm-arch-1",
+      since: "2026-05-20T10:00:00.000Z",
+    }]);
   });
 
   test("bursts coalesce into a single write per microtask", async () => {
@@ -792,12 +816,15 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
     const persistence = createLocalStorageResumePersistence("alice@example.com");
     const tabA = new ReconnectCatchup(persistence);
     const tabB = new ReconnectCatchup(persistence);
-    tabA.recordDmSeen("bob@example.com", "2026-05-20T10:00:00Z", "dm-arch-A");
+    tabA.recordDmSeen("room@rooms.waddle.example/alice", "2026-05-20T10:00:00Z", "dm-arch-A", [], "muc-occupant");
     tabB.recordRoomSeen("general@muc.example.com", "2026-05-20T11:00:00Z", "room-arch-B");
     await new Promise((resolve) => setTimeout(resolve, 0));
     const final = persistence.loadCatchup();
     expect(final).not.toBeNull();
-    expect(final!.dmLastSeen.map((e) => e[0])).toContain("bob@example.com");
+    expect(final!.dmLastSeen).toContainEqual([
+      "room@rooms.waddle.example/alice",
+      expect.objectContaining({ scope: "muc-occupant" }),
+    ]);
     expect(final!.roomLastSeen.map((e) => e[0])).toContain("general@muc.example.com");
   });
 });

--- a/chat/tests/resume-persistence.test.ts
+++ b/chat/tests/resume-persistence.test.ts
@@ -120,6 +120,10 @@ async function flushMicrotasks() {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+function catchupShardKey(accountKey: string, ownerId: string): string {
+  return `waddle.chat.resume-cursors.${accountKey.length}:${accountKey}.${ownerId}`;
+}
+
 describe("ReconnectCatchup persistence — hydrate from snapshot on construct", () => {
   test("hydrates DM + room cursors from the persistence snapshot", () => {
     const persistence = inMemoryPersistence();
@@ -814,14 +818,14 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
 
   test("loadCatchup returns null for malformed JSON", () => {
     const persistence = createLocalStorageResumePersistence("alice@example.com", "tab-a");
-    window.localStorage.setItem("waddle.chat.resume-cursors.alice@example.com.tab-a", "{not valid json");
+    window.localStorage.setItem(catchupShardKey("alice@example.com", "tab-a"), "{not valid json");
     expect(persistence.loadCatchup()).toBeNull();
   });
 
   test("loadCatchup rejects payloads with the wrong shape", () => {
     const persistence = createLocalStorageResumePersistence("alice@example.com", "tab-a");
     window.localStorage.setItem(
-      "waddle.chat.resume-cursors.alice@example.com.tab-a",
+      catchupShardKey("alice@example.com", "tab-a"),
       JSON.stringify({ dmLastSeen: "not-an-array", roomLastSeen: [] }),
     );
     expect(persistence.loadCatchup()).toBeNull();
@@ -847,7 +851,25 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
       expect.objectContaining({ scope: "muc-occupant" }),
     ]);
     expect(final!.roomLastSeen.map((e) => e[0])).toContain("general@muc.example.com");
-    expect(window.localStorage.getItem("waddle.chat.resume-cursors.alice@example.com.tab-a")).not.toBeNull();
-    expect(window.localStorage.getItem("waddle.chat.resume-cursors.alice@example.com.tab-b")).not.toBeNull();
+    expect(window.localStorage.getItem(catchupShardKey("alice@example.com", "tab-a"))).not.toBeNull();
+    expect(window.localStorage.getItem(catchupShardKey("alice@example.com", "tab-b"))).not.toBeNull();
+  });
+
+  test("account shard prefixes cannot read or clear a longer JID", () => {
+    const alice = createLocalStorageResumePersistence("alice@example.com", "tab-a");
+    const evil = createLocalStorageResumePersistence("alice@example.com.evil", "tab-b");
+    alice.saveCatchup({
+      dmLastSeen: [["bob@example.com", { timestamp: "2026-05-20T10:00:00.000Z" }]],
+      roomLastSeen: [],
+    });
+    evil.saveCatchup({
+      dmLastSeen: [["mallory@example.com.evil", { timestamp: "2026-05-20T11:00:00.000Z" }]],
+      roomLastSeen: [],
+    });
+
+    expect(alice.loadCatchup()?.dmLastSeen.map(([key]) => key)).toEqual(["bob@example.com"]);
+    alice.clearCatchup();
+    expect(alice.loadCatchup()).toBeNull();
+    expect(evil.loadCatchup()?.dmLastSeen.map(([key]) => key)).toEqual(["mallory@example.com.evil"]);
   });
 });

--- a/chat/tests/resume-persistence.test.ts
+++ b/chat/tests/resume-persistence.test.ts
@@ -138,6 +138,26 @@ describe("ReconnectCatchup persistence — hydrate from snapshot on construct", 
     expect(c.getRoomLastSeen("general@muc.example.com")).toBe("2026-05-20T11:00:00.000Z");
   });
 
+  test("canonicalized hydrate collisions merge cursor progress instead of using persistence order", () => {
+    const persistence = inMemoryPersistence();
+    persistence.saveCatchup({
+      dmLastSeen: [
+        ["BOB@EXAMPLE.COM/desktop", { timestamp: "2026-05-20T12:00:00.000Z", archiveId: "new" }],
+        ["bob@example.com/mobile", { timestamp: "2026-05-20T10:00:00.000Z", archiveId: "old" }],
+      ],
+      roomLastSeen: [],
+    });
+
+    const catchup = new ReconnectCatchup(persistence);
+    expect(catchup.onSessionStarted()).toEqual([{
+      kind: "dm",
+      key: "bob@example.com",
+      scope: "account",
+      after: "new",
+      since: "2026-05-20T12:00:00.000Z",
+    }]);
+  });
+
   test("hydrated instance returns cursors on the *first* onSessionStarted (PR3 whole point)", () => {
     // A hydrated `ReconnectCatchup` represents a prior tab session
     // that left cursors behind in localStorage. The next page load
@@ -793,38 +813,41 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
   });
 
   test("loadCatchup returns null for malformed JSON", () => {
-    const persistence = createLocalStorageResumePersistence("alice@example.com");
-    window.localStorage.setItem("waddle.chat.resume-cursors.alice@example.com", "{not valid json");
+    const persistence = createLocalStorageResumePersistence("alice@example.com", "tab-a");
+    window.localStorage.setItem("waddle.chat.resume-cursors.alice@example.com.tab-a", "{not valid json");
     expect(persistence.loadCatchup()).toBeNull();
   });
 
   test("loadCatchup rejects payloads with the wrong shape", () => {
-    const persistence = createLocalStorageResumePersistence("alice@example.com");
+    const persistence = createLocalStorageResumePersistence("alice@example.com", "tab-a");
     window.localStorage.setItem(
-      "waddle.chat.resume-cursors.alice@example.com",
+      "waddle.chat.resume-cursors.alice@example.com.tab-a",
       JSON.stringify({ dmLastSeen: "not-an-array", roomLastSeen: [] }),
     );
     expect(persistence.loadCatchup()).toBeNull();
   });
 
-  test("two tabs converge: read-merge-write avoids cursor clobber", async () => {
+  test("two tab shards preserve concurrent cursor writes", async () => {
     // Simulate two `ReconnectCatchup` instances sharing the same
     // localStorage (two tabs of the same account). Each advances
     // its own conversation; after both persist, BOTH conversations
     // are present in storage — the pre-fix behavior would have
     // overwritten one with the other.
-    const persistence = createLocalStorageResumePersistence("alice@example.com");
-    const tabA = new ReconnectCatchup(persistence);
-    const tabB = new ReconnectCatchup(persistence);
+    const persistenceA = createLocalStorageResumePersistence("alice@example.com", "tab-a");
+    const persistenceB = createLocalStorageResumePersistence("alice@example.com", "tab-b");
+    const tabA = new ReconnectCatchup(persistenceA);
+    const tabB = new ReconnectCatchup(persistenceB);
     tabA.recordDmSeen("room@rooms.waddle.example/alice", "2026-05-20T10:00:00Z", "dm-arch-A", [], "muc-occupant");
     tabB.recordRoomSeen("general@muc.example.com", "2026-05-20T11:00:00Z", "room-arch-B");
     await new Promise((resolve) => setTimeout(resolve, 0));
-    const final = persistence.loadCatchup();
+    const final = persistenceA.loadCatchup();
     expect(final).not.toBeNull();
     expect(final!.dmLastSeen).toContainEqual([
       "room@rooms.waddle.example/alice",
       expect.objectContaining({ scope: "muc-occupant" }),
     ]);
     expect(final!.roomLastSeen.map((e) => e[0])).toContain("general@muc.example.com");
+    expect(window.localStorage.getItem("waddle.chat.resume-cursors.alice@example.com.tab-a")).not.toBeNull();
+    expect(window.localStorage.getItem("waddle.chat.resume-cursors.alice@example.com.tab-b")).not.toBeNull();
   });
 });

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -40,12 +40,15 @@ function makeRoomClient(queryMamResults: LiveRoomMessage[] = []) {
   return ref({ ...handlerStubs(), queryMam } as never) as never;
 }
 
-function makeDmMessaging(xmppClient: ReturnType<typeof makeDmClient>) {
+function makeDmMessaging(
+  xmppClient: ReturnType<typeof makeDmClient>,
+  activePeerJid = "bob@example.com",
+) {
   const actionError = ref("");
   const dm = useDirectMessages(
     ref(session()),
     xmppClient,
-    ref("bob@example.com"),
+    ref(activePeerJid),
     String,
     actionError,
     () => {
@@ -55,9 +58,12 @@ function makeDmMessaging(xmppClient: ReturnType<typeof makeDmClient>) {
   return { dm, actionError };
 }
 
-function makeDmClient(queryPersonalMamResults: LiveDmMessage[] = []) {
+function makeDmClient(
+  queryPersonalMamResults: LiveDmMessage[] = [],
+  isMucPmPeer = (peerJid: string) => peerJid.includes("@muc.example.com/"),
+) {
   const queryPersonalMam = mock(async () => queryPersonalMamResults);
-  return ref({ queryPersonalMam } as never) as never;
+  return ref({ queryPersonalMam, isMucPmPeer } as never) as never;
 }
 
 describe("XEP-0198 delivery status (group chat)", () => {
@@ -610,6 +616,84 @@ describe("XEP-0198 delivery status (DM)", () => {
     };
     expect(clientAny.value.queryPersonalMam).not.toHaveBeenCalled();
     expect(dm.messages.value).toEqual(existing);
+  });
+
+  test("fresh MUC-PM session reloads when catch-up covers only a sibling occupant", async () => {
+    const client = makeDmClient();
+    const { dm } = makeDmMessaging(client, "room@muc.example.com/bob");
+    dm.messages.value = [{
+      id: "pm-old",
+      author: "bob",
+      body: "earlier",
+      createdAt: "2024-01-01T00:00:00Z",
+      isSelf: false,
+    }];
+
+    dm.onSessionLifecycle({
+      type: "fresh",
+      catchup: { dmJids: ["room@muc.example.com/alice"], roomJids: [] },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const clientAny = client as unknown as {
+      value: { queryPersonalMam: ReturnType<typeof mock> };
+    };
+    expect(clientAny.value.queryPersonalMam).toHaveBeenCalledWith(
+      "room@muc.example.com/bob",
+      100,
+    );
+  });
+
+  test("fresh custom-service MUC-PM session reloads when catch-up covers only a sibling occupant", async () => {
+    // Cold reload: topology discovery has not yet updated the client's MUC
+    // service, so persisted cursor scope is the authoritative signal.
+    const client = makeDmClient([], () => false);
+    const { dm } = makeDmMessaging(client, "room@rooms.waddle.example/bob");
+    dm.messages.value = [{
+      id: "pm-old",
+      author: "bob",
+      body: "earlier",
+      createdAt: "2024-01-01T00:00:00Z",
+      isSelf: false,
+    }];
+
+    dm.onSessionLifecycle({
+      type: "fresh",
+      catchup: {
+        dmJids: ["room@rooms.waddle.example/alice"],
+        dmOccupantJids: ["room@rooms.waddle.example/alice"],
+        roomJids: [],
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const clientAny = client as unknown as {
+      value: { queryPersonalMam: ReturnType<typeof mock> };
+    };
+    expect(clientAny.value.queryPersonalMam).toHaveBeenCalledWith(
+      "room@rooms.waddle.example/bob",
+      100,
+    );
+  });
+
+  test("MUC-PM catch-up failure reloads only the same occupant", async () => {
+    const client = makeDmClient();
+    const { dm } = makeDmMessaging(client, "room@muc.example.com/bob");
+    dm.messages.value = [{
+      id: "pm-old",
+      author: "bob",
+      body: "earlier",
+      createdAt: "2024-01-01T00:00:00Z",
+      isSelf: false,
+    }];
+
+    dm.onCatchupFailed({ kind: "dm", key: "room@muc.example.com/alice" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const clientAny = client as unknown as {
+      value: { queryPersonalMam: ReturnType<typeof mock> };
+    };
+    expect(clientAny.value.queryPersonalMam).not.toHaveBeenCalled();
   });
 
   test("catch-up failure for the active DM peer falls back to the wholesale reload", async () => {

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -23,6 +23,7 @@ import {
   reportStatusChange,
 } from "../src/lib/telemetry";
 import { installInstrumentation } from "../src/lib/xmpp/xmpp-instrumentation";
+import type { ReconnectCatchupEntry } from "../src/lib/xmpp/reconnect-catchup";
 
 function session(partial: Partial<WaddleSession> = {}): WaddleSession {
   return {
@@ -663,15 +664,15 @@ describe("BrowserXmppClient telemetry hooks", () => {
       connected: boolean;
       runReconnectCatchup: (
         xmpp: unknown,
-        entries: Array<{ kind: "dm"; key: string; after?: string }>,
+        entries: ReconnectCatchupEntry[],
       ) => Promise<void>;
     };
     internal.xmpp = xmpp;
     internal.connected = true;
 
     await internal.runReconnectCatchup(xmpp, [
-      { kind: "dm", key: "bob@example.com", after: "mam-1" },
-      { kind: "dm", key: "carol@example.com", after: "mam-1" },
+      { kind: "dm", key: "bob@example.com", scope: "account", after: "mam-1" },
+      { kind: "dm", key: "carol@example.com", scope: "account", after: "mam-1" },
     ]);
 
     expect(events).toHaveLength(1);

--- a/server/crates/waddle-server/src/server/routes/interpret/direct_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/direct_archive.rs
@@ -7,8 +7,8 @@ const DM_CALL_STATE_MAX_KEYS: usize = 4096;
 pub(super) async fn archive_direct(
     deps: &Deps<'_>,
     archive_jid: BareJid,
-    from: BareJid,
-    to: BareJid,
+    from: jid::Jid,
+    to: jid::Jid,
     message: Box<Message>,
 ) -> Option<ArchiveIdRewrite> {
     let mut message = *message;
@@ -21,9 +21,27 @@ pub(super) async fn archive_direct(
         );
         return None;
     };
-    if let Some(active) =
-        prepare_dm_call_thread_archive_message(deps, &archive_jid, &from, &to, &message)
-    {
+    let canonical_from_bare = from.to_bare();
+    let canonical_to_bare = to.to_bare();
+    // The archive-fidelity endpoint tuple is the MAM storage shape. Existing
+    // DM-adjacent projections (call threads, activity, previews) intentionally
+    // keep their archive-owner/peer bare tuple. The typed tuple identifies the
+    // archive pass; the serialized stanza may already carry a room-authored
+    // occupant `from`, which must not turn a sender-owned MUC-PM row into a
+    // synthetic recipient/self projection.
+    let sender_archive = canonical_from_bare == archive_jid;
+    let (projection_from, projection_to) = if sender_archive {
+        (archive_jid.clone(), canonical_to_bare)
+    } else {
+        (canonical_from_bare, archive_jid.clone())
+    };
+    if let Some(active) = prepare_dm_call_thread_archive_message(
+        deps,
+        &archive_jid,
+        &projection_from,
+        &projection_to,
+        &message,
+    ) {
         add_dm_call_thread_archive_payloads(&mut message, &active);
     }
     // Per XEP-0313 §5.1.3, the eligibility check is
@@ -34,8 +52,8 @@ pub(super) async fn archive_direct(
     // it for replay.
     let archived = build_direct_archived_message(
         &jid::Jid::from(archive_jid.clone()),
-        jid::Jid::from(from.clone()),
-        jid::Jid::from(to.clone()),
+        from.clone(),
+        to.clone(),
         &message,
     );
     let requested_archive_id = archived.id.clone();
@@ -54,9 +72,12 @@ pub(super) async fn archive_direct(
             // `(sender, peer)` activity, gated by `archive_jid ==
             // from`: persisting the message into the recipient's
             // archive does NOT indicate the recipient is active.
-            if archive_jid == from {
+            if archive_jid == projection_from {
                 super::notification_activity_ingest::record_outbound_message_activity(
-                    deps, &from, &to, &message,
+                    deps,
+                    &projection_from,
+                    &projection_to,
+                    &message,
                 )
                 .await;
             }
@@ -65,9 +86,23 @@ pub(super) async fn archive_direct(
                 requested_archive_id,
                 archive_id.clone(),
             );
-            maybe_project_dm_call_thread(deps, &archive_jid, &from, &to, &archive_id, &message)
-                .await;
-            update_direct_link_preview_refs(deps, &archive_jid, &from, &archive_id, &message).await;
+            maybe_project_dm_call_thread(
+                deps,
+                &archive_jid,
+                &projection_from,
+                &projection_to,
+                &archive_id,
+                &message,
+            )
+            .await;
+            update_direct_link_preview_refs(
+                deps,
+                &archive_jid,
+                &projection_from,
+                &archive_id,
+                &message,
+            )
+            .await;
             apply_direct_retraction_tombstone(deps, &archive_jid, &message).await;
             rewrite
         }

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -335,8 +335,8 @@ async fn xep_0313_archive_direct_persists_to_mam_storage() {
 
     let events = vec![OutboundEvent::ArchiveDirect {
         archive_jid: archive_jid.clone(),
-        from,
-        to,
+        from: from.into(),
+        to: to.into(),
         message: Box::new(msg),
     }];
     let _outcome = interpret(events, &deps).await;
@@ -477,8 +477,8 @@ async fn xep_0359_archive_ref_pivots_inbox_row_to_mam_row_via_archive_or_stanza_
     let events = vec![
         OutboundEvent::ArchiveDirect {
             archive_jid: alice.clone(),
-            from: alice.clone(),
-            to: bob.clone(),
+            from: alice.clone().into(),
+            to: bob.clone().into(),
             message: Box::new(msg.clone()),
         },
         OutboundEvent::ProjectInbox {
@@ -562,8 +562,8 @@ async fn origin_id_dedup_rewrites_downstream_archive_refs_to_existing_mam_id() {
     let events = vec![
         OutboundEvent::ArchiveDirect {
             archive_jid: alice.clone(),
-            from: alice.clone(),
-            to: bob.clone(),
+            from: alice.clone().into(),
+            to: bob.clone().into(),
             message: Box::new(retry.clone()),
         },
         OutboundEvent::ProjectInbox {
@@ -651,8 +651,8 @@ async fn origin_id_collision_with_distinct_content_keeps_fresh_archive_refs() {
     let events = vec![
         OutboundEvent::ArchiveDirect {
             archive_jid: alice.clone(),
-            from: alice.clone(),
-            to: bob.clone(),
+            from: alice.clone().into(),
+            to: bob.clone().into(),
             message: Box::new(distinct.clone()),
         },
         OutboundEvent::ProjectInbox {
@@ -698,14 +698,14 @@ async fn xep_0313_archive_direct_writes_one_entry_per_event() {
     let events = vec![
         OutboundEvent::ArchiveDirect {
             archive_jid: alice.clone(),
-            from: alice.clone(),
-            to: bob.clone(),
+            from: alice.clone().into(),
+            to: bob.clone().into(),
             message: Box::new(msg.clone()),
         },
         OutboundEvent::ArchiveDirect {
             archive_jid: bob.clone(),
-            from: alice.clone(),
-            to: bob.clone(),
+            from: alice.clone().into(),
+            to: bob.clone().into(),
             message: Box::new(msg),
         },
     ];
@@ -817,8 +817,8 @@ async fn xep_0313_archive_direct_drops_when_storage_errors() {
     let msg = chat_msg("alice@example.com/web", "bob@example.com", "yo");
     let events = vec![OutboundEvent::ArchiveDirect {
         archive_jid: alice.clone(),
-        from: alice,
-        to: bob,
+        from: alice.into(),
+        to: bob.into(),
         message: Box::new(msg),
     }];
     let outcome = interpret(events, &deps).await;

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message/muc_direct.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message/muc_direct.rs
@@ -151,8 +151,10 @@ async fn handle_muc_private_message(
     // archived (body-less chat-state PMs get none — an id with no MAM
     // row behind it is a lie), and interpreting the archive first lets
     // an origin-id dedupe's ArchiveIdRewrite land on the wire copy, so
-    // live/MAM id parity holds under retries. Both user archives key
-    // the conversation by the room bare JID.
+    // live/MAM id parity holds under retries. Archive ownership remains
+    // the user's bare JID. The peer endpoint retains the full occupant JID
+    // required for exact `with=room/nick` matching, while the owner endpoint
+    // preserves the stanza the user actually sent or received (§7.5).
     let should_archive = !incoming.bodies.is_empty();
     let mut events: Vec<waddle_xmpp::protocol::OutboundEvent> = Vec::new();
     if should_archive {
@@ -175,12 +177,14 @@ async fn handle_muc_private_message(
         };
         waddle_xmpp_core::xep0359::add_stanza_id(&mut sent_form, &sender_sid);
 
+        let occupant_from = jid::Jid::from(from_room_jid.clone());
+        let occupant_to = jid::Jid::from(target_occupant_jid.clone());
         let mut recipient_archive = relayed.clone();
         recipient_archive.to = Some(jid::Jid::from(recipient_bare.clone()));
         events.push(waddle_xmpp::protocol::OutboundEvent::ArchiveDirect {
             archive_jid: recipient_bare.clone(),
-            from: room_jid.clone(),
-            to: recipient_bare.clone(),
+            from: occupant_from.clone(),
+            to: jid::Jid::from(recipient_bare.clone()),
             message: Box::new(recipient_archive),
         });
         // A self-PM (own nick) would otherwise archive twice into the
@@ -188,8 +192,8 @@ async fn handle_muc_private_message(
         if recipient_bare != sender_bare {
             events.push(waddle_xmpp::protocol::OutboundEvent::ArchiveDirect {
                 archive_jid: sender_bare.clone(),
-                from: sender_bare.clone(),
-                to: room_jid.clone(),
+                from: jid::Jid::from(sender_bare.clone()),
+                to: occupant_to,
                 message: Box::new(sent_form.clone()),
             });
         }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -21,6 +21,88 @@ fn dm_call_message(from: &str, to: &str, payload: Element) -> xmpp_parsers::mess
     message
 }
 
+#[tokio::test]
+async fn muc_pm_sender_archive_uses_typed_tuple_for_ancillary_projections() {
+    use crate::notification_activity::NotificationActivityReader;
+
+    let state = create_test_websocket_state().await;
+    let sender: BareJid = "alice@example.com".parse().expect("sender bare jid");
+    let room: BareJid = "room@muc.example.com".parse().expect("room bare jid");
+    let target: jid::FullJid = "room@muc.example.com/bob"
+        .parse()
+        .expect("target occupant jid");
+    let sid = xmpp_parsers::jingle::SessionId("muc-pm-call-projection".to_owned());
+    let propose = waddle_xmpp::xep::xep0353::build_propose(
+        sid.clone(),
+        waddle_xmpp::xep::xep0353::CallOffer::audio_video(),
+    );
+    // The archived row's typed tuple identifies the sender-owned pass. Its
+    // serialized stanza may already carry the room-authored occupant `from`.
+    let message = dm_call_message(
+        "room@muc.example.com/alice",
+        "room@muc.example.com/bob",
+        propose,
+    );
+    let deps = build_interpret_deps(state.as_ref(), None);
+
+    crate::server::routes::interpret::interpret(
+        vec![waddle_xmpp::protocol::OutboundEvent::ArchiveDirect {
+            archive_jid: sender.clone(),
+            from: jid::Jid::from(sender.clone()),
+            to: jid::Jid::from(target),
+            message: Box::new(message),
+        }],
+        &deps,
+    )
+    .await;
+
+    let expected_key = crate::server::routes::websocket::DmCallThreadKey::new(
+        sender.clone(),
+        room.clone(),
+        sid.clone(),
+    );
+    assert!(
+        state
+            .deps
+            .protocol
+            .pending_dm_call_offers
+            .contains_key(&expected_key),
+        "sender-side MUC-PM call projection must remain sender -> room bare"
+    );
+    let wrong_self_key =
+        crate::server::routes::websocket::DmCallThreadKey::new(sender.clone(), sender.clone(), sid);
+    assert!(
+        !state
+            .deps
+            .protocol
+            .pending_dm_call_offers
+            .contains_key(&wrong_self_key),
+        "occupant wire `from` must not misclassify the sender archive as recipient-owned"
+    );
+    assert!(
+        state
+            .deps
+            .protocol
+            .notification_activity
+            .read_activity(&sender, &room)
+            .await
+            .expect("read sender-room activity")
+            .is_some(),
+        "outbound activity must remain keyed by sender and room"
+    );
+    assert!(
+        state
+            .deps
+            .protocol
+            .notification_activity
+            .read_activity(&sender, &sender)
+            .await
+            .expect("read wrong self activity")
+            .is_none(),
+        "sender-side MUC-PM must not create self-conversation activity"
+    );
+}
+
 async fn drive_dm_message(
     state: &WebSocketState,
     full_jid: FullJid,
@@ -147,14 +229,14 @@ async fn dm_jmi_proceed_projects_call_thread_anchor_for_both_peers() {
         vec![
             waddle_xmpp::protocol::OutboundEvent::ArchiveDirect {
                 archive_jid: bob.clone(),
-                from: bob.clone(),
-                to: alice.clone(),
+                from: bob.clone().into(),
+                to: alice.clone().into(),
                 message: Box::new(accepted_proceed.clone()),
             },
             waddle_xmpp::protocol::OutboundEvent::ArchiveDirect {
                 archive_jid: alice.clone(),
-                from: bob.clone(),
-                to: alice.clone(),
+                from: bob.clone().into(),
+                to: alice.clone().into(),
                 message: Box::new(accepted_proceed),
             },
         ],
@@ -238,8 +320,8 @@ async fn dm_jmi_proceed_projects_call_thread_anchor_for_both_peers() {
     let _ = crate::server::routes::interpret::interpret(
         vec![waddle_xmpp::protocol::OutboundEvent::ArchiveDirect {
             archive_jid: alice.clone(),
-            from: alice.clone(),
-            to: bob.clone(),
+            from: alice.clone().into(),
+            to: bob.clone().into(),
             message: Box::new(dm_call_message(
                 "alice@example.com/web",
                 "bob@example.com/phone",
@@ -297,14 +379,14 @@ async fn dm_jmi_proceed_projects_call_thread_anchor_for_both_peers() {
         vec![
             waddle_xmpp::protocol::OutboundEvent::ArchiveDirect {
                 archive_jid: bob.clone(),
-                from: bob.clone(),
-                to: alice.clone(),
+                from: bob.clone().into(),
+                to: alice.clone().into(),
                 message: Box::new(replayed_proceed.clone()),
             },
             waddle_xmpp::protocol::OutboundEvent::ArchiveDirect {
                 archive_jid: alice.clone(),
-                from: bob.clone(),
-                to: alice.clone(),
+                from: bob.clone().into(),
+                to: alice.clone().into(),
                 message: Box::new(replayed_proceed),
             },
         ],
@@ -2823,8 +2905,8 @@ async fn notification_candidate_recovery_preserves_sender_resource_from_archived
     crate::server::routes::interpret::interpret(
         vec![waddle_xmpp::protocol::OutboundEvent::ArchiveDirect {
             archive_jid: recipient.clone(),
-            from: sender_bare.clone(),
-            to: recipient.clone(),
+            from: sender_bare.clone().into(),
+            to: recipient.clone().into(),
             message: Box::new(message),
         }],
         &deps,
@@ -3831,6 +3913,97 @@ async fn muc_private_message_routes_from_sender_room_nick_to_target_session() {
             "caller-supplied stanza-ids must not survive: {xml}"
         );
     }
+
+    let alice_archive = state
+        .deps
+        .protocol
+        .mam_storage
+        .query_messages(&alice_jid.to_bare(), &Default::default())
+        .await
+        .expect("query sender MAM archive");
+    let bob_archive = state
+        .deps
+        .protocol
+        .mam_storage
+        .query_messages(&bob_jid.to_bare(), &Default::default())
+        .await
+        .expect("query recipient MAM archive");
+    let sender_row = alice_archive.messages.last().expect("sender archive row");
+    assert_eq!(
+        sender_row.from.to_string(),
+        alice_jid.to_bare().to_string(),
+        "sender archive must preserve the sender account endpoint"
+    );
+    assert_eq!(
+        sender_row.to.to_string(),
+        format!("{room_jid}/bob"),
+        "sender archive must retain the recipient occupant peer"
+    );
+    let recipient_row = bob_archive.messages.last().expect("recipient archive row");
+    assert_eq!(
+        recipient_row.from.to_string(),
+        format!("{room_jid}/alice"),
+        "recipient archive must retain the sender occupant peer"
+    );
+    assert_eq!(
+        recipient_row.to.to_string(),
+        bob_jid.to_bare().to_string(),
+        "recipient archive must preserve the delivered account endpoint"
+    );
+}
+
+#[tokio::test]
+async fn muc_private_message_to_own_nick_archives_one_delivered_tuple() {
+    let state = create_test_websocket_state().await;
+    let alice_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "pm-self-room@muc.example.com".parse().expect("room jid");
+    let alice_jid: FullJid = format!("{}@example.com/web", alice_session.xmpp_localpart)
+        .parse()
+        .expect("alice jid");
+
+    handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &alice_jid,
+        "alice",
+        None,
+        &Some(alice_session.clone()),
+    )
+    .await;
+
+    let mut message = xmpp_parsers::message::Message::new(Some(jid::Jid::from(
+        room_jid
+            .clone()
+            .with_resource_str("alice")
+            .expect("self occupant jid"),
+    )));
+    message.type_ = XmppMessageType::Chat;
+    message.id = Some(xmpp_parsers::message::Id("muc-pm-self-1".to_string()));
+    message.bodies.insert(
+        xmpp_parsers::message::Lang::new(),
+        "private note to self".to_string(),
+    );
+
+    let responses =
+        handle_message_for_test(state.as_ref(), &alice_jid, Some(&alice_session), message).await;
+    assert!(responses.is_empty(), "self-PM routes asynchronously");
+
+    let archive = state
+        .deps
+        .protocol
+        .mam_storage
+        .query_messages(&alice_jid.to_bare(), &Default::default())
+        .await
+        .expect("query self-PM archive");
+    let self_rows: Vec<_> = archive
+        .messages
+        .iter()
+        .filter(|row| row.body.as_deref() == Some("private note to self"))
+        .collect();
+    assert_eq!(self_rows.len(), 1, "self-PM must archive exactly once");
+    assert_eq!(self_rows[0].from.to_string(), format!("{room_jid}/alice"));
+    assert_eq!(self_rows[0].to.to_string(), alice_jid.to_bare().to_string());
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/tests/xep0045_muc_pm_ws.rs
+++ b/server/crates/waddle-server/tests/xep0045_muc_pm_ws.rs
@@ -15,8 +15,8 @@
 //!    (`<sent/>`) to the sender's other carbon-enabled resource.
 //! 3. XEP-0198: a PM to a detached-but-resumable occupant session is
 //!    queued and replayed on resume, not lost.
-//! 4. XEP-0313: the PM lands in both users' archives, keyed by the
-//!    room bare JID.
+//! 4. XEP-0313: the PM lands in both users' archives with the peer's full
+//!    occupant endpoint, so `with=room/nick` excludes sibling PM threads.
 //! 5. `muc#roomconfig_allowpm` is honored (`none` → `<forbidden/>`).
 //! 6. A PM to an unknown nick still bounces `<item-not-found/>`.
 
@@ -37,6 +37,8 @@ const NS_XDATA: &str = "jabber:x:data";
 const NS_OCCUPANT_ID: &str = "urn:xmpp:occupant-id:0";
 const NS_SID: &str = "urn:xmpp:sid:0";
 const NS_CARBONS: &str = "urn:xmpp:carbons:2";
+const NS_MAM: &str = "urn:xmpp:mam:2";
+const NS_RSM: &str = "http://jabber.org/protocol/rsm";
 const NS_XMPP_STANZAS: &str = "urn:ietf:params:xml:ns:xmpp-stanzas";
 const MUC_ROOMCONFIG_FORM: &str = "http://jabber.org/protocol/muc#roomconfig";
 
@@ -161,6 +163,56 @@ fn data_form_field(var: &str, field_type: Option<&str>, value: &str) -> Element 
                 .build(),
         )
         .build()
+}
+
+fn mam_with_query_xml(
+    archive_jid: &str,
+    query_id: &str,
+    with: &str,
+    max: u32,
+    after: Option<&str>,
+) -> String {
+    let form = Element::builder("x", NS_XDATA)
+        .attr(attr_name("type").to_owned(), "submit")
+        .append(data_form_field("FORM_TYPE", Some("hidden"), NS_MAM))
+        .append(data_form_field("with", Some("jid-single"), with))
+        .build();
+    let mut rsm = Element::builder("set", NS_RSM).append(
+        Element::builder("max", NS_RSM)
+            .append(max.to_string())
+            .build(),
+    );
+    if let Some(after) = after {
+        rsm = rsm.append(
+            Element::builder("after", NS_RSM)
+                .append(after.to_owned())
+                .build(),
+        );
+    }
+    element_to_xml(
+        Element::builder("iq", NS_CLIENT)
+            .attr(attr_name("type").to_owned(), "set")
+            .attr(attr_name("id").to_owned(), query_id.to_owned())
+            .attr(attr_name("to").to_owned(), archive_jid.to_owned())
+            .append(
+                Element::builder("query", NS_MAM)
+                    .attr(attr_name("queryid").to_owned(), query_id.to_owned())
+                    .append(form)
+                    .append(rsm.build())
+                    .build(),
+            )
+            .build(),
+    )
+}
+
+fn mam_page_last(frames: &[String]) -> String {
+    frames
+        .iter()
+        .find_map(|frame| {
+            let element = frame.parse::<Element>().ok()?;
+            find_descendant(&element, "last", NS_RSM).map(|last| last.text())
+        })
+        .expect("MAM page has an RSM <last> cursor")
 }
 
 /// Submit a §10.2 owner-config form setting `muc#roomconfig_allowpm`.
@@ -372,8 +424,8 @@ async fn muc_pm_to_detached_resumable_occupant_replays_on_resume() {
     }
 }
 
-/// XEP-0313 (#1257): the PM is archived in BOTH users' archives, keyed
-/// by the room bare JID.
+/// XEP-0313 (#1257/#1281): the PM is owned by BOTH users' bare archives;
+/// each row retains the peer's full room occupant JID.
 #[tokio::test]
 async fn muc_pm_archived_in_both_user_archives() {
     let _guard = TEST_SERIAL.lock().await;
@@ -425,6 +477,137 @@ async fn muc_pm_archived_in_both_user_archives() {
 
     let _ = admin.close().await;
     let _ = alice.close().await;
+}
+
+/// #1281: a full-occupant MAM `with` filter is applied before RSM paging.
+/// Interleaved PMs to another nick must neither leak into the page nor consume
+/// its limit/cursor.
+#[tokio::test]
+async fn muc_pm_mam_with_full_occupant_excludes_siblings_across_pages() {
+    let _guard = TEST_SERIAL.lock().await;
+    let alice_pass = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let bob_pass = format!("bob-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[(ALICE, &alice_pass), ("bob", &bob_pass)]);
+    let admin_pass = server.fixed_account_password().to_string();
+
+    let mut admin = connect(&server, ADMIN, &admin_pass, "pm-scope-admin").await;
+    let mut alice = connect(&server, ALICE, &alice_pass, "pm-scope-alice").await;
+    let mut bob = connect(&server, "bob", &bob_pass, "pm-scope-bob").await;
+    let room = format!("pm-scope-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut admin, &room, ADMIN).await;
+    join_room(&mut alice, &room, ALICE).await;
+    join_room(&mut bob, &room, "bob").await;
+
+    let alice_first = format!("alice-first-{}", uuid::Uuid::new_v4());
+    let bob_middle = format!("bob-middle-{}", uuid::Uuid::new_v4());
+    let alice_second = format!("alice-second-{}", uuid::Uuid::new_v4());
+    for (target, body) in [
+        (ALICE, alice_first.as_str()),
+        ("bob", bob_middle.as_str()),
+        (ALICE, alice_second.as_str()),
+    ] {
+        admin
+            .send(&pm_xml(&room, target, body, body))
+            .await
+            .expect("send interleaved PM");
+        let recipient = if target == ALICE {
+            &mut alice
+        } else {
+            &mut bob
+        };
+        recipient
+            .recv_matching(|frame| frame.contains(body))
+            .await
+            .expect("recipient receives interleaved PM");
+    }
+
+    let admin_archive = format!("{ADMIN}@{DOMAIN}");
+    let alice_occupant = format!("{room}/{ALICE}");
+    admin
+        .send(&mam_with_query_xml(
+            &admin_archive,
+            "pm-scope-page-1",
+            &alice_occupant,
+            1,
+            None,
+        ))
+        .await
+        .expect("send first scoped MAM query");
+    let first = admin
+        .recv_until(|frame| frame.contains("<fin") && frame.contains("pm-scope-page-1"))
+        .await
+        .expect("first scoped MAM page completes");
+    assert!(first.iter().any(|frame| frame.contains(&alice_first)));
+    assert!(!first.iter().any(|frame| frame.contains(&bob_middle)));
+    assert!(!first.iter().any(|frame| frame.contains(&alice_second)));
+    let cursor = mam_page_last(&first);
+
+    admin
+        .send(&mam_with_query_xml(
+            &admin_archive,
+            "pm-scope-page-2",
+            &alice_occupant,
+            1,
+            Some(&cursor),
+        ))
+        .await
+        .expect("send second scoped MAM query");
+    let second = admin
+        .recv_until(|frame| frame.contains("<fin") && frame.contains("pm-scope-page-2"))
+        .await
+        .expect("second scoped MAM page completes");
+    assert!(second.iter().any(|frame| frame.contains(&alice_second)));
+    assert!(!second.iter().any(|frame| frame.contains(&bob_middle)));
+
+    let _ = admin.close().await;
+    let _ = alice.close().await;
+    let _ = bob.close().await;
+}
+
+/// #1281: a PM to one's own nick is archived once under the personal archive,
+/// with the full self occupant JID remaining queryable as the MAM peer.
+#[tokio::test]
+async fn muc_self_pm_is_single_and_queryable_by_full_occupant() {
+    let _guard = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let admin_pass = server.fixed_account_password().to_string();
+    let mut admin = connect(&server, ADMIN, &admin_pass, "pm-self-admin").await;
+    let room = format!("pm-self-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room(&mut admin, &room, ADMIN).await;
+
+    let body = format!("self-pm-{}", uuid::Uuid::new_v4());
+    admin
+        .send(&pm_xml(&room, ADMIN, "pm-self-1", &body))
+        .await
+        .expect("send self-PM");
+    admin
+        .recv_matching(|frame| frame.contains(&body))
+        .await
+        .expect("self-PM is delivered");
+
+    let archive = format!("{ADMIN}@{DOMAIN}");
+    let occupant = format!("{room}/{ADMIN}");
+    admin
+        .send(&mam_with_query_xml(
+            &archive,
+            "pm-self-query",
+            &occupant,
+            10,
+            None,
+        ))
+        .await
+        .expect("query self-PM");
+    let frames = admin
+        .recv_until(|frame| frame.contains("<fin") && frame.contains("pm-self-query"))
+        .await
+        .expect("self-PM MAM query completes");
+    assert_eq!(
+        frames.iter().filter(|frame| frame.contains(&body)).count(),
+        1,
+        "self-PM must have exactly one archived result: {frames:?}"
+    );
+
+    let _ = admin.close().await;
 }
 
 /// `muc#roomconfig_allowpm` (#1257): `none` disables PMs with

--- a/server/crates/waddle-xmpp/src/mam/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tests.rs
@@ -518,6 +518,110 @@ async fn test_query_with_pagination() {
 }
 
 #[tokio::test]
+async fn sqlite_full_occupant_with_excludes_siblings_before_pagination() {
+    let storage = create_test_storage().await;
+    assert_full_occupant_with_excludes_siblings_before_pagination(&storage).await;
+}
+
+#[tokio::test]
+async fn inmemory_full_occupant_with_excludes_siblings_before_pagination() {
+    let storage = InMemoryMamStorage::new();
+    assert_full_occupant_with_excludes_siblings_before_pagination(&storage).await;
+}
+
+async fn assert_full_occupant_with_excludes_siblings_before_pagination(storage: &dyn MamStorage) {
+    let archive = bare("user@example.com");
+    let owner_account = jid("user@example.com");
+    let alice_occupant = jid("room@conference.example.com/alice");
+    let bob_occupant = jid("room@conference.example.com/bob");
+    let base = DateTime::parse_from_rfc3339("2026-07-01T12:00:00Z")
+        .expect("valid timestamp")
+        .with_timezone(&Utc);
+
+    for (id, seconds, from, to, body) in [
+        (
+            "alice-incoming",
+            0,
+            alice_occupant.clone(),
+            owner_account.clone(),
+            "alice incoming",
+        ),
+        (
+            "bob-incoming",
+            1,
+            bob_occupant.clone(),
+            owner_account.clone(),
+            "bob incoming",
+        ),
+        (
+            "alice-outgoing",
+            2,
+            owner_account.clone(),
+            alice_occupant.clone(),
+            "alice outgoing",
+        ),
+        (
+            "bob-outgoing",
+            3,
+            owner_account.clone(),
+            bob_occupant.clone(),
+            "bob outgoing",
+        ),
+        (
+            "alice-later",
+            4,
+            alice_occupant.clone(),
+            owner_account.clone(),
+            "alice later",
+        ),
+    ] {
+        storage
+            .store_message(
+                &archive,
+                &ArchivedMessage {
+                    id: id.to_string(),
+                    timestamp: base + ChronoDuration::seconds(seconds),
+                    body: Some(body.to_string()),
+                    ..ArchivedMessage::for_test(from, to)
+                },
+            )
+            .await
+            .expect("store interleaved MUC PM");
+    }
+
+    let first = storage
+        .query_messages(
+            &archive,
+            &MamQuery {
+                with: Some(alice_occupant.clone()),
+                max: Some(2),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query alice first page");
+    assert_eq!(bodies(&first), vec!["alice incoming", "alice outgoing"]);
+    assert_eq!(first.count, Some(3));
+    assert!(!first.complete);
+
+    let second = storage
+        .query_messages(
+            &archive,
+            &MamQuery {
+                with: Some(alice_occupant),
+                after_id: first.last_id.clone(),
+                max: Some(2),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query alice second page");
+    assert_eq!(bodies(&second), vec!["alice later"]);
+    assert_eq!(second.count, Some(3));
+    assert!(second.complete);
+}
+
+#[tokio::test]
 async fn test_sqlite_rsm_after_uses_archive_order_not_lexical_id_order() {
     let storage = create_test_storage().await;
     assert_rsm_after_uses_archive_order_not_lexical_id_order(&storage).await;

--- a/server/crates/waddle-xmpp/src/protocol/dispatch_message_l2_tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/dispatch_message_l2_tests.rs
@@ -62,8 +62,8 @@ impl MessageHandler for ArchiveProbe {
         let archive_jid = from_bare.clone();
         HandlerOutcome::Continue(vec![OutboundEvent::ArchiveDirect {
             archive_jid,
-            from: from_bare,
-            to: to_bare,
+            from: from_bare.into(),
+            to: to_bare.into(),
             message: Box::new(message.clone()),
         }])
     }

--- a/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
@@ -134,11 +134,13 @@ pub enum OutboundEvent {
     /// emits this field as the local user's bare JID, so the interpreter
     /// is dumb glue that does not need to reason about sender/recipient
     /// pass semantics. `from` and `to` carry the canonical message tuple
-    /// for telemetry and remain on the typed `message` payload.
+    /// for telemetry and MAM `with` matching. A MUC-PM peer remains a full
+    /// occupant JID while the user's side remains its account JID; ordinary
+    /// direct-message producers keep supplying bare JIDs for both sides.
     ArchiveDirect {
         archive_jid: BareJid,
-        from: BareJid,
-        to: BareJid,
+        from: jid::Jid,
+        to: jid::Jid,
         message: Box<Message>,
     },
     /// Project a message into the local user's inbox (Waddle conversation

--- a/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/archive.rs
@@ -72,8 +72,8 @@ impl MessageHandler for ArchiveHandler {
                 let from = from_bare.clone().unwrap_or_else(|| local_bare.clone());
                 events.push(OutboundEvent::ArchiveDirect {
                     archive_jid: from.clone(),
-                    from,
-                    to,
+                    from: jid::Jid::from(from),
+                    to: jid::Jid::from(to),
                     message: Box::new(message.clone()),
                 });
             }
@@ -96,8 +96,8 @@ impl MessageHandler for ArchiveHandler {
                     let to = to_bare.unwrap_or_else(|| local_bare.clone());
                     events.push(OutboundEvent::ArchiveDirect {
                         archive_jid: to.clone(),
-                        from,
-                        to,
+                        from: jid::Jid::from(from),
+                        to: jid::Jid::from(to),
                         message: Box::new(message.clone()),
                     });
                 }
@@ -229,7 +229,7 @@ mod tests {
         ArchiveHandler.handle(msg, &ctx)
     }
 
-    fn extract_archive_events(outcome: &HandlerOutcome) -> Vec<(BareJid, BareJid)> {
+    fn extract_archive_events(outcome: &HandlerOutcome) -> Vec<(jid::Jid, jid::Jid)> {
         match outcome {
             HandlerOutcome::Continue(events) => events
                 .iter()
@@ -268,8 +268,8 @@ mod tests {
         let outcome = run(&local, &mut msg);
         let archives = extract_archive_events(&outcome);
         assert_eq!(archives.len(), 1);
-        assert_eq!(archives[0].0, bare("alice@example.com"));
-        assert_eq!(archives[0].1, bare("bob@example.com"));
+        assert_eq!(archives[0].0, jid::Jid::from(bare("alice@example.com")));
+        assert_eq!(archives[0].1, jid::Jid::from(bare("bob@example.com")));
     }
 
     #[test]
@@ -279,8 +279,8 @@ mod tests {
         let outcome = run(&local, &mut msg);
         let archives = extract_archive_events(&outcome);
         assert_eq!(archives.len(), 1);
-        assert_eq!(archives[0].0, bare("alice@example.com"));
-        assert_eq!(archives[0].1, bare("bob@example.com"));
+        assert_eq!(archives[0].0, jid::Jid::from(bare("alice@example.com")));
+        assert_eq!(archives[0].1, jid::Jid::from(bare("bob@example.com")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Scope MUC private-message archive history to the full occupant JID so opening `room/alice` cannot render, watermark, process, or send to `room/bob` history.

The server now preserves archive-faithful full occupant endpoints for incoming, outgoing, and self PMs. The client uses exact occupant identity across page, thread, search, reconnect, call-state hydration, fresh-session coverage, and outbound addressing, including custom MUC services before topology discovery.

Closes #1281. Child of #1279. Relates #945 and #210.

## Implementation

1. Preserve typed full `Jid` endpoints through `ArchiveDirect` and MAM storage while deriving bare endpoints only for call/activity/link-preview projections.
2. Store recipient rows as `room/sender -> recipient`, sender rows as `sender -> room/target`, and self-PMs as one `room/self -> owner` row.
3. Prove both MAM backends apply exact full-JID `with` filtering before RSM count and pagination.
4. Filter client MAM rows by exact raw counterpart before conversion, watermarks, events, statistics, and call-state effects while preserving raw RSM cursors.
5. Persist typed DM conversation scope (`account` or `muc-occupant`) so cold reconnects retain custom-service identity before discovery.
6. Thread reconnect scope request-locally so overlapping old/new XMPP handles cannot erase one another's authority.
7. Fail closed on resource-qualified personal-archive rows during global DM call hydration; ordinary Waddle DM archive tuples remain bare.
8. Preserve full occupant addressing for all outbound MUC-PM operations from persisted scope before topology discovery.

## XEP review

- XEP-0045 models an occupant as the full `room@service/nick` JID and delivers private messages between occupant JIDs.
- XEP-0313 requires `with` to return only rows whose `from` or `to` matches the supplied JID.
- MUC private messages belong to the participants' user archives, not the room archive.

## Verification

- Chat: 3,366 tests passed, 0 failed (8,342 assertions).
- Focused MUC-PM/reconnect/persistence/session suite: 170 passed, 0 failed (443 assertions).
- Server library: 1,525 passed, 0 failed.
- Dedicated XEP-0045 MUC-PM suite: 10 passed, 0 failed.
- `cargo clippy -p waddle-server -p waddle-xmpp --all-targets --all-features -- -D warnings`: passed.
- Astro check: 0 errors (4 pre-existing hints).
- Knip: clean.
- Rust formatting and `git diff --check`: clean.
- Final adversarial client concurrency/integration review: clean.
- Final adversarial XEP-0045/XEP-0313 server/storage review: clean.

## Review fixes already incorporated

- Corrected sender-row direction to derive the archive pass from the typed endpoint tuple rather than the serialized room-authored stanza.
- Replaced hardcoded `muc.*` syntax with authoritative service context and persisted typed scope.
- Removed shared reconnect scope state after an overlapping-handle race was found; scope is request-local.
- Suppressed custom-service MUC-PM call hydration before topology discovery using the archive tuple invariant.
- Preserved custom-service MUC-PM outbound occupant addresses from persisted scope before topology discovery.
- Canonicalized persisted account and occupant cursor keys across hydrate, cross-tab merge, record, and lookup.
- Sharded catch-up persistence by tab so concurrent localStorage writers cannot lose conversation cursors.
- Length-prefixed account shard keys so one valid JID cannot prefix-match another account's reconnect state.
- Merged canonicalized hydrate collisions by cursor progress and let current MUC authority override stale account scope.

## Merge gate

Do not merge until CI is green, Greptile succeeds on the final SHA, Qodo reports zero actionable findings on the final revision, and no review thread remains unresolved.
