### PR TITLE
telemetry(server): add service.instance.id to OTLP resource so pods stop clobbering metrics

### DIFF
--- a/server/crates/waddle-server/src/telemetry.rs
+++ b/server/crates/waddle-server/src/telemetry.rs
@@ -32,13 +32,35 @@ fn build_resource() -> Resource {
         std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| "waddle-server".to_string());
     let service_version = std::env::var("OTEL_SERVICE_VERSION")
         .unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string());
+    let service_instance_id = resolve_service_instance_id(
+        std::env::var("OTEL_SERVICE_INSTANCE_ID").ok(),
+        std::env::var("HOSTNAME").ok(),
+    );
 
     Resource::builder()
         .with_attributes([
             KeyValue::new("service.name", service_name),
             KeyValue::new("service.version", service_version),
+            KeyValue::new("service.instance.id", service_instance_id),
         ])
         .build()
+}
+
+/// Resolve the `service.instance.id` resource attribute.
+///
+/// With multiple replicas, OTLP-pushed metrics that share an identical
+/// resource collapse into one clobbered series downstream, so every
+/// process needs a distinct, stable-for-its-lifetime identity.
+/// Precedence: explicit `OTEL_SERVICE_INSTANCE_ID` override, then
+/// `HOSTNAME` (the kubelet sets it to the pod name in every pod), then
+/// a pid-suffixed fallback for local runs. Blank values are skipped.
+fn resolve_service_instance_id(explicit: Option<String>, hostname: Option<String>) -> String {
+    [explicit, hostname]
+        .into_iter()
+        .flatten()
+        .map(|value| value.trim().to_string())
+        .find(|value| !value.is_empty())
+        .unwrap_or_else(|| format!("waddle-server-{}", std::process::id()))
 }
 
 fn default_filter() -> EnvFilter {
@@ -122,6 +144,8 @@ fn build_log_filter() -> EnvFilter {
 /// - `OTEL_EXPORTER_OTLP_ENDPOINT`: OTLP endpoint (default: http://localhost:4317)
 /// - `OTEL_SERVICE_NAME`: Service name (default: waddle-server)
 /// - `OTEL_SERVICE_VERSION`: Service version (default: crate version)
+/// - `OTEL_SERVICE_INSTANCE_ID`: Per-replica instance id (default: `HOSTNAME`,
+///   i.e. the pod name in Kubernetes, then a pid-suffixed fallback)
 /// - `RUST_LOG`: Log filter (default: info)
 ///
 /// # Example
@@ -301,10 +325,53 @@ pub fn shutdown() {
 }
 #[cfg(test)]
 mod tests {
+    use opentelemetry::Key;
+
     #[test]
     fn test_build_resource() {
         // Test that resource building doesn't panic
         let _resource = super::build_resource();
+    }
+
+    #[test]
+    fn build_resource_includes_nonempty_service_instance_id() {
+        let resource = super::build_resource();
+        let value = resource
+            .get(&Key::from_static_str("service.instance.id"))
+            .expect("resource must carry service.instance.id");
+        assert!(
+            !value.as_str().trim().is_empty(),
+            "service.instance.id must be non-empty"
+        );
+    }
+
+    #[test]
+    fn instance_id_prefers_explicit_override() {
+        let id = super::resolve_service_instance_id(
+            Some("explicit-id".to_string()),
+            Some("pod-name".to_string()),
+        );
+        assert_eq!(id, "explicit-id");
+    }
+
+    #[test]
+    fn instance_id_falls_back_to_hostname() {
+        let id =
+            super::resolve_service_instance_id(None, Some("waddle-server-abc-xyz".to_string()));
+        assert_eq!(id, "waddle-server-abc-xyz");
+    }
+
+    #[test]
+    fn instance_id_skips_blank_values() {
+        let id =
+            super::resolve_service_instance_id(Some("   ".to_string()), Some("\t".to_string()));
+        assert_eq!(id, format!("waddle-server-{}", std::process::id()));
+    }
+
+    #[test]
+    fn instance_id_trims_surrounding_whitespace() {
+        let id = super::resolve_service_instance_id(None, Some(" pod-1 \n".to_string()));
+        assert_eq!(id, "pod-1");
     }
 
     #[test]

--- a/server/crates/waddle-server/src/telemetry.rs
+++ b/server/crates/waddle-server/src/telemetry.rs
@@ -35,6 +35,8 @@ fn build_resource() -> Resource {
     let service_instance_id = resolve_service_instance_id(
         std::env::var("OTEL_SERVICE_INSTANCE_ID").ok(),
         std::env::var("HOSTNAME").ok(),
+        std::process::id(),
+        uuid::Uuid::new_v4().simple().to_string().as_str(),
     );
 
     Resource::builder()
@@ -52,15 +54,31 @@ fn build_resource() -> Resource {
 /// resource collapse into one clobbered series downstream, so every
 /// process needs a distinct, stable-for-its-lifetime identity.
 /// Precedence: explicit `OTEL_SERVICE_INSTANCE_ID` override, then
-/// `HOSTNAME` (the kubelet sets it to the pod name in every pod), then
-/// a pid-suffixed fallback for local runs. Blank values are skipped.
-fn resolve_service_instance_id(explicit: Option<String>, hostname: Option<String>) -> String {
-    [explicit, hostname]
-        .into_iter()
-        .flatten()
+/// `HOSTNAME` (the kubelet sets it to the pod name in every pod)
+/// suffixed with the pid so several processes sharing a hostname —
+/// bare metal, docker-compose — stay distinguishable, then a
+/// pid+entropy fallback: pids alone repeat across PID namespaces, so
+/// hostname-less containers need the per-process entropy to avoid
+/// colliding. Blank values are skipped.
+fn resolve_service_instance_id(
+    explicit: Option<String>,
+    hostname: Option<String>,
+    pid: u32,
+    fallback_entropy: &str,
+) -> String {
+    if let Some(id) = nonblank(explicit) {
+        return id;
+    }
+    if let Some(host) = nonblank(hostname) {
+        return format!("{host}-{pid}");
+    }
+    format!("waddle-server-{pid}-{fallback_entropy}")
+}
+
+fn nonblank(value: Option<String>) -> Option<String> {
+    value
         .map(|value| value.trim().to_string())
-        .find(|value| !value.is_empty())
-        .unwrap_or_else(|| format!("waddle-server-{}", std::process::id()))
+        .filter(|value| !value.is_empty())
 }
 
 fn default_filter() -> EnvFilter {
@@ -144,8 +162,9 @@ fn build_log_filter() -> EnvFilter {
 /// - `OTEL_EXPORTER_OTLP_ENDPOINT`: OTLP endpoint (default: http://localhost:4317)
 /// - `OTEL_SERVICE_NAME`: Service name (default: waddle-server)
 /// - `OTEL_SERVICE_VERSION`: Service version (default: crate version)
-/// - `OTEL_SERVICE_INSTANCE_ID`: Per-replica instance id (default: `HOSTNAME`,
-///   i.e. the pod name in Kubernetes, then a pid-suffixed fallback)
+/// - `OTEL_SERVICE_INSTANCE_ID`: Per-replica instance id (default:
+///   `<HOSTNAME>-<pid>` — the pod name in Kubernetes — then a
+///   pid+entropy fallback when no hostname is available)
 /// - `RUST_LOG`: Log filter (default: info)
 ///
 /// # Example
@@ -350,28 +369,43 @@ mod tests {
         let id = super::resolve_service_instance_id(
             Some("explicit-id".to_string()),
             Some("pod-name".to_string()),
+            7,
+            "entropy",
         );
         assert_eq!(id, "explicit-id");
     }
 
     #[test]
-    fn instance_id_falls_back_to_hostname() {
-        let id =
-            super::resolve_service_instance_id(None, Some("waddle-server-abc-xyz".to_string()));
-        assert_eq!(id, "waddle-server-abc-xyz");
+    fn instance_id_uses_hostname_with_pid_suffix() {
+        // The pid suffix keeps several processes sharing a hostname
+        // (bare metal, docker-compose) from publishing one identity.
+        let id = super::resolve_service_instance_id(
+            None,
+            Some("waddle-server-abc-xyz".to_string()),
+            7,
+            "entropy",
+        );
+        assert_eq!(id, "waddle-server-abc-xyz-7");
     }
 
     #[test]
-    fn instance_id_skips_blank_values() {
-        let id =
-            super::resolve_service_instance_id(Some("   ".to_string()), Some("\t".to_string()));
-        assert_eq!(id, format!("waddle-server-{}", std::process::id()));
+    fn instance_id_falls_back_to_pid_and_entropy() {
+        // Pids repeat across PID namespaces, so the hostname-less
+        // fallback must carry per-process entropy.
+        let id = super::resolve_service_instance_id(
+            Some("   ".to_string()),
+            Some("\t".to_string()),
+            7,
+            "0a1b2c3d",
+        );
+        assert_eq!(id, "waddle-server-7-0a1b2c3d");
     }
 
     #[test]
     fn instance_id_trims_surrounding_whitespace() {
-        let id = super::resolve_service_instance_id(None, Some(" pod-1 \n".to_string()));
-        assert_eq!(id, "pod-1");
+        let id =
+            super::resolve_service_instance_id(None, Some(" pod-1 \n".to_string()), 7, "entropy");
+        assert_eq!(id, "pod-1-7");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1299.

## Problem

OTLP-pushed metrics (clustering counters, process/state gauges), traces, and logs carry a resource with only `service.name` + `service.version`. With 2 replicas, both pods push identical series and clobber each other in Grafana Cloud — per-node state was invisible during the 2026-07-11 clustering incident. The scraped Prometheus-text endpoint is unaffected (scrape config adds `instance`).

## Plan

- Add `service.instance.id` to the OTLP resource built in `telemetry::build_resource()`, which is shared by the tracer, meter, and logger providers — one identity across traces, metrics, and logs.
- Resolution order: `OTEL_SERVICE_INSTANCE_ID` env (explicit override) → `HOSTNAME` env (set by the kubelet in every pod; equals the pod name) → `waddle-server-<pid>` fallback so local runs still get a stable-for-process-lifetime id. Blank/whitespace values are skipped.
- TDD seams: a pure `resolve_service_instance_id()` resolution function (precedence + trimming + fallback tests) and a `build_resource()` test asserting the attribute is present and non-empty.

No deployment config changes needed — `HOSTNAME` is standard in Kubernetes pods.

## Review

Two-axis review (standards + spec) ran clean: no hard violations; all code-level acceptance criteria met. Local: `cargo test -p waddle-server --lib` 1529 passed, clippy `-D warnings` clean, fmt applied.

**Owed post-deploy:** verify in Grafana Cloud that two replicas now produce two distinguishable series for a clustering metric (final acceptance criterion on #1299).
