### PR TITLE
fix(chat): prevent cross-occupant MUC message-ID collisions

### DIFF
--- a/chat/src/channels/message-timeline-state.ts
+++ b/chat/src/channels/message-timeline-state.ts
@@ -20,7 +20,7 @@ import { isStaleReactionUpdate } from "@/lib/messaging/reactions";
 import { retractTimelineMessage } from "@/lib/messaging/retraction";
 import { mergeRetractionTombstone } from "@/lib/messaging/timeline-insert";
 import { adoptArchiveIdentity, findSynthesizedIdMergeTarget } from "@/lib/messaging/synthesized-id-merge";
-import { findSenderScopedIdTarget } from "@/lib/messaging/sender-scoped-ids";
+import { SenderScopedIdIndex } from "@/lib/messaging/sender-scoped-ids";
 
 function mergeReplyToMetadata(
   existing: TimelineMessage["replyTo"],
@@ -82,6 +82,7 @@ function mergeMissingThreadMetadata(
             authorRealJid: canonicalRoomMessage.authorRealJid,
           }
         : {}),
+      authorOccupantJid: canonicalRoomMessage.authorOccupantJid,
       ...(canonicalRoomMessage.displayedMarkerRequested
         ? { displayedMarkerRequested: true }
         : {}),
@@ -360,7 +361,7 @@ export function buildChannelTimelineFromMamResults(params: {
   for (const message of existing) {
     byId.add(message);
   }
-  const identityRows = [...existing];
+  const identityIndex = new SenderScopedIdIndex(existing);
   const timeline = options.seedExistingOnly ? [] : [...existing];
   // #1182: rows whose primary id had to be fabricated (id-less live
   // stanzas) can only reconcile by content. Each is consumable once so
@@ -371,7 +372,7 @@ export function buildChannelTimelineFromMamResults(params: {
     const tm = mapped.isRetracted
       ? retractTimelineMessage(mapped, mapped.retractionId)
       : mapped;
-    const idMatch = findSenderScopedIdTarget(identityRows, tm);
+    const idMatch = identityIndex.find(tm);
     const synthesizedMatch = idMatch ? undefined : findSynthesizedIdMergeTarget(synthesizedRows, tm);
     if (synthesizedMatch) synthesizedRows.splice(synthesizedRows.indexOf(synthesizedMatch), 1);
     const existingMessage = idMatch ?? synthesizedMatch;
@@ -389,13 +390,11 @@ export function buildChannelTimelineFromMamResults(params: {
         if (index !== -1) timeline[index] = merged;
         byId.add(merged);
       }
-      const identityIndex = identityRows.indexOf(existingMessage);
-      if (identityIndex === -1) identityRows.push(merged);
-      else identityRows[identityIndex] = merged;
+      identityIndex.replace(existingMessage, merged);
       continue;
     }
     byId.add(tm);
-    identityRows.push(tm);
+    identityIndex.add(tm);
     timeline.push(tm);
   }
 

--- a/chat/src/channels/message-timeline-state.ts
+++ b/chat/src/channels/message-timeline-state.ts
@@ -20,6 +20,7 @@ import { isStaleReactionUpdate } from "@/lib/messaging/reactions";
 import { retractTimelineMessage } from "@/lib/messaging/retraction";
 import { mergeRetractionTombstone } from "@/lib/messaging/timeline-insert";
 import { adoptArchiveIdentity, findSynthesizedIdMergeTarget } from "@/lib/messaging/synthesized-id-merge";
+import { findSenderScopedIdTarget } from "@/lib/messaging/sender-scoped-ids";
 
 function mergeReplyToMetadata(
   existing: TimelineMessage["replyTo"],
@@ -50,8 +51,42 @@ function mergeMissingThreadMetadata(
     next = next === existing ? { ...existing, ...patch } : { ...next, ...patch };
   };
 
-  const ids = mergeMessageIds(next, next.id, [incoming.id, ...(incoming.wireIds ?? [])]);
+  const canonicalRoomMessage = [incoming, existing].find((message) =>
+    !!message.authorOccupantJid
+    && !!message.stanzaId
+    && !!message.stanzaIdBy
+  );
+  const ids = mergeMessageIds(
+    next,
+    canonicalRoomMessage?.stanzaId ?? next.id,
+    [incoming.id, ...(incoming.wireIds ?? [])],
+  );
   if (ids.id !== next.id || !sameStringList(ids.wireIds, next.wireIds)) next = ids;
+
+  if (canonicalRoomMessage) {
+    assign({
+      stanzaId: canonicalRoomMessage.stanzaId,
+      stanzaIdBy: canonicalRoomMessage.stanzaIdBy,
+      ...(canonicalRoomMessage.replyableId
+        ? { replyableId: canonicalRoomMessage.replyableId }
+        : {}),
+      ...(canonicalRoomMessage.reactionTargetId
+        ? { reactionTargetId: canonicalRoomMessage.reactionTargetId }
+        : {}),
+      ...(canonicalRoomMessage.correctionTargetId
+        ? { correctionTargetId: canonicalRoomMessage.correctionTargetId }
+        : {}),
+      ...(canonicalRoomMessage.authorRealJid
+        ? {
+            authorJid: canonicalRoomMessage.authorRealJid,
+            authorRealJid: canonicalRoomMessage.authorRealJid,
+          }
+        : {}),
+      ...(canonicalRoomMessage.displayedMarkerRequested
+        ? { displayedMarkerRequested: true }
+        : {}),
+    });
+  }
 
   if (!next.threadId && incoming.threadId) assign({ threadId: incoming.threadId });
   if (!next.parentThreadId && incoming.parentThreadId) assign({ parentThreadId: incoming.parentThreadId });
@@ -325,6 +360,7 @@ export function buildChannelTimelineFromMamResults(params: {
   for (const message of existing) {
     byId.add(message);
   }
+  const identityRows = [...existing];
   const timeline = options.seedExistingOnly ? [] : [...existing];
   // #1182: rows whose primary id had to be fabricated (id-less live
   // stanzas) can only reconcile by content. Each is consumable once so
@@ -335,9 +371,7 @@ export function buildChannelTimelineFromMamResults(params: {
     const tm = mapped.isRetracted
       ? retractTimelineMessage(mapped, mapped.retractionId)
       : mapped;
-    const idMatch = [tm.id, ...(tm.wireIds ?? [])]
-      .map((id) => byId.get(id))
-      .find((message): message is TimelineMessage => !!message);
+    const idMatch = findSenderScopedIdTarget(identityRows, tm);
     const synthesizedMatch = idMatch ? undefined : findSynthesizedIdMergeTarget(synthesizedRows, tm);
     if (synthesizedMatch) synthesizedRows.splice(synthesizedRows.indexOf(synthesizedMatch), 1);
     const existingMessage = idMatch ?? synthesizedMatch;
@@ -355,9 +389,13 @@ export function buildChannelTimelineFromMamResults(params: {
         if (index !== -1) timeline[index] = merged;
         byId.add(merged);
       }
+      const identityIndex = identityRows.indexOf(existingMessage);
+      if (identityIndex === -1) identityRows.push(merged);
+      else identityRows[identityIndex] = merged;
       continue;
     }
     byId.add(tm);
+    identityRows.push(tm);
     timeline.push(tm);
   }
 

--- a/chat/src/channels/message-timeline-state.ts
+++ b/chat/src/channels/message-timeline-state.ts
@@ -417,8 +417,12 @@ export function buildChannelTimelineFromMamResults(params: {
   }
 
   for (const update of correctionUpdates) {
-    const target = findMessageById(timeline, update.targetId);
-    if (!target || !isSameMucCorrectionSender(target, update.correctionSender)) continue;
+    const target = findMessageById(
+      timeline,
+      update.targetId,
+      (candidate) => isSameMucCorrectionSender(candidate, update.correctionSender),
+    );
+    if (!target || target.isRetracted) continue;
     assignCorrectionFields(target, update.payload);
   }
 

--- a/chat/src/dms/message-timeline-state.ts
+++ b/chat/src/dms/message-timeline-state.ts
@@ -243,13 +243,21 @@ export function buildDmTimelineFromMamResults(params: {
     timeline.push(tm);
   }
   for (const update of correctionUpdates) {
-    const target = findMessageById(timeline, update.targetId);
-    if (!target || !isSameDmCorrectionSender(target, update.correctionFromJid)) continue;
+    const target = findMessageById(
+      timeline,
+      update.targetId,
+      (candidate) => isSameDmCorrectionSender(candidate, update.correctionFromJid),
+    );
+    if (!target || target.isRetracted) continue;
     assignCorrectionFields(target, update.payload);
   }
   for (const update of retractionUpdates) {
-    const target = findMessageById(timeline, update.targetId);
-    if (!target || !isSameDmCorrectionSender(target, update.fromJid)) continue;
+    const target = findMessageById(
+      timeline,
+      update.targetId,
+      (candidate) => isSameDmCorrectionSender(candidate, update.fromJid),
+    );
+    if (!target) continue;
     const index = timeline.indexOf(target);
     if (index === -1) continue;
     const retracted = retractTimelineMessage(target);

--- a/chat/src/lib/messaging/correction.ts
+++ b/chat/src/lib/messaging/correction.ts
@@ -80,11 +80,13 @@ export function applyCorrection(
   payload: CorrectionPayload,
   policy: CorrectionPolicy,
 ): TimelineMessage[] | null {
-  const index = findMessageIndexById(messages, replacesId);
+  // Scope before resolving aliases. Two occupants may legitimately reuse the
+  // same sender-selected id; their verified sender identity disambiguates the
+  // target, while multiple claims inside one sender scope still fail closed.
+  const index = findMessageIndexById(messages, replacesId, policy.senderMatches);
   if (index < 0) return null;
   const current = messages[index]!;
   if (current.isRetracted) return null;
-  if (!policy.senderMatches(current)) return null;
   const updated: TimelineMessage = { ...current };
   assignCorrectionFields(updated, { ...payload, body: payload.body.trim() });
   const next = messages.slice();

--- a/chat/src/lib/messaging/retraction.ts
+++ b/chat/src/lib/messaging/retraction.ts
@@ -62,10 +62,12 @@ export function applyRetraction(
   event: RetractionEvent,
   policy: RetractionPolicy,
 ): TimelineMessage[] | null {
-  const index = findMessageIndexById(messages, event.retractsId);
+  // Resolve aliases inside the authorization scope. In direct chats both
+  // participants may reuse the same sender-selected id; sender identity can
+  // disambiguate them, while duplicate claims by one sender still fail closed.
+  const index = findMessageIndexById(messages, event.retractsId, policy.canRetract);
   if (index < 0) return null;
   const target = messages[index]!;
-  if (!policy.canRetract(target)) return null;
   const next = messages.slice();
   next[index] = retractTimelineMessage(target, event.retractionId);
   return next;

--- a/chat/src/lib/messaging/self-echo.ts
+++ b/chat/src/lib/messaging/self-echo.ts
@@ -1,5 +1,9 @@
 import type { TimelineMessage } from "@/lib/chat-ui";
 import { findMessageById } from "@/lib/message-ids";
+import {
+  findSenderScopedIdTarget,
+  hasMessageSenderContinuity,
+} from "@/lib/messaging/sender-scoped-ids";
 
 // Self-echo reconciliation for the live merge path, shared verbatim by
 // the channel and DM pipelines (XEP-0359 alias resolution + body-match
@@ -35,16 +39,20 @@ export function findLiveMergeTarget(
   msg: TimelineMessage,
   pendingEchoClientIds: ReadonlySet<string>,
 ): TimelineMessage | undefined {
-  const existingById = [msg.id, ...(msg.wireIds ?? [])]
-    .map((id) => findMessageById(messages, id))
-    .find((message): message is TimelineMessage => !!message);
+  const mucScoped = !!msg.authorOccupantJid || messages.some((message) => !!message.authorOccupantJid);
+  const existingById = mucScoped
+    ? findSenderScopedIdTarget(messages, msg)
+    : [msg.id, ...(msg.wireIds ?? [])]
+      .map((id) => findMessageById(messages, id))
+      .find((message): message is TimelineMessage => !!message);
   const bodyFallbackAllowed = !existingById && canUseSelfEchoBodyFallback(msg);
   const pendingSelfEcho = bodyFallbackAllowed
     ? messages.find(
       (m) =>
         pendingEchoClientIds.has(m.id)
         && m.isSelf
-        && m.body === msg.body,
+        && m.body === msg.body
+        && (!mucScoped || hasMessageSenderContinuity(m, msg)),
     )
     : undefined;
   const preservedSelfEcho = bodyFallbackAllowed
@@ -53,7 +61,8 @@ export function findLiveMergeTarget(
         m.isSelf
         && m.body === msg.body
         && !!m.deliveryStatus
-        && m.deliveryStatus !== "delivered",
+        && m.deliveryStatus !== "delivered"
+        && (!mucScoped || hasMessageSenderContinuity(m, msg)),
     )
     : undefined;
   return existingById ?? pendingSelfEcho ?? preservedSelfEcho;

--- a/chat/src/lib/messaging/sender-scoped-ids.ts
+++ b/chat/src/lib/messaging/sender-scoped-ids.ts
@@ -69,28 +69,58 @@ export function findSenderScopedIdTarget(
   messages: readonly TimelineMessage[],
   incoming: TimelineMessage,
 ): TimelineMessage | undefined {
-  const primaryMatches = messages.filter(
-    (message) =>
-      message.id === incoming.id
-      && !hasConflictingRoomCanonicalIdentity(message, incoming)
-      && hasMessageSenderContinuity(message, incoming),
-  );
-  if (primaryMatches.length === 1) return primaryMatches[0];
-  if (primaryMatches.length > 1) return undefined;
+  return new SenderScopedIdIndex(messages).find(incoming);
+}
 
-  let target: TimelineMessage | undefined;
-  for (const id of [incoming.id, ...(incoming.wireIds ?? [])]) {
-    const matches = messages.filter(
+/** Collision-preserving identity index for repeated MAM reconciliation. */
+export class SenderScopedIdIndex {
+  private readonly byId = new Map<string, Set<TimelineMessage>>();
+
+  constructor(messages: readonly TimelineMessage[] = []) {
+    for (const message of messages) this.add(message);
+  }
+
+  add(message: TimelineMessage): void {
+    for (const id of new Set([message.id, ...(message.wireIds ?? [])])) {
+      const bucket = this.byId.get(id) ?? new Set<TimelineMessage>();
+      bucket.add(message);
+      this.byId.set(id, bucket);
+    }
+  }
+
+  replace(existing: TimelineMessage, replacement: TimelineMessage): void {
+    for (const id of new Set([existing.id, ...(existing.wireIds ?? [])])) {
+      const bucket = this.byId.get(id);
+      bucket?.delete(existing);
+      if (bucket?.size === 0) this.byId.delete(id);
+    }
+    this.add(replacement);
+  }
+
+  private matches(id: string, incoming: TimelineMessage): TimelineMessage[] {
+    return [...(this.byId.get(id) ?? [])].filter(
       (message) =>
-        (message.id === id || message.wireIds?.includes(id))
-        && !hasConflictingRoomCanonicalIdentity(message, incoming)
+        !hasConflictingRoomCanonicalIdentity(message, incoming)
         && hasMessageSenderContinuity(message, incoming),
     );
-    if (matches.length > 1) return undefined;
-    const match = matches[0];
-    if (!match) continue;
-    if (target && target !== match) return undefined;
-    target = match;
   }
-  return target;
+
+  find(incoming: TimelineMessage): TimelineMessage | undefined {
+    const primaryMatches = this.matches(incoming.id, incoming).filter(
+      (message) => message.id === incoming.id,
+    );
+    if (primaryMatches.length === 1) return primaryMatches[0];
+    if (primaryMatches.length > 1) return undefined;
+
+    let target: TimelineMessage | undefined;
+    for (const id of new Set([incoming.id, ...(incoming.wireIds ?? [])])) {
+      const matches = this.matches(id, incoming);
+      if (matches.length > 1) return undefined;
+      const match = matches[0];
+      if (!match) continue;
+      if (target && target !== match) return undefined;
+      target = match;
+    }
+    return target;
+  }
 }

--- a/chat/src/lib/messaging/sender-scoped-ids.ts
+++ b/chat/src/lib/messaging/sender-scoped-ids.ts
@@ -60,7 +60,6 @@ export function hasMessageSenderContinuity(
   const incomingAuthorJid = bareJidKey(incoming.authorJid ?? "");
   return !!existingAuthorJid
     && !!incomingAuthorJid
-    && existing.author === incoming.author
     && existingAuthorJid === incomingAuthorJid;
 }
 
@@ -156,7 +155,7 @@ function continuityKey(...parts: readonly string[]): string {
 
 function legacySenderKey(message: TimelineMessage): string | undefined {
   const authorJid = bareJidKey(message.authorJid ?? "");
-  return authorJid ? continuityKey(message.author, authorJid) : undefined;
+  return authorJid || undefined;
 }
 
 class SenderContinuityIndex {

--- a/chat/src/lib/messaging/sender-scoped-ids.ts
+++ b/chat/src/lib/messaging/sender-scoped-ids.ts
@@ -1,5 +1,5 @@
 import type { TimelineMessage } from "@/lib/chat-ui";
-import { barePeerJid } from "@/lib/xmpp-client";
+import { bareJidKey, barePeerJid } from "@/lib/xmpp-client";
 
 function normalizedRealJid(message: TimelineMessage): string | undefined {
   return message.authorRealJid
@@ -57,7 +57,7 @@ export function hasMessageSenderContinuity(
   }
 
   return existing.author === incoming.author
-    && barePeerJid(existing.authorJid ?? "") === barePeerJid(incoming.authorJid ?? "");
+    && bareJidKey(existing.authorJid ?? "") === bareJidKey(incoming.authorJid ?? "");
 }
 
 /**
@@ -151,7 +151,7 @@ function continuityKey(...parts: readonly string[]): string {
 }
 
 function legacySenderKey(message: TimelineMessage): string {
-  return continuityKey(message.author, barePeerJid(message.authorJid ?? ""));
+  return continuityKey(message.author, bareJidKey(message.authorJid ?? ""));
 }
 
 class SenderContinuityIndex {

--- a/chat/src/lib/messaging/sender-scoped-ids.ts
+++ b/chat/src/lib/messaging/sender-scoped-ids.ts
@@ -69,54 +69,344 @@ export function findSenderScopedIdTarget(
   messages: readonly TimelineMessage[],
   incoming: TimelineMessage,
 ): TimelineMessage | undefined {
-  return new SenderScopedIdIndex(messages).find(incoming);
+  const primaryMatches = messages.filter(
+    (message) =>
+      message.id === incoming.id
+      && !hasConflictingRoomCanonicalIdentity(message, incoming)
+      && hasMessageSenderContinuity(message, incoming),
+  );
+  if (primaryMatches.length === 1) return primaryMatches[0];
+  if (primaryMatches.length > 1) return undefined;
+
+  let target: TimelineMessage | undefined;
+  for (const id of new Set([incoming.id, ...(incoming.wireIds ?? [])])) {
+    const matches = messages.filter(
+      (message) =>
+        (message.id === id || message.wireIds?.includes(id))
+        && !hasConflictingRoomCanonicalIdentity(message, incoming)
+        && hasMessageSenderContinuity(message, incoming),
+    );
+    if (matches.length > 1) return undefined;
+    const match = matches[0];
+    if (!match) continue;
+    if (target && target !== match) return undefined;
+    target = match;
+  }
+  return target;
+}
+
+type Resolution = {
+  ambiguous: boolean;
+  match?: TimelineMessage;
+};
+
+function addToIndex(
+  index: Map<string, Set<TimelineMessage>>,
+  key: string | undefined,
+  message: TimelineMessage,
+): void {
+  if (!key) return;
+  const matches = index.get(key) ?? new Set<TimelineMessage>();
+  matches.add(message);
+  index.set(key, matches);
+}
+
+function removeFromIndex(
+  index: Map<string, Set<TimelineMessage>>,
+  key: string | undefined,
+  message: TimelineMessage,
+): void {
+  if (!key) return;
+  const matches = index.get(key);
+  matches?.delete(message);
+  if (matches?.size === 0) index.delete(key);
+}
+
+function combineResolutions(resolutions: readonly Resolution[]): Resolution {
+  let match: TimelineMessage | undefined;
+  for (const resolution of resolutions) {
+    if (resolution.ambiguous) return { ambiguous: true };
+    if (!resolution.match) continue;
+    if (match && match !== resolution.match) return { ambiguous: true };
+    match = resolution.match;
+  }
+  return match ? { ambiguous: false, match } : { ambiguous: false };
+}
+
+function resolveSets(sets: readonly (Set<TimelineMessage> | undefined)[]): Resolution {
+  let match: TimelineMessage | undefined;
+  for (const messages of sets) {
+    if (!messages || messages.size === 0) continue;
+    if (messages.size > 1) return { ambiguous: true };
+    const candidate = messages.values().next().value;
+    if (!candidate) continue;
+    if (match && match !== candidate) return { ambiguous: true };
+    match = candidate;
+  }
+  return match ? { ambiguous: false, match } : { ambiguous: false };
+}
+
+function continuityKey(...parts: readonly string[]): string {
+  return parts.join("\u0000");
+}
+
+function legacySenderKey(message: TimelineMessage): string {
+  return continuityKey(message.author, barePeerJid(message.authorJid ?? ""));
+}
+
+class SenderContinuityIndex {
+  private messageCount = 0;
+  private readonly occupantAll = new Map<string, Set<TimelineMessage>>();
+  private readonly occupantByReal = new Map<string, Set<TimelineMessage>>();
+  private readonly occupantByJidAndReal = new Map<string, Set<TimelineMessage>>();
+  private readonly occupantWithoutReal = new Map<string, Set<TimelineMessage>>();
+  private readonly accountAllByLegacy = new Map<string, Set<TimelineMessage>>();
+  private readonly accountAllByScope = new Map<string, Set<TimelineMessage>>();
+  private readonly accountByReal = new Map<string, Set<TimelineMessage>>();
+  private readonly accountWithoutRealByLegacy = new Map<string, Set<TimelineMessage>>();
+  private readonly accountWithoutRealByScope = new Map<string, Set<TimelineMessage>>();
+
+  constructor(private readonly noteProbe: () => void) {}
+
+  get empty(): boolean {
+    return this.messageCount === 0;
+  }
+
+  private get(
+    index: Map<string, Set<TimelineMessage>>,
+    key: string | undefined,
+  ): Set<TimelineMessage> | undefined {
+    this.noteProbe();
+    return key ? index.get(key) : undefined;
+  }
+
+  add(message: TimelineMessage): void {
+    this.messageCount += 1;
+    const occupant = message.authorOccupantJid;
+    const real = normalizedRealJid(message) || undefined;
+    if (occupant) {
+      addToIndex(this.occupantAll, occupant, message);
+      if (real) {
+        addToIndex(this.occupantByReal, real, message);
+        addToIndex(this.occupantByJidAndReal, continuityKey(occupant, real), message);
+      } else {
+        addToIndex(this.occupantWithoutReal, occupant, message);
+      }
+      return;
+    }
+
+    const scope = senderScopeJid(message) || undefined;
+    const legacy = legacySenderKey(message);
+    addToIndex(this.accountAllByLegacy, legacy, message);
+    addToIndex(this.accountAllByScope, scope, message);
+    if (real) {
+      addToIndex(this.accountByReal, real, message);
+    } else {
+      addToIndex(this.accountWithoutRealByLegacy, legacy, message);
+      addToIndex(this.accountWithoutRealByScope, scope, message);
+    }
+  }
+
+  remove(message: TimelineMessage): void {
+    this.messageCount -= 1;
+    const occupant = message.authorOccupantJid;
+    const real = normalizedRealJid(message) || undefined;
+    if (occupant) {
+      removeFromIndex(this.occupantAll, occupant, message);
+      if (real) {
+        removeFromIndex(this.occupantByReal, real, message);
+        removeFromIndex(this.occupantByJidAndReal, continuityKey(occupant, real), message);
+      } else {
+        removeFromIndex(this.occupantWithoutReal, occupant, message);
+      }
+      return;
+    }
+
+    const scope = senderScopeJid(message) || undefined;
+    const legacy = legacySenderKey(message);
+    removeFromIndex(this.accountAllByLegacy, legacy, message);
+    removeFromIndex(this.accountAllByScope, scope, message);
+    if (real) {
+      removeFromIndex(this.accountByReal, real, message);
+    } else {
+      removeFromIndex(this.accountWithoutRealByLegacy, legacy, message);
+      removeFromIndex(this.accountWithoutRealByScope, scope, message);
+    }
+  }
+
+  resolve(incoming: TimelineMessage): Resolution {
+    const occupant = incoming.authorOccupantJid;
+    const real = normalizedRealJid(incoming) || undefined;
+    if (occupant && real) {
+      return resolveSets([
+        this.get(this.occupantByJidAndReal, continuityKey(occupant, real)),
+        this.get(this.occupantWithoutReal, occupant),
+        this.get(this.accountByReal, real),
+        this.get(this.accountWithoutRealByScope, occupant),
+      ]);
+    }
+    if (occupant) {
+      return resolveSets([
+        this.get(this.occupantAll, occupant),
+        this.get(this.accountAllByScope, occupant),
+      ]);
+    }
+
+    const scope = senderScopeJid(incoming) || undefined;
+    const legacy = legacySenderKey(incoming);
+    if (real) {
+      return resolveSets([
+        this.get(this.accountByReal, real),
+        this.get(this.accountWithoutRealByLegacy, legacy),
+        this.get(this.occupantByReal, real),
+        this.get(this.occupantWithoutReal, scope),
+      ]);
+    }
+    return resolveSets([
+      this.get(this.accountAllByLegacy, legacy),
+      this.get(this.occupantAll, scope),
+    ]);
+  }
+}
+
+class SenderIdBucket {
+  private readonly messages = new Map<TimelineMessage, number>();
+  private readonly all: SenderContinuityIndex;
+  private readonly withoutCanonical: SenderContinuityIndex;
+  private readonly byCanonical = new Map<string, SenderContinuityIndex>();
+
+  constructor(private readonly noteProbe: () => void) {
+    this.all = new SenderContinuityIndex(noteProbe);
+    this.withoutCanonical = new SenderContinuityIndex(noteProbe);
+  }
+
+  get empty(): boolean {
+    return this.messages.size === 0;
+  }
+
+  get canonicalPartitionCount(): number {
+    return this.byCanonical.size;
+  }
+
+  add(message: TimelineMessage): void {
+    const occurrences = this.messages.get(message) ?? 0;
+    this.messages.set(message, occurrences + 1);
+    if (occurrences > 0) return;
+    this.all.add(message);
+    const canonical = roomCanonicalIdentity(message);
+    if (!canonical) {
+      this.withoutCanonical.add(message);
+      return;
+    }
+    const index = this.byCanonical.get(canonical) ?? new SenderContinuityIndex(this.noteProbe);
+    index.add(message);
+    this.byCanonical.set(canonical, index);
+  }
+
+  remove(message: TimelineMessage): void {
+    const occurrences = this.messages.get(message) ?? 0;
+    if (occurrences === 0) return;
+    if (occurrences > 1) {
+      this.messages.set(message, occurrences - 1);
+      return;
+    }
+    this.messages.delete(message);
+    this.all.remove(message);
+    const canonical = roomCanonicalIdentity(message);
+    if (!canonical) {
+      this.withoutCanonical.remove(message);
+      return;
+    }
+    const index = this.byCanonical.get(canonical);
+    index?.remove(message);
+    if (index?.empty) this.byCanonical.delete(canonical);
+  }
+
+  resolve(incoming: TimelineMessage): Resolution {
+    const canonical = roomCanonicalIdentity(incoming);
+    const resolution = !canonical
+      ? this.all.resolve(incoming)
+      : combineResolutions([
+      this.byCanonical.get(canonical)?.resolve(incoming) ?? { ambiguous: false },
+      this.withoutCanonical.resolve(incoming),
+    ]);
+    if (resolution.match && (this.messages.get(resolution.match) ?? 0) > 1) {
+      return { ambiguous: true };
+    }
+    return resolution;
+  }
 }
 
 /** Collision-preserving identity index for repeated MAM reconciliation. */
 export class SenderScopedIdIndex {
-  private readonly byId = new Map<string, Set<TimelineMessage>>();
+  private readonly byId = new Map<string, SenderIdBucket>();
+  private readonly primaryById = new Map<string, SenderIdBucket>();
+  private probes = 0;
 
   constructor(messages: readonly TimelineMessage[] = []) {
     for (const message of messages) this.add(message);
   }
 
+  /** Stable work counter for complexity regression tests and diagnostics. */
+  get resolutionProbeCount(): number {
+    return this.probes;
+  }
+
+  /** Number of live canonical sub-indexes retained across every ID bucket. */
+  get retainedCanonicalPartitionCount(): number {
+    return [...this.byId.values(), ...this.primaryById.values()]
+      .reduce((total, bucket) => total + bucket.canonicalPartitionCount, 0);
+  }
+
+  private noteProbe = (): void => {
+    this.probes += 1;
+  };
+
+  private addToBucket(
+    buckets: Map<string, SenderIdBucket>,
+    id: string,
+    message: TimelineMessage,
+  ): void {
+    const bucket = buckets.get(id) ?? new SenderIdBucket(this.noteProbe);
+    bucket.add(message);
+    buckets.set(id, bucket);
+  }
+
+  private removeFromBucket(
+    buckets: Map<string, SenderIdBucket>,
+    id: string,
+    message: TimelineMessage,
+  ): void {
+    const bucket = buckets.get(id);
+    bucket?.remove(message);
+    if (bucket?.empty) buckets.delete(id);
+  }
+
   add(message: TimelineMessage): void {
     for (const id of new Set([message.id, ...(message.wireIds ?? [])])) {
-      const bucket = this.byId.get(id) ?? new Set<TimelineMessage>();
-      bucket.add(message);
-      this.byId.set(id, bucket);
+      this.addToBucket(this.byId, id, message);
     }
+    this.addToBucket(this.primaryById, message.id, message);
   }
 
   replace(existing: TimelineMessage, replacement: TimelineMessage): void {
     for (const id of new Set([existing.id, ...(existing.wireIds ?? [])])) {
-      const bucket = this.byId.get(id);
-      bucket?.delete(existing);
-      if (bucket?.size === 0) this.byId.delete(id);
+      this.removeFromBucket(this.byId, id, existing);
     }
+    this.removeFromBucket(this.primaryById, existing.id, existing);
     this.add(replacement);
   }
 
-  private matches(id: string, incoming: TimelineMessage): TimelineMessage[] {
-    return [...(this.byId.get(id) ?? [])].filter(
-      (message) =>
-        !hasConflictingRoomCanonicalIdentity(message, incoming)
-        && hasMessageSenderContinuity(message, incoming),
-    );
-  }
-
   find(incoming: TimelineMessage): TimelineMessage | undefined {
-    const primaryMatches = this.matches(incoming.id, incoming).filter(
-      (message) => message.id === incoming.id,
-    );
-    if (primaryMatches.length === 1) return primaryMatches[0];
-    if (primaryMatches.length > 1) return undefined;
+    const primary = this.primaryById.get(incoming.id)?.resolve(incoming);
+    if (primary?.ambiguous) return undefined;
+    if (primary?.match) return primary.match;
 
     let target: TimelineMessage | undefined;
     for (const id of new Set([incoming.id, ...(incoming.wireIds ?? [])])) {
-      const matches = this.matches(id, incoming);
-      if (matches.length > 1) return undefined;
-      const match = matches[0];
+      const resolution = this.byId.get(id)?.resolve(incoming);
+      if (resolution?.ambiguous) return undefined;
+      const match = resolution?.match;
       if (!match) continue;
       if (target && target !== match) return undefined;
       target = match;

--- a/chat/src/lib/messaging/sender-scoped-ids.ts
+++ b/chat/src/lib/messaging/sender-scoped-ids.ts
@@ -1,0 +1,94 @@
+import type { TimelineMessage } from "@/lib/chat-ui";
+import { barePeerJid } from "@/lib/xmpp-client";
+
+function normalizedRealJid(message: TimelineMessage): string | undefined {
+  return message.authorRealJid ? barePeerJid(message.authorRealJid) : undefined;
+}
+
+function senderScopeJid(message: TimelineMessage): string | undefined {
+  return message.authorOccupantJid ?? message.authorJid;
+}
+
+function roomCanonicalIdentity(message: TimelineMessage): string | undefined {
+  if (
+    !message.authorOccupantJid
+    || !message.stanzaId
+    || !message.stanzaIdBy
+  ) return undefined;
+  return `${barePeerJid(message.stanzaIdBy).toLowerCase()}\u0000${message.stanzaId}`;
+}
+
+function hasConflictingRoomCanonicalIdentity(
+  existing: TimelineMessage,
+  incoming: TimelineMessage,
+): boolean {
+  const existingIdentity = roomCanonicalIdentity(existing);
+  const incomingIdentity = roomCanonicalIdentity(incoming);
+  return !!existingIdentity && !!incomingIdentity && existingIdentity !== incomingIdentity;
+}
+
+/**
+ * Establishes continuity without treating a display nick as identity.
+ * Real JIDs take precedence when both copies expose them; otherwise the
+ * full occupant JID bridges an optimistic/live copy that lacks the real JID.
+ */
+export function hasMessageSenderContinuity(
+  existing: TimelineMessage,
+  incoming: TimelineMessage,
+): boolean {
+  if (
+    existing.authorOccupantJid
+    && incoming.authorOccupantJid
+    && existing.authorOccupantJid !== incoming.authorOccupantJid
+  ) return false;
+
+  const existingRealJid = normalizedRealJid(existing);
+  const incomingRealJid = normalizedRealJid(incoming);
+  if (existingRealJid && incomingRealJid) return existingRealJid === incomingRealJid;
+
+  const existingOccupantJid = senderScopeJid(existing);
+  const incomingOccupantJid = senderScopeJid(incoming);
+  if (existing.authorOccupantJid || incoming.authorOccupantJid) {
+    return !!existingOccupantJid
+      && !!incomingOccupantJid
+      && existingOccupantJid === incomingOccupantJid;
+  }
+
+  return existing.author === incoming.author
+    && barePeerJid(existing.authorJid ?? "") === barePeerJid(incoming.authorJid ?? "");
+}
+
+/**
+ * Resolves sender-chosen ids only inside a verified sender scope. A primary
+ * match wins; aliases must identify exactly one row, and aliases that point
+ * at different rows fail closed.
+ */
+export function findSenderScopedIdTarget(
+  messages: readonly TimelineMessage[],
+  incoming: TimelineMessage,
+): TimelineMessage | undefined {
+  const primaryMatches = messages.filter(
+    (message) =>
+      message.id === incoming.id
+      && !hasConflictingRoomCanonicalIdentity(message, incoming)
+      && hasMessageSenderContinuity(message, incoming),
+  );
+  if (primaryMatches.length === 1) return primaryMatches[0];
+  if (primaryMatches.length > 1) return undefined;
+
+  let target: TimelineMessage | undefined;
+  for (const id of [incoming.id, ...(incoming.wireIds ?? [])]) {
+    const matches = messages.filter(
+      (message) =>
+        (message.id === id || message.wireIds?.includes(id))
+        && !hasConflictingRoomCanonicalIdentity(message, incoming)
+        && hasMessageSenderContinuity(message, incoming),
+    );
+    if (matches.length > 1) return undefined;
+    const match = matches[0];
+    if (!match) continue;
+    if (target && target !== match) return undefined;
+    target = match;
+  }
+  return target;
+}

--- a/chat/src/lib/messaging/sender-scoped-ids.ts
+++ b/chat/src/lib/messaging/sender-scoped-ids.ts
@@ -2,7 +2,9 @@ import type { TimelineMessage } from "@/lib/chat-ui";
 import { barePeerJid } from "@/lib/xmpp-client";
 
 function normalizedRealJid(message: TimelineMessage): string | undefined {
-  return message.authorRealJid ? barePeerJid(message.authorRealJid) : undefined;
+  return message.authorRealJid
+    ? barePeerJid(message.authorRealJid).trim().toLowerCase()
+    : undefined;
 }
 
 function senderScopeJid(message: TimelineMessage): string | undefined {

--- a/chat/src/lib/messaging/sender-scoped-ids.ts
+++ b/chat/src/lib/messaging/sender-scoped-ids.ts
@@ -56,8 +56,12 @@ export function hasMessageSenderContinuity(
       && existingOccupantJid === incomingOccupantJid;
   }
 
-  return existing.author === incoming.author
-    && bareJidKey(existing.authorJid ?? "") === bareJidKey(incoming.authorJid ?? "");
+  const existingAuthorJid = bareJidKey(existing.authorJid ?? "");
+  const incomingAuthorJid = bareJidKey(incoming.authorJid ?? "");
+  return !!existingAuthorJid
+    && !!incomingAuthorJid
+    && existing.author === incoming.author
+    && existingAuthorJid === incomingAuthorJid;
 }
 
 /**
@@ -150,8 +154,9 @@ function continuityKey(...parts: readonly string[]): string {
   return parts.join("\u0000");
 }
 
-function legacySenderKey(message: TimelineMessage): string {
-  return continuityKey(message.author, bareJidKey(message.authorJid ?? ""));
+function legacySenderKey(message: TimelineMessage): string | undefined {
+  const authorJid = bareJidKey(message.authorJid ?? "");
+  return authorJid ? continuityKey(message.author, authorJid) : undefined;
 }
 
 class SenderContinuityIndex {

--- a/chat/src/lib/messaging/synthesized-id-merge.ts
+++ b/chat/src/lib/messaging/synthesized-id-merge.ts
@@ -1,6 +1,6 @@
 import type { TimelineMessage } from "@/lib/chat-ui";
 import { mergeMessageIds } from "@/lib/message-ids";
-import { barePeerJid } from "@/lib/xmpp-client";
+import { hasMessageSenderContinuity } from "@/lib/messaging/sender-scoped-ids";
 
 // #1182: a live stanza with no wire identity (no client id, no XEP-0359
 // stanza-id/origin-id) is keyed on a fabricated UUID (`synthesizedId`).
@@ -31,14 +31,6 @@ const REAL_STAMP_AHEAD_TOLERANCE_MS = 90_000;
  * room-occupant JID (the MAM copy may add a real JID the live copy never
  * saw); DM rows compare the bare sender JID.
  */
-function sameAuthor(a: TimelineMessage, b: TimelineMessage): boolean {
-  if (a.authorOccupantJid || b.authorOccupantJid) {
-    return a.authorOccupantJid === b.authorOccupantJid;
-  }
-  return a.author === b.author
-    && barePeerJid(a.authorJid ?? "") === barePeerJid(b.authorJid ?? "");
-}
-
 /**
  * Asymmetric stamp check: the real side may trail the synthesized
  * receipt by the full window (slow delivery, skew) but only lead it by
@@ -82,7 +74,7 @@ export function findSynthesizedIdMergeTarget(
   return candidates.find((existing) =>
     !existing.synthesizedId !== !incoming.synthesizedId
     && contentKey(existing) === incomingKey
-    && sameAuthor(existing, incoming)
+    && hasMessageSenderContinuity(existing, incoming)
     && (incoming.synthesizedId
       ? stampsReconcilable(incoming, existing)
       : stampsReconcilable(existing, incoming))

--- a/chat/src/lib/messaging/timeline-insert.ts
+++ b/chat/src/lib/messaging/timeline-insert.ts
@@ -122,7 +122,7 @@ export function insertLiveMessage(
     ?? (contentMatchable ? findSynthesizedIdMergeTarget(messages, msg) : undefined);
   if (existing) {
     const merged = messages
-      .map((m) => (m.id === existing.id ? mergedLiveRow(m, msg) : m))
+      .map((m) => (m === existing ? mergedLiveRow(m, msg) : m))
       .sort(compareTimelineMessages);
     consumeReconciledEchoIds(pendingEchoClientIds, existing);
     return { messages: finalize(merged), appended: false };

--- a/chat/src/lib/xmpp/wasm-message-codecs.ts
+++ b/chat/src/lib/xmpp/wasm-message-codecs.ts
@@ -463,7 +463,10 @@ export function roomMessageFromArchived(
     ? message.moderation_target_id
     : undefined;
   const activeRetractionTarget = moderationTargetId ?? (!message.moderation_target_id ? message.retracts_id : undefined);
-  const roomPrimaryId = message.id ?? stampedByRoom ?? message.mam_id;
+  // XEP-0359 sender-selected ids are aliases, never room-global identity.
+  // Prefer the room-authored stanza-id; without one, use the archive/live
+  // envelope id and retain client id/origin-id only for sender-scoped merge.
+  const roomPrimaryId = stampedByRoom ?? message.mam_id;
   const roomWireIds = [message.id, message.origin_id, stampedByRoom]
     .filter((value): value is string => !!value && value !== roomPrimaryId);
   // #1182: on the live path `mam_id` is fabricated by the dispatcher
@@ -515,7 +518,7 @@ export function roomMessageFromArchived(
     return {
       // #1267 item 3: only trust a stanza-id whose `by` is the room
       // (XEP-0359 §Security) — never the unverified first-listed one.
-      id: message.id ?? stampedByRoom ?? message.mam_id,
+      id: roomPrimaryId,
       archiveId: message.mam_id,
       roomJid,
       nick: "",

--- a/chat/tests/channel-live-merge.test.ts
+++ b/chat/tests/channel-live-merge.test.ts
@@ -592,7 +592,7 @@ describe("mergeLiveMessage self-echo reconciliation", () => {
     ]);
   });
 
-  test("keeps correction and retraction targeting canonical ids after alias collision", () => {
+  test("sender-scopes a correction alias after a cross-occupant collision", () => {
     const h = harness();
     h.messages.value = [
       {
@@ -619,10 +619,7 @@ describe("mergeLiveMessage self-echo reconciliation", () => {
       },
     ];
 
-    h.liveMerge.applyCorrection("shared-client-id", "ambiguous", {
-      authorJid: "room@muc.example.com/alice",
-    });
-    h.liveMerge.applyCorrection("room-stanza-alice", "alice edited", {
+    h.liveMerge.applyCorrection("shared-client-id", "alice edited", {
       authorJid: "room@muc.example.com/alice",
     });
     h.liveMerge.applyRetraction(makeLive({
@@ -633,6 +630,29 @@ describe("mergeLiveMessage self-echo reconciliation", () => {
 
     expect(h.messages.value[0]).toMatchObject({ body: "alice edited", isEdited: true });
     expect(h.messages.value[1]).toMatchObject({ body: "", isRetracted: true });
+  });
+
+  test("fails closed when a correction alias selects multiple rows inside one sender scope", () => {
+    const h = harness();
+    const alice = {
+      wireIds: ["shared-client-id"],
+      author: "alice",
+      authorJid: "room@muc.example.com/alice",
+      authorOccupantJid: "room@muc.example.com/alice",
+      isSelf: false,
+      createdAtSource: "delay" as const,
+    };
+    h.messages.value = [
+      { ...alice, id: "room-stanza-1", body: "first", createdAt: "2026-05-14T10:36:55Z" },
+      { ...alice, id: "room-stanza-2", body: "second", createdAt: "2026-05-14T10:36:56Z" },
+    ];
+
+    h.liveMerge.applyCorrection("shared-client-id", "ambiguous edit", {
+      authorJid: "room@muc.example.com/alice",
+    });
+
+    expect(h.messages.value.map((message) => message.body)).toEqual(["first", "second"]);
+    expect(h.messages.value.every((message) => !message.isEdited)).toBe(true);
   });
 
   test("keeps timeline ordered when an older catch-up message lands after a newer live message", () => {

--- a/chat/tests/channel-live-merge.test.ts
+++ b/chat/tests/channel-live-merge.test.ts
@@ -324,6 +324,287 @@ describe("applyCorrection sender-match gate (XEP-0308)", () => {
 });
 
 describe("mergeLiveMessage self-echo reconciliation", () => {
+  test("preserves two occupants that reuse the same sender-selected id", () => {
+    const h = harness();
+    h.liveMerge.mergeLiveMessage({
+      id: "room-stanza-alice",
+      wireIds: ["shared-client-id"],
+      author: "alice",
+      authorJid: "room@muc.example.com/alice",
+      authorOccupantJid: "room@muc.example.com/alice",
+      authorRealJid: "alice@example.com/phone",
+      body: "from alice",
+      isSelf: false,
+      createdAt: "2026-05-14T10:36:55.000Z",
+      createdAtSource: "delay",
+    });
+    h.liveMerge.mergeLiveMessage({
+      id: "room-stanza-bob",
+      wireIds: ["shared-client-id"],
+      author: "bob",
+      authorJid: "room@muc.example.com/bob",
+      authorOccupantJid: "room@muc.example.com/bob",
+      authorRealJid: "bob@example.com/laptop",
+      body: "from bob",
+      isSelf: false,
+      createdAt: "2026-05-14T10:36:56.000Z",
+      createdAtSource: "delay",
+    });
+
+    expect(h.messages.value.map(({ id, body }) => ({ id, body }))).toEqual([
+      { id: "room-stanza-alice", body: "from alice" },
+      { id: "room-stanza-bob", body: "from bob" },
+    ]);
+  });
+
+  test("preserves same-occupant messages with distinct room-authored stanza ids", () => {
+    const h = harness();
+    const sender = {
+      wireIds: ["reused-client-id"],
+      stanzaIdBy: "room@muc.example.com",
+      author: "alice",
+      authorJid: "alice@example.com/phone",
+      authorOccupantJid: "room@muc.example.com/alice",
+      authorRealJid: "alice@example.com/phone",
+      isSelf: false,
+      createdAtSource: "delay" as const,
+    };
+    h.liveMerge.mergeLiveMessage({
+      ...sender,
+      id: "room-stanza-1",
+      stanzaId: "room-stanza-1",
+      replyableId: "room-stanza-1",
+      body: "first",
+      createdAt: "2026-05-14T10:36:55Z",
+    });
+    h.liveMerge.mergeLiveMessage({
+      ...sender,
+      id: "room-stanza-2",
+      stanzaId: "room-stanza-2",
+      replyableId: "room-stanza-2",
+      body: "second",
+      createdAt: "2026-05-14T10:36:56Z",
+    });
+
+    expect(h.messages.value.map(({ id, body }) => ({ id, body }))).toEqual([
+      { id: "room-stanza-1", body: "first" },
+      { id: "room-stanza-2", body: "second" },
+    ]);
+  });
+
+  test("preserves distinct room-stamped messages across nicks for the same bare real JID", () => {
+    const h = harness();
+    for (const [index, nick] of ["alice-phone", "alice-laptop"].entries()) {
+      const stanzaId = `room-stanza-${index + 1}`;
+      h.liveMerge.mergeLiveMessage({
+        id: stanzaId,
+        wireIds: ["reused-client-id"],
+        stanzaId,
+        stanzaIdBy: "room@muc.example.com",
+        replyableId: stanzaId,
+        author: nick,
+        authorJid: `alice@example.com/${nick}`,
+        authorOccupantJid: `room@muc.example.com/${nick}`,
+        authorRealJid: `alice@example.com/${nick}`,
+        body: `message ${index + 1}`,
+        isSelf: false,
+        createdAt: `2026-05-14T10:36:5${index + 5}Z`,
+        createdAtSource: "delay",
+      });
+    }
+
+    expect(h.messages.value.map((message) => message.id)).toEqual([
+      "room-stanza-1",
+      "room-stanza-2",
+    ]);
+  });
+
+  test("preserves distinct room stamps when an anonymous nick is reused after departure", () => {
+    const h = harness();
+    for (const [index, body] of ["departed occupant", "replacement occupant"].entries()) {
+      const stanzaId = `room-stanza-${index + 1}`;
+      h.liveMerge.mergeLiveMessage({
+        id: stanzaId,
+        wireIds: ["reused-client-id"],
+        stanzaId,
+        stanzaIdBy: "room@muc.example.com",
+        replyableId: stanzaId,
+        author: "guest",
+        authorJid: "room@muc.example.com/guest",
+        authorOccupantJid: "room@muc.example.com/guest",
+        body,
+        isSelf: false,
+        createdAt: `2026-05-14T10:36:5${index + 5}Z`,
+        createdAtSource: "delay",
+      });
+    }
+
+    expect(h.messages.value.map((message) => message.body)).toEqual([
+      "departed occupant",
+      "replacement occupant",
+    ]);
+  });
+
+  test("does not merge unstamped simultaneous occupants with the same bare real JID", () => {
+    const h = harness();
+    for (const [index, nick] of ["alice-phone", "alice-laptop"].entries()) {
+      h.liveMerge.mergeLiveMessage({
+        id: `envelope-${index + 1}`,
+        wireIds: ["reused-client-id"],
+        author: nick,
+        authorJid: `alice@example.com/${nick}`,
+        authorOccupantJid: `room@muc.example.com/${nick}`,
+        authorRealJid: `alice@example.com/${nick}`,
+        body: `message ${index + 1}`,
+        isSelf: false,
+        createdAt: `2026-05-14T10:36:5${index + 5}Z`,
+        createdAtSource: "delay",
+      });
+    }
+
+    expect(h.messages.value.map((message) => message.id)).toEqual([
+      "envelope-1",
+      "envelope-2",
+    ]);
+  });
+
+  test("does not trust a reused nick when the known real JID changed", () => {
+    const h = harness();
+    h.liveMerge.mergeLiveMessage({
+      id: "room-stanza-old-alice",
+      wireIds: ["shared-client-id"],
+      author: "alice",
+      authorJid: "old-alice@example.com/phone",
+      authorOccupantJid: "room@muc.example.com/alice",
+      authorRealJid: "old-alice@example.com/phone",
+      body: "before nick reuse",
+      isSelf: false,
+      createdAt: "2026-05-14T10:36:55.000Z",
+      createdAtSource: "delay",
+    });
+    h.liveMerge.mergeLiveMessage({
+      id: "room-stanza-new-alice",
+      wireIds: ["shared-client-id"],
+      author: "alice",
+      authorJid: "new-alice@example.com/laptop",
+      authorOccupantJid: "room@muc.example.com/alice",
+      authorRealJid: "new-alice@example.com/laptop",
+      body: "after nick reuse",
+      isSelf: false,
+      createdAt: "2026-05-14T10:36:56.000Z",
+      createdAtSource: "delay",
+    });
+
+    expect(h.messages.value).toHaveLength(2);
+  });
+
+  test("promotes an optimistic sender id to the room-authored stanza id", () => {
+    const h = harness();
+    h.pendingEchoClientIds.add("client-id");
+    h.messages.value = [{
+      id: "client-id",
+      author: "alice",
+      authorJid: "room@muc.example.com/alice",
+      authorOccupantJid: "room@muc.example.com/alice",
+      body: "my message",
+      isSelf: true,
+      deliveryStatus: "sending",
+      createdAt: "2026-05-14T10:36:55.000Z",
+      createdAtSource: "queued",
+    }];
+
+    h.liveMerge.mergeLiveMessage({
+      id: "room-stanza-self",
+      wireIds: ["client-id"],
+      author: "alice",
+      authorJid: "alice@example.com/phone",
+      authorOccupantJid: "room@muc.example.com/alice",
+      authorRealJid: "alice@example.com/phone",
+      body: "my message",
+      isSelf: true,
+      createdAt: "2026-05-14T10:36:56.000Z",
+      createdAtSource: "delay",
+    });
+
+    expect(h.messages.value).toHaveLength(1);
+    expect(h.messages.value[0]?.id).toBe("room-stanza-self");
+    expect(h.messages.value[0]?.wireIds).toEqual(["client-id"]);
+    expect(h.messages.value[0]?.deliveryStatus).toBe("delivered");
+  });
+
+  test("fails closed when sender-scoped aliases select multiple rows", () => {
+    const h = harness();
+    const sender = {
+      author: "alice",
+      authorJid: "alice@example.com/phone",
+      authorOccupantJid: "room@muc.example.com/alice",
+      authorRealJid: "alice@example.com/phone",
+      isSelf: false,
+      createdAtSource: "delay" as const,
+    };
+    h.messages.value = [
+      { ...sender, id: "room-stanza-1", wireIds: ["alias-a"], body: "one", createdAt: "2026-05-14T10:36:55Z" },
+      { ...sender, id: "room-stanza-2", wireIds: ["alias-b"], body: "two", createdAt: "2026-05-14T10:36:56Z" },
+    ];
+
+    h.liveMerge.mergeLiveMessage({
+      ...sender,
+      id: "room-stanza-3",
+      wireIds: ["alias-a", "alias-b"],
+      body: "three",
+      createdAt: "2026-05-14T10:36:57Z",
+    });
+
+    expect(h.messages.value.map((message) => message.id)).toEqual([
+      "room-stanza-1",
+      "room-stanza-2",
+      "room-stanza-3",
+    ]);
+  });
+
+  test("keeps correction and retraction targeting canonical ids after alias collision", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "room-stanza-alice",
+        wireIds: ["shared-client-id"],
+        author: "alice",
+        authorJid: "room@muc.example.com/alice",
+        authorOccupantJid: "room@muc.example.com/alice",
+        body: "alice original",
+        isSelf: false,
+        createdAt: "2026-05-14T10:36:55Z",
+        createdAtSource: "delay",
+      },
+      {
+        id: "room-stanza-bob",
+        wireIds: ["shared-client-id"],
+        author: "bob",
+        authorJid: "room@muc.example.com/bob",
+        authorOccupantJid: "room@muc.example.com/bob",
+        body: "bob original",
+        isSelf: false,
+        createdAt: "2026-05-14T10:36:56Z",
+        createdAtSource: "delay",
+      },
+    ];
+
+    h.liveMerge.applyCorrection("shared-client-id", "ambiguous", {
+      authorJid: "room@muc.example.com/alice",
+    });
+    h.liveMerge.applyCorrection("room-stanza-alice", "alice edited", {
+      authorJid: "room@muc.example.com/alice",
+    });
+    h.liveMerge.applyRetraction(makeLive({
+      retractsId: "room-stanza-bob",
+      fromJid: "room@muc.example.com/bob",
+      nick: "bob",
+    }));
+
+    expect(h.messages.value[0]).toMatchObject({ body: "alice edited", isEdited: true });
+    expect(h.messages.value[1]).toMatchObject({ body: "", isRetracted: true });
+  });
+
   test("keeps timeline ordered when an older catch-up message lands after a newer live message", () => {
     const h = harness();
     h.messages.value = [

--- a/chat/tests/channel-live-merge.test.ts
+++ b/chat/tests/channel-live-merge.test.ts
@@ -392,6 +392,36 @@ describe("mergeLiveMessage self-echo reconciliation", () => {
     ]);
   });
 
+  test("reconciles the same real JID across wire casing differences", () => {
+    const h = harness();
+    const base = {
+      id: "room-stanza-1",
+      stanzaId: "room-stanza-1",
+      stanzaIdBy: "room@muc.example.com",
+      replyableId: "room-stanza-1",
+      author: "alice",
+      authorOccupantJid: "room@muc.example.com/alice",
+      body: "same message",
+      isSelf: false,
+      createdAtSource: "delay" as const,
+    };
+    h.liveMerge.mergeLiveMessage({
+      ...base,
+      authorJid: "Alice@Example.COM/phone",
+      authorRealJid: "Alice@Example.COM/phone",
+      createdAt: "2026-05-14T10:36:55Z",
+    });
+    h.liveMerge.mergeLiveMessage({
+      ...base,
+      authorJid: "alice@example.com/laptop",
+      authorRealJid: "alice@example.com/laptop",
+      createdAt: "2026-05-14T10:36:56Z",
+    });
+
+    expect(h.messages.value).toHaveLength(1);
+    expect(h.messages.value[0]?.id).toBe("room-stanza-1");
+  });
+
   test("preserves distinct room-stamped messages across nicks for the same bare real JID", () => {
     const h = harness();
     for (const [index, nick] of ["alice-phone", "alice-laptop"].entries()) {

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -2238,7 +2238,7 @@ describe("client keepalive lifecycle", () => {
 
     expect(fetchRoomHistoryByThread).toHaveBeenCalledWith(roomJid, "thread-1", 100, null);
     expect((client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted()).toEqual([
-      { kind: "room", key: roomJid, after: "mam-thread-1", since: "2024-01-01T00:00:01.000Z", seenIds: ["room-thread-1"] },
+      { kind: "room", key: roomJid, after: "mam-thread-1", since: "2024-01-01T00:00:01.000Z", seenIds: ["mam-thread-1", "room-thread-1"] },
     ]);
   });
 
@@ -2325,7 +2325,7 @@ describe("client keepalive lifecycle", () => {
 
     expect(fetchRoomHistoryByThread).toHaveBeenCalledWith(roomJid, "thread-1", 100, null);
     expect((client as unknown as { catchup: { onSessionStarted: () => unknown[] } }).catchup.onSessionStarted()).toEqual([
-      { kind: "room", key: roomJid, after: "mam-thread-list-1", since: "2024-01-01T00:00:01.000Z", seenIds: ["room-thread-list-1"] },
+      { kind: "room", key: roomJid, after: "mam-thread-list-1", since: "2024-01-01T00:00:01.000Z", seenIds: ["mam-thread-list-1", "room-thread-list-1"] },
     ]);
   });
 
@@ -2377,7 +2377,7 @@ describe("client keepalive lifecycle", () => {
       body: "newer missed room message",
     }));
     expect(catchup.onSessionStarted()).toEqual([
-      { kind: "room", key: roomJid, after: "mam-room-newer", since: "2024-01-01T00:00:01.000Z", seenIds: ["room-newer"] },
+      { kind: "room", key: roomJid, after: "mam-room-newer", since: "2024-01-01T00:00:01.000Z", seenIds: ["mam-room-newer", "room-newer"] },
     ]);
   });
 
@@ -2474,9 +2474,9 @@ describe("client keepalive lifecycle", () => {
     });
     expect(fetchRoomHistoryPage).toHaveBeenCalledTimes(3);
     expect(roomHandler).toHaveBeenCalledTimes(3);
-    expect(roomHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "room-newer-2" }));
-    expect(roomHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "room-newer-1" }));
-    expect(roomHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "room-same-time-missed" }));
+    expect(roomHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "mam-room-newer-2" }));
+    expect(roomHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "mam-room-newer-1" }));
+    expect(roomHandler).toHaveBeenCalledWith(expect.objectContaining({ id: "mam-room-same-time-missed" }));
   });
 
   test("room stale archive cursor catch-up filters live activity already seen after that cursor", async () => {
@@ -2618,7 +2618,7 @@ describe("client keepalive lifecycle", () => {
 
     await client.queryMamPage("w1", "c1", 100, { type: "latest" });
     expect(catchup.onSessionStarted()).toEqual([
-      { kind: "room", key: roomJid, after: "mam-room-1", since: "2024-01-01T00:00:00.000Z", seenIds: ["room-1"] },
+      { kind: "room", key: roomJid, after: "mam-room-1", since: "2024-01-01T00:00:00.000Z", seenIds: ["mam-room-1", "room-1"] },
     ]);
 
     (client as unknown as { currentRoom: string | null }).currentRoom = roomJid;
@@ -2636,12 +2636,12 @@ describe("client keepalive lifecycle", () => {
     });
     expect(fetchRoomHistoryPage).toHaveBeenCalledTimes(3);
     expect(roomHandler).toHaveBeenCalledWith(expect.objectContaining({
-      id: "room-2",
+      id: "mam-room-2",
       body: "first missed room page",
       roomJid,
     }));
     expect(roomHandler).toHaveBeenCalledWith(expect.objectContaining({
-      id: "room-3",
+      id: "mam-room-3",
       body: "second missed room page",
       roomJid,
     }));

--- a/chat/tests/dm-live-merge.test.ts
+++ b/chat/tests/dm-live-merge.test.ts
@@ -230,6 +230,38 @@ describe("applyRetraction sender-match gate (XEP-0424)", () => {
     }));
     expect(h.messages.value[0]?.isRetracted).toBeFalsy();
   });
+
+  test("sender-scopes a reused alias before retracting", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "alice-canonical",
+        wireIds: ["shared-id"],
+        body: "alice message",
+        nick: "alice",
+        authorJid: "alice@example.com/phone",
+        timestamp: 0,
+      } as TimelineMessage,
+      {
+        id: "bob-canonical",
+        wireIds: ["shared-id"],
+        body: "bob message",
+        nick: "bob",
+        authorJid: "bob@example.com/laptop",
+        timestamp: 1,
+      } as TimelineMessage,
+    ];
+
+    h.liveMerge.applyRetraction(makeLive({
+      retractsId: "shared-id",
+      retractionId: "bob-retraction",
+      fromJid: "bob@example.com/mobile",
+      nick: "bob",
+    }));
+
+    expect(h.messages.value[0]).toMatchObject({ body: "alice message" });
+    expect(h.messages.value[1]).toMatchObject({ body: "", isRetracted: true });
+  });
 });
 
 describe("applyCorrection sender-match gate (XEP-0308)", () => {
@@ -247,6 +279,56 @@ describe("applyCorrection sender-match gate (XEP-0308)", () => {
     h.liveMerge.applyCorrection("m1", "hijacked!", "mallory@example.com");
     expect(h.messages.value[0]?.body).toBe("from bob");
     expect(h.messages.value[0]?.isEdited).toBeFalsy();
+  });
+
+  test("sender-scopes a reused alias before correcting", () => {
+    const h = harness();
+    h.messages.value = [
+      {
+        id: "alice-canonical",
+        wireIds: ["shared-id"],
+        body: "alice message",
+        nick: "alice",
+        authorJid: "alice@example.com/phone",
+        timestamp: 0,
+      } as TimelineMessage,
+      {
+        id: "bob-canonical",
+        wireIds: ["shared-id"],
+        body: "bob message",
+        nick: "bob",
+        authorJid: "bob@example.com/laptop",
+        timestamp: 1,
+      } as TimelineMessage,
+    ];
+
+    h.liveMerge.applyCorrection("shared-id", "bob edited", "bob@example.com/mobile");
+
+    expect(h.messages.value[0]).toMatchObject({ body: "alice message" });
+    expect(h.messages.value[1]).toMatchObject({ body: "bob edited", isEdited: true });
+  });
+
+  test("fails closed when one sender claims a correction or retraction alias twice", () => {
+    const h = harness();
+    const bob = {
+      wireIds: ["shared-id"],
+      nick: "bob",
+      authorJid: "bob@example.com/laptop",
+    };
+    h.messages.value = [
+      { ...bob, id: "bob-1", body: "first", timestamp: 0 } as TimelineMessage,
+      { ...bob, id: "bob-2", body: "second", timestamp: 1 } as TimelineMessage,
+    ];
+
+    h.liveMerge.applyCorrection("shared-id", "ambiguous edit", "bob@example.com/mobile");
+    h.liveMerge.applyRetraction(makeLive({
+      retractsId: "shared-id",
+      fromJid: "bob@example.com/mobile",
+      nick: "bob",
+    }));
+
+    expect(h.messages.value.map((message) => message.body)).toEqual(["first", "second"]);
+    expect(h.messages.value.every((message) => !message.isEdited && !message.isRetracted)).toBe(true);
   });
 });
 

--- a/chat/tests/inbound-references.test.ts
+++ b/chat/tests/inbound-references.test.ts
@@ -263,10 +263,13 @@ describe("roomMessageFromArchived", () => {
       existing: [{
         id: "client-1",
         wireIds: ["room-stanza-1"],
+        author: "alice",
+        authorJid: "room@conf.example.com/alice",
+        authorOccupantJid: "room@conf.example.com/alice",
         body: "read https://example.com",
-        nick: "alice",
         isSelf: true,
         createdAt: "2026-06-01T12:00:00.000Z",
+        createdAtSource: "queued",
         linkPreviews: [{ originalUrl: "https://example.com", title: "Example" }],
       }],
     });
@@ -390,10 +393,121 @@ describe("roomMessageFromArchived", () => {
 
     const result = roomMessageFromArchived(archived);
 
+    expect(result?.id).toBe("room-stanza-xyz");
     expect(result?.reactionTargetId).toBe("room-stanza-xyz");
     expect(result?.replyableId).toBe("room-stanza-xyz");
-    expect(result?.wireIds).toContain("room-stanza-xyz");
+    expect(result?.wireIds).toContain("client-origin-id");
     expect(result?.wireIds).not.toContain("foreign-stanza-xyz");
+  });
+
+  test("keeps archived occupants distinct when they reuse a sender-selected id", () => {
+    const decoded = [
+      roomMessageFromArchived({
+        ...baseArchivedRoom,
+        mam_id: "mam-alice",
+        id: "shared-client-id",
+        stanza_id: "room-stanza-alice",
+        stanza_id_by: "room@conf.example.com",
+        from: "room@conf.example.com/alice",
+        author_real_jid: "alice@example.com/phone",
+        body: "from alice",
+      }),
+      roomMessageFromArchived({
+        ...baseArchivedRoom,
+        mam_id: "mam-bob",
+        id: "shared-client-id",
+        stanza_id: "room-stanza-bob",
+        stanza_id_by: "room@conf.example.com",
+        from: "room@conf.example.com/bob",
+        author_real_jid: "bob@example.com/laptop",
+        body: "from bob",
+      }),
+    ].filter((message): message is NonNullable<typeof message> => !!message);
+
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: decoded,
+    });
+
+    expect(timeline.map(({ id, body }) => ({ id, body }))).toEqual([
+      { id: "room-stanza-alice", body: "from alice" },
+      { id: "room-stanza-bob", body: "from bob" },
+    ]);
+    expect(timeline.every((message) => message.wireIds?.includes("shared-client-id"))).toBe(true);
+  });
+
+  test("keeps same-occupant archive rows with distinct room stanza ids", () => {
+    const decoded = ["room-stanza-1", "room-stanza-2"].map((stanzaId, index) =>
+      roomMessageFromArchived({
+        ...baseArchivedRoom,
+        mam_id: `mam-${index + 1}`,
+        id: "reused-client-id",
+        stanza_id: stanzaId,
+        stanza_id_by: "room@conf.example.com",
+        from: "room@conf.example.com/alice",
+        author_real_jid: "alice@example.com/phone",
+        body: index === 0 ? "first" : "second",
+      })!
+    );
+
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: decoded,
+    });
+
+    expect(timeline.map(({ id, body }) => ({ id, body }))).toEqual([
+      { id: "room-stanza-1", body: "first" },
+      { id: "room-stanza-2", body: "second" },
+    ]);
+  });
+
+  test("MAM reconciliation promotes an optimistic alias to canonical room identity", () => {
+    const archived = roomMessageFromArchived({
+      ...baseArchivedRoom,
+      mam_id: "mam-self",
+      id: "client-id",
+      origin_id: "origin-id",
+      stanza_id: "room-stanza-self",
+      stanza_id_by: "room@conf.example.com",
+      from: "room@conf.example.com/alice",
+      author_real_jid: "alice@example.com/phone",
+      body: "my message",
+    })!;
+    const optimistic = {
+      id: "client-id",
+      correctionTargetId: "client-id",
+      author: "alice",
+      authorJid: "room@conf.example.com/alice",
+      authorOccupantJid: "room@conf.example.com/alice",
+      body: "my message",
+      createdAt: "2026-05-14T10:36:55Z",
+      createdAtSource: "queued" as const,
+      isSelf: true,
+      deliveryStatus: "sending" as const,
+    };
+
+    for (const seedExistingOnly of [false, true]) {
+      const timeline = buildChannelTimelineFromMamResults({
+        session,
+        channelIsForum: false,
+        mamResults: [archived],
+        existing: [optimistic],
+        options: { seedExistingOnly },
+      });
+
+      expect(timeline).toHaveLength(1);
+      expect(timeline[0]).toMatchObject({
+        id: "room-stanza-self",
+        stanzaId: "room-stanza-self",
+        stanzaIdBy: "room@conf.example.com",
+        replyableId: "room-stanza-self",
+        reactionTargetId: "room-stanza-self",
+        correctionTargetId: "origin-id",
+      });
+      expect(timeline[0]?.wireIds).toEqual(expect.arrayContaining(["client-id", "origin-id"]));
+    }
   });
 
   test("leaves room-targeted ids undefined when the room did not assign the stanza-id", () => {
@@ -406,9 +520,10 @@ describe("roomMessageFromArchived", () => {
 
     const result = roomMessageFromArchived(archived);
 
+    expect(result?.id).toBe("mam-1");
     expect(result?.reactionTargetId).toBeUndefined();
     expect(result?.replyableId).toBeUndefined();
-    expect(result?.wireIds).toBeUndefined();
+    expect(result?.wireIds).toEqual(["client-origin-id"]);
   });
 
   test("requires an exact room JID on XEP-0359 stanza-id by", () => {
@@ -424,9 +539,10 @@ describe("roomMessageFromArchived", () => {
 
     const result = roomMessageFromArchived(archived);
 
+    expect(result?.id).toBe("mam-1");
     expect(result?.reactionTargetId).toBeUndefined();
     expect(result?.replyableId).toBeUndefined();
-    expect(result?.wireIds).toBeUndefined();
+    expect(result?.wireIds).toEqual(["client-origin-id"]);
   });
 
   test("maps XEP-0424 tombstones without projecting a new retraction target", () => {
@@ -442,7 +558,8 @@ describe("roomMessageFromArchived", () => {
     const result = roomMessageFromArchived(archived);
 
     expect(result).toMatchObject({
-      id: "original-message-id",
+      id: "mam-1",
+      wireIds: ["original-message-id"],
       body: "",
       isRetracted: true,
       retractionId: "retract-message-id",

--- a/chat/tests/inbound-references.test.ts
+++ b/chat/tests/inbound-references.test.ts
@@ -480,7 +480,6 @@ describe("roomMessageFromArchived", () => {
       correctionTargetId: "client-id",
       author: "alice",
       authorJid: "room@conf.example.com/alice",
-      authorOccupantJid: "room@conf.example.com/alice",
       body: "my message",
       createdAt: "2026-05-14T10:36:55Z",
       createdAtSource: "queued" as const,
@@ -505,6 +504,7 @@ describe("roomMessageFromArchived", () => {
         replyableId: "room-stanza-self",
         reactionTargetId: "room-stanza-self",
         correctionTargetId: "origin-id",
+        authorOccupantJid: "room@conf.example.com/alice",
       });
       expect(timeline[0]?.wireIds).toEqual(expect.arrayContaining(["client-id", "origin-id"]));
     }

--- a/chat/tests/sender-scoped-ids.test.ts
+++ b/chat/tests/sender-scoped-ids.test.ts
@@ -28,12 +28,14 @@ describe("SenderScopedIdIndex", () => {
   test("normalizes bare sender JIDs identically in the scan and index", () => {
     const existing: TimelineMessage = {
       ...canonicalRoomMessage(0),
+      author: "Alice",
       authorOccupantJid: undefined,
       authorRealJid: undefined,
       authorJid: " Alice@Example.COM/phone ",
     };
     const incoming: TimelineMessage = {
       ...existing,
+      author: "alice",
       authorJid: "alice@example.com/laptop",
     };
 

--- a/chat/tests/sender-scoped-ids.test.ts
+++ b/chat/tests/sender-scoped-ids.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+
+import type { TimelineMessage } from "@/lib/chat-ui";
+import { SenderScopedIdIndex } from "@/lib/messaging/sender-scoped-ids";
+
+function canonicalRoomMessage(index: number): TimelineMessage {
+  const stanzaId = `room-stanza-${index}`;
+  return {
+    id: stanzaId,
+    wireIds: ["reused-client-id"],
+    stanzaId,
+    stanzaIdBy: "room@muc.example.com",
+    author: "alice",
+    authorJid: "alice@example.com/phone",
+    authorOccupantJid: "room@muc.example.com/alice",
+    authorRealJid: "alice@example.com/phone",
+    body: `message ${index}`,
+    isSelf: false,
+    createdAt: "2026-05-14T10:36:55Z",
+    createdAtSource: "archive",
+  };
+}
+
+describe("SenderScopedIdIndex", () => {
+  test("preserves fail-closed multiplicity for a repeated object reference", () => {
+    const message = canonicalRoomMessage(0);
+    const index = new SenderScopedIdIndex([message, message]);
+
+    expect(index.find(message)).toBeUndefined();
+  });
+
+  test("bounds resolution work when one sender reuses an alias across canonical messages", () => {
+    const messageCount = 2_000;
+    const index = new SenderScopedIdIndex();
+
+    for (let candidate = 0; candidate < messageCount; candidate += 1) {
+      const message = canonicalRoomMessage(candidate);
+      expect(index.find(message)).toBeUndefined();
+      index.add(message);
+    }
+
+    expect(index.resolutionProbeCount).toBeLessThanOrEqual(messageCount * 12);
+  });
+
+  test("prunes canonical partitions after repeated replacement", () => {
+    const index = new SenderScopedIdIndex();
+    let current = canonicalRoomMessage(0);
+    index.add(current);
+
+    for (let candidate = 1; candidate <= 2_000; candidate += 1) {
+      const replacement = canonicalRoomMessage(candidate);
+      index.replace(current, replacement);
+      current = replacement;
+    }
+
+    expect(index.retainedCanonicalPartitionCount).toBe(3);
+  });
+});

--- a/chat/tests/sender-scoped-ids.test.ts
+++ b/chat/tests/sender-scoped-ids.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import type { TimelineMessage } from "@/lib/chat-ui";
-import { SenderScopedIdIndex } from "@/lib/messaging/sender-scoped-ids";
+import {
+  findSenderScopedIdTarget,
+  SenderScopedIdIndex,
+} from "@/lib/messaging/sender-scoped-ids";
 
 function canonicalRoomMessage(index: number): TimelineMessage {
   const stanzaId = `room-stanza-${index}`;
@@ -22,6 +25,22 @@ function canonicalRoomMessage(index: number): TimelineMessage {
 }
 
 describe("SenderScopedIdIndex", () => {
+  test("normalizes bare sender JIDs identically in the scan and index", () => {
+    const existing: TimelineMessage = {
+      ...canonicalRoomMessage(0),
+      authorOccupantJid: undefined,
+      authorRealJid: undefined,
+      authorJid: " Alice@Example.COM/phone ",
+    };
+    const incoming: TimelineMessage = {
+      ...existing,
+      authorJid: "alice@example.com/laptop",
+    };
+
+    expect(findSenderScopedIdTarget([existing], incoming)).toBe(existing);
+    expect(new SenderScopedIdIndex([existing]).find(incoming)).toBe(existing);
+  });
+
   test("preserves fail-closed multiplicity for a repeated object reference", () => {
     const message = canonicalRoomMessage(0);
     const index = new SenderScopedIdIndex([message, message]);

--- a/chat/tests/sender-scoped-ids.test.ts
+++ b/chat/tests/sender-scoped-ids.test.ts
@@ -41,6 +41,19 @@ describe("SenderScopedIdIndex", () => {
     expect(new SenderScopedIdIndex([existing]).find(incoming)).toBe(existing);
   });
 
+  test("fails closed when only a display nick identifies the sender", () => {
+    const existing: TimelineMessage = {
+      ...canonicalRoomMessage(0),
+      authorOccupantJid: undefined,
+      authorRealJid: undefined,
+      authorJid: undefined,
+    };
+    const incoming: TimelineMessage = { ...existing };
+
+    expect(findSenderScopedIdTarget([existing], incoming)).toBeUndefined();
+    expect(new SenderScopedIdIndex([existing]).find(incoming)).toBeUndefined();
+  });
+
   test("preserves fail-closed multiplicity for a repeated object reference", () => {
     const message = canonicalRoomMessage(0);
     const index = new SenderScopedIdIndex([message, message]);

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -333,8 +333,11 @@ describe("XEP-0198 session lifecycle catch-up (group chat)", () => {
       {
         id: "thread-42",
         author: "alice",
+        authorJid: "w1-c1@rooms.example.com/alice",
+        authorOccupantJid: "w1-c1@rooms.example.com/alice",
         body: "topic root",
         createdAt: "2024-01-01T00:00:00Z",
+        createdAtSource: "delay",
         isSelf: true,
       },
       {
@@ -342,8 +345,11 @@ describe("XEP-0198 session lifecycle catch-up (group chat)", () => {
         wireIds: ["reply-archive"],
         reactionTargetId: "reply-live",
         author: "bob",
+        authorJid: "w1-c1@rooms.example.com/bob",
+        authorOccupantJid: "w1-c1@rooms.example.com/bob",
         body: "live reply",
         createdAt: "2024-01-01T00:01:00Z",
+        createdAtSource: "delay",
         isSelf: false,
         replyTo: {
           id: "thread-42",

--- a/chat/tests/tombstone-replay.test.ts
+++ b/chat/tests/tombstone-replay.test.ts
@@ -331,6 +331,55 @@ describe("XEP-0424 tombstone replay", () => {
     expect(timeline[0]?.extensionBodyFallback).toBeUndefined();
   });
 
+  test("MAM channel corrections resolve reused sender ids inside the verified occupant scope", () => {
+    const existing: TimelineMessage[] = [
+      {
+        id: "room-stanza-alice",
+        wireIds: ["shared-client-id"],
+        author: "alice",
+        authorJid: "room@muc.example.com/alice",
+        authorOccupantJid: "room@muc.example.com/alice",
+        body: "alice original",
+        createdAt: "2026-05-08T13:00:00Z",
+        isSelf: false,
+      },
+      {
+        id: "room-stanza-bob",
+        wireIds: ["shared-client-id"],
+        author: "bob",
+        authorJid: "room@muc.example.com/bob",
+        authorOccupantJid: "room@muc.example.com/bob",
+        body: "bob original",
+        createdAt: "2026-05-08T13:00:01Z",
+        isSelf: false,
+      },
+    ];
+    const correction: LiveRoomMessage = {
+      id: "edit-message",
+      roomJid: "room@muc.example.com",
+      nick: "alice",
+      body: "alice edited",
+      createdAt: "2026-05-08T13:01:00Z",
+      type: "message",
+      replacesId: "shared-client-id",
+    };
+
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [correction],
+      existing,
+    });
+
+    expect(timeline.find((message) => message.id === "room-stanza-alice")).toMatchObject({
+      body: "alice edited",
+      isEdited: true,
+    });
+    expect(timeline.find((message) => message.id === "room-stanza-bob")).toMatchObject({
+      body: "bob original",
+    });
+  });
+
   test("MAM channel corrections replace and clear link preview state", () => {
     const existing: TimelineMessage = {
       id: "original-message",
@@ -374,6 +423,46 @@ describe("XEP-0424 tombstone replay", () => {
       existing: [withPreview[0]!],
     });
     expect(withoutPreview[0]?.linkPreviews).toBeUndefined();
+  });
+
+  test("MAM channel corrections never repopulate an already-retracted message", () => {
+    const tombstone: TimelineMessage = {
+      id: "room-stanza-1",
+      author: "bob",
+      authorJid: "room@muc.example.com/bob",
+      authorOccupantJid: "room@muc.example.com/bob",
+      body: "",
+      createdAt: "2026-05-08T13:00:00Z",
+      isSelf: false,
+      isRetracted: true,
+      retractionId: "room-retract-1",
+    };
+    const correction: LiveRoomMessage = {
+      id: "edit-message",
+      roomJid: "room@muc.example.com",
+      nick: "bob",
+      body: "must stay deleted",
+      createdAt: "2026-05-08T13:01:00Z",
+      type: "message",
+      replacesId: "room-stanza-1",
+      extensionAnnotations: [extensionAnnotation],
+      extensionBodyFallback: true,
+    };
+
+    const timeline = buildChannelTimelineFromMamResults({
+      session,
+      channelIsForum: false,
+      mamResults: [correction],
+      existing: [tombstone],
+    });
+
+    expect(timeline[0]).toMatchObject({
+      body: "",
+      isRetracted: true,
+      retractionId: "room-retract-1",
+    });
+    expect(timeline[0]?.isEdited).toBeUndefined();
+    expect(timeline[0]?.extensionAnnotations).toBeUndefined();
   });
 
   test("updates an already-loaded direct message from a MAM tombstone", () => {
@@ -452,6 +541,158 @@ describe("XEP-0424 tombstone replay", () => {
     expect(timeline[0]?.isEdited).toBe(true);
     expect(timeline[0]?.extensionAnnotations).toEqual([extensionAnnotation]);
     expect(timeline[0]?.extensionBodyFallback).toBe(true);
+  });
+
+  test("MAM direct-message corrections never repopulate an already-retracted message", () => {
+    const tombstone: TimelineMessage = {
+      id: "dm-origin",
+      author: "bob",
+      authorJid: "bob@example.com/mobile",
+      body: "",
+      createdAt: "2026-05-08T13:00:00Z",
+      isSelf: false,
+      isRetracted: true,
+      retractionId: "dm-retract",
+    };
+    const correction: LiveDmMessage = {
+      id: "dm-edit",
+      peerJid: "bob@example.com",
+      fromJid: "bob@example.com/mobile",
+      nick: "bob",
+      body: "must stay deleted",
+      createdAt: "2026-05-08T13:01:00Z",
+      type: "message",
+      replacesId: "dm-origin",
+      extensionAnnotations: [extensionAnnotation],
+      extensionBodyFallback: true,
+    };
+
+    const timeline = buildDmTimelineFromMamResults({
+      session,
+      mamResults: [correction],
+      existing: [tombstone],
+    });
+
+    expect(timeline[0]).toMatchObject({
+      body: "",
+      isRetracted: true,
+      retractionId: "dm-retract",
+    });
+    expect(timeline[0]?.isEdited).toBeUndefined();
+    expect(timeline[0]?.extensionAnnotations).toBeUndefined();
+  });
+
+  test("MAM direct-message corrections and retractions resolve aliases inside sender scope", () => {
+    const existing: TimelineMessage[] = [
+      {
+        id: "alice-canonical",
+        wireIds: ["shared-id"],
+        author: "alice",
+        authorJid: "alice@example.com/phone",
+        body: "alice message",
+        createdAt: "2026-05-08T13:00:00Z",
+        isSelf: true,
+      },
+      {
+        id: "bob-canonical",
+        wireIds: ["shared-id"],
+        author: "bob",
+        authorJid: "bob@example.com/laptop",
+        body: "bob message",
+        createdAt: "2026-05-08T13:00:01Z",
+        isSelf: false,
+      },
+    ];
+    const correction: LiveDmMessage = {
+      id: "bob-edit",
+      peerJid: "bob@example.com",
+      fromJid: "bob@example.com/mobile",
+      nick: "bob",
+      body: "bob edited",
+      createdAt: "2026-05-08T13:01:00Z",
+      type: "message",
+      replacesId: "shared-id",
+    };
+    const corrected = buildDmTimelineFromMamResults({
+      session,
+      mamResults: [correction],
+      existing,
+    });
+
+    expect(corrected.find((message) => message.id === "alice-canonical")).toMatchObject({
+      body: "alice message",
+    });
+    expect(corrected.find((message) => message.id === "bob-canonical")).toMatchObject({
+      body: "bob edited",
+      isEdited: true,
+    });
+
+    const retraction: LiveDmMessage = {
+      id: "bob-retraction",
+      peerJid: "bob@example.com",
+      fromJid: "bob@example.com/mobile",
+      nick: "bob",
+      body: "",
+      createdAt: "2026-05-08T13:02:00Z",
+      type: "message",
+      retractsId: "shared-id",
+      retractionId: "bob-retraction",
+    };
+    const retracted = buildDmTimelineFromMamResults({
+      session,
+      mamResults: [retraction],
+      existing,
+    });
+
+    expect(retracted.find((message) => message.id === "alice-canonical")).toMatchObject({
+      body: "alice message",
+    });
+    expect(retracted.find((message) => message.id === "bob-canonical")).toMatchObject({
+      body: "",
+      isRetracted: true,
+    });
+  });
+
+  test("MAM direct-message mutations fail closed for duplicate aliases inside one sender scope", () => {
+    const bob = {
+      wireIds: ["shared-id"],
+      author: "bob",
+      authorJid: "bob@example.com/laptop",
+      isSelf: false,
+    };
+    const existing: TimelineMessage[] = [
+      { ...bob, id: "bob-1", body: "first", createdAt: "2026-05-08T13:00:00Z" },
+      { ...bob, id: "bob-2", body: "second", createdAt: "2026-05-08T13:00:01Z" },
+    ];
+    const correction: LiveDmMessage = {
+      id: "bob-edit",
+      peerJid: "bob@example.com",
+      fromJid: "bob@example.com/mobile",
+      nick: "bob",
+      body: "ambiguous edit",
+      createdAt: "2026-05-08T13:01:00Z",
+      type: "message",
+      replacesId: "shared-id",
+    };
+    const retraction: LiveDmMessage = {
+      id: "bob-retraction",
+      peerJid: "bob@example.com",
+      fromJid: "bob@example.com/mobile",
+      nick: "bob",
+      body: "",
+      createdAt: "2026-05-08T13:02:00Z",
+      type: "message",
+      retractsId: "shared-id",
+    };
+
+    const timeline = buildDmTimelineFromMamResults({
+      session,
+      mamResults: [correction, retraction],
+      existing,
+    });
+
+    expect(timeline.map((message) => message.body)).toEqual(["first", "second"]);
+    expect(timeline.every((message) => !message.isEdited && !message.isRetracted)).toBe(true);
   });
 
   test("MAM direct-message corrections replace and clear link preview state", () => {

--- a/chat/tests/unread-overview-state.test.ts
+++ b/chat/tests/unread-overview-state.test.ts
@@ -440,12 +440,12 @@ describe("useUnreadOverview", () => {
     expect(overview.error.value).toBeNull();
     expect(overview.groups.value[0]?.channelMessages).toHaveLength(2);
     const reacted = overview.groups.value[0]?.channelMessages.find((message) =>
-      message.id === "channel-1"
+      message.id === "stanza-channel-1"
     );
     expect(reacted?.body).toBe("older reacted target");
     expect(reacted?.reactions).toEqual({ "👍": ["bob"] });
     const retracted = overview.groups.value[0]?.channelMessages.find((message) =>
-      message.id === "channel-2"
+      message.id === "stanza-channel-2"
     );
     expect(retracted?.body).toBe("");
     expect(retracted?.isRetracted).toBe(true);
@@ -504,7 +504,7 @@ describe("useUnreadOverview", () => {
     await flushOverviewRefresh();
 
     expect(overview.groups.value[0]?.channelMessages.map((message) => message.id)).toEqual([
-      "channel-1",
+      "stanza-channel-1",
     ]);
     expect(overview.groups.value[0]?.channelMessages[0]?.reactions).toEqual({ "👍": ["bob"] });
     scope.stop();

--- a/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
+++ b/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
@@ -20,6 +20,19 @@ const NS_MUC: &str = "http://jabber.org/protocol/muc";
 const NS_SID: &str = "urn:xmpp:sid:0";
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct EnvelopeId(String);
+
+impl EnvelopeId {
+    fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 fn element_to_xml(element: Element) -> String {
     let mut bytes = Vec::new();
     element.write_to(&mut bytes).expect("serialize XML");
@@ -48,25 +61,33 @@ fn frame_has_message_body(frame: &str, body: &str) -> bool {
         .is_some()
 }
 
-fn message_ids(frame: &str, body: &str, room: &BareJid) -> (String, Vec<String>, Vec<String>) {
+fn message_ids(
+    frame: &str,
+    body: &str,
+    room: &BareJid,
+) -> (EnvelopeId, Vec<OriginId>, Vec<StanzaId>) {
     let root = frame.parse::<Element>().expect("valid XML frame");
     let message = find_message_by_body(&root, body)
         .unwrap_or_else(|| panic!("message with body {body:?} missing from frame: {frame}"));
-    let envelope_id = message.attr("id").expect("message id preserved").to_owned();
+    let envelope_id = EnvelopeId::new(message.attr("id").expect("message id preserved"));
     let origin_ids = message
         .children()
         .filter(|child| child.is("origin-id", NS_SID))
-        .filter_map(|child| child.attr("id").map(str::to_owned))
+        .filter_map(|child| child.attr("id").map(OriginId::new))
         .collect();
     let room_stanza_ids = message
         .children()
         .filter(|child| child.is("stanza-id", NS_SID) && child.attr("by") == Some(room.as_str()))
-        .filter_map(|child| child.attr("id").map(str::to_owned))
+        .filter_map(|child| {
+            child
+                .attr("id")
+                .map(|id| StanzaId::new(id, Jid::from(room.clone())))
+        })
         .collect();
     (envelope_id, origin_ids, room_stanza_ids)
 }
 
-fn groupchat_message(room: &BareJid, id: &str, origin_id: &str, body: &str) -> String {
+fn groupchat_message(room: &BareJid, id: &EnvelopeId, origin_id: &OriginId, body: &str) -> String {
     element_to_xml(
         Element::builder("message", NS_CLIENT)
             .attr(
@@ -79,14 +100,14 @@ fn groupchat_message(room: &BareJid, id: &str, origin_id: &str, body: &str) -> S
             )
             .attr(
                 xmpp_parsers::minidom::rxml::xml_ncname!("id").to_owned(),
-                id,
+                id.as_str(),
             )
             .append(Element::builder("body", NS_CLIENT).append(body).build())
             .append(
                 Element::builder("origin-id", NS_SID)
                     .attr(
                         xmpp_parsers::minidom::rxml::xml_ncname!("id").to_owned(),
-                        origin_id,
+                        origin_id.as_str(),
                     )
                     .build(),
             )
@@ -203,15 +224,15 @@ async fn room_assigns_distinct_stanza_ids_when_occupants_reuse_sender_ids() {
     join_room_as(&mut admin, &room, USERNAME).await;
     join_room_as(&mut alice, &room, ALICE).await;
 
-    let shared_envelope_id = "reused-client-id";
-    let shared_origin_id = "reused-origin-id";
+    let shared_envelope_id = EnvelopeId::new("reused-client-id");
+    let shared_origin_id = OriginId::new("reused-origin-id");
     let admin_body = "admin collision message";
     let alice_body = "alice collision message";
     admin
         .send(&groupchat_message(
             &room,
-            shared_envelope_id,
-            shared_origin_id,
+            &shared_envelope_id,
+            &shared_origin_id,
             admin_body,
         ))
         .await
@@ -223,8 +244,8 @@ async fn room_assigns_distinct_stanza_ids_when_occupants_reuse_sender_ids() {
     alice
         .send(&groupchat_message(
             &room,
-            shared_envelope_id,
-            shared_origin_id,
+            &shared_envelope_id,
+            &shared_origin_id,
             alice_body,
         ))
         .await
@@ -240,12 +261,12 @@ async fn room_assigns_distinct_stanza_ids_when_occupants_reuse_sender_ids() {
         message_ids(&alice_reflection, alice_body, &room);
     assert_eq!(admin_envelope, shared_envelope_id);
     assert_eq!(alice_envelope, shared_envelope_id);
-    assert_eq!(admin_origins, vec![shared_origin_id]);
-    assert_eq!(alice_origins, vec![shared_origin_id]);
+    assert_eq!(admin_origins, vec![shared_origin_id.clone()]);
+    assert_eq!(alice_origins, vec![shared_origin_id.clone()]);
     assert_eq!(admin_room_ids.len(), 1);
     assert_eq!(alice_room_ids.len(), 1);
-    assert!(!admin_room_ids[0].is_empty());
-    assert!(!alice_room_ids[0].is_empty());
+    assert!(!admin_room_ids[0].id.is_empty());
+    assert!(!alice_room_ids[0].id.is_empty());
     assert_ne!(
         admin_room_ids[0], alice_room_ids[0],
         "the room authority must assign distinct identities despite reused sender aliases"
@@ -289,7 +310,7 @@ async fn room_assigns_distinct_stanza_ids_when_occupants_reuse_sender_ids() {
         message_ids(alice_mam, alice_body, &room);
     assert_eq!(admin_mam_envelope, shared_envelope_id);
     assert_eq!(alice_mam_envelope, shared_envelope_id);
-    assert_eq!(admin_mam_origins, vec![shared_origin_id]);
+    assert_eq!(admin_mam_origins, vec![shared_origin_id.clone()]);
     assert_eq!(alice_mam_origins, vec![shared_origin_id]);
     assert_eq!(admin_mam_room_ids, admin_room_ids);
     assert_eq!(alice_mam_room_ids, alice_room_ids);

--- a/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
+++ b/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
@@ -10,14 +10,11 @@ use waddle_xmpp::mam::{ArchivedMessage, InMemoryMamStorage, MamQuery, MamStorage
 use waddle_xmpp_core::xep0359::{add_stanza_id, OriginId, StanzaId};
 use xmpp_parsers::message::{Message, MessageType};
 use xmpp_parsers::minidom::Element;
+use xmpp_parsers::ns::{JABBER_CLIENT as NS_CLIENT, MAM as NS_MAM, MUC as NS_MUC, SID as NS_SID};
 
 const DOMAIN: &str = "localhost";
 const USERNAME: &str = "admin";
 const ALICE: &str = "alice";
-const NS_CLIENT: &str = "jabber:client";
-const NS_MAM: &str = "urn:xmpp:mam:2";
-const NS_MUC: &str = "http://jabber.org/protocol/muc";
-const NS_SID: &str = "urn:xmpp:sid:0";
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
+++ b/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
@@ -48,7 +48,7 @@ fn frame_has_message_body(frame: &str, body: &str) -> bool {
         .is_some()
 }
 
-fn message_ids(frame: &str, body: &str, room: &str) -> (String, Vec<String>, Vec<String>) {
+fn message_ids(frame: &str, body: &str, room: &BareJid) -> (String, Vec<String>, Vec<String>) {
     let root = frame.parse::<Element>().expect("valid XML frame");
     let message = find_message_by_body(&root, body)
         .unwrap_or_else(|| panic!("message with body {body:?} missing from frame: {frame}"));
@@ -60,18 +60,18 @@ fn message_ids(frame: &str, body: &str, room: &str) -> (String, Vec<String>, Vec
         .collect();
     let room_stanza_ids = message
         .children()
-        .filter(|child| child.is("stanza-id", NS_SID) && child.attr("by") == Some(room))
+        .filter(|child| child.is("stanza-id", NS_SID) && child.attr("by") == Some(room.as_str()))
         .filter_map(|child| child.attr("id").map(str::to_owned))
         .collect();
     (envelope_id, origin_ids, room_stanza_ids)
 }
 
-fn groupchat_message(room: &str, id: &str, origin_id: &str, body: &str) -> String {
+fn groupchat_message(room: &BareJid, id: &str, origin_id: &str, body: &str) -> String {
     element_to_xml(
         Element::builder("message", NS_CLIENT)
             .attr(
                 xmpp_parsers::minidom::rxml::xml_ncname!("to").to_owned(),
-                room,
+                room.as_str(),
             )
             .attr(
                 xmpp_parsers::minidom::rxml::xml_ncname!("type").to_owned(),
@@ -94,12 +94,15 @@ fn groupchat_message(room: &str, id: &str, origin_id: &str, body: &str) -> Strin
     )
 }
 
-async fn join_room_as(client: &mut WsXmppClient, room: &str, nick: &str) {
-    let occupant = format!("{room}/{nick}");
+async fn join_room_as(client: &mut WsXmppClient, room: &BareJid, nick: &str) {
+    let occupant = room
+        .clone()
+        .with_resource_str(nick)
+        .expect("valid occupant resource");
     let presence = Element::builder("presence", NS_CLIENT)
         .attr(
             xmpp_parsers::minidom::rxml::xml_ncname!("to").to_owned(),
-            occupant,
+            occupant.as_str(),
         )
         .append(Element::builder("x", NS_MUC).build())
         .build();
@@ -194,7 +197,9 @@ async fn room_assigns_distinct_stanza_ids_when_occupants_reuse_sender_ids() {
     )
     .await
     .expect("connect alice");
-    let room = format!("sid-collision-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    let room: BareJid = format!("sid-collision-{}@muc.{DOMAIN}", uuid::Uuid::new_v4())
+        .parse()
+        .expect("valid room JID");
     join_room_as(&mut admin, &room, USERNAME).await;
     join_room_as(&mut alice, &room, ALICE).await;
 

--- a/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
+++ b/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
@@ -9,10 +9,109 @@ use jid::{BareJid, Jid};
 use waddle_xmpp::mam::{ArchivedMessage, InMemoryMamStorage, MamQuery, MamStorage};
 use waddle_xmpp_core::xep0359::{add_stanza_id, OriginId, StanzaId};
 use xmpp_parsers::message::{Message, MessageType};
+use xmpp_parsers::minidom::Element;
 
 const DOMAIN: &str = "localhost";
 const USERNAME: &str = "admin";
+const ALICE: &str = "alice";
+const NS_CLIENT: &str = "jabber:client";
+const NS_MAM: &str = "urn:xmpp:mam:2";
+const NS_MUC: &str = "http://jabber.org/protocol/muc";
+const NS_SID: &str = "urn:xmpp:sid:0";
 static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
+
+fn element_to_xml(element: Element) -> String {
+    let mut bytes = Vec::new();
+    element.write_to(&mut bytes).expect("serialize XML");
+    String::from_utf8(bytes).expect("XML serialization is UTF-8")
+}
+
+fn find_message_by_body<'a>(element: &'a Element, body: &str) -> Option<&'a Element> {
+    if element.name() == "message"
+        && element
+            .children()
+            .find(|child| child.name() == "body")
+            .is_some_and(|candidate| candidate.text() == body)
+    {
+        return Some(element);
+    }
+    element
+        .children()
+        .find_map(|child| find_message_by_body(child, body))
+}
+
+fn frame_has_message_body(frame: &str, body: &str) -> bool {
+    frame
+        .parse::<Element>()
+        .ok()
+        .and_then(|root| find_message_by_body(&root, body).map(|_| ()))
+        .is_some()
+}
+
+fn message_ids(frame: &str, body: &str, room: &str) -> (String, Vec<String>, Vec<String>) {
+    let root = frame.parse::<Element>().expect("valid XML frame");
+    let message = find_message_by_body(&root, body)
+        .unwrap_or_else(|| panic!("message with body {body:?} missing from frame: {frame}"));
+    let envelope_id = message.attr("id").expect("message id preserved").to_owned();
+    let origin_ids = message
+        .children()
+        .filter(|child| child.is("origin-id", NS_SID))
+        .filter_map(|child| child.attr("id").map(str::to_owned))
+        .collect();
+    let room_stanza_ids = message
+        .children()
+        .filter(|child| child.is("stanza-id", NS_SID) && child.attr("by") == Some(room))
+        .filter_map(|child| child.attr("id").map(str::to_owned))
+        .collect();
+    (envelope_id, origin_ids, room_stanza_ids)
+}
+
+fn groupchat_message(room: &str, id: &str, origin_id: &str, body: &str) -> String {
+    element_to_xml(
+        Element::builder("message", NS_CLIENT)
+            .attr(
+                xmpp_parsers::minidom::rxml::xml_ncname!("to").to_owned(),
+                room,
+            )
+            .attr(
+                xmpp_parsers::minidom::rxml::xml_ncname!("type").to_owned(),
+                "groupchat",
+            )
+            .attr(
+                xmpp_parsers::minidom::rxml::xml_ncname!("id").to_owned(),
+                id,
+            )
+            .append(Element::builder("body", NS_CLIENT).append(body).build())
+            .append(
+                Element::builder("origin-id", NS_SID)
+                    .attr(
+                        xmpp_parsers::minidom::rxml::xml_ncname!("id").to_owned(),
+                        origin_id,
+                    )
+                    .build(),
+            )
+            .build(),
+    )
+}
+
+async fn join_room_as(client: &mut WsXmppClient, room: &str, nick: &str) {
+    let occupant = format!("{room}/{nick}");
+    let presence = Element::builder("presence", NS_CLIENT)
+        .attr(
+            xmpp_parsers::minidom::rxml::xml_ncname!("to").to_owned(),
+            occupant,
+        )
+        .append(Element::builder("x", NS_MUC).build())
+        .build();
+    client
+        .send(&element_to_xml(presence))
+        .await
+        .expect("send join");
+    client
+        .recv_until(|frame| frame.contains("<subject"))
+        .await
+        .expect("join responses");
+}
 
 async fn setup() -> (TestServer, WsXmppClient) {
     let server = TestServer::start();
@@ -69,6 +168,129 @@ async fn room_replaces_spoofed_room_stanza_id_and_preserves_origin_id() {
     assert!(echo.contains(&format!("by='{room}'")) || echo.contains(&format!("by='{room}'")));
 
     let _ = client.close().await;
+}
+
+#[tokio::test]
+async fn room_assigns_distinct_stanza_ids_when_occupants_reuse_sender_ids() {
+    let _guard = TEST_SERIAL.lock().await;
+    let alice_password = format!("alice-pass-{}", uuid::Uuid::new_v4());
+    let server = TestServer::start_with_extra_accounts(&[(ALICE, &alice_password)]);
+    let admin_password = server.fixed_account_password().to_owned();
+    let mut admin = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        USERNAME,
+        &admin_password,
+        "sid-collision-admin",
+    )
+    .await
+    .expect("connect admin");
+    let mut alice = WsXmppClient::connect_and_auth(
+        &server.ws_url(),
+        DOMAIN,
+        ALICE,
+        &alice_password,
+        "sid-collision-alice",
+    )
+    .await
+    .expect("connect alice");
+    let room = format!("sid-collision-{}@muc.{DOMAIN}", uuid::Uuid::new_v4());
+    join_room_as(&mut admin, &room, USERNAME).await;
+    join_room_as(&mut alice, &room, ALICE).await;
+
+    let shared_envelope_id = "reused-client-id";
+    let shared_origin_id = "reused-origin-id";
+    let admin_body = "admin collision message";
+    let alice_body = "alice collision message";
+    admin
+        .send(&groupchat_message(
+            &room,
+            shared_envelope_id,
+            shared_origin_id,
+            admin_body,
+        ))
+        .await
+        .expect("send admin message");
+    let admin_reflection = admin
+        .recv_matching(|frame| frame_has_message_body(frame, admin_body))
+        .await
+        .expect("admin reflection");
+    alice
+        .send(&groupchat_message(
+            &room,
+            shared_envelope_id,
+            shared_origin_id,
+            alice_body,
+        ))
+        .await
+        .expect("send alice message");
+    let alice_reflection = admin
+        .recv_matching(|frame| frame_has_message_body(frame, alice_body))
+        .await
+        .expect("alice reflection");
+
+    let (admin_envelope, admin_origins, admin_room_ids) =
+        message_ids(&admin_reflection, admin_body, &room);
+    let (alice_envelope, alice_origins, alice_room_ids) =
+        message_ids(&alice_reflection, alice_body, &room);
+    assert_eq!(admin_envelope, shared_envelope_id);
+    assert_eq!(alice_envelope, shared_envelope_id);
+    assert_eq!(admin_origins, vec![shared_origin_id]);
+    assert_eq!(alice_origins, vec![shared_origin_id]);
+    assert_eq!(admin_room_ids.len(), 1);
+    assert_eq!(alice_room_ids.len(), 1);
+    assert!(!admin_room_ids[0].is_empty());
+    assert!(!alice_room_ids[0].is_empty());
+    assert_ne!(
+        admin_room_ids[0], alice_room_ids[0],
+        "the room authority must assign distinct identities despite reused sender aliases"
+    );
+
+    let query_id = "mam-sid-collision";
+    let mam_query = Element::builder("iq", NS_CLIENT)
+        .attr(
+            xmpp_parsers::minidom::rxml::xml_ncname!("type").to_owned(),
+            "set",
+        )
+        .attr(
+            xmpp_parsers::minidom::rxml::xml_ncname!("id").to_owned(),
+            query_id,
+        )
+        .attr(
+            xmpp_parsers::minidom::rxml::xml_ncname!("to").to_owned(),
+            room.as_str(),
+        )
+        .append(Element::builder("query", NS_MAM).build())
+        .build();
+    admin
+        .send(&element_to_xml(mam_query))
+        .await
+        .expect("query room MAM");
+    let mam_frames = admin
+        .recv_until(|frame| frame.contains(query_id) && frame.contains("<fin"))
+        .await
+        .expect("MAM results");
+    let admin_mam = mam_frames
+        .iter()
+        .find(|frame| frame_has_message_body(frame, admin_body))
+        .expect("admin MAM row");
+    let alice_mam = mam_frames
+        .iter()
+        .find(|frame| frame_has_message_body(frame, alice_body))
+        .expect("alice MAM row");
+    let (admin_mam_envelope, admin_mam_origins, admin_mam_room_ids) =
+        message_ids(admin_mam, admin_body, &room);
+    let (alice_mam_envelope, alice_mam_origins, alice_mam_room_ids) =
+        message_ids(alice_mam, alice_body, &room);
+    assert_eq!(admin_mam_envelope, shared_envelope_id);
+    assert_eq!(alice_mam_envelope, shared_envelope_id);
+    assert_eq!(admin_mam_origins, vec![shared_origin_id]);
+    assert_eq!(alice_mam_origins, vec![shared_origin_id]);
+    assert_eq!(admin_mam_room_ids, admin_room_ids);
+    assert_eq!(alice_mam_room_ids, alice_room_ids);
+
+    let _ = admin.close().await;
+    let _ = alice.close().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Prevent one MUC occupant from overwriting, suppressing, or aliasing another occupant's timeline row by reusing a sender-selected message ID.

The client now treats a verified room-authored XEP-0359 stanza ID as canonical. Sender-selected IDs remain aliases only inside a verified sender scope; conflicting authoritative identities and ambiguous aliases fail closed.

Closes #1288. Child of #1279. Relates #475.

## Implementation

1. Decode the room-authored stanza ID as the primary room timeline identity and keep client/origin IDs as aliases.
2. Centralize sender continuity using full occupant JID plus real-JID continuity without trusting display nick alone.
3. Reject alias reconciliation when explicit occupant JIDs differ or both rows carry distinct verified room identities.
4. Apply sender-scoped resolution to live insertion, MAM/bootstrap, synthesized-ID reconciliation, and self-echo handling.
5. Promote optimistic rows to canonical room identity during live and MAM reconciliation, including reply/reaction/correction/display metadata.
6. Fail closed when aliases select multiple rows and update a matched row by object identity rather than duplicate primary value.
7. Add a dedicated Rust XEP-0359 websocket regression proving colliding sender IDs receive distinct room IDs in reflection and MAM.
8. Partition batch identity lookups by canonical room identity and exact sender continuity so repeated hostile aliases remain bounded without weakening fail-closed ambiguity.

## XEP review

- XEP-0359 room-assigned stanza IDs provide the authoritative stable identity for groupchat messages.
- Sender-selected envelope IDs and origin IDs are spoofable aliases and cannot establish cross-sender identity.
- XEP-0308 corrections, XEP-0424 retractions, XEP-0444 reactions, and XEP-0461 replies retain their existing sender/room-authority gates.
- XEP-0421 occupant-ID lifecycle work remains in #1268; this change fails closed when current identity evidence is insufficient.

## Verification

- Full chat suite: 3,359 passed, 0 failed (10,307 assertions across 305 files).
- Focused hostile-identity/mutation/MAM suite: 158 passed, 0 failed.
- Hostile same-sender collision regression: 2,000 rows resolved in 7,996 indexed probes; randomized differential checks matched the scan oracle.
- Dedicated Rust XEP-0359 websocket suite: 7 passed, 0 failed.
- Astro check: 0 errors, 0 warnings (4 pre-existing hints).
- Astro build: passed.
- Knip/lint: clean.
- Rust formatting and `git diff --check`: clean.
- Final adversarial XEP/security review: clean.
- Final independent spec-axis review: clean.

## Review fixes already incorporated

- Distinct room-authored IDs now dominate aliases even when the same occupant reuses an ID.
- MAM/bootstrap promotion now adopts canonical room ID and protocol metadata for optimistic rows.
- Different explicit occupant JIDs fail before bare-real-JID continuity, covering same-account multi-resource occupants.
- Anonymous nick reuse cannot collapse distinct room-stamped messages.
- Real bare JIDs are case-normalized before continuity comparison.
- Legacy sender JIDs use the same repository equality key in both the scan oracle and optimized index.
- Rows with no occupant, real, or author JID fail closed instead of matching on display nick alone.
- Canonical MAM promotion retains `authorOccupantJid` for later sender-gated actions.
- Repeated MAM reconciliation uses a collision-preserving sender index instead of timeline scans.
- Duplicate row references preserve fail-closed multiplicity, and replacement churn prunes empty canonical partitions.
- Dedicated Rust helpers carry typed envelope, origin, stanza, and JID identities to the XML boundary.
- XEP-0308 corrections and direct-message XEP-0424 retractions scope alias resolution by verified sender before ambiguity checks, while duplicate aliases inside one sender remain fail-closed.
- Live and MAM correction paths refuse to repopulate a retracted tombstone.

## Merge gate

Do not merge until CI is green, Greptile succeeds on the final SHA, Qodo reports zero actionable findings on the final revision, and no review thread remains unresolved.

## Lore commit record

Constraint: Sender-selected MUC envelope and origin IDs are untrusted; only a room-authored XEP-0359 stanza ID plus verified sender continuity can establish timeline identity.

Rejected: Globally deduplicate sender-selected IDs | a malicious occupant can reuse another occupant's ID and suppress that message.

Rejected: Fall back to display nick when occupant/JID evidence is missing | nick reuse and spoofing make that identity non-authoritative.

Confidence: high

Scope-risk: moderate

Reversibility: clean

Directive: Keep sender aliases scoped to verified occupant identity and preserve fail-closed multiplicity; never make a sender-selected ID the room timeline primary key.

Tested: Full chat 3359; focused hostile-identity/mutation/MAM 158; 80000-state randomized oracle; dedicated XEP-0359 websocket 7; Knip; Astro check/build; Rust formatting; final-head CI/Greptile/Qodo required again after the latest revision.

Not-tested: Live hostile-client interoperability against a third-party MUC service.
