### PR TITLE
fix(client): advertise XEP-0085 in entity capabilities

### DIFF
--- a/server/crates/waddle-xmpp-client/src/caps.rs
+++ b/server/crates/waddle-xmpp-client/src/caps.rs
@@ -3,7 +3,9 @@ use minidom::Element;
 use sha1::{Digest, Sha1};
 
 use crate::discovery::DISCO_INFO_NS;
-use crate::messaging::{NS_CHAT_MARKERS, NS_MESSAGE_CORRECT, NS_MESSAGE_RETRACT, NS_REACTIONS};
+use crate::messaging::{
+    NS_CHAT_MARKERS, NS_CHAT_STATES, NS_MESSAGE_CORRECT, NS_MESSAGE_RETRACT, NS_REACTIONS,
+};
 
 pub const NS_CAPS: &str = "http://jabber.org/protocol/caps";
 pub const CAPS_NODE: &str = "https://waddle.social/caps";
@@ -31,6 +33,10 @@ pub fn client_caps_features() -> Vec<&'static str> {
         // implemented by this client (builders + parse + UI), and its
         // XEP requires/recommends the disco feature on supporting
         // clients.
+        //
+        // XEP-0085 §Determining Support: an implementing entity MUST
+        // advertise the chatstates namespace in disco#info.
+        NS_CHAT_STATES,
         //
         // XEP-0424 §Discovering support: a client implementing message
         // retraction MUST advertise this.
@@ -193,6 +199,48 @@ mod tests {
         );
     }
 
+    #[test]
+    fn caps_advertise_xep0085_chatstates_exactly_once() {
+        let count = client_caps_features()
+            .into_iter()
+            .filter(|feature| *feature == crate::messaging::NS_CHAT_STATES)
+            .count();
+        assert_eq!(count, 1, "XEP-0085 chatstates feature cardinality");
+    }
+
+    /// XEP-0115 §5.1 golden vector for Waddle's concrete client identity and
+    /// feature set. The expected SHA-1/Base64 value was calculated outside
+    /// this implementation from the byte-sorted verification string using
+    /// `openssl dgst -sha1 -binary | openssl base64 -A`. Pinning the literal
+    /// makes this sensitive to identity fields, feature membership, octet
+    /// ordering, and every required `<` separator.
+    #[test]
+    fn client_caps_verification_hash_matches_fixed_golden_vector() {
+        let mut features = client_caps_features();
+        features.sort_unstable();
+        assert_eq!(
+            features,
+            vec![
+                crate::pep::NS_ACTIVITY_NOTIFY,
+                NS_CAPS,
+                crate::messaging::NS_CHAT_STATES,
+                DISCO_INFO_NS,
+                crate::pep::NS_STATUS_PREFERENCE_NOTIFY,
+                NS_CHAT_MARKERS,
+                crate::mds::NS_MDS_NOTIFY,
+                NS_MESSAGE_CORRECT,
+                NS_MESSAGE_RETRACT,
+                NS_REACTIONS,
+                crate::messaging::NS_STANZA_ID,
+            ],
+            "the golden hash is valid only for this exact concrete feature set"
+        );
+        assert_eq!(
+            client_caps_verification_string(),
+            "xOykj9pu3F2sZWOM/yD+WvlIkgU="
+        );
+    }
+
     /// XEP-0115 §5.1: the ver string is derived from the sorted feature
     /// set, so every advertised feature must be unique or the hash is
     /// ill-formed (§5.4 validation would reject it).
@@ -253,6 +301,18 @@ mod tests {
                 && child.ns() == DISCO_INFO_NS
                 && child.attr("var") == Some(crate::mds::NS_MDS_NOTIFY)
         }));
+        assert_eq!(
+            query
+                .children()
+                .filter(|child| {
+                    child.name() == "feature"
+                        && child.ns() == DISCO_INFO_NS
+                        && child.attr("var") == Some(crate::messaging::NS_CHAT_STATES)
+                })
+                .count(),
+            1,
+            "the current caps node must disclose XEP-0085 exactly once"
+        );
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client/src/messaging/builders.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/builders.rs
@@ -18,21 +18,12 @@ pub fn build_chat_state_message(
     thread: Option<&xep_thread::ThreadRef>,
 ) -> ClientResult<Element> {
     let state = validate_chat_state(state)?;
-    let stanza_id = Uuid::new_v4().to_string();
     let mut builder = Element::builder("message", NS_CLIENT)
         .attr(minidom::rxml::xml_ncname!("to").to_owned(), to)
         .attr(minidom::rxml::xml_ncname!("type").to_owned(), message_type)
         .append(Element::builder(state, NS_CHAT_STATES).build());
     if let Some(thread) = thread {
         builder = builder.append(xep_thread::build_thread_element(thread));
-    }
-    if should_stamp_origin_id(message_type) {
-        builder = builder
-            .attr(
-                minidom::rxml::xml_ncname!("id").to_owned(),
-                stanza_id.as_str(),
-            )
-            .append(build_origin_id(&stanza_id));
     }
     Ok(builder.build())
 }

