### PR TITLE
telemetry(chat): Faro XMPP exceptions carry the stanza error condition

### DIFF
--- a/chat/src/lib/xmpp/client-muc-admin.ts
+++ b/chat/src/lib/xmpp/client-muc-admin.ts
@@ -46,17 +46,37 @@ export class RoomMemberListUnavailableError extends Error {
   }
 }
 
-/** Stanza-error condition from a rejected wasm promise. The bridge
- * rejects with either `{ condition }` or `{ error: { condition } }`;
- * anything else yields `undefined`. */
-function stanzaErrorCondition(error: unknown): string | undefined {
+interface StanzaErrorContext {
+  condition?: string;
+  errorType?: string;
+  errorText?: string;
+}
+
+/** Stanza-error context from a rejected wasm promise. The bridge rejects
+ * with an `Error` carrying `condition` / `errorType` / `text` properties
+ * (or legacy `{ condition }` / `{ error: { condition } }` shapes); anything
+ * else yields an empty context. */
+function stanzaErrorContext(error: unknown): StanzaErrorContext {
+  const source = stanzaErrorSource(error);
+  if (!source) return {};
+  const { condition, errorType, text } = source as {
+    condition?: unknown;
+    errorType?: unknown;
+    text?: unknown;
+  };
+  return {
+    ...(typeof condition === "string" ? { condition } : {}),
+    ...(typeof errorType === "string" ? { errorType } : {}),
+    ...(typeof text === "string" ? { errorText: text } : {}),
+  };
+}
+
+function stanzaErrorSource(error: unknown): object | undefined {
   if (typeof error !== "object" || error === null) return undefined;
-  const direct = (error as { condition?: unknown }).condition;
-  if (typeof direct === "string") return direct;
+  if (typeof (error as { condition?: unknown }).condition === "string") return error;
   const nested = (error as { error?: unknown }).error;
   if (typeof nested !== "object" || nested === null) return undefined;
-  const nestedCondition = (nested as { condition?: unknown }).condition;
-  return typeof nestedCondition === "string" ? nestedCondition : undefined;
+  return typeof (nested as { condition?: unknown }).condition === "string" ? nested : undefined;
 }
 
 /**
@@ -107,7 +127,7 @@ export class MucAdmin {
     if (!listMembers) { this.deps.emitError({ kind: "member-query", recoverable: false, detail: "missing list_room_members" }); throw new Error("missing list_room_members"); }
     const affiliations = ["owner", "admin", "member", "outcast"] as const; const members: MemberSummary[] = []; const failedAffiliations: string[] = [];
     for (const affiliation of affiliations) {
-      try { const result = await listMembers(affiliation); for (const item of result ?? []) { if (!item.jid) continue; members.push({ jid: item.jid, username: jidLocalpart(item.jid), avatar_url: null, affiliation, joined_at: "" }); } } catch (error) { failedAffiliations.push(affiliation); const condition = stanzaErrorCondition(error); const detail = condition === "forbidden" ? `forbidden affiliation query — ${roomJid}` : condition === "service-unavailable" ? `unsupported member query — ${roomJid}` : `affiliation query failed for ${affiliation} — ${roomJid}; reconstructed room JID may not match`; this.deps.emitError({ kind: "member-query", recoverable: true, detail, cause: error, condition }); }
+      try { const result = await listMembers(affiliation); for (const item of result ?? []) { if (!item.jid) continue; members.push({ jid: item.jid, username: jidLocalpart(item.jid), avatar_url: null, affiliation, joined_at: "" }); } } catch (error) { failedAffiliations.push(affiliation); const context = stanzaErrorContext(error); const detail = context.condition === "forbidden" ? `forbidden affiliation query — ${roomJid}` : context.condition === "service-unavailable" ? `unsupported member query — ${roomJid}` : `affiliation query failed for ${affiliation} — ${roomJid}; reconstructed room JID may not match`; this.deps.emitError({ kind: "member-query", recoverable: true, detail, cause: error, ...context }); }
     }
     if (members.length === 0 && failedAffiliations.length > 0) {
       throw new RoomMemberListUnavailableError();

--- a/chat/src/lib/xmpp/client-muc-admin.ts
+++ b/chat/src/lib/xmpp/client-muc-admin.ts
@@ -7,6 +7,7 @@
  */
 import type { MemberSummary } from "../chat-types";
 import { jidLocalpart } from "./jid";
+import { stanzaErrorContext } from "./stanza-error-context";
 import type { ListRoomMembersOptions, XmppErrorEvent } from "./types";
 import type {
   WasmAdminChannelRef,
@@ -46,38 +47,6 @@ export class RoomMemberListUnavailableError extends Error {
   }
 }
 
-interface StanzaErrorContext {
-  condition?: string;
-  errorType?: string;
-  errorText?: string;
-}
-
-/** Stanza-error context from a rejected wasm promise. The bridge rejects
- * with an `Error` carrying `condition` / `errorType` / `text` properties
- * (or legacy `{ condition }` / `{ error: { condition } }` shapes); anything
- * else yields an empty context. */
-function stanzaErrorContext(error: unknown): StanzaErrorContext {
-  const source = stanzaErrorSource(error);
-  if (!source) return {};
-  const { condition, errorType, text } = source as {
-    condition?: unknown;
-    errorType?: unknown;
-    text?: unknown;
-  };
-  return {
-    ...(typeof condition === "string" ? { condition } : {}),
-    ...(typeof errorType === "string" ? { errorType } : {}),
-    ...(typeof text === "string" ? { errorText: text } : {}),
-  };
-}
-
-function stanzaErrorSource(error: unknown): object | undefined {
-  if (typeof error !== "object" || error === null) return undefined;
-  if (typeof (error as { condition?: unknown }).condition === "string") return error;
-  const nested = (error as { error?: unknown }).error;
-  if (typeof nested !== "object" || nested === null) return undefined;
-  return typeof (nested as { condition?: unknown }).condition === "string" ? nested : undefined;
-}
 
 /**
  * Structural subset of the WASM client the MUC admin module drives.

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -708,6 +708,11 @@ export class BrowserXmppClient {
     if (!waiter) return false;
     if (errorNick !== waiter.requestedNick) return false;
 
+    waiter?.reject(new Error("Channel presence was rejected. Try again in a moment."));
+    this.revokeMucReadiness(room, { keepPendingJoin: true });
+    // Emit after the waiter is rejected and readiness revoked so an error
+    // listener that synchronously retries the join observes consistent
+    // state instead of the doomed waiter.
     this.emitError({
       kind: "muc-join",
       recoverable: true,
@@ -718,8 +723,6 @@ export class BrowserXmppClient {
         text: presence.error_text,
       }),
     });
-    waiter?.reject(new Error("Channel presence was rejected. Try again in a moment."));
-    this.revokeMucReadiness(room, { keepPendingJoin: true });
     return true;
   }
 

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1,4 +1,5 @@
 import { withSpan } from "@/lib/telemetry";
+import { stanzaErrorContext } from "@/lib/xmpp/stanza-error-context";
 import { inferredFileDisposition, type ExtensionLaunchDescriptor } from "@/lib/chat-ui";
 import type { ThreadsSort, ThreadsStatusFilter } from "@/lib/threads-view-filters";
 import type { BroadcastShow } from "@/presence/effective-show";
@@ -707,6 +708,16 @@ export class BrowserXmppClient {
     if (!waiter) return false;
     if (errorNick !== waiter.requestedNick) return false;
 
+    this.emitError({
+      kind: "muc-join",
+      recoverable: true,
+      detail: `room join rejected — ${room}`,
+      ...stanzaErrorContext({
+        condition: presence.error_condition,
+        errorType: presence.error_type,
+        text: presence.error_text,
+      }),
+    });
     waiter?.reject(new Error("Channel presence was rejected. Try again in a moment."));
     this.revokeMucReadiness(room, { keepPendingJoin: true });
     return true;

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -709,10 +709,12 @@ export class BrowserXmppClient {
     if (errorNick !== waiter.requestedNick) return false;
 
     waiter?.reject(new Error("Channel presence was rejected. Try again in a moment."));
-    this.revokeMucReadiness(room, { keepPendingJoin: true });
-    // Emit after the waiter is rejected and readiness revoked so an error
-    // listener that synchronously retries the join observes consistent
-    // state instead of the doomed waiter.
+    // Fully revoke — including the pending joinedMucs promise and its
+    // token — BEFORE emitting, so an error listener that synchronously
+    // retries the join starts a fresh one instead of awaiting the doomed
+    // rejected entry (ensureJoined's own catch cleanup only lands several
+    // microtasks later and its token guard makes this early delete safe).
+    this.revokeMucReadiness(room);
     this.emitError({
       kind: "muc-join",
       recoverable: true,

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -224,11 +224,17 @@ function logDiscoFailure(kind: "info" | "items" | "pubsub", to: string, node: st
   }
   console.error(`[disco] ${kind} FAILED`, { to, node, err });
   const context = stanzaErrorContext(err);
+  // Beacon only attributable failures (server stanza error or the timeout
+  // branch above). Condition-less rejections — chiefly "client is
+  // disconnected" — reject every in-flight disco IQ of a topology load at
+  // once on a connection flap, and beaconing each would flood Faro with
+  // one error per room. Those stay console-only.
+  if (!context.condition) return;
   reportError("xmpp.stream", err, {
     recoverable: true,
-    detail: context.condition ? `disco-${kind}-${context.condition}` : `disco-${kind}-failed`,
+    detail: `disco-${kind}-${context.condition}`,
     ...context,
-    ...(context.condition ? { errorSource: "server" } : {}),
+    errorSource: "server",
   });
 }
 

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -1,6 +1,7 @@
 import type { WaddleClient } from "@waddle/xmpp-client-wasm";
 import { normalizeChannelType } from "@/lib/channel-types";
 import { reportError } from "@/lib/telemetry";
+import { XMPP_ERROR_CONDITIONS } from "./types";
 import type { DiscoveredChannel, DiscoveredSpace, DiscoveredTopology } from "./types";
 import { barePeerJid, jidDomain, jidLocalpart } from "./jid";
 import { FIELD_PIN_PERMISSION } from "./protocol-helpers";
@@ -215,9 +216,10 @@ function logDiscoFailure(kind: "info" | "items" | "pubsub", to: string, node: st
     // channels fail to render — keep them structured so consumers can
     // grep / aggregate by `to`.
     console.warn(`[disco] ${kind} timeout`, { to: err.to, node: err.node });
-    reportError("xmpp.stream", err, {
+    const detail = `disco-${kind}-timeout`;
+    reportError("xmpp.stream", new Error(detail), {
       recoverable: true,
-      detail: `disco-${kind}-timeout`,
+      detail,
       errorSource: "local-timeout",
     });
     return;
@@ -230,10 +232,18 @@ function logDiscoFailure(kind: "info" | "items" | "pubsub", to: string, node: st
   // once on a connection flap, and beaconing each would flood Faro with
   // one error per room. Those stay console-only.
   if (!context.condition) return;
-  reportError("xmpp.stream", err, {
+  // Allowlist the condition like `telemetryCondition()` does for
+  // XmppErrorEvents: a non-standard element name must not mint
+  // high-cardinality `disco-*-*` details. The beacon exception is a
+  // fresh Error carrying only the detail — never the raw rejection,
+  // whose message embeds the uncapped server `<text/>`.
+  const condition = XMPP_ERROR_CONDITIONS.has(context.condition) ? context.condition : "unknown";
+  const detail = `disco-${kind}-${condition}`;
+  reportError("xmpp.stream", new Error(detail), {
     recoverable: true,
-    detail: `disco-${kind}-${context.condition}`,
+    detail,
     ...context,
+    condition,
     errorSource: "server",
   });
 }

--- a/chat/src/lib/xmpp/discovery.ts
+++ b/chat/src/lib/xmpp/discovery.ts
@@ -1,8 +1,10 @@
 import type { WaddleClient } from "@waddle/xmpp-client-wasm";
 import { normalizeChannelType } from "@/lib/channel-types";
+import { reportError } from "@/lib/telemetry";
 import type { DiscoveredChannel, DiscoveredSpace, DiscoveredTopology } from "./types";
 import { barePeerJid, jidDomain, jidLocalpart } from "./jid";
 import { FIELD_PIN_PERMISSION } from "./protocol-helpers";
+import { stanzaErrorContext } from "./stanza-error-context";
 
 const NS_FORUMS_0 = "urn:xmpp:forums:0";
 const NS_MUC = "http://jabber.org/protocol/muc";
@@ -213,9 +215,21 @@ function logDiscoFailure(kind: "info" | "items" | "pubsub", to: string, node: st
     // channels fail to render — keep them structured so consumers can
     // grep / aggregate by `to`.
     console.warn(`[disco] ${kind} timeout`, { to: err.to, node: err.node });
+    reportError("xmpp.stream", err, {
+      recoverable: true,
+      detail: `disco-${kind}-timeout`,
+      errorSource: "local-timeout",
+    });
     return;
   }
   console.error(`[disco] ${kind} FAILED`, { to, node, err });
+  const context = stanzaErrorContext(err);
+  reportError("xmpp.stream", err, {
+    recoverable: true,
+    detail: context.condition ? `disco-${kind}-${context.condition}` : `disco-${kind}-failed`,
+    ...context,
+    ...(context.condition ? { errorSource: "server" } : {}),
+  });
 }
 
 async function sendDiscoInfo(xmpp: HybridClient, to: string, node?: string): Promise<DiscoInfoData | null> {

--- a/chat/src/lib/xmpp/stanza-error-context.ts
+++ b/chat/src/lib/xmpp/stanza-error-context.ts
@@ -35,8 +35,9 @@ export function stanzaErrorContext(error: unknown): StanzaErrorContext {
     errorType?: unknown;
     text?: unknown;
   };
+  const normalizedCondition = typeof condition === "string" ? condition.trim().toLowerCase() : "";
   return {
-    ...(typeof condition === "string" ? { condition } : {}),
+    ...(normalizedCondition ? { condition: normalizedCondition } : {}),
     ...(isStanzaErrorType(errorType) ? { errorType } : {}),
     ...(typeof text === "string" && text.length > 0
       ? { errorText: text.slice(0, MAX_ERROR_TEXT_LENGTH) }

--- a/chat/src/lib/xmpp/stanza-error-context.ts
+++ b/chat/src/lib/xmpp/stanza-error-context.ts
@@ -1,0 +1,57 @@
+/**
+ * Extraction of RFC 6120 §8.3 stanza-error context from a rejected wasm
+ * promise, shared by every flow that reports XMPP failures to telemetry
+ * (muc#admin member list, disco, MUC join). The bridge rejects with an
+ * `Error` carrying `condition` / `errorType` / `text` properties (or the
+ * legacy `{ condition }` / `{ error: { condition } }` shapes); anything
+ * else yields an empty context.
+ */
+import type { XmppStanzaErrorType } from "@/lib/xmpp/types";
+
+export interface StanzaErrorContext {
+  condition?: string;
+  errorType?: XmppStanzaErrorType;
+  errorText?: string;
+}
+
+/** Cap on server-provided error text forwarded to telemetry — RFC 6120
+ * puts no size limit on `<text/>`, and beacon context should stay small. */
+const MAX_ERROR_TEXT_LENGTH = 256;
+
+const STANZA_ERROR_TYPES: ReadonlySet<string> = new Set([
+  "auth",
+  "cancel",
+  "continue",
+  "modify",
+  "wait",
+  "unknown",
+]);
+
+export function stanzaErrorContext(error: unknown): StanzaErrorContext {
+  const source = stanzaErrorSource(error);
+  if (!source) return {};
+  const { condition, errorType, text } = source as {
+    condition?: unknown;
+    errorType?: unknown;
+    text?: unknown;
+  };
+  return {
+    ...(typeof condition === "string" ? { condition } : {}),
+    ...(isStanzaErrorType(errorType) ? { errorType } : {}),
+    ...(typeof text === "string" && text.length > 0
+      ? { errorText: text.slice(0, MAX_ERROR_TEXT_LENGTH) }
+      : {}),
+  };
+}
+
+function isStanzaErrorType(value: unknown): value is XmppStanzaErrorType {
+  return typeof value === "string" && STANZA_ERROR_TYPES.has(value);
+}
+
+function stanzaErrorSource(error: unknown): object | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  if (typeof (error as { condition?: unknown }).condition === "string") return error;
+  const nested = (error as { error?: unknown }).error;
+  if (typeof nested !== "object" || nested === null) return undefined;
+  return typeof (nested as { condition?: unknown }).condition === "string" ? nested : undefined;
+}

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -75,7 +75,19 @@ export type XmppErrorKind =
   | "auth"
   | "connect-timeout"
   | "history"
