### PR TITLE
fix(xmpp): reject duplicate capability form types

### DIFF
--- a/server/crates/waddle-server/tests/xep0115_caps_ws.rs
+++ b/server/crates/waddle-server/tests/xep0115_caps_ws.rs
@@ -23,9 +23,11 @@
 
 use waddle_ws_test_support as ws_common;
 
+use jid::FullJid;
 use std::time::Duration;
 use tokio::sync::Mutex;
 use ws_common::{extract_attr_after, TestServer, WsXmppClient};
+use xmpp_parsers::minidom::Element;
 
 const DOMAIN: &str = "localhost";
 const ADMIN: &str = "admin";
@@ -33,6 +35,12 @@ static TEST_SERIAL: Mutex<()> = Mutex::const_new(());
 
 const NS_CAPS: &str = "http://jabber.org/protocol/caps";
 const NS_DISCO_INFO: &str = "http://jabber.org/protocol/disco#info";
+
+fn element_to_xml(element: Element) -> String {
+    let mut bytes = Vec::new();
+    element.write_to(&mut bytes).expect("serialize element");
+    String::from_utf8(bytes).expect("serializer emits utf-8")
+}
 
 async fn admin_client(server: &TestServer, resource: &str) -> WsXmppClient {
     let password = server.fixed_account_password().to_string();
@@ -135,7 +143,6 @@ fn caps_verification_string_with_forms(
 ) -> String {
     use waddle_xmpp::disco::info::{Feature, Identity};
     use waddle_xmpp::xep::xep0115::compute_caps_hash_with_extensions;
-    use xmpp_parsers::minidom::Element;
 
     let identities = vec![Identity::new("client", "pc", Some(identity_name))];
     let features: Vec<Feature> = features
@@ -144,34 +151,94 @@ fn caps_verification_string_with_forms(
         .collect();
     let extensions = forms
         .iter()
-        .map(|(form_type, software)| {
-            Element::builder("x", "jabber:x:data")
-                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
-                .append(
-                    Element::builder("field", "jabber:x:data")
-                        .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
-                        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
-                        .append(
-                            Element::builder("value", "jabber:x:data")
-                                .append(*form_type)
-                                .build(),
-                        )
-                        .build(),
-                )
-                .append(
-                    Element::builder("field", "jabber:x:data")
-                        .attr(minidom::rxml::xml_ncname!("var").to_owned(), "software")
-                        .append(
-                            Element::builder("value", "jabber:x:data")
-                                .append(*software)
-                                .build(),
-                        )
-                        .build(),
-                )
-                .build()
-        })
+        .map(|(form_type, software)| caps_data_form(form_type, software))
         .collect::<Vec<_>>();
     compute_caps_hash_with_extensions(&identities, &features, &extensions)
+}
+
+fn caps_data_form(form_type: &str, software: &str) -> Element {
+    Element::builder("x", "jabber:x:data")
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+        .append(
+            Element::builder("field", "jabber:x:data")
+                .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
+                .append(
+                    Element::builder("value", "jabber:x:data")
+                        .append(form_type)
+                        .build(),
+                )
+                .build(),
+        )
+        .append(
+            Element::builder("field", "jabber:x:data")
+                .attr(minidom::rxml::xml_ncname!("var").to_owned(), "software")
+                .append(
+                    Element::builder("value", "jabber:x:data")
+                        .append(software)
+                        .build(),
+                )
+                .build(),
+        )
+        .build()
+}
+
+fn caps_presence_xml(node: &str, ver: &str) -> String {
+    use waddle_xmpp::xep::xep0115::Caps;
+
+    element_to_xml(
+        Element::builder("presence", "jabber:client")
+            .append(Caps::new(node, ver).build_element())
+            .build(),
+    )
+}
+
+fn caps_disco_result_xml(
+    iq_id: &str,
+    from: &FullJid,
+    node: &str,
+    ver: &str,
+    identity_name: &str,
+    features: &[&str],
+    forms: &[(&str, &str)],
+) -> String {
+    use waddle_xmpp::xep::xep0115::Caps;
+
+    let caps = Caps::new(node, ver);
+    let mut query = Element::builder("query", NS_DISCO_INFO)
+        .attr(
+            minidom::rxml::xml_ncname!("node").to_owned(),
+            caps.node_ver(),
+        )
+        .append(
+            Element::builder("identity", NS_DISCO_INFO)
+                .attr(minidom::rxml::xml_ncname!("category").to_owned(), "client")
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "pc")
+                .attr(minidom::rxml::xml_ncname!("name").to_owned(), identity_name)
+                .build(),
+        );
+    for feature in features {
+        query = query.append(
+            Element::builder("feature", NS_DISCO_INFO)
+                .attr(minidom::rxml::xml_ncname!("var").to_owned(), *feature)
+                .build(),
+        );
+    }
+    for (form_type, software) in forms {
+        query = query.append(caps_data_form(form_type, software));
+    }
+
+    element_to_xml(
+        Element::builder("iq", "jabber:client")
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), iq_id)
+            .attr(
+                minidom::rxml::xml_ncname!("from").to_owned(),
+                from.to_string(),
+            )
+            .append(query.build())
+            .build(),
+    )
 }
 
 /// Send a ping IQ and wait for its result. Used as a deterministic
