### PR TITLE
fix(xmpp): make mediated-invite grants actor-atomic

### DIFF
--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -1716,6 +1716,9 @@ fn apply_channel_type(config: &mut RoomConfig, channel_type: ChannelType) {
     config.group_dm = matches!(channel_type, ChannelType::GroupDm);
     config.forum = matches!(channel_type, ChannelType::Forum);
     config.moderated = matches!(channel_type, ChannelType::Announcement);
+    if config.group_dm {
+        config.members_only = true;
+    }
 }
 
 async fn upsert_channel_catalog(
@@ -2009,7 +2012,7 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
         topic: args.topic.clone(),
         channel_type: args.channel_type,
         is_public: args.is_public,
-        members_only,
+        members_only: config.members_only,
     })
 }
 
@@ -3084,25 +3087,26 @@ async fn run_update(
         None
     };
 
-    let members_only_enforcement_affiliations = if !existing.members_only && new_members_only {
-        let snapshot = actor
-            .ask(waddle_xmpp::muc::room_actor::GetSnapshot)
-            .await
-            .map_err(send_err("room actor GetSnapshot"))?;
-        let occupant_jids: Vec<BareJid> = snapshot
-            .room
-            .occupants
-            .values()
-            .map(|occupant| occupant.real_jid.to_bare())
-            .collect();
-        Some(
-            explicit_channel_affiliations_for_jids(state, &channel_id, occupant_jids)
+    let members_only_enforcement_affiliations =
+        if !existing.requires_membership() && updated.requires_membership() {
+            let snapshot = actor
+                .ask(waddle_xmpp::muc::room_actor::GetSnapshot)
                 .await
-                .map_err(internal_err)?,
-        )
-    } else {
-        None
-    };
+                .map_err(send_err("room actor GetSnapshot"))?;
+            let occupant_jids: Vec<BareJid> = snapshot
+                .room
+                .occupants
+                .values()
+                .map(|occupant| occupant.real_jid.to_bare())
+                .collect();
+            Some(
+                explicit_channel_affiliations_for_jids(state, &channel_id, occupant_jids)
+                    .await
+                    .map_err(internal_err)?,
+            )
+        } else {
+            None
+        };
 
     let expected_revision = actor
         .ask(UpdateConfig {
@@ -3182,7 +3186,7 @@ async fn run_update(
         topic: new_topic,
         channel_type: new_channel_type,
         is_public: new_public_room,
-        members_only: new_members_only,
+        members_only: updated.members_only,
     })
 }
 
@@ -4357,6 +4361,19 @@ mod tests {
             channel_type_from_catalog_or_config(Some(&record), &config),
             ChannelType::Announcement
         );
+    }
+
+    #[test]
+    fn group_dm_channel_type_forces_members_only_config() {
+        let mut config = RoomConfig {
+            members_only: false,
+            ..RoomConfig::default()
+        };
+
+        apply_channel_type(&mut config, ChannelType::GroupDm);
+
+        assert!(config.group_dm);
+        assert!(config.members_only);
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_config.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_config.rs
@@ -51,6 +51,7 @@ pub(super) fn project_channel_type_to_config(
         waddle_xmpp::ChannelType::GroupDm => {
             config.group_dm = true;
             config.forum = false;
+            config.members_only = true;
         }
     }
 }
@@ -382,5 +383,18 @@ mod channel_type_projection_tests {
         assert!(!config.group_dm);
         assert!(!config.forum);
         assert!(config.moderated);
+    }
+
+    #[test]
+    fn group_dm_projection_forces_members_only() {
+        let mut config = waddle_xmpp::muc::RoomConfig {
+            members_only: false,
+            ..waddle_xmpp::muc::RoomConfig::default()
+        };
+
+        project_channel_type_to_config(&mut config, waddle_xmpp::ChannelType::GroupDm);
+
+        assert!(config.group_dm);
+        assert!(config.members_only);
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -5972,6 +5972,16 @@ async fn xep0045_destroy_group_dm_revokes_member_permission_tuples() {
     crate::admin::channels::persist_group_dm_member_tuple(
         &state.deps.app_state,
         "destroy-gdm",
+        &owner_session
+            .user_jid
+            .parse()
+            .expect("owner-session permission principal"),
+    )
+    .await
+    .expect("seed alice member tuple");
+    crate::admin::channels::persist_group_dm_member_tuple(
+        &state.deps.app_state,
+        "destroy-gdm",
         &bob,
     )
     .await

--- a/server/crates/waddle-server/src/server/xmpp_channels.rs
+++ b/server/crates/waddle-server/src/server/xmpp_channels.rs
@@ -71,20 +71,38 @@ fn db_bool(row: &crate::db::actor::RowValues, index: usize, name: &str) -> Resul
     }
 }
 