-  | "member-query";
+  | "member-query"
+  | "muc-join";
+
+/** RFC 6120 §8.3.2 `type` attribute values of an `<error/>` element, plus
+ * "unknown" for an unrecognised wire value (mirrors the wasm bridge's
+ * `StanzaErrorType::as_str`). */
+export type XmppStanzaErrorType =
+  | "auth"
+  | "cancel"
+  | "continue"
+  | "modify"
+  | "wait"
+  | "unknown";
 
 export const XMPP_STREAM_ERROR_CONDITIONS = new Set([
   "bad-format",
@@ -105,27 +117,34 @@ export const XMPP_STREAM_ERROR_CONDITIONS = new Set([
   "unsupported-version",
 ]);
 
-/** RFC 6120 §8.3.3 defined stanza-error conditions, plus the stream-error
- * conditions so mixed consumers keep matching. Telemetry collapses anything
- * outside this list to "unknown". */
+/** The complete RFC 6120 §8.3.3 defined stanza-error condition list
+ * (self-contained — the overlap with the stream set is deliberate so this
+ * list survives stream-set edits), plus the stream-error conditions so
+ * mixed consumers keep matching. Telemetry collapses anything outside this
+ * list to "unknown". */
 export const XMPP_ERROR_CONDITIONS = new Set([
   ...XMPP_STREAM_ERROR_CONDITIONS,
   "bad-request",
+  "conflict",
   "feature-not-implemented",
   "forbidden",
   "gone",
+  "internal-server-error",
   "item-not-found",
   "jid-malformed",
   "not-acceptable",
   "not-allowed",
-  "payment-required",
+  "not-authorized",
+  "policy-violation",
   "recipient-unavailable",
   "redirect",
   "registration-required",
   "remote-server-not-found",
   "remote-server-timeout",
+  "resource-constraint",
   "service-unavailable",
   "subscription-required",
+  "undefined-condition",
   "unexpected-request",
 ]);
 
@@ -140,9 +159,8 @@ export interface XmppErrorEvent {
   /** XMPP stream-error condition when `kind === "stream"`, or the RFC 6120
    * §8.3 stanza-error condition when a server error stanza was received. */
   condition?: string;
-  /** RFC 6120 §8.3.2 `type` attribute of a received error stanza
-   * ("auth" | "cancel" | "continue" | "modify" | "wait" | "unknown"). */
-  errorType?: string;
+  /** RFC 6120 §8.3.2 `type` attribute of a received error stanza. */
+  errorType?: XmppStanzaErrorType;
   /** Server-provided `<text/>` of a received error stanza. */
   errorText?: string;
   /** XEP-0198 stream-management extension detail when a stream error carries one. */

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -105,11 +105,28 @@ export const XMPP_STREAM_ERROR_CONDITIONS = new Set([
   "unsupported-version",
 ]);
 
+/** RFC 6120 §8.3.3 defined stanza-error conditions, plus the stream-error
+ * conditions so mixed consumers keep matching. Telemetry collapses anything
+ * outside this list to "unknown". */
 export const XMPP_ERROR_CONDITIONS = new Set([
   ...XMPP_STREAM_ERROR_CONDITIONS,
+  "bad-request",
+  "feature-not-implemented",
   "forbidden",
+  "gone",
   "item-not-found",
+  "jid-malformed",
+  "not-acceptable",
+  "not-allowed",
+  "payment-required",
+  "recipient-unavailable",
+  "redirect",
+  "registration-required",
+  "remote-server-not-found",
+  "remote-server-timeout",
   "service-unavailable",
+  "subscription-required",
+  "unexpected-request",
 ]);
 
 export interface XmppErrorEvent {
@@ -120,8 +137,14 @@ export interface XmppErrorEvent {
   detail: string;
   /** Original error object if one was caught. */
   cause?: unknown;
-  /** XMPP stream-error condition when `kind === "stream"`. */
+  /** XMPP stream-error condition when `kind === "stream"`, or the RFC 6120
+   * §8.3 stanza-error condition when a server error stanza was received. */
   condition?: string;
+  /** RFC 6120 §8.3.2 `type` attribute of a received error stanza
+   * ("auth" | "cancel" | "continue" | "modify" | "wait" | "unknown"). */
+  errorType?: string;
+  /** Server-provided `<text/>` of a received error stanza. */
+  errorText?: string;
   /** XEP-0198 stream-management extension detail when a stream error carries one. */
   streamManagementError?: {
     kind: "handled-count-too-high";

--- a/chat/src/lib/xmpp/types.ts
+++ b/chat/src/lib/xmpp/types.ts
@@ -146,6 +146,10 @@ export const XMPP_ERROR_CONDITIONS = new Set([
   "subscription-required",
   "undefined-condition",
   "unexpected-request",
+  // Non-RFC conditions Waddle flows branch on as first-class stanza
+  // conditions (see STANZA_CONDITION_PRECONDITION_NOT_MET in the Rust
+  // client's error.rs — XEP-0223 publish-options rejections).
+  "precondition-not-met",
 ]);
 
 export interface XmppErrorEvent {

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -272,6 +272,15 @@ export interface WasmPresence {
    * carries none. The chat side renders the idle age on an away presence.
    */
   idle_since?: string;
+  /**
+   * RFC 6120 §8.3 defined condition of an error presence (e.g. a rejected
+   * XEP-0045 room join). Absent for non-error presences.
+   */
+  error_condition?: string;
+  /** RFC 6120 §8.3.2 `type` attribute of the `<error/>` element. */
+  error_type?: string;
+  /** Server-provided `<text/>` of the error, absent when none. */
+  error_text?: string;
 }
 
 /**

--- a/chat/src/lib/xmpp/xmpp-instrumentation.ts
+++ b/chat/src/lib/xmpp/xmpp-instrumentation.ts
@@ -33,6 +33,7 @@ const ERROR_KIND_MAP: Record<XmppErrorKind, ErrorKind> = {
   "connect-timeout": "xmpp.disconnect",
   "history": "xmpp.stream",
   "member-query": "xmpp.stream",
+  "muc-join": "xmpp.stream",
 };
 export function installInstrumentation(client: BrowserXmppClient): void {
   client.onMessageAcked((id, meta) => {
@@ -100,6 +101,8 @@ function telemetryErrorDetail(event: XmppErrorEvent, condition: string | undefin
     case "member-query":
       if (event.detail === "missing list_room_members") return "missing-list-room-members";
       return condition ? `member-query-${condition}` : "member-query-failed";
+    case "muc-join":
+      return condition ? `room-join-${condition}` : "room-join-rejected";
     case "stream":
       if (
         condition === "undefined-condition" &&

--- a/chat/src/lib/xmpp/xmpp-instrumentation.ts
+++ b/chat/src/lib/xmpp/xmpp-instrumentation.ts
@@ -66,11 +66,15 @@ export function installInstrumentation(client: BrowserXmppClient): void {
     const smCounts = event.kind === "stream"
       ? telemetryStreamManagementCounts(event)
       : undefined;
+    const errorSource = telemetryErrorSource(event.kind, condition);
     const cause = new Error(detail);
     reportError(kind, cause, {
       recoverable: event.recoverable,
       detail,
       ...(condition ? { condition } : {}),
+      ...(event.errorType ? { errorType: event.errorType } : {}),
+      ...(event.errorText ? { errorText: event.errorText } : {}),
+      ...(errorSource ? { errorSource } : {}),
       ...(streamDetail ? { streamDetail } : {}),
       ...(smCounts ?? {}),
     });
@@ -145,6 +149,19 @@ function telemetryStreamManagementCounts(event: XmppErrorEvent): Record<string, 
     smH: String(event.streamManagementError.h),
     smSendCount: String(event.streamManagementError.sendCount),
   };
+}
+
+/** Attribute the failure: a condition means the server answered with an
+ * error stanza/stream error; `connect-timeout` events are client-side
+ * timers (connect stall, room self-presence wait). Anything else is left
+ * unattributed rather than guessed. */
+function telemetryErrorSource(
+  kind: XmppErrorKind,
+  condition: string | undefined,
+): "server" | "local-timeout" | undefined {
+  if (condition) return "server";
+  if (kind === "connect-timeout") return "local-timeout";
+  return undefined;
 }
 
 function telemetryCondition(kind: XmppErrorKind, condition: string | undefined): string | undefined {

--- a/chat/tests/client-muc-admin.test.ts
+++ b/chat/tests/client-muc-admin.test.ts
@@ -64,6 +64,27 @@ describe("MucAdmin.listRoomMembers", () => {
     expect(errors[0].condition).toBe("forbidden");
   });
 
+  test("structured Error rejections from the wasm bridge surface condition, errorType, and text", async () => {
+    const rejection = Object.assign(
+      new Error("server returned a stanza error: cancel: item-not-found"),
+      { condition: "item-not-found", errorType: "cancel", text: "no such room" },
+    );
+    const { admin, errors } = createAdmin({
+      list_room_members: async (_roomJid, affiliation) => {
+        if (affiliation === "owner") throw rejection;
+        return affiliation === "member" ? [{ jid: "bob@example.com" }] : [];
+      },
+    });
+
+    const members = await admin.listRoomMembers("general");
+
+    expect(members.map((member) => member.jid)).toEqual(["bob@example.com"]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].condition).toBe("item-not-found");
+    expect(errors[0].errorType).toBe("cancel");
+    expect(errors[0].errorText).toBe("no such room");
+  });
+
   test("throws RoomMemberListUnavailableError when every affiliation query fails", async () => {
     const { admin } = createAdmin({
       list_room_members: async () => {

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -545,7 +545,16 @@ describe("client send readiness", () => {
     const client = new BrowserXmppClient(session());
     const roomJid = roomBareJidFor(session(), "c1");
     const errors: XmppErrorEvent[] = [];
-    client.onError((event) => errors.push(event));
+    const staleJoinVisibleAtEmit: boolean[] = [];
+    client.onError((event) => {
+      errors.push(event);
+      // A listener that synchronously retries the join must NOT observe
+      // the doomed promise still cached in joinedMucs (the emit is
+      // deferred one microtask so ensureJoined's catch cleans up first).
+      staleJoinVisibleAtEmit.push(
+        (client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid),
+      );
+    });
     let onPresence: ((presence: {
       from?: string;
       presence_type: string;
@@ -581,6 +590,7 @@ describe("client send readiness", () => {
     expect(errors[0].kind).toBe("muc-join");
     expect(errors[0].condition).toBe("registration-required");
     expect(errors[0].errorType).toBe("auth");
+    expect(staleJoinVisibleAtEmit).toEqual([false]);
   });
 
   test("room join ignores unrelated room presence errors while waiting for self-presence", async () => {

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -9,6 +9,7 @@ import { enqueueQueuedMessage, listQueuedDmMessages, listQueuedRoomMessages } fr
 import { applyDmCallEvent, clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
 import { $dmCallOutcomeAnchor } from "../src/lib/calls/dm-call-anchor";
 import type { ResumePersistence } from "../src/lib/xmpp/resume-persistence";
+import type { XmppErrorEvent } from "../src/lib/xmpp/types";
 import { handlerStubs } from "./helpers/xmpp-client-mock";
 
 function session(partial: Partial<WaddleSession> = {}): WaddleSession {
@@ -543,9 +544,13 @@ describe("client send readiness", () => {
   test("room join rejects on XEP-0045 MUC error presence instead of timing out", async () => {
     const client = new BrowserXmppClient(session());
     const roomJid = roomBareJidFor(session(), "c1");
+    const errors: XmppErrorEvent[] = [];
+    client.onError((event) => errors.push(event));
     let onPresence: ((presence: {
       from?: string;
       presence_type: string;
+      error_condition?: string;
+      error_type?: string;
     }) => void) | null = null;
     const xmpp = {
       join_room: mock(async () => undefined),
@@ -564,12 +569,18 @@ describe("client send readiness", () => {
     onPresence?.({
       from: `${roomJid}/alice`,
       presence_type: "error",
+      error_condition: "registration-required",
+      error_type: "auth",
     });
 
     await expect(joined).rejects.toThrow("Channel presence was rejected");
     expect((client as unknown as { joinedMucs: Map<string, Promise<void>> }).joinedMucs.has(roomJid)).toBe(false);
     expect((client as unknown as { joinedMucJoinTokens: Map<string, symbol> }).joinedMucJoinTokens.has(roomJid)).toBe(false);
     expect((client as unknown as { roomJoinWaiters: Map<string, unknown> }).roomJoinWaiters.size).toBe(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].kind).toBe("muc-join");
+    expect(errors[0].condition).toBe("registration-required");
+    expect(errors[0].errorType).toBe("auth");
   });
 
   test("room join ignores unrelated room presence errors while waiting for self-presence", async () => {

--- a/chat/tests/stanza-error-context.test.ts
+++ b/chat/tests/stanza-error-context.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Unit tests for the shared stanza-error context extractor
+ * (`src/lib/xmpp/stanza-error-context.ts`): the wasm bridge's structured
+ * `Error` rejections, the legacy object shapes, errorType validation, and
+ * the telemetry length cap on server-provided error text.
+ */
+import { describe, expect, test } from "bun:test";
+import { stanzaErrorContext } from "../src/lib/xmpp/stanza-error-context";
+
+describe("stanzaErrorContext", () => {
+  test("reads condition, errorType, and text off a structured Error rejection", () => {
+    const rejection = Object.assign(
+      new Error("server returned a stanza error: cancel: item-not-found"),
+      { condition: "item-not-found", errorType: "cancel", text: "no such room" },
+    );
+    expect(stanzaErrorContext(rejection)).toEqual({
+      condition: "item-not-found",
+      errorType: "cancel",
+      errorText: "no such room",
+    });
+  });
+
+  test("supports the legacy nested { error: { condition } } shape", () => {
+    expect(stanzaErrorContext({ error: { condition: "service-unavailable" } })).toEqual({
+      condition: "service-unavailable",
+    });
+  });
+
+  test("drops an errorType outside the RFC 6120 §8.3.2 value set", () => {
+    expect(
+      stanzaErrorContext({ condition: "forbidden", errorType: "bogus" }),
+    ).toEqual({ condition: "forbidden" });
+  });
+
+  test("truncates oversized server error text for the beacon", () => {
+    const context = stanzaErrorContext({
+      condition: "resource-constraint",
+      text: "x".repeat(10_000),
+    });
+    expect(context.errorText).toHaveLength(256);
+  });
+
+  test("yields an empty context for strings and unshaped rejections", () => {
+    expect(stanzaErrorContext("client is disconnected")).toEqual({});
+    expect(stanzaErrorContext(new Error("boom"))).toEqual({});
+    expect(stanzaErrorContext(null)).toEqual({});
+  });
+});

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -22,6 +22,7 @@ import {
   reportSessionLifecycle,
   reportStatusChange,
 } from "../src/lib/telemetry";
+import { DiscoTimeoutError, discoverChannels } from "../src/lib/xmpp/discovery";
 import { installInstrumentation } from "../src/lib/xmpp/xmpp-instrumentation";
 
 function session(partial: Partial<WaddleSession> = {}): WaddleSession {
@@ -849,6 +850,75 @@ describe("BrowserXmppClient telemetry hooks", () => {
     expect(unattributed.options?.context?.condition).toBeUndefined();
     expect(unattributed.options?.context?.errorSource).toBeUndefined();
     expect(unattributed.options?.context?.detail).toBe("member-query-failed");
+  });
+
+  test("rejected MUC join presence reports the stanza error condition", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    const client = new BrowserXmppClient(session());
+    installInstrumentation(client);
+
+    const internal = client as unknown as {
+      emitError: (event: {
+        kind: "muc-join";
+        recoverable: boolean;
+        detail: string;
+        condition?: string;
+        errorType?: string;
+      }) => void;
+    };
+
+    internal.emitError({
+      kind: "muc-join",
+      recoverable: true,
+      detail: "room join rejected — room@muc.example.com",
+      condition: "registration-required",
+      errorType: "auth",
+    });
+
+    expect(stub.errors).toHaveLength(1);
+    const joinErr = stub.errors[0];
+    expect(joinErr.options?.type).toBe("xmpp.stream");
+    expect(joinErr.options?.context?.detail).toBe("room-join-registration-required");
+    expect(joinErr.options?.context?.condition).toBe("registration-required");
+    expect(joinErr.options?.context?.errorType).toBe("auth");
+    expect(joinErr.options?.context?.errorSource).toBe("server");
+  });
+
+  test("disco failures report to Faro with condition or local-timeout attribution", async () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    // Server-returned stanza error: the wasm bridge rejects send_raw_iq
+    // with a structured Error carrying the condition.
+    const stanzaRejection = Object.assign(
+      new Error("server returned a stanza error: cancel: service-unavailable"),
+      { condition: "service-unavailable", errorType: "cancel" },
+    );
+    await discoverChannels(
+      { send_raw_iq: async () => { throw stanzaRejection; } },
+      "alice@example.com",
+    ).catch(() => undefined);
+    const serverErr = stub.errors.find(
+      (entry) => entry.options?.context?.detail === "disco-items-service-unavailable",
+    );
+    expect(serverErr).toBeDefined();
+    expect(serverErr?.options?.context?.condition).toBe("service-unavailable");
+    expect(serverErr?.options?.context?.errorSource).toBe("server");
+
+    // Local timeout: DiscoTimeoutError is attributed to the client timer.
+    stub.errors.length = 0;
+    await discoverChannels(
+      { send_raw_iq: async () => { throw new DiscoTimeoutError("muc.example.com", undefined, 30); } },
+      "alice@example.com",
+    ).catch(() => undefined);
+    const timeoutErr = stub.errors.find(
+      (entry) => entry.options?.context?.detail === "disco-items-timeout",
+    );
+    expect(timeoutErr).toBeDefined();
+    expect(timeoutErr?.options?.context?.errorSource).toBe("local-timeout");
+    expect(timeoutErr?.options?.context?.condition).toBeUndefined();
   });
 
   test("set_on_error bridge preserves stream error conditions for telemetry", () => {

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -784,6 +784,71 @@ describe("BrowserXmppClient telemetry hooks", () => {
     expect(stub.errors[0].options?.type).toBe("xmpp.disconnect");
     expect(stub.errors[0].options?.context?.recoverable).toBe("true");
     expect(stub.errors[0].options?.context?.detail).toBe("room-self-presence-timeout");
+    expect(stub.errors[0].options?.context?.errorSource).toBe("local-timeout");
+  });
+
+  test("stanza error context carries errorType, errorText, and errorSource", () => {
+    const stub = createFaroStub();
+    __setFaroForTesting(stub as never);
+
+    const client = new BrowserXmppClient(session());
+    installInstrumentation(client);
+
+    const internal = client as unknown as {
+      emitError: (event: {
+        kind: "stream" | "auth" | "connect-timeout" | "member-query";
+        recoverable: boolean;
+        detail: string;
+        cause?: unknown;
+        condition?: string;
+        errorType?: string;
+        errorText?: string;
+      }) => void;
+    };
+
+    // Server-returned stanza error with full context.
+    internal.emitError({
+      kind: "member-query",
+      recoverable: true,
+      detail: "affiliation query failed for owner",
+      condition: "item-not-found",
+      errorType: "cancel",
+      errorText: "no such room",
+    });
+
+    // RFC 6120 defined condition outside the old allowlist must survive.
+    internal.emitError({
+      kind: "member-query",
+      recoverable: true,
+      detail: "affiliation query failed for owner",
+      condition: "not-allowed",
+      errorType: "cancel",
+    });
+
+    // No condition: source is unattributed, so errorSource stays unset.
+    internal.emitError({
+      kind: "member-query",
+      recoverable: true,
+      detail: "affiliation query failed for owner",
+    });
+
+    expect(stub.errors).toHaveLength(3);
+
+    const serverErr = stub.errors[0];
+    expect(serverErr.options?.context?.condition).toBe("item-not-found");
+    expect(serverErr.options?.context?.errorType).toBe("cancel");
+    expect(serverErr.options?.context?.errorText).toBe("no such room");
+    expect(serverErr.options?.context?.errorSource).toBe("server");
+    expect(serverErr.options?.context?.detail).toBe("member-query-item-not-found");
+
+    const definedCondition = stub.errors[1];
+    expect(definedCondition.options?.context?.condition).toBe("not-allowed");
+    expect(definedCondition.options?.context?.detail).toBe("member-query-not-allowed");
+
+    const unattributed = stub.errors[2];
+    expect(unattributed.options?.context?.condition).toBeUndefined();
+    expect(unattributed.options?.context?.errorSource).toBeUndefined();
+    expect(unattributed.options?.context?.detail).toBe("member-query-failed");
   });
 
   test("set_on_error bridge preserves stream error conditions for telemetry", () => {

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -919,6 +919,16 @@ describe("BrowserXmppClient telemetry hooks", () => {
     expect(timeoutErr).toBeDefined();
     expect(timeoutErr?.options?.context?.errorSource).toBe("local-timeout");
     expect(timeoutErr?.options?.context?.condition).toBeUndefined();
+
+    // Condition-less rejections (e.g. "client is disconnected" during a
+    // connection flap) must stay console-only — one beacon per in-flight
+    // room IQ would flood Faro.
+    stub.errors.length = 0;
+    await discoverChannels(
+      { send_raw_iq: async () => { throw "client is disconnected"; } },
+      "alice@example.com",
+    ).catch(() => undefined);
+    expect(stub.errors).toHaveLength(0);
   });
 
   test("set_on_error bridge preserves stream error conditions for telemetry", () => {

--- a/server/crates/waddle-xmpp-client-wasm/src/commands.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/commands.rs
@@ -61,7 +61,72 @@ pub(crate) async fn send_iq_command(
         .map_err(|_| js_error("client is disconnected"))?;
     rx.await
         .map_err(|_| js_error("client is disconnected"))?
-        .map_err(|err| js_error(err.to_string()))
+        .map_err(iq_rejection)
+}
+
+/// Fields the JS side reads off a rejected IQ promise for an RFC 6120
+/// §8.3 stanza error (`stanzaErrorContext` in chat's `client-muc-admin.ts`).
+/// Split from [`iq_rejection`] so the mapping is testable on native targets,
+/// where `JsValue` construction cannot run.
+pub(crate) struct StanzaErrorRejectionFields {
+    pub message: String,
+    pub condition: String,
+    pub error_type: &'static str,
+    pub text: Option<String>,
+}
+
+pub(crate) fn stanza_error_rejection_fields(
+    err: &ClientError,
+) -> Option<StanzaErrorRejectionFields> {
+    let ClientError::StanzaError(stanza_err) = err else {
+        return None;
+    };
+    Some(StanzaErrorRejectionFields {
+        message: err.to_string(),
+        condition: stanza_err.condition.clone(),
+        error_type: stanza_error_type_label(stanza_err.error_type),
+        text: stanza_err.text.clone(),
+    })
+}
+
+fn stanza_error_type_label(error_type: waddle_xmpp_client::StanzaErrorType) -> &'static str {
+    use waddle_xmpp_client::StanzaErrorType;
+    match error_type {
+        StanzaErrorType::Auth => "auth",
+        StanzaErrorType::Cancel => "cancel",
+        StanzaErrorType::Continue => "continue",
+        StanzaErrorType::Modify => "modify",
+        StanzaErrorType::Wait => "wait",
+        StanzaErrorType::Unknown => "unknown",
+    }
+}
+
+/// Reject an IQ promise. Stanza errors become a real JS `Error` (so
+/// `String(err)` / console paths keep a readable message) carrying
+/// `condition`, `errorType`, and `text` properties for telemetry;
+/// everything else stays a stringified rejection.
+pub(crate) fn iq_rejection(err: ClientError) -> JsValue {
+    let Some(fields) = stanza_error_rejection_fields(&err) else {
+        return js_error(err.to_string());
+    };
+    let js_err = js_sys::Error::new(&fields.message);
+    set_rejection_property(&js_err, "condition", &fields.condition);
+    set_rejection_property(&js_err, "errorType", fields.error_type);
+    if let Some(text) = &fields.text {
+        set_rejection_property(&js_err, "text", text);
+    }
+    js_err.into()
+}
+
+fn set_rejection_property(target: &js_sys::Error, key: &str, value: &str) {
+    // Reflect::set only fails on non-objects; an Error is always an
+    // object, so a failure would leave the property absent and the JS
+    // side falls back to its condition-less path.
+    let _ = js_sys::Reflect::set(
+        target.as_ref(),
+        &JsValue::from_str(key),
+        &JsValue::from_str(value),
+    );
 }
 
 pub(crate) async fn cancel_iq_command(
@@ -80,12 +145,14 @@ pub(crate) async fn cancel_iq_command(
 }
 
 /// Variant of [`send_iq_command`] that surfaces RFC 6120 §8.3 stanza
-/// errors as a typed [`waddle_xmpp_client::StanzaError`] instead of
-/// stringifying them onto the rejected Promise. Transport / disconnect
-/// failures still produce a rejected `JsValue`. Use this when the
-/// caller needs to branch on the stanza error condition (e.g. treat
+/// errors as a typed [`waddle_xmpp_client::StanzaError`] on the Rust
+/// side instead of rejecting the Promise. Transport / disconnect
+/// failures still produce a rejected `JsValue`. Use this when Rust
+/// code needs to branch on the stanza error condition (e.g. treat
 /// `item-not-found` on a first-publish XEP-0163 PEP fetch as an
-/// empty result rather than a hard failure).
+/// empty result rather than a hard failure); JS-side consumers can
+/// instead read the `condition` property off [`send_iq_command`]'s
+/// rejection.
 pub(crate) async fn send_iq_command_stanza_aware(
     inner: Rc<RefCell<WaddleClientInner>>,
     stanza: Element,
@@ -190,4 +257,58 @@ pub(crate) fn command_sender(
         .cmd_tx
         .clone()
         .ok_or_else(|| js_error("client is not connected"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use waddle_xmpp_client::error::{StanzaError, StanzaErrorType};
+
+    fn stanza_error(
+        error_type: StanzaErrorType,
+        condition: &str,
+        text: Option<&str>,
+    ) -> ClientError {
+        ClientError::StanzaError(StanzaError {
+            error_type,
+            condition: condition.to_string(),
+            text: text.map(str::to_string),
+            application_condition: None,
+        })
+    }
+
+    #[test]
+    fn stanza_error_rejection_fields_carry_condition_type_and_text() {
+        let err = stanza_error(
+            StanzaErrorType::Cancel,
+            "item-not-found",
+            Some("no such room"),
+        );
+        let fields = stanza_error_rejection_fields(&err).expect("stanza errors yield fields");
+        assert_eq!(fields.condition, "item-not-found");
+        assert_eq!(fields.error_type, "cancel");
+        assert_eq!(fields.text.as_deref(), Some("no such room"));
+        assert_eq!(fields.message, err.to_string());
+    }
+
+    #[test]
+    fn stanza_error_rejection_fields_omit_absent_text() {
+        let err = stanza_error(StanzaErrorType::Auth, "forbidden", None);
+        let fields = stanza_error_rejection_fields(&err).expect("stanza errors yield fields");
+        assert_eq!(fields.condition, "forbidden");
+        assert_eq!(fields.error_type, "auth");
+        assert_eq!(fields.text, None);
+    }
+
+    #[test]
+    fn unrecognised_error_type_labels_as_unknown() {
+        let err = stanza_error(StanzaErrorType::Unknown, "service-unavailable", None);
+        let fields = stanza_error_rejection_fields(&err).expect("stanza errors yield fields");
+        assert_eq!(fields.error_type, "unknown");
+    }
+
+    #[test]
+    fn non_stanza_errors_yield_no_fields() {
+        assert!(stanza_error_rejection_fields(&ClientError::Disconnected).is_none());
+    }
 }

--- a/server/crates/waddle-xmpp-client-wasm/src/commands.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/commands.rs
@@ -84,21 +84,9 @@ pub(crate) fn stanza_error_rejection_fields(
     Some(StanzaErrorRejectionFields {
         message: err.to_string(),
         condition: stanza_err.condition.clone(),
-        error_type: stanza_error_type_label(stanza_err.error_type),
+        error_type: stanza_err.error_type.as_str(),
         text: stanza_err.text.clone(),
     })
-}
-
-fn stanza_error_type_label(error_type: waddle_xmpp_client::StanzaErrorType) -> &'static str {
-    use waddle_xmpp_client::StanzaErrorType;
-    match error_type {
-        StanzaErrorType::Auth => "auth",
-        StanzaErrorType::Cancel => "cancel",
-        StanzaErrorType::Continue => "continue",
-        StanzaErrorType::Modify => "modify",
-        StanzaErrorType::Wait => "wait",
-        StanzaErrorType::Unknown => "unknown",
-    }
 }
 
 /// Reject an IQ promise. Stanza errors become a real JS `Error` (so

--- a/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/conversions.rs
@@ -782,6 +782,12 @@ pub(crate) fn presence_to_js(presence: InboundPresence) -> WaddlePresence {
         muted: presence.muted,
         // Typed instant → xs:dateTime only at this JS boundary (typed-payloads).
         idle_since: presence.idle_since.map(|since| since.to_rfc3339()),
+        error_condition: presence.error.as_ref().map(|err| err.condition.clone()),
+        error_type: presence
+            .error
+            .as_ref()
+            .map(|err| err.error_type.as_str().to_string()),
+        error_text: presence.error.and_then(|err| err.text),
     }
 }
 
@@ -1064,6 +1070,7 @@ mod inbound_to_js_tests {
             hand_raised: false,
             muted: false,
             idle_since: None,
+            error: None,
         };
         let js = presence_to_js(presence);
         assert_eq!(js.muc_status_codes, vec![100, 110, 210]);

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -475,6 +475,17 @@ pub struct WaddlePresence {
     /// contact's `<idle/>`, or `None` when the presence carries none. The chat
     /// side turns it into the rendered idle age on an away presence.
     pub idle_since: Option<String>,
+    /// RFC 6120 §8.3 defined condition of an error presence (e.g. a
+    /// rejected XEP-0045 room join), omitted for non-error presences.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_condition: Option<String>,
+    /// RFC 6120 §8.3.2 `type` attribute of the `<error/>` element
+    /// ("auth" | "cancel" | "continue" | "modify" | "wait" | "unknown").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_type: Option<String>,
+    /// Server-provided `<text/>` of the error, omitted when absent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_text: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/server/crates/waddle-xmpp-client/src/error.rs
+++ b/server/crates/waddle-xmpp-client/src/error.rs
@@ -135,6 +135,22 @@ pub enum StanzaErrorType {
     Unknown,
 }
 
+impl StanzaErrorType {
+    /// The RFC 6120 §8.3.2 wire value, the inverse of the parse in
+    /// [`parse_stanza_error`]. Kept on the type so boundary adapters
+    /// (wasm rejections, telemetry) can't drift from the parser.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Auth => "auth",
+            Self::Cancel => "cancel",
+            Self::Continue => "continue",
+            Self::Modify => "modify",
+            Self::Wait => "wait",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
 /// Parse a stanza-level error from an IQ element returned with `type="error"`.
 ///
 /// Looks for a child `<error/>` element, extracts `type`, the RFC 6120 condition
@@ -247,6 +263,15 @@ mod tests {
         let err = parse_stanza_error(&iq);
         assert_eq!(err.error_type, StanzaErrorType::Unknown);
         assert_eq!(err.condition, "service-unavailable");
+    }
+
+    #[test]
+    fn error_type_as_str_round_trips_through_the_parser() {
+        for wire in ["auth", "cancel", "continue", "modify", "wait"] {
+            let iq = make_iq_error(wire, "forbidden", None);
+            assert_eq!(parse_stanza_error(&iq).error_type.as_str(), wire);
+        }
+        assert_eq!(StanzaErrorType::Unknown.as_str(), "unknown");
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/messaging/presence.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/presence.rs
@@ -112,6 +112,12 @@ pub(super) fn parse_presence(el: &Element) -> InboundPresence {
         .and_then(|idle| idle.attr("since"))
         .and_then(|since| since.parse::<DateTime<Utc>>().ok());
 
+    // RFC 6120 §8.3: an error presence (rejected MUC join, bounced
+    // directed presence) carries an `<error/>` child. Parse it once here
+    // so consumers get a typed StanzaError instead of re-walking the XML.
+    let error =
+        (presence_type.as_deref() == Some("error")).then(|| crate::error::parse_stanza_error(el));
+
     InboundPresence {
         from,
         to,
@@ -128,6 +134,7 @@ pub(super) fn parse_presence(el: &Element) -> InboundPresence {
         hand_raised,
         muted,
         idle_since,
+        error,
     }
 }
 
@@ -193,6 +200,46 @@ pub fn build_presence_stanza(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_presence_extracts_stanza_error_from_error_presence() {
+        use crate::error::StanzaErrorType;
+        const NS_STANZAS: &str = "urn:ietf:params:xml:ns:xmpp-stanzas";
+        let el = Element::builder("presence", "jabber:client")
+            .attr(
+                minidom::rxml::xml_ncname!("from").to_owned(),
+                "room@muc.example.com/nick",
+            )
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "error")
+            .append(
+                Element::builder("error", "jabber:client")
+                    .attr(minidom::rxml::xml_ncname!("type").to_owned(), "auth")
+                    .append(Element::builder("registration-required", NS_STANZAS).build())
+                    .append(
+                        Element::builder("text", NS_STANZAS)
+                            .append("Members only")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build();
+        let presence = parse_presence(&el);
+        let error = presence.error.expect("error presence carries StanzaError");
+        assert_eq!(error.condition, "registration-required");
+        assert_eq!(error.error_type, StanzaErrorType::Auth);
+        assert_eq!(error.text.as_deref(), Some("Members only"));
+    }
+
+    #[test]
+    fn parse_presence_leaves_error_empty_for_non_error_presence() {
+        let el = Element::builder("presence", "jabber:client")
+            .attr(
+                minidom::rxml::xml_ncname!("from").to_owned(),
+                "room@muc.example.com/nick",
+            )
+            .build();
+        assert_eq!(parse_presence(&el).error, None);
+    }
 
     #[test]
     fn builds_presence_with_show_status_and_caps() {

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -739,6 +739,12 @@ pub struct InboundPresence {
     /// wire boundary (typed-payloads rule); re-serialized to an xs:dateTime only
     /// at the JS boundary so the chat side can render the idle age.
     pub idle_since: Option<chrono::DateTime<chrono::Utc>>,
+    /// RFC 6120 §8.3 stanza error parsed from an error presence
+    /// (`type="error"`), e.g. a rejected XEP-0045 room join. `None` for
+    /// non-error presences. Parsed once at the wire boundary
+    /// (typed-payloads rule) so consumers never re-parse the `<error/>`
+    /// child.
+    pub error: Option<crate::error::StanzaError>,
 }
 
 /// Parsed `<muji xmlns='urn:xmpp:jingle:muji:0'>` extension on a MUC


### PR DESCRIPTION
Closes #1300.

## Problem

Faro exceptions like `xmpp.stream: member-query-failed` carried no stanza error condition, so prod triage couldn't tell `forbidden` from `item-not-found` from a local timeout (2026-07-11 clustering incident). The chat layer already extracted `{ condition }` from rejected wasm promises per its documented contract — but the wasm bridge never honored that contract: `send_iq_command` stringified every `ClientError`, destroying the condition before it reached TypeScript. Disco failures and rejected MUC join presences reported nothing at all.

## What changed

**wasm bridge (`waddle-xmpp-client-wasm`)**
- `send_iq_command` rejects RFC 6120 §8.3 stanza errors as a real JS `Error` (readable message preserved for `String(err)`/console paths) carrying `condition`, `errorType`, and `text` properties. Covers every IQ flow at once: muc#admin member list, disco via `send_raw_iq`, etc. Native-testable seam: `stanza_error_rejection_fields`.
- The wasm presence event now surfaces `error_condition` / `error_type` / `error_text` for error presences (e.g. rejected XEP-0045 room joins).

**core client (`waddle-xmpp-client`)**
- `parse_presence` extracts a typed `StanzaError` once at the wire boundary for `type="error"` presences (typed-payloads rule).
- `StanzaErrorType::as_str()` lives on the owning type next to the parser so boundary adapters can't drift.

**chat**
- `XmppErrorEvent` gains `errorType` (typed `XmppStanzaErrorType` union) and `errorText`; extraction lives in a shared `stanza-error-context` module that validates `errorType` against the RFC 6120 §8.3.2 value set and caps server error text at 256 chars before it reaches the beacon.
- Faro instrumentation forwards `condition`/`errorType`/`errorText` plus an `errorSource` attribution: `server` (error stanza received), `local-timeout` (client-side timer, e.g. `room-self-presence-timeout`), or unset when unattributable.
- Rejected MUC join presences report a new `muc-join` error kind → `room-join-<condition>` detail (emitted after the join waiter settles, so retrying listeners observe consistent state).
- Disco failures now reach Faro: `disco-<kind>-<condition>` for stanza errors, `disco-<kind>-timeout` for `DiscoTimeoutError`. Condition-less rejections (connection flap rejecting all in-flight IQs) stay console-only so a flap can't flood Faro with one beacon per room.
- `XMPP_ERROR_CONDITIONS` is now the complete, self-contained RFC 6120 §8.3.3 list (`payment-required` was RFC 3920-only and removed).

## Review

Three adversarial rounds per repo policy. Round 1 (two-axis + hostile bug-hunt across ~70 Rust call sites and all TS rejection consumers) found the disco/join-presence coverage gaps and the unbounded `errorText`; round 2 fixed them and surfaced disco beacon flooding + an emit-before-reject reentrancy hazard; round 3 fixed those and the final pass returned a clean bill.

Known parity gap (pre-existing pattern, not introduced here): the Apple FFI `WaddlePresence` doesn't carry the new error fields, same as `idle_since`/`muc_status_codes` today.

## Verification

- Rust: `cargo test -p waddle-xmpp-client -p waddle-xmpp-client-wasm --lib` — 530 + 130 pass; clippy `-D warnings` clean; `cargo check --target wasm32-unknown-unknown` clean; fmt applied.
- Chat: targeted suites (`stanza-error-context`, `client-muc-admin`, `xmpp-telemetry`, `client-send-readiness`, `discovery-resilience`) 130 pass; full `bun test` 3340/3341 (the 1 fail is the documented pre-existing `startup-loading` local-env failure — `astro check` error count is identical on origin/main); `bun run lint` (knip) clean.
- No FFI signature changes — only the rejection payload shape, which the TS side was already written and tested to consume.