@@ -1061,7 +1128,12 @@ async fn caps_duplicate_form_types_across_forms_are_ill_formed_and_not_cached() 
     let _serial = TEST_SERIAL.lock().await;
     let server = TestServer::start();
     let mut admin = admin_client(&server, "caps-duplicate-forms-1").await;
-    let admin_full_jid = admin.full_jid.clone().expect("full jid");
+    let admin_full_jid: FullJid = admin
+        .full_jid
+        .as_deref()
+        .expect("full jid")
+        .parse()
+        .expect("typed full jid");
 
     let node = "https://example.test/caps#duplicate-forms";
     let identity_name = "Duplicate Form Client";
@@ -1071,9 +1143,7 @@ async fn caps_duplicate_form_types_across_forms_are_ill_formed_and_not_cached() 
     let ver = caps_verification_string_with_forms(identity_name, &features, &forms);
 
     admin
-        .send(&format!(
-            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
-        ))
+        .send(&caps_presence_xml(node, &ver))
         .await
         .expect("send caps presence");
     let disco_query = admin
@@ -1085,18 +1155,15 @@ async fn caps_duplicate_form_types_across_forms_are_ill_formed_and_not_cached() 
         .await
         .expect("server queries admin");
     let iq_id = extract_iq_id(&disco_query);
-    let forms_xml: String = forms
-        .iter()
-        .map(|(form_type, software)| {
-            format!(
-                r#"<x xmlns="jabber:x:data" type="result"><field var="FORM_TYPE" type="hidden"><value>{form_type}</value></field><field var="software"><value>{software}</value></field></x>"#
-            )
-        })
-        .collect();
-
     admin