+fn effective_members_only(channel_type: &str, members_only: bool) -> bool {
+    members_only
+        || matches!(
+            waddle_xmpp::ChannelType::parse(channel_type),
+            Some(waddle_xmpp::ChannelType::GroupDm)
+        )
+}
+
+fn canonical_channel_type(channel_type: &str) -> &str {
+    match waddle_xmpp::ChannelType::parse(channel_type) {
+        Some(channel_type) => channel_type.as_str(),
+        None => channel_type,
+    }
+}
+
 fn parse_channel_record(row: &crate::db::actor::RowValues) -> Result<XmppChannelRecord, String> {
     let pin_permission_raw = db_string(row, 6, "pin_permission")?;
     let pin_permission = PinPermission::from_form_value(&pin_permission_raw).ok_or_else(|| {
         format!("Failed to get pin_permission: unexpected value {pin_permission_raw:?}")
     })?;
+    let raw_channel_type = db_string(row, 3, "channel_type")?;
+    let channel_type = canonical_channel_type(&raw_channel_type).to_string();
+    let members_only = effective_members_only(&channel_type, db_bool(row, 9, "members_only")?);
     Ok(XmppChannelRecord {
         id: db_string(row, 0, "id")?,
         name: db_string(row, 1, "name")?,
         description: db_optional_string(row, 2, "description")?,
-        channel_type: db_string(row, 3, "channel_type")?,
+        channel_type,
         position: db_i32(row, 4, "position")?,
         is_default: db_bool(row, 5, "is_default")?,
         pin_permission,
-        members_only: db_bool(row, 9, "members_only")?,
+        members_only,
         public_room: db_bool(row, 10, "public_room")?,
         created_at: db_string(row, 7, "created_at")?,
         updated_at: db_optional_string(row, 8, "updated_at")?,
@@ -138,6 +156,8 @@ pub(crate) async fn upsert_xmpp_channel(
     channel: &XmppChannelUpsert,
 ) -> Result<(), String> {
     let now = chrono::Utc::now().to_rfc3339();
+    let channel_type = canonical_channel_type(&channel.channel_type);
+    let members_only = effective_members_only(channel_type, channel.members_only);
     actor
         .ask(DbExecute {
             sql: r#"
@@ -162,11 +182,11 @@ pub(crate) async fn upsert_xmpp_channel(
                 channel.id.clone().into(),
                 channel.name.clone().into(),
                 channel.description.clone().into(),
-                channel.channel_type.clone().into(),
+                channel_type.into(),
                 (channel.position as i64).into(),
                 channel.is_default.into(),
                 channel.pin_permission.as_form_value().into(),
-                channel.members_only.into(),
+                members_only.into(),
                 channel.public_room.into(),
                 now.clone().into(),
                 now.into(),
@@ -189,4 +209,96 @@ pub(crate) async fn delete_xmpp_channel(
         .await
         .map_err(|e| format!("Failed to delete channel: {e}"))?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        effective_members_only, parse_channel_record, upsert_xmpp_channel, PinPermission,
+        XmppChannelUpsert,
+    };
+    use crate::db::actor::DbQueryOne;
+    use crate::db::{DatabaseConfig, DatabasePool, MigrationRunner, PoolConfig};
+
+    #[test]
+    fn group_dm_catalog_rows_are_members_only_even_if_stored_flag_is_false() {
+        assert!(effective_members_only(
+            waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM,
+            false,
+        ));
+        assert!(effective_members_only(" group-dm", false));
+        assert!(effective_members_only("group-dm ", false));
+        assert!(!effective_members_only("text", false));
+        assert!(effective_members_only("text", true));
+    }
+
+    #[test]
+    fn catalog_read_canonicalizes_recognized_channel_types() {
+        let row = vec![
+            crate::db::Value::Text("group".to_string()),
+            crate::db::Value::Text("Group".to_string()),
+            crate::db::Value::NullText,
+            crate::db::Value::Text(" group-dm ".to_string()),
+            crate::db::Value::Integer(0),
+            crate::db::Value::Integer(0),
+            crate::db::Value::Text("admins-only".to_string()),
+            crate::db::Value::Text("2026-07-14T00:00:00Z".to_string()),
+            crate::db::Value::NullText,
+            crate::db::Value::Integer(0),
+            crate::db::Value::Integer(0),
+        ];
+
+        let record = parse_channel_record(&row).expect("catalog row");
+
+        assert_eq!(
+            record.channel_type,
+            waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM,
+        );
+        assert!(record.members_only);
+    }
+
+    #[tokio::test]
+    async fn catalog_write_persists_canonical_group_dm_type() {
+        let db_pool = DatabasePool::new(DatabaseConfig::default(), PoolConfig)
+            .await
+            .expect("db pool");
+        MigrationRunner::global()
+            .run(db_pool.global())
+            .await
+            .expect("migrations");
+        let db_actor = db_pool.global_actor().clone();
+        upsert_xmpp_channel(
+            db_actor.clone(),
+            &XmppChannelUpsert {
+                id: "group".to_string(),
+                name: "Group".to_string(),
+                description: None,
+                channel_type: " group-dm ".to_string(),
+                position: 0,
+                is_default: false,
+                pin_permission: PinPermission::AdminsOnly,
+                members_only: false,
+                public_room: false,
+            },
+        )
+        .await
+        .expect("catalog upsert");
+
+        let row = db_actor
+            .ask(DbQueryOne {
+                sql: "SELECT channel_type, members_only FROM channels WHERE id = ?".to_string(),
+                params: vec!["group".into()],
+            })
+            .await
+            .expect("catalog query")
+            .expect("catalog row");
+
+        assert_eq!(
+            row,
+            vec![
+                waddle_xmpp::admin::CHANNEL_TYPE_GROUP_DM.into(),
+                true.into(),
+            ],
+        );
+    }
 }

--- a/server/crates/waddle-xmpp/src/muc/room.rs
+++ b/server/crates/waddle-xmpp/src/muc/room.rs
@@ -125,6 +125,24 @@ pub struct RoomConfig {
     pub federated_affiliation_config: FederatedAffiliationConfig,
 }
 
+impl RoomConfig {
+    /// Whether admission requires at least Member affiliation.
+    ///
+    /// Group DMs are always membership-scoped, even if an untrusted or
+    /// legacy config payload carries a false `members_only` flag.
+    pub const fn requires_membership(&self) -> bool {
+        self.members_only || self.group_dm
+    }
+
+    /// Restore the invariant that every group DM is members-only.
+    pub fn normalized(mut self) -> Self {
+        if self.group_dm {
+            self.members_only = true;
+        }
+        self
+    }
+}
+
 impl Default for RoomConfig {
     fn default() -> Self {
         Self {
@@ -262,7 +280,7 @@ impl MucRoom {
             room_jid,
             waddle_id,
             channel_id,
-            config,
+            config: config.normalized(),
             subject: None,
             occupants: HashMap::new(),
             occupant_sessions: HashMap::new(),

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 use jid::{BareJid, FullJid};
 use kameo::message::Context;
 use kameo::Actor;
-use std::convert::Infallible;
+use std::{collections::HashMap, convert::Infallible};
 use thiserror::Error;
 
 use super::affiliation::AffiliationEntry;
@@ -18,14 +18,24 @@ use super::{MucRoom, RoomConfig, RoomSubjectTexts, SubjectState};
 use crate::types::{Affiliation, Role};
 
 mod admin_handlers;
+mod mediated_invites;
 mod occupancy_handlers;
 mod snapshot_handlers;
 #[cfg(test)]
 mod tests;
 
 pub use admin_handlers::{
-    ApplyAdminItems, ApplyAffiliationChange, EnforceMembersOnly, EnforceMembersOnlyAffiliations,
-    GetAdminContext, IsOwner,
+    AdminItemsApplied, ApplyAdminItems, ApplyAffiliationChange, EnforceMembersOnly,
+    EnforceMembersOnlyAffiliations, GetAdminContext, IsOwner,
+};
+use mediated_invites::MediatedInviteOperationRecord;
+pub use mediated_invites::{
+    AbortMediatedInviteGrantRollback, AcknowledgeMediatedInviteOperation, AuthorizeMediatedInvite,
+    CommitMediatedInviteGrantRollback, FinalizeMediatedInviteGrant, InviteMembershipGrant,
+    MediatedInviteAuthorized, MediatedInviteGrantError, MediatedInviteGrantFinalization,
+    MediatedInviteOperationAcknowledgement, MediatedInviteOperationId, MediatedInviteRollbackAbort,
+    MediatedInviteRollbackCommit, MediatedInviteRollbackError, MediatedInviteRollbackPreparation,
+    PrepareMediatedInviteGrantRollback,
 };
 pub use occupancy_handlers::{
     ClearMujiPresence, InCallPresenceUpdateOutcome, JoinAffiliationGrant, JoinWithAffiliation,
@@ -150,6 +160,8 @@ pub enum AdminApplyError {
     CannotAdminModifyOwner,
     #[error("admins and moderators cannot change an owner or admin role")]
     CannotModifyPrivilegedRole,
+    #[error("invitee affiliation is fenced pending invite rollback acknowledgement")]
+    InviteRollbackPending,
     #[error("{0}")]
     PermissionDenied(String),
     /// ADR-0017 Phase 3 Slice 7 FIX 2 (council-adjudicated): the
@@ -223,6 +235,35 @@ pub enum RoomMutationError {
     PersistFailed(String),
 }
 
+/// Failure from an affiliation mutation that can collide with an
+/// in-progress mediated-invite compensation.
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum AffiliationMutationError {
+    #[error("this room's ownership has moved to another node")]
+    NotOwner,
+    #[error("durable persist failed after the in-memory mutation committed: {0}")]
+    PersistFailed(String),
+    #[error("invitee affiliation is fenced pending invite rollback acknowledgement")]
+    InviteRollbackPending,
+}
+
+impl From<RoomMutationError> for AffiliationMutationError {
+    fn from(error: RoomMutationError) -> Self {
+        match error {
+            RoomMutationError::NotOwner => Self::NotOwner,
+            RoomMutationError::PersistFailed(detail) => Self::PersistFailed(detail),
+        }
+    }
+}
+
+impl From<DurablePersistError> for AffiliationMutationError {
+    fn from(error: DurablePersistError) -> Self {
+        match error {
+            DurablePersistError::Failed(detail) => Self::PersistFailed(detail),
+        }
+    }
+}
+
 /// FIX 2: typed outcome of a best-effort durable `save_*` call inside
 /// [`RoomActor::persist_config`]/[`RoomActor::persist_subject`]/
 /// [`RoomActor::persist_affiliation`]. Wraps the underlying
@@ -268,6 +309,8 @@ pub struct RoomActor {
     room: MucRoom,
     config_revision: u64,
     admission_revision: u64,
+    invite_operations: HashMap<MediatedInviteOperationId, MediatedInviteOperationRecord>,
+    invite_operation_by_invitee: HashMap<BareJid, MediatedInviteOperationId>,
     /// Monotonically increasing counter bumped on every successful
     /// admission (#1108). The dormancy probe ([`IsDormant`]) returns
     /// it and the registry's guarded destroy
@@ -357,6 +400,8 @@ pub enum RoomActorError {
     JoinForbidden { reason: JoinDenialReason },
     #[error("join admission snapshot is stale")]
     StaleAdmissionRevision,
+    #[error("join is blocked pending invite membership rollback acknowledgement")]
+    InviteRollbackPending,
     /// #1108: this room actor was sealed by the registry's guarded
     /// destroy and is about to be dropped. Retryable — the caller must
     /// re-run the registry lookup, which respawns the room.
@@ -405,11 +450,17 @@ pub enum RoomActorError {
 
 impl RoomActor {
     /// Create a new `RoomActor` wrapping the given room.
-    pub fn new(room: MucRoom, occupant_id_secret: crate::xep::xep0421::OccupantIdSecret) -> Self {
+    pub fn new(
+        mut room: MucRoom,
+        occupant_id_secret: crate::xep::xep0421::OccupantIdSecret,
+    ) -> Self {
+        room.config = room.config.normalized();
         Self {
             room,
             config_revision: 0,
             admission_revision: 0,
+            invite_operations: HashMap::new(),
+            invite_operation_by_invitee: HashMap::new(),
             occupancy_revision: 0,
             sealed: false,
             occupant_id_secret,
@@ -488,7 +539,7 @@ impl RoomActor {
             Ok(Some(state)) => {
                 self.room.waddle_id = state.waddle_id;
                 self.room.channel_id = state.channel_id;
-                self.room.config = state.config;
+                self.replace_config(state.config);
                 self.room.subject = state.subject;
                 self.room.restore_affiliations(state.affiliations);
                 self.restore_state = DurableRestoreState::Ready;
@@ -538,6 +589,11 @@ impl RoomActor {
                 );
                 DurablePersistError::Failed(error.to_string())
             })
+    }
+
+    /// Replace config only after restoring cross-field privacy invariants.
+    fn replace_config(&mut self, config: RoomConfig) {
+        self.room.config = config.normalized();
     }
 
     /// Best-effort durable persist of the current subject. See
@@ -759,7 +815,7 @@ impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
             Ok(Some(state)) => {
                 self.room.waddle_id = state.waddle_id;
                 self.room.channel_id = state.channel_id;
-                self.room.config = state.config;
+                self.replace_config(state.config);
                 self.room.subject = state.subject;
                 self.room.restore_affiliations(state.affiliations);
                 self.restore_state = DurableRestoreState::Ready;
@@ -812,6 +868,9 @@ impl kameo::message::Message<Join> for RoomActor {
     async fn handle(&mut self, msg: Join, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
         if self.sealed {
             return Err(RoomActorError::RoomSealed);
+        }
+        if self.invite_rollback_pending(&msg.real_jid.to_bare()) {
+            return Err(RoomActorError::InviteRollbackPending);
         }
         if self.room.is_full() && !affiliation_overflows_full_room(msg.affiliation) {
             return Err(RoomActorError::RoomFull);
@@ -934,7 +993,7 @@ impl kameo::message::Message<UpdateConfig> for RoomActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         self.gate_mutation().await?;
-        self.room.config = msg.config;
+        self.replace_config(msg.config);
         self.config_revision = self.config_revision.saturating_add(1);
         self.admission_revision = self.admission_revision.saturating_add(1);
         self.persist_config().await?;
@@ -962,7 +1021,7 @@ impl kameo::message::Message<RollbackConfigIfRevision> for RoomActor {
             return Ok(false);
         }
         self.gate_mutation().await?;
-        self.room.config = msg.config;
+        self.replace_config(msg.config);
         self.config_revision = self.config_revision.saturating_add(1);
         self.admission_revision = self.admission_revision.saturating_add(1);
         self.persist_config().await?;
@@ -1042,7 +1101,9 @@ impl kameo::message::Message<UpdateGroupDmConfigByMember> for RoomActor {
             return Err(UpdateGroupDmConfigByMemberError::NotOccupant);
         }
         self.gate_mutation().await?;
-        self.room.config = msg.config;
+        let mut config = msg.config;
+        config.group_dm = true;
+        self.replace_config(config);
         self.config_revision = self.config_revision.saturating_add(1);
         self.admission_revision = self.admission_revision.saturating_add(1);
         self.persist_config().await?;
@@ -1136,7 +1197,7 @@ pub struct ChangeAffiliation {
 }
 
 impl kameo::message::Message<ChangeAffiliation> for RoomActor {
-    type Reply = Result<(), RoomMutationError>;
+    type Reply = Result<(), AffiliationMutationError>;
 
     async fn handle(
         &mut self,
@@ -1144,6 +1205,10 @@ impl kameo::message::Message<ChangeAffiliation> for RoomActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         self.gate_mutation().await?;
+        if self.invite_rollback_pending(&msg.jid) {
+            return Err(AffiliationMutationError::InviteRollbackPending);
+        }
+        self.invalidate_invite_grant(&msg.jid);
         let needs_rehydration = self.prune_durable_recipient_if_removed(&msg.jid, msg.affiliation);
         if self
             .room
@@ -1292,7 +1357,13 @@ impl kameo::message::Message<IsDormant> for RoomActor {
             // reply timed out (explicit creator-Owner grant keeps
             // `is_dormant()` false) would never be re-confirmed by the
             // janitor — a permanently unjoinable registered room.
-            dormant: self.sealed || self.room.is_dormant(),
+            // Completed and no-grant operation records are replay metadata,
+            // not live room state. An unresolved temporary grant still owns
+            // compensation responsibility and must survive both lifecycle
+            // guards (the Dormant guard is also protected by the explicit
+            // Member affiliation itself).
+            dormant: self.sealed
+                || (self.room.is_dormant() && !self.has_lifecycle_fenced_invite_operation()),
             occupancy_revision: self.occupancy_revision,
         }
     }
@@ -1358,12 +1429,13 @@ impl kameo::message::Message<SealIfInactive> for RoomActor {
         if self.occupancy_revision != msg.expected_occupancy_revision {
             return false;
         }
-        let inactive = match msg.guard {
-            SealGuard::Dormant => self.room.is_dormant(),
-            SealGuard::EmptyNonPersistent => {
-                self.room.occupants.is_empty() && !self.room.config.persistent
-            }
-        };
+        let inactive = !self.has_lifecycle_fenced_invite_operation()
+            && match msg.guard {
+                SealGuard::Dormant => self.room.is_dormant(),
+                SealGuard::EmptyNonPersistent => {
+                    self.room.occupants.is_empty() && !self.room.config.persistent
+                }
+            };
         if inactive {
             self.sealed = true;
         }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
@@ -75,7 +75,7 @@ fn removal_presence_updates(
         .collect()
 }
 
-fn apply_affiliation_change(
+pub(super) fn apply_affiliation_change(
     room: &mut MucRoom,
     occupant_id_secret: &OccupantIdSecret,
     target_jid: BareJid,
@@ -339,7 +339,7 @@ pub struct ApplyAdminItems {
 /// participation — Membership-scoped visibility says a call is only
 /// joinable (and stayable) by current occupants. Voluntary leaves and
 /// presence loss never appear here.
-#[derive(Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AdminItemsApplied {
     pub presence_updates: Vec<(FullJid, Presence)>,
     pub removed_by_moderation: Vec<FullJid>,
@@ -358,6 +358,15 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
         // are applied — a `NotOwner` here means NONE of this ask's items
         // were applied (the gate runs before the first mutation below).
         self.gate_mutation().await?;
+        if msg.items.iter().any(|item| {
+            item.affiliation.is_some()
+                && item
+                    .jid
+                    .as_ref()
+                    .is_some_and(|jid| self.invite_rollback_pending(jid))
+        }) {
+            return Err(AdminApplyError::InviteRollbackPending);
+        }
         let mut presence_updates: Vec<(FullJid, Presence)> = Vec::new();
         let mut removed_by_moderation: Vec<FullJid> = Vec::new();
         // FIX 2: a persist failure partway through this batch must not
@@ -582,6 +591,7 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                 {
                     return Err(AdminApplyError::CannotAdminModifyOwner);
                 }
+                self.invalidate_invite_grant(&target_jid);
                 let actor = msg.sender_jid.to_bare();
                 let applied = apply_affiliation_change(
                     &mut self.room,
@@ -640,7 +650,11 @@ impl kameo::message::Message<ApplyAffiliationChange> for RoomActor {
     ) -> Self::Reply {
         // ADR-0017 Phase 3 Slice 7 FIX 2: verify ownership BEFORE mutating.
         self.gate_mutation().await?;
+        if self.invite_rollback_pending(&msg.jid) {
+            return Err(AdminApplyError::InviteRollbackPending);
+        }
         let previous_affiliation = self.room.get_affiliation(&msg.jid);
+        self.invalidate_invite_grant(&msg.jid);
         let updates = apply_affiliation_change(
             &mut self.room,
             &self.occupant_id_secret,
@@ -680,7 +694,7 @@ pub struct EnforceMembersOnlyAffiliations {
 }
 
 impl kameo::message::Message<EnforceMembersOnlyAffiliations> for RoomActor {
-    type Reply = Result<Vec<(FullJid, Presence)>, super::RoomMutationError>;
+    type Reply = Result<Vec<(FullJid, Presence)>, super::AffiliationMutationError>;
 
     async fn handle(
         &mut self,
@@ -697,6 +711,12 @@ impl kameo::message::Message<EnforceMembersOnlyAffiliations> for RoomActor {
             .values()
             .map(|occupant| occupant.real_jid.to_bare())
             .collect();
+        if occupied_jids
+            .iter()
+            .any(|jid| self.invite_rollback_pending(jid))
+        {
+            return Err(super::AffiliationMutationError::InviteRollbackPending);
+        }
         let mut needs_rehydration = false;
         // FIX 2: same batch-persist-failure handling as `ApplyAdminItems`
         // — don't abort mid-loop (earlier iterations already mutated
@@ -705,6 +725,7 @@ impl kameo::message::Message<EnforceMembersOnlyAffiliations> for RoomActor {
         let mut persist_failure: Option<super::DurablePersistError> = None;
         for jid in occupied_jids {
             let affiliation = affiliations.get(&jid).copied().unwrap_or(Affiliation::None);
+            self.invalidate_invite_grant(&jid);
             needs_rehydration |= self.prune_durable_recipient_if_removed(&jid, affiliation);
             if self
                 .room

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites.rs
@@ -78,6 +78,8 @@ pub enum MediatedInviteGrantError {
     NotOccupant,
     #[error("the inviter may not invite users under this room's policy")]
     Forbidden,
+    #[error("the invitee is banned from this room")]
+    InviteeBanned,
     #[error("the invitee is already a member of this group DM")]
     InviteeAlreadyMember,
     #[error("another mediated invite owns a temporary membership grant for this invitee")]

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites.rs
@@ -1,0 +1,241 @@
+use super::*;
+
+mod authorization;
+mod completion;
+mod rollback;
+
+pub use authorization::AuthorizeMediatedInvite;
+pub use completion::{AcknowledgeMediatedInviteOperation, FinalizeMediatedInviteGrant};
+pub use rollback::{
+    AbortMediatedInviteGrantRollback, CommitMediatedInviteGrantRollback,
+    PrepareMediatedInviteGrantRollback,
+};
+
+/// Maximum actor-local idempotency and rollback records retained for one room.
+///
+/// Records are never evicted while the actor remains alive: forgetting a known
+/// id would let a delayed retry be re-authorized under changed room policy.
+/// Once the bound is full, known ids still replay and new ids fail closed until
+/// a caller acknowledges one or an otherwise safe room eviction drops the
+/// actor-local replay cache.
+pub(super) const MAX_RETAINED_MEDIATED_INVITE_OPERATIONS: usize = 256;
+
+/// Caller-chosen idempotency key for one mediated-invite operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MediatedInviteOperationId(uuid::Uuid);
+
+impl MediatedInviteOperationId {
+    pub const fn new(id: uuid::Uuid) -> Self {
+        Self(id)
+    }
+
+    pub fn generate() -> Self {
+        Self(uuid::Uuid::now_v7())
+    }
+
+    pub const fn as_uuid(self) -> uuid::Uuid {
+        self.0
+    }
+}
+
+/// Opaque authority to compensate the exact temporary membership grant
+/// created by one mediated-invite authorization turn.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InviteMembershipGrant {
+    operation_id: MediatedInviteOperationId,
+    invitee: BareJid,
+    previous_affiliation: Affiliation,
+}
+
+impl InviteMembershipGrant {
+    pub fn operation_id(&self) -> MediatedInviteOperationId {
+        self.operation_id
+    }
+
+    pub fn invitee(&self) -> &BareJid {
+        &self.invitee
+    }
+
+    pub fn previous_affiliation(&self) -> Affiliation {
+        self.previous_affiliation
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MediatedInviteAuthorized {
+    pub grant: Option<InviteMembershipGrant>,
+    pub invitee_affiliation: Affiliation,
+    pub members_only: bool,
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum MediatedInviteGrantError {
+    #[error("the mediated-invite operation id was already used with different inputs")]
+    OperationMismatch,
+    #[error("the room actor is sealed pending destruction")]
+    RoomSealed,
+    #[error("the inviter is not an occupant of this room")]
+    NotOccupant,
+    #[error("the inviter may not invite users under this room's policy")]
+    Forbidden,
+    #[error("the invitee is already a member of this group DM")]
+    InviteeAlreadyMember,
+    #[error("another mediated invite owns a temporary membership grant for this invitee")]
+    GrantPending,
+    #[error("durable room-state restore has not yet completed; retry")]
+    RestorePending,
+    #[error("the temporary membership grant could not be persisted before commit: {0}")]
+    GrantPersistFailed(#[source] DurablePersistError),
+    #[error("the room has too many unresolved mediated-invite operations")]
+    OperationCapacityReached,
+    #[error(transparent)]
+    Mutation(#[from] RoomMutationError),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediatedInviteRollbackPreparation {
+    Prepared,
+    /// The rollback committed, but its exact output is still cached and unacknowledged.
+    ///
+    /// Callers must replay [`CommitMediatedInviteGrantRollback`], deliver the
+    /// returned effects, and only then send [`AcknowledgeMediatedInviteOperation`].
+    AlreadyRolledBack,
+    Superseded,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum MediatedInviteRollbackCommit {
+    Applied {
+        previous_affiliation: Affiliation,
+        updates: AdminItemsApplied,
+    },
+    Superseded,
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum MediatedInviteRollbackError {
+    #[error("this room's ownership has moved to another node")]
+    NotOwner,
+    #[error("the invite rollback could not be persisted before it was applied: {0}")]
+    PersistFailedBeforeApply(#[source] DurablePersistError),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
+pub enum MediatedInviteRollbackAbort {
+    Aborted,
+    NotPrepared,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
+pub enum MediatedInviteGrantFinalization {
+    Finalized,
+    RollbackPending,
+    Superseded,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
+pub enum MediatedInviteOperationAcknowledgement {
+    Acknowledged,
+    Pending,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MediatedInviteOperationCompletion {
+    Completed,
+    NoGrantRequired,
+    Superseded,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum MediatedInviteOperationState {
+    Active,
+    Prepared,
+    RolledBackUnacknowledged(MediatedInviteRollbackCommit),
+    Finalized(MediatedInviteOperationCompletion),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct MediatedInviteOperationRecord {
+    inviter: FullJid,
+    invitee: BareJid,
+    authorization: MediatedInviteAuthorized,
+    state: MediatedInviteOperationState,
+}
+
+impl RoomActor {
+    pub(super) fn has_lifecycle_fenced_invite_operation(&self) -> bool {
+        self.invite_operations.values().any(|record| {
+            matches!(
+                &record.state,
+                MediatedInviteOperationState::Prepared
+                    | MediatedInviteOperationState::Active
+                    | MediatedInviteOperationState::RolledBackUnacknowledged(_)
+            ) && record.authorization.grant.is_some()
+        })
+    }
+
+    fn has_invite_operation_capacity(&self) -> bool {
+        self.invite_operations.len() < MAX_RETAINED_MEDIATED_INVITE_OPERATIONS
+    }
+
+    fn invite_grant_is_active(&self, grant: &InviteMembershipGrant) -> bool {
+        self.invite_operations
+            .get(&grant.operation_id)
+            .is_some_and(|record| {
+                record.authorization.grant.as_ref() == Some(grant)
+                    && record.state == MediatedInviteOperationState::Active
+            })
+    }
+
+    fn invite_rollback_is_prepared(&self, grant: &InviteMembershipGrant) -> bool {
+        self.invite_operations
+            .get(&grant.operation_id)
+            .is_some_and(|record| {
+                record.authorization.grant.as_ref() == Some(grant)
+                    && record.state == MediatedInviteOperationState::Prepared
+            })
+    }
+
+    pub(super) fn invite_rollback_pending(&self, jid: &BareJid) -> bool {
+        self.invite_operation_by_invitee
+            .get(jid)
+            .and_then(|operation_id| self.invite_operations.get(operation_id))
+            .is_some_and(|record| {
+                matches!(
+                    record.state,
+                    MediatedInviteOperationState::Prepared
+                        | MediatedInviteOperationState::RolledBackUnacknowledged(_)
+                )
+            })
+    }
+
+    fn release_invitee_operation(
+        &mut self,
+        invitee: &BareJid,
+        operation_id: MediatedInviteOperationId,
+    ) {
+        if self.invite_operation_by_invitee.get(invitee) == Some(&operation_id) {
+            self.invite_operation_by_invitee.remove(invitee);
+        }
+    }
+
+    pub(super) fn invalidate_invite_grant(&mut self, jid: &BareJid) {
+        let Some(operation_id) = self.invite_operation_by_invitee.get(jid).copied() else {
+            return;
+        };
+        let Some(record) = self.invite_operations.get(&operation_id) else {
+            self.invite_operation_by_invitee.remove(jid);
+            return;
+        };
+        if record.state != MediatedInviteOperationState::Active {
+            return;
+        }
+        self.invite_operations
+            .get_mut(&operation_id)
+            .expect("record was just observed")
+            .state =
+            MediatedInviteOperationState::Finalized(MediatedInviteOperationCompletion::Superseded);
+        self.release_invitee_operation(jid, operation_id);
+    }
+}

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/authorization.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/authorization.rs
@@ -1,0 +1,114 @@
+use super::*;
+
+pub struct AuthorizeMediatedInvite {
+    pub operation_id: MediatedInviteOperationId,
+    pub inviter: FullJid,
+    pub invitee: BareJid,
+}
+
+impl kameo::message::Message<AuthorizeMediatedInvite> for RoomActor {
+    type Reply = Result<MediatedInviteAuthorized, MediatedInviteGrantError>;
+
+    async fn handle(
+        &mut self,
+        msg: AuthorizeMediatedInvite,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if let Some(record) = self.invite_operations.get(&msg.operation_id) {
+            return if record.inviter == msg.inviter && record.invitee == msg.invitee {
+                Ok(record.authorization.clone())
+            } else {
+                Err(MediatedInviteGrantError::OperationMismatch)
+            };
+        }
+        if self.sealed {
+            return Err(MediatedInviteGrantError::RoomSealed);
+        }
+        self.gate_mutation().await?;
+        if self.ensure_restored_before_join().await.is_err() {
+            return Err(MediatedInviteGrantError::RestorePending);
+        }
+        if self.room.find_nick_by_real_jid(&msg.inviter).is_none() {
+            return Err(MediatedInviteGrantError::NotOccupant);
+        }
+        let inviter_affiliation = self.room.get_affiliation(&msg.inviter.to_bare());
+        let lacks_required_affiliation = if self.room.config.group_dm {
+            inviter_affiliation < Affiliation::Member
+        } else if self.room.config.members_only {
+            inviter_affiliation < Affiliation::Admin
+        } else {
+            false
+        };
+        if lacks_required_affiliation {
+            return Err(MediatedInviteGrantError::Forbidden);
+        }
+        let membership_grant_is_relevant = self.room.config.requires_membership();
+        if membership_grant_is_relevant
+            && self.invite_operation_by_invitee.contains_key(&msg.invitee)
+        {
+            return Err(MediatedInviteGrantError::GrantPending);
+        }
+        let previous_affiliation = self.room.get_affiliation(&msg.invitee);
+        if self.room.config.group_dm && previous_affiliation >= Affiliation::Member {
+            return Err(MediatedInviteGrantError::InviteeAlreadyMember);
+        }
+        if !self.has_invite_operation_capacity() {
+            return Err(MediatedInviteGrantError::OperationCapacityReached);
+        }
+        let authorization = if !membership_grant_is_relevant {
+            MediatedInviteAuthorized {
+                grant: None,
+                invitee_affiliation: previous_affiliation,
+                members_only: false,
+            }
+        } else if previous_affiliation >= Affiliation::Member {
+            MediatedInviteAuthorized {
+                grant: None,
+                invitee_affiliation: previous_affiliation,
+                members_only: true,
+            }
+        } else {
+            // The durable affiliation is authoritative across actor restarts.
+            // Persist first; only a successful write permits the infallible
+            // in-memory transition and creation of rollback authority.
+            self.persist_affiliation(&msg.invitee, Affiliation::Member)
+                .await
+                .map_err(MediatedInviteGrantError::GrantPersistFailed)?;
+            let changed = self
+                .room
+                .set_affiliation(msg.invitee.clone(), Affiliation::Member);
+            debug_assert!(changed.is_some(), "a below-Member affiliation must change");
+            self.admission_revision = self.admission_revision.saturating_add(1);
+            MediatedInviteAuthorized {
+                grant: Some(InviteMembershipGrant {
+                    operation_id: msg.operation_id,
+                    invitee: msg.invitee.clone(),
+                    previous_affiliation,
+                }),
+                invitee_affiliation: Affiliation::Member,
+                members_only: membership_grant_is_relevant,
+            }
+        };
+        if authorization.grant.is_some() {
+            self.invite_operation_by_invitee
+                .insert(msg.invitee.clone(), msg.operation_id);
+        }
+        let operation_state = if authorization.grant.is_some() {
+            MediatedInviteOperationState::Active
+        } else {
+            MediatedInviteOperationState::Finalized(
+                MediatedInviteOperationCompletion::NoGrantRequired,
+            )
+        };
+        self.invite_operations.insert(
+            msg.operation_id,
+            MediatedInviteOperationRecord {
+                inviter: msg.inviter,
+                invitee: msg.invitee,
+                authorization: authorization.clone(),
+                state: operation_state,
+            },
+        );
+        Ok(authorization)
+    }
+}

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/authorization.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/authorization.rs
@@ -49,6 +49,9 @@ impl kameo::message::Message<AuthorizeMediatedInvite> for RoomActor {
             return Err(MediatedInviteGrantError::GrantPending);
         }
         let previous_affiliation = self.room.get_affiliation(&msg.invitee);
+        if previous_affiliation == Affiliation::Outcast {
+            return Err(MediatedInviteGrantError::InviteeBanned);
+        }
         if self.room.config.group_dm && previous_affiliation >= Affiliation::Member {
             return Err(MediatedInviteGrantError::InviteeAlreadyMember);
         }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/completion.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/completion.rs
@@ -1,0 +1,79 @@
+use super::*;
+
+pub struct FinalizeMediatedInviteGrant {
+    pub operation_id: MediatedInviteOperationId,
+}
+
+impl kameo::message::Message<FinalizeMediatedInviteGrant> for RoomActor {
+    type Reply = MediatedInviteGrantFinalization;
+
+    async fn handle(
+        &mut self,
+        msg: FinalizeMediatedInviteGrant,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let Some(record) = self.invite_operations.get_mut(&msg.operation_id) else {
+            return MediatedInviteGrantFinalization::Superseded;
+        };
+        let mut release_invitee = None;
+        let outcome = match record.state {
+            MediatedInviteOperationState::Active => {
+                let had_grant = record.authorization.grant.is_some();
+                record.state = MediatedInviteOperationState::Finalized(if had_grant {
+                    MediatedInviteOperationCompletion::Completed
+                } else {
+                    MediatedInviteOperationCompletion::NoGrantRequired
+                });
+                if had_grant {
+                    release_invitee = Some(record.invitee.clone());
+                }
+                MediatedInviteGrantFinalization::Finalized
+            }
+            MediatedInviteOperationState::Prepared
+            | MediatedInviteOperationState::RolledBackUnacknowledged(_) => {
+                MediatedInviteGrantFinalization::RollbackPending
+            }
+            MediatedInviteOperationState::Finalized(
+                MediatedInviteOperationCompletion::Completed
+                | MediatedInviteOperationCompletion::NoGrantRequired,
+            ) => MediatedInviteGrantFinalization::Finalized,
+            MediatedInviteOperationState::Finalized(
+                MediatedInviteOperationCompletion::Superseded,
+            ) => MediatedInviteGrantFinalization::Superseded,
+        };
+        if let Some(invitee) = release_invitee {
+            self.release_invitee_operation(&invitee, msg.operation_id);
+        }
+        outcome
+    }
+}
+
+pub struct AcknowledgeMediatedInviteOperation {
+    pub operation_id: MediatedInviteOperationId,
+}
+
+impl kameo::message::Message<AcknowledgeMediatedInviteOperation> for RoomActor {
+    type Reply = MediatedInviteOperationAcknowledgement;
+
+    async fn handle(
+        &mut self,
+        msg: AcknowledgeMediatedInviteOperation,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let Some(record) = self.invite_operations.get(&msg.operation_id) else {
+            return MediatedInviteOperationAcknowledgement::Unknown;
+        };
+        if matches!(
+            record.state,
+            MediatedInviteOperationState::Active | MediatedInviteOperationState::Prepared
+        ) {
+            return MediatedInviteOperationAcknowledgement::Pending;
+        }
+        let record = self
+            .invite_operations
+            .remove(&msg.operation_id)
+            .expect("record was just observed");
+        self.release_invitee_operation(&record.invitee, msg.operation_id);
+        MediatedInviteOperationAcknowledgement::Acknowledged
+    }
+}

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/rollback.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/rollback.rs
@@ -1,0 +1,158 @@
+use super::*;
+
+/// Enter the fail-closed compensation phase for one temporary grant.
+///
+/// Before sending this message, callers must durably retain the operation id,
+/// inviter, and invitee. A prepared operation is intentionally never expired
+/// or auto-aborted: an external managed-membership write may have committed
+/// even when its reply was lost. Recovery replays [`AuthorizeMediatedInvite`]
+/// with the same operation id and exact inputs to recover the grant, then
+/// either retries [`CommitMediatedInviteGrantRollback`] or restores the
+/// external Member relation before [`AbortMediatedInviteGrantRollback`].
+/// An [`MediatedInviteRollbackPreparation::AlreadyRolledBack`] reply means
+/// the exact rollback output remains cached after a lost reply. The caller
+/// must replay [`CommitMediatedInviteGrantRollback`], deliver that output,
+/// and acknowledge the operation only after delivery.
+pub struct PrepareMediatedInviteGrantRollback {
+    pub grant: InviteMembershipGrant,
+}
+
+impl kameo::message::Message<PrepareMediatedInviteGrantRollback> for RoomActor {
+    type Reply = Result<MediatedInviteRollbackPreparation, RoomMutationError>;
+
+    async fn handle(
+        &mut self,
+        msg: PrepareMediatedInviteGrantRollback,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self
+            .invite_operations
+            .get(&msg.grant.operation_id)
+            .is_some_and(|record| {
+                record.authorization.grant.as_ref() == Some(&msg.grant)
+                    && matches!(
+                        record.state,
+                        MediatedInviteOperationState::RolledBackUnacknowledged(_)
+                    )
+            })
+        {
+            return Ok(MediatedInviteRollbackPreparation::AlreadyRolledBack);
+        }
+        if self.invite_rollback_is_prepared(&msg.grant) {
+            return Ok(MediatedInviteRollbackPreparation::Prepared);
+        }
+        if !self.invite_grant_is_active(&msg.grant)
+            || self.room.get_affiliation(&msg.grant.invitee) != Affiliation::Member
+        {
+            return Ok(MediatedInviteRollbackPreparation::Superseded);
+        }
+        self.gate_mutation().await?;
+        self.invite_operations
+            .get_mut(&msg.grant.operation_id)
+            .expect("active grant has an operation record")
+            .state = MediatedInviteOperationState::Prepared;
+        Ok(MediatedInviteRollbackPreparation::Prepared)
+    }
+}
+
+pub struct CommitMediatedInviteGrantRollback {
+    pub grant: InviteMembershipGrant,
+}
+
+impl kameo::message::Message<CommitMediatedInviteGrantRollback> for RoomActor {
+    type Reply = Result<MediatedInviteRollbackCommit, MediatedInviteRollbackError>;
+
+    async fn handle(
+        &mut self,
+        msg: CommitMediatedInviteGrantRollback,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let Some(record) = self.invite_operations.get(&msg.grant.operation_id) else {
+            return Ok(MediatedInviteRollbackCommit::Superseded);
+        };
+        if record.authorization.grant.as_ref() != Some(&msg.grant) {
+            return Ok(MediatedInviteRollbackCommit::Superseded);
+        }
+        match &record.state {
+            MediatedInviteOperationState::RolledBackUnacknowledged(outcome) => {
+                return Ok(outcome.clone());
+            }
+            MediatedInviteOperationState::Prepared => {}
+            MediatedInviteOperationState::Active => {
+                return Ok(MediatedInviteRollbackCommit::Superseded);
+            }
+            MediatedInviteOperationState::Finalized(_) => {
+                return Ok(MediatedInviteRollbackCommit::Superseded);
+            }
+        }
+        if self.room.get_affiliation(&msg.grant.invitee) != Affiliation::Member {
+            return Ok(MediatedInviteRollbackCommit::Superseded);
+        }
+        match self.gate_mutation().await {
+            Ok(()) => {}
+            Err(RoomMutationError::NotOwner) => {
+                return Err(MediatedInviteRollbackError::NotOwner);
+            }
+            Err(RoomMutationError::PersistFailed(_)) => {
+                unreachable!("the pre-mutation ownership gate never persists room state")
+            }
+        }
+        self.persist_affiliation(&msg.grant.invitee, msg.grant.previous_affiliation)
+            .await
+            .map_err(MediatedInviteRollbackError::PersistFailedBeforeApply)?;
+
+        // Token construction proves `previous_affiliation < Member`, so
+        // the existing last-owner guard cannot reject this transition.
+        // Persistence has already succeeded; the remaining memory update
+        // is therefore infallible and emits the canonical status-321/ban
+        // presence through the same guarded path as admin changes.
+        let updates = super::super::admin_handlers::apply_affiliation_change(
+            &mut self.room,
+            &self.occupant_id_secret,
+            msg.grant.invitee.clone(),
+            msg.grant.previous_affiliation,
+            None,
+            None,
+        )
+        .expect("invite rollback restores only a below-Member affiliation");
+        let needs_rehydration = self
+            .prune_durable_recipient_if_removed(&msg.grant.invitee, msg.grant.previous_affiliation);
+        self.admission_revision = self.admission_revision.saturating_add(1);
+        if needs_rehydration {
+            self.refresh_durable_recipients_from_source().await;
+        }
+        let outcome = MediatedInviteRollbackCommit::Applied {
+            previous_affiliation: msg.grant.previous_affiliation,
+            updates,
+        };
+        self.invite_operations
+            .get_mut(&msg.grant.operation_id)
+            .expect("prepared grant has an operation record")
+            .state = MediatedInviteOperationState::RolledBackUnacknowledged(outcome.clone());
+        Ok(outcome)
+    }
+}
+
+pub struct AbortMediatedInviteGrantRollback {
+    pub grant: InviteMembershipGrant,
+}
+
+impl kameo::message::Message<AbortMediatedInviteGrantRollback> for RoomActor {
+    type Reply = MediatedInviteRollbackAbort;
+
+    async fn handle(
+        &mut self,
+        msg: AbortMediatedInviteGrantRollback,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self.invite_rollback_is_prepared(&msg.grant) {
+            self.invite_operations
+                .get_mut(&msg.grant.operation_id)
+                .expect("prepared grant has an operation record")
+                .state = MediatedInviteOperationState::Active;
+            MediatedInviteRollbackAbort::Aborted
+        } else {
+            MediatedInviteRollbackAbort::NotPrepared
+        }
+    }
+}

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -57,6 +57,9 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
         // unresolved (a genuine backend failure, not a legitimate brand
         // -new room) — see `RoomActor::ensure_restored_before_join`.
         self.ensure_restored_before_join().await?;
+        if self.invite_rollback_pending(&msg.sender_jid.to_bare()) {
+            return Err(RoomActorError::InviteRollbackPending);
+        }
         if msg.admission_revision != self.admission_revision {
             return Err(RoomActorError::StaleAdmissionRevision);
         }
@@ -83,6 +86,7 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
                     .update_affiliation_from_resolver(msg.sender_jid.to_bare(), affiliation)
                     .is_some()
                 {
+                    self.invalidate_invite_grant(&msg.sender_jid.to_bare());
                     self.admission_revision = self.admission_revision.saturating_add(1);
                 }
             }
@@ -96,6 +100,7 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
                 if !self.room.has_owner() {
                     self.room
                         .set_affiliation(msg.sender_jid.to_bare(), Affiliation::Owner);
+                    self.invalidate_invite_grant(&msg.sender_jid.to_bare());
                 }
             }
         }
@@ -582,7 +587,7 @@ impl kameo::message::Message<ReconcileChannelBackedRoom> for RoomActor {
         }
         self.room.waddle_id = msg.waddle_id;
         self.room.channel_id = msg.channel_id;
-        self.room.config = desired_config;
+        self.replace_config(desired_config);
         self.persist_config().await?;
         Ok(())
     }
@@ -621,6 +626,9 @@ pub enum ResolverAffiliationSyncOutcome {
     StaleAdmissionRevision,
     /// The actor is sealed pending destruction (#1108); nothing to sync.
     RoomSealed,
+    /// An invite compensation owns the invitee affiliation until its
+    /// terminal result is acknowledged.
+    InviteRollbackPending,
 }
 
 impl kameo::message::Message<SyncResolverAffiliation> for RoomActor {
@@ -634,6 +642,9 @@ impl kameo::message::Message<SyncResolverAffiliation> for RoomActor {
         if self.sealed {
             return ResolverAffiliationSyncOutcome::RoomSealed;
         }
+        if self.invite_rollback_pending(&msg.jid) {
+            return ResolverAffiliationSyncOutcome::InviteRollbackPending;
+        }
         if msg.expected_admission_revision != self.admission_revision {
             return ResolverAffiliationSyncOutcome::StaleAdmissionRevision;
         }
@@ -642,9 +653,10 @@ impl kameo::message::Message<SyncResolverAffiliation> for RoomActor {
         // any join admitted against the pre-sync snapshot retries.
         if self
             .room
-            .update_affiliation_from_resolver(msg.jid, msg.affiliation)
+            .update_affiliation_from_resolver(msg.jid.clone(), msg.affiliation)
             .is_some()
         {
+            self.invalidate_invite_grant(&msg.jid);
             self.admission_revision = self.admission_revision.saturating_add(1);
         }
         ResolverAffiliationSyncOutcome::Applied

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -6,6 +6,8 @@ use kameo::actor::{ActorRef, Spawn};
 use kameo::error::SendError;
 use xmpp_parsers::presence::{Presence, Type as PresenceType};
 
+mod mediated_invites;
+
 fn test_secret() -> OccupantIdSecret {
     OccupantIdSecret::for_testing(b"test-secret".to_vec())
 }
@@ -3373,6 +3375,7 @@ struct FakeDurableStore {
     fenced: std::sync::Mutex<Option<bool>>,
     fail_persist: bool,
     save_calls: std::sync::atomic::AtomicUsize,
+    saved_affiliations: std::sync::Mutex<Vec<(BareJid, BareJid, Affiliation)>>,
 }
 
 impl FakeDurableStore {
@@ -3402,11 +3405,16 @@ impl FakeDurableStore {
             fenced: std::sync::Mutex::new(Some(true)),
             fail_persist: true,
             save_calls: std::sync::atomic::AtomicUsize::new(0),
+            saved_affiliations: std::sync::Mutex::new(Vec::new()),
         })
     }
 
     fn save_call_count(&self) -> usize {
         self.save_calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    fn saved_affiliations(&self) -> Vec<(BareJid, BareJid, Affiliation)> {
+        self.saved_affiliations.lock().expect("lock").clone()
     }
 }
 
@@ -3461,11 +3469,16 @@ impl crate::muc::durable::MucDurableStore for FakeDurableStore {
 
     fn save_affiliation<'a>(
         &'a self,
-        _room_jid: &'a BareJid,
-        _entry: &'a crate::muc::affiliation::AffiliationEntry,
+        room_jid: &'a BareJid,
+        entry: &'a crate::muc::affiliation::AffiliationEntry,
     ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
         self.save_calls
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        self.saved_affiliations.lock().expect("lock").push((
+            room_jid.clone(),
+            entry.jid.clone(),
+            entry.affiliation,
+        ));
         let fail = self.fail_persist;
         Box::pin(async move {
             if fail {
@@ -3489,6 +3502,73 @@ impl crate::muc::durable::MucDurableStore for FakeDurableStore {
                 None => Err(crate::XmppError::internal(
                     "simulated transient fencing failure",
                 )),
+            }
+        })
+    }
+}
+
+struct FailNthAffiliationSaveStore {
+    fail_on_call: usize,
+    save_calls: std::sync::atomic::AtomicUsize,
+}
+
+impl FailNthAffiliationSaveStore {
+    fn new(fail_on_call: usize) -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self {
+            fail_on_call,
+            save_calls: std::sync::atomic::AtomicUsize::new(0),
+        })
+    }
+
+    fn save_call_count(&self) -> usize {
+        self.save_calls.load(std::sync::atomic::Ordering::SeqCst)
+    }
+}
+
+impl crate::muc::durable::MucDurableStore for FailNthAffiliationSaveStore {
+    fn load_room_state<'a>(
+        &'a self,
+        _room_jid: &'a BareJid,
+    ) -> crate::muc::durable::MucDurableFuture<'a, Option<crate::muc::durable::DurableRoomState>>
+    {
+        Box::pin(async { Ok(None) })
+    }
+
+    fn save_config<'a>(
+        &'a self,
+        _room_jid: &'a BareJid,
+        _waddle_id: &'a str,
+        _channel_id: &'a str,
+        _config: &'a RoomConfig,
+    ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn save_subject<'a>(
+        &'a self,
+        _room_jid: &'a BareJid,
+        _subject: Option<&'a SubjectState>,
+    ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn save_affiliation<'a>(
+        &'a self,
+        _room_jid: &'a BareJid,
+        _entry: &'a crate::muc::affiliation::AffiliationEntry,
+    ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
+        let call = self
+            .save_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            + 1;
+        let fail = call == self.fail_on_call;
+        Box::pin(async move {
+            if fail {
+                Err(crate::XmppError::internal(
+                    "simulated affiliation persist failure",
+                ))
+            } else {
+                Ok(())
             }
         })
     }
@@ -3755,7 +3835,7 @@ async fn change_affiliation_gate_blocks_the_mutation_when_deposed() {
     assert!(
         matches!(
             result,
-            Err(SendError::HandlerError(RoomMutationError::NotOwner))
+            Err(SendError::HandlerError(AffiliationMutationError::NotOwner))
         ),
         "expected NotOwner, got: {result:?}"
     );

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/affiliation_fencing.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/affiliation_fencing.rs
@@ -241,7 +241,7 @@ async fn accepted_same_value_member_reaffirmation_supersedes_invite_rollback_aut
 }
 
 #[tokio::test]
-async fn mediated_invite_rollback_restores_an_outcast_ban() {
+async fn mediated_invite_authorization_never_lifts_an_outcast_ban() {
     let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
     actor
         .ask(ChangeAffiliation {
@@ -250,29 +250,24 @@ async fn mediated_invite_rollback_restores_an_outcast_ban() {
         })
         .await
         .expect("ban invitee");
-    let grant = authorize_invite_grant(&actor, inviter, invitee.clone()).await;
-    assert_eq!(grant.previous_affiliation(), Affiliation::Outcast);
-    actor
-        .ask(PrepareMediatedInviteGrantRollback {
-            grant: grant.clone(),
-        })
-        .await
-        .expect("prepare rollback");
+
     assert!(matches!(
         actor
-            .ask(CommitMediatedInviteGrantRollback { grant })
-            .await
-            .expect("commit rollback"),
-        MediatedInviteRollbackCommit::Applied {
-            previous_affiliation: Affiliation::Outcast,
-            ..
-        }
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter,
+                invitee: invitee.clone(),
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::InviteeBanned
+        ))
     ));
     assert_eq!(
         actor
             .ask(GetAffiliation { jid: invitee })
             .await
-            .expect("restored ban"),
+            .expect("ban remains authoritative"),
         Affiliation::Outcast,
     );
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/affiliation_fencing.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/affiliation_fencing.rs
@@ -1,0 +1,625 @@
+use super::*;
+
+#[tokio::test]
+async fn rolled_back_unacknowledged_invite_fences_regrant_join_and_mutation_until_ack() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let invitee_session = test_full_jid("invitee");
+    let operation_id = invite_operation_id();
+    let grant = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id,
+            inviter: inviter.clone(),
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("authorize")
+        .grant
+        .expect("temporary grant");
+    actor
+        .ask(Join {
+            nick: "invitee".to_string(),
+            real_jid: invitee_session.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("invitee joins before compensation");
+    actor
+        .ask(PrepareMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("prepare");
+    let first = actor
+        .ask(CommitMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("commit");
+    assert!(matches!(
+        &first,
+        MediatedInviteRollbackCommit::Applied { updates, .. }
+            if !updates.presence_updates.is_empty()
+    ));
+
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter: inviter.clone(),
+                invitee: invitee.clone(),
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::GrantPending
+        ))
+    ));
+    assert!(matches!(
+        actor
+            .ask(Join {
+                nick: "invitee".to_string(),
+                real_jid: invitee_session.clone(),
+                role: Role::Participant,
+                affiliation: Affiliation::None,
+            })
+            .await,
+        Err(SendError::HandlerError(
+            RoomActorError::InviteRollbackPending
+        ))
+    ));
+    assert!(matches!(
+        actor
+            .ask(ChangeAffiliation {
+                jid: invitee.clone(),
+                affiliation: Affiliation::Member,
+            })
+            .await,
+        Err(SendError::HandlerError(
+            AffiliationMutationError::InviteRollbackPending
+        ))
+    ));
+    assert!(matches!(
+        actor
+            .ask(ApplyAffiliationChange {
+                actor: Some(inviter.to_bare()),
+                jid: invitee.clone(),
+                affiliation: Affiliation::Admin,
+            })
+            .await,
+        Err(SendError::HandlerError(
+            AdminApplyError::InviteRollbackPending
+        ))
+    ));
+    assert_eq!(
+        actor
+            .ask(SyncResolverAffiliation {
+                jid: invitee.clone(),
+                affiliation: Affiliation::Member,
+                expected_admission_revision: current_admission_revision(&actor).await,
+            })
+            .await
+            .expect("resolver fence outcome"),
+        ResolverAffiliationSyncOutcome::InviteRollbackPending,
+    );
+    assert_eq!(
+        actor
+            .ask(CommitMediatedInviteGrantRollback { grant })
+            .await
+            .expect("duplicate commit"),
+        first,
+    );
+
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation { operation_id })
+            .await
+            .expect("acknowledge"),
+        MediatedInviteOperationAcknowledgement::Acknowledged,
+    );
+    actor
+        .ask(ChangeAffiliation {
+            jid: invitee.clone(),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("mutation proceeds after acknowledgement");
+    actor
+        .ask(Join {
+            nick: "invitee".to_string(),
+            real_jid: invitee_session,
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("join proceeds after acknowledgement");
+}
+
+#[tokio::test]
+async fn prepared_invite_rollback_reserves_the_invitee_from_join_and_affiliation_writes() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let grant = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter,
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("authorize invite")
+        .grant
+        .expect("temporary membership grant");
+    actor
+        .ask(PrepareMediatedInviteGrantRollback { grant })
+        .await
+        .expect("prepare rollback");
+    let revision = current_admission_revision(&actor).await;
+
+    let join = actor
+        .ask(JoinWithAffiliation {
+            sender_jid: test_full_jid("invitee"),
+            nick: "invitee".to_string(),
+            affiliation_grant: JoinAffiliationGrant::Unaffiliated,
+            local_domain: "example.com".to_string(),
+            admission_revision: revision,
+        })
+        .await;
+    assert!(matches!(
+        join,
+        Err(SendError::HandlerError(
+            RoomActorError::InviteRollbackPending
+        ))
+    ));
+    assert_eq!(
+        actor
+            .ask(SyncResolverAffiliation {
+                jid: invitee.clone(),
+                affiliation: Affiliation::Member,
+                expected_admission_revision: revision,
+            })
+            .await
+            .expect("resolver sync reply"),
+        ResolverAffiliationSyncOutcome::InviteRollbackPending,
+    );
+    assert!(matches!(
+        actor
+            .ask(ChangeAffiliation {
+                jid: invitee,
+                affiliation: Affiliation::Admin,
+            })
+            .await,
+        Err(SendError::HandlerError(
+            AffiliationMutationError::InviteRollbackPending
+        ))
+    ));
+}
+
+#[tokio::test]
+async fn accepted_same_value_member_reaffirmation_supersedes_invite_rollback_authority() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let grant = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter: inviter.clone(),
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("authorize invite")
+        .grant
+        .expect("temporary membership grant");
+
+    actor
+        .ask(ChangeAffiliation {
+            jid: invitee.clone(),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("explicitly reaffirm membership");
+
+    assert_eq!(
+        actor
+            .ask(PrepareMediatedInviteGrantRollback { grant })
+            .await
+            .expect("prepare stale grant"),
+        MediatedInviteRollbackPreparation::Superseded,
+    );
+    actor
+        .ask(ChangeAffiliation {
+            jid: invitee.clone(),
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("remove superseding membership");
+    assert!(actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter,
+            invitee,
+        })
+        .await
+        .expect("superseded operation released the invitee index")
+        .grant
+        .is_some());
+}
+
+#[tokio::test]
+async fn mediated_invite_rollback_restores_an_outcast_ban() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    actor
+        .ask(ChangeAffiliation {
+            jid: invitee.clone(),
+            affiliation: Affiliation::Outcast,
+        })
+        .await
+        .expect("ban invitee");
+    let grant = authorize_invite_grant(&actor, inviter, invitee.clone()).await;
+    assert_eq!(grant.previous_affiliation(), Affiliation::Outcast);
+    actor
+        .ask(PrepareMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("prepare rollback");
+    assert!(matches!(
+        actor
+            .ask(CommitMediatedInviteGrantRollback { grant })
+            .await
+            .expect("commit rollback"),
+        MediatedInviteRollbackCommit::Applied {
+            previous_affiliation: Affiliation::Outcast,
+            ..
+        }
+    ));
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid: invitee })
+            .await
+            .expect("restored ban"),
+        Affiliation::Outcast,
+    );
+}
+
+#[tokio::test]
+async fn later_admin_and_owner_promotions_cannot_be_clobbered_by_invite_rollback() {
+    for promotion in [Affiliation::Admin, Affiliation::Owner] {
+        let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+        let grant = authorize_invite_grant(&actor, inviter, invitee.clone()).await;
+        actor
+            .ask(ChangeAffiliation {
+                jid: invitee.clone(),
+                affiliation: promotion,
+            })
+            .await
+            .expect("promote invitee");
+        assert_eq!(
+            actor
+                .ask(PrepareMediatedInviteGrantRollback { grant })
+                .await
+                .expect("prepare superseded rollback"),
+            MediatedInviteRollbackPreparation::Superseded,
+        );
+        assert_eq!(
+            actor
+                .ask(GetAffiliation { jid: invitee })
+                .await
+                .expect("promotion survives"),
+            promotion,
+        );
+    }
+}
+
+#[tokio::test]
+async fn successor_owner_promotion_survives_original_owner_demotion_and_stale_rollback() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    actor
+        .ask(ChangeAffiliation {
+            jid: inviter.to_bare(),
+            affiliation: Affiliation::Owner,
+        })
+        .await
+        .expect("make inviter the original owner");
+    let grant = authorize_invite_grant(&actor, inviter.clone(), invitee.clone()).await;
+
+    actor
+        .ask(ApplyAdminItems {
+            sender_jid: inviter.clone(),
+            sender_affiliation: Affiliation::Owner,
+            sender_role: Role::Moderator,
+            items: vec![
+                AdminItem {
+                    jid: Some(invitee.clone()),
+                    affiliation: Some(Affiliation::Owner),
+                    role: None,
+                    nick: None,
+                    reason: None,
+                },
+                AdminItem {
+                    jid: Some(inviter.to_bare()),
+                    affiliation: Some(Affiliation::Member),
+                    role: None,
+                    nick: None,
+                    reason: None,
+                },
+            ],
+        })
+        .await
+        .expect("promote successor before demoting original owner");
+
+    assert_eq!(
+        actor
+            .ask(PrepareMediatedInviteGrantRollback { grant })
+            .await
+            .expect("stale rollback"),
+        MediatedInviteRollbackPreparation::Superseded,
+    );
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid: invitee })
+            .await
+            .expect("successor affiliation"),
+        Affiliation::Owner,
+    );
+    assert_eq!(
+        actor
+            .ask(GetAffiliation {
+                jid: inviter.to_bare(),
+            })
+            .await
+            .expect("original owner affiliation"),
+        Affiliation::Member,
+    );
+}
+
+#[tokio::test]
+async fn prepared_rollback_blocks_guarded_and_batched_affiliation_paths() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let grant = authorize_invite_grant(&actor, inviter.clone(), invitee.clone()).await;
+    let revision = current_admission_revision(&actor).await;
+    let invitee_full = test_full_jid("invitee");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: invitee_full.clone(),
+            nick: "invitee".to_string(),
+            affiliation_grant: JoinAffiliationGrant::Unaffiliated,
+            local_domain: "example.com".to_string(),
+            admission_revision: revision,
+        })
+        .await
+        .expect("invitee joins before compensation");
+    actor
+        .ask(PrepareMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("prepare rollback");
+
+    assert!(matches!(
+        actor
+            .ask(ApplyAffiliationChange {
+                actor: Some(inviter.to_bare()),
+                jid: invitee.clone(),
+                affiliation: Affiliation::Admin,
+            })
+            .await,
+        Err(SendError::HandlerError(
+            AdminApplyError::InviteRollbackPending
+        ))
+    ));
+    assert!(matches!(
+        actor
+            .ask(ApplyAdminItems {
+                sender_jid: inviter,
+                sender_affiliation: Affiliation::Admin,
+                sender_role: Role::Moderator,
+                items: vec![AdminItem {
+                    jid: Some(invitee.clone()),
+                    affiliation: Some(Affiliation::Member),
+                    role: None,
+                    nick: None,
+                    reason: None,
+                }],
+            })
+            .await,
+        Err(SendError::HandlerError(
+            AdminApplyError::InviteRollbackPending
+        ))
+    ));
+    assert!(matches!(
+        actor
+            .ask(EnforceMembersOnlyAffiliations {
+                affiliations: vec![(invitee.clone(), Affiliation::Member)],
+            })
+            .await,
+        Err(SendError::HandlerError(
+            AffiliationMutationError::InviteRollbackPending
+        ))
+    ));
+    assert!(matches!(
+        actor
+            .ask(Join {
+                nick: "invitee-phone".to_string(),
+                real_jid: test_full_jid_resource("invitee", "phone"),
+                role: Role::Participant,
+                affiliation: Affiliation::Member,
+            })
+            .await,
+        Err(SendError::HandlerError(
+            RoomActorError::InviteRollbackPending
+        ))
+    ));
+
+    assert_eq!(
+        actor
+            .ask(AbortMediatedInviteGrantRollback { grant })
+            .await
+            .expect("abort rollback"),
+        MediatedInviteRollbackAbort::Aborted,
+    );
+    assert!(actor
+        .ask(GetOccupantByJid { jid: invitee_full })
+        .await
+        .expect("occupant lookup")
+        .is_some());
+}
+
+#[tokio::test]
+async fn a_batch_targeting_a_reserved_invitee_is_rejected_before_any_item_applies() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let unaffected: BareJid = "unaffected@example.com".parse().expect("bare jid");
+    let grant = authorize_invite_grant(&actor, inviter.clone(), invitee.clone()).await;
+    actor
+        .ask(PrepareMediatedInviteGrantRollback { grant })
+        .await
+        .expect("prepare rollback");
+
+    assert!(matches!(
+        actor
+            .ask(ApplyAdminItems {
+                sender_jid: inviter,
+                sender_affiliation: Affiliation::Admin,
+                sender_role: Role::Moderator,
+                items: vec![
+                    AdminItem {
+                        jid: Some(unaffected.clone()),
+                        affiliation: Some(Affiliation::Member),
+                        role: None,
+                        nick: None,
+                        reason: None,
+                    },
+                    AdminItem {
+                        jid: Some(invitee),
+                        affiliation: Some(Affiliation::Member),
+                        role: None,
+                        nick: None,
+                        reason: None,
+                    },
+                ],
+            })
+            .await,
+        Err(SendError::HandlerError(
+            AdminApplyError::InviteRollbackPending
+        ))
+    ));
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid: unaffected })
+            .await
+            .expect("unaffected affiliation"),
+        Affiliation::None,
+        "the item before the reserved invitee was not partially applied",
+    );
+}
+
+#[tokio::test]
+async fn committed_rollback_ejects_a_joined_invitee_with_status_321() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let grant = authorize_invite_grant(&actor, inviter, invitee.clone()).await;
+    let invitee_full = test_full_jid("invitee");
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: invitee_full.clone(),
+            nick: "invitee".to_string(),
+            affiliation_grant: JoinAffiliationGrant::Unaffiliated,
+            local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&actor).await,
+        })
+        .await
+        .expect("invitee joins");
+    actor
+        .ask(PrepareMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("prepare rollback");
+    let MediatedInviteRollbackCommit::Applied { updates, .. } = actor
+        .ask(CommitMediatedInviteGrantRollback { grant })
+        .await
+        .expect("commit rollback")
+    else {
+        panic!("exact prepared grant must apply");
+    };
+    assert!(updates
+        .presence_updates
+        .iter()
+        .any(|(recipient, presence)| recipient == &invitee_full
+            && presence_has_status(presence, "321")));
+    assert!(actor
+        .ask(GetOccupantByJid { jid: invitee_full })
+        .await
+        .expect("occupant lookup")
+        .is_none());
+}
+
+#[tokio::test]
+async fn refused_resolver_affiliation_writes_preserve_invite_rollback_authority() {
+    let (join_actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let join_grant = authorize_invite_grant(&join_actor, inviter, invitee.clone()).await;
+    join_actor
+        .ask(JoinWithAffiliation {
+            sender_jid: test_full_jid("invitee"),
+            nick: "invitee".to_string(),
+            affiliation_grant: JoinAffiliationGrant::Resolver(Affiliation::Member),
+            local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&join_actor).await,
+        })
+        .await
+        .expect("resolver-derived join is admitted by explicit invite membership");
+    assert_eq!(
+        join_actor
+            .ask(PrepareMediatedInviteGrantRollback { grant: join_grant })
+            .await
+            .expect("prepare after refused join resolver write"),
+        MediatedInviteRollbackPreparation::Prepared,
+    );
+
+    let (sync_actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let sync_grant = authorize_invite_grant(&sync_actor, inviter, invitee.clone()).await;
+    assert_eq!(
+        sync_actor
+            .ask(SyncResolverAffiliation {
+                jid: invitee,
+                affiliation: Affiliation::None,
+                expected_admission_revision: current_admission_revision(&sync_actor).await,
+            })
+            .await
+            .expect("resolver sync"),
+        ResolverAffiliationSyncOutcome::Applied,
+    );
+    assert_eq!(
+        sync_actor
+            .ask(PrepareMediatedInviteGrantRollback { grant: sync_grant })
+            .await
+            .expect("prepare after refused resolver sync"),
+        MediatedInviteRollbackPreparation::Prepared,
+    );
+}
+
+#[tokio::test]
+async fn rejected_creator_owner_grant_preserves_invite_rollback_authority() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    actor
+        .ask(ChangeAffiliation {
+            jid: inviter.to_bare(),
+            affiliation: Affiliation::Owner,
+        })
+        .await
+        .expect("establish an existing owner");
+    let grant = authorize_invite_grant(&actor, inviter, invitee.clone()).await;
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: test_full_jid("invitee"),
+            nick: "invitee".to_string(),
+            affiliation_grant: JoinAffiliationGrant::CreatorOwner,
+            local_domain: "example.com".to_string(),
+            admission_revision: current_admission_revision(&actor).await,
+        })
+        .await
+        .expect("creator claim is ignored because an owner exists");
+
+    assert_eq!(
+        actor
+            .ask(PrepareMediatedInviteGrantRollback { grant })
+            .await
+            .expect("prepare after ignored creator claim"),
+        MediatedInviteRollbackPreparation::Prepared,
+    );
+}

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/authorization.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/authorization.rs
@@ -1,0 +1,485 @@
+use super::*;
+
+#[tokio::test]
+async fn mediated_invite_authorization_rejects_a_demoted_inviter_without_granting_membership() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    actor
+        .ask(ChangeAffiliation {
+            jid: inviter.to_bare(),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("demote inviter before invite authorization");
+
+    let result = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter: inviter.clone(),
+            invitee: invitee.clone(),
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(SendError::HandlerError(MediatedInviteGrantError::Forbidden))
+    ));
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid: invitee })
+            .await
+            .expect("invitee affiliation"),
+        Affiliation::None,
+    );
+}
+
+#[tokio::test]
+async fn mediated_invite_authorization_grants_member_only_when_the_actor_creates_membership() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+
+    let authorized = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter,
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("members-only admin invite");
+
+    let grant = authorized.grant.expect("actor-created membership token");
+    assert_eq!(grant.invitee(), &invitee);
+    assert_eq!(grant.previous_affiliation(), Affiliation::None);
+    assert_eq!(authorized.invitee_affiliation, Affiliation::Member);
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid: invitee })
+            .await
+            .expect("invitee affiliation"),
+        Affiliation::Member,
+    );
+}
+
+#[tokio::test]
+async fn mediated_invite_requires_the_exact_full_jid_to_remain_an_occupant() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    actor
+        .ask(LeaveByRealJid {
+            sender_jid: inviter.clone(),
+        })
+        .await
+        .expect("leave reply")
+        .expect("departed occupant");
+
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter,
+                invitee,
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::NotOccupant
+        ))
+    ));
+}
+
+#[tokio::test]
+async fn mediated_invite_rejects_a_sibling_resource_that_is_not_the_occupant() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let sibling_resource = test_full_jid_resource("inviter", "phone");
+    assert_ne!(sibling_resource, inviter);
+
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter: sibling_resource,
+                invitee,
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::NotOccupant
+        ))
+    ));
+}
+
+#[tokio::test]
+async fn open_room_occupant_invite_never_changes_the_member_list() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: false,
+        ..RoomConfig::default()
+    })
+    .await;
+    let inviter = test_full_jid("visitor");
+    let invitee = test_full_jid("invitee").to_bare();
+    actor
+        .ask(Join {
+            nick: "visitor".to_string(),
+            real_jid: inviter.clone(),
+            role: Role::Participant,
+            // Authorization in an open room is occupant-scoped only. This
+            // intentionally unusual fixture proves affiliation is not
+            // accidentally consulted by the invite policy.
+            affiliation: Affiliation::Outcast,
+        })
+        .await
+        .expect("open-room join");
+
+    let authorized = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter,
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("open-room occupant invite");
+    assert!(authorized.grant.is_none());
+    assert_eq!(authorized.invitee_affiliation, Affiliation::None);
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid: invitee })
+            .await
+            .expect("invitee affiliation"),
+        Affiliation::None,
+    );
+}
+
+#[tokio::test]
+async fn open_room_no_grant_operations_do_not_reserve_the_invitee_index() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: false,
+        group_dm: false,
+        ..RoomConfig::default()
+    })
+    .await;
+    let first_inviter = test_full_jid("first");
+    let second_inviter = test_full_jid("second");
+    let invitee = test_full_jid("invitee").to_bare();
+    for (nick, inviter) in [
+        ("first", first_inviter.clone()),
+        ("second", second_inviter.clone()),
+    ] {
+        actor
+            .ask(Join {
+                nick: nick.to_string(),
+                real_jid: inviter,
+                role: Role::Participant,
+                affiliation: Affiliation::None,
+            })
+            .await
+            .expect("join inviter");
+    }
+
+    let first = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter: first_inviter,
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("first no-grant authorization");
+    let second = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter: second_inviter,
+            invitee,
+        })
+        .await
+        .expect("second no-grant authorization");
+    assert!(first.grant.is_none());
+    assert!(second.grant.is_none());
+}
+
+#[tokio::test]
+async fn ordinary_members_only_invites_require_admin_and_preserve_existing_membership() {
+    let (actor, admin, invitee) = joined_members_only_invite_actor().await;
+    let member = test_full_jid("member");
+    actor
+        .ask(Join {
+            nick: "member".to_string(),
+            real_jid: member.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("join member");
+    actor
+        .ask(ChangeAffiliation {
+            jid: member.to_bare(),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("store member affiliation");
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter: member,
+                invitee: invitee.clone(),
+            })
+            .await,
+        Err(SendError::HandlerError(MediatedInviteGrantError::Forbidden))
+    ));
+
+    actor
+        .ask(ChangeAffiliation {
+            jid: invitee.clone(),
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("pre-existing admin");
+    let authorized = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter: admin,
+            invitee,
+        })
+        .await
+        .expect("admin invite of existing affiliate");
+    assert!(authorized.grant.is_none());
+    assert_eq!(authorized.invitee_affiliation, Affiliation::Admin);
+}
+
+#[tokio::test]
+async fn group_dm_invites_require_member_and_conflict_with_existing_membership() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: true,
+        group_dm: true,
+        ..RoomConfig::default()
+    })
+    .await;
+    let inviter = test_full_jid("member");
+    let invitee = test_full_jid("invitee").to_bare();
+    actor
+        .ask(Join {
+            nick: "member".to_string(),
+            real_jid: inviter.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("join group-DM member");
+    actor
+        .ask(ChangeAffiliation {
+            jid: inviter.to_bare(),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("store inviter membership");
+    let grant = authorize_invite_grant(&actor, inviter.clone(), invitee.clone()).await;
+    actor
+        .ask(FinalizeMediatedInviteGrant {
+            operation_id: grant.operation_id(),
+        })
+        .await
+        .expect("finalize first invite");
+    actor
+        .ask(AcknowledgeMediatedInviteOperation {
+            operation_id: grant.operation_id(),
+        })
+        .await
+        .expect("acknowledge first invite");
+
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter,
+                invitee,
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::InviteeAlreadyMember
+        ))
+    ));
+}
+
+#[tokio::test]
+async fn group_dm_invites_reject_an_occupant_below_member() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: true,
+        group_dm: true,
+        ..RoomConfig::default()
+    })
+    .await;
+    let inviter = test_full_jid("visitor");
+    let invitee = test_full_jid("invitee").to_bare();
+    actor
+        .ask(Join {
+            nick: "visitor".to_string(),
+            real_jid: inviter.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("join below-Member occupant");
+
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter,
+                invitee,
+            })
+            .await,
+        Err(SendError::HandlerError(MediatedInviteGrantError::Forbidden))
+    ));
+}
+
+#[test]
+fn group_dm_admission_is_members_only_even_if_config_state_is_inconsistent() {
+    let mut room = MucRoom::new(
+        "group@muc.example.com".parse().expect("room jid"),
+        "waddle".to_string(),
+        "channel".to_string(),
+        RoomConfig::default(),
+    );
+    room.config.group_dm = true;
+    room.config.members_only = false;
+
+    assert!(
+        !room.can_user_join(&test_full_jid("stranger").to_bare()),
+        "group-DM privacy must not depend on a redundant config flag remaining normalized",
+    );
+}
+
+#[tokio::test]
+async fn group_dm_construction_normalizes_members_only_before_admission() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: false,
+        group_dm: true,
+        ..RoomConfig::default()
+    })
+    .await;
+    let snapshot = actor.ask(GetSnapshot).await.expect("group-DM snapshot");
+    assert!(
+        snapshot.room.config.members_only,
+        "a group DM must expose a normalized members-only config",
+    );
+
+    let outcome = actor
+        .ask(JoinWithAffiliation {
+            sender_jid: test_full_jid("stranger"),
+            nick: "stranger".to_string(),
+            affiliation_grant: JoinAffiliationGrant::Unaffiliated,
+            local_domain: "example.com".to_string(),
+            admission_revision: snapshot.admission_revision,
+        })
+        .await;
+    assert!(matches!(
+        outcome,
+        Err(SendError::HandlerError(RoomActorError::JoinForbidden {
+            reason: JoinDenialReason::MembersOnly,
+        }))
+    ));
+}
+
+#[tokio::test]
+async fn group_dm_member_config_update_cannot_disable_members_only() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: true,
+        group_dm: true,
+        ..RoomConfig::default()
+    })
+    .await;
+    let member = test_full_jid("member");
+    actor
+        .ask(Join {
+            nick: "member".to_string(),
+            real_jid: member.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("join group-DM member");
+    actor
+        .ask(ChangeAffiliation {
+            jid: member.to_bare(),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("store member affiliation");
+    let mut config = actor.ask(GetConfig).await.expect("group-DM config");
+    config.members_only = false;
+    config.group_dm = false;
+
+    let snapshot = actor
+        .ask(UpdateGroupDmConfigByMember {
+            config,
+            sender_jid: member,
+        })
+        .await
+        .expect("member config update");
+    assert!(
+        snapshot.room.config.members_only,
+        "group-DM config updates must preserve members-only admission",
+    );
+    assert!(
+        snapshot.room.config.group_dm,
+        "a group-DM member update cannot reclassify the room",
+    );
+}
+
+#[tokio::test]
+async fn room_actor_boundary_normalizes_group_dm_authorization_policy() {
+    let mut room = test_room();
+    room.config.group_dm = true;
+    room.config.members_only = false;
+    let actor = RoomActor::spawn(RoomActor::new(room, test_secret()));
+    let inviter = test_full_jid("member");
+    let invitee = test_full_jid("invitee").to_bare();
+    actor
+        .ask(Join {
+            nick: "member".to_string(),
+            real_jid: inviter.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("join group-DM member");
+    actor
+        .ask(ChangeAffiliation {
+            jid: inviter.to_bare(),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("store inviter membership");
+
+    let snapshot = actor.ask(GetSnapshot).await.expect("normalized snapshot");
+    assert!(snapshot.room.config.members_only);
+    let authorized = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter,
+            invitee,
+        })
+        .await
+        .expect("group-DM mediated invitation");
+
+    assert!(authorized.grant.is_some());
+    assert_eq!(authorized.invitee_affiliation, Affiliation::Member);
+    assert!(authorized.members_only);
+}
+
+#[tokio::test]
+async fn generic_config_update_normalizes_group_dm_members_only() {
+    let actor = spawn_room_actor_with_config(RoomConfig::default()).await;
+    let config = RoomConfig {
+        members_only: false,
+        group_dm: true,
+        ..RoomConfig::default()
+    };
+
+    actor
+        .ask(UpdateConfig { config })
+        .await
+        .expect("generic config update");
+
+    assert!(
+        actor
+            .ask(GetConfig)
+            .await
+            .expect("normalized config")
+            .members_only,
+    );
+}

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/durability.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/durability.rs
@@ -175,6 +175,54 @@ async fn invite_grant_persist_failure_leaves_memory_unchanged_and_creates_no_tok
 }
 
 #[tokio::test]
+async fn banned_invitee_rejection_performs_no_durable_member_write() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let store = FakeDurableStore::owned();
+    actor
+        .ask(RestoreDurableRoomState {
+            store: store.clone(),
+        })
+        .await
+        .expect("attach recording durable store");
+    actor
+        .ask(ChangeAffiliation {
+            jid: inviter.to_bare(),
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("persist inviter affiliation after restore");
+    actor
+        .ask(ChangeAffiliation {
+            jid: invitee.clone(),
+            affiliation: Affiliation::Outcast,
+        })
+        .await
+        .expect("persist invitee ban");
+    let writes_before_invite = store.saved_affiliations();
+
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter,
+                invitee: invitee.clone(),
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::InviteeBanned
+        ))
+    ));
+    assert_eq!(store.saved_affiliations(), writes_before_invite);
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid: invitee })
+            .await
+            .expect("ban remains authoritative"),
+        Affiliation::Outcast,
+    );
+}
+
+#[tokio::test]
 async fn invite_grant_and_rollback_persist_the_exact_room_invitee_and_affiliations() {
     let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
     let store = FakeDurableStore::owned();

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/durability.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/durability.rs
@@ -1,0 +1,376 @@
+use super::*;
+
+#[tokio::test]
+async fn unacknowledged_rollback_blocks_dormancy_and_both_seal_guards() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: true,
+        persistent: false,
+        ..RoomConfig::default()
+    })
+    .await;
+    let inviter = test_full_jid("inviter");
+    let invitee = test_full_jid("invitee").to_bare();
+    actor
+        .ask(Join {
+            nick: "inviter".to_string(),
+            real_jid: inviter.clone(),
+            role: Role::Moderator,
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("join inviter");
+    actor
+        .ask(ChangeAffiliation {
+            jid: inviter.to_bare(),
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("persist inviter affiliation");
+    let operation_id = invite_operation_id();
+    let grant = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id,
+            inviter: inviter.clone(),
+            invitee,
+        })
+        .await
+        .expect("authorize")
+        .grant
+        .expect("temporary grant");
+    actor
+        .ask(PrepareMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("prepare");
+    actor
+        .ask(CommitMediatedInviteGrantRollback { grant })
+        .await
+        .expect("commit");
+    actor
+        .ask(ChangeAffiliation {
+            jid: inviter.to_bare(),
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("remove inviter affiliation");
+    actor
+        .ask(Leave {
+            nick: "inviter".to_string(),
+        })
+        .await
+        .expect("leave room");
+
+    let probe = actor.ask(IsDormant).await.expect("dormancy probe");
+    assert!(
+        !probe.dormant,
+        "unacknowledged rollback output must block dormancy"
+    );
+    for guard in [SealGuard::Dormant, SealGuard::EmptyNonPersistent] {
+        assert!(
+            !actor
+                .ask(SealIfInactive {
+                    expected_occupancy_revision: probe.occupancy_revision,
+                    guard,
+                })
+                .await
+                .expect("seal verdict"),
+            "unacknowledged rollback output must block {guard:?} sealing",
+        );
+    }
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation { operation_id })
+            .await
+            .expect("acknowledge"),
+        MediatedInviteOperationAcknowledgement::Acknowledged,
+    );
+    assert!(
+        actor
+            .ask(IsDormant)
+            .await
+            .expect("post-ack dormancy probe")
+            .dormant,
+        "acknowledgement releases the actor lifecycle fence",
+    );
+}
+
+#[tokio::test]
+async fn mediated_invite_authorization_fails_closed_while_durable_restore_is_pending() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let store = FlakyThenRecoveringStore::new(usize::MAX, invitee.clone());
+    actor
+        .ask(RestoreDurableRoomState { store })
+        .await
+        .expect("failed restore still replies");
+
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter,
+                invitee: invitee.clone(),
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::RestorePending
+        ))
+    ));
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid: invitee })
+            .await
+            .expect("no grant from default state"),
+        Affiliation::None,
+    );
+}
+
+#[tokio::test]
+async fn invite_grant_persist_failure_leaves_memory_unchanged_and_creates_no_token() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let store = FailNthAffiliationSaveStore::new(1);
+    actor
+        .ask(RestoreDurableRoomState {
+            store: store.clone(),
+        })
+        .await
+        .expect("attach durable store");
+
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter: inviter.clone(),
+                invitee: invitee.clone(),
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::GrantPersistFailed(_)
+        ))
+    ));
+    assert_eq!(
+        actor
+            .ask(GetAffiliation {
+                jid: invitee.clone(),
+            })
+            .await
+            .expect("unchanged affiliation"),
+        Affiliation::None,
+    );
+    assert_eq!(store.save_call_count(), 1);
+
+    let retry = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter,
+            invitee,
+        })
+        .await
+        .expect("retry after the one failed persistence call");
+    assert!(
+        retry.grant.is_some(),
+        "failed persistence created no ghost token"
+    );
+    assert_eq!(store.save_call_count(), 2);
+}
+
+#[tokio::test]
+async fn invite_grant_and_rollback_persist_the_exact_room_invitee_and_affiliations() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let store = FakeDurableStore::owned();
+    actor
+        .ask(RestoreDurableRoomState {
+            store: store.clone(),
+        })
+        .await
+        .expect("attach recording durable store");
+
+    let grant = authorize_invite_grant(&actor, inviter, invitee.clone()).await;
+    actor
+        .ask(PrepareMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("prepare rollback");
+    actor
+        .ask(CommitMediatedInviteGrantRollback { grant })
+        .await
+        .expect("commit rollback");
+
+    let room_jid: BareJid = "testroom@muc.example.com".parse().expect("room jid");
+    assert_eq!(
+        store.saved_affiliations(),
+        vec![
+            (room_jid.clone(), invitee.clone(), Affiliation::Member),
+            (room_jid, invitee, Affiliation::None),
+        ],
+    );
+}
+
+#[tokio::test]
+async fn rollback_persist_failure_retains_the_exact_token_and_reservation_for_retry() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let store = FailNthAffiliationSaveStore::new(2);
+    actor
+        .ask(RestoreDurableRoomState {
+            store: store.clone(),
+        })
+        .await
+        .expect("attach durable store");
+    let operation_id = invite_operation_id();
+    let grant = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id,
+            inviter: inviter.clone(),
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("authorize")
+        .grant
+        .expect("temporary grant");
+    actor
+        .ask(PrepareMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("prepare rollback");
+
+    assert!(matches!(
+        actor
+            .ask(CommitMediatedInviteGrantRollback {
+                grant: grant.clone(),
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteRollbackError::PersistFailedBeforeApply(_)
+        ))
+    ));
+    assert_eq!(
+        actor
+            .ask(GetAffiliation {
+                jid: invitee.clone(),
+            })
+            .await
+            .expect("membership remains after failed commit"),
+        Affiliation::Member,
+    );
+    assert!(matches!(
+        actor
+            .ask(ChangeAffiliation {
+                jid: invitee.clone(),
+                affiliation: Affiliation::Admin,
+            })
+            .await,
+        Err(SendError::HandlerError(
+            AffiliationMutationError::InviteRollbackPending
+        ))
+    ));
+    actor
+        .ask(Leave {
+            nick: "inviter".to_string(),
+        })
+        .await
+        .expect("leave while rollback remains prepared");
+    let probe = actor.ask(IsDormant).await.expect("dormancy probe");
+    assert!(
+        !actor
+            .ask(SealIfInactive {
+                expected_occupancy_revision: probe.occupancy_revision,
+                guard: SealGuard::EmptyNonPersistent,
+            })
+            .await
+            .expect("empty-room seal verdict"),
+        "a prepared rollback must survive empty non-persistent room cleanup",
+    );
+    let expected_grant = grant.clone();
+    drop(grant);
+    let recovered_grant = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id,
+            inviter,
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("recover exact authorization after losing the first reply state")
+        .grant
+        .expect("recover exact rollback authority");
+    assert_eq!(recovered_grant, expected_grant);
+    assert_eq!(
+        actor
+            .ask(PrepareMediatedInviteGrantRollback {
+                grant: recovered_grant.clone(),
+            })
+            .await
+            .expect("same token is still prepared"),
+        MediatedInviteRollbackPreparation::Prepared,
+    );
+    assert!(matches!(
+        actor
+            .ask(CommitMediatedInviteGrantRollback {
+                grant: recovered_grant,
+            })
+            .await
+            .expect("retry rollback after transient failure"),
+        MediatedInviteRollbackCommit::Applied { .. }
+    ));
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid: invitee })
+            .await
+            .expect("rollback eventually converges"),
+        Affiliation::None,
+    );
+    assert_eq!(store.save_call_count(), 3);
+}
+
+#[tokio::test]
+async fn rollback_ownership_loss_is_typed_and_keeps_the_operation_prepared() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let store = FakeDurableStore::owned();
+    actor
+        .ask(RestoreDurableRoomState {
+            store: store.clone(),
+        })
+        .await
+        .expect("attach owned durable store");
+    let grant = authorize_invite_grant(&actor, inviter, invitee.clone()).await;
+    actor
+        .ask(PrepareMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("prepare while the actor owns the room");
+    *store.fenced.lock().expect("fence lock") = Some(false);
+
+    assert!(matches!(
+        actor
+            .ask(CommitMediatedInviteGrantRollback {
+                grant: grant.clone(),
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteRollbackError::NotOwner
+        ))
+    ));
+    assert_eq!(
+        store.save_call_count(),
+        1,
+        "ownership rejection must happen before rollback persistence",
+    );
+    assert_eq!(
+        actor
+            .ask(GetAffiliation {
+                jid: invitee.clone(),
+            })
+            .await
+            .expect("unchanged temporary membership"),
+        Affiliation::Member,
+    );
+    assert_eq!(
+        actor
+            .ask(PrepareMediatedInviteGrantRollback { grant })
+            .await
+            .expect("prepared state remains replayable"),
+        MediatedInviteRollbackPreparation::Prepared,
+    );
+}

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/lifecycle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/lifecycle.rs
@@ -1,0 +1,710 @@
+use super::*;
+
+#[tokio::test]
+async fn mediated_invite_operation_replays_exact_authorization_without_a_second_save() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let store = FakeDurableStore::owned();
+    actor
+        .ask(RestoreDurableRoomState {
+            store: store.clone(),
+        })
+        .await
+        .expect("attach durable store");
+    let operation_id = invite_operation_id();
+
+    let first = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id,
+            inviter: inviter.clone(),
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("first authorization");
+    assert_eq!(store.save_call_count(), 1);
+    let replay = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id,
+            inviter: inviter.clone(),
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("replayed authorization");
+
+    assert_eq!(replay, first);
+    assert_eq!(store.save_call_count(), 1, "replay must not persist twice");
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id,
+                inviter: inviter.clone(),
+                invitee: "different@example.com".parse().expect("bare jid"),
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::OperationMismatch
+        ))
+    ));
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter,
+                invitee,
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::GrantPending
+        ))
+    ));
+}
+
+#[tokio::test]
+async fn mediated_invite_prepare_abort_finalize_and_ack_are_idempotent() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let operation_id = invite_operation_id();
+    let grant = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id,
+            inviter,
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("authorize")
+        .grant
+        .expect("temporary grant");
+
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation { operation_id })
+            .await
+            .expect("active acknowledgement attempt"),
+        MediatedInviteOperationAcknowledgement::Pending,
+    );
+
+    for _ in 0..2 {
+        assert_eq!(
+            actor
+                .ask(PrepareMediatedInviteGrantRollback {
+                    grant: grant.clone(),
+                })
+                .await
+                .expect("prepare"),
+            MediatedInviteRollbackPreparation::Prepared,
+        );
+    }
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation { operation_id })
+            .await
+            .expect("prepared acknowledgement attempt"),
+        MediatedInviteOperationAcknowledgement::Pending,
+    );
+    assert_eq!(
+        actor
+            .ask(FinalizeMediatedInviteGrant { operation_id })
+            .await
+            .expect("finalize prepared operation"),
+        MediatedInviteGrantFinalization::RollbackPending,
+    );
+    assert_eq!(
+        actor
+            .ask(AbortMediatedInviteGrantRollback {
+                grant: grant.clone(),
+            })
+            .await
+            .expect("abort"),
+        MediatedInviteRollbackAbort::Aborted,
+    );
+    assert_eq!(
+        actor
+            .ask(AbortMediatedInviteGrantRollback {
+                grant: grant.clone(),
+            })
+            .await
+            .expect("replay abort"),
+        MediatedInviteRollbackAbort::NotPrepared,
+    );
+    assert_eq!(
+        actor
+            .ask(PrepareMediatedInviteGrantRollback {
+                grant: grant.clone(),
+            })
+            .await
+            .expect("prepare after abort"),
+        MediatedInviteRollbackPreparation::Prepared,
+    );
+    assert_eq!(
+        actor
+            .ask(AbortMediatedInviteGrantRollback { grant })
+            .await
+            .expect("return to active"),
+        MediatedInviteRollbackAbort::Aborted,
+    );
+    assert_eq!(
+        actor
+            .ask(FinalizeMediatedInviteGrant { operation_id })
+            .await
+            .expect("finalize"),
+        MediatedInviteGrantFinalization::Finalized,
+    );
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid: invitee })
+            .await
+            .expect("membership after finalization"),
+        Affiliation::Member,
+    );
+    assert_eq!(
+        actor
+            .ask(FinalizeMediatedInviteGrant { operation_id })
+            .await
+            .expect("replay finalize"),
+        MediatedInviteGrantFinalization::Finalized,
+    );
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation { operation_id })
+            .await
+            .expect("acknowledge"),
+        MediatedInviteOperationAcknowledgement::Acknowledged,
+    );
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation { operation_id })
+            .await
+            .expect("replay acknowledgement"),
+        MediatedInviteOperationAcknowledgement::Unknown,
+    );
+}
+
+#[tokio::test]
+async fn mediated_invite_rollback_commit_replays_exact_outcome_until_acknowledged() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let store = FakeDurableStore::owned();
+    actor
+        .ask(RestoreDurableRoomState {
+            store: store.clone(),
+        })
+        .await
+        .expect("attach recording durable store");
+    let operation_id = invite_operation_id();
+    let grant = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id,
+            inviter,
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("authorize")
+        .grant
+        .expect("temporary grant");
+    assert_eq!(store.save_call_count(), 1, "grant persists exactly once");
+    actor
+        .ask(PrepareMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("prepare");
+
+    let first = actor
+        .ask(CommitMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("commit");
+    assert_eq!(store.save_call_count(), 2, "rollback persists exactly once");
+    let recovery_prepare = actor
+        .ask(PrepareMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("replay prepare after a lost commit reply");
+    assert_eq!(
+        recovery_prepare,
+        MediatedInviteRollbackPreparation::AlreadyRolledBack,
+        "the cached rollback outcome must remain explicit in a strict prepare-then-commit recovery loop",
+    );
+    let replay = actor
+        .ask(CommitMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("replay commit");
+    assert_eq!(replay, first);
+    assert_eq!(
+        store.save_call_count(),
+        2,
+        "lost-reply recovery must replay the cached outcome without persisting again",
+    );
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid: invitee })
+            .await
+            .expect("rolled-back affiliation"),
+        Affiliation::None,
+    );
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation { operation_id })
+            .await
+            .expect("acknowledge"),
+        MediatedInviteOperationAcknowledgement::Acknowledged,
+    );
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation { operation_id })
+            .await
+            .expect("replay acknowledgement"),
+        MediatedInviteOperationAcknowledgement::Unknown,
+    );
+    assert_eq!(
+        actor
+            .ask(CommitMediatedInviteGrantRollback { grant })
+            .await
+            .expect("commit after acknowledgement"),
+        MediatedInviteRollbackCommit::Superseded,
+    );
+}
+
+#[tokio::test]
+async fn delayed_ack_of_finalized_operation_does_not_release_a_newer_grant() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let old_operation_id = invite_operation_id();
+    actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: old_operation_id,
+            inviter: inviter.clone(),
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("authorize old operation");
+    assert_eq!(
+        actor
+            .ask(FinalizeMediatedInviteGrant {
+                operation_id: old_operation_id,
+            })
+            .await
+            .expect("finalize old operation"),
+        MediatedInviteGrantFinalization::Finalized,
+    );
+    actor
+        .ask(ChangeAffiliation {
+            jid: invitee.clone(),
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("remove finalized membership");
+
+    let newer = authorize_invite_grant(&actor, inviter.clone(), invitee.clone()).await;
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation {
+                operation_id: old_operation_id,
+            })
+            .await
+            .expect("delayed old acknowledgement"),
+        MediatedInviteOperationAcknowledgement::Acknowledged,
+    );
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter,
+                invitee,
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::GrantPending
+        ))
+    ));
+    assert_eq!(
+        actor
+            .ask(PrepareMediatedInviteGrantRollback { grant: newer })
+            .await
+            .expect("newer grant still owns the invitee fence"),
+        MediatedInviteRollbackPreparation::Prepared,
+    );
+}
+
+#[tokio::test]
+async fn no_grant_invite_operation_is_replayed_finalized_and_acknowledged() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: false,
+        ..RoomConfig::default()
+    })
+    .await;
+    let inviter = test_full_jid("inviter");
+    let invitee = test_full_jid("invitee").to_bare();
+    actor
+        .ask(Join {
+            nick: "inviter".to_string(),
+            real_jid: inviter.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("join inviter");
+    let operation_id = invite_operation_id();
+    let first = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id,
+            inviter: inviter.clone(),
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("authorize open-room invite");
+    assert!(first.grant.is_none());
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation { operation_id })
+            .await
+            .expect("acknowledge already-terminal no-grant operation"),
+        MediatedInviteOperationAcknowledgement::Acknowledged,
+    );
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation { operation_id })
+            .await
+            .expect("replay no-grant acknowledgement"),
+        MediatedInviteOperationAcknowledgement::Unknown,
+        "acknowledging a no-grant operation removes its replay record",
+    );
+
+    let replay_operation_id = invite_operation_id();
+    let replayable = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: replay_operation_id,
+            inviter: inviter.clone(),
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("authorize replayable open-room invite");
+    assert_eq!(
+        actor
+            .ask(FinalizeMediatedInviteGrant {
+                operation_id: replay_operation_id,
+            })
+            .await
+            .expect("finalize"),
+        MediatedInviteGrantFinalization::Finalized,
+    );
+    assert_eq!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: replay_operation_id,
+                inviter,
+                invitee,
+            })
+            .await
+            .expect("replay finalized authorization"),
+        replayable,
+    );
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation {
+                operation_id: replay_operation_id,
+            })
+            .await
+            .expect("acknowledge"),
+        MediatedInviteOperationAcknowledgement::Acknowledged,
+    );
+}
+
+#[tokio::test]
+async fn completed_no_grant_operations_are_bounded_without_forgetting_known_ids() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: false,
+        group_dm: false,
+        ..RoomConfig::default()
+    })
+    .await;
+    let inviter = test_full_jid("inviter");
+    actor
+        .ask(Join {
+            nick: "inviter".to_string(),
+            real_jid: inviter.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("join inviter");
+
+    let mut operation_ids = Vec::new();
+    let first_invitee: BareJid = "invitee-0@example.com".parse().expect("bare invitee JID");
+    let mut first_authorization = None;
+    for index in 0..MAX_RETAINED_MEDIATED_INVITE_OPERATIONS {
+        let operation_id = invite_operation_id();
+        operation_ids.push(operation_id);
+        let authorization = actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id,
+                inviter: inviter.clone(),
+                invitee: format!("invitee-{index}@example.com")
+                    .parse()
+                    .expect("bare invitee JID"),
+            })
+            .await
+            .expect("bounded no-grant authorization");
+        if index == 0 {
+            first_authorization = Some(authorization);
+        }
+    }
+
+    assert_eq!(
+        actor
+            .ask(GetMediatedInviteOperationCount)
+            .await
+            .expect("operation count"),
+        MAX_RETAINED_MEDIATED_INVITE_OPERATIONS,
+    );
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter: inviter.clone(),
+                invitee: "overflow@example.com".parse().expect("bare invitee JID"),
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::OperationCapacityReached
+        ))
+    ));
+    assert_eq!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: operation_ids[0],
+                inviter: inviter.clone(),
+                invitee: first_invitee,
+            })
+            .await
+            .expect("known operation replays at capacity"),
+        first_authorization.expect("first authorization"),
+        "capacity must not forget a known idempotency key",
+    );
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation {
+                operation_id: operation_ids[0],
+            })
+            .await
+            .expect("acknowledge one completed operation"),
+        MediatedInviteOperationAcknowledgement::Acknowledged,
+    );
+    actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter,
+            invitee: "after-ack@example.com".parse().expect("bare invitee JID"),
+        })
+        .await
+        .expect("acknowledgement releases one bounded slot");
+    assert_eq!(
+        actor
+            .ask(GetMediatedInviteOperationCount)
+            .await
+            .expect("operation count after replacement"),
+        MAX_RETAINED_MEDIATED_INVITE_OPERATIONS,
+    );
+}
+
+#[tokio::test]
+async fn no_grant_operation_does_not_pin_an_otherwise_dormant_room() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: false,
+        persistent: false,
+        ..RoomConfig::default()
+    })
+    .await;
+    let inviter = test_full_jid("inviter");
+    actor
+        .ask(Join {
+            nick: "inviter".to_string(),
+            real_jid: inviter.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::None,
+        })
+        .await
+        .expect("join inviter");
+    actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter,
+            invitee: "invitee@example.com".parse().expect("bare invitee JID"),
+        })
+        .await
+        .expect("authorize no-grant invite");
+    actor
+        .ask(Leave {
+            nick: "inviter".to_string(),
+        })
+        .await
+        .expect("leave room");
+
+    let probe = actor.ask(IsDormant).await.expect("dormancy probe");
+    assert!(probe.dormant, "no-grant replay state must not pin the room");
+    assert!(
+        actor
+            .ask(SealIfInactive {
+                expected_occupancy_revision: probe.occupancy_revision,
+                guard: SealGuard::Dormant,
+            })
+            .await
+            .expect("seal dormant room"),
+        "no-grant replay state must not block guarded sealing",
+    );
+}
+
+#[tokio::test]
+async fn capacity_never_evicts_live_grants_or_persists_an_overflow_grant() {
+    let (actor, inviter, _) = joined_members_only_invite_actor().await;
+    let store = FakeDurableStore::owned();
+    actor
+        .ask(RestoreDurableRoomState {
+            store: store.clone(),
+        })
+        .await
+        .expect("attach durable store");
+    let mut first_operation = None;
+
+    for index in 0..MAX_RETAINED_MEDIATED_INVITE_OPERATIONS {
+        let operation_id = invite_operation_id();
+        let invitee: BareJid = format!("pending-{index}@example.com")
+            .parse()
+            .expect("bare invitee JID");
+        let authorization = actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id,
+                inviter: inviter.clone(),
+                invitee: invitee.clone(),
+            })
+            .await
+            .expect("authorize live grant within capacity");
+        if index == 0 {
+            first_operation = Some((operation_id, invitee, authorization));
+        }
+    }
+    assert_eq!(
+        store.save_call_count(),
+        MAX_RETAINED_MEDIATED_INVITE_OPERATIONS
+    );
+
+    assert!(matches!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: invite_operation_id(),
+                inviter: inviter.clone(),
+                invitee: "overflow@example.com".parse().expect("bare invitee JID"),
+            })
+            .await,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::OperationCapacityReached
+        ))
+    ));
+    assert_eq!(
+        store.save_call_count(),
+        MAX_RETAINED_MEDIATED_INVITE_OPERATIONS,
+        "capacity rejection must happen before durable persistence",
+    );
+    assert_eq!(
+        actor
+            .ask(GetMediatedInviteOperationCount)
+            .await
+            .expect("operation count after overflow rejection"),
+        MAX_RETAINED_MEDIATED_INVITE_OPERATIONS,
+        "capacity rejection must not evict a live operation",
+    );
+
+    let (first_operation_id, first_invitee, first_authorization) =
+        first_operation.expect("first operation");
+    assert_eq!(
+        actor
+            .ask(AuthorizeMediatedInvite {
+                operation_id: first_operation_id,
+                inviter: inviter.clone(),
+                invitee: first_invitee,
+            })
+            .await
+            .expect("replay first live operation"),
+        first_authorization,
+        "the first live record must survive capacity rejection",
+    );
+
+    assert_eq!(
+        actor
+            .ask(FinalizeMediatedInviteGrant {
+                operation_id: first_operation_id,
+            })
+            .await
+            .expect("finalize one live grant"),
+        MediatedInviteGrantFinalization::Finalized,
+        "the live record remains finalizable after capacity rejection",
+    );
+    assert_eq!(
+        actor
+            .ask(AcknowledgeMediatedInviteOperation {
+                operation_id: first_operation_id,
+            })
+            .await
+            .expect("acknowledge finalized operation"),
+        MediatedInviteOperationAcknowledgement::Acknowledged,
+    );
+    actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter,
+            invitee: "after-finalize@example.com"
+                .parse()
+                .expect("bare invitee JID"),
+        })
+        .await
+        .expect("completed record makes room for the next grant");
+    assert_eq!(
+        actor
+            .ask(GetMediatedInviteOperationCount)
+            .await
+            .expect("operation count"),
+        MAX_RETAINED_MEDIATED_INVITE_OPERATIONS,
+    );
+}
+
+#[tokio::test]
+async fn invite_grant_and_rollback_advance_the_admission_fence() {
+    let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
+    let before_grant = current_admission_revision(&actor).await;
+    let grant = authorize_invite_grant(&actor, inviter, invitee).await;
+    assert_eq!(
+        current_admission_revision(&actor).await,
+        before_grant + 1,
+        "the temporary membership changes admission state",
+    );
+    assert!(matches!(
+        actor
+            .ask(JoinWithAffiliation {
+                sender_jid: test_full_jid("stale"),
+                nick: "stale".to_string(),
+                affiliation_grant: JoinAffiliationGrant::Unaffiliated,
+                local_domain: "example.com".to_string(),
+                admission_revision: before_grant,
+            })
+            .await,
+        Err(SendError::HandlerError(
+            RoomActorError::StaleAdmissionRevision
+        ))
+    ));
+
+    actor
+        .ask(PrepareMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("prepare rollback");
+    actor
+        .ask(CommitMediatedInviteGrantRollback { grant })
+        .await
+        .expect("commit rollback");
+    assert_eq!(
+        current_admission_revision(&actor).await,
+        before_grant + 2,
+        "restoring the prior affiliation changes admission state again",
+    );
+}

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/mod.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/mod.rs
@@ -1,0 +1,69 @@
+use super::*;
+use crate::muc::room_actor::mediated_invites::MAX_RETAINED_MEDIATED_INVITE_OPERATIONS;
+
+fn invite_operation_id() -> MediatedInviteOperationId {
+    MediatedInviteOperationId::generate()
+}
+
+struct GetMediatedInviteOperationCount;
+
+impl kameo::message::Message<GetMediatedInviteOperationCount> for RoomActor {
+    type Reply = usize;
+
+    async fn handle(
+        &mut self,
+        _msg: GetMediatedInviteOperationCount,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.invite_operations.len()
+    }
+}
+
+async fn joined_members_only_invite_actor() -> (ActorRef<RoomActor>, FullJid, BareJid) {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: true,
+        ..RoomConfig::default()
+    })
+    .await;
+    let inviter = test_full_jid("inviter");
+    let invitee = test_full_jid("invitee").to_bare();
+    actor
+        .ask(Join {
+            nick: "inviter".to_string(),
+            real_jid: inviter.clone(),
+            role: Role::Moderator,
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("join inviter");
+    actor
+        .ask(ChangeAffiliation {
+            jid: inviter.to_bare(),
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("persist inviter admin affiliation");
+    (actor, inviter, invitee)
+}
+
+async fn authorize_invite_grant(
+    actor: &ActorRef<RoomActor>,
+    inviter: FullJid,
+    invitee: BareJid,
+) -> InviteMembershipGrant {
+    actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: invite_operation_id(),
+            inviter,
+            invitee,
+        })
+        .await
+        .expect("authorize mediated invite")
+        .grant
+        .expect("actor-created temporary membership")
+}
+
+mod affiliation_fencing;
+mod authorization;
+mod durability;
+mod lifecycle;

--- a/server/crates/waddle-xmpp/src/muc/room_affiliations.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_affiliations.rs
@@ -93,9 +93,11 @@ impl MucRoom {
 
     /// Check if a user can join this room based on affiliation.
     ///
-    /// For members-only rooms, users need at least Member affiliation.
+    /// For members-only rooms and group DMs, users need at least Member
+    /// affiliation. The group-DM check is intentionally redundant with
+    /// config normalization so malformed restored state fails closed.
     pub fn can_user_join(&self, jid: &BareJid) -> bool {
-        if !self.config.members_only {
+        if !self.config.requires_membership() {
             self.get_affiliation(jid) != Affiliation::Outcast
         } else {
             self.has_affiliation_at_least(jid, Affiliation::Member)

--- a/server/crates/waddle-xmpp/tests/xep0045_mediated_invitation_actor.rs
+++ b/server/crates/waddle-xmpp/tests/xep0045_mediated_invitation_actor.rs
@@ -8,7 +8,7 @@ use kameo::actor::{ActorRef, Spawn};
 use kameo::error::SendError;
 use waddle_xmpp::muc::presence::NS_MUC_USER;
 use waddle_xmpp::muc::room_actor::{
-    AuthorizeMediatedInvite, ChangeAffiliation, CommitMediatedInviteGrantRollback,
+    AuthorizeMediatedInvite, ChangeAffiliation, CommitMediatedInviteGrantRollback, GetAffiliation,
     InviteMembershipGrant, Join, MediatedInviteGrantError, MediatedInviteOperationId,
     MediatedInviteRollbackCommit, PrepareMediatedInviteGrantRollback, RoomActor,
 };
@@ -197,6 +197,66 @@ async fn group_dm_member_invite_reports_members_only_and_grants_membership() {
     assert!(authorized.grant.is_some());
     assert_eq!(authorized.invitee_affiliation, Affiliation::Member);
     assert!(authorized.members_only);
+}
+
+#[tokio::test]
+async fn mediated_invitation_cannot_replace_an_outcast_ban_with_membership() {
+    for (config, inviter_affiliation) in [
+        (
+            RoomConfig {
+                members_only: true,
+                ..RoomConfig::default()
+            },
+            Affiliation::Admin,
+        ),
+        (
+            RoomConfig {
+                group_dm: true,
+                members_only: false,
+                ..RoomConfig::default()
+            },
+            Affiliation::Member,
+        ),
+    ] {
+        let actor = spawn_room(config);
+        let inviter = full_jid("web");
+        let invitee = invitee();
+        join(&actor, inviter.clone(), inviter_affiliation).await;
+        actor
+            .ask(ChangeAffiliation {
+                jid: inviter.to_bare(),
+                affiliation: inviter_affiliation,
+            })
+            .await
+            .expect("persist inviter affiliation");
+        actor
+            .ask(ChangeAffiliation {
+                jid: invitee.clone(),
+                affiliation: Affiliation::Outcast,
+            })
+            .await
+            .expect("ban invitee");
+
+        assert!(matches!(
+            actor
+                .ask(AuthorizeMediatedInvite {
+                    operation_id: MediatedInviteOperationId::generate(),
+                    inviter,
+                    invitee: invitee.clone(),
+                })
+                .await,
+            Err(SendError::HandlerError(
+                MediatedInviteGrantError::InviteeBanned
+            ))
+        ));
+        assert_eq!(
+            actor
+                .ask(GetAffiliation { jid: invitee })
+                .await
+                .expect("ban remains authoritative"),
+            Affiliation::Outcast,
+        );
+    }
 }
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp/tests/xep0045_mediated_invitation_actor.rs
+++ b/server/crates/waddle-xmpp/tests/xep0045_mediated_invitation_actor.rs
@@ -1,0 +1,266 @@
+//! XEP-0045 §7.8 mediated-invitation actor conformance tests.
+//!
+//! The room actor is the policy boundary that verifies the exact inviting
+//! occupant and, when required, creates the temporary member-list grant.
+
+use jid::{BareJid, FullJid};
+use kameo::actor::{ActorRef, Spawn};
+use kameo::error::SendError;
+use waddle_xmpp::muc::presence::NS_MUC_USER;
+use waddle_xmpp::muc::room_actor::{
+    AuthorizeMediatedInvite, ChangeAffiliation, CommitMediatedInviteGrantRollback,
+    InviteMembershipGrant, Join, MediatedInviteGrantError, MediatedInviteOperationId,
+    MediatedInviteRollbackCommit, PrepareMediatedInviteGrantRollback, RoomActor,
+};
+use waddle_xmpp::muc::{MucRoom, MucStatusCode, RoomConfig};
+use waddle_xmpp::xep::xep0421::{OccupantIdSecret, OCCUPANT_ID_SECRET_MIN_BYTES};
+use waddle_xmpp::{Affiliation, Role};
+
+fn full_jid(resource: &str) -> FullJid {
+    format!("inviter@example.com/{resource}")
+        .parse()
+        .expect("valid inviter JID")
+}
+
+fn invitee() -> BareJid {
+    "invitee@example.com".parse().expect("valid invitee JID")
+}
+
+fn spawn_room(config: RoomConfig) -> ActorRef<RoomActor> {
+    let room_jid = "invitations@muc.example.com"
+        .parse()
+        .expect("valid room JID");
+    let room = MucRoom::new(
+        room_jid,
+        "waddle-1".to_string(),
+        "channel-1".to_string(),
+        config,
+    );
+    let secret = OccupantIdSecret::new(vec![7; OCCUPANT_ID_SECRET_MIN_BYTES])
+        .expect("valid occupant-id secret");
+    RoomActor::spawn(RoomActor::new(room, secret))
+}
+
+async fn join(actor: &ActorRef<RoomActor>, jid: FullJid, affiliation: Affiliation) {
+    actor
+        .ask(waddle_xmpp::muc::room_actor::Join {
+            nick: "inviter".to_string(),
+            real_jid: jid,
+            role: Role::Moderator,
+            affiliation,
+        })
+        .await
+        .expect("join inviter");
+}
+
+#[tokio::test]
+async fn open_room_occupied_inviter_needs_no_membership_grant() {
+    let actor = spawn_room(RoomConfig {
+        members_only: false,
+        ..RoomConfig::default()
+    });
+    let inviter = full_jid("web");
+    join(&actor, inviter.clone(), Affiliation::None).await;
+
+    let authorized = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: MediatedInviteOperationId::generate(),
+            inviter,
+            invitee: invitee(),
+        })
+        .await
+        .expect("occupied inviter may invite into an open room");
+
+    assert!(authorized.grant.is_none());
+    assert!(!authorized.members_only);
+    assert_eq!(authorized.invitee_affiliation, Affiliation::None);
+}
+
+#[tokio::test]
+async fn occupancy_is_scoped_to_the_exact_full_jid() {
+    let actor = spawn_room(RoomConfig {
+        members_only: false,
+        ..RoomConfig::default()
+    });
+    join(&actor, full_jid("web"), Affiliation::None).await;
+
+    let result = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: MediatedInviteOperationId::generate(),
+            inviter: full_jid("mobile"),
+            invitee: invitee(),
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(SendError::HandlerError(
+            MediatedInviteGrantError::NotOccupant
+        ))
+    ));
+}
+
+#[tokio::test]
+async fn members_only_admin_gets_typed_temporary_member_grant_with_stable_replay() {
+    let actor = spawn_room(RoomConfig {
+        members_only: true,
+        ..RoomConfig::default()
+    });
+    let inviter = full_jid("web");
+    join(&actor, inviter.clone(), Affiliation::Admin).await;
+    actor
+        .ask(ChangeAffiliation {
+            jid: inviter.to_bare(),
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("persist inviter admin affiliation");
+    let operation_id = MediatedInviteOperationId::generate();
+    let invitee = invitee();
+    let request = || AuthorizeMediatedInvite {
+        operation_id,
+        inviter: inviter.clone(),
+        invitee: invitee.clone(),
+    };
+
+    let first = actor
+        .ask(request())
+        .await
+        .expect("admin may invite into a members-only room");
+    let replay = actor
+        .ask(request())
+        .await
+        .expect("same operation replays its authorization");
+
+    assert_eq!(replay, first);
+    let grant: &InviteMembershipGrant = first
+        .grant
+        .as_ref()
+        .expect("actor-created temporary membership authority");
+    assert_eq!(grant.operation_id(), operation_id);
+    assert_eq!(grant.invitee(), &invitee);
+    assert_eq!(grant.previous_affiliation(), Affiliation::None);
+    assert_eq!(first.invitee_affiliation, Affiliation::Member);
+    assert!(first.members_only);
+}
+
+#[tokio::test]
+async fn group_dm_rejects_an_occupied_inviter_below_member() {
+    let actor = spawn_room(RoomConfig {
+        group_dm: true,
+        members_only: true,
+        ..RoomConfig::default()
+    });
+    let inviter = full_jid("web");
+    join(&actor, inviter.clone(), Affiliation::None).await;
+
+    let result = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: MediatedInviteOperationId::generate(),
+            inviter,
+            invitee: invitee(),
+        })
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(SendError::HandlerError(MediatedInviteGrantError::Forbidden))
+    ));
+}
+
+#[tokio::test]
+async fn group_dm_member_invite_reports_members_only_and_grants_membership() {
+    let actor = spawn_room(RoomConfig {
+        group_dm: true,
+        members_only: false,
+        ..RoomConfig::default()
+    });
+    let inviter = full_jid("web");
+    join(&actor, inviter.clone(), Affiliation::Member).await;
+    actor
+        .ask(ChangeAffiliation {
+            jid: inviter.to_bare(),
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("persist inviter membership");
+
+    let authorized = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: MediatedInviteOperationId::generate(),
+            inviter,
+            invitee: invitee(),
+        })
+        .await
+        .expect("group-DM member may invite");
+
+    assert!(authorized.grant.is_some());
+    assert_eq!(authorized.invitee_affiliation, Affiliation::Member);
+    assert!(authorized.members_only);
+}
+
+#[tokio::test]
+async fn rolling_back_a_joined_invitee_emits_xep0045_status_321() {
+    let actor = spawn_room(RoomConfig {
+        members_only: true,
+        ..RoomConfig::default()
+    });
+    let inviter = full_jid("web");
+    join(&actor, inviter.clone(), Affiliation::Admin).await;
+    actor
+        .ask(ChangeAffiliation {
+            jid: inviter.to_bare(),
+            affiliation: Affiliation::Admin,
+        })
+        .await
+        .expect("persist inviter admin affiliation");
+    let invitee = invitee();
+    let grant = actor
+        .ask(AuthorizeMediatedInvite {
+            operation_id: MediatedInviteOperationId::generate(),
+            inviter,
+            invitee: invitee.clone(),
+        })
+        .await
+        .expect("authorize members-only invite")
+        .grant
+        .expect("temporary membership grant");
+    let invitee_session: FullJid = "invitee@example.com/web"
+        .parse()
+        .expect("valid invitee full JID");
+    actor
+        .ask(Join {
+            nick: "invitee".to_string(),
+            real_jid: invitee_session,
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("invitee joins before delivery fails");
+    actor
+        .ask(PrepareMediatedInviteGrantRollback {
+            grant: grant.clone(),
+        })
+        .await
+        .expect("prepare compensation");
+
+    let MediatedInviteRollbackCommit::Applied { updates, .. } = actor
+        .ask(CommitMediatedInviteGrantRollback { grant })
+        .await
+        .expect("commit compensation")
+    else {
+        panic!("the exact temporary membership grant must roll back");
+    };
+    assert!(updates.presence_updates.iter().any(|(_, presence)| {
+        presence.payloads.iter().any(|payload| {
+            payload.name() == "x"
+                && payload.ns() == NS_MUC_USER
+                && payload.children().any(|child| {
+                    child.name() == "status"
+                        && child.ns() == NS_MUC_USER
+                        && child.attr("code").and_then(|code| code.parse::<u16>().ok())
+                            == Some(MucStatusCode::AffiliationChange as u16)
+                })
+        })
+    }));
+}

--- a/server/crates/waddle-xmpp/tests/xep_waddle_group_dm.rs
+++ b/server/crates/waddle-xmpp/tests/xep_waddle_group_dm.rs
@@ -1,4 +1,5 @@
 use minidom::Element;
+use waddle_xmpp::muc::{MucRoom, RoomConfig};
 use waddle_xmpp::xep::xep_waddle_group_dm::{
     build_history_access, history_access_from_mediated_invite, GroupDmHistoryAccess, NS_GROUP_DM,
 };
@@ -34,4 +35,21 @@ fn group_dm_history_access_defaults_to_from_join_when_mode_is_absent() {
         history_access_from_mediated_invite(&invite),
         Some(GroupDmHistoryAccess::FromJoin)
     );
+}
+
+#[test]
+fn group_dm_admission_is_always_members_only() {
+    let room = MucRoom::new(
+        "group@muc.example.com".parse().expect("room jid"),
+        "waddle".to_string(),
+        "channel".to_string(),
+        RoomConfig {
+            group_dm: true,
+            members_only: false,
+            ..RoomConfig::default()
+        },
+    );
+
+    assert!(room.config.members_only);
+    assert!(!room.can_user_join(&"stranger@example.com".parse().expect("stranger bare jid"),));
 }


### PR DESCRIPTION
## Summary

Introduce the RoomActor protocol that makes mediated-invite authorization, temporary membership grants, and conditional rollback linearizable under concurrent affiliation changes.

Part of #1289 and child of #1279. This actor-only slice does not close #1289; server persistence/handler integration and the group-DM adapter follow in separate PRs.

## Problem

The current handler authorizes from a snapshot, later grants `Member` through raw `ChangeAffiliation`, and restores the snapshot-era affiliation on failure. An inviter can be demoted between those steps, while rollback can overwrite a later Admin/Owner promotion or remove the last owner.

## Implementation

1. Add one actor-linearized `AuthorizeMediatedInvite` command using the exact inviter full JID.
2. Derive policy inside the actor: occupant-only for open rooms, Admin+ for ordinary members-only rooms, and Member+ for group DMs.
3. Key each operation with a caller-supplied typed UUID so an ambiguous actor reply can replay the exact authorization instead of losing rollback authority.
4. Return an opaque typed grant only when the actor creates a temporary `< Member → Member` affiliation.
5. Model compensation as `Active → Prepared → RolledBack(unacknowledged) → Acknowledged`, with abort and successful-finalization branches.
6. Cache the exact rollback result, including status-321 presence and moderation effects, until the caller acknowledges it.
7. Report committed-but-unacknowledged rollback as `AlreadyRolledBack`, so strict `Prepare → Commit` recovery after a lost commit reply replays the cached effects without another durable write.
8. Invalidate active grants on accepted later affiliation mutations, including same-value reaffirmation, while refused resolver/creator writes preserve the grant.
9. Fence joins, resolver synchronization, re-grants, and competing affiliation mutations through prepared and rolled-back-unacknowledged states.
10. Release finalized/superseded ownership without allowing a delayed acknowledgement to remove a newer operation's fence.
11. Route rollback through the guarded affiliation path so persistence, status-321 presence, and last-owner protection remain authoritative.
12. Return narrow typed errors for grant persistence, rollback pre-apply persistence, ownership loss, and operation-capacity exhaustion so callers cannot confuse pre-commit failures with post-commit uncertainty.
13. Bound the actor-local replay inventory at 256 operations without evicting known operation IDs; existing IDs remain exactly replayable, no-grant operations are immediately finalizable, and explicit acknowledgement releases capacity.
14. Keep prepared and rolled-back-unacknowledged operations lifecycle-fencing until recovery/acknowledgement, including empty non-persistent room sealing.
15. Split authorization, rollback, and completion into focused modules behind stable public re-exports, with a dedicated black-box XEP-0045 invitation suite.
16. Enforce `group_dm => members_only` at room construction, actor replacement/restore, owner/admin projections, and channel-catalog read/write boundaries; canonicalize every recognized stored channel type on catalog reads and writes; admission also checks the effective policy independently so malformed legacy state fails closed.
17. Reject `Outcast` invitees with a typed `InviteeBanned` result before any temporary membership persistence or operation creation.

## XEP review

- XEP-0045 §7.8 defines mediated invitation as an occupant action and permits membership grants in members-only rooms.
- §7.8 and member-list administration restrict ordinary members-only invitation privileges to room admins under Waddle's existing policy.
- Open-room invitations must not add the invitee to the member list.
- Outcast bans remain authoritative: mediated invitations cannot implicitly replace `Outcast` with `Member`; unbanning requires an explicit affiliation change.
- Group-DM admission and mediated invitation stay participant-scoped even when a legacy catalog/config row carries `members_only=false`.
- Membership rollback uses the existing guarded affiliation behavior, including status 321 when a joined member loses membership.

## Scope boundary

This PR remains an actor-protocol slice and does not wire the new invite flow into production handlers. Review exposed one adjacent privacy invariant required by that protocol: group DMs must never become open through inconsistent config or catalog state. The PR therefore also normalizes that invariant at the existing server projection/catalog boundaries. It intentionally excludes managed-membership CAS, invite ledger/delivery sequencing, production invite-handler integration, group-DM bookmarks/archive compensation, migrations, and recovery sagas.

The operation ledger in this slice is actor-incarnation-local. Cross-process/node recovery requires the next server-ledger slice to durably key affiliation and lifecycle state by the same operation ID. Prepared rollback intentionally has no actor-local timeout: after an ambiguous external CAS result, auto-abort or auto-commit could choose the wrong outcome. The caller must persist the operation inputs and replay the same authorization/rollback operation during recovery.

The new actor API is not wired into production handlers until that durability boundary is implemented. Adding only an IQ error mapping would leave the current optimistic permission write plus snapshot compensation in place, which can race actor commit/ack and resurrect temporary membership. The durable transaction/CAS integration will map retryable actor state at the stanza boundary and compensate by exact operation token. This PR does not close #1289.

## Follow-up sequence

1. Durable actor operation journal and restart restoration, atomically coupled to affiliation transitions.
2. Operation-identified managed-membership CAS across every affiliation writer.
3. Ordinary MUC coordinator/recovery wiring, typed full-JID delivery, and websocket XEP tests.
4. Group-DM adapter using the same operation and compensation primitives.

## Verification

- `cargo test -p waddle-xmpp --all-features` — 2,579 library tests plus all integration/doc targets passed.
- `cargo test -p waddle-server --all-features --lib` — 1,904 tests passed.
- `cargo test -p waddle-xmpp muc::room_actor::tests::mediated_invites:: --lib` — 41 focused lifecycle/policy/fencing/durability tests passed.
- `cargo test -p waddle-xmpp --test xep0045_mediated_invitation_actor --all-features` — 7 dedicated XEP-0045 tests passed.
- `cargo test -p waddle-xmpp --test xep_waddle_group_dm --all-features` — 3 group-DM conformance/invariant tests passed.
- `cargo clippy -p waddle-xmpp -p waddle-server --all-targets --all-features -- -D warnings` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.
- Independent standards/API review — approved after documenting the mandatory replay-before-acknowledgement contract.
- Independent split/test-equivalence review — approved after proving lost-reply recovery performs no duplicate durable write.
- Repeated concurrency/adversarial review — approved after reply-loss, resolver, finalization, stale-output, no-grant, and delayed-ack races were fixed.

## Merge gate

Keep draft until focused/full relevant tests, formatting, clippy with `-D warnings`, independent adversarial review, final-SHA Qodo 0, final-SHA Greptile success, green CI, and zero unresolved threads.

