### PR TITLE
fix(server): enforce typed XEP-0313 archive semantics

### DIFF
--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -2523,6 +2523,17 @@ impl MamStorage for LookupOutageMamStorage {
             .get_message_by_message_id(archive_jid, message_id)
             .await
     }
+    async fn get_message_by_sender_and_origin_id(
+        &self,
+        archive_jid: &BareJid,
+        archive_kind: waddle_xmpp::mam::MamArchiveKind,
+        sender: &jid::Jid,
+        origin_id: &waddle_xmpp_core::xep0359::OriginId,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        self.inner
+            .get_message_by_sender_and_origin_id(archive_jid, archive_kind, sender, origin_id)
+            .await
+    }
     async fn get_message_by_archive_or_stanza_id(
         &self,
         archive_jid: &BareJid,

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -2483,9 +2483,12 @@ impl MamStorage for LookupOutageMamStorage {
     async fn query_messages(
         &self,
         archive_jid: &BareJid,
+        archive_kind: waddle_xmpp::mam::MamArchiveKind,
         query: &waddle_xmpp_core::mam::MamQuery,
     ) -> Result<waddle_xmpp_core::mam::MamResult, MamStorageError> {
-        self.inner.query_messages(archive_jid, query).await
+        self.inner
+            .query_messages(archive_jid, archive_kind, query)
+            .await
     }
     async fn get_message(
         &self,

--- a/server/crates/waddle-server/src/server/extension_host_adapter/host_tools.rs
+++ b/server/crates/waddle-server/src/server/extension_host_adapter/host_tools.rs
@@ -140,9 +140,15 @@ impl ext_host::ExtensionHostTools for ExtensionHostAdapter {
     ) -> Result<ext_host::MamQueryResponse, ext_host::HostToolError> {
         let invocation = self.invocation_for_context(context).await?;
         let requester = invocation.actor_jid.to_bare();
-        let (archive, with) = match query.target {
-            ext_host::MamTarget::Room(jid) => (jid, query.sender),
-            ext_host::MamTarget::Conversation(peer) => (requester, Some(peer)),
+        let (archive, archive_kind, with) = match query.target {
+            ext_host::MamTarget::Room(jid) => {
+                (jid, waddle_xmpp::mam::MamArchiveKind::Room, query.sender)
+            }
+            ext_host::MamTarget::Conversation(peer) => (
+                requester,
+                waddle_xmpp::mam::MamArchiveKind::Personal,
+                Some(peer),
+            ),
         };
         self.authorize_archive(&invocation, &archive)
             .await
@@ -170,7 +176,7 @@ impl ext_host::ExtensionHostTools for ExtensionHostAdapter {
             .deps
             .protocol
             .mam_storage
-            .query_messages(&archive, &xmpp_query)
+            .query_messages(&archive, archive_kind, &xmpp_query)
             .await
             .map_err(|error| {
                 host_tool_error(ExtensionHostAdapterError::Storage(error.to_string()))

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -498,9 +498,11 @@ async fn interpret_with_depth(
             OutboundEvent::LookupArchivedMessage {
                 id,
                 archive,
+                archive_kind,
                 reference,
             } => {
-                let result = lookup_archived_message(deps, &archive, &reference).await;
+                let result =
+                    lookup_archived_message(deps, &archive, archive_kind, &reference).await;
                 outcome
                     .feedback
                     .push(InboundEvent::ArchivedMessageLoaded { id, result });

--- a/server/crates/waddle-server/src/server/routes/interpret/archive_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/archive_lookup.rs
@@ -9,7 +9,7 @@ pub(super) fn waddle_id_for_room_jid(room_jid: &BareJid) -> WaddleId {
     WaddleId::new(value).expect("static room Waddle scope is non-empty")
 }
 
-/// Resolve a typed [`MessageRef`] against `archive`'s personal MAM
+/// Resolve a typed [`MessageRef`] against the explicitly selected MAM
 /// archive and project the storage row into the typed protocol
 /// [`ProtocolArchivedMessage`] shape the
 /// [`waddle_xmpp::protocol::handlers::rich_target_validation::RichTargetValidationHandler`]
@@ -24,6 +24,7 @@ pub(super) fn waddle_id_for_room_jid(room_jid: &BareJid) -> WaddleId {
 pub(super) async fn lookup_archived_message(
     deps: &Deps<'_>,
     archive: &jid::BareJid,
+    archive_kind: waddle_xmpp::mam::MamArchiveKind,
     reference: &MessageRef,
 ) -> Option<Box<ProtocolArchivedMessage>> {
     let Some(mam_storage) = deps.mam_storage else {
@@ -46,10 +47,10 @@ pub(super) async fn lookup_archived_message(
         }
         MessageRef::OriginId { sender, origin_id } => {
             // No origin-id-only accessor on `MamStorage` today, so we
-            // narrow with `MamQuery.with = sender` (storage-level
-            // sender filter) and pick the first row whose `origin_id`
-            // *or wire `id` attribute* (`stanza_id` column) matches
-            // the requested value. The fall-through to the wire id
+            // narrow with the storage-level sender filter when its MAM
+            // semantics match this lookup, then pick the first row whose
+            // `origin_id` *or wire `id` attribute* (`stanza_id` column)
+            // matches the requested value. The fall-through to the wire id
             // mirrors the legacy `lookup_correction_target_message`
             // behaviour — many clients (and the CUE e2e scenarios)
             // omit the explicit `<origin-id/>` payload and rely on
@@ -57,17 +58,19 @@ pub(super) async fn lookup_archived_message(
             // target. Sender-bound matching keeps the
             // OR-collision protection from #229 PR8: only rows sent
             // by the original author can satisfy the correction.
-            let query = waddle_xmpp::mam::MamQuery {
-                with: Some(jid::Jid::from(sender.clone())),
-                ..Default::default()
-            };
-            match mam_storage.query_messages(archive, &query).await {
-                Ok(result) => Ok(result.messages.into_iter().find(|row| {
-                    row_matches_origin_id(row, sender, origin_id.as_str())
-                        || row_matches_wire_id(row, sender, origin_id.as_str())
-                })),
-                Err(e) => Err(e),
-            }
+            // XEP-0313 §4.3.1 gives `with=archive-owner` special self-chat
+            // semantics in personal archives. Rich-target validation is
+            // instead asking for messages authored by that owner, so using
+            // `with` there would exclude ordinary owner -> peer messages.
+            // The typed sender post-filter below remains authoritative.
+            lookup_origin_id_across_pages(
+                mam_storage.as_ref(),
+                archive,
+                archive_kind,
+                sender,
+                origin_id.as_str(),
+            )
+            .await
         }
     };
     match lookup {
@@ -81,6 +84,67 @@ pub(super) async fn lookup_archived_message(
             );
             None
         }
+    }
+}
+
+/// Search every forward RSM page that can contain an origin-id target.
+///
+/// The storage-level `with` filter is only a narrowing optimization: personal
+/// owner-origin lookups must omit it because XEP-0313 gives `with=owner`
+/// self-chat semantics, while ordinary personal and room lookups can still
+/// contain rows authored by the other endpoint. Consequently the typed sender
+/// predicate remains authoritative on every page.
+pub(super) async fn lookup_origin_id_across_pages(
+    mam_storage: &dyn waddle_xmpp::mam::MamStorage,
+    archive: &jid::BareJid,
+    archive_kind: waddle_xmpp::mam::MamArchiveKind,
+    sender: &jid::BareJid,
+    origin_id: &str,
+) -> Result<Option<MamArchivedMessage>, waddle_xmpp::mam::MamStorageError> {
+    const PAGE_SIZE: u32 = 100;
+
+    let with = if archive_kind == waddle_xmpp::mam::MamArchiveKind::Personal && sender == archive {
+        None
+    } else {
+        Some(jid::Jid::from(sender.clone()))
+    };
+    let mut after_id = None;
+    let mut seen_cursors = std::collections::HashSet::new();
+    loop {
+        let query = waddle_xmpp::mam::MamQuery {
+            with: with.clone(),
+            max: Some(PAGE_SIZE),
+            after_id: after_id.clone(),
+            ..Default::default()
+        };
+        let result = mam_storage
+            .query_messages(archive, archive_kind, &query)
+            .await?;
+        if let Some(row) = result.messages.into_iter().find(|row| {
+            row_matches_origin_id(row, sender, origin_id)
+                || row_matches_wire_id(row, sender, origin_id)
+        }) {
+            return Ok(Some(row));
+        }
+        if result.complete {
+            return Ok(None);
+        }
+        let Some(next_cursor) = result.last_id else {
+            warn!(
+                archive = %archive,
+                "LookupArchivedMessage: incomplete MAM page had no forward cursor"
+            );
+            return Ok(None);
+        };
+        if !seen_cursors.insert(next_cursor.clone()) {
+            warn!(
+                archive = %archive,
+                cursor = %next_cursor,
+                "LookupArchivedMessage: MAM cursor did not advance"
+            );
+            return Ok(None);
+        }
+        after_id = Some(next_cursor);
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/interpret/archive_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/archive_lookup.rs
@@ -46,31 +46,13 @@ pub(super) async fn lookup_archived_message(
                 .await
         }
         MessageRef::OriginId { sender, origin_id } => {
-            // No origin-id-only accessor on `MamStorage` today, so we
-            // narrow with the storage-level sender filter when its MAM
-            // semantics match this lookup, then pick the first row whose
-            // `origin_id` *or wire `id` attribute* (`stanza_id` column)
-            // matches the requested value. The fall-through to the wire id
-            // mirrors the legacy `lookup_correction_target_message`
-            // behaviour — many clients (and the CUE e2e scenarios)
-            // omit the explicit `<origin-id/>` payload and rely on
-            // the message's `id` attribute as the correction
-            // target. Sender-bound matching keeps the
-            // OR-collision protection from #229 PR8: only rows sent
-            // by the original author can satisfy the correction.
-            // XEP-0313 §4.3.1 gives `with=archive-owner` special self-chat
-            // semantics in personal archives. Rich-target validation is
-            // instead asking for messages authored by that owner, so using
-            // `with` there would exclude ordinary owner -> peer messages.
-            // The typed sender post-filter below remains authoritative.
-            lookup_origin_id_across_pages(
-                mam_storage.as_ref(),
-                archive,
-                archive_kind,
-                sender,
-                origin_id.as_str(),
-            )
-            .await
+            // Use the backend's bounded sender-owned lookup. It matches the
+            // explicit origin-id first shape and the legacy wire `id`
+            // fallback without applying XEP-0313 `with=owner` self-chat
+            // semantics or scanning sequential MAM pages.
+            mam_storage
+                .get_message_by_sender_and_origin_id(archive, archive_kind, sender, origin_id)
+                .await
         }
     };
     match lookup {
@@ -85,99 +67,6 @@ pub(super) async fn lookup_archived_message(
             None
         }
     }
-}
-
-/// Search every forward RSM page that can contain an origin-id target.
-///
-/// The storage-level `with` filter is only a narrowing optimization: personal
-/// owner-origin lookups must omit it because XEP-0313 gives `with=owner`
-/// self-chat semantics, while ordinary personal and room lookups can still
-/// contain rows authored by the other endpoint. Consequently the typed sender
-/// predicate remains authoritative on every page.
-pub(super) async fn lookup_origin_id_across_pages(
-    mam_storage: &dyn waddle_xmpp::mam::MamStorage,
-    archive: &jid::BareJid,
-    archive_kind: waddle_xmpp::mam::MamArchiveKind,
-    sender: &jid::BareJid,
-    origin_id: &str,
-) -> Result<Option<MamArchivedMessage>, waddle_xmpp::mam::MamStorageError> {
-    const PAGE_SIZE: u32 = 100;
-
-    let with = if archive_kind == waddle_xmpp::mam::MamArchiveKind::Personal && sender == archive {
-        None
-    } else {
-        Some(jid::Jid::from(sender.clone()))
-    };
-    let mut after_id = None;
-    let mut seen_cursors = std::collections::HashSet::new();
-    loop {
-        let query = waddle_xmpp::mam::MamQuery {
-            with: with.clone(),
-            max: Some(PAGE_SIZE),
-            after_id: after_id.clone(),
-            ..Default::default()
-        };
-        let result = mam_storage
-            .query_messages(archive, archive_kind, &query)
-            .await?;
-        if let Some(row) = result.messages.into_iter().find(|row| {
-            row_matches_origin_id(row, sender, origin_id)
-                || row_matches_wire_id(row, sender, origin_id)
-        }) {
-            return Ok(Some(row));
-        }
-        if result.complete {
-            return Ok(None);
-        }
-        let Some(next_cursor) = result.last_id else {
-            warn!(
-                archive = %archive,
-                "LookupArchivedMessage: incomplete MAM page had no forward cursor"
-            );
-            return Ok(None);
-        };
-        if !seen_cursors.insert(next_cursor.clone()) {
-            warn!(
-                archive = %archive,
-                cursor = %next_cursor,
-                "LookupArchivedMessage: MAM cursor did not advance"
-            );
-            return Ok(None);
-        }
-        after_id = Some(next_cursor);
-    }
-}
-
-/// Verify a storage row genuinely matches the typed
-/// [`MessageRef::OriginId`] key — `origin_id` field equality plus
-/// `sender` (`from`) equality via parsed [`jid::BareJid`] comparison.
-/// String equality on `from` would mishandle case-folded localparts
-/// or full-JID-vs-bare-JID strings; the typed compare normalizes both.
-pub(super) fn row_matches_origin_id(
-    row: &MamArchivedMessage,
-    expected_sender: &jid::BareJid,
-    expected_origin_id: &str,
-) -> bool {
-    if row.origin_id.as_ref().map(|o| o.id.as_str()) != Some(expected_origin_id) {
-        return false;
-    }
-    row.from.to_bare() == *expected_sender
-}
-
-/// Fallback match for the legacy XEP-0308 correction-target shape
-/// where the message carries no explicit `<origin-id/>` payload —
-/// matches the row's wire `id` attribute (the `stanza_id` storage
-/// column) to the correction's `replaces_id`. Same sender-bound
-/// scoping as [`row_matches_origin_id`].
-pub(super) fn row_matches_wire_id(
-    row: &MamArchivedMessage,
-    expected_sender: &jid::BareJid,
-    expected_wire_id: &str,
-) -> bool {
-    if row.stanza_id.as_ref().map(|s| s.id.as_str()) != Some(expected_wire_id) {
-        return false;
-    }
-    row.from.to_bare() == *expected_sender
 }
 
 /// Project a storage [`MamArchivedMessage`] row into the protocol-side

--- a/server/crates/waddle-server/src/server/routes/interpret/direct_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/direct_archive.rs
@@ -561,20 +561,16 @@ pub(super) async fn resolve_direct_correction_target_message_id(
     replaces_id: &str,
 ) -> Option<String> {
     let mam_storage = deps.mam_storage?;
-    let query = waddle_xmpp::mam::MamQuery {
-        with: Some(jid::Jid::from(sender.clone())),
-        ..Default::default()
-    };
-    let result = mam_storage.query_messages(archive_jid, &query).await.ok()?;
-    result.messages.into_iter().find_map(|row| {
-        if super::archive_lookup::row_matches_origin_id(&row, sender, replaces_id)
-            || super::archive_lookup::row_matches_wire_id(&row, sender, replaces_id)
-        {
-            row.stanza_id.map(|stanza_id| stanza_id.id)
-        } else {
-            None
-        }
-    })
+    super::archive_lookup::lookup_origin_id_across_pages(
+        mam_storage.as_ref(),
+        archive_jid,
+        waddle_xmpp::mam::MamArchiveKind::Personal,
+        sender,
+        replaces_id,
+    )
+    .await
+    .ok()?
+    .and_then(|row| row.stanza_id.map(|stanza_id| stanza_id.id))
 }
 
 async fn apply_direct_retraction_tombstone(

--- a/server/crates/waddle-server/src/server/routes/interpret/direct_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/direct_archive.rs
@@ -561,16 +561,18 @@ pub(super) async fn resolve_direct_correction_target_message_id(
     replaces_id: &str,
 ) -> Option<String> {
     let mam_storage = deps.mam_storage?;
-    super::archive_lookup::lookup_origin_id_across_pages(
-        mam_storage.as_ref(),
-        archive_jid,
-        waddle_xmpp::mam::MamArchiveKind::Personal,
-        sender,
-        replaces_id,
-    )
-    .await
-    .ok()?
-    .and_then(|row| row.stanza_id.map(|stanza_id| stanza_id.id))
+    let origin_id = waddle_xmpp_core::xep0359::OriginId::new(replaces_id);
+    let sender = jid::Jid::from(sender.clone());
+    mam_storage
+        .get_message_by_sender_and_origin_id(
+            archive_jid,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &sender,
+            &origin_id,
+        )
+        .await
+        .ok()?
+        .and_then(|row| row.stanza_id.map(|stanza_id| stanza_id.id))
 }
 
 async fn apply_direct_retraction_tombstone(

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -800,6 +800,15 @@ async fn xep_0313_archive_direct_drops_when_storage_errors() {
         ) -> Result<Option<ArchivedMessage>, MamStorageError> {
             Ok(None)
         }
+        async fn get_message_by_sender_and_origin_id(
+            &self,
+            _: &jid::BareJid,
+            _: waddle_xmpp::mam::MamArchiveKind,
+            _: &jid::Jid,
+            _: &waddle_xmpp_core::xep0359::OriginId,
+        ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+            Ok(None)
+        }
         async fn get_message_by_archive_or_stanza_id(
             &self,
             _: &jid::BareJid,
@@ -1088,7 +1097,7 @@ async fn xep_0359_lookup_archived_message_by_origin_id_feeds_archived_loaded_bac
         archive: archive_jid.clone(),
         archive_kind: waddle_xmpp::mam::MamArchiveKind::Personal,
         reference: MessageRef::OriginId {
-            sender: alice_bare.clone(),
+            sender: alice_bare.clone().into(),
             origin_id: OriginId::new("collision"),
         },
     }];
@@ -1109,7 +1118,7 @@ async fn xep_0359_lookup_archived_message_by_origin_id_feeds_archived_loaded_bac
     }
 }
 
-async fn assert_origin_lookup_pages_past_sender_decoys(mam: Arc<dyn MamStorage>) {
+async fn assert_origin_lookup_finds_targets_beyond_default_page(mam: Arc<dyn MamStorage>) {
     use waddle_xmpp::mam::{ArchivedMessage, MamArchiveKind};
     use waddle_xmpp_core::xep0359::OriginId;
 
@@ -1146,9 +1155,9 @@ async fn assert_origin_lookup_pages_past_sender_decoys(mam: Arc<dyn MamStorage>)
         Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
     let deps = Deps::test_with_storage(&registry, &mam, &inbox);
 
-    // Personal owner-origin lookup cannot use `with=owner`: place a
-    // cross-sender collision and enough ordinary rows ahead of the target to
-    // force the authoritative sender check onto page two.
+    // Place a cross-sender collision and enough ordinary rows ahead of the
+    // target to prove lookup is sender-indexed rather than bounded by the
+    // default MAM page.
     let owner_archive: jid::BareJid = "owner@example.com".parse().expect("owner archive");
     store_row(
         mam.as_ref(),
@@ -1197,20 +1206,19 @@ async fn assert_origin_lookup_pages_past_sender_decoys(mam: Arc<dyn MamStorage>)
         &owner_archive,
         MamArchiveKind::Personal,
         &MessageRef::OriginId {
-            sender: owner_archive.clone(),
+            sender: owner_archive.clone().into(),
             origin_id: OriginId::new("owner-target"),
         },
     )
     .await
-    .expect("owner target beyond first page");
+    .expect("owner target beyond default page boundary");
     assert_eq!(
         owner_result.message.bodies.get("").map(String::as_str),
         Some("owner page two target")
     );
 
-    // A non-owner `with=sender` query can still contain rows where that JID
-    // is the recipient. Those rows must not exhaust the first page and hide a
-    // later row actually authored by the requested sender.
+    // Recipient-side decoys with the same origin id must not hide a later row
+    // actually authored by the requested sender.
     let peer_archive: jid::BareJid = "archive@example.com".parse().expect("peer archive");
     for index in 0..=100 {
         store_row(
@@ -1250,12 +1258,12 @@ async fn assert_origin_lookup_pages_past_sender_decoys(mam: Arc<dyn MamStorage>)
         &peer_archive,
         MamArchiveKind::Personal,
         &MessageRef::OriginId {
-            sender,
+            sender: sender.into(),
             origin_id: OriginId::new("peer-target"),
         },
     )
     .await
-    .expect("sender target beyond first matching page");
+    .expect("sender target beyond default page boundary");
     assert_eq!(
         peer_result.message.bodies.get("").map(String::as_str),
         Some("sender page two target")
@@ -1263,19 +1271,19 @@ async fn assert_origin_lookup_pages_past_sender_decoys(mam: Arc<dyn MamStorage>)
 }
 
 #[tokio::test]
-async fn origin_lookup_pages_past_sender_decoys_in_memory() {
-    assert_origin_lookup_pages_past_sender_decoys(Arc::new(
+async fn origin_lookup_finds_targets_beyond_default_page_in_memory() {
+    assert_origin_lookup_finds_targets_beyond_default_page(Arc::new(
         waddle_xmpp::mam::InMemoryMamStorage::new(),
     ))
     .await;
 }
 
 #[tokio::test]
-async fn origin_lookup_pages_past_sender_decoys_in_sqlite() {
+async fn origin_lookup_finds_targets_beyond_default_page_in_sqlite() {
     let storage = waddle_xmpp::mam::SqlxMamStorage::open_in_memory()
         .await
         .expect("SQLite MAM storage");
-    assert_origin_lookup_pages_past_sender_decoys(Arc::new(storage)).await;
+    assert_origin_lookup_finds_targets_beyond_default_page(Arc::new(storage)).await;
 }
 
 #[tokio::test]
@@ -1349,6 +1357,21 @@ async fn xep_0359_lookup_archived_message_propagates_room_archive_kind() {
             Ok(None)
         }
 
+        async fn get_message_by_sender_and_origin_id(
+            &self,
+            _: &jid::BareJid,
+            archive_kind: MamArchiveKind,
+            _: &jid::Jid,
+            _: &OriginId,
+        ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+            assert_eq!(
+                archive_kind,
+                MamArchiveKind::Room,
+                "event archive kind must reach MamStorage"
+            );
+            Ok(Some(self.row.clone()))
+        }
+
         async fn get_message_by_archive_or_stanza_id(
             &self,
             _: &jid::BareJid,
@@ -1401,7 +1424,9 @@ async fn xep_0359_lookup_archived_message_propagates_room_archive_kind() {
             archive: room.clone(),
             archive_kind: MamArchiveKind::Room,
             reference: MessageRef::OriginId {
-                sender: room,
+                sender: "room@conference.example/alice"
+                    .parse()
+                    .expect("occupant JID"),
                 origin_id: OriginId::new("room-origin-1"),
             },
         }],
@@ -1465,7 +1490,7 @@ async fn xep_0359_lookup_archived_message_by_origin_id_rejects_cross_sender_coll
         archive: archive_jid,
         archive_kind: waddle_xmpp::mam::MamArchiveKind::Personal,
         reference: MessageRef::OriginId {
-            sender: charlie_bare,
+            sender: charlie_bare.into(),
             origin_id: OriginId::new("oid-1"),
         },
     }];

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -342,7 +342,11 @@ async fn xep_0313_archive_direct_persists_to_mam_storage() {
     let _outcome = interpret(events, &deps).await;
 
     let stored = mam
-        .query_messages(&archive_jid, &Default::default())
+        .query_messages(
+            &archive_jid,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query");
     assert_eq!(
@@ -712,11 +716,19 @@ async fn xep_0313_archive_direct_writes_one_entry_per_event() {
     let _outcome = interpret(events, &deps).await;
 
     let alice_archive = mam
-        .query_messages(&alice, &Default::default())
+        .query_messages(
+            &alice,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query alice");
     let bob_archive = mam
-        .query_messages(&bob, &Default::default())
+        .query_messages(
+            &bob,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert_eq!(
@@ -753,6 +765,7 @@ async fn xep_0313_archive_direct_drops_when_storage_errors() {
         async fn query_messages(
             &self,
             _: &jid::BareJid,
+            _: waddle_xmpp::mam::MamArchiveKind,
             _: &MamQuery,
         ) -> Result<MamResult, MamStorageError> {
             Ok(MamResult {
@@ -944,6 +957,7 @@ async fn xep_0424_lookup_archived_message_by_stanza_id_feeds_archived_loaded_bac
     let events = vec![OutboundEvent::LookupArchivedMessage {
         id: CallbackId(7),
         archive: archive_jid.clone(),
+        archive_kind: waddle_xmpp::mam::MamArchiveKind::Personal,
         reference: MessageRef::StanzaId {
             stanza_id: StanzaId::new("canon-A1", jid::Jid::from(archive_jid.clone())),
         },
@@ -984,6 +998,7 @@ async fn xep_0424_lookup_archived_message_not_found_feeds_none_back() {
     let events = vec![OutboundEvent::LookupArchivedMessage {
         id: CallbackId(11),
         archive: archive_jid.clone(),
+        archive_kind: waddle_xmpp::mam::MamArchiveKind::Personal,
         reference: MessageRef::StanzaId {
             stanza_id: StanzaId::new("never-stamped", jid::Jid::from(archive_jid)),
         },
@@ -1071,6 +1086,7 @@ async fn xep_0359_lookup_archived_message_by_origin_id_feeds_archived_loaded_bac
     let events = vec![OutboundEvent::LookupArchivedMessage {
         id: CallbackId(21),
         archive: archive_jid.clone(),
+        archive_kind: waddle_xmpp::mam::MamArchiveKind::Personal,
         reference: MessageRef::OriginId {
             sender: alice_bare.clone(),
             origin_id: OriginId::new("collision"),
@@ -1090,6 +1106,318 @@ async fn xep_0359_lookup_archived_message_by_origin_id_feeds_archived_loaded_bac
             );
         }
         other => panic!("expected alice-authored row, got {other:?}"),
+    }
+}
+
+async fn assert_origin_lookup_pages_past_sender_decoys(mam: Arc<dyn MamStorage>) {
+    use waddle_xmpp::mam::{ArchivedMessage, MamArchiveKind};
+    use waddle_xmpp_core::xep0359::OriginId;
+
+    struct SeedRow<'a> {
+        id: String,
+        offset: i64,
+        from: &'a str,
+        to: &'a str,
+        origin_id: String,
+        body: String,
+    }
+
+    async fn store_row(mam: &dyn MamStorage, archive: &jid::BareJid, seed: SeedRow<'_>) {
+        let row = ArchivedMessage {
+            id: seed.id,
+            timestamp: chrono::DateTime::from_timestamp(1_700_000_000 + seed.offset, 0)
+                .expect("fixture timestamp"),
+            from: seed.from.parse().expect("from JID"),
+            to: seed.to.parse().expect("to JID"),
+            body: Some(seed.body),
+            origin_id: Some(OriginId::new(seed.origin_id)),
+            ..ArchivedMessage::for_test(
+                seed.from.parse().expect("from JID"),
+                seed.to.parse().expect("to JID"),
+            )
+        };
+        mam.store_message(archive, &row)
+            .await
+            .expect("seed MAM row");
+    }
+
+    let registry = ConnectionRegistry::new();
+    let inbox: Arc<dyn InboxStorage> =
+        Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
+    let deps = Deps::test_with_storage(&registry, &mam, &inbox);
+
+    // Personal owner-origin lookup cannot use `with=owner`: place a
+    // cross-sender collision and enough ordinary rows ahead of the target to
+    // force the authoritative sender check onto page two.
+    let owner_archive: jid::BareJid = "owner@example.com".parse().expect("owner archive");
+    store_row(
+        mam.as_ref(),
+        &owner_archive,
+        SeedRow {
+            id: "owner-000".to_string(),
+            offset: 0,
+            from: "mallory@example.com",
+            to: "owner@example.com",
+            origin_id: "owner-target".to_string(),
+            body: "collision decoy".to_string(),
+        },
+    )
+    .await;
+    for index in 1..=100 {
+        store_row(
+            mam.as_ref(),
+            &owner_archive,
+            SeedRow {
+                id: format!("owner-{index:03}"),
+                offset: index,
+                from: "owner@example.com",
+                to: "peer@example.com",
+                origin_id: format!("owner-decoy-{index}"),
+                body: format!("owner decoy {index}"),
+            },
+        )
+        .await;
+    }
+    store_row(
+        mam.as_ref(),
+        &owner_archive,
+        SeedRow {
+            id: "owner-101".to_string(),
+            offset: 101,
+            from: "owner@example.com",
+            to: "peer@example.com",
+            origin_id: "owner-target".to_string(),
+            body: "owner page two target".to_string(),
+        },
+    )
+    .await;
+
+    let owner_result = super::archive_lookup::lookup_archived_message(
+        &deps,
+        &owner_archive,
+        MamArchiveKind::Personal,
+        &MessageRef::OriginId {
+            sender: owner_archive.clone(),
+            origin_id: OriginId::new("owner-target"),
+        },
+    )
+    .await
+    .expect("owner target beyond first page");
+    assert_eq!(
+        owner_result.message.bodies.get("").map(String::as_str),
+        Some("owner page two target")
+    );
+
+    // A non-owner `with=sender` query can still contain rows where that JID
+    // is the recipient. Those rows must not exhaust the first page and hide a
+    // later row actually authored by the requested sender.
+    let peer_archive: jid::BareJid = "archive@example.com".parse().expect("peer archive");
+    for index in 0..=100 {
+        store_row(
+            mam.as_ref(),
+            &peer_archive,
+            SeedRow {
+                id: format!("peer-{index:03}"),
+                offset: index,
+                from: "archive@example.com",
+                to: "sender@example.com",
+                origin_id: if index == 0 {
+                    "peer-target".to_string()
+                } else {
+                    format!("peer-decoy-{index}")
+                },
+                body: format!("peer decoy {index}"),
+            },
+        )
+        .await;
+    }
+    store_row(
+        mam.as_ref(),
+        &peer_archive,
+        SeedRow {
+            id: "peer-101".to_string(),
+            offset: 101,
+            from: "sender@example.com/mobile",
+            to: "archive@example.com",
+            origin_id: "peer-target".to_string(),
+            body: "sender page two target".to_string(),
+        },
+    )
+    .await;
+    let sender: jid::BareJid = "sender@example.com".parse().expect("sender");
+    let peer_result = super::archive_lookup::lookup_archived_message(
+        &deps,
+        &peer_archive,
+        MamArchiveKind::Personal,
+        &MessageRef::OriginId {
+            sender,
+            origin_id: OriginId::new("peer-target"),
+        },
+    )
+    .await
+    .expect("sender target beyond first matching page");
+    assert_eq!(
+        peer_result.message.bodies.get("").map(String::as_str),
+        Some("sender page two target")
+    );
+}
+
+#[tokio::test]
+async fn origin_lookup_pages_past_sender_decoys_in_memory() {
+    assert_origin_lookup_pages_past_sender_decoys(Arc::new(
+        waddle_xmpp::mam::InMemoryMamStorage::new(),
+    ))
+    .await;
+}
+
+#[tokio::test]
+async fn origin_lookup_pages_past_sender_decoys_in_sqlite() {
+    let storage = waddle_xmpp::mam::SqlxMamStorage::open_in_memory()
+        .await
+        .expect("SQLite MAM storage");
+    assert_origin_lookup_pages_past_sender_decoys(Arc::new(storage)).await;
+}
+
+#[tokio::test]
+async fn xep_0359_lookup_archived_message_propagates_room_archive_kind() {
+    use async_trait::async_trait;
+    use waddle_xmpp::mam::{
+        ArchivedMessage, ArchivedTombstone, MamArchiveKind, MamQuery, MamResult, MamStorageError,
+    };
+    use waddle_xmpp::protocol::event::CallbackId;
+    use waddle_xmpp_core::xep0359::OriginId;
+
+    struct KindProbeMam {
+        row: ArchivedMessage,
+    }
+
+    #[async_trait]
+    impl MamStorage for KindProbeMam {
+        async fn store_message(
+            &self,
+            _: &jid::BareJid,
+            _: &ArchivedMessage,
+        ) -> Result<String, MamStorageError> {
+            unreachable!("lookup regression never stores")
+        }
+
+        async fn query_messages(
+            &self,
+            _: &jid::BareJid,
+            archive_kind: MamArchiveKind,
+            _: &MamQuery,
+        ) -> Result<MamResult, MamStorageError> {
+            assert_eq!(
+                archive_kind,
+                MamArchiveKind::Room,
+                "event archive kind must reach MamStorage"
+            );
+            Ok(MamResult {
+                messages: vec![self.row.clone()],
+                complete: true,
+                first_id: Some(self.row.id.clone()),
+                last_id: Some(self.row.id.clone()),
+                count: Some(1),
+            })
+        }
+
+        async fn get_message(&self, _: &str) -> Result<Option<ArchivedMessage>, MamStorageError> {
+            Ok(None)
+        }
+
+        async fn replace_with_tombstone(
+            &self,
+            _: &str,
+            _: ArchivedTombstone,
+        ) -> Result<bool, MamStorageError> {
+            Ok(false)
+        }
+
+        async fn get_message_by_stanza_id(
+            &self,
+            _: &jid::BareJid,
+            _: &str,
+        ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+            Ok(None)
+        }
+
+        async fn get_message_by_message_id(
+            &self,
+            _: &jid::BareJid,
+            _: &str,
+        ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+            Ok(None)
+        }
+
+        async fn get_message_by_archive_or_stanza_id(
+            &self,
+            _: &jid::BareJid,
+            _: &str,
+        ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+            Ok(None)
+        }
+
+        async fn count_messages(&self, _: &jid::BareJid) -> Result<u32, MamStorageError> {
+            Ok(0)
+        }
+
+        async fn delete_before(
+            &self,
+            _: &jid::BareJid,
+            _: chrono::DateTime<chrono::Utc>,
+        ) -> Result<u64, MamStorageError> {
+            Ok(0)
+        }
+    }
+
+    let registry = ConnectionRegistry::new();
+    let inbox: Arc<dyn InboxStorage> =
+        Arc::new(waddle_xmpp::inbox::storage::InMemoryInboxStorage::new());
+
+    let room: jid::BareJid = "room@conference.example".parse().expect("room bare");
+    let row = ArchivedMessage {
+        id: "room-row-1".to_string(),
+        timestamp: chrono::Utc::now(),
+        from: "room@conference.example/alice"
+            .parse()
+            .expect("occupant jid"),
+        to: "bob@example.com".parse().expect("recipient jid"),
+        body: Some("room message".to_string()),
+        stanza_id: None,
+        thread: None,
+        reply: None,
+        origin_id: Some(OriginId::new("room-origin-1")),
+        message_type: XmppMessageType::Groupchat,
+        stanza_xml: None,
+        rich: None,
+        nickname_generation: None,
+    };
+    let mam: Arc<dyn MamStorage> = Arc::new(KindProbeMam { row });
+    let deps = Deps::test_with_storage(&registry, &mam, &inbox);
+
+    let outcome = interpret(
+        vec![OutboundEvent::LookupArchivedMessage {
+            id: CallbackId(22),
+            archive: room.clone(),
+            archive_kind: MamArchiveKind::Room,
+            reference: MessageRef::OriginId {
+                sender: room,
+                origin_id: OriginId::new("room-origin-1"),
+            },
+        }],
+        &deps,
+    )
+    .await;
+
+    match outcome.feedback.into_iter().next().expect("feedback") {
+        InboundEvent::ArchivedMessageLoaded {
+            id: CallbackId(22),
+            result: Some(archived),
+        } => assert_eq!(
+            archived.message.bodies.get("").map(String::as_str),
+            Some("room message"),
+        ),
+        other => panic!("room archive kind must reach storage lookup, got {other:?}"),
     }
 }
 
@@ -1135,6 +1463,7 @@ async fn xep_0359_lookup_archived_message_by_origin_id_rejects_cross_sender_coll
     let events = vec![OutboundEvent::LookupArchivedMessage {
         id: CallbackId(31),
         archive: archive_jid,
+        archive_kind: waddle_xmpp::mam::MamArchiveKind::Personal,
         reference: MessageRef::OriginId {
             sender: charlie_bare,
             origin_id: OriginId::new("oid-1"),
@@ -1196,6 +1525,7 @@ async fn xep_0359_lookup_archived_message_strict_stanza_id_ignores_origin_id_col
     let events = vec![OutboundEvent::LookupArchivedMessage {
         id: CallbackId(41),
         archive: archive_jid.clone(),
+        archive_kind: waddle_xmpp::mam::MamArchiveKind::Personal,
         reference: MessageRef::StanzaId {
             stanza_id: StanzaId::new("queried-id", jid::Jid::from(archive_jid)),
         },
@@ -1263,6 +1593,7 @@ async fn xep_0424_lookup_archived_message_propagates_tombstone_state() {
     let events = vec![OutboundEvent::LookupArchivedMessage {
         id: CallbackId(13),
         archive: archive_jid.clone(),
+        archive_kind: waddle_xmpp::mam::MamArchiveKind::Personal,
         reference: MessageRef::StanzaId {
             stanza_id: StanzaId::new("tomb-1", jid::Jid::from(archive_jid)),
         },
@@ -1846,7 +2177,11 @@ async fn route_to_connection_bare_jid_sole_stale_extra_self_heals_via_dropped_cl
     // though the sole live target's channel was dead.
     let bob_bare: jid::BareJid = "bob@example.com".parse().expect("bare");
     let archive = mam
-        .query_messages(&bob_bare, &Default::default())
+        .query_messages(
+            &bob_bare,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert_eq!(
@@ -1938,11 +2273,15 @@ async fn route_to_connection_bare_jid_stale_top_priority_extra_self_heals_to_liv
     assert!(drain_inbound(&mut low_rx).is_empty());
     let bob_bare: jid::BareJid = "bob@example.com".parse().expect("bare");
     assert_eq!(
-        mam.query_messages(&bob_bare, &Default::default())
-            .await
-            .expect("query bob")
-            .messages
-            .len(),
+        mam.query_messages(
+            &bob_bare,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default()
+        )
+        .await
+        .expect("query bob")
+        .messages
+        .len(),
         1,
         "no message loss: the first DM is persisted to the recipient's MAM"
     );
@@ -2405,7 +2744,11 @@ async fn offline_recipient_pass_persists_archive_for_bare_jid_target() {
 
     let bob_bare: jid::BareJid = "bob@example.com".parse().expect("bare");
     let bob_archive = mam
-        .query_messages(&bob_bare, &Default::default())
+        .query_messages(
+            &bob_bare,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert_eq!(
@@ -2487,7 +2830,11 @@ async fn route_to_connection_at_max_recursion_depth_drops_without_persistence() 
 
     let bob: jid::BareJid = "bob@example.com".parse().expect("bare");
     let bob_archive = mam
-        .query_messages(&bob, &Default::default())
+        .query_messages(
+            &bob,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert!(
@@ -2570,7 +2917,11 @@ async fn offline_recipient_pass_blocklist_loaded_from_storage_blocks_filtered_me
 
     let bob_bare: jid::BareJid = "bob@example.com".parse().expect("bare");
     let bob_archive = mam
-        .query_messages(&bob_bare, &Default::default())
+        .query_messages(
+            &bob_bare,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert!(
@@ -2626,7 +2977,11 @@ async fn offline_recipient_pass_blocklist_storage_error_skips_recipient_persiste
 
     let bob: jid::BareJid = "bob@example.com".parse().expect("bare");
     let bob_archive = mam
-        .query_messages(&bob, &Default::default())
+        .query_messages(
+            &bob,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert!(
@@ -2707,7 +3062,11 @@ async fn xep_0359_offline_recipient_pass_emits_recipient_archive_with_recipient_
     // alice's MAM has 1 entry; <stanza-id by='alice@example.com'>
     // present.
     let alice_archive = mam
-        .query_messages(&alice_bare, &Default::default())
+        .query_messages(
+            &alice_bare,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query alice");
     assert_eq!(
@@ -2729,7 +3088,11 @@ async fn xep_0359_offline_recipient_pass_emits_recipient_archive_with_recipient_
     // bob's MAM has 1 entry; <stanza-id by='bob@example.com'>
     // present (recipient-side stamp by the headless pass).
     let bob_archive = mam
-        .query_messages(&bob, &Default::default())
+        .query_messages(
+            &bob,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert_eq!(
@@ -2797,7 +3160,11 @@ async fn offline_recipient_pass_skipped_for_remote_domain() {
 
     let bob_remote: jid::BareJid = "bob@other.example.com".parse().expect("bare");
     let bob_archive = mam
-        .query_messages(&bob_remote, &Default::default())
+        .query_messages(
+            &bob_remote,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert!(
@@ -3423,7 +3790,11 @@ async fn fanout_pass_applies_archive_id_rewrite_to_the_delivered_stanza() {
 
     let bob_bare: jid::BareJid = "bob@example.com".parse().expect("bare");
     let archive = mam
-        .query_messages(&bob_bare, &Default::default())
+        .query_messages(
+            &bob_bare,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob archive");
     assert_eq!(
@@ -3505,7 +3876,11 @@ async fn route_full_jid_dm_offline_resource_falls_back_to_other_live_resource() 
 
     let bob_bare: jid::BareJid = "bob@example.com".parse().expect("bare");
     let bob_archive = mam
-        .query_messages(&bob_bare, &Default::default())
+        .query_messages(
+            &bob_bare,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert_eq!(
@@ -3543,7 +3918,11 @@ async fn route_full_jid_dm_no_resources_stores_offline() {
 
     let bob_bare: jid::BareJid = "bob@example.com".parse().expect("bare");
     let bob_archive = mam
-        .query_messages(&bob_bare, &Default::default())
+        .query_messages(
+            &bob_bare,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert_eq!(
@@ -3626,7 +4005,11 @@ async fn route_full_jid_dm_to_detached_resource_runs_recipient_pipeline() {
     // XEP-0313 §6.1: the recipient archive captured the message.
     let bob_bare: jid::BareJid = "bob@example.com".parse().expect("bare");
     let bob_archive = mam
-        .query_messages(&bob_bare, &Default::default())
+        .query_messages(
+            &bob_bare,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert_eq!(
@@ -3718,7 +4101,11 @@ async fn route_bare_jid_message_to_nonexistent_local_user_bounces() {
 
     let typo_bare: jid::BareJid = "typo@example.com".parse().expect("bare");
     let typo_archive = mam
-        .query_messages(&typo_bare, &Default::default())
+        .query_messages(
+            &typo_bare,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query typo");
     assert!(
@@ -3788,7 +4175,11 @@ async fn route_bare_jid_message_to_existing_oidc_user_persists_offline() {
 
     let bob_bare: jid::BareJid = "bob@example.com".parse().expect("bare");
     let bob_archive = mam
-        .query_messages(&bob_bare, &Default::default())
+        .query_messages(
+            &bob_bare,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert_eq!(
@@ -3888,7 +4279,11 @@ async fn route_to_connection_bare_jid_all_negative_priority_goes_offline() {
     );
     let bob_bare: jid::BareJid = "bob@example.com".parse().expect("bare");
     let bob_archive = mam
-        .query_messages(&bob_bare, &Default::default())
+        .query_messages(
+            &bob_bare,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert_eq!(
@@ -4008,7 +4403,11 @@ async fn route_bare_jid_dm_to_detached_only_recipient_runs_recipient_pipeline() 
 
     let bob_bare: jid::BareJid = "bob@example.com".parse().expect("bare");
     let bob_archive = mam
-        .query_messages(&bob_bare, &Default::default())
+        .query_messages(
+            &bob_bare,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert_eq!(
@@ -4092,7 +4491,11 @@ async fn route_bare_jid_dm_from_blocked_sender_to_detached_only_recipient_is_fil
     );
     let bob_bare: jid::BareJid = "bob@example.com".parse().expect("bare");
     let bob_archive = mam
-        .query_messages(&bob_bare, &Default::default())
+        .query_messages(
+            &bob_bare,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query bob");
     assert!(

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/archive_inbox_upload.rs
@@ -156,7 +156,15 @@ pub(super) async fn handle_archive_inbox_upload_iq(
             .deps
             .protocol
             .mam_storage
-            .query_messages(&target_bare, &query)
+            .query_messages(
+                &target_bare,
+                if is_personal {
+                    waddle_xmpp::mam::MamArchiveKind::Personal
+                } else {
+                    waddle_xmpp::mam::MamArchiveKind::Room
+                },
+                &query,
+            )
             .await
         {
             Ok(result) => result,

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/messages.rs
@@ -163,7 +163,11 @@ async fn archived_dm_call_anchor(
         .deps
         .protocol
         .mam_storage
-        .query_messages(owner, &Default::default())
+        .query_messages(
+            owner,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query DM MAM")
         .messages
@@ -306,7 +310,11 @@ async fn dm_jmi_proceed_projects_call_thread_anchor_for_both_peers() {
         .deps
         .protocol
         .mam_storage
-        .query_messages(&alice, &Default::default())
+        .query_messages(
+            &alice,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query alice MAM before self proceed")
         .messages
@@ -335,7 +343,11 @@ async fn dm_jmi_proceed_projects_call_thread_anchor_for_both_peers() {
         .deps
         .protocol
         .mam_storage
-        .query_messages(&alice, &Default::default())
+        .query_messages(
+            &alice,
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query alice MAM after self proceed")
         .messages;
@@ -3918,14 +3930,22 @@ async fn muc_private_message_routes_from_sender_room_nick_to_target_session() {
         .deps
         .protocol
         .mam_storage
-        .query_messages(&alice_jid.to_bare(), &Default::default())
+        .query_messages(
+            &alice_jid.to_bare(),
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query sender MAM archive");
     let bob_archive = state
         .deps
         .protocol
         .mam_storage
-        .query_messages(&bob_jid.to_bare(), &Default::default())
+        .query_messages(
+            &bob_jid.to_bare(),
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query recipient MAM archive");
     let sender_row = alice_archive.messages.last().expect("sender archive row");
@@ -3993,7 +4013,11 @@ async fn muc_private_message_to_own_nick_archives_one_delivered_tuple() {
         .deps
         .protocol
         .mam_storage
-        .query_messages(&alice_jid.to_bare(), &Default::default())
+        .query_messages(
+            &alice_jid.to_bare(),
+            waddle_xmpp::mam::MamArchiveKind::Personal,
+            &Default::default(),
+        )
         .await
         .expect("query self-PM archive");
     let self_rows: Vec<_> = archive

--- a/server/crates/waddle-server/tests/xep0313_mam_integration.rs
+++ b/server/crates/waddle-server/tests/xep0313_mam_integration.rs
@@ -6,7 +6,9 @@ use waddle_ws_test_support as ws_common;
 
 use jid::Jid;
 use tokio::sync::Mutex;
-use waddle_xmpp::mam::{ArchivedMessage, MamQuery, MamStorage, MamStorageError, SqlxMamStorage};
+use waddle_xmpp::mam::{
+    ArchivedMessage, MamArchiveKind, MamQuery, MamStorage, MamStorageError, SqlxMamStorage,
+};
 use ws_common::{disco_info_query, TestServer, WsXmppClient};
 use xmpp_parsers::message::MessageType;
 use xmpp_parsers::minidom::Element;
@@ -696,7 +698,7 @@ async fn xep_0313_full_jid_from_round_trips_through_mam_without_resource_truncat
     storage.store_message(&archive, &row).await.expect("store");
 
     let result = storage
-        .query_messages(&archive, &MamQuery::default())
+        .query_messages(&archive, MamArchiveKind::Room, &MamQuery::default())
         .await
         .expect("query");
     assert_eq!(result.messages.len(), 1);
@@ -746,7 +748,7 @@ async fn xep_0313_bare_jid_to_round_trips_through_mam() {
     storage.store_message(&archive, &row).await.expect("store");
 
     let result = storage
-        .query_messages(&archive, &MamQuery::default())
+        .query_messages(&archive, MamArchiveKind::Room, &MamQuery::default())
         .await
         .expect("query");
     assert_eq!(result.messages.len(), 1);
@@ -788,7 +790,9 @@ async fn xep_0313_decode_rejects_unparseable_from_jid_row() {
         .await
         .expect("raw insert");
 
-    let result = storage.query_messages(&archive, &MamQuery::default()).await;
+    let result = storage
+        .query_messages(&archive, MamArchiveKind::Room, &MamQuery::default())
+        .await;
     match result {
         Err(MamStorageError::Serialization(message)) => {
             assert!(
@@ -837,7 +841,9 @@ async fn xep_0313_decode_rejects_unknown_message_type_row() {
         .await
         .expect("raw insert");
 
-    let result = storage.query_messages(&archive, &MamQuery::default()).await;
+    let result = storage
+        .query_messages(&archive, MamArchiveKind::Room, &MamQuery::default())
+        .await;
     match result {
         Err(MamStorageError::Serialization(message)) => {
             assert!(
@@ -935,7 +941,7 @@ async fn xep_0313_with_filter_does_not_match_domain_prefix_collision() {
         ..MamQuery::default()
     };
     let bare_result = storage
-        .query_messages(&archive, &bare_with_query)
+        .query_messages(&archive, MamArchiveKind::Room, &bare_with_query)
         .await
         .expect("query bare with");
     assert_eq!(
@@ -957,7 +963,7 @@ async fn xep_0313_with_filter_does_not_match_domain_prefix_collision() {
         ..MamQuery::default()
     };
     let full_result = storage
-        .query_messages(&archive, &full_with_query)
+        .query_messages(&archive, MamArchiveKind::Room, &full_with_query)
         .await
         .expect("query full with");
     assert!(
@@ -977,7 +983,7 @@ async fn xep_0313_with_filter_does_not_match_domain_prefix_collision() {
         ..MamQuery::default()
     };
     let exact_result = storage
-        .query_messages(&archive, &exact_full_with_query)
+        .query_messages(&archive, MamArchiveKind::Room, &exact_full_with_query)
         .await
         .expect("query exact full with");
     assert_eq!(

--- a/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
+++ b/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
@@ -187,6 +187,7 @@ async fn xep_0359_query_filter_finds_row_by_typed_stanza_id() {
     let result = storage
         .query_messages(
             &archive,
+            waddle_xmpp::mam::MamArchiveKind::Room,
             &MamQuery {
                 thread_id: waddle_xmpp_core::mam::ThreadId::new("thread-by-stanza-id"),
                 ..Default::default()

--- a/server/crates/waddle-server/tests/xep0461_replies_ws.rs
+++ b/server/crates/waddle-server/tests/xep0461_replies_ws.rs
@@ -293,7 +293,11 @@ async fn xep_0461_collapsed_reply_field_round_trips_bare_to_jid_through_storage(
         .expect("store row");
 
     let result = storage
-        .query_messages(&storage_archive_bare(), &MamQuery::default())
+        .query_messages(
+            &storage_archive_bare(),
+            waddle_xmpp::mam::MamArchiveKind::Room,
+            &MamQuery::default(),
+        )
         .await
         .expect("query");
     assert_eq!(result.messages.len(), 1);
@@ -327,7 +331,11 @@ async fn xep_0461_collapsed_reply_field_round_trips_full_to_jid_through_storage(
         .expect("store row");
 
     let result = storage
-        .query_messages(&storage_archive_bare(), &MamQuery::default())
+        .query_messages(
+            &storage_archive_bare(),
+            waddle_xmpp::mam::MamArchiveKind::Room,
+            &MamQuery::default(),
+        )
         .await
         .expect("query");
     assert_eq!(result.messages.len(), 1);
@@ -362,7 +370,11 @@ async fn xep_0461_collapsed_reply_field_round_trips_no_to_jid_through_storage() 
         .expect("store row");
 
     let result = storage
-        .query_messages(&storage_archive_bare(), &MamQuery::default())
+        .query_messages(
+            &storage_archive_bare(),
+            waddle_xmpp::mam::MamArchiveKind::Room,
+            &MamQuery::default(),
+        )
         .await
         .expect("query");
     assert_eq!(result.messages.len(), 1);
@@ -403,7 +415,11 @@ async fn xep_0461_decode_rejects_orphan_reply_to_jid_row() {
         .expect("raw insert");
 
     let result = storage
-        .query_messages(&storage_archive_bare(), &MamQuery::default())
+        .query_messages(
+            &storage_archive_bare(),
+            waddle_xmpp::mam::MamArchiveKind::Room,
+            &MamQuery::default(),
+        )
         .await;
     match result {
         Err(MamStorageError::Serialization(message)) => {

--- a/server/crates/waddle-xmpp/src/mam/mod.rs
+++ b/server/crates/waddle-xmpp/src/mam/mod.rs
@@ -16,7 +16,9 @@
 pub mod projection;
 pub mod storage;
 
-pub use storage::{InMemoryMamStorage, MamStorage, MamStorageError, SqlxMamStorage};
+pub use storage::{
+    InMemoryMamStorage, MamArchiveKind, MamStorage, MamStorageError, SqlxMamStorage,
+};
 pub use waddle_xmpp_core::mam::{
     archived_inner_message, build_fin_iq, build_query_form_iq, build_result_messages, is_mam_query,
     is_mam_query_form_request, parse_mam_query, ArchivedMention, ArchivedMessage,

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -20,4 +20,4 @@ mod tests;
 pub use error::MamStorageError;
 pub use in_memory::InMemoryMamStorage;
 pub use sqlx_store::SqlxMamStorage;
-pub use traits::MamStorage;
+pub use traits::{MamArchiveKind, MamStorage};

--- a/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
@@ -21,7 +21,7 @@ use super::{MamStorage, MamStorageError};
 
 #[derive(Clone, Default)]
 pub struct InMemoryMamStorage {
-    entries: Arc<RwLock<Vec<(String, ArchivedMessage)>>>,
+    entries: Arc<RwLock<Vec<(BareJid, ArchivedMessage)>>>,
 }
 
 impl InMemoryMamStorage {
@@ -41,11 +41,10 @@ impl MamStorage for InMemoryMamStorage {
         archive_jid: &BareJid,
         message: &ArchivedMessage,
     ) -> Result<String, MamStorageError> {
-        let archive_jid_str = archive_jid.to_string();
         let mut entries = self.entries.write().await;
         if message.origin_id.is_some() {
             if let Some((_, existing)) = entries.iter().find(|(jid, existing)| {
-                jid == &archive_jid_str && origin_id_dedup_match(existing, message)
+                jid == archive_jid && origin_id_dedup_match(existing, message)
             }) {
                 return Ok(existing.id.clone());
             }
@@ -60,7 +59,7 @@ impl MamStorage for InMemoryMamStorage {
         let mut stored = message.clone();
         stored.id = archive_id.clone();
 
-        entries.push((archive_jid_str, stored));
+        entries.push((archive_jid.clone(), stored));
         Ok(archive_id)
     }
 
@@ -70,11 +69,10 @@ impl MamStorage for InMemoryMamStorage {
         archive_kind: super::MamArchiveKind,
         query: &MamQuery,
     ) -> Result<MamResult, MamStorageError> {
-        let archive_jid_str = archive_jid.to_string();
         let entries = self.entries.read().await;
         let mut messages: Vec<ArchivedMessage> = entries
             .iter()
-            .filter(|(jid, _)| jid == &archive_jid_str)
+            .filter(|(jid, _)| jid == archive_jid)
             .map(|(_, message)| message.clone())
             .collect();
         let filter_before_cursor = match query.filter_before_id.as_deref() {
@@ -229,12 +227,11 @@ impl MamStorage for InMemoryMamStorage {
         archive_jid: &BareJid,
         stanza_id: &str,
     ) -> Result<Option<ArchivedMessage>, MamStorageError> {
-        let archive_jid_str = archive_jid.to_string();
         let entries = self.entries.read().await;
         Ok(entries
             .iter()
             .find(|(jid, message)| {
-                jid == &archive_jid_str
+                jid == archive_jid
                     && (message.stanza_id.as_ref().map(|s| s.id.as_str()) == Some(stanza_id)
                         || message.origin_id.as_ref().map(|o| o.id.as_str()) == Some(stanza_id))
             })
@@ -246,12 +243,11 @@ impl MamStorage for InMemoryMamStorage {
         archive_jid: &BareJid,
         message_id: &str,
     ) -> Result<Option<ArchivedMessage>, MamStorageError> {
-        let archive_jid_str = archive_jid.to_string();
         let entries = self.entries.read().await;
         Ok(entries
             .iter()
             .find(|(jid, message)| {
-                jid == &archive_jid_str
+                jid == archive_jid
                     && message.stanza_id.as_ref().map(|s| s.id.as_str()) == Some(message_id)
             })
             .map(|(_, message)| message.clone()))
@@ -264,7 +260,6 @@ impl MamStorage for InMemoryMamStorage {
         sender: &jid::Jid,
         origin_id: &OriginId,
     ) -> Result<Option<ArchivedMessage>, MamStorageError> {
-        let archive_jid = archive_jid.to_string();
         let entries = self.entries.read().await;
         Ok(entries
             .iter()
@@ -273,7 +268,7 @@ impl MamStorage for InMemoryMamStorage {
                     super::MamArchiveKind::Personal => message.from.to_bare() == sender.to_bare(),
                     super::MamArchiveKind::Room => &message.from == sender,
                 };
-                if stored_archive != &archive_jid || !sender_matches {
+                if stored_archive != archive_jid || !sender_matches {
                     return None;
                 }
                 let match_priority = if message
@@ -309,12 +304,11 @@ impl MamStorage for InMemoryMamStorage {
         archive_jid: &BareJid,
         stanza_id: &str,
     ) -> Result<Option<ArchivedMessage>, MamStorageError> {
-        let archive_jid_str = archive_jid.to_string();
         let entries = self.entries.read().await;
         Ok(entries
             .iter()
             .find(|(jid, message)| {
-                jid == &archive_jid_str
+                jid == archive_jid
                     && (message.id == stanza_id
                         || message.stanza_id.as_ref().map(|s| s.id.as_str()) == Some(stanza_id))
             })
@@ -322,12 +316,8 @@ impl MamStorage for InMemoryMamStorage {
     }
 
     async fn count_messages(&self, room_jid: &BareJid) -> Result<u32, MamStorageError> {
-        let room_jid_str = room_jid.to_string();
         let entries = self.entries.read().await;
-        Ok(entries
-            .iter()
-            .filter(|(jid, _)| jid == &room_jid_str)
-            .count() as u32)
+        Ok(entries.iter().filter(|(jid, _)| jid == room_jid).count() as u32)
     }
 
     async fn delete_before(
@@ -335,10 +325,9 @@ impl MamStorage for InMemoryMamStorage {
         room_jid: &BareJid,
         before: DateTime<Utc>,
     ) -> Result<u64, MamStorageError> {
-        let room_jid_str = room_jid.to_string();
         let mut entries = self.entries.write().await;
         let previous_len = entries.len();
-        entries.retain(|(jid, message)| !(jid == &room_jid_str && message.timestamp < before));
+        entries.retain(|(jid, message)| !(jid == room_jid && message.timestamp < before));
         Ok((previous_len - entries.len()) as u64)
     }
 

--- a/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
@@ -12,7 +12,7 @@ use crate::xep::matches_fulltext;
 
 use super::origin_dedup::origin_id_dedup_match;
 use super::query_semantics::{
-    archive_order_after, archive_order_before, jid_matches_with_filter, matches_thread_filter,
+    archive_order_after, archive_order_before, matches_thread_filter, message_matches_with_filter,
     missing_requested_id, uses_backward_pagination,
 };
 use super::tombstone::apply_tombstone;
@@ -66,6 +66,7 @@ impl MamStorage for InMemoryMamStorage {
     async fn query_messages(
         &self,
         archive_jid: &BareJid,
+        archive_kind: super::MamArchiveKind,
         query: &MamQuery,
     ) -> Result<MamResult, MamStorageError> {
         let archive_jid_str = archive_jid.to_string();
@@ -126,23 +127,14 @@ impl MamStorage for InMemoryMamStorage {
             messages.retain(|message| message.timestamp <= end);
         }
         if let Some(with) = query.with.as_ref() {
-            // XEP-0313 §4.3.1: `with` matches sender or recipient.
-            //  - Bare `with` matches archived JIDs whose **bare form**
-            //    equals `with`, regardless of resource (so the row may
-            //    be `alice@example.com` or `alice@example.com/web`).
-            //  - Full `with` matches only the exact full JID.
-            //
-            // Earlier this was a textual `starts_with` prefix match
-            // which is incorrect: `alice@example.com` would match
-            // `alice@example.com.evil/whatever`, leaking unrelated
-            // archive rows across XMPP domains. Compare via parsed
-            // [`jid::Jid`] values so the matching respects JID
-            // structure, not byte-prefix overlap.
-            let with_resource = with.resource().is_some();
-            let with_bare = with.to_bare();
             messages.retain(|message| {
-                jid_matches_with_filter(&message.from, &with_bare, with_resource, with)
-                    || jid_matches_with_filter(&message.to, &with_bare, with_resource, with)
+                message_matches_with_filter(
+                    archive_jid,
+                    archive_kind,
+                    &message.from,
+                    &message.to,
+                    with,
+                )
             });
         }
         if !query.ids.is_empty() {

--- a/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
@@ -7,6 +7,7 @@ use jid::BareJid;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 use waddle_xmpp_core::mam::{ArchivedMessage, MamQuery, MamResult};
+use waddle_xmpp_core::xep0359::OriginId;
 
 use crate::xep::matches_fulltext;
 
@@ -254,6 +255,53 @@ impl MamStorage for InMemoryMamStorage {
                     && message.stanza_id.as_ref().map(|s| s.id.as_str()) == Some(message_id)
             })
             .map(|(_, message)| message.clone()))
+    }
+
+    async fn get_message_by_sender_and_origin_id(
+        &self,
+        archive_jid: &BareJid,
+        archive_kind: super::MamArchiveKind,
+        sender: &jid::Jid,
+        origin_id: &OriginId,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        let archive_jid = archive_jid.to_string();
+        let entries = self.entries.read().await;
+        Ok(entries
+            .iter()
+            .filter_map(|(stored_archive, message)| {
+                let sender_matches = match archive_kind {
+                    super::MamArchiveKind::Personal => message.from.to_bare() == sender.to_bare(),
+                    super::MamArchiveKind::Room => &message.from == sender,
+                };
+                if stored_archive != &archive_jid || !sender_matches {
+                    return None;
+                }
+                let match_priority = if message
+                    .origin_id
+                    .as_ref()
+                    .is_some_and(|candidate| candidate == origin_id)
+                {
+                    0
+                } else if message
+                    .stanza_id
+                    .as_ref()
+                    .is_some_and(|candidate| candidate.id.as_str() == origin_id.as_str())
+                {
+                    1
+                } else {
+                    return None;
+                };
+                Some((match_priority, message))
+            })
+            .min_by(|(left_priority, left), (right_priority, right)| {
+                left_priority.cmp(right_priority).then_with(|| {
+                    left.timestamp
+                        .cmp(&right.timestamp)
+                        .then_with(|| left.id.cmp(&right.id))
+                })
+            })
+            .map(|(_, message)| message)
+            .cloned())
     }
 
     async fn get_message_by_archive_or_stanza_id(

--- a/server/crates/waddle-xmpp/src/mam/storage/query_semantics.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/query_semantics.rs
@@ -108,8 +108,8 @@ pub(super) fn jid_matches_with_filter(
 
 /// XEP-0313 §4.3.1 `with` predicate for an archived message.
 ///
-/// In a personal archive, a query for the owner's own bare JID (including
-/// when the supplied JID has a resource) is the self-chat special case:
+/// In a personal archive, a query for the owner's own bare JID is the
+/// self-chat special case:
 /// both endpoints must be bare-equivalent to the archive owner. Room
 /// archives and all other queries keep ordinary sender-or-recipient
 /// semantics.
@@ -121,7 +121,10 @@ pub(super) fn message_matches_with_filter(
     with: &jid::Jid,
 ) -> bool {
     let with_bare = with.to_bare();
-    if archive_kind == MamArchiveKind::Personal && &with_bare == archive_jid {
+    if archive_kind == MamArchiveKind::Personal
+        && with.resource().is_none()
+        && &with_bare == archive_jid
+    {
         return &from.to_bare() == archive_jid && &to.to_bare() == archive_jid;
     }
 

--- a/server/crates/waddle-xmpp/src/mam/storage/query_semantics.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/query_semantics.rs
@@ -3,6 +3,8 @@ use std::collections::HashSet;
 use jid::BareJid;
 use waddle_xmpp_core::mam::{ArchivedMessage, MamQuery, MamResult};
 
+use super::MamArchiveKind;
+
 pub(super) fn uses_backward_pagination(query: &MamQuery) -> bool {
     // XEP-0059 §2.5: an empty <before/> element requests the last page of
     // results. We treat any present `before_id` — including `Some("")` — as a
@@ -102,6 +104,30 @@ pub(super) fn jid_matches_with_filter(
     } else {
         &archived.to_bare() == with_bare
     }
+}
+
+/// XEP-0313 §4.3.1 `with` predicate for an archived message.
+///
+/// In a personal archive, a query for the owner's own bare JID (including
+/// when the supplied JID has a resource) is the self-chat special case:
+/// both endpoints must be bare-equivalent to the archive owner. Room
+/// archives and all other queries keep ordinary sender-or-recipient
+/// semantics.
+pub(super) fn message_matches_with_filter(
+    archive_jid: &BareJid,
+    archive_kind: MamArchiveKind,
+    from: &jid::Jid,
+    to: &jid::Jid,
+    with: &jid::Jid,
+) -> bool {
+    let with_bare = with.to_bare();
+    if archive_kind == MamArchiveKind::Personal && &with_bare == archive_jid {
+        return &from.to_bare() == archive_jid && &to.to_bare() == archive_jid;
+    }
+
+    let with_has_resource = with.resource().is_some();
+    jid_matches_with_filter(from, &with_bare, with_has_resource, with)
+        || jid_matches_with_filter(to, &with_bare, with_has_resource, with)
 }
 
 pub(super) fn matches_thread_filter(message: &ArchivedMessage, thread_id: &str) -> bool {

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/impls.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/impls.rs
@@ -6,6 +6,7 @@ use sqlx::sqlite::SqliteRow;
 use sqlx::{Postgres, QueryBuilder, Sqlite};
 use tracing::{debug, instrument};
 use waddle_xmpp_core::mam::{ArchivedMessage, MamQuery, MamResult};
+use waddle_xmpp_core::xep0359::OriginId;
 
 use crate::mam::storage::query_semantics::{finalize_result, uses_backward_pagination};
 use crate::mam::storage::{MamStorage, MamStorageError};
@@ -13,8 +14,9 @@ use crate::muc::RoomClaimFenceContext;
 
 use super::decode::{decode_postgres_message_row, decode_sqlite_message_row};
 use super::query::{
-    ensure_postgres_requested_ids_exist, ensure_sqlite_requested_ids_exist, fetch_postgres_cursor,
-    fetch_sqlite_cursor, push_postgres_mam_filters, push_sqlite_mam_filters, WithFilter,
+    ensure_postgres_requested_ids_exist, ensure_sqlite_requested_ids_exist, escape_like_pattern,
+    fetch_postgres_cursor, fetch_sqlite_cursor, push_postgres_mam_filters, push_sqlite_mam_filters,
+    WithFilter,
 };
 use super::schema::SELECT_COLUMNS;
 use super::{MamDatabaseBackend, SqlxMamStorage};
@@ -321,6 +323,83 @@ impl MamStorage for SqlxMamStorage {
                 .bind(message_id)
                 .fetch_optional(pool)
                 .await?;
+                row.as_ref().map(decode_postgres_message_row).transpose()
+            }
+        }
+    }
+
+    async fn get_message_by_sender_and_origin_id(
+        &self,
+        archive_jid: &BareJid,
+        archive_kind: crate::mam::MamArchiveKind,
+        sender: &jid::Jid,
+        origin_id: &OriginId,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError> {
+        let archive_jid = archive_jid.to_string();
+        let sender_full = sender.to_string();
+        let sender_bare = sender.to_bare().to_string();
+        let sender_resource_prefix = format!("{}/%", escape_like_pattern(&sender_bare));
+        match &self.backend {
+            MamDatabaseBackend::Sqlite(pool) => {
+                let mut builder = QueryBuilder::<Sqlite>::new(format!(
+                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
+                ));
+                builder
+                    .push_bind(archive_jid.as_str())
+                    .push(" AND (origin_id = ")
+                    .push_bind(origin_id.as_str())
+                    .push(" OR stanza_id = ")
+                    .push_bind(origin_id.as_str())
+                    .push(") AND ");
+                match archive_kind {
+                    crate::mam::MamArchiveKind::Personal => {
+                        builder
+                            .push("(from_jid = ")
+                            .push_bind(sender_bare.as_str())
+                            .push(" OR from_jid LIKE ")
+                            .push_bind(sender_resource_prefix.as_str())
+                            .push(" ESCAPE '\\')");
+                    }
+                    crate::mam::MamArchiveKind::Room => {
+                        builder.push("from_jid = ").push_bind(sender_full.as_str());
+                    }
+                }
+                builder
+                    .push(" ORDER BY CASE WHEN origin_id = ")
+                    .push_bind(origin_id.as_str())
+                    .push(" THEN 0 ELSE 1 END, timestamp ASC, id ASC LIMIT 1");
+                let row = builder.build().fetch_optional(pool).await?;
+                row.as_ref().map(decode_sqlite_message_row).transpose()
+            }
+            MamDatabaseBackend::Postgres(pool) => {
+                let mut builder = QueryBuilder::<Postgres>::new(format!(
+                    "SELECT {SELECT_COLUMNS} FROM mam_messages WHERE room_jid = "
+                ));
+                builder
+                    .push_bind(archive_jid.as_str())
+                    .push(" AND (origin_id = ")
+                    .push_bind(origin_id.as_str())
+                    .push(" OR stanza_id = ")
+                    .push_bind(origin_id.as_str())
+                    .push(") AND ");
+                match archive_kind {
+                    crate::mam::MamArchiveKind::Personal => {
+                        builder
+                            .push("(from_jid = ")
+                            .push_bind(sender_bare.as_str())
+                            .push(" OR from_jid LIKE ")
+                            .push_bind(sender_resource_prefix.as_str())
+                            .push(" ESCAPE '\\')");
+                    }
+                    crate::mam::MamArchiveKind::Room => {
+                        builder.push("from_jid = ").push_bind(sender_full.as_str());
+                    }
+                }
+                builder
+                    .push(" ORDER BY CASE WHEN origin_id = ")
+                    .push_bind(origin_id.as_str())
+                    .push(" THEN 0 ELSE 1 END, timestamp ASC, id ASC LIMIT 1");
+                let row = builder.build().fetch_optional(pool).await?;
                 row.as_ref().map(decode_postgres_message_row).transpose()
             }
         }

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/impls.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/impls.rs
@@ -47,10 +47,13 @@ impl MamStorage for SqlxMamStorage {
     async fn query_messages(
         &self,
         archive_jid: &BareJid,
+        archive_kind: crate::mam::MamArchiveKind,
         query: &MamQuery,
     ) -> Result<MamResult, MamStorageError> {
         let limit = i64::from(query.max.unwrap_or(100).min(500)) + 1;
-        // XEP-0313 §4.3.1 `with` filter: a bare `with` matches the
+        // XEP-0313 §4.3.1 `with` filter: an owner-equivalent `with`
+        // requires both endpoints to match the owner's bare JID. Otherwise,
+        // a bare `with` matches the
         // bare form of the archived sender/recipient (so the row's
         // resource can be anything, or absent); a full `with` matches
         // only the exact full JID. The strings are stable for sqlx's
@@ -61,7 +64,10 @@ impl MamStorage for SqlxMamStorage {
         // `alice@example.com` would match `alice@example.com.evil/...`
         // because the prefix overlaps. The corrected shape is exact
         // equality plus a `LIKE 'bare/%'` for the resource form.
-        let with_filter = query.with.as_ref().map(WithFilter::from_with);
+        let with_filter = query
+            .with
+            .as_ref()
+            .map(|with| WithFilter::new(archive_jid, archive_kind, with));
         let archive_jid_str = archive_jid.to_string();
 
         match &self.backend {

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/query.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/query.rs
@@ -28,9 +28,8 @@ pub(super) struct WithFilter {
     /// in that case the SQL emits an exact-equality match against the
     /// full form. `None` when the query `with` is bare.
     full: Option<String>,
-    /// Whether this is a personal archive whose `with`, ignoring any
-    /// resource, is the archive owner. This case requires both archived
-    /// endpoints to match `bare`.
+    /// Whether this is a personal archive queried with the owner's bare JID.
+    /// This case requires both archived endpoints to match `bare`.
     owner_self: bool,
 }
 
@@ -42,7 +41,9 @@ impl WithFilter {
     ) -> Self {
         let bare = with.to_bare();
         Self {
-            owner_self: archive_kind == MamArchiveKind::Personal && &bare == archive_jid,
+            owner_self: archive_kind == MamArchiveKind::Personal
+                && with.resource().is_none()
+                && &bare == archive_jid,
             bare: bare.to_string(),
             full: with.resource().is_some().then(|| with.to_string()),
         }
@@ -67,7 +68,7 @@ const LIKE_ESCAPE: &str = "\\";
 /// resulting bind. Order matters: the escape character itself must be
 /// doubled first so the subsequent `%`/`_` substitutions don't double-
 /// escape.
-fn escape_like_pattern(value: &str) -> String {
+pub(super) fn escape_like_pattern(value: &str) -> String {
     value
         .replace(LIKE_ESCAPE, "\\\\")
         .replace('%', "\\%")

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/query.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/query.rs
@@ -7,6 +7,7 @@ use sqlx::{Postgres, QueryBuilder, Sqlite};
 use waddle_xmpp_core::mam::{ArchivedMessage, MamQuery};
 
 use crate::mam::storage::MamStorageError;
+use crate::mam::MamArchiveKind;
 
 use super::decode::{decode_postgres_message_row, decode_sqlite_message_row};
 use super::schema::SELECT_COLUMNS;
@@ -14,10 +15,9 @@ use crate::mam::storage::query_semantics::missing_requested_id_in_set;
 
 /// Pre-computed bind values for the SQL `with` filter.
 ///
-/// XEP-0313 §4.3.1 distinguishes bare and full `with` semantics:
-/// bare matches the archived JID's bare form (resource may be any /
-/// absent); full matches only exact equality. Pre-computing both
-/// values keeps the bind site lifetime stable for sqlx and makes the
+/// XEP-0313 §4.3.1 distinguishes the owner self-chat case from ordinary
+/// bare and full `with` semantics. Pre-computing the classification and
+/// bind values keeps their lifetimes stable for sqlx and makes the
 /// matching shape readable at the SQL emit site.
 pub(super) struct WithFilter {
     /// The bare form of the query `with`. Used for both equality
@@ -28,12 +28,22 @@ pub(super) struct WithFilter {
     /// in that case the SQL emits an exact-equality match against the
     /// full form. `None` when the query `with` is bare.
     full: Option<String>,
+    /// Whether this is a personal archive whose `with`, ignoring any
+    /// resource, is the archive owner. This case requires both archived
+    /// endpoints to match `bare`.
+    owner_self: bool,
 }
 
 impl WithFilter {
-    pub(super) fn from_with(with: &jid::Jid) -> Self {
+    pub(super) fn new(
+        archive_jid: &BareJid,
+        archive_kind: MamArchiveKind,
+        with: &jid::Jid,
+    ) -> Self {
+        let bare = with.to_bare();
         Self {
-            bare: with.to_bare().to_string(),
+            owner_self: archive_kind == MamArchiveKind::Personal && &bare == archive_jid,
+            bare: bare.to_string(),
             full: with.resource().is_some().then(|| with.to_string()),
         }
     }
@@ -67,14 +77,30 @@ fn escape_like_pattern(value: &str) -> String {
 macro_rules! push_common_mam_filters {
     ($builder:expr, $query:expr, $with_filter:expr) => {{
         if let Some(with) = $with_filter {
-            // Bare `with`: archived JID may be bare (`= bare`) or full
+            // Owner `with`: both archived endpoints must be bare-equivalent
+            // to the owner, even when the supplied `with` is full.
+            //
+            // Ordinary bare `with`: archived JID may be bare (`= bare`) or full
             // with any resource (`LIKE 'bare/%'`). The resource prefix
             // MUST include the `/` separator so domain prefix
             // collisions (`example.com` vs `example.com.evil`) cannot
             // match.
             //
-            // Full `with`: archived JID must equal exactly.
-            if let Some(full) = with.full.as_deref() {
+            // Ordinary full `with`: archived JID must equal exactly.
+            if with.owner_self {
+                let bare = with.bare.as_str();
+                let resource_prefix = with.bare_resource_prefix();
+                $builder
+                    .push(" AND ((from_jid = ")
+                    .push_bind(bare)
+                    .push(" OR from_jid LIKE ")
+                    .push_bind(resource_prefix.clone())
+                    .push(" ESCAPE '\\') AND (to_jid = ")
+                    .push_bind(bare)
+                    .push(" OR to_jid LIKE ")
+                    .push_bind(resource_prefix)
+                    .push(" ESCAPE '\\'))");
+            } else if let Some(full) = with.full.as_deref() {
                 $builder
                     .push(" AND (from_jid = ")
                     .push_bind(full)

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/schema.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/schema.rs
@@ -62,6 +62,8 @@ CREATE INDEX IF NOT EXISTS idx_mam_room_reply_to
     ON mam_messages(room_jid, reply_to_id, timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_mam_room_origin
     ON mam_messages(room_jid, origin_id);
+CREATE INDEX IF NOT EXISTS idx_mam_room_stanza
+    ON mam_messages(room_jid, stanza_id);
 "#;
 
 const SQLITE_MAM_ORIGIN_DEDUP_INDEXES: &str = r#"
@@ -121,6 +123,8 @@ CREATE INDEX IF NOT EXISTS idx_mam_room_reply_to
     ON mam_messages(room_jid, reply_to_id, timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_mam_room_origin
     ON mam_messages(room_jid, origin_id);
+CREATE INDEX IF NOT EXISTS idx_mam_room_stanza
+    ON mam_messages(room_jid, stanza_id);
 "#;
 
 const POSTGRES_MAM_ORIGIN_DEDUP_INDEXES: &str = r#"

--- a/server/crates/waddle-xmpp/src/mam/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tests.rs
@@ -152,7 +152,7 @@ async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn
     assert_eq!(next_generation_id, "archive-next-generation");
 
     let result = storage
-        .query_messages(&archive, &MamQuery::default())
+        .query_messages(&archive, MamArchiveKind::Room, &MamQuery::default())
         .await
         .unwrap();
     let ids: Vec<&str> = result
@@ -287,7 +287,7 @@ async fn assert_origin_id_dedup_ignores_per_session_muc_sender(storage: &dyn Mam
     );
 
     let result = storage
-        .query_messages(&archive, &MamQuery::default())
+        .query_messages(&archive, MamArchiveKind::Room, &MamQuery::default())
         .await
         .unwrap();
     assert_eq!(
@@ -493,6 +493,7 @@ async fn test_query_with_pagination() {
     let page_one = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 max: Some(2),
                 ..Default::default()
@@ -506,6 +507,7 @@ async fn test_query_with_pagination() {
     let page_two = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 after_id: page_one.last_id.clone(),
                 ..Default::default()
@@ -592,6 +594,7 @@ async fn assert_full_occupant_with_excludes_siblings_before_pagination(storage: 
     let first = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 with: Some(alice_occupant.clone()),
                 max: Some(2),
@@ -607,6 +610,7 @@ async fn assert_full_occupant_with_excludes_siblings_before_pagination(storage: 
     let second = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 with: Some(alice_occupant),
                 after_id: first.last_id.clone(),
@@ -619,6 +623,270 @@ async fn assert_full_occupant_with_excludes_siblings_before_pagination(storage: 
     assert_eq!(bodies(&second), vec!["alice later"]);
     assert_eq!(second.count, Some(3));
     assert!(second.complete);
+}
+
+#[tokio::test]
+async fn sqlite_owner_with_returns_only_self_chat_rows() {
+    let storage = create_test_storage().await;
+    assert_owner_with_returns_only_self_chat_rows(&storage).await;
+}
+
+#[tokio::test]
+async fn inmemory_owner_with_returns_only_self_chat_rows() {
+    let storage = InMemoryMamStorage::new();
+    assert_owner_with_returns_only_self_chat_rows(&storage).await;
+}
+
+async fn assert_owner_with_returns_only_self_chat_rows(storage: &dyn MamStorage) {
+    let archive = bare("juliet@example.com");
+    let owner = jid("juliet@example.com");
+    let base = DateTime::parse_from_rfc3339("2026-07-01T12:00:00Z")
+        .expect("valid timestamp")
+        .with_timezone(&Utc);
+
+    for (id, seconds, from, to) in [
+        (
+            "self-chat-one",
+            0,
+            jid("juliet@example.com/balcony"),
+            jid("juliet@example.com/chamber"),
+        ),
+        (
+            "ordinary-outgoing",
+            1,
+            jid("juliet@example.com/phone"),
+            jid("romeo@example.com/mobile"),
+        ),
+        (
+            "ordinary-incoming",
+            2,
+            jid("romeo@example.com/desktop"),
+            jid("juliet@example.com/tablet"),
+        ),
+        ("self-chat-two", 3, jid("juliet@example.com/balcony"), owner),
+        (
+            "unrelated",
+            4,
+            jid("mercutio@example.com/phone"),
+            jid("benvolio@example.com/tablet"),
+        ),
+    ] {
+        storage
+            .store_message(
+                &archive,
+                &ArchivedMessage {
+                    id: id.to_string(),
+                    timestamp: base + ChronoDuration::seconds(seconds),
+                    body: Some(id.to_string()),
+                    ..ArchivedMessage::for_test(from, to)
+                },
+            )
+            .await
+            .expect("store archive fixture");
+    }
+
+    let bare_owner = storage
+        .query_messages(
+            &archive,
+            MamArchiveKind::Personal,
+            &MamQuery {
+                with: Some(jid("juliet@example.com")),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query self-chat archive");
+
+    let ids = bare_owner
+        .messages
+        .iter()
+        .map(|message| message.id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["self-chat-one", "self-chat-two"]);
+    assert_eq!(bare_owner.count, Some(2));
+
+    let first_page = storage
+        .query_messages(
+            &archive,
+            MamArchiveKind::Personal,
+            &MamQuery {
+                with: Some(jid("juliet@example.com/query-device")),
+                max: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query first self-chat page with full owner JID");
+    assert_eq!(first_page.messages[0].id, "self-chat-one");
+    assert_eq!(first_page.count, Some(2));
+    assert!(!first_page.complete);
+
+    let second_page = storage
+        .query_messages(
+            &archive,
+            MamArchiveKind::Personal,
+            &MamQuery {
+                with: Some(jid("juliet@example.com/query-device")),
+                after_id: first_page.last_id,
+                max: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query second self-chat page with full owner JID");
+    assert_eq!(second_page.messages[0].id, "self-chat-two");
+    assert_eq!(second_page.count, Some(2));
+    assert!(second_page.complete);
+
+    let ordinary_bare = storage
+        .query_messages(
+            &archive,
+            MamArchiveKind::Personal,
+            &MamQuery {
+                with: Some(jid("romeo@example.com")),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query ordinary contact by bare JID");
+    let ordinary_ids = ordinary_bare
+        .messages
+        .iter()
+        .map(|message| message.id.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(ordinary_ids, vec!["ordinary-outgoing", "ordinary-incoming"]);
+    assert_eq!(ordinary_bare.count, Some(2));
+
+    let ordinary_full = storage
+        .query_messages(
+            &archive,
+            MamArchiveKind::Personal,
+            &MamQuery {
+                with: Some(jid("romeo@example.com/desktop")),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query ordinary contact by full JID");
+    assert_eq!(ordinary_full.messages[0].id, "ordinary-incoming");
+    assert_eq!(ordinary_full.messages.len(), 1);
+    assert_eq!(ordinary_full.count, Some(1));
+
+    let empty = storage
+        .query_messages(
+            &archive,
+            MamArchiveKind::Personal,
+            &MamQuery {
+                with: Some(jid("tybalt@example.com")),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query contact absent from archive");
+    assert!(empty.messages.is_empty());
+    assert_eq!(empty.count, Some(0));
+    assert!(empty.complete);
+}
+
+#[tokio::test]
+async fn sqlite_room_archive_full_occupant_with_is_exact() {
+    let storage = create_test_storage().await;
+    assert_room_archive_full_occupant_with_is_exact(&storage).await;
+}
+
+#[tokio::test]
+async fn inmemory_room_archive_full_occupant_with_is_exact() {
+    let storage = InMemoryMamStorage::new();
+    assert_room_archive_full_occupant_with_is_exact(&storage).await;
+}
+
+async fn assert_room_archive_full_occupant_with_is_exact(storage: &dyn MamStorage) {
+    let room = bare("room@example.com");
+    let room_jid = jid("room@example.com");
+    let alice = jid("room@example.com/alice");
+    let bob = jid("room@example.com/bob");
+    let base = DateTime::parse_from_rfc3339("2026-07-02T12:00:00Z")
+        .expect("valid timestamp")
+        .with_timezone(&Utc);
+
+    for (id, seconds, from) in [
+        ("alice-one", 0, alice.clone()),
+        ("bob-one", 1, bob),
+        ("alice-two", 2, alice.clone()),
+    ] {
+        storage
+            .store_message(
+                &room,
+                &ArchivedMessage {
+                    id: id.to_string(),
+                    timestamp: base + ChronoDuration::seconds(seconds),
+                    ..ArchivedMessage::for_test(from, room_jid.clone())
+                },
+            )
+            .await
+            .expect("store room archive fixture");
+    }
+
+    let first = storage
+        .query_messages(
+            &room,
+            MamArchiveKind::Room,
+            &MamQuery {
+                with: Some(alice.clone()),
+                max: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query first Alice page");
+    assert_eq!(first.messages[0].id, "alice-one");
+    assert_eq!(first.count, Some(2));
+    assert!(!first.complete);
+
+    let second = storage
+        .query_messages(
+            &room,
+            MamArchiveKind::Room,
+            &MamQuery {
+                with: Some(alice),
+                after_id: first.last_id,
+                max: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query second Alice page");
+    assert_eq!(second.messages[0].id, "alice-two");
+    assert_eq!(second.count, Some(2));
+    assert!(second.complete);
+
+    let bare_room = storage
+        .query_messages(
+            &room,
+            MamArchiveKind::Room,
+            &MamQuery {
+                with: Some(room_jid),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query room by bare JID");
+    assert_eq!(bare_room.messages.len(), 3);
+    assert_eq!(bare_room.count, Some(3));
+
+    let empty = storage
+        .query_messages(
+            &room,
+            MamArchiveKind::Room,
+            &MamQuery {
+                with: Some(jid("room@example.com/charlie")),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query absent occupant");
+    assert!(empty.messages.is_empty());
+    assert_eq!(empty.count, Some(0));
 }
 
 #[tokio::test]
@@ -641,6 +909,7 @@ async fn assert_rsm_after_uses_archive_order_not_lexical_id_order(storage: &dyn 
     let page_one = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 max: Some(2),
                 ..Default::default()
@@ -654,6 +923,7 @@ async fn assert_rsm_after_uses_archive_order_not_lexical_id_order(storage: &dyn 
     let page_two = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 max: Some(2),
                 after_id: page_one.last_id.clone(),
@@ -668,6 +938,7 @@ async fn assert_rsm_after_uses_archive_order_not_lexical_id_order(storage: &dyn 
     let page_three = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 max: Some(2),
                 after_id: page_two.last_id.clone(),
@@ -700,6 +971,7 @@ async fn assert_rsm_before_uses_archive_order_not_lexical_id_order(storage: &dyn
     let page = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 max: Some(2),
                 before_id: Some("x-fifth".to_string()),
@@ -748,6 +1020,7 @@ async fn assert_rsm_cursors_page_same_timestamp_by_archive_id(storage: &dyn MamS
     let after = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 max: Some(2),
                 after_id: Some("id-b".to_string()),
@@ -765,6 +1038,7 @@ async fn assert_rsm_cursors_page_same_timestamp_by_archive_id(storage: &dyn MamS
     let before = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 max: Some(2),
                 before_id: Some("id-d".to_string()),
@@ -800,6 +1074,7 @@ async fn assert_extended_before_id_filters_without_flipping_order(storage: &dyn 
     let result = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 filter_before_id: Some("x-fifth".to_string()),
                 ..Default::default()
@@ -834,6 +1109,7 @@ async fn assert_extended_ids_query_returns_specific_messages(storage: &dyn MamSt
     let result = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 ids: vec!["x-fifth".to_string(), "a-second".to_string()],
                 ..Default::default()
@@ -910,6 +1186,7 @@ async fn assert_missing_rsm_cursor_returns_not_found(storage: &dyn MamStorage) {
     let error = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 after_id: Some("missing-id".to_string()),
                 ..Default::default()
@@ -923,6 +1200,7 @@ async fn assert_missing_rsm_cursor_returns_not_found(storage: &dyn MamStorage) {
     let error = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 before_id: Some("missing-before-id".to_string()),
                 ..Default::default()
@@ -936,6 +1214,7 @@ async fn assert_missing_rsm_cursor_returns_not_found(storage: &dyn MamStorage) {
     let error = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 filter_before_id: Some("missing-filter-before-id".to_string()),
                 ..Default::default()
@@ -949,6 +1228,7 @@ async fn assert_missing_rsm_cursor_returns_not_found(storage: &dyn MamStorage) {
     let error = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 filter_after_id: Some("missing-filter-after-id".to_string()),
                 ..Default::default()
@@ -962,6 +1242,7 @@ async fn assert_missing_rsm_cursor_returns_not_found(storage: &dyn MamStorage) {
     let error = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 ids: vec!["known-id".to_string(), "missing-query-id".to_string()],
                 ..Default::default()
@@ -993,6 +1274,7 @@ async fn assert_rsm_cursor_outside_query_filters_still_pages(storage: &dyn MamSt
     let result = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 start: Some(base + ChronoDuration::seconds(3)),
                 after_id: Some("a-second".to_string()),
@@ -1025,6 +1307,7 @@ async fn assert_rsm_max_zero_returns_count_only(storage: &dyn MamStorage) {
     let result = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 max: Some(0),
                 ..Default::default()
@@ -1060,6 +1343,7 @@ async fn assert_rsm_empty_edge_pages_omit_first_and_last(storage: &dyn MamStorag
     let after_last = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 max: Some(2),
                 after_id: Some("x-fifth".to_string()),
@@ -1077,6 +1361,7 @@ async fn assert_rsm_empty_edge_pages_omit_first_and_last(storage: &dyn MamStorag
     let before_first = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 max: Some(2),
                 before_id: Some("z-first".to_string()),
@@ -1144,6 +1429,7 @@ async fn test_thread_query_filters_before_pagination_and_count() {
     let result = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 thread_id: waddle_xmpp_core::mam::ThreadId::new("a-thread-root"),
                 max: Some(2),
@@ -1191,6 +1477,7 @@ async fn test_fulltext_query_filters_before_pagination_and_count() {
     let result = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 fulltext: waddle_xmpp_core::mam::RichText::new("release notes"),
                 max: Some(1),
@@ -1230,7 +1517,7 @@ async fn test_sqlite_file_backing_persists() {
 
     let reopened = SqlxMamStorage::open(&database_url).await.expect("reopen");
     let result = reopened
-        .query_messages(&archive, &MamQuery::default())
+        .query_messages(&archive, MamArchiveKind::Room, &MamQuery::default())
         .await
         .expect("query");
     assert_eq!(result.messages.len(), 1);
@@ -1276,7 +1563,7 @@ async fn reaction_round_trips_through_in_memory_storage() {
     storage.store_message(&archive, &msg).await.expect("store");
 
     let result = storage
-        .query_messages(&archive, &MamQuery::default())
+        .query_messages(&archive, MamArchiveKind::Room, &MamQuery::default())
         .await
         .expect("query");
 
@@ -1336,7 +1623,7 @@ async fn reaction_round_trips_through_persistent_sqlite() {
 
     let reopened = SqlxMamStorage::open(&database_url).await.expect("reopen");
     let result = reopened
-        .query_messages(&archive, &MamQuery::default())
+        .query_messages(&archive, MamArchiveKind::Room, &MamQuery::default())
         .await
         .expect("query");
 
@@ -1470,7 +1757,7 @@ async fn reaction_lands_after_legacy_body_not_null_schema_migrated() {
 
     // 4. Confirm the row is there with the reaction payload intact.
     let result = storage
-        .query_messages(&archive, &MamQuery::default())
+        .query_messages(&archive, MamArchiveKind::Room, &MamQuery::default())
         .await
         .expect("query");
     assert_eq!(result.messages.len(), 1);
@@ -1529,6 +1816,7 @@ async fn test_empty_before_returns_last_page() {
     let last_page = storage
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 max: Some(3),
                 before_id: Some(String::new()),
@@ -1729,7 +2017,7 @@ async fn xep_0313_sqlx_archive_returns_messages_in_chronological_order() {
     storage.store_message(&archive, &earlier).await.unwrap();
 
     let result = storage
-        .query_messages(&archive, &MamQuery::default())
+        .query_messages(&archive, MamArchiveKind::Room, &MamQuery::default())
         .await
         .unwrap();
 
@@ -1771,7 +2059,7 @@ async fn xep_0313_in_memory_archive_returns_messages_in_chronological_order() {
     storage.store_message(&archive, &earlier).await.unwrap();
 
     let result = storage
-        .query_messages(&archive, &MamQuery::default())
+        .query_messages(&archive, MamArchiveKind::Room, &MamQuery::default())
         .await
         .unwrap();
 
@@ -1816,7 +2104,7 @@ async fn xep_0313_sqlx_archive_uses_id_as_deterministic_tiebreak_when_timestamps
     storage.store_message(&archive, &first).await.unwrap();
 
     let result = storage
-        .query_messages(&archive, &MamQuery::default())
+        .query_messages(&archive, MamArchiveKind::Room, &MamQuery::default())
         .await
         .unwrap();
     let ids: Vec<&str> = result.messages.iter().map(|m| m.id.as_str()).collect();
@@ -1885,6 +2173,7 @@ async fn in_memory_query_filters_by_stanza_id() {
     let result = store
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 stanza_ids: vec![filter_id("uuid-A"), filter_id("uuid-C")],
                 ..Default::default()
@@ -1913,6 +2202,7 @@ async fn in_memory_query_stanza_id_no_match_returns_empty() {
     let result = store
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 stanza_ids: vec![filter_id("uuid-missing")],
                 ..Default::default()
@@ -1959,6 +2249,7 @@ async fn sqlx_query_filters_by_stanza_id() {
     let result = store
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 stanza_ids: vec![filter_id("uuid-B"), filter_id("uuid-C")],
                 ..Default::default()

--- a/server/crates/waddle-xmpp/src/mam/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tests.rs
@@ -30,6 +30,104 @@ fn archive_alice(archive: &BareJid) -> Jid {
         .expect("valid jid")
 }
 
+async fn assert_sender_origin_lookup_precedence_and_room_scope(storage: &dyn MamStorage) {
+    use waddle_xmpp_core::xep0359::{OriginId, StanzaId};
+
+    let personal_archive = bare("alice@example.com");
+    let collision = OriginId::new("collision-id");
+    let base = DateTime::parse_from_rfc3339("2026-07-01T12:00:00Z")
+        .expect("valid timestamp")
+        .with_timezone(&Utc);
+    storage
+        .store_message(
+            &personal_archive,
+            &ArchivedMessage {
+                id: "legacy-wire-collision".to_string(),
+                timestamp: base,
+                stanza_id: Some(StanzaId::new(
+                    collision.as_str(),
+                    Jid::from(personal_archive.clone()),
+                )),
+                ..ArchivedMessage::for_test(
+                    jid("alice@example.com/phone"),
+                    jid("bob@example.com/laptop"),
+                )
+            },
+        )
+        .await
+        .expect("store wire-id collision");
+    storage
+        .store_message(
+            &personal_archive,
+            &ArchivedMessage {
+                id: "explicit-origin-target".to_string(),
+                timestamp: base + ChronoDuration::seconds(1),
+                origin_id: Some(collision.clone()),
+                stanza_id: Some(StanzaId::new(
+                    "explicit-wire-id",
+                    Jid::from(personal_archive.clone()),
+                )),
+                ..ArchivedMessage::for_test(
+                    jid("alice@example.com/tablet"),
+                    jid("bob@example.com/laptop"),
+                )
+            },
+        )
+        .await
+        .expect("store explicit origin target");
+
+    let personal = storage
+        .get_message_by_sender_and_origin_id(
+            &personal_archive,
+            MamArchiveKind::Personal,
+            &jid("alice@example.com"),
+            &collision,
+        )
+        .await
+        .expect("personal lookup")
+        .expect("personal target");
+    assert_eq!(personal.id, "explicit-origin-target");
+
+    let room = bare("room@conference.example");
+    for (id, sender) in [
+        ("alice-room-message", "room@conference.example/alice"),
+        ("bob-room-message", "room@conference.example/bob"),
+    ] {
+        storage
+            .store_message(
+                &room,
+                &ArchivedMessage {
+                    id: id.to_string(),
+                    origin_id: Some(OriginId::new("shared-room-origin")),
+                    ..ArchivedMessage::for_test(jid(sender), jid("room@conference.example"))
+                },
+            )
+            .await
+            .expect("store room occupant row");
+    }
+    let room_target = storage
+        .get_message_by_sender_and_origin_id(
+            &room,
+            MamArchiveKind::Room,
+            &jid("room@conference.example/alice"),
+            &OriginId::new("shared-room-origin"),
+        )
+        .await
+        .expect("room lookup")
+        .expect("room target");
+    assert_eq!(room_target.id, "alice-room-message");
+}
+
+#[tokio::test]
+async fn inmemory_sender_origin_lookup_prefers_origin_and_scopes_room_occupants() {
+    assert_sender_origin_lookup_precedence_and_room_scope(&InMemoryMamStorage::new()).await;
+}
+
+#[tokio::test]
+async fn sqlite_sender_origin_lookup_prefers_origin_and_scopes_room_occupants() {
+    assert_sender_origin_lookup_precedence_and_room_scope(&create_test_storage().await).await;
+}
+
 #[tokio::test]
 async fn test_store_and_retrieve_message() {
     let storage = create_test_storage().await;
@@ -705,38 +803,20 @@ async fn assert_owner_with_returns_only_self_chat_rows(storage: &dyn MamStorage)
     assert_eq!(ids, vec!["self-chat-one", "self-chat-two"]);
     assert_eq!(bare_owner.count, Some(2));
 
-    let first_page = storage
+    let full_owner_resource = storage
         .query_messages(
             &archive,
             MamArchiveKind::Personal,
             &MamQuery {
                 with: Some(jid("juliet@example.com/query-device")),
-                max: Some(1),
                 ..Default::default()
             },
         )
         .await
-        .expect("query first self-chat page with full owner JID");
-    assert_eq!(first_page.messages[0].id, "self-chat-one");
-    assert_eq!(first_page.count, Some(2));
-    assert!(!first_page.complete);
-
-    let second_page = storage
-        .query_messages(
-            &archive,
-            MamArchiveKind::Personal,
-            &MamQuery {
-                with: Some(jid("juliet@example.com/query-device")),
-                after_id: first_page.last_id,
-                max: Some(1),
-                ..Default::default()
-            },
-        )
-        .await
-        .expect("query second self-chat page with full owner JID");
-    assert_eq!(second_page.messages[0].id, "self-chat-two");
-    assert_eq!(second_page.count, Some(2));
-    assert!(second_page.complete);
+        .expect("query exact full owner resource");
+    assert!(full_owner_resource.messages.is_empty());
+    assert_eq!(full_owner_resource.count, Some(0));
+    assert!(full_owner_resource.complete);
 
     let ordinary_bare = storage
         .query_messages(

--- a/server/crates/waddle-xmpp/src/mam/storage/traits.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/traits.rs
@@ -1,7 +1,8 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use jid::BareJid;
+use jid::{BareJid, Jid};
 use waddle_xmpp_core::mam::{ArchivedMessage, MamQuery, MamResult};
+use waddle_xmpp_core::xep0359::OriginId;
 
 use crate::muc::RoomClaimFenceContext;
 
@@ -134,6 +135,19 @@ pub trait MamStorage: Send + Sync {
         &self,
         archive_jid: &BareJid,
         message_id: &str,
+    ) -> Result<Option<ArchivedMessage>, MamStorageError>;
+
+    /// Resolve a sender-owned origin id, falling back to the same sender's
+    /// wire stanza id for legacy XEP-0308 clients that omit `<origin-id/>`.
+    /// Backends must perform this as one bounded lookup rather than paging an
+    /// archive. Personal archives compare the sender by bare account JID;
+    /// room archives compare the exact full occupant JID.
+    async fn get_message_by_sender_and_origin_id(
+        &self,
+        archive_jid: &BareJid,
+        archive_kind: MamArchiveKind,
+        sender: &Jid,
+        origin_id: &OriginId,
     ) -> Result<Option<ArchivedMessage>, MamStorageError>;
 
     /// Get a message by server archive id or stanza id, excluding client origin-id.

--- a/server/crates/waddle-xmpp/src/mam/storage/traits.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/traits.rs
@@ -7,6 +7,17 @@ use crate::muc::RoomClaimFenceContext;
 
 use super::MamStorageError;
 
+/// The XEP-0313 archive context that defines query semantics.
+///
+/// A bare JID alone cannot distinguish a personal archive from a room
+/// archive. Callers must supply the protocol context explicitly so the
+/// owner-self `with` rule is never inferred from domain naming.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MamArchiveKind {
+    Personal,
+    Room,
+}
+
 /// Trait for MAM message storage backends.
 ///
 /// Per XEP-0313 §4.1, archive addressing is normatively a **bare JID**
@@ -76,10 +87,15 @@ pub trait MamStorage: Send + Sync {
     /// - For MUC archives: the room bare JID
     /// - For personal archives: the user's bare JID
     ///
+    /// `archive_kind` is mandatory because XEP-0313 §4.3.1 gives
+    /// owner-equivalent `with` queries special semantics only for personal
+    /// archives. The JID itself is not sufficient to infer that context.
+    ///
     /// Supports filtering by time range, sender, and RSM pagination.
     async fn query_messages(
         &self,
         archive_jid: &BareJid,
+        archive_kind: MamArchiveKind,
         query: &MamQuery,
     ) -> Result<MamResult, MamStorageError>;
 

--- a/server/crates/waddle-xmpp/src/protocol/event.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event.rs
@@ -18,7 +18,7 @@
 use super::frame::InboundFrame;
 use crate::xep::{CallThreadKind, CallThreadMedia};
 use crate::Stanza;
-use jid::{BareJid, FullJid};
+use jid::{FullJid, Jid};
 use waddle_xmpp_core::xep0359::{OriginId, StanzaId};
 use xmpp_parsers::message::Message;
 
@@ -51,8 +51,9 @@ pub enum MessageRef {
     },
     /// XEP-0359 origin-id, scoped to the original sender.
     OriginId {
-        /// Bare JID of the original sender.
-        sender: BareJid,
+        /// Original sender identity: bare account JID in personal archives,
+        /// exact full occupant JID in room archives.
+        sender: Jid,
         /// The client-supplied opaque origin-id value (canonical
         /// [`OriginId`] from `waddle-xmpp-core`).
         origin_id: OriginId,

--- a/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
@@ -5,6 +5,7 @@ use waddle_xmpp_core::xep0359::StanzaId;
 use xmpp_parsers::iq::Iq;
 use xmpp_parsers::message::Message;
 
+use crate::mam::MamArchiveKind;
 use crate::muc::PinChangeRequest;
 use crate::Stanza;
 
@@ -400,11 +401,12 @@ pub enum OutboundEvent {
     /// XEP-0425 moderation, XEP-0461 reply). Result arrives as
     /// [`InboundEvent::ArchivedMessageLoaded`].
     ///
-    /// `archive` is the bare JID whose MAM is queried (the user's bare
-    /// JID for 1:1 messages, the room JID for groupchat).
+    /// `archive` is the bare JID whose MAM is queried. `archive_kind`
+    /// carries the protocol context that a bare JID alone cannot encode.
     LookupArchivedMessage {
         id: CallbackId,
         archive: BareJid,
+        archive_kind: MamArchiveKind,
         reference: MessageRef,
     },
 

--- a/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
@@ -190,7 +190,7 @@ pub fn detect(message: &Message, ctx: &MessageContext<'_>) -> Option<DetectedRic
         return Some(DetectedRichTarget {
             kind: RichTargetKind::Correction,
             reference: MessageRef::OriginId {
-                sender: author.clone(),
+                sender: jid::Jid::from(author.clone()),
                 origin_id: OriginId::new(correction.replaces_id),
             },
             author,

--- a/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation.rs
@@ -46,6 +46,7 @@
 use super::errors::{
     bad_request_reply, item_not_found_reply, not_acceptable_reply, send_message_error,
 };
+use crate::mam::MamArchiveKind;
 use crate::protocol::event::{ArchivedMessage, CallbackId, MessageRef, OutboundEvent};
 use crate::protocol::message_context::MessageContext;
 use crate::protocol::traits::{HandlerOutcome, MessageHandler};
@@ -130,6 +131,7 @@ impl MessageHandler for RichTargetValidationHandler {
         HandlerOutcome::AwaitCallback(vec![OutboundEvent::LookupArchivedMessage {
             id: RICH_TARGET_LOOKUP_CALLBACK_SENTINEL,
             archive: detected.author.clone(),
+            archive_kind: MamArchiveKind::Personal,
             reference: detected.reference,
         }])
     }

--- a/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation/tests.rs
+++ b/server/crates/waddle-xmpp/src/protocol/handlers/rich_target_validation/tests.rs
@@ -69,7 +69,9 @@ fn archived_message_from(from: &str, body: &str) -> ArchivedMessage {
     }
 }
 
-fn extract_lookup_event(outcome: &HandlerOutcome) -> (&CallbackId, &BareJid, &MessageRef) {
+fn extract_lookup_event(
+    outcome: &HandlerOutcome,
+) -> (&CallbackId, &BareJid, MamArchiveKind, &MessageRef) {
     let events = match outcome {
         HandlerOutcome::AwaitCallback(events) => events,
         other => panic!("expected AwaitCallback, got {other:?}"),
@@ -79,8 +81,9 @@ fn extract_lookup_event(outcome: &HandlerOutcome) -> (&CallbackId, &BareJid, &Me
         OutboundEvent::LookupArchivedMessage {
             id,
             archive,
+            archive_kind,
             reference,
-        } => (id, archive, reference),
+        } => (id, archive, *archive_kind, reference),
         other => panic!("expected LookupArchivedMessage, got {other:?}"),
     }
 }
@@ -117,8 +120,9 @@ fn xep_0308_correction_emits_lookup_with_origin_id() {
     msg.payloads.push(build_replace_element("orig-msg-1"));
 
     let outcome = run(&local, &mut msg);
-    let (_id, archive, reference) = extract_lookup_event(&outcome);
+    let (_id, archive, archive_kind, reference) = extract_lookup_event(&outcome);
     assert_eq!(*archive, bare("alice@example.com"));
+    assert_eq!(archive_kind, MamArchiveKind::Personal);
     match reference {
         MessageRef::OriginId { sender, origin_id } => {
             assert_eq!(*sender, bare("alice@example.com"));
@@ -176,7 +180,7 @@ fn xep_0424_retraction_emits_lookup_with_stanza_id() {
     msg.payloads.push(build_retract_element("stanza-X"));
 
     let outcome = run(&local, &mut msg);
-    let (_id, _archive, reference) = extract_lookup_event(&outcome);
+    let (_id, _archive, _archive_kind, reference) = extract_lookup_event(&outcome);
     match reference {
         MessageRef::StanzaId { stanza_id } => {
             let expected_by: jid::Jid = bare("alice@example.com").into();
@@ -196,7 +200,7 @@ fn xep_0461_reply_emits_lookup_with_stanza_id() {
     ));
 
     let outcome = run(&local, &mut msg);
-    let (_id, _archive, reference) = extract_lookup_event(&outcome);
+    let (_id, _archive, _archive_kind, reference) = extract_lookup_event(&outcome);
     match reference {
         MessageRef::StanzaId { stanza_id } => {
             assert_eq!(stanza_id.as_str(), "stanza-Y");

--- a/server/crates/waddle-xmpp/src/xep/xep_waddle_mam_stanza_id_tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep_waddle_mam_stanza_id_tests.rs
@@ -32,7 +32,7 @@ use waddle_xmpp_core::mam::{
 use waddle_xmpp_core::xep0359::StanzaId;
 use xmpp_parsers::message::MessageType;
 
-use crate::mam::{build_result_messages, InMemoryMamStorage, MamStorage};
+use crate::mam::{build_result_messages, InMemoryMamStorage, MamArchiveKind, MamStorage};
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -140,6 +140,7 @@ async fn stanza_id_filter_returns_only_matching_message() {
     let result = store
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 stanza_ids: vec![filter_id("uuid-m1")],
                 ..Default::default()
@@ -180,6 +181,7 @@ async fn stanza_id_filter_matches_wire_message_id_for_dm_pin_hydration() {
     let result = store
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 stanza_ids: vec![filter_id("shared-wire-id")],
                 ..Default::default()
@@ -227,6 +229,7 @@ async fn stanza_id_filter_with_no_match_returns_empty_not_error() {
     let result = store
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 stanza_ids: vec![filter_id("sid-missing")],
                 ..Default::default()
@@ -320,6 +323,7 @@ async fn stanza_id_filter_preserves_rich_payload_roundtrip() {
     let result = store
         .query_messages(
             &archive,
+            MamArchiveKind::Room,
             &MamQuery {
                 stanza_ids: vec![filter_id("archive-rich-1")],
                 ..Default::default()

--- a/server/crates/waddle-xmpp/tests/xep0201_thread_parent.rs
+++ b/server/crates/waddle-xmpp/tests/xep0201_thread_parent.rs
@@ -20,7 +20,7 @@
 use chrono::Utc;
 use jid::{BareJid, Jid};
 use minidom::Element;
-use waddle_xmpp::mam::{ArchivedMessage, MamQuery, MamStorage};
+use waddle_xmpp::mam::{ArchivedMessage, MamArchiveKind, MamQuery, MamStorage};
 use waddle_xmpp::mam::{InMemoryMamStorage, SqlxMamStorage};
 use waddle_xmpp_core::mam::ThreadId;
 use waddle_xmpp_core::xep0201::{
@@ -98,7 +98,7 @@ async fn xep_0201_nested_thread_round_trips_through_mam() {
 
     let query = MamQuery::default();
     let result = storage
-        .query_messages(&room_bare(), &query)
+        .query_messages(&room_bare(), MamArchiveKind::Room, &query)
         .await
         .expect("query archive");
     assert_eq!(result.messages.len(), 1);
@@ -268,7 +268,7 @@ async fn xep_0201_cross_archive_parent_thread_id_round_trips_without_validation(
         .expect("store row");
 
     let result = storage
-        .query_messages(&room_bare(), &MamQuery::default())
+        .query_messages(&room_bare(), MamArchiveKind::Room, &MamQuery::default())
         .await
         .expect("query");
     assert_eq!(result.messages.len(), 1);
@@ -339,7 +339,7 @@ async fn xep_0201_inmemory_mam_storage_also_round_trips_parent() {
         .await
         .expect("store in-memory");
     let result = storage
-        .query_messages(&room_bare(), &MamQuery::default())
+        .query_messages(&room_bare(), MamArchiveKind::Room, &MamQuery::default())
         .await
         .expect("query in-memory");
     assert_eq!(result.messages.len(), 1);
@@ -382,7 +382,7 @@ async fn xep_0201_collapsed_thread_field_round_trips_nested_through_storage() {
         .expect("store row");
 
     let result = storage
-        .query_messages(&room_bare(), &MamQuery::default())
+        .query_messages(&room_bare(), MamArchiveKind::Room, &MamQuery::default())
         .await
         .expect("query");
     assert_eq!(result.messages.len(), 1);
@@ -411,7 +411,7 @@ async fn xep_0201_collapsed_thread_field_round_trips_root_only_through_storage()
         .expect("store row");
 
     let result = storage
-        .query_messages(&room_bare(), &MamQuery::default())
+        .query_messages(&room_bare(), MamArchiveKind::Room, &MamQuery::default())
         .await
         .expect("query");
     assert_eq!(result.messages.len(), 1);
@@ -458,7 +458,7 @@ async fn xep_0201_collapsed_thread_field_round_trips_no_thread_through_storage()
         .expect("store row");
 
     let result = storage
-        .query_messages(&room_bare(), &MamQuery::default())
+        .query_messages(&room_bare(), MamArchiveKind::Room, &MamQuery::default())
         .await
         .expect("query");
     assert_eq!(result.messages.len(), 1);

--- a/server/crates/waddle-xmpp/tests/xep0313_mam.rs
+++ b/server/crates/waddle-xmpp/tests/xep0313_mam.rs
@@ -19,7 +19,7 @@ fn muc_room_disco_advertises_mam_extended_for_supported_id_filters() {
 }
 
 /// XEP-0313 §4.3.1: querying a personal archive with `with` equal to
-/// the archive owner (bare or full) is a self-chat query. Both archived
+/// the archive owner's bare JID is a self-chat query. Both archived
 /// endpoints must match the owner's bare JID; ordinary contacts and
 /// unrelated rows must not leak into the result set or its RSM count.
 #[tokio::test]
@@ -66,7 +66,7 @@ async fn owner_with_filters_self_chat_before_rsm_pagination() {
             &archive,
             MamArchiveKind::Personal,
             &MamQuery {
-                with: Some("juliet@example.com/query-device".parse().unwrap()),
+                with: Some("juliet@example.com".parse().unwrap()),
                 max: Some(1),
                 ..Default::default()
             },
@@ -82,7 +82,7 @@ async fn owner_with_filters_self_chat_before_rsm_pagination() {
             &archive,
             MamArchiveKind::Personal,
             &MamQuery {
-                with: Some("juliet@example.com/query-device".parse().unwrap()),
+                with: Some("juliet@example.com".parse().unwrap()),
                 after_id: first.last_id,
                 max: Some(1),
                 ..Default::default()
@@ -99,7 +99,7 @@ async fn owner_with_filters_self_chat_before_rsm_pagination() {
             &archive,
             MamArchiveKind::Personal,
             &MamQuery {
-                with: Some("juliet@example.com/query-device".parse().unwrap()),
+                with: Some("juliet@example.com".parse().unwrap()),
                 after_id: second.last_id,
                 max: Some(1),
                 ..Default::default()

--- a/server/crates/waddle-xmpp/tests/xep0313_mam.rs
+++ b/server/crates/waddle-xmpp/tests/xep0313_mam.rs
@@ -1,4 +1,6 @@
 use waddle_xmpp::disco::info::{muc_room_features, server_features, Feature};
+use waddle_xmpp::mam::{InMemoryMamStorage, MamArchiveKind, MamStorage};
+use waddle_xmpp_core::mam::{ArchivedMessage, MamQuery};
 
 #[test]
 fn server_root_disco_does_not_advertise_a_domain_archive() {
@@ -14,6 +16,193 @@ fn muc_room_disco_advertises_mam_extended_for_supported_id_filters() {
 
     assert!(features.contains(&Feature::mam()));
     assert!(features.contains(&Feature::mam_extended()));
+}
+
+/// XEP-0313 §4.3.1: querying a personal archive with `with` equal to
+/// the archive owner (bare or full) is a self-chat query. Both archived
+/// endpoints must match the owner's bare JID; ordinary contacts and
+/// unrelated rows must not leak into the result set or its RSM count.
+#[tokio::test]
+async fn owner_with_filters_self_chat_before_rsm_pagination() {
+    let storage = InMemoryMamStorage::new();
+    let archive: BareJid = "juliet@example.com".parse().unwrap();
+
+    for (id, from, to) in [
+        (
+            "self-one",
+            "juliet@example.com/balcony",
+            "juliet@example.com/chamber",
+        ),
+        (
+            "ordinary-contact",
+            "romeo@example.com/phone",
+            "juliet@example.com/chamber",
+        ),
+        (
+            "self-two",
+            "juliet@example.com/tablet",
+            "juliet@example.com",
+        ),
+        (
+            "unrelated",
+            "mercutio@example.com/phone",
+            "benvolio@example.com/tablet",
+        ),
+    ] {
+        storage
+            .store_message(
+                &archive,
+                &ArchivedMessage {
+                    id: id.to_string(),
+                    ..ArchivedMessage::for_test(from.parse().unwrap(), to.parse().unwrap())
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    let first = storage
+        .query_messages(
+            &archive,
+            MamArchiveKind::Personal,
+            &MamQuery {
+                with: Some("juliet@example.com/query-device".parse().unwrap()),
+                max: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.messages[0].id, "self-one");
+    assert_eq!(first.count, Some(2));
+    assert!(!first.complete);
+
+    let second = storage
+        .query_messages(
+            &archive,
+            MamArchiveKind::Personal,
+            &MamQuery {
+                with: Some("juliet@example.com/query-device".parse().unwrap()),
+                after_id: first.last_id,
+                max: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.messages[0].id, "self-two");
+    assert_eq!(second.count, Some(2));
+    assert!(second.complete);
+
+    let empty = storage
+        .query_messages(
+            &archive,
+            MamArchiveKind::Personal,
+            &MamQuery {
+                with: Some("juliet@example.com/query-device".parse().unwrap()),
+                after_id: second.last_id,
+                max: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert!(empty.messages.is_empty());
+    assert_eq!(empty.count, Some(2));
+    assert!(empty.complete);
+}
+
+/// XEP-0313 §4.3.1 ordinary `with` semantics still apply to room
+/// archives. A full occupant JID is an exact publisher filter; it is
+/// not the personal-archive owner-self special case merely because its
+/// bare form equals the archive JID.
+#[tokio::test]
+async fn room_archive_full_occupant_with_is_exact_before_rsm_pagination() {
+    let storage = InMemoryMamStorage::new();
+    let room: BareJid = "room@example.com".parse().unwrap();
+    let room_jid: Jid = "room@example.com".parse().unwrap();
+    let alice: Jid = "room@example.com/alice".parse().unwrap();
+    let base = chrono::DateTime::parse_from_rfc3339("2026-07-02T12:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+
+    for (id, seconds, from) in [
+        ("alice-one", 0, alice.clone()),
+        ("bob-one", 1, "room@example.com/bob".parse().unwrap()),
+        ("alice-two", 2, alice.clone()),
+    ] {
+        storage
+            .store_message(
+                &room,
+                &ArchivedMessage {
+                    id: id.to_string(),
+                    timestamp: base + chrono::Duration::seconds(seconds),
+                    ..ArchivedMessage::for_test(from, room_jid.clone())
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    let first = storage
+        .query_messages(
+            &room,
+            MamArchiveKind::Room,
+            &MamQuery {
+                with: Some(alice.clone()),
+                max: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(first.messages[0].id, "alice-one");
+    assert_eq!(first.count, Some(2));
+    assert!(!first.complete);
+
+    let second = storage
+        .query_messages(
+            &room,
+            MamArchiveKind::Room,
+            &MamQuery {
+                with: Some(alice),
+                after_id: first.last_id,
+                max: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(second.messages[0].id, "alice-two");
+    assert_eq!(second.count, Some(2));
+    assert!(second.complete);
+
+    let bare_room = storage
+        .query_messages(
+            &room,
+            MamArchiveKind::Room,
+            &MamQuery {
+                with: Some(room_jid),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(bare_room.messages.len(), 3);
+
+    let empty = storage
+        .query_messages(
+            &room,
+            MamArchiveKind::Room,
+            &MamQuery {
+                with: Some("room@example.com/charlie".parse().unwrap()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    assert!(empty.messages.is_empty());
+    assert_eq!(empty.count, Some(0));
 }
 
 // ── §Security "Sender Impersonation" + "MUC message spoofing" +


### PR DESCRIPTION
## Outcome

XEP-0313 `with=self` now applies the required endpoint intersection only to personal archives. Room archives retain occupant-exact semantics, so `room/alice` cannot page `room/bob`, while bare-room queries still cover the room archive.

## Implementation

1. Add mandatory typed `MamArchiveKind::{Personal, Room}` to the MAM storage query contract and propagate it through runtime routes, extension targets, protocol events, mocks, and tests.
2. Apply `with=owner` as `from == owner AND to == owner` only when the supplied owner JID is bare; a full owner/resource remains an exact ordinary endpoint filter.
3. Preserve ordinary room filtering: full occupant JIDs match exactly on either endpoint; a bare room matches its resource-qualified occupants.
4. Keep InMemory, SQLite, and PostgreSQL on the same classified filter semantics.
5. Carry archive kind through `LookupArchivedMessage` instead of hardcoding Personal.
6. Resolve sender-owned origin targets through one bounded indexed storage query instead of scanning MAM pages; explicit origin IDs outrank legacy wire-ID fallback collisions.
7. Carry typed sender identity through rich-target events: personal archives compare bare accounts, while room archives compare the exact full occupant.
8. Add the missing stanza-ID archive index and reuse the bounded lookup for direct-correction target resolution.
9. Store in-memory archive keys as typed `BareJid` values so archive identity never round-trips through strings outside the SQL adapter.

## Verification

- `waddle-xmpp` library: 2,397 tests passed.
- Dedicated XEP-0313 suite: 7 passed; server XEP-0313 integration: 15 passed.
- Interpreter module: 77 passed; MAM storage module: 54 passed.
- InMemory and SQLite regressions cover owner-self parity, full-owner-resource exactness, Alice/Bob room isolation, counts, two RSM pages, bare-room queries, explicit-origin precedence, exact room-occupant lookup, empty results, and targets beyond 100 decoys.
- Full all-target/all-feature clippy with `-D warnings`, cargo check, cargo fmt, and diff checks passed.
- Repeated adversarial passes found and verified archive-kind, typed-boundary, first-page lookup, bounded-lookup precedence, full-owner, and room-occupant fixes; final review reported no actionable issues.

## Known gaps

- PostgreSQL uses the shared compiled SQL path but was not executed against a live PostgreSQL service locally.

Closes #1290. Child of #1279. Relates #1173 and #210.

## Merge gate

Do not merge until CI is green, Greptile and Qodo have reviewed the final head SHA with zero actionable findings, and all review threads are resolved.

## Lore commit record

Constraint: A bare archive JID cannot determine whether storage represents a personal or room archive.

Rejected: Infer archive kind from JID domains | custom services and user domains make that heuristic unsound.

Rejected: Page through MAM until a correction target is found | archive validation work would grow with archive size.

Rejected: Bare-fold room senders | sibling occupants can choose colliding origin IDs and redirect rich-target resolution.

Confidence: high

Scope-risk: moderate

Reversibility: clean

Directive: Propagate `MamArchiveKind` across every query/event boundary; explicit origin IDs outrank wire-ID fallback, personal senders are bare-scoped, and room senders are exact full-occupant scoped.

Tested: waddle-xmpp 2397; XEP-0313 7; server XEP-0313 15; interpreter 77; MAM storage 54; InMemory/SQLite bounded lookup and archive-filter parity; all-target/all-feature clippy -D warnings; cargo fmt; git diff --check.

Not-tested: Live PostgreSQL execution; its shared SQL path compiled and clippied.