-        .send(&format!(
-            r#"<iq xmlns="jabber:client" type="result" id="{iq_id}" from="{admin_full_jid}"><query xmlns="{NS_DISCO_INFO}" node="{node}#{ver}"><identity category="client" type="pc" name="{identity_name}"/><feature var="urn:xmpp:ping"/>{forms_xml}</query></iq>"#
+        .send(&caps_disco_result_xml(
+            &iq_id,
+            &admin_full_jid,
+            node,
+            &ver,
+            identity_name,
+            &features,
+            &forms,
         ))
         .await
         .expect("send duplicate-form response");
@@ -1104,9 +1171,7 @@ async fn caps_duplicate_form_types_across_forms_are_ill_formed_and_not_cached() 
 
     let mut admin2 = admin_client(&server, "caps-duplicate-forms-2").await;
     admin2
-        .send(&format!(
-            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
-        ))
+        .send(&caps_presence_xml(node, &ver))
         .await
         .expect("admin2 sends caps");
     let _re_query = admin2
@@ -1276,9 +1341,7 @@ fn roster_get_iq_xml(id: &str) -> String {
         .attr(attr("id"), id)
         .append(minidom::Element::builder("query", "jabber:iq:roster").build())
         .build();
-    let mut bytes = Vec::new();
-    element.write_to(&mut bytes).expect("serialize element");
-    String::from_utf8(bytes).expect("serializer emits utf-8")
+    element_to_xml(element)
 }
 
 /// XEP-0115 §1: caps describe the *generating entity*. Presence relayed to a

--- a/server/crates/waddle-server/tests/xep0115_caps_ws.rs
+++ b/server/crates/waddle-server/tests/xep0115_caps_ws.rs
@@ -14,6 +14,8 @@
 //!   and MUST NOT trigger resolution (§6.1 legacy format).
 //! - An ill-formed reply (duplicate feature var, §5.4 step 2.4) is
 //!   discarded whole and the next advert re-resolves.
+//! - Extension forms that repeat a FORM_TYPE are discarded and never
+//!   cached, even when the advertised hash matches the malformed set.
 //! - A reply arriving from a different resource than the one queried
 //!   is dropped and never cached.
 //! - Re-advertising the same `(hash, ver)` while a resolution is
@@ -124,6 +126,52 @@ fn caps_verification_string_with_softwareinfo_form(
         )
         .build();
     compute_caps_hash_with_extensions(&identities, &features, std::slice::from_ref(&form))
+}
+
+fn caps_verification_string_with_forms(
+    identity_name: &str,
+    features: &[&str],
+    forms: &[(&str, &str)],
+) -> String {
+    use waddle_xmpp::disco::info::{Feature, Identity};
+    use waddle_xmpp::xep::xep0115::compute_caps_hash_with_extensions;
+    use xmpp_parsers::minidom::Element;
+
+    let identities = vec![Identity::new("client", "pc", Some(identity_name))];
+    let features: Vec<Feature> = features
+        .iter()
+        .map(|feature| Feature::new(feature))
+        .collect();
+    let extensions = forms
+        .iter()
+        .map(|(form_type, software)| {
+            Element::builder("x", "jabber:x:data")
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+                .append(
+                    Element::builder("field", "jabber:x:data")
+                        .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+                        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden")
+                        .append(
+                            Element::builder("value", "jabber:x:data")
+                                .append(*form_type)
+                                .build(),
+                        )
+                        .build(),
+                )
+                .append(
+                    Element::builder("field", "jabber:x:data")
+                        .attr(minidom::rxml::xml_ncname!("var").to_owned(), "software")
+                        .append(
+                            Element::builder("value", "jabber:x:data")
+                                .append(*software)
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build()
+        })
+        .collect::<Vec<_>>();
+    compute_caps_hash_with_extensions(&identities, &features, &extensions)
 }
 
 /// Send a ping IQ and wait for its result. Used as a deterministic
@@ -995,6 +1043,80 @@ async fn caps_duplicate_feature_reply_is_ill_formed_and_not_cached() {
         })
         .await
         .expect("ill-formed reply MUST NOT be cached; next advert MUST re-resolve (§5.4 step 2.4)");
+
+    let _ = admin.close().await;
+    let _ = admin2.close().await;
+}
+
+// ============================================================================
+// Test 10b — duplicate FORM_TYPE values across forms are not cached
+// ============================================================================
+//
+// XEP-0115 §5.4: two extended discovery forms with the same
+// FORM_TYPE make the entire response ill-formed. The advertised hash
+// deliberately matches the malformed form set, proving rejection is
+// a structural check rather than an incidental hash mismatch.
+#[tokio::test]
+async fn caps_duplicate_form_types_across_forms_are_ill_formed_and_not_cached() {
+    let _serial = TEST_SERIAL.lock().await;
+    let server = TestServer::start();
+    let mut admin = admin_client(&server, "caps-duplicate-forms-1").await;
+    let admin_full_jid = admin.full_jid.clone().expect("full jid");
+
+    let node = "https://example.test/caps#duplicate-forms";
+    let identity_name = "Duplicate Form Client";
+    let features = ["urn:xmpp:ping"];
+    let form_type = "urn:xmpp:dataforms:softwareinfo";
+    let forms = [(form_type, "Client A"), (form_type, "Client B")];
+    let ver = caps_verification_string_with_forms(identity_name, &features, &forms);
+
+    admin
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("send caps presence");
+    let disco_query = admin
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type='get'"#)
+                && frame.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("server queries admin");
+    let iq_id = extract_iq_id(&disco_query);
+    let forms_xml: String = forms
+        .iter()
+        .map(|(form_type, software)| {
+            format!(
+                r#"<x xmlns="jabber:x:data" type="result"><field var="FORM_TYPE" type="hidden"><value>{form_type}</value></field><field var="software"><value>{software}</value></field></x>"#
+            )
+        })
+        .collect();
+
+    admin
+        .send(&format!(
+            r#"<iq xmlns="jabber:client" type="result" id="{iq_id}" from="{admin_full_jid}"><query xmlns="{NS_DISCO_INFO}" node="{node}#{ver}"><identity category="client" type="pc" name="{identity_name}"/><feature var="urn:xmpp:ping"/>{forms_xml}</query></iq>"#
+        ))
+        .await
+        .expect("send duplicate-form response");
+    ping_anchor(&mut admin, "caps-duplicate-forms-anchor-1").await;
+
+    let mut admin2 = admin_client(&server, "caps-duplicate-forms-2").await;
+    admin2
+        .send(&format!(
+            r#"<presence xmlns="jabber:client"><c xmlns="{NS_CAPS}" hash="sha-1" node="{node}" ver="{ver}"/></presence>"#
+        ))
+        .await
+        .expect("admin2 sends caps");
+    let _re_query = admin2
+        .recv_matching(|frame| {
+            frame.contains("<iq")
+                && frame.contains(r#"type='get'"#)
+                && frame.contains(NS_DISCO_INFO)
+        })
+        .await
+        .expect("duplicate FORM_TYPE response MUST NOT be cached; next advert must re-resolve");
 
     let _ = admin.close().await;
     let _ = admin2.close().await;

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -311,6 +311,7 @@ fn caps_form_type(form: &Element) -> Option<String> {
         .children()
         .find(|child| child.name() == "value" && child.ns() == NS_DATA_FORMS)
         .map(Element::text)
+        .filter(|value| !value.trim().is_empty())
 }
 
 /// Build a disco#info response IQ.

--- a/server/crates/waddle-xmpp-core/src/disco/info.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info.rs
@@ -160,7 +160,8 @@ const NS_DATA_FORMS: &str = "jabber:x:data";
 ///
 /// `ill_formed` is true when the response violates one of XEP-0115
 /// §5.4 step 2.4's well-formedness rules — duplicate identities,
-/// duplicate features, or multi-FORM_TYPE extension forms. The
+/// duplicate features, multi-FORM_TYPE extension forms, or repeated
+/// FORM_TYPE values across extension forms. The
 /// parser still surfaces what it could read so callers can log
 /// diagnostics, but XEP-0115 verification MUST treat such a reply
 /// as invalid (do not cache).
@@ -194,6 +195,7 @@ pub fn parse_disco_info_response(query: &Element) -> Result<DiscoInfoResponse, C
     let mut seen_identities: std::collections::HashSet<(String, String, String, String)> =
         std::collections::HashSet::new();
     let mut seen_features: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut seen_form_types: std::collections::HashSet<String> = std::collections::HashSet::new();
     let mut ill_formed = false;
 
     for child in query.children() {
@@ -246,6 +248,10 @@ pub fn parse_disco_info_response(query: &Element) -> Result<DiscoInfoResponse, C
             ("x", NS_DATA_FORMS) => {
                 if has_multiple_form_types(child) {
                     ill_formed = true;
+                } else if let Some(form_type) = caps_form_type(child) {
+                    if !seen_form_types.insert(form_type) {
+                        ill_formed = true;
+                    }
                 }
                 extensions.push(child.clone());
             }
@@ -282,6 +288,29 @@ fn has_multiple_form_types(form: &Element) -> bool {
         }
     }
     form_type_fields > 1 || form_type_values > 1
+}
+
+/// Return the FORM_TYPE used by a well-formed XEP-0128 result form.
+/// Forms with an absent, non-hidden, or valueless FORM_TYPE do not
+/// participate in XEP-0115 verification and are ignored per §5.4.
+fn caps_form_type(form: &Element) -> Option<String> {
+    if form.attr("type") != Some("result") {
+        return None;
+    }
+
+    let field = form.children().find(|child| {
+        child.name() == "field"
+            && child.ns() == NS_DATA_FORMS
+            && child.attr("var") == Some("FORM_TYPE")
+    })?;
+    if field.attr("type") != Some("hidden") {
+        return None;
+    }
+
+    field
+        .children()
+        .find(|child| child.name() == "value" && child.ns() == NS_DATA_FORMS)
+        .map(Element::text)
 }
 
 /// Build a disco#info response IQ.

--- a/server/crates/waddle-xmpp-core/src/disco/info/tests.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info/tests.rs
@@ -171,6 +171,21 @@ fn test_parse_disco_info_response_accepts_distinct_form_types() {
 }
 
 #[test]
+fn test_parse_disco_info_response_ignores_repeated_empty_form_types() {
+    let query = Element::builder("query", DISCO_INFO_NS)
+        .append(result_form(""))
+        .append(result_form("   "))
+        .build();
+
+    let parsed = parse_disco_info_response(&query).expect("parseable response");
+
+    assert!(
+        !parsed.ill_formed,
+        "valueless FORM_TYPE fields do not participate in duplicate detection"
+    );
+}
+
+#[test]
 fn test_parse_disco_info_response_retains_within_form_rejection() {
     let duplicate_fields = Element::builder("x", NS_DATA_FORMS)
         .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")

--- a/server/crates/waddle-xmpp-core/src/disco/info/tests.rs
+++ b/server/crates/waddle-xmpp-core/src/disco/info/tests.rs
@@ -1,5 +1,26 @@
 use super::*;
 
+fn form_type_field(values: &[&str]) -> Element {
+    let mut field = Element::builder("field", NS_DATA_FORMS)
+        .attr(minidom::rxml::xml_ncname!("var").to_owned(), "FORM_TYPE")
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "hidden");
+    for value in values {
+        field = field.append(
+            Element::builder("value", NS_DATA_FORMS)
+                .append(*value)
+                .build(),
+        );
+    }
+    field.build()
+}
+
+fn result_form(form_type: &str) -> Element {
+    Element::builder("x", NS_DATA_FORMS)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+        .append(form_type_field(&[form_type]))
+        .build()
+}
+
 #[test]
 fn test_is_disco_info_query() {
     let query_elem = Element::builder("query", DISCO_INFO_NS).build();
@@ -118,6 +139,59 @@ fn test_build_disco_info_response_dedupes_features_and_identities() {
         ],
         "first occurrence wins; order preserved"
     );
+}
+
+#[test]
+fn test_parse_disco_info_response_rejects_duplicate_form_types_across_forms() {
+    let form_type = "urn:xmpp:dataforms:softwareinfo";
+    let query = Element::builder("query", DISCO_INFO_NS)
+        .append(result_form(form_type))
+        .append(result_form(form_type))
+        .build();
+
+    let parsed = parse_disco_info_response(&query).expect("parseable response");
+
+    assert!(
+        parsed.ill_formed,
+        "XEP-0115 §5.4 requires duplicate FORM_TYPE values across forms to invalidate the response"
+    );
+}
+
+#[test]
+fn test_parse_disco_info_response_accepts_distinct_form_types() {
+    let query = Element::builder("query", DISCO_INFO_NS)
+        .append(result_form("urn:xmpp:dataforms:softwareinfo"))
+        .append(result_form("urn:xmpp:dataforms:clientinfo"))
+        .build();
+
+    let parsed = parse_disco_info_response(&query).expect("parseable response");
+
+    assert!(!parsed.ill_formed);
+    assert_eq!(parsed.extensions.len(), 2);
+}
+
+#[test]
+fn test_parse_disco_info_response_retains_within_form_rejection() {
+    let duplicate_fields = Element::builder("x", NS_DATA_FORMS)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+        .append(form_type_field(&["urn:xmpp:dataforms:first"]))
+        .append(form_type_field(&["urn:xmpp:dataforms:second"]))
+        .build();
+    let duplicate_values = Element::builder("x", NS_DATA_FORMS)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+        .append(form_type_field(&[
+            "urn:xmpp:dataforms:first",
+            "urn:xmpp:dataforms:second",
+        ]))
+        .build();
+
+    for malformed_form in [duplicate_fields, duplicate_values] {
+        let query = Element::builder("query", DISCO_INFO_NS)
+            .append(malformed_form)
+            .build();
+        let parsed = parse_disco_info_response(&query).expect("parseable response");
+        assert!(parsed.ill_formed);
+    }
 }
 
 #[test]

--- a/server/crates/waddle-xmpp/src/xep/xep0115.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0115.rs
@@ -436,7 +436,10 @@ fn parse_caps_data_form(extension: &Element) -> Option<CapsDataForm> {
             }
 
             if field.attr("type") == Some("hidden") {
-                form_type = values.first().cloned();
+                form_type = values
+                    .first()
+                    .filter(|value| !value.trim().is_empty())
+                    .cloned();
             }
             continue;
         }