--- a/server/crates/waddle-xmpp-client/src/messaging/builders.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/builders.rs
@@ -18,9 +18,14 @@ pub fn build_chat_state_message(
     thread: Option<&xep_thread::ThreadRef>,
 ) -> ClientResult<Element> {
     let state = validate_chat_state(state)?;
+    let stanza_id = Uuid::new_v4().to_string();
     let mut builder = Element::builder("message", NS_CLIENT)
         .attr(minidom::rxml::xml_ncname!("to").to_owned(), to)
         .attr(minidom::rxml::xml_ncname!("type").to_owned(), message_type)
+        .attr(
+            minidom::rxml::xml_ncname!("id").to_owned(),
+            stanza_id.as_str(),
+        )
         .append(Element::builder(state, NS_CHAT_STATES).build());
     if let Some(thread) = thread {
         builder = builder.append(xep_thread::build_thread_element(thread));

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -2088,8 +2088,10 @@ fn build_chat_state_message_validates_state() {
         .expect("valid chat state");
     assert_eq!(stanza.attr("to"), Some("alice@example.com"));
     assert_eq!(stanza.attr("type"), Some("chat"));
-    assert_origin_id_matches_message_id(&stanza);
+    assert!(stanza.attr("id").is_none());
+    assert!(stanza.get_child("origin-id", NS_ORIGIN_ID).is_none());
     assert!(stanza.get_child("composing", NS_CHAT_STATES).is_some());
+    assert_eq!(stanza.children().count(), 1);
     assert!(build_chat_state_message("alice@example.com", "typing", "chat", None).is_err());
 }
 

--- a/server/crates/waddle-xmpp-client/src/messaging/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/tests.rs
@@ -2088,7 +2088,7 @@ fn build_chat_state_message_validates_state() {
         .expect("valid chat state");
     assert_eq!(stanza.attr("to"), Some("alice@example.com"));
     assert_eq!(stanza.attr("type"), Some("chat"));
-    assert!(stanza.attr("id").is_none());
+    assert!(!stanza.attr("id").expect("delivery id").is_empty());
     assert!(stanza.get_child("origin-id", NS_ORIGIN_ID).is_none());
     assert!(stanza.get_child("composing", NS_CHAT_STATES).is_some());
     assert_eq!(stanza.children().count(), 1);

--- a/server/crates/waddle-xmpp-client/tests/xep0085_chat_state_notifications.rs
+++ b/server/crates/waddle-xmpp-client/tests/xep0085_chat_state_notifications.rs
@@ -55,7 +55,7 @@ fn xep0085_client_builds_and_parses_a_chat_state_notification() {
     let parsed = parse_chat_state_payload(&message).expect("chat state parses");
 
     assert_eq!(parsed.state, "composing");
-    assert!(message.attr("id").is_none());
+    assert!(!message.attr("id").expect("delivery id").is_empty());
     assert!(message
         .children()
         .any(|child| child.is("composing", NS_CHAT_STATES)));

--- a/server/crates/waddle-xmpp-client/tests/xep0085_chat_state_notifications.rs
+++ b/server/crates/waddle-xmpp-client/tests/xep0085_chat_state_notifications.rs
@@ -1,0 +1,62 @@
+//! XEP-0085: Chat State Notifications dedicated client suite.
+
+use minidom::Element;
+use waddle_xmpp_client::{
+    caps::{build_client_caps_disco_info_response, client_caps_features, client_caps_node_ver},
+    messaging::{build_chat_state_message, parse_chat_state_payload, NS_CHAT_STATES, NS_CLIENT},
+};
+
+const NS_DISCO_INFO: &str = "http://jabber.org/protocol/disco#info";
+
+#[test]
+fn xep0085_client_advertises_chatstates_exactly_once() {
+    assert_eq!(
+        client_caps_features()
+            .into_iter()
+            .filter(|feature| *feature == NS_CHAT_STATES)
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn xep0085_current_caps_node_disco_includes_chatstates_exactly_once() {
+    let request = Element::builder("iq", NS_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
+        .append(
+            Element::builder("query", NS_DISCO_INFO)
+                .attr(
+                    minidom::rxml::xml_ncname!("node").to_owned(),
+                    client_caps_node_ver(),
+                )
+                .build(),
+        )
+        .build();
+    let response = build_client_caps_disco_info_response(&request, None)
+        .expect("the current caps node is served");
+    let query = response
+        .get_child("query", NS_DISCO_INFO)
+        .expect("disco query is present");
+
+    assert_eq!(
+        query
+            .children()
+            .filter(|child| {
+                child.is("feature", NS_DISCO_INFO) && child.attr("var") == Some(NS_CHAT_STATES)
+            })
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn xep0085_client_builds_and_parses_a_chat_state_notification() {
+    let message = build_chat_state_message("juliet@example.com", "composing", "chat", None)
+        .expect("valid chat state builds");
+    let parsed = parse_chat_state_payload(&message).expect("chat state parses");
+
+    assert_eq!(parsed.state, "composing");
+    assert!(message
+        .children()
+        .any(|child| child.is("composing", NS_CHAT_STATES)));
+}

--- a/server/crates/waddle-xmpp-client/tests/xep0085_chat_state_notifications.rs
+++ b/server/crates/waddle-xmpp-client/tests/xep0085_chat_state_notifications.rs
@@ -3,10 +3,9 @@
 use minidom::Element;
 use waddle_xmpp_client::{
     caps::{build_client_caps_disco_info_response, client_caps_features, client_caps_node_ver},
+    discovery::DISCO_INFO_NS,
     messaging::{build_chat_state_message, parse_chat_state_payload, NS_CHAT_STATES, NS_CLIENT},
 };
-
-const NS_DISCO_INFO: &str = "http://jabber.org/protocol/disco#info";
 
 #[test]
 fn xep0085_client_advertises_chatstates_exactly_once() {
@@ -24,7 +23,7 @@ fn xep0085_current_caps_node_disco_includes_chatstates_exactly_once() {
     let request = Element::builder("iq", NS_CLIENT)
         .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
         .append(
-            Element::builder("query", NS_DISCO_INFO)
+            Element::builder("query", DISCO_INFO_NS)
                 .attr(
                     minidom::rxml::xml_ncname!("node").to_owned(),
                     client_caps_node_ver(),
@@ -35,14 +34,14 @@ fn xep0085_current_caps_node_disco_includes_chatstates_exactly_once() {
     let response = build_client_caps_disco_info_response(&request, None)
         .expect("the current caps node is served");
     let query = response
-        .get_child("query", NS_DISCO_INFO)
+        .get_child("query", DISCO_INFO_NS)
         .expect("disco query is present");
 
     assert_eq!(
         query
             .children()
             .filter(|child| {
-                child.is("feature", NS_DISCO_INFO) && child.attr("var") == Some(NS_CHAT_STATES)
+                child.is("feature", DISCO_INFO_NS) && child.attr("var") == Some(NS_CHAT_STATES)
             })
             .count(),
         1

--- a/server/crates/waddle-xmpp-client/tests/xep0085_chat_state_notifications.rs
+++ b/server/crates/waddle-xmpp-client/tests/xep0085_chat_state_notifications.rs
@@ -55,7 +55,24 @@ fn xep0085_client_builds_and_parses_a_chat_state_notification() {
     let parsed = parse_chat_state_payload(&message).expect("chat state parses");
 
     assert_eq!(parsed.state, "composing");
+    assert!(message.attr("id").is_none());
     assert!(message
         .children()
         .any(|child| child.is("composing", NS_CHAT_STATES)));
+    assert_eq!(message.children().count(), 1, "§5.6 permits no extra child");
+}
+
+#[test]
+fn xep0085_thread_is_the_only_optional_standalone_child() {
+    let thread = waddle_xmpp_client::xep::thread::ThreadRef {
+        id: "thread-1".to_owned(),
+        parent: None,
+    };
+    let message =
+        build_chat_state_message("room@muc.example", "composing", "groupchat", Some(&thread))
+            .expect("threaded chat state builds");
+
+    assert_eq!(message.children().count(), 2);
+    assert!(message.get_child("composing", NS_CHAT_STATES).is_some());
+    assert!(message.get_child("thread", NS_CLIENT).is_some());
 }


### PR DESCRIPTION
## Summary

Advertise the already-implemented XEP-0085 chat-state protocol through Waddle's client entity capabilities so conforming peers can discover typing-state support.

Closes #1286. Child of #1279. Relates #1258 and #210.

## Implementation

1. Add the canonical `NS_CHAT_STATES` namespace exactly once to `client_caps_features`.
2. Serve that same feature through disco for the current XEP-0115 caps node.
3. Pin the exact concrete sorted feature set and independently OpenSSL-derived verification hash `xOykj9pu3F2sZWOM/yD+WvlIkgU=`.
4. Add a dedicated client XEP-0085 suite covering advertisement, caps-node disco, and typed build/parse behavior while retaining the server/MUC suite.
5. Keep standalone notifications conformant with §5.6 by emitting no child other than the chat-state element and optional thread, while retaining the standard `id` attribute for delivery reporting.

## XEP review

- XEP-0085 requires implementing entities to advertise `http://jabber.org/protocol/chatstates` through disco.
- XEP-0115 verification strings use i;octet ordering and `<` separators across the identity and exact feature set.

## Verification

- Client caps tests: 8 passed.
- Runtime caps-node disco test: passed.
- Client chat-state parse/build tests: 4 passed.
- Waddle XMPP client unit suite: 530 passed.
- Client integration suite: 11 passed.
- Dedicated client XEP-0085 custom suite: 4 passed.
- Dedicated server/MUC XEP-0085 custom suite: 2 passed.
- XEP-0115 tests: 39 passed.
- Strict all-target/all-feature Clippy: passed.
- Rust formatting and `git diff --check`: clean.

## Merge gate

Do not merge until CI is green, Greptile and Qodo succeed on the final SHA with zero actionable findings, and no review thread remains unresolved.
