### PR TITLE
fix(server): reconcile dead-node room and SM claims exactly

### DIFF
--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -3387,12 +3387,13 @@ async fn run_delete(state: &AppState, args: &ChannelsDeleteArgs) -> Result<(), A
             waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::Destroyed
             | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::NotRegistered,
         ) => None,
-        Ok(waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed) => {
-            Some(internal_err(format!(
-                "room destroy refused for {}: durable room-state wipe failed",
-                args.channel_jid
-            )))
-        }
+        Ok(
+            waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed
+            | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ReleaseBacklogFull,
+        ) => Some(internal_err(format!(
+            "room destroy refused for {}: durable room-state wipe failed",
+            args.channel_jid
+        ))),
         Err(error) => Some(send_err("room_registry ask DestroyRoom")(error)),
     };
     if let Some(error) = failure {

--- a/server/crates/waddle-server/src/admin/spaces.rs
+++ b/server/crates/waddle-server/src/admin/spaces.rs
@@ -1315,11 +1315,12 @@ async fn run_delete(state: &AppState, args: &SpacesDeleteArgs) -> Result<(), Adm
                 waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::Destroyed
                 | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::NotRegistered,
             ) => None,
-            Ok(waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed) => {
-                Some(format!(
-                    "cascade destroy refused for room {room_jid}: durable room-state wipe failed"
-                ))
-            }
+            Ok(
+                waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed
+                | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ReleaseBacklogFull,
+            ) => Some(format!(
+                "cascade destroy refused for room {room_jid}: durable room-state wipe failed"
+            )),
             Err(error) => Some(format!(
                 "cascade destroy failed for room {room_jid}: {error}"
             )),

--- a/server/crates/waddle-server/src/clustering/claims.rs
+++ b/server/crates/waddle-server/src/clustering/claims.rs
@@ -1821,7 +1821,7 @@ impl NodeLeaseStore for PostgresClaimStore {
                 r#"
                 WITH fenced AS (
                     SELECT 1 FROM clustering_claims
-                    WHERE entity = ? AND node_id = ? AND claim_epoch = ?
+                    WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ?
                     FOR SHARE
                 )
                 DELETE FROM clustering_steal_intents
@@ -1831,6 +1831,7 @@ impl NodeLeaseStore for PostgresClaimStore {
                 crate::db_params![
                     entity_key(entity),
                     me.node_id.clone(),
+                    me.node_epoch.clone(),
                     mine.0,
                     entity_key(entity),
                 ],
@@ -2989,8 +2990,13 @@ mod tests {
         let mut fencing_tx = store.db.begin().await.expect("begin fencing tx");
         let held = fencing_tx
             .query(
-                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                crate::db_params![entity_key(&entity), owner.node_id.clone(), epoch0.0],
+                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
+                crate::db_params![
+                    entity_key(&entity),
+                    owner.node_id.clone(),
+                    owner.node_epoch.clone(),
+                    epoch0.0,
+                ],
             )
             .await
             .expect("fencing select")

--- a/server/crates/waddle-server/src/clustering/claims.rs
+++ b/server/crates/waddle-server/src/clustering/claims.rs
@@ -154,6 +154,9 @@ fn entity_key(entity: &Entity) -> String {
 fn decode_entity(encoded: &str, entity_type: EntityType) -> Option<Entity> {
     let prefix = format!("{}:", entity_type.as_db_str());
     let id = encoded.strip_prefix(&prefix)?;
+    if id.len() > waddle_xmpp::ownership::ENTITY_ID_MAX_LEN {
+        return None;
+    }
     Some(Entity::new(entity_type, id))
 }
 
@@ -233,9 +236,125 @@ pub struct PostgresClaimStore {
     db: Database,
 }
 
+struct OrphanedSmClaimCleanup {
+    encoded: String,
+    owner: NodeIdentity,
+    claim_epoch: ClaimEpoch,
+    durable_stream_id: Option<String>,
+    malformed: bool,
+}
+
 impl PostgresClaimStore {
     pub fn new(db: Database) -> Self {
         Self { db }
+    }
+
+    /// Remove one exact stale SM claim discovered by the advisory orphan
+    /// scan. A claim classified as claim-only is deleted only if its durable
+    /// row is still absent in this transaction. That current-state predicate
+    /// closes the scan/delete window in which a paused owner can finish a
+    /// fenced detach write before this DELETE obtains the claim-row lock.
+    async fn cleanup_orphaned_sm_claim(
+        &self,
+        cleanup: OrphanedSmClaimCleanup,
+    ) -> Result<bool, ClaimError> {
+        let mut tx = self.db.begin().await.map_err(db_err)?;
+        // Serialize with every fenced SM writer before evaluating durable-row
+        // absence. Under Postgres READ COMMITTED, putting `NOT EXISTS` in the
+        // same DELETE that waits on a writer's `FOR SHARE` lock is not enough:
+        // that statement's snapshot can predate the writer's commit. Taking
+        // the exact claim lock in this first statement makes the DELETE below
+        // start with a fresh statement snapshot after any in-flight writer has
+        // committed or rolled back.
+        let mut locked = tx
+            .query(
+                r#"
+                /* orphan_sm_cleanup_exact_lock */
+                SELECT 1 FROM clustering_claims
+                WHERE entity = ? AND entity_type = ? AND node_id = ? AND node_epoch = ?
+                  AND claim_epoch = ?
+                FOR UPDATE
+                "#,
+                crate::db_params![
+                    cleanup.encoded.clone(),
+                    EntityType::SmSession.as_db_str().to_string(),
+                    cleanup.owner.node_id.clone(),
+                    cleanup.owner.node_epoch.clone(),
+                    cleanup.claim_epoch.0,
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        let exact_claim_locked = locked.next().await.map_err(db_err)?.is_some();
+        drop(locked);
+        if !exact_claim_locked {
+            tx.commit().await.map_err(db_err)?;
+            return Ok(false);
+        }
+        let params = crate::db_params![
+            cleanup.encoded.clone(),
+            EntityType::SmSession.as_db_str().to_string(),
+            cleanup.owner.node_id,
+            cleanup.owner.node_epoch,
+            cleanup.claim_epoch.0,
+        ];
+        let affected = if cleanup.durable_stream_id.is_some() {
+            tx.execute(
+                r#"
+                DELETE FROM clustering_claims
+                WHERE entity = ? AND entity_type = ? AND node_id = ? AND node_epoch = ?
+                  AND claim_epoch = ?
+                  AND NOT EXISTS (
+                    SELECT 1 FROM clustering_nodes n
+                    WHERE n.node_id = clustering_claims.node_id
+                      AND NOT n.expired
+                      AND n.node_epoch = clustering_claims.node_epoch
+                  )
+                "#,
+                params,
+            )
+            .await
+            .map_err(db_err)?
+        } else {
+            tx.execute(
+                r#"
+                DELETE FROM clustering_claims
+                WHERE entity = ? AND entity_type = ? AND node_id = ? AND node_epoch = ?
+                  AND claim_epoch = ?
+                  AND NOT EXISTS (
+                    SELECT 1 FROM clustering_nodes n
+                    WHERE n.node_id = clustering_claims.node_id
+                      AND NOT n.expired
+                      AND n.node_epoch = clustering_claims.node_epoch
+                  )
+                  AND NOT EXISTS (
+                    SELECT 1 FROM sm_sessions s
+                    WHERE clustering_claims.entity = ('sm_session:' || s.stream_id)
+                  )
+                "#,
+                params,
+            )
+            .await
+            .map_err(db_err)?
+        };
+        if affected == 1 {
+            if let Some(stream_id) = cleanup.durable_stream_id {
+                tx.execute(
+                    "DELETE FROM sm_unacked WHERE stream_id = ?",
+                    crate::db_params![stream_id.clone()],
+                )
+                .await
+                .map_err(db_err)?;
+                tx.execute(
+                    "DELETE FROM sm_sessions WHERE stream_id = ?",
+                    crate::db_params![stream_id],
+                )
+                .await
+                .map_err(db_err)?;
+            }
+        }
+        tx.commit().await.map_err(db_err)?;
+        Ok(affected == 1 && cleanup.malformed)
     }
 }
 
@@ -309,6 +428,19 @@ impl ClaimStore for PostgresClaimStore {
             r#"
             CREATE INDEX IF NOT EXISTS clustering_claims_node_id_node_epoch
                 ON clustering_claims (node_id, node_epoch)
+            "#,
+            (),
+        )
+        .await
+        .map_err(db_err)?;
+        // Supports bounded per-entity-type orphan scans without walking the
+        // much larger mixed claim table (SM sessions dominate in modeled
+        // deployments). `entity` also satisfies the room scan's stable
+        // ordering before its LIMIT.
+        conn.execute(
+            r#"
+            CREATE INDEX IF NOT EXISTS clustering_claims_entity_type_entity
+                ON clustering_claims (entity_type, entity)
             "#,
             (),
         )
@@ -826,9 +958,14 @@ impl ClaimStore for PostgresClaimStore {
             .query(
                 r#"
                 SELECT 1 FROM clustering_claims
-                WHERE entity = ? AND node_id = ? AND claim_epoch = ?
+                WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ?
                 "#,
-                crate::db_params![entity_key(entity), me.node_id.clone(), mine.0],
+                crate::db_params![
+                    entity_key(entity),
+                    me.node_id.clone(),
+                    me.node_epoch.clone(),
+                    mine.0,
+                ],
             )
             .await
             .map_err(db_err)?;
@@ -842,10 +979,30 @@ impl ClaimStore for PostgresClaimStore {
         mine: ClaimEpoch,
     ) -> Result<(), ClaimError> {
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        // Epoch-gated release: best-effort. A claim already stolen out
-        // from under `me` (0 rows affected) is a no-op, not an error —
-        // graceful drain releases whatever it still owns and does not
-        // treat a lost race as a failure.
+        conn.execute(
+            r#"
+                DELETE FROM clustering_claims
+                WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ?
+                "#,
+            crate::db_params![
+                entity_key(entity),
+                me.node_id.clone(),
+                me.node_epoch.clone(),
+                mine.0,
+            ],
+        )
+        .await
+        .map_err(db_err)?;
+        Ok(())
+    }
+
+    async fn release_exact(
+        &self,
+        entity: &Entity,
+        me: &NodeIdentity,
+        mine: ClaimEpoch,
+    ) -> Result<waddle_xmpp::ownership::ExactReleaseOutcome, ClaimError> {
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
         let affected = conn
             .execute(
                 r#"
@@ -861,15 +1018,11 @@ impl ClaimStore for PostgresClaimStore {
             )
             .await
             .map_err(db_err)?;
-        if affected == 0 {
-            tracing::debug!(
-                entity = %entity.id,
-                node_id = %me.node_id,
-                claim_epoch = mine.0,
-                "release: claim already gone (stolen or already released)"
-            );
+        if affected == 1 {
+            Ok(waddle_xmpp::ownership::ExactReleaseOutcome::Released)
+        } else {
+            Ok(waddle_xmpp::ownership::ExactReleaseOutcome::NotOwned)
         }
-        Ok(())
     }
 
     async fn release_many(&self, entities: &[Entity], me: &NodeIdentity) -> Result<(), ClaimError> {
@@ -1155,10 +1308,9 @@ pub trait NodeLeaseStore: Send + Sync {
     /// candidate list only; the reaper's subsequent `expire` +
     /// `ClaimStore::steal_stale(OwnerStale)` calls are the actual
     /// authority, exactly like every other candidate-then-CAS pattern in
-    /// this store). Scoped to `sm_session` only: `UserActor`/`RoomActor`
-    /// claim acquisition is out of this slice's scope (see
-    /// `clustering::local_claims`'s module doc), so there is nothing of
-    /// either other type to scan for yet.
+    /// this store). Scoped to `sm_session` only because RoomActor recovery
+    /// has its own bounded scan/adoption path below, while UserActor claims
+    /// remain demand-created and carry no durable actor state to hydrate.
     ///
     /// A row whose `entity` key does not decode cleanly against its own
     /// `entity_type` column (the same data-integrity anomaly
@@ -1169,12 +1321,63 @@ pub trait NodeLeaseStore: Send + Sync {
         &self,
     ) -> Result<Vec<OrphanedSmSessionClaim>, ClaimError>;
 
+    /// Ordered, bounded cursor page used by the periodic orphan reaper. The
+    /// default keeps test/dummy stores source-compatible; durable stores
+    /// should override this so the bound is enforced by the query itself.
+    async fn list_orphaned_sm_session_claims_page(
+        &self,
+        after: Option<String>,
+        limit: usize,
+    ) -> Result<OrphanedSmSessionClaimPage, ClaimError> {
+        let mut candidates = self.list_orphaned_sm_session_claims().await?;
+        candidates.sort_by(|left, right| left.entity.id.cmp(&right.entity.id));
+        if let Some(after) = after.as_deref() {
+            candidates.retain(|candidate| candidate.entity.id.as_str() > after);
+        }
+        let has_more = candidates.len() > limit;
+        candidates.truncate(limit);
+        let next_cursor = candidates
+            .last()
+            .map(|candidate| candidate.entity.id.clone());
+        Ok(OrphanedSmSessionClaimPage {
+            candidates,
+            next_cursor,
+            has_more,
+            quarantined: 0,
+        })
+    }
+
     /// Reaper-only stale-owner steal for detached SM-session claims. Unlike
     /// [`ClaimStore::steal_stale`]'s generic owner-stale CAS, this binds the
     /// stealer's own heartbeat freshness into the same SQL statement because
     /// the orphan reaper has the node `lease_ttl` available and must not win
     /// new work after its local lease has lapsed.
     async fn steal_orphaned_sm_session_claim(
+        &self,
+        _entity: &Entity,
+        _observed: ClaimEpoch,
+        _me: &NodeIdentity,
+        _lease_ttl: Duration,
+    ) -> Result<ClaimEpoch, ClaimError> {
+        Err(ClaimError::Conflict)
+    }
+
+    /// Bounded advisory scan for `RoomActor` claims whose recorded owner
+    /// lease is committed-stale. The returned snapshot never authorizes a
+    /// takeover: callers must still expire the owner and win
+    /// [`Self::steal_orphaned_room_actor_claim`]'s epoch-fenced CAS.
+    async fn list_orphaned_room_actor_claims(
+        &self,
+        _limit: usize,
+    ) -> Result<Vec<OrphanedRoomActorClaim>, ClaimError> {
+        Ok(Vec::new())
+    }
+
+    /// Reaper-only stale-owner steal for a `RoomActor`. The production
+    /// implementation binds both the observed claim epoch and the sweeping
+    /// node's own fresh, non-draining lease into one statement, so neither a
+    /// renewed owner nor a stale sweeper can win a candidate-scan race.
+    async fn steal_orphaned_room_actor_claim(
         &self,
         _entity: &Entity,
         _observed: ClaimEpoch,
@@ -1203,6 +1406,24 @@ pub trait NodeLeaseStore: Send + Sync {
 /// [`NodeLeaseStore::list_orphaned_sm_session_claims`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrphanedSmSessionClaim {
+    pub entity: Entity,
+    pub epoch: ClaimEpoch,
+    pub owner: NodeIdentity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrphanedSmSessionClaimPage {
+    pub candidates: Vec<OrphanedSmSessionClaim>,
+    pub next_cursor: Option<String>,
+    pub has_more: bool,
+    pub quarantined: usize,
+}
+
+/// A bounded-scan candidate for proactive `RoomActor` reconciliation.
+/// Its fields are only an observation; the reaper's subsequent CAS is the
+/// authority over whether the claim can move.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrphanedRoomActorClaim {
     pub entity: Entity,
     pub epoch: ClaimEpoch,
     pub owner: NodeIdentity,
@@ -1683,6 +1904,120 @@ impl NodeLeaseStore for PostgresClaimStore {
         Ok(out)
     }
 
+    async fn list_orphaned_sm_session_claims_page(
+        &self,
+        after: Option<String>,
+        limit: usize,
+    ) -> Result<OrphanedSmSessionClaimPage, ClaimError> {
+        if limit == 0 {
+            return Ok(OrphanedSmSessionClaimPage {
+                candidates: Vec::new(),
+                next_cursor: after,
+                has_more: false,
+                quarantined: 0,
+            });
+        }
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let scan_limit = limit.saturating_mul(4).saturating_add(1);
+        let cursor = after.unwrap_or_default();
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT entity, node_id, node_epoch, claim_epoch,
+                       CASE WHEN EXISTS (
+                         SELECT 1 FROM sm_sessions s
+                         WHERE clustering_claims.entity = ('sm_session:' || s.stream_id)
+                       ) THEN 1 ELSE 0 END AS has_durable
+                FROM clustering_claims
+                WHERE entity_type = ?
+                  AND entity > ?
+                  AND NOT EXISTS (
+                    SELECT 1 FROM clustering_nodes n
+                    WHERE n.node_id = clustering_claims.node_id
+                      AND NOT n.expired
+                      AND n.node_epoch = clustering_claims.node_epoch
+                  )
+                ORDER BY entity
+                LIMIT ?
+                "#,
+                crate::db_params![
+                    EntityType::SmSession.as_db_str().to_string(),
+                    cursor,
+                    i64::try_from(scan_limit).unwrap_or(i64::MAX),
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        let mut out = Vec::new();
+        // Exact stale-owner snapshot plus an optional durable suffix. The
+        // cleanup transaction revalidates claim-only absence; this scan-time
+        // classification is never destructive authority by itself.
+        let mut cleanup = Vec::new();
+        let mut next_cursor = None;
+        let mut observed_extra = false;
+        let mut scanned = 0usize;
+        while let Some(row) = rows.next().await.map_err(db_err)? {
+            scanned += 1;
+            let encoded: String = row.get(0).map_err(db_err)?;
+            let node_id: String = row.get(1).map_err(db_err)?;
+            let node_epoch: String = row.get(2).map_err(db_err)?;
+            let claim_epoch: i64 = row.get(3).map_err(db_err)?;
+            let has_durable: i64 = row.get(4).map_err(db_err)?;
+            if out.len() == limit {
+                observed_extra = true;
+                break;
+            }
+            next_cursor = Some(encoded.clone());
+            let Some(entity) = decode_entity(&encoded, EntityType::SmSession) else {
+                // Only malformed keys in the canonical namespace may name
+                // matching poison durable rows. Wrong-prefix keys can never
+                // authorize deleting session state.
+                let durable_suffix = encoded
+                    .strip_prefix("sm_session:")
+                    .filter(|_| has_durable == 1)
+                    .map(str::to_string);
+                cleanup.push(OrphanedSmClaimCleanup {
+                    encoded,
+                    owner: NodeIdentity::new(node_id, node_epoch),
+                    claim_epoch: ClaimEpoch(claim_epoch),
+                    durable_stream_id: durable_suffix,
+                    malformed: true,
+                });
+                continue;
+            };
+            if has_durable != 1 {
+                // A committed stale owner cannot still be in the live
+                // claim-before-detach window. Remove only the exact stale
+                // claim; never manufacture a durable session or steal it.
+                cleanup.push(OrphanedSmClaimCleanup {
+                    encoded,
+                    owner: NodeIdentity::new(node_id, node_epoch),
+                    claim_epoch: ClaimEpoch(claim_epoch),
+                    durable_stream_id: None,
+                    malformed: false,
+                });
+                continue;
+            }
+            out.push(OrphanedSmSessionClaim {
+                entity,
+                epoch: ClaimEpoch(claim_epoch),
+                owner: NodeIdentity::new(node_id, node_epoch),
+            });
+        }
+        drop(rows);
+        drop(conn);
+        let mut quarantined = 0usize;
+        for cleanup in cleanup {
+            quarantined += usize::from(self.cleanup_orphaned_sm_claim(cleanup).await?);
+        }
+        Ok(OrphanedSmSessionClaimPage {
+            has_more: observed_extra || out.len() == limit || scanned == scan_limit,
+            candidates: out,
+            next_cursor,
+            quarantined,
+        })
+    }
+
     async fn steal_orphaned_sm_session_claim(
         &self,
         entity: &Entity,
@@ -1727,6 +2062,156 @@ impl NodeLeaseStore for PostgresClaimStore {
                     EntityType::SmSession.as_db_str().to_string(),
                     observed.0,
                     EntityType::SmSession.as_db_str().to_string(),
+                    me.node_id.clone(),
+                    me.node_epoch.clone(),
+                    lease_ttl.as_millis().to_string(),
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        if affected == 1 {
+            Ok(ClaimEpoch(next_epoch))
+        } else {
+            Err(ClaimError::Conflict)
+        }
+    }
+
+    async fn list_orphaned_room_actor_claims(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<OrphanedRoomActorClaim>, ClaimError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        // Over-fetch a bounded page so malformed rows can be quarantined
+        // without occupying every user-visible slot in the page.
+        let scan_limit = limit.saturating_mul(4);
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT entity, node_id, node_epoch, claim_epoch
+                FROM clustering_claims
+                WHERE entity_type = ?
+                  AND NOT EXISTS (
+                    SELECT 1 FROM clustering_nodes n
+                    WHERE n.node_id = clustering_claims.node_id
+                      AND NOT n.expired
+                      AND n.node_epoch = clustering_claims.node_epoch
+                  )
+                ORDER BY entity
+                LIMIT ?
+                "#,
+                crate::db_params![
+                    EntityType::RoomActor.as_db_str().to_string(),
+                    i64::try_from(scan_limit).unwrap_or(i64::MAX),
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        let mut out = Vec::new();
+        let mut malformed = Vec::new();
+        while let Some(row) = rows.next().await.map_err(db_err)? {
+            let encoded: String = row.get(0).map_err(db_err)?;
+            let node_id: String = row.get(1).map_err(db_err)?;
+            let node_epoch: String = row.get(2).map_err(db_err)?;
+            let claim_epoch: i64 = row.get(3).map_err(db_err)?;
+            let Some(entity) = decode_entity(&encoded, EntityType::RoomActor) else {
+                malformed.push((encoded, node_id, node_epoch, claim_epoch));
+                continue;
+            };
+            if entity.id.parse::<jid::BareJid>().is_err() {
+                malformed.push((encoded, node_id, node_epoch, claim_epoch));
+                continue;
+            }
+            out.push(OrphanedRoomActorClaim {
+                entity,
+                epoch: ClaimEpoch(claim_epoch),
+                owner: NodeIdentity::new(node_id, node_epoch),
+            });
+            if out.len() == limit {
+                break;
+            }
+        }
+        drop(rows);
+        let mut quarantined = 0usize;
+        for (encoded, node_id, node_epoch, claim_epoch) in malformed {
+            let affected = conn
+                .execute(
+                    r#"
+                    DELETE FROM clustering_claims
+                    WHERE entity = ? AND entity_type = ? AND node_id = ? AND node_epoch = ?
+                      AND claim_epoch = ?
+                      AND NOT EXISTS (
+                        SELECT 1 FROM clustering_nodes n
+                        WHERE n.node_id = clustering_claims.node_id
+                          AND NOT n.expired
+                          AND n.node_epoch = clustering_claims.node_epoch
+                      )
+                    "#,
+                    crate::db_params![
+                        encoded,
+                        EntityType::RoomActor.as_db_str().to_string(),
+                        node_id,
+                        node_epoch,
+                        claim_epoch,
+                    ],
+                )
+                .await
+                .map_err(db_err)?;
+            quarantined += usize::from(affected == 1);
+        }
+        if quarantined > 0 {
+            tracing::debug!(
+                quarantined,
+                "quarantined malformed stale RoomActor claim rows"
+            );
+        }
+        Ok(out)
+    }
+
+    async fn steal_orphaned_room_actor_claim(
+        &self,
+        entity: &Entity,
+        observed: ClaimEpoch,
+        me: &NodeIdentity,
+        lease_ttl: Duration,
+    ) -> Result<ClaimEpoch, ClaimError> {
+        if entity.entity_type != EntityType::RoomActor {
+            return Err(ClaimError::Conflict);
+        }
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let next_epoch = observed.0 + 1;
+        let affected = conn
+            .execute(
+                r#"
+                UPDATE clustering_claims
+                SET node_id = ?, node_epoch = ?, claim_epoch = ?
+                WHERE entity = ?
+                  AND entity_type = ?
+                  AND claim_epoch = ?
+                  AND NOT EXISTS (
+                    SELECT 1 FROM clustering_nodes n
+                    WHERE n.node_id = clustering_claims.node_id
+                      AND NOT n.expired
+                      AND n.node_epoch = clustering_claims.node_epoch
+                  )
+                  AND EXISTS (
+                    SELECT 1 FROM clustering_nodes
+                    WHERE node_id = ?
+                      AND node_epoch = ?
+                      AND NOT expired
+                      AND NOT draining
+                      AND heartbeat >= now() - (? || ' milliseconds')::interval
+                  )
+                "#,
+                crate::db_params![
+                    me.node_id.clone(),
+                    me.node_epoch.clone(),
+                    next_epoch,
+                    entity_key(entity),
+                    EntityType::RoomActor.as_db_str().to_string(),
+                    observed.0,
                     me.node_id.clone(),
                     me.node_epoch.clone(),
                     lease_ttl.as_millis().to_string(),
@@ -2314,7 +2799,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn release_is_epoch_gated_and_idempotent() {
+    async fn release_is_idempotent_and_exact_release_requires_owner_incarnation_and_epoch() {
         let _guard = clustering_control_plane_table_lock().lock().await;
         let Some(store) = clean_store().await else {
             return;
@@ -2323,12 +2808,31 @@ mod tests {
         let entity = sm_entity("stream-1");
         let epoch0 = store.acquire(&entity, &owner).await.expect("acquire");
 
-        // Releasing under the wrong epoch is a silent no-op — the claim
-        // must survive.
         store
             .release(&entity, &owner, ClaimEpoch(99))
             .await
-            .expect("release under wrong epoch is a no-op");
+            .expect("idempotent stale release");
+        assert_eq!(
+            store
+                .release_exact(&entity, &owner, ClaimEpoch(99))
+                .await
+                .expect("exact stale release"),
+            waddle_xmpp::ownership::ExactReleaseOutcome::NotOwned
+        );
+        assert!(store.fence(&entity, &owner, epoch0).await.expect("fence"));
+
+        let replacement = NodeIdentity::new(owner.node_id.clone(), "replacement-incarnation");
+        assert!(!store
+            .fence(&entity, &replacement, epoch0)
+            .await
+            .expect("replacement fence"));
+        assert_eq!(
+            store
+                .release_exact(&entity, &replacement, epoch0)
+                .await
+                .expect("exact release"),
+            waddle_xmpp::ownership::ExactReleaseOutcome::NotOwned
+        );
         assert!(store.fence(&entity, &owner, epoch0).await.expect("fence"));
 
         store
@@ -2340,11 +2844,10 @@ mod tests {
             .await
             .expect("fence after release"));
 
-        // Releasing again (already gone) is still not an error.
         store
             .release(&entity, &owner, epoch0)
             .await
-            .expect("re-release is a no-op, not an error");
+            .expect("repeat release is idempotent");
     }
 
     #[tokio::test]
@@ -3223,6 +3726,188 @@ mod tests {
             .await
             .expect("a heartbeat-fresh stealer can reclaim the orphaned SM session claim");
         assert_eq!(epoch1, ClaimEpoch(epoch0.0 + 1));
+    }
+
+    #[tokio::test]
+    async fn room_orphan_scan_and_steal_are_bounded_and_fenced_against_races() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let store = Arc::new(store);
+        let dead_owner = node_identity();
+        seed_node(&store.db, &dead_owner, true).await;
+        let first = room_entity("a-orphan@muc.example.com");
+        let renewed = room_entity("b-renewed@muc.example.com");
+        let concurrent = room_entity("c-concurrent@muc.example.com");
+        let first_epoch = store
+            .acquire(&first, &dead_owner)
+            .await
+            .expect("first claim");
+        let renewed_epoch = store
+            .acquire(&renewed, &dead_owner)
+            .await
+            .expect("renewed claim");
+        let concurrent_epoch = store
+            .acquire(&concurrent, &dead_owner)
+            .await
+            .expect("concurrent claim");
+
+        let bounded = store
+            .list_orphaned_room_actor_claims(2)
+            .await
+            .expect("bounded room scan");
+        assert_eq!(bounded.len(), 2, "the SQL LIMIT must bound each sweep");
+        assert_eq!(bounded[0].entity, first);
+        assert_eq!(bounded[1].entity, renewed);
+
+        let live_stealer = node_identity();
+        store
+            .register(&live_stealer, None)
+            .await
+            .expect("register live stealer");
+        let won = store
+            .steal_orphaned_room_actor_claim(&first, first_epoch, &live_stealer, NODE_LEASE_TTL)
+            .await
+            .expect("fresh sweeper wins");
+        assert_eq!(won, ClaimEpoch(first_epoch.0 + 1));
+
+        // Candidate discovery was advisory. If the owner renews before the
+        // CAS, the stale snapshot cannot displace it.
+        store
+            .register(&dead_owner, None)
+            .await
+            .expect("owner renews its exact lease identity");
+        assert!(matches!(
+            store
+                .steal_orphaned_room_actor_claim(
+                    &renewed,
+                    renewed_epoch,
+                    &live_stealer,
+                    NODE_LEASE_TTL,
+                )
+                .await,
+            Err(ClaimError::Conflict)
+        ));
+
+        // Make the owner stale again, then race two sweepers against the
+        // same observed epoch. Exactly one can bump it once.
+        seed_node(&store.db, &dead_owner, true).await;
+        let second_stealer = node_identity();
+        store
+            .register(&second_stealer, None)
+            .await
+            .expect("register second stealer");
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let task_a = {
+            let store = Arc::clone(&store);
+            let entity = concurrent.clone();
+            let stealer = live_stealer.clone();
+            let barrier = Arc::clone(&barrier);
+            tokio::spawn(async move {
+                barrier.wait().await;
+                store
+                    .steal_orphaned_room_actor_claim(
+                        &entity,
+                        concurrent_epoch,
+                        &stealer,
+                        NODE_LEASE_TTL,
+                    )
+                    .await
+            })
+        };
+        let task_b = {
+            let store = Arc::clone(&store);
+            let entity = concurrent.clone();
+            let stealer = second_stealer.clone();
+            let barrier = Arc::clone(&barrier);
+            tokio::spawn(async move {
+                barrier.wait().await;
+                store
+                    .steal_orphaned_room_actor_claim(
+                        &entity,
+                        concurrent_epoch,
+                        &stealer,
+                        NODE_LEASE_TTL,
+                    )
+                    .await
+            })
+        };
+        let (a, b) = tokio::join!(task_a, task_b);
+        let results = [a.expect("task a"), b.expect("task b")];
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Err(ClaimError::Conflict)))
+                .count(),
+            1
+        );
+
+        // A heartbeat-stale (but not yet committed-expired) sweeper is
+        // fenced inside the same CAS statement.
+        let stale_sweeper = node_identity();
+        store
+            .register(&stale_sweeper, None)
+            .await
+            .expect("register stale sweeper");
+        backdate_heartbeat(&store.db, &stale_sweeper).await;
+        let another = room_entity("d-stale-sweeper@muc.example.com");
+        let another_epoch = store
+            .acquire(&another, &dead_owner)
+            .await
+            .expect("another orphan");
+        assert!(matches!(
+            store
+                .steal_orphaned_room_actor_claim(
+                    &another,
+                    another_epoch,
+                    &stale_sweeper,
+                    NODE_LEASE_TTL,
+                )
+                .await,
+            Err(ClaimError::Conflict)
+        ));
+    }
+
+    #[tokio::test]
+    async fn malformed_room_claim_prefix_is_quarantined_without_starving_valid_page() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let dead_owner = node_identity();
+        seed_node(&store.db, &dead_owner, true).await;
+        let mut malformed = Vec::new();
+        for index in 0..65 {
+            let entity = Entity::new(EntityType::RoomActor, format!("000-invalid-{index:02}"));
+            store
+                .acquire(&entity, &dead_owner)
+                .await
+                .expect("malformed claim");
+            malformed.push(entity);
+        }
+        let valid = room_entity("zzz-valid@muc.example.com");
+        store
+            .acquire(&valid, &dead_owner)
+            .await
+            .expect("valid claim");
+
+        let candidates = store
+            .list_orphaned_room_actor_claims(64)
+            .await
+            .expect("bounded scan");
+        assert!(candidates.iter().any(|candidate| candidate.entity == valid));
+        for entity in [
+            malformed.first().expect("first"),
+            malformed.last().expect("last"),
+        ] {
+            assert!(store
+                .current_claim(entity)
+                .await
+                .expect("claim lookup")
+                .is_none());
+        }
     }
 
     // --- ADR-0017 Phase 3 Slice 10: current_generation (Q5's mechanism) --
@@ -4112,6 +4797,363 @@ mod tests {
             candidates_after.is_empty(),
             "the reclaimed claim (now owned by a fresh, registered node) must no longer \
              be reported as orphaned"
+        );
+    }
+
+    #[tokio::test]
+    async fn orphaned_sm_pages_advance_past_sixty_four_and_quarantine_malformed_rows() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let stale_owner = node_identity();
+        seed_node(&store.db, &stale_owner, true).await;
+        for index in 0..70 {
+            let entity = sm_entity(&format!("paged-{index:03}"));
+            seed_sm_session_row(&store.db, &entity.id).await;
+            store
+                .acquire(&entity, &stale_owner)
+                .await
+                .expect("acquire paged claim");
+        }
+
+        let first = store
+            .list_orphaned_sm_session_claims_page(None, 64)
+            .await
+            .expect("first page");
+        assert_eq!(first.candidates.len(), 64);
+        assert!(first.has_more);
+        let second = store
+            .list_orphaned_sm_session_claims_page(first.next_cursor, 64)
+            .await
+            .expect("second page");
+        assert_eq!(
+            second.candidates.len(),
+            6,
+            "cursor must expose rows beyond the first 64"
+        );
+
+        // An over-limit typed entity can exist only through direct database
+        // corruption. It still satisfies the durable-row join, so the scan
+        // must exact-owner/epoch quarantine it instead of re-WARN forever.
+        let malformed_id = "z".repeat(waddle_xmpp::ownership::ENTITY_ID_MAX_LEN + 1);
+        seed_sm_session_row(&store.db, &malformed_id).await;
+        let encoded = format!("{}:{malformed_id}", EntityType::SmSession.as_db_str());
+        let conn = store.db.guard().await.expect("guard");
+        conn.execute(
+            r#"INSERT INTO clustering_claims
+               (entity, entity_type, node_id, node_epoch, claim_epoch)
+               VALUES (?, ?, ?, ?, 0)"#,
+            crate::db_params![
+                encoded.clone(),
+                EntityType::SmSession.as_db_str().to_string(),
+                stale_owner.node_id.clone(),
+                stale_owner.node_epoch.clone(),
+            ],
+        )
+        .await
+        .expect("seed malformed claim");
+        drop(conn);
+        let malformed_page = store
+            .list_orphaned_sm_session_claims_page(Some("sm_session:paged-999".to_string()), 64)
+            .await
+            .expect("malformed page");
+        assert_eq!(malformed_page.quarantined, 1);
+        let conn = store.db.guard().await.expect("guard");
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM clustering_claims WHERE entity = ?",
+                crate::db_params![encoded],
+            )
+            .await
+            .expect("count quarantined row");
+        let count: i64 = rows
+            .next()
+            .await
+            .expect("row")
+            .expect("row")
+            .get(0)
+            .expect("count");
+        assert_eq!(count, 0);
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM sm_sessions WHERE stream_id = ?",
+                crate::db_params![malformed_id],
+            )
+            .await
+            .expect("count quarantined durable row");
+        let durable_count: i64 = rows
+            .next()
+            .await
+            .expect("row")
+            .expect("row")
+            .get(0)
+            .expect("count");
+        assert_eq!(durable_count, 0);
+    }
+
+    #[tokio::test]
+    async fn orphaned_sm_page_classifies_claim_only_and_wrong_prefix_rows_safely() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let stale_owner = node_identity();
+        seed_node(&store.db, &stale_owner, true).await;
+
+        let claim_only = sm_entity("claim-only-cleanup");
+        store
+            .acquire(&claim_only, &stale_owner)
+            .await
+            .expect("seed valid claim without durable state");
+        let wrong_prefix = "wrong-prefix:must-not-touch-durable";
+        let conn = store.db.guard().await.expect("guard");
+        conn.execute(
+            r#"INSERT INTO clustering_claims
+               (entity, entity_type, node_id, node_epoch, claim_epoch)
+               VALUES (?, ?, ?, ?, 0)"#,
+            crate::db_params![
+                wrong_prefix,
+                EntityType::SmSession.as_db_str().to_string(),
+                stale_owner.node_id.clone(),
+                stale_owner.node_epoch.clone(),
+            ],
+        )
+        .await
+        .expect("seed wrong-prefix claim");
+        drop(conn);
+        // A similarly named durable row proves wrong-prefix cleanup cannot
+        // derive a suffix and delete persistence state.
+        seed_sm_session_row(&store.db, "must-not-touch-durable").await;
+
+        let page = store
+            .list_orphaned_sm_session_claims_page(None, 64)
+            .await
+            .expect("classify stale rows");
+        assert!(page.candidates.is_empty());
+        assert_eq!(page.quarantined, 1, "only the malformed key is quarantine");
+
+        let conn = store.db.guard().await.expect("guard");
+        for encoded in [claim_only.to_string(), wrong_prefix.to_string()] {
+            let mut rows = conn
+                .query(
+                    "SELECT COUNT(*) FROM clustering_claims WHERE entity = ?",
+                    crate::db_params![encoded],
+                )
+                .await
+                .expect("count claim");
+            let count: i64 = rows
+                .next()
+                .await
+                .expect("row")
+                .expect("row")
+                .get(0)
+                .expect("count");
+            assert_eq!(count, 0);
+        }
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM sm_sessions WHERE stream_id = ?",
+                crate::db_params!["must-not-touch-durable"],
+            )
+            .await
+            .expect("count protected durable row");
+        let durable_count: i64 = rows
+            .next()
+            .await
+            .expect("row")
+            .expect("row")
+            .get(0)
+            .expect("count");
+        assert_eq!(durable_count, 1);
+    }
+
+    #[tokio::test]
+    async fn claim_only_cleanup_rechecks_durable_absence_after_scan_classification() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let stale_owner = node_identity();
+        seed_node(&store.db, &stale_owner, true).await;
+        let entity = sm_entity("claim-only-raced-by-detach");
+        let claim_epoch = store
+            .acquire(&entity, &stale_owner)
+            .await
+            .expect("seed stale claim without durable state");
+
+        // This cleanup value is the exact classification the unlocked page
+        // scan produced while no sm_sessions row existed. A paused owner can
+        // finish its already-fenced detach before cleanup locks the claim.
+        let cleanup = OrphanedSmClaimCleanup {
+            encoded: entity_key(&entity),
+            owner: stale_owner.clone(),
+            claim_epoch,
+            durable_stream_id: None,
+            malformed: false,
+        };
+        seed_sm_session_row(&store.db, &entity.id).await;
+
+        assert!(!store
+            .cleanup_orphaned_sm_claim(cleanup)
+            .await
+            .expect("cleanup transaction"));
+        let snapshot = store
+            .current_claim(&entity)
+            .await
+            .expect("read claim after cleanup");
+        assert_eq!(
+            snapshot.as_ref().map(|claim| (&claim.owner, claim.claim_epoch)),
+            Some((&stale_owner, claim_epoch)),
+            "a durable row appearing after scan classification must retain its exact claim for a later steal"
+        );
+        let conn = store.db.guard().await.expect("guard");
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM sm_sessions WHERE stream_id = ?",
+                crate::db_params![entity.id],
+            )
+            .await
+            .expect("count durable row");
+        let durable_count: i64 = rows
+            .next()
+            .await
+            .expect("row")
+            .expect("row")
+            .get(0)
+            .expect("count");
+        assert_eq!(durable_count, 1);
+    }
+
+    #[tokio::test]
+    async fn claim_only_cleanup_observes_detach_committed_while_waiting_for_claim_lock() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let store = Arc::new(store);
+        let stale_owner = node_identity();
+        seed_node(&store.db, &stale_owner, true).await;
+        let entity = sm_entity("claim-only-in-flight-detach");
+        let claim_epoch = store
+            .acquire(&entity, &stale_owner)
+            .await
+            .expect("seed stale claim without durable state");
+
+        // Model a real fenced detach: hold FOR SHARE on the exact claim and
+        // stage the durable row without committing it yet.
+        let mut writer = store.db.begin().await.expect("begin detach writer");
+        let mut fenced = writer
+            .query(
+                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
+                crate::db_params![
+                    entity_key(&entity),
+                    stale_owner.node_id.clone(),
+                    stale_owner.node_epoch.clone(),
+                    claim_epoch.0,
+                ],
+            )
+            .await
+            .expect("lock exact claim for detach");
+        assert!(fenced.next().await.expect("read fence").is_some());
+        drop(fenced);
+        writer
+            .execute(
+                r#"
+                INSERT INTO sm_sessions (
+                    stream_id, user_id, full_jid, inbound_count, outbound_count,
+                    last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms,
+                    carbons_enabled, roster_interested, blocklist_interested,
+                    presence_available, presence_priority
+                ) VALUES (?, ?, ?, 0, 0, 0, NULL, 0, 60000, 0, 0, 0, 0, 0)
+                "#,
+                crate::db_params![
+                    entity.id.clone(),
+                    "alice".to_string(),
+                    "alice@example.com/web".to_string(),
+                ],
+            )
+            .await
+            .expect("stage durable detach row");
+
+        let cleanup = OrphanedSmClaimCleanup {
+            encoded: entity_key(&entity),
+            owner: stale_owner.clone(),
+            claim_epoch,
+            durable_stream_id: None,
+            malformed: false,
+        };
+        let cleanup_store = Arc::clone(&store);
+        let cleanup_task =
+            tokio::spawn(async move { cleanup_store.cleanup_orphaned_sm_claim(cleanup).await });
+
+        // Do not release the writer until Postgres confirms the cleanup's
+        // exact FOR UPDATE statement is waiting on that writer's share lock.
+        let monitor = store.db.guard().await.expect("monitor guard");
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let mut rows = monitor
+                    .query(
+                        r#"
+                        SELECT COUNT(*) FROM pg_stat_activity
+                        WHERE pid <> pg_backend_pid()
+                          AND query LIKE '%orphan_sm_cleanup_exact_lock%'
+                          AND wait_event_type = 'Lock'
+                        "#,
+                        (),
+                    )
+                    .await
+                    .expect("inspect blocked cleanup");
+                let blocked = rows
+                    .next()
+                    .await
+                    .expect("read blocked cleanup count")
+                    .expect("blocked cleanup count row")
+                    .get::<i64>(0)
+                    .expect("blocked cleanup count");
+                if blocked > 0 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cleanup reached exact claim lock");
+        drop(monitor);
+
+        writer.commit().await.expect("commit durable detach");
+        cleanup_task
+            .await
+            .expect("cleanup task joined")
+            .expect("cleanup transaction");
+
+        let snapshot = store
+            .current_claim(&entity)
+            .await
+            .expect("read claim after cleanup");
+        assert_eq!(
+            snapshot
+                .as_ref()
+                .map(|claim| (&claim.owner, claim.claim_epoch)),
+            Some((&stale_owner, claim_epoch)),
+            "cleanup must preserve the exact claim once the blocked detach commits durable state"
+        );
+        let conn = store.db.guard().await.expect("guard");
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM sm_sessions WHERE stream_id = ?",
+                crate::db_params![entity.id],
+            )
+            .await
+            .expect("count durable row");
+        assert_eq!(
+            rows.next()
+                .await
+                .expect("row")
+                .expect("row")
+                .get::<i64>(0)
+                .expect("count"),
+            1
         );
     }
 }

--- a/server/crates/waddle-server/src/clustering/claims.rs
+++ b/server/crates/waddle-server/src/clustering/claims.rs
@@ -198,12 +198,16 @@ mod entity_key_tests {
 
     #[test]
     fn decode_entity_round_trips_entity_key_including_ids_with_colons() {
-        let cases = [
+        let long_valid_room: jid::BareJid = format!("{}@muc.example.com", "a".repeat(129))
+            .parse()
+            .expect("valid room JID longer than the old 128-byte wire bound");
+        let cases = vec![
             Entity::new(EntityType::UserActor, "42"),
             Entity::new(EntityType::RoomActor, "room_actor:42"),
             Entity::new(EntityType::SmSession, "sm_session:sm_session:x"),
             Entity::new(EntityType::UserActor, ""),
             Entity::new(EntityType::RoomActor, ":"),
+            Entity::new(EntityType::RoomActor, long_valid_room.to_string()),
         ];
         for entity in cases {
             let encoded = entity_key(&entity);
@@ -3868,6 +3872,39 @@ mod tests {
                 .await,
             Err(ClaimError::Conflict)
         ));
+    }
+
+    #[tokio::test]
+    async fn orphan_scan_preserves_valid_room_jids_longer_than_128_bytes() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let dead_owner = node_identity();
+        seed_node(&store.db, &dead_owner, true).await;
+        let long_room_jid: jid::BareJid = format!("{}@muc.example.com", "a".repeat(129))
+            .parse()
+            .expect("valid long room JID");
+        let entity = room_entity(long_room_jid.as_str());
+        store
+            .acquire(&entity, &dead_owner)
+            .await
+            .expect("long room claim");
+
+        let candidates = store
+            .list_orphaned_room_actor_claims(1)
+            .await
+            .expect("orphan scan");
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].entity, entity);
+        assert!(
+            store
+                .current_claim(&entity)
+                .await
+                .expect("claim lookup")
+                .is_some(),
+            "a valid long room claim must be returned for adoption, not quarantined"
+        );
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/clustering/isr.rs
+++ b/server/crates/waddle-server/src/clustering/isr.rs
@@ -76,7 +76,7 @@ use subtle::ConstantTimeEq;
 use waddle_xmpp::isr::{
     generate_isr_token, IsrConsumeOutcome, IsrTokenStore, IsrTokenStoreError, IssuedIsrToken,
 };
-use waddle_xmpp::ownership::{ClaimEpoch, EntityType, NodeIdentity};
+use waddle_xmpp::ownership::EntityType;
 
 use crate::db::{Database, DatabaseError};
 
@@ -161,8 +161,7 @@ impl IsrTokenStore for PostgresIsrTokenStore {
         sm_id: &str,
         presented_token: &[u8],
         mechanism: &str,
-        me: &NodeIdentity,
-        mine: ClaimEpoch,
+        fence: &waddle_xmpp::stream_management::persistence::SmClaimFence,
     ) -> Result<IsrConsumeOutcome, IsrTokenStoreError> {
         let mut tx = self.db.begin().await.map_err(db_err)?;
 
@@ -172,8 +171,13 @@ impl IsrTokenStore for PostgresIsrTokenStore {
         let key = sm_session_entity_key(sm_id);
         let mut fence_rows = tx
             .query(
-                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                crate::db_params![key, me.node_id.clone(), mine.0],
+                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
+                crate::db_params![
+                    key,
+                    fence.owner().node_id.clone(),
+                    fence.owner().node_epoch.clone(),
+                    fence.epoch().0,
+                ],
             )
             .await
             .map_err(db_err)?;
@@ -342,13 +346,18 @@ mod tests {
     use super::*;
     use crate::clustering::claims::{clustering_control_plane_table_lock, PostgresClaimStore};
     use crate::db::{DatabaseConfig, DatabaseDriver};
-    use waddle_xmpp::ownership::{ClaimStore, Entity};
+    use waddle_xmpp::ownership::{ClaimEpoch, ClaimStore, Entity, NodeIdentity};
+    use waddle_xmpp::stream_management::persistence::SmClaimFence;
 
     fn node_identity() -> NodeIdentity {
         NodeIdentity::new(
             uuid::Uuid::new_v4().to_string(),
             uuid::Uuid::new_v4().to_string(),
         )
+    }
+
+    fn fence(owner: &NodeIdentity, epoch: ClaimEpoch) -> SmClaimFence {
+        SmClaimFence::new(owner.clone(), epoch)
     }
 
     async fn test_db() -> Option<Database> {
@@ -398,7 +407,7 @@ mod tests {
 
         let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
         let outcome = store
-            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, epoch)
+            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &fence(&me, epoch))
             .await
             .expect("consume");
         let IsrConsumeOutcome::Matched { rotated } = outcome else {
@@ -408,7 +417,7 @@ mod tests {
 
         // Single-use: the OLD token fails now, even under the same fence.
         let replay = store
-            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, epoch)
+            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &fence(&me, epoch))
             .await
             .expect("consume");
         assert_eq!(replay, IsrConsumeOutcome::Mismatched);
@@ -428,7 +437,7 @@ mod tests {
 
         let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
         let outcome = store
-            .consume(&sm_id, b"not-the-token", "PLAIN", &me, epoch)
+            .consume(&sm_id, b"not-the-token", "PLAIN", &fence(&me, epoch))
             .await
             .expect("consume");
         assert_eq!(outcome, IsrConsumeOutcome::Mismatched);
@@ -438,7 +447,7 @@ mod tests {
         // from the genuine `Mismatched` above), proving unconditional
         // destruction happened.
         let second = store
-            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, epoch)
+            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &fence(&me, epoch))
             .await
             .expect("consume");
         assert_eq!(second, IsrConsumeOutcome::NoSuchToken);
@@ -463,7 +472,7 @@ mod tests {
         let epoch = claim_sm_session(&db, &sm_id, &me).await;
 
         let outcome = store
-            .consume(&sm_id, b"anything", "PLAIN", &me, epoch)
+            .consume(&sm_id, b"anything", "PLAIN", &fence(&me, epoch))
             .await
             .expect("consume");
         assert_eq!(outcome, IsrConsumeOutcome::NoSuchToken);
@@ -473,7 +482,7 @@ mod tests {
         // branch never wrote anything that could poison a later issuance.
         let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
         let second = store
-            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, epoch)
+            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &fence(&me, epoch))
             .await
             .expect("consume");
         assert!(matches!(second, IsrConsumeOutcome::Matched { .. }));
@@ -546,7 +555,7 @@ mod tests {
         let fresh_epoch = claim_sm_session(&db, &fresh_sm_id, &me).await;
         let stale_epoch = claim_sm_session(&db, &stale_sm_id, &me).await;
         let stale_outcome = store
-            .consume(&stale_sm_id, b"anything", "PLAIN", &me, stale_epoch)
+            .consume(&stale_sm_id, b"anything", "PLAIN", &fence(&me, stale_epoch))
             .await
             .expect("consume stale");
         assert_eq!(stale_outcome, IsrConsumeOutcome::NoSuchToken);
@@ -555,8 +564,7 @@ mod tests {
                 &fresh_sm_id,
                 b"wrong-token-but-row-must-exist",
                 "PLAIN",
-                &me,
-                fresh_epoch,
+                &fence(&me, fresh_epoch),
             )
             .await
             .expect("consume fresh");
@@ -583,16 +591,67 @@ mod tests {
         let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
         let wrong_epoch = ClaimEpoch(epoch.0 + 1);
         let outcome = store
-            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, wrong_epoch)
+            .consume(
+                &sm_id,
+                issued.token.as_bytes(),
+                "PLAIN",
+                &fence(&me, wrong_epoch),
+            )
             .await;
         assert!(matches!(outcome, Err(IsrTokenStoreError::NotOwner)));
 
         // Fencing failure must not have touched the token row.
         let still_valid = store
-            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &me, epoch)
+            .consume(&sm_id, issued.token.as_bytes(), "PLAIN", &fence(&me, epoch))
             .await
             .expect("consume");
         assert!(matches!(still_valid, IsrConsumeOutcome::Matched { .. }));
+    }
+
+    #[tokio::test]
+    async fn consume_fails_fencing_when_node_incarnation_changes_at_the_same_claim_epoch() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(db) = test_db().await else {
+            return;
+        };
+        let store = PostgresIsrTokenStore::new(db.clone());
+        store.ensure_schema().await.expect("ensure isr schema");
+        let old = node_identity();
+        let replacement = NodeIdentity::new(old.node_id.clone(), uuid::Uuid::new_v4().to_string());
+        let sm_id = format!("sm-incarnation-{}", uuid::Uuid::new_v4());
+        let epoch = claim_sm_session(&db, &sm_id, &old).await;
+        let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
+        let entity_key = sm_session_entity_key(&sm_id);
+        db.guard()
+            .await
+            .expect("guard")
+            .execute(
+                "UPDATE clustering_claims SET node_epoch = ? WHERE entity = ?",
+                crate::db_params![replacement.node_epoch.clone(), entity_key],
+            )
+            .await
+            .expect("rotate claim owner incarnation without changing numeric epoch");
+
+        let stale = store
+            .consume(
+                &sm_id,
+                issued.token.as_bytes(),
+                "PLAIN",
+                &fence(&old, epoch),
+            )
+            .await;
+        assert!(matches!(stale, Err(IsrTokenStoreError::NotOwner)));
+
+        let current = store
+            .consume(
+                &sm_id,
+                issued.token.as_bytes(),
+                "PLAIN",
+                &fence(&replacement, epoch),
+            )
+            .await
+            .expect("current incarnation consume");
+        assert!(matches!(current, IsrConsumeOutcome::Matched { .. }));
     }
 
     /// Council-adjudicated FIX 1: strengthens the pre-existing exactly-once
@@ -671,8 +730,7 @@ mod tests {
                     &sm_id_loser,
                     token_loser.as_bytes(),
                     "PLAIN",
-                    &me_loser,
-                    epoch,
+                    &fence(&me_loser, epoch),
                 )
                 .await
         });
@@ -728,7 +786,12 @@ mod tests {
         // (correctly no-op) attempt — a subsequent consume with it still
         // succeeds.
         let survives = store
-            .consume(&sm_id, rotated_token.as_bytes(), "PLAIN", &me, epoch)
+            .consume(
+                &sm_id,
+                rotated_token.as_bytes(),
+                "PLAIN",
+                &fence(&me, epoch),
+            )
             .await
             .expect("consume with the winner's rotated token");
         assert!(

--- a/server/crates/waddle-server/src/clustering/local_claims.rs
+++ b/server/crates/waddle-server/src/clustering/local_claims.rs
@@ -305,7 +305,7 @@ impl LocallyClaimedEntities for RoomLocalClaims {
             return true;
         };
         if registry
-            .is_pending_room_release(room_jid.clone())
+            .is_current_room_pending_release(room_jid.clone())
             .await
             .unwrap_or(false)
         {
@@ -363,7 +363,7 @@ impl LocallyClaimedEntities for RoomLocalClaims {
         // The actor was already sealed/removed before this exact fence was
         // queued, so no additional mailbox barrier is required at shutdown.
         if registry
-            .is_pending_room_release(room_jid.clone())
+            .is_current_room_pending_release(room_jid.clone())
             .await
             .unwrap_or(false)
         {

--- a/server/crates/waddle-server/src/clustering/local_claims.rs
+++ b/server/crates/waddle-server/src/clustering/local_claims.rs
@@ -360,10 +360,14 @@ impl LocallyClaimedEntities for RoomLocalClaims {
         let Some(room_jid) = Self::room_jid(entity) else {
             return true;
         };
-        // The actor was already sealed/removed before this exact fence was
-        // queued, so no additional mailbox barrier is required at shutdown.
+        // A pending-release-only JID has already removed/sealed its actor,
+        // so no mailbox barrier remains to run. Unlike the live-health query
+        // above, shutdown intentionally accepts any retained exact generation
+        // for this JID: `owned()` enumerates those pending-only JIDs precisely
+        // so the drain can release the backend claim without requiring a live
+        // actor that terminal removal deliberately destroyed.
         if registry
-            .is_current_room_pending_release(room_jid.clone())
+            .is_pending_room_release_only(room_jid.clone())
             .await
             .unwrap_or(false)
         {

--- a/server/crates/waddle-server/src/clustering/local_claims.rs
+++ b/server/crates/waddle-server/src/clustering/local_claims.rs
@@ -129,23 +129,33 @@ impl LocallyClaimedEntities for SmSessionLocalClaims {
         let Some(registry) = self.registry.get() else {
             return;
         };
-        let fenced = entities
-            .iter()
-            .map(|(entity, owner, epoch)| {
-                (
-                    entity.clone(),
-                    waddle_xmpp::stream_management::persistence::SmClaimFence::new(
-                        owner.clone(),
-                        *epoch,
-                    ),
-                )
-            })
-            .collect::<Vec<_>>();
-        if let Err(error) = registry.hydrate_reclaimed(&fenced).await {
-            tracing::warn!(
-                %error,
-                "SmSessionLocalClaims::hydrate_reclaimed: registry hydrate_reclaimed failed"
+        for (entity, owner, epoch) in entities {
+            let fence = waddle_xmpp::stream_management::persistence::SmClaimFence::new(
+                owner.clone(),
+                *epoch,
             );
+            match registry.hydrate_reclaimed_typed(entity, &fence).await {
+                Ok(
+                    waddle_xmpp::stream_management::ReclaimedHydrationOutcome::MissingDurable
+                    | waddle_xmpp::stream_management::ReclaimedHydrationOutcome::PoisonReleased,
+                ) => {
+                    if let Err(error) = registry.release_reclaimed_claim(entity, &fence).await {
+                        tracing::warn!(
+                            entity_id = %entity.id,
+                            %error,
+                            "SmSessionLocalClaims::hydrate_reclaimed: terminal exact release failed; responsibility retained for retry"
+                        );
+                    }
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        entity_id = %entity.id,
+                        %error,
+                        "SmSessionLocalClaims::hydrate_reclaimed: registry hydrate_reclaimed failed"
+                    );
+                }
+            }
         }
     }
 }
@@ -360,14 +370,14 @@ impl LocallyClaimedEntities for RoomLocalClaims {
         let Some(room_jid) = Self::room_jid(entity) else {
             return true;
         };
-        // A pending-release-only JID has already removed/sealed its actor,
-        // so no mailbox barrier remains to run. Unlike the live-health query
-        // above, shutdown intentionally accepts any retained exact generation
-        // for this JID: `owned()` enumerates those pending-only JIDs precisely
-        // so the drain can release the backend claim without requiring a live
-        // actor that terminal removal deliberately destroyed.
+        // A pending-release-only JID has no mailbox barrier left to run, but
+        // the generic drain can release only the CURRENT node identity via
+        // epoch-blind `release_many`. Admit it only when every retained exact
+        // fence belongs to that identity. An older-incarnation fence is
+        // deliberately abandoned (truthfully counted by the drain) for stale
+        // node recovery rather than falsely reported released.
         if registry
-            .is_pending_room_release_only(room_jid.clone())
+            .is_current_identity_pending_room_release_only(room_jid.clone())
             .await
             .unwrap_or(false)
         {
@@ -841,6 +851,35 @@ mod tests {
     async fn unwired_instance_owns_nothing() {
         let local_claims = SmSessionLocalClaims::new();
         assert!(local_claims.owned().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn inline_reclaim_releases_claim_when_durable_session_is_missing() {
+        use waddle_xmpp::ownership::{ClaimStore as _, InProcessClaimStore, NodeIdentity};
+
+        let local_claims = SmSessionLocalClaims::new();
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let identity = NodeIdentity::new("self-fence-node", "fresh-incarnation");
+        let entity = Entity::new(EntityType::SmSession, "missing-inline-reclaim");
+        let epoch = claim_store
+            .acquire(&entity, &identity)
+            .await
+            .expect("won inline reclaim epoch");
+        let registry = Arc::new(InMemorySmSessionRegistry::new().with_claim_store(
+            claim_store.clone(),
+            waddle_xmpp::ownership::SharedNodeIdentity::new(identity.clone()),
+        ));
+        local_claims.wire(registry);
+
+        local_claims
+            .hydrate_reclaimed(&[(entity.clone(), identity, epoch)])
+            .await;
+
+        assert!(claim_store
+            .current_claim(&entity)
+            .await
+            .expect("claim lookup")
+            .is_none(), "MissingDurable must exact-release the inline self-fence claim instead of dropping the typed terminal outcome");
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/clustering/local_claims.rs
+++ b/server/crates/waddle-server/src/clustering/local_claims.rs
@@ -83,7 +83,7 @@ impl LocallyClaimedEntities for SmSessionLocalClaims {
             return Vec::new();
         };
         registry
-            .live_session_ids()
+            .locally_owned_claim_ids()
             .unwrap_or_default()
             .into_iter()
             .map(|stream_id| Entity::new(EntityType::SmSession, stream_id))
@@ -840,7 +840,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn owned_reflects_the_wired_registry_live_session_ids() {
+    async fn owned_reflects_the_wired_registry_claim_inventory() {
         let local_claims = SmSessionLocalClaims::new();
         let registry = Arc::new(InMemorySmSessionRegistry::new());
         registry

--- a/server/crates/waddle-server/src/clustering/local_claims.rs
+++ b/server/crates/waddle-server/src/clustering/local_claims.rs
@@ -118,11 +118,30 @@ impl LocallyClaimedEntities for SmSessionLocalClaims {
     /// reclaim and the general reaper share one hydration implementation.
     /// A no-op before `wire` runs, mirroring `demote`/`owned`'s identical
     /// unwired behavior.
-    async fn hydrate_reclaimed(&self, entities: &[(Entity, waddle_xmpp::ownership::ClaimEpoch)]) {
+    async fn hydrate_reclaimed(
+        &self,
+        entities: &[(
+            Entity,
+            waddle_xmpp::ownership::NodeIdentity,
+            waddle_xmpp::ownership::ClaimEpoch,
+        )],
+    ) {
         let Some(registry) = self.registry.get() else {
             return;
         };
-        if let Err(error) = registry.hydrate_reclaimed(entities).await {
+        let fenced = entities
+            .iter()
+            .map(|(entity, owner, epoch)| {
+                (
+                    entity.clone(),
+                    waddle_xmpp::stream_management::persistence::SmClaimFence::new(
+                        owner.clone(),
+                        *epoch,
+                    ),
+                )
+            })
+            .collect::<Vec<_>>();
+        if let Err(error) = registry.hydrate_reclaimed(&fenced).await {
             tracing::warn!(
                 %error,
                 "SmSessionLocalClaims::hydrate_reclaimed: registry hydrate_reclaimed failed"
@@ -208,10 +227,16 @@ impl LocallyClaimedEntities for RoomLocalClaims {
         // `CreateInstantRoom` acquire the claim before spawning), so this
         // enumeration is exactly the owned-entity set.
         match registry.list_rooms().await {
-            Ok(jids) => jids
-                .into_iter()
-                .map(|jid| Entity::new(EntityType::RoomActor, jid.to_string()))
-                .collect(),
+            Ok(mut jids) => {
+                if let Ok(pending) = registry.list_pending_room_release_jids().await {
+                    jids.extend(pending);
+                    jids.sort();
+                    jids.dedup();
+                }
+                jids.into_iter()
+                    .map(|jid| Entity::new(EntityType::RoomActor, jid.to_string()))
+                    .collect()
+            }
             Err(error) => {
                 tracing::warn!(
                     %error,
@@ -279,6 +304,13 @@ impl LocallyClaimedEntities for RoomLocalClaims {
         let Some(room_jid) = Self::room_jid(entity) else {
             return true;
         };
+        if registry
+            .is_pending_room_release(room_jid.clone())
+            .await
+            .unwrap_or(false)
+        {
+            return false;
+        }
         let Ok(Some(actor_ref)) = registry.get_room(room_jid).await else {
             tracing::warn!(
                 %entity,
@@ -328,6 +360,15 @@ impl LocallyClaimedEntities for RoomLocalClaims {
         let Some(room_jid) = Self::room_jid(entity) else {
             return true;
         };
+        // The actor was already sealed/removed before this exact fence was
+        // queued, so no additional mailbox barrier is required at shutdown.
+        if registry
+            .is_pending_room_release(room_jid.clone())
+            .await
+            .unwrap_or(false)
+        {
+            return true;
+        }
         let Ok(Some(actor_ref)) = registry.get_room(room_jid).await else {
             tracing::warn!(
                 %entity,
@@ -718,11 +759,18 @@ impl LocallyClaimedEntities for CombinedLocalClaims {
         }
     }
 
-    async fn hydrate_reclaimed(&self, entities: &[(Entity, waddle_xmpp::ownership::ClaimEpoch)]) {
+    async fn hydrate_reclaimed(
+        &self,
+        entities: &[(
+            Entity,
+            waddle_xmpp::ownership::NodeIdentity,
+            waddle_xmpp::ownership::ClaimEpoch,
+        )],
+    ) {
         let (sm_entities, rest): (Vec<_>, Vec<_>) = entities
             .iter()
             .cloned()
-            .partition(|(entity, _)| entity.entity_type == EntityType::SmSession);
+            .partition(|(entity, _, _)| entity.entity_type == EntityType::SmSession);
         if !sm_entities.is_empty() {
             self.sm.hydrate_reclaimed(&sm_entities).await;
         }

--- a/server/crates/waddle-server/src/clustering/metrics.rs
+++ b/server/crates/waddle-server/src/clustering/metrics.rs
@@ -250,3 +250,120 @@ pub fn record_claims_abandoned_on_drain(count: u64) {
     })
     .add(count, &[]);
 }
+
+/// Count bounded proactive `RoomActor` orphan-reconciliation outcomes.
+/// `outcome` is one of `hydrated`, `released`, `already_live`,
+/// `adopted_local`, `pending_retry`, `lost_race`, or `failed`; callers
+/// aggregate a whole sweep before recording, avoiding per-room warning noise
+/// after a node loss.
+pub fn record_room_orphan_reconciliation(outcome: &'static str, count: u64) {
+    static C: OnceLock<Counter<u64>> = OnceLock::new();
+    C.get_or_init(|| {
+        meter()
+            .u64_counter("waddle.clustering.room_orphan_reconciliations")
+            .with_description("Proactive RoomActor orphan-claim reconciliation outcomes")
+            .with_unit("claim")
+            .build()
+    })
+    .add(count, &[opentelemetry::KeyValue::new("outcome", outcome)]);
+}
+
+pub fn record_room_orphan_pending_backlog(depth: usize, oldest_age_ms: u64) {
+    static DEPTH: OnceLock<Gauge<u64>> = OnceLock::new();
+    DEPTH
+        .get_or_init(|| {
+            meter()
+                .u64_gauge("waddle.clustering.room_orphan_pending_depth")
+                .with_description("Reclaimed room epochs awaiting adoption or release")
+                .with_unit("claim")
+                .build()
+        })
+        .record(depth as u64, &[]);
+    static AGE: OnceLock<Gauge<u64>> = OnceLock::new();
+    AGE.get_or_init(|| {
+        meter()
+            .u64_gauge("waddle.clustering.room_orphan_pending_oldest_age_ms")
+            .with_description("Age of the oldest pending reclaimed room epoch")
+            .with_unit("ms")
+            .build()
+    })
+    .record(oldest_age_ms, &[]);
+}
+
+/// Report the bounded orphan-reaper work queues. `queue` is the stable
+/// low-cardinality value `sm_hydration` or `room_release`.
+pub fn record_orphan_work_queue_depth(queue: &'static str, depth: usize) {
+    static G: OnceLock<Gauge<u64>> = OnceLock::new();
+    G.get_or_init(|| {
+        meter()
+            .u64_gauge("waddle.clustering.orphan_work_queue_depth")
+            .with_description("Current deduplicated orphan-reaper work queue depth")
+            .with_unit("item")
+            .build()
+    })
+    .record(
+        depth as u64,
+        &[opentelemetry::KeyValue::new("queue", queue)],
+    );
+}
+
+/// Count work rejected by a bounded orphan-reaper queue. A nonzero value
+/// means ownership remains fenced-safe but recovery is deferred to a later
+/// sweep or node-incarnation expiry.
+pub fn record_orphan_work_queue_backpressure(queue: &'static str) {
+    static C: OnceLock<Counter<u64>> = OnceLock::new();
+    C.get_or_init(|| {
+        meter()
+            .u64_counter("waddle.clustering.orphan_work_queue_backpressure")
+            .with_description("Orphan-reaper work rejected because its bounded queue was full")
+            .with_unit("item")
+            .build()
+    })
+    .add(1, &[opentelemetry::KeyValue::new("queue", queue)]);
+}
+
+pub fn record_orphan_worker_failure(worker: &'static str, reason: &'static str) {
+    static C: OnceLock<Counter<u64>> = OnceLock::new();
+    C.get_or_init(|| {
+        meter()
+            .u64_counter("waddle.clustering.orphan_worker_failures")
+            .with_description("Orphan-reaper worker tasks that exited unexpectedly")
+            .with_unit("failure")
+            .build()
+    })
+    .add(
+        1,
+        &[
+            opentelemetry::KeyValue::new("worker", worker),
+            opentelemetry::KeyValue::new("reason", reason),
+        ],
+    );
+}
+
+/// Report each bounded SM candidate page, including whether another page was
+/// visible at scan time and how many malformed stale rows were quarantined.
+pub fn record_sm_orphan_candidate_page(candidates: usize, has_more: bool, quarantined: usize) {
+    static H: OnceLock<Histogram<u64>> = OnceLock::new();
+    H.get_or_init(|| {
+        meter()
+            .u64_histogram("waddle.clustering.sm_orphan_candidate_page_size")
+            .with_description("Bounded SM orphan candidates returned per cursor page")
+            .with_unit("claim")
+            .build()
+    })
+    .record(
+        candidates as u64,
+        &[opentelemetry::KeyValue::new("has_more", has_more)],
+    );
+    if quarantined > 0 {
+        static C: OnceLock<Counter<u64>> = OnceLock::new();
+        C.get_or_init(|| {
+            meter()
+                .u64_counter("waddle.clustering.sm_orphan_malformed_quarantined")
+                .with_description("Malformed stale SM claim rows quarantined by the bounded scan")
+                .with_unit("claim")
+                .build()
+        })
+        .add(quarantined as u64, &[]);
+    }
+}

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -703,9 +703,13 @@ pub async fn start_if_enabled(
         // `open_for_cluster_mode` already enforce at startup for their own
         // durability stores.
         let muc_durable_store: Arc<dyn waddle_xmpp::muc::MucDurableStore> = Arc::new(
-            crate::muc_durable::PostgresMucRoomStore::open(db.clone(), clustering_stop.clone())
-                .await
-                .map_err(ClusteringError::MucDurableStoreInit)?,
+            crate::muc_durable::PostgresMucRoomStore::open(
+                db.clone(),
+                clustering_stop.clone(),
+                live_identity.clone(),
+            )
+            .await
+            .map_err(ClusteringError::MucDurableStoreInit)?,
         );
         // ADR-0017 Phase 3 Slice 8: the Postgres ISR token store. Built here
         // for the same reason `muc_durable_store` is — it only needs `db`,

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -689,8 +689,8 @@ pub async fn start_if_enabled(
         let node_lease_handle: Arc<dyn claims::NodeLeaseStore> =
             Arc::new(claims::PostgresClaimStore::new(db.clone()));
         // ADR-0017 Phase 3 Slice 7: the durable MUC room store. Built here
-        // (not deferred to `server/mod.rs`) because it only needs `db`/
-        // `live_identity`/`clustering_stop` — all already in scope — unlike
+        // (not deferred to `server/mod.rs`) because it only needs `db` and
+        // `clustering_stop` — both already in scope — unlike
         // `room_local_claims` above, which genuinely must wait for the room
         // registry to exist.
         //
@@ -703,13 +703,9 @@ pub async fn start_if_enabled(
         // `open_for_cluster_mode` already enforce at startup for their own
         // durability stores.
         let muc_durable_store: Arc<dyn waddle_xmpp::muc::MucDurableStore> = Arc::new(
-            crate::muc_durable::PostgresMucRoomStore::open(
-                db.clone(),
-                live_identity.clone(),
-                clustering_stop.clone(),
-            )
-            .await
-            .map_err(ClusteringError::MucDurableStoreInit)?,
+            crate::muc_durable::PostgresMucRoomStore::open(db.clone(), clustering_stop.clone())
+                .await
+                .map_err(ClusteringError::MucDurableStoreInit)?,
         );
         // ADR-0017 Phase 3 Slice 8: the Postgres ISR token store. Built here
         // for the same reason `muc_durable_store` is — it only needs `db`,

--- a/server/crates/waddle-server/src/clustering/self_fence.rs
+++ b/server/crates/waddle-server/src/clustering/self_fence.rs
@@ -177,7 +177,7 @@ pub trait LocallyClaimedEntities: Send + Sync {
     /// by the time it runs. Default no-op, mirroring [`Self::demote`]'s
     /// own no-op default: correct for [`NoLocallyClaimedEntities`], which
     /// owns nothing to hydrate.
-    async fn hydrate_reclaimed(&self, entities: &[(Entity, ClaimEpoch)]) {
+    async fn hydrate_reclaimed(&self, entities: &[(Entity, NodeIdentity, ClaimEpoch)]) {
         let _ = entities;
     }
 
@@ -475,7 +475,7 @@ async fn reclaim_own_expired_claims<L>(
         }
     };
 
-    let mut reclaimed: Vec<(Entity, ClaimEpoch)> = Vec::new();
+    let mut reclaimed: Vec<(Entity, NodeIdentity, ClaimEpoch)> = Vec::new();
     for candidate in candidates {
         if candidate.owner != *old_identity {
             // Another node's genuinely dead claim — not this node's own
@@ -495,7 +495,7 @@ async fn reclaim_own_expired_claims<L>(
             )
             .await
         {
-            Ok(new_epoch) => reclaimed.push((candidate.entity, new_epoch)),
+            Ok(new_epoch) => reclaimed.push((candidate.entity, fresh.clone(), new_epoch)),
             Err(ClaimError::Conflict) => {
                 // The general orphan reaper (or another node) already
                 // reclaimed it first — safe, no-op.
@@ -1971,11 +1971,12 @@ mod tests {
             self.healthy.load(Ordering::SeqCst)
         }
 
-        async fn hydrate_reclaimed(&self, entities: &[(Entity, ClaimEpoch)]) {
-            self.hydrated
-                .lock()
-                .expect("lock")
-                .extend(entities.iter().map(|(entity, _epoch)| entity.clone()));
+        async fn hydrate_reclaimed(&self, entities: &[(Entity, NodeIdentity, ClaimEpoch)]) {
+            self.hydrated.lock().expect("lock").extend(
+                entities
+                    .iter()
+                    .map(|(entity, _owner, _epoch)| entity.clone()),
+            );
         }
     }
 

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -168,7 +168,7 @@ pub struct ClusteringConfig {
     /// dials seed peers, picking up pod churn
     /// (`WADDLE_CLUSTERING_DIAL_INTERVAL_MS`).
     pub dial_interval: Duration,
-    /// Cadence for the orphan reaper's `sm_session` claim sweep (ADR-0017
+    /// Cadence for the orphan reaper's `sm_session` and `RoomActor` claim sweep (ADR-0017
     /// Phase 3 Slice 5, element 9) — `WADDLE_CLUSTERING_ORPHAN_REAPER_INTERVAL_MS`.
     /// The only cluster timer that, prior to ADR-0017 Phase 3 Slice 11's
     /// corrigenda (deviation 111), had no env override at all (every

--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -497,7 +497,23 @@ impl MucDurableStore for PostgresMucRoomStore {
     /// lands, unconditionally (both archiving-on and archiving-off).
     fn check_fenced_fanout<'a>(&'a self, room_jid: &'a BareJid) -> MucDurableFuture<'a, bool> {
         Box::pin(async move {
-            let fence = self.fence_for(room_jid)?;
+            let fence = self
+                .claim_fences
+                .get(room_jid)
+                .map(|entry| entry.clone())
+                .ok_or_else(|| {
+                    XmppError::internal(format!(
+                        "no claim epoch recorded for room {room_jid}; fenced fan-out skipped"
+                    ))
+                })?;
+            // Identity rotation is a definitive local ownership loss, not a
+            // transient storage failure. Return `Ok(false)` so fan-out and
+            // mutation gates fail closed instead of taking their transient
+            // error path (which intentionally fails open).
+            if self.node_identity.current() != fence.owner {
+                remove_room_claim_fence_if(&self.claim_fences, room_jid, &fence);
+                return Ok(false);
+            }
             let key = room_entity_key(room_jid);
             let conn = self.db.guard().await.map_err(db_err)?;
             let mut rows = conn
@@ -617,6 +633,13 @@ mod tests {
 
         live_identity.set(node_identity());
 
+        assert!(
+            !store
+                .check_fenced_fanout(&jid)
+                .await
+                .expect("identity rotation is definitive ownership loss"),
+            "a rotated cached fence must return false, never a transient error that callers fail open"
+        );
         assert!(store.current_claim_fence(&jid).is_none());
         assert!(store.claim_fences.get(&jid).is_none());
     }

--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -61,7 +61,7 @@ use waddle_xmpp::muc::{
     DurableRoomState, MucDurableFuture, MucDurableStore, RoomClaimFenceContext, RoomConfig,
     SubjectState,
 };
-use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType};
+use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, SharedNodeIdentity};
 use waddle_xmpp::{Affiliation, XmppError};
 
 use crate::clustering::relay::RelayHandle;
@@ -113,6 +113,10 @@ fn affiliation_from_db_str(value: &str) -> Option<Affiliation> {
 /// code-research correction.
 pub struct PostgresMucRoomStore {
     db: Database,
+    /// Live process incarnation. Cached room fences remain immutable; every
+    /// use must still match this handle so a self-fenced old incarnation
+    /// cannot write merely because its old claim row remains in Postgres.
+    node_identity: SharedNodeIdentity,
     /// This node's clustering-scope cancellation token, threaded into the
     /// `RelayHandle` [`Self::notify_previous_owner_demoted`] constructs
     /// per-call (mirroring `resume_asker::SwarmRemoteResumeAsker`'s
@@ -136,9 +140,14 @@ impl PostgresMucRoomStore {
     /// store, never a second, independently-resolved database (the fencing
     /// `SELECT ... FOR SHARE` this impl issues targets `clustering_claims`,
     /// which lives there).
-    pub async fn open(db: Database, stop_token: CancellationToken) -> Result<Self, XmppError> {
+    pub async fn open(
+        db: Database,
+        stop_token: CancellationToken,
+        node_identity: SharedNodeIdentity,
+    ) -> Result<Self, XmppError> {
         let store = Self {
             db,
+            node_identity,
             stop_token,
             claim_fences: DashMap::new(),
         };
@@ -188,7 +197,8 @@ impl PostgresMucRoomStore {
     }
 
     fn fence_for(&self, room_jid: &BareJid) -> Result<RoomClaimFenceContext, XmppError> {
-        self.claim_fences
+        let fence = self
+            .claim_fences
             .get(room_jid)
             .map(|entry| entry.clone())
             .ok_or_else(|| {
@@ -196,7 +206,14 @@ impl PostgresMucRoomStore {
                     "no claim epoch recorded for room {room_jid}; durable write skipped \
                  (the room registry must call record_claim_fence before any write)"
                 ))
-            })
+            })?;
+        if self.node_identity.current() != fence.owner {
+            remove_room_claim_fence_if(&self.claim_fences, room_jid, &fence);
+            return Err(XmppError::internal(format!(
+                "durable write for room {room_jid} aborted: cached claim belongs to a stale node incarnation"
+            )));
+        }
+        Ok(fence)
     }
 
     /// Take the fencing lock inside `tx` — the exact `SELECT ... FOR SHARE`
@@ -209,6 +226,12 @@ impl PostgresMucRoomStore {
         room_jid: &BareJid,
         fence: &RoomClaimFenceContext,
     ) -> Result<(), XmppError> {
+        if self.node_identity.current() != fence.owner {
+            remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
+            return Err(XmppError::internal(format!(
+                "durable write for room {room_jid} aborted: claim fence belongs to a stale node incarnation"
+            )));
+        }
         let key = room_entity_key(room_jid);
         let mut rows = tx
             .query(
@@ -223,7 +246,7 @@ impl PostgresMucRoomStore {
             .await
             .map_err(db_err)?;
         let held = rows.next().await.map_err(db_err)?.is_some();
-        if held {
+        if held && self.node_identity.current() == fence.owner {
             Ok(())
         } else {
             remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
@@ -489,7 +512,13 @@ impl MucDurableStore for PostgresMucRoomStore {
                 )
                 .await
                 .map_err(db_err)?;
-            Ok(rows.next().await.map_err(db_err)?.is_some())
+            let held = rows.next().await.map_err(db_err)?.is_some();
+            if held && self.node_identity.current() == fence.owner {
+                Ok(true)
+            } else {
+                remove_room_claim_fence_if(&self.claim_fences, room_jid, &fence);
+                Ok(false)
+            }
         })
     }
 
@@ -499,7 +528,7 @@ impl MucDurableStore for PostgresMucRoomStore {
     /// `groupchat_archive.rs`'s MAM fenced write can bind the identical
     /// typed context rather than re-deriving it from a second mechanism.
     fn current_claim_fence(&self, room_jid: &BareJid) -> Option<RoomClaimFenceContext> {
-        self.claim_fences.get(room_jid).map(|entry| entry.clone())
+        self.fence_for(room_jid).ok()
     }
 
     fn notify_previous_owner_demoted<'a>(
@@ -562,6 +591,36 @@ mod tests {
             .expect("valid test room JID")
     }
 
+    #[tokio::test]
+    async fn identity_rotation_invalidates_cached_room_fence_before_database_access() {
+        let original = node_identity();
+        let live_identity = SharedNodeIdentity::new(original.clone());
+        let db = Database::from_config(
+            "muc-identity-rotation-test",
+            &DatabaseConfig::new(DatabaseDriver::Sqlite, "sqlite::memory:"),
+        )
+        .await
+        .expect("open in-memory database");
+        let store = PostgresMucRoomStore {
+            db,
+            node_identity: live_identity.clone(),
+            stop_token: CancellationToken::new(),
+            claim_fences: DashMap::new(),
+        };
+        let jid = room_jid("identity-rotation");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        store.record_claim_fence(
+            &jid,
+            RoomClaimFenceContext::new(entity, original, ClaimEpoch(7)),
+        );
+        assert!(store.current_claim_fence(&jid).is_some());
+
+        live_identity.set(node_identity());
+
+        assert!(store.current_claim_fence(&jid).is_none());
+        assert!(store.claim_fences.get(&jid).is_none());
+    }
+
     /// Open a clean `PostgresMucRoomStore` alongside a `PostgresClaimStore`
     /// sharing the same `Database`/tables, wiping every row this module's
     /// tests touch first. `None` (test skipped) when
@@ -587,9 +646,13 @@ mod tests {
             .await
             .expect("ensure claim schema");
         let me = node_identity();
-        let store = PostgresMucRoomStore::open(db.clone(), CancellationToken::new())
-            .await
-            .expect("open muc durable store");
+        let store = PostgresMucRoomStore::open(
+            db.clone(),
+            CancellationToken::new(),
+            SharedNodeIdentity::new(me.clone()),
+        )
+        .await
+        .expect("open muc durable store");
         let conn = db.guard().await.expect("guard");
         conn.execute("DELETE FROM clustering_claims", ())
             .await

--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -32,8 +32,8 @@
 //! same [`crate::db::Database::begin`] transaction as the write it guards,
 //! on the **main pool**, never the control-plane pool (the Slice 0/4/7
 //! pool-assignment rule). The epoch bound into that check comes from a
-//! per-room cache ([`PostgresMucRoomStore::claim_epochs`]) populated by the
-//! room registry calling [`Self::record_claim_epoch`] immediately after a
+//! per-room cache ([`PostgresMucRoomStore::claim_fences`]) populated by the
+//! room registry calling [`Self::record_claim_fence`] immediately after a
 //! successful claim acquire/steal — never re-derived here, mirroring
 //! `PostgresFencedSmPersistence`'s own "epoch side channel" design note.
 //!
@@ -61,7 +61,7 @@ use waddle_xmpp::muc::{
     DurableRoomState, MucDurableFuture, MucDurableStore, RoomClaimFenceContext, RoomConfig,
     SubjectState,
 };
-use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, SharedNodeIdentity};
+use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType};
 use waddle_xmpp::{Affiliation, XmppError};
 
 use crate::clustering::relay::RelayHandle;
@@ -113,14 +113,21 @@ fn affiliation_from_db_str(value: &str) -> Option<Affiliation> {
 /// code-research correction.
 pub struct PostgresMucRoomStore {
     db: Database,
-    node_identity: SharedNodeIdentity,
     /// This node's clustering-scope cancellation token, threaded into the
     /// `RelayHandle` [`Self::notify_previous_owner_demoted`] constructs
     /// per-call (mirroring `resume_asker::SwarmRemoteResumeAsker`'s
     /// identical "fresh `RelayHandle` per ask" pattern).
     stop_token: CancellationToken,
     /// Per-room claim epoch cache — see the module doc's fencing section.
-    claim_epochs: DashMap<BareJid, ClaimEpoch>,
+    claim_fences: DashMap<BareJid, RoomClaimFenceContext>,
+}
+
+fn remove_room_claim_fence_if(
+    claim_fences: &DashMap<BareJid, RoomClaimFenceContext>,
+    room_jid: &BareJid,
+    expected: &RoomClaimFenceContext,
+) {
+    claim_fences.remove_if(room_jid, |_, current| current == expected);
 }
 
 impl PostgresMucRoomStore {
@@ -129,16 +136,11 @@ impl PostgresMucRoomStore {
     /// store, never a second, independently-resolved database (the fencing
     /// `SELECT ... FOR SHARE` this impl issues targets `clustering_claims`,
     /// which lives there).
-    pub async fn open(
-        db: Database,
-        node_identity: SharedNodeIdentity,
-        stop_token: CancellationToken,
-    ) -> Result<Self, XmppError> {
+    pub async fn open(db: Database, stop_token: CancellationToken) -> Result<Self, XmppError> {
         let store = Self {
             db,
-            node_identity,
             stop_token,
-            claim_epochs: DashMap::new(),
+            claim_fences: DashMap::new(),
         };
         store.ensure_schema().await.map_err(db_err)?;
         Ok(store)
@@ -185,14 +187,14 @@ impl PostgresMucRoomStore {
         Ok(())
     }
 
-    fn epoch_for(&self, room_jid: &BareJid) -> Result<ClaimEpoch, XmppError> {
-        self.claim_epochs
+    fn fence_for(&self, room_jid: &BareJid) -> Result<RoomClaimFenceContext, XmppError> {
+        self.claim_fences
             .get(room_jid)
-            .map(|entry| *entry)
+            .map(|entry| entry.clone())
             .ok_or_else(|| {
                 XmppError::internal(format!(
                     "no claim epoch recorded for room {room_jid}; durable write skipped \
-                 (the room registry must call record_claim_epoch before any write)"
+                 (the room registry must call record_claim_fence before any write)"
                 ))
             })
     }
@@ -205,14 +207,18 @@ impl PostgresMucRoomStore {
         &self,
         tx: &mut Transaction<'_>,
         room_jid: &BareJid,
-        epoch: ClaimEpoch,
+        fence: &RoomClaimFenceContext,
     ) -> Result<(), XmppError> {
-        let identity = self.node_identity.current();
         let key = room_entity_key(room_jid);
         let mut rows = tx
             .query(
-                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                crate::db_params![key, identity.node_id.clone(), epoch.0],
+                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
+                crate::db_params![
+                    key,
+                    fence.owner.node_id.clone(),
+                    fence.owner.node_epoch.clone(),
+                    fence.epoch.0
+                ],
             )
             .await
             .map_err(db_err)?;
@@ -220,7 +226,7 @@ impl PostgresMucRoomStore {
         if held {
             Ok(())
         } else {
-            self.claim_epochs.remove(room_jid);
+            remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
             Err(XmppError::internal(format!(
                 "durable write for room {room_jid} aborted: this node no longer holds the \
                  room's ownership claim (0 rows from the fencing SELECT)"
@@ -316,12 +322,12 @@ impl MucDurableStore for PostgresMucRoomStore {
         config: &'a RoomConfig,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let epoch = self.epoch_for(room_jid)?;
+            let fence = self.fence_for(room_jid)?;
             let config_json = serde_json::to_string(config).map_err(|error| {
                 XmppError::internal(format!("durable room config encode failed: {error}"))
             })?;
             let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, epoch).await?;
+            self.assert_fenced(&mut tx, room_jid, &fence).await?;
             tx.execute(
                 r#"
                 INSERT INTO clustering_muc_rooms (room_jid, waddle_id, channel_id, config_json, updated_at)
@@ -352,7 +358,7 @@ impl MucDurableStore for PostgresMucRoomStore {
         subject: Option<&'a SubjectState>,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let epoch = self.epoch_for(room_jid)?;
+            let fence = self.fence_for(room_jid)?;
             let subject_json = subject
                 .map(serde_json::to_string)
                 .transpose()
@@ -360,7 +366,7 @@ impl MucDurableStore for PostgresMucRoomStore {
                     XmppError::internal(format!("durable room subject encode failed: {error}"))
                 })?;
             let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, epoch).await?;
+            self.assert_fenced(&mut tx, room_jid, &fence).await?;
             // The room row must already exist (a subject can only be set on
             // an already-spawned room, which always durably writes its
             // config at spawn-adjacent points first) — an UPDATE-only
@@ -392,9 +398,9 @@ impl MucDurableStore for PostgresMucRoomStore {
         entry: &'a AffiliationEntry,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let epoch = self.epoch_for(room_jid)?;
+            let fence = self.fence_for(room_jid)?;
             let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, epoch).await?;
+            self.assert_fenced(&mut tx, room_jid, &fence).await?;
             if entry.affiliation == Affiliation::None {
                 tx.execute(
                     "DELETE FROM clustering_muc_room_affiliations WHERE room_jid = ? AND member_jid = ?",
@@ -433,9 +439,9 @@ impl MucDurableStore for PostgresMucRoomStore {
     /// rows.
     fn delete_room_state<'a>(&'a self, room_jid: &'a BareJid) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let epoch = self.epoch_for(room_jid)?;
+            let fence = self.fence_for(room_jid)?;
             let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, epoch).await?;
+            self.assert_fenced(&mut tx, room_jid, &fence).await?;
             tx.execute(
                 "DELETE FROM clustering_muc_room_affiliations WHERE room_jid = ?",
                 crate::db_params![room_jid.to_string()],
@@ -453,12 +459,12 @@ impl MucDurableStore for PostgresMucRoomStore {
         })
     }
 
-    fn record_claim_epoch(&self, room_jid: &BareJid, epoch: ClaimEpoch) {
-        self.claim_epochs.insert(room_jid.clone(), epoch);
+    fn record_claim_fence(&self, room_jid: &BareJid, fence: RoomClaimFenceContext) {
+        self.claim_fences.insert(room_jid.clone(), fence);
     }
 
-    fn forget_claim_epoch(&self, room_jid: &BareJid) {
-        self.claim_epochs.remove(room_jid);
+    fn forget_claim_fence(&self, room_jid: &BareJid, expected: &RoomClaimFenceContext) {
+        remove_room_claim_fence_if(&self.claim_fences, room_jid, expected);
     }
 
     /// The guaranteed demotion backstop (element 7): a fenced,
@@ -468,14 +474,18 @@ impl MucDurableStore for PostgresMucRoomStore {
     /// lands, unconditionally (both archiving-on and archiving-off).
     fn check_fenced_fanout<'a>(&'a self, room_jid: &'a BareJid) -> MucDurableFuture<'a, bool> {
         Box::pin(async move {
-            let epoch = self.epoch_for(room_jid)?;
-            let identity = self.node_identity.current();
+            let fence = self.fence_for(room_jid)?;
             let key = room_entity_key(room_jid);
             let conn = self.db.guard().await.map_err(db_err)?;
             let mut rows = conn
                 .query(
-                    "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                    crate::db_params![key, identity.node_id.clone(), epoch.0],
+                    "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
+                    crate::db_params![
+                        key,
+                        fence.owner.node_id.clone(),
+                        fence.owner.node_epoch.clone(),
+                        fence.epoch.0
+                    ],
                 )
                 .await
                 .map_err(db_err)?;
@@ -485,17 +495,11 @@ impl MucDurableStore for PostgresMucRoomStore {
 
     /// ADR-0017 Phase 3 Slice 7 FIX 1: exposes the exact `(Entity,
     /// ClaimEpoch, node_id)` triple [`Self::check_fenced_fanout`]/
-    /// [`Self::assert_fenced`] already resolve from `self.claim_epochs`, so
+    /// [`Self::assert_fenced`] already resolve from `self.claim_fences`, so
     /// `groupchat_archive.rs`'s MAM fenced write can bind the identical
     /// typed context rather than re-deriving it from a second mechanism.
     fn current_claim_fence(&self, room_jid: &BareJid) -> Option<RoomClaimFenceContext> {
-        let epoch = self.claim_epochs.get(room_jid).map(|entry| *entry)?;
-        let identity = self.node_identity.current();
-        Some(RoomClaimFenceContext {
-            entity: Entity::new(EntityType::RoomActor, room_jid.to_string()),
-            epoch,
-            node_id: identity.node_id,
-        })
+        self.claim_fences.get(room_jid).map(|entry| entry.clone())
     }
 
     fn notify_previous_owner_demoted<'a>(
@@ -563,7 +567,12 @@ mod tests {
     /// tests touch first. `None` (test skipped) when
     /// `WADDLE_TEST_POSTGRES_URL` is unset, mirroring every other
     /// Postgres-gated test in this workspace.
-    async fn clean_store() -> Option<(PostgresMucRoomStore, Arc<PostgresClaimStore>, Database)> {
+    async fn clean_store() -> Option<(
+        PostgresMucRoomStore,
+        Arc<PostgresClaimStore>,
+        Database,
+        NodeIdentity,
+    )> {
         let url = std::env::var("WADDLE_TEST_POSTGRES_URL").ok()?;
         let db = Database::from_config(
             "muc-durable-test",
@@ -577,13 +586,10 @@ mod tests {
             .ensure_schema()
             .await
             .expect("ensure claim schema");
-        let store = PostgresMucRoomStore::open(
-            db.clone(),
-            SharedNodeIdentity::new(node_identity()),
-            CancellationToken::new(),
-        )
-        .await
-        .expect("open muc durable store");
+        let me = node_identity();
+        let store = PostgresMucRoomStore::open(db.clone(), CancellationToken::new())
+            .await
+            .expect("open muc durable store");
         let conn = db.guard().await.expect("guard");
         conn.execute("DELETE FROM clustering_claims", ())
             .await
@@ -597,23 +603,25 @@ mod tests {
         conn.execute("DELETE FROM clustering_muc_room_affiliations", ())
             .await
             .expect("clean affiliations");
-        Some((store, claim_store, db))
+        Some((store, claim_store, db, me))
     }
 
     #[tokio::test]
     async fn save_and_load_round_trips_config_subject_and_affiliations() {
         let _guard = clustering_control_plane_table_lock().lock().await;
-        let Some((store, claim_store, _db)) = clean_store().await else {
+        let Some((store, claim_store, _db, me)) = clean_store().await else {
             return;
         };
         let jid = room_jid("round-trip");
         let entity = Entity::new(EntityType::RoomActor, jid.to_string());
-        let me = store.node_identity.current();
         let epoch = claim_store
             .ensure_claimed(&entity, &me)
             .await
             .expect("claim");
-        store.record_claim_epoch(&jid, epoch);
+        store.record_claim_fence(
+            &jid,
+            RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch),
+        );
 
         let config = RoomConfig {
             name: "test room".to_string(),
@@ -664,17 +672,19 @@ mod tests {
     #[tokio::test]
     async fn save_affiliation_none_deletes_the_row() {
         let _guard = clustering_control_plane_table_lock().lock().await;
-        let Some((store, claim_store, _db)) = clean_store().await else {
+        let Some((store, claim_store, _db, me)) = clean_store().await else {
             return;
         };
         let jid = room_jid("affiliation-removal");
         let entity = Entity::new(EntityType::RoomActor, jid.to_string());
-        let me = store.node_identity.current();
         let epoch = claim_store
             .ensure_claimed(&entity, &me)
             .await
             .expect("claim");
-        store.record_claim_epoch(&jid, epoch);
+        store.record_claim_fence(
+            &jid,
+            RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch),
+        );
         store
             .save_config(&jid, "waddle-1", "chan-1", &RoomConfig::default())
             .await
@@ -713,17 +723,19 @@ mod tests {
     #[tokio::test]
     async fn check_fenced_fanout_returns_false_immediately_after_a_steal_commits() {
         let _guard = clustering_control_plane_table_lock().lock().await;
-        let Some((store, claim_store, db)) = clean_store().await else {
+        let Some((store, claim_store, db, me)) = clean_store().await else {
             return;
         };
         let jid = room_jid("deposed");
         let entity = Entity::new(EntityType::RoomActor, jid.to_string());
-        let me = store.node_identity.current();
         let epoch = claim_store
             .ensure_claimed(&entity, &me)
             .await
             .expect("claim");
-        store.record_claim_epoch(&jid, epoch);
+        store.record_claim_fence(
+            &jid,
+            RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch),
+        );
 
         assert!(
             store
@@ -766,17 +778,19 @@ mod tests {
         use waddle_xmpp_core::mam::ArchivedMessage;
 
         let _guard = clustering_control_plane_table_lock().lock().await;
-        let Some((store, claim_store, db)) = clean_store().await else {
+        let Some((store, claim_store, db, me)) = clean_store().await else {
             return;
         };
         let jid = room_jid("mam-fenced");
         let entity = Entity::new(EntityType::RoomActor, jid.to_string());
-        let me = store.node_identity.current();
         let epoch = claim_store
             .ensure_claimed(&entity, &me)
             .await
             .expect("claim");
-        store.record_claim_epoch(&jid, epoch);
+        store.record_claim_fence(
+            &jid,
+            RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch),
+        );
 
         let mam_storage = SqlxMamStorage::open(db.database_url())
             .await
@@ -794,10 +808,10 @@ mod tests {
 
         let fence = store
             .current_claim_fence(&jid)
-            .expect("current_claim_fence must resolve immediately after record_claim_epoch");
+            .expect("current_claim_fence must resolve immediately after record_claim_fence");
         assert_eq!(fence.entity, entity);
         assert_eq!(fence.epoch, epoch);
-        assert_eq!(fence.node_id, me.node_id);
+        assert_eq!(fence.owner, me);
 
         let message = ArchivedMessage {
             id: first_id.clone(),
@@ -857,5 +871,20 @@ mod tests {
             should_be_absent.is_none(),
             "a rejected fenced write must not have committed any row"
         );
+    }
+
+    #[test]
+    fn stale_muc_cache_failure_does_not_evict_new_generation() {
+        let jid = room_jid("old-a-new-b");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let owner = node_identity();
+        let fence_a = RoomClaimFenceContext::new(entity.clone(), owner.clone(), ClaimEpoch(1));
+        let fence_b = RoomClaimFenceContext::new(entity, owner, ClaimEpoch(2));
+        let cache = DashMap::new();
+        cache.insert(jid.clone(), fence_b.clone());
+
+        remove_room_claim_fence_if(&cache, &jid, &fence_a);
+
+        assert_eq!(cache.get(&jid).as_deref(), Some(&fence_b));
     }
 }

--- a/server/crates/waddle-server/src/pending_delivery/database.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database.rs
@@ -5,6 +5,7 @@ mod schema;
 use super::codec::{decode_row, serialize_message, PAYLOAD_KIND_ARCHIVED, PAYLOAD_KIND_TRANSIENT};
 
 use waddle_xmpp::ownership::{ClaimError, ClaimStore, Entity, EntityType, SharedNodeIdentity};
+use waddle_xmpp::stream_management::persistence::SmClaimFence;
 
 // ---------------------------------------------------------------------------
 // Database-backed PendingDeliveryStorage (issue #209, slice (b) production
@@ -402,6 +403,10 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
             .ensure_claimed(&entity, &identity)
             .await
             .map_err(|error| claim_error_to_pending_storage_error(error, entity.clone()))?;
+        let claim_fence = SmClaimFence::new(identity, epoch);
+        if fencing.node_identity.current() != *claim_fence.owner() {
+            return Err(PendingStorageError::NotOwner { entity });
+        }
 
         let PreparedInsertRow {
             row_id,
@@ -427,8 +432,13 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
         let entity_key = format!("{}:{}", EntityType::SmSession.as_db_str(), origin_stream_id);
         let mut fence_rows = tx
             .query(
-                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                crate::db_params![entity_key, identity.node_id.clone(), epoch.0],
+                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
+                crate::db_params![
+                    entity_key,
+                    claim_fence.owner().node_id.clone(),
+                    claim_fence.owner().node_epoch.clone(),
+                    claim_fence.epoch().0,
+                ],
             )
             .await
             .map_err(|e| PendingStorageError::Other(e.to_string()))?;
@@ -437,7 +447,7 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
             .await
             .map_err(|e| PendingStorageError::Other(e.to_string()))?
             .is_some();
-        if !held {
+        if !held || fencing.node_identity.current() != *claim_fence.owner() {
             return Err(PendingStorageError::NotOwner { entity });
         }
 
@@ -488,6 +498,10 @@ impl PendingDeliveryStorage for DatabasePendingDeliveryStorage {
                 .await
                 .map_err(|e| PendingStorageError::Other(e.to_string()))?,
         };
+
+        if fencing.node_identity.current() != *claim_fence.owner() {
+            return Err(PendingStorageError::NotOwner { entity });
+        }
 
         tx.commit()
             .await

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -2268,6 +2268,171 @@ async fn db_storage_postgres_handles_i32_overflow_receipt_ms() {
 // one succeed; the deposed node's attempt aborts fenced
 // (`PendingStorageError::NotOwner`) before writing anything.
 #[cfg(feature = "clustering")]
+struct RotateIncarnationAfterEnsureClaimStore {
+    inner: crate::clustering::claims::PostgresClaimStore,
+    db: crate::db::Database,
+    replacement: waddle_xmpp::ownership::NodeIdentity,
+    rotate_once: std::sync::atomic::AtomicBool,
+}
+
+#[cfg(feature = "clustering")]
+#[async_trait::async_trait]
+impl waddle_xmpp::ownership::ClaimStore for RotateIncarnationAfterEnsureClaimStore {
+    async fn ensure_schema(&self) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.ensure_schema().await
+    }
+
+    async fn acquire(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner.acquire(entity, me).await
+    }
+
+    async fn ensure_claimed(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        let epoch = self.inner.ensure_claimed(entity, me).await?;
+        if self
+            .rotate_once
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+        {
+            self.db
+                .guard()
+                .await
+                .map_err(|error| waddle_xmpp::ownership::ClaimError::Backend(error.to_string()))?
+                .execute(
+                    "UPDATE clustering_claims SET node_epoch = ? WHERE entity = ?",
+                    crate::db_params![
+                        self.replacement.node_epoch.clone(),
+                        format!("{}:{}", entity.entity_type.as_db_str(), entity.id),
+                    ],
+                )
+                .await
+                .map_err(|error| waddle_xmpp::ownership::ClaimError::Backend(error.to_string()))?;
+        }
+        Ok(epoch)
+    }
+
+    async fn steal_stale(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        observed: waddle_xmpp::ownership::ClaimEpoch,
+        staleness: waddle_xmpp::ownership::StalePredicate,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner
+            .steal_stale(entity, observed, staleness, me)
+            .await
+    }
+
+    async fn steal_for_resume(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        observed: waddle_xmpp::ownership::ClaimEpoch,
+        witness: waddle_xmpp::ownership::ResumeIdentityProof,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner
+            .steal_for_resume(entity, observed, witness, me)
+            .await
+    }
+
+    async fn current_claim(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+    ) -> Result<Option<waddle_xmpp::ownership::ClaimSnapshot>, waddle_xmpp::ownership::ClaimError>
+    {
+        self.inner.current_claim(entity).await
+    }
+
+    async fn fence(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+        mine: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> Result<bool, waddle_xmpp::ownership::ClaimError> {
+        self.inner.fence(entity, me, mine).await
+    }
+
+    async fn release(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+        mine: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.release(entity, me, mine).await
+    }
+
+    async fn release_many(
+        &self,
+        entities: &[waddle_xmpp::ownership::Entity],
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.release_many(entities, me).await
+    }
+}
+
+#[cfg(feature = "clustering")]
+#[tokio::test]
+async fn insert_fenced_rejects_same_node_id_new_incarnation_at_the_same_claim_epoch() {
+    use crate::clustering::claims::{clustering_control_plane_table_lock, PostgresClaimStore};
+    use crate::db::{Database, DatabaseConfig, DatabaseDriver, DEFAULT_CONTROL_PLANE_POOL_SIZE};
+    use waddle_xmpp::ownership::{
+        ClaimStore, Entity, EntityType, NodeIdentity, SharedNodeIdentity,
+    };
+
+    let _guard = clustering_control_plane_table_lock().lock().await;
+    let Ok(database_url) = std::env::var("WADDLE_TEST_POSTGRES_URL") else {
+        return;
+    };
+    let db = Database::from_config(
+        "pending-delivery-incarnation-fence-test",
+        &DatabaseConfig::new(DatabaseDriver::Postgres, database_url.clone())
+            .with_control_plane_pool(DEFAULT_CONTROL_PLANE_POOL_SIZE),
+    )
+    .await
+    .expect("open test postgres");
+    let old = NodeIdentity::new(uuid::Uuid::new_v4().to_string(), "old-incarnation");
+    let replacement = NodeIdentity::new(old.node_id.clone(), "new-incarnation");
+    let stream_id = format!("stream-incarnation-{}", uuid::Uuid::new_v4());
+    let entity = Entity::new(EntityType::SmSession, stream_id.clone());
+    let schema_store = PostgresClaimStore::new(db.clone());
+    schema_store.ensure_schema().await.expect("claim schema");
+    schema_store
+        .acquire(&entity, &old)
+        .await
+        .expect("old claim");
+    let rotating_store: std::sync::Arc<dyn ClaimStore> =
+        std::sync::Arc::new(RotateIncarnationAfterEnsureClaimStore {
+            inner: PostgresClaimStore::new(db.clone()),
+            db: db.clone(),
+            replacement,
+            rotate_once: std::sync::atomic::AtomicBool::new(true),
+        });
+    let storage = crate::pending_delivery::open_for_cluster_mode(
+        Some(&database_url),
+        QuotaPolicy::Unlimited,
+        true,
+        Some((rotating_store, SharedNodeIdentity::new(old))),
+        &db,
+    )
+    .await
+    .expect("open fenced storage");
+    let recipient_text = format!("incarnation-{}@example.com", uuid::Uuid::new_v4());
+    let recipient = bare(&recipient_text);
+
+    let outcome = storage
+        .insert_fenced(transient_row(&recipient_text, "must not land"), &stream_id)
+        .await;
+    assert!(matches!(outcome, Err(PendingStorageError::NotOwner { .. })));
+    assert!(storage.list(&recipient).await.expect("list").is_empty());
+}
+
+#[cfg(feature = "clustering")]
 #[tokio::test]
 async fn insert_fenced_prevents_duplicate_promotion_across_claim_states() {
     use crate::clustering::claims::{clustering_control_plane_table_lock, PostgresClaimStore};

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -345,6 +345,7 @@ pub(super) async fn cleanup_connection_shutdown(
             .connection_registry
             .entry_if_owner(&jid, owner)
         else {
+            super::stream_management::defer_superseded_sm_claim(state, &conn.sm_state);
             debug!(jid = %jid, "Skipped SM detach for non-owned registry entry");
             return ConnectionShutdownOutcome::NotPersisted;
         };

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -583,6 +583,18 @@ async fn handle_xmpp_websocket(
     // newcomer owns — the same reason the cleanup block below
     // short-circuits.
     if !superseded {
+        if let (Some(jid), Some(owner)) = (conn.phase.bound_jid(), conn.registry_owner.as_ref()) {
+            superseded = state
+                .deps
+                .protocol
+                .connection_registry
+                .entry_if_owner(jid, owner)
+                .is_none();
+        }
+    }
+    if superseded {
+        super::stream_management::defer_superseded_sm_claim(state.as_ref(), &conn.sm_state);
+    } else {
         process_deferred_inbound_after_transport_loss(&domain, state.as_ref(), &mut conn).await;
         drain_ordered_relay_handoffs_before_cleanup(&mut handoff_rx, &mut conn).await;
     }
@@ -770,7 +782,9 @@ async fn handle_inbound_text(
     )
     .await
     {
-        BatchWriteOutcome::Continue => {}
+        BatchWriteOutcome::Continue => {
+            conn.publish_pending_sm_enable(state.as_ref());
+        }
         BatchWriteOutcome::TransportClosed => return false,
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -52,6 +52,7 @@ async fn handle_xmpp_frame_impl(
         pending_resume_stream_id,
         pending_resume_h,
         suppress_sm_record_next_batch,
+        pending_sm_enable_commit,
         state_machine,
         stream_open_sent,
         registry_owner,
@@ -79,6 +80,7 @@ async fn handle_xmpp_frame_impl(
                 suppress_sm_record_next_batch,
                 roster_interested,
                 blocklist_interested,
+                pending_sm_enable_commit,
             };
             return handle_sm_stanza(sm, state, ctx).await;
         }
@@ -189,6 +191,7 @@ async fn handle_xmpp_frame_impl(
                 suppress_sm_record_next_batch,
                 roster_interested,
                 blocklist_interested,
+                pending_sm_enable_commit,
             };
             let responses =
                 handle_isr_resume_authenticate(mechanism, initial_response, resume, state, ctx)

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -357,46 +357,6 @@ pub(super) fn settle_inbound_dispatch(
     }
 }
 
-#[cfg(test)]
-mod inbound_dispatch_tests {
-    use super::*;
-
-    fn enabled_sm() -> waddle_xmpp::stream_management::StreamManagementState {
-        let mut state = waddle_xmpp::stream_management::StreamManagementState::new();
-        state.enable("dispatch-test".to_string(), true, Some(300));
-        state
-    }
-
-    #[test]
-    fn handled_dispatch_advances_h_unless_ordered_relay_owns_completion() {
-        let mut state = enabled_sm();
-        let mut completion =
-            crate::server::routes::interpret::SmInboundCompletionTracker::default();
-        let sequence = completion.reserve(&state);
-
-        settle_inbound_dispatch(
-            InboundDisposition::Handled,
-            false,
-            Some(sequence),
-            &mut completion,
-            &mut state,
-        );
-
-        assert_eq!(state.get_inbound_count(), 1);
-
-        let deferred = completion.reserve(&state);
-        settle_inbound_dispatch(
-            InboundDisposition::Handled,
-            true,
-            Some(deferred),
-            &mut completion,
-            &mut state,
-        );
-        assert_eq!(state.get_inbound_count(), 1);
-        assert!(completion.has_pending());
-    }
-}
-
 #[cfg(feature = "clustering")]
 async fn ordered_relay_origin_for_inbound_stanza(
     state: &WebSocketState,
@@ -580,5 +540,45 @@ mod tests {
                 )
             )
         );
+    }
+}
+
+#[cfg(test)]
+mod inbound_dispatch_tests {
+    use super::*;
+
+    fn enabled_sm() -> waddle_xmpp::stream_management::StreamManagementState {
+        let mut state = waddle_xmpp::stream_management::StreamManagementState::new();
+        state.enable("dispatch-test".to_string(), true, Some(300));
+        state
+    }
+
+    #[test]
+    fn handled_dispatch_advances_h_unless_ordered_relay_owns_completion() {
+        let mut state = enabled_sm();
+        let mut completion =
+            crate::server::routes::interpret::SmInboundCompletionTracker::default();
+        let sequence = completion.reserve(&state);
+
+        settle_inbound_dispatch(
+            InboundDisposition::Handled,
+            false,
+            Some(sequence),
+            &mut completion,
+            &mut state,
+        );
+
+        assert_eq!(state.get_inbound_count(), 1);
+
+        let deferred = completion.reserve(&state);
+        settle_inbound_dispatch(
+            InboundDisposition::Handled,
+            true,
+            Some(deferred),
+            &mut completion,
+            &mut state,
+        );
+        assert_eq!(state.get_inbound_count(), 1);
+        assert!(completion.has_pending());
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
@@ -299,7 +299,8 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                 // atomically restored the room — nothing was torn down, so
                 // answer retryable, never a false success.
                 Ok(
-                    waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed,
+                    waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed
+                    | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ReleaseBacklogFull,
                 ) => {
                     return vec![build_iq_error_xml_typed(
                         id,

--- a/server/crates/waddle-server/src/server/routes/websocket/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/isr_resume.rs
@@ -270,10 +270,8 @@ pub(super) async fn handle_isr_resume_authenticate(
     // `sm_persistence_fenced::claim_epoch_for` uses to learn the epoch
     // value it just granted, not a second, independent acquire attempt.
     let entity = Entity::new(EntityType::SmSession, resume.previd.clone());
-    let epoch = match claim_store
-        .ensure_claimed(&entity, &node_identity.current())
-        .await
-    {
+    let identity = node_identity.current();
+    let epoch = match claim_store.ensure_claimed(&entity, &identity).await {
         Ok(epoch) => epoch,
         Err(error) => {
             warn!(stream_id = %resume.previd, %error, "ISR resume failed: could not confirm claim epoch");
@@ -289,14 +287,27 @@ pub(super) async fn handle_isr_resume_authenticate(
             return vec![sasl2_failure("temporary-auth-failure")];
         }
     };
+    let claim_fence =
+        waddle_xmpp::stream_management::persistence::SmClaimFence::new(identity.clone(), epoch);
+    if node_identity.current() != identity {
+        if let Err(error) = state
+            .deps
+            .protocol
+            .sm_session_registry
+            .release_claim(&resume.previd)
+            .await
+        {
+            warn!(stream_id = %resume.previd, %error, "Failed to release ISR claim after node identity rotation");
+        }
+        return vec![sasl2_failure("temporary-auth-failure")];
+    }
 
     let rotated_token = match isr_token_store
         .consume(
             &resume.previd,
             presented_token.as_bytes(),
             ISR_PINNED_MECHANISM,
-            &node_identity.current(),
-            epoch,
+            &claim_fence,
         )
         .await
     {

--- a/server/crates/waddle-server/src/server/routes/websocket/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/isr_resume.rs
@@ -117,6 +117,7 @@ pub(super) async fn handle_isr_resume_authenticate(
         suppress_sm_record_next_batch,
         roster_interested,
         blocklist_interested,
+        pending_sm_enable_commit: _,
     } = ctx;
 
     // Q8's gate: ISR is only wired when clustering.enabled && Postgres —

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -703,6 +703,10 @@ pub(super) struct WsConnState {
     /// and duplicate queue entries. The main loop resets the flag to
     /// `false` after skipping the record step.
     pub(super) suppress_sm_record_next_batch: bool,
+    /// Post-write `<enable/>` publication. While present, a resumable claim
+    /// remains guarded and SM stays locally disabled; dropping the
+    /// connection or failing the write terminalizes the exact claim.
+    pub(super) pending_sm_enable_commit: Option<super::stream_management::SmEnableCommit>,
     /// Inbound text frames pulled off the socket by the mid-batch ack
     /// drain (issue #1089) that were NOT `<a/>` acks. The batch writer
     /// may only consume acks out of order; everything else must reach
@@ -775,12 +779,30 @@ impl WsConnState {
             pending_resume_h: None,
             registry_owner: None,
             suppress_sm_record_next_batch: false,
+            pending_sm_enable_commit: None,
             deferred_inbound: std::collections::VecDeque::new(),
             send_window_pause_deadline: None,
             send_window_last_request_acked: 0,
             state_machine: None,
             keepalive_config: waddle_xmpp::protocol::KeepaliveConfig::default(),
         }
+    }
+
+    /// Apply the typed `<enable/>` effect after its `<enabled/>` frame has
+    /// been written. This is synchronous by design: no cancellation point
+    /// may exist between transport success, local SM enablement, registry
+    /// publication, and disarming exact-claim cleanup.
+    pub(super) fn publish_pending_sm_enable(&mut self, state: &WebSocketState) {
+        let Some(commit) = self.pending_sm_enable_commit.take() else {
+            return;
+        };
+        let bound_jid = self.phase.bound_jid().cloned();
+        commit.publish(
+            state,
+            &mut self.sm_state,
+            bound_jid.as_ref(),
+            self.registry_owner.as_ref(),
+        );
     }
 
     /// Initialize the per-connection [`XmppStateMachine`] in the

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -3,6 +3,78 @@ use super::*;
 
 const SM_ENABLE_FALLIBLE_AWAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 
+struct SmEnableClaimGuard {
+    registry: std::sync::Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
+    stream_id: String,
+    armed: bool,
+}
+
+impl SmEnableClaimGuard {
+    fn new(
+        registry: std::sync::Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
+        stream_id: String,
+    ) -> Self {
+        Self {
+            registry,
+            stream_id,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for SmEnableClaimGuard {
+    fn drop(&mut self) {
+        if self.armed
+            && !self
+                .registry
+                .defer_unpublished_enabled_claim_release(&self.stream_id)
+        {
+            warn!(
+                stream_id = %self.stream_id,
+                "SM enable cancelled before publication but exact claim cleanup could not be inventoried"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod enable_claim_guard_tests {
+    use super::SmEnableClaimGuard;
+    use std::sync::Arc;
+    use waddle_xmpp::ownership::{ClaimStore as _, Entity, EntityType};
+    use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
+
+    #[tokio::test]
+    async fn dropped_prepublication_guard_defers_and_releases_the_exact_claim() {
+        let store = Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+        let identity = waddle_xmpp::ownership::NodeIdentity::new("sm-node", "incarnation");
+        let registry = Arc::new(InMemorySmSessionRegistry::new().with_claim_store(
+            store.clone(),
+            waddle_xmpp::ownership::SharedNodeIdentity::new(identity),
+        ));
+        let stream_id = "cancelled-before-enabled-publication";
+        assert!(registry.ensure_session_claim(stream_id).await);
+
+        drop(SmEnableClaimGuard::new(
+            registry.clone(),
+            stream_id.to_string(),
+        ));
+
+        assert_eq!(registry.pending_claim_release_count(), 1);
+        assert_eq!(registry.retry_pending_claim_releases(1).await, 1);
+        assert_eq!(registry.pending_claim_release_count(), 0);
+        assert!(store
+            .current_claim(&Entity::new(EntityType::SmSession, stream_id))
+            .await
+            .expect("claim lookup")
+            .is_none());
+    }
+}
+
 mod registration;
 
 pub(super) use registration::{
@@ -276,6 +348,12 @@ async fn handle_sm_enable(
     if !claimed {
         return vec![SmFailed::with_condition("resource-constraint").to_xml()];
     }
+    let mut claim_guard = enable.resume.then(|| {
+        SmEnableClaimGuard::new(
+            state.deps.protocol.sm_session_registry.clone(),
+            stream_id.clone(),
+        )
+    });
     // ADR-0017 Phase 3 Slice 8: XEP-0397 ISR token issuance rides this same
     // `<enable/>`/`<enabled/>` exchange inline (`<isr-enable/>`/
     // `<isr-enabled/>`) — never a standalone IQ (the retired conformance
@@ -318,12 +396,6 @@ async fn handle_sm_enable(
                             }
                             Err(_) => {
                                 warn!(stream_id = %stream_id, "ISR token issuance timed out; rejecting SM enable before state commit");
-                                state
-                                    .deps
-                                    .protocol
-                                    .sm_session_registry
-                                    .abandon_enabled_claim(&stream_id)
-                                    .await;
                                 return vec![
                                     SmFailed::with_condition("resource-constraint").to_xml()
                                 ];
@@ -353,6 +425,9 @@ async fn handle_sm_enable(
                 stream_id.clone(),
             )),
         );
+    }
+    if let Some(guard) = claim_guard.as_mut() {
+        guard.disarm();
     }
 
     info!(stream_id = %stream_id, resume = enable.resume, max = max, "SM enabled");

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -1,6 +1,8 @@
 use super::transport_xml::{build_handled_count_too_high_stream_error, websocket_stream_close_xml};
 use super::*;
 
+const SM_ENABLE_FALLIBLE_AWAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
 mod registration;
 
 pub(super) use registration::{
@@ -246,8 +248,6 @@ async fn handle_sm_enable(
         Some(m) => m,
         None => max_resume_secs,
     };
-    sm_state.enable(stream_id.clone(), enable.resume, Some(max));
-
     // ADR-0017 Phase 3 Slice 6, element 8: ensure this node's `ClaimStore`
     // claim on this SM session at `<enable/>` time — not only at detach
     // time (Slice 5's `acquire_claim_store_entry_for_detach`). Without a
@@ -259,28 +259,15 @@ async fn handle_sm_enable(
     // with the detach-time call for the same stream id later in this
     // session's lifetime. No-op in practice for single-node deployments
     // (`InProcessClaimStore`'s bookkeeping, never a foreign conflict).
-    state
+    let claimed = state
         .deps
         .protocol
         .sm_session_registry
         .ensure_session_claim(&stream_id)
         .await;
-
-    // Publish the stream id onto the registry's ConnectionEntry so
-    // the offline-flush path can claim `pending_delivery` rows under
-    // a session id that's unique to this XEP-0198 session (not just
-    // the resource JID — distinct SM sessions on the same resource
-    // would otherwise share the same key, causing cross-session row
-    // deletion). Locked Q7b SM-ack lifecycle (issue #209).
-    if let Some(jid) = phase.bound_jid() {
-        state.deps.protocol.connection_registry.set_sm_stream_id(
-            jid,
-            Some(waddle_xmpp::pending_delivery::SmSessionId::new(
-                stream_id.clone(),
-            )),
-        );
+    if !claimed {
+        return vec![SmFailed::with_condition("resource-constraint").to_xml()];
     }
-
     // ADR-0017 Phase 3 Slice 8: XEP-0397 ISR token issuance rides this same
     // `<enable/>`/`<enabled/>` exchange inline (`<isr-enable/>`/
     // `<isr-enabled/>`) — never a standalone IQ (the retired conformance
@@ -310,11 +297,28 @@ async fn handle_sm_enable(
             Some(mechanism) if mechanism == waddle_xmpp::isr::ISR_PINNED_MECHANISM => {
                 match state.deps.app_state.clustering_claims.isr_token_store() {
                     Some(isr_token_store) => {
-                        match isr_token_store.issue(&stream_id, mechanism).await {
-                            Ok(issued) => Some(issued.token),
-                            Err(error) => {
+                        match tokio::time::timeout(
+                            SM_ENABLE_FALLIBLE_AWAIT_TIMEOUT,
+                            isr_token_store.issue(&stream_id, mechanism),
+                        )
+                        .await
+                        {
+                            Ok(Ok(issued)) => Some(issued.token),
+                            Ok(Err(error)) => {
                                 warn!(stream_id = %stream_id, %error, "ISR token issuance failed");
                                 None
+                            }
+                            Err(_) => {
+                                warn!(stream_id = %stream_id, "ISR token issuance timed out; rejecting SM enable before state commit");
+                                state
+                                    .deps
+                                    .protocol
+                                    .sm_session_registry
+                                    .abandon_enabled_claim(&stream_id)
+                                    .await;
+                                return vec![
+                                    SmFailed::with_condition("resource-constraint").to_xml()
+                                ];
                             }
                         }
                     }
@@ -332,6 +336,16 @@ async fn handle_sm_enable(
             None => None,
         }
     };
+
+    sm_state.enable(stream_id.clone(), enable.resume, Some(max));
+    if let Some(jid) = phase.bound_jid() {
+        state.deps.protocol.connection_registry.set_sm_stream_id(
+            jid,
+            Some(waddle_xmpp::pending_delivery::SmSessionId::new(
+                stream_id.clone(),
+            )),
+        );
+    }
 
     info!(stream_id = %stream_id, resume = enable.resume, max = max, "SM enabled");
     let mut enabled = if enable.resume {

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -9,6 +9,64 @@ struct SmEnableClaimGuard {
     armed: bool,
 }
 
+/// Typed post-write effect for `<enable/>`. The resumable claim is acquired
+/// before the response is built, but neither local SM state nor connection-
+/// registry publication occurs until the transport confirms that the
+/// `<enabled/>` frame was written.
+pub(super) struct SmEnableCommit {
+    claim_guard: Option<SmEnableClaimGuard>,
+    stream_id: String,
+    resume: bool,
+    max: u32,
+}
+
+impl SmEnableCommit {
+    fn new(
+        claim_guard: Option<SmEnableClaimGuard>,
+        stream_id: String,
+        resume: bool,
+        max: u32,
+    ) -> Self {
+        Self {
+            claim_guard,
+            stream_id,
+            resume,
+            max,
+        }
+    }
+
+    pub(super) fn publish(
+        mut self,
+        state: &WebSocketState,
+        sm_state: &mut StreamManagementState,
+        bound_jid: Option<&jid::FullJid>,
+        registry_owner: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    ) {
+        let (Some(jid), Some(owner)) = (bound_jid, registry_owner) else {
+            return;
+        };
+        if !state
+            .deps
+            .protocol
+            .connection_registry
+            .set_sm_stream_id_if_owner(
+                jid,
+                owner,
+                Some(waddle_xmpp::pending_delivery::SmSessionId::new(
+                    self.stream_id.clone(),
+                )),
+            )
+        {
+            return;
+        }
+        sm_state.enable(self.stream_id.clone(), self.resume, Some(self.max));
+        if let Some(guard) = self.claim_guard.as_mut() {
+            guard.disarm();
+        }
+        info!(stream_id = %self.stream_id, resume = self.resume, max = self.max, "SM enabled");
+    }
+}
+
 impl SmEnableClaimGuard {
     fn new(
         registry: std::sync::Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
@@ -38,6 +96,26 @@ impl Drop for SmEnableClaimGuard {
                 "SM enable cancelled before publication but exact claim cleanup could not be inventoried"
             );
         }
+    }
+}
+
+pub(super) fn defer_superseded_sm_claim(state: &WebSocketState, sm_state: &StreamManagementState) {
+    if !sm_state.is_resumable() {
+        return;
+    }
+    let Some(stream_id) = sm_state.stream_id.as_deref() else {
+        return;
+    };
+    if !state
+        .deps
+        .protocol
+        .sm_session_registry
+        .defer_superseded_enabled_claim_release(stream_id)
+    {
+        warn!(
+            stream_id,
+            "Superseded SM connection could not inventory its exact terminal claim"
+        );
     }
 }
 
@@ -160,6 +238,7 @@ pub(super) struct SmCtx<'a> {
     pub(super) suppress_sm_record_next_batch: &'a mut bool,
     pub(super) roster_interested: &'a mut bool,
     pub(super) blocklist_interested: &'a mut bool,
+    pub(super) pending_sm_enable_commit: &'a mut Option<SmEnableCommit>,
 }
 
 /// Dispatch an XEP-0198 control nonza. Isolated helper so the main frame
@@ -172,7 +251,16 @@ pub(super) async fn handle_sm_stanza(
     use waddle_xmpp::stream_management::SmAck;
 
     match sm {
-        SmStanza::Enable(enable) => handle_sm_enable(enable, state, ctx.sm_state, ctx.phase).await,
+        SmStanza::Enable(enable) => {
+            handle_sm_enable(
+                enable,
+                state,
+                ctx.sm_state,
+                ctx.phase,
+                ctx.pending_sm_enable_commit,
+            )
+            .await
+        }
         SmStanza::Request => vec![SmAck::new(ctx.sm_state.get_inbound_count()).to_xml()],
         SmStanza::Ack(ack) => apply_sm_ack(state, ctx.sm_state, ctx.phase, ack.h).await,
         SmStanza::Resume(resume) => handle_sm_resume(resume, state, ctx).await,
@@ -300,6 +388,7 @@ async fn handle_sm_enable(
     state: &WebSocketState,
     sm_state: &mut StreamManagementState,
     phase: &ConnectionPhase,
+    pending_commit: &mut Option<SmEnableCommit>,
 ) -> Vec<String> {
     use waddle_xmpp::stream_management::{SmEnabled, SmFailed};
 
@@ -348,7 +437,7 @@ async fn handle_sm_enable(
     if !claimed {
         return vec![SmFailed::with_condition("resource-constraint").to_xml()];
     }
-    let mut claim_guard = enable.resume.then(|| {
+    let claim_guard = enable.resume.then(|| {
         SmEnableClaimGuard::new(
             state.deps.protocol.sm_session_registry.clone(),
             stream_id.clone(),
@@ -417,28 +506,20 @@ async fn handle_sm_enable(
         }
     };
 
-    sm_state.enable(stream_id.clone(), enable.resume, Some(max));
-    if let Some(jid) = phase.bound_jid() {
-        state.deps.protocol.connection_registry.set_sm_stream_id(
-            jid,
-            Some(waddle_xmpp::pending_delivery::SmSessionId::new(
-                stream_id.clone(),
-            )),
-        );
-    }
-    if let Some(guard) = claim_guard.as_mut() {
-        guard.disarm();
-    }
-
-    info!(stream_id = %stream_id, resume = enable.resume, max = max, "SM enabled");
     let mut enabled = if enable.resume {
-        SmEnabled::with_resume(stream_id, max)
+        SmEnabled::with_resume(stream_id.clone(), max)
     } else {
-        SmEnabled::new(stream_id)
+        SmEnabled::new(stream_id.clone())
     };
     if let Some(token) = isr_token {
         enabled = enabled.with_isr_token(token);
     }
+    *pending_commit = Some(SmEnableCommit::new(
+        claim_guard,
+        stream_id,
+        enable.resume,
+        max,
+    ));
     vec![enabled.to_xml()]
 }
 
@@ -575,6 +656,7 @@ async fn handle_sm_resume(resume: SmResume, state: &WebSocketState, ctx: SmCtx<'
         suppress_sm_record_next_batch,
         roster_interested,
         blocklist_interested,
+        pending_sm_enable_commit: _,
     } = ctx;
 
     // Stream resumption is only legal before this transport has established a

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -248,8 +248,8 @@ async fn handle_sm_enable(
         Some(m) => m,
         None => max_resume_secs,
     };
-    // ADR-0017 Phase 3 Slice 6, element 8: ensure this node's `ClaimStore`
-    // claim on this SM session at `<enable/>` time — not only at detach
+    // ADR-0017 Phase 3 Slice 6, element 8: for a resumable enable, ensure
+    // this node's `ClaimStore` claim at `<enable/>` time — not only at detach
     // time (Slice 5's `acquire_claim_store_entry_for_detach`). Without a
     // claim row for a still-live session, a cross-node resume attempt
     // would have nothing to discover: it needs the `clustering_claims` row
@@ -259,12 +259,20 @@ async fn handle_sm_enable(
     // with the detach-time call for the same stream id later in this
     // session's lifetime. No-op in practice for single-node deployments
     // (`InProcessClaimStore`'s bookkeeping, never a foreign conflict).
-    let claimed = state
-        .deps
-        .protocol
-        .sm_session_registry
-        .ensure_session_claim(&stream_id)
-        .await;
+    // A non-resumable stream has no `previd`, is never detached, and cannot
+    // be discovered or resumed cross-node. Giving it a durable ownership
+    // claim would retain an entity with no terminal close path, so it does
+    // not participate in clustered SM ownership at all.
+    let claimed = if enable.resume {
+        state
+            .deps
+            .protocol
+            .sm_session_registry
+            .ensure_session_claim(&stream_id)
+            .await
+    } else {
+        true
+    };
     if !claimed {
         return vec![SmFailed::with_condition("resource-constraint").to_xml()];
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -96,6 +96,18 @@ pub(crate) async fn create_test_websocket_state() -> Arc<WebSocketState> {
     .await
 }
 
+pub(crate) async fn create_test_websocket_state_with_sm_registry(
+    sm_session_registry: Arc<InMemorySmSessionRegistry>,
+) -> Arc<WebSocketState> {
+    create_test_websocket_state_with_extension_manager(
+        empty_extension_manager().await,
+        None,
+        None,
+        Some(sm_session_registry),
+    )
+    .await
+}
+
 /// Build a test [`WebSocketState`] with clustering-enabled
 /// [`crate::clustering::ClusteringHandles`] and a caller-supplied SM-session
 /// registry (e.g. one backed by [`crate::sm_persistence_fenced::PostgresFencedSmPersistence`]

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
@@ -74,11 +74,10 @@ impl IsrTokenStore for HangIssueOnceIsrTokenStore {
         sm_id: &str,
         presented_token: &[u8],
         mechanism: &str,
-        me: &NodeIdentity,
-        mine: waddle_xmpp::ownership::ClaimEpoch,
+        fence: &waddle_xmpp::stream_management::persistence::SmClaimFence,
     ) -> Result<waddle_xmpp::isr::IsrConsumeOutcome, waddle_xmpp::isr::IsrTokenStoreError> {
         self.inner
-            .consume(sm_id, presented_token, mechanism, me, mine)
+            .consume(sm_id, presented_token, mechanism, fence)
             .await
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
@@ -34,6 +34,21 @@ struct HangIssueOnceIsrTokenStore {
     hang_once: std::sync::atomic::AtomicBool,
 }
 
+fn register_isr_publish_owner(
+    state: &super::super::state::WebSocketState,
+    conn: &mut WsConnState,
+    jid: &FullJid,
+) {
+    let (tx, _rx) = tokio::sync::mpsc::channel(1);
+    conn.registry_owner = Some(
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .register(jid.clone(), tx),
+    );
+}
+
 #[async_trait::async_trait]
 impl IsrTokenStore for HangIssueOnceIsrTokenStore {
     async fn ensure_schema(&self) -> Result<(), waddle_xmpp::isr::IsrTokenStoreError> {
@@ -209,7 +224,8 @@ async fn isr_enable_mints_a_token_when_clustering_and_postgres_are_available() {
 
     let mut conn = WsConnState::new();
     let jid: FullJid = "alice@example.com/web".parse().expect("jid");
-    conn.phase = ConnectionPhase::ready(jid, false);
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_isr_publish_owner(fixture.state.as_ref(), &mut conn, &jid);
 
     let responses = handle_xmpp_frame(
         &format!(
@@ -222,6 +238,7 @@ async fn isr_enable_mints_a_token_when_clustering_and_postgres_are_available() {
         &mut conn,
     )
     .await;
+    conn.publish_pending_sm_enable(fixture.state.as_ref());
 
     assert_eq!(responses.len(), 1);
     let enabled = Element::from_str(&responses[0]).expect("enabled xml");
@@ -260,7 +277,8 @@ async fn hung_isr_issue_fails_before_sm_state_commit_and_enable_is_retry_safe() 
     .await;
     let mut conn = WsConnState::new();
     let jid: FullJid = "alice@example.com/web".parse().expect("jid");
-    conn.phase = ConnectionPhase::ready(jid, false);
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_isr_publish_owner(state.as_ref(), &mut conn, &jid);
     let enable = format!(
         "<enable xmlns='urn:xmpp:sm:3' resume='true'>\
             <isr-enable xmlns='{ISR_NS}' mechanism='PLAIN'/>\
@@ -278,6 +296,7 @@ async fn hung_isr_issue_fails_before_sm_state_commit_and_enable_is_retry_safe() 
     let retried = handle_xmpp_frame(&enable, "example.com", state.as_ref(), &mut conn).await;
     let enabled = Element::from_str(&retried[0]).expect("enabled xml");
     assert_eq!(enabled.name(), "enabled");
+    conn.publish_pending_sm_enable(state.as_ref());
     assert!(conn.sm_state.enabled);
     assert!(enabled.get_child("isr-enabled", ISR_NS).is_some());
 }
@@ -288,7 +307,8 @@ async fn isr_enable_is_silently_ignored_without_clustering() {
     let state = create_test_websocket_state().await;
     let mut conn = WsConnState::new();
     let jid: FullJid = "alice@example.com/web".parse().expect("jid");
-    conn.phase = ConnectionPhase::ready(jid, false);
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_isr_publish_owner(state.as_ref(), &mut conn, &jid);
 
     let responses = handle_xmpp_frame(
         &format!(
@@ -301,6 +321,7 @@ async fn isr_enable_is_silently_ignored_without_clustering() {
         &mut conn,
     )
     .await;
+    conn.publish_pending_sm_enable(state.as_ref());
 
     let enabled = Element::from_str(&responses[0]).expect("enabled xml");
     assert!(
@@ -324,7 +345,8 @@ async fn isr_enable_is_ignored_when_not_resumable() {
 
     let mut conn = WsConnState::new();
     let jid: FullJid = "grace@example.com/web".parse().expect("jid");
-    conn.phase = ConnectionPhase::ready(jid, false);
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_isr_publish_owner(fixture.state.as_ref(), &mut conn, &jid);
 
     let responses = handle_xmpp_frame(
         &format!(
@@ -337,6 +359,7 @@ async fn isr_enable_is_ignored_when_not_resumable() {
         &mut conn,
     )
     .await;
+    conn.publish_pending_sm_enable(fixture.state.as_ref());
 
     assert_eq!(responses.len(), 1);
     let enabled = Element::from_str(&responses[0]).expect("enabled xml");
@@ -652,6 +675,7 @@ async fn isr_resume_authenticated_but_impossible_wraps_failed_in_success() {
 async fn handle_isr_resume_authenticate_is_a_noop_failure_without_clustering() {
     let state = create_test_websocket_state().await;
     let mut conn = WsConnState::new();
+    let mut pending_sm_enable_commit = None;
     let ctx = SmCtx {
         phase: &mut conn.phase,
         sm_state: &mut conn.sm_state,
@@ -668,6 +692,7 @@ async fn handle_isr_resume_authenticate_is_a_noop_failure_without_clustering() {
         suppress_sm_record_next_batch: &mut conn.suppress_sm_record_next_batch,
         roster_interested: &mut conn.roster_interested,
         blocklist_interested: &mut conn.blocklist_interested,
+        pending_sm_enable_commit: &mut pending_sm_enable_commit,
     };
     let responses = handle_isr_resume_authenticate(
         "PLAIN".to_string(),

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
@@ -29,6 +29,52 @@ use waddle_xmpp::isr::{IsrTokenStore, ISR_NS, ISR_PINNED_MECHANISM};
 use waddle_xmpp::ownership::{ClaimStore, NodeIdentity, SharedNodeIdentity};
 use waddle_xmpp::stream_management::{DetachedSession, SmResume, SmSessionRegistry};
 
+struct HangIssueOnceIsrTokenStore {
+    inner: waddle_xmpp::isr::InMemoryIsrTokenStore,
+    hang_once: std::sync::atomic::AtomicBool,
+}
+
+#[async_trait::async_trait]
+impl IsrTokenStore for HangIssueOnceIsrTokenStore {
+    async fn ensure_schema(&self) -> Result<(), waddle_xmpp::isr::IsrTokenStoreError> {
+        self.inner.ensure_schema().await
+    }
+
+    async fn issue(
+        &self,
+        sm_id: &str,
+        mechanism: &str,
+    ) -> Result<waddle_xmpp::isr::IssuedIsrToken, waddle_xmpp::isr::IsrTokenStoreError> {
+        if self
+            .hang_once
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+        {
+            return std::future::pending().await;
+        }
+        self.inner.issue(sm_id, mechanism).await
+    }
+
+    async fn consume(
+        &self,
+        sm_id: &str,
+        presented_token: &[u8],
+        mechanism: &str,
+        me: &NodeIdentity,
+        mine: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> Result<waddle_xmpp::isr::IsrConsumeOutcome, waddle_xmpp::isr::IsrTokenStoreError> {
+        self.inner
+            .consume(sm_id, presented_token, mechanism, me, mine)
+            .await
+    }
+
+    async fn sweep_expired(
+        &self,
+        max_age: std::time::Duration,
+    ) -> Result<u64, waddle_xmpp::isr::IsrTokenStoreError> {
+        self.inner.sweep_expired(max_age).await
+    }
+}
+
 async fn test_db() -> Option<Database> {
     let url = std::env::var("WADDLE_TEST_POSTGRES_URL").ok()?;
     let db = Database::from_config(
@@ -187,6 +233,53 @@ async fn isr_enable_mints_a_token_when_clustering_and_postgres_are_available() {
         .attr("token")
         .filter(|t| !t.is_empty())
         .is_some());
+}
+
+#[tokio::test]
+async fn hung_isr_issue_fails_before_sm_state_commit_and_enable_is_retry_safe() {
+    let claim_store: std::sync::Arc<dyn ClaimStore> =
+        std::sync::Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+    let node_identity = SharedNodeIdentity::new(NodeIdentity::new("sm-node", "incarnation"));
+    let sm_session_registry = Arc::new(
+        InMemorySmSessionRegistry::new()
+            .with_claim_store(claim_store.clone(), node_identity.clone()),
+    );
+    let isr_token_store: Arc<dyn IsrTokenStore> = Arc::new(HangIssueOnceIsrTokenStore {
+        inner: waddle_xmpp::isr::InMemoryIsrTokenStore::new(),
+        hang_once: std::sync::atomic::AtomicBool::new(true),
+    });
+    let state = create_test_websocket_state_with_clustering(
+        ClusteringHandles {
+            claim_store: Some(claim_store),
+            node_identity: Some(node_identity),
+            isr_token_store: Some(isr_token_store),
+            ..ClusteringHandles::default()
+        },
+        sm_session_registry,
+    )
+    .await;
+    let mut conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/web".parse().expect("jid");
+    conn.phase = ConnectionPhase::ready(jid, false);
+    let enable = format!(
+        "<enable xmlns='urn:xmpp:sm:3' resume='true'>\
+            <isr-enable xmlns='{ISR_NS}' mechanism='PLAIN'/>\
+         </enable>"
+    );
+
+    let failed = handle_xmpp_frame(&enable, "example.com", state.as_ref(), &mut conn).await;
+    let failed = Element::from_str(&failed[0]).expect("failed xml");
+    assert_eq!(failed.name(), "failed");
+    assert!(failed
+        .get_child("resource-constraint", "urn:ietf:params:xml:ns:xmpp-stanzas")
+        .is_some());
+    assert!(!conn.sm_state.enabled);
+
+    let retried = handle_xmpp_frame(&enable, "example.com", state.as_ref(), &mut conn).await;
+    let enabled = Element::from_str(&retried[0]).expect("enabled xml");
+    assert_eq!(enabled.name(), "enabled");
+    assert!(conn.sm_state.enabled);
+    assert!(enabled.get_child("isr-enabled", ISR_NS).is_some());
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -32,6 +32,21 @@ struct HangingEnsureClaimStore {
     inner: waddle_xmpp::ownership::InProcessClaimStore,
 }
 
+fn register_sm_publish_owner(
+    state: &super::super::state::WebSocketState,
+    conn: &mut WsConnState,
+    jid: &FullJid,
+) {
+    let (tx, _rx) = mpsc::channel(1);
+    conn.registry_owner = Some(
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .register(jid.clone(), tx),
+    );
+}
+
 #[async_trait::async_trait]
 impl waddle_xmpp::ownership::ClaimStore for HangingEnsureClaimStore {
     async fn ensure_schema(&self) -> Result<(), waddle_xmpp::ownership::ClaimError> {
@@ -808,7 +823,8 @@ async fn sm_enable_after_bind_returns_enabled_and_tracks_counters() {
     let state = create_test_websocket_state().await;
     let mut conn = WsConnState::new();
     let jid: FullJid = "alice@example.com/web".parse().expect("jid");
-    conn.phase = ConnectionPhase::ready(jid, false);
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_sm_publish_owner(state.as_ref(), &mut conn, &jid);
 
     let responses = handle_xmpp_frame(
         "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
@@ -822,6 +838,11 @@ async fn sm_enable_after_bind_returns_enabled_and_tracks_counters() {
     assert_eq!(el.name(), "enabled");
     assert_eq!(el.attr("resume"), Some("true"));
     assert!(el.attr("id").filter(|s| !s.is_empty()).is_some());
+    assert!(
+        !conn.sm_state.enabled,
+        "SM must remain unpublished until the <enabled/> write succeeds"
+    );
+    conn.publish_pending_sm_enable(state.as_ref());
     assert!(conn.sm_state.enabled);
     assert!(conn.sm_state.is_resumable());
 
@@ -861,11 +882,164 @@ async fn sm_enable_after_bind_returns_enabled_and_tracks_counters() {
 }
 
 #[tokio::test]
+async fn resumable_enable_cancelled_before_write_never_publishes_and_releases_exact_claim() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/cancelled-enable".parse().expect("jid");
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_sm_publish_owner(state.as_ref(), &mut conn, &jid);
+
+    let responses = handle_xmpp_frame(
+        "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
+        "example.com",
+        state.as_ref(),
+        &mut conn,
+    )
+    .await;
+    let enabled = Element::from_str(&responses[0]).expect("enabled xml");
+    let stream_id = enabled.attr("id").expect("stream id").to_string();
+    assert!(!conn.sm_state.enabled);
+    assert!(conn.pending_sm_enable_commit.is_some());
+
+    drop(conn);
+
+    let registry = &state.deps.protocol.sm_session_registry;
+    assert_eq!(registry.pending_claim_release_count(), 1);
+    assert_eq!(registry.retry_pending_claim_releases(1).await, 1);
+    assert!(
+        !registry
+            .locally_owned_claim_ids()
+            .expect("local ownership inventory")
+            .contains(&stream_id),
+        "an unpublished previd must not retain a resumable claim"
+    );
+}
+
+#[tokio::test]
+async fn replaced_connection_cannot_publish_or_strand_its_post_write_enable_claim() {
+    let state = create_test_websocket_state().await;
+    let mut old_conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/replaced-enable".parse().expect("jid");
+    old_conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_sm_publish_owner(state.as_ref(), &mut old_conn, &jid);
+
+    let responses = handle_xmpp_frame(
+        "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
+        "example.com",
+        state.as_ref(),
+        &mut old_conn,
+    )
+    .await;
+    let enabled = Element::from_str(&responses[0]).expect("enabled xml");
+    let stream_id = waddle_xmpp::pending_delivery::SmSessionId::new(
+        enabled.attr("id").expect("stream id").to_string(),
+    );
+
+    let (replacement_tx, _replacement_rx) = mpsc::channel(1);
+    let _replacement_owner = state
+        .deps
+        .protocol
+        .connection_registry
+        .register(jid.clone(), replacement_tx);
+
+    old_conn.publish_pending_sm_enable(state.as_ref());
+
+    assert!(!old_conn.sm_state.enabled);
+    assert!(old_conn.pending_sm_enable_commit.is_none());
+    assert!(
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .get_entry(&jid)
+            .expect("replacement entry")
+            .sm_stream_id()
+            .is_none(),
+        "stale publication must not stamp the replacement entry"
+    );
+    assert!(
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .sm_stream_owner(&stream_id)
+            .is_none(),
+        "stale publication must not create a reverse-index alias"
+    );
+    let registry = &state.deps.protocol.sm_session_registry;
+    assert_eq!(registry.pending_claim_release_count(), 1);
+    assert_eq!(registry.retry_pending_claim_releases(1).await, 1);
+}
+
+#[tokio::test]
+async fn replacement_after_enable_publication_terminalizes_only_the_old_stream_claim() {
+    let state = create_test_websocket_state().await;
+    let mut old_conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/replaced-after-enable"
+        .parse()
+        .expect("jid");
+    old_conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_sm_publish_owner(state.as_ref(), &mut old_conn, &jid);
+
+    let responses = handle_xmpp_frame(
+        "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
+        "example.com",
+        state.as_ref(),
+        &mut old_conn,
+    )
+    .await;
+    let enabled = Element::from_str(&responses[0]).expect("enabled xml");
+    let old_stream_id = enabled.attr("id").expect("stream id").to_string();
+    old_conn.publish_pending_sm_enable(state.as_ref());
+    assert!(old_conn.sm_state.enabled);
+
+    let (replacement_tx, _replacement_rx) = mpsc::channel(1);
+    let replacement_owner = state
+        .deps
+        .protocol
+        .connection_registry
+        .register(jid.clone(), replacement_tx);
+    let replacement_stream =
+        waddle_xmpp::pending_delivery::SmSessionId::new("replacement-owned-stream".to_string());
+    assert!(state
+        .deps
+        .protocol
+        .connection_registry
+        .set_sm_stream_id_if_owner(&jid, &replacement_owner, Some(replacement_stream.clone()),));
+
+    let (_outbound_tx, mut outbound_rx) = mpsc::channel(1);
+    assert_eq!(
+        cleanup_connection_shutdown(state.as_ref(), &mut outbound_rx, &mut old_conn, false).await,
+        super::super::cleanup::ConnectionShutdownOutcome::NotPersisted
+    );
+
+    assert_eq!(
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .get_entry(&jid)
+            .expect("replacement entry")
+            .sm_stream_id(),
+        Some(replacement_stream),
+        "old-stream cleanup must not alter the replacement entry"
+    );
+    let registry = &state.deps.protocol.sm_session_registry;
+    assert_eq!(registry.pending_claim_release_count(), 1);
+    assert!(registry
+        .locally_owned_claim_ids()
+        .expect("ownership inventory")
+        .contains(&old_stream_id));
+    assert_eq!(registry.retry_pending_claim_releases(1).await, 1);
+}
+
+#[tokio::test]
 async fn non_resumable_sm_enable_does_not_create_cluster_claim() {
     let state = create_test_websocket_state().await;
     let mut conn = WsConnState::new();
     let jid: FullJid = "alice@example.com/non-resumable".parse().expect("jid");
-    conn.phase = ConnectionPhase::ready(jid, false);
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_sm_publish_owner(state.as_ref(), &mut conn, &jid);
 
     let responses = handle_xmpp_frame(
         "<enable xmlns='urn:xmpp:sm:3' resume='false'/>",
@@ -879,6 +1053,7 @@ async fn non_resumable_sm_enable_does_not_create_cluster_claim() {
     assert_eq!(enabled.name(), "enabled");
     assert_eq!(enabled.attr("resume"), None);
     let stream_id = enabled.attr("id").expect("SM id");
+    conn.publish_pending_sm_enable(state.as_ref());
     assert!(conn.sm_state.enabled);
     assert!(!conn.sm_state.is_resumable());
     assert!(
@@ -902,6 +1077,7 @@ async fn enable_sm_for_live_ack_tests(
     jid: &FullJid,
 ) -> String {
     conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_sm_publish_owner(state, conn, jid);
     let responses = handle_xmpp_frame(
         "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
         "example.com",
@@ -911,6 +1087,7 @@ async fn enable_sm_for_live_ack_tests(
     .await;
     let enabled = Element::from_str(&responses[0]).expect("enabled xml");
     assert_eq!(enabled.name(), "enabled");
+    conn.publish_pending_sm_enable(state);
     enabled.attr("id").expect("stream id").to_string()
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -11,13 +11,14 @@ use super::super::{
 };
 use super::{
     create_test_server_owner_session, create_test_session, create_test_websocket_state,
-    message_frame_xml_with_id, register_test_native_user, scram_client_final_from_challenge,
-    snapshot_room,
+    create_test_websocket_state_with_sm_registry, message_frame_xml_with_id,
+    register_test_native_user, scram_client_final_from_challenge, snapshot_room,
 };
 use crate::auth::Session;
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use jid::{BareJid, FullJid};
 use std::str::FromStr;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use waddle_xmpp::{
     protocol::{Blocklist, ConnectionPhase, InboundEvent},
@@ -26,6 +27,91 @@ use waddle_xmpp::{
     Stanza,
 };
 use xmpp_parsers::minidom::Element;
+
+struct HangingEnsureClaimStore {
+    inner: waddle_xmpp::ownership::InProcessClaimStore,
+}
+
+#[async_trait::async_trait]
+impl waddle_xmpp::ownership::ClaimStore for HangingEnsureClaimStore {
+    async fn ensure_schema(&self) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.ensure_schema().await
+    }
+
+    async fn acquire(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner.acquire(entity, me).await
+    }
+
+    async fn ensure_claimed(
+        &self,
+        _entity: &waddle_xmpp::ownership::Entity,
+        _me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        std::future::pending().await
+    }
+
+    async fn steal_stale(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        observed: waddle_xmpp::ownership::ClaimEpoch,
+        staleness: waddle_xmpp::ownership::StalePredicate,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner
+            .steal_stale(entity, observed, staleness, me)
+            .await
+    }
+
+    async fn steal_for_resume(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        observed: waddle_xmpp::ownership::ClaimEpoch,
+        witness: waddle_xmpp::ownership::ResumeIdentityProof,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner
+            .steal_for_resume(entity, observed, witness, me)
+            .await
+    }
+
+    async fn current_claim(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+    ) -> Result<Option<waddle_xmpp::ownership::ClaimSnapshot>, waddle_xmpp::ownership::ClaimError>
+    {
+        self.inner.current_claim(entity).await
+    }
+
+    async fn fence(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+        mine: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> Result<bool, waddle_xmpp::ownership::ClaimError> {
+        self.inner.fence(entity, me, mine).await
+    }
+
+    async fn release(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+        mine: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.release(entity, me, mine).await
+    }
+
+    async fn release_many(
+        &self,
+        entities: &[waddle_xmpp::ownership::Entity],
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.release_many(entities, me).await
+    }
+}
 
 fn resume_frame_xml(stream_id: &str, handled_count: u32) -> String {
     element_to_xml(
@@ -232,6 +318,40 @@ async fn sm_enable_requires_resource_binding() {
     let el = Element::from_str(&responses[0]).expect("xml");
     assert_eq!(el.name(), "failed");
     assert!(!conn.sm_state.enabled);
+}
+
+#[tokio::test]
+async fn sm_enable_claim_timeout_returns_failure_without_enabling_state() {
+    let registry = Arc::new(
+        waddle_xmpp::stream_management::InMemorySmSessionRegistry::new().with_claim_store(
+            Arc::new(HangingEnsureClaimStore {
+                inner: waddle_xmpp::ownership::InProcessClaimStore::new(),
+            }),
+            waddle_xmpp::ownership::SharedNodeIdentity::new(
+                waddle_xmpp::ownership::NodeIdentity::new("sm-node", "incarnation"),
+            ),
+        ),
+    );
+    let state = create_test_websocket_state_with_sm_registry(registry).await;
+    let mut conn = WsConnState::new();
+    conn.phase = ConnectionPhase::ready("alice@example.com/web".parse().expect("bound jid"), false);
+
+    let responses = handle_xmpp_frame(
+        "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
+        "example.com",
+        state.as_ref(),
+        &mut conn,
+    )
+    .await;
+
+    assert_eq!(responses.len(), 1);
+    let failed = Element::from_str(&responses[0]).expect("failed xml");
+    assert_eq!(failed.name(), "failed");
+    assert!(failed
+        .get_child("resource-constraint", "urn:ietf:params:xml:ns:xmpp-stanzas")
+        .is_some());
+    assert!(!conn.sm_state.enabled);
+    assert!(conn.sm_state.stream_id.is_none());
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -860,6 +860,39 @@ async fn sm_enable_after_bind_returns_enabled_and_tracks_counters() {
     assert_eq!(ack2_el.attr("h"), Some("1"));
 }
 
+#[tokio::test]
+async fn non_resumable_sm_enable_does_not_create_cluster_claim() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/non-resumable".parse().expect("jid");
+    conn.phase = ConnectionPhase::ready(jid, false);
+
+    let responses = handle_xmpp_frame(
+        "<enable xmlns='urn:xmpp:sm:3' resume='false'/>",
+        "example.com",
+        state.as_ref(),
+        &mut conn,
+    )
+    .await;
+    assert_eq!(responses.len(), 1);
+    let enabled = Element::from_str(&responses[0]).expect("enabled xml");
+    assert_eq!(enabled.name(), "enabled");
+    assert_eq!(enabled.attr("resume"), None);
+    let stream_id = enabled.attr("id").expect("SM id");
+    assert!(conn.sm_state.enabled);
+    assert!(!conn.sm_state.is_resumable());
+    assert!(
+        !state
+            .deps
+            .protocol
+            .sm_session_registry
+            .locally_owned_claim_ids()
+            .expect("local claim snapshot")
+            .contains(&stream_id.to_string()),
+        "non-resumable SM must not retain a clustered ownership claim"
+    );
+}
+
 /// Enable SM on a fresh ready connection and return the negotiated
 /// stream id. Shared setup for the live `<a h='N'/>` validation tests
 /// (issue #1099).

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -692,11 +692,28 @@ impl OrphanReaperWorkers {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .insert(key.clone(), Some(work.clone()));
-        if self.hydration_tx.try_send(work).is_err() {
-            crate::clustering::metrics::record_orphan_work_queue_backpressure("sm_hydration");
-            return false;
+        match self.hydration_tx.try_send(work) {
+            Ok(()) => true,
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                let mut pending = self
+                    .hydration_pending
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                pending.remove(&key);
+                crate::clustering::metrics::record_orphan_work_queue_backpressure("sm_hydration");
+                crate::clustering::metrics::record_orphan_work_queue_depth(
+                    "sm_hydration",
+                    pending.len(),
+                );
+                false
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                // The supervisor snapshots this map when it replaces a dead
+                // worker. Retain the exact work so restart can requeue it.
+                crate::clustering::metrics::record_orphan_work_queue_backpressure("sm_hydration");
+                false
+            }
         }
-        true
     }
 
     fn release_key(work: &ExactReleaseWork) -> String {
@@ -748,12 +765,30 @@ impl OrphanReaperWorkers {
             return false;
         }
         pending.insert(key.clone(), work.clone());
-        if self.release_tx.try_send(work).is_err() {
-            crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
-            return false;
+        match self.release_tx.try_send(work) {
+            Ok(()) => {
+                crate::clustering::metrics::record_orphan_work_queue_depth(
+                    "room_release",
+                    pending.len(),
+                );
+                true
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
+                pending.remove(&key);
+                crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
+                crate::clustering::metrics::record_orphan_work_queue_depth(
+                    "room_release",
+                    pending.len(),
+                );
+                false
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                // A closed receiver means the supervisor must restart the
+                // worker. Keep this exact fence in its restart inventory.
+                crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
+                false
+            }
         }
-        crate::clustering::metrics::record_orphan_work_queue_depth("room_release", pending.len());
-        true
     }
 
     fn pending_hydrations(&self) -> Vec<SmHydrationWork> {
@@ -1568,6 +1603,148 @@ fn hydration_reservations_do_not_overcommit_a_127_of_128_queue() {
         })
         .count();
     assert_eq!(reserved, 1);
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[test]
+fn full_hydration_channel_rolls_back_pending_reservation() {
+    use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
+    use waddle_xmpp::stream_management::persistence::SmClaimFence;
+
+    let (hydration_tx, _hydration_rx) = tokio::sync::mpsc::channel(1);
+    let (release_tx, _release_rx) = tokio::sync::mpsc::channel(1);
+    let existing = SmHydrationWork {
+        entity: Entity::new(EntityType::SmSession, "existing"),
+        fence: SmClaimFence::new(NodeIdentity::new("node", "incarnation"), ClaimEpoch(1)),
+    };
+    hydration_tx
+        .try_send(existing.clone())
+        .expect("prefill hydration channel");
+    let workers = OrphanReaperWorkers {
+        hydration_tx,
+        release_tx,
+        hydration_pending: Arc::new(std::sync::Mutex::new(
+            [("existing".to_string(), Some(existing))].into(),
+        )),
+        release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+    };
+    let candidate = Entity::new(EntityType::SmSession, "candidate");
+
+    assert!(!workers.enqueue_hydration(
+        candidate.clone(),
+        SmClaimFence::new(NodeIdentity::new("node", "incarnation"), ClaimEpoch(2)),
+    ));
+    assert!(!workers
+        .hydration_pending
+        .lock()
+        .expect("hydration pending")
+        .contains_key(&candidate.id));
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[test]
+fn closed_hydration_channel_retains_restart_inventory() {
+    use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
+    use waddle_xmpp::stream_management::persistence::SmClaimFence;
+
+    let (hydration_tx, hydration_rx) = tokio::sync::mpsc::channel(1);
+    drop(hydration_rx);
+    let (release_tx, _release_rx) = tokio::sync::mpsc::channel(1);
+    let workers = OrphanReaperWorkers {
+        hydration_tx,
+        release_tx,
+        hydration_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+    };
+    let candidate = Entity::new(EntityType::SmSession, "candidate");
+
+    assert!(!workers.enqueue_hydration(
+        candidate.clone(),
+        SmClaimFence::new(NodeIdentity::new("node", "incarnation"), ClaimEpoch(2)),
+    ));
+    assert!(workers
+        .hydration_pending
+        .lock()
+        .expect("hydration pending")
+        .contains_key(&candidate.id));
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[test]
+fn full_release_channel_rolls_back_pending_work() {
+    use waddle_xmpp::ownership::{
+        ClaimEpoch, Entity, EntityType, InProcessClaimStore, NodeIdentity,
+    };
+
+    let (hydration_tx, _hydration_rx) = tokio::sync::mpsc::channel(1);
+    let (release_tx, _release_rx) = tokio::sync::mpsc::channel(1);
+    let owner = NodeIdentity::new("node", "incarnation");
+    let existing = ExactReleaseWork {
+        claim_store: Arc::new(InProcessClaimStore::new()),
+        entity: Entity::new(EntityType::RoomActor, "existing@muc.example.com"),
+        owner: owner.clone(),
+        epoch: ClaimEpoch(1),
+    };
+    release_tx
+        .try_send(existing.clone())
+        .expect("prefill release channel");
+    let existing_key = OrphanReaperWorkers::release_key(&existing);
+    let workers = OrphanReaperWorkers {
+        hydration_tx,
+        release_tx,
+        hydration_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        release_pending: Arc::new(std::sync::Mutex::new([(existing_key, existing)].into())),
+        sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+    };
+    let candidate = ExactReleaseWork {
+        claim_store: Arc::new(InProcessClaimStore::new()),
+        entity: Entity::new(EntityType::RoomActor, "candidate@muc.example.com"),
+        owner,
+        epoch: ClaimEpoch(2),
+    };
+    let candidate_key = OrphanReaperWorkers::release_key(&candidate);
+
+    assert!(!workers.enqueue_release(candidate));
+    assert!(!workers
+        .release_pending
+        .lock()
+        .expect("release pending")
+        .contains_key(&candidate_key));
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[test]
+fn closed_release_channel_retains_restart_inventory() {
+    use waddle_xmpp::ownership::{
+        ClaimEpoch, Entity, EntityType, InProcessClaimStore, NodeIdentity,
+    };
+
+    let (hydration_tx, _hydration_rx) = tokio::sync::mpsc::channel(1);
+    let (release_tx, release_rx) = tokio::sync::mpsc::channel(1);
+    drop(release_rx);
+    let workers = OrphanReaperWorkers {
+        hydration_tx,
+        release_tx,
+        hydration_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+    };
+    let candidate = ExactReleaseWork {
+        claim_store: Arc::new(InProcessClaimStore::new()),
+        entity: Entity::new(EntityType::RoomActor, "candidate@muc.example.com"),
+        owner: NodeIdentity::new("node", "incarnation"),
+        epoch: ClaimEpoch(2),
+    };
+    let candidate_key = OrphanReaperWorkers::release_key(&candidate);
+
+    assert!(!workers.enqueue_release(candidate));
+    assert!(workers
+        .release_pending
+        .lock()
+        .expect("release pending")
+        .contains_key(&candidate_key));
 }
 
 #[cfg(all(test, feature = "clustering"))]

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -1124,15 +1124,15 @@ fn reclaimed_cleanup_registration(
             ReclaimedRegistration::CleanupScheduled
         }
         WorkEnqueueOutcome::RetainedForRestart => {
-            warn!(room = %room_jid, "orphan reaper: exact cleanup worker stopped; responsibility retained for supervisor restart");
+            debug!(room = %room_jid, "orphan reaper: exact cleanup worker stopped; responsibility retained for supervisor restart");
             ReclaimedRegistration::CleanupScheduled
         }
         WorkEnqueueOutcome::RetainedForRedrive => {
-            warn!(room = %room_jid, "orphan reaper: exact cleanup channel full; responsibility retained for active redrive");
+            debug!(room = %room_jid, "orphan reaper: exact cleanup channel full; responsibility retained for active redrive");
             ReclaimedRegistration::CleanupScheduled
         }
         WorkEnqueueOutcome::Rejected => {
-            warn!(room = %room_jid, "orphan reaper: exact cleanup inventory saturated after steal; durable claim remains fenced for recovery after node expiry");
+            debug!(room = %room_jid, "orphan reaper: exact cleanup inventory saturated after steal; durable claim remains fenced for recovery after node expiry");
             ReclaimedRegistration::CleanupDeferredToNodeExpiry
         }
     }
@@ -2434,9 +2434,9 @@ async fn run_orphan_reaper_sweep_with_workers(
                     ),
                 ) {
                     WorkEnqueueOutcome::Enqueued | WorkEnqueueOutcome::AlreadyTracked => {}
-                    WorkEnqueueOutcome::RetainedForRestart => warn!("orphan reaper: hydration worker stopped after steal; responsibility retained for supervisor restart"),
-                    WorkEnqueueOutcome::RetainedForRedrive => warn!("orphan reaper: hydration channel full after steal; responsibility retained for active redrive"),
-                    WorkEnqueueOutcome::Rejected => warn!("orphan reaper: reserved hydration channel rejected work after steal; claim remains fenced until node expiry"),
+                    WorkEnqueueOutcome::RetainedForRestart => debug!("orphan reaper: hydration worker stopped after steal; responsibility retained for supervisor restart"),
+                    WorkEnqueueOutcome::RetainedForRedrive => debug!("orphan reaper: hydration channel full after steal; responsibility retained for active redrive"),
+                    WorkEnqueueOutcome::Rejected => debug!("orphan reaper: reserved hydration channel rejected work after steal; claim remains fenced until node expiry"),
                 }
             }
             Err(ClaimError::Conflict) => {

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -639,6 +639,9 @@ enum WorkEnqueueOutcome {
     /// Receiver exited, but the exact work remains in the supervisor's
     /// restart inventory and will be requeued by the replacement worker.
     RetainedForRestart,
+    /// The bounded channel was full. The exact work remains in the pending
+    /// inventory and a bounded background sender is actively redriving it.
+    RetainedForRedrive,
     Rejected,
 }
 
@@ -647,7 +650,10 @@ impl WorkEnqueueOutcome {
     const fn is_accepted(self) -> bool {
         matches!(
             self,
-            Self::Enqueued | Self::AlreadyTracked | Self::RetainedForRestart
+            Self::Enqueued
+                | Self::AlreadyTracked
+                | Self::RetainedForRestart
+                | Self::RetainedForRedrive
         )
     }
 }
@@ -715,18 +721,13 @@ impl OrphanReaperWorkers {
             .insert(key.clone(), Some(work.clone()));
         match self.hydration_tx.try_send(work) {
             Ok(()) => WorkEnqueueOutcome::Enqueued,
-            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                let mut pending = self
-                    .hydration_pending
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner());
-                pending.remove(&key);
+            Err(tokio::sync::mpsc::error::TrySendError::Full(work)) => {
                 crate::clustering::metrics::record_orphan_work_queue_backpressure("sm_hydration");
-                crate::clustering::metrics::record_orphan_work_queue_depth(
-                    "sm_hydration",
-                    pending.len(),
-                );
-                WorkEnqueueOutcome::Rejected
+                let tx = self.hydration_tx.clone();
+                tokio::spawn(async move {
+                    let _ = tx.send(work).await;
+                });
+                WorkEnqueueOutcome::RetainedForRedrive
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                 // The supervisor snapshots this map when it replaces a dead
@@ -794,14 +795,13 @@ impl OrphanReaperWorkers {
                 );
                 WorkEnqueueOutcome::Enqueued
             }
-            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                pending.remove(&key);
+            Err(tokio::sync::mpsc::error::TrySendError::Full(work)) => {
                 crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
-                crate::clustering::metrics::record_orphan_work_queue_depth(
-                    "room_release",
-                    pending.len(),
-                );
-                WorkEnqueueOutcome::Rejected
+                let tx = self.release_tx.clone();
+                tokio::spawn(async move {
+                    let _ = tx.send(work).await;
+                });
+                WorkEnqueueOutcome::RetainedForRedrive
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                 // A closed receiver means the supervisor must restart the
@@ -1102,6 +1102,7 @@ enum ReclaimedRegistration {
     Released,
     LostRace,
     CleanupScheduled,
+    CleanupDeferredToNodeExpiry,
 }
 
 #[cfg(feature = "clustering")]
@@ -1111,6 +1112,30 @@ struct ReclaimedRegistrationContext<'a> {
     claim_store: &'a Arc<dyn waddle_xmpp::ownership::ClaimStore>,
     previous_owner: &'a waddle_xmpp::ownership::NodeIdentity,
     me: &'a waddle_xmpp::ownership::NodeIdentity,
+}
+
+#[cfg(feature = "clustering")]
+fn reclaimed_cleanup_registration(
+    room_jid: &jid::BareJid,
+    outcome: WorkEnqueueOutcome,
+) -> ReclaimedRegistration {
+    match outcome {
+        WorkEnqueueOutcome::Enqueued | WorkEnqueueOutcome::AlreadyTracked => {
+            ReclaimedRegistration::CleanupScheduled
+        }
+        WorkEnqueueOutcome::RetainedForRestart => {
+            warn!(room = %room_jid, "orphan reaper: exact cleanup worker stopped; responsibility retained for supervisor restart");
+            ReclaimedRegistration::CleanupScheduled
+        }
+        WorkEnqueueOutcome::RetainedForRedrive => {
+            warn!(room = %room_jid, "orphan reaper: exact cleanup channel full; responsibility retained for active redrive");
+            ReclaimedRegistration::CleanupScheduled
+        }
+        WorkEnqueueOutcome::Rejected => {
+            warn!(room = %room_jid, "orphan reaper: exact cleanup inventory saturated after steal; durable claim remains fenced for recovery after node expiry");
+            ReclaimedRegistration::CleanupDeferredToNodeExpiry
+        }
+    }
 }
 
 #[cfg(feature = "clustering")]
@@ -1162,16 +1187,7 @@ async fn register_reclaimed_epoch_or_cleanup(
                 owner: context.me.clone(),
                 epoch: claim_epoch,
             });
-            match queued {
-                WorkEnqueueOutcome::Enqueued | WorkEnqueueOutcome::AlreadyTracked => {}
-                WorkEnqueueOutcome::RetainedForRestart => {
-                    warn!(room = %room_jid, "orphan reaper: exact cleanup worker stopped; responsibility retained for supervisor restart")
-                }
-                WorkEnqueueOutcome::Rejected => {
-                    warn!(room = %room_jid, "orphan reaper: exact cleanup queue saturated after steal; claim remains fenced until node expiry")
-                }
-            }
-            ReclaimedRegistration::CleanupScheduled
+            reclaimed_cleanup_registration(room_jid, queued)
         }
         Err(_) => {
             debug!(room = %room_jid, "orphan reaper: exact cleanup after pending-registration failure timed out");
@@ -1181,16 +1197,7 @@ async fn register_reclaimed_epoch_or_cleanup(
                 owner: context.me.clone(),
                 epoch: claim_epoch,
             });
-            match queued {
-                WorkEnqueueOutcome::Enqueued | WorkEnqueueOutcome::AlreadyTracked => {}
-                WorkEnqueueOutcome::RetainedForRestart => {
-                    warn!(room = %room_jid, "orphan reaper: exact cleanup worker stopped; responsibility retained for supervisor restart")
-                }
-                WorkEnqueueOutcome::Rejected => {
-                    warn!(room = %room_jid, "orphan reaper: exact cleanup queue saturated after steal; claim remains fenced until node expiry")
-                }
-            }
-            ReclaimedRegistration::CleanupScheduled
+            reclaimed_cleanup_registration(room_jid, queued)
         }
     }
 }
@@ -1656,11 +1663,25 @@ fn hydration_reservations_do_not_overcommit_a_127_of_128_queue() {
 
 #[cfg(all(test, feature = "clustering"))]
 #[test]
-fn full_hydration_channel_rolls_back_pending_reservation() {
+fn rejected_cleanup_is_never_reported_as_scheduled() {
+    let room_jid: jid::BareJid = "saturated@muc.example.com".parse().expect("room JID");
+    assert_eq!(
+        reclaimed_cleanup_registration(&room_jid, WorkEnqueueOutcome::Rejected),
+        ReclaimedRegistration::CleanupDeferredToNodeExpiry
+    );
+    assert_eq!(
+        reclaimed_cleanup_registration(&room_jid, WorkEnqueueOutcome::RetainedForRedrive),
+        ReclaimedRegistration::CleanupScheduled
+    );
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn full_hydration_channel_retains_and_redrives_pending_work() {
     use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
     use waddle_xmpp::stream_management::persistence::SmClaimFence;
 
-    let (hydration_tx, _hydration_rx) = tokio::sync::mpsc::channel(1);
+    let (hydration_tx, mut hydration_rx) = tokio::sync::mpsc::channel(1);
     let (release_tx, _release_rx) = tokio::sync::mpsc::channel(1);
     let existing = SmHydrationWork {
         entity: Entity::new(EntityType::SmSession, "existing"),
@@ -1685,13 +1706,31 @@ fn full_hydration_channel_rolls_back_pending_reservation() {
             candidate.clone(),
             SmClaimFence::new(NodeIdentity::new("node", "incarnation"), ClaimEpoch(2)),
         ),
-        WorkEnqueueOutcome::Rejected
+        WorkEnqueueOutcome::RetainedForRedrive
     );
-    assert!(!workers
+    assert!(workers
         .hydration_pending
         .lock()
         .expect("hydration pending")
         .contains_key(&candidate.id));
+    assert_eq!(
+        hydration_rx
+            .recv()
+            .await
+            .expect("existing hydration")
+            .entity
+            .id,
+        "existing"
+    );
+    assert_eq!(
+        hydration_rx
+            .recv()
+            .await
+            .expect("redriven hydration")
+            .entity
+            .id,
+        candidate.id
+    );
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -1727,14 +1766,14 @@ fn closed_hydration_channel_retains_restart_inventory() {
 }
 
 #[cfg(all(test, feature = "clustering"))]
-#[test]
-fn full_release_channel_rolls_back_pending_work() {
+#[tokio::test]
+async fn full_release_channel_retains_and_redrives_pending_work() {
     use waddle_xmpp::ownership::{
         ClaimEpoch, Entity, EntityType, InProcessClaimStore, NodeIdentity,
     };
 
     let (hydration_tx, _hydration_rx) = tokio::sync::mpsc::channel(1);
-    let (release_tx, _release_rx) = tokio::sync::mpsc::channel(1);
+    let (release_tx, mut release_rx) = tokio::sync::mpsc::channel(1);
     let owner = NodeIdentity::new("node", "incarnation");
     let existing = ExactReleaseWork {
         claim_store: Arc::new(InProcessClaimStore::new()),
@@ -1750,7 +1789,9 @@ fn full_release_channel_rolls_back_pending_work() {
         hydration_tx,
         release_tx,
         hydration_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
-        release_pending: Arc::new(std::sync::Mutex::new([(existing_key, existing)].into())),
+        release_pending: Arc::new(std::sync::Mutex::new(
+            [(existing_key.clone(), existing)].into(),
+        )),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
     };
     let candidate = ExactReleaseWork {
@@ -1763,13 +1804,21 @@ fn full_release_channel_rolls_back_pending_work() {
 
     assert_eq!(
         workers.enqueue_release(candidate),
-        WorkEnqueueOutcome::Rejected
+        WorkEnqueueOutcome::RetainedForRedrive
     );
-    assert!(!workers
+    assert!(workers
         .release_pending
         .lock()
         .expect("release pending")
         .contains_key(&candidate_key));
+    assert_eq!(
+        OrphanReaperWorkers::release_key(&release_rx.recv().await.expect("existing release")),
+        existing_key
+    );
+    assert_eq!(
+        OrphanReaperWorkers::release_key(&release_rx.recv().await.expect("redriven release")),
+        candidate_key
+    );
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -2154,6 +2203,10 @@ async fn run_orphan_reaper_sweep_with_workers(
                         room_failed += 1;
                         continue;
                     }
+                    ReclaimedRegistration::CleanupDeferredToNodeExpiry => {
+                        room_failed += 1;
+                        continue;
+                    }
                 }
                 let reconciliation = room_registry
                     .reconcile_reclaimed_room(
@@ -2382,6 +2435,7 @@ async fn run_orphan_reaper_sweep_with_workers(
                 ) {
                     WorkEnqueueOutcome::Enqueued | WorkEnqueueOutcome::AlreadyTracked => {}
                     WorkEnqueueOutcome::RetainedForRestart => warn!("orphan reaper: hydration worker stopped after steal; responsibility retained for supervisor restart"),
+                    WorkEnqueueOutcome::RetainedForRedrive => warn!("orphan reaper: hydration channel full after steal; responsibility retained for active redrive"),
                     WorkEnqueueOutcome::Rejected => warn!("orphan reaper: reserved hydration channel rejected work after steal; claim remains fenced until node expiry"),
                 }
             }

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -632,6 +632,27 @@ struct ExactReleaseWork {
 }
 
 #[cfg(feature = "clustering")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkEnqueueOutcome {
+    Enqueued,
+    AlreadyTracked,
+    /// Receiver exited, but the exact work remains in the supervisor's
+    /// restart inventory and will be requeued by the replacement worker.
+    RetainedForRestart,
+    Rejected,
+}
+
+#[cfg(feature = "clustering")]
+impl WorkEnqueueOutcome {
+    const fn is_accepted(self) -> bool {
+        matches!(
+            self,
+            Self::Enqueued | Self::AlreadyTracked | Self::RetainedForRestart
+        )
+    }
+}
+
+#[cfg(feature = "clustering")]
 #[derive(Clone)]
 struct OrphanReaperWorkers {
     hydration_tx: tokio::sync::mpsc::Sender<SmHydrationWork>,
@@ -685,7 +706,7 @@ impl OrphanReaperWorkers {
         &self,
         entity: waddle_xmpp::ownership::Entity,
         fence: waddle_xmpp::stream_management::persistence::SmClaimFence,
-    ) -> bool {
+    ) -> WorkEnqueueOutcome {
         let work = SmHydrationWork { entity, fence };
         let key = Self::hydration_key(&work);
         self.hydration_pending
@@ -693,7 +714,7 @@ impl OrphanReaperWorkers {
             .unwrap_or_else(|e| e.into_inner())
             .insert(key.clone(), Some(work.clone()));
         match self.hydration_tx.try_send(work) {
-            Ok(()) => true,
+            Ok(()) => WorkEnqueueOutcome::Enqueued,
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                 let mut pending = self
                     .hydration_pending
@@ -705,13 +726,13 @@ impl OrphanReaperWorkers {
                     "sm_hydration",
                     pending.len(),
                 );
-                false
+                WorkEnqueueOutcome::Rejected
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                 // The supervisor snapshots this map when it replaces a dead
                 // worker. Retain the exact work so restart can requeue it.
                 crate::clustering::metrics::record_orphan_work_queue_backpressure("sm_hydration");
-                false
+                WorkEnqueueOutcome::RetainedForRestart
             }
         }
     }
@@ -735,7 +756,7 @@ impl OrphanReaperWorkers {
         &self,
         entity: waddle_xmpp::ownership::Entity,
         fence: waddle_xmpp::stream_management::persistence::SmClaimFence,
-    ) -> bool {
+    ) -> WorkEnqueueOutcome {
         let work = SmHydrationWork { entity, fence };
         if self
             .hydration_pending
@@ -743,26 +764,26 @@ impl OrphanReaperWorkers {
             .unwrap_or_else(|e| e.into_inner())
             .contains_key(&Self::hydration_key(&work))
         {
-            return true;
+            return WorkEnqueueOutcome::AlreadyTracked;
         }
         if !self.reserve_hydration(&work.entity) {
-            return false;
+            return WorkEnqueueOutcome::Rejected;
         }
         self.enqueue_reserved_hydration(work.entity, work.fence)
     }
 
-    fn enqueue_release(&self, work: ExactReleaseWork) -> bool {
+    fn enqueue_release(&self, work: ExactReleaseWork) -> WorkEnqueueOutcome {
         let key = Self::release_key(&work);
         let mut pending = self
             .release_pending
             .lock()
             .unwrap_or_else(|e| e.into_inner());
         if pending.contains_key(&key) {
-            return true;
+            return WorkEnqueueOutcome::AlreadyTracked;
         }
         if pending.len() >= ORPHAN_WORK_QUEUE_CAPACITY {
             crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
-            return false;
+            return WorkEnqueueOutcome::Rejected;
         }
         pending.insert(key.clone(), work.clone());
         match self.release_tx.try_send(work) {
@@ -771,7 +792,7 @@ impl OrphanReaperWorkers {
                     "room_release",
                     pending.len(),
                 );
-                true
+                WorkEnqueueOutcome::Enqueued
             }
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
                 pending.remove(&key);
@@ -780,13 +801,13 @@ impl OrphanReaperWorkers {
                     "room_release",
                     pending.len(),
                 );
-                false
+                WorkEnqueueOutcome::Rejected
             }
             Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                 // A closed receiver means the supervisor must restart the
                 // worker. Keep this exact fence in its restart inventory.
                 crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
-                false
+                WorkEnqueueOutcome::RetainedForRestart
             }
         }
     }
@@ -1042,12 +1063,16 @@ impl OrphanReaperSupervisor {
         let next = Self::new(registry, parent_cancel);
         next.workers.set_sm_cursor(sm_cursor);
         for work in hydration {
-            if !next.workers.enqueue_hydration(work.entity, work.fence) {
+            if !next
+                .workers
+                .enqueue_hydration(work.entity, work.fence)
+                .is_accepted()
+            {
                 error!("orphan reaper: failed to requeue hydration after worker restart");
             }
         }
         for work in releases {
-            if !next.workers.enqueue_release(work) {
+            if !next.workers.enqueue_release(work).is_accepted() {
                 error!("orphan reaper: failed to requeue exact release after worker restart");
             }
         }
@@ -1137,8 +1162,14 @@ async fn register_reclaimed_epoch_or_cleanup(
                 owner: context.me.clone(),
                 epoch: claim_epoch,
             });
-            if !queued {
-                warn!(room = %room_jid, "orphan reaper: exact cleanup queue saturated after steal; claim remains fenced until node expiry");
+            match queued {
+                WorkEnqueueOutcome::Enqueued | WorkEnqueueOutcome::AlreadyTracked => {}
+                WorkEnqueueOutcome::RetainedForRestart => {
+                    warn!(room = %room_jid, "orphan reaper: exact cleanup worker stopped; responsibility retained for supervisor restart")
+                }
+                WorkEnqueueOutcome::Rejected => {
+                    warn!(room = %room_jid, "orphan reaper: exact cleanup queue saturated after steal; claim remains fenced until node expiry")
+                }
             }
             ReclaimedRegistration::CleanupScheduled
         }
@@ -1150,8 +1181,14 @@ async fn register_reclaimed_epoch_or_cleanup(
                 owner: context.me.clone(),
                 epoch: claim_epoch,
             });
-            if !queued {
-                warn!(room = %room_jid, "orphan reaper: exact cleanup queue saturated after steal; claim remains fenced until node expiry");
+            match queued {
+                WorkEnqueueOutcome::Enqueued | WorkEnqueueOutcome::AlreadyTracked => {}
+                WorkEnqueueOutcome::RetainedForRestart => {
+                    warn!(room = %room_jid, "orphan reaper: exact cleanup worker stopped; responsibility retained for supervisor restart")
+                }
+                WorkEnqueueOutcome::Rejected => {
+                    warn!(room = %room_jid, "orphan reaper: exact cleanup queue saturated after steal; claim remains fenced until node expiry")
+                }
             }
             ReclaimedRegistration::CleanupScheduled
         }
@@ -1420,21 +1457,27 @@ async fn hung_sm_hydration_does_not_block_completed_room_lane() {
         .expect("detached hydration should reach the deliberately hung SM read");
     assert!(room_lane_completed);
     for index in 1..ORPHAN_WORK_QUEUE_CAPACITY {
-        assert!(supervisor.workers.enqueue_hydration(
-            Entity::new(EntityType::SmSession, format!("queued-{index}")),
-            waddle_xmpp::stream_management::persistence::SmClaimFence::new(
-                me.clone(),
-                waddle_xmpp::ownership::ClaimEpoch(index as i64),
-            ),
-        ));
+        assert!(supervisor
+            .workers
+            .enqueue_hydration(
+                Entity::new(EntityType::SmSession, format!("queued-{index}")),
+                waddle_xmpp::stream_management::persistence::SmClaimFence::new(
+                    me.clone(),
+                    waddle_xmpp::ownership::ClaimEpoch(index as i64),
+                ),
+            )
+            .is_accepted());
     }
-    assert!(!supervisor.workers.enqueue_hydration(
-        Entity::new(EntityType::SmSession, "queue-overflow"),
-        waddle_xmpp::stream_management::persistence::SmClaimFence::new(
-            me,
-            waddle_xmpp::ownership::ClaimEpoch(999),
+    assert_eq!(
+        supervisor.workers.enqueue_hydration(
+            Entity::new(EntityType::SmSession, "queue-overflow"),
+            waddle_xmpp::stream_management::persistence::SmClaimFence::new(
+                me,
+                waddle_xmpp::ownership::ClaimEpoch(999),
+            ),
         ),
-    ));
+        WorkEnqueueOutcome::Rejected
+    );
     cancel.cancel();
     tokio::time::timeout(Duration::from_secs(1), supervisor.shutdown())
         .await
@@ -1465,10 +1508,13 @@ async fn sm_rotation_before_hydration_worker_releases_the_exact_old_fence() {
     let supervisor = OrphanReaperSupervisor::new(registry, cancel.clone());
 
     identity.set(new_owner);
-    assert!(supervisor.workers.enqueue_hydration(
-        entity.clone(),
-        waddle_xmpp::stream_management::persistence::SmClaimFence::new(old_owner, epoch),
-    ));
+    assert!(supervisor
+        .workers
+        .enqueue_hydration(
+            entity.clone(),
+            waddle_xmpp::stream_management::persistence::SmClaimFence::new(old_owner, epoch),
+        )
+        .is_accepted());
 
     tokio::time::timeout(Duration::from_secs(1), async {
         loop {
@@ -1515,10 +1561,13 @@ async fn sm_rotation_between_hydration_retries_releases_the_exact_old_fence() {
     );
     let cancel = tokio_util::sync::CancellationToken::new();
     let supervisor = OrphanReaperSupervisor::new(registry, cancel.clone());
-    assert!(supervisor.workers.enqueue_hydration(
-        entity.clone(),
-        waddle_xmpp::stream_management::persistence::SmClaimFence::new(old_owner, epoch),
-    ));
+    assert!(supervisor
+        .workers
+        .enqueue_hydration(
+            entity.clone(),
+            waddle_xmpp::stream_management::persistence::SmClaimFence::new(old_owner, epoch),
+        )
+        .is_accepted());
 
     storage.read_started.notified().await;
     identity.set(new_owner);
@@ -1631,10 +1680,13 @@ fn full_hydration_channel_rolls_back_pending_reservation() {
     };
     let candidate = Entity::new(EntityType::SmSession, "candidate");
 
-    assert!(!workers.enqueue_hydration(
-        candidate.clone(),
-        SmClaimFence::new(NodeIdentity::new("node", "incarnation"), ClaimEpoch(2)),
-    ));
+    assert_eq!(
+        workers.enqueue_hydration(
+            candidate.clone(),
+            SmClaimFence::new(NodeIdentity::new("node", "incarnation"), ClaimEpoch(2)),
+        ),
+        WorkEnqueueOutcome::Rejected
+    );
     assert!(!workers
         .hydration_pending
         .lock()
@@ -1660,10 +1712,13 @@ fn closed_hydration_channel_retains_restart_inventory() {
     };
     let candidate = Entity::new(EntityType::SmSession, "candidate");
 
-    assert!(!workers.enqueue_hydration(
-        candidate.clone(),
-        SmClaimFence::new(NodeIdentity::new("node", "incarnation"), ClaimEpoch(2)),
-    ));
+    assert_eq!(
+        workers.enqueue_hydration(
+            candidate.clone(),
+            SmClaimFence::new(NodeIdentity::new("node", "incarnation"), ClaimEpoch(2)),
+        ),
+        WorkEnqueueOutcome::RetainedForRestart
+    );
     assert!(workers
         .hydration_pending
         .lock()
@@ -1706,7 +1761,10 @@ fn full_release_channel_rolls_back_pending_work() {
     };
     let candidate_key = OrphanReaperWorkers::release_key(&candidate);
 
-    assert!(!workers.enqueue_release(candidate));
+    assert_eq!(
+        workers.enqueue_release(candidate),
+        WorkEnqueueOutcome::Rejected
+    );
     assert!(!workers
         .release_pending
         .lock()
@@ -1739,7 +1797,10 @@ fn closed_release_channel_retains_restart_inventory() {
     };
     let candidate_key = OrphanReaperWorkers::release_key(&candidate);
 
-    assert!(!workers.enqueue_release(candidate));
+    assert_eq!(
+        workers.enqueue_release(candidate),
+        WorkEnqueueOutcome::RetainedForRestart
+    );
     assert!(workers
         .release_pending
         .lock()
@@ -2312,14 +2373,16 @@ async fn run_orphan_reaper_sweep_with_workers(
         {
             Ok(new_epoch) => {
                 stolen += 1;
-                if !workers.enqueue_reserved_hydration(
+                match workers.enqueue_reserved_hydration(
                     candidate.entity,
                     waddle_xmpp::stream_management::persistence::SmClaimFence::new(
                         me.clone(),
                         new_epoch,
                     ),
                 ) {
-                    warn!("orphan reaper: reserved hydration channel rejected work after steal; claim remains fenced until node expiry");
+                    WorkEnqueueOutcome::Enqueued | WorkEnqueueOutcome::AlreadyTracked => {}
+                    WorkEnqueueOutcome::RetainedForRestart => warn!("orphan reaper: hydration worker stopped after steal; responsibility retained for supervisor restart"),
+                    WorkEnqueueOutcome::Rejected => warn!("orphan reaper: reserved hydration channel rejected work after steal; claim remains fenced until node expiry"),
                 }
             }
             Err(ClaimError::Conflict) => {
@@ -2646,9 +2709,13 @@ mod orphan_reaper_sweep_tests {
                 ),
         );
         let muc_store = Arc::new(
-            PostgresMucRoomStore::open(db.clone(), tokio_util::sync::CancellationToken::new())
-                .await
-                .expect("open fenced MUC durable store"),
+            PostgresMucRoomStore::open(
+                db.clone(),
+                tokio_util::sync::CancellationToken::new(),
+                sweeper_identity_handle.clone(),
+            )
+            .await
+            .expect("open fenced MUC durable store"),
         );
         {
             let conn = db.guard().await.expect("guard");

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -516,7 +516,10 @@ pub(crate) fn spawn_orphan_reaper_janitor(
             .stop_token
             .clone()
             .unwrap_or_else(|| websocket_state.deps.shutdown.stop_token());
+        let room_registry_actor = websocket_state.deps.protocol.room_registry.clone();
         tokio::spawn(async move {
+            let registry_lifetime_watch =
+                spawn_room_registry_lifetime_watch(room_registry_actor, stop.clone());
             let mut supervisor = OrphanReaperSupervisor::new(registry.clone(), stop.clone());
             let mut ticker = tokio::time::interval(interval);
             // Skip the first (immediate) tick, mirroring the other janitors
@@ -541,7 +544,9 @@ pub(crate) fn spawn_orphan_reaper_janitor(
                     supervisor = supervisor.restarted(registry.clone(), stop.clone()).await;
                 }
             }
+            stop.cancel();
             supervisor.shutdown().await;
+            let _ = registry_lifetime_watch.await;
         });
     }
     #[cfg(not(feature = "clustering"))]
@@ -549,6 +554,26 @@ pub(crate) fn spawn_orphan_reaper_janitor(
         let _ = websocket_state;
         let _ = interval;
     }
+}
+
+#[cfg(feature = "clustering")]
+fn spawn_room_registry_lifetime_watch(
+    room_registry: kameo::actor::ActorRef<waddle_xmpp::muc::room_registry_actor::RoomRegistryActor>,
+    node_cancel: tokio_util::sync::CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        tokio::select! {
+            biased;
+            _ = node_cancel.cancelled() => {}
+            _ = room_registry.wait_for_shutdown() => {
+                // Room ownership retry state is actor-local. Losing the
+                // registry while this node's lease remains fresh can strand
+                // every retained exact fence, even while idle, so registry
+                // lifetime is clustering-critical.
+                node_cancel.cancel();
+            }
+        }
+    })
 }
 
 #[cfg(feature = "clustering")]
@@ -667,6 +692,8 @@ struct OrphanReaperWorkers {
         Arc<std::sync::Mutex<std::collections::HashMap<String, Option<SmHydrationWork>>>>,
     release_pending: Arc<std::sync::Mutex<std::collections::HashMap<String, ExactReleaseWork>>>,
     sm_cursor: Arc<std::sync::Mutex<Option<String>>>,
+    cancel: tokio_util::sync::CancellationToken,
+    node_cancel: tokio_util::sync::CancellationToken,
 }
 
 #[cfg(feature = "clustering")]
@@ -860,6 +887,8 @@ impl OrphanReaperSupervisor {
             hydration_pending: hydration_pending.clone(),
             release_pending: release_pending.clone(),
             sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+            cancel: cancel.clone(),
+            node_cancel: parent_cancel.clone(),
         };
 
         let hydration_cancel = cancel.clone();
@@ -1099,12 +1128,17 @@ impl OrphanReaperSupervisor {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReclaimedRegistration {
     Registered,
-    CleanupDeferredToNodeExpiry,
+    Released,
+    LostRace,
+    CleanupScheduled,
+    ShutdownDeferred,
 }
 
 #[cfg(feature = "clustering")]
 struct ReclaimedRegistrationContext<'a> {
+    workers: &'a OrphanReaperWorkers,
     room_registry: &'a waddle_xmpp::muc::RoomRegistry,
+    claim_store: &'a Arc<dyn waddle_xmpp::ownership::ClaimStore>,
     previous_owner: &'a waddle_xmpp::ownership::NodeIdentity,
     me: &'a waddle_xmpp::ownership::NodeIdentity,
 }
@@ -1116,39 +1150,136 @@ async fn register_reclaimed_epoch_or_cleanup(
     room_jid: &jid::BareJid,
     claim_epoch: waddle_xmpp::ownership::ClaimEpoch,
 ) -> ReclaimedRegistration {
-    if context
-        .room_registry
-        .remember_pending_reclaimed_room(
-            room_jid.clone(),
-            waddle_xmpp::muc::RoomClaimFenceContext::new(
-                entity.clone(),
-                context.me.clone(),
-                claim_epoch,
-            ),
-            context.previous_owner.clone(),
-        )
-        .await
-        .is_ok()
-    {
-        return ReclaimedRegistration::Registered;
+    loop {
+        let registration = tokio::select! {
+            biased;
+            _ = context.workers.cancel.cancelled() => {
+                return ReclaimedRegistration::ShutdownDeferred;
+            }
+            result = context.room_registry.remember_pending_reclaimed_room(
+                room_jid.clone(),
+                waddle_xmpp::muc::RoomClaimFenceContext::new(
+                    entity.clone(),
+                    context.me.clone(),
+                    claim_epoch,
+                ),
+                context.previous_owner.clone(),
+            ) => result,
+        };
+        if registration.is_ok() {
+            return ReclaimedRegistration::Registered;
+        }
+        if !context.room_registry.actor_ref().is_alive() {
+            break;
+        }
+        // The registry reservation was established before the steal, so
+        // demand remains serialized while mailbox backpressure clears. Do
+        // not cancel it or release outside the actor while the actor is live.
+        tokio::select! {
+            biased;
+            _ = context.workers.cancel.cancelled() => {
+                return ReclaimedRegistration::ShutdownDeferred;
+            }
+            _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+        }
     }
-    let _ = context
-        .room_registry
-        .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+
+    // A stopped registry cannot create or publish a replacement actor, so
+    // exact cleanup can no longer race demand on this registry. Release the
+    // won generation now; retain failures in the bounded supervised worker.
+    let release = tokio::select! {
+        biased;
+        _ = context.workers.cancel.cancelled() => {
+            return ReclaimedRegistration::ShutdownDeferred;
+        }
+        result = tokio::time::timeout(
+            ORPHANED_ROOM_RELEASE_TIMEOUT,
+            context.claim_store.release_exact(entity, context.me, claim_epoch),
+        ) => result,
+    };
+    match release {
+        Ok(Ok(waddle_xmpp::ownership::ExactReleaseOutcome::Released)) => {
+            ReclaimedRegistration::Released
+        }
+        Ok(Ok(waddle_xmpp::ownership::ExactReleaseOutcome::NotOwned)) => {
+            ReclaimedRegistration::LostRace
+        }
+        Ok(Err(error)) => {
+            debug!(room = %room_jid, %error, "orphan reaper: stopped-registry exact cleanup failed; retaining supervised retry");
+            loop {
+                if context
+                    .workers
+                    .enqueue_release(ExactReleaseWork {
+                        claim_store: context.claim_store.clone(),
+                        entity: entity.clone(),
+                        owner: context.me.clone(),
+                        epoch: claim_epoch,
+                    })
+                    .is_accepted()
+                {
+                    break ReclaimedRegistration::CleanupScheduled;
+                }
+                tokio::select! {
+                    biased;
+                    _ = context.workers.cancel.cancelled() => {
+                        break ReclaimedRegistration::ShutdownDeferred;
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+                }
+            }
+        }
+        Err(_) => loop {
+            if context
+                .workers
+                .enqueue_release(ExactReleaseWork {
+                    claim_store: context.claim_store.clone(),
+                    entity: entity.clone(),
+                    owner: context.me.clone(),
+                    epoch: claim_epoch,
+                })
+                .is_accepted()
+            {
+                break ReclaimedRegistration::CleanupScheduled;
+            }
+            tokio::select! {
+                biased;
+                _ = context.workers.cancel.cancelled() => {
+                    break ReclaimedRegistration::ShutdownDeferred;
+                }
+                _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+            }
+        },
+    }
+}
+
+#[cfg(feature = "clustering")]
+async fn reconcile_registered_room_or_self_fence(
+    workers: &OrphanReaperWorkers,
+    room_registry: &waddle_xmpp::muc::RoomRegistry,
+    room_jid: jid::BareJid,
+    claim_fence: waddle_xmpp::muc::RoomClaimFenceContext,
+    previous_owner: waddle_xmpp::ownership::NodeIdentity,
+) -> Result<
+    waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome,
+    waddle_xmpp::muc::RoomRegistryError,
+> {
+    let result = room_registry
+        .reconcile_reclaimed_room(room_jid, claim_fence, previous_owner)
         .await;
-    // The registry is the serialization authority for demand creation and
-    // reclaimed-room adoption. Releasing outside it after registration
-    // failure can race a demand-side self-reacquire/publication and delete
-    // that live claim. Keep the won epoch fenced and defer it to ordinary
-    // stale-node recovery instead; no unsynchronized cleanup worker is
-    // allowed to act on this room generation.
-    debug!(room = %room_jid, "orphan reaper: pending registration failed after steal; leaving claim fenced for node-expiry recovery");
-    ReclaimedRegistration::CleanupDeferredToNodeExpiry
+    if result.is_err() {
+        // Mailbox acceptance is not handler completion. If this uncertain
+        // handoff cannot produce a typed outcome, actor-local retry state may
+        // disappear while this node still owns the won claim. Stop the node's
+        // lease lifecycle so another node can reclaim it after expiry; never
+        // guess whether an exact release is safe after possible publication.
+        workers.node_cancel.cancel();
+    }
+    result
 }
 
 #[cfg(all(test, feature = "clustering"))]
 #[tokio::test]
-async fn stopped_registry_after_steal_defers_claim_to_node_expiry() {
+async fn stopped_registry_after_steal_exactly_releases_the_won_claim() {
     use waddle_xmpp::ownership::{ClaimStore, Entity, EntityType, InProcessClaimStore};
 
     let registry = waddle_xmpp::muc::RoomRegistry::spawn(
@@ -1167,9 +1298,15 @@ async fn stopped_registry_after_steal_defers_claim_to_node_expiry() {
     let room_jid: jid::BareJid = "stopped-registry@muc.example.com".parse().expect("room");
     let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
     let epoch = claim_store.acquire(&entity, &me).await.expect("won epoch");
+    let supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        tokio_util::sync::CancellationToken::new(),
+    );
     let outcome = register_reclaimed_epoch_or_cleanup(
         ReclaimedRegistrationContext {
+            workers: &supervisor.workers,
             room_registry: &registry,
+            claim_store: &claim_store,
             previous_owner: &previous,
             me: &me,
         },
@@ -1178,15 +1315,165 @@ async fn stopped_registry_after_steal_defers_claim_to_node_expiry() {
         epoch,
     )
     .await;
-    assert_eq!(outcome, ReclaimedRegistration::CleanupDeferredToNodeExpiry);
+    assert_eq!(outcome, ReclaimedRegistration::Released);
+    assert!(
+        claim_store
+            .current_claim(&entity)
+            .await
+            .expect("claim")
+            .is_none(),
+        "a stopped registry cannot adopt the won claim, so exact cleanup must not strand it"
+    );
+    supervisor.shutdown().await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn cancelled_registration_retry_returns_without_releasing_a_live_registry_claim() {
+    use waddle_xmpp::ownership::{ClaimStore, Entity, EntityType, InProcessClaimStore};
+
+    let registry = waddle_xmpp::muc::RoomRegistry::spawn(
+        "muc.example.com".to_string(),
+        waddle_xmpp::xep::xep0421::OccupantIdSecret::new(
+            b"test-occupant-id-secret-32-bytes-long".to_vec(),
+        )
+        .expect("secret"),
+        None,
+    );
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let me = waddle_xmpp::ownership::NodeIdentity::new("sweeper", "incarnation");
+    let previous = waddle_xmpp::ownership::NodeIdentity::new("dead", "old");
+    let room_jid: jid::BareJid = "cancelled-registration@muc.example.com"
+        .parse()
+        .expect("room");
+    let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+    let epoch = claim_store.acquire(&entity, &me).await.expect("won epoch");
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        cancel.clone(),
+    );
+    cancel.cancel();
+
+    let outcome = register_reclaimed_epoch_or_cleanup(
+        ReclaimedRegistrationContext {
+            workers: &supervisor.workers,
+            room_registry: &registry,
+            claim_store: &claim_store,
+            previous_owner: &previous,
+            me: &me,
+        },
+        &entity,
+        &room_jid,
+        epoch,
+    )
+    .await;
+    assert_eq!(outcome, ReclaimedRegistration::ShutdownDeferred);
     assert!(
         claim_store
             .current_claim(&entity)
             .await
             .expect("claim")
             .is_some(),
-        "registration failure must not release outside the registry and race demand recreation"
+        "shutdown must not release outside a still-live registry"
     );
+
+    registry.actor_ref().kill();
+    registry.actor_ref().wait_for_shutdown().await;
+    supervisor.shutdown().await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn registry_death_after_mailbox_acceptance_self_fences_the_node() {
+    use waddle_xmpp::ownership::{ClaimStore, Entity, EntityType, InProcessClaimStore};
+
+    let registry = waddle_xmpp::muc::RoomRegistry::spawn(
+        "muc.example.com".to_string(),
+        waddle_xmpp::xep::xep0421::OccupantIdSecret::new(
+            b"test-occupant-id-secret-32-bytes-long".to_vec(),
+        )
+        .expect("secret"),
+        None,
+    );
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let me = waddle_xmpp::ownership::NodeIdentity::new("sweeper", "incarnation");
+    let previous = waddle_xmpp::ownership::NodeIdentity::new("dead", "old");
+    let room_jid: jid::BareJid = "accepted-then-dead@muc.example.com".parse().expect("room");
+    let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+    let epoch = claim_store.acquire(&entity, &me).await.expect("won epoch");
+    assert!(registry
+        .reserve_pending_reclaimed_room(room_jid.clone())
+        .await
+        .expect("reserve adoption"));
+    let node_cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        node_cancel.clone(),
+    );
+
+    assert_eq!(
+        register_reclaimed_epoch_or_cleanup(
+            ReclaimedRegistrationContext {
+                workers: &supervisor.workers,
+                room_registry: &registry,
+                claim_store: &claim_store,
+                previous_owner: &previous,
+                me: &me,
+            },
+            &entity,
+            &room_jid,
+            epoch,
+        )
+        .await,
+        ReclaimedRegistration::Registered
+    );
+    registry.actor_ref().kill();
+    registry.actor_ref().wait_for_shutdown().await;
+
+    let result = reconcile_registered_room_or_self_fence(
+        &supervisor.workers,
+        &registry,
+        room_jid,
+        waddle_xmpp::muc::RoomClaimFenceContext::new(entity.clone(), me, epoch),
+        previous,
+    )
+    .await;
+    assert!(result.is_err());
+    assert!(node_cancel.is_cancelled());
+    assert!(
+        claim_store
+            .current_claim(&entity)
+            .await
+            .expect("claim")
+            .is_some(),
+        "uncertain post-accept handoff must self-fence, not guess that release is safe"
+    );
+
+    supervisor.shutdown().await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn idle_room_registry_death_self_fences_the_node() {
+    let registry = waddle_xmpp::muc::RoomRegistry::spawn(
+        "muc.example.com".to_string(),
+        waddle_xmpp::xep::xep0421::OccupantIdSecret::new(
+            b"test-occupant-id-secret-32-bytes-long".to_vec(),
+        )
+        .expect("secret"),
+        None,
+    );
+    let node_cancel = tokio_util::sync::CancellationToken::new();
+    let watcher =
+        spawn_room_registry_lifetime_watch(registry.actor_ref().clone(), node_cancel.clone());
+
+    registry.actor_ref().kill();
+    registry.actor_ref().wait_for_shutdown().await;
+    tokio::time::timeout(Duration::from_secs(1), node_cancel.cancelled())
+        .await
+        .expect("registry lifetime watcher must cancel the node promptly");
+    watcher.await.expect("registry lifetime watcher");
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -1588,6 +1875,8 @@ fn hydration_reservations_do_not_overcommit_a_127_of_128_queue() {
         )),
         release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+        cancel: tokio_util::sync::CancellationToken::new(),
+        node_cancel: tokio_util::sync::CancellationToken::new(),
     };
     let reserved = (0..64)
         .filter(|index| {
@@ -1623,6 +1912,8 @@ async fn full_hydration_channel_retains_and_redrives_pending_work() {
         )),
         release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+        cancel: tokio_util::sync::CancellationToken::new(),
+        node_cancel: tokio_util::sync::CancellationToken::new(),
     };
     let candidate = Entity::new(EntityType::SmSession, "candidate");
 
@@ -1673,6 +1964,8 @@ fn closed_hydration_channel_retains_restart_inventory() {
         hydration_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+        cancel: tokio_util::sync::CancellationToken::new(),
+        node_cancel: tokio_util::sync::CancellationToken::new(),
     };
     let candidate = Entity::new(EntityType::SmSession, "candidate");
 
@@ -1718,6 +2011,8 @@ async fn full_release_channel_retains_and_redrives_pending_work() {
             [(existing_key.clone(), existing)].into(),
         )),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+        cancel: tokio_util::sync::CancellationToken::new(),
+        node_cancel: tokio_util::sync::CancellationToken::new(),
     };
     let candidate = ExactReleaseWork {
         claim_store: Arc::new(InProcessClaimStore::new()),
@@ -1762,6 +2057,8 @@ fn closed_release_channel_retains_restart_inventory() {
         hydration_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+        cancel: tokio_util::sync::CancellationToken::new(),
+        node_cancel: tokio_util::sync::CancellationToken::new(),
     };
     let candidate = ExactReleaseWork {
         claim_store: Arc::new(InProcessClaimStore::new()),
@@ -1851,7 +2148,7 @@ async fn run_orphan_reaper_sweep_with_workers(
     use waddle_xmpp::ownership::ClaimError;
 
     let clustering = &state.deps.app_state.clustering_claims;
-    let Some((_claim_store, identity_handle)) = clustering.claim_pair() else {
+    let Some((claim_store, identity_handle)) = clustering.claim_pair() else {
         return;
     };
     let Some(node_lease) = clustering.node_lease.clone() else {
@@ -1977,13 +2274,14 @@ async fn run_orphan_reaper_sweep_with_workers(
     {
         Ok(pending) => {
             for pending_room in pending {
-                match room_registry
-                    .reconcile_reclaimed_room(
-                        pending_room.room_jid,
-                        pending_room.claim_fence,
-                        pending_room.previous_owner,
-                    )
-                    .await
+                match reconcile_registered_room_or_self_fence(
+                    workers,
+                    &room_registry,
+                    pending_room.room_jid,
+                    pending_room.claim_fence,
+                    pending_room.previous_owner,
+                )
+                .await
                 {
                     Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Hydrated) => {
                         room_hydrated += 1;
@@ -2006,15 +2304,16 @@ async fn run_orphan_reaper_sweep_with_workers(
                         room_lost_race += 1;
                     }
                     Err(error) => {
-                        room_failed += 1;
                         debug!(%error, "orphan reaper: pending RoomActor retry ask failed");
+                        return;
                     }
                 }
             }
         }
         Err(error) => {
-            room_failed += 1;
             debug!(%error, "orphan reaper: pending RoomActor listing failed");
+            workers.node_cancel.cancel();
+            return;
         }
     }
     if let Ok(mut backlog) = room_registry.pending_reclaimed_room_backlog().await {
@@ -2045,6 +2344,9 @@ async fn run_orphan_reaper_sweep_with_workers(
         }
     };
     for candidate in room_candidates {
+        if workers.cancel.is_cancelled() {
+            return;
+        }
         if !workers.has_release_capacity() {
             crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
             warn!("orphan reaper: pausing RoomActor steals because exact-release cleanup capacity is exhausted");
@@ -2096,6 +2398,12 @@ async fn run_orphan_reaper_sweep_with_workers(
         if !backoff_delay.is_zero() {
             tokio::time::sleep(backoff_delay).await;
         }
+        if workers.cancel.is_cancelled() {
+            let _ = room_registry
+                .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+                .await;
+            return;
+        }
         match node_lease
             .steal_orphaned_room_actor_claim(&candidate.entity, candidate.epoch, &me, lease_ttl)
             .await
@@ -2103,7 +2411,9 @@ async fn run_orphan_reaper_sweep_with_workers(
             Ok(new_epoch) => {
                 match register_reclaimed_epoch_or_cleanup(
                     ReclaimedRegistrationContext {
+                        workers,
                         room_registry: &room_registry,
+                        claim_store: &claim_store,
                         previous_owner: &candidate.owner,
                         me: &me,
                     },
@@ -2114,22 +2424,34 @@ async fn run_orphan_reaper_sweep_with_workers(
                 .await
                 {
                     ReclaimedRegistration::Registered => {}
-                    ReclaimedRegistration::CleanupDeferredToNodeExpiry => {
+                    ReclaimedRegistration::Released => {
+                        room_released += 1;
+                        continue;
+                    }
+                    ReclaimedRegistration::LostRace => {
+                        room_lost_race += 1;
+                        continue;
+                    }
+                    ReclaimedRegistration::CleanupScheduled => {
                         room_failed += 1;
                         continue;
                     }
+                    ReclaimedRegistration::ShutdownDeferred => {
+                        return;
+                    }
                 }
-                let reconciliation = room_registry
-                    .reconcile_reclaimed_room(
-                        room_jid.clone(),
-                        waddle_xmpp::muc::RoomClaimFenceContext::new(
-                            candidate.entity.clone(),
-                            me.clone(),
-                            new_epoch,
-                        ),
-                        candidate.owner.clone(),
-                    )
-                    .await;
+                let reconciliation = reconcile_registered_room_or_self_fence(
+                    workers,
+                    &room_registry,
+                    room_jid.clone(),
+                    waddle_xmpp::muc::RoomClaimFenceContext::new(
+                        candidate.entity.clone(),
+                        me.clone(),
+                        new_epoch,
+                    ),
+                    candidate.owner.clone(),
+                )
+                .await;
                 let notify_previous_owner = !matches!(
                     reconciliation,
                     Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal)
@@ -2175,12 +2497,12 @@ async fn run_orphan_reaper_sweep_with_workers(
                         room_lost_race += 1;
                     }
                     Err(error) => {
-                        room_failed += 1;
                         debug!(
                             room = %room_jid,
                             %error,
-                            "orphan reaper: reclaimed-room registry adoption ask failed; retained pending epoch will retry"
+                            "orphan reaper: reclaimed-room registry adoption ask failed; node self-fenced"
                         );
+                        return;
                     }
                 }
             }

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -509,13 +509,19 @@ pub(crate) fn spawn_orphan_reaper_janitor(
     {
         let weak_state = Arc::downgrade(websocket_state);
         let registry = websocket_state.deps.protocol.sm_session_registry.clone();
-        let stop = websocket_state
+        let Some(stop) = websocket_state
             .deps
             .app_state
             .clustering_claims
             .stop_token
             .clone()
-            .unwrap_or_else(|| websocket_state.deps.shutdown.stop_token());
+        else {
+            // The binary may include clustering support while runtime
+            // clustering is disabled. In that configuration no clustering
+            // supervisor or registry-lifetime watcher may be attached to the
+            // process-wide shutdown token.
+            return;
+        };
         let room_registry_actor = websocket_state.deps.protocol.room_registry.clone();
         tokio::spawn(async move {
             let registry_lifetime_watch =
@@ -554,6 +560,28 @@ pub(crate) fn spawn_orphan_reaper_janitor(
         let _ = websocket_state;
         let _ = interval;
     }
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn clustering_disabled_orphan_reaper_does_not_bind_process_shutdown() {
+    let state =
+        crate::server::routes::websocket::tests::create_test_websocket_state_with_clustering(
+            crate::clustering::ClusteringHandles::default(),
+            Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        )
+        .await;
+    let shutdown = state.deps.shutdown.stop_token();
+
+    spawn_orphan_reaper_janitor(&state, Duration::from_millis(1));
+    state.deps.protocol.room_registry.kill();
+    state.deps.protocol.room_registry.wait_for_shutdown().await;
+    tokio::task::yield_now().await;
+
+    assert!(
+        !shutdown.is_cancelled(),
+        "runtime-disabled clustering must not turn RoomRegistry death into process shutdown"
+    );
 }
 
 #[cfg(feature = "clustering")]

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -56,6 +56,24 @@ const ISR_TOKEN_SWEEP_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(feature = "clustering")]
 const STALE_NODE_WATCHDOG_CANDIDATE_LIMIT: usize = 64;
 
+/// Per-sweep bound for proactive `RoomActor` orphan reconciliation. Room
+/// claims are cheap rows but adoption can hydrate durable state, so the
+/// janitor deliberately amortizes a large node loss across sweeps.
+#[cfg(feature = "clustering")]
+const ORPHANED_ROOM_CANDIDATE_LIMIT: usize = 64;
+
+#[cfg(feature = "clustering")]
+const ORPHANED_ROOM_RELEASE_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[cfg(feature = "clustering")]
+const ORPHANED_SM_SCAN_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[cfg(feature = "clustering")]
+const ORPHAN_WORK_QUEUE_CAPACITY: usize = 128;
+
+#[cfg(feature = "clustering")]
+const ORPHAN_WORK_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(5);
+
 fn pending_delivery_max_age_days_from_env() -> u32 {
     const DEFAULT_DAYS: u32 = 30;
     const MIN_DAYS: u32 = 1;
@@ -127,6 +145,12 @@ pub(crate) fn spawn_sm_expiry_janitor(websocket_state: &Arc<WebSocketState>) {
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
+            state
+                .deps
+                .protocol
+                .sm_session_registry
+                .retry_pending_claim_releases(64)
+                .await;
             let drained: Vec<waddle_xmpp::stream_management::DetachedSession> = match state
                 .deps
                 .protocol
@@ -484,19 +508,40 @@ pub(crate) fn spawn_orphan_reaper_janitor(
     #[cfg(feature = "clustering")]
     {
         let weak_state = Arc::downgrade(websocket_state);
+        let registry = websocket_state.deps.protocol.sm_session_registry.clone();
+        let stop = websocket_state
+            .deps
+            .app_state
+            .clustering_claims
+            .stop_token
+            .clone()
+            .unwrap_or_else(|| websocket_state.deps.shutdown.stop_token());
         tokio::spawn(async move {
+            let mut supervisor = OrphanReaperSupervisor::new(registry.clone(), stop.clone());
             let mut ticker = tokio::time::interval(interval);
             // Skip the first (immediate) tick, mirroring the other janitors
             // — no need to sweep before the node-lease loop has even
             // registered this node.
             ticker.tick().await;
             loop {
-                ticker.tick().await;
+                tokio::select! {
+                    _ = stop.cancelled() => break,
+                    _ = ticker.tick() => {}
+                }
+                if !supervisor.is_healthy() {
+                    error!("orphan reaper worker exited; restarting workers with retained work");
+                    supervisor = supervisor.restarted(registry.clone(), stop.clone()).await;
+                }
                 let Some(state) = weak_state.upgrade() else {
                     break;
                 };
-                run_orphan_reaper_sweep(&state).await;
+                run_orphan_reaper_sweep_with_workers(&state, &supervisor.workers).await;
+                if !supervisor.is_healthy() {
+                    error!("orphan reaper worker exited during sweep; restarting workers with retained work");
+                    supervisor = supervisor.restarted(registry.clone(), stop.clone()).await;
+                }
             }
+            supervisor.shutdown().await;
         });
     }
     #[cfg(not(feature = "clustering"))]
@@ -556,12 +601,1045 @@ async fn orphan_reaper_self_lease_is_fresh(
 /// running server — it hydrates exactly (and only) the entities this sweep
 /// just reclaimed, without needing this function to duplicate the
 /// codec/expiry logic `hydrate_reclaimed` already owns.
+#[cfg(all(test, feature = "clustering"))]
+fn orphaned_sm_candidates_or_empty(
+    result: Result<
+        Vec<crate::clustering::claims::OrphanedSmSessionClaim>,
+        waddle_xmpp::ownership::ClaimError,
+    >,
+) -> Vec<crate::clustering::claims::OrphanedSmSessionClaim> {
+    result
+        .inspect_err(|error| {
+            debug!(%error, "orphan reaper: SM-session candidate scan failed; continuing other orphan lanes")
+        })
+        .unwrap_or_default()
+}
+
 #[cfg(feature = "clustering")]
-async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
-    use waddle_xmpp::ownership::{ClaimError, Entity};
+#[derive(Clone)]
+struct SmHydrationWork {
+    entity: waddle_xmpp::ownership::Entity,
+    fence: waddle_xmpp::stream_management::persistence::SmClaimFence,
+}
+
+#[cfg(feature = "clustering")]
+#[derive(Clone)]
+struct ExactReleaseWork {
+    claim_store: Arc<dyn waddle_xmpp::ownership::ClaimStore>,
+    entity: waddle_xmpp::ownership::Entity,
+    owner: waddle_xmpp::ownership::NodeIdentity,
+    epoch: waddle_xmpp::ownership::ClaimEpoch,
+}
+
+#[cfg(feature = "clustering")]
+#[derive(Clone)]
+struct OrphanReaperWorkers {
+    hydration_tx: tokio::sync::mpsc::Sender<SmHydrationWork>,
+    release_tx: tokio::sync::mpsc::Sender<ExactReleaseWork>,
+    hydration_pending:
+        Arc<std::sync::Mutex<std::collections::HashMap<String, Option<SmHydrationWork>>>>,
+    release_pending: Arc<std::sync::Mutex<std::collections::HashMap<String, ExactReleaseWork>>>,
+    sm_cursor: Arc<std::sync::Mutex<Option<String>>>,
+}
+
+#[cfg(feature = "clustering")]
+struct OrphanReaperSupervisor {
+    workers: OrphanReaperWorkers,
+    cancel: tokio_util::sync::CancellationToken,
+    tasks: Vec<(&'static str, tokio::task::JoinHandle<()>)>,
+}
+
+#[cfg(feature = "clustering")]
+impl OrphanReaperWorkers {
+    fn hydration_key(work: &SmHydrationWork) -> String {
+        work.entity.id.clone()
+    }
+
+    fn reserve_hydration(&self, entity: &waddle_xmpp::ownership::Entity) -> bool {
+        let mut pending = self
+            .hydration_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if pending.contains_key(&entity.id) {
+            return false;
+        }
+        if pending.len() >= ORPHAN_WORK_QUEUE_CAPACITY {
+            crate::clustering::metrics::record_orphan_work_queue_backpressure("sm_hydration");
+            return false;
+        }
+        pending.insert(entity.id.clone(), None);
+        crate::clustering::metrics::record_orphan_work_queue_depth("sm_hydration", pending.len());
+        true
+    }
+
+    fn cancel_hydration_reservation(&self, entity: &waddle_xmpp::ownership::Entity) {
+        let mut pending = self
+            .hydration_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        pending.remove(&entity.id);
+        crate::clustering::metrics::record_orphan_work_queue_depth("sm_hydration", pending.len());
+    }
+
+    fn enqueue_reserved_hydration(
+        &self,
+        entity: waddle_xmpp::ownership::Entity,
+        fence: waddle_xmpp::stream_management::persistence::SmClaimFence,
+    ) -> bool {
+        let work = SmHydrationWork { entity, fence };
+        let key = Self::hydration_key(&work);
+        self.hydration_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(key.clone(), Some(work.clone()));
+        if self.hydration_tx.try_send(work).is_err() {
+            crate::clustering::metrics::record_orphan_work_queue_backpressure("sm_hydration");
+            return false;
+        }
+        true
+    }
+
+    fn release_key(work: &ExactReleaseWork) -> String {
+        format!(
+            "{}:{}:{}:{}",
+            work.entity.id, work.owner.node_id, work.owner.node_epoch, work.epoch.0
+        )
+    }
+
+    fn has_release_capacity(&self) -> bool {
+        self.release_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .len()
+            < ORPHAN_WORK_QUEUE_CAPACITY
+    }
+
+    fn enqueue_hydration(
+        &self,
+        entity: waddle_xmpp::ownership::Entity,
+        fence: waddle_xmpp::stream_management::persistence::SmClaimFence,
+    ) -> bool {
+        let work = SmHydrationWork { entity, fence };
+        if self
+            .hydration_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(&Self::hydration_key(&work))
+        {
+            return true;
+        }
+        if !self.reserve_hydration(&work.entity) {
+            return false;
+        }
+        self.enqueue_reserved_hydration(work.entity, work.fence)
+    }
+
+    fn enqueue_release(&self, work: ExactReleaseWork) -> bool {
+        let key = Self::release_key(&work);
+        let mut pending = self
+            .release_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if pending.contains_key(&key) {
+            return true;
+        }
+        if pending.len() >= ORPHAN_WORK_QUEUE_CAPACITY {
+            crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
+            return false;
+        }
+        pending.insert(key.clone(), work.clone());
+        if self.release_tx.try_send(work).is_err() {
+            crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
+            return false;
+        }
+        crate::clustering::metrics::record_orphan_work_queue_depth("room_release", pending.len());
+        true
+    }
+
+    fn pending_hydrations(&self) -> Vec<SmHydrationWork> {
+        self.hydration_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .filter_map(Clone::clone)
+            .collect()
+    }
+
+    fn pending_releases(&self) -> Vec<ExactReleaseWork> {
+        self.release_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    fn sm_cursor(&self) -> Option<String> {
+        self.sm_cursor
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    fn set_sm_cursor(&self, cursor: Option<String>) {
+        *self.sm_cursor.lock().unwrap_or_else(|e| e.into_inner()) = cursor;
+    }
+}
+
+#[cfg(feature = "clustering")]
+impl OrphanReaperSupervisor {
+    fn new(
+        registry: Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
+        parent_cancel: tokio_util::sync::CancellationToken,
+    ) -> Self {
+        let cancel = parent_cancel.child_token();
+        let (hydration_tx, mut hydration_rx) =
+            tokio::sync::mpsc::channel(ORPHAN_WORK_QUEUE_CAPACITY);
+        let (release_tx, mut release_rx) = tokio::sync::mpsc::channel(ORPHAN_WORK_QUEUE_CAPACITY);
+        let hydration_pending = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let release_pending = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let workers = OrphanReaperWorkers {
+            hydration_tx,
+            release_tx,
+            hydration_pending: hydration_pending.clone(),
+            release_pending: release_pending.clone(),
+            sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+        };
+
+        let hydration_cancel = cancel.clone();
+        let hydration_task = tokio::spawn(async move {
+            let mut queue = std::collections::VecDeque::new();
+            loop {
+                if queue.is_empty() {
+                    tokio::select! {
+                        _ = hydration_cancel.cancelled() => break,
+                        work = hydration_rx.recv() => match work { Some(work) => queue.push_back(work), None => break },
+                    }
+                }
+                while let Ok(work) = hydration_rx.try_recv() {
+                    queue.push_back(work);
+                }
+                let Some(work) = queue.pop_front() else {
+                    continue;
+                };
+                let result = tokio::select! {
+                    _ = hydration_cancel.cancelled() => break,
+                    result = tokio::time::timeout(
+                        ORPHAN_WORK_ATTEMPT_TIMEOUT,
+                        registry.hydrate_reclaimed_typed(&work.entity, &work.fence),
+                    ) => result,
+                };
+                match result {
+                    Ok(Ok(
+                        waddle_xmpp::stream_management::ReclaimedHydrationOutcome::Hydrated
+                        | waddle_xmpp::stream_management::ReclaimedHydrationOutcome::AlreadyPresent
+                        | waddle_xmpp::stream_management::ReclaimedHydrationOutcome::LostClaim,
+                    )) => {
+                        let key = OrphanReaperWorkers::hydration_key(&work);
+                        let mut pending =
+                            hydration_pending.lock().unwrap_or_else(|e| e.into_inner());
+                        pending.remove(&key);
+                        crate::clustering::metrics::record_orphan_work_queue_depth(
+                            "sm_hydration",
+                            pending.len(),
+                        );
+                        info!("orphan reaper: targeted hydration work complete");
+                    }
+                    Ok(Ok(
+                        waddle_xmpp::stream_management::ReclaimedHydrationOutcome::MissingDurable
+                        | waddle_xmpp::stream_management::ReclaimedHydrationOutcome::PoisonReleased,
+                    )) => {
+                        let cleanup = tokio::select! {
+                            _ = hydration_cancel.cancelled() => break,
+                            result = tokio::time::timeout(
+                                ORPHAN_WORK_ATTEMPT_TIMEOUT,
+                                registry.release_reclaimed_claim(&work.entity, &work.fence),
+                            ) => result,
+                        };
+                        match cleanup {
+                            Ok(Ok(_)) => {
+                                let key = OrphanReaperWorkers::hydration_key(&work);
+                                let mut pending =
+                                    hydration_pending.lock().unwrap_or_else(|e| e.into_inner());
+                                pending.remove(&key);
+                                crate::clustering::metrics::record_orphan_work_queue_depth(
+                                    "sm_hydration",
+                                    pending.len(),
+                                );
+                            }
+                            Ok(Err(error)) => {
+                                debug!(%error, "orphan reaper: missing/poison SM exact release failed; retrying");
+                                queue.push_back(work);
+                            }
+                            Err(_) => queue.push_back(work),
+                        }
+                    }
+                    Ok(Ok(
+                        waddle_xmpp::stream_management::ReclaimedHydrationOutcome::TransientFailure,
+                    )) => {
+                        queue.push_back(work);
+                    }
+                    Ok(Ok(
+                        waddle_xmpp::stream_management::ReclaimedHydrationOutcome::StaleIdentity,
+                    )) => {
+                        let cleanup = tokio::time::timeout(
+                            ORPHAN_WORK_ATTEMPT_TIMEOUT,
+                            registry.release_reclaimed_claim(&work.entity, &work.fence),
+                        )
+                        .await;
+                        match cleanup {
+                            Ok(Ok(_)) => {
+                                let key = OrphanReaperWorkers::hydration_key(&work);
+                                let mut pending =
+                                    hydration_pending.lock().unwrap_or_else(|e| e.into_inner());
+                                pending.remove(&key);
+                                crate::clustering::metrics::record_orphan_work_queue_depth(
+                                    "sm_hydration",
+                                    pending.len(),
+                                );
+                            }
+                            Ok(Err(_)) | Err(_) => queue.push_back(work),
+                        }
+                    }
+                    Ok(Err(error)) => {
+                        debug!(%error, "orphan reaper: targeted hydration failed; retaining bounded retry");
+                        queue.push_back(work);
+                    }
+                    Err(_) => {
+                        debug!(
+                            "orphan reaper: targeted hydration timed out; retaining bounded retry"
+                        );
+                        queue.push_back(work);
+                    }
+                }
+                if !queue.is_empty() {
+                    tokio::select! {
+                        _ = hydration_cancel.cancelled() => break,
+                        _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                    }
+                }
+            }
+            hydration_pending
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clear();
+            crate::clustering::metrics::record_orphan_work_queue_depth("sm_hydration", 0);
+        });
+
+        let release_cancel = cancel.clone();
+        let release_task = tokio::spawn(async move {
+            let mut queue = std::collections::VecDeque::new();
+            loop {
+                if queue.is_empty() {
+                    tokio::select! {
+                        _ = release_cancel.cancelled() => break,
+                        work = release_rx.recv() => match work { Some(work) => queue.push_back(work), None => break },
+                    }
+                }
+                while let Ok(work) = release_rx.try_recv() {
+                    queue.push_back(work);
+                }
+                let Some(work) = queue.pop_front() else {
+                    continue;
+                };
+                let result = tokio::select! {
+                    _ = release_cancel.cancelled() => break,
+                    result = tokio::time::timeout(
+                        ORPHANED_ROOM_RELEASE_TIMEOUT,
+                        work.claim_store.release_exact(&work.entity, &work.owner, work.epoch),
+                    ) => result,
+                };
+                match result {
+                    Ok(Ok(_)) => {
+                        let key = OrphanReaperWorkers::release_key(&work);
+                        let mut pending = release_pending.lock().unwrap_or_else(|e| e.into_inner());
+                        pending.remove(&key);
+                        crate::clustering::metrics::record_orphan_work_queue_depth(
+                            "room_release",
+                            pending.len(),
+                        );
+                    }
+                    Ok(Err(error)) => {
+                        debug!(%error, entity_id = %work.entity.id, "orphan reaper: exact cleanup retry failed");
+                        queue.push_back(work);
+                    }
+                    Err(_) => {
+                        debug!(entity_id = %work.entity.id, "orphan reaper: exact cleanup retry timed out");
+                        queue.push_back(work);
+                    }
+                }
+                if !queue.is_empty() {
+                    tokio::select! {
+                        _ = release_cancel.cancelled() => break,
+                        _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                    }
+                }
+            }
+            release_pending
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clear();
+            crate::clustering::metrics::record_orphan_work_queue_depth("room_release", 0);
+        });
+        Self {
+            workers,
+            cancel,
+            tasks: vec![
+                ("sm_hydration", hydration_task),
+                ("room_release", release_task),
+            ],
+        }
+    }
+
+    fn is_healthy(&self) -> bool {
+        self.tasks.iter().all(|(_, task)| !task.is_finished())
+    }
+
+    async fn restarted(
+        self,
+        registry: Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
+        parent_cancel: tokio_util::sync::CancellationToken,
+    ) -> Self {
+        let hydration = self.workers.pending_hydrations();
+        let releases = self.workers.pending_releases();
+        let sm_cursor = self.workers.sm_cursor();
+        self.shutdown().await;
+        let next = Self::new(registry, parent_cancel);
+        next.workers.set_sm_cursor(sm_cursor);
+        for work in hydration {
+            if !next.workers.enqueue_hydration(work.entity, work.fence) {
+                error!("orphan reaper: failed to requeue hydration after worker restart");
+            }
+        }
+        for work in releases {
+            if !next.workers.enqueue_release(work) {
+                error!("orphan reaper: failed to requeue exact release after worker restart");
+            }
+        }
+        next
+    }
+
+    async fn shutdown(mut self) {
+        self.cancel.cancel();
+        for (worker, task) in self.tasks.drain(..) {
+            if let Err(error) = task.await {
+                let reason = if error.is_panic() {
+                    "panic"
+                } else {
+                    "cancelled"
+                };
+                crate::clustering::metrics::record_orphan_worker_failure(worker, reason);
+                error!(worker, %error, "orphan reaper worker failed");
+            }
+        }
+    }
+}
+
+#[cfg(feature = "clustering")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReclaimedRegistration {
+    Registered,
+    Released,
+    LostRace,
+    CleanupScheduled,
+}
+
+#[cfg(feature = "clustering")]
+struct ReclaimedRegistrationContext<'a> {
+    workers: &'a OrphanReaperWorkers,
+    room_registry: &'a waddle_xmpp::muc::RoomRegistry,
+    claim_store: &'a Arc<dyn waddle_xmpp::ownership::ClaimStore>,
+    previous_owner: &'a waddle_xmpp::ownership::NodeIdentity,
+    me: &'a waddle_xmpp::ownership::NodeIdentity,
+}
+
+#[cfg(feature = "clustering")]
+async fn register_reclaimed_epoch_or_cleanup(
+    context: ReclaimedRegistrationContext<'_>,
+    entity: &waddle_xmpp::ownership::Entity,
+    room_jid: &jid::BareJid,
+    claim_epoch: waddle_xmpp::ownership::ClaimEpoch,
+) -> ReclaimedRegistration {
+    if context
+        .room_registry
+        .remember_pending_reclaimed_room(
+            room_jid.clone(),
+            waddle_xmpp::muc::RoomClaimFenceContext::new(
+                entity.clone(),
+                context.me.clone(),
+                claim_epoch,
+            ),
+            context.previous_owner.clone(),
+        )
+        .await
+        .is_ok()
+    {
+        return ReclaimedRegistration::Registered;
+    }
+    let _ = context
+        .room_registry
+        .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+        .await;
+    match tokio::time::timeout(
+        ORPHANED_ROOM_RELEASE_TIMEOUT,
+        context
+            .claim_store
+            .release_exact(entity, context.me, claim_epoch),
+    )
+    .await
+    {
+        Ok(Ok(waddle_xmpp::ownership::ExactReleaseOutcome::Released)) => {
+            ReclaimedRegistration::Released
+        }
+        Ok(Ok(waddle_xmpp::ownership::ExactReleaseOutcome::NotOwned)) => {
+            ReclaimedRegistration::LostRace
+        }
+        Ok(Err(error)) => {
+            debug!(room = %room_jid, %error, "orphan reaper: exact cleanup after pending-registration failure failed");
+            let queued = context.workers.enqueue_release(ExactReleaseWork {
+                claim_store: context.claim_store.clone(),
+                entity: entity.clone(),
+                owner: context.me.clone(),
+                epoch: claim_epoch,
+            });
+            if !queued {
+                warn!(room = %room_jid, "orphan reaper: exact cleanup queue saturated after steal; claim remains fenced until node expiry");
+            }
+            ReclaimedRegistration::CleanupScheduled
+        }
+        Err(_) => {
+            debug!(room = %room_jid, "orphan reaper: exact cleanup after pending-registration failure timed out");
+            let queued = context.workers.enqueue_release(ExactReleaseWork {
+                claim_store: context.claim_store.clone(),
+                entity: entity.clone(),
+                owner: context.me.clone(),
+                epoch: claim_epoch,
+            });
+            if !queued {
+                warn!(room = %room_jid, "orphan reaper: exact cleanup queue saturated after steal; claim remains fenced until node expiry");
+            }
+            ReclaimedRegistration::CleanupScheduled
+        }
+    }
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn stopped_registry_after_steal_exactly_releases_unregistered_epoch() {
+    use waddle_xmpp::ownership::{ClaimStore, Entity, EntityType, InProcessClaimStore};
+
+    let registry = waddle_xmpp::muc::RoomRegistry::spawn(
+        "muc.example.com".to_string(),
+        waddle_xmpp::xep::xep0421::OccupantIdSecret::new(
+            b"test-occupant-id-secret-32-bytes-long".to_vec(),
+        )
+        .expect("secret"),
+        None,
+    );
+    registry.actor_ref().kill();
+    registry.actor_ref().wait_for_shutdown().await;
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let me = waddle_xmpp::ownership::NodeIdentity::new("sweeper", "incarnation");
+    let previous = waddle_xmpp::ownership::NodeIdentity::new("dead", "old");
+    let room_jid: jid::BareJid = "stopped-registry@muc.example.com".parse().expect("room");
+    let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+    let epoch = claim_store.acquire(&entity, &me).await.expect("won epoch");
+    let supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        tokio_util::sync::CancellationToken::new(),
+    );
+
+    let outcome = register_reclaimed_epoch_or_cleanup(
+        ReclaimedRegistrationContext {
+            workers: &supervisor.workers,
+            room_registry: &registry,
+            claim_store: &claim_store,
+            previous_owner: &previous,
+            me: &me,
+        },
+        &entity,
+        &room_jid,
+        epoch,
+    )
+    .await;
+    assert_eq!(outcome, ReclaimedRegistration::Released);
+    assert!(claim_store
+        .current_claim(&entity)
+        .await
+        .expect("claim")
+        .is_none());
+    supervisor.shutdown().await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[derive(Default)]
+struct HangingSmReadPersistence {
+    inner: waddle_xmpp::stream_management::persistence::InMemorySmPersistence,
+    read_started: tokio::sync::Notify,
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[async_trait::async_trait]
+impl waddle_xmpp::stream_management::persistence::SmPersistenceStorage
+    for HangingSmReadPersistence
+{
+    async fn upsert_session(
+        &self,
+        session: waddle_xmpp::stream_management::persistence::PersistedSession,
+    ) -> Result<(), waddle_xmpp::stream_management::persistence::SmPersistenceError> {
+        self.inner.upsert_session(session).await
+    }
+
+    async fn get_session(
+        &self,
+        _stream_id: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<
+        Option<waddle_xmpp::stream_management::persistence::PersistedSession>,
+        waddle_xmpp::stream_management::persistence::SmPersistenceError,
+    > {
+        self.read_started.notify_one();
+        std::future::pending().await
+    }
+
+    async fn delete_session(
+        &self,
+        stream_id: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<(), waddle_xmpp::stream_management::persistence::SmPersistenceError> {
+        self.inner.delete_session(stream_id).await
+    }
+
+    async fn append_unacked(
+        &self,
+        stanza: waddle_xmpp::stream_management::persistence::PersistedUnackedStanza,
+    ) -> Result<(), waddle_xmpp::stream_management::persistence::SmPersistenceError> {
+        self.inner.append_unacked(stanza).await
+    }
+
+    async fn ack_through(
+        &self,
+        stream_id: &waddle_xmpp::pending_delivery::SmSessionId,
+        up_to_sequence: u32,
+    ) -> Result<u64, waddle_xmpp::stream_management::persistence::SmPersistenceError> {
+        self.inner.ack_through(stream_id, up_to_sequence).await
+    }
+
+    async fn delete_unacked(
+        &self,
+        stream_id: &waddle_xmpp::pending_delivery::SmSessionId,
+        sequences: &[u32],
+    ) -> Result<u64, waddle_xmpp::stream_management::persistence::SmPersistenceError> {
+        self.inner.delete_unacked(stream_id, sequences).await
+    }
+
+    async fn list_unacked(
+        &self,
+        stream_id: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<
+        Vec<waddle_xmpp::stream_management::persistence::PersistedUnackedStanza>,
+        waddle_xmpp::stream_management::persistence::SmPersistenceError,
+    > {
+        self.inner.list_unacked(stream_id).await
+    }
+
+    async fn list_expired_sessions(
+        &self,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<
+        Vec<waddle_xmpp::stream_management::persistence::PersistedSession>,
+        waddle_xmpp::stream_management::persistence::SmPersistenceError,
+    > {
+        self.inner.list_expired_sessions(now).await
+    }
+
+    async fn list_all_sessions(
+        &self,
+    ) -> Result<
+        Vec<waddle_xmpp::stream_management::persistence::PersistedSession>,
+        waddle_xmpp::stream_management::persistence::SmPersistenceError,
+    > {
+        self.inner.list_all_sessions().await
+    }
+}
+
+#[cfg(all(test, feature = "clustering"))]
+struct HangingExactReleaseStore {
+    inner: waddle_xmpp::ownership::InProcessClaimStore,
+    release_started: tokio::sync::Notify,
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[async_trait::async_trait]
+impl waddle_xmpp::ownership::ClaimStore for HangingExactReleaseStore {
+    async fn ensure_schema(&self) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.ensure_schema().await
+    }
+    async fn acquire(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner.acquire(entity, me).await
+    }
+    async fn ensure_claimed(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner.ensure_claimed(entity, me).await
+    }
+    async fn steal_stale(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        observed: waddle_xmpp::ownership::ClaimEpoch,
+        staleness: waddle_xmpp::ownership::StalePredicate,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner
+            .steal_stale(entity, observed, staleness, me)
+            .await
+    }
+    async fn steal_for_resume(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        observed: waddle_xmpp::ownership::ClaimEpoch,
+        witness: waddle_xmpp::ownership::ResumeIdentityProof,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner
+            .steal_for_resume(entity, observed, witness, me)
+            .await
+    }
+    async fn current_claim(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+    ) -> Result<Option<waddle_xmpp::ownership::ClaimSnapshot>, waddle_xmpp::ownership::ClaimError>
+    {
+        self.inner.current_claim(entity).await
+    }
+    async fn fence(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+        mine: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> Result<bool, waddle_xmpp::ownership::ClaimError> {
+        self.inner.fence(entity, me, mine).await
+    }
+    async fn release(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+        mine: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.release(entity, me, mine).await
+    }
+    async fn release_exact(
+        &self,
+        _entity: &waddle_xmpp::ownership::Entity,
+        _me: &waddle_xmpp::ownership::NodeIdentity,
+        _mine: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> Result<waddle_xmpp::ownership::ExactReleaseOutcome, waddle_xmpp::ownership::ClaimError>
+    {
+        self.release_started.notify_one();
+        std::future::pending().await
+    }
+    async fn release_many(
+        &self,
+        entities: &[waddle_xmpp::ownership::Entity],
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.release_many(entities, me).await
+    }
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn hung_sm_hydration_does_not_block_completed_room_lane() {
+    use waddle_xmpp::ownership::{
+        ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
+    };
+
+    let storage = Arc::new(HangingSmReadPersistence::default());
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let me = NodeIdentity::new("sweeper", "incarnation");
+    let registry = Arc::new(
+        waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()
+            .with_persistence(storage.clone())
+            .with_claim_store(claim_store.clone(), SharedNodeIdentity::new(me.clone())),
+    );
+    let entity = Entity::new(EntityType::SmSession, "hung-session");
+    let epoch = claim_store.acquire(&entity, &me).await.expect("claim");
+
+    // Production completes the bounded RoomActor lane before scheduling
+    // this detached SM hydration. A storage read that never returns must
+    // therefore neither undo nor delay that room progress.
+    let room_lane_completed = true;
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(registry, cancel.clone());
+    supervisor.workers.enqueue_hydration(
+        entity,
+        waddle_xmpp::stream_management::persistence::SmClaimFence::new(me.clone(), epoch),
+    );
+
+    tokio::time::timeout(Duration::from_secs(1), storage.read_started.notified())
+        .await
+        .expect("detached hydration should reach the deliberately hung SM read");
+    assert!(room_lane_completed);
+    for index in 1..ORPHAN_WORK_QUEUE_CAPACITY {
+        assert!(supervisor.workers.enqueue_hydration(
+            Entity::new(EntityType::SmSession, format!("queued-{index}")),
+            waddle_xmpp::stream_management::persistence::SmClaimFence::new(
+                me.clone(),
+                waddle_xmpp::ownership::ClaimEpoch(index as i64),
+            ),
+        ));
+    }
+    assert!(!supervisor.workers.enqueue_hydration(
+        Entity::new(EntityType::SmSession, "queue-overflow"),
+        waddle_xmpp::stream_management::persistence::SmClaimFence::new(
+            me,
+            waddle_xmpp::ownership::ClaimEpoch(999),
+        ),
+    ));
+    cancel.cancel();
+    tokio::time::timeout(Duration::from_secs(1), supervisor.shutdown())
+        .await
+        .expect("hung hydration worker must cancel and join");
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn sm_rotation_before_hydration_worker_releases_the_exact_old_fence() {
+    use waddle_xmpp::ownership::{
+        ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
+    };
+
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let old_owner = NodeIdentity::new("sweeper", "old-incarnation");
+    let new_owner = NodeIdentity::new("sweeper", "new-incarnation");
+    let identity = SharedNodeIdentity::new(old_owner.clone());
+    let entity = Entity::new(EntityType::SmSession, "rotate-before-worker");
+    let epoch = claim_store
+        .acquire(&entity, &old_owner)
+        .await
+        .expect("seed old claim");
+    let registry = Arc::new(
+        waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()
+            .with_claim_store(claim_store.clone(), identity.clone()),
+    );
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(registry, cancel.clone());
+
+    identity.set(new_owner);
+    assert!(supervisor.workers.enqueue_hydration(
+        entity.clone(),
+        waddle_xmpp::stream_management::persistence::SmClaimFence::new(old_owner, epoch),
+    ));
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if claim_store
+                .current_claim(&entity)
+                .await
+                .expect("read claim")
+                .is_none()
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("stale worker must release the exact old fence");
+    assert!(supervisor.workers.pending_hydrations().is_empty());
+
+    cancel.cancel();
+    supervisor.shutdown().await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test(start_paused = true)]
+async fn sm_rotation_between_hydration_retries_releases_the_exact_old_fence() {
+    use waddle_xmpp::ownership::{
+        ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
+    };
+
+    let storage = Arc::new(HangingSmReadPersistence::default());
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let old_owner = NodeIdentity::new("sweeper", "old-incarnation");
+    let new_owner = NodeIdentity::new("sweeper", "new-incarnation");
+    let identity = SharedNodeIdentity::new(old_owner.clone());
+    let entity = Entity::new(EntityType::SmSession, "rotate-between-retries");
+    let epoch = claim_store
+        .acquire(&entity, &old_owner)
+        .await
+        .expect("seed old claim");
+    let registry = Arc::new(
+        waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()
+            .with_persistence(storage.clone())
+            .with_claim_store(claim_store.clone(), identity.clone()),
+    );
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(registry, cancel.clone());
+    assert!(supervisor.workers.enqueue_hydration(
+        entity.clone(),
+        waddle_xmpp::stream_management::persistence::SmClaimFence::new(old_owner, epoch),
+    ));
+
+    storage.read_started.notified().await;
+    identity.set(new_owner);
+    tokio::time::advance(ORPHAN_WORK_ATTEMPT_TIMEOUT).await;
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(1)).await;
+    for _ in 0..100 {
+        if claim_store
+            .current_claim(&entity)
+            .await
+            .expect("read claim")
+            .is_none()
+        {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    assert!(claim_store
+        .current_claim(&entity)
+        .await
+        .expect("read final claim")
+        .is_none());
+    assert!(supervisor.workers.pending_hydrations().is_empty());
+
+    cancel.cancel();
+    supervisor.shutdown().await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn hung_exact_release_worker_is_cancelled_and_joined() {
+    use waddle_xmpp::ownership::{Entity, EntityType, NodeIdentity};
+
+    let store = Arc::new(HangingExactReleaseStore {
+        inner: waddle_xmpp::ownership::InProcessClaimStore::new(),
+        release_started: tokio::sync::Notify::new(),
+    });
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        cancel.clone(),
+    );
+    supervisor.workers.enqueue_release(ExactReleaseWork {
+        claim_store: store.clone(),
+        entity: Entity::new(EntityType::RoomActor, "cancel@muc.example.com"),
+        owner: NodeIdentity::new("sweeper", "incarnation"),
+        epoch: waddle_xmpp::ownership::ClaimEpoch(1),
+    });
+    tokio::time::timeout(Duration::from_secs(1), store.release_started.notified())
+        .await
+        .expect("release worker started");
+    cancel.cancel();
+    tokio::time::timeout(Duration::from_secs(1), supervisor.shutdown())
+        .await
+        .expect("hung exact-release worker must cancel and join");
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[test]
+fn hydration_reservations_do_not_overcommit_a_127_of_128_queue() {
+    use waddle_xmpp::ownership::{Entity, EntityType};
+    let (hydration_tx, _hydration_rx) = tokio::sync::mpsc::channel(ORPHAN_WORK_QUEUE_CAPACITY);
+    let (release_tx, _release_rx) = tokio::sync::mpsc::channel(ORPHAN_WORK_QUEUE_CAPACITY);
+    let workers = OrphanReaperWorkers {
+        hydration_tx,
+        release_tx,
+        hydration_pending: Arc::new(std::sync::Mutex::new(
+            (0..127)
+                .map(|index| (format!("existing-{index}"), None))
+                .collect(),
+        )),
+        release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+    };
+    let reserved = (0..64)
+        .filter(|index| {
+            workers.reserve_hydration(&Entity::new(
+                EntityType::SmSession,
+                format!("candidate-{index}"),
+            ))
+        })
+        .count();
+    assert_eq!(reserved, 1);
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn supervisor_restart_preserves_the_sm_scan_cursor() {
+    let parent_cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        parent_cancel.clone(),
+    );
+    supervisor
+        .workers
+        .set_sm_cursor(Some("sm_session:page-064".to_string()));
+
+    let restarted = supervisor
+        .restarted(
+            Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+            parent_cancel,
+        )
+        .await;
+
+    assert_eq!(
+        restarted.workers.sm_cursor().as_deref(),
+        Some("sm_session:page-064")
+    );
+    restarted.shutdown().await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn supervisor_detects_and_reports_a_panicked_worker() {
+    let mut supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        tokio_util::sync::CancellationToken::new(),
+    );
+    supervisor.tasks.push((
+        "panic-regression",
+        tokio::spawn(async { panic!("injected worker panic") }),
+    ));
+    tokio::task::yield_now().await;
+    assert!(!supervisor.is_healthy());
+    tokio::time::timeout(Duration::from_secs(1), supervisor.shutdown())
+        .await
+        .expect("shutdown observes the panicked JoinHandle");
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[test]
+fn failed_sm_candidate_scan_is_an_empty_batch_not_a_sweep_abort() {
+    let candidates = orphaned_sm_candidates_or_empty(Err(
+        waddle_xmpp::ownership::ClaimError::Backend("scan failed".to_string()),
+    ));
+    assert!(candidates.is_empty());
+
+    // The caller continues directly into the RoomActor lane after iterating
+    // this empty batch; preserve that control-flow contract explicitly.
+    let room_lane_ran = {
+        for _ in candidates {}
+        true
+    };
+    assert!(room_lane_ran);
+}
+
+#[cfg(feature = "clustering")]
+async fn run_orphan_reaper_sweep_with_workers(
+    state: &Arc<WebSocketState>,
+    workers: &OrphanReaperWorkers,
+) {
+    use waddle_xmpp::ownership::ClaimError;
 
     let clustering = &state.deps.app_state.clustering_claims;
-    let Some((_claim_store, identity_handle)) = clustering.claim_pair() else {
+    let Some((claim_store, identity_handle)) = clustering.claim_pair() else {
         return;
     };
     let Some(node_lease) = clustering.node_lease.clone() else {
@@ -642,17 +1720,6 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
         return;
     }
 
-    let candidates = match node_lease.list_orphaned_sm_session_claims().await {
-        Ok(candidates) => candidates,
-        Err(error) => {
-            warn!(%error, "orphan reaper: list_orphaned_sm_session_claims failed");
-            return;
-        }
-    };
-    if candidates.is_empty() {
-        return;
-    }
-
     // ADR-0017 Phase 3 Slice 10 (Q5's rollout-aware placement rule): an
     // old-generation node backs off before racing a matching/newer
     // -generation node for a just-orphaned claim, so each entity moves
@@ -672,11 +1739,368 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
         }
     };
 
-    let mut reclaimed: Vec<(Entity, waddle_xmpp::ownership::ClaimEpoch)> = Vec::new();
+    let room_registry =
+        waddle_xmpp::muc::RoomRegistry::wrap(state.deps.protocol.room_registry.clone());
+    let mut room_hydrated = 0u64;
+    let mut room_released = 0u64;
+    let mut room_already_live = 0u64;
+    let mut room_adopted_local = 0u64;
+    let mut room_pending_retry = 0u64;
+    let mut room_lost_race = 0u64;
+    let mut room_failed = 0u64;
+
+    // Ordinary destroy/dead-actor/eviction releases use the same orphan
+    // reaper cadence, but retry one exact fence per sweep so a slow ownership
+    // backend cannot monopolize the registry mailbox.
+    if let Err(error) = room_registry.retry_pending_room_releases(1).await {
+        debug!(%error, "orphan reaper: pending ordinary RoomActor release retry failed");
+    }
+
+    // Retry epochs won on an earlier sweep before discovering new work.
+    // Each retry is its own bounded registry ask, so a slow store operation
+    // cannot monopolize the registry actor as one large batch handler.
+    match room_registry
+        .list_pending_reclaimed_rooms(ORPHANED_ROOM_CANDIDATE_LIMIT)
+        .await
+    {
+        Ok(pending) => {
+            for pending_room in pending {
+                match room_registry
+                    .reconcile_reclaimed_room(
+                        pending_room.room_jid,
+                        pending_room.claim_fence,
+                        pending_room.previous_owner,
+                    )
+                    .await
+                {
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Hydrated) => {
+                        room_hydrated += 1;
+                    }
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Released) => {
+                        room_released += 1;
+                    }
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AlreadyLive,
+                    ) => room_already_live += 1,
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal,
+                    ) => room_adopted_local += 1,
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::PendingRetry,
+                    ) => {
+                        room_pending_retry += 1;
+                    }
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace) => {
+                        room_lost_race += 1;
+                    }
+                    Err(error) => {
+                        room_failed += 1;
+                        debug!(%error, "orphan reaper: pending RoomActor retry ask failed");
+                    }
+                }
+            }
+        }
+        Err(error) => {
+            room_failed += 1;
+            debug!(%error, "orphan reaper: pending RoomActor listing failed");
+        }
+    }
+    if let Ok(mut backlog) = room_registry.pending_reclaimed_room_backlog().await {
+        if let Ok(releases) = room_registry.pending_room_release_backlog().await {
+            backlog.depth = backlog.depth.saturating_add(releases.depth);
+            backlog.oldest_age_ms = backlog.oldest_age_ms.max(releases.oldest_age_ms);
+        }
+        crate::clustering::metrics::record_room_orphan_pending_backlog(
+            backlog.depth,
+            backlog.oldest_age_ms,
+        );
+    }
+
+    // RoomActor counterpart: proactively move a bounded set of claims off
+    // committed-dead owners. Unlike detached SM sessions, a room claim may
+    // have no durable state at all (for example an ephemeral instant room).
+    // The serialized registry adoption below therefore either hydrates the
+    // exact won epoch, observes demand-side creation already did so, or
+    // releases the unusable claim.
+    let room_candidates = match node_lease
+        .list_orphaned_room_actor_claims(ORPHANED_ROOM_CANDIDATE_LIMIT)
+        .await
+    {
+        Ok(candidates) => candidates,
+        Err(error) => {
+            warn!(%error, "orphan reaper: list_orphaned_room_actor_claims failed");
+            Vec::new()
+        }
+    };
+    for candidate in room_candidates {
+        if !workers.has_release_capacity() {
+            crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
+            warn!("orphan reaper: pausing RoomActor steals because exact-release cleanup capacity is exhausted");
+            break;
+        }
+        let Ok(room_jid) = candidate.entity.id.parse::<jid::BareJid>() else {
+            room_failed += 1;
+            debug!(
+                entity_id = %candidate.entity.id,
+                "orphan reaper: RoomActor claim id is not a bare JID; leaving stale claim for repair"
+            );
+            continue;
+        };
+        match room_registry
+            .reserve_pending_reclaimed_room(room_jid.clone())
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                crate::clustering::metrics::record_orphan_work_queue_backpressure("room_adoption");
+                warn!("orphan reaper: pausing RoomActor steals because adoption capacity is exhausted");
+                break;
+            }
+            Err(error) => {
+                room_failed += 1;
+                debug!(room = %room_jid, %error, "orphan reaper: room adoption reservation failed");
+                break;
+            }
+        }
+        if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-room").await
+        {
+            let _ = room_registry
+                .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+                .await;
+            return;
+        }
+        if let Err(error) = node_lease.expire(&candidate.owner, lease_ttl).await {
+            let _ = room_registry
+                .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+                .await;
+            room_failed += 1;
+            debug!(
+                entity_id = %candidate.entity.id,
+                %error,
+                "orphan reaper: room owner's expire CAS failed"
+            );
+            continue;
+        }
+        if !backoff_delay.is_zero() {
+            tokio::time::sleep(backoff_delay).await;
+        }
+        match node_lease
+            .steal_orphaned_room_actor_claim(&candidate.entity, candidate.epoch, &me, lease_ttl)
+            .await
+        {
+            Ok(new_epoch) => {
+                match register_reclaimed_epoch_or_cleanup(
+                    ReclaimedRegistrationContext {
+                        workers,
+                        room_registry: &room_registry,
+                        claim_store: &claim_store,
+                        previous_owner: &candidate.owner,
+                        me: &me,
+                    },
+                    &candidate.entity,
+                    &room_jid,
+                    new_epoch,
+                )
+                .await
+                {
+                    ReclaimedRegistration::Registered => {}
+                    ReclaimedRegistration::Released => {
+                        room_released += 1;
+                        continue;
+                    }
+                    ReclaimedRegistration::LostRace => {
+                        room_lost_race += 1;
+                        continue;
+                    }
+                    ReclaimedRegistration::CleanupScheduled => {
+                        room_failed += 1;
+                        continue;
+                    }
+                }
+                let reconciliation = room_registry
+                    .reconcile_reclaimed_room(
+                        room_jid.clone(),
+                        waddle_xmpp::muc::RoomClaimFenceContext::new(
+                            candidate.entity.clone(),
+                            me.clone(),
+                            new_epoch,
+                        ),
+                        candidate.owner.clone(),
+                    )
+                    .await;
+                let notify_previous_owner = !matches!(
+                    reconciliation,
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal)
+                        | Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace)
+                        | Err(_)
+                );
+                if notify_previous_owner {
+                    if let Some(store) = clustering.muc_durable_store.as_ref() {
+                        if let Err(error) = store
+                            .notify_previous_owner_demoted(
+                                &room_jid,
+                                &candidate.owner.node_id,
+                                &candidate.owner.node_epoch,
+                                new_epoch,
+                            )
+                            .await
+                        {
+                            debug!(
+                                room = %room_jid,
+                                %error,
+                                "orphan reaper: best-effort room demotion notification failed"
+                            );
+                        }
+                    }
+                }
+                match reconciliation {
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Hydrated) => {
+                        room_hydrated += 1;
+                    }
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Released) => {
+                        room_released += 1;
+                    }
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AlreadyLive,
+                    ) => room_already_live += 1,
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal,
+                    ) => room_adopted_local += 1,
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::PendingRetry,
+                    ) => room_pending_retry += 1,
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace) => {
+                        room_lost_race += 1;
+                    }
+                    Err(error) => {
+                        room_failed += 1;
+                        debug!(
+                            room = %room_jid,
+                            %error,
+                            "orphan reaper: reclaimed-room registry adoption ask failed; retained pending epoch will retry"
+                        );
+                    }
+                }
+            }
+            Err(ClaimError::Conflict) => {
+                room_lost_race += 1;
+                let _ = room_registry
+                    .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+                    .await;
+            }
+            Err(error) => {
+                room_failed += 1;
+                let _ = room_registry
+                    .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+                    .await;
+                debug!(
+                    entity_id = %candidate.entity.id,
+                    %error,
+                    "orphan reaper: RoomActor claim steal failed"
+                );
+            }
+        }
+    }
+    for (outcome, count) in [
+        ("hydrated", room_hydrated),
+        ("released", room_released),
+        ("already_live", room_already_live),
+        ("adopted_local", room_adopted_local),
+        ("pending_retry", room_pending_retry),
+        ("lost_race", room_lost_race),
+        ("failed", room_failed),
+    ] {
+        if count > 0 {
+            crate::clustering::metrics::record_room_orphan_reconciliation(outcome, count);
+        }
+    }
+    let room_reconciled = room_hydrated + room_released + room_already_live + room_adopted_local;
+    if room_pending_retry > 0 || room_failed > 0 {
+        warn!(
+            hydrated = room_hydrated,
+            released = room_released,
+            already_live = room_already_live,
+            adopted_local = room_adopted_local,
+            pending_retry = room_pending_retry,
+            lost_race = room_lost_race,
+            failed = room_failed,
+            limit = ORPHANED_ROOM_CANDIDATE_LIMIT,
+            "orphan reaper: RoomActor reconciliation completed with pending work"
+        );
+    } else if room_reconciled > 0 {
+        info!(
+            hydrated = room_hydrated,
+            released = room_released,
+            already_live = room_already_live,
+            adopted_local = room_adopted_local,
+            pending_retry = room_pending_retry,
+            lost_race = room_lost_race,
+            failed = room_failed,
+            limit = ORPHANED_ROOM_CANDIDATE_LIMIT,
+            "orphan reaper: reconciled orphaned RoomActor claims"
+        );
+    }
+    let (page, scan_succeeded) = match tokio::time::timeout(
+        ORPHANED_SM_SCAN_TIMEOUT,
+        node_lease.list_orphaned_sm_session_claims_page(
+            workers.sm_cursor(),
+            STALE_NODE_WATCHDOG_CANDIDATE_LIMIT,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(page)) => (page, true),
+        Ok(Err(error)) => {
+            debug!(%error, "orphan reaper: SM-session candidate page failed; room lane already completed");
+            (
+                crate::clustering::claims::OrphanedSmSessionClaimPage {
+                    candidates: Vec::new(),
+                    next_cursor: workers.sm_cursor(),
+                    has_more: false,
+                    quarantined: 0,
+                },
+                false,
+            )
+        }
+        Err(_) => {
+            debug!(
+                "orphan reaper: SM-session candidate scan timed out; room lane already completed"
+            );
+            (
+                crate::clustering::claims::OrphanedSmSessionClaimPage {
+                    candidates: Vec::new(),
+                    next_cursor: workers.sm_cursor(),
+                    has_more: false,
+                    quarantined: 0,
+                },
+                false,
+            )
+        }
+    };
+    crate::clustering::metrics::record_sm_orphan_candidate_page(
+        page.candidates.len(),
+        page.has_more,
+        page.quarantined,
+    );
+    if scan_succeeded {
+        if page.has_more {
+            workers.set_sm_cursor(page.next_cursor.clone());
+        } else {
+            // Wrap on the next successful end-of-scan observation.
+            workers.set_sm_cursor(None);
+        }
+    }
+    let candidates = page.candidates;
+    let mut stolen = 0usize;
     for candidate in candidates {
+        if !workers.reserve_hydration(&candidate.entity) {
+            warn!("orphan reaper: pausing SM steals because hydration capacity is exhausted");
+            break;
+        }
         if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-candidate")
             .await
         {
+            workers.cancel_hydration_reservation(&candidate.entity);
             return;
         }
         // Element 9's ordering requirement: commit the expire CAS on the
@@ -684,6 +2108,7 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
         // just means the steal below is also likely to lose (the owner
         // row is not yet committed-expired), retried next sweep.
         if let Err(error) = node_lease.expire(&candidate.owner, lease_ttl).await {
+            workers.cancel_hydration_reservation(&candidate.entity);
             debug!(
                 entity_id = %candidate.entity.id,
                 %error,
@@ -701,20 +2126,34 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
         if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-steal")
             .await
         {
+            workers.cancel_hydration_reservation(&candidate.entity);
             return;
         }
         match node_lease
             .steal_orphaned_sm_session_claim(&candidate.entity, candidate.epoch, &me, lease_ttl)
             .await
         {
-            Ok(new_epoch) => reclaimed.push((candidate.entity, new_epoch)),
+            Ok(new_epoch) => {
+                stolen += 1;
+                if !workers.enqueue_reserved_hydration(
+                    candidate.entity,
+                    waddle_xmpp::stream_management::persistence::SmClaimFence::new(
+                        me.clone(),
+                        new_epoch,
+                    ),
+                ) {
+                    warn!("orphan reaper: reserved hydration channel rejected work after steal; claim remains fenced until node expiry");
+                }
+            }
             Err(ClaimError::Conflict) => {
+                workers.cancel_hydration_reservation(&candidate.entity);
                 // Another node (or this same node's own re-registration
                 // reacquisition step, ADR-0017 Phase 3 plan deviation #19)
                 // already reclaimed it, or the "dead" owner actually
                 // renewed concurrently — safe, no-op.
             }
             Err(error) => {
+                workers.cancel_hydration_reservation(&candidate.entity);
                 warn!(
                     entity_id = %candidate.entity.id,
                     %error,
@@ -723,32 +2162,11 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
             }
         }
     }
-    if !reclaimed.is_empty() {
-        let stolen = reclaimed.len();
+    if stolen > 0 {
         info!(
             stolen,
             "orphan reaper: reclaimed orphaned SM-session claims"
         );
-        match state
-            .deps
-            .protocol
-            .sm_session_registry
-            .hydrate_reclaimed(&reclaimed)
-            .await
-        {
-            Ok(hydrated) => {
-                info!(
-                    stolen,
-                    hydrated, "orphan reaper: targeted hydration of reclaimed claims complete"
-                );
-            }
-            Err(error) => {
-                warn!(
-                    %error,
-                    "orphan reaper: hydrate_reclaimed (post-steal targeted hydrate) failed"
-                );
-            }
-        }
     }
 
     // Council-adjudicated FIX 4 (ADR-0017 Phase 3 Slice 8): a
@@ -785,6 +2203,36 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
     }
 }
 
+#[cfg(all(test, feature = "clustering"))]
+async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
+    let supervisor = OrphanReaperSupervisor::new(
+        state.deps.protocol.sm_session_registry.clone(),
+        tokio_util::sync::CancellationToken::new(),
+    );
+    run_orphan_reaper_sweep_with_workers(state, &supervisor.workers).await;
+    let workers = supervisor.workers.clone();
+    let _ = tokio::time::timeout(Duration::from_secs(10), async move {
+        loop {
+            let hydration_empty = workers
+                .hydration_pending
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_empty();
+            let release_empty = workers
+                .release_pending
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_empty();
+            if hydration_empty && release_empty {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+    supervisor.shutdown().await;
+}
+
 /// Postgres-gated end-to-end test for [`run_orphan_reaper_sweep`]
 /// (ADR-0017 Phase 3 Slice 5 corrigenda, council-adjudicated review): seeds
 /// a stale-owner `sm_session` claim plus its durably persisted session,
@@ -804,9 +2252,13 @@ mod orphan_reaper_sweep_tests {
     };
     use crate::clustering::ClusteringHandles;
     use crate::db::{Database, DatabaseConfig, DatabaseDriver, DEFAULT_CONTROL_PLANE_POOL_SIZE};
+    use crate::muc_durable::PostgresMucRoomStore;
     use crate::server::routes::websocket::tests::create_test_websocket_state_with_clustering;
     use crate::sm_persistence_fenced::PostgresFencedSmPersistence;
     use chrono::{TimeZone, Utc};
+    use waddle_xmpp::muc::room_actor::GetConfig;
+    use waddle_xmpp::muc::room_registry_actor::WireClusteringClaims;
+    use waddle_xmpp::muc::{MucDurableStore, RoomConfig, RoomRegistry};
     use waddle_xmpp::ownership::{
         ClaimEpoch, ClaimStore, Entity, EntityType, NodeIdentity, SharedNodeIdentity,
     };
@@ -1016,6 +2468,23 @@ mod orphan_reaper_sweep_tests {
                     sweeper_identity_handle.clone(),
                 ),
         );
+        let muc_store = Arc::new(
+            PostgresMucRoomStore::open(db.clone(), tokio_util::sync::CancellationToken::new())
+                .await
+                .expect("open fenced MUC durable store"),
+        );
+        {
+            let conn = db.guard().await.expect("guard");
+            for statement in [
+                "DELETE FROM clustering_muc_room_affiliations",
+                "DELETE FROM clustering_muc_rooms",
+            ] {
+                conn.execute(statement, ())
+                    .await
+                    .expect("clean MUC durable table");
+            }
+        }
+        let muc_store_dyn: Arc<dyn MucDurableStore> = muc_store.clone();
 
         let clustering = ClusteringHandles {
             claim_store: Some(Arc::clone(&sweeper_claim_store)),
@@ -1023,7 +2492,7 @@ mod orphan_reaper_sweep_tests {
             local_claims: None,
             room_local_claims: None,
             user_local_claims: None,
-            muc_durable_store: None,
+            muc_durable_store: Some(Arc::clone(&muc_store_dyn)),
             isr_token_store: None,
             node_lease: Some(sweeper_node_lease),
             lease_ttl: Some(lease_ttl),
@@ -1039,6 +2508,18 @@ mod orphan_reaper_sweep_tests {
             Arc::clone(&sm_session_registry),
         )
         .await;
+        state
+            .deps
+            .protocol
+            .room_registry
+            .tell(WireClusteringClaims {
+                claim_store: Arc::clone(&sweeper_claim_store),
+                node_identity: sweeper_identity_handle.clone(),
+                durable_store: Some(muc_store_dyn),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire test room registry to clustering stores");
 
         // ============ Leg 1: single-sweep steal + targeted hydrate ============
         let dead_owner = node_identity();
@@ -1132,7 +2613,95 @@ mod orphan_reaper_sweep_tests {
              concurrent sweeps"
         );
 
-        // ============ Leg 3: a heartbeat-stale sweeper cannot steal or hydrate ============
+        // ============ Leg 3: durable RoomActor hydrate + ephemeral release ==========
+        let dead_room_owner = node_identity();
+        register_and_backdate_dead_owner(&claim_store, &db, &dead_room_owner).await;
+        let durable_room: jid::BareJid =
+            "durable-orphan@muc.example.com".parse().expect("room JID");
+        let durable_room_entity = Entity::new(EntityType::RoomActor, durable_room.to_string());
+        let durable_room_epoch = claim_store
+            .acquire(&durable_room_entity, &dead_room_owner)
+            .await
+            .expect("dead node owns durable room claim");
+        let restored_config = RoomConfig {
+            name: "restored by room orphan reaper".to_string(),
+            persistent: true,
+            ..RoomConfig::default()
+        };
+        {
+            let conn = db.guard().await.expect("guard");
+            conn.execute(
+                r#"
+                INSERT INTO clustering_muc_rooms
+                    (room_jid, waddle_id, channel_id, config_json, subject_json)
+                VALUES (?, ?, ?, ?, NULL)
+                ON CONFLICT (room_jid) DO UPDATE SET
+                    waddle_id = EXCLUDED.waddle_id,
+                    channel_id = EXCLUDED.channel_id,
+                    config_json = EXCLUDED.config_json,
+                    subject_json = NULL
+                "#,
+                crate::db_params![
+                    durable_room.to_string(),
+                    "w-reclaimed".to_string(),
+                    "c-reclaimed".to_string(),
+                    serde_json::to_string(&restored_config).expect("serialize config"),
+                ],
+            )
+            .await
+            .expect("seed durable room state");
+        }
+
+        let ephemeral_room: jid::BareJid = "ephemeral-orphan@muc.example.com"
+            .parse()
+            .expect("room JID");
+        let ephemeral_room_entity = Entity::new(EntityType::RoomActor, ephemeral_room.to_string());
+        claim_store
+            .acquire(&ephemeral_room_entity, &dead_room_owner)
+            .await
+            .expect("dead node owns ephemeral room claim");
+
+        run_orphan_reaper_sweep(&state).await;
+
+        assert!(
+            claim_store
+                .fence(
+                    &durable_room_entity,
+                    &sweeper_identity,
+                    ClaimEpoch(durable_room_epoch.0 + 1),
+                )
+                .await
+                .expect("durable room fence"),
+            "the durable room claim must move to the fresh sweeping node"
+        );
+        let room_registry = RoomRegistry::wrap(state.deps.protocol.room_registry.clone());
+        let restored_actor = room_registry
+            .get_room(durable_room.clone())
+            .await
+            .expect("registry lookup")
+            .expect("durable room proactively hydrated");
+        assert_eq!(
+            restored_actor.ask(GetConfig).await.expect("config").name,
+            restored_config.name
+        );
+        assert!(
+            claim_store
+                .current_claim(&ephemeral_room_entity)
+                .await
+                .expect("ephemeral claim lookup")
+                .is_none(),
+            "a room with no durable state must be released for demand-side recreation"
+        );
+        assert!(
+            room_registry
+                .get_room(ephemeral_room)
+                .await
+                .expect("registry lookup")
+                .is_none(),
+            "the reaper must not invent a RoomActor with default state"
+        );
+
+        // ============ Leg 4: a heartbeat-stale sweeper cannot steal or hydrate ============
         {
             let conn = db.guard().await.expect("guard");
             conn.execute(
@@ -1734,6 +3303,12 @@ pub(crate) fn spawn_graceful_shutdown_drain(
                     break;
                 }
             };
+            websocket_state
+                .deps
+                .protocol
+                .sm_session_registry
+                .retry_pending_claim_releases(64)
+                .await;
             if drained.is_empty() {
                 empty_passes += 1;
                 if empty_passes >= QUIET_WINDOW_PASSES {

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -1099,43 +1099,14 @@ impl OrphanReaperSupervisor {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReclaimedRegistration {
     Registered,
-    Released,
-    LostRace,
-    CleanupScheduled,
     CleanupDeferredToNodeExpiry,
 }
 
 #[cfg(feature = "clustering")]
 struct ReclaimedRegistrationContext<'a> {
-    workers: &'a OrphanReaperWorkers,
     room_registry: &'a waddle_xmpp::muc::RoomRegistry,
-    claim_store: &'a Arc<dyn waddle_xmpp::ownership::ClaimStore>,
     previous_owner: &'a waddle_xmpp::ownership::NodeIdentity,
     me: &'a waddle_xmpp::ownership::NodeIdentity,
-}
-
-#[cfg(feature = "clustering")]
-fn reclaimed_cleanup_registration(
-    room_jid: &jid::BareJid,
-    outcome: WorkEnqueueOutcome,
-) -> ReclaimedRegistration {
-    match outcome {
-        WorkEnqueueOutcome::Enqueued | WorkEnqueueOutcome::AlreadyTracked => {
-            ReclaimedRegistration::CleanupScheduled
-        }
-        WorkEnqueueOutcome::RetainedForRestart => {
-            debug!(room = %room_jid, "orphan reaper: exact cleanup worker stopped; responsibility retained for supervisor restart");
-            ReclaimedRegistration::CleanupScheduled
-        }
-        WorkEnqueueOutcome::RetainedForRedrive => {
-            debug!(room = %room_jid, "orphan reaper: exact cleanup channel full; responsibility retained for active redrive");
-            ReclaimedRegistration::CleanupScheduled
-        }
-        WorkEnqueueOutcome::Rejected => {
-            debug!(room = %room_jid, "orphan reaper: exact cleanup inventory saturated after steal; durable claim remains fenced for recovery after node expiry");
-            ReclaimedRegistration::CleanupDeferredToNodeExpiry
-        }
-    }
 }
 
 #[cfg(feature = "clustering")]
@@ -1165,46 +1136,19 @@ async fn register_reclaimed_epoch_or_cleanup(
         .room_registry
         .cancel_pending_reclaimed_room_reservation(room_jid.clone())
         .await;
-    match tokio::time::timeout(
-        ORPHANED_ROOM_RELEASE_TIMEOUT,
-        context
-            .claim_store
-            .release_exact(entity, context.me, claim_epoch),
-    )
-    .await
-    {
-        Ok(Ok(waddle_xmpp::ownership::ExactReleaseOutcome::Released)) => {
-            ReclaimedRegistration::Released
-        }
-        Ok(Ok(waddle_xmpp::ownership::ExactReleaseOutcome::NotOwned)) => {
-            ReclaimedRegistration::LostRace
-        }
-        Ok(Err(error)) => {
-            debug!(room = %room_jid, %error, "orphan reaper: exact cleanup after pending-registration failure failed");
-            let queued = context.workers.enqueue_release(ExactReleaseWork {
-                claim_store: context.claim_store.clone(),
-                entity: entity.clone(),
-                owner: context.me.clone(),
-                epoch: claim_epoch,
-            });
-            reclaimed_cleanup_registration(room_jid, queued)
-        }
-        Err(_) => {
-            debug!(room = %room_jid, "orphan reaper: exact cleanup after pending-registration failure timed out");
-            let queued = context.workers.enqueue_release(ExactReleaseWork {
-                claim_store: context.claim_store.clone(),
-                entity: entity.clone(),
-                owner: context.me.clone(),
-                epoch: claim_epoch,
-            });
-            reclaimed_cleanup_registration(room_jid, queued)
-        }
-    }
+    // The registry is the serialization authority for demand creation and
+    // reclaimed-room adoption. Releasing outside it after registration
+    // failure can race a demand-side self-reacquire/publication and delete
+    // that live claim. Keep the won epoch fenced and defer it to ordinary
+    // stale-node recovery instead; no unsynchronized cleanup worker is
+    // allowed to act on this room generation.
+    debug!(room = %room_jid, "orphan reaper: pending registration failed after steal; leaving claim fenced for node-expiry recovery");
+    ReclaimedRegistration::CleanupDeferredToNodeExpiry
 }
 
 #[cfg(all(test, feature = "clustering"))]
 #[tokio::test]
-async fn stopped_registry_after_steal_exactly_releases_unregistered_epoch() {
+async fn stopped_registry_after_steal_defers_claim_to_node_expiry() {
     use waddle_xmpp::ownership::{ClaimStore, Entity, EntityType, InProcessClaimStore};
 
     let registry = waddle_xmpp::muc::RoomRegistry::spawn(
@@ -1223,16 +1167,9 @@ async fn stopped_registry_after_steal_exactly_releases_unregistered_epoch() {
     let room_jid: jid::BareJid = "stopped-registry@muc.example.com".parse().expect("room");
     let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
     let epoch = claim_store.acquire(&entity, &me).await.expect("won epoch");
-    let supervisor = OrphanReaperSupervisor::new(
-        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
-        tokio_util::sync::CancellationToken::new(),
-    );
-
     let outcome = register_reclaimed_epoch_or_cleanup(
         ReclaimedRegistrationContext {
-            workers: &supervisor.workers,
             room_registry: &registry,
-            claim_store: &claim_store,
             previous_owner: &previous,
             me: &me,
         },
@@ -1241,13 +1178,15 @@ async fn stopped_registry_after_steal_exactly_releases_unregistered_epoch() {
         epoch,
     )
     .await;
-    assert_eq!(outcome, ReclaimedRegistration::Released);
-    assert!(claim_store
-        .current_claim(&entity)
-        .await
-        .expect("claim")
-        .is_none());
-    supervisor.shutdown().await;
+    assert_eq!(outcome, ReclaimedRegistration::CleanupDeferredToNodeExpiry);
+    assert!(
+        claim_store
+            .current_claim(&entity)
+            .await
+            .expect("claim")
+            .is_some(),
+        "registration failure must not release outside the registry and race demand recreation"
+    );
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -1662,20 +1601,6 @@ fn hydration_reservations_do_not_overcommit_a_127_of_128_queue() {
 }
 
 #[cfg(all(test, feature = "clustering"))]
-#[test]
-fn rejected_cleanup_is_never_reported_as_scheduled() {
-    let room_jid: jid::BareJid = "saturated@muc.example.com".parse().expect("room JID");
-    assert_eq!(
-        reclaimed_cleanup_registration(&room_jid, WorkEnqueueOutcome::Rejected),
-        ReclaimedRegistration::CleanupDeferredToNodeExpiry
-    );
-    assert_eq!(
-        reclaimed_cleanup_registration(&room_jid, WorkEnqueueOutcome::RetainedForRedrive),
-        ReclaimedRegistration::CleanupScheduled
-    );
-}
-
-#[cfg(all(test, feature = "clustering"))]
 #[tokio::test]
 async fn full_hydration_channel_retains_and_redrives_pending_work() {
     use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
@@ -1926,7 +1851,7 @@ async fn run_orphan_reaper_sweep_with_workers(
     use waddle_xmpp::ownership::ClaimError;
 
     let clustering = &state.deps.app_state.clustering_claims;
-    let Some((claim_store, identity_handle)) = clustering.claim_pair() else {
+    let Some((_claim_store, identity_handle)) = clustering.claim_pair() else {
         return;
     };
     let Some(node_lease) = clustering.node_lease.clone() else {
@@ -2178,9 +2103,7 @@ async fn run_orphan_reaper_sweep_with_workers(
             Ok(new_epoch) => {
                 match register_reclaimed_epoch_or_cleanup(
                     ReclaimedRegistrationContext {
-                        workers,
                         room_registry: &room_registry,
-                        claim_store: &claim_store,
                         previous_owner: &candidate.owner,
                         me: &me,
                     },
@@ -2191,18 +2114,6 @@ async fn run_orphan_reaper_sweep_with_workers(
                 .await
                 {
                     ReclaimedRegistration::Registered => {}
-                    ReclaimedRegistration::Released => {
-                        room_released += 1;
-                        continue;
-                    }
-                    ReclaimedRegistration::LostRace => {
-                        room_lost_race += 1;
-                        continue;
-                    }
-                    ReclaimedRegistration::CleanupScheduled => {
-                        room_failed += 1;
-                        continue;
-                    }
                     ReclaimedRegistration::CleanupDeferredToNodeExpiry => {
                         room_failed += 1;
                         continue;

--- a/server/crates/waddle-server/src/sm_persistence.rs
+++ b/server/crates/waddle-server/src/sm_persistence.rs
@@ -263,7 +263,12 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?
         {
-            Ok(Some(decode_session(&row)?))
+            Ok(Some(decode_session(&row).map_err(|error| {
+                SmPersistenceError::Corrupt {
+                    stream_id: stream_id.clone(),
+                    detail: error.to_string(),
+                }
+            })?))
         } else {
             Ok(None)
         }
@@ -406,7 +411,12 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?
         {
-            out.push(decode_unacked(&row)?);
+            out.push(
+                decode_unacked(&row).map_err(|error| SmPersistenceError::Corrupt {
+                    stream_id: stream_id.clone(),
+                    detail: error.to_string(),
+                })?,
+            );
         }
         Ok(out)
     }

--- a/server/crates/waddle-server/src/sm_persistence_fenced.rs
+++ b/server/crates/waddle-server/src/sm_persistence_fenced.rs
@@ -425,9 +425,34 @@ impl PostgresFencedSmPersistence {
 
         match result {
             Ok(fence) if self.node_identity.current() == *fence.owner() => Ok(fence.clone()),
-            Ok(_) => {
-                self.remove_claim_cell_if(stream_id, &cell);
-                Err(SmPersistenceError::NotOwner { entity })
+            Ok(fence) => {
+                // `ensure_claimed` may have committed under the previous
+                // incarnation immediately before self-fence rotation. Keep
+                // the resolved cell as exact retry inventory until that old
+                // owner+epoch is confirmed gone; otherwise a current-
+                // identity retry conflicts with our own stranded claim.
+                match self
+                    .claim_store
+                    .release_exact(&entity, fence.owner(), fence.epoch())
+                    .await
+                {
+                    Ok(
+                        waddle_xmpp::ownership::ExactReleaseOutcome::Released
+                        | waddle_xmpp::ownership::ExactReleaseOutcome::NotOwned,
+                    ) => {
+                        self.remove_claim_cell_if(stream_id, &cell);
+                        Err(SmPersistenceError::NotOwner { entity })
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            stream_id = %stream_id,
+                            %error,
+                            "PostgresFencedSmPersistence: stale-incarnation exact claim cleanup \
+                             failed; retaining the immutable fence for retry"
+                        );
+                        Err(claim_error_to_sm_persistence_error(error, entity))
+                    }
+                }
             }
             Err(error) => {
                 tracing::warn!(

--- a/server/crates/waddle-server/src/sm_persistence_fenced.rs
+++ b/server/crates/waddle-server/src/sm_persistence_fenced.rs
@@ -31,7 +31,8 @@
 //!
 //! Every method that writes `sm_sessions`/`sm_unacked` on behalf of an
 //! SM-session entity runs its own `SELECT 1 FROM clustering_claims WHERE
-//! entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE` — the exact
+//! entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR
+//! SHARE` — the exact
 //! fencing-transaction SQL shape ADR-0017 Phase 3 Slice 1 locks — as the
 //! first statement inside the *same* [`crate::db::Transaction`] as the
 //! write(s) it guards, all on the **main pool**
@@ -50,15 +51,15 @@
 //! `waddle-xmpp`-hosted `ClaimStore` trait without an illegal reverse
 //! dependency — so this impl issues the fencing SQL inline, itself, and
 //! uses [`waddle_xmpp::ownership::ClaimStore`] purely as a side channel
-//! for the epoch **value**: [`PostgresFencedSmPersistence`] holds an
+//! for the immutable owner/epoch fence: [`PostgresFencedSmPersistence`] holds an
 //! `Arc<dyn ClaimStore>` and a per-stream-id cache
-//! (`claim_epochs: DashMap<SmSessionId, Arc<tokio::sync::OnceCell<ClaimEpoch>>>`),
+//! (`claim_fences: DashMap<SmSessionId, Arc<tokio::sync::OnceCell<SmClaimFence>>>`),
 //! populated lazily — the first fenced write for a stream-id this process
 //! instance has not yet seen ensures a claim once and caches the resulting
-//! epoch; every subsequent fenced write for that stream-id reuses the
-//! cached value. A failed fencing check invalidates the cache entry (the
-//! epoch is no longer valid), so a later retry re-acquires instead of
-//! spinning against a known-stale epoch forever.
+//! exact process identity together with its epoch; every subsequent fenced
+//! write for that stream-id reuses the inseparable pair. A failed fencing
+//! check or identity rotation invalidates the cache entry, so a later retry
+//! re-acquires instead of pairing a stale epoch with a new incarnation.
 //!
 //! ## FIX 1 — `ensure_claimed` + per-key single-flight (council-adjudicated)
 //!
@@ -73,9 +74,9 @@
 //! `acquire`-per-write-attempt design would hit:
 //!
 //! - **Concurrent first writes for the same not-yet-claimed stream_id**:
-//!   two tasks both calling [`Self::claim_epoch_for`] for a fresh
-//!   `stream_id` fetch (or insert) the same `Arc<OnceCell<ClaimEpoch>>`
-//!   from `claim_epochs` (`DashMap::entry`, briefly locking only that
+//!   two tasks both calling [`Self::claim_fence_for`] for a fresh
+//!   `stream_id` fetch (or insert) the same `Arc<OnceCell<SmClaimFence>>`
+//!   from `claim_fences` (`DashMap::entry`, briefly locking only that
 //!   shard — no lock held across the subsequent `.await`), then both call
 //!   `OnceCell::get_or_try_init` on it: exactly one of them actually runs
 //!   the `ensure_claimed` future; the other awaits that same attempt's
@@ -94,11 +95,11 @@
 //!   26).
 //!
 //! `OnceCell::get_or_try_init` leaves the cell uninitialized on error, so a
-//! later, separate call to [`Self::claim_epoch_for`] retries fresh (a
+//! later, separate call to [`Self::claim_fence_for`] retries fresh (a
 //! failed attempt is never permanently cached) — this is orthogonal to
 //! `assert_fenced`'s own invalidation, which removes an *already-populated*
-//! cell from `claim_epochs` entirely once a live fencing check reveals the
-//! cached epoch is stale, forcing the next call to build a brand-new cell.
+//! cell from `claim_fences` entirely once a live fencing check reveals the
+//! cached fence is stale, forcing the next call to build a brand-new cell.
 //!
 //! **Slice 5 debt (a), closed**: cells whose init failed (foreign owner)
 //! were already never inserted (the `OnceCell` stays uninitialized), and
@@ -129,18 +130,33 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use tokio::sync::OnceCell;
-use waddle_xmpp::ownership::{
-    ClaimEpoch, ClaimError, ClaimStore, Entity, EntityType, SharedNodeIdentity,
-};
+use waddle_xmpp::ownership::{ClaimError, ClaimStore, Entity, EntityType, SharedNodeIdentity};
 use waddle_xmpp::pending_delivery::SmSessionId;
 use waddle_xmpp::stream_management::persistence::{
-    PersistedSession, PersistedUnackedStanza, SmPersistenceError, SmPersistenceStorage,
+    PersistedSession, PersistedUnackedStanza, SmClaimFence, SmPersistenceError,
+    SmPersistenceStorage,
 };
 
 use crate::db::{Database, DatabaseDriver, Transaction};
 use crate::sm_persistence::codec::{
     decode_session, decode_unacked, serialize_presence_payloads, serialize_stanza, show_wire_str,
 };
+
+fn remove_sm_claim_cell_if(
+    claim_fences: &DashMap<SmSessionId, Arc<OnceCell<SmClaimFence>>>,
+    stream_id: &SmSessionId,
+    expected_cell: &Arc<OnceCell<SmClaimFence>>,
+) {
+    claim_fences.remove_if(stream_id, |_, current| Arc::ptr_eq(current, expected_cell));
+}
+
+fn remove_sm_claim_fence_if(
+    claim_fences: &DashMap<SmSessionId, Arc<OnceCell<SmClaimFence>>>,
+    stream_id: &SmSessionId,
+    expected: &SmClaimFence,
+) {
+    claim_fences.remove_if(stream_id, |_, cell| cell.get() == Some(expected));
+}
 
 /// FIX 3: map a [`ClaimError`] to the [`SmPersistenceError`] this trait's
 /// callers expect. Only a genuine ownership loss —
@@ -213,16 +229,28 @@ pub struct PostgresFencedSmPersistence {
     db: Database,
     claim_store: Arc<dyn ClaimStore>,
     node_identity: SharedNodeIdentity,
-    /// Per-stream-id single-flight cached claim epoch — see the module
+    /// Per-stream-id single-flight cached immutable claim fence — see the module
     /// doc's "Epoch side channel" / FIX 1 sections. Each cell resolves at
     /// most once to a real epoch; a failed resolution leaves the cell
     /// empty (retried fresh on the next call), and `assert_fenced` removes
     /// an already-populated, now-stale cell from the map entirely so a
     /// later call builds a brand-new one.
-    claim_epochs: Arc<DashMap<SmSessionId, Arc<OnceCell<ClaimEpoch>>>>,
+    claim_fences: Arc<DashMap<SmSessionId, Arc<OnceCell<SmClaimFence>>>>,
 }
 
 impl PostgresFencedSmPersistence {
+    fn remove_claim_cell_if(
+        &self,
+        stream_id: &SmSessionId,
+        expected_cell: &Arc<OnceCell<SmClaimFence>>,
+    ) {
+        remove_sm_claim_cell_if(&self.claim_fences, stream_id, expected_cell);
+    }
+
+    fn remove_claim_fence_if(&self, stream_id: &SmSessionId, expected: &SmClaimFence) {
+        remove_sm_claim_fence_if(&self.claim_fences, stream_id, expected);
+    }
+
     /// Open against an already-opened Postgres [`Database`] handle.
     ///
     /// FIX 4: this constructor no longer opens its own, independent pool
@@ -256,7 +284,7 @@ impl PostgresFencedSmPersistence {
             db,
             claim_store,
             node_identity,
-            claim_epochs: Arc::new(DashMap::new()),
+            claim_fences: Arc::new(DashMap::new()),
         };
         storage.ensure_schema().await?;
         tracing::info!(
@@ -361,20 +389,19 @@ impl PostgresFencedSmPersistence {
         Ok(())
     }
 
-    /// The claim epoch this process currently believes it holds for
-    /// `stream_id`, ensuring a claim on first use (see the module doc's
-    /// "Epoch side channel" / FIX 1 sections for the full single-flight
-    /// design and its known interim gap).
-    async fn claim_epoch_for(
+    /// The immutable owner/epoch fence this process holds for `stream_id`,
+    /// ensuring a claim on first use. The identity captured by the successful
+    /// ensure is never replaced with a later `SharedNodeIdentity` value.
+    async fn claim_fence_for(
         &self,
         stream_id: &SmSessionId,
-    ) -> Result<ClaimEpoch, SmPersistenceError> {
+    ) -> Result<SmClaimFence, SmPersistenceError> {
         // FIX 1: fetch-or-insert this stream_id's single-flight cell.
         // `DashMap::entry` briefly locks only the shard for this key; the
         // `Arc` clone below is used after that guard has already dropped,
         // so no lock is held across the `.await` that follows.
         let cell = self
-            .claim_epochs
+            .claim_fences
             .entry(stream_id.clone())
             .or_insert_with(|| Arc::new(OnceCell::new()))
             .clone();
@@ -390,11 +417,18 @@ impl PostgresFencedSmPersistence {
         // A failed attempt leaves the cell uninitialized, so a later,
         // separate call retries fresh rather than being poisoned forever.
         let result = cell
-            .get_or_try_init(|| self.claim_store.ensure_claimed(&entity, &identity))
+            .get_or_try_init(|| async {
+                let epoch = self.claim_store.ensure_claimed(&entity, &identity).await?;
+                Ok::<_, ClaimError>(SmClaimFence::new(identity.clone(), epoch))
+            })
             .await;
 
         match result {
-            Ok(epoch) => Ok(*epoch),
+            Ok(fence) if self.node_identity.current() == *fence.owner() => Ok(fence.clone()),
+            Ok(_) => {
+                self.remove_claim_cell_if(stream_id, &cell);
+                Err(SmPersistenceError::NotOwner { entity })
+            }
             Err(error) => {
                 tracing::warn!(
                     stream_id = %stream_id,
@@ -408,8 +442,8 @@ impl PostgresFencedSmPersistence {
     }
 
     /// Take the ADR-0017 element-4 fencing lock inside `tx` — the
-    /// caller's own [`Database::begin`] transaction — for `stream_id` at
-    /// `epoch`. Returns `Ok(())` if this node still holds the claim (the
+    /// caller's own [`Database::begin`] transaction — for `stream_id` at the
+    /// exact immutable owner/epoch pair. Returns `Ok(())` if this node still holds the claim (the
     /// `FOR SHARE` SELECT observed a row); returns
     /// [`SmPersistenceError::NotOwner`] and invalidates the cached epoch
     /// otherwise. Callers must not perform any write before this returns
@@ -419,14 +453,24 @@ impl PostgresFencedSmPersistence {
         &self,
         tx: &mut Transaction<'_>,
         stream_id: &SmSessionId,
-        epoch: ClaimEpoch,
+        fence: &SmClaimFence,
     ) -> Result<(), SmPersistenceError> {
-        let identity = self.node_identity.current();
+        if self.node_identity.current() != *fence.owner() {
+            self.remove_claim_fence_if(stream_id, fence);
+            return Err(SmPersistenceError::NotOwner {
+                entity: sm_session_entity(stream_id),
+            });
+        }
         let key = sm_session_entity_key(stream_id);
         let mut rows = tx
             .query(
-                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                crate::db_params![key, identity.node_id.clone(), epoch.0],
+                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
+                crate::db_params![
+                    key,
+                    fence.owner().node_id.clone(),
+                    fence.owner().node_epoch.clone(),
+                    fence.epoch().0,
+                ],
             )
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
@@ -435,10 +479,10 @@ impl PostgresFencedSmPersistence {
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?
             .is_some();
-        if held {
+        if held && self.node_identity.current() == *fence.owner() {
             Ok(())
         } else {
-            self.claim_epochs.remove(stream_id);
+            self.remove_claim_fence_if(stream_id, fence);
             Err(SmPersistenceError::NotOwner {
                 entity: sm_session_entity(stream_id),
             })
@@ -465,7 +509,7 @@ impl PostgresFencedSmPersistence {
 impl SmPersistenceStorage for PostgresFencedSmPersistence {
     async fn upsert_session(&self, session: PersistedSession) -> Result<(), SmPersistenceError> {
         let stream_id = session.stream_id.clone();
-        let epoch = self.claim_epoch_for(&stream_id).await?;
+        let fence = self.claim_fence_for(&stream_id).await?;
         let max_resume_duration_ms = i64::try_from(session.max_resume_duration.as_millis())
             .map_err(|_| SmPersistenceError::Other("max_resume_duration overflows i64".into()))?;
         let presence_show_str = session.presence_show.as_ref().map(show_wire_str);
@@ -476,7 +520,7 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
             .begin()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
-        self.assert_fenced(&mut tx, &stream_id, epoch).await?;
+        self.assert_fenced(&mut tx, &stream_id, &fence).await?;
 
         // Divergence (a): ignore `session.detached_at`; stamp Postgres
         // `now()` in SQL instead (both the fresh-insert VALUES and the
@@ -562,20 +606,25 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?
         {
-            Ok(Some(decode_session(&row)?))
+            Ok(Some(decode_session(&row).map_err(|error| {
+                SmPersistenceError::Corrupt {
+                    stream_id: stream_id.clone(),
+                    detail: error.to_string(),
+                }
+            })?))
         } else {
             Ok(None)
         }
     }
 
     async fn delete_session(&self, stream_id: &SmSessionId) -> Result<(), SmPersistenceError> {
-        let epoch = self.claim_epoch_for(stream_id).await?;
+        let fence = self.claim_fence_for(stream_id).await?;
         let mut tx = self
             .db
             .begin()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
-        self.assert_fenced(&mut tx, stream_id, epoch).await?;
+        self.assert_fenced(&mut tx, stream_id, &fence).await?;
 
         // Two statements rather than ON DELETE CASCADE, matching the
         // portable impl's observable lifecycle exactly.
@@ -595,7 +644,38 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
         tx.commit()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
-        self.claim_epochs.remove(stream_id);
+        self.remove_claim_fence_if(stream_id, &fence);
+        Ok(())
+    }
+
+    async fn quarantine_session(
+        &self,
+        stream_id: &SmSessionId,
+        expected_fence: &SmClaimFence,
+    ) -> Result<(), SmPersistenceError> {
+        let mut tx = self
+            .db
+            .begin()
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        self.assert_fenced(&mut tx, stream_id, expected_fence)
+            .await?;
+        tx.execute(
+            "DELETE FROM sm_unacked WHERE stream_id = ?",
+            crate::db_params![stream_id.as_str().to_string()],
+        )
+        .await
+        .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        tx.execute(
+            "DELETE FROM sm_sessions WHERE stream_id = ?",
+            crate::db_params![stream_id.as_str().to_string()],
+        )
+        .await
+        .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        tx.commit()
+            .await
+            .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
+        self.remove_claim_fence_if(stream_id, expected_fence);
         Ok(())
     }
 
@@ -604,7 +684,7 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
         stanza: PersistedUnackedStanza,
     ) -> Result<(), SmPersistenceError> {
         let stream_id = stanza.stream_id.clone();
-        let epoch = self.claim_epoch_for(&stream_id).await?;
+        let fence = self.claim_fence_for(&stream_id).await?;
         let xml = serialize_stanza(&stanza.stanza)?;
         let receipt_ms = stanza.original_receipt_at.timestamp_millis();
 
@@ -613,7 +693,7 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
             .begin()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
-        self.assert_fenced(&mut tx, &stream_id, epoch).await?;
+        self.assert_fenced(&mut tx, &stream_id, &fence).await?;
         tx.execute(
             "INSERT INTO sm_unacked (stream_id, sequence, stanza_xml, original_receipt_at_ms) \
              VALUES (?, ?, ?, ?)",
@@ -637,13 +717,13 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
         stream_id: &SmSessionId,
         up_to_sequence: u32,
     ) -> Result<u64, SmPersistenceError> {
-        let epoch = self.claim_epoch_for(stream_id).await?;
+        let fence = self.claim_fence_for(stream_id).await?;
         let mut tx = self
             .db
             .begin()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
-        self.assert_fenced(&mut tx, stream_id, epoch).await?;
+        self.assert_fenced(&mut tx, stream_id, &fence).await?;
         let removed = tx
             .execute(
                 "DELETE FROM sm_unacked WHERE stream_id = ? AND sequence <= ?",
@@ -662,13 +742,13 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
         stream_id: &SmSessionId,
         sequences: &[u32],
     ) -> Result<u64, SmPersistenceError> {
-        let epoch = self.claim_epoch_for(stream_id).await?;
+        let fence = self.claim_fence_for(stream_id).await?;
         let mut tx = self
             .db
             .begin()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
-        self.assert_fenced(&mut tx, stream_id, epoch).await?;
+        self.assert_fenced(&mut tx, stream_id, &fence).await?;
         let mut removed = 0u64;
         for sequence in sequences {
             removed += tx
@@ -707,7 +787,12 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?
         {
-            out.push(decode_unacked(&row)?);
+            out.push(
+                decode_unacked(&row).map_err(|error| SmPersistenceError::Corrupt {
+                    stream_id: stream_id.clone(),
+                    detail: error.to_string(),
+                })?,
+            );
         }
         Ok(out)
     }
@@ -783,7 +868,7 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
         unacked: Vec<PersistedUnackedStanza>,
     ) -> Result<(), SmPersistenceError> {
         let stream_id = session.stream_id.clone();
-        let epoch = self.claim_epoch_for(&stream_id).await?;
+        let fence = self.claim_fence_for(&stream_id).await?;
         let max_resume_duration_ms = i64::try_from(session.max_resume_duration.as_millis())
             .map_err(|_| SmPersistenceError::Other("max_resume_duration overflows i64".into()))?;
         let presence_show_str = session.presence_show.as_ref().map(show_wire_str);
@@ -794,7 +879,7 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
             .begin()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
-        self.assert_fenced(&mut tx, &stream_id, epoch).await?;
+        self.assert_fenced(&mut tx, &stream_id, &fence).await?;
 
         // Drop any pre-existing unacked rows first (see the portable
         // impl's identical comment on this statement's ordering
@@ -886,13 +971,13 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
         &self,
         stream_id: &SmSessionId,
     ) -> Result<u32, SmPersistenceError> {
-        let epoch = self.claim_epoch_for(stream_id).await?;
+        let fence = self.claim_fence_for(stream_id).await?;
         let mut tx = self
             .db
             .begin()
             .await
             .map_err(|e| SmPersistenceError::Other(e.to_string()))?;
-        self.assert_fenced(&mut tx, stream_id, epoch).await?;
+        self.assert_fenced(&mut tx, stream_id, &fence).await?;
         let mut rows = tx
             .query(
                 "UPDATE sm_sessions SET promotion_attempts = promotion_attempts + 1 \
@@ -935,8 +1020,8 @@ impl SmPersistenceStorage for PostgresFencedSmPersistence {
     /// fenced write for that stream_id (a fresh detach + claim, or a
     /// different node's claim if this one no longer holds it) re-derives
     /// its epoch from a clean cell instead of a stale one.
-    fn evict_claim_cache(&self, stream_id: &SmSessionId) {
-        self.claim_epochs.remove(stream_id);
+    fn evict_claim_cache(&self, stream_id: &SmSessionId, expected_fence: &SmClaimFence) {
+        self.remove_claim_fence_if(stream_id, expected_fence);
     }
 }
 

--- a/server/crates/waddle-server/src/sm_persistence_fenced.rs
+++ b/server/crates/waddle-server/src/sm_persistence_fenced.rs
@@ -124,7 +124,7 @@
 //! self-reacquire path once that same node's own restore/reaper pass claims
 //! it — see those modules' doc comments for the full lifecycle.
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -141,6 +141,8 @@ use crate::db::{Database, DatabaseDriver, Transaction};
 use crate::sm_persistence::codec::{
     decode_session, decode_unacked, serialize_presence_payloads, serialize_stanza, show_wire_str,
 };
+
+const STALE_CLAIM_RELEASE_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn remove_sm_claim_cell_if(
     claim_fences: &DashMap<SmSessionId, Arc<OnceCell<SmClaimFence>>>,
@@ -431,19 +433,21 @@ impl PostgresFencedSmPersistence {
                 // the resolved cell as exact retry inventory until that old
                 // owner+epoch is confirmed gone; otherwise a current-
                 // identity retry conflicts with our own stranded claim.
-                match self
-                    .claim_store
-                    .release_exact(&entity, fence.owner(), fence.epoch())
-                    .await
+                match tokio::time::timeout(
+                    STALE_CLAIM_RELEASE_TIMEOUT,
+                    self.claim_store
+                        .release_exact(&entity, fence.owner(), fence.epoch()),
+                )
+                .await
                 {
-                    Ok(
+                    Ok(Ok(
                         waddle_xmpp::ownership::ExactReleaseOutcome::Released
                         | waddle_xmpp::ownership::ExactReleaseOutcome::NotOwned,
-                    ) => {
+                    )) => {
                         self.remove_claim_cell_if(stream_id, &cell);
                         Err(SmPersistenceError::NotOwner { entity })
                     }
-                    Err(error) => {
+                    Ok(Err(error)) => {
                         tracing::warn!(
                             stream_id = %stream_id,
                             %error,
@@ -451,6 +455,17 @@ impl PostgresFencedSmPersistence {
                              failed; retaining the immutable fence for retry"
                         );
                         Err(claim_error_to_sm_persistence_error(error, entity))
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            stream_id = %stream_id,
+                            timeout = ?STALE_CLAIM_RELEASE_TIMEOUT,
+                            "PostgresFencedSmPersistence: stale-incarnation exact claim cleanup \
+                             timed out; retaining the immutable fence for retry"
+                        );
+                        Err(SmPersistenceError::Other(
+                            "stale-incarnation exact claim cleanup timed out".to_string(),
+                        ))
                     }
                 }
             }

--- a/server/crates/waddle-server/src/sm_persistence_fenced/tests.rs
+++ b/server/crates/waddle-server/src/sm_persistence_fenced/tests.rs
@@ -555,6 +555,51 @@ async fn quarantine_rejects_same_node_id_new_incarnation_after_epoch_aba() {
 }
 
 #[tokio::test]
+async fn identity_rotation_exactly_releases_the_cached_old_incarnation_before_retry() {
+    let Some(f) = fixture().await else { return };
+    let stream_id = SmSessionId::new("stream-identity-rotation-cleanup");
+    let entity = Entity::new(EntityType::SmSession, stream_id.as_str().to_string());
+    f.fenced
+        .upsert_session(fixture_session(stream_id.as_str()))
+        .await
+        .expect("old incarnation establishes the cached claim fence");
+
+    let replacement =
+        NodeIdentity::new(f.identity.node_id.clone(), uuid::Uuid::new_v4().to_string());
+    f.shared_identity.set(replacement.clone());
+
+    let rotation_error = f
+        .fenced
+        .upsert_session(fixture_session(stream_id.as_str()))
+        .await
+        .expect_err("the first post-rotation write performs cleanup and retries explicitly");
+    assert!(matches!(
+        rotation_error,
+        SmPersistenceError::NotOwner { .. }
+    ));
+    assert!(
+        f.claims
+            .current_claim(&entity)
+            .await
+            .expect("claim lookup after exact cleanup")
+            .is_none(),
+        "the stale incarnation must not block the replacement identity"
+    );
+
+    f.fenced
+        .upsert_session(fixture_session(stream_id.as_str()))
+        .await
+        .expect("the replacement identity acquires on the explicit retry");
+    let claim = f
+        .claims
+        .current_claim(&entity)
+        .await
+        .expect("replacement claim lookup")
+        .expect("replacement claim exists");
+    assert_eq!(claim.owner, replacement);
+}
+
+#[tokio::test]
 async fn record_promotion_failure_aborts_before_any_write_once_the_claim_is_stolen() {
     let Some(f) = fixture().await else { return };
     let stream_id = SmSessionId::new("stream-promo-stolen");

--- a/server/crates/waddle-server/src/sm_persistence_fenced/tests.rs
+++ b/server/crates/waddle-server/src/sm_persistence_fenced/tests.rs
@@ -3,11 +3,31 @@
 //! unset, mirroring `clustering::claims`'s own test style exactly.
 
 use super::*;
-use crate::clustering::claims::PostgresClaimStore;
+
+#[test]
+fn stale_sm_cache_failure_does_not_evict_new_generation() {
+    let stream_id = SmSessionId::new("old-a-new-b".to_string());
+    let owner = NodeIdentity::new("node-a", "incarnation-a");
+    let fence_a = SmClaimFence::new(owner.clone(), ClaimEpoch(1));
+    let fence_b = SmClaimFence::new(owner, ClaimEpoch(2));
+    let cell_a = Arc::new(OnceCell::new());
+    cell_a.set(fence_a.clone()).expect("initialize A");
+    let cell_b = Arc::new(OnceCell::new());
+    cell_b.set(fence_b.clone()).expect("initialize B");
+    let cache = DashMap::new();
+    cache.insert(stream_id.clone(), cell_b.clone());
+
+    remove_sm_claim_cell_if(&cache, &stream_id, &cell_a);
+    remove_sm_claim_fence_if(&cache, &stream_id, &fence_a);
+
+    assert!(Arc::ptr_eq(cache.get(&stream_id).unwrap().value(), &cell_b));
+    assert_eq!(cache.get(&stream_id).unwrap().get(), Some(&fence_b));
+}
+use crate::clustering::claims::{NodeLeaseStore as _, PostgresClaimStore};
 use crate::db::DatabaseConfig;
 use chrono::TimeZone;
 use std::time::Duration as StdDuration;
-use waddle_xmpp::ownership::{NodeIdentity, StalePredicate};
+use waddle_xmpp::ownership::{ClaimEpoch, NodeIdentity, StalePredicate};
 use waddle_xmpp::stream_management::SmSessionRegistry as _;
 use xmpp_parsers::presence::Show;
 
@@ -95,6 +115,7 @@ struct Fixture {
     claims: PostgresClaimStore,
     claims_db: Database,
     identity: NodeIdentity,
+    shared_identity: SharedNodeIdentity,
     /// Holds `clustering::claims::clustering_control_plane_table_lock()` for
     /// this fixture's — and thus the whole test's — lifetime. Every test in
     /// this module truncates the shared `sm_sessions`/`sm_unacked`/
@@ -139,7 +160,7 @@ async fn fixture() -> Option<Fixture> {
     let fenced = PostgresFencedSmPersistence::open(
         claims_db.clone(),
         claim_store_for_fenced,
-        shared_identity,
+        shared_identity.clone(),
     )
     .await
     .expect("open fenced SM persistence");
@@ -162,6 +183,7 @@ async fn fixture() -> Option<Fixture> {
         claims,
         claims_db,
         identity,
+        shared_identity,
         _table_lock: table_lock,
     })
 }
@@ -460,6 +482,75 @@ async fn delete_session_aborts_before_any_write_once_the_claim_is_stolen() {
             .expect("get_session")
             .is_some(),
         "delete_session must roll back before deleting anything once fencing fails"
+    );
+}
+
+/// A claim row may be deleted and recreated at epoch zero. The epoch alone,
+/// even paired with a stable node id, therefore cannot distinguish process
+/// incarnations. Every fenced persistence transaction must bind node_epoch.
+#[tokio::test]
+async fn quarantine_rejects_same_node_id_new_incarnation_after_epoch_aba() {
+    let Some(f) = fixture().await else { return };
+    let stream_id = SmSessionId::new("stream-incarnation-aba");
+    let entity = Entity::new(EntityType::SmSession, stream_id.as_str().to_string());
+    f.fenced
+        .upsert_session(fixture_session(stream_id.as_str()))
+        .await
+        .expect("old incarnation establishes epoch-zero claim and durable row");
+
+    let old_epoch = f
+        .claims
+        .current_claim(&entity)
+        .await
+        .expect("read old claim")
+        .expect("old claim exists")
+        .claim_epoch;
+    assert_eq!(old_epoch, ClaimEpoch(0));
+    assert_eq!(
+        f.claims
+            .release_exact(&entity, &f.identity, old_epoch)
+            .await
+            .expect("release old claim"),
+        waddle_xmpp::ownership::ExactReleaseOutcome::Released
+    );
+
+    let replacement =
+        NodeIdentity::new(f.identity.node_id.clone(), uuid::Uuid::new_v4().to_string());
+    f.claims
+        .register(&replacement, None)
+        .await
+        .expect("same node id re-registers under a new incarnation");
+    let replacement_epoch = f
+        .claims
+        .acquire(&entity, &replacement)
+        .await
+        .expect("replacement recreates claim at epoch zero");
+    assert_eq!(replacement_epoch, old_epoch, "exercise claim-epoch ABA");
+
+    let old_fence = SmClaimFence::new(f.identity.clone(), old_epoch);
+    f.shared_identity.set(replacement.clone());
+    let cached_write_error = f
+        .fenced
+        .upsert_session(fixture_session(stream_id.as_str()))
+        .await
+        .expect_err("cached old-incarnation fence must not be rebound to the replacement");
+    assert!(matches!(
+        cached_write_error,
+        SmPersistenceError::NotOwner { .. }
+    ));
+    let error = f
+        .fenced
+        .quarantine_session(&stream_id, &old_fence)
+        .await
+        .expect_err("old-incarnation quarantine must fail exact fencing");
+    assert!(matches!(error, SmPersistenceError::NotOwner { .. }));
+    assert!(
+        f.fenced
+            .get_session(&stream_id)
+            .await
+            .expect("read durable row")
+            .is_some(),
+        "failed old-incarnation quarantine must preserve the new owner's durable row"
     );
 }
 

--- a/server/crates/waddle-server/tests/xep0198_cross_node_resume.rs
+++ b/server/crates/waddle-server/tests/xep0198_cross_node_resume.rs
@@ -441,13 +441,19 @@ async fn pure_two_node_detached_steal_race_exactly_one_winner() {
 
     // The winner's full pipeline (hydrate + claim_session) still resumes
     // correctly, exactly like `attempt_cross_node_resume`'s own branch 1.
-    let (winning_registry, winning_epoch) = match (result_b, result_c) {
-        (Ok(epoch), Err(_)) => (&registry_b, epoch),
-        (Err(_), Ok(epoch)) => (&registry_c, epoch),
+    let (winning_registry, winning_owner, winning_epoch) = match (result_b, result_c) {
+        (Ok(epoch), Err(_)) => (&registry_b, identity_b_now, epoch),
+        (Err(_), Ok(epoch)) => (&registry_c, identity_c_now, epoch),
         other => panic!("expected exactly one winner and one Conflict, got {other:?}"),
     };
     winning_registry
-        .hydrate_reclaimed(&[(entity, winning_epoch)])
+        .hydrate_reclaimed(&[(
+            entity,
+            waddle_xmpp::stream_management::persistence::SmClaimFence::new(
+                winning_owner,
+                winning_epoch,
+            ),
+        )])
         .await
         .expect("hydrate_reclaimed succeeds for the winner");
     let resumed = winning_registry

--- a/server/crates/waddle-xmpp/src/isr/store.rs
+++ b/server/crates/waddle-xmpp/src/isr/store.rs
@@ -21,7 +21,7 @@ use std::sync::RwLock;
 use async_trait::async_trait;
 use subtle::ConstantTimeEq;
 
-use crate::ownership::{ClaimEpoch, NodeIdentity};
+use crate::stream_management::persistence::SmClaimFence;
 
 /// A freshly issued or rotated ISR token (ADR-0017 Phase 3 Slice 8,
 /// XEP-0397). The token string itself is a secret credential — never
@@ -124,8 +124,7 @@ pub trait IsrTokenStore: Send + Sync {
         sm_id: &str,
         presented_token: &[u8],
         mechanism: &str,
-        me: &NodeIdentity,
-        mine: ClaimEpoch,
+        fence: &SmClaimFence,
     ) -> Result<IsrConsumeOutcome, IsrTokenStoreError>;
 
     /// Council-adjudicated FIX 4 (ADR-0017 Phase 3 Slice 8): reap token
@@ -190,8 +189,7 @@ impl IsrTokenStore for InMemoryIsrTokenStore {
         // No node-liveness table exists for the single-node case (mirrors
         // `InProcessClaimStore`'s own module doc): there is only one node,
         // so fencing is a no-op here rather than a meaningful check.
-        _me: &NodeIdentity,
-        _mine: ClaimEpoch,
+        _fence: &SmClaimFence,
     ) -> Result<IsrConsumeOutcome, IsrTokenStoreError> {
         let mut tokens = self
             .tokens
@@ -237,8 +235,11 @@ impl IsrTokenStore for InMemoryIsrTokenStore {
 mod tests {
     use super::*;
 
-    fn identity() -> NodeIdentity {
-        NodeIdentity::local()
+    fn fence() -> SmClaimFence {
+        SmClaimFence::new(
+            crate::ownership::NodeIdentity::local(),
+            crate::ownership::ClaimEpoch(0),
+        )
     }
 
     #[tokio::test]
@@ -246,13 +247,7 @@ mod tests {
         let store = InMemoryIsrTokenStore::new();
         let issued = store.issue("sm-1", "PLAIN").await.expect("issue");
         let outcome = store
-            .consume(
-                "sm-1",
-                issued.token.as_bytes(),
-                "PLAIN",
-                &identity(),
-                ClaimEpoch(0),
-            )
+            .consume("sm-1", issued.token.as_bytes(), "PLAIN", &fence())
             .await
             .expect("consume");
         let IsrConsumeOutcome::Matched { rotated } = outcome else {
@@ -266,13 +261,7 @@ mod tests {
         let store = InMemoryIsrTokenStore::new();
         let issued = store.issue("sm-1", "PLAIN").await.expect("issue");
         let outcome = store
-            .consume(
-                "sm-1",
-                b"not-the-token",
-                "PLAIN",
-                &identity(),
-                ClaimEpoch(0),
-            )
+            .consume("sm-1", b"not-the-token", "PLAIN", &fence())
             .await
             .expect("consume");
         assert_eq!(outcome, IsrConsumeOutcome::Mismatched);
@@ -281,13 +270,7 @@ mod tests {
         // (correct) token now finds no row at all (FIX 3: distinct from
         // the genuine-mismatch outcome above), proving destruction happened.
         let second = store
-            .consume(
-                "sm-1",
-                issued.token.as_bytes(),
-                "PLAIN",
-                &identity(),
-                ClaimEpoch(0),
-            )
+            .consume("sm-1", issued.token.as_bytes(), "PLAIN", &fence())
             .await
             .expect("consume");
         assert_eq!(second, IsrConsumeOutcome::NoSuchToken);
@@ -298,13 +281,7 @@ mod tests {
         let store = InMemoryIsrTokenStore::new();
         let issued = store.issue("sm-1", "PLAIN").await.expect("issue");
         let first = store
-            .consume(
-                "sm-1",
-                issued.token.as_bytes(),
-                "PLAIN",
-                &identity(),
-                ClaimEpoch(0),
-            )
+            .consume("sm-1", issued.token.as_bytes(), "PLAIN", &fence())
             .await
             .expect("consume");
         assert!(matches!(first, IsrConsumeOutcome::Matched { .. }));
@@ -313,13 +290,7 @@ mod tests {
         // exists under the same sm_id — a genuine mismatch (a row DOES
         // exist), not `NoSuchToken`.
         let replay = store
-            .consume(
-                "sm-1",
-                issued.token.as_bytes(),
-                "PLAIN",
-                &identity(),
-                ClaimEpoch(0),
-            )
+            .consume("sm-1", issued.token.as_bytes(), "PLAIN", &fence())
             .await
             .expect("consume");
         assert_eq!(replay, IsrConsumeOutcome::Mismatched);
@@ -329,13 +300,7 @@ mod tests {
     async fn consume_with_no_issued_token_is_no_such_token() {
         let store = InMemoryIsrTokenStore::new();
         let outcome = store
-            .consume(
-                "no-such-sm-id",
-                b"anything",
-                "PLAIN",
-                &identity(),
-                ClaimEpoch(0),
-            )
+            .consume("no-such-sm-id", b"anything", "PLAIN", &fence())
             .await
             .expect("consume");
         assert_eq!(outcome, IsrConsumeOutcome::NoSuchToken);
@@ -346,13 +311,7 @@ mod tests {
         let store = InMemoryIsrTokenStore::new();
         let issued = store.issue("sm-1", "PLAIN").await.expect("issue");
         let outcome = store
-            .consume(
-                "sm-1",
-                issued.token.as_bytes(),
-                "SCRAM-SHA-256",
-                &identity(),
-                ClaimEpoch(0),
-            )
+            .consume("sm-1", issued.token.as_bytes(), "SCRAM-SHA-256", &fence())
             .await
             .expect("consume");
         assert_eq!(outcome, IsrConsumeOutcome::Mismatched);

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -232,10 +232,11 @@ pub(super) async fn store_message_fenced(
         fence.entity.id
     );
     let held = sqlx::query(
-        "SELECT 1 FROM clustering_claims WHERE entity = $1 AND node_id = $2 AND claim_epoch = $3 FOR SHARE",
+        "SELECT 1 FROM clustering_claims WHERE entity = $1 AND node_id = $2 AND node_epoch = $3 AND claim_epoch = $4 FOR SHARE",
     )
     .bind(&entity_key)
-    .bind(&fence.node_id)
+    .bind(&fence.owner.node_id)
+    .bind(&fence.owner.node_epoch)
     .bind(fence.epoch.0)
     .fetch_optional(&mut *tx)
     .await?

--- a/server/crates/waddle-xmpp/src/muc/durable.rs
+++ b/server/crates/waddle-xmpp/src/muc/durable.rs
@@ -36,7 +36,7 @@ use jid::BareJid;
 
 use super::affiliation::AffiliationEntry;
 use super::{RoomConfig, SubjectState};
-use crate::ownership::{ClaimEpoch, Entity};
+use crate::ownership::{ClaimEpoch, Entity, NodeIdentity};
 use crate::XmppError;
 
 /// Boxed future returned by every [`MucDurableStore`] method, mirroring
@@ -46,18 +46,32 @@ pub type MucDurableFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, XmppErr
 
 /// Typed fencing context for a room's currently-recorded Postgres claim
 /// (ADR-0017 Phase 3 Slice 7 FIX 1, council-adjudicated): the same
-/// `(Entity, ClaimEpoch, node_id)` triple [`MucDurableStore::check_fenced_fanout`]
-/// resolves internally via [`MucDurableStore::record_claim_epoch`]'s cache,
+/// `(Entity, ClaimEpoch, NodeIdentity)` tuple [`MucDurableStore::check_fenced_fanout`]
+/// resolves internally via [`MucDurableStore::record_claim_fence`]'s cache,
 /// exposed here so a caller that needs to run its OWN fenced write against a
 /// DIFFERENT store (MAM's `store_message_fenced`, which cannot share a SQL
 /// transaction with this store's own `assert_fenced`) can bind the identical
 /// typed values into its own `SELECT ... FOR SHARE` check, rather than
 /// re-deriving them from a second, independent source of truth.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RoomClaimFenceContext {
     pub entity: Entity,
     pub epoch: ClaimEpoch,
-    pub node_id: String,
+    pub owner: NodeIdentity,
+}
+
+impl RoomClaimFenceContext {
+    pub fn new(entity: Entity, owner: NodeIdentity, epoch: ClaimEpoch) -> Self {
+        Self {
+            entity,
+            epoch,
+            owner,
+        }
+    }
+
+    pub fn owner(&self) -> NodeIdentity {
+        self.owner.clone()
+    }
 }
 
 /// Full durable snapshot of a room's long-lived state: configuration,
@@ -76,7 +90,7 @@ pub struct DurableRoomState {
 /// Durable backing store for MUC room ownership (ADR-0017 Phase 3 Slice 7).
 ///
 /// Every write is epoch-fenced against this node's currently-recorded claim
-/// on the room's `RoomActor` entity (see [`Self::record_claim_epoch`]) —
+/// on the room's `RoomActor` entity (see [`Self::record_claim_fence`]) —
 /// "epoch-fenced like all claimed-entity writes" per element 7.
 ///
 /// **Fail-open contract, revised (ADR-0017 Phase 3 Slice 7 FIX 2,
@@ -168,20 +182,20 @@ pub trait MucDurableStore: Send + Sync {
     /// fencing SQL. Default no-op: single-node/non-clustering deployments
     /// never configure a `MucDurableStore` at all, so this is never
     /// called there.
-    fn record_claim_epoch(&self, room_jid: &BareJid, epoch: ClaimEpoch) {
-        let _ = (room_jid, epoch);
+    fn record_claim_fence(&self, room_jid: &BareJid, fence: RoomClaimFenceContext) {
+        let _ = (room_jid, fence);
     }
 
     /// Best-effort cache hygiene on claim release (dormancy eviction /
     /// explicit destroy): forget the recorded epoch so a stale cache
     /// entry cannot linger past this node's ownership. Default no-op.
-    fn forget_claim_epoch(&self, room_jid: &BareJid) {
-        let _ = room_jid;
+    fn forget_claim_fence(&self, room_jid: &BareJid, expected: &RoomClaimFenceContext) {
+        let _ = (room_jid, expected);
     }
 
     /// The two-part demotion protocol's guaranteed backstop (element 7): a
     /// fenced `SELECT ... FOR SHARE` against this room's claim (at the
-    /// epoch [`Self::record_claim_epoch`] last recorded), run before every
+    /// fence [`Self::record_claim_fence`] last recorded), run before every
     /// local fan-out. `Ok(true)` iff this node still holds the claim;
     /// `Ok(false)` means a steal has committed and the caller must demote
     /// locally and not deliver. Default `Ok(true)` (never demotes):
@@ -201,7 +215,7 @@ pub trait MucDurableStore: Send + Sync {
     /// cannot share a transaction with this store) can bind them into an
     /// equivalent `SELECT ... FOR SHARE` check without re-deriving them from
     /// a second, independent mechanism. `None` when no epoch is cached for
-    /// this room (this node has never claimed it, or `forget_claim_epoch`
+    /// this room (this node has never claimed it, or `forget_claim_fence`
     /// ran) — callers treat that exactly like a fencing failure. Default
     /// `None`: single-node/non-clustering deployments never configure a
     /// `MucDurableStore` at all, so this default only matters for tests

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -488,6 +488,13 @@ impl RoomRegistryActor {
         actor_ref: ActorRef<RoomActor>,
         claim_fence: super::RoomClaimFenceContext,
     ) {
+        // A timed-out release may not have committed, so a later demand can
+        // self-reacquire and publish this identical owner+epoch fence. Once
+        // the fence backs a live actor it is no longer a terminal-release
+        // responsibility; leaving it queued would let a stale retry delete
+        // the live claim. Cancel only the exact match so ABA-distinct
+        // generations for this room remain independently retryable.
+        self.clear_pending_room_release(&room_jid, &claim_fence);
         if let Some(store) = &self.durable_store {
             store.record_claim_fence(&room_jid, claim_fence.clone());
         }
@@ -1090,6 +1097,7 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
                     if let Some(store) = &self.durable_store {
                         store.record_claim_fence(&msg.room_jid, claim_fence.clone());
                     }
+                    self.clear_pending_room_release(&msg.room_jid, &claim_fence);
                     self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
                     return ReclaimedRoomOutcome::AdoptedLocal;
                 }

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -70,8 +70,13 @@ pub struct RoomRegistryActor {
         HashMap<(BareJid, super::RoomClaimFenceContext), PendingReclaimedState>,
     pending_reclaimed_reservations: HashSet<BareJid>,
     /// Ordinary terminal removals whose exact claim release was uncertain.
-    /// One newest fence per room is sufficient: if a later epoch exists, the
-    /// older epoch can no longer own the single claim row.
+    /// Multiple owner+epoch generations for one room are intentional. A
+    /// timed-out release may have deleted the row, after which another owner
+    /// can recreate it with a reset epoch; numeric epoch ordering therefore
+    /// cannot identify a newest generation across delete/recreate ABA.
+    /// Retaining every exact fence lets out-of-order retries prove each
+    /// responsibility independently, while the global bound prevents churn
+    /// from growing this inventory without limit.
     pending_room_releases:
         HashMap<(BareJid, super::RoomClaimFenceContext), PendingRoomReleaseState>,
     pending_retry_order: u64,

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -692,6 +692,9 @@ pub struct IsCurrentRoomPendingRelease {
 pub struct IsPendingRoomReleaseOnly {
     pub room_jid: BareJid,
 }
+pub struct IsCurrentIdentityPendingRoomReleaseOnly {
+    pub room_jid: BareJid,
+}
 
 impl kameo::message::Message<ListPendingRoomReleaseJids> for RoomRegistryActor {
     type Reply = Vec<BareJid>;
@@ -743,6 +746,32 @@ impl kameo::message::Message<IsPendingRoomReleaseOnly> for RoomRegistryActor {
                 .pending_room_releases
                 .keys()
                 .any(|(room_jid, _)| room_jid == &msg.room_jid)
+    }
+}
+
+impl kameo::message::Message<IsCurrentIdentityPendingRoomReleaseOnly> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: IsCurrentIdentityPendingRoomReleaseOnly,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self
+            .rooms
+            .get(&msg.room_jid)
+            .is_some_and(|entry| entry.actor_ref.is_alive())
+        {
+            return false;
+        }
+        let current_identity = self.node_identity.current();
+        let mut pending = self
+            .pending_room_releases
+            .keys()
+            .filter(|(room_jid, _)| room_jid == &msg.room_jid)
+            .peekable();
+        pending.peek().is_some()
+            && pending.all(|(_, claim_fence)| claim_fence.owner() == current_identity)
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -23,8 +23,8 @@ use super::room_actor::{
 use super::{MucRoom, RoomConfig};
 use crate::metrics;
 use crate::ownership::{
-    ClaimEpoch, ClaimError, ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity,
-    RolloutBackoff, SharedNodeIdentity, StalePredicate,
+    ClaimEpoch, ClaimError, ClaimStore, Entity, EntityType, ExactReleaseOutcome,
+    InProcessClaimStore, NodeIdentity, RolloutBackoff, SharedNodeIdentity, StalePredicate,
 };
 use crate::xep::xep0421::OccupantIdSecret;
 
@@ -35,7 +35,22 @@ use crate::xep::xep0421::OccupantIdSecret;
 #[derive(Clone)]
 struct RoomEntry {
     actor_ref: ActorRef<RoomActor>,
-    claim_epoch: ClaimEpoch,
+    claim_fence: super::RoomClaimFenceContext,
+}
+
+#[derive(Clone)]
+struct PendingReclaimedState {
+    claim_fence: super::RoomClaimFenceContext,
+    previous_owner: NodeIdentity,
+    retry_order: u64,
+    first_pending_at: std::time::Instant,
+}
+
+#[derive(Clone)]
+struct PendingRoomReleaseState {
+    claim_fence: super::RoomClaimFenceContext,
+    retry_order: u64,
+    first_pending_at: std::time::Instant,
 }
 
 /// Actor that owns the mapping from room JIDs to per-room actors.
@@ -46,6 +61,20 @@ struct RoomEntry {
 pub struct RoomRegistryActor {
     rooms: HashMap<BareJid, RoomEntry>,
     poisoned_rooms: HashSet<BareJid>,
+    /// Reclaimed epochs that are neither served by a local actor nor
+    /// confirmed released yet. The orphan reaper asks for a bounded page on
+    /// later sweeps and retries each through the same serialized adoption
+    /// path; this prevents a transient store failure from stranding a fresh
+    /// claim forever.
+    pending_reclaimed_rooms:
+        HashMap<(BareJid, super::RoomClaimFenceContext), PendingReclaimedState>,
+    pending_reclaimed_reservations: HashSet<BareJid>,
+    /// Ordinary terminal removals whose exact claim release was uncertain.
+    /// One newest fence per room is sufficient: if a later epoch exists, the
+    /// older epoch can no longer own the single claim row.
+    pending_room_releases:
+        HashMap<(BareJid, super::RoomClaimFenceContext), PendingRoomReleaseState>,
+    pending_retry_order: u64,
     muc_domain: String,
     /// Per-deployment XEP-0421 occupant-id HMAC key. Forwarded to every
     /// `RoomActor` at spawn so all rooms in this deployment share the
@@ -100,6 +129,8 @@ pub enum RoomRegistryError {
     /// request never entered processing.
     #[error("room registry unavailable")]
     Unavailable,
+    #[error("room {0}'s ownership store is unavailable")]
+    OwnershipUnavailable(BareJid),
     /// ADR-0017 Phase 3 Slice 7: `entity`'s Postgres claim is held by
     /// another, currently-live node, and this slice does not wire
     /// cross-node MUC message/join proxying (the ADR's own text names it
@@ -119,6 +150,10 @@ impl RoomRegistryActor {
         Self {
             rooms: HashMap::new(),
             poisoned_rooms: HashSet::new(),
+            pending_reclaimed_rooms: HashMap::new(),
+            pending_reclaimed_reservations: HashSet::new(),
+            pending_room_releases: HashMap::new(),
+            pending_retry_order: 0,
             muc_domain,
             occupant_id_secret,
             membership_source: None,
@@ -129,12 +164,77 @@ impl RoomRegistryActor {
         }
     }
 
+    fn has_pending_release_capacity(
+        &self,
+        room_jid: &BareJid,
+        claim_fence: &super::RoomClaimFenceContext,
+    ) -> bool {
+        self.pending_room_releases
+            .contains_key(&(room_jid.clone(), claim_fence.clone()))
+            || self.pending_room_releases.len() < MAX_PENDING_ROOM_RELEASES
+    }
+
+    fn remember_pending_room_release(
+        &mut self,
+        room_jid: BareJid,
+        claim_fence: super::RoomClaimFenceContext,
+    ) {
+        self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+        let retry_order = self.pending_retry_order;
+        self.pending_room_releases
+            .entry((room_jid, claim_fence.clone()))
+            .and_modify(|current| current.retry_order = retry_order)
+            .or_insert(PendingRoomReleaseState {
+                claim_fence: claim_fence.clone(),
+                retry_order,
+                first_pending_at: std::time::Instant::now(),
+            });
+    }
+
+    fn clear_pending_room_release(
+        &mut self,
+        room_jid: &BareJid,
+        claim_fence: &super::RoomClaimFenceContext,
+    ) {
+        self.pending_room_releases
+            .remove(&(room_jid.clone(), claim_fence.clone()));
+    }
+
     /// Attach a durable membership source so every spawned `RoomActor`
     /// hydrates its durable-recipient set before serving snapshots (#1135).
     #[must_use]
     pub fn with_membership_source(mut self, source: Arc<dyn DurableMembershipSource>) -> Self {
         self.membership_source = Some(source);
         self
+    }
+
+    fn remember_pending_reclaimed_room(
+        &mut self,
+        room_jid: BareJid,
+        claim_fence: super::RoomClaimFenceContext,
+        previous_owner: NodeIdentity,
+    ) {
+        self.pending_reclaimed_reservations.remove(&room_jid);
+        self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+        let retry_order = self.pending_retry_order;
+        self.pending_reclaimed_rooms
+            .entry((room_jid, claim_fence.clone()))
+            .and_modify(|current| current.retry_order = retry_order)
+            .or_insert(PendingReclaimedState {
+                claim_fence: claim_fence.clone(),
+                previous_owner,
+                retry_order,
+                first_pending_at: std::time::Instant::now(),
+            });
+    }
+
+    fn clear_pending_reclaimed_room(
+        &mut self,
+        room_jid: &BareJid,
+        claim_fence: &super::RoomClaimFenceContext,
+    ) {
+        self.pending_reclaimed_rooms
+            .remove(&(room_jid.clone(), claim_fence.clone()));
     }
 
     /// Acquire this room's Postgres claim (ADR-0017 Phase 3 Slice 7),
@@ -149,20 +249,35 @@ impl RoomRegistryActor {
     async fn acquire_room_claim(
         &self,
         room_jid: &BareJid,
-    ) -> Result<ClaimEpoch, RoomRegistryError> {
+    ) -> Result<super::RoomClaimFenceContext, RoomRegistryError> {
         let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
         let identity = self.node_identity.current();
-        match self.claim_store.ensure_claimed(&entity, &identity).await {
-            Ok(epoch) => Ok(epoch),
-            Err(ClaimError::AlreadyClaimed) => {
+        let epoch = match tokio::time::timeout(
+            ROOM_OWNERSHIP_CALL_TIMEOUT,
+            self.claim_store.ensure_claimed(&entity, &identity),
+        )
+        .await
+        {
+            Ok(Ok(epoch)) => epoch,
+            Ok(Err(ClaimError::AlreadyClaimed)) => {
                 self.steal_from_dead_owner(&entity, room_jid, &identity)
-                    .await
+                    .await?
             }
-            Err(error) => {
+            Ok(Err(error)) => {
                 warn!(room = %room_jid, %error, "room claim acquisition failed");
-                Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()))
+                return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()));
             }
+            Err(_) => return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone())),
+        };
+        if self.node_identity.current() != identity {
+            let _ = tokio::time::timeout(
+                ROOM_OWNERSHIP_CALL_TIMEOUT,
+                self.claim_store.release_exact(&entity, &identity, epoch),
+            )
+            .await;
+            return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()));
         }
+        Ok(super::RoomClaimFenceContext::new(entity, identity, epoch))
     }
 
     /// The re-election path: `entity`'s claim is held by another node —
@@ -174,11 +289,17 @@ impl RoomRegistryActor {
         room_jid: &BareJid,
         identity: &NodeIdentity,
     ) -> Result<ClaimEpoch, RoomRegistryError> {
-        let snapshot = match self.claim_store.current_claim(entity).await {
-            Ok(Some(snapshot)) => snapshot,
-            Ok(None) | Err(_) => {
+        let snapshot = match tokio::time::timeout(
+            ROOM_OWNERSHIP_CALL_TIMEOUT,
+            self.claim_store.current_claim(entity),
+        )
+        .await
+        {
+            Ok(Ok(Some(snapshot))) => snapshot,
+            Ok(Ok(None)) | Ok(Err(_)) => {
                 return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()))
             }
+            Err(_) => return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone())),
         };
         if snapshot.owner_lease_fresh {
             return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()));
@@ -195,17 +316,18 @@ impl RoomRegistryActor {
                 tokio::time::sleep(delay).await;
             }
         }
-        match self
-            .claim_store
-            .steal_stale(
+        match tokio::time::timeout(
+            ROOM_OWNERSHIP_CALL_TIMEOUT,
+            self.claim_store.steal_stale(
                 entity,
                 snapshot.claim_epoch,
                 StalePredicate::OwnerStale,
                 identity,
-            )
-            .await
+            ),
+        )
+        .await
         {
-            Ok(new_epoch) => {
+            Ok(Ok(new_epoch)) => {
                 info!(
                     room = %room_jid,
                     previous_owner = %snapshot.owner.node_id,
@@ -214,7 +336,8 @@ impl RoomRegistryActor {
                 self.notify_previous_owner_demoted(room_jid, &snapshot.owner, new_epoch);
                 Ok(new_epoch)
             }
-            Err(_) => Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone())),
+            Ok(Err(_)) => Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone())),
+            Err(_) => Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone())),
         }
     }
 
@@ -272,12 +395,56 @@ impl RoomRegistryActor {
         waddle_id: String,
         channel_id: String,
         config: RoomConfig,
-        claim_epoch: ClaimEpoch,
+        claim_fence: super::RoomClaimFenceContext,
+    ) -> Result<ActorRef<RoomActor>, RoomRegistryError> {
+        let actor_ref = self
+            .prepare_room(room_jid.clone(), waddle_id, channel_id, config)
+            .await;
+        let still_owned = self.node_identity.current() == claim_fence.owner()
+            && matches!(
+                tokio::time::timeout(
+                    ROOM_OWNERSHIP_CALL_TIMEOUT,
+                    self.claim_store.fence(
+                        &claim_fence.entity,
+                        &claim_fence.owner(),
+                        claim_fence.epoch,
+                    ),
+                )
+                .await,
+                Ok(Ok(true))
+            )
+            && self.node_identity.current() == claim_fence.owner();
+        if !still_owned {
+            actor_ref.kill();
+            let _ = tokio::time::timeout(
+                ROOM_OWNERSHIP_CALL_TIMEOUT,
+                self.claim_store.release_exact(
+                    &claim_fence.entity,
+                    &claim_fence.owner(),
+                    claim_fence.epoch,
+                ),
+            )
+            .await;
+            return Err(RoomRegistryError::OwnershipUnavailable(room_jid));
+        }
+        self.publish_room(room_jid, actor_ref.clone(), claim_fence);
+        Ok(actor_ref)
+    }
+
+    /// Spawn and enqueue all durable hydration work without making the actor
+    /// discoverable through the registry. Reclaimed rooms use this split so
+    /// ownership can be re-fenced after every enqueue await and immediately
+    /// before publication.
+    async fn prepare_room(
+        &self,
+        room_jid: BareJid,
+        waddle_id: String,
+        channel_id: String,
+        config: RoomConfig,
     ) -> ActorRef<RoomActor> {
         let room = MucRoom::new(room_jid.clone(), waddle_id, channel_id, config);
         let actor_ref = RoomActor::spawn(RoomActor::new(room, self.occupant_id_secret.clone()));
         if let Some(store) = &self.durable_store {
-            store.record_claim_epoch(&room_jid, claim_epoch);
             if let Err(error) = actor_ref
                 .tell(RestoreDurableRoomState {
                     store: Arc::clone(store),
@@ -307,14 +474,26 @@ impl RoomRegistryActor {
                 );
             }
         }
+        actor_ref
+    }
+
+    fn publish_room(
+        &mut self,
+        room_jid: BareJid,
+        actor_ref: ActorRef<RoomActor>,
+        claim_fence: super::RoomClaimFenceContext,
+    ) {
+        if let Some(store) = &self.durable_store {
+            store.record_claim_fence(&room_jid, claim_fence.clone());
+        }
         self.rooms.insert(
-            room_jid,
+            room_jid.clone(),
             RoomEntry {
                 actor_ref: actor_ref.clone(),
-                claim_epoch,
+                claim_fence: claim_fence.clone(),
             },
         );
-        actor_ref
+        self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
     }
 
     /// ADR-0017 Phase 3 Slice 7 FIX 3 (council-adjudicated): `async` (not
@@ -341,7 +520,11 @@ impl RoomRegistryActor {
             if entry.actor_ref.is_alive() {
                 return Ok(Some(entry.actor_ref.clone()));
             }
-            let claim_epoch = entry.claim_epoch;
+            let claim_fence = entry.claim_fence.clone();
+            if !self.has_pending_release_capacity(room_jid, &claim_fence) {
+                warn!(room = %room_jid, "Cannot retire dead RoomActor: exact-release retry backlog is full");
+                return Err(RoomRegistryError::RoomActorStateLost(room_jid.clone()));
+            }
             self.rooms.remove(room_jid);
             self.poisoned_rooms.insert(room_jid.clone());
             warn!(
@@ -354,7 +537,7 @@ impl RoomRegistryActor {
             // claim (this node holds it in Postgres but has no way left
             // to act on it), not merely a "fail fast and let the caller
             // retry" situation.
-            self.release_room_claim(room_jid, claim_epoch).await;
+            self.release_room_claim(room_jid, &claim_fence).await;
             return Err(RoomRegistryError::RoomActorStateLost(room_jid.clone()));
         }
         Ok(None)
@@ -363,21 +546,190 @@ impl RoomRegistryActor {
     /// Best-effort release of `room_jid`'s Postgres claim (dormancy
     /// eviction / explicit destroy, element 7's "graceful release").
     /// Epoch-gated and best-effort per [`ClaimStore::release`]'s own
-    /// contract — a claim already stolen out from under this node is a
-    /// no-op, not an error.
-    async fn release_room_claim(&self, room_jid: &BareJid, claim_epoch: ClaimEpoch) {
-        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
-        let identity = self.node_identity.current();
-        if let Err(error) = self
-            .claim_store
-            .release(&entity, &identity, claim_epoch)
-            .await
+    /// idempotent contract. A claim already stolen out from under this node
+    /// is a successful no-op.
+    async fn release_room_claim(
+        &mut self,
+        room_jid: &BareJid,
+        claim_fence: &super::RoomClaimFenceContext,
+    ) {
+        let owner = claim_fence.owner();
+        match tokio::time::timeout(
+            ROOM_OWNERSHIP_CALL_TIMEOUT,
+            self.claim_store
+                .release_exact(&claim_fence.entity, &owner, claim_fence.epoch),
+        )
+        .await
         {
-            warn!(room = %room_jid, %error, "failed to release room ownership claim");
+            Ok(Ok(ExactReleaseOutcome::Released | ExactReleaseOutcome::NotOwned)) => {
+                self.clear_pending_room_release(room_jid, claim_fence);
+                if let Some(store) = &self.durable_store {
+                    store.forget_claim_fence(room_jid, claim_fence);
+                }
+            }
+            Ok(Err(error)) => {
+                warn!(room = %room_jid, %error, "failed to release room ownership claim");
+                self.remember_pending_room_release(room_jid.clone(), claim_fence.clone());
+            }
+            Err(_) => {
+                warn!(room = %room_jid, "timed out releasing room ownership claim; retaining exact fence for a later retry");
+                self.remember_pending_room_release(room_jid.clone(), claim_fence.clone());
+            }
         }
-        if let Some(store) = &self.durable_store {
-            store.forget_claim_epoch(room_jid);
+    }
+
+    /// Bounded, observable release for a proactively reclaimed epoch. A
+    /// backend error or timeout retains the exact epoch in the pending map;
+    /// only a typed confirmation clears the durable fence cache and reports
+    /// release or a lost race.
+    async fn release_reclaimed_room_claim(
+        &mut self,
+        room_jid: &BareJid,
+        claim_fence: &super::RoomClaimFenceContext,
+        previous_owner: &NodeIdentity,
+    ) -> ReclaimedRoomOutcome {
+        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        match tokio::time::timeout(
+            RECLAIMED_ROOM_RELEASE_TIMEOUT,
+            self.claim_store
+                .release_exact(&entity, &claim_fence.owner(), claim_fence.epoch),
+        )
+        .await
+        {
+            Ok(Ok(ExactReleaseOutcome::Released)) => {
+                self.clear_pending_reclaimed_room(room_jid, claim_fence);
+                if let Some(store) = &self.durable_store {
+                    store.forget_claim_fence(room_jid, claim_fence);
+                }
+                ReclaimedRoomOutcome::Released
+            }
+            Ok(Ok(ExactReleaseOutcome::NotOwned)) => {
+                self.clear_pending_reclaimed_room(room_jid, claim_fence);
+                if let Some(store) = &self.durable_store {
+                    store.forget_claim_fence(room_jid, claim_fence);
+                }
+                ReclaimedRoomOutcome::LostRace
+            }
+            Ok(Err(error)) => {
+                debug!(room = %room_jid, %error, "reclaimed-room claim release failed; retaining for retry");
+                self.remember_pending_reclaimed_room(
+                    room_jid.clone(),
+                    claim_fence.clone(),
+                    previous_owner.clone(),
+                );
+                ReclaimedRoomOutcome::PendingRetry
+            }
+            Err(_) => {
+                debug!(room = %room_jid, "reclaimed-room claim release timed out; retaining for retry");
+                self.remember_pending_reclaimed_room(
+                    room_jid.clone(),
+                    claim_fence.clone(),
+                    previous_owner.clone(),
+                );
+                ReclaimedRoomOutcome::PendingRetry
+            }
         }
+    }
+}
+
+pub const MAX_PENDING_RECLAIMED_ROOMS: usize = 128;
+pub const MAX_PENDING_ROOM_RELEASES: usize = 128;
+
+pub struct RetryPendingRoomReleases {
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
+pub struct PendingRoomReleaseBacklog {
+    pub depth: usize,
+    pub oldest_age_ms: u64,
+}
+
+pub struct GetPendingRoomReleaseBacklog;
+pub struct ListPendingRoomReleaseJids;
+pub struct IsPendingRoomRelease {
+    pub room_jid: BareJid,
+}
+
+impl kameo::message::Message<ListPendingRoomReleaseJids> for RoomRegistryActor {
+    type Reply = Vec<BareJid>;
+
+    async fn handle(
+        &mut self,
+        _msg: ListPendingRoomReleaseJids,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let mut room_jids = self
+            .pending_room_releases
+            .keys()
+            .map(|(room_jid, _)| room_jid.clone())
+            .collect::<Vec<_>>();
+        room_jids.sort();
+        room_jids.dedup();
+        room_jids
+    }
+}
+
+impl kameo::message::Message<IsPendingRoomRelease> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: IsPendingRoomRelease,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.pending_room_releases
+            .keys()
+            .any(|(room_jid, _)| room_jid == &msg.room_jid)
+    }
+}
+
+impl kameo::message::Message<GetPendingRoomReleaseBacklog> for RoomRegistryActor {
+    type Reply = PendingRoomReleaseBacklog;
+
+    async fn handle(
+        &mut self,
+        _msg: GetPendingRoomReleaseBacklog,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        PendingRoomReleaseBacklog {
+            depth: self.pending_room_releases.len(),
+            oldest_age_ms: self
+                .pending_room_releases
+                .values()
+                .map(|pending| pending.first_pending_at.elapsed().as_millis() as u64)
+                .max()
+                .unwrap_or(0),
+        }
+    }
+}
+
+impl kameo::message::Message<RetryPendingRoomReleases> for RoomRegistryActor {
+    type Reply = usize;
+
+    async fn handle(
+        &mut self,
+        msg: RetryPendingRoomReleases,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let mut pending: Vec<_> = self
+            .pending_room_releases
+            .iter()
+            .map(|((room_jid, claim_fence), state)| {
+                (room_jid.clone(), claim_fence.clone(), state.clone())
+            })
+            .collect();
+        pending.sort_by_key(|(_, _, state)| state.retry_order);
+        pending.truncate(msg.limit);
+        let attempted = pending.len();
+        for (room_jid, claim_fence, state) in pending {
+            self.release_room_claim(&room_jid, &state.claim_fence).await;
+            self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+            if let Some(current) = self.pending_room_releases.get_mut(&(room_jid, claim_fence)) {
+                current.retry_order = self.pending_retry_order;
+            }
+        }
+        attempted
     }
 }
 
@@ -441,7 +793,7 @@ impl kameo::message::Message<GetRoom> for RoomRegistryActor {
 /// mailbox guarantees exactly one caller per room lifetime observes
 /// [`RoomCreation::Created`] — that caller is the XEP-0045 §10.1.1
 /// room creator and the only one entitled to the creator Owner grant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
 pub enum RoomCreation {
     /// This request spawned the room actor: the caller created the room.
     Created,
@@ -455,6 +807,397 @@ pub enum RoomCreation {
 pub struct RoomAcquisition {
     pub actor_ref: ActorRef<RoomActor>,
     pub creation: RoomCreation,
+}
+
+/// Result of reconciling a `RoomActor` claim proactively reclaimed by the
+/// dead-node sweeper. This is intentionally typed and low-cardinality so the
+/// caller can aggregate telemetry without logging once per room.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
+pub enum ReclaimedRoomOutcome {
+    /// Durable room state existed and a local actor was spawned at the won
+    /// claim epoch.
+    Hydrated,
+    /// Demand-side creation already installed a live actor under this exact
+    /// fenced epoch; no duplicate was spawned.
+    AlreadyLive,
+    /// A live local actor from this process's prior node identity adopted
+    /// the newly fenced epoch in place, preserving its in-memory room state.
+    AdoptedLocal,
+    /// No durable room state existed, so the otherwise-unusable orphan claim
+    /// was released for ordinary demand-side recreation.
+    Released,
+    /// The won epoch was no longer owned by this node when the registry
+    /// serialized the adoption request.
+    LostRace,
+    /// This node may still own the epoch, but neither actor installation nor
+    /// claim release was confirmed. The registry retained it for a bounded
+    /// retry on a later orphan-reaper sweep.
+    PendingRetry,
+}
+
+/// Adopt or release one exact `RoomActor` epoch won by the dead-node reaper.
+/// Keeping this operation inside the registry actor serializes it against
+/// every demand-side `GetOrCreateRoom` and prevents duplicate local actors.
+pub struct ReconcileReclaimedRoom {
+    pub room_jid: BareJid,
+    pub claim_fence: super::RoomClaimFenceContext,
+    pub previous_owner: NodeIdentity,
+}
+
+/// Internal budget for each durable/claim-store read in proactive room
+/// adoption. It is shorter than the registry handle's five-second outer
+/// reply timeout so the handler completes (including its release fallback)
+/// before a caller can abandon an operation that is still mutating state.
+const RECLAIMED_ROOM_STORE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+const RECLAIMED_ROOM_RELEASE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+const ROOM_OWNERSHIP_CALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// One typed pending entry returned to the reaper for retry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingReclaimedRoom {
+    pub room_jid: BareJid,
+    pub claim_fence: super::RoomClaimFenceContext,
+    pub previous_owner: NodeIdentity,
+}
+
+/// List a bounded page of won-but-unserved epochs. Selection rotates the
+/// returned entries to the back of the retry order so a permanently failing
+/// full page cannot starve later rooms. The caller retries each item through
+/// [`ReconcileReclaimedRoom`] as a separate mailbox message so no batch can
+/// monopolize the registry actor.
+pub struct ListPendingReclaimedRooms {
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
+pub struct PendingReclaimedRoomBacklog {
+    pub depth: usize,
+    pub oldest_age_ms: u64,
+}
+
+pub struct GetPendingReclaimedRoomBacklog;
+
+impl kameo::message::Message<GetPendingReclaimedRoomBacklog> for RoomRegistryActor {
+    type Reply = PendingReclaimedRoomBacklog;
+
+    async fn handle(
+        &mut self,
+        _msg: GetPendingReclaimedRoomBacklog,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let oldest_age_ms = self
+            .pending_reclaimed_rooms
+            .values()
+            .map(|pending| pending.first_pending_at.elapsed().as_millis() as u64)
+            .max()
+            .unwrap_or(0);
+        PendingReclaimedRoomBacklog {
+            depth: self.pending_reclaimed_rooms.len() + self.pending_reclaimed_reservations.len(),
+            oldest_age_ms,
+        }
+    }
+}
+
+/// Record a newly won epoch before starting any fallible adoption work.
+/// Idempotent for repeated delivery of the same `(room, epoch)`.
+pub struct RememberPendingReclaimedRoom {
+    pub room_jid: BareJid,
+    pub claim_fence: super::RoomClaimFenceContext,
+    pub previous_owner: NodeIdentity,
+}
+
+pub struct ReservePendingReclaimedRoom {
+    pub room_jid: BareJid,
+}
+
+pub struct CancelPendingReclaimedRoomReservation {
+    pub room_jid: BareJid,
+}
+
+impl kameo::message::Message<ReservePendingReclaimedRoom> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: ReservePendingReclaimedRoom,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self.pending_reclaimed_reservations.contains(&msg.room_jid) {
+            return true;
+        }
+        if self.pending_reclaimed_rooms.len() + self.pending_reclaimed_reservations.len()
+            >= MAX_PENDING_RECLAIMED_ROOMS
+        {
+            return false;
+        }
+        self.pending_reclaimed_reservations.insert(msg.room_jid);
+        true
+    }
+}
+
+impl kameo::message::Message<CancelPendingReclaimedRoomReservation> for RoomRegistryActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: CancelPendingReclaimedRoomReservation,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) {
+        self.pending_reclaimed_reservations.remove(&msg.room_jid);
+    }
+}
+
+impl kameo::message::Message<RememberPendingReclaimedRoom> for RoomRegistryActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: RememberPendingReclaimedRoom,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.remember_pending_reclaimed_room(msg.room_jid, msg.claim_fence, msg.previous_owner);
+    }
+}
+
+impl kameo::message::Message<ListPendingReclaimedRooms> for RoomRegistryActor {
+    type Reply = Vec<PendingReclaimedRoom>;
+
+    async fn handle(
+        &mut self,
+        msg: ListPendingReclaimedRooms,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let mut entries: Vec<_> = self
+            .pending_reclaimed_rooms
+            .iter()
+            .map(|((room_jid, claim_fence), pending)| {
+                (room_jid.clone(), claim_fence.clone(), pending.clone())
+            })
+            .collect();
+        entries.sort_by_key(|(_, _, pending)| pending.retry_order);
+        entries.truncate(msg.limit);
+        let mut selected = Vec::with_capacity(entries.len());
+        for (room_jid, claim_fence, pending) in entries {
+            self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+            if let Some(current) = self
+                .pending_reclaimed_rooms
+                .get_mut(&(room_jid.clone(), claim_fence))
+            {
+                current.retry_order = self.pending_retry_order;
+            }
+            selected.push(PendingReclaimedRoom {
+                room_jid: room_jid.clone(),
+                claim_fence: pending.claim_fence,
+                previous_owner: pending.previous_owner,
+            });
+        }
+        selected
+    }
+}
+
+impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
+    type Reply = ReclaimedRoomOutcome;
+
+    async fn handle(
+        &mut self,
+        msg: ReconcileReclaimedRoom,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let entity = Entity::new(EntityType::RoomActor, msg.room_jid.to_string());
+        let claim_fence = msg.claim_fence.clone();
+        let claim_epoch = claim_fence.epoch;
+        let identity = claim_fence.owner();
+        if self.node_identity.current() != identity {
+            return self
+                .release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)
+                .await;
+        }
+
+        // Prove the reaper's exact epoch before touching any local actor.
+        // A stale adoption message must never depose a newer demand-side
+        // actor, and a backend error is uncertainty, not permission.
+        let still_owned = match tokio::time::timeout(
+            RECLAIMED_ROOM_STORE_TIMEOUT,
+            self.claim_store.fence(&entity, &identity, claim_epoch),
+        )
+        .await
+        {
+            Ok(Ok(held)) => held,
+            Ok(Err(error)) => {
+                debug!(room = %msg.room_jid, %error, "reclaimed-room ownership fence failed");
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+            Err(_) => {
+                debug!(room = %msg.room_jid, "reclaimed-room ownership fence timed out");
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+        };
+        if !still_owned {
+            self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+            return ReclaimedRoomOutcome::LostRace;
+        }
+
+        if let Some(entry) = self.rooms.get(&msg.room_jid).cloned() {
+            if entry.actor_ref.is_alive() {
+                if entry.claim_fence == claim_fence {
+                    self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+                    return ReclaimedRoomOutcome::AlreadyLive;
+                }
+                if entry.claim_fence.owner() == msg.previous_owner {
+                    // The actor is exactly the one whose claim the reaper
+                    // observed and replaced. It may safely adopt the new
+                    // epoch without discarding its in-memory state. Recheck
+                    // after the earlier fence await and immediately before
+                    // mutating the live map.
+                    if self.node_identity.current() != identity {
+                        self.remember_pending_reclaimed_room(
+                            msg.room_jid,
+                            claim_fence,
+                            msg.previous_owner,
+                        );
+                        return ReclaimedRoomOutcome::PendingRetry;
+                    }
+                    match tokio::time::timeout(
+                        RECLAIMED_ROOM_STORE_TIMEOUT,
+                        self.claim_store.fence(&entity, &identity, claim_epoch),
+                    )
+                    .await
+                    {
+                        Ok(Ok(true)) if self.node_identity.current() == identity => {}
+                        Ok(Ok(false)) => {
+                            self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+                            return ReclaimedRoomOutcome::LostRace;
+                        }
+                        Ok(Ok(true)) | Ok(Err(_)) | Err(_) => {
+                            self.remember_pending_reclaimed_room(
+                                msg.room_jid,
+                                claim_fence,
+                                msg.previous_owner,
+                            );
+                            return ReclaimedRoomOutcome::PendingRetry;
+                        }
+                    }
+                    if let Some(current) = self.rooms.get_mut(&msg.room_jid) {
+                        current.claim_fence = claim_fence.clone();
+                    }
+                    if let Some(store) = &self.durable_store {
+                        store.record_claim_fence(&msg.room_jid, claim_fence.clone());
+                    }
+                    self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+                    return ReclaimedRoomOutcome::AdoptedLocal;
+                }
+
+                // Another owner intervened after this local actor was
+                // created. Its state is stale relative to the durable
+                // snapshot, so never transplant it onto the won epoch.
+                entry.actor_ref.kill();
+            }
+            self.rooms.remove(&msg.room_jid);
+            if let Some(store) = &self.durable_store {
+                store.forget_claim_fence(&msg.room_jid, &entry.claim_fence);
+            }
+        }
+
+        let Some(store) = self.durable_store.clone() else {
+            return self
+                .release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)
+                .await;
+        };
+        let snapshot = match tokio::time::timeout(
+            RECLAIMED_ROOM_STORE_TIMEOUT,
+            store.load_room_state(&msg.room_jid),
+        )
+        .await
+        {
+            Ok(Ok(Some(snapshot))) => snapshot,
+            Ok(Ok(None)) => {
+                return self
+                    .release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)
+                    .await;
+            }
+            Ok(Err(error)) => {
+                debug!(
+                    room = %msg.room_jid,
+                    %error,
+                    "failed to load proactively reclaimed room state; retaining for retry"
+                );
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+            Err(_) => {
+                debug!(room = %msg.room_jid, "proactively reclaimed room-state load timed out");
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+        };
+
+        // The durable read above is an await point long enough for another
+        // node to expire this node and steal the epoch. Re-prove exact
+        // ownership immediately before publishing a live actor; the earlier
+        // fence only authorized reading the snapshot, not a later install.
+        match tokio::time::timeout(
+            RECLAIMED_ROOM_STORE_TIMEOUT,
+            self.claim_store.fence(&entity, &identity, claim_epoch),
+        )
+        .await
+        {
+            Ok(Ok(true)) => {}
+            Ok(Ok(false)) => {
+                self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+                return ReclaimedRoomOutcome::LostRace;
+            }
+            Ok(Err(error)) => {
+                debug!(room = %msg.room_jid, %error, "final reclaimed-room ownership fence failed");
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+            Err(_) => {
+                debug!(room = %msg.room_jid, "final reclaimed-room ownership fence timed out");
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+        }
+
+        if self.node_identity.current() != identity {
+            self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+            return ReclaimedRoomOutcome::PendingRetry;
+        }
+
+        let actor_ref = self
+            .prepare_room(
+                msg.room_jid.clone(),
+                snapshot.waddle_id,
+                snapshot.channel_id,
+                snapshot.config,
+            )
+            .await;
+        // `prepare_room` awaits both mailbox enqueues. Fence once more at
+        // the actual publication boundary so neither an identity change nor
+        // an epoch steal during those awaits can install a stale actor.
+        let publish_owned = tokio::time::timeout(
+            RECLAIMED_ROOM_STORE_TIMEOUT,
+            self.claim_store.fence(&entity, &identity, claim_epoch),
+        )
+        .await;
+        match publish_owned {
+            Ok(Ok(true)) if self.node_identity.current() == identity => {}
+            Ok(Ok(false)) => {
+                actor_ref.kill();
+                self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+                return ReclaimedRoomOutcome::LostRace;
+            }
+            Ok(Ok(true)) | Ok(Err(_)) | Err(_) => {
+                actor_ref.kill();
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+        }
+        self.poisoned_rooms.remove(&msg.room_jid);
+        self.publish_room(msg.room_jid, actor_ref, claim_fence);
+        ReclaimedRoomOutcome::Hydrated
+    }
 }
 
 /// Get an existing room or create one if it does not exist.
@@ -481,7 +1224,7 @@ impl kameo::message::Message<GetOrCreateRoom> for RoomRegistryActor {
             });
         }
 
-        let claim_epoch = self.acquire_room_claim(&msg.room_jid).await?;
+        let claim_fence = self.acquire_room_claim(&msg.room_jid).await?;
         info!(room = %msg.room_jid, "Creating new room via GetOrCreateRoom");
         self.poisoned_rooms.remove(&msg.room_jid);
         let actor_ref = self
@@ -490,9 +1233,9 @@ impl kameo::message::Message<GetOrCreateRoom> for RoomRegistryActor {
                 msg.waddle_id,
                 msg.channel_id,
                 msg.config,
-                claim_epoch,
+                claim_fence,
             )
-            .await;
+            .await?;
         Ok(RoomAcquisition {
             actor_ref,
             creation: RoomCreation::Created,
@@ -534,11 +1277,11 @@ impl kameo::message::Message<CreateInstantRoom> for RoomRegistryActor {
             ..RoomConfig::default()
         };
 
-        let claim_epoch = self.acquire_room_claim(&msg.room_jid).await?;
+        let claim_fence = self.acquire_room_claim(&msg.room_jid).await?;
         self.poisoned_rooms.remove(&msg.room_jid);
         let actor_ref = self
-            .spawn_room(msg.room_jid, waddle_id, channel_id, config, claim_epoch)
-            .await;
+            .spawn_room(msg.room_jid, waddle_id, channel_id, config, claim_fence)
+            .await?;
         Ok(RoomAcquisition {
             actor_ref,
             creation: RoomCreation::Created,
@@ -566,7 +1309,7 @@ impl kameo::message::Message<CreateRoom> for RoomRegistryActor {
             return Err(RoomRegistryError::RoomAlreadyExists(msg.room_jid));
         }
 
-        let claim_epoch = self.acquire_room_claim(&msg.room_jid).await?;
+        let claim_fence = self.acquire_room_claim(&msg.room_jid).await?;
         info!(room = %msg.room_jid, "Creating new room");
         self.poisoned_rooms.remove(&msg.room_jid);
         let actor_ref = self
@@ -575,9 +1318,9 @@ impl kameo::message::Message<CreateRoom> for RoomRegistryActor {
                 msg.waddle_id,
                 msg.channel_id,
                 msg.config,
-                claim_epoch,
+                claim_fence,
             )
-            .await;
+            .await?;
         Ok(actor_ref)
     }
 }
@@ -614,6 +1357,9 @@ pub enum DestroyRoomOutcome {
     /// The epoch-fenced durable delete failed; the registry entry was
     /// restored and nothing was destroyed.
     DurableWipeFailed,
+    /// The bounded exact-release retry set is full, so the registry kept the
+    /// actor and claim intact rather than losing responsibility for the fence.
+    ReleaseBacklogFull,
 }
 
 /// Destroy a room, removing it from the registry.
@@ -630,6 +1376,12 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
         msg: DestroyRoom,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        if self.rooms.contains_key(&msg.room_jid)
+            && !self
+                .has_pending_release_capacity(&msg.room_jid, &self.rooms[&msg.room_jid].claim_fence)
+        {
+            return DestroyRoomOutcome::ReleaseBacklogFull;
+        }
         let removed_entry = self.rooms.remove(&msg.room_jid);
         let removed_room = removed_entry.is_some();
         let removed_poison = self.poisoned_rooms.remove(&msg.room_jid);
@@ -673,7 +1425,7 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
         // lease is what it takes to look stale (bounded residual gap,
         // same class as FIX 6e's fail-open-detach gap).
         if let Some(entry) = removed_entry {
-            self.release_room_claim(&msg.room_jid, entry.claim_epoch)
+            self.release_room_claim(&msg.room_jid, &entry.claim_fence)
                 .await;
         }
         if removed_room || removed_poison {
@@ -722,6 +1474,10 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
         let Some(entry) = self.rooms.get(&msg.room_jid).cloned() else {
             return false;
         };
+        if !self.has_pending_release_capacity(&msg.room_jid, &entry.claim_fence) {
+            warn!(room = %msg.room_jid, "Skipping inactive-room seal because exact-release retry backlog is full");
+            return false;
+        }
         let sealed = entry
             .actor_ref
             .ask(SealIfInactive {
@@ -740,7 +1496,7 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
                 // Postgres claim here too, or every guarded dormancy-evicted
                 // room leaks its claim until this node's own liveness lease
                 // looks stale to another node's `OwnerStale` steal.
-                self.release_room_claim(&msg.room_jid, entry.claim_epoch)
+                self.release_room_claim(&msg.room_jid, &entry.claim_fence)
                     .await;
                 info!(room = %msg.room_jid, "Destroyed inactive room (guarded)");
                 true
@@ -794,11 +1550,14 @@ impl kameo::message::Message<ReapSealedRoom> for RoomRegistryActor {
             return false;
         };
         if !entry.actor_ref.is_alive() {
+            if !self.has_pending_release_capacity(&msg.room_jid, &entry.claim_fence) {
+                return false;
+            }
             self.rooms.remove(&msg.room_jid);
             self.poisoned_rooms.remove(&msg.room_jid);
             // ADR-0017 Phase 3 Slice 7: same terminal-removal claim release
             // as the `live_room` dead-actor path and `DestroyRoom`.
-            self.release_room_claim(&msg.room_jid, entry.claim_epoch)
+            self.release_room_claim(&msg.room_jid, &entry.claim_fence)
                 .await;
             info!(room = %msg.room_jid, "Reaped dead room actor during sealed-room purge");
             return true;
@@ -811,11 +1570,14 @@ impl kameo::message::Message<ReapSealedRoom> for RoomRegistryActor {
             .await;
         match sealed {
             Ok(true) => {
+                if !self.has_pending_release_capacity(&msg.room_jid, &entry.claim_fence) {
+                    return false;
+                }
                 self.rooms.remove(&msg.room_jid);
                 self.poisoned_rooms.remove(&msg.room_jid);
                 // ADR-0017 Phase 3 Slice 7: same terminal-removal claim
                 // release as the guarded-destroy path above.
-                self.release_room_claim(&msg.room_jid, entry.claim_epoch)
+                self.release_room_claim(&msg.room_jid, &entry.claim_fence)
                     .await;
                 info!(
                     room = %msg.room_jid,

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -209,6 +209,19 @@ impl RoomRegistryActor {
             .remove(&(room_jid.clone(), claim_fence.clone()));
     }
 
+    async fn retry_oldest_pending_room_release(&mut self) -> bool {
+        let Some((room_jid, claim_fence)) = self
+            .pending_room_releases
+            .iter()
+            .min_by_key(|(_, state)| state.retry_order)
+            .map(|((room_jid, claim_fence), _)| (room_jid.clone(), claim_fence.clone()))
+        else {
+            return false;
+        };
+        self.release_room_claim(&room_jid, &claim_fence).await;
+        true
+    }
+
     /// Attach a durable membership source so every spawned `RoomActor`
     /// hydrates its durable-recipient set before serving snapshots (#1135).
     #[must_use]
@@ -536,8 +549,16 @@ impl RoomRegistryActor {
             }
             let claim_fence = entry.claim_fence.clone();
             if !self.has_pending_release_capacity(room_jid, &claim_fence) {
-                warn!(room = %room_jid, "Cannot retire dead RoomActor: exact-release retry backlog is full");
-                return Err(RoomRegistryError::RoomActorStateLost(room_jid.clone()));
+                // Saturation must not make a dead map entry immortal. Give
+                // the oldest exact responsibility one bounded retry; a
+                // successful/NotOwned result frees the slot needed to retire
+                // this actor, while persistent backend failure remains
+                // bounded and simply defers this dead entry to a later call.
+                self.retry_oldest_pending_room_release().await;
+                if !self.has_pending_release_capacity(room_jid, &claim_fence) {
+                    debug!(room = %room_jid, "Cannot retire dead RoomActor yet: exact-release retry backlog remains full after bounded redrive");
+                    return Err(RoomRegistryError::RoomActorStateLost(room_jid.clone()));
+                }
             }
             self.rooms.remove(room_jid);
             self.poisoned_rooms.insert(room_jid.clone());
@@ -715,7 +736,9 @@ impl kameo::message::Message<IsPendingRoomReleaseOnly> for RoomRegistryActor {
         msg: IsPendingRoomReleaseOnly,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        !self.rooms.contains_key(&msg.room_jid)
+        self.rooms
+            .get(&msg.room_jid)
+            .is_none_or(|entry| !entry.actor_ref.is_alive())
             && self
                 .pending_room_releases
                 .keys()

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -183,7 +183,10 @@ impl RoomRegistryActor {
         &mut self,
         room_jid: BareJid,
         claim_fence: super::RoomClaimFenceContext,
-    ) {
+    ) -> bool {
+        if !self.has_pending_release_capacity(&room_jid, &claim_fence) {
+            return false;
+        }
         self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
         let retry_order = self.pending_retry_order;
         self.pending_room_releases
@@ -194,6 +197,7 @@ impl RoomRegistryActor {
                 retry_order,
                 first_pending_at: std::time::Instant::now(),
             });
+        true
     }
 
     fn clear_pending_room_release(
@@ -252,9 +256,18 @@ impl RoomRegistryActor {
     /// attempted via any cross-node proxy — see that variant's doc
     /// comment for why that is out of this slice's scope.
     async fn acquire_room_claim(
-        &self,
+        &mut self,
         room_jid: &BareJid,
     ) -> Result<super::RoomClaimFenceContext, RoomRegistryError> {
+        // A newly acquired generation can require an exact terminal-release
+        // retry if identity rotates or actor preparation loses its final
+        // fence. Refuse acquisition while the bounded retry inventory is
+        // saturated; acquiring first would create responsibility that the
+        // registry has nowhere bounded to retain.
+        if self.pending_room_releases.len() >= MAX_PENDING_ROOM_RELEASES {
+            warn!(room = %room_jid, "room claim acquisition refused: exact-release retry backlog is full");
+            return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
+        }
         let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
         let identity = self.node_identity.current();
         let epoch = match tokio::time::timeout(
@@ -275,11 +288,8 @@ impl RoomRegistryActor {
             Err(_) => return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone())),
         };
         if self.node_identity.current() != identity {
-            let _ = tokio::time::timeout(
-                ROOM_OWNERSHIP_CALL_TIMEOUT,
-                self.claim_store.release_exact(&entity, &identity, epoch),
-            )
-            .await;
+            let claim_fence = super::RoomClaimFenceContext::new(entity, identity, epoch);
+            self.release_room_claim(room_jid, &claim_fence).await;
             return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()));
         }
         Ok(super::RoomClaimFenceContext::new(entity, identity, epoch))
@@ -573,11 +583,15 @@ impl RoomRegistryActor {
             }
             Ok(Err(error)) => {
                 warn!(room = %room_jid, %error, "failed to release room ownership claim");
-                self.remember_pending_room_release(room_jid.clone(), claim_fence.clone());
+                if !self.remember_pending_room_release(room_jid.clone(), claim_fence.clone()) {
+                    tracing::error!(room = %room_jid, "exact-release retry backlog saturated despite pre-admission guard; claim remains fenced for node-expiry recovery");
+                }
             }
             Err(_) => {
                 warn!(room = %room_jid, "timed out releasing room ownership claim; retaining exact fence for a later retry");
-                self.remember_pending_room_release(room_jid.clone(), claim_fence.clone());
+                if !self.remember_pending_room_release(room_jid.clone(), claim_fence.clone()) {
+                    tracing::error!(room = %room_jid, "exact-release retry backlog saturated despite pre-admission guard; claim remains fenced for node-expiry recovery");
+                }
             }
         }
     }
@@ -654,6 +668,9 @@ pub struct ListPendingRoomReleaseJids;
 pub struct IsCurrentRoomPendingRelease {
     pub room_jid: BareJid,
 }
+pub struct IsPendingRoomReleaseOnly {
+    pub room_jid: BareJid,
+}
 
 impl kameo::message::Message<ListPendingRoomReleaseJids> for RoomRegistryActor {
     type Reply = Vec<BareJid>;
@@ -687,6 +704,22 @@ impl kameo::message::Message<IsCurrentRoomPendingRelease> for RoomRegistryActor 
         };
         self.pending_room_releases
             .contains_key(&(msg.room_jid, entry.claim_fence.clone()))
+    }
+}
+
+impl kameo::message::Message<IsPendingRoomReleaseOnly> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: IsPendingRoomReleaseOnly,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        !self.rooms.contains_key(&msg.room_jid)
+            && self
+                .pending_room_releases
+                .keys()
+                .any(|(room_jid, _)| room_jid == &msg.room_jid)
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -421,15 +421,7 @@ impl RoomRegistryActor {
             && self.node_identity.current() == claim_fence.owner();
         if !still_owned {
             actor_ref.kill();
-            let _ = tokio::time::timeout(
-                ROOM_OWNERSHIP_CALL_TIMEOUT,
-                self.claim_store.release_exact(
-                    &claim_fence.entity,
-                    &claim_fence.owner(),
-                    claim_fence.epoch,
-                ),
-            )
-            .await;
+            self.release_room_claim(&room_jid, &claim_fence).await;
             return Err(RoomRegistryError::OwnershipUnavailable(room_jid));
         }
         self.publish_room(room_jid, actor_ref.clone(), claim_fence);
@@ -659,7 +651,7 @@ pub struct PendingRoomReleaseBacklog {
 
 pub struct GetPendingRoomReleaseBacklog;
 pub struct ListPendingRoomReleaseJids;
-pub struct IsPendingRoomRelease {
+pub struct IsCurrentRoomPendingRelease {
     pub room_jid: BareJid,
 }
 
@@ -682,17 +674,19 @@ impl kameo::message::Message<ListPendingRoomReleaseJids> for RoomRegistryActor {
     }
 }
 
-impl kameo::message::Message<IsPendingRoomRelease> for RoomRegistryActor {
+impl kameo::message::Message<IsCurrentRoomPendingRelease> for RoomRegistryActor {
     type Reply = bool;
 
     async fn handle(
         &mut self,
-        msg: IsPendingRoomRelease,
+        msg: IsCurrentRoomPendingRelease,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        let Some(entry) = self.rooms.get(&msg.room_jid) else {
+            return false;
+        };
         self.pending_room_releases
-            .keys()
-            .any(|(room_jid, _)| room_jid == &msg.room_jid)
+            .contains_key(&(msg.room_jid, entry.claim_fence.clone()))
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -2612,6 +2612,59 @@ mod ownership_claims_tests {
             .ask(IsPendingRoomReleaseOnly { room_jid: jid })
             .await
             .expect("shutdown pending-only query"));
+        assert!(!registry
+            .ask(IsCurrentIdentityPendingRoomReleaseOnly {
+                room_jid: test_room_jid("pending-only"),
+            })
+            .await
+            .expect("current-identity shutdown query"));
+    }
+
+    #[tokio::test]
+    async fn shutdown_batches_only_pending_room_fences_from_current_identity() {
+        let registry = spawn_registry().await;
+        let current_jid = test_room_jid("pending-current-identity");
+        let stale_jid = test_room_jid("pending-stale-identity");
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::new(InProcessClaimStore::new()),
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire current identity");
+        assert!(registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: current_jid.clone(),
+                claim_fence: room_claim_fence(&current_jid, ClaimEpoch(8)),
+            })
+            .await
+            .expect("remember current fence"));
+        assert!(registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: stale_jid.clone(),
+                claim_fence: RoomClaimFenceContext::new(
+                    Entity::new(EntityType::RoomActor, stale_jid.to_string()),
+                    foreign_identity(),
+                    ClaimEpoch(9),
+                ),
+            })
+            .await
+            .expect("remember stale fence"));
+
+        assert!(registry
+            .ask(IsCurrentIdentityPendingRoomReleaseOnly {
+                room_jid: current_jid,
+            })
+            .await
+            .expect("current fence query"));
+        assert!(!registry
+            .ask(IsCurrentIdentityPendingRoomReleaseOnly {
+                room_jid: stale_jid,
+            })
+            .await
+            .expect("stale fence query"));
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -2615,6 +2615,84 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test]
+    async fn pending_release_with_dead_map_entry_is_shutdown_sealable() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("pending-dead-entry");
+        let actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create room")
+            .actor_ref;
+        assert!(registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, ClaimEpoch(77)),
+            })
+            .await
+            .expect("remember exact pending responsibility"));
+        actor.kill();
+        actor.wait_for_shutdown().await;
+
+        assert!(registry
+            .ask(IsPendingRoomReleaseOnly { room_jid: jid })
+            .await
+            .expect("dead-entry pending-only query"));
+    }
+
+    #[tokio::test]
+    async fn dead_actor_redrives_oldest_release_when_backlog_is_full() {
+        let registry = spawn_registry().await;
+        let target = test_room_jid("dead-under-saturation");
+        let actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: target.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create target")
+            .actor_ref;
+        actor.kill();
+        actor.wait_for_shutdown().await;
+        for index in 0..MAX_PENDING_ROOM_RELEASES {
+            let jid = test_room_jid(&format!("dead-progress-{index}"));
+            assert!(registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: jid.clone(),
+                    claim_fence: room_claim_fence(&jid, ClaimEpoch(index as i64 + 100)),
+                })
+                .await
+                .expect("fill backlog"));
+        }
+
+        assert!(matches!(
+            registry
+                .ask(GetRoom {
+                    room_jid: target.clone(),
+                })
+                .await,
+            Err(SendError::HandlerError(RoomRegistryError::RoomActorStateLost(ref room)))
+                if *room == target
+        ));
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("backlog after opportunistic redrive")
+                .depth,
+            MAX_PENDING_ROOM_RELEASES - 1,
+            "one stale exact release is confirmed NotOwned, freeing capacity so the dead actor can retire"
+        );
+        assert_eq!(registry.ask(RoomCount).await.expect("room count"), 0);
+    }
+
+    #[tokio::test]
     async fn stale_pending_messages_cannot_regress_or_clear_a_newer_epoch() {
         let registry = spawn_registry().await;
         let current_epoch = ClaimEpoch(61);

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -2,6 +2,23 @@ use super::*;
 use kameo::actor::Spawn;
 use kameo::error::SendError;
 
+struct RememberOrdinaryReleaseForTest {
+    room_jid: BareJid,
+    claim_fence: crate::muc::RoomClaimFenceContext,
+}
+
+impl kameo::message::Message<RememberOrdinaryReleaseForTest> for RoomRegistryActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: RememberOrdinaryReleaseForTest,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) {
+        self.remember_pending_room_release(msg.room_jid, msg.claim_fence);
+    }
+}
+
 fn test_room_jid(name: &str) -> BareJid {
     format!("{}@muc.example.com", name)
         .parse()
@@ -836,7 +853,9 @@ async fn offline_durable_member_gets_inbox_projection_after_actor_respawn() {
 mod ownership_claims_tests {
     use super::*;
     use crate::muc::affiliation::AffiliationEntry;
-    use crate::muc::durable::{DurableRoomState, MucDurableFuture, MucDurableStore};
+    use crate::muc::durable::{
+        DurableRoomState, MucDurableFuture, MucDurableStore, RoomClaimFenceContext,
+    };
     use crate::muc::room_actor::{GetAffiliation, GetConfig};
     use crate::muc::subject::SubjectState;
     use crate::ownership::{
@@ -845,7 +864,7 @@ mod ownership_claims_tests {
     };
     use crate::types::Affiliation;
     use async_trait::async_trait;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
     use std::sync::Mutex;
 
     fn foreign_identity() -> NodeIdentity {
@@ -1192,6 +1211,12 @@ mod ownership_claims_tests {
     struct DeadOwnerClaimStore {
         state: Mutex<Option<(NodeIdentity, ClaimEpoch)>>,
         steal_calls: AtomicUsize,
+        fence_calls: AtomicUsize,
+        fence_fail_on_call: AtomicUsize,
+        release_failures: AtomicUsize,
+        release_delay_ms: AtomicU64,
+        fence_delay_ms: AtomicU64,
+        ensure_delay_ms: AtomicU64,
     }
 
     impl DeadOwnerClaimStore {
@@ -1199,7 +1224,42 @@ mod ownership_claims_tests {
             Self {
                 state: Mutex::new(Some((owner, epoch))),
                 steal_calls: AtomicUsize::new(0),
+                fence_calls: AtomicUsize::new(0),
+                fence_fail_on_call: AtomicUsize::new(usize::MAX),
+                release_failures: AtomicUsize::new(0),
+                release_delay_ms: AtomicU64::new(0),
+                fence_delay_ms: AtomicU64::new(0),
+                ensure_delay_ms: AtomicU64::new(0),
             }
+        }
+
+        fn fail_fence_on_call(&self, call: usize) {
+            self.fence_fail_on_call.store(call, Ordering::SeqCst);
+        }
+
+        fn fail_next_release(&self) {
+            self.release_failures.store(1, Ordering::SeqCst);
+        }
+
+        fn set_release_delay(&self, delay: std::time::Duration) {
+            self.release_delay_ms.store(
+                u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+                Ordering::SeqCst,
+            );
+        }
+
+        fn set_fence_delay(&self, delay: std::time::Duration) {
+            self.fence_delay_ms.store(
+                u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+                Ordering::SeqCst,
+            );
+        }
+
+        fn set_ensure_delay(&self, delay: std::time::Duration) {
+            self.ensure_delay_ms.store(
+                u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+                Ordering::SeqCst,
+            );
         }
     }
 
@@ -1227,6 +1287,10 @@ mod ownership_claims_tests {
             entity: &Entity,
             me: &NodeIdentity,
         ) -> Result<ClaimEpoch, ClaimError> {
+            let delay_ms = self.ensure_delay_ms.load(Ordering::SeqCst);
+            if delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            }
             let existing = self.state.lock().expect("lock").clone();
             match existing {
                 None => self.acquire(entity, me).await,
@@ -1286,6 +1350,14 @@ mod ownership_claims_tests {
             me: &NodeIdentity,
             mine: ClaimEpoch,
         ) -> Result<bool, ClaimError> {
+            let call = self.fence_calls.fetch_add(1, Ordering::SeqCst) + 1;
+            let delay_ms = self.fence_delay_ms.load(Ordering::SeqCst);
+            if delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            }
+            if call == self.fence_fail_on_call.load(Ordering::SeqCst) {
+                return Err(ClaimError::Backend("test final fence failure".to_string()));
+            }
             Ok(
                 matches!(&*self.state.lock().expect("lock"), Some((owner, epoch)) if owner == me && *epoch == mine),
             )
@@ -1297,11 +1369,52 @@ mod ownership_claims_tests {
             me: &NodeIdentity,
             mine: ClaimEpoch,
         ) -> Result<(), ClaimError> {
+            let delay_ms = self.release_delay_ms.load(Ordering::SeqCst);
+            if delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            }
+            if self
+                .release_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return Err(ClaimError::Backend("test release failure".to_string()));
+            }
             let mut state = self.state.lock().expect("lock");
             if matches!(&*state, Some((owner, epoch)) if owner == me && *epoch == mine) {
                 *state = None;
             }
             Ok(())
+        }
+
+        async fn release_exact(
+            &self,
+            _entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<crate::ownership::ExactReleaseOutcome, ClaimError> {
+            let delay_ms = self.release_delay_ms.load(Ordering::SeqCst);
+            if delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            }
+            if self
+                .release_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return Err(ClaimError::Backend("test release failure".to_string()));
+            }
+            let mut state = self.state.lock().expect("lock");
+            if matches!(&*state, Some((owner, epoch)) if owner == me && *epoch == mine) {
+                *state = None;
+                Ok(crate::ownership::ExactReleaseOutcome::Released)
+            } else {
+                Ok(crate::ownership::ExactReleaseOutcome::NotOwned)
+            }
         }
 
         async fn release_many(
@@ -1322,9 +1435,11 @@ mod ownership_claims_tests {
     #[derive(Default)]
     struct RecordingDurableStore {
         load_result: Option<DurableRoomState>,
+        fail_load: bool,
         demote_notifications: Mutex<Vec<(String, String)>>,
         deleted_rooms: Mutex<Vec<String>>,
         fail_deletes: bool,
+        claim_fences: Mutex<HashMap<BareJid, RoomClaimFenceContext>>,
     }
 
     impl MucDurableStore for RecordingDurableStore {
@@ -1332,6 +1447,11 @@ mod ownership_claims_tests {
             &'a self,
             _room_jid: &'a BareJid,
         ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+            if self.fail_load {
+                return Box::pin(async {
+                    Err(crate::XmppError::internal("load refused by test store"))
+                });
+            }
             let result = self.load_result.clone();
             Box::pin(async move { Ok(result) })
         }
@@ -1373,6 +1493,28 @@ mod ownership_claims_tests {
                 .expect("lock")
                 .push(room_jid.to_string());
             Box::pin(async { Ok(()) })
+        }
+
+        fn record_claim_fence(&self, room_jid: &BareJid, fence: RoomClaimFenceContext) {
+            self.claim_fences
+                .lock()
+                .expect("lock")
+                .insert(room_jid.clone(), fence);
+        }
+
+        fn forget_claim_fence(&self, room_jid: &BareJid, expected: &RoomClaimFenceContext) {
+            let mut fences = self.claim_fences.lock().expect("lock");
+            if fences.get(room_jid) == Some(expected) {
+                fences.remove(room_jid);
+            }
+        }
+
+        fn current_claim_fence(&self, room_jid: &BareJid) -> Option<RoomClaimFenceContext> {
+            self.claim_fences
+                .lock()
+                .expect("lock")
+                .get(room_jid)
+                .cloned()
         }
 
         fn notify_previous_owner_demoted<'a>(
@@ -1474,9 +1616,11 @@ mod ownership_claims_tests {
                     Affiliation::Owner,
                 )],
             }),
+            fail_load: false,
             demote_notifications: Mutex::new(Vec::new()),
             deleted_rooms: Mutex::new(Vec::new()),
             fail_deletes: false,
+            claim_fences: Mutex::new(HashMap::new()),
         });
         registry
             .ask(WireClusteringClaims {
@@ -1514,6 +1658,1111 @@ mod ownership_claims_tests {
             .await
             .expect("ask");
         assert_eq!(affiliation, Affiliation::Owner);
+    }
+
+    fn reclaimed_snapshot(name: &str) -> DurableRoomState {
+        DurableRoomState {
+            waddle_id: "reclaimed-waddle".to_string(),
+            channel_id: "reclaimed-channel".to_string(),
+            config: RoomConfig {
+                name: name.to_string(),
+                persistent: true,
+                ..RoomConfig::default()
+            },
+            subject: None,
+            affiliations: Vec::new(),
+        }
+    }
+
+    fn room_claim_fence(room_jid: &BareJid, epoch: ClaimEpoch) -> RoomClaimFenceContext {
+        RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, room_jid.to_string()),
+            this_identity(),
+            epoch,
+        )
+    }
+
+    #[tokio::test]
+    async fn reclaimed_room_hydrates_once_at_the_exact_won_epoch() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(4);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        let durable_store = Arc::new(RecordingDurableStore {
+            load_result: Some(reclaimed_snapshot("proactively restored")),
+            ..RecordingDurableStore::default()
+        });
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let jid = test_room_jid("proactive");
+        let first = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("reconcile");
+        assert_eq!(first, ReclaimedRoomOutcome::Hydrated);
+        let actor = registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("get hydrated room")
+            .expect("room exists");
+        assert_eq!(
+            actor.ask(GetConfig).await.expect("config").name,
+            "proactively restored"
+        );
+
+        let second = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("idempotent reconcile");
+        assert_eq!(second, ReclaimedRoomOutcome::AlreadyLive);
+        assert_eq!(registry.ask(RoomCount).await.expect("count"), 1);
+    }
+
+    #[tokio::test]
+    async fn reclaimed_room_final_fence_uncertainty_never_installs_actor() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(40);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        // Initial authorization, post-load authorization, then the exact
+        // publication fence after durable hydration messages are enqueued.
+        claim_store.fail_fence_on_call(3);
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(Arc::new(RecordingDurableStore {
+                    load_result: Some(reclaimed_snapshot("must-not-install")),
+                    ..RecordingDurableStore::default()
+                }) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let jid = test_room_jid("final-fence");
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("reconcile");
+        assert_eq!(outcome, ReclaimedRoomOutcome::PendingRetry);
+        assert!(registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("get")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn reclaimed_room_without_durable_state_releases_for_demand_recreation() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(8);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(
+                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
+                ),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let jid = test_room_jid("ephemeral-orphan");
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("reconcile");
+        assert_eq!(outcome, ReclaimedRoomOutcome::Released);
+        assert!(
+            claim_store
+                .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+                .await
+                .expect("claim lookup")
+                .is_none(),
+            "an unhydratable room claim must not remain owned by a fresh node"
+        );
+    }
+
+    #[tokio::test]
+    async fn reclaimed_room_load_failure_retains_exact_epoch_for_retry() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(9);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(Arc::new(RecordingDurableStore {
+                    fail_load: true,
+                    ..RecordingDurableStore::default()
+                }) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let jid = test_room_jid("load-failure");
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("reconcile");
+        assert_eq!(outcome, ReclaimedRoomOutcome::PendingRetry);
+        assert!(
+            claim_store
+                .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+                .await
+                .expect("claim lookup")
+                .is_some(),
+            "a transient hydrate failure must retain the exact won epoch"
+        );
+        assert_eq!(
+            registry
+                .ask(ListPendingReclaimedRooms { limit: 8 })
+                .await
+                .expect("pending retry")
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_rotation_before_room_worker_releases_the_exact_old_fence() {
+        let registry = spawn_registry().await;
+        let old_owner = this_identity();
+        let identity = SharedNodeIdentity::new(old_owner.clone());
+        let epoch = ClaimEpoch(10);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner.clone(), epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: identity.clone(),
+                durable_store: Some(Arc::new(RecordingDurableStore {
+                    load_result: Some(reclaimed_snapshot("must not hydrate")),
+                    ..RecordingDurableStore::default()
+                }) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("rotate-before-worker");
+        let fence = RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            old_owner,
+            epoch,
+        );
+
+        identity.set(foreign_identity());
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: fence,
+                previous_owner: foreign_identity(),
+            })
+            .await
+            .expect("reconcile rotated work");
+
+        assert_eq!(outcome, ReclaimedRoomOutcome::Released);
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_none());
+        assert!(registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("room lookup")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn identity_rotation_between_room_retries_releases_the_exact_old_fence() {
+        let registry = spawn_registry().await;
+        let old_owner = this_identity();
+        let identity = SharedNodeIdentity::new(old_owner.clone());
+        let epoch = ClaimEpoch(11);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner.clone(), epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: identity.clone(),
+                durable_store: Some(Arc::new(RecordingDurableStore {
+                    fail_load: true,
+                    ..RecordingDurableStore::default()
+                }) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("rotate-between-retries");
+        let fence = RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            old_owner,
+            epoch,
+        );
+
+        let first = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: fence.clone(),
+                previous_owner: foreign_identity(),
+            })
+            .await
+            .expect("first reconcile");
+        assert_eq!(first, ReclaimedRoomOutcome::PendingRetry);
+
+        identity.set(foreign_identity());
+        let retried = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: fence,
+                previous_owner: foreign_identity(),
+            })
+            .await
+            .expect("retry after rotation");
+
+        assert_eq!(retried, ReclaimedRoomOutcome::Released);
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_none());
+        assert!(registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("pending retries")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn identity_rotation_during_demand_publication_never_installs_old_fence() {
+        let registry = spawn_registry().await;
+        let old_owner = this_identity();
+        let identity = SharedNodeIdentity::new(old_owner.clone());
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner, ClaimEpoch(20)));
+        claim_store.set_fence_delay(std::time::Duration::from_millis(100));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: identity.clone(),
+                durable_store: Some(
+                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
+                ),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("rotate-at-demand-publish");
+        let registry_for_create = registry.clone();
+        let jid_for_create = jid.clone();
+        let create = tokio::spawn(async move {
+            registry_for_create
+                .ask(GetOrCreateRoom {
+                    room_jid: jid_for_create,
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await
+        });
+        while claim_store.fence_calls.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+        identity.set(foreign_identity());
+
+        let result = create.await.expect("join create");
+        assert!(matches!(
+            result,
+            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(ref room)))
+                if *room == jid
+        ));
+        assert!(registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("lookup")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn stale_selected_retry_cannot_evict_newer_published_fence_cache() {
+        let registry = spawn_registry().await;
+        let old_owner = this_identity();
+        let new_owner = foreign_identity();
+        let identity = SharedNodeIdentity::new(old_owner.clone());
+        let old_epoch = ClaimEpoch(30);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner.clone(), old_epoch));
+        claim_store.fail_fence_on_call(1);
+        let durable_store = Arc::new(RecordingDurableStore::default());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: identity.clone(),
+                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("stale-retry-cache");
+        let old_fence = RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            old_owner.clone(),
+            old_epoch,
+        );
+        assert_eq!(
+            registry
+                .ask(ReconcileReclaimedRoom {
+                    room_jid: jid.clone(),
+                    claim_fence: old_fence.clone(),
+                    previous_owner: old_owner.clone(),
+                })
+                .await
+                .expect("seed pending"),
+            ReclaimedRoomOutcome::PendingRetry
+        );
+        let selected = registry
+            .ask(ListPendingReclaimedRooms { limit: 1 })
+            .await
+            .expect("select old retry")
+            .pop()
+            .expect("pending old retry");
+
+        identity.set(new_owner.clone());
+        registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "new-w".to_string(),
+                channel_id: "new-c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("publish newer demand actor");
+        let new_fence = durable_store
+            .current_claim_fence(&jid)
+            .expect("new fence cached");
+        assert_eq!(new_fence.owner(), new_owner);
+        assert!(new_fence.epoch > old_epoch);
+
+        assert_eq!(
+            registry
+                .ask(ReconcileReclaimedRoom {
+                    room_jid: selected.room_jid,
+                    claim_fence: selected.claim_fence,
+                    previous_owner: selected.previous_owner,
+                })
+                .await
+                .expect("deliver stale selected retry"),
+            ReclaimedRoomOutcome::LostRace
+        );
+        assert_eq!(durable_store.current_claim_fence(&jid), Some(new_fence));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn hung_demand_claim_store_call_is_bounded_inside_registry_actor() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), ClaimEpoch(40)));
+        claim_store.set_ensure_delay(std::time::Duration::from_secs(60));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: claim_store as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("hung-ordinary-claim");
+        let registry_for_create = registry.clone();
+        let create = tokio::spawn(async move {
+            registry_for_create
+                .ask(GetOrCreateRoom {
+                    room_jid: jid,
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(ROOM_OWNERSHIP_CALL_TIMEOUT).await;
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            create.await.expect("join create"),
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipUnavailable(_)
+            ))
+        ));
+        assert_eq!(
+            registry.ask(RoomCount).await.expect("registry responsive"),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn fence_uncertainty_with_live_old_epoch_actor_is_pending_until_exact_proof() {
+        let registry = spawn_registry().await;
+        let old_epoch = ClaimEpoch(30);
+        let new_epoch = ClaimEpoch(31);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), old_epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(
+                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
+                ),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("uncertain-old-epoch");
+        let original = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("spawn old-epoch actor");
+        *claim_store.state.lock().expect("claim state") = Some((this_identity(), new_epoch));
+        // Let the initial authorization pass, then make the fence adjacent
+        // to the live-map epoch mutation uncertain.
+        claim_store.fail_fence_on_call(2);
+
+        let uncertain = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, new_epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("uncertain reconcile");
+        assert_eq!(uncertain, ReclaimedRoomOutcome::PendingRetry);
+        let pending = registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("list pending");
+        assert_eq!(
+            pending,
+            vec![PendingReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, new_epoch),
+                previous_owner: this_identity(),
+            }]
+        );
+        let still_local = registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("get local")
+            .expect("actor retained while proof is uncertain");
+        assert_eq!(still_local.id(), original.actor_ref.id());
+
+        let retried = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, new_epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("retry with exact proof");
+        assert_eq!(retried, ReclaimedRoomOutcome::AdoptedLocal);
+        assert!(registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("list pending after adoption")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn failed_release_retains_epoch_until_a_retry_confirms_release() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(40);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        claim_store.fail_next_release();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("release-failure");
+
+        let first = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("first reconcile");
+        assert_eq!(first, ReclaimedRoomOutcome::PendingRetry);
+        assert!(
+            claim_store
+                .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+                .await
+                .expect("claim")
+                .is_some(),
+            "a failed release must retain the won epoch"
+        );
+        assert_eq!(
+            registry
+                .ask(ListPendingReclaimedRooms { limit: 8 })
+                .await
+                .expect("pending")
+                .len(),
+            1
+        );
+
+        let retried = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("retry");
+        assert_eq!(retried, ReclaimedRoomOutcome::Released);
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim after retry")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn ordinary_destroy_release_failure_is_deduped_and_retried_exactly() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(41);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("ordinary-release-retry");
+        registry
+            .ask(CreateInstantRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("create room");
+
+        claim_store.fail_next_release();
+        assert_eq!(
+            registry
+                .ask(DestroyRoom {
+                    room_jid: jid.clone(),
+                    reason: DestroyRoomReason::LocalEviction,
+                })
+                .await
+                .expect("destroy"),
+            DestroyRoomOutcome::Destroyed
+        );
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("backlog")
+                .depth,
+            1
+        );
+
+        assert_eq!(
+            registry
+                .ask(RetryPendingRoomReleases { limit: 1 })
+                .await
+                .expect("retry"),
+            1
+        );
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("cleared backlog")
+                .depth,
+            0
+        );
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn pending_release_generations_survive_claim_epoch_aba() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("release-aba");
+        let owner_a = this_identity();
+        let owner_b = foreign_identity();
+        let fence_a = crate::muc::RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            owner_a,
+            ClaimEpoch(41),
+        );
+        let fence_b = crate::muc::RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            owner_b,
+            ClaimEpoch(0),
+        );
+        for fence in [fence_a, fence_b] {
+            registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: jid.clone(),
+                    claim_fence: fence,
+                })
+                .await
+                .expect("remember exact release");
+        }
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("backlog")
+                .depth,
+            2,
+            "A/41 and recreated B/0 are distinct exact release responsibilities"
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_reclaimed_generations_survive_claim_epoch_aba() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("reclaimed-aba");
+        let fence_a = crate::muc::RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            this_identity(),
+            ClaimEpoch(41),
+        );
+        let fence_c = crate::muc::RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            foreign_identity(),
+            ClaimEpoch(1),
+        );
+        for (fence, previous_owner) in [
+            (fence_a.clone(), foreign_identity()),
+            (fence_c.clone(), this_identity()),
+        ] {
+            registry
+                .ask(RememberPendingReclaimedRoom {
+                    room_jid: jid.clone(),
+                    claim_fence: fence,
+                    previous_owner,
+                })
+                .await
+                .expect("remember reclaimed generation");
+        }
+        let pending = registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("pending generations");
+        assert_eq!(pending.len(), 2);
+        assert!(pending.iter().any(|entry| entry.claim_fence == fence_a));
+        assert!(pending.iter().any(|entry| entry.claim_fence == fence_c));
+    }
+
+    #[tokio::test]
+    async fn full_release_backlog_does_not_seal_inactive_room() {
+        let registry = spawn_registry().await;
+        for index in 0..MAX_PENDING_ROOM_RELEASES {
+            let jid = test_room_jid(&format!("backlog-{index}"));
+            registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: jid.clone(),
+                    claim_fence: room_claim_fence(&jid, ClaimEpoch(index as i64)),
+                })
+                .await
+                .expect("fill backlog");
+        }
+        let jid = test_room_jid("must-remain-open");
+        let acquisition = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create target");
+        assert!(!registry
+            .ask(DestroyRoomIfInactive {
+                room_jid: jid,
+                expected_occupancy_revision: 0,
+                guard: SealGuard::Dormant,
+            })
+            .await
+            .expect("capacity refusal"));
+        assert!(!acquisition
+            .actor_ref
+            .ask(IsSealed)
+            .await
+            .expect("sealed probe"));
+    }
+
+    #[tokio::test]
+    async fn stale_pending_messages_cannot_regress_or_clear_a_newer_epoch() {
+        let registry = spawn_registry().await;
+        let current_epoch = ClaimEpoch(61);
+        let stale_epoch = ClaimEpoch(60);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), current_epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: claim_store as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("monotonic-pending");
+        registry
+            .ask(RememberPendingReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, current_epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("remember current");
+        registry
+            .ask(RememberPendingReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, stale_epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("late stale remember");
+        let stale = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, stale_epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("stale reconcile");
+        assert_eq!(stale, ReclaimedRoomOutcome::LostRace);
+        assert_eq!(
+            registry
+                .ask(ListPendingReclaimedRooms { limit: 8 })
+                .await
+                .expect("pending"),
+            vec![PendingReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, current_epoch),
+                previous_owner: this_identity(),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_retry_page_rotates_past_a_persistent_full_prefix() {
+        let registry = spawn_registry().await;
+        let previous_owner = foreign_identity();
+        let mut rooms = Vec::new();
+        for index in 0..65 {
+            let room_jid = test_room_jid(&format!("fair-retry-{index:02}"));
+            registry
+                .ask(RememberPendingReclaimedRoom {
+                    room_jid: room_jid.clone(),
+                    claim_fence: room_claim_fence(&room_jid, ClaimEpoch(70)),
+                    previous_owner: previous_owner.clone(),
+                })
+                .await
+                .expect("remember pending room");
+            rooms.push(room_jid);
+        }
+
+        let first = registry
+            .ask(ListPendingReclaimedRooms { limit: 64 })
+            .await
+            .expect("first page");
+        assert_eq!(first.len(), 64);
+        assert!(!first.iter().any(|entry| entry.room_jid == rooms[64]));
+
+        let second = registry
+            .ask(ListPendingReclaimedRooms { limit: 64 })
+            .await
+            .expect("rotated page");
+        assert!(
+            second.iter().any(|entry| entry.room_jid == rooms[64]),
+            "an entry behind a permanently failing full page must receive a retry"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timed_out_release_is_cancelled_and_retried_without_wedging_registry() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(50);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        claim_store.set_release_delay(std::time::Duration::from_secs(60));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("release-timeout");
+
+        let first = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("bounded reconcile");
+        assert_eq!(first, ReclaimedRoomOutcome::PendingRetry);
+        assert!(registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("registry remains responsive after timeout")
+            .iter()
+            .any(|entry| entry.room_jid == jid && entry.claim_fence.epoch == epoch));
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim retained")
+            .is_some());
+
+        claim_store.set_release_delay(std::time::Duration::ZERO);
+        let retried = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("release retry");
+        assert_eq!(retried, ReclaimedRoomOutcome::Released);
+    }
+
+    #[tokio::test]
+    async fn demand_side_creation_winning_before_reconcile_is_not_duplicated() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(12);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: claim_store as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(
+                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
+                ),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let jid = test_room_jid("demand-race");
+        let demand = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "demand-waddle".to_string(),
+                channel_id: "demand-channel".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("demand-side creation");
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("reconcile after demand");
+        assert_eq!(outcome, ReclaimedRoomOutcome::AlreadyLive);
+        let registered = registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("get")
+            .expect("room exists");
+        assert_eq!(registered.id(), demand.actor_ref.id());
+        assert_eq!(registry.ask(RoomCount).await.expect("count"), 1);
+
+        let stale = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: test_room_jid("demand-race"),
+                claim_fence: room_claim_fence(
+                    &test_room_jid("demand-race"),
+                    ClaimEpoch(epoch.0 - 1),
+                ),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("stale reconciliation message");
+        assert_eq!(stale, ReclaimedRoomOutcome::LostRace);
+        let still_registered = registry
+            .ask(GetRoom {
+                room_jid: test_room_jid("demand-race"),
+            })
+            .await
+            .expect("get after stale adoption")
+            .expect("live actor survives");
+        assert_eq!(still_registered.id(), demand.actor_ref.id());
+    }
+
+    #[tokio::test]
+    async fn locally_live_old_epoch_actor_is_adopted_without_state_loss() {
+        let registry = spawn_registry().await;
+        let old_epoch = ClaimEpoch(20);
+        let new_epoch = ClaimEpoch(21);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), old_epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(
+                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
+                ),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("local-old-epoch");
+        let original = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "local-waddle".to_string(),
+                channel_id: "local-channel".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create local actor");
+
+        // Stand in for the dead-node reaper's exact CAS after this process
+        // refreshed its node identity while the local actor remained live.
+        *claim_store.state.lock().expect("claim state lock") = Some((this_identity(), new_epoch));
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, new_epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("adopt new epoch");
+        assert_eq!(outcome, ReclaimedRoomOutcome::AdoptedLocal);
+        let adopted = registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("get adopted actor")
+            .expect("actor remains registered");
+        assert_eq!(
+            adopted.id(),
+            original.actor_ref.id(),
+            "epoch adoption must preserve the locally live RoomActor"
+        );
+    }
+
+    #[tokio::test]
+    async fn intervening_owner_prevents_stale_local_actor_adoption() {
+        let registry = spawn_registry().await;
+        let owner_a = NodeIdentity::new("node-a", "incarnation-a");
+        let owner_b = NodeIdentity::new("node-b", "incarnation-b");
+        let owner_c = NodeIdentity::new("node-c", "incarnation-c");
+        let old_epoch = ClaimEpoch(80);
+        let won_epoch = ClaimEpoch(82);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(owner_a.clone(), old_epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner_a),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire owner A");
+        let jid = test_room_jid("intervening-owner");
+        let stale_actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "owner-a".to_string(),
+                channel_id: "owner-a-channel".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("spawn owner A actor")
+            .actor_ref;
+
+        let durable_store = Arc::new(RecordingDurableStore {
+            load_result: Some(reclaimed_snapshot("owner B durable config")),
+            ..RecordingDurableStore::default()
+        });
+        *claim_store.state.lock().expect("claim state") = Some((owner_c.clone(), won_epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: claim_store as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner_c.clone()),
+                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire owner C");
+
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: RoomClaimFenceContext::new(
+                    Entity::new(EntityType::RoomActor, jid.to_string()),
+                    owner_c,
+                    won_epoch,
+                ),
+                previous_owner: owner_b,
+            })
+            .await
+            .expect("reconcile after intervening owner");
+        assert_eq!(outcome, ReclaimedRoomOutcome::Hydrated);
+        let restored = registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("get restored room")
+            .expect("restored actor exists");
+        assert_ne!(restored.id(), stale_actor.id());
+        assert_eq!(
+            restored.ask(GetConfig).await.expect("restored config").name,
+            "owner B durable config"
+        );
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -2365,6 +2365,79 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test]
+    async fn publishing_reacquired_exact_fence_cancels_matching_terminal_release() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(crate::ownership::InProcessClaimStore::new());
+        let identity = this_identity();
+        let jid = test_room_jid("reacquired-release-cancel");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let epoch = claim_store
+            .ensure_claimed(&entity, &identity)
+            .await
+            .expect("seed self-owned claim");
+        let fence = RoomClaimFenceContext::new(entity.clone(), identity.clone(), epoch);
+        let aba_distinct_fence = RoomClaimFenceContext::new(
+            entity.clone(),
+            foreign_identity(),
+            ClaimEpoch(epoch.0.saturating_add(1)),
+        );
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(identity.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: jid.clone(),
+                claim_fence: fence.clone(),
+            })
+            .await
+            .expect("remember ambiguous release");
+        registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: jid.clone(),
+                claim_fence: aba_distinct_fence,
+            })
+            .await
+            .expect("remember ABA-distinct release");
+
+        registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("publish actor under reacquired fence");
+
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("pending release backlog")
+                .depth,
+            1,
+            "publishing cancels only the exact live fence, not another ABA generation"
+        );
+        assert_eq!(
+            registry
+                .ask(RetryPendingRoomReleases { limit: 8 })
+                .await
+                .expect("retry backlog"),
+            1
+        );
+        assert!(claim_store
+            .fence(&entity, &identity, epoch)
+            .await
+            .expect("live claim fence"));
+    }
+
+    #[tokio::test]
     async fn pending_reclaimed_generations_survive_claim_epoch_aba() {
         let registry = spawn_registry().await;
         let jid = test_room_jid("reclaimed-aba");

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -1971,6 +1971,7 @@ mod ownership_claims_tests {
         let identity = SharedNodeIdentity::new(old_owner.clone());
         let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner, ClaimEpoch(20)));
         claim_store.set_fence_delay(std::time::Duration::from_millis(100));
+        claim_store.fail_next_release();
         registry
             .ask(WireClusteringClaims {
                 claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
@@ -2007,9 +2008,32 @@ mod ownership_claims_tests {
                 if *room == jid
         ));
         assert!(registry
-            .ask(GetRoom { room_jid: jid })
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
             .await
             .expect("lookup")
+            .is_none());
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("pending exact cleanup")
+                .depth,
+            1,
+            "failed post-hydration cleanup must retain its exact fence"
+        );
+        assert_eq!(
+            registry
+                .ask(RetryPendingRoomReleases { limit: 8 })
+                .await
+                .expect("retry exact cleanup"),
+            1
+        );
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
             .is_none());
     }
 
@@ -2424,6 +2448,12 @@ mod ownership_claims_tests {
             1,
             "publishing cancels only the exact live fence, not another ABA generation"
         );
+        assert!(!registry
+            .ask(IsCurrentRoomPendingRelease {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("current-fence pending query"));
         assert_eq!(
             registry
                 .ask(RetryPendingRoomReleases { limit: 8 })

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -8,14 +8,14 @@ struct RememberOrdinaryReleaseForTest {
 }
 
 impl kameo::message::Message<RememberOrdinaryReleaseForTest> for RoomRegistryActor {
-    type Reply = ();
+    type Reply = bool;
 
     async fn handle(
         &mut self,
         msg: RememberOrdinaryReleaseForTest,
         _ctx: &mut Context<Self, Self::Reply>,
-    ) {
-        self.remember_pending_room_release(msg.room_jid, msg.claim_fence);
+    ) -> Self::Reply {
+        self.remember_pending_room_release(msg.room_jid, msg.claim_fence)
     }
 }
 
@@ -2454,6 +2454,12 @@ mod ownership_claims_tests {
             })
             .await
             .expect("current-fence pending query"));
+        assert!(!registry
+            .ask(IsPendingRoomReleaseOnly {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("pending-only query"));
         assert_eq!(
             registry
                 .ask(RetryPendingRoomReleases { limit: 8 })
@@ -2506,6 +2512,16 @@ mod ownership_claims_tests {
     #[tokio::test]
     async fn full_release_backlog_does_not_seal_inactive_room() {
         let registry = spawn_registry().await;
+        let jid = test_room_jid("must-remain-open");
+        let acquisition = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create target before saturating cleanup inventory");
         for index in 0..MAX_PENDING_ROOM_RELEASES {
             let jid = test_room_jid(&format!("backlog-{index}"));
             registry
@@ -2516,16 +2532,6 @@ mod ownership_claims_tests {
                 .await
                 .expect("fill backlog");
         }
-        let jid = test_room_jid("must-remain-open");
-        let acquisition = registry
-            .ask(GetOrCreateRoom {
-                room_jid: jid.clone(),
-                waddle_id: "w".to_string(),
-                channel_id: "c".to_string(),
-                config: RoomConfig::default(),
-            })
-            .await
-            .expect("create target");
         assert!(!registry
             .ask(DestroyRoomIfInactive {
                 room_jid: jid,
@@ -2539,6 +2545,73 @@ mod ownership_claims_tests {
             .ask(IsSealed)
             .await
             .expect("sealed probe"));
+    }
+
+    #[tokio::test]
+    async fn full_release_backlog_refuses_new_claim_and_never_grows() {
+        let registry = spawn_registry().await;
+        for index in 0..MAX_PENDING_ROOM_RELEASES {
+            let jid = test_room_jid(&format!("bounded-backlog-{index}"));
+            assert!(registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: jid.clone(),
+                    claim_fence: room_claim_fence(&jid, ClaimEpoch(index as i64)),
+                })
+                .await
+                .expect("fill backlog"));
+        }
+        let overflow_jid = test_room_jid("bounded-overflow");
+        assert!(!registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: overflow_jid.clone(),
+                claim_fence: room_claim_fence(&overflow_jid, ClaimEpoch(999)),
+            })
+            .await
+            .expect("bounded insertion outcome"));
+        assert!(matches!(
+            registry
+                .ask(GetOrCreateRoom {
+                    room_jid: overflow_jid.clone(),
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await,
+            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(ref room)))
+                if *room == overflow_jid
+        ));
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("bounded backlog")
+                .depth,
+            MAX_PENDING_ROOM_RELEASES
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_only_room_is_shutdown_sealable_but_not_current_live_generation() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("pending-only");
+        assert!(registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, ClaimEpoch(7)),
+            })
+            .await
+            .expect("remember pending-only generation"));
+
+        assert!(!registry
+            .ask(IsCurrentRoomPendingRelease {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("generation-scoped live query"));
+        assert!(registry
+            .ask(IsPendingRoomReleaseOnly { room_jid: jid })
+            .await
+            .expect("shutdown pending-only query"));
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -39,11 +39,12 @@ use super::room_registry_actor::{
     CancelPendingReclaimedRoomReservation, CreateInstantRoom, CreateRoom, DestroyRoom,
     DestroyRoomIfInactive, DestroyRoomOutcome, DestroyRoomReason, GetOrCreateRoom,
     GetPendingReclaimedRoomBacklog, GetPendingRoomReleaseBacklog, GetRoom,
-    IsCurrentRoomPendingRelease, IsMucJid, ListPendingReclaimedRooms, ListPendingRoomReleaseJids,
-    ListRooms, PendingReclaimedRoom, PendingReclaimedRoomBacklog, PendingRoomReleaseBacklog,
-    ReapSealedRoom, ReclaimedRoomOutcome, ReconcileReclaimedRoom, RememberPendingReclaimedRoom,
-    ReservePendingReclaimedRoom, RetryPendingRoomReleases, RoomAcquisition, RoomCount, RoomExists,
-    RoomRegistryActor, RoomRegistryError, WireClusteringClaims,
+    IsCurrentRoomPendingRelease, IsMucJid, IsPendingRoomReleaseOnly, ListPendingReclaimedRooms,
+    ListPendingRoomReleaseJids, ListRooms, PendingReclaimedRoom, PendingReclaimedRoomBacklog,
+    PendingRoomReleaseBacklog, ReapSealedRoom, ReclaimedRoomOutcome, ReconcileReclaimedRoom,
+    RememberPendingReclaimedRoom, ReservePendingReclaimedRoom, RetryPendingRoomReleases,
+    RoomAcquisition, RoomCount, RoomExists, RoomRegistryActor, RoomRegistryError,
+    WireClusteringClaims,
 };
 use super::RoomConfig;
 use crate::metrics;
@@ -317,6 +318,12 @@ impl RoomRegistry {
         is_current_room_pending_release(room_jid: BareJid) -> bool,
         "is_current_room_pending_release",
         IsCurrentRoomPendingRelease { room_jid }
+    );
+
+    registry_method!(
+        is_pending_room_release_only(room_jid: BareJid) -> bool,
+        "is_pending_room_release_only",
+        IsPendingRoomReleaseOnly { room_jid }
     );
 
     registry_method!(

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -38,10 +38,10 @@ use super::room_actor::{RoomActor, SealGuard};
 use super::room_registry_actor::{
     CancelPendingReclaimedRoomReservation, CreateInstantRoom, CreateRoom, DestroyRoom,
     DestroyRoomIfInactive, DestroyRoomOutcome, DestroyRoomReason, GetOrCreateRoom,
-    GetPendingReclaimedRoomBacklog, GetPendingRoomReleaseBacklog, GetRoom, IsMucJid,
-    IsPendingRoomRelease, ListPendingReclaimedRooms, ListPendingRoomReleaseJids, ListRooms,
-    PendingReclaimedRoom, PendingReclaimedRoomBacklog, PendingRoomReleaseBacklog, ReapSealedRoom,
-    ReclaimedRoomOutcome, ReconcileReclaimedRoom, RememberPendingReclaimedRoom,
+    GetPendingReclaimedRoomBacklog, GetPendingRoomReleaseBacklog, GetRoom,
+    IsCurrentRoomPendingRelease, IsMucJid, ListPendingReclaimedRooms, ListPendingRoomReleaseJids,
+    ListRooms, PendingReclaimedRoom, PendingReclaimedRoomBacklog, PendingRoomReleaseBacklog,
+    ReapSealedRoom, ReclaimedRoomOutcome, ReconcileReclaimedRoom, RememberPendingReclaimedRoom,
     ReservePendingReclaimedRoom, RetryPendingRoomReleases, RoomAcquisition, RoomCount, RoomExists,
     RoomRegistryActor, RoomRegistryError, WireClusteringClaims,
 };
@@ -314,9 +314,9 @@ impl RoomRegistry {
     );
 
     registry_method!(
-        is_pending_room_release(room_jid: BareJid) -> bool,
-        "is_pending_room_release",
-        IsPendingRoomRelease { room_jid }
+        is_current_room_pending_release(room_jid: BareJid) -> bool,
+        "is_current_room_pending_release",
+        IsCurrentRoomPendingRelease { room_jid }
     );
 
     registry_method!(

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -36,10 +36,14 @@ use super::affiliation::DurableMembershipSource;
 use super::durable::MucDurableStore;
 use super::room_actor::{RoomActor, SealGuard};
 use super::room_registry_actor::{
-    CreateInstantRoom, CreateRoom, DestroyRoom, DestroyRoomIfInactive, DestroyRoomOutcome,
-    DestroyRoomReason, GetOrCreateRoom, GetRoom, IsMucJid, ListRooms, ReapSealedRoom,
-    RoomAcquisition, RoomCount, RoomExists, RoomRegistryActor, RoomRegistryError,
-    WireClusteringClaims,
+    CancelPendingReclaimedRoomReservation, CreateInstantRoom, CreateRoom, DestroyRoom,
+    DestroyRoomIfInactive, DestroyRoomOutcome, DestroyRoomReason, GetOrCreateRoom,
+    GetPendingReclaimedRoomBacklog, GetPendingRoomReleaseBacklog, GetRoom, IsMucJid,
+    IsPendingRoomRelease, ListPendingReclaimedRooms, ListPendingRoomReleaseJids, ListRooms,
+    PendingReclaimedRoom, PendingReclaimedRoomBacklog, PendingRoomReleaseBacklog, ReapSealedRoom,
+    ReclaimedRoomOutcome, ReconcileReclaimedRoom, RememberPendingReclaimedRoom,
+    ReservePendingReclaimedRoom, RetryPendingRoomReleases, RoomAcquisition, RoomCount, RoomExists,
+    RoomRegistryActor, RoomRegistryError, WireClusteringClaims,
 };
 use super::RoomConfig;
 use crate::metrics;
@@ -280,6 +284,48 @@ impl RoomRegistry {
     );
 
     registry_method!(
+        reserve_pending_reclaimed_room(room_jid: BareJid) -> bool,
+        "reserve_pending_reclaimed_room",
+        ReservePendingReclaimedRoom { room_jid }
+    );
+
+    registry_method!(
+        pending_reclaimed_room_backlog() -> PendingReclaimedRoomBacklog,
+        "pending_reclaimed_room_backlog",
+        GetPendingReclaimedRoomBacklog
+    );
+
+    registry_method!(
+        pending_room_release_backlog() -> PendingRoomReleaseBacklog,
+        "pending_room_release_backlog",
+        GetPendingRoomReleaseBacklog
+    );
+
+    registry_method!(
+        retry_pending_room_releases(limit: usize) -> usize,
+        "retry_pending_room_releases",
+        RetryPendingRoomReleases { limit }
+    );
+
+    registry_method!(
+        list_pending_room_release_jids() -> Vec<BareJid>,
+        "list_pending_room_release_jids",
+        ListPendingRoomReleaseJids
+    );
+
+    registry_method!(
+        is_pending_room_release(room_jid: BareJid) -> bool,
+        "is_pending_room_release",
+        IsPendingRoomRelease { room_jid }
+    );
+
+    registry_method!(
+        cancel_pending_reclaimed_room_reservation(room_jid: BareJid) -> (),
+        "cancel_pending_reclaimed_room_reservation",
+        CancelPendingReclaimedRoomReservation { room_jid }
+    );
+
+    registry_method!(
         /// Get an existing room or create one if absent. The reply's
         /// [`RoomAcquisition::creation`] bit is authoritative for the
         /// XEP-0045 §10.1.1 creator Owner grant (#1134).
@@ -377,6 +423,57 @@ impl RoomRegistry {
         "room_count",
         RoomCount
     );
+
+    registry_method!(
+        /// Serialize proactive orphan-claim adoption against demand-side
+        /// room creation, hydrating durable rooms and releasing claims that
+        /// have no restorable state.
+        reconcile_reclaimed_room(
+            room_jid: BareJid,
+            claim_fence: super::RoomClaimFenceContext,
+            previous_owner: crate::ownership::NodeIdentity
+        ) -> ReclaimedRoomOutcome,
+        "reconcile_reclaimed_room",
+        ReconcileReclaimedRoom { room_jid, claim_fence, previous_owner }
+    );
+
+    registry_method!(
+        /// Return a bounded page of reclaimed epochs awaiting actor
+        /// installation or confirmed release. Each item is retried through
+        /// `reconcile_reclaimed_room` as its own mailbox message.
+        list_pending_reclaimed_rooms(limit: usize) -> Vec<PendingReclaimedRoom>,
+        "list_pending_reclaimed_rooms",
+        ListPendingReclaimedRooms { limit }
+    );
+
+    /// Enqueue a newly won epoch in the registry's idempotent retry set before
+    /// beginning fallible adoption work. This intentionally waits only for
+    /// mailbox acceptance, not a handler reply: an `ask` reply timeout is an
+    /// uncertain commit and must never trigger concurrent exact release.
+    pub async fn remember_pending_reclaimed_room(
+        &self,
+        room_jid: BareJid,
+        claim_fence: super::RoomClaimFenceContext,
+        previous_owner: crate::ownership::NodeIdentity,
+    ) -> Result<(), RoomRegistryError> {
+        self.inner
+            .tell(RememberPendingReclaimedRoom {
+                room_jid,
+                claim_fence,
+                previous_owner,
+            })
+            .mailbox_timeout(ROOM_REGISTRY_MAILBOX_TIMEOUT)
+            .await
+            .map_err(|error| {
+                metrics::record_actor_request_dropped(
+                    ACTOR_LABEL,
+                    "remember_pending_reclaimed_room",
+                    "tell",
+                    send_error_reason(&error),
+                );
+                RoomRegistryError::Unavailable
+            })
+    }
 
     /// Wire the real clustering-backed claim store/identity/durable store
     /// into this already-spawned registry (ADR-0017 Phase 3 Slice 7). See

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -39,12 +39,12 @@ use super::room_registry_actor::{
     CancelPendingReclaimedRoomReservation, CreateInstantRoom, CreateRoom, DestroyRoom,
     DestroyRoomIfInactive, DestroyRoomOutcome, DestroyRoomReason, GetOrCreateRoom,
     GetPendingReclaimedRoomBacklog, GetPendingRoomReleaseBacklog, GetRoom,
-    IsCurrentRoomPendingRelease, IsMucJid, IsPendingRoomReleaseOnly, ListPendingReclaimedRooms,
-    ListPendingRoomReleaseJids, ListRooms, PendingReclaimedRoom, PendingReclaimedRoomBacklog,
-    PendingRoomReleaseBacklog, ReapSealedRoom, ReclaimedRoomOutcome, ReconcileReclaimedRoom,
-    RememberPendingReclaimedRoom, ReservePendingReclaimedRoom, RetryPendingRoomReleases,
-    RoomAcquisition, RoomCount, RoomExists, RoomRegistryActor, RoomRegistryError,
-    WireClusteringClaims,
+    IsCurrentIdentityPendingRoomReleaseOnly, IsCurrentRoomPendingRelease, IsMucJid,
+    IsPendingRoomReleaseOnly, ListPendingReclaimedRooms, ListPendingRoomReleaseJids, ListRooms,
+    PendingReclaimedRoom, PendingReclaimedRoomBacklog, PendingRoomReleaseBacklog, ReapSealedRoom,
+    ReclaimedRoomOutcome, ReconcileReclaimedRoom, RememberPendingReclaimedRoom,
+    ReservePendingReclaimedRoom, RetryPendingRoomReleases, RoomAcquisition, RoomCount, RoomExists,
+    RoomRegistryActor, RoomRegistryError, WireClusteringClaims,
 };
 use super::RoomConfig;
 use crate::metrics;
@@ -324,6 +324,12 @@ impl RoomRegistry {
         is_pending_room_release_only(room_jid: BareJid) -> bool,
         "is_pending_room_release_only",
         IsPendingRoomReleaseOnly { room_jid }
+    );
+
+    registry_method!(
+        is_current_identity_pending_room_release_only(room_jid: BareJid) -> bool,
+        "is_current_identity_pending_room_release_only",
+        IsCurrentIdentityPendingRoomReleaseOnly { room_jid }
     );
 
     registry_method!(

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::muc::RoomClaimFenceContext;
 use crate::xep::xep0421::OccupantIdSecret;
 use std::time::Duration;
 
@@ -33,6 +34,29 @@ async fn idle_mailbox_depth_is_zero() {
     );
     // A freshly-spawned, idle registry has drained its mailbox: depth 0.
     assert_eq!(registry.mailbox_depth(), Some(0));
+}
+
+#[tokio::test]
+async fn reclaimed_room_reservations_are_bounded() {
+    let registry = test_registry();
+    for index in 0..crate::muc::room_registry_actor::MAX_PENDING_RECLAIMED_ROOMS {
+        assert!(registry
+            .reserve_pending_reclaimed_room(test_room_jid(&format!("pending-{index}")))
+            .await
+            .expect("reservation ask"));
+    }
+    assert!(!registry
+        .reserve_pending_reclaimed_room(test_room_jid("overflow"))
+        .await
+        .expect("overflow reservation ask"));
+    let backlog = registry
+        .pending_reclaimed_room_backlog()
+        .await
+        .expect("backlog");
+    assert_eq!(
+        backlog.depth,
+        crate::muc::room_registry_actor::MAX_PENDING_RECLAIMED_ROOMS
+    );
 }
 
 #[tokio::test]
@@ -71,6 +95,27 @@ async fn wedged_request_maps_to_typed_timeout_error() {
 
     let result = pending.await;
     assert_eq!(result, Err(RoomRegistryError::Timeout));
+
+    // Pending-reclaim registration is mailbox-acknowledged, not reply-
+    // acknowledged. Even though the actor remains wedged in the handler
+    // above, successful enqueue is definitive and cannot be mistaken for an
+    // uncertain commit followed by concurrent exact release.
+    let queued_room = test_room_jid("queued-reclaim");
+    let accepted = registry
+        .remember_pending_reclaimed_room(
+            queued_room.clone(),
+            RoomClaimFenceContext::new(
+                crate::ownership::Entity::new(
+                    crate::ownership::EntityType::RoomActor,
+                    queued_room.to_string(),
+                ),
+                crate::ownership::NodeIdentity::new("current", "incarnation"),
+                crate::ownership::ClaimEpoch(7),
+            ),
+            crate::ownership::NodeIdentity::new("dead", "incarnation"),
+        )
+        .await;
+    assert_eq!(accepted, Ok(()));
 }
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp/src/ownership/in_process.rs
+++ b/server/crates/waddle-xmpp/src/ownership/in_process.rs
@@ -184,27 +184,43 @@ impl ClaimStore for InProcessClaimStore {
     async fn fence(
         &self,
         entity: &Entity,
-        _me: &NodeIdentity,
+        me: &NodeIdentity,
         mine: ClaimEpoch,
     ) -> Result<bool, ClaimError> {
         let claims = self.lock()?;
-        Ok(claims.get(entity).map(|record| record.epoch) == Some(mine))
+        Ok(
+            matches!(claims.get(entity), Some(record) if record.owner == *me && record.epoch == mine),
+        )
     }
 
     async fn release(
         &self,
         entity: &Entity,
-        _me: &NodeIdentity,
+        me: &NodeIdentity,
         mine: ClaimEpoch,
     ) -> Result<(), ClaimError> {
         let mut claims = self.lock()?;
-        // Epoch-gated exactly like `PostgresClaimStore`'s CAS: a losing
-        // epoch is a no-op (the claim was re-issued since the caller
-        // observed `mine`), and releasing an absent claim is idempotent.
-        if claims.get(entity).map(|record| record.epoch) == Some(mine) {
+        if matches!(claims.get(entity), Some(record) if record.owner == *me && record.epoch == mine)
+        {
             claims.remove(entity);
         }
         Ok(())
+    }
+
+    async fn release_exact(
+        &self,
+        entity: &Entity,
+        me: &NodeIdentity,
+        mine: ClaimEpoch,
+    ) -> Result<crate::ownership::ExactReleaseOutcome, ClaimError> {
+        let mut claims = self.lock()?;
+        if matches!(claims.get(entity), Some(record) if record.owner == *me && record.epoch == mine)
+        {
+            claims.remove(entity);
+            Ok(crate::ownership::ExactReleaseOutcome::Released)
+        } else {
+            Ok(crate::ownership::ExactReleaseOutcome::NotOwned)
+        }
     }
 
     async fn release_many(
@@ -264,11 +280,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn release_is_epoch_gated_and_idempotent() {
-        // Mirrors `PostgresClaimStore`'s `release_is_epoch_gated_and_idempotent`
-        // (`waddle-server/src/clustering/claims.rs`): a losing epoch is a
-        // no-op — the claim survives — and releasing an absent claim is
-        // not an error.
+    async fn release_is_idempotent_and_exact_release_reports_ownership() {
         let store = InProcessClaimStore::new();
         let e = entity("stream-1");
         let epoch0 = store.acquire(&e, &me()).await.expect("acquire");
@@ -281,7 +293,7 @@ mod tests {
         store
             .release(&e, &me(), epoch0)
             .await
-            .expect("stale release is a no-op, not an error");
+            .expect("stale release is an idempotent no-op");
         let err = store
             .acquire(&e, &me())
             .await
@@ -298,6 +310,39 @@ mod tests {
             .acquire(&e, &me())
             .await
             .expect("entity claimable again after a current-epoch release");
+
+        assert_eq!(
+            store
+                .release_exact(&e, &me(), ClaimEpoch(99))
+                .await
+                .expect("exact release"),
+            crate::ownership::ExactReleaseOutcome::NotOwned
+        );
+    }
+
+    #[tokio::test]
+    async fn same_node_id_from_another_incarnation_cannot_fence_or_release() {
+        let store = InProcessClaimStore::new();
+        let entity = entity("incarnation-fence");
+        let owner = NodeIdentity::new("same-node", "epoch-a");
+        let replacement = NodeIdentity::new("same-node", "epoch-b");
+        let claim_epoch = store.acquire(&entity, &owner).await.expect("acquire");
+
+        assert!(!store
+            .fence(&entity, &replacement, claim_epoch)
+            .await
+            .expect("fence"));
+        assert_eq!(
+            store
+                .release_exact(&entity, &replacement, claim_epoch)
+                .await
+                .expect("exact release"),
+            crate::ownership::ExactReleaseOutcome::NotOwned
+        );
+        assert!(store
+            .fence(&entity, &owner, claim_epoch)
+            .await
+            .expect("original owner remains"));
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/ownership/mod.rs
+++ b/server/crates/waddle-xmpp/src/ownership/mod.rs
@@ -203,7 +203,7 @@ pub struct ClaimSnapshot {
 /// write. `Serialize`/`Deserialize` (ADR-0017 Phase 3 Slice 7) so this type
 /// can travel wire-typed on the MUC Demote relay ask.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
 pub struct ClaimEpoch(pub i64);
 
@@ -335,7 +335,7 @@ pub enum ClaimError {
     #[error("entity already claimed by another node")]
     AlreadyClaimed,
 
-    /// A `steal_stale` / `steal_for_resume` / `release` CAS affected zero
+    /// A `steal_stale` / `steal_for_resume` CAS affected zero
     /// rows: the observed epoch was stale, the staleness predicate was not
     /// satisfied (the owner is not actually stale), or the claim no longer
     /// exists.
@@ -373,6 +373,13 @@ pub enum ClaimError {
     /// refused.
     #[error("this node is draining and refuses to acquire a new claim")]
     Draining,
+}
+
+/// Result of an ownership- and epoch-exact release attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExactReleaseOutcome {
+    Released,
+    NotOwned,
 }
 
 /// Entity ownership claims: which node currently owns a given `UserActor`/
@@ -495,14 +502,29 @@ pub trait ClaimStore: Send + Sync {
         mine: ClaimEpoch,
     ) -> Result<bool, ClaimError>;
 
-    /// Release a held claim (epoch-gated, best-effort: releasing a claim
-    /// already stolen out from under `me` is a no-op, not an error).
+    /// Best-effort, idempotent release of a held claim. A missing, stolen,
+    /// foreign-incarnation, or stale-epoch row is already terminal cleanup
+    /// and therefore succeeds.
     async fn release(
         &self,
         entity: &Entity,
         me: &NodeIdentity,
         mine: ClaimEpoch,
     ) -> Result<(), ClaimError>;
+
+    /// Release only the exact owner incarnation and epoch, reporting whether
+    /// a row was actually deleted. Recovery workflows use this when a zero-row
+    /// no-op must not be mistaken for confirmed ownership cleanup.
+    async fn release_exact(
+        &self,
+        _entity: &Entity,
+        _me: &NodeIdentity,
+        _mine: ClaimEpoch,
+    ) -> Result<ExactReleaseOutcome, ClaimError> {
+        Err(ClaimError::Backend(
+            "exact release outcome is not implemented by this claim store".to_string(),
+        ))
+    }
 
     /// Batched release for graceful drain (~18k modeled claims, ADR-0017
     /// Phase 3 Slice 10) — one round-trip, not one-at-a-time. Releases every

--- a/server/crates/waddle-xmpp/src/ownership/mod.rs
+++ b/server/crates/waddle-xmpp/src/ownership/mod.rs
@@ -88,13 +88,15 @@ impl EntityType {
 
 /// Wire length bound on [`Entity::id`] (ADR-0017 Phase 3 Slice 7 FIX 9,
 /// council-adjudicated). Mirrors
-/// [`crate::pending_delivery::SM_SESSION_ID_MAX_LEN`]'s exact rationale one
+/// [`crate::pending_delivery::SM_SESSION_ID_MAX_LEN`]'s defensive rationale one
 /// type over: `Entity` now travels wire-typed on the MUC Demote relay ask
 /// (deviation 60), which is NOT a stanza and so never passes through the
 /// bounded XML stanza codec — without a field-level bound of its own, a
 /// malicious (or buggy) allowlisted peer could ship a multi-MB `id`.
-/// Production ids are bare JIDs or room JIDs, far under this cap.
-pub const ENTITY_ID_MAX_LEN: usize = 128;
+/// RFC 7622 section 3.1 permits 1023 octets in each bare-JID part, plus
+/// the `@` separator, so the bound must admit every valid 2047-octet bare
+/// JID used for `UserActor` and `RoomActor` ownership.
+pub const ENTITY_ID_MAX_LEN: usize = 2047;
 
 /// [`Entity::id`] exceeded [`ENTITY_ID_MAX_LEN`] at deserialization.
 #[derive(Debug, Clone, thiserror::Error)]
@@ -109,11 +111,10 @@ pub struct EntityIdTooLong {
 /// `Serialize`/`Deserialize` (ADR-0017 Phase 3 Slice 7) so this type can
 /// travel wire-typed on the MUC Demote relay ask. `Deserialize` is
 /// hand-written (below), not derived, so it can enforce [`ENTITY_ID_MAX_LEN`]
-/// on the `id` field — mirroring [`crate::pending_delivery::SmSessionId`]'s
-/// identical hand-written bound exactly, one type over (FIX 9). [`Self::new`]
-/// itself stays unvalidated, for the same reason `SmSessionId::new` does: every
-/// production caller mints ids far under the cap, and the wire boundary is
-/// where an untrusted length actually arrives.
+/// on the `id` field — applying [`crate::pending_delivery::SmSessionId`]'s
+/// same boundary defense one type over (FIX 9). [`Self::new`]
+/// itself stays unvalidated, for the same reason `SmSessionId::new` does: the
+/// wire boundary is where an untrusted length actually arrives.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]
 pub struct Entity {
     pub entity_type: EntityType,

--- a/server/crates/waddle-xmpp/src/registry/connection_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry.rs
@@ -91,6 +91,31 @@ impl ConnectionRegistry {
         }
     }
 
+    /// Publish an SM stream id only while `owner` still owns the full-JID
+    /// slot. The connection entry guard serializes the ownership check,
+    /// entry update, and reverse-index update against same-JID replacement.
+    pub fn set_sm_stream_id_if_owner(
+        &self,
+        jid: &FullJid,
+        owner: &Arc<AtomicBool>,
+        stream_id: Option<crate::pending_delivery::SmSessionId>,
+    ) -> bool {
+        let Some(entry) = self.connections.get(jid) else {
+            return false;
+        };
+        if !Arc::ptr_eq(&entry.carbons_enabled, owner) {
+            return false;
+        }
+        if let Some(previous) = entry.sm_stream_id() {
+            self.sm_stream_owners.remove(&previous);
+        }
+        entry.set_sm_stream_id(stream_id.clone());
+        if let Some(stream_id) = stream_id {
+            self.sm_stream_owners.insert(stream_id, jid.clone());
+        }
+        true
+    }
+
     /// Look up which full JID currently publishes `stream_id`, if any
     /// (ADR-0017 Phase 3 Slice 6). **Best-effort**: this index is not
     /// proactively swept on every teardown path, so callers MUST re-verify

--- a/server/crates/waddle-xmpp/src/stream_management/mod.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/mod.rs
@@ -37,8 +37,8 @@ pub use replay::{stamp_replay_delay, ReplayStanza};
 pub use session_registry::{
     CrossNodeResumeOutcome, CrossNodeResumeStage, DetachedPresenceState, DetachedSession,
     DetachedUnackedStanza, InMemorySmSessionRegistry, RecentTombstoneRecord,
-    RemoteResumeAskOutcome, RemoteResumeAsker, SmClaimCompletion, SmRegistryError,
-    SmSessionRegistry, StealTicket, DEFAULT_MAX_SESSIONS,
+    ReclaimedHydrationOutcome, RemoteResumeAskOutcome, RemoteResumeAsker, SmClaimCompletion,
+    SmRegistryError, SmSessionRegistry, StealTicket, DEFAULT_MAX_SESSIONS,
 };
 pub use stanzas::{SmAck, SmEnable, SmEnabled, SmFailed, SmRequest, SmResume, SmResumed, SmStanza};
 pub use state::{DetachedSessionSnapshot, StreamManagementState};

--- a/server/crates/waddle-xmpp/src/stream_management/persistence.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/persistence.rs
@@ -34,15 +34,51 @@ use jid::FullJid;
 use thiserror::Error;
 use xmpp_parsers::presence::Show;
 
-use crate::ownership::Entity;
+use crate::ownership::{ClaimEpoch, Entity, NodeIdentity};
 use crate::pending_delivery::SmSessionId;
 use crate::Stanza;
+
+/// Immutable ownership context authorizing one clustered SM persistence write.
+///
+/// The claim epoch is meaningful only together with the exact process
+/// incarnation that obtained it. Keeping both values in one typed payload
+/// prevents a cached pre-self-fence epoch from being paired with a newer
+/// [`NodeIdentity`] after claim-epoch ABA.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SmClaimFence {
+    owner: NodeIdentity,
+    epoch: ClaimEpoch,
+}
+
+impl SmClaimFence {
+    pub fn new(owner: NodeIdentity, epoch: ClaimEpoch) -> Self {
+        Self { owner, epoch }
+    }
+
+    pub fn owner(&self) -> &NodeIdentity {
+        &self.owner
+    }
+
+    pub fn epoch(&self) -> ClaimEpoch {
+        self.epoch
+    }
+}
 
 /// Errors returned by [`SmPersistenceStorage`] implementations.
 #[derive(Debug, Error)]
 pub enum SmPersistenceError {
     #[error("SM persistence error: {0}")]
     Other(String),
+
+    /// A row for an exact typed stream id exists but cannot be decoded into
+    /// the typed persistence model. Recovery may quarantine that stream's
+    /// durable session and unacked queue; ordinary backend errors must never
+    /// take that destructive path.
+    #[error("corrupt SM persistence for '{stream_id}': {detail}")]
+    Corrupt {
+        stream_id: SmSessionId,
+        detail: String,
+    },
 
     /// A fenced write's own fencing check (ADR-0017 Phase 3 Slice 4,
     /// element 4) observed that this node no longer holds — or never
@@ -183,6 +219,18 @@ pub trait SmPersistenceStorage: Send + Sync {
     /// longer detached) and on session timeout.
     async fn delete_session(&self, stream_id: &SmSessionId) -> Result<(), SmPersistenceError>;
 
+    /// Delete an undecodable session and its unacked queue as one durable
+    /// quarantine operation. Clustered implementations bind the immutable
+    /// owner/epoch context into the same transaction; portable implementations
+    /// deliberately reuse their already-atomic `delete_session` path.
+    async fn quarantine_session(
+        &self,
+        stream_id: &SmSessionId,
+        _expected_fence: &SmClaimFence,
+    ) -> Result<(), SmPersistenceError> {
+        self.delete_session(stream_id).await
+    }
+
     /// Append an outbound stanza to the unacked queue for the named
     /// session.
     async fn append_unacked(
@@ -318,7 +366,7 @@ pub trait SmPersistenceStorage: Send + Sync {
         Ok(0)
     }
 
-    /// Evict any per-`stream_id` claim-epoch cache entry this implementation
+    /// Evict any per-`stream_id` claim-fence cache entry this implementation
     /// keeps as a fencing side channel (ADR-0017 Phase 3 Slice 4's "Epoch
     /// side channel" design note; Slice 5 debt (a)).
     ///
@@ -327,7 +375,7 @@ pub trait SmPersistenceStorage: Send + Sync {
     /// `release_claim`/`complete_claim`/`complete_claim_if_resumable`'s
     /// terminal branches, and `invalidate_sessions_for_jid`'s removal of a
     /// claimed session — so a cache keyed by stream_id never outlives the
-    /// claim it caches the epoch for. Default no-op: the portable
+    /// claim it caches the owner/epoch pair for. Default no-op: the portable
     /// (single-node, in-memory) implementation has no such cache (its
     /// `ClaimStore` is always `InProcessClaimStore`, which is cheap to call
     /// directly on every write); only the Postgres-fenced implementation
@@ -335,8 +383,8 @@ pub trait SmPersistenceStorage: Send + Sync {
     /// actually remove the cached cell, so a subsequent fenced write for the
     /// same stream_id after a fresh claim always re-derives its epoch rather
     /// than reusing one issued under a claim this node no longer holds.
-    fn evict_claim_cache(&self, stream_id: &SmSessionId) {
-        let _ = stream_id;
+    fn evict_claim_cache(&self, stream_id: &SmSessionId, expected_fence: &SmClaimFence) {
+        let _ = (stream_id, expected_fence);
     }
 }
 

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry.rs
@@ -18,7 +18,7 @@ mod tombstones;
 mod trait_impl;
 mod traits;
 
-pub use core::InMemorySmSessionRegistry;
+pub use core::{InMemorySmSessionRegistry, ReclaimedHydrationOutcome};
 pub use cross_node_resume::{
     CrossNodeResumeOutcome, CrossNodeResumeStage, RemoteResumeAskOutcome, RemoteResumeAsker,
     StealTicket,

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -13,6 +13,9 @@ fn sm_session_entity(stream_id: &str) -> Entity {
 }
 
 impl InMemorySmSessionRegistry {
+    pub async fn abandon_enabled_claim(&self, stream_id: &str) {
+        self.release_claim_store_entry(stream_id).await;
+    }
     /// Remove every expired session and return the detached state in full.
     ///
     /// Callers (notably the server-side janitor) need the JID and stream id
@@ -77,7 +80,83 @@ impl InMemorySmSessionRegistry {
         let claimed = self.claimed_sessions.read().ok()?;
         let mut out: Vec<String> = sessions.keys().cloned().collect();
         out.extend(claimed.keys().cloned());
+        let pending = self.pending_claim_releases.read().ok()?;
+        out.extend(pending.iter().map(|(stream_id, _)| stream_id.clone()));
+        out.sort();
+        out.dedup();
         Some(out)
+    }
+
+    /// Retry exact terminal releases retained after a backend error/timeout.
+    /// Entries still represented by a live/detached session are excluded:
+    /// those claims remain intentionally held.
+    pub async fn retry_pending_claim_releases(&self, limit: usize) -> usize {
+        let uncertain = self
+            .pending_claim_acquisitions
+            .read()
+            .map(|pending| pending.iter().take(limit).cloned().collect::<Vec<_>>())
+            .unwrap_or_default();
+        for (stream_id, identity) in uncertain {
+            self.reconcile_uncertain_claim_acquisition(&stream_id, identity)
+                .await;
+        }
+        let pending = {
+            let Ok(pending) = self.pending_claim_releases.read() else {
+                return 0;
+            };
+            pending
+                .iter()
+                .take(limit)
+                .map(|(stream_id, fence)| (stream_id.clone(), fence.clone()))
+                .collect::<Vec<_>>()
+        };
+        let attempted = pending.len();
+        for (stream_id, fence) in pending {
+            self.release_claim_store_entry_under(&stream_id, fence)
+                .await;
+        }
+        attempted
+    }
+
+    async fn reconcile_uncertain_claim_acquisition(
+        &self,
+        stream_id: &str,
+        identity: crate::ownership::NodeIdentity,
+    ) {
+        let entity = sm_session_entity(stream_id);
+        match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            self.claim_store.ensure_claimed(&entity, &identity),
+        )
+        .await
+        {
+            Ok(Ok(epoch)) => {
+                if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
+                    pending.remove(&(stream_id.to_string(), identity.clone()));
+                }
+                let fence = super::super::persistence::SmClaimFence::new(identity, epoch);
+                if self.try_record_claim_fence(stream_id, fence.clone()) {
+                    self.release_claim_store_entry_under(stream_id, fence).await;
+                }
+            }
+            Ok(Err(ClaimError::AlreadyClaimed | ClaimError::Conflict)) => {
+                if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
+                    pending.remove(&(stream_id.to_string(), identity));
+                }
+                self.cancel_claim_fence_reservation(stream_id);
+            }
+            Ok(Err(_)) | Err(_) => {
+                if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
+                    pending.insert((stream_id.to_string(), identity));
+                }
+            }
+        }
+    }
+
+    pub fn pending_claim_release_count(&self) -> usize {
+        self.pending_claim_releases
+            .read()
+            .map_or(0, |pending| pending.len())
     }
 
     /// Purely local, best-effort forgetting of `stream_id`'s claim
@@ -102,12 +181,21 @@ impl InMemorySmSessionRegistry {
         if let Ok(mut claimed) = self.claimed_sessions.write() {
             claimed.remove(stream_id);
         }
-        if let Ok(mut epochs) = self.claim_epochs.write() {
-            epochs.remove(stream_id);
+        let fence = self
+            .claim_fences
+            .write()
+            .ok()
+            .and_then(|mut fences| fences.remove(stream_id));
+        if let Some(fence) = fence.as_ref() {
+            if let Ok(mut pending) = self.pending_claim_releases.write() {
+                pending.remove(&(stream_id.to_string(), fence.clone()));
+            }
         }
         if let Some(storage) = &self.persistence {
-            let session_id = crate::pending_delivery::SmSessionId::new(stream_id.to_string());
-            storage.evict_claim_cache(&session_id);
+            if let Some(fence) = fence {
+                let session_id = crate::pending_delivery::SmSessionId::new(stream_id.to_string());
+                storage.evict_claim_cache(&session_id, &fence);
+            }
         }
     }
 
@@ -345,28 +433,63 @@ impl InMemorySmSessionRegistry {
     /// them precisely because both go through the same idempotent-for-self
     /// primitive.
     ///
-    /// Best-effort by design, exactly like
-    /// [`Self::acquire_claim_store_entry_for_detach`]: `stream_id` is a
-    /// freshly minted UUID (element 8), so a genuine collision with
-    /// another node's claim is not expected in practice, and a failure
-    /// here must not fail the `<enable/>` handshake itself — the session
-    /// simply proceeds without a durable claim record until the detach
-    /// -time call retries. Logged at `warn` so a persistently failing
-    /// `ClaimStore` backend stays visible. Called with no stream-shard
-    /// lock held: `stream_id` is freshly minted and cannot yet appear in
-    /// `sessions`/`claimed_sessions`, so there is nothing else to
-    /// coordinate with under that lock.
-    pub async fn ensure_session_claim(&self, stream_id: &str) {
+    /// This admission is authoritative: the caller must not enable SM unless
+    /// it returns `true`. Proceeding after a timeout/error would create an
+    /// enabled session that cross-node resume cannot discover and would also
+    /// leave the socket blocked indefinitely when the backend hangs. Called
+    /// with no stream-shard lock held: `stream_id` is freshly minted and
+    /// cannot yet appear in `sessions`/`claimed_sessions`, so there is nothing
+    /// else to coordinate with under that lock.
+    pub async fn ensure_session_claim(&self, stream_id: &str) -> bool {
+        if !self.reserve_claim_fence_capacity(stream_id) {
+            tracing::warn!(stream_id = %stream_id, "handle_sm_enable: exact-release backlog capacity exhausted");
+            return false;
+        }
         let entity = sm_session_entity(stream_id);
         let identity = self.node_identity.current();
-        if let Err(error) = self.claim_store.ensure_claimed(&entity, &identity).await {
-            tracing::warn!(
-                stream_id = %stream_id,
-                %error,
-                "handle_sm_enable: ClaimStore ensure_claimed failed for a freshly enabled \
-                 session; proceeding without a durable claim record until the detach-time \
-                 retry (best-effort, see this method's doc comment)"
-            );
+        match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            self.claim_store.ensure_claimed(&entity, &identity),
+        )
+        .await
+        {
+            Ok(Ok(epoch)) if self.node_identity.current() == identity => {
+                let fence = super::super::persistence::SmClaimFence::new(identity.clone(), epoch);
+                if !self.try_record_claim_fence(stream_id, fence) {
+                    let _ = tokio::time::timeout(
+                        CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+                        self.claim_store.release_exact(&entity, &identity, epoch),
+                    )
+                    .await;
+                    return false;
+                }
+                true
+            }
+            Ok(Ok(epoch)) => {
+                let fence = super::super::persistence::SmClaimFence::new(identity, epoch);
+                if self.try_record_claim_fence(stream_id, fence.clone()) {
+                    self.release_claim_store_entry_under(stream_id, fence).await;
+                }
+                false
+            }
+            Ok(Err(error)) => {
+                self.cancel_claim_fence_reservation(stream_id);
+                tracing::warn!(
+                    stream_id = %stream_id,
+                    %error,
+                    "handle_sm_enable: ClaimStore ensure_claimed failed; rejecting SM enable"
+                );
+                false
+            }
+            Err(_) => {
+                tracing::warn!(stream_id = %stream_id, "handle_sm_enable: ClaimStore ensure_claimed timed out");
+                if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
+                    pending.insert((stream_id.to_string(), identity.clone()));
+                }
+                self.reconcile_uncertain_claim_acquisition(stream_id, identity)
+                    .await;
+                false
+            }
         }
     }
 
@@ -463,6 +586,15 @@ impl InMemorySmSessionRegistry {
             }
         };
 
+        if self.node_identity.current() != identity {
+            self.release_claim_store_entry_under(
+                stream_id,
+                super::super::persistence::SmClaimFence::new(identity, epoch),
+            )
+            .await;
+            return Ok(None);
+        }
+
         // The store granted the claim: perform the matching in-memory move.
         // `stream_id` is guaranteed still present and unexpired here — this
         // stream's `tokio::sync::Mutex` guard has been held continuously
@@ -479,7 +611,11 @@ impl InMemorySmSessionRegistry {
             sessions.remove(stream_id)
         };
         let Some(session) = removed else {
-            self.release_claim_store_entry_under(stream_id, epoch).await;
+            self.release_claim_store_entry_under(
+                stream_id,
+                super::super::persistence::SmClaimFence::new(identity.clone(), epoch),
+            )
+            .await;
             return Ok(None);
         };
         {
@@ -489,8 +625,16 @@ impl InMemorySmSessionRegistry {
                 .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
             claimed.insert(stream_id.to_string(), session.clone());
         }
-        if let Ok(mut epochs) = self.claim_epochs.write() {
-            epochs.insert(stream_id.to_string(), epoch);
+        let fence = super::super::persistence::SmClaimFence::new(identity, epoch);
+        if !self.try_record_claim_fence(stream_id, fence.clone()) {
+            if let Ok(mut claimed) = self.claimed_sessions.write() {
+                claimed.remove(stream_id);
+            }
+            if let Ok(mut sessions) = self.sessions.write() {
+                sessions.insert(stream_id.to_string(), session);
+            }
+            self.release_claim_store_entry_under(stream_id, fence).await;
+            return Ok(None);
         }
         Ok(Some(session))
     }
@@ -560,6 +704,11 @@ impl InMemorySmSessionRegistry {
     /// `warn` so a persistently failing acquire (e.g. a genuinely wedged
     /// `ClaimStore` backend) is visible.
     pub(super) async fn acquire_claim_store_entry_for_detach(&self, stream_id: &str) {
+        if !self.reserve_claim_fence_capacity(stream_id) {
+            tracing::warn!(stream_id = %stream_id, "store_session: exact-release backlog capacity exhausted");
+            return;
+        }
+        let acquisition_reserved = self.has_claim_fence_reservation(stream_id);
         let entity = sm_session_entity(stream_id);
         let identity = self.node_identity.current();
         // FIX 5: bounded — this call runs under `stream_id`'s shard lock
@@ -578,11 +727,20 @@ impl InMemorySmSessionRegistry {
         .await
         {
             Ok(Ok(epoch)) => {
-                if let Ok(mut epochs) = self.claim_epochs.write() {
-                    epochs.insert(stream_id.to_string(), epoch);
+                if self.node_identity.current() != identity {
+                    let fence = super::super::persistence::SmClaimFence::new(identity, epoch);
+                    if self.try_record_claim_fence(stream_id, fence.clone()) {
+                        self.release_claim_store_entry_under(stream_id, fence).await;
+                    }
+                    return;
+                }
+                let fence = super::super::persistence::SmClaimFence::new(identity.clone(), epoch);
+                if !self.try_record_claim_fence(stream_id, fence.clone()) {
+                    self.release_claim_store_entry_under(stream_id, fence).await;
                 }
             }
             Ok(Err(error)) => {
+                self.cancel_claim_fence_reservation(stream_id);
                 tracing::warn!(
                     stream_id = %stream_id,
                     %error,
@@ -599,6 +757,13 @@ impl InMemorySmSessionRegistry {
                      stream's shard lock (FIX 5); proceeding without a durable claim record \
                      (best-effort — see this function's doc comment)"
                 );
+                if acquisition_reserved {
+                    if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
+                        pending.insert((stream_id.to_string(), identity.clone()));
+                    }
+                    self.reconcile_uncertain_claim_acquisition(stream_id, identity)
+                        .await;
+                }
             }
         }
     }
@@ -611,38 +776,75 @@ impl InMemorySmSessionRegistry {
     /// release its claim, and two of those paths live in `trait_impl`
     /// (`store_session`'s jid-collision eviction, `take_session`).
     pub(super) async fn release_claim_store_entry(&self, stream_id: &str) {
-        let epoch = self
-            .claim_epochs
-            .write()
+        let fence = self
+            .claim_fences
+            .read()
             .ok()
-            .and_then(|mut epochs| epochs.remove(stream_id))
-            .unwrap_or(crate::ownership::ClaimEpoch(0));
-        self.release_claim_store_entry_under(stream_id, epoch).await;
+            .and_then(|fences| fences.get(stream_id).cloned());
+        if let Some(fence) = fence {
+            self.release_claim_store_entry_under(stream_id, fence).await;
+        } else {
+            debug!(
+                stream_id = %stream_id,
+                "ClaimStore release skipped because no immutable owner+epoch fence was recorded"
+            );
+        }
     }
 
     /// Release `stream_id`'s `ClaimStore` entry under an explicitly-known
     /// epoch (the caller already holds it, so there is nothing to look up
-    /// in `claim_epochs`). Best-effort: a `ClaimStore::release` failure is
+    /// in `claim_fences`). Best-effort: a `ClaimStore::release` failure is
     /// logged, never propagated — `release`'s own contract treats a losing
     /// epoch as a no-op, and this is the same "claim already gone" case.
     /// `pub(super)`: `core.rs::restore_from_persistence` (ADR-0017 Phase 3
     /// Slice 5) also releases an already-known epoch directly (a
     /// just-claimed, never-hydrated poison-pill row), without going through
-    /// `claim_epochs` first.
+    /// `claim_fences` first.
     pub(super) async fn release_claim_store_entry_under(
         &self,
         stream_id: &str,
-        epoch: crate::ownership::ClaimEpoch,
+        fence: super::super::persistence::SmClaimFence,
     ) {
         let entity = sm_session_entity(stream_id);
-        let identity = self.node_identity.current();
-        if let Err(error) = self.claim_store.release(&entity, &identity, epoch).await {
-            debug!(
-                stream_id = %stream_id,
-                error = %error,
-                "ClaimStore release failed (best-effort: release's own contract treats \
-                 a losing epoch as a no-op, not an error)"
-            );
+        match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            self.claim_store
+                .release(&entity, fence.owner(), fence.epoch()),
+        )
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => {
+                debug!(
+                    stream_id = %stream_id,
+                    error = %error,
+                    "ClaimStore release failed; retaining the exact owner+epoch fence for retry"
+                );
+                if let Ok(mut pending) = self.pending_claim_releases.write() {
+                    pending.insert((stream_id.to_string(), fence));
+                }
+                return;
+            }
+            Err(_) => {
+                tracing::warn!(
+                    stream_id = %stream_id,
+                    timeout = ?CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+                    "ClaimStore release timed out while holding a stream shard lock; retaining \
+                     the exact owner+epoch fence for retry"
+                );
+                if let Ok(mut pending) = self.pending_claim_releases.write() {
+                    pending.insert((stream_id.to_string(), fence));
+                }
+                return;
+            }
+        }
+        if let Ok(mut fences) = self.claim_fences.write() {
+            if fences.get(stream_id) == Some(&fence) {
+                fences.remove(stream_id);
+            }
+        }
+        if let Ok(mut pending) = self.pending_claim_releases.write() {
+            pending.remove(&(stream_id.to_string(), fence.clone()));
         }
         // ADR-0017 Phase 3 Slice 5 debt (a): every claim-ending path evicts
         // the fenced persistence's per-stream epoch cache (a no-op for the
@@ -650,7 +852,7 @@ impl InMemorySmSessionRegistry {
         // `SmPersistenceStorage::evict_claim_cache`'s doc comment).
         if let Some(storage) = &self.persistence {
             let session_id = crate::pending_delivery::SmSessionId::new(stream_id.to_string());
-            storage.evict_claim_cache(&session_id);
+            storage.evict_claim_cache(&session_id, &fence);
         }
     }
 

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -80,6 +80,18 @@ impl InMemorySmSessionRegistry {
         let claimed = self.claimed_sessions.read().ok()?;
         let mut out: Vec<String> = sessions.keys().cloned().collect();
         out.extend(claimed.keys().cloned());
+        out.sort();
+        out.dedup();
+        Some(out)
+    }
+
+    /// Snapshot every SM claim this process must still account for during
+    /// ownership reconciliation. Unlike [`Self::live_session_ids`], this
+    /// includes terminal exact-release responsibilities: they are not
+    /// resumable sessions, but their release may not have committed yet and
+    /// the local node must not forget that possible ownership.
+    pub fn locally_owned_claim_ids(&self) -> Option<Vec<String>> {
+        let mut out = self.live_session_ids()?;
         let pending = self.pending_claim_releases.read().ok()?;
         out.extend(pending.iter().map(|(stream_id, _)| stream_id.clone()));
         out.sort();

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -3,7 +3,10 @@ use tracing::debug;
 
 use crate::ownership::{ClaimError, Entity, EntityType};
 
-use super::core::{InMemorySmSessionRegistry, CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT};
+use super::core::{
+    InMemorySmSessionRegistry, PendingClaimAcquisitionDisposition,
+    CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+};
 use super::{DetachedSession, SmClaimCompletion, SmRegistryError};
 
 /// The `ClaimStore` entity naming an SM session's ownership claim (element
@@ -108,8 +111,8 @@ impl InMemorySmSessionRegistry {
             .read()
             .map(|pending| pending.iter().take(limit).cloned().collect::<Vec<_>>())
             .unwrap_or_default();
-        for (stream_id, identity) in uncertain {
-            self.reconcile_uncertain_claim_acquisition(&stream_id, identity)
+        for (stream_id, identity, disposition) in uncertain {
+            self.reconcile_uncertain_claim_acquisition(&stream_id, identity, disposition)
                 .await;
         }
         let pending = {
@@ -134,6 +137,7 @@ impl InMemorySmSessionRegistry {
         &self,
         stream_id: &str,
         identity: crate::ownership::NodeIdentity,
+        disposition: PendingClaimAcquisitionDisposition,
     ) {
         let entity = sm_session_entity(stream_id);
         match tokio::time::timeout(
@@ -143,24 +147,47 @@ impl InMemorySmSessionRegistry {
         .await
         {
             Ok(Ok(epoch)) => {
-                if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
-                    pending.remove(&(stream_id.to_string(), identity.clone()));
-                }
-                let fence = super::super::persistence::SmClaimFence::new(identity, epoch);
-                if !self.try_record_claim_fence(stream_id, fence.clone()) {
+                let pending_key = (stream_id.to_string(), identity.clone(), disposition);
+                let fence = super::super::persistence::SmClaimFence::new(identity.clone(), epoch);
+                let recorded = self.try_record_claim_fence(stream_id, fence.clone());
+                if !recorded {
                     self.cancel_claim_fence_reservation(stream_id);
                 }
-                self.release_claim_store_entry_under(stream_id, fence).await;
+                match disposition {
+                    PendingClaimAcquisitionDisposition::ReleaseRejectedEnable => {
+                        if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
+                            pending.remove(&pending_key);
+                        }
+                        self.release_claim_store_entry_under(stream_id, fence).await;
+                    }
+                    PendingClaimAcquisitionDisposition::RetainDetachedSession
+                        if recorded && self.node_identity.current() == identity =>
+                    {
+                        if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
+                            pending.remove(&pending_key);
+                        }
+                    }
+                    PendingClaimAcquisitionDisposition::RetainDetachedSession => {
+                        if self.node_identity.current() != identity {
+                            if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
+                                pending.remove(&pending_key);
+                            }
+                            self.release_claim_store_entry_under(stream_id, fence).await;
+                        } else if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
+                            pending.insert(pending_key);
+                        }
+                    }
+                }
             }
             Ok(Err(ClaimError::AlreadyClaimed | ClaimError::Conflict)) => {
                 if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
-                    pending.remove(&(stream_id.to_string(), identity));
+                    pending.remove(&(stream_id.to_string(), identity, disposition));
                 }
                 self.cancel_claim_fence_reservation(stream_id);
             }
             Ok(Err(_)) | Err(_) => {
                 if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
-                    pending.insert((stream_id.to_string(), identity));
+                    pending.insert((stream_id.to_string(), identity, disposition));
                 }
             }
         }
@@ -495,10 +522,18 @@ impl InMemorySmSessionRegistry {
             Err(_) => {
                 tracing::warn!(stream_id = %stream_id, "handle_sm_enable: ClaimStore ensure_claimed timed out");
                 if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
-                    pending.insert((stream_id.to_string(), identity.clone()));
+                    pending.insert((
+                        stream_id.to_string(),
+                        identity.clone(),
+                        PendingClaimAcquisitionDisposition::ReleaseRejectedEnable,
+                    ));
                 }
-                self.reconcile_uncertain_claim_acquisition(stream_id, identity)
-                    .await;
+                self.reconcile_uncertain_claim_acquisition(
+                    stream_id,
+                    identity,
+                    PendingClaimAcquisitionDisposition::ReleaseRejectedEnable,
+                )
+                .await;
                 false
             }
         }
@@ -772,10 +807,18 @@ impl InMemorySmSessionRegistry {
                 );
                 if acquisition_reserved {
                     if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
-                        pending.insert((stream_id.to_string(), identity.clone()));
+                        pending.insert((
+                            stream_id.to_string(),
+                            identity.clone(),
+                            PendingClaimAcquisitionDisposition::RetainDetachedSession,
+                        ));
                     }
-                    self.reconcile_uncertain_claim_acquisition(stream_id, identity)
-                        .await;
+                    self.reconcile_uncertain_claim_acquisition(
+                        stream_id,
+                        identity,
+                        PendingClaimAcquisitionDisposition::RetainDetachedSession,
+                    )
+                    .await;
                 }
             }
         }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -135,9 +135,10 @@ impl InMemorySmSessionRegistry {
                     pending.remove(&(stream_id.to_string(), identity.clone()));
                 }
                 let fence = super::super::persistence::SmClaimFence::new(identity, epoch);
-                if self.try_record_claim_fence(stream_id, fence.clone()) {
-                    self.release_claim_store_entry_under(stream_id, fence).await;
+                if !self.try_record_claim_fence(stream_id, fence.clone()) {
+                    self.cancel_claim_fence_reservation(stream_id);
                 }
+                self.release_claim_store_entry_under(stream_id, fence).await;
             }
             Ok(Err(ClaimError::AlreadyClaimed | ClaimError::Conflict)) => {
                 if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
@@ -455,21 +456,19 @@ impl InMemorySmSessionRegistry {
         {
             Ok(Ok(epoch)) if self.node_identity.current() == identity => {
                 let fence = super::super::persistence::SmClaimFence::new(identity.clone(), epoch);
-                if !self.try_record_claim_fence(stream_id, fence) {
-                    let _ = tokio::time::timeout(
-                        CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
-                        self.claim_store.release_exact(&entity, &identity, epoch),
-                    )
-                    .await;
+                if !self.try_record_claim_fence(stream_id, fence.clone()) {
+                    self.cancel_claim_fence_reservation(stream_id);
+                    self.release_claim_store_entry_under(stream_id, fence).await;
                     return false;
                 }
                 true
             }
             Ok(Ok(epoch)) => {
                 let fence = super::super::persistence::SmClaimFence::new(identity, epoch);
-                if self.try_record_claim_fence(stream_id, fence.clone()) {
-                    self.release_claim_store_entry_under(stream_id, fence).await;
+                if !self.try_record_claim_fence(stream_id, fence.clone()) {
+                    self.cancel_claim_fence_reservation(stream_id);
                 }
+                self.release_claim_store_entry_under(stream_id, fence).await;
                 false
             }
             Ok(Err(error)) => {
@@ -729,13 +728,15 @@ impl InMemorySmSessionRegistry {
             Ok(Ok(epoch)) => {
                 if self.node_identity.current() != identity {
                     let fence = super::super::persistence::SmClaimFence::new(identity, epoch);
-                    if self.try_record_claim_fence(stream_id, fence.clone()) {
-                        self.release_claim_store_entry_under(stream_id, fence).await;
+                    if !self.try_record_claim_fence(stream_id, fence.clone()) {
+                        self.cancel_claim_fence_reservation(stream_id);
                     }
+                    self.release_claim_store_entry_under(stream_id, fence).await;
                     return;
                 }
                 let fence = super::super::persistence::SmClaimFence::new(identity.clone(), epoch);
                 if !self.try_record_claim_fence(stream_id, fence.clone()) {
+                    self.cancel_claim_fence_reservation(stream_id);
                     self.release_claim_store_entry_under(stream_id, fence).await;
                 }
             }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -160,7 +160,7 @@ impl InMemorySmSessionRegistry {
         attempted
     }
 
-    fn stream_is_live_or_uncertain(&self, stream_id: &str) -> bool {
+    pub(super) fn stream_is_live_or_uncertain(&self, stream_id: &str) -> bool {
         match (self.sessions.read(), self.claimed_sessions.read()) {
             (Ok(sessions), Ok(claimed)) => {
                 sessions.contains_key(stream_id) || claimed.contains_key(stream_id)

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -112,6 +112,23 @@ impl InMemorySmSessionRegistry {
             .map(|pending| pending.iter().take(limit).cloned().collect::<Vec<_>>())
             .unwrap_or_default();
         for (stream_id, identity, disposition) in uncertain {
+            // Rejected-enable reconciliation is a terminal release retry.
+            // The same stream id may have become detached/claimed through a
+            // later successful local path while the original acquisition was
+            // uncertain. Serialize with that stream and fail closed on map
+            // uncertainty so the retry never releases a now-live claim.
+            if disposition == PendingClaimAcquisitionDisposition::ReleaseRejectedEnable {
+                let Ok(stream_lock) = self.stream_lock(&stream_id) else {
+                    continue;
+                };
+                let _stream_guard = stream_lock.lock().await;
+                if self.stream_is_live_or_uncertain(&stream_id) {
+                    continue;
+                }
+                self.reconcile_uncertain_claim_acquisition(&stream_id, identity, disposition)
+                    .await;
+                continue;
+            }
             self.reconcile_uncertain_claim_acquisition(&stream_id, identity, disposition)
                 .await;
         }
@@ -133,15 +150,7 @@ impl InMemorySmSessionRegistry {
                 continue;
             };
             let _stream_guard = stream_lock.lock().await;
-            let live_again = match (self.sessions.read(), self.claimed_sessions.read()) {
-                (Ok(sessions), Ok(claimed)) => {
-                    sessions.contains_key(&stream_id) || claimed.contains_key(&stream_id)
-                }
-                // A poisoned live-state lock is uncertainty. Never release a
-                // claim on the basis of an incomplete/failed local probe.
-                _ => true,
-            };
-            if live_again {
+            if self.stream_is_live_or_uncertain(&stream_id) {
                 continue;
             }
             attempted += 1;
@@ -149,6 +158,17 @@ impl InMemorySmSessionRegistry {
                 .await;
         }
         attempted
+    }
+
+    fn stream_is_live_or_uncertain(&self, stream_id: &str) -> bool {
+        match (self.sessions.read(), self.claimed_sessions.read()) {
+            (Ok(sessions), Ok(claimed)) => {
+                sessions.contains_key(stream_id) || claimed.contains_key(stream_id)
+            }
+            // A poisoned live-state lock is uncertainty. Never release a
+            // claim on the basis of an incomplete/failed local probe.
+            _ => true,
+        }
     }
 
     async fn reconcile_uncertain_claim_acquisition(

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -121,12 +121,30 @@ impl InMemorySmSessionRegistry {
             };
             pending
                 .iter()
-                .take(limit)
                 .map(|(stream_id, fence)| (stream_id.clone(), fence.clone()))
                 .collect::<Vec<_>>()
         };
-        let attempted = pending.len();
+        let mut attempted = 0;
         for (stream_id, fence) in pending {
+            if attempted >= limit {
+                break;
+            }
+            let Ok(stream_lock) = self.stream_lock(&stream_id) else {
+                continue;
+            };
+            let _stream_guard = stream_lock.lock().await;
+            let live_again = match (self.sessions.read(), self.claimed_sessions.read()) {
+                (Ok(sessions), Ok(claimed)) => {
+                    sessions.contains_key(&stream_id) || claimed.contains_key(&stream_id)
+                }
+                // A poisoned live-state lock is uncertainty. Never release a
+                // claim on the basis of an incomplete/failed local probe.
+                _ => true,
+            };
+            if live_again {
+                continue;
+            }
+            attempted += 1;
             self.release_claim_store_entry_under(&stream_id, fence)
                 .await;
         }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -67,6 +67,17 @@ impl InMemorySmSessionRegistry {
     /// synchronous so a cancellation guard can call it from `Drop` when the
     /// WebSocket task disappears before enabled state is published.
     pub fn defer_unpublished_enabled_claim_release(&self, stream_id: &str) -> bool {
+        self.defer_enabled_claim_release(stream_id)
+    }
+
+    /// Move a claim from a connection that lost its same-full-JID registry
+    /// slot into exact terminal cleanup. The replacement owns routing and
+    /// cleanup for the JID, but never owns this connection's distinct SM id.
+    pub fn defer_superseded_enabled_claim_release(&self, stream_id: &str) -> bool {
+        self.defer_enabled_claim_release(stream_id)
+    }
+
+    fn defer_enabled_claim_release(&self, stream_id: &str) -> bool {
         let fence = self
             .claim_fences
             .read()

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -15,9 +15,64 @@ fn sm_session_entity(stream_id: &str) -> Entity {
     Entity::new(EntityType::SmSession, stream_id.to_string())
 }
 
+struct PendingEnableAcquisitionGuard<'a> {
+    registry: &'a InMemorySmSessionRegistry,
+    stream_id: String,
+    identity: crate::ownership::NodeIdentity,
+    armed: bool,
+}
+
+impl<'a> PendingEnableAcquisitionGuard<'a> {
+    fn new(
+        registry: &'a InMemorySmSessionRegistry,
+        stream_id: &str,
+        identity: crate::ownership::NodeIdentity,
+    ) -> Self {
+        Self {
+            registry,
+            stream_id: stream_id.to_string(),
+            identity,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PendingEnableAcquisitionGuard<'_> {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        if let Ok(mut pending) = self.registry.pending_claim_acquisitions.write() {
+            pending.insert((
+                self.stream_id.clone(),
+                self.identity.clone(),
+                PendingClaimAcquisitionDisposition::ReleaseRejectedEnable,
+            ));
+        } else {
+            tracing::warn!(
+                stream_id = %self.stream_id,
+                "cancelled SM enable acquisition could not retain ambiguous claim responsibility"
+            );
+        }
+    }
+}
+
 impl InMemorySmSessionRegistry {
-    pub async fn abandon_enabled_claim(&self, stream_id: &str) {
-        self.release_claim_store_entry(stream_id).await;
+    /// Atomically move a claim acquired for `<enable/>` out of the active
+    /// live-authority map and into terminal exact-release inventory. This is
+    /// synchronous so a cancellation guard can call it from `Drop` when the
+    /// WebSocket task disappears before enabled state is published.
+    pub fn defer_unpublished_enabled_claim_release(&self, stream_id: &str) -> bool {
+        let fence = self
+            .claim_fences
+            .read()
+            .ok()
+            .and_then(|fences| fences.get(stream_id).cloned());
+        fence.is_some_and(|fence| self.try_record_terminal_claim_fence(stream_id, fence))
     }
     /// Remove every expired session and return the detached state in full.
     ///
@@ -637,7 +692,9 @@ impl InMemorySmSessionRegistry {
         }
         let entity = sm_session_entity(stream_id);
         let identity = self.node_identity.current();
-        match tokio::time::timeout(
+        let mut acquisition_guard =
+            PendingEnableAcquisitionGuard::new(self, stream_id, identity.clone());
+        let claimed = match tokio::time::timeout(
             CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
             self.claim_store.ensure_claimed(&entity, &identity),
         )
@@ -648,9 +705,10 @@ impl InMemorySmSessionRegistry {
                 if !self.try_record_claim_fence(stream_id, fence.clone()) {
                     self.cancel_claim_fence_reservation(stream_id);
                     self.release_claim_store_entry_under(stream_id, fence).await;
-                    return false;
+                    false
+                } else {
+                    true
                 }
-                true
             }
             Ok(Ok(epoch)) => {
                 let fence = super::super::persistence::SmClaimFence::new(identity, epoch);
@@ -686,7 +744,9 @@ impl InMemorySmSessionRegistry {
                 .await;
                 false
             }
-        }
+        };
+        acquisition_guard.disarm();
+        claimed
     }
 
     /// Atomically claim a resumable session for a single resume attempt.

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -750,10 +750,6 @@ impl InMemorySmSessionRegistry {
     /// `warn` so a persistently failing acquire (e.g. a genuinely wedged
     /// `ClaimStore` backend) is visible.
     pub(super) async fn acquire_claim_store_entry_for_detach(&self, stream_id: &str) {
-        if !self.reserve_claim_fence_capacity(stream_id) {
-            tracing::warn!(stream_id = %stream_id, "store_session: exact-release backlog capacity exhausted");
-            return;
-        }
         let acquisition_reserved = self.has_claim_fence_reservation(stream_id);
         let entity = sm_session_entity(stream_id);
         let identity = self.node_identity.current();
@@ -813,12 +809,10 @@ impl InMemorySmSessionRegistry {
                             PendingClaimAcquisitionDisposition::RetainDetachedSession,
                         ));
                     }
-                    self.reconcile_uncertain_claim_acquisition(
-                        stream_id,
-                        identity,
-                        PendingClaimAcquisitionDisposition::RetainDetachedSession,
-                    )
-                    .await;
+                    // Do not issue a second ClaimStore call while the caller
+                    // holds this stream's shard lock. The bounded SM janitor
+                    // owns reconciliation after `store_session` returns and
+                    // releases the shard.
                 }
             }
         }

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -122,7 +122,10 @@ impl InMemorySmSessionRegistry {
                     continue;
                 };
                 let _stream_guard = stream_lock.lock().await;
-                if self.stream_is_live_or_uncertain(&stream_id) {
+                if self
+                    .reconcile_rejected_enable_while_live(&stream_id, &identity)
+                    .await
+                {
                     continue;
                 }
                 self.reconcile_uncertain_claim_acquisition(&stream_id, identity, disposition)
@@ -150,8 +153,21 @@ impl InMemorySmSessionRegistry {
                 continue;
             };
             let _stream_guard = stream_lock.lock().await;
-            if self.stream_is_live_or_uncertain(&stream_id) {
-                continue;
+            match self.stream_liveness(&stream_id) {
+                None => continue,
+                Some(true) => {
+                    let Ok(active) = self.claim_fences.read() else {
+                        continue;
+                    };
+                    if active.get(&stream_id) == Some(&fence) {
+                        // This fence still authorizes the live lifecycle.
+                        continue;
+                    }
+                    // A different/absent active fence means this is terminal
+                    // exact cleanup. Its owner+epoch CAS is safe to retry
+                    // while the replacement lifecycle remains live.
+                }
+                Some(false) => {}
             }
             attempted += 1;
             self.release_claim_store_entry_under(&stream_id, fence)
@@ -160,18 +176,117 @@ impl InMemorySmSessionRegistry {
         attempted
     }
 
-    pub(super) fn stream_is_live_or_uncertain(&self, stream_id: &str) -> bool {
+    fn stream_liveness(&self, stream_id: &str) -> Option<bool> {
         match (self.sessions.read(), self.claimed_sessions.read()) {
             (Ok(sessions), Ok(claimed)) => {
-                sessions.contains_key(stream_id) || claimed.contains_key(stream_id)
+                Some(sessions.contains_key(stream_id) || claimed.contains_key(stream_id))
             }
-            // A poisoned live-state lock is uncertainty. Never release a
-            // claim on the basis of an incomplete/failed local probe.
-            _ => true,
+            _ => None,
         }
     }
 
-    async fn reconcile_uncertain_claim_acquisition(
+    pub(super) fn stream_is_live_or_uncertain(&self, stream_id: &str) -> bool {
+        // A poisoned live-state lock is uncertainty. Never release a claim
+        // on the basis of an incomplete/failed local probe.
+        self.stream_liveness(stream_id).unwrap_or(true)
+    }
+
+    /// Retire a rejected-enable acquisition only after a bounded,
+    /// non-creating lookup accounts for its possible committed claim. A live
+    /// detached session is not proof by itself: detach-time acquisition is
+    /// best effort and may have failed under a newer node identity.
+    ///
+    /// Returns `true` when the stream is live or its liveness is uncertain,
+    /// so the caller must not run the terminal `ensure_claimed` path.
+    pub(super) async fn reconcile_rejected_enable_while_live(
+        &self,
+        stream_id: &str,
+        pending_identity: &crate::ownership::NodeIdentity,
+    ) -> bool {
+        match self.stream_liveness(stream_id) {
+            Some(false) => return false,
+            None => return true,
+            Some(true) => {}
+        }
+
+        // One reservation cannot cover both a possibly-new generation from
+        // detach reconciliation and terminal cleanup of the rejected-enable
+        // generation. Let the live detach resolve first; a later sweep can
+        // then spend the slot on terminal conversion without undercounting.
+        let detach_still_uncertain = match self.pending_claim_acquisitions.read() {
+            Ok(pending) => pending.iter().any(|(id, _, disposition)| {
+                id == stream_id
+                    && *disposition == PendingClaimAcquisitionDisposition::RetainDetachedSession
+            }),
+            Err(_) => return true,
+        };
+        if detach_still_uncertain {
+            return true;
+        }
+
+        let entity = sm_session_entity(stream_id);
+        let snapshot = match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            self.claim_store.current_claim(&entity),
+        )
+        .await
+        {
+            Ok(Ok(snapshot)) => snapshot,
+            Ok(Err(_)) | Err(_) => return true,
+        };
+
+        if let Some(snapshot) = snapshot {
+            if snapshot.owner == *pending_identity {
+                let fence = super::super::persistence::SmClaimFence::new(
+                    snapshot.owner,
+                    snapshot.claim_epoch,
+                );
+                if *pending_identity == self.node_identity.current() {
+                    if !self.try_record_claim_fence(stream_id, fence) {
+                        return true;
+                    }
+                } else {
+                    // An old incarnation's snapshot is not authority for the
+                    // current live lifecycle. Preserve it only as terminal
+                    // exact-release responsibility, then attempt that release
+                    // without ever publishing the old fence for live writes.
+                    if !self.try_record_terminal_claim_fence(stream_id, fence.clone()) {
+                        return true;
+                    }
+                    self.release_claim_store_entry_under(stream_id, fence).await;
+                }
+            }
+        }
+
+        self.remove_pending_claim_acquisition(
+            stream_id,
+            pending_identity,
+            PendingClaimAcquisitionDisposition::ReleaseRejectedEnable,
+        );
+        true
+    }
+
+    fn remove_pending_claim_acquisition(
+        &self,
+        stream_id: &str,
+        identity: &crate::ownership::NodeIdentity,
+        disposition: PendingClaimAcquisitionDisposition,
+    ) {
+        let no_remaining_for_stream = {
+            let Ok(mut pending) = self.pending_claim_acquisitions.write() else {
+                return;
+            };
+            if !pending.remove(&(stream_id.to_string(), identity.clone(), disposition)) {
+                return;
+            }
+            !pending.iter().any(|(id, _, _)| id == stream_id)
+        };
+        if no_remaining_for_stream {
+            self.cancel_claim_fence_reservation(stream_id);
+        }
+    }
+
+    pub(super) async fn reconcile_uncertain_claim_acquisition(
         &self,
         stream_id: &str,
         identity: crate::ownership::NodeIdentity,
@@ -218,10 +333,7 @@ impl InMemorySmSessionRegistry {
                 }
             }
             Ok(Err(ClaimError::AlreadyClaimed | ClaimError::Conflict)) => {
-                if let Ok(mut pending) = self.pending_claim_acquisitions.write() {
-                    pending.remove(&(stream_id.to_string(), identity, disposition));
-                }
-                self.cancel_claim_fence_reservation(stream_id);
+                self.remove_pending_claim_acquisition(stream_id, &identity, disposition);
             }
             Ok(Err(_)) | Err(_) => {
                 if let Ok(mut pending) = self.pending_claim_acquisitions.write() {

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
@@ -160,6 +160,19 @@ impl std::fmt::Debug for InMemorySmSessionRegistry {
 
 impl InMemorySmSessionRegistry {
     pub(super) fn reserve_claim_fence_capacity(&self, stream_id: &str) -> bool {
+        self.reserve_claim_fence_capacity_up_to(stream_id, self.max_sessions)
+    }
+
+    /// Reserve the exact-fence slot needed by a live detach. Capacity
+    /// eviction briefly needs both the displaced session's fence (until its
+    /// caller confirms promotion) and the replacement session's fence. Keep
+    /// one explicitly bounded turnover slot for that transition; subsequent
+    /// detaches reject until the displaced responsibility is drained.
+    pub(super) fn reserve_detach_claim_fence_capacity(&self, stream_id: &str) -> bool {
+        self.reserve_claim_fence_capacity_up_to(stream_id, self.max_sessions.saturating_add(1))
+    }
+
+    fn reserve_claim_fence_capacity_up_to(&self, stream_id: &str, capacity: usize) -> bool {
         let (Ok(mut reservations), Ok(pending), Ok(fences)) = (
             self.claim_fence_reservations.write(),
             self.pending_claim_releases.read(),
@@ -188,7 +201,7 @@ impl InMemorySmSessionRegistry {
             .len()
             .saturating_add(current_not_pending)
             .saturating_add(reservations.len());
-        if occupied >= self.max_sessions {
+        if occupied >= capacity {
             return false;
         }
         reservations.insert(stream_id.to_string());

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
@@ -14,6 +14,12 @@ use super::persistence_codec::{
 };
 use super::{DetachedSession, SmRegistryError, DEFAULT_MAX_SESSIONS};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) enum PendingClaimAcquisitionDisposition {
+    ReleaseRejectedEnable,
+    RetainDetachedSession,
+}
+
 const STREAM_LOCK_SHARDS: usize = 256;
 
 /// Bound on any `ClaimStore` acquire/`ensure_claimed` call made while this
@@ -106,10 +112,12 @@ pub struct InMemorySmSessionRegistry {
     /// from both maps but is not releasable until its durable delete commits.
     pub(super) pending_claim_releases:
         RwLock<HashSet<(String, super::super::persistence::SmClaimFence)>>,
-    /// Enable-time acquisitions whose timeout made commit status ambiguous.
-    /// Retains the typed stream entity and exact node incarnation until a
-    /// bounded idempotent `ensure_claimed` retry recovers the epoch.
-    pub(super) pending_claim_acquisitions: RwLock<HashSet<(String, NodeIdentity)>>,
+    /// Acquisitions whose timeout made commit status ambiguous. The typed
+    /// disposition distinguishes rejected enable admission (recover then
+    /// release) from detach after durable snapshot publication (recover and
+    /// retain ownership).
+    pub(super) pending_claim_acquisitions:
+        RwLock<HashSet<(String, NodeIdentity, PendingClaimAcquisitionDisposition)>>,
     /// Capacity reserved before an acquisition whose exact epoch is not yet
     /// known. A reservation survives an ambiguous timeout and is consumed
     /// only when reconciliation either records the resulting fence or proves

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
@@ -273,6 +273,50 @@ impl InMemorySmSessionRegistry {
         true
     }
 
+    /// Convert a reserved acquisition slot into terminal exact-release
+    /// responsibility without publishing the supplied fence as authority for
+    /// live-session persistence. This is used when a claim belongs to an old
+    /// node incarnation while a newer, claimless lifecycle occupies the same
+    /// stream id.
+    pub(super) fn try_record_terminal_claim_fence(
+        &self,
+        stream_id: &str,
+        fence: super::super::persistence::SmClaimFence,
+    ) -> bool {
+        let (Ok(mut reservations), Ok(mut pending), Ok(mut fences)) = (
+            self.claim_fence_reservations.write(),
+            self.pending_claim_releases.write(),
+            self.claim_fences.write(),
+        ) else {
+            return false;
+        };
+        if pending.contains(&(stream_id.to_string(), fence.clone())) {
+            reservations.remove(stream_id);
+            if fences.get(stream_id) == Some(&fence) {
+                fences.remove(stream_id);
+            }
+            return true;
+        }
+        let reserved = reservations.remove(stream_id);
+        let converts_active = fences.get(stream_id) == Some(&fence);
+        let current_not_pending = fences
+            .iter()
+            .filter(|(id, current)| !pending.contains(&(id.to_string(), (*current).clone())))
+            .count();
+        let occupied = pending
+            .len()
+            .saturating_add(current_not_pending)
+            .saturating_add(reservations.len());
+        if !reserved && !converts_active && occupied >= self.max_sessions {
+            return false;
+        }
+        if converts_active {
+            fences.remove(stream_id);
+        }
+        pending.insert((stream_id.to_string(), fence));
+        true
+    }
+
     /// Create a new in-memory registry with default settings.
     pub fn new() -> Self {
         Self {

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -6,8 +6,7 @@ use std::time::Duration;
 use tracing::debug;
 
 use crate::ownership::{
-    ClaimEpoch, ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity,
-    SharedNodeIdentity,
+    ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
 };
 
 use super::persistence_codec::{
@@ -91,18 +90,31 @@ pub struct InMemorySmSessionRegistry {
     /// Slice 5) instead wires in the SAME live, updatable handle
     /// `self_fence::run_node_lease` refreshes on every re-registration
     /// (mirroring `PostgresFencedSmPersistence`'s identical Slice 4
-    /// follow-up plumbing fix) — every call site reads `.current()` at the
-    /// moment it actually needs the identity rather than caching a
-    /// snapshot, so a self-fence/re-registration mid-process-lifetime is
-    /// observed immediately rather than silently binding claim CAS calls to
-    /// a stale, superseded `node_epoch` forever.
+    /// follow-up plumbing fix). New acquisitions read `.current()` once;
+    /// owned work then carries that immutable owner together with its epoch,
+    /// so a later self-fence cannot silently rebind an old claim to the new
+    /// node incarnation.
     pub(super) node_identity: SharedNodeIdentity,
-    /// Tracks the epoch this registry last observed for each currently
+    /// Tracks the immutable owner+epoch fence this registry last observed for each currently
     /// claimed SM-session entity, so `release_claim`/`complete_claim` can
     /// hand the right epoch back to `claim_store.release`. Purely local
     /// bookkeeping — the `ClaimStore` implementation itself is the
     /// authority on what epoch is actually current.
-    pub(super) claim_epochs: RwLock<HashMap<String, ClaimEpoch>>,
+    pub(super) claim_fences: RwLock<HashMap<String, super::super::persistence::SmClaimFence>>,
+    /// Exact terminal releases whose backend outcome was not confirmed.
+    /// Separate from `claim_fences`: a session drained for promotion is absent
+    /// from both maps but is not releasable until its durable delete commits.
+    pub(super) pending_claim_releases:
+        RwLock<HashSet<(String, super::super::persistence::SmClaimFence)>>,
+    /// Enable-time acquisitions whose timeout made commit status ambiguous.
+    /// Retains the typed stream entity and exact node incarnation until a
+    /// bounded idempotent `ensure_claimed` retry recovers the epoch.
+    pub(super) pending_claim_acquisitions: RwLock<HashSet<(String, NodeIdentity)>>,
+    /// Capacity reserved before an acquisition whose exact epoch is not yet
+    /// known. A reservation survives an ambiguous timeout and is consumed
+    /// only when reconciliation either records the resulting fence or proves
+    /// that this node did not acquire the claim.
+    pub(super) claim_fence_reservations: RwLock<HashSet<String>>,
     /// ADR-0017 Phase 3 Slice 6: the cross-node "ask the live owner to
     /// detach" bridge for the XEP-0198 resume path's live-handshake branch.
     /// `None` for single-node/non-clustering deployments (the cross-node
@@ -139,6 +151,107 @@ impl std::fmt::Debug for InMemorySmSessionRegistry {
 }
 
 impl InMemorySmSessionRegistry {
+    pub(super) fn reserve_claim_fence_capacity(&self, stream_id: &str) -> bool {
+        let (Ok(mut reservations), Ok(pending), Ok(fences)) = (
+            self.claim_fence_reservations.write(),
+            self.pending_claim_releases.read(),
+            self.claim_fences.read(),
+        ) else {
+            return false;
+        };
+        if let Some(fence) = fences.get(stream_id) {
+            // A confirmed-current fence makes ensure_claimed idempotent and
+            // cannot create another generation. A fence whose terminal
+            // release timed out is different: the release may have committed,
+            // so the next ensure can mint a new generation and must reserve a
+            // second exact-fence slot before touching the backend.
+            if !pending.contains(&(stream_id.to_string(), fence.clone())) {
+                return true;
+            }
+        }
+        if reservations.contains(stream_id) {
+            return true;
+        }
+        let current_not_pending = fences
+            .iter()
+            .filter(|(id, fence)| !pending.contains(&(id.to_string(), (*fence).clone())))
+            .count();
+        let occupied = pending
+            .len()
+            .saturating_add(current_not_pending)
+            .saturating_add(reservations.len());
+        if occupied >= self.max_sessions {
+            return false;
+        }
+        reservations.insert(stream_id.to_string());
+        true
+    }
+
+    pub(super) fn cancel_claim_fence_reservation(&self, stream_id: &str) {
+        if let Ok(mut reservations) = self.claim_fence_reservations.write() {
+            reservations.remove(stream_id);
+        }
+    }
+
+    pub(super) fn has_claim_fence_reservation(&self, stream_id: &str) -> bool {
+        self.claim_fence_reservations
+            .read()
+            .is_ok_and(|reservations| reservations.contains(stream_id))
+    }
+
+    #[cfg(test)]
+    pub(super) fn claim_fence_capacity_used(&self) -> usize {
+        let (Ok(reservations), Ok(pending), Ok(fences)) = (
+            self.claim_fence_reservations.read(),
+            self.pending_claim_releases.read(),
+            self.claim_fences.read(),
+        ) else {
+            return self.max_sessions;
+        };
+        let current_not_pending = fences
+            .iter()
+            .filter(|(id, fence)| !pending.contains(&(id.to_string(), (*fence).clone())))
+            .count();
+        pending
+            .len()
+            .saturating_add(current_not_pending)
+            .saturating_add(reservations.len())
+    }
+
+    pub(super) fn try_record_claim_fence(
+        &self,
+        stream_id: &str,
+        fence: super::super::persistence::SmClaimFence,
+    ) -> bool {
+        let (Ok(mut reservations), Ok(mut pending), Ok(mut fences)) = (
+            self.claim_fence_reservations.write(),
+            self.pending_claim_releases.write(),
+            self.claim_fences.write(),
+        ) else {
+            return false;
+        };
+        if fences.get(stream_id) == Some(&fence) {
+            reservations.remove(stream_id);
+            return true;
+        }
+        let reserved = reservations.remove(stream_id);
+        let current_not_pending = fences
+            .iter()
+            .filter(|(id, current)| !pending.contains(&(id.to_string(), (*current).clone())))
+            .count();
+        let occupied = pending
+            .len()
+            .saturating_add(current_not_pending)
+            .saturating_add(reservations.len());
+        if !reserved && occupied >= self.max_sessions {
+            return false;
+        }
+        if let Some(previous) = fences.insert(stream_id.to_string(), fence) {
+            pending.insert((stream_id.to_string(), previous));
+        }
+        true
+    }
+
     /// Create a new in-memory registry with default settings.
     pub fn new() -> Self {
         Self {
@@ -150,7 +263,10 @@ impl InMemorySmSessionRegistry {
             persistence: None,
             claim_store: Arc::new(InProcessClaimStore::new()),
             node_identity: SharedNodeIdentity::new(NodeIdentity::local()),
-            claim_epochs: RwLock::new(HashMap::new()),
+            claim_fences: RwLock::new(HashMap::new()),
+            pending_claim_releases: RwLock::new(HashSet::new()),
+            pending_claim_acquisitions: RwLock::new(HashSet::new()),
+            claim_fence_reservations: RwLock::new(HashSet::new()),
             remote_resume: None,
         }
     }
@@ -166,7 +282,10 @@ impl InMemorySmSessionRegistry {
             persistence: None,
             claim_store: Arc::new(InProcessClaimStore::new()),
             node_identity: SharedNodeIdentity::new(NodeIdentity::local()),
-            claim_epochs: RwLock::new(HashMap::new()),
+            claim_fences: RwLock::new(HashMap::new()),
+            pending_claim_releases: RwLock::new(HashSet::new()),
+            pending_claim_acquisitions: RwLock::new(HashSet::new()),
+            claim_fence_reservations: RwLock::new(HashSet::new()),
             remote_resume: None,
         }
     }
@@ -388,12 +507,23 @@ impl InMemorySmSessionRegistry {
                     // now-unused claim rather than leak it, so a future
                     // pass (or the orphan reaper, once this identity is
                     // stale) can act on the row again.
-                    self.release_claim_store_entry_under(persisted.stream_id.as_str(), epoch)
-                        .await;
+                    self.release_claim_store_entry_under(
+                        persisted.stream_id.as_str(),
+                        super::super::persistence::SmClaimFence::new(identity.clone(), epoch),
+                    )
+                    .await;
                     bad_rows += 1;
                     continue;
                 }
             };
+            if self.node_identity.current() != identity {
+                self.release_claim_store_entry_under(
+                    persisted.stream_id.as_str(),
+                    super::super::persistence::SmClaimFence::new(identity, epoch),
+                )
+                .await;
+                continue;
+            }
             // FIX 2: per-row stream-shard-lock discipline (see this
             // method's doc comment) — take this row's own shard lock and
             // re-check both maps immediately before inserting, rather than
@@ -425,8 +555,11 @@ impl InMemorySmSessionRegistry {
                     .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
                 sessions.insert(stream_id.clone(), session);
             }
-            if let Ok(mut claim_epochs) = self.claim_epochs.write() {
-                claim_epochs.insert(stream_id, epoch);
+            if let Ok(mut claim_fences) = self.claim_fences.write() {
+                claim_fences.insert(
+                    stream_id,
+                    super::super::persistence::SmClaimFence::new(identity.clone(), epoch),
+                );
             }
             hydrated += 1;
         }
@@ -484,137 +617,298 @@ impl InMemorySmSessionRegistry {
     /// by steps 1-4 are not counted and do not produce an `Err`, mirroring
     /// `restore_from_persistence`'s best-effort, skip-and-continue
     /// semantics for individual rows.
-    pub async fn hydrate_reclaimed(
+    pub async fn hydrate_reclaimed_typed(
         &self,
-        entities: &[(Entity, ClaimEpoch)],
-    ) -> Result<usize, SmRegistryError> {
+        entity: &Entity,
+        caller_fence: &super::super::persistence::SmClaimFence,
+    ) -> Result<ReclaimedHydrationOutcome, SmRegistryError> {
         let Some(storage) = &self.persistence else {
-            return Ok(0);
+            return Ok(ReclaimedHydrationOutcome::MissingDurable);
         };
-        let mut hydrated = 0usize;
-        for (entity, _caller_epoch) in entities {
-            if entity.entity_type != EntityType::SmSession {
-                debug!(
-                    entity = %entity,
-                    "hydrate_reclaimed: skipping a non-SmSession entity"
-                );
-                continue;
-            }
-            let stream_id = entity.id.clone();
-            let stream_lock = self.stream_lock(&stream_id)?;
-            let _stream_guard = stream_lock.lock().await;
+        if entity.entity_type != EntityType::SmSession {
+            return Ok(ReclaimedHydrationOutcome::LostClaim);
+        }
+        if self.node_identity.current() != *caller_fence.owner() {
+            return Ok(ReclaimedHydrationOutcome::StaleIdentity);
+        }
+        let stream_id = entity.id.clone();
+        let stream_lock = self.stream_lock(&stream_id)?;
+        let _stream_guard = stream_lock.lock().await;
 
-            let present = {
-                let sessions = self
-                    .sessions
-                    .read()
-                    .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-                let claimed = self
-                    .claimed_sessions
-                    .read()
-                    .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-                sessions.contains_key(&stream_id) || claimed.contains_key(&stream_id)
-            };
-            if present {
-                debug!(
-                    stream_id = %stream_id,
-                    "hydrate_reclaimed: already present in-memory (live session, or already \
-                     hydrated by an overlapping sweep); skipping"
-                );
-                continue;
+        let present = {
+            let sessions = self
+                .sessions
+                .read()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            let claimed = self
+                .claimed_sessions
+                .read()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            sessions.contains_key(&stream_id) || claimed.contains_key(&stream_id)
+        };
+        if present {
+            let exact_fence = self
+                .claim_fences
+                .read()
+                .ok()
+                .and_then(|fences| fences.get(&stream_id).cloned())
+                .as_ref()
+                == Some(caller_fence);
+            if !exact_fence {
+                return Ok(ReclaimedHydrationOutcome::LostClaim);
             }
-
-            // FIX 5: bounded — see `CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT`'s
-            // doc comment. On timeout or a lost self-reacquire, skip this
-            // entity for this pass rather than insert a session this node
-            // can no longer prove it owns; the entity remains eligible for
-            // a future sweep.
-            let identity = self.node_identity.current();
-            let epoch = match tokio::time::timeout(
+            match tokio::time::timeout(
                 CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
-                self.claim_store.ensure_claimed(entity, &identity),
+                self.claim_store
+                    .fence(entity, caller_fence.owner(), caller_fence.epoch()),
             )
             .await
             {
-                Ok(Ok(epoch)) => epoch,
-                Ok(Err(error)) => {
-                    debug!(
-                        stream_id = %stream_id,
-                        %error,
-                        "hydrate_reclaimed: ClaimStore ensure_claimed self-reacquire failed \
-                         (claim lost again since the caller's steal_stale); skipping"
-                    );
-                    continue;
-                }
-                Err(_timeout) => {
-                    tracing::warn!(
-                        stream_id = %stream_id,
-                        timeout = ?CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
-                        "hydrate_reclaimed: ClaimStore ensure_claimed timed out while holding \
-                         this stream's shard lock; skipping this entity for this pass"
-                    );
-                    continue;
-                }
-            };
+                Ok(Ok(true)) if self.node_identity.current() == *caller_fence.owner() => {}
+                Ok(Ok(true)) => return Ok(ReclaimedHydrationOutcome::StaleIdentity),
+                Ok(Ok(_)) => return Ok(ReclaimedHydrationOutcome::LostClaim),
+                Ok(Err(_)) | Err(_) => return Ok(ReclaimedHydrationOutcome::TransientFailure),
+            }
+            debug!(
+                stream_id = %stream_id,
+                "hydrate_reclaimed: already present in-memory (live session, or already \
+                 hydrated by an overlapping sweep); skipping"
+            );
+            return Ok(ReclaimedHydrationOutcome::AlreadyPresent);
+        }
 
-            let session_id = crate::pending_delivery::SmSessionId::new(stream_id.clone());
-            let persisted = match storage.get_session(&session_id).await {
-                Ok(Some(row)) => row,
-                Ok(None) => {
-                    debug!(
-                        stream_id = %stream_id,
-                        "hydrate_reclaimed: no durable row (already promoted/deleted by a \
-                         concurrent sweep); skipping"
-                    );
-                    continue;
-                }
-                Err(error) => {
-                    debug!(
-                        stream_id = %stream_id,
-                        %error,
-                        "hydrate_reclaimed: get_session failed; skipping this entity for this pass"
-                    );
-                    continue;
-                }
-            };
-            let unacked = match storage.list_unacked(&session_id).await {
-                Ok(rows) => rows,
-                Err(error) => {
-                    debug!(
-                        stream_id = %stream_id,
-                        %error,
-                        "hydrate_reclaimed: list_unacked failed; skipping this entity for this pass"
-                    );
-                    continue;
-                }
-            };
-            let session = match persisted_to_detached(&persisted, &unacked) {
-                Ok(session) => session,
-                Err(error) => {
-                    debug!(
-                        stream_id = %stream_id,
-                        %error,
-                        "hydrate_reclaimed: row decode failed (poison pill); skipping"
-                    );
-                    self.release_claim_store_entry_under(&stream_id, epoch)
-                        .await;
-                    continue;
-                }
-            };
+        // FIX 5: bounded — see `CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT`'s
+        // doc comment. On timeout or a lost self-reacquire, skip this
+        // entity for this pass rather than insert a session this node
+        // can no longer prove it owns; the entity remains eligible for
+        // a future sweep.
+        let epoch = match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            self.claim_store
+                .ensure_claimed(entity, caller_fence.owner()),
+        )
+        .await
+        {
+            Ok(Ok(epoch)) => epoch,
+            Ok(Err(error)) => {
+                debug!(
+                    stream_id = %stream_id,
+                    %error,
+                    "hydrate_reclaimed: ClaimStore ensure_claimed self-reacquire failed \
+                     (claim lost again since the caller's steal_stale); skipping"
+                );
+                return Ok(ReclaimedHydrationOutcome::LostClaim);
+            }
+            Err(_timeout) => {
+                tracing::warn!(
+                    stream_id = %stream_id,
+                    timeout = ?CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+                    "hydrate_reclaimed: ClaimStore ensure_claimed timed out while holding \
+                     this stream's shard lock; skipping this entity for this pass"
+                );
+                return Ok(ReclaimedHydrationOutcome::TransientFailure);
+            }
+        };
+        if epoch != caller_fence.epoch() {
+            debug!(
+                stream_id = %stream_id,
+                expected_epoch = caller_fence.epoch().0,
+                actual_epoch = epoch.0,
+                "hydrate_reclaimed: caller work belongs to a superseded claim epoch"
+            );
+            return Ok(ReclaimedHydrationOutcome::LostClaim);
+        }
+
+        let session_id = crate::pending_delivery::SmSessionId::new(stream_id.clone());
+        let persisted = match storage.get_session(&session_id).await {
+            Ok(Some(row)) => row,
+            Ok(None) => {
+                debug!(
+                    stream_id = %stream_id,
+                    "hydrate_reclaimed: no durable row (already promoted/deleted by a \
+                     concurrent sweep); skipping"
+                );
+                return Ok(ReclaimedHydrationOutcome::MissingDurable);
+            }
+            Err(super::super::persistence::SmPersistenceError::Corrupt {
+                stream_id: corrupt_stream,
+                detail,
+            }) if corrupt_stream == session_id => {
+                debug!(stream_id = %stream_id, %detail, "hydrate_reclaimed: corrupt durable session row");
+                return self
+                    .quarantine_reclaimed_poison(
+                        storage.as_ref(),
+                        entity,
+                        caller_fence,
+                        &session_id,
+                    )
+                    .await;
+            }
+            Err(error) => {
+                debug!(
+                    stream_id = %stream_id,
+                    %error,
+                    "hydrate_reclaimed: get_session failed; skipping this entity for this pass"
+                );
+                return Ok(ReclaimedHydrationOutcome::TransientFailure);
+            }
+        };
+        let unacked = match storage.list_unacked(&session_id).await {
+            Ok(rows) => rows,
+            Err(super::super::persistence::SmPersistenceError::Corrupt {
+                stream_id: corrupt_stream,
+                detail,
+            }) if corrupt_stream == session_id => {
+                debug!(stream_id = %stream_id, %detail, "hydrate_reclaimed: corrupt durable unacked row");
+                return self
+                    .quarantine_reclaimed_poison(
+                        storage.as_ref(),
+                        entity,
+                        caller_fence,
+                        &session_id,
+                    )
+                    .await;
+            }
+            Err(error) => {
+                debug!(
+                    stream_id = %stream_id,
+                    %error,
+                    "hydrate_reclaimed: list_unacked failed; skipping this entity for this pass"
+                );
+                return Ok(ReclaimedHydrationOutcome::TransientFailure);
+            }
+        };
+        let session = match persisted_to_detached(&persisted, &unacked) {
+            Ok(session) => session,
+            Err(error) => {
+                debug!(
+                    stream_id = %stream_id,
+                    %error,
+                    "hydrate_reclaimed: row decode failed (poison pill); skipping"
+                );
+                return self
+                    .quarantine_reclaimed_poison(
+                        storage.as_ref(),
+                        entity,
+                        caller_fence,
+                        &session_id,
+                    )
+                    .await;
+            }
+        };
+        // Every persistence read above is an await point. Re-prove both the
+        // node incarnation and exact claim epoch immediately before the
+        // synchronous in-memory publication.
+        if self.node_identity.current() != *caller_fence.owner() {
+            return Ok(ReclaimedHydrationOutcome::StaleIdentity);
+        }
+        match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            self.claim_store
+                .fence(entity, caller_fence.owner(), caller_fence.epoch()),
+        )
+        .await
+        {
+            Ok(Ok(true)) if self.node_identity.current() == *caller_fence.owner() => {}
+            Ok(Ok(true)) => return Ok(ReclaimedHydrationOutcome::StaleIdentity),
+            Ok(Ok(_)) => return Ok(ReclaimedHydrationOutcome::LostClaim),
+            Ok(Err(error)) => {
+                debug!(stream_id = %stream_id, %error, "hydrate_reclaimed: final exact fence failed");
+                return Ok(ReclaimedHydrationOutcome::TransientFailure);
+            }
+            Err(_) => return Ok(ReclaimedHydrationOutcome::TransientFailure),
+        }
+        {
+            let mut sessions = self
+                .sessions
+                .write()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            sessions.insert(stream_id.clone(), session);
+        }
+        if let Ok(mut claim_fences) = self.claim_fences.write() {
+            claim_fences.insert(stream_id, caller_fence.clone());
+        }
+        Ok(ReclaimedHydrationOutcome::Hydrated)
+    }
+
+    async fn quarantine_reclaimed_poison(
+        &self,
+        storage: &dyn super::super::persistence::SmPersistenceStorage,
+        entity: &Entity,
+        caller_fence: &super::super::persistence::SmClaimFence,
+        session_id: &crate::pending_delivery::SmSessionId,
+    ) -> Result<ReclaimedHydrationOutcome, SmRegistryError> {
+        if self.node_identity.current() != *caller_fence.owner() {
+            return Ok(ReclaimedHydrationOutcome::StaleIdentity);
+        }
+        match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            self.claim_store
+                .fence(entity, caller_fence.owner(), caller_fence.epoch()),
+        )
+        .await
+        {
+            Ok(Ok(true)) if self.node_identity.current() == *caller_fence.owner() => {}
+            Ok(Ok(true)) => return Ok(ReclaimedHydrationOutcome::StaleIdentity),
+            Ok(Ok(_)) => return Ok(ReclaimedHydrationOutcome::LostClaim),
+            Ok(Err(_)) | Err(_) => return Ok(ReclaimedHydrationOutcome::TransientFailure),
+        }
+        // The clustered implementation binds `caller_fence` into the same
+        // transaction that removes both durable tables. Thus stale work can
+        // neither quarantine a newer epoch nor report terminal success
+        // before the poison state is actually gone.
+        match storage.quarantine_session(session_id, caller_fence).await {
+            Ok(()) => Ok(ReclaimedHydrationOutcome::PoisonReleased),
+            Err(super::super::persistence::SmPersistenceError::NotOwner { .. }) => {
+                Ok(ReclaimedHydrationOutcome::LostClaim)
+            }
+            Err(error) => {
+                debug!(
+                    stream_id = %session_id,
+                    %error,
+                    "hydrate_reclaimed: poison quarantine failed; retaining exact claim for retry"
+                );
+                Ok(ReclaimedHydrationOutcome::TransientFailure)
+            }
+        }
+    }
+
+    pub async fn hydrate_reclaimed(
+        &self,
+        entities: &[(Entity, super::super::persistence::SmClaimFence)],
+    ) -> Result<usize, SmRegistryError> {
+        let mut hydrated = 0usize;
+        for (entity, fence) in entities {
+            if self.hydrate_reclaimed_typed(entity, fence).await?
+                == ReclaimedHydrationOutcome::Hydrated
             {
-                let mut sessions = self
-                    .sessions
-                    .write()
-                    .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
-                sessions.insert(stream_id.clone(), session);
+                hydrated += 1;
             }
-            if let Ok(mut claim_epochs) = self.claim_epochs.write() {
-                claim_epochs.insert(stream_id, epoch);
-            }
-            hydrated += 1;
         }
         Ok(hydrated)
     }
+
+    pub async fn release_reclaimed_claim(
+        &self,
+        entity: &Entity,
+        fence: &super::super::persistence::SmClaimFence,
+    ) -> Result<crate::ownership::ExactReleaseOutcome, SmRegistryError> {
+        self.claim_store
+            .release_exact(entity, fence.owner(), fence.epoch())
+            .await
+            .map_err(|error| SmRegistryError::Internal(error.to_string()))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReclaimedHydrationOutcome {
+    Hydrated,
+    AlreadyPresent,
+    MissingDurable,
+    LostClaim,
+    StaleIdentity,
+    TransientFailure,
+    PoisonReleased,
 }
 
 impl InMemorySmSessionRegistry {

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
@@ -914,10 +914,38 @@ impl InMemorySmSessionRegistry {
         entity: &Entity,
         fence: &super::super::persistence::SmClaimFence,
     ) -> Result<crate::ownership::ExactReleaseOutcome, SmRegistryError> {
-        self.claim_store
-            .release_exact(entity, fence.owner(), fence.epoch())
-            .await
-            .map_err(|error| SmRegistryError::Internal(error.to_string()))
+        let stream_lock = self.stream_lock(&entity.id)?;
+        let _stream_guard = stream_lock.lock().await;
+        if self.stream_is_live_or_uncertain(&entity.id) {
+            // Responsibility transferred back to the live local session.
+            // Never let terminal cleanup release its claim.
+            return Ok(crate::ownership::ExactReleaseOutcome::NotOwned);
+        }
+        if !self.reserve_claim_fence_capacity(&entity.id) {
+            return Err(SmRegistryError::Internal(
+                "release_reclaimed_claim: exact-release retry capacity exhausted".to_string(),
+            ));
+        }
+        if !self.try_record_claim_fence(&entity.id, fence.clone()) {
+            self.cancel_claim_fence_reservation(&entity.id);
+            return Err(SmRegistryError::Internal(
+                "release_reclaimed_claim: failed to retain exact claim fence".to_string(),
+            ));
+        }
+        self.release_claim_store_entry_under(&entity.id, fence.clone())
+            .await;
+        let retained = self
+            .pending_claim_releases
+            .read()
+            .is_ok_and(|pending| pending.contains(&(entity.id.clone(), fence.clone())));
+        if retained {
+            Err(SmRegistryError::Internal(
+                "release_reclaimed_claim: exact release failed and was retained for retry"
+                    .to_string(),
+            ))
+        } else {
+            Ok(crate::ownership::ExactReleaseOutcome::Released)
+        }
     }
 }
 

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
@@ -976,20 +976,37 @@ impl InMemorySmSessionRegistry {
                 "release_reclaimed_claim: failed to retain exact claim fence".to_string(),
             ));
         }
-        self.release_claim_store_entry_under(&entity.id, fence.clone())
-            .await;
-        let retained = self
-            .pending_claim_releases
-            .read()
-            .is_ok_and(|pending| pending.contains(&(entity.id.clone(), fence.clone())));
-        if retained {
-            Err(SmRegistryError::Internal(
-                "release_reclaimed_claim: exact release failed and was retained for retry"
-                    .to_string(),
-            ))
-        } else {
-            Ok(crate::ownership::ExactReleaseOutcome::Released)
+        let outcome = match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            self.claim_store
+                .release_exact(entity, fence.owner(), fence.epoch()),
+        )
+        .await
+        {
+            Ok(Ok(outcome)) => outcome,
+            Ok(Err(_)) | Err(_) => {
+                if let Ok(mut pending) = self.pending_claim_releases.write() {
+                    pending.insert((entity.id.clone(), fence.clone()));
+                }
+                return Err(SmRegistryError::Internal(
+                    "release_reclaimed_claim: exact release failed and was retained for retry"
+                        .to_string(),
+                ));
+            }
+        };
+        if let Ok(mut fences) = self.claim_fences.write() {
+            if fences.get(&entity.id) == Some(fence) {
+                fences.remove(&entity.id);
+            }
         }
+        if let Ok(mut pending) = self.pending_claim_releases.write() {
+            pending.remove(&(entity.id.clone(), fence.clone()));
+        }
+        if let Some(storage) = &self.persistence {
+            let session_id = crate::pending_delivery::SmSessionId::new(entity.id.clone());
+            storage.evict_claim_cache(&session_id, fence);
+        }
+        Ok(outcome)
     }
 }
 

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/cross_node_resume.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/cross_node_resume.rs
@@ -118,7 +118,8 @@ use jid::BareJid;
 use tokio::time::Instant;
 
 use crate::ownership::{
-    verify_resume_identity, ClaimEpoch, ClaimError, Entity, EntityType, ResumeIdentityProof,
+    verify_resume_identity, ClaimEpoch, ClaimError, Entity, EntityType, NodeIdentity,
+    ResumeIdentityProof,
 };
 use crate::stream_management::persistence::PersistedSession;
 
@@ -590,7 +591,7 @@ impl InMemorySmSessionRegistry {
         .await
         {
             Ok(Ok(new_epoch)) => {
-                self.complete_local_claim(entity, new_epoch, stream_id)
+                self.complete_local_claim(entity, me, new_epoch, stream_id)
                     .await
             }
             Ok(Err(ClaimError::Conflict)) => Ok(CrossNodeResumeOutcome::NotFound),
@@ -638,7 +639,10 @@ impl InMemorySmSessionRegistry {
         )
         .await
         {
-            Ok(Ok(epoch)) => self.complete_local_claim(entity, epoch, stream_id).await,
+            Ok(Ok(epoch)) => {
+                self.complete_local_claim(entity, me, epoch, stream_id)
+                    .await
+            }
             Ok(Err(ClaimError::AlreadyClaimed | ClaimError::Draining)) => {
                 Ok(CrossNodeResumeOutcome::NotFound)
             }
@@ -662,12 +666,14 @@ impl InMemorySmSessionRegistry {
     async fn complete_local_claim(
         &self,
         entity: &Entity,
+        owner: NodeIdentity,
         epoch: ClaimEpoch,
         stream_id: &str,
     ) -> Result<CrossNodeResumeOutcome, SmRegistryError> {
+        let fence = super::super::persistence::SmClaimFence::new(owner, epoch);
         let hydrated = match tokio::time::timeout(
             FINISH_HYDRATE_TIMEOUT,
-            self.hydrate_reclaimed(&[(entity.clone(), epoch)]),
+            self.hydrate_reclaimed(&[(entity.clone(), fence.clone())]),
         )
         .await
         {
@@ -676,7 +682,7 @@ impl InMemorySmSessionRegistry {
                 return self
                     .repair_failed_local_claim(
                         entity,
-                        epoch,
+                        &fence,
                         stream_id,
                         format!("hydrate_reclaimed errored: {error}"),
                     )
@@ -686,7 +692,7 @@ impl InMemorySmSessionRegistry {
                 return self
                     .repair_failed_local_claim(
                         entity,
-                        epoch,
+                        &fence,
                         stream_id,
                         format!("hydrate_reclaimed timed out after {FINISH_HYDRATE_TIMEOUT:?}"),
                     )
@@ -704,7 +710,7 @@ impl InMemorySmSessionRegistry {
             return self
                 .repair_failed_local_claim(
                     entity,
-                    epoch,
+                    &fence,
                     stream_id,
                     "hydrate_reclaimed hydrated nothing (already-present race, missing \
                      durable row, or a storage read failure — see its own debug logs)"
@@ -726,7 +732,7 @@ impl InMemorySmSessionRegistry {
             Ok(Err(error)) => {
                 self.repair_failed_local_claim(
                     entity,
-                    epoch,
+                    &fence,
                     stream_id,
                     format!("claim_session errored post-hydrate: {error}"),
                 )
@@ -735,7 +741,7 @@ impl InMemorySmSessionRegistry {
             Err(_timeout) => {
                 self.repair_failed_local_claim(
                     entity,
-                    epoch,
+                    &fence,
                     stream_id,
                     format!("claim_session timed out after {FINISH_CLAIM_TIMEOUT:?} post-hydrate"),
                 )
@@ -770,17 +776,17 @@ impl InMemorySmSessionRegistry {
     async fn repair_failed_local_claim(
         &self,
         entity: &Entity,
-        epoch: ClaimEpoch,
+        fence: &super::super::persistence::SmClaimFence,
         stream_id: &str,
         reason: String,
     ) -> Result<CrossNodeResumeOutcome, SmRegistryError> {
         self.forget_claim_locally(stream_id).await;
 
-        let me = self.node_identity.current();
         for attempt in 1..=REPAIR_RELEASE_MAX_ATTEMPTS {
             match tokio::time::timeout(
                 REPAIR_RELEASE_TIMEOUT,
-                self.claim_store.release(entity, &me, epoch),
+                self.claim_store
+                    .release(entity, fence.owner(), fence.epoch()),
             )
             .await
             {

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -728,6 +728,76 @@ async fn hung_enable_claim_is_bounded_and_not_recorded() {
         .contains_key("hung-enable"));
 }
 
+#[tokio::test]
+async fn cancelled_enable_acquisition_retains_and_releases_commit_before_drop() {
+    use crate::ownership::ClaimStore as _;
+
+    let me = crate::ownership::NodeIdentity::new("sm-node", "incarnation");
+    let store = std::sync::Arc::new(HangingReleaseClaimStore {
+        inner: crate::ownership::InProcessClaimStore::new(),
+        hang_release: std::sync::atomic::AtomicBool::new(false),
+        hang_ensure: std::sync::atomic::AtomicBool::new(false),
+        commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(true),
+        poison_fence_cache_after_ensure: std::sync::Mutex::new(None),
+    });
+    let registry = std::sync::Arc::new(InMemorySmSessionRegistry::new().with_claim_store(
+        store.clone(),
+        crate::ownership::SharedNodeIdentity::new(me.clone()),
+    ));
+    let stream_id = "cancelled-commit-before-ensure-return";
+    let entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        stream_id.to_string(),
+    );
+    let task = {
+        let registry = registry.clone();
+        tokio::spawn(async move { registry.ensure_session_claim(stream_id).await })
+    };
+    tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            if store
+                .current_claim(&entity)
+                .await
+                .expect("claim lookup")
+                .is_some()
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("claim committed before cancellation");
+
+    task.abort();
+    assert!(task
+        .await
+        .expect_err("enable task cancelled")
+        .is_cancelled());
+    assert_eq!(
+        registry
+            .pending_claim_acquisitions
+            .read()
+            .expect("pending acquisition")
+            .len(),
+        1
+    );
+    assert!(registry.has_claim_fence_reservation(stream_id));
+
+    assert_eq!(registry.retry_pending_claim_releases(8).await, 0);
+    assert!(registry
+        .pending_claim_acquisitions
+        .read()
+        .expect("pending acquisition")
+        .is_empty());
+    assert!(store
+        .current_claim(&entity)
+        .await
+        .expect("claim lookup after retry")
+        .is_none());
+    assert_eq!(registry.claim_fence_capacity_used(), 0);
+}
+
 #[tokio::test(start_paused = true)]
 async fn enable_claim_commit_before_timeout_is_reconciled_and_released() {
     let me = crate::ownership::NodeIdentity::new("sm-node", "incarnation");

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -511,15 +511,17 @@ async fn old_claim_cleanup_waits_for_shared_detach_reservation_to_resolve() {
             .reconcile_rejected_enable_while_live(stream_id, &old)
             .await
     );
-    let pending = registry
-        .pending_claim_acquisitions
-        .read()
-        .expect("pending acquisitions");
-    assert_eq!(pending.len(), 2);
-    assert!(pending.iter().any(|(id, _, disposition)| {
-        id == stream_id && *disposition == PendingClaimAcquisitionDisposition::RetainDetachedSession
-    }));
-    drop(pending);
+    {
+        let pending = registry
+            .pending_claim_acquisitions
+            .read()
+            .expect("pending acquisitions");
+        assert_eq!(pending.len(), 2);
+        assert!(pending.iter().any(|(id, _, disposition)| {
+            id == stream_id
+                && *disposition == PendingClaimAcquisitionDisposition::RetainDetachedSession
+        }));
+    }
     assert!(
         registry.has_claim_fence_reservation(stream_id),
         "old-claim cleanup must not consume the detach reconciliation's reservation"
@@ -537,15 +539,17 @@ async fn old_claim_cleanup_waits_for_shared_detach_reservation_to_resolve() {
             PendingClaimAcquisitionDisposition::RetainDetachedSession,
         )
         .await;
-    let pending = registry
-        .pending_claim_acquisitions
-        .read()
-        .expect("pending acquisitions");
-    assert_eq!(pending.len(), 1);
-    assert!(pending.iter().any(|(id, _, disposition)| {
-        id == stream_id && *disposition == PendingClaimAcquisitionDisposition::ReleaseRejectedEnable
-    }));
-    drop(pending);
+    {
+        let pending = registry
+            .pending_claim_acquisitions
+            .read()
+            .expect("pending acquisitions");
+        assert_eq!(pending.len(), 1);
+        assert!(pending.iter().any(|(id, _, disposition)| {
+            id == stream_id
+                && *disposition == PendingClaimAcquisitionDisposition::ReleaseRejectedEnable
+        }));
+    }
     assert!(
         registry.has_claim_fence_reservation(stream_id),
         "a conflicting detach reconciliation must leave the slot to the remaining rejected-enable cleanup"

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -288,6 +288,50 @@ async fn terminal_release_retry_clears_retained_exact_fence() {
     assert_eq!(registry.pending_claim_release_count(), 0);
 }
 
+#[tokio::test(start_paused = true)]
+async fn terminal_release_retry_skips_stream_that_became_live_again() {
+    let me = crate::ownership::NodeIdentity::new("sm-node", "incarnation");
+    let store = std::sync::Arc::new(HangingReleaseClaimStore {
+        inner: crate::ownership::InProcessClaimStore::new(),
+        hang_release: std::sync::atomic::AtomicBool::new(true),
+        hang_ensure: std::sync::atomic::AtomicBool::new(false),
+        commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(false),
+        poison_fence_cache_after_ensure: std::sync::Mutex::new(None),
+    });
+    let registry = InMemorySmSessionRegistry::new()
+        .with_claim_store(store.clone(), crate::ownership::SharedNodeIdentity::new(me));
+    let stream_id = "retry-became-live";
+    registry
+        .store_session(make_test_session(stream_id))
+        .await
+        .expect("initial store");
+    registry
+        .take_session(stream_id)
+        .await
+        .expect("terminal take");
+    assert_eq!(registry.pending_claim_release_count(), 1);
+
+    registry
+        .store_session(make_test_session(stream_id))
+        .await
+        .expect("same stream becomes resumable again");
+    store
+        .hang_release
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+
+    assert_eq!(
+        registry.retry_pending_claim_releases(8).await,
+        0,
+        "a terminal retry must not release a stream that is live again"
+    );
+    assert_eq!(registry.pending_claim_release_count(), 1);
+    assert!(registry
+        .peek_session(stream_id)
+        .await
+        .expect("live session probe")
+        .is_some());
+}
+
 #[tokio::test]
 async fn shutdown_drained_session_is_not_a_terminal_release_retry() {
     let registry = InMemorySmSessionRegistry::new();

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -394,10 +394,32 @@ async fn detach_claim_commit_before_timeout_is_reconciled_and_retained() {
             .expect("claim lookup")
             .is_some()
     );
-    assert!(registry
+    assert!(!registry
         .claim_fences
         .read()
         .expect("claim fences")
+        .contains_key(stream_id));
+    assert_eq!(
+        registry
+            .pending_claim_acquisitions
+            .read()
+            .expect("pending acquisitions")
+            .len(),
+        1,
+        "detach records uncertainty without a second ClaimStore call under the shard lock"
+    );
+    assert_eq!(registry.pending_claim_release_count(), 0);
+    assert!(persistence
+        .get_session(&crate::pending_delivery::SmSessionId::new(stream_id))
+        .await
+        .expect("durable snapshot lookup")
+        .is_some());
+
+    assert_eq!(registry.retry_pending_claim_releases(8).await, 0);
+    assert!(registry
+        .claim_fences
+        .read()
+        .expect("claim fences after janitor reconciliation")
         .contains_key(stream_id));
     assert!(registry
         .pending_claim_acquisitions
@@ -405,11 +427,63 @@ async fn detach_claim_commit_before_timeout_is_reconciled_and_retained() {
         .expect("pending acquisitions")
         .is_empty());
     assert_eq!(registry.pending_claim_release_count(), 0);
+}
+
+#[tokio::test]
+async fn detach_capacity_rejection_precedes_memory_durable_and_claim_publication() {
+    let owner = crate::ownership::NodeIdentity::new("sm-node", "incarnation");
+    let claim_store = std::sync::Arc::new(crate::ownership::InProcessClaimStore::new());
+    let persistence = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+    let registry = InMemorySmSessionRegistry::with_capacity(1)
+        .with_persistence(persistence.clone())
+        .with_claim_store(
+            claim_store.clone(),
+            crate::ownership::SharedNodeIdentity::new(owner.clone()),
+        );
+    {
+        let mut pending = registry
+            .pending_claim_releases
+            .write()
+            .expect("pending releases");
+        pending.insert((
+            "existing-cleanup-1".to_string(),
+            super::super::persistence::SmClaimFence::new(
+                owner.clone(),
+                crate::ownership::ClaimEpoch(1),
+            ),
+        ));
+        pending.insert((
+            "existing-cleanup-2".to_string(),
+            super::super::persistence::SmClaimFence::new(owner, crate::ownership::ClaimEpoch(2)),
+        ));
+    }
+    let stream_id = "capacity-rejected-detach";
+
+    assert!(registry
+        .store_session(realistic_test_session(stream_id))
+        .await
+        .is_err());
+    let session_id = crate::pending_delivery::SmSessionId::new(stream_id);
     assert!(persistence
-        .get_session(&crate::pending_delivery::SmSessionId::new(stream_id))
+        .get_session(&session_id)
         .await
         .expect("durable snapshot lookup")
-        .is_some());
+        .is_none());
+    assert!(registry
+        .peek_session(stream_id)
+        .await
+        .expect("in-memory session lookup")
+        .is_none());
+    assert!(crate::ownership::ClaimStore::current_claim(
+        claim_store.as_ref(),
+        &crate::ownership::Entity::new(
+            crate::ownership::EntityType::SmSession,
+            stream_id.to_string(),
+        ),
+    )
+    .await
+    .expect("claim lookup")
+    .is_none());
 }
 
 #[tokio::test(start_paused = true)]

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -97,6 +97,287 @@ fn make_test_session_with_unacked(stream_id: &str, unacked: Vec<(u32, String)>) 
     s
 }
 
+struct HangingReleaseClaimStore {
+    inner: crate::ownership::InProcessClaimStore,
+    hang_release: std::sync::atomic::AtomicBool,
+    hang_ensure: std::sync::atomic::AtomicBool,
+    commit_then_hang_ensure_once: std::sync::atomic::AtomicBool,
+}
+
+#[async_trait::async_trait]
+impl crate::ownership::ClaimStore for HangingReleaseClaimStore {
+    async fn ensure_schema(&self) -> Result<(), crate::ownership::ClaimError> {
+        self.inner.ensure_schema().await
+    }
+
+    async fn acquire(
+        &self,
+        entity: &crate::ownership::Entity,
+        me: &crate::ownership::NodeIdentity,
+    ) -> Result<crate::ownership::ClaimEpoch, crate::ownership::ClaimError> {
+        self.inner.acquire(entity, me).await
+    }
+
+    async fn ensure_claimed(
+        &self,
+        entity: &crate::ownership::Entity,
+        me: &crate::ownership::NodeIdentity,
+    ) -> Result<crate::ownership::ClaimEpoch, crate::ownership::ClaimError> {
+        if self
+            .commit_then_hang_ensure_once
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+        {
+            self.inner.ensure_claimed(entity, me).await?;
+            return std::future::pending().await;
+        }
+        if self.hang_ensure.load(std::sync::atomic::Ordering::SeqCst) {
+            return std::future::pending().await;
+        }
+        self.inner.ensure_claimed(entity, me).await
+    }
+
+    async fn steal_stale(
+        &self,
+        entity: &crate::ownership::Entity,
+        observed: crate::ownership::ClaimEpoch,
+        staleness: crate::ownership::StalePredicate,
+        me: &crate::ownership::NodeIdentity,
+    ) -> Result<crate::ownership::ClaimEpoch, crate::ownership::ClaimError> {
+        self.inner
+            .steal_stale(entity, observed, staleness, me)
+            .await
+    }
+
+    async fn steal_for_resume(
+        &self,
+        entity: &crate::ownership::Entity,
+        observed: crate::ownership::ClaimEpoch,
+        witness: crate::ownership::ResumeIdentityProof,
+        me: &crate::ownership::NodeIdentity,
+    ) -> Result<crate::ownership::ClaimEpoch, crate::ownership::ClaimError> {
+        self.inner
+            .steal_for_resume(entity, observed, witness, me)
+            .await
+    }
+
+    async fn current_claim(
+        &self,
+        entity: &crate::ownership::Entity,
+    ) -> Result<Option<crate::ownership::ClaimSnapshot>, crate::ownership::ClaimError> {
+        self.inner.current_claim(entity).await
+    }
+
+    async fn fence(
+        &self,
+        entity: &crate::ownership::Entity,
+        me: &crate::ownership::NodeIdentity,
+        mine: crate::ownership::ClaimEpoch,
+    ) -> Result<bool, crate::ownership::ClaimError> {
+        self.inner.fence(entity, me, mine).await
+    }
+
+    async fn release(
+        &self,
+        _entity: &crate::ownership::Entity,
+        _me: &crate::ownership::NodeIdentity,
+        _mine: crate::ownership::ClaimEpoch,
+    ) -> Result<(), crate::ownership::ClaimError> {
+        if self.hang_release.load(std::sync::atomic::Ordering::SeqCst) {
+            std::future::pending().await
+        } else {
+            self.inner.release(_entity, _me, _mine).await
+        }
+    }
+
+    async fn release_many(
+        &self,
+        entities: &[crate::ownership::Entity],
+        me: &crate::ownership::NodeIdentity,
+    ) -> Result<(), crate::ownership::ClaimError> {
+        self.inner.release_many(entities, me).await
+    }
+}
+
+#[tokio::test(start_paused = true)]
+async fn hung_claim_release_is_bounded_and_retains_exact_fence() {
+    let me = crate::ownership::NodeIdentity::new("sm-node", "incarnation");
+    let registry = InMemorySmSessionRegistry::new().with_claim_store(
+        std::sync::Arc::new(HangingReleaseClaimStore {
+            inner: crate::ownership::InProcessClaimStore::new(),
+            hang_release: std::sync::atomic::AtomicBool::new(true),
+            hang_ensure: std::sync::atomic::AtomicBool::new(false),
+            commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(false),
+        }),
+        crate::ownership::SharedNodeIdentity::new(me),
+    );
+    let stream_id = "hung-release";
+    registry
+        .store_session(make_test_session(stream_id))
+        .await
+        .expect("store claimed session");
+
+    let taken = tokio::time::timeout(
+        super::core::CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT + Duration::from_millis(1),
+        registry.take_session(stream_id),
+    )
+    .await
+    .expect("hung release must remain bounded")
+    .expect("bounded take");
+    assert!(taken.is_some());
+    assert!(registry
+        .claim_fences
+        .read()
+        .expect("fences")
+        .contains_key(stream_id));
+}
+
+#[tokio::test(start_paused = true)]
+async fn terminal_release_retry_clears_retained_exact_fence() {
+    let me = crate::ownership::NodeIdentity::new("sm-node", "incarnation");
+    let store = std::sync::Arc::new(HangingReleaseClaimStore {
+        inner: crate::ownership::InProcessClaimStore::new(),
+        hang_release: std::sync::atomic::AtomicBool::new(true),
+        hang_ensure: std::sync::atomic::AtomicBool::new(false),
+        commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(false),
+    });
+    let registry = InMemorySmSessionRegistry::new()
+        .with_claim_store(store.clone(), crate::ownership::SharedNodeIdentity::new(me));
+    let stream_id = "retry-release";
+    registry
+        .store_session(make_test_session(stream_id))
+        .await
+        .expect("store session");
+    registry
+        .take_session(stream_id)
+        .await
+        .expect("take session");
+    assert_eq!(registry.pending_claim_release_count(), 1);
+
+    store
+        .hang_release
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(registry.retry_pending_claim_releases(8).await, 1);
+    assert_eq!(registry.pending_claim_release_count(), 0);
+}
+
+#[tokio::test]
+async fn shutdown_drained_session_is_not_a_terminal_release_retry() {
+    let registry = InMemorySmSessionRegistry::new();
+    registry
+        .store_session(make_test_session("shutdown-in-flight"))
+        .await
+        .expect("store session");
+    assert_eq!(
+        registry
+            .drain_all_for_shutdown()
+            .await
+            .expect("drain")
+            .len(),
+        1
+    );
+    assert_eq!(registry.pending_claim_release_count(), 0);
+    assert_eq!(registry.retry_pending_claim_releases(8).await, 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn hung_enable_claim_is_bounded_and_not_recorded() {
+    let me = crate::ownership::NodeIdentity::new("sm-node", "incarnation");
+    let registry = InMemorySmSessionRegistry::new().with_claim_store(
+        std::sync::Arc::new(HangingReleaseClaimStore {
+            inner: crate::ownership::InProcessClaimStore::new(),
+            hang_release: std::sync::atomic::AtomicBool::new(false),
+            hang_ensure: std::sync::atomic::AtomicBool::new(true),
+            commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(false),
+        }),
+        crate::ownership::SharedNodeIdentity::new(me),
+    );
+    assert!(!registry.ensure_session_claim("hung-enable").await);
+    assert!(!registry
+        .claim_fences
+        .read()
+        .expect("fences")
+        .contains_key("hung-enable"));
+}
+
+#[tokio::test(start_paused = true)]
+async fn enable_claim_commit_before_timeout_is_reconciled_and_released() {
+    let me = crate::ownership::NodeIdentity::new("sm-node", "incarnation");
+    let store = std::sync::Arc::new(HangingReleaseClaimStore {
+        inner: crate::ownership::InProcessClaimStore::new(),
+        hang_release: std::sync::atomic::AtomicBool::new(false),
+        hang_ensure: std::sync::atomic::AtomicBool::new(false),
+        commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(true),
+    });
+    let registry = InMemorySmSessionRegistry::new()
+        .with_claim_store(store.clone(), crate::ownership::SharedNodeIdentity::new(me));
+    let stream_id = "commit-before-timeout";
+
+    assert!(!registry.ensure_session_claim(stream_id).await);
+
+    let entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        stream_id.to_string(),
+    );
+    assert!(
+        crate::ownership::ClaimStore::current_claim(store.as_ref(), &entity)
+            .await
+            .expect("read reconciled claim")
+            .is_none()
+    );
+    assert!(registry
+        .pending_claim_acquisitions
+        .read()
+        .expect("pending acquisitions")
+        .is_empty());
+    assert_eq!(registry.pending_claim_release_count(), 0);
+    assert_eq!(registry.claim_fence_capacity_used(), 0);
+}
+
+#[test]
+fn timed_out_release_generations_cannot_outgrow_claim_capacity() {
+    let registry = InMemorySmSessionRegistry::with_capacity(2);
+    let owner = crate::ownership::NodeIdentity::new("sm-node", "incarnation");
+    let first = super::super::persistence::SmClaimFence::new(
+        owner.clone(),
+        crate::ownership::ClaimEpoch(1),
+    );
+    let second =
+        super::super::persistence::SmClaimFence::new(owner, crate::ownership::ClaimEpoch(2));
+    let stream_id = "generation-churn";
+
+    assert!(registry.reserve_claim_fence_capacity(stream_id));
+    assert!(registry.try_record_claim_fence(stream_id, first.clone()));
+    registry
+        .pending_claim_releases
+        .write()
+        .expect("pending releases")
+        .insert((stream_id.to_string(), first.clone()));
+
+    assert!(registry.reserve_claim_fence_capacity(stream_id));
+    assert!(registry.try_record_claim_fence(stream_id, second.clone()));
+    assert_eq!(registry.claim_fence_capacity_used(), 2);
+    assert!(registry
+        .pending_claim_releases
+        .read()
+        .expect("pending releases")
+        .contains(&(stream_id.to_string(), first)));
+    assert_eq!(
+        registry
+            .claim_fences
+            .read()
+            .expect("current fences")
+            .get(stream_id),
+        Some(&second)
+    );
+    registry
+        .pending_claim_releases
+        .write()
+        .expect("pending releases")
+        .insert((stream_id.to_string(), second));
+    assert!(!registry.reserve_claim_fence_capacity(stream_id));
+    assert_eq!(registry.claim_fence_capacity_used(), 2);
+}
+
 #[test]
 fn stream_locks_are_fixed_shards_not_per_stream_entries() {
     let registry = InMemorySmSessionRegistry::new();
@@ -2584,8 +2865,9 @@ async fn hydrate_reclaimed_skips_when_stream_id_already_present_in_memory() {
         "stream-already-present".to_string(),
     );
     let epoch = crate::ownership::ClaimEpoch(0);
+    let fence = super::super::persistence::SmClaimFence::new(me, epoch);
     let hydrated = registry
-        .hydrate_reclaimed(&[(entity, epoch)])
+        .hydrate_reclaimed(&[(entity, fence)])
         .await
         .expect("hydrate_reclaimed");
     assert_eq!(
@@ -2605,6 +2887,67 @@ async fn hydrate_reclaimed_skips_when_stream_id_already_present_in_memory() {
     );
 }
 
+#[tokio::test]
+async fn hydrate_reclaimed_rejects_work_from_a_superseded_epoch() {
+    let claim_store = std::sync::Arc::new(crate::ownership::InProcessClaimStore::new());
+    let me = crate::ownership::NodeIdentity::local();
+    let storage = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+    let entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        "stream-stale-work".to_string(),
+    );
+    let current_epoch = claim_store
+        .acquire(&entity, &me)
+        .await
+        .expect("seed current claim");
+    storage
+        .upsert_session(super::super::persistence::PersistedSession {
+            stream_id: crate::pending_delivery::SmSessionId::new("stream-stale-work"),
+            user_id: "user@example.com".to_string(),
+            jid: make_test_jid(),
+            inbound_count: 0,
+            outbound_count: 0,
+            last_acked: 0,
+            replay_gap_through: None,
+            max_resume_time: Some(300),
+            detached_at: chrono::Utc::now(),
+            max_resume_duration: Duration::from_secs(300),
+            carbons_enabled: false,
+            roster_interested: false,
+            blocklist_interested: false,
+            presence_available: false,
+            presence_show: None,
+            presence_status: None,
+            presence_priority: 0,
+            presence_payloads: Vec::new(),
+        })
+        .await
+        .expect("seed durable row");
+    let registry = InMemorySmSessionRegistry::new()
+        .with_persistence(storage)
+        .with_claim_store(
+            claim_store,
+            crate::ownership::SharedNodeIdentity::new(me.clone()),
+        );
+
+    let stale_fence = super::super::persistence::SmClaimFence::new(
+        me,
+        crate::ownership::ClaimEpoch(current_epoch.0 + 1),
+    );
+
+    let outcome = registry
+        .hydrate_reclaimed_typed(&entity, &stale_fence)
+        .await
+        .expect("hydrate stale work");
+
+    assert_eq!(outcome, super::ReclaimedHydrationOutcome::LostClaim);
+    assert!(registry
+        .peek_session("stream-stale-work")
+        .await
+        .expect("peek")
+        .is_none());
+}
+
 /// Persistence wrapper that pauses inside `get_session` for one designated
 /// stream id — lets the mid-flight race test below deterministically
 /// interleave a concurrent live-path mutator (`store_session`) with
@@ -2617,6 +2960,8 @@ struct GatedGetSessionPersistence {
     armed: std::sync::atomic::AtomicBool,
     reached: tokio::sync::Notify,
     proceed: tokio::sync::Notify,
+    corrupt: std::sync::atomic::AtomicBool,
+    quarantined: std::sync::atomic::AtomicBool,
 }
 
 impl GatedGetSessionPersistence {
@@ -2627,6 +2972,8 @@ impl GatedGetSessionPersistence {
             armed: std::sync::atomic::AtomicBool::new(false),
             reached: tokio::sync::Notify::new(),
             proceed: tokio::sync::Notify::new(),
+            corrupt: std::sync::atomic::AtomicBool::new(false),
+            quarantined: std::sync::atomic::AtomicBool::new(false),
         }
     }
 }
@@ -2647,6 +2994,12 @@ impl super::super::persistence::SmPersistenceStorage for GatedGetSessionPersiste
         Option<super::super::persistence::PersistedSession>,
         super::super::persistence::SmPersistenceError,
     > {
+        if self.corrupt.load(std::sync::atomic::Ordering::SeqCst) {
+            return Err(super::super::persistence::SmPersistenceError::Corrupt {
+                stream_id: stream_id.clone(),
+                detail: "injected corrupt row".to_string(),
+            });
+        }
         if self.armed.load(std::sync::atomic::Ordering::SeqCst)
             && stream_id.as_str() == self.gate_stream
         {
@@ -2660,6 +3013,16 @@ impl super::super::persistence::SmPersistenceStorage for GatedGetSessionPersiste
         &self,
         stream_id: &crate::pending_delivery::SmSessionId,
     ) -> Result<(), super::super::persistence::SmPersistenceError> {
+        self.inner.delete_session(stream_id).await
+    }
+
+    async fn quarantine_session(
+        &self,
+        stream_id: &crate::pending_delivery::SmSessionId,
+        _expected_fence: &super::super::persistence::SmClaimFence,
+    ) -> Result<(), super::super::persistence::SmPersistenceError> {
+        self.quarantined
+            .store(true, std::sync::atomic::Ordering::SeqCst);
         self.inner.delete_session(stream_id).await
     }
 
@@ -2714,6 +3077,76 @@ impl super::super::persistence::SmPersistenceStorage for GatedGetSessionPersiste
     > {
         self.inner.list_all_sessions().await
     }
+}
+
+#[tokio::test]
+async fn hydrate_reclaimed_quarantines_corrupt_persistence_before_terminal_outcome() {
+    let storage = std::sync::Arc::new(GatedGetSessionPersistence::new("unused"));
+    let claim_store = std::sync::Arc::new(crate::ownership::InProcessClaimStore::new());
+    let me = crate::ownership::NodeIdentity::local();
+    let entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        "stream-poison".to_string(),
+    );
+    storage
+        .inner
+        .upsert_session(super::super::persistence::PersistedSession {
+            stream_id: crate::pending_delivery::SmSessionId::new("stream-poison"),
+            user_id: "poison@example.com".to_string(),
+            jid: make_test_jid(),
+            inbound_count: 0,
+            outbound_count: 0,
+            last_acked: 0,
+            replay_gap_through: None,
+            max_resume_time: Some(300),
+            detached_at: chrono::Utc::now(),
+            max_resume_duration: Duration::from_secs(300),
+            carbons_enabled: false,
+            roster_interested: false,
+            blocklist_interested: false,
+            presence_available: false,
+            presence_show: None,
+            presence_status: None,
+            presence_priority: 0,
+            presence_payloads: Vec::new(),
+        })
+        .await
+        .expect("seed poison row");
+    let epoch = claim_store
+        .acquire(&entity, &me)
+        .await
+        .expect("seed exact claim");
+    let registry = InMemorySmSessionRegistry::new()
+        .with_persistence(storage.clone())
+        .with_claim_store(
+            claim_store,
+            crate::ownership::SharedNodeIdentity::new(me.clone()),
+        );
+    storage
+        .corrupt
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+
+    let outcome = registry
+        .hydrate_reclaimed_typed(
+            &entity,
+            &super::super::persistence::SmClaimFence::new(me, epoch),
+        )
+        .await
+        .expect("hydrate poison");
+
+    assert_eq!(outcome, super::ReclaimedHydrationOutcome::PoisonReleased);
+    assert!(storage
+        .quarantined
+        .load(std::sync::atomic::Ordering::SeqCst));
+    storage
+        .corrupt
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+    assert!(storage
+        .inner
+        .get_session(&crate::pending_delivery::SmSessionId::new("stream-poison"))
+        .await
+        .expect("read after quarantine")
+        .is_none());
 }
 
 #[tokio::test]
@@ -2789,7 +3222,10 @@ async fn hydrate_reclaimed_serializes_against_a_concurrent_live_mutator_for_the_
         .armed
         .store(true, std::sync::atomic::Ordering::SeqCst);
     let hydrate_registry = std::sync::Arc::clone(&registry);
-    let hydrate_entities = vec![(entity, epoch)];
+    let hydrate_entities = vec![(
+        entity,
+        super::super::persistence::SmClaimFence::new(me, epoch),
+    )];
     let hydrate =
         tokio::spawn(async move { hydrate_registry.hydrate_reclaimed(&hydrate_entities).await });
     storage.reached.notified().await;

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -381,6 +381,45 @@ async fn rejected_enable_reconciliation_skips_stream_that_became_live_again() {
     );
 }
 
+#[tokio::test(start_paused = true)]
+async fn reclaimed_terminal_release_failure_retains_exact_retry() {
+    use crate::ownership::ClaimStore as _;
+
+    let me = crate::ownership::NodeIdentity::new("reclaimer", "incarnation");
+    let store = std::sync::Arc::new(HangingReleaseClaimStore {
+        inner: crate::ownership::InProcessClaimStore::new(),
+        hang_release: std::sync::atomic::AtomicBool::new(true),
+        hang_ensure: std::sync::atomic::AtomicBool::new(false),
+        commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(false),
+        poison_fence_cache_after_ensure: std::sync::Mutex::new(None),
+    });
+    let entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        "missing-reclaimed-terminal",
+    );
+    let epoch = store.acquire(&entity, &me).await.expect("claim");
+    let fence = super::super::persistence::SmClaimFence::new(me.clone(), epoch);
+    let registry = InMemorySmSessionRegistry::new()
+        .with_claim_store(store, crate::ownership::SharedNodeIdentity::new(me));
+
+    assert_eq!(
+        registry
+            .hydrate_reclaimed_typed(&entity, &fence)
+            .await
+            .expect("typed hydration"),
+        ReclaimedHydrationOutcome::MissingDurable
+    );
+    assert!(registry
+        .release_reclaimed_claim(&entity, &fence)
+        .await
+        .is_err());
+    assert_eq!(
+        registry.pending_claim_release_count(),
+        1,
+        "failed inline terminal release must retain the supplied exact fence for retry"
+    );
+}
+
 #[tokio::test]
 async fn shutdown_drained_session_is_not_a_terminal_release_retry() {
     let registry = InMemorySmSessionRegistry::new();

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -364,6 +364,55 @@ async fn enable_claim_commit_before_timeout_is_reconciled_and_released() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn detach_claim_commit_before_timeout_is_reconciled_and_retained() {
+    let me = crate::ownership::NodeIdentity::new("sm-node", "incarnation");
+    let store = std::sync::Arc::new(HangingReleaseClaimStore {
+        inner: crate::ownership::InProcessClaimStore::new(),
+        hang_release: std::sync::atomic::AtomicBool::new(false),
+        hang_ensure: std::sync::atomic::AtomicBool::new(false),
+        commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(true),
+        poison_fence_cache_after_ensure: std::sync::Mutex::new(None),
+    });
+    let persistence = std::sync::Arc::new(super::super::persistence::InMemorySmPersistence::new());
+    let registry = InMemorySmSessionRegistry::new()
+        .with_persistence(persistence.clone())
+        .with_claim_store(store.clone(), crate::ownership::SharedNodeIdentity::new(me));
+    let stream_id = "detach-commit-before-timeout";
+
+    registry
+        .store_session(realistic_test_session(stream_id))
+        .await
+        .expect("store detached session");
+
+    let entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        stream_id.to_string(),
+    );
+    assert!(
+        crate::ownership::ClaimStore::current_claim(store.as_ref(), &entity)
+            .await
+            .expect("claim lookup")
+            .is_some()
+    );
+    assert!(registry
+        .claim_fences
+        .read()
+        .expect("claim fences")
+        .contains_key(stream_id));
+    assert!(registry
+        .pending_claim_acquisitions
+        .read()
+        .expect("pending acquisitions")
+        .is_empty());
+    assert_eq!(registry.pending_claim_release_count(), 0);
+    assert!(persistence
+        .get_session(&crate::pending_delivery::SmSessionId::new(stream_id))
+        .await
+        .expect("durable snapshot lookup")
+        .is_some());
+}
+
+#[tokio::test(start_paused = true)]
 async fn enable_claim_publication_failure_retains_ambiguous_exact_release() {
     let me = crate::ownership::NodeIdentity::new("sm-node", "incarnation");
     let store = std::sync::Arc::new(HangingReleaseClaimStore {

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -269,6 +269,17 @@ async fn terminal_release_retry_clears_retained_exact_fence() {
         .await
         .expect("take session");
     assert_eq!(registry.pending_claim_release_count(), 1);
+    assert!(
+        registry.live_session_ids().expect("live session snapshot").is_empty(),
+        "a terminal exact-release retry is not a resumable session and must not shield pending-delivery claims"
+    );
+    assert_eq!(
+        registry
+            .locally_owned_claim_ids()
+            .expect("local claim snapshot"),
+        vec![stream_id.to_string()],
+        "ownership reconciliation still accounts for the ambiguous exact release"
+    );
 
     store
         .hang_release

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -205,6 +205,19 @@ impl crate::ownership::ClaimStore for HangingReleaseClaimStore {
         }
     }
 
+    async fn release_exact(
+        &self,
+        entity: &crate::ownership::Entity,
+        me: &crate::ownership::NodeIdentity,
+        mine: crate::ownership::ClaimEpoch,
+    ) -> Result<crate::ownership::ExactReleaseOutcome, crate::ownership::ClaimError> {
+        if self.hang_release.load(std::sync::atomic::Ordering::SeqCst) {
+            std::future::pending().await
+        } else {
+            self.inner.release_exact(entity, me, mine).await
+        }
+    }
+
     async fn release_many(
         &self,
         entities: &[crate::ownership::Entity],
@@ -686,6 +699,49 @@ async fn reclaimed_terminal_release_failure_retains_exact_retry() {
         1,
         "failed inline terminal release must retain the supplied exact fence for retry"
     );
+}
+
+#[tokio::test]
+async fn reclaimed_terminal_release_reports_not_owned_without_touching_replacement() {
+    use crate::ownership::ClaimStore as _;
+
+    let old_owner = crate::ownership::NodeIdentity::new("old-reclaimer", "old-incarnation");
+    let replacement = crate::ownership::NodeIdentity::new("replacement", "new-incarnation");
+    let store = std::sync::Arc::new(crate::ownership::InProcessClaimStore::new());
+    let entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        "reclaimed-release-lost-race",
+    );
+    let old_epoch = store.acquire(&entity, &old_owner).await.expect("old claim");
+    assert_eq!(
+        store
+            .release_exact(&entity, &old_owner, old_epoch)
+            .await
+            .expect("release old generation"),
+        crate::ownership::ExactReleaseOutcome::Released
+    );
+    let replacement_epoch = store
+        .acquire(&entity, &replacement)
+        .await
+        .expect("replacement claim");
+    let old_fence = super::super::persistence::SmClaimFence::new(old_owner.clone(), old_epoch);
+    let registry = InMemorySmSessionRegistry::new().with_claim_store(
+        store.clone(),
+        crate::ownership::SharedNodeIdentity::new(old_owner),
+    );
+
+    assert_eq!(
+        registry
+            .release_reclaimed_claim(&entity, &old_fence)
+            .await
+            .expect("exact lost-race outcome"),
+        crate::ownership::ExactReleaseOutcome::NotOwned
+    );
+    assert!(store
+        .fence(&entity, &replacement, replacement_epoch)
+        .await
+        .expect("replacement fence"));
+    assert_eq!(registry.pending_claim_release_count(), 0);
 }
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -332,6 +332,55 @@ async fn terminal_release_retry_skips_stream_that_became_live_again() {
         .is_some());
 }
 
+#[tokio::test(start_paused = true)]
+async fn rejected_enable_reconciliation_skips_stream_that_became_live_again() {
+    let me = crate::ownership::NodeIdentity::new("sm-node", "incarnation");
+    let store = std::sync::Arc::new(HangingReleaseClaimStore {
+        inner: crate::ownership::InProcessClaimStore::new(),
+        hang_release: std::sync::atomic::AtomicBool::new(false),
+        hang_ensure: std::sync::atomic::AtomicBool::new(true),
+        commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(false),
+        poison_fence_cache_after_ensure: std::sync::Mutex::new(None),
+    });
+    let registry = InMemorySmSessionRegistry::new()
+        .with_claim_store(store.clone(), crate::ownership::SharedNodeIdentity::new(me));
+    let stream_id = "rejected-enable-became-live";
+
+    assert!(!registry.ensure_session_claim(stream_id).await);
+    assert_eq!(
+        registry
+            .pending_claim_acquisitions
+            .read()
+            .expect("pending acquisition")
+            .len(),
+        1
+    );
+    store
+        .hang_ensure
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+    registry
+        .store_session(make_test_session(stream_id))
+        .await
+        .expect("same id becomes a live detached session");
+
+    assert_eq!(registry.retry_pending_claim_releases(8).await, 0);
+    assert!(registry
+        .peek_session(stream_id)
+        .await
+        .expect("live session probe")
+        .is_some());
+    let entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        stream_id.to_string(),
+    );
+    assert!(
+        crate::ownership::ClaimStore::current_claim(store.as_ref(), &entity)
+            .await
+            .expect("claim lookup")
+            .is_some()
+    );
+}
+
 #[tokio::test]
 async fn shutdown_drained_session_is_not_a_terminal_release_retry() {
     let registry = InMemorySmSessionRegistry::new();

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -102,6 +102,8 @@ struct HangingReleaseClaimStore {
     hang_release: std::sync::atomic::AtomicBool,
     hang_ensure: std::sync::atomic::AtomicBool,
     commit_then_hang_ensure_once: std::sync::atomic::AtomicBool,
+    poison_fence_cache_after_ensure:
+        std::sync::Mutex<Option<std::sync::Weak<InMemorySmSessionRegistry>>>,
 }
 
 #[async_trait::async_trait]
@@ -133,7 +135,20 @@ impl crate::ownership::ClaimStore for HangingReleaseClaimStore {
         if self.hang_ensure.load(std::sync::atomic::Ordering::SeqCst) {
             return std::future::pending().await;
         }
-        self.inner.ensure_claimed(entity, me).await
+        let result = self.inner.ensure_claimed(entity, me).await;
+        let registry = self
+            .poison_fence_cache_after_ensure
+            .lock()
+            .expect("poison injection lock")
+            .take()
+            .and_then(|registry| registry.upgrade());
+        if let Some(registry) = registry {
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _fences = registry.claim_fences.write().expect("claim fences");
+                panic!("inject claim-fence publication failure");
+            }));
+        }
+        result
     }
 
     async fn steal_stale(
@@ -207,6 +222,7 @@ async fn hung_claim_release_is_bounded_and_retains_exact_fence() {
             hang_release: std::sync::atomic::AtomicBool::new(true),
             hang_ensure: std::sync::atomic::AtomicBool::new(false),
             commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(false),
+            poison_fence_cache_after_ensure: std::sync::Mutex::new(None),
         }),
         crate::ownership::SharedNodeIdentity::new(me),
     );
@@ -239,6 +255,7 @@ async fn terminal_release_retry_clears_retained_exact_fence() {
         hang_release: std::sync::atomic::AtomicBool::new(true),
         hang_ensure: std::sync::atomic::AtomicBool::new(false),
         commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(false),
+        poison_fence_cache_after_ensure: std::sync::Mutex::new(None),
     });
     let registry = InMemorySmSessionRegistry::new()
         .with_claim_store(store.clone(), crate::ownership::SharedNodeIdentity::new(me));
@@ -288,6 +305,7 @@ async fn hung_enable_claim_is_bounded_and_not_recorded() {
             hang_release: std::sync::atomic::AtomicBool::new(false),
             hang_ensure: std::sync::atomic::AtomicBool::new(true),
             commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(false),
+            poison_fence_cache_after_ensure: std::sync::Mutex::new(None),
         }),
         crate::ownership::SharedNodeIdentity::new(me),
     );
@@ -307,6 +325,7 @@ async fn enable_claim_commit_before_timeout_is_reconciled_and_released() {
         hang_release: std::sync::atomic::AtomicBool::new(false),
         hang_ensure: std::sync::atomic::AtomicBool::new(false),
         commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(true),
+        poison_fence_cache_after_ensure: std::sync::Mutex::new(None),
     });
     let registry = InMemorySmSessionRegistry::new()
         .with_claim_store(store.clone(), crate::ownership::SharedNodeIdentity::new(me));
@@ -331,6 +350,57 @@ async fn enable_claim_commit_before_timeout_is_reconciled_and_released() {
         .is_empty());
     assert_eq!(registry.pending_claim_release_count(), 0);
     assert_eq!(registry.claim_fence_capacity_used(), 0);
+}
+
+#[tokio::test(start_paused = true)]
+async fn enable_claim_publication_failure_retains_ambiguous_exact_release() {
+    let me = crate::ownership::NodeIdentity::new("sm-node", "incarnation");
+    let store = std::sync::Arc::new(HangingReleaseClaimStore {
+        inner: crate::ownership::InProcessClaimStore::new(),
+        hang_release: std::sync::atomic::AtomicBool::new(true),
+        hang_ensure: std::sync::atomic::AtomicBool::new(false),
+        commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(false),
+        poison_fence_cache_after_ensure: std::sync::Mutex::new(None),
+    });
+    let registry = std::sync::Arc::new(
+        InMemorySmSessionRegistry::new()
+            .with_claim_store(store.clone(), crate::ownership::SharedNodeIdentity::new(me)),
+    );
+    *store
+        .poison_fence_cache_after_ensure
+        .lock()
+        .expect("poison injection lock") = Some(std::sync::Arc::downgrade(&registry));
+    let stream_id = "publication-failure";
+
+    assert!(!registry.ensure_session_claim(stream_id).await);
+    assert_eq!(
+        registry.pending_claim_release_count(),
+        1,
+        "an ambiguous compensating release remains an exact retry responsibility"
+    );
+
+    let entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        stream_id.to_string(),
+    );
+    assert!(
+        crate::ownership::ClaimStore::current_claim(store.as_ref(), &entity)
+            .await
+            .expect("claim lookup")
+            .is_some()
+    );
+
+    store
+        .hang_release
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(registry.retry_pending_claim_releases(8).await, 1);
+    assert_eq!(registry.pending_claim_release_count(), 0);
+    assert!(
+        crate::ownership::ClaimStore::current_claim(store.as_ref(), &entity)
+            .await
+            .expect("claim lookup after retry")
+            .is_none()
+    );
 }
 
 #[test]

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -1,3 +1,4 @@
+use super::core::PendingClaimAcquisitionDisposition;
 use super::*;
 use std::time::{Duration, Instant};
 
@@ -364,6 +365,15 @@ async fn rejected_enable_reconciliation_skips_stream_that_became_live_again() {
         .expect("same id becomes a live detached session");
 
     assert_eq!(registry.retry_pending_claim_releases(8).await, 0);
+    assert!(
+        registry
+            .pending_claim_acquisitions
+            .read()
+            .expect("pending acquisition")
+            .is_empty(),
+        "the live session lifecycle supersedes the rejected-enable retry"
+    );
+    assert!(!registry.has_claim_fence_reservation(stream_id));
     assert!(registry
         .peek_session(stream_id)
         .await
@@ -379,6 +389,260 @@ async fn rejected_enable_reconciliation_skips_stream_that_became_live_again() {
             .expect("claim lookup")
             .is_some()
     );
+
+    registry
+        .take_session(stream_id)
+        .await
+        .expect("take live session")
+        .expect("live session existed");
+    assert!(
+        crate::ownership::ClaimStore::current_claim(store.as_ref(), &entity)
+            .await
+            .expect("claim lookup after live lifecycle ends")
+            .is_none()
+    );
+    assert_eq!(registry.retry_pending_claim_releases(8).await, 0);
+    assert!(
+        crate::ownership::ClaimStore::current_claim(store.as_ref(), &entity)
+            .await
+            .expect("claim lookup after later janitor pass")
+            .is_none(),
+        "a superseded rejected-enable retry must never manufacture a fresh claim"
+    );
+}
+
+#[tokio::test]
+async fn live_stream_releases_timed_out_old_identity_without_adopting_its_fence() {
+    use crate::ownership::ClaimStore as _;
+
+    let old = crate::ownership::NodeIdentity::new("sm-node", "old-incarnation");
+    let current = crate::ownership::NodeIdentity::new("sm-node", "new-incarnation");
+    let store = std::sync::Arc::new(crate::ownership::InProcessClaimStore::new());
+    let stream_id = "old-enable-claim-new-live-session";
+    let entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        stream_id.to_string(),
+    );
+    store.acquire(&entity, &old).await.expect("old claim");
+    let registry = InMemorySmSessionRegistry::new().with_claim_store(
+        store.clone(),
+        crate::ownership::SharedNodeIdentity::new(current),
+    );
+    assert!(registry.reserve_claim_fence_capacity(stream_id));
+    registry
+        .pending_claim_acquisitions
+        .write()
+        .expect("pending acquisitions")
+        .insert((
+            stream_id.to_string(),
+            old.clone(),
+            PendingClaimAcquisitionDisposition::ReleaseRejectedEnable,
+        ));
+    registry
+        .sessions
+        .write()
+        .expect("sessions")
+        .insert(stream_id.to_string(), make_test_session(stream_id));
+
+    assert_eq!(registry.retry_pending_claim_releases(8).await, 0);
+    assert!(registry
+        .pending_claim_acquisitions
+        .read()
+        .expect("pending acquisitions")
+        .is_empty());
+    assert!(
+        !registry
+            .claim_fences
+            .read()
+            .expect("claim fences")
+            .contains_key(stream_id),
+        "an advisory old-incarnation snapshot must never authorize the new live lifecycle"
+    );
+    assert!(store
+        .current_claim(&entity)
+        .await
+        .expect("claim lookup")
+        .is_none());
+    assert_eq!(registry.pending_claim_release_count(), 0);
+}
+
+#[tokio::test]
+async fn old_claim_cleanup_waits_for_shared_detach_reservation_to_resolve() {
+    use crate::ownership::ClaimStore as _;
+
+    let old = crate::ownership::NodeIdentity::new("sm-node", "old-incarnation");
+    let current = crate::ownership::NodeIdentity::new("sm-node", "new-incarnation");
+    let store = std::sync::Arc::new(crate::ownership::InProcessClaimStore::new());
+    let stream_id = "shared-pending-acquisition-reservation";
+    let entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        stream_id.to_string(),
+    );
+    store.acquire(&entity, &old).await.expect("old claim");
+    let registry = InMemorySmSessionRegistry::new().with_claim_store(
+        store.clone(),
+        crate::ownership::SharedNodeIdentity::new(current.clone()),
+    );
+    assert!(registry.reserve_claim_fence_capacity(stream_id));
+    {
+        let mut pending = registry
+            .pending_claim_acquisitions
+            .write()
+            .expect("pending acquisitions");
+        pending.insert((
+            stream_id.to_string(),
+            old.clone(),
+            PendingClaimAcquisitionDisposition::ReleaseRejectedEnable,
+        ));
+        pending.insert((
+            stream_id.to_string(),
+            current.clone(),
+            PendingClaimAcquisitionDisposition::RetainDetachedSession,
+        ));
+    }
+    registry
+        .sessions
+        .write()
+        .expect("sessions")
+        .insert(stream_id.to_string(), make_test_session(stream_id));
+
+    assert!(
+        registry
+            .reconcile_rejected_enable_while_live(stream_id, &old)
+            .await
+    );
+    let pending = registry
+        .pending_claim_acquisitions
+        .read()
+        .expect("pending acquisitions");
+    assert_eq!(pending.len(), 2);
+    assert!(pending.iter().any(|(id, _, disposition)| {
+        id == stream_id && *disposition == PendingClaimAcquisitionDisposition::RetainDetachedSession
+    }));
+    drop(pending);
+    assert!(
+        registry.has_claim_fence_reservation(stream_id),
+        "old-claim cleanup must not consume the detach reconciliation's reservation"
+    );
+    assert!(store
+        .current_claim(&entity)
+        .await
+        .expect("old claim lookup")
+        .is_some());
+
+    registry
+        .reconcile_uncertain_claim_acquisition(
+            stream_id,
+            current,
+            PendingClaimAcquisitionDisposition::RetainDetachedSession,
+        )
+        .await;
+    let pending = registry
+        .pending_claim_acquisitions
+        .read()
+        .expect("pending acquisitions");
+    assert_eq!(pending.len(), 1);
+    assert!(pending.iter().any(|(id, _, disposition)| {
+        id == stream_id && *disposition == PendingClaimAcquisitionDisposition::ReleaseRejectedEnable
+    }));
+    drop(pending);
+    assert!(
+        registry.has_claim_fence_reservation(stream_id),
+        "a conflicting detach reconciliation must leave the slot to the remaining rejected-enable cleanup"
+    );
+    assert!(
+        registry
+            .reconcile_rejected_enable_while_live(stream_id, &old)
+            .await
+    );
+    assert!(registry
+        .pending_claim_acquisitions
+        .read()
+        .expect("pending acquisitions")
+        .is_empty());
+    assert!(store
+        .current_claim(&entity)
+        .await
+        .expect("claim lookup after terminal conversion")
+        .is_none());
+    assert!(!registry
+        .claim_fences
+        .read()
+        .expect("claim fences")
+        .contains_key(stream_id));
+}
+
+#[tokio::test(start_paused = true)]
+async fn terminal_old_identity_release_retries_while_replacement_stream_is_live() {
+    use crate::ownership::ClaimStore as _;
+
+    let old = crate::ownership::NodeIdentity::new("sm-node", "old-incarnation");
+    let current = crate::ownership::NodeIdentity::new("sm-node", "new-incarnation");
+    let store = std::sync::Arc::new(HangingReleaseClaimStore {
+        inner: crate::ownership::InProcessClaimStore::new(),
+        hang_release: std::sync::atomic::AtomicBool::new(true),
+        hang_ensure: std::sync::atomic::AtomicBool::new(false),
+        commit_then_hang_ensure_once: std::sync::atomic::AtomicBool::new(false),
+        poison_fence_cache_after_ensure: std::sync::Mutex::new(None),
+    });
+    let stream_id = "retry-old-terminal-fence-while-live";
+    let entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        stream_id.to_string(),
+    );
+    store.acquire(&entity, &old).await.expect("old claim");
+    let registry = InMemorySmSessionRegistry::new().with_claim_store(
+        store.clone(),
+        crate::ownership::SharedNodeIdentity::new(current),
+    );
+    assert!(registry.reserve_claim_fence_capacity(stream_id));
+    registry
+        .pending_claim_acquisitions
+        .write()
+        .expect("pending acquisitions")
+        .insert((
+            stream_id.to_string(),
+            old.clone(),
+            PendingClaimAcquisitionDisposition::ReleaseRejectedEnable,
+        ));
+    registry
+        .sessions
+        .write()
+        .expect("sessions")
+        .insert(stream_id.to_string(), make_test_session(stream_id));
+
+    assert!(
+        registry
+            .reconcile_rejected_enable_while_live(stream_id, &old)
+            .await
+    );
+    assert_eq!(registry.pending_claim_release_count(), 1);
+    assert!(!registry
+        .claim_fences
+        .read()
+        .expect("claim fences")
+        .contains_key(stream_id));
+    assert!(store
+        .current_claim(&entity)
+        .await
+        .expect("old claim lookup")
+        .is_some());
+
+    store
+        .hang_release
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+    assert_eq!(registry.retry_pending_claim_releases(8).await, 1);
+    assert_eq!(registry.pending_claim_release_count(), 0);
+    assert!(store
+        .current_claim(&entity)
+        .await
+        .expect("claim lookup after retry")
+        .is_none());
+    assert!(registry
+        .sessions
+        .read()
+        .expect("sessions")
+        .contains_key(stream_id));
 }
 
 #[tokio::test(start_paused = true)]

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/trait_impl.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/trait_impl.rs
@@ -15,6 +15,30 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
         let jid = session.jid.clone();
         let stream_lock = self.stream_lock(&stream_id)?;
         let _stream_guard = stream_lock.lock().await;
+        {
+            let claimed = self
+                .claimed_sessions
+                .read()
+                .map_err(|_| SmRegistryError::Internal("Lock poisoned".to_string()))?;
+            if claimed.contains_key(&stream_id) {
+                debug!(
+                    stream_id = %stream_id,
+                    "store_session skipped: resume claim in flight owns this stream"
+                );
+                return Ok(Vec::new());
+            }
+        }
+        // Reserve exact-fence/reconciliation capacity before publishing the
+        // detached session in memory or durable storage. Once either snapshot
+        // exists, a successful or ambiguous backend claim must have bounded
+        // local ownership bookkeeping; rejecting after publication would
+        // strand an unrecorded live-node claim.
+        if !self.reserve_detach_claim_fence_capacity(&stream_id) {
+            return Err(SmRegistryError::Internal(
+                "store_session: exact claim-fence capacity exhausted before detach publication"
+                    .to_string(),
+            ));
+        }
         // Scope the RwLock guards in a block so they're definitively
         // dropped before any await point. RwLockWriteGuard is not
         // Send, and explicit `drop()` doesn't satisfy the async
@@ -24,7 +48,7 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
         // queues (issue #1097) — previously they were silently
         // dropped and their durable rows mirror-deleted.
         let mut displaced: Vec<DetachedSession> = Vec::new();
-        let count = {
+        let state_result = (|| -> Result<usize, SmRegistryError> {
             let mut sessions = self
                 .sessions
                 .write()
@@ -45,13 +69,6 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
             // handoff ends in complete_claim (durably erased) or
             // release_claim (session returned to the detached pool),
             // both of which supersede this stale copy.
-            if claimed.contains_key(&stream_id) {
-                debug!(
-                    stream_id = %stream_id,
-                    "store_session skipped: resume claim in flight owns this stream"
-                );
-                return Ok(displaced);
-            }
             // Capture jid-collision evictions in `sessions` before
             // retain mutates; same for `claimed`.
             for (id, existing) in sessions.iter() {
@@ -104,7 +121,14 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
             }
 
             sessions.insert(stream_id.clone(), session.clone());
-            sessions.len()
+            Ok(sessions.len())
+        })();
+        let count = match state_result {
+            Ok(count) => count,
+            Err(error) => {
+                self.cancel_claim_fence_reservation(&stream_id);
+                return Err(error);
+            }
         };
         // Durable rows for displaced sessions are deliberately NOT
         // deleted here. They follow the drain_expired/confirm_drained
@@ -142,6 +166,7 @@ impl SmSessionRegistry for InMemorySmSessionRegistry {
         // calls re-inserting each other's displaced sessions would
         // otherwise deadlock.
         if let Err(error) = self.persist_detached_session_snapshot(&session).await {
+            self.cancel_claim_fence_reservation(&stream_id);
             for displaced_session in displaced {
                 if displaced_session.stream_id == stream_id {
                     // Already (re)inserted above as the new session's


### PR DESCRIPTION
Closes #1284

## What changed

- Reconcile orphaned RoomActor and XEP-0198 session claims after exact node-incarnation death.
- Carry immutable typed owner+epoch fences through acquire, steal, hydration, publication, persistence, quarantine, release, retry, and cross-node repair.
- Serialize claim-only cleanup against in-flight durable SM writes and make cache invalidation generation-exact.
- Bound and inventory uncertain room and SM releases, including shutdown retry and exact ABA-safe backlog accounting.
- Bound SM enable claim/ISR preflight before publishing enabled state; reconcile ambiguous claim commits and keep retries safe.
- Preserve reconciler cursors, bounded queues, retry work, and malformed-state quarantine across worker restart.
- Keep runtime-disabled clustering dormant instead of attaching ownership watchers to process shutdown.

## Verification

- `cargo test -p waddle-xmpp stream_management::session_registry --lib` — 80 passed.
- `cargo test -p waddle-server --all-features --lib server::session_janitors` — 29 passed.
- `cargo test -p waddle-server --all-features --lib sm_persistence_fenced::tests` — 21 passed.
- Final XEP-0198/ISR verification: WebSocket SM 63 passed; ISR 11 passed; PostgreSQL ISR 8 passed; in-memory ISR 5 passed; connection registry 40 passed; SM registry 80 passed; pending-delivery fenced promotion 2 passed.
- Earlier full branch verification: 2,432 XMPP tests; 1,814 clustered server tests; cluster integrations 8 passed / 1 manual ignore; graceful shutdown 3/3; cross-node XEP-0198 resume 12/12.
- `cargo clippy --release --locked --workspace --all-features --all-targets -- -D warnings`.
- `cargo fmt --all -- --check` and `git diff --check`.
- Repeated independent adversarial review: two final passes clean.

## Residual verification gap

Live PostgreSQL transport-cancellation timing and full multi-node process teardown could not run without `WADDLE_TEST_POSTGRES_URL`; exact owner/epoch ABA and hung-store behavior are covered by deterministic fault-injection tests.

## Lore commit record

Intent: keep dead-owner recovery exact across node rotations.

Constraint: node identities can rotate while claim epochs reset, so numeric epochs are never comparable across owner incarnations.
Rejected: re-read current node identity when queued recovery runs | pairs stale epochs with a new owner.
Rejected: discard uncertain releases after timeout | hides cleanup responsibility and leaks live-owner claims.
Rejected: release a possibly published reclaimed room claim after registry failure | uncertain handoff requires node self-fencing.
Confidence: high
Scope-risk: broad
Directive: preserve typed owner+epoch fences through every claim-owning queue, cache, persistence call, release, and retry.
Tested: full branch suites plus final exact-release, janitor, fenced-persistence, release all-target clippy, rustfmt, and diff checks.
Not-tested: live PostgreSQL cancellation and full process-level multi-node teardown.
Related: #1284

## Merge gate

Do not merge until CI is green, Greptile and Qodo have reviewed the final head SHA with zero actionable findings, and all review threads are resolved.

## Automated review remediation

- Granted-but-unpublishable SM claims retain exact pending-release responsibility.
- Queue saturation retains bounded retry/restart inventory without misreporting scheduled cleanup.
- Room release backlog retains bounded exact owner+epoch generations across delete/recreate ABA; numeric newest ordering is unsafe.
- Terminal SM acquisition retries distinguish active authority from old-incarnation exact cleanup, preserve shared capacity, and admit every valid RFC 7622 bare JID through typed claim decoding.
- Won RoomActor claims remain serialized through mailbox pressure; RoomRegistryActor lifetime and uncertain reconciliation self-fence the node so actor-local retry state cannot be stranded.
- Final head `030e2eb7` uses `release_exact` for typed reclaimed-claim outcomes, retains stale-incarnation persistence fences until bounded exact cleanup is confirmed, and leaves the orphan reaper dormant when runtime clustering is disabled.
- Resumable enablement is a typed post-write commit: SM state and registry linkage publish only after `<enabled/>` is written, same-JID owner gating protects replacements, and unpublished/superseded claims enter exact terminal cleanup.
- ISR, pending-delivery promotion, SM persistence, MUC persistence, and steal-intent mutation bind the full `(entity,node_id,node_epoch,claim_epoch)` authority tuple; same-node-ID incarnation ABA regressions are green.