--- a/server/crates/waddle-xmpp/src/xep/xep0115/tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0115/tests.rs
@@ -473,6 +473,33 @@ fn test_compute_caps_hash_with_extensions_complex_example() {
 }
 
 #[test]
+fn test_compute_caps_hash_with_distinct_forms_is_order_independent() {
+    let identities = vec![Identity::server(Some("Waddle"))];
+    let features = vec![Feature::disco_info()];
+    let software_info = software_info_form();
+    let client_info = Element::builder("x", DATA_FORMS_NS)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+        .append(data_form_field(
+            FORM_TYPE_FIELD,
+            Some("hidden"),
+            &["urn:xmpp:dataforms:clientinfo"],
+        ))
+        .append(data_form_field("client", None, &["Waddle Web"]))
+        .build();
+
+    let forward = compute_caps_hash_with_extensions(
+        &identities,
+        &features,
+        &[software_info.clone(), client_info.clone()],
+    );
+    let reverse =
+        compute_caps_hash_with_extensions(&identities, &features, &[client_info, software_info]);
+
+    assert_eq!(forward, reverse);
+    assert_ne!(forward, compute_caps_hash(&identities, &features));
+}
+
+#[test]
 fn test_compute_caps_hash_ignores_non_result_forms() {
     let identities = vec![Identity::server(Some("Waddle"))];
     let features = vec![Feature::disco_info(), Feature::disco_items()];

--- a/server/crates/waddle-xmpp/src/xep/xep0115/tests.rs
+++ b/server/crates/waddle-xmpp/src/xep/xep0115/tests.rs
@@ -115,6 +115,14 @@ fn software_info_form_with_empty_value_field() -> Element {
         .build()
 }
 
+fn form_with_empty_form_type() -> Element {
+    Element::builder("x", DATA_FORMS_NS)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+        .append(data_form_field(FORM_TYPE_FIELD, Some("hidden"), &[" "]))
+        .append(data_form_field("software", None, &["Psi"]))
+        .build()
+}
+
 fn software_info_form_with_duplicate_form_type() -> Element {
     Element::builder("x", DATA_FORMS_NS)
         .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
@@ -563,6 +571,18 @@ fn test_compute_caps_hash_ignores_forms_with_duplicate_form_type_fields() {
     let extensions = vec![software_info_form_with_duplicate_form_type()];
 
     let hash = compute_caps_hash_with_extensions(&identities, &features, &extensions);
+    assert_eq!(hash, baseline);
+}
+
+#[test]
+fn test_compute_caps_hash_ignores_form_with_empty_form_type() {
+    let identities = vec![Identity::server(Some("Waddle"))];
+    let features = vec![Feature::disco_info(), Feature::disco_items()];
+    let baseline = compute_caps_hash(&identities, &features);
+
+    let hash =
+        compute_caps_hash_with_extensions(&identities, &features, &[form_with_empty_form_type()]);
+
     assert_eq!(hash, baseline);
 }
 


### PR DESCRIPTION
Closes #1291

## Plan

1. Review XEP-0115 §5.4 and map the existing typed capability-form parser, verification hash, and cache boundary.
2. Add dedicated XEP-0115 regressions for duplicate FORM_TYPE values across forms, existing within-form invalidity, distinct valid forms, and cache refusal.
3. Reject repeated FORM_TYPE values across the full disco response without changing valid canonical hashing.
4. Run the focused and full Rust verification suites, clippy with warnings denied, formatting, and diff checks.

## Status

Implemented and independently adversarially reviewed with no remaining actionable findings.

## Implementation

- Track valid XEP-0128 result-form `FORM_TYPE` values across the full disco#info response.
- Mark the response ill-formed when a later form repeats a value, preventing hash verification and cache insertion.
- Preserve rejection of multiple FORM_TYPE fields/values inside one form.
- Preserve deterministic hashing for multiple forms with distinct FORM_TYPE values.
- Ignore absent, empty, and whitespace-only FORM_TYPE values in both duplicate tracking and verification-string hashing.
- Build the malformed WebSocket regression entirely through typed/minidom XML builders; one form builder supplies both the advertised hash input and serialized wire payload.

## Verification

- Focused core disco suite — 20 passed, including repeated empty FORM_TYPE handling.
- `cargo test -p waddle-xmpp` — full package and dedicated XEP test matrix passed.
- `cargo test -p waddle-server --test xep0115_caps_ws` — 15 passed, including cache refusal when the advertised hash matches the malformed duplicate-form set.
- `cargo clippy -p waddle-server --test xep0115_caps_ws -- -D warnings` — passed after the typed XML review fix.
- `cargo clippy -p waddle-xmpp-core --all-targets --all-features -- -D warnings` — passed.
- `cargo clippy -p waddle-xmpp -p waddle-server --all-targets --all-features -- -D warnings` — passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.
- XEP-0115 hash unit suite — 41 passed, including empty FORM_TYPE exclusion.
- The initial independent review was clean; Qodo then identified the empty-value edge case, which is fixed at the current head and requires final-head review again.

## XEP review

Reviewed local `xeps/xep-0115.xml` §5.4. It requires the entire response to be treated as ill-formed when more than one extended service-discovery form uses the same FORM_TYPE.

## Merge gate

Do not merge until CI is green, Greptile and Qodo have reviewed the final head SHA with zero actionable findings, and all review threads are resolved.

## Lore commit record

Constraint: XEP-0115 §5.4 makes duplicate FORM_TYPE values across extended disco forms invalidate the entire capability response.

Rejected: Deduplicate forms before hashing | that would accept a response the XEP requires clients to reject.

Confidence: high

Scope-risk: narrow

Reversibility: clean

Directive: Detect duplicate non-empty valid FORM_TYPE values across the full response before computing or caching a capability hash; empty and malformed forms must never enter canonical hashing.

Tested: Core disco 20; XEP-0115 hash unit 41; XEP-0115 WebSocket 15; all-target/all-feature clippy -D warnings; cargo fmt; git diff --check; final-head external review pending.

Not-tested: Live interoperability against a third-party entity emitting malformed duplicate forms.
