### PR TITLE
fix(chat): scope MUC-PM displayed state to occupant JIDs

### DIFF
--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
@@ -2376,8 +2376,8 @@ public struct WaddleMdsDisplayedEntry: Equatable, Hashable {
      */
     public var stanzaId: String
     /**
-     * Assigning entity's XEP-0359 `by` JID; preserve exactly for
-     * stanza-id authority matching.
+     * Resource-less room or account-server authority from the XEP-0359 `by`
+     * attribute, as required by XEP-0490.
      */
     public var stanzaIdBy: String
 
@@ -2391,8 +2391,8 @@ public struct WaddleMdsDisplayedEntry: Equatable, Hashable {
          * XEP-0359 id of the displayed message.
          */stanzaId: String,
         /**
-         * Assigning entity's XEP-0359 `by` JID; preserve exactly for
-         * stanza-id authority matching.
+         * Resource-less room or account-server authority from the XEP-0359 `by`
+         * attribute, as required by XEP-0490.
          */stanzaIdBy: String) {
         self.chatId = chatId
         self.stanzaId = stanzaId

--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
@@ -2376,8 +2376,8 @@ public struct WaddleMdsDisplayedEntry: Equatable, Hashable {
      */
     public var stanzaId: String
     /**
-     * JID that injected the stanza-id (the room for groupchat; the
-     * user's own server for DMs and MUC PMs).
+     * Assigning entity's XEP-0359 `by` JID; preserve exactly for
+     * stanza-id authority matching.
      */
     public var stanzaIdBy: String
 
@@ -2391,8 +2391,8 @@ public struct WaddleMdsDisplayedEntry: Equatable, Hashable {
          * XEP-0359 id of the displayed message.
          */stanzaId: String,
         /**
-         * JID that injected the stanza-id (the room for groupchat; the
-         * user's own server for DMs and MUC PMs).
+         * Assigning entity's XEP-0359 `by` JID; preserve exactly for
+         * stanza-id authority matching.
          */stanzaIdBy: String) {
         self.chatId = chatId
         self.stanzaId = stanzaId

--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
@@ -2363,12 +2363,12 @@ public func FfiConverterTypeWaddleMamPage_lower(_ value: WaddleMamPage) -> RustB
  * XEP-0490 §3 displayed-marker entry surfaced to Swift. Mirrors
  * `waddle_xmpp_client::messaging::MdsDisplayedEntry` 1:1 — the
  * FFI does not collapse or rename fields so the Swift consumer
- * can correlate `chat_id` (PEP item id = bare JID of the chat)
+ * can correlate `chat_id` (PEP item id = the exact chat JID)
  * with its locally-tracked conversation list directly.
  */
 public struct WaddleMdsDisplayedEntry: Equatable, Hashable {
     /**
-     * PEP item id = bare JID of the chat (DM contact or MUC room).
+     * PEP item id = bare for DMs/rooms, full occupant for MUC PMs.
      */
     public var chatId: String
     /**
@@ -2376,8 +2376,8 @@ public struct WaddleMdsDisplayedEntry: Equatable, Hashable {
      */
     public var stanzaId: String
     /**
-     * JID that injected the stanza-id (the MUC room for group
-     * chats; the user's own server for 1:1 chats).
+     * JID that injected the stanza-id (the room for groupchat; the
+     * user's own server for DMs and MUC PMs).
      */
     public var stanzaIdBy: String
 
@@ -2385,14 +2385,14 @@ public struct WaddleMdsDisplayedEntry: Equatable, Hashable {
     // declare one manually.
     public init(
         /**
-         * PEP item id = bare JID of the chat (DM contact or MUC room).
+         * PEP item id = bare for DMs/rooms, full occupant for MUC PMs.
          */chatId: String,
         /**
          * XEP-0359 id of the displayed message.
          */stanzaId: String,
         /**
-         * JID that injected the stanza-id (the MUC room for group
-         * chats; the user's own server for 1:1 chats).
+         * JID that injected the stanza-id (the room for groupchat; the
+         * user's own server for DMs and MUC PMs).
          */stanzaIdBy: String) {
         self.chatId = chatId
         self.stanzaId = stanzaId

--- a/chat/src/channels/messages.ts
+++ b/chat/src/channels/messages.ts
@@ -638,7 +638,11 @@ export function useChannelMessages(
 
   function applyMdsDisplayed(chatId: string, displayed: MdsDisplayedState): boolean {
     const roomJid = currentRoomJid.value;
-    if (!roomJid || barePeerJid(chatId) !== barePeerJid(roomJid)) return false;
+    // XEP-0490 scopes groupchat to the bare room and MUC PMs to a full
+    // occupant JID. Never let an occupant item advance the room timeline.
+    if (!roomJid || chatId.includes("/") || barePeerJid(chatId) !== barePeerJid(roomJid)) {
+      return false;
+    }
     const feedTimeline = messages.value.filter(isFeedVisible);
     const key = mdsChatKey(barePeerJid(roomJid));
     if (!displayedStateCanAdvance(feedTimeline, getMdsDisplayed(key), displayed)) return false;

--- a/chat/src/dms/chat-send.ts
+++ b/chat/src/dms/chat-send.ts
@@ -1,6 +1,7 @@
 import { ref, type Ref } from "vue";
 import type { WaddleSession } from "@/lib/server-auth";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import type { DmConversationScope } from "@/lib/xmpp-client";
 import { MAX_FILE_UPLOAD_BYTES } from "@/lib/xmpp/file-upload";
 import type { OutboundFileAttachment } from "@/lib/xmpp";
 import { composerLinkPreviewPayloadIsFresh, type ComposerLinkPreviewSendPayload } from "@/lib/link-preview-composer";
@@ -28,12 +29,14 @@ type UseChatSendDeps = {
   clearActionError: () => void;
   normalizeError: (e: unknown) => string;
   scrollToPinnedEdgeAndPin: () => Promise<boolean>;
+  conversationScope?: (peerJid: string) => DmConversationScope;
   // Mirror of useMucSend's contract: the orchestrator handles XEP-0085 chat
   // state cleanup until that axis lands its own composable in PR 5.
   onSendComplete: (
     result: ChatSendResult,
     peerJid: string,
     isStillActive: boolean,
+    scope: DmConversationScope,
   ) => void;
 };
 
@@ -48,6 +51,7 @@ export function useChatSend(deps: UseChatSendDeps) {
     clearActionError,
     normalizeError,
     scrollToPinnedEdgeAndPin,
+    conversationScope,
     onSendComplete,
   } = deps;
 
@@ -76,6 +80,7 @@ export function useChatSend(deps: UseChatSendDeps) {
     const hasFiles = !!files && files.length > 0;
     if (!client || !peerJid || !session.value) return;
     if (!bodyText.trim() && !hasFiles) return;
+    const scope = conversationScope?.(peerJid) ?? "account";
 
     if (hasFiles) {
       for (const f of files!) {
@@ -124,6 +129,7 @@ export function useChatSend(deps: UseChatSendDeps) {
         ...(wireReplyTo ? { replyTo: wireReplyTo } : {}),
         ...(thread ? { threadId: thread.id } : {}),
         ...(thread?.parent ? { parentThreadId: thread.parent } : {}),
+        mucPm: scope === "muc-occupant",
       });
       const msgId = result?.id ?? null;
       const isStillActive = xmppClient.value === client && activePeerJid.value === peerJid;
@@ -176,7 +182,7 @@ export function useChatSend(deps: UseChatSendDeps) {
       // orchestrator (chat-state cleanup, XEP-0085 "active" send) can't be
       // mistaken for a send failure and surface as actionError.
       try {
-        onSendComplete(result ?? null, peerJid, isStillActive);
+        onSendComplete(result ?? null, peerJid, isStillActive, scope);
       } catch (callbackError) {
         console.warn("useChatSend onSendComplete callback threw", callbackError);
       }
@@ -196,6 +202,7 @@ export function useChatSend(deps: UseChatSendDeps) {
     linkPreview?: ComposerLinkPreviewSendPayload,
   ) {
     if (!xmppClient.value || !activePeerJid.value || !newBody.trim()) return;
+    const scope = conversationScope?.(activePeerJid.value) ?? "account";
     const message = findMessageById(messages.value, messageId);
     const targetId = message?.correctionTargetId ?? messageId;
     const freshLinkPreview = composerLinkPreviewPayloadIsFresh(linkPreview) ? linkPreview : undefined;
@@ -212,6 +219,7 @@ export function useChatSend(deps: UseChatSendDeps) {
           linkPreviewExpiresAt: freshLinkPreview.expiresAt,
         } : undefined,
         dmThreadRefFromMessage(message),
+        scope,
       );
     } catch (e) {
       actionError.value = normalizeError(e);

--- a/chat/src/dms/chat-states.ts
+++ b/chat/src/dms/chat-states.ts
@@ -1,5 +1,5 @@
 import { getCurrentScope, onScopeDispose, ref, type Ref } from "vue";
-import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import type { BrowserXmppClient, DmConversationScope } from "@/lib/xmpp-client";
 
 // XEP-0085 chat-state notifications for the DM side. Mirrors
 // useChannelChatStates with the same debounce machine, scoped to the
@@ -8,13 +8,14 @@ import type { BrowserXmppClient } from "@/lib/xmpp-client";
 type UseDmChatStatesDeps = {
   xmppClient: Ref<BrowserXmppClient | null>;
   activePeerJid: Ref<string | null>;
+  conversationScope?: (peerJid: string) => DmConversationScope;
 };
 
 const TYPING_EXPIRY_MS = 5000;
 const COMPOSING_PAUSE_MS = 3000;
 
 export function useDmChatStates(deps: UseDmChatStatesDeps) {
-  const { xmppClient, activePeerJid } = deps;
+  const { xmppClient, activePeerJid, conversationScope } = deps;
 
   const typingUsers = ref<string[]>([]);
   const typingTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -67,15 +68,16 @@ export function useDmChatStates(deps: UseDmChatStatesDeps) {
     const client = xmppClient.value;
     const peerJid = activePeerJid.value;
     if (!client || !peerJid) return;
+    const scope = conversationScope?.(peerJid) ?? "account";
     if (lastChatState !== "composing") {
       lastChatState = "composing";
-      void client.sendDmChatState(peerJid, "composing", thread).catch(() => undefined);
+      void client.sendDmChatState(peerJid, "composing", thread, scope).catch(() => undefined);
     }
     if (composingTimeout) clearTimeout(composingTimeout);
     composingTimeout = setTimeout(() => {
       if (xmppClient.value !== client || activePeerJid.value !== peerJid) return;
       lastChatState = "paused";
-      void client.sendDmChatState(peerJid, "paused", thread).catch(() => undefined);
+      void client.sendDmChatState(peerJid, "paused", thread, scope).catch(() => undefined);
     }, COMPOSING_PAUSE_MS);
   }
 

--- a/chat/src/dms/conversations.ts
+++ b/chat/src/dms/conversations.ts
@@ -1,6 +1,13 @@
 import { computed, ref, watch, type Ref } from "vue";
 import type { WaddleSession } from "@/lib/server-auth";
-import type { BrowserXmppClient, DmConversation, InboxEntry, LiveDmMessage, PresenceUpdateEvent } from "@/lib/xmpp-client";
+import type {
+  BrowserXmppClient,
+  DmConversation,
+  DmConversationScope,
+  InboxEntry,
+  LiveDmMessage,
+  PresenceUpdateEvent,
+} from "@/lib/xmpp-client";
 import { barePeerJid, jidLocalpart } from "@/lib/xmpp-client";
 
 function peerUsername(peerJid: string): string {
@@ -60,6 +67,12 @@ export function useDirectMessageConversations(
     conversations.value.reduce((total, conversation) => total + Math.max(0, conversation.unreadCount), 0)
   );
   const selfBareJid = computed(() => barePeerJid(session.value?.jid ?? ""));
+  const activeConversationScope = computed<DmConversationScope | null>(() => {
+    const active = activePeerJid.value;
+    if (!active) return null;
+    const conversation = conversations.value.find((candidate) => candidate.peerJid === active);
+    return conversation?.mucPm ? "muc-occupant" : "account";
+  });
 
   let inboxRequestId = 0;
   const pendingMarkRead = new Set<string>();
@@ -98,21 +111,25 @@ export function useDirectMessageConversations(
       const raw = window.sessionStorage.getItem(key);
       if (!raw) return;
       const parsed = JSON.parse(raw) as { conversations?: DmConversation[]; activePeerJid?: string | null };
-      conversations.value = sortByRecent((parsed.conversations ?? []).map((c) => ({
-        ...c,
-        // #1256: MUC-PM conversations are keyed by the FULL occupant JID —
-        // bare-folding on restore would re-key them to the room bare JID
-        // (a reply from that row would broadcast to the room). The
-        // resource heuristic backstops the flag: normal DM rows are
-        // always persisted bare, so a resource-carrying key IS an
-        // occupant conversation even in a blob written without the flag.
-        peerJid: c.mucPm || c.peerJid.includes("/") ? c.peerJid : barePeerJid(c.peerJid),
-        peerUsername: c.peerUsername || (c.mucPm ? mucPmDisplayName(c.peerJid) : peerUsername(c.peerJid)),
-        unreadCount: c.unreadCount ?? 0,
-        // Clear any idle age from an older persisted blob — it starts empty and
-        // only repopulates from live presence updates.
-        presenceIdleSince: undefined,
-      })));
+      conversations.value = sortByRecent((parsed.conversations ?? []).map((c) => {
+        const mucPm = c.mucPm === true || c.peerJid.includes("/");
+        return {
+          ...c,
+          // #1256: MUC-PM conversations are keyed by the FULL occupant JID —
+          // bare-folding on restore would re-key them to the room bare JID
+          // (a reply from that row would broadcast to the room). The
+          // resource heuristic backstops the flag: normal DM rows are
+          // always persisted bare, so a resource-carrying key IS an
+          // occupant conversation even in a blob written without the flag.
+          peerJid: mucPm ? c.peerJid : barePeerJid(c.peerJid),
+          peerUsername: c.peerUsername || (mucPm ? mucPmDisplayName(c.peerJid) : peerUsername(c.peerJid)),
+          ...(mucPm ? { mucPm: true, mucPmRoomJid: c.mucPmRoomJid ?? barePeerJid(c.peerJid) } : {}),
+          unreadCount: c.unreadCount ?? 0,
+          // Clear any idle age from an older persisted blob — it starts empty and
+          // only repopulates from live presence updates.
+          presenceIdleSince: undefined,
+        };
+      }));
       const restoredActive = parsed.activePeerJid ?? null;
       activePeerJid.value = restoredActive
         ? (conversations.value.some((c) => c.peerJid === restoredActive.trim())
@@ -478,6 +495,7 @@ export function useDirectMessageConversations(
   return {
     conversations,
     activePeerJid,
+    activeConversationScope,
     hasUnread,
     totalUnreadCount,
     openDm,

--- a/chat/src/dms/mam-paging.ts
+++ b/chat/src/dms/mam-paging.ts
@@ -1,6 +1,6 @@
 import { nextTick, ref, type Ref } from "vue";
-import type { BrowserXmppClient, LiveDmMessage } from "@/lib/xmpp-client";
-import { barePeerJid } from "@/lib/xmpp-client";
+import type { BrowserXmppClient, DmConversationScope, LiveDmMessage } from "@/lib/xmpp-client";
+import { dmConversationIdentityKey } from "@/lib/xmpp-client";
 import type { WaddleSession } from "@/lib/server-auth";
 import type { TimelineMessage } from "@/lib/chat-ui";
 import type { TimelineLoadResult } from "@/lib/timeline-load-result";
@@ -46,8 +46,9 @@ type UseDmMamPagingDeps = {
   appendQueuedMessages: (timeline: TimelineMessage[], peerJid: string) => TimelineMessage[];
   scrollToPinnedEdgeAndPin: () => Promise<boolean>;
   isFeedVisible: (m: TimelineMessage) => boolean;
-  persistLastSeen: (peerJid: string, messageId: string) => void;
+  persistLastSeen: (peerJid: string, messageId: string, capturedConversationId?: string) => void;
   dmLoadErrorMessage: (peerJid: string, opts?: { queuedOnly?: boolean }) => string;
+  conversationScope?: (peerJid: string) => DmConversationScope;
 };
 
 export function useDmMamPaging(deps: UseDmMamPagingDeps) {
@@ -70,7 +71,18 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
     isFeedVisible,
     persistLastSeen,
     dmLoadErrorMessage,
+    conversationScope,
   } = deps;
+
+  function scopeForPeer(peerJid: string): DmConversationScope {
+    const client = xmppClient.value;
+    return conversationScope?.(peerJid)
+      ?? (client?.isMucPmPeer?.(peerJid) === true ? "muc-occupant" : "account");
+  }
+
+  function conversationIdForPeer(peerJid: string, scope: DmConversationScope): string {
+    return dmConversationIdentityKey(peerJid, () => scope === "muc-occupant");
+  }
 
   const isLoadingMessages = ref(false);
   const isLoadingOlderMessages = ref(false);
@@ -97,6 +109,11 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
 
   async function loadMessages(peerJid: string, unreadAtLoad = 0): Promise<TimelineLoadResult> {
     if (!session.value) return "aborted";
+    // Capture the typed conversation scope before the async MAM request.
+    // A disconnect/client replacement while awaiting the page must not
+    // reclassify a full occupant JID as an ordinary bare-resource DM.
+    const dmScope = scopeForPeer(peerJid);
+    const conversationId = conversationIdForPeer(peerJid, dmScope);
     const requestId = ++messageRequestId;
     initialLatestPagePinned = false;
     isLoadingMessages.value = true;
@@ -113,12 +130,12 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
 
     try {
       const page = xmppClient.value && "queryPersonalMamPage" in xmppClient.value
-        ? await xmppClient.value.queryPersonalMamPage(peerJid, PAGE_SIZE, { type: "latest" })
+        ? await xmppClient.value.queryPersonalMamPage(peerJid, PAGE_SIZE, { type: "latest" }, dmScope)
         : null;
       const mamResults = page
         ? page.messages
         : xmppClient.value
-          ? await xmppClient.value.queryPersonalMam(peerJid, PAGE_SIZE)
+          ? await xmppClient.value.queryPersonalMam(peerJid, PAGE_SIZE, dmScope)
           : [];
       if (requestId !== messageRequestId || activePeerJid.value !== peerJid) return "aborted";
       loadErrorPeerJid.value = null;
@@ -145,7 +162,7 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
       if (requestId === messageRequestId) isLoadingMessages.value = false;
 
       const feedTimeline = timelineWithQueue.filter(isFeedVisible);
-      const mdsKey = mdsChatKey(barePeerJid(peerJid));
+      const mdsKey = mdsChatKey(conversationId);
       const displayed = latestDisplayedStateOnTimeline(
         feedTimeline,
         getMdsDisplayedCandidates(mdsKey),
@@ -170,7 +187,7 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
       if (!pinned) return "loaded";
       initialLatestPagePinned = true;
       const newest = [...timelineWithQueue].reverse().find(isFeedVisible);
-      if (newest) persistLastSeen(peerJid, newest.id);
+      if (newest) persistLastSeen(peerJid, newest.id, conversationId);
       return "loaded";
     } catch {
       if (requestId !== messageRequestId) return "aborted";
@@ -218,7 +235,7 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
     const previousTop = el?.scrollTop ?? 0;
     isLoadingOlderMessages.value = true;
     try {
-      const page = await client.queryPersonalMamPage(peerJid, PAGE_SIZE, { type: "before", before });
+      const page = await client.queryPersonalMamPage(peerJid, PAGE_SIZE, { type: "before", before }, scopeForPeer(peerJid));
       if (!isCurrentRequest()) return;
       const advanced = advanceCursorWithBeforePage({
         prior: { oldestArchiveId, hasOlderMessages: hasOlderMessages.value },
@@ -271,7 +288,7 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
       const previousBefore = before;
       let page: Awaited<ReturnType<typeof client.queryPersonalMamPage>>;
       try {
-        page = await client.queryPersonalMamPage(peerJid, PAGE_SIZE, { type: "before", before });
+        page = await client.queryPersonalMamPage(peerJid, PAGE_SIZE, { type: "before", before }, scopeForPeer(peerJid));
       } catch (e) {
         const classified = classifyMamError(e);
         if (isMamCursorNotFound(classified)) {
@@ -333,7 +350,7 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
       activePeerJid.value === peerJid;
     let page: Awaited<ReturnType<typeof client.queryPersonalMamThreadPage>>;
     try {
-      page = await client.queryPersonalMamThreadPage(peerJid, threadId, PAGE_SIZE, { type: "latest" });
+      page = await client.queryPersonalMamThreadPage(peerJid, threadId, PAGE_SIZE, { type: "latest" }, scopeForPeer(peerJid));
     } catch (e) {
       if (isCurrentRequest()) {
         threadHasOlder.value = { ...threadHasOlder.value, [threadId]: false };
@@ -372,7 +389,7 @@ export function useDmMamPaging(deps: UseDmMamPagingDeps) {
       activePeerJid.value === peerJid;
     loadingOlderThreadIds.value = new Set([...loadingOlderThreadIds.value, threadId]);
     try {
-      const page = await client.queryPersonalMamThreadPage(peerJid, threadId, PAGE_SIZE, { type: "before", before });
+      const page = await client.queryPersonalMamThreadPage(peerJid, threadId, PAGE_SIZE, { type: "before", before }, scopeForPeer(peerJid));
       if (!isCurrentRequest()) return;
       const advanced = advanceThreadCursor({ prior: { oldestId: before }, page });
       if (advanced.oldestId !== undefined) oldestThreadArchiveIds.set(threadId, advanced.oldestId);

--- a/chat/src/dms/message-actions.ts
+++ b/chat/src/dms/message-actions.ts
@@ -1,6 +1,6 @@
 import type { Ref } from "vue";
 import type { WaddleSession } from "@/lib/server-auth";
-import type { BrowserXmppClient } from "@/lib/xmpp-client";
+import type { BrowserXmppClient, DmConversationScope } from "@/lib/xmpp-client";
 import type { ExtensionAnnotationAction, TimelineMessage } from "@/lib/chat-ui";
 import type { ExtensionCommandResult } from "@/lib/xmpp/extension-commands";
 import { findMessageById } from "@/lib/message-ids";
@@ -22,6 +22,7 @@ type UseDmMessageActionsDeps = {
   clearActionError: () => void;
   normalizeError: (e: unknown) => string;
   applyReaction: (messageId: string, nick: string, emojis: string[]) => void;
+  conversationScope?: (peerJid: string) => DmConversationScope;
 };
 
 export function useDmMessageActions(deps: UseDmMessageActionsDeps) {
@@ -34,6 +35,7 @@ export function useDmMessageActions(deps: UseDmMessageActionsDeps) {
     clearActionError,
     normalizeError,
     applyReaction,
+    conversationScope,
   } = deps;
 
   /**
@@ -45,6 +47,8 @@ export function useDmMessageActions(deps: UseDmMessageActionsDeps) {
   async function toggleReaction(messageId: string, emoji: string) {
     if (!xmppClient.value || !activePeerJid.value || !session.value) return;
     const msg = findMessageById(messages.value, messageId);
+    const peerJid = activePeerJid.value;
+    const scope = conversationScope?.(peerJid) ?? "account";
     const targetId = msg?.replyableId ?? msg?.id ?? messageId;
     const myNick = session.value.username;
     const currentReactions = msg?.reactions ?? {};
@@ -60,7 +64,7 @@ export function useDmMessageActions(deps: UseDmMessageActionsDeps) {
     applyReaction(targetId, myNick, nextEmojis);
 
     try {
-      await xmppClient.value.sendDmReaction(activePeerJid.value, targetId, nextEmojis, dmThreadRefFromMessage(msg));
+      await xmppClient.value.sendDmReaction(peerJid, targetId, nextEmojis, dmThreadRefFromMessage(msg), scope);
     } catch (e) {
       applyReaction(targetId, myNick, previousEmojis);
       actionError.value = normalizeError(e);
@@ -78,10 +82,12 @@ export function useDmMessageActions(deps: UseDmMessageActionsDeps) {
   async function retractMessage(messageId: string) {
     if (!xmppClient.value || !activePeerJid.value) return;
     const target = findMessageById(messages.value, messageId);
+    const peerJid = activePeerJid.value;
+    const scope = conversationScope?.(peerJid) ?? "account";
     const targetId = target?.replyableId ?? target?.id ?? messageId;
     clearActionError();
     try {
-      await xmppClient.value.sendDmRetraction(activePeerJid.value, targetId, dmThreadRefFromMessage(target));
+      await xmppClient.value.sendDmRetraction(peerJid, targetId, dmThreadRefFromMessage(target), scope);
     } catch (e) {
       actionError.value = normalizeError(e);
     }

--- a/chat/src/dms/message-search.ts
+++ b/chat/src/dms/message-search.ts
@@ -1,5 +1,5 @@
 import { ref, type Ref } from "vue";
-import type { BrowserXmppClient, MessageSearchResult } from "@/lib/xmpp-client";
+import type { BrowserXmppClient, DmConversationScope, MessageSearchResult } from "@/lib/xmpp-client";
 
 // XEP-0313 archive query with the `query=` parameter for the DM side.
 // Mirrors useChannelMessageSearch, scoped to activePeerJid and using
@@ -14,6 +14,7 @@ type UseDmMessageSearchDeps = {
   actionError: Ref<string>;
   clearActionError: () => void;
   normalizeError: (e: unknown) => string;
+  conversationScope?: (peerJid: string) => DmConversationScope;
 };
 
 export function useDmMessageSearch(deps: UseDmMessageSearchDeps) {
@@ -23,6 +24,7 @@ export function useDmMessageSearch(deps: UseDmMessageSearchDeps) {
     actionError,
     clearActionError,
     normalizeError,
+    conversationScope,
   } = deps;
 
   const searchResults = ref<MessageSearchResult[]>([]);
@@ -44,7 +46,12 @@ export function useDmMessageSearch(deps: UseDmMessageSearchDeps) {
     isSearching.value = true;
     clearActionError();
     try {
-      const results = await client.searchDmMessages(peerJid, trimmed);
+      const results = await client.searchDmMessages(
+        peerJid,
+        trimmed,
+        20,
+        conversationScope?.(peerJid),
+      );
       // Race-id guard: same purpose as the channel side — drop stale
       // results from earlier queries / different peers.
       if (

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -2,6 +2,7 @@ import { getCurrentScope, nextTick, onScopeDispose, ref, watch, type Ref } from 
 import type { TimelineMessage } from "@/lib/chat-ui";
 import type {
   BrowserXmppClient,
+  DmConversationScope,
   DmChatStateEvent,
   DmDisplayedEvent,
   DmReactionEvent,
@@ -9,6 +10,7 @@ import type {
   SessionLifecycleEvent,
 } from "@/lib/xmpp-client";
 import { barePeerJid, dmConversationIdentityKey, jidLocalpart } from "@/lib/xmpp-client";
+import { bareJidKey, fullJidIdentityKey, resourceOf } from "@/lib/xmpp/jid";
 import type { CatchupConversationFailure } from "@/lib/xmpp-client";
 import type { WaddleSession } from "@/lib/server-auth";
 import {
@@ -48,6 +50,7 @@ export function useDirectMessages(
   normalizeError: (v: unknown) => string,
   actionError: Ref<string>,
   clearActionError: () => void,
+  activeConversationScope?: Readonly<Ref<DmConversationScope | null>>,
 ) {
   const { mode: scrollDirection } = useScrollDirectionPreference();
   const peerNameFromJid = (jid: string) => jidLocalpart(jid);
@@ -79,7 +82,19 @@ export function useDirectMessages(
     notifyComposing,
   } = chatStates;
 
-  const readMarkers = useDmReadMarkers({ xmppClient, activePeerJid, messages });
+  function conversationScope(peerJid: string): DmConversationScope {
+    if (activePeerJid.value === peerJid && activeConversationScope?.value) {
+      return activeConversationScope.value;
+    }
+    return xmppClient.value?.isMucPmPeer?.(peerJid) === true ? "muc-occupant" : "account";
+  }
+
+  const readMarkers = useDmReadMarkers({
+    xmppClient,
+    activePeerJid,
+    messages,
+    conversationScope,
+  });
   const {
     firstUnseenId,
     latestRemoteMessageId,
@@ -93,6 +108,7 @@ export function useDirectMessages(
     actionError,
     clearActionError,
     normalizeError,
+    conversationScope,
   });
   const {
     searchResults,
@@ -268,6 +284,7 @@ export function useDirectMessages(
     isFeedVisible,
     persistLastSeen,
     dmLoadErrorMessage,
+    conversationScope,
   });
   const {
     isLoadingMessages,
@@ -384,9 +401,25 @@ export function useDirectMessages(
 
   function applyMdsDisplayed(chatId: string, displayed: MdsDisplayedState): boolean {
     const peerJid = activePeerJid.value;
-    if (!peerJid || barePeerJid(chatId) !== barePeerJid(peerJid)) return false;
+    const client = xmppClient.value;
+    if (!peerJid || !client) return false;
+    // Inbound XEP-0490 item IDs have already crossed the typed Rust
+    // boundary: a resource-bearing id is an occupant identity and must
+    // compare exactly even before custom-service discovery completes.
+    const chatIdentity = resourceOf(chatId)
+      ? fullJidIdentityKey(chatId)
+      : bareJidKey(chatId);
+    const explicitScope = activePeerJid.value === peerJid
+      ? activeConversationScope?.value
+      : null;
+    const peerIdentity = dmConversationIdentityKey(peerJid, () =>
+      explicitScope
+        ? explicitScope === "muc-occupant"
+        : resourceOf(chatId) !== "" || conversationScope(peerJid) === "muc-occupant"
+    );
+    if (chatIdentity !== peerIdentity) return false;
     const feedTimeline = messages.value.filter(isFeedVisible);
-    const key = mdsChatKey(barePeerJid(peerJid));
+    const key = mdsChatKey(chatIdentity);
     if (!displayedStateCanAdvance(feedTimeline, getMdsDisplayed(key), displayed)) return false;
     firstUnseenId.value = firstUnseenIdAfterDisplayedState(
       feedTimeline,

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -120,7 +120,11 @@ export function useDirectMessages(
   function queuedMessagesForPeer(peerJid: string): TimelineMessage[] {
     const currentSession = session.value;
     if (!currentSession) return [];
-    const queued = listQueuedDmMessages(barePeerJid(currentSession.jid), barePeerJid(peerJid));
+    const queuePeer = dmConversationIdentityKey(
+      peerJid,
+      () => conversationScope(peerJid) === "muc-occupant",
+    );
+    const queued = listQueuedDmMessages(barePeerJid(currentSession.jid), queuePeer);
     for (const message of queued) pendingEchoClientIds.add(message.id);
     return queued.map((message) => queuedDmMessageToTimeline(currentSession, message));
   }

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -73,7 +73,7 @@ export function useDirectMessages(
   const loadErrorPeerJid = ref<string | null>(null);
   const loadErrorMessage = ref("");
 
-  const chatStates = useDmChatStates({ xmppClient, activePeerJid });
+  const chatStates = useDmChatStates({ xmppClient, activePeerJid, conversationScope });
   const {
     typingUsers,
     addTypingUser,
@@ -181,7 +181,8 @@ export function useDirectMessages(
     clearActionError,
     normalizeError,
     scrollToPinnedEdgeAndPin,
-    onSendComplete: (result, peerJid, isStillActive) => {
+    conversationScope,
+    onSendComplete: (result, peerJid, isStillActive, scope) => {
       if (!isStillActive) {
         // Client swap or peer change happened during the send. Don't
         // emit XEP-0085 "active" through the new session targeting the
@@ -190,7 +191,7 @@ export function useDirectMessages(
       }
       chatStates.resetOnSend();
       if (result?.state === "sending" && xmppClient.value) {
-        void xmppClient.value.sendDmChatState(peerJid, "active").catch(() => undefined);
+        void xmppClient.value.sendDmChatState(peerJid, "active", undefined, scope).catch(() => undefined);
       }
     },
   });
@@ -258,6 +259,7 @@ export function useDirectMessages(
     clearActionError,
     normalizeError,
     applyReaction,
+    conversationScope,
   });
   const {
     toggleReaction,

--- a/chat/src/dms/messages.ts
+++ b/chat/src/dms/messages.ts
@@ -124,7 +124,11 @@ export function useDirectMessages(
       peerJid,
       () => conversationScope(peerJid) === "muc-occupant",
     );
-    const queued = listQueuedDmMessages(barePeerJid(currentSession.jid), queuePeer);
+    const queued = listQueuedDmMessages(
+      barePeerJid(currentSession.jid),
+      queuePeer,
+      conversationScope(peerJid),
+    );
     for (const message of queued) pendingEchoClientIds.add(message.id);
     return queued.map((message) => queuedDmMessageToTimeline(currentSession, message));
   }

--- a/chat/src/dms/read-markers.ts
+++ b/chat/src/dms/read-markers.ts
@@ -1,6 +1,6 @@
 import { computed, ref, type ComputedRef, type Ref } from "vue";
-import type { BrowserXmppClient } from "@/lib/xmpp-client";
-import { barePeerJid } from "@/lib/xmpp-client";
+import type { BrowserXmppClient, DmConversationScope } from "@/lib/xmpp-client";
+import { dmConversationIdentityKey } from "@/lib/xmpp-client";
 import type { TimelineMessage } from "@/lib/chat-ui";
 import { findMessageById } from "@/lib/message-ids";
 import { dmKey, setLastSeen } from "@/lib/last-seen-store";
@@ -9,26 +9,34 @@ import { useReadReceiptPreference } from "@/preferences/read-receipts";
 import { dmThreadRefFromMessage } from "@/dms/threading";
 
 // XEP-0333 chat-marker outbound state for the DM side. Mirrors
-// useChannelReadMarkers; uses `dmKey(barePeerJid(peerJid))` as the
+// useChannelReadMarkers; uses the exact conversation identity as the
 // last-seen-store key instead of the channel's roomKey.
 
 type UseDmReadMarkersDeps = {
   xmppClient: Ref<BrowserXmppClient | null>;
   activePeerJid: Ref<string | null>;
   messages: Ref<TimelineMessage[]>;
+  conversationScope?: (peerJid: string) => DmConversationScope;
 };
 type MarkDisplayedOptions = {
   syncMds?: boolean;
 };
 
 export function useDmReadMarkers(deps: UseDmReadMarkersDeps) {
-  const { xmppClient, activePeerJid, messages } = deps;
+  const { xmppClient, activePeerJid, messages, conversationScope } = deps;
 
   const firstUnseenId = ref<string | null>(null);
   const { sendDisplayedMarkers } = useReadReceiptPreference();
   const latestRemoteMessageId: ComputedRef<string | null> = computed(() =>
     latestRemoteMessageIdFor(messages.value),
   );
+
+  function conversationId(peerJid: string): string {
+    const client = xmppClient.value;
+    const scope = conversationScope?.(peerJid)
+      ?? (client?.isMucPmPeer?.(peerJid) === true ? "muc-occupant" : "account");
+    return dmConversationIdentityKey(peerJid, () => scope === "muc-occupant");
+  }
 
   function markDisplayed(messageId: string, options: MarkDisplayedOptions = {}) {
     if (!xmppClient.value || !activePeerJid.value) return;
@@ -37,8 +45,9 @@ export function useDmReadMarkers(deps: UseDmReadMarkersDeps) {
     const client = xmppClient.value;
     const peerJid = activePeerJid.value;
     if (sendDisplayedMarkers.value && target?.displayedMarkerRequested) {
+      const scope = conversationScope?.(peerJid);
       void client
-        .sendDmDisplayed(peerJid, targetId, dmThreadRefFromMessage(target))
+        .sendDmDisplayed(peerJid, targetId, dmThreadRefFromMessage(target), scope)
         .catch(() => undefined);
     }
     // XEP-0490 §3 publish for the DM. The chat id is the peer bare
@@ -48,13 +57,13 @@ export function useDmReadMarkers(deps: UseDmReadMarkersDeps) {
     const stanzaIdBy = target?.stanzaIdBy;
     if (options.syncMds !== false && stanzaId && stanzaIdBy) {
       void client
-        .publishMdsDisplayed(barePeerJid(peerJid), stanzaId, stanzaIdBy)
+        .publishMdsDisplayed(conversationId(peerJid), stanzaId, stanzaIdBy)
         .catch(() => undefined);
     }
   }
 
-  function persistLastSeen(peerJid: string, messageId: string) {
-    setLastSeen(dmKey(barePeerJid(peerJid)), messageId);
+  function persistLastSeen(peerJid: string, messageId: string, capturedConversationId?: string) {
+    setLastSeen(dmKey(capturedConversationId ?? conversationId(peerJid)), messageId);
   }
 
   return {

--- a/chat/src/lib/last-seen-store.ts
+++ b/chat/src/lib/last-seen-store.ts
@@ -9,20 +9,21 @@ export function roomKey(channelId: string): string {
   return `${PREFIX}.room.${channelId}`;
 }
 
-export function dmKey(peerBareJid: string): string {
-  return `${PREFIX}.dm.${peerBareJid}`;
+export function dmKey(peerConversationJid: string): string {
+  return `${PREFIX}.dm.${peerConversationJid}`;
 }
 
 /**
  * Key used by XEP-0490 MDS to persist the latest displayed stanza-id
  * received from another device of the same account. The chat id is
- * the bare JID of the chat (DM contact or MUC room) per XEP-0490 §3.
+ * bare for a DM contact or room, and full occupant JID for a MUC PM,
+ * per XEP-0490 §3.
  * The local readers that own the "new messages" divider for the
  * corresponding conversation can look up this key in addition to
  * their conversation-scoped key.
  */
-export function mdsChatKey(chatBareJid: string): string {
-  return `${PREFIX}.mds.${chatBareJid}`;
+export function mdsChatKey(chatJid: string): string {
+  return `${PREFIX}.mds.${chatJid}`;
 }
 
 export type MdsDisplayedState = {

--- a/chat/src/lib/outbound-queue-store.ts
+++ b/chat/src/lib/outbound-queue-store.ts
@@ -1,6 +1,7 @@
 import type { MarkupSpan, MessageReference } from "@/lib/chat-ui";
 import type { OutboundFileAttachment, ReplyTarget } from "@/lib/xmpp/send-types";
 import { reportError } from "@/lib/telemetry";
+import { bareJidKey, fullJidIdentityKey } from "@/lib/xmpp/jid";
 
 const PREFIX = "waddle.chat.outbound-queue";
 
@@ -241,8 +242,14 @@ export function listQueuedDmMessages(
 ): PersistedQueuedDmMessage[] {
   return readQueue(accountKey).filter(
     (message): message is PersistedQueuedDmMessage =>
-      message.kind === "dm" && message.peerJid === peerJid,
+      message.kind === "dm"
+      && dmQueuePeerKey(message.peerJid, message.mucPm === true)
+        === dmQueuePeerKey(peerJid, message.mucPm === true),
   );
+}
+
+function dmQueuePeerKey(peerJid: string, mucPm: boolean): string {
+  return mucPm ? fullJidIdentityKey(peerJid) : bareJidKey(peerJid);
 }
 
 export function enqueueQueuedMessage(
@@ -250,7 +257,12 @@ export function enqueueQueuedMessage(
   message: PersistedQueuedMessage,
 ): void {
   const next = readQueue(accountKey).filter((entry) => entry.id !== message.id);
-  next.push(message);
+  next.push(message.kind === "dm"
+    ? {
+        ...message,
+        peerJid: dmQueuePeerKey(message.peerJid, message.mucPm === true),
+      }
+    : message);
   writeQueue(accountKey, next);
 }
 

--- a/chat/src/lib/outbound-queue-store.ts
+++ b/chat/src/lib/outbound-queue-store.ts
@@ -2,6 +2,7 @@ import type { MarkupSpan, MessageReference } from "@/lib/chat-ui";
 import type { OutboundFileAttachment, ReplyTarget } from "@/lib/xmpp/send-types";
 import { reportError } from "@/lib/telemetry";
 import { bareJidKey, fullJidIdentityKey } from "@/lib/xmpp/jid";
+import type { DmConversationScope } from "@/lib/xmpp/reconnect-catchup";
 
 const PREFIX = "waddle.chat.outbound-queue";
 
@@ -239,12 +240,21 @@ export function listQueuedRoomMessages(
 export function listQueuedDmMessages(
   accountKey: string,
   peerJid: string,
+  scope: DmConversationScope,
 ): PersistedQueuedDmMessage[] {
+  const requestedMucPm = scope === "muc-occupant";
+  const requestedKey = dmQueuePeerKey(peerJid, requestedMucPm);
   return readQueue(accountKey).filter(
-    (message): message is PersistedQueuedDmMessage =>
-      message.kind === "dm"
-      && dmQueuePeerKey(message.peerJid, message.mucPm === true)
-        === dmQueuePeerKey(peerJid, message.mucPm === true),
+    (message): message is PersistedQueuedDmMessage => {
+      if (message.kind !== "dm") return false;
+      const rowMucPm = message.mucPm === true;
+      if (rowMucPm !== requestedMucPm) return false;
+      // Before the scope bit existed, account DMs were already persisted
+      // bare. A resource-bearing row without `mucPm` is therefore ambiguous
+      // legacy data and must fail closed instead of aliasing a room occupant.
+      if (!rowMucPm && message.peerJid.includes("/")) return false;
+      return dmQueuePeerKey(message.peerJid, rowMucPm) === requestedKey;
+    },
   );
 }
 

--- a/chat/src/lib/xmpp/client-events.ts
+++ b/chat/src/lib/xmpp/client-events.ts
@@ -48,7 +48,7 @@ export type ClientEventMap = Record<string, ReadonlyArray<unknown>>;
  * callback parameter without importing this name.
  */
 export interface MdsDisplayedEntry {
-  /** PEP item id = bare JID of the chat (DM contact or MUC room). */
+  /** PEP item id: bare for DMs/rooms, full occupant for MUC PMs. */
   chatId: string;
   /** XEP-0359 id of the latest displayed message. */
   stanzaId: string;

--- a/chat/src/lib/xmpp/client-mam.ts
+++ b/chat/src/lib/xmpp/client-mam.ts
@@ -473,14 +473,19 @@ export class MamPager {
     return parsed.filter((message) => !!message.body).map((message, index) => ({ id: message.id, ...(page?.messages[index]?.mam_id ? { archiveId: page.messages[index].mam_id } : {}), nick: message.nick, body: message.body, createdAt: message.createdAt, ...(message.threadId ? { threadId: message.threadId } : {}), ...(message.parentThreadId ? { parentThreadId: message.parentThreadId } : {}), roomJid: message.roomJid }));
   }
 
-  async queryPersonalMam(peerJid: string, max = 100): Promise<LiveDmMessage[]> {
-    const page = await this.queryPersonalMamPage(peerJid, max, { type: "latest" });
+  async queryPersonalMam(peerJid: string, max = 100, requestedScope?: DmConversationScope): Promise<LiveDmMessage[]> {
+    const page = await this.queryPersonalMamPage(peerJid, max, { type: "latest" }, requestedScope);
     return page.messages;
   }
 
-  async queryPersonalMamPage(peerJid: string, max = 100, pageParam: MamPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveDmMessage>> {
+  async queryPersonalMamPage(
+    peerJid: string,
+    max = 100,
+    pageParam: MamPageParam = { type: "latest" },
+    requestedScope?: DmConversationScope,
+  ): Promise<MamHistoryPage<LiveDmMessage>> {
     const xmpp = await this.deps.requireConnectedXmpp();
-    const dmScope = this.deps.catchup.getDmScope(peerJid);
+    const dmScope = requestedScope ?? this.deps.catchup.getDmScope(peerJid);
     const archivePeerJid = this.dmArchivePeerJid(peerJid, dmScope);
     const page = await xmpp.fetch_dm_history_page?.(archivePeerJid, max, pageParam);
     if (!page) return { messages: [], complete: true };
@@ -489,10 +494,16 @@ export class MamPager {
     return result;
   }
 
-  async queryPersonalMamThreadPage(peerJid: string, threadId: string, max = 100, pageParam: MamThreadPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveDmMessage>> {
+  async queryPersonalMamThreadPage(
+    peerJid: string,
+    threadId: string,
+    max = 100,
+    pageParam: MamThreadPageParam = { type: "latest" },
+    requestedScope?: DmConversationScope,
+  ): Promise<MamHistoryPage<LiveDmMessage>> {
     if (!threadId) return { messages: [], complete: true };
     const xmpp = await this.deps.requireConnectedXmpp();
-    const dmScope = this.deps.catchup.getDmScope(peerJid);
+    const dmScope = requestedScope ?? this.deps.catchup.getDmScope(peerJid);
     const archivePeerJid = this.dmArchivePeerJid(peerJid, dmScope);
     const page = await xmpp.fetch_dm_history_by_thread?.(archivePeerJid, threadId, max, pageParam.type === "before" ? pageParam.before : null);
     if (!page) return { messages: [], complete: true };
@@ -546,10 +557,15 @@ export class MamPager {
     }
   }
 
-  async searchDmMessages(peerJid: string, query: string, max = 20): Promise<MessageSearchResult[]> {
+  async searchDmMessages(
+    peerJid: string,
+    query: string,
+    max = 20,
+    requestedScope?: DmConversationScope,
+  ): Promise<MessageSearchResult[]> {
     if (!query.trim()) return [];
     const xmpp = await this.deps.requireConnectedXmpp();
-    const dmScope = this.deps.catchup.getDmScope(peerJid);
+    const dmScope = requestedScope ?? this.deps.catchup.getDmScope(peerJid);
     const archivePeerJid = this.dmArchivePeerJid(peerJid, dmScope);
     const page = await xmpp.search_dm_history?.(archivePeerJid, query, max);
     const selfBare = this.selfBare();

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -100,7 +100,11 @@ import { prepareEncryptedAttachmentUpload } from "./encrypted-attachments";
 import { discoverChannels, discoverTopology } from "./discovery";
 import { discoverUploadService, uploadFile, type UploadProgress } from "./file-upload";
 import { createGroupDm, type CreateGroupDmResult } from "./group-dm";
-import { ReconnectCatchup, type ReconnectCatchupEntry } from "./reconnect-catchup";
+import {
+  ReconnectCatchup,
+  type DmConversationScope,
+  type ReconnectCatchupEntry,
+} from "./reconnect-catchup";
 import {
   parseRegisterDeviceResult,
   parseRegisterPushDeviceRejection,
@@ -559,7 +563,7 @@ export class BrowserXmppClient {
       // same occupant classification as the live path, so a MUC PM never
       // re-files under the room bare JID after a reconnect.
       classifyMucPm: (message) => this.mucPmOccupant(message),
-      isMucPmPeer: (peerJid) => this.isMucServiceOccupant(peerJid),
+      isMucPmPeer: (peerJid) => this.isMucPmPeer(peerJid),
     });
     this.mucAdmin = new MucAdmin({
       requireConnectedXmpp: () => this.requireConnectedXmpp(),
@@ -1477,15 +1481,9 @@ export class BrowserXmppClient {
    * occupant JID and replies MUST go to `room@service/nick` — sending to
    * the room bare JID would broadcast. Everything else addresses the
    * bare peer JID. */
-  private directMessageAddress(peerJid: string): string {
-    const hasResource = peerJid.includes("/");
-    return hasResource && (
-      this.isMucServiceOccupant(peerJid)
-      || this.isKnownMucRoomBare(barePeerJid(peerJid))
-      || this.catchup.getDmScope(peerJid) === "muc-occupant"
-    )
-      ? peerJid
-      : barePeerJid(peerJid);
+  private directMessageAddress(peerJid: string, scope?: DmConversationScope): string {
+    const mucPm = scope ? scope === "muc-occupant" : this.isMucPmPeer(peerJid);
+    return mucPm ? peerJid : barePeerJid(peerJid);
   }
 
   async sendDirectMessage(peerJid: string, body: string, opts: SendDirectMessageOptions = {}): Promise<OutboundSendResult | null> {
@@ -1607,7 +1605,7 @@ export class BrowserXmppClient {
     return await this.compatSendCorrection(xmpp, roomJid, "groupchat", body, replacesId, opts);
   }
   async sendDmChatState(peerJid: string, state: ChatStateType, thread?: { id: string; parent?: string }): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendChatState(xmpp, this.directMessageAddress(peerJid), "chat", state, thread); }
-  async sendDmDisplayed(peerJid: string, messageId: string, thread?: { id: string; parent?: string }): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendDisplayed(xmpp, this.directMessageAddress(peerJid), "chat", messageId, thread); }
+  async sendDmDisplayed(peerJid: string, messageId: string, thread?: { id: string; parent?: string }, scope?: DmConversationScope): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendDisplayed(xmpp, this.directMessageAddress(peerJid, scope), "chat", messageId, thread); }
   async sendDmRetraction(peerJid: string, messageId: string, thread?: { id: string; parent?: string }): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendRetraction(xmpp, this.directMessageAddress(peerJid), "chat", messageId, thread); }
   async sendDmCorrection(peerJid: string, body: string, replacesId: string, markup?: SendDirectMessageOptions["markup"], references?: SendDirectMessageOptions["references"], preview?: Pick<SendDirectMessageOptions, "linkPreviewToken" | "linkPreviewExpiresAt">, thread?: { id: string; parent?: string }): Promise<string | null> {
     const xmpp = await this.requireConnectedXmpp();
@@ -1621,7 +1619,8 @@ export class BrowserXmppClient {
 
   /**
    * XEP-0490 §3 multi-device "read up to here" publish. `chatId` is
-   * the bare JID of the chat (DM contact or MUC room); `stanzaId` is
+   * bare for a DM contact or room, and the full occupant JID for a MUC PM;
+   * `stanzaId` is
    * the XEP-0359 id of the latest displayed message; `stanzaIdBy` is
    * the JID that injected that stanza-id (room for MUC, user's own
    * server for 1:1). Failures are intentionally silent — MDS is a
@@ -2174,12 +2173,12 @@ export class BrowserXmppClient {
   async queryMamByThread(spaceId: string, channelId: string, threadId: string, max = 100): Promise<LiveRoomMessage[]> { return this.mam.queryMamByThread(spaceId, channelId, threadId, max); }
   async queryMamThreadPage(spaceId: string, channelId: string, threadId: string, max = 100, pageParam: MamThreadPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveRoomMessage>> { return this.mam.queryMamThreadPage(spaceId, channelId, threadId, max, pageParam); }
   async searchMessages(_spaceId: string, channelId: string, query: string, max = 20): Promise<MessageSearchResult[]> { return this.mam.searchMessages(channelId, query, max); }
-  async queryPersonalMam(peerJid: string, max = 100): Promise<LiveDmMessage[]> { return this.mam.queryPersonalMam(peerJid, max); }
-  async queryPersonalMamPage(peerJid: string, max = 100, pageParam: MamPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveDmMessage>> { return this.mam.queryPersonalMamPage(peerJid, max, pageParam); }
-  async queryPersonalMamThreadPage(peerJid: string, threadId: string, max = 100, pageParam: MamThreadPageParam = { type: "latest" }): Promise<MamHistoryPage<LiveDmMessage>> { return this.mam.queryPersonalMamThreadPage(peerJid, threadId, max, pageParam); }
+  async queryPersonalMam(peerJid: string, max = 100, scope?: DmConversationScope): Promise<LiveDmMessage[]> { return this.mam.queryPersonalMam(peerJid, max, scope); }
+  async queryPersonalMamPage(peerJid: string, max = 100, pageParam: MamPageParam = { type: "latest" }, scope?: DmConversationScope): Promise<MamHistoryPage<LiveDmMessage>> { return this.mam.queryPersonalMamPage(peerJid, max, pageParam, scope); }
+  async queryPersonalMamThreadPage(peerJid: string, threadId: string, max = 100, pageParam: MamThreadPageParam = { type: "latest" }, scope?: DmConversationScope): Promise<MamHistoryPage<LiveDmMessage>> { return this.mam.queryPersonalMamThreadPage(peerJid, threadId, max, pageParam, scope); }
   async hydrateRecentDmCallActivity(peerJid: string, options: DmCallActivityHydrationOptions = {}): Promise<void> { return this.mam.hydrateRecentDmCallActivity(peerJid, options); }
   async hydrateRecentDmCallActivities(options: DmCallActivityHydrationOptions = {}): Promise<void> { return this.mam.hydrateRecentDmCallActivities(options); }
-  async searchDmMessages(peerJid: string, query: string, max = 20): Promise<MessageSearchResult[]> { return this.mam.searchDmMessages(peerJid, query, max); }
+  async searchDmMessages(peerJid: string, query: string, max = 20, scope?: DmConversationScope): Promise<MessageSearchResult[]> { return this.mam.searchDmMessages(peerJid, query, max, scope); }
   async subscribeToPeerPresence(peerJid: string): Promise<void> { return this.presence.subscribeToPeerPresence(peerJid); }
   async setPresence(show: BroadcastShow, idleSince?: number | null): Promise<void> { return this.presence.setPresence(show, idleSince); }
   async listRosterContacts(): Promise<RosterContact[]> { const xmpp = await this.requireConnectedXmpp(); const roster = await xmpp.list_roster_contacts?.() as WasmRosterContact[]; return (roster ?? []).map((item) => { const jid = barePeerJid(item.jid); return { jid, name: item.name, username: item.name?.trim() || jidLocalpart(jid) || jid, subscription: (item.subscription ?? "none") as RosterContact["subscription"], groups: item.groups ?? [] }; }); }
@@ -2775,10 +2774,13 @@ export class BrowserXmppClient {
     return this.isKnownMucRoomBare(barePeerJid(bareJid));
   }
 
-  /** Public: whether `peerJid` is a full occupant JID on the session's
-   * authoritative MUC service (fallback or service discovery result). */
+  /** Public: whether `peerJid` is a full occupant JID proven by the
+   * configured MUC service, a discovered room, or persisted catch-up scope. */
   isMucPmPeer(peerJid: string): boolean {
-    return this.isMucServiceOccupant(peerJid);
+    if (!resourceOf(peerJid)) return false;
+    return this.isMucServiceOccupant(peerJid)
+      || this.isKnownMucRoomBare(barePeerJid(peerJid))
+      || this.catchup.getDmScope(peerJid) === "muc-occupant";
   }
   private runReconnectCatchup(
     xmpp: XmppClientInstance,

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -1488,7 +1488,10 @@ export class BrowserXmppClient {
 
   async sendDirectMessage(peerJid: string, body: string, opts: SendDirectMessageOptions = {}): Promise<OutboundSendResult | null> {
     if (!body.trim() && !opts.files?.length) return null;
-    const normalizedPeerJid = this.directMessageAddress(peerJid);
+    const explicitScope = typeof opts.mucPm === "boolean"
+      ? opts.mucPm ? "muc-occupant" : "account"
+      : undefined;
+    const normalizedPeerJid = this.directMessageAddress(peerJid, explicitScope);
     // XEP-0045 §7.5: mark MUC PMs so the builder appends the muc#user
     // <x/> element (sent-carbon classification on our other devices).
     const mucPm = normalizedPeerJid.includes("/");
@@ -1604,17 +1607,18 @@ export class BrowserXmppClient {
     if (thread?.parent) opts.parentThreadId = thread.parent;
     return await this.compatSendCorrection(xmpp, roomJid, "groupchat", body, replacesId, opts);
   }
-  async sendDmChatState(peerJid: string, state: ChatStateType, thread?: { id: string; parent?: string }): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendChatState(xmpp, this.directMessageAddress(peerJid), "chat", state, thread); }
+  async sendDmChatState(peerJid: string, state: ChatStateType, thread?: { id: string; parent?: string }, scope?: DmConversationScope): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendChatState(xmpp, this.directMessageAddress(peerJid, scope), "chat", state, thread); }
   async sendDmDisplayed(peerJid: string, messageId: string, thread?: { id: string; parent?: string }, scope?: DmConversationScope): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendDisplayed(xmpp, this.directMessageAddress(peerJid, scope), "chat", messageId, thread); }
-  async sendDmRetraction(peerJid: string, messageId: string, thread?: { id: string; parent?: string }): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendRetraction(xmpp, this.directMessageAddress(peerJid), "chat", messageId, thread); }
-  async sendDmCorrection(peerJid: string, body: string, replacesId: string, markup?: SendDirectMessageOptions["markup"], references?: SendDirectMessageOptions["references"], preview?: Pick<SendDirectMessageOptions, "linkPreviewToken" | "linkPreviewExpiresAt">, thread?: { id: string; parent?: string }): Promise<string | null> {
+  async sendDmRetraction(peerJid: string, messageId: string, thread?: { id: string; parent?: string }, scope?: DmConversationScope): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendRetraction(xmpp, this.directMessageAddress(peerJid, scope), "chat", messageId, thread); }
+  async sendDmCorrection(peerJid: string, body: string, replacesId: string, markup?: SendDirectMessageOptions["markup"], references?: SendDirectMessageOptions["references"], preview?: Pick<SendDirectMessageOptions, "linkPreviewToken" | "linkPreviewExpiresAt">, thread?: { id: string; parent?: string }, scope?: DmConversationScope): Promise<string | null> {
     const xmpp = await this.requireConnectedXmpp();
-    const opts: SendDirectMessageOptions = { markup, references, ...preview, ...(this.directMessageAddress(peerJid).includes("/") ? { mucPm: true } : {}) };
+    const address = this.directMessageAddress(peerJid, scope);
+    const opts: SendDirectMessageOptions = { markup, references, ...preview, ...(address.includes("/") ? { mucPm: true } : {}) };
     if (thread?.id) opts.threadId = thread.id;
     if (thread?.parent) opts.parentThreadId = thread.parent;
-    return await this.compatSendCorrection(xmpp, this.directMessageAddress(peerJid), "chat", body, replacesId, opts);
+    return await this.compatSendCorrection(xmpp, address, "chat", body, replacesId, opts);
   }
-  async sendDmReaction(peerJid: string, messageId: string, emojis: string[], thread?: { id: string; parent?: string }): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendReaction(xmpp, this.directMessageAddress(peerJid), "chat", messageId, emojis, thread); }
+  async sendDmReaction(peerJid: string, messageId: string, emojis: string[], thread?: { id: string; parent?: string }, scope?: DmConversationScope): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendReaction(xmpp, this.directMessageAddress(peerJid, scope), "chat", messageId, emojis, thread); }
   async sendDmInCallReaction(peerJid: string, sid: string, emoji: string): Promise<void> { const xmpp = await this.requireConnectedXmpp(); await this.compatSendInCallReaction(xmpp, peerJid, "chat", sid, emoji); }
 
   /**

--- a/chat/src/lib/xmpp/index.ts
+++ b/chat/src/lib/xmpp/index.ts
@@ -79,6 +79,7 @@ export {
   sortEventsUpcomingFirst,
 } from "./event-calendar";
 export type { UserPepProfile } from "./pep-types";
+export type { DmConversationScope } from "./reconnect-catchup";
 export type {
   DmChatStateEvent,
   DmConversation,

--- a/chat/src/shell/chat-app-controller.ts
+++ b/chat/src/shell/chat-app-controller.ts
@@ -126,6 +126,7 @@ export function useChatAppController() {
     ui.normalizeError,
     ui.actionError,
     ui.clearActionError,
+    dmConversations.activeConversationScope,
   );
 
   // --- Shared reactive state wired explicitly between the feature

--- a/chat/src/shell/controllers/use-connection-lifecycle.ts
+++ b/chat/src/shell/controllers/use-connection-lifecycle.ts
@@ -20,6 +20,7 @@ import type { NotifySettingsStore } from "@/lib/notify-settings";
 import type { BrowserXmppClient } from "@/lib/xmpp-client";
 import type { WaddleSession } from "@/lib/server-auth";
 import { barePeerJid } from "@/lib/xmpp-client";
+import { bareJidKey, fullJidIdentityKey, resourceOf } from "@/lib/xmpp/jid";
 import { mdsChatKey, queueMdsDisplayed, setMdsDisplayed } from "@/lib/last-seen-store";
 import { resetPinnedRooms } from "@/stores/pinned-messages";
 import { matchLocation, navigate, type RouteMatch } from "@/router";
@@ -172,12 +173,17 @@ export function useConnectionLifecycle(deps: ConnectionLifecycleDeps) {
     // chat as displayed. Persist the stanza-id under the MDS-scoped
     // last-seen key so existing conversation-scoped readers can pick
     // it up alongside their own divider state. The chat-id is the
-    // bare JID of either the MUC room or the DM peer.
+    // bare JID for DMs/rooms and full occupant JID for MUC PMs.
     client.setMdsDisplayedHandler((entry) => {
-      const chatId = barePeerJid(entry.chatId);
+      // The XEP-0490 item id is already the protocol's typed chat
+      // identity. Do not reclassify it through mutable local discovery:
+      // an event for a not-yet-opened occupant must remain full too.
+      const chatId = resourceOf(entry.chatId)
+        ? fullJidIdentityKey(entry.chatId)
+        : bareJidKey(entry.chatId);
       const displayed = {
         stanzaId: entry.stanzaId,
-        stanzaIdBy: barePeerJid(entry.stanzaIdBy),
+        stanzaIdBy: entry.stanzaIdBy,
       };
       const accepted = isActiveDirectDmSurface()
         ? dmMessaging.applyMdsDisplayed(chatId, displayed)

--- a/chat/tests/client-mam.test.ts
+++ b/chat/tests/client-mam.test.ts
@@ -363,6 +363,48 @@ describe("MUC-PM classification and archive isolation (#1256, #1281)", () => {
     expect(search.map((message) => message.body)).toEqual(["matching alice"]);
   });
 
+  test("explicit restored occupant scope isolates page, thread, and search before discovery or catchup", async () => {
+    const mixed = page([
+      archivedMucPm("restored-bob", CUSTOM_MUC_PM_BOB, "bob secret", "2026-07-01T10:00:00.000Z"),
+      archivedMucPm("restored-alice", CUSTOM_MUC_PM_ALICE, "alice secret", "2026-07-01T10:00:01.000Z"),
+    ], { complete: true });
+    const requestedPeers: string[] = [];
+    const xmpp: MamWasmClient = {
+      fetch_dm_history_page: async (peerJid) => { requestedPeers.push(peerJid); return mixed; },
+      fetch_dm_history_by_thread: async (peerJid) => { requestedPeers.push(peerJid); return mixed; },
+      search_dm_history: async (peerJid) => { requestedPeers.push(peerJid); return mixed; },
+    };
+    const { pager } = createPager(xmpp, {
+      classifyMucPm: () => undefined,
+      isMucPmPeer: () => false,
+    });
+
+    const history = await pager.queryPersonalMamPage(
+      CUSTOM_MUC_PM_ALICE,
+      100,
+      { type: "latest" },
+      "muc-occupant",
+    );
+    const thread = await pager.queryPersonalMamThreadPage(
+      CUSTOM_MUC_PM_ALICE,
+      "thread-1",
+      100,
+      { type: "latest" },
+      "muc-occupant",
+    );
+    const search = await pager.searchDmMessages(
+      CUSTOM_MUC_PM_ALICE,
+      "secret",
+      20,
+      "muc-occupant",
+    );
+
+    expect(requestedPeers).toEqual(Array(3).fill(CUSTOM_MUC_PM_ALICE));
+    expect(history.messages.map((message) => message.body)).toEqual(["alice secret"]);
+    expect(thread.messages.map((message) => message.body)).toEqual(["alice secret"]);
+    expect(search.map((message) => message.body)).toEqual(["alice secret"]);
+  });
+
   test("cold-reload catch-up retains custom MUC occupant scope before topology discovery", async () => {
     const catchup = new ReconnectCatchup();
     catchup.onSessionStarted();

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -1089,7 +1089,7 @@ describe("client send readiness", () => {
     const result = await client.sendDirectMessage("bob@example.com", "hello");
 
     expect(result?.state).toBe("queued");
-    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toHaveLength(1);
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toHaveLength(1);
     await expect(client.sendDmReaction("bob@example.com", "msg-1", ["👍"])).rejects.toThrow(
       "Reconnection timed out",
     );
@@ -1107,7 +1107,7 @@ describe("client send readiness", () => {
     (client as unknown as { connected: boolean }).connected = true;
 
     await expect(client.sendDirectMessage("bob@example.com/mobile", "hello", { id: "dm-send-invalid" })).rejects.toThrow("XMPP send failed: invalid-recipient");
-    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toEqual([]);
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toEqual([]);
   });
 
   test("DM sends are durable until XEP-0198 ack confirms server handling", async () => {
@@ -1119,12 +1119,12 @@ describe("client send readiness", () => {
     const result = await client.sendDirectMessage("bob@example.com", "hello", { id: "dm-live-1" });
 
     expect(result).toEqual({ id: "dm-live-1", state: "sending" });
-    expect(listQueuedDmMessages("alice@example.com", "bob@example.com").map((message) => message.id)).toEqual([
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account").map((message) => message.id)).toEqual([
       "dm-live-1",
     ]);
 
     (client as unknown as { handleMessageAck: (id: string) => void }).handleMessageAck("dm-live-1");
-    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toEqual([]);
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toEqual([]);
   });
 
   test("custom-service MUC-PM sends preserve the occupant resource before room discovery", async () => {
@@ -1266,7 +1266,7 @@ describe("client send readiness", () => {
     (client as unknown as { handleMessageFailed: (id: string) => void }).handleMessageFailed("dm-live-1");
     (client as unknown as { clearReconnectTimer: () => void }).clearReconnectTimer();
 
-    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toEqual([]);
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toEqual([]);
   });
 });
 

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -4,7 +4,7 @@ import { ref } from "vue";
 import type { WaddleSession } from "../src/lib/server-auth";
 import { useDirectMessages } from "../src/dms/messages";
 import { useChannelMessages } from "../src/channels/messages";
-import { BrowserXmppClient, roomBareJidFor, type InboxEntry, type LiveDmMessage, type RoomActivityEvent } from "../src/lib/xmpp-client";
+import { BrowserXmppClient, roomBareJidFor, type DmConversationScope, type InboxEntry, type LiveDmMessage, type RoomActivityEvent } from "../src/lib/xmpp-client";
 import { enqueueQueuedMessage, listQueuedDmMessages, listQueuedRoomMessages } from "../src/lib/outbound-queue-store";
 import { applyDmCallEvent, clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
 import { $dmCallOutcomeAnchor } from "../src/lib/calls/dm-call-anchor";
@@ -1168,6 +1168,82 @@ describe("client send readiness", () => {
       (client as unknown as { directMessageAddress: (peerJid: string) => string })
         .directMessageAddress("user@accounts.example/phone"),
     ).toBe("user@accounts.example");
+  });
+
+  test("explicit restored scope preserves every MUC-PM outbound target before discovery", async () => {
+    const sentTargets: string[] = [];
+    const captureTarget = async (target: string) => { sentTargets.push(target); };
+    const xmpp = {
+      send_chat_message: mock(async (target: string) => { sentTargets.push(target); return "muc-pm-send"; }),
+      send_chat_state: mock(captureTarget),
+      send_displayed: mock(captureTarget),
+      send_retraction: mock(captureTarget),
+      send_correction: mock(async (target: string) => { sentTargets.push(target); return "muc-pm-correction"; }),
+      send_reaction: mock(captureTarget),
+    };
+    const client = new BrowserXmppClient(session());
+    const occupant = "room@rooms.custom.example/alice";
+    (client as unknown as { xmpp: typeof xmpp }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+
+    expect(client.isMucPmPeer(occupant)).toBe(false);
+    await client.sendDirectMessage(occupant, "hello", { id: "muc-pm-send", mucPm: true });
+    await client.sendDmChatState(occupant, "composing", undefined, "muc-occupant");
+    await client.sendDmDisplayed(occupant, "message-1", undefined, "muc-occupant");
+    await client.sendDmRetraction(occupant, "message-1", undefined, "muc-occupant");
+    await client.sendDmCorrection(
+      occupant,
+      "edited",
+      "message-1",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "muc-occupant",
+    );
+    await client.sendDmReaction(occupant, "message-1", ["👍"], undefined, "muc-occupant");
+
+    expect(sentTargets).toEqual(Array(6).fill(occupant));
+    expect((xmpp.send_chat_message.mock.calls[0]?.[2] as { muc_pm?: boolean }).muc_pm).toBe(true);
+  });
+
+  test("restored conversation scope reaches every DM composer and mutation send", async () => {
+    const occupant = "room@rooms.custom.example/alice";
+    const sendDirectMessage = mock(async () => ({ id: "outbound-1", state: "sending" as const }));
+    const sendDmChatState = mock(async () => undefined);
+    const sendDmCorrection = mock(async () => "correction-1");
+    const sendDmReaction = mock(async () => undefined);
+    const sendDmRetraction = mock(async () => undefined);
+    const messaging = useDirectMessages(
+      ref(session()),
+      ref({
+        sendDirectMessage,
+        sendDmChatState,
+        sendDmCorrection,
+        sendDmReaction,
+        sendDmRetraction,
+        isMucPmPeer: () => false,
+      } as never),
+      ref(occupant),
+      normalizeError,
+      ref(""),
+      () => undefined,
+      ref<DmConversationScope | null>("muc-occupant"),
+    );
+
+    await messaging.sendMessage("private hello", []);
+    await messaging.editMessage("outbound-1", "edited");
+    await messaging.toggleReaction("outbound-1", "👍");
+    await messaging.retractMessage("outbound-1");
+    messaging.notifyComposing();
+    await Promise.resolve();
+
+    expect(sendDirectMessage.mock.calls[0]?.[2]).toMatchObject({ mucPm: true });
+    expect(sendDmCorrection.mock.calls[0]?.[7]).toBe("muc-occupant");
+    expect(sendDmReaction.mock.calls[0]?.[4]).toBe("muc-occupant");
+    expect(sendDmRetraction.mock.calls[0]?.[3]).toBe("muc-occupant");
+    expect(sendDmChatState.mock.calls.some((call) => call[3] === "muc-occupant")).toBe(true);
+    messaging.disconnect();
   });
 
   test("native failed-resume fallback owns resend for live unacked DM sends", async () => {

--- a/chat/tests/dm-conversations.test.ts
+++ b/chat/tests/dm-conversations.test.ts
@@ -342,6 +342,7 @@ describe("useDirectMessageConversations", () => {
       mucPm: true,
     });
     expect(reloaded.activePeerJid.value).toBe("room@muc.example.com/juliet");
+    expect(reloaded.activeConversationScope.value).toBe("muc-occupant");
     delete (globalThis as unknown as { window?: unknown }).window;
   });
 
@@ -363,13 +364,17 @@ describe("useDirectMessageConversations", () => {
         peerUsername: "juliet (room)",
         unreadCount: 0,
       }],
-      activePeerJid: null,
+      activePeerJid: "room@muc.example.com/juliet",
     }));
 
     const { composable } = makeComposable();
     await nextTick();
 
-    expect(composable.conversations.value[0]?.peerJid).toBe("room@muc.example.com/juliet");
+    expect(composable.conversations.value[0]).toMatchObject({
+      peerJid: "room@muc.example.com/juliet",
+      mucPm: true,
+    });
+    expect(composable.activeConversationScope.value).toBe("muc-occupant");
     delete (globalThis as unknown as { window?: unknown }).window;
   });
 

--- a/chat/tests/mds-publish.test.ts
+++ b/chat/tests/mds-publish.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, mock, test } from "bun:test";
+import { ref } from "vue";
 import { BrowserXmppClient } from "../src/lib/xmpp/client";
+import { useDmReadMarkers } from "../src/dms/read-markers";
+import type { TimelineMessage } from "../src/lib/chat-ui";
+import { nullResumePersistence, type ResumePersistence } from "../src/lib/xmpp/resume-persistence";
 import type { WaddleSession } from "../src/lib/server-auth";
 
 function session(partial: Partial<WaddleSession> = {}): WaddleSession {
@@ -24,7 +28,104 @@ function connectedClient(xmpp: Record<string, unknown>): BrowserXmppClient {
   return client;
 }
 
+function persistedOccupants(...occupants: string[]): ResumePersistence {
+  return {
+    ...nullResumePersistence,
+    loadCatchup: () => ({
+      dmLastSeen: occupants.map((occupant, index) => [occupant, {
+        timestamp: `2026-07-01T10:00:0${index}.000Z`,
+        scope: "muc-occupant" as const,
+      }]),
+      roomLastSeen: [],
+    }),
+  };
+}
+
 describe("BrowserXmppClient MDS publish preflight", () => {
+  test("persisted custom-service occupant scope drives public classification and outbound item id", async () => {
+    const alice = "room@rooms.custom.example/alice";
+    const publish = mock(async () => undefined);
+    const client = new BrowserXmppClient(session(), persistedOccupants(alice));
+    (client as unknown as { xmpp: unknown }).xmpp = {
+      publish_mds_displayed: publish,
+      supports_mds_publish_options: mock(async () => true),
+    };
+    (client as unknown as { connected: boolean }).connected = true;
+
+    expect(client.isMucPmPeer(alice)).toBe(true);
+    expect(client.isMucPmPeer("bob@example.com/phone")).toBe(false);
+
+    const markers = useDmReadMarkers({
+      xmppClient: ref(client),
+      activePeerJid: ref(alice),
+      messages: ref<TimelineMessage[]>([{
+        id: "pm-1",
+        stanzaId: "pm-sid-1",
+        stanzaIdBy: "example.com",
+        body: "",
+        nick: "alice",
+        timestamp: 0,
+      } as TimelineMessage]),
+    });
+    markers.markDisplayed("pm-1");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(publish).toHaveBeenCalledWith(alice, "pm-sid-1", "example.com");
+  });
+
+  test("persisted occupant identities survive MDS catch-up and live events", async () => {
+    const alice = "room@rooms.custom.example/alice";
+    const bob = "room@rooms.custom.example/bob";
+    let onDisplayed: ((entry: {
+      chat_id: string;
+      stanza_id: string;
+      stanza_id_by: string;
+    }) => void) | undefined;
+    const xmpp = {
+      fetch_mds_displayed: mock(async () => [
+        { chat_id: alice, stanza_id: "alice-catchup", stanza_id_by: "archive.example" },
+        { chat_id: bob, stanza_id: "bob-catchup", stanza_id_by: "archive.example" },
+      ]),
+      subscribe_mds_displayed: mock(async () => undefined),
+      set_on_mds_displayed: (handler: typeof onDisplayed) => { onDisplayed = handler; },
+    };
+    const client = connectedClient(xmpp);
+    const received: Array<{ chatId: string; stanzaId: string }> = [];
+    client.setMdsDisplayedHandler((entry) => received.push(entry));
+
+    (client as unknown as { wireEvents: (handle: typeof xmpp) => void }).wireEvents(xmpp);
+    await (client as unknown as { bootstrapMdsDisplayed: (handle: typeof xmpp) => Promise<void> })
+      .bootstrapMdsDisplayed(xmpp);
+    onDisplayed?.({ chat_id: alice, stanza_id: "alice-live", stanza_id_by: "archive.example" });
+
+    expect(received).toEqual([
+      { chatId: alice, stanzaId: "alice-catchup", stanzaIdBy: "archive.example" },
+      { chatId: bob, stanzaId: "bob-catchup", stanzaIdBy: "archive.example" },
+      { chatId: alice, stanzaId: "alice-live", stanzaIdBy: "archive.example" },
+    ]);
+  });
+
+  test("a discovered custom MUC service scopes later Browser MAM paging to the occupant", async () => {
+    const alice = "room@rooms.custom.example/alice";
+    const fetchPage = mock(async (peerJid: string) => ({
+      messages: [],
+      first_archive_id: undefined,
+      last_archive_id: undefined,
+      complete: true,
+      peerJid,
+    }));
+    const client = connectedClient({ fetch_dm_history_page: fetchPage });
+
+    // `discoverTopology()` assigns this field from the disco result. Keep this
+    // test focused on the Browser-to-MAM handoff rather than duplicating the
+    // exhaustive XEP-0030 fixtures in discovery-pin-permission.test.ts.
+    (client as unknown as { mucServiceJid: string }).mucServiceJid = "rooms.custom.example";
+    await client.queryPersonalMamPage(alice);
+
+    expect(client.isMucPmPeer(alice)).toBe(true);
+    expect(fetchPage.mock.calls[0]?.[0]).toBe(alice);
+  });
+
   test("does not publish when the server lacks pubsub publish-options", async () => {
     const publish = mock(async () => undefined);
     const supports = mock(async () => false);

--- a/chat/tests/offline-queue.test.ts
+++ b/chat/tests/offline-queue.test.ts
@@ -91,7 +91,7 @@ describe("offline outbound queue replay", () => {
       kind: "dm",
       id: "dm-preview-replay",
       createdAt: new Date().toISOString(),
-      peerJid: "bob@example.com",
+      peerJid: " Bob@Example.COM/desktop ",
       body: "read https://example.com/article",
     });
 
@@ -296,7 +296,7 @@ describe("offline outbound queue hydration", () => {
       // See `room timelines restore queued messages from localStorage` —
       // the queue store now prunes entries older than 7 days.
       createdAt: new Date().toISOString(),
-      peerJid: "bob@example.com",
+      peerJid: " Bob@Example.COM/desktop ",
       body: "hello from storage",
     });
 
@@ -327,7 +327,8 @@ describe("offline outbound queue hydration", () => {
       kind: "dm",
       id: "queued-muc-pm-alice",
       createdAt: new Date().toISOString(),
-      peerJid: "room@conference.example/alice",
+      peerJid: " Room@Conference.Example/alice ",
+      mucPm: true,
       body: "private hello",
     });
     enqueueQueuedMessage("alice@example.com", {
@@ -335,6 +336,7 @@ describe("offline outbound queue hydration", () => {
       id: "queued-muc-pm-bob",
       createdAt: new Date().toISOString(),
       peerJid: "room@conference.example/bob",
+      mucPm: true,
       body: "other occupant",
     });
 

--- a/chat/tests/offline-queue.test.ts
+++ b/chat/tests/offline-queue.test.ts
@@ -120,7 +120,7 @@ describe("offline outbound queue replay", () => {
 
     await client.sendDirectMessage("bob@example.com", "first", { id: "dm-1" });
     await client.sendDirectMessage("bob@example.com", "second", { id: "dm-2" });
-    expect(listQueuedDmMessages("alice@example.com", "bob@example.com").map((message) => message.id)).toEqual([
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account").map((message) => message.id)).toEqual([
       "dm-1",
       "dm-2",
     ]);
@@ -166,7 +166,7 @@ describe("offline outbound queue replay", () => {
     // Post-fix: persisted queue entries linger until XEP-0198
     // `message:acked` confirms the server received them.
     expect(
-      listQueuedDmMessages("alice@example.com", "bob@example.com").map((message) => message.id),
+      listQueuedDmMessages("alice@example.com", "bob@example.com", "account").map((message) => message.id),
     ).toEqual(["dm-1", "dm-2"]);
 
     // A second flush in the same session must NOT re-send: both entries
@@ -179,11 +179,11 @@ describe("offline outbound queue replay", () => {
     // persisted queue; dm-2 is still pending.
     xmpp.emit("message:acked", { id: "dm-1" });
     expect(
-      listQueuedDmMessages("alice@example.com", "bob@example.com").map((message) => message.id),
+      listQueuedDmMessages("alice@example.com", "bob@example.com", "account").map((message) => message.id),
     ).toEqual(["dm-2"]);
 
     xmpp.emit("message:acked", { id: "dm-2" });
-    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toEqual([]);
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toEqual([]);
   });
 
   test("replays queued room messages in order after the room rejoins", async () => {
@@ -251,6 +251,32 @@ describe("offline outbound queue replay", () => {
 });
 
 describe("offline outbound queue hydration", () => {
+  test("ambiguous resource-bearing legacy rows fail closed for every DM scope", () => {
+    localStorage.setItem(
+      "waddle.chat.outbound-queue.alice@example.com",
+      JSON.stringify([
+        {
+          kind: "dm",
+          id: "legacy-unscoped-occupant",
+          createdAt: new Date().toISOString(),
+          peerJid: "room@conference.example/alice",
+          body: "ambiguous",
+        },
+      ]),
+    );
+
+    expect(
+      listQueuedDmMessages("alice@example.com", "room@conference.example", "account"),
+    ).toEqual([]);
+    expect(
+      listQueuedDmMessages(
+        "alice@example.com",
+        "room@conference.example/alice",
+        "muc-occupant",
+      ),
+    ).toEqual([]);
+  });
+
   test("room timelines restore queued messages from localStorage", async () => {
     const roomJid = roomBareJidFor(session(), "c1");
     enqueueQueuedMessage("alice@example.com", {

--- a/chat/tests/offline-queue.test.ts
+++ b/chat/tests/offline-queue.test.ts
@@ -321,4 +321,40 @@ describe("offline outbound queue hydration", () => {
       deliveryStatus: "queued",
     });
   });
+
+  test("MUC-PM timelines restore only the full occupant's queued messages", async () => {
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "dm",
+      id: "queued-muc-pm-alice",
+      createdAt: new Date().toISOString(),
+      peerJid: "room@conference.example/alice",
+      body: "private hello",
+    });
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "dm",
+      id: "queued-muc-pm-bob",
+      createdAt: new Date().toISOString(),
+      peerJid: "room@conference.example/bob",
+      body: "other occupant",
+    });
+
+    const actionError = ref("");
+    const messaging = useDirectMessages(
+      ref(session()),
+      ref(null),
+      ref("room@conference.example/alice"),
+      String,
+      actionError,
+      () => {
+        actionError.value = "";
+      },
+      ref("muc-occupant"),
+    );
+
+    await messaging.loadMessages("room@conference.example/alice");
+
+    expect(messaging.messages.value.map((message) => message.id)).toEqual([
+      "queued-muc-pm-alice",
+    ]);
+  });
 });

--- a/chat/tests/outbound-queue-ttl.test.ts
+++ b/chat/tests/outbound-queue-ttl.test.ts
@@ -67,7 +67,7 @@ describe("outbound queue TTL", () => {
       peerJid: "bob@example.com",
       body: "still in window",
     });
-    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toHaveLength(1);
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toHaveLength(1);
   });
 
   test("entries older than 7 days are pruned on read", () => {
@@ -78,7 +78,7 @@ describe("outbound queue TTL", () => {
       peerJid: "bob@example.com",
       body: "ancient draft",
     });
-    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toEqual([]);
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toEqual([]);
   });
 
   test("pruning rewrites the persisted snapshot (the entry is gone, not just hidden)", () => {
@@ -135,6 +135,6 @@ describe("outbound queue TTL", () => {
       peerJid: "bob@example.com",
       body: "weird stamp",
     });
-    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toHaveLength(1);
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toHaveLength(1);
   });
 });

--- a/chat/tests/read-markers.test.ts
+++ b/chat/tests/read-markers.test.ts
@@ -22,8 +22,9 @@ function makeChannelClient(
 function makeDmClient(
   sendDmDisplayed = mock(async () => undefined),
   publishMdsDisplayed = mock(async () => undefined),
+  isMucPmPeer = (_peerJid: string) => false,
 ): BrowserXmppClient {
-  return { sendDmDisplayed, publishMdsDisplayed } as unknown as BrowserXmppClient;
+  return { sendDmDisplayed, publishMdsDisplayed, isMucPmPeer } as unknown as BrowserXmppClient;
 }
 function channel(features: string[] = [NS_STANZA_ID]): ChannelSummary {
   return {
@@ -320,6 +321,79 @@ describe("useDmReadMarkers", () => {
     expect(publishMdsDisplayed).toHaveBeenCalledWith(
       "bob@example.com",
       "server-stanza-id",
+      "example.com",
+    );
+  });
+
+  test("MUC-PM MDS uses the full occupant while ordinary resources stay bare", () => {
+    const occupantPublish = mock(async () => undefined);
+    const occupant = "room@conference.example/alice";
+    const occupantMarkers = useDmReadMarkers({
+      xmppClient: ref<BrowserXmppClient | null>(makeDmClient(
+        mock(async () => undefined),
+        occupantPublish,
+        (peerJid) => peerJid.startsWith("room@conference.example/"),
+      )),
+      activePeerJid: ref(occupant),
+      messages: ref<TimelineMessage[]>([{
+        id: "pm-1",
+        stanzaId: "pm-sid-1",
+        stanzaIdBy: "example.com",
+        body: "",
+        nick: "alice",
+        timestamp: 0,
+      } as TimelineMessage]),
+    });
+
+    occupantMarkers.markDisplayed("pm-1");
+
+    expect(occupantPublish).toHaveBeenCalledWith(occupant, "pm-sid-1", "example.com");
+
+    const dmPublish = mock(async () => undefined);
+    const dmMarkers = useDmReadMarkers({
+      xmppClient: ref<BrowserXmppClient | null>(makeDmClient(mock(async () => undefined), dmPublish)),
+      activePeerJid: ref("bob@example.com/phone"),
+      messages: ref<TimelineMessage[]>([{
+        id: "dm-resource-1",
+        stanzaId: "dm-sid-1",
+        stanzaIdBy: "example.com",
+        body: "",
+        nick: "bob",
+        timestamp: 0,
+      } as TimelineMessage]),
+    });
+
+    dmMarkers.markDisplayed("dm-resource-1");
+
+    expect(dmPublish).toHaveBeenCalledWith("bob@example.com", "dm-sid-1", "example.com");
+  });
+
+  test("restored MUC-PM scope publishes the full item id before client discovery", () => {
+    const publishMdsDisplayed = mock(async () => undefined);
+    const occupant = "room@rooms.custom.example/alice";
+    const markers = useDmReadMarkers({
+      xmppClient: ref<BrowserXmppClient | null>(makeDmClient(
+        mock(async () => undefined),
+        publishMdsDisplayed,
+        () => false,
+      )),
+      activePeerJid: ref(occupant),
+      conversationScope: () => "muc-occupant",
+      messages: ref<TimelineMessage[]>([{
+        id: "pm-restored",
+        stanzaId: "pm-restored-sid",
+        stanzaIdBy: "example.com",
+        body: "",
+        nick: "alice",
+        timestamp: 0,
+      } as TimelineMessage]),
+    });
+
+    markers.markDisplayed("pm-restored");
+
+    expect(publishMdsDisplayed).toHaveBeenCalledWith(
+      occupant,
+      "pm-restored-sid",
       "example.com",
     );
   });

--- a/chat/tests/resume-persistence.test.ts
+++ b/chat/tests/resume-persistence.test.ts
@@ -636,7 +636,7 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
 
     (client as unknown as { handleMessageAck: (id: string) => void }).handleMessageAck("dm-live-1");
 
-    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toEqual([]);
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toEqual([]);
   });
 
   test("BrowserXmppClient removes restored SM queue entries when native fallback retry owns resend", () => {
@@ -662,7 +662,7 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
 
     (client as unknown as { handleMessageFailed: (id: string) => void }).handleMessageFailed("dm-live-1");
 
-    expect(listQueuedDmMessages("alice@example.com", "bob@example.com")).toEqual([]);
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toEqual([]);
   });
 
   test("BrowserXmppClient persists SM state when the native replay queue is empty", () => {

--- a/chat/tests/scroll-direction.test.ts
+++ b/chat/tests/scroll-direction.test.ts
@@ -18,7 +18,7 @@ import {
   setMdsDisplayed,
 } from "../src/lib/last-seen-store";
 import type { WaddleSession } from "../src/lib/server-auth";
-import type { LiveRoomMessage } from "../src/lib/xmpp-client";
+import type { LiveDmMessage, LiveRoomMessage } from "../src/lib/xmpp-client";
 
 function createStorageMock() {
   const values = new Map<string, string>();
@@ -367,6 +367,10 @@ describe("scroll direction preference", () => {
     await messaging.loadMessages("w1", "c1", 2);
 
     expect(messaging.firstUnseenId.value).toBe("room-2");
+    expect(messaging.applyMdsDisplayed("w1-c1@rooms.example.com/alice", {
+      stanzaId: "room-stanza-2",
+      stanzaIdBy: "w1-c1@rooms.example.com",
+    })).toBe(false);
   });
 
   test("room initial load re-pins when the virtual timeline ref appears after messages", async () => {
@@ -761,6 +765,214 @@ describe("scroll direction preference", () => {
     await dm.loadMessages("bob@example.com", 2);
 
     expect(dm.firstUnseenId.value).toBe("dm-2");
+  });
+
+  test("MUC-PM paging and live MDS isolate two occupants in the same room", async () => {
+    const alice = "room@conference.example/alice";
+    const bob = "room@conference.example/bob";
+    setMdsDisplayed(mdsChatKey(alice), {
+      stanzaId: "alice-stanza-1",
+      stanzaIdBy: "example.com",
+    });
+    setMdsDisplayed(mdsChatKey(bob), {
+      stanzaId: "bob-stanza-9",
+      stanzaIdBy: "example.com",
+    });
+    const queryPersonalMam = mock(async () => [
+      {
+        id: "alice-1",
+        stanzaId: "alice-stanza-1",
+        stanzaIdBy: "example.com",
+        peerJid: alice,
+        fromJid: alice,
+        nick: "alice",
+        body: "earlier",
+        createdAt: "2024-01-01T00:00:00Z",
+        type: "message" as const,
+        mucPm: true,
+      },
+      {
+        id: "alice-2",
+        stanzaId: "alice-stanza-2",
+        stanzaIdBy: "example.com",
+        peerJid: alice,
+        fromJid: alice,
+        nick: "alice",
+        body: "later",
+        createdAt: "2024-01-01T00:00:10Z",
+        type: "message" as const,
+        mucPm: true,
+      },
+    ]);
+    const actionError = ref("");
+    const dm = useDirectMessages(
+      ref(session()),
+      ref({
+        queryPersonalMam,
+        isMucPmPeer: (peerJid: string) => peerJid.startsWith("room@conference.example/"),
+      } as never) as never,
+      ref(alice),
+      String,
+      actionError,
+      () => { actionError.value = ""; },
+    );
+    dm.timelineEl.value = makeTimelineEl();
+
+    await dm.loadMessages(alice, 2);
+
+    expect(dm.firstUnseenId.value).toBe("alice-2");
+    expect(localStorage.getItem(dmKey(alice))).toBe("alice-2");
+    expect(localStorage.getItem(dmKey(bob))).toBeNull();
+    expect(dm.applyMdsDisplayed(bob, {
+      stanzaId: "bob-stanza-9",
+      stanzaIdBy: "example.com",
+    })).toBe(false);
+    expect(dm.applyMdsDisplayed(alice, {
+      stanzaId: "alice-stanza-2",
+      stanzaIdBy: "example.com",
+    })).toBe(true);
+    expect(dm.firstUnseenId.value).toBeNull();
+  });
+
+  test("MUC-PM paging keeps request-start identity when the client clears during await", async () => {
+    const alice = "room@rooms.custom.example/alice";
+    setMdsDisplayed(mdsChatKey(alice), {
+      stanzaId: "alice-stanza-1",
+      stanzaIdBy: "example.com",
+    });
+    let resolvePage!: (messages: LiveDmMessage[]) => void;
+    const queryPersonalMam = mock(async () => new Promise<LiveDmMessage[]>((resolve) => {
+      resolvePage = resolve;
+    }));
+    const client = {
+      queryPersonalMam,
+      isMucPmPeer: (peerJid: string) => peerJid === alice,
+    } as never;
+    const clientRef = ref(client);
+    const actionError = ref("");
+    const dm = useDirectMessages(
+      ref(session()),
+      clientRef,
+      ref(alice),
+      String,
+      actionError,
+      () => { actionError.value = ""; },
+    );
+    dm.timelineEl.value = makeTimelineEl();
+
+    const load = dm.loadMessages(alice, 2);
+    await Promise.resolve();
+    clientRef.value = null as never;
+    resolvePage([
+      {
+        id: "alice-1",
+        stanzaId: "alice-stanza-1",
+        stanzaIdBy: "example.com",
+        peerJid: alice,
+        fromJid: alice,
+        nick: "alice",
+        body: "earlier",
+        createdAt: "2024-01-01T00:00:00Z",
+        type: "message",
+        mucPm: true,
+      },
+      {
+        id: "alice-2",
+        stanzaId: "alice-stanza-2",
+        stanzaIdBy: "example.com",
+        peerJid: alice,
+        fromJid: alice,
+        nick: "alice",
+        body: "later",
+        createdAt: "2024-01-01T00:00:10Z",
+        type: "message",
+        mucPm: true,
+      },
+    ]);
+    await load;
+
+    expect(dm.firstUnseenId.value).toBe("alice-2");
+    expect(localStorage.getItem(dmKey(alice))).toBe("alice-2");
+  });
+
+  test("typed inbound MDS isolates an unknown occupant before custom-service discovery", async () => {
+    const alice = "room@rooms.custom.example/alice";
+    const bob = "room@rooms.custom.example/bob";
+    const actionError = ref("");
+    const dm = useDirectMessages(
+      ref(session()),
+      ref({
+        queryPersonalMam: mock(async () => [{
+          id: "bob-1",
+          stanzaId: "shared-stanza-id",
+          stanzaIdBy: "example.com",
+          peerJid: bob,
+          fromJid: bob,
+          nick: "bob",
+          body: "hello",
+          createdAt: "2024-01-01T00:00:00Z",
+          type: "message" as const,
+          mucPm: true,
+        }]),
+        // Reproduces the pre-discovery window: the custom MUC service is
+        // not known locally yet, but the inbound item ID is already typed.
+        isMucPmPeer: () => false,
+      } as never) as never,
+      ref(bob),
+      String,
+      actionError,
+      () => { actionError.value = ""; },
+    );
+    dm.timelineEl.value = makeTimelineEl();
+    await dm.loadMessages(bob, 1);
+
+    expect(dm.applyMdsDisplayed(alice, {
+      stanzaId: "shared-stanza-id",
+      stanzaIdBy: "example.com",
+    })).toBe(false);
+    expect(dm.applyMdsDisplayed(bob, {
+      stanzaId: "shared-stanza-id",
+      stanzaIdBy: "example.com",
+    })).toBe(true);
+  });
+
+  test("restored occupant scope reconciles the full inbound MDS key before discovery", async () => {
+    const alice = "room@rooms.custom.example/alice";
+    setMdsDisplayed(mdsChatKey(alice), {
+      stanzaId: "alice-restored-sid",
+      stanzaIdBy: "example.com",
+    });
+    const actionError = ref("");
+    const dm = useDirectMessages(
+      ref(session()),
+      ref({
+        queryPersonalMam: mock(async () => [{
+          id: "alice-restored",
+          stanzaId: "alice-restored-sid",
+          stanzaIdBy: "example.com",
+          peerJid: alice,
+          fromJid: alice,
+          nick: "alice",
+          body: "restored",
+          createdAt: "2024-01-01T00:00:00Z",
+          type: "message" as const,
+          mucPm: true,
+        }]),
+        isMucPmPeer: () => false,
+      } as never) as never,
+      ref(alice),
+      String,
+      actionError,
+      () => { actionError.value = ""; },
+      ref("muc-occupant"),
+    );
+    dm.timelineEl.value = makeTimelineEl();
+
+    await dm.loadMessages(alice, 1);
+
+    expect(dm.firstUnseenId.value).toBeNull();
+    expect(localStorage.getItem(dmKey(alice))).toBe("alice-restored");
+    expect(localStorage.getItem(dmKey("room@rooms.custom.example"))).toBeNull();
   });
 
   test("DM initial load reconciles queued inactive MDS candidates without moving backward", async () => {

--- a/chat/tests/session-bootstrap-choreography.test.ts
+++ b/chat/tests/session-bootstrap-choreography.test.ts
@@ -60,13 +60,14 @@ function makeHarness(options: {
   channelInbox?: () => Promise<boolean>;
 } = {}) {
   let lifecycleHandler: ((event: SessionLifecycleEvent) => void) | null = null;
+  let mdsDisplayedHandler: ((entry: { chatId: string; stanzaId: string; stanzaIdBy: string }) => void) | null = null;
   const client = {
     ...handlerStubs(),
     setDirectMessageHandler: () => {},
     setDmChatStateHandler: () => {},
     setDmDisplayedHandler: () => {},
     setDmReactionHandler: () => {},
-    setMdsDisplayedHandler: () => {},
+    setMdsDisplayedHandler: (handler: typeof mdsDisplayedHandler) => { mdsDisplayedHandler = handler; },
     setPresenceUpdateHandler: () => {},
     addPubsubEventHandler: () => {},
     setMemberJidHandler: () => {},
@@ -209,6 +210,12 @@ function makeHarness(options: {
       if (!lifecycleHandler) throw new Error("session lifecycle handler was not registered");
       lifecycleHandler(event);
     },
+    dispatchMdsDisplayed: (entry: { chatId: string; stanzaId: string; stanzaIdBy: string }) => {
+      if (!mdsDisplayedHandler) throw new Error("MDS displayed handler was not registered");
+      mdsDisplayedHandler(entry);
+    },
+    dmApplyMdsDisplayed: deps.dmMessaging.applyMdsDisplayed,
+    roomApplyMdsDisplayed: deps.messaging.applyMdsDisplayed,
     counts: () => ({
       dmInbox: hydrateDmInbox.mock.calls.length,
       channelInbox: hydrateChannelInbox.mock.calls.length,
@@ -222,6 +229,29 @@ function makeHarness(options: {
 }
 
 describe("session bootstrap choreography (#754)", () => {
+  test("cross-resource MDS keeps an unknown second occupant in one room isolated", async () => {
+    const harness = makeHarness();
+    harness.dispatchMdsDisplayed({
+      chatId: "room@conference.example/alice",
+      stanzaId: "sid-alice",
+      stanzaIdBy: "example.com",
+    });
+    harness.dispatchMdsDisplayed({
+      chatId: "room@conference.example/bob",
+      stanzaId: "sid-bob",
+      stanzaIdBy: "example.com",
+    });
+
+    expect(harness.roomApplyMdsDisplayed).toHaveBeenNthCalledWith(1,
+      "room@conference.example/alice",
+      { stanzaId: "sid-alice", stanzaIdBy: "example.com" },
+    );
+    expect(harness.roomApplyMdsDisplayed).toHaveBeenNthCalledWith(2,
+      "room@conference.example/bob",
+      { stanzaId: "sid-bob", stanzaIdBy: "example.com" },
+    );
+    harness.scope.stop();
+  });
   test("a resumed session-ready re-hydrates each surface exactly once (inbox pushes are not SM-replayed)", async () => {
     // XEP-0198 resume replays peer-routed stanzas, but the server
     // fire-and-forgets inbox pushes to live resources only — a detached

--- a/chat/tests/sm-delivery.test.ts
+++ b/chat/tests/sm-delivery.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, mock, test } from "bun:test";
 import { nextTick, ref } from "vue";
 import type { WaddleSession } from "../src/lib/server-auth";
-import { roomBareJidFor, type LiveDmMessage, type LiveRoomMessage } from "../src/lib/xmpp-client";
+import {
+  roomBareJidFor,
+  type DmConversationScope,
+  type LiveDmMessage,
+  type LiveRoomMessage,
+} from "../src/lib/xmpp-client";
 import { useDirectMessages } from "../src/dms/messages";
 import { useChannelMessages } from "../src/channels/messages";
 import { dmMessageFromArchived, roomMessageFromArchived } from "../src/lib/xmpp/client";
@@ -43,6 +48,7 @@ function makeRoomClient(queryMamResults: LiveRoomMessage[] = []) {
 function makeDmMessaging(
   xmppClient: ReturnType<typeof makeDmClient>,
   activePeerJid = "bob@example.com",
+  conversationScope?: DmConversationScope,
 ) {
   const actionError = ref("");
   const dm = useDirectMessages(
@@ -54,6 +60,7 @@ function makeDmMessaging(
     () => {
       actionError.value = "";
     },
+    conversationScope ? ref(conversationScope) : undefined,
   );
   return { dm, actionError };
 }
@@ -641,6 +648,7 @@ describe("XEP-0198 delivery status (DM)", () => {
     expect(clientAny.value.queryPersonalMam).toHaveBeenCalledWith(
       "room@muc.example.com/bob",
       100,
+      "muc-occupant",
     );
   });
 
@@ -648,7 +656,11 @@ describe("XEP-0198 delivery status (DM)", () => {
     // Cold reload: topology discovery has not yet updated the client's MUC
     // service, so persisted cursor scope is the authoritative signal.
     const client = makeDmClient([], () => false);
-    const { dm } = makeDmMessaging(client, "room@rooms.waddle.example/bob");
+    const { dm } = makeDmMessaging(
+      client,
+      "room@rooms.waddle.example/bob",
+      "muc-occupant",
+    );
     dm.messages.value = [{
       id: "pm-old",
       author: "bob",
@@ -673,6 +685,7 @@ describe("XEP-0198 delivery status (DM)", () => {
     expect(clientAny.value.queryPersonalMam).toHaveBeenCalledWith(
       "room@rooms.waddle.example/bob",
       100,
+      "muc-occupant",
     );
   });
 
@@ -716,7 +729,7 @@ describe("XEP-0198 delivery status (DM)", () => {
     const clientAny = client as unknown as {
       value: { queryPersonalMam: ReturnType<typeof mock> };
     };
-    expect(clientAny.value.queryPersonalMam).toHaveBeenCalledWith("bob@example.com", 100);
+    expect(clientAny.value.queryPersonalMam).toHaveBeenCalledWith("bob@example.com", 100, "account");
   });
 
   test("a failed DM fallback reload restores the pre-reload timeline instead of wiping it", async () => {
@@ -838,7 +851,7 @@ describe("XEP-0198 delivery status (DM)", () => {
     const clientAny = client as unknown as {
       value: { queryPersonalMam: ReturnType<typeof mock> };
     };
-    expect(clientAny.value.queryPersonalMam).toHaveBeenCalledWith("bob@example.com", 100);
+    expect(clientAny.value.queryPersonalMam).toHaveBeenCalledWith("bob@example.com", 100, "account");
   });
 
   test("MAM-replayed DM reactions attach to the original message after a fresh load", async () => {

--- a/server/crates/waddle-xmpp-client-ffi/src/types.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/types.rs
@@ -66,8 +66,8 @@ pub struct WaddleMdsDisplayedEntry {
     pub chat_id: String,
     /// XEP-0359 id of the displayed message.
     pub stanza_id: String,
-    /// JID that injected the stanza-id (the room for groupchat; the
-    /// user's own server for DMs and MUC PMs).
+    /// Assigning entity's XEP-0359 `by` JID; preserve exactly for
+    /// stanza-id authority matching.
     pub stanza_id_by: String,
 }
 

--- a/server/crates/waddle-xmpp-client-ffi/src/types.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/types.rs
@@ -58,16 +58,16 @@ pub struct WaddleCallThreadAnchor {
 /// XEP-0490 §3 displayed-marker entry surfaced to Swift. Mirrors
 /// `waddle_xmpp_client::messaging::MdsDisplayedEntry` 1:1 — the
 /// FFI does not collapse or rename fields so the Swift consumer
-/// can correlate `chat_id` (PEP item id = bare JID of the chat)
+/// can correlate `chat_id` (PEP item id = the exact chat JID)
 /// with its locally-tracked conversation list directly.
 #[derive(uniffi::Record, Clone)]
 pub struct WaddleMdsDisplayedEntry {
-    /// PEP item id = bare JID of the chat (DM contact or MUC room).
+    /// PEP item id = bare for DMs/rooms, full occupant for MUC PMs.
     pub chat_id: String,
     /// XEP-0359 id of the displayed message.
     pub stanza_id: String,
-    /// JID that injected the stanza-id (the MUC room for group
-    /// chats; the user's own server for 1:1 chats).
+    /// JID that injected the stanza-id (the room for groupchat; the
+    /// user's own server for DMs and MUC PMs).
     pub stanza_id_by: String,
 }
 

--- a/server/crates/waddle-xmpp-client-ffi/src/types.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/types.rs
@@ -66,8 +66,8 @@ pub struct WaddleMdsDisplayedEntry {
     pub chat_id: String,
     /// XEP-0359 id of the displayed message.
     pub stanza_id: String,
-    /// Assigning entity's XEP-0359 `by` JID; preserve exactly for
-    /// stanza-id authority matching.
+    /// Resource-less room or account-server authority from the XEP-0359 `by`
+    /// attribute, as required by XEP-0490.
     pub stanza_id_by: String,
 }
 

--- a/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
@@ -96,9 +96,9 @@ impl WaddleClient {
     /// the JID of the chat (bare DM contact, bare MUC room, or full MUC
     /// occupant for a private message) which becomes the PEP item id;
     /// `stanza_id` is the XEP-0359 id of the latest
-    /// displayed message; `stanza_id_by` is the JID that injected
-    /// that stanza-id (the room for groupchat, the user's own server
-    /// for DMs and MUC PMs). The publish carries the spec-mandated
+    /// displayed message; `stanza_id_by` is the assigning entity's
+    /// XEP-0359 `by` JID and must be preserved exactly for authority
+    /// matching. The publish carries the spec-mandated
     /// publish-options as preconditions.
     pub fn publish_mds_displayed(
         &self,

--- a/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
@@ -93,11 +93,12 @@ impl WaddleClient {
     }
 
     /// XEP-0490 §3 publish to `urn:xmpp:mds:displayed:0`. `chat_id` is
-    /// the bare JID of the chat (DM contact or MUC room) which becomes
-    /// the PEP item id; `stanza_id` is the XEP-0359 id of the latest
+    /// the JID of the chat (bare DM contact, bare MUC room, or full MUC
+    /// occupant for a private message) which becomes the PEP item id;
+    /// `stanza_id` is the XEP-0359 id of the latest
     /// displayed message; `stanza_id_by` is the JID that injected
-    /// that stanza-id (the MUC room for group chats, the user's own
-    /// server for 1:1). The publish carries the spec-mandated
+    /// that stanza-id (the room for groupchat, the user's own server
+    /// for DMs and MUC PMs). The publish carries the spec-mandated
     /// publish-options as preconditions.
     pub fn publish_mds_displayed(
         &self,
@@ -108,12 +109,12 @@ impl WaddleClient {
         let inner = self.inner.clone();
         future_to_promise(async move {
             let iq_id = uuid::Uuid::new_v4().to_string();
-            let chat_id: BareJid = chat_id
+            let chat_id: Jid = chat_id
                 .parse()
                 .map_err(|err| js_error(format!("invalid MDS chat id: {err}")))?;
             let stanza_id = StanzaId::new(stanza_id)
                 .map_err(|err| js_error(format!("invalid MDS stanza id: {err}")))?;
-            let stanza_id_by: BareJid = stanza_id_by
+            let stanza_id_by: Jid = stanza_id_by
                 .parse()
                 .map_err(|err| js_error(format!("invalid MDS stanza-id by JID: {err}")))?;
             let iq = build_mds_publish_iq(&iq_id, &chat_id, &stanza_id, &stanza_id_by);

--- a/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_messaging.rs
@@ -96,9 +96,8 @@ impl WaddleClient {
     /// the JID of the chat (bare DM contact, bare MUC room, or full MUC
     /// occupant for a private message) which becomes the PEP item id;
     /// `stanza_id` is the XEP-0359 id of the latest
-    /// displayed message; `stanza_id_by` is the assigning entity's
-    /// XEP-0359 `by` JID and must be preserved exactly for authority
-    /// matching. The publish carries the spec-mandated
+    /// displayed message; `stanza_id_by` is the resource-less room or
+    /// account-server authority required by XEP-0490. The publish carries the spec-mandated
     /// publish-options as preconditions.
     pub fn publish_mds_displayed(
         &self,
@@ -114,7 +113,7 @@ impl WaddleClient {
                 .map_err(|err| js_error(format!("invalid MDS chat id: {err}")))?;
             let stanza_id = StanzaId::new(stanza_id)
                 .map_err(|err| js_error(format!("invalid MDS stanza id: {err}")))?;
-            let stanza_id_by: Jid = stanza_id_by
+            let stanza_id_by: BareJid = stanza_id_by
                 .parse()
                 .map_err(|err| js_error(format!("invalid MDS stanza-id by JID: {err}")))?;
             let iq = build_mds_publish_iq(&iq_id, &chat_id, &stanza_id, &stanza_id_by);

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -878,13 +878,12 @@ pub struct WaddleVCard4 {
 /// One XEP-0490 §3 displayed entry surfaced to the chat client.
 #[derive(Debug, Serialize)]
 pub struct WaddleMdsDisplayedEntry {
-    /// The PEP item id — the bare JID of the chat (DM contact or
-    /// MUC room).
+    /// The PEP item id — bare for DMs/rooms, full occupant for MUC PMs.
     pub chat_id: String,
     /// XEP-0359 stanza-id of the displayed message.
     pub stanza_id: String,
-    /// JID that injected the stanza-id (the MUC room for group
-    /// chats; the user's own server for 1:1 chats).
+    /// JID that injected the stanza-id (the room for groupchat; the
+    /// user's own server for DMs and MUC PMs).
     pub stanza_id_by: String,
 }
 

--- a/server/crates/waddle-xmpp-client-wasm/src/types.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/types.rs
@@ -882,8 +882,8 @@ pub struct WaddleMdsDisplayedEntry {
     pub chat_id: String,
     /// XEP-0359 stanza-id of the displayed message.
     pub stanza_id: String,
-    /// JID that injected the stanza-id (the room for groupchat; the
-    /// user's own server for DMs and MUC PMs).
+    /// Assigning entity's XEP-0359 `by` JID; preserve exactly for
+    /// stanza-id authority matching.
     pub stanza_id_by: String,
 }
 

--- a/server/crates/waddle-xmpp-client/src/mds.rs
+++ b/server/crates/waddle-xmpp-client/src/mds.rs
@@ -26,13 +26,13 @@ const PUBSUB_PUBLISH_OPTIONS_FORM_TYPE: &str = "http://jabber.org/protocol/pubsu
 
 /// Typed representation of one MDS catch-up entry. `chat_id` is the
 /// PEP item id (= JID of the chat). `stanza_id` is the XEP-0359 id of
-/// the displayed message; `stanza_id_by` is the assigning entity's JID from
-/// XEP-0359 and must be preserved exactly for authority matching.
+/// the displayed message; `stanza_id_by` is the resource-less assigning
+/// entity required by XEP-0490 for room and account-server stanza IDs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MdsCatchupEntry {
     pub chat_id: Jid,
     pub stanza_id: StanzaId,
-    pub stanza_id_by: Jid,
+    pub stanza_id_by: BareJid,
 }
 
 fn build_publish_options_form() -> Element {
@@ -75,7 +75,7 @@ fn field(var: &str, value: &str) -> Element {
         .build()
 }
 
-fn build_displayed_payload(stanza_id: &StanzaId, stanza_id_by: &Jid) -> Element {
+fn build_displayed_payload(stanza_id: &StanzaId, stanza_id_by: &BareJid) -> Element {
     Element::builder("displayed", NS_MDS)
         .append(
             Element::builder("stanza-id", NS_STANZA_ID)
@@ -99,7 +99,7 @@ pub fn build_mds_publish_iq(
     iq_id: &str,
     chat_id: &Jid,
     stanza_id: &StanzaId,
-    stanza_id_by: &Jid,
+    stanza_id_by: &BareJid,
 ) -> Element {
     let item = Element::builder("item", NS_PUBSUB)
         .attr(
@@ -208,7 +208,7 @@ pub fn parse_mds_event(message: &Element) -> Option<Vec<MdsCatchupEntry>> {
     Some(entries)
 }
 
-fn parse_displayed_payload(displayed: &Element) -> Option<(StanzaId, Jid)> {
+fn parse_displayed_payload(displayed: &Element) -> Option<(StanzaId, BareJid)> {
     if !displayed.is("displayed", NS_MDS) {
         return None;
     }
@@ -220,7 +220,7 @@ fn parse_displayed_payload(displayed: &Element) -> Option<(StanzaId, Jid)> {
         return None;
     }
     let stanza_id = StanzaId::new(stanza_id_elem.attr("id")?).ok()?;
-    let stanza_id_by = stanza_id_elem.attr("by")?.parse::<Jid>().ok()?;
+    let stanza_id_by = stanza_id_elem.attr("by")?.parse::<BareJid>().ok()?;
     Some((stanza_id, stanza_id_by))
 }
 
@@ -251,12 +251,16 @@ mod tests {
         value.parse().expect("test JID parses")
     }
 
+    fn bare_jid(value: &str) -> BareJid {
+        value.parse().expect("test bare JID parses")
+    }
+
     fn stanza_id(value: &str) -> StanzaId {
         StanzaId::new(value).expect("test stanza id is non-empty")
     }
 
     fn displayed_payload(id: &str, by: &str) -> Element {
-        build_displayed_payload(&stanza_id(id), &jid(by))
+        build_displayed_payload(&stanza_id(id), &bare_jid(by))
     }
 
     fn stanza_id_element(id: &str, by: &str) -> Element {
@@ -328,7 +332,7 @@ mod tests {
             "iq-1",
             &jid("romeo@montague.lit"),
             &stanza_id("stanza-id-1"),
-            &jid("juliet@capulet.lit"),
+            &bare_jid("juliet@capulet.lit"),
         );
         let xml = xml_of(&iq);
         // `minidom` serialises namespace attributes with single
@@ -395,10 +399,10 @@ mod tests {
         assert_eq!(entries.len(), 2);
         assert_eq!(entries[0].chat_id, jid("romeo@montague.lit"));
         assert_eq!(entries[0].stanza_id, stanza_id("dm-sid"));
-        assert_eq!(entries[0].stanza_id_by, jid("juliet@capulet.lit"));
+        assert_eq!(entries[0].stanza_id_by, bare_jid("juliet@capulet.lit"));
         assert_eq!(
             entries[1].chat_id,
-            jid("example@conference.shakespeare.lit")
+            bare_jid("example@conference.shakespeare.lit")
         );
         assert_eq!(
             entries[1].stanza_id_by,
@@ -418,6 +422,11 @@ mod tests {
                 NS_PUBSUB,
                 "invalid-by",
                 displayed_with(vec![stanza_id_element("sid-1", "not a jid")]),
+            ),
+            item(
+                NS_PUBSUB,
+                "resource-by",
+                displayed_with(vec![stanza_id_element("sid-1", "alice@example.com/phone")]),
             ),
             item(
                 NS_PUBSUB,

--- a/server/crates/waddle-xmpp-client/src/mds.rs
+++ b/server/crates/waddle-xmpp-client/src/mds.rs
@@ -26,8 +26,8 @@ const PUBSUB_PUBLISH_OPTIONS_FORM_TYPE: &str = "http://jabber.org/protocol/pubsu
 
 /// Typed representation of one MDS catch-up entry. `chat_id` is the
 /// PEP item id (= JID of the chat). `stanza_id` is the XEP-0359 id of
-/// the displayed message; `stanza_id_by` is the JID that injected the
-/// stanza-id (the room for groupchat, the user's server for DMs and MUC PMs).
+/// the displayed message; `stanza_id_by` is the assigning entity's JID from
+/// XEP-0359 and must be preserved exactly for authority matching.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MdsCatchupEntry {
     pub chat_id: Jid,

--- a/server/crates/waddle-xmpp-client/src/mds.rs
+++ b/server/crates/waddle-xmpp-client/src/mds.rs
@@ -6,7 +6,7 @@
 //! `<displayed/>` payload enforces the XEP-0490 shape strictly so the
 //! typed `MdsDisplayed` value flows end-to-end.
 
-use jid::BareJid;
+use jid::{BareJid, Jid};
 use minidom::Element;
 
 use crate::request::StanzaId;
@@ -27,12 +27,12 @@ const PUBSUB_PUBLISH_OPTIONS_FORM_TYPE: &str = "http://jabber.org/protocol/pubsu
 /// Typed representation of one MDS catch-up entry. `chat_id` is the
 /// PEP item id (= JID of the chat). `stanza_id` is the XEP-0359 id of
 /// the displayed message; `stanza_id_by` is the JID that injected the
-/// stanza-id (the room for MUC, the user's server for 1:1).
+/// stanza-id (the room for groupchat, the user's server for DMs and MUC PMs).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MdsCatchupEntry {
-    pub chat_id: BareJid,
+    pub chat_id: Jid,
     pub stanza_id: StanzaId,
-    pub stanza_id_by: BareJid,
+    pub stanza_id_by: Jid,
 }
 
 fn build_publish_options_form() -> Element {
@@ -75,7 +75,7 @@ fn field(var: &str, value: &str) -> Element {
         .build()
 }
 
-fn build_displayed_payload(stanza_id: &StanzaId, stanza_id_by: &BareJid) -> Element {
+fn build_displayed_payload(stanza_id: &StanzaId, stanza_id_by: &Jid) -> Element {
     Element::builder("displayed", NS_MDS)
         .append(
             Element::builder("stanza-id", NS_STANZA_ID)
@@ -97,9 +97,9 @@ fn build_displayed_payload(stanza_id: &StanzaId, stanza_id_by: &BareJid) -> Elem
 /// the user's own PEP service per XEP-0163.
 pub fn build_mds_publish_iq(
     iq_id: &str,
-    chat_id: &BareJid,
+    chat_id: &Jid,
     stanza_id: &StanzaId,
-    stanza_id_by: &BareJid,
+    stanza_id_by: &Jid,
 ) -> Element {
     let item = Element::builder("item", NS_PUBSUB)
         .attr(
@@ -159,7 +159,7 @@ pub fn build_mds_subscribe_iq(iq_id: &str, subscriber_bare_jid: &str) -> Element
 }
 
 fn parse_displayed_into_entry(item: &Element) -> Option<MdsCatchupEntry> {
-    let chat_id = item.attr("id")?.parse::<BareJid>().ok()?;
+    let chat_id = item.attr("id")?.parse::<Jid>().ok()?;
     let displayed = item.get_child("displayed", NS_MDS)?;
     let (stanza_id, stanza_id_by) = parse_displayed_payload(displayed)?;
     Some(MdsCatchupEntry {
@@ -208,7 +208,7 @@ pub fn parse_mds_event(message: &Element) -> Option<Vec<MdsCatchupEntry>> {
     Some(entries)
 }
 
-fn parse_displayed_payload(displayed: &Element) -> Option<(StanzaId, BareJid)> {
+fn parse_displayed_payload(displayed: &Element) -> Option<(StanzaId, Jid)> {
     if !displayed.is("displayed", NS_MDS) {
         return None;
     }
@@ -220,7 +220,7 @@ fn parse_displayed_payload(displayed: &Element) -> Option<(StanzaId, BareJid)> {
         return None;
     }
     let stanza_id = StanzaId::new(stanza_id_elem.attr("id")?).ok()?;
-    let stanza_id_by = stanza_id_elem.attr("by")?.parse::<BareJid>().ok()?;
+    let stanza_id_by = stanza_id_elem.attr("by")?.parse::<Jid>().ok()?;
     Some((stanza_id, stanza_id_by))
 }
 
@@ -247,8 +247,8 @@ mod tests {
         String::from(elem)
     }
 
-    fn bare_jid(value: &str) -> BareJid {
-        value.parse().expect("test bare JID parses")
+    fn jid(value: &str) -> Jid {
+        value.parse().expect("test JID parses")
     }
 
     fn stanza_id(value: &str) -> StanzaId {
@@ -256,7 +256,7 @@ mod tests {
     }
 
     fn displayed_payload(id: &str, by: &str) -> Element {
-        build_displayed_payload(&stanza_id(id), &bare_jid(by))
+        build_displayed_payload(&stanza_id(id), &jid(by))
     }
 
     fn stanza_id_element(id: &str, by: &str) -> Element {
@@ -326,9 +326,9 @@ mod tests {
     fn publish_iq_carries_spec_publish_options() {
         let iq = build_mds_publish_iq(
             "iq-1",
-            &bare_jid("romeo@montague.lit"),
+            &jid("romeo@montague.lit"),
             &stanza_id("stanza-id-1"),
-            &bare_jid("juliet@capulet.lit"),
+            &jid("juliet@capulet.lit"),
         );
         let xml = xml_of(&iq);
         // `minidom` serialises namespace attributes with single
@@ -393,16 +393,16 @@ mod tests {
         ]);
         let entries = parse_mds_catchup_result(&iq);
         assert_eq!(entries.len(), 2);
-        assert_eq!(entries[0].chat_id, bare_jid("romeo@montague.lit"));
+        assert_eq!(entries[0].chat_id, jid("romeo@montague.lit"));
         assert_eq!(entries[0].stanza_id, stanza_id("dm-sid"));
-        assert_eq!(entries[0].stanza_id_by, bare_jid("juliet@capulet.lit"));
+        assert_eq!(entries[0].stanza_id_by, jid("juliet@capulet.lit"));
         assert_eq!(
             entries[1].chat_id,
-            bare_jid("example@conference.shakespeare.lit")
+            jid("example@conference.shakespeare.lit")
         );
         assert_eq!(
             entries[1].stanza_id_by,
-            bare_jid("example@conference.shakespeare.lit")
+            jid("example@conference.shakespeare.lit")
         );
     }
 
@@ -435,7 +435,7 @@ mod tests {
         ]);
         let entries = parse_mds_catchup_result(&iq);
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].chat_id, bare_jid("valid@example.com"));
+        assert_eq!(entries[0].chat_id, jid("valid@example.com"));
         assert_eq!(entries[0].stanza_id, stanza_id("sid-valid"));
     }
 
@@ -448,7 +448,7 @@ mod tests {
         )]);
         let entries = parse_mds_event(&msg).expect("is MDS event");
         assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].chat_id, bare_jid("romeo@montague.lit"));
+        assert_eq!(entries[0].chat_id, jid("romeo@montague.lit"));
         assert_eq!(entries[0].stanza_id, stanza_id("evt-sid"));
     }
 

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -304,9 +304,8 @@ pub struct MdsDisplayedEntry {
     pub chat_id: Jid,
     /// XEP-0359 id of the displayed message.
     pub stanza_id: StanzaId,
-    /// Assigning entity's XEP-0359 `by` JID; preserve exactly for
-    /// stanza-id authority matching.
-    pub stanza_id_by: Jid,
+    /// Resource-less assigning entity from the XEP-0359 `by` attribute.
+    pub stanza_id_by: BareJid,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -304,8 +304,8 @@ pub struct MdsDisplayedEntry {
     pub chat_id: Jid,
     /// XEP-0359 id of the displayed message.
     pub stanza_id: StanzaId,
-    /// JID that injected the stanza-id (the room for groupchat; the
-    /// user's own server for DMs and MUC PMs).
+    /// Assigning entity's XEP-0359 `by` JID; preserve exactly for
+    /// stanza-id authority matching.
     pub stanza_id_by: Jid,
 }
 

--- a/server/crates/waddle-xmpp-client/src/messaging/types.rs
+++ b/server/crates/waddle-xmpp-client/src/messaging/types.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use jid::{BareJid, FullJid};
+use jid::{BareJid, FullJid, Jid};
 use std::fmt;
 use url::Url;
 use waddle_xmpp_core::xep0359::StanzaId as StableStanzaId;
@@ -300,13 +300,13 @@ pub struct InboundMessage {
 /// XEP-0490 §3 displayed entry as surfaced from a PEP event.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MdsDisplayedEntry {
-    /// PEP item id = bare JID of the chat (DM contact or MUC room).
-    pub chat_id: BareJid,
+    /// PEP item id = chat JID: bare for DMs/rooms, full occupant for MUC PMs.
+    pub chat_id: Jid,
     /// XEP-0359 id of the displayed message.
     pub stanza_id: StanzaId,
-    /// JID that injected the stanza-id (the MUC room for group
-    /// chats; the user's own server for 1:1 chats).
-    pub stanza_id_by: BareJid,
+    /// JID that injected the stanza-id (the room for groupchat; the
+    /// user's own server for DMs and MUC PMs).
+    pub stanza_id_by: Jid,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/server/crates/waddle-xmpp-client/tests/xep0490_mds.rs
+++ b/server/crates/waddle-xmpp-client/tests/xep0490_mds.rs
@@ -1,6 +1,6 @@
 //! XEP-0490: Message Displayed Synchronization dedicated client suite.
 
-use jid::Jid;
+use jid::{BareJid, Jid};
 use minidom::Element;
 use waddle_xmpp_client::{
     mds::{
@@ -16,11 +16,15 @@ fn jid(value: &str) -> Jid {
     value.parse().expect("test JID parses")
 }
 
+fn bare_jid(value: &str) -> BareJid {
+    value.parse().expect("test bare JID parses")
+}
+
 fn stanza_id(value: &str) -> StanzaId {
     StanzaId::new(value).expect("test stanza id is non-empty")
 }
 
-fn item(namespace: &str, chat_id: &Jid, stanza_id: &StanzaId, by: &Jid) -> Element {
+fn item(namespace: &str, chat_id: &Jid, stanza_id: &StanzaId, by: &BareJid) -> Element {
     Element::builder("item", namespace)
         .attr(
             minidom::rxml::xml_ncname!("id").to_owned(),
@@ -45,7 +49,7 @@ fn item(namespace: &str, chat_id: &Jid, stanza_id: &StanzaId, by: &Jid) -> Eleme
 #[test]
 fn xep0490_muc_pm_publish_uses_full_occupant_item_id() {
     let occupant = jid("room@conference.example/alice");
-    let account_server = jid("example.com");
+    let account_server = bare_jid("example.com");
     let iq = build_mds_publish_iq("mds-1", &occupant, &stanza_id("sid-alice"), &account_server);
     let published = iq
         .get_child("pubsub", NS_PUBSUB)
@@ -69,13 +73,13 @@ fn xep0490_catchup_preserves_two_occupants_in_one_room() {
                             NS_PUBSUB,
                             &jid("room@conference.example/alice"),
                             &stanza_id("sid-alice"),
-                            &jid("example.com"),
+                            &bare_jid("example.com"),
                         ))
                         .append(item(
                             NS_PUBSUB,
                             &jid("room@conference.example/bob"),
                             &stanza_id("sid-bob"),
-                            &jid("example.com"),
+                            &bare_jid("example.com"),
                         ))
                         .build(),
                 )
@@ -105,7 +109,7 @@ fn xep0490_cross_resource_event_preserves_full_occupant() {
                             NS_PUBSUB_EVENT,
                             &jid("room@conference.example/alice"),
                             &stanza_id("sid-alice"),
-                            &jid("example.com"),
+                            &bare_jid("example.com"),
                         ))
                         .build(),
                 )
@@ -115,4 +119,45 @@ fn xep0490_cross_resource_event_preserves_full_occupant() {
 
     let entries = parse_mds_event(&message).expect("MDS event");
     assert_eq!(entries[0].chat_id, jid("room@conference.example/alice"));
+}
+
+#[test]
+fn xep0490_rejects_resource_bearing_stanza_id_authority() {
+    let message = Element::builder("message", NS_CLIENT)
+        .append(
+            Element::builder("event", NS_PUBSUB_EVENT)
+                .append(
+                    Element::builder("items", NS_PUBSUB_EVENT)
+                        .attr(minidom::rxml::xml_ncname!("node").to_owned(), MDS_NODE)
+                        .append(
+                            Element::builder("item", NS_PUBSUB_EVENT)
+                                .attr(
+                                    minidom::rxml::xml_ncname!("id").to_owned(),
+                                    "room@conference.example/alice",
+                                )
+                                .append(
+                                    Element::builder("displayed", NS_MDS)
+                                        .append(
+                                            Element::builder("stanza-id", NS_STANZA_ID)
+                                                .attr(
+                                                    minidom::rxml::xml_ncname!("id").to_owned(),
+                                                    "sid-alice",
+                                                )
+                                                .attr(
+                                                    minidom::rxml::xml_ncname!("by").to_owned(),
+                                                    "example.com/phone",
+                                                )
+                                                .build(),
+                                        )
+                                        .build(),
+                                )
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )
+        .build();
+
+    assert_eq!(parse_mds_event(&message), Some(Vec::new()));
 }

--- a/server/crates/waddle-xmpp-client/tests/xep0490_mds.rs
+++ b/server/crates/waddle-xmpp-client/tests/xep0490_mds.rs
@@ -20,15 +20,21 @@ fn stanza_id(value: &str) -> StanzaId {
     StanzaId::new(value).expect("test stanza id is non-empty")
 }
 
-fn item(namespace: &str, chat_id: &str, stanza_id: &str, by: &str) -> Element {
+fn item(namespace: &str, chat_id: &Jid, stanza_id: &StanzaId, by: &Jid) -> Element {
     Element::builder("item", namespace)
-        .attr(minidom::rxml::xml_ncname!("id").to_owned(), chat_id)
+        .attr(
+            minidom::rxml::xml_ncname!("id").to_owned(),
+            chat_id.as_str(),
+        )
         .append(
             Element::builder("displayed", NS_MDS)
                 .append(
                     Element::builder("stanza-id", NS_STANZA_ID)
-                        .attr(minidom::rxml::xml_ncname!("id").to_owned(), stanza_id)
-                        .attr(minidom::rxml::xml_ncname!("by").to_owned(), by)
+                        .attr(
+                            minidom::rxml::xml_ncname!("id").to_owned(),
+                            stanza_id.as_str(),
+                        )
+                        .attr(minidom::rxml::xml_ncname!("by").to_owned(), by.as_str())
                         .build(),
                 )
                 .build(),
@@ -61,15 +67,15 @@ fn xep0490_catchup_preserves_two_occupants_in_one_room() {
                         .attr(minidom::rxml::xml_ncname!("node").to_owned(), MDS_NODE)
                         .append(item(
                             NS_PUBSUB,
-                            "room@conference.example/alice",
-                            "sid-alice",
-                            "example.com",
+                            &jid("room@conference.example/alice"),
+                            &stanza_id("sid-alice"),
+                            &jid("example.com"),
                         ))
                         .append(item(
                             NS_PUBSUB,
-                            "room@conference.example/bob",
-                            "sid-bob",
-                            "example.com",
+                            &jid("room@conference.example/bob"),
+                            &stanza_id("sid-bob"),
+                            &jid("example.com"),
                         ))
                         .build(),
                 )
@@ -97,9 +103,9 @@ fn xep0490_cross_resource_event_preserves_full_occupant() {
                         .attr(minidom::rxml::xml_ncname!("node").to_owned(), MDS_NODE)
                         .append(item(
                             NS_PUBSUB_EVENT,
-                            "room@conference.example/alice",
-                            "sid-alice",
-                            "example.com",
+                            &jid("room@conference.example/alice"),
+                            &stanza_id("sid-alice"),
+                            &jid("example.com"),
                         ))
                         .build(),
                 )

--- a/server/crates/waddle-xmpp-client/tests/xep0490_mds.rs
+++ b/server/crates/waddle-xmpp-client/tests/xep0490_mds.rs
@@ -1,0 +1,112 @@
+//! XEP-0490: Message Displayed Synchronization dedicated client suite.
+
+use jid::Jid;
+use minidom::Element;
+use waddle_xmpp_client::{
+    mds::{
+        build_mds_publish_iq, parse_mds_catchup_result, parse_mds_event, MDS_NODE, NS_MDS,
+        NS_STANZA_ID,
+    },
+    messaging::NS_CLIENT,
+    pep::{NS_PUBSUB, NS_PUBSUB_EVENT},
+    StanzaId,
+};
+
+fn jid(value: &str) -> Jid {
+    value.parse().expect("test JID parses")
+}
+
+fn stanza_id(value: &str) -> StanzaId {
+    StanzaId::new(value).expect("test stanza id is non-empty")
+}
+
+fn item(namespace: &str, chat_id: &str, stanza_id: &str, by: &str) -> Element {
+    Element::builder("item", namespace)
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), chat_id)
+        .append(
+            Element::builder("displayed", NS_MDS)
+                .append(
+                    Element::builder("stanza-id", NS_STANZA_ID)
+                        .attr(minidom::rxml::xml_ncname!("id").to_owned(), stanza_id)
+                        .attr(minidom::rxml::xml_ncname!("by").to_owned(), by)
+                        .build(),
+                )
+                .build(),
+        )
+        .build()
+}
+
+#[test]
+fn xep0490_muc_pm_publish_uses_full_occupant_item_id() {
+    let occupant = jid("room@conference.example/alice");
+    let account_server = jid("example.com");
+    let iq = build_mds_publish_iq("mds-1", &occupant, &stanza_id("sid-alice"), &account_server);
+    let published = iq
+        .get_child("pubsub", NS_PUBSUB)
+        .and_then(|pubsub| pubsub.get_child("publish", NS_PUBSUB))
+        .and_then(|publish| publish.get_child("item", NS_PUBSUB))
+        .expect("published item");
+
+    assert_eq!(published.attr("id"), Some("room@conference.example/alice"));
+}
+
+#[test]
+fn xep0490_catchup_preserves_two_occupants_in_one_room() {
+    let result = Element::builder("iq", NS_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+        .append(
+            Element::builder("pubsub", NS_PUBSUB)
+                .append(
+                    Element::builder("items", NS_PUBSUB)
+                        .attr(minidom::rxml::xml_ncname!("node").to_owned(), MDS_NODE)
+                        .append(item(
+                            NS_PUBSUB,
+                            "room@conference.example/alice",
+                            "sid-alice",
+                            "example.com",
+                        ))
+                        .append(item(
+                            NS_PUBSUB,
+                            "room@conference.example/bob",
+                            "sid-bob",
+                            "example.com",
+                        ))
+                        .build(),
+                )
+                .build(),
+        )
+        .build();
+
+    let entries = parse_mds_catchup_result(&result);
+    assert_eq!(entries.len(), 2);
+    assert_eq!(entries[0].chat_id, jid("room@conference.example/alice"));
+    assert_eq!(entries[1].chat_id, jid("room@conference.example/bob"));
+}
+
+#[test]
+fn xep0490_cross_resource_event_preserves_full_occupant() {
+    let message = Element::builder("message", NS_CLIENT)
+        .attr(
+            minidom::rxml::xml_ncname!("from").to_owned(),
+            "juliet@example.com/phone",
+        )
+        .append(
+            Element::builder("event", NS_PUBSUB_EVENT)
+                .append(
+                    Element::builder("items", NS_PUBSUB_EVENT)
+                        .attr(minidom::rxml::xml_ncname!("node").to_owned(), MDS_NODE)
+                        .append(item(
+                            NS_PUBSUB_EVENT,
+                            "room@conference.example/alice",
+                            "sid-alice",
+                            "example.com",
+                        ))
+                        .build(),
+                )
+                .build(),
+        )
+        .build();
+
+    let entries = parse_mds_event(&message).expect("MDS event");
+    assert_eq!(entries[0].chat_id, jid("room@conference.example/alice"));
+}

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -248,9 +248,8 @@ export class WaddleClient {
      * the JID of the chat (bare DM contact, bare MUC room, or full MUC
      * occupant for a private message) which becomes the PEP item id;
      * `stanza_id` is the XEP-0359 id of the latest
-     * displayed message; `stanza_id_by` is the assigning entity's
-     * XEP-0359 `by` JID and must be preserved exactly for authority
-     * matching. The publish carries the spec-mandated
+     * displayed message; `stanza_id_by` is the resource-less room or
+     * account-server authority required by XEP-0490. The publish carries the spec-mandated
      * publish-options as preconditions.
      */
     publish_mds_displayed(chat_id: string, stanza_id: string, stanza_id_by: string): Promise<any>;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -245,11 +245,12 @@ export class WaddleClient {
     publish_activity(activity_json: any): Promise<any>;
     /**
      * XEP-0490 §3 publish to `urn:xmpp:mds:displayed:0`. `chat_id` is
-     * the bare JID of the chat (DM contact or MUC room) which becomes
-     * the PEP item id; `stanza_id` is the XEP-0359 id of the latest
+     * the JID of the chat (bare DM contact, bare MUC room, or full MUC
+     * occupant for a private message) which becomes the PEP item id;
+     * `stanza_id` is the XEP-0359 id of the latest
      * displayed message; `stanza_id_by` is the JID that injected
-     * that stanza-id (the MUC room for group chats, the user's own
-     * server for 1:1). The publish carries the spec-mandated
+     * that stanza-id (the room for groupchat, the user's own server
+     * for DMs and MUC PMs). The publish carries the spec-mandated
      * publish-options as preconditions.
      */
     publish_mds_displayed(chat_id: string, stanza_id: string, stanza_id_by: string): Promise<any>;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -248,9 +248,9 @@ export class WaddleClient {
      * the JID of the chat (bare DM contact, bare MUC room, or full MUC
      * occupant for a private message) which becomes the PEP item id;
      * `stanza_id` is the XEP-0359 id of the latest
-     * displayed message; `stanza_id_by` is the JID that injected
-     * that stanza-id (the room for groupchat, the user's own server
-     * for DMs and MUC PMs). The publish carries the spec-mandated
+     * displayed message; `stanza_id_by` is the assigning entity's
+     * XEP-0359 `by` JID and must be preserved exactly for authority
+     * matching. The publish carries the spec-mandated
      * publish-options as preconditions.
      */
     publish_mds_displayed(chat_id: string, stanza_id: string, stanza_id_by: string): Promise<any>;

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=0b8f635e8d15";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=0b8f635e8d15";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=0b8f635e8d15";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=4b0e753a0194";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=4b0e753a0194";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=4b0e753a0194";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=0b8f635e8d15";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=4b0e753a0194";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=7753d24b9486";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=7753d24b9486";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=7753d24b9486";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=5064c1298188";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=5064c1298188";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=5064c1298188";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=7753d24b9486";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=5064c1298188";

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=4b0e753a0194";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=4b0e753a0194";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=4b0e753a0194";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=7753d24b9486";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=7753d24b9486";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=7753d24b9486";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=4b0e753a0194";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=7753d24b9486";


### PR DESCRIPTION
## Outcome

MUC private-message displayed state and archive reads are now scoped by the participant's full occupant JID. Restored custom-service conversations keep that identity before service discovery or catch-up state is available, preventing Alice/Bob history and marker aliasing.

## Implementation

1. Carry a typed `account | muc-occupant` conversation scope from the restored/live conversation model into MAM page, older-page, thread, and search operations.
2. Preserve full occupant JIDs for MUC-PM MAM queries and exact-filter raw and converted results; keep ordinary resource DMs bare-scoped.
3. Publish XEP-0490 displayed state under the full participant JID and use the same identity for read markers, dividers, and last-seen persistence.
4. Preserve typed full-JID MDS item IDs across Rust, WASM, FFI, catch-up, and live events without reclassifying them through mutable discovery.
5. Capture conversation identity before asynchronous MAM work so client rotation cannot re-key persisted state.
6. Add cold-start custom-service, cross-occupant, async-race, reconnect, generated-binding, and dedicated XEP-0490 regressions.
7. Reload queued MUC-PMs under the same full occupant identity used at enqueue time, isolating sibling occupants after refresh.
8. Constrain XEP-0490 stanza-id authorities to typed resource-less room/account-server JIDs while retaining full JIDs for MUC-PM item IDs.

## Verification

- Full chat suite: 3,388 tests passed.
- Focused final outbound/scoping adversarial suite: 197 tests passed.
- Dedicated XEP-0490 suite: 4 passed; Rust MDS unit tests: 10 passed; WASM: 130 passed.
- Knip, Astro check/build, TypeScript typecheck, Rust clippy with `-D warnings`, cargo fmt, and diff checks passed.
- Apple UniFFI generated-binding drift check passed after regenerating the checked-in Swift surface.
- Two adversarial passes found and then verified fixes for pre-discovery identity reclassification; the final pass reported no actionable issues.

## Review fixes already incorporated

- Restored custom-service scope now controls message sends, composing/paused/active chat states, corrections, retractions, reactions, displayed markers, and queued delivery before discovery.
- Account scope explicitly keeps ordinary resource DMs bare even if mutable discovery state disagrees.
- Scope is captured before attachment upload and other asynchronous work, so peer/client changes cannot readdress a completed send.
- Dedicated XEP-0490 test builders carry typed JIDs and stanza IDs to the XML construction boundary.
- Regenerated Apple UniFFI bindings after the exported Rust contract documentation changed.
- Modelled `stanzaIdBy` as the resource-less room/account-server authority required by XEP-0490; malformed resource-bearing authorities are rejected at publish and parse boundaries.
- Queued MUC-PM hydration now uses the captured conversation scope and has a sibling-occupant isolation regression.
- Outbound queue writes and reads now share scope-aware canonical JID identity, so harmless bare-part casing/whitespace differences cannot hide a durable queued DM while MUC-PM resources remain exact.
- Queue hydration requires an explicit typed conversation scope, rejects rows from the other scope, and fails closed on ambiguous legacy resource-bearing rows.
- Regenerated both WASM and Apple bindings after tightening the authority contract.

## Known gap

- No live interoperability run against a third-party XEP-0490 server; wire shapes are covered against the repository's checked-in XEP.

Closes #1287. Child of #1279. Relates #945 and #210.

## Merge gate

Do not merge until CI is green, Greptile and Qodo have reviewed the final head SHA with zero actionable findings, and all review threads are resolved.

## Lore commit record

Constraint: XEP-0490 participant state for a MUC private chat is keyed by the participant's full occupant JID, while ordinary direct chats and groupchat remain bare-JID scoped.

Rejected: Infer MUC-PM identity only from mutable service discovery or catch-up state | restored custom-service conversations can arrive first and alias sibling occupants.

Confidence: high

Scope-risk: moderate

Reversibility: clean

Directive: Treat explicit `muc-occupant` conversation scope and resource-bearing typed inbound MDS item IDs as authoritative; keep stanza-id authorities resource-less and never bare-fold chat item IDs through discovery heuristics.

Tested: Full chat 3388; focused final outbound/scoping suite 197; queue/readiness/TTL/resume 150; XEP-0490 4; MDS unit 10; WASM 130; Knip; TypeScript; Rust clippy -D warnings; WASM regeneration; Apple UniFFI drift check; cargo fmt; git diff --check; final-head external gates required again after the latest revision.

Not-tested: Live multi-device interoperability against a third-party XEP-0490 server.
