### PR TITLE
fix(server): publish resumable SM ownership after transport commit

### DIFF
--- a/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
+++ b/infrastructure/waddle.cloud/gitops/waddle-server/helmrelease.yaml
@@ -120,6 +120,7 @@ spec:
             key: uri
     xmpp:
       domain: waddle.social
+      publicWebsocketUrl: wss://xmpp.waddle.social/ws
       tls:
         secretName: waddle-xmpp-tls
     persistence:

--- a/server/README.md
+++ b/server/README.md
@@ -63,6 +63,7 @@ cuenv task dev
   - Shorthand examples: `debug`, `info`, `warn`, `error`
   - Full filter examples: `info,waddle_server=debug,waddle_xmpp=debug`
 - Default logging filter (when neither env var is set): `info,waddle_server=debug,waddle_xmpp=debug`
+- `WADDLE_XMPP_PUBLIC_WEBSOCKET_URL`: Trusted public RFC 7395 endpoint (`ws://` or `wss://`). TLS-only XEP-0397 ISR is enabled only for `wss://`; when omitted, the server derives a fail-closed `ws://<xmpp-domain>/ws` endpoint.
 - `WADDLE_MEDIA_BACKEND`: Media backend selector (`disabled`, `webrtc-rs-sfu`, or `embedded-sfu`).
 - `WADDLE_MEDIA_PUBLIC_BASE_URL`: Public base URL used to generate media join endpoints.
 - `WADDLE_MEDIA_SFU_SIGNALING_PATH`: Path prefix used for SFU signaling URLs (default `/v1/media/sfu`).

--- a/server/charts/waddle-server/README.md
+++ b/server/charts/waddle-server/README.md
@@ -29,6 +29,7 @@ helm upgrade --install waddle ./charts/waddle-server \
   --create-namespace \
   --set config.baseUrl=https://chat.example.com \
   --set xmpp.domain=chat.example.com \
+  --set xmpp.publicWebsocketUrl=wss://chat.example.com/ws \
   --set ingress.enabled=true \
   --set ingress.hosts[0].host=chat.example.com \
   --set ingress.tls[0].secretName=chat-example-com-tls \
@@ -194,6 +195,7 @@ helm upgrade --install waddle ./charts/waddle-server \
   --set config.baseUrl=https://xmpp.waddle.social \
   --set config.corsOrigins='https://waddle.chat,http://localhost:4321' \
   --set xmpp.domain=waddle.social \
+  --set xmpp.publicWebsocketUrl=wss://xmpp.waddle.social/ws \
   --set-json secret.authProvidersJson='[{"id":"colony","display_name":"Colony","kind":"oidc","dynamic_client_registration":true,"client_id":"","token_endpoint_auth_method":"none","require_dpop":true,"issuer":"https://colony.waddle.social","scopes":["openid","profile","email"],"subject_claim":"sub","username_claim":"preferred_username","email_claim":"email"}]'
 ```
 

--- a/server/charts/waddle-server/templates/configmap.yaml
+++ b/server/charts/waddle-server/templates/configmap.yaml
@@ -12,6 +12,9 @@ data:
   WADDLE_DB_CONTROL_PLANE_POOL_SIZE: {{ .Values.database.controlPlanePoolSize | toString | quote }}
   WADDLE_XMPP_ENABLED: {{ .Values.xmpp.enabled | toString | quote }}
   WADDLE_XMPP_DOMAIN: {{ .Values.xmpp.domain | quote }}
+  {{- if .Values.xmpp.publicWebsocketUrl }}
+  WADDLE_XMPP_PUBLIC_WEBSOCKET_URL: {{ .Values.xmpp.publicWebsocketUrl | quote }}
+  {{- end }}
   WADDLE_NATIVE_AUTH_ENABLED: {{ .Values.xmpp.nativeAuthEnabled | toString | quote }}
   WADDLE_REGISTRATION_ENABLED: {{ .Values.xmpp.registrationEnabled | toString | quote }}
   WADDLE_EXTENSIONS_JSON: {{ .Values.extensions | toJson | quote }}

--- a/server/charts/waddle-server/values.yaml
+++ b/server/charts/waddle-server/values.yaml
@@ -147,6 +147,10 @@ database:
 xmpp:
   enabled: true
   domain: waddle.local
+  # Trusted public RFC 7395 endpoint. Use wss:// when TLS is terminated at
+  # the ingress/gateway; TLS-only XEP-0397 ISR stays disabled for ws://. Empty
+  # derives the fail-closed ws://<xmpp.domain>/ws endpoint at server startup.
+  publicWebsocketUrl: ""
   tls:
     secretName: ""
     mountPath: /etc/waddle/tls

--- a/server/crates/waddle-server/src/clustering/isr.rs
+++ b/server/crates/waddle-server/src/clustering/isr.rs
@@ -30,10 +30,10 @@
 //! `clustering_claims` and its `clustering_isr_tokens` reads/writes all run
 //! on the **main pool** ([`Database::begin`]) — a fencing lock and the
 //! write it guards must share one connection/one transaction, exactly the
-//! rule Slices 4 and 7 already follow. `ensure_schema`/`issue` are
-//! single-statement, non-fenced operations and run on the main pool via
-//! [`Database::guard`] (mirroring `ensure_schema`'s own placement in
-//! `claims.rs`/`lease.rs`/`allowlist.rs`).
+//! rule Slices 4 and 7 already follow. `ensure_schema` runs on the main pool
+//! via [`Database::guard`]. Token publication, revocation, and consume use
+//! main-pool transactions sharing a per-SM-ID advisory lock so an ambiguous
+//! late publication cannot cross exact revocation-fence installation.
 //!
 //! **Identity binding**: this store does *not* itself call
 //! `ownership::resume::verify_resume_identity` — that check happens in the
@@ -74,9 +74,11 @@
 use async_trait::async_trait;
 use subtle::ConstantTimeEq;
 use waddle_xmpp::isr::{
-    generate_isr_token, IsrConsumeOutcome, IsrTokenStore, IsrTokenStoreError, IssuedIsrToken,
+    generate_isr_token, IsrConsumeOutcome, IsrRevokeOutcome, IsrTokenStore, IsrTokenStoreError,
+    IssuedIsrToken,
 };
 use waddle_xmpp::ownership::EntityType;
+use waddle_xmpp::pending_delivery::SmSessionId;
 
 use crate::db::{Database, DatabaseError};
 
@@ -95,8 +97,28 @@ fn db_err(error: DatabaseError) -> IsrTokenStoreError {
 /// imported for the same reason `sm_persistence_fenced.rs` duplicates it:
 /// this store owns its own inline fencing SQL, so it also owns its own copy
 /// of the key encoding it binds into that SQL.
-fn sm_session_entity_key(sm_id: &str) -> String {
+fn sm_session_entity_key(sm_id: &SmSessionId) -> String {
     format!("{}:{}", EntityType::SmSession.as_db_str(), sm_id)
+}
+
+/// Serialize token publication and exact negative-fence installation for one
+/// SM session. A transaction-scoped advisory lock avoids a gap between the
+/// live-token and revocation-fence tables where a timed-out UPSERT could land
+/// after cleanup had already declared success.
+async fn lock_isr_stream(
+    tx: &mut crate::db::Transaction<'_>,
+    sm_id: &SmSessionId,
+) -> Result<(), IsrTokenStoreError> {
+    let mut rows = tx
+        .query(
+            "SELECT pg_advisory_xact_lock(hashtextextended(?, 0))",
+            crate::db_params![sm_id.to_string()],
+        )
+        .await
+        .map_err(db_err)?;
+    rows.next().await.map_err(db_err)?;
+    drop(rows);
+    Ok(())
 }
 
 /// Postgres-only, `clustering`-fenced [`IsrTokenStore`].
@@ -131,40 +153,33 @@ impl IsrTokenStore for PostgresIsrTokenStore {
         )
         .await
         .map_err(db_err)?;
-        Ok(())
-    }
-
-    async fn persist_issued(
-        &self,
-        sm_id: &str,
-        issued: &IssuedIsrToken,
-    ) -> Result<(), IsrTokenStoreError> {
-        let conn = self.db.guard().await.map_err(db_err)?;
         conn.execute(
-            "INSERT INTO clustering_isr_tokens (sm_id, token, mechanism, created_at) \
-             VALUES (?, ?, ?, now()) \
-             ON CONFLICT (sm_id) DO UPDATE SET \
-                 token = EXCLUDED.token, mechanism = EXCLUDED.mechanism, created_at = now()",
-            crate::db_params![
-                sm_id.to_string(),
-                issued.token.clone(),
-                issued.mechanism.clone()
-            ],
+            r#"
+            CREATE TABLE IF NOT EXISTS clustering_isr_revocation_fences (
+                sm_id      TEXT NOT NULL,
+                token      TEXT NOT NULL,
+                mechanism  TEXT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                PRIMARY KEY (sm_id, token, mechanism)
+            )
+            "#,
+            (),
         )
         .await
         .map_err(db_err)?;
         Ok(())
     }
 
-    async fn revoke_if_current(
+    async fn persist_issued(
         &self,
-        sm_id: &str,
+        sm_id: &SmSessionId,
         issued: &IssuedIsrToken,
-    ) -> Result<bool, IsrTokenStoreError> {
-        let conn = self.db.guard().await.map_err(db_err)?;
-        let deleted = conn
+    ) -> Result<(), IsrTokenStoreError> {
+        let mut tx = self.db.begin().await.map_err(db_err)?;
+        lock_isr_stream(&mut tx, sm_id).await?;
+        let suppressed = tx
             .execute(
-                "DELETE FROM clustering_isr_tokens \
+                "DELETE FROM clustering_isr_revocation_fences \
                  WHERE sm_id = ? AND token = ? AND mechanism = ?",
                 crate::db_params![
                     sm_id.to_string(),
@@ -174,17 +189,87 @@ impl IsrTokenStore for PostgresIsrTokenStore {
             )
             .await
             .map_err(db_err)?;
-        Ok(deleted > 0)
+        if suppressed == 0 {
+            tx.execute(
+                "INSERT INTO clustering_isr_tokens (sm_id, token, mechanism, created_at) \
+                 VALUES (?, ?, ?, now()) \
+                 ON CONFLICT (sm_id) DO UPDATE SET \
+                     token = EXCLUDED.token, mechanism = EXCLUDED.mechanism, created_at = now()",
+                crate::db_params![
+                    sm_id.to_string(),
+                    issued.token.clone(),
+                    issued.mechanism.clone()
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        }
+        tx.commit().await.map_err(db_err)?;
+        Ok(())
+    }
+
+    async fn revoke_if_current(
+        &self,
+        sm_id: &SmSessionId,
+        issued: &IssuedIsrToken,
+    ) -> Result<IsrRevokeOutcome, IsrTokenStoreError> {
+        let mut tx = self.db.begin().await.map_err(db_err)?;
+        lock_isr_stream(&mut tx, sm_id).await?;
+        let mut current = tx
+            .query(
+                "SELECT token, mechanism FROM clustering_isr_tokens WHERE sm_id = ?",
+                crate::db_params![sm_id.to_string()],
+            )
+            .await
+            .map_err(db_err)?;
+        let live = current.next().await.map_err(db_err)?;
+        let outcome = if let Some(row) = live {
+            let token: String = row.get(0).map_err(db_err)?;
+            let mechanism: String = row.get(1).map_err(db_err)?;
+            if mechanism == issued.mechanism
+                && bool::from(token.as_bytes().ct_eq(issued.token.as_bytes()))
+            {
+                IsrRevokeOutcome::Revoked
+            } else {
+                IsrRevokeOutcome::Superseded
+            }
+        } else {
+            IsrRevokeOutcome::Missing
+        };
+        drop(current);
+        if outcome == IsrRevokeOutcome::Revoked {
+            tx.execute(
+                "DELETE FROM clustering_isr_tokens WHERE sm_id = ?",
+                crate::db_params![sm_id.to_string()],
+            )
+            .await
+            .map_err(db_err)?;
+        }
+        tx.execute(
+            "INSERT INTO clustering_isr_revocation_fences \
+             (sm_id, token, mechanism, created_at) VALUES (?, ?, ?, now()) \
+             ON CONFLICT (sm_id, token, mechanism) DO UPDATE SET created_at = now()",
+            crate::db_params![
+                sm_id.to_string(),
+                issued.token.clone(),
+                issued.mechanism.clone()
+            ],
+        )
+        .await
+        .map_err(db_err)?;
+        tx.commit().await.map_err(db_err)?;
+        Ok(outcome)
     }
 
     async fn consume(
         &self,
-        sm_id: &str,
+        sm_id: &SmSessionId,
         presented_token: &[u8],
         mechanism: &str,
         fence: &waddle_xmpp::stream_management::persistence::SmClaimFence,
     ) -> Result<IsrConsumeOutcome, IsrTokenStoreError> {
         let mut tx = self.db.begin().await.map_err(db_err)?;
+        lock_isr_stream(&mut tx, sm_id).await?;
 
         // Fencing check: identical shape to `assert_fenced` in
         // `sm_persistence_fenced.rs`/`muc_durable.rs` — one connection, one
@@ -350,7 +435,7 @@ impl IsrTokenStore for PostgresIsrTokenStore {
         // correct option. Mirrors `lease.rs`'s own
         // `(? || ' milliseconds')::interval` TTL-comparison idiom.
         let conn = self.db.guard().await.map_err(db_err)?;
-        let deleted = conn
+        let deleted_tokens = conn
             .execute(
                 "DELETE FROM clustering_isr_tokens \
                  WHERE created_at < now() - (? || ' milliseconds')::interval",
@@ -358,7 +443,14 @@ impl IsrTokenStore for PostgresIsrTokenStore {
             )
             .await
             .map_err(db_err)?;
-        Ok(deleted)
+        conn.execute(
+            "DELETE FROM clustering_isr_revocation_fences \
+                 WHERE created_at < now() - (? || ' milliseconds')::interval",
+            crate::db_params![max_age.as_millis().to_string()],
+        )
+        .await
+        .map_err(db_err)?;
+        Ok(deleted_tokens)
     }
 }
 
@@ -401,7 +493,7 @@ mod tests {
     /// `consume` test can present a genuinely fenced `(me, epoch)` pair —
     /// mirrors how `sm_persistence_fenced.rs`'s own Postgres-gated tests
     /// establish a fenceable claim before exercising a fenced write.
-    async fn claim_sm_session(db: &Database, sm_id: &str, me: &NodeIdentity) -> ClaimEpoch {
+    async fn claim_sm_session(db: &Database, sm_id: &SmSessionId, me: &NodeIdentity) -> ClaimEpoch {
         let claim_store = PostgresClaimStore::new(db.clone());
         claim_store
             .ensure_schema()
@@ -423,7 +515,7 @@ mod tests {
         let store = PostgresIsrTokenStore::new(db.clone());
         store.ensure_schema().await.expect("ensure isr schema");
         let me = node_identity();
-        let sm_id = format!("sm-{}", uuid::Uuid::new_v4());
+        let sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
         let epoch = claim_sm_session(&db, &sm_id, &me).await;
 
         let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
@@ -452,18 +544,69 @@ mod tests {
         };
         let store = PostgresIsrTokenStore::new(db);
         store.ensure_schema().await.expect("ensure isr schema");
-        let sm_id = format!("sm-{}", uuid::Uuid::new_v4());
+        let sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
         let old = store.issue(&sm_id, "PLAIN").await.expect("old issue");
         let current = store.issue(&sm_id, "PLAIN").await.expect("new issue");
 
-        assert!(!store
-            .revoke_if_current(&sm_id, &old)
+        assert_eq!(
+            store
+                .revoke_if_current(&sm_id, &old)
+                .await
+                .expect("stale revoke"),
+            IsrRevokeOutcome::Superseded
+        );
+        store
+            .persist_issued(&sm_id, &old)
             .await
-            .expect("stale revoke"));
-        assert!(store
-            .revoke_if_current(&sm_id, &current)
-            .await
-            .expect("exact revoke"));
+            .expect("late old persistence is suppressed by its exact fence");
+        assert_eq!(
+            store
+                .revoke_if_current(&sm_id, &current)
+                .await
+                .expect("exact revoke"),
+            IsrRevokeOutcome::Revoked
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_consume_and_exact_revoke_preserve_the_serialized_winner() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(db) = test_db().await else {
+            return;
+        };
+        let store = PostgresIsrTokenStore::new(db.clone());
+        store.ensure_schema().await.expect("ensure isr schema");
+        let me = node_identity();
+        let sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
+        let epoch = claim_sm_session(&db, &sm_id, &me).await;
+        let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
+        let claim_fence = fence(&me, epoch);
+
+        let (consumed, revoked) = tokio::join!(
+            store.consume(&sm_id, issued.token.as_bytes(), "PLAIN", &claim_fence,),
+            store.revoke_if_current(&sm_id, &issued),
+        );
+        let consumed = consumed.expect("consume result");
+        let revoked = revoked.expect("revoke result");
+
+        match (consumed, revoked) {
+            (IsrConsumeOutcome::Matched { rotated }, IsrRevokeOutcome::Superseded) => {
+                assert!(matches!(
+                    store
+                        .consume(
+                            &sm_id,
+                            rotated.token.as_bytes(),
+                            "PLAIN",
+                            &fence(&me, epoch),
+                        )
+                        .await
+                        .expect("rotated token survives stale cleanup"),
+                    IsrConsumeOutcome::Matched { .. }
+                ));
+            }
+            (IsrConsumeOutcome::NoSuchToken, IsrRevokeOutcome::Revoked) => {}
+            outcome => panic!("consume/revoke did not serialize safely: {outcome:?}"),
+        }
     }
 
     #[tokio::test]
@@ -475,7 +618,7 @@ mod tests {
         let store = PostgresIsrTokenStore::new(db.clone());
         store.ensure_schema().await.expect("ensure isr schema");
         let me = node_identity();
-        let sm_id = format!("sm-{}", uuid::Uuid::new_v4());
+        let sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
         let epoch = claim_sm_session(&db, &sm_id, &me).await;
 
         let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
@@ -511,7 +654,7 @@ mod tests {
         let store = PostgresIsrTokenStore::new(db.clone());
         store.ensure_schema().await.expect("ensure isr schema");
         let me = node_identity();
-        let sm_id = format!("sm-{}", uuid::Uuid::new_v4());
+        let sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
         let epoch = claim_sm_session(&db, &sm_id, &me).await;
 
         let outcome = store
@@ -563,8 +706,8 @@ mod tests {
         let store = PostgresIsrTokenStore::new(db.clone());
         store.ensure_schema().await.expect("ensure isr schema");
 
-        let fresh_sm_id = format!("sm-{}", uuid::Uuid::new_v4());
-        let stale_sm_id = format!("sm-{}", uuid::Uuid::new_v4());
+        let fresh_sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
+        let stale_sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
         store
             .issue(&fresh_sm_id, "PLAIN")
             .await
@@ -581,7 +724,7 @@ mod tests {
         conn.execute(
             "UPDATE clustering_isr_tokens SET created_at = now() - interval '1 day' \
              WHERE sm_id = ?",
-            crate::db_params![stale_sm_id.clone()],
+            crate::db_params![stale_sm_id.to_string()],
         )
         .await
         .expect("backdate stale row");
@@ -628,7 +771,7 @@ mod tests {
         let store = PostgresIsrTokenStore::new(db.clone());
         store.ensure_schema().await.expect("ensure isr schema");
         let me = node_identity();
-        let sm_id = format!("sm-{}", uuid::Uuid::new_v4());
+        let sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
         let epoch = claim_sm_session(&db, &sm_id, &me).await;
 
         let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
@@ -661,7 +804,7 @@ mod tests {
         store.ensure_schema().await.expect("ensure isr schema");
         let old = node_identity();
         let replacement = NodeIdentity::new(old.node_id.clone(), uuid::Uuid::new_v4().to_string());
-        let sm_id = format!("sm-incarnation-{}", uuid::Uuid::new_v4());
+        let sm_id = SmSessionId::new(format!("sm-incarnation-{}", uuid::Uuid::new_v4()));
         let epoch = claim_sm_session(&db, &sm_id, &old).await;
         let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
         let entity_key = sm_session_entity_key(&sm_id);
@@ -731,7 +874,7 @@ mod tests {
         let store = std::sync::Arc::new(PostgresIsrTokenStore::new(db.clone()));
         store.ensure_schema().await.expect("ensure isr schema");
         let me = node_identity();
-        let sm_id = format!("sm-{}", uuid::Uuid::new_v4());
+        let sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
         let epoch = claim_sm_session(&db, &sm_id, &me).await;
         let issued = store.issue(&sm_id, "PLAIN").await.expect("issue");
 
@@ -744,7 +887,7 @@ mod tests {
         let mut locked_rows = winner_tx
             .query(
                 "SELECT token, mechanism FROM clustering_isr_tokens WHERE sm_id = ? FOR UPDATE",
-                crate::db_params![sm_id.clone()],
+                crate::db_params![sm_id.to_string()],
             )
             .await
             .expect("lock the token row");
@@ -790,7 +933,7 @@ mod tests {
         winner_tx
             .execute(
                 "DELETE FROM clustering_isr_tokens WHERE sm_id = ?",
-                crate::db_params![sm_id.clone()],
+                crate::db_params![sm_id.to_string()],
             )
             .await
             .expect("winner delete");
@@ -799,7 +942,11 @@ mod tests {
             .execute(
                 "INSERT INTO clustering_isr_tokens (sm_id, token, mechanism, created_at) \
                  VALUES (?, ?, ?, now())",
-                crate::db_params![sm_id.clone(), rotated_token.clone(), "PLAIN".to_string()],
+                crate::db_params![
+                    sm_id.to_string(),
+                    rotated_token.clone(),
+                    "PLAIN".to_string()
+                ],
             )
             .await
             .expect("winner rotate insert");

--- a/server/crates/waddle-server/src/clustering/isr.rs
+++ b/server/crates/waddle-server/src/clustering/isr.rs
@@ -134,26 +134,26 @@ impl IsrTokenStore for PostgresIsrTokenStore {
         Ok(())
     }
 
-    async fn issue(
+    async fn persist_issued(
         &self,
         sm_id: &str,
-        mechanism: &str,
-    ) -> Result<IssuedIsrToken, IsrTokenStoreError> {
-        let token = generate_isr_token();
+        issued: &IssuedIsrToken,
+    ) -> Result<(), IsrTokenStoreError> {
         let conn = self.db.guard().await.map_err(db_err)?;
         conn.execute(
             "INSERT INTO clustering_isr_tokens (sm_id, token, mechanism, created_at) \
              VALUES (?, ?, ?, now()) \
              ON CONFLICT (sm_id) DO UPDATE SET \
                  token = EXCLUDED.token, mechanism = EXCLUDED.mechanism, created_at = now()",
-            crate::db_params![sm_id.to_string(), token.clone(), mechanism.to_string()],
+            crate::db_params![
+                sm_id.to_string(),
+                issued.token.clone(),
+                issued.mechanism.clone()
+            ],
         )
         .await
         .map_err(db_err)?;
-        Ok(IssuedIsrToken {
-            token,
-            mechanism: mechanism.to_string(),
-        })
+        Ok(())
     }
 
     async fn revoke_if_current(

--- a/server/crates/waddle-server/src/clustering/isr.rs
+++ b/server/crates/waddle-server/src/clustering/isr.rs
@@ -156,6 +156,27 @@ impl IsrTokenStore for PostgresIsrTokenStore {
         })
     }
 
+    async fn revoke_if_current(
+        &self,
+        sm_id: &str,
+        issued: &IssuedIsrToken,
+    ) -> Result<bool, IsrTokenStoreError> {
+        let conn = self.db.guard().await.map_err(db_err)?;
+        let deleted = conn
+            .execute(
+                "DELETE FROM clustering_isr_tokens \
+                 WHERE sm_id = ? AND token = ? AND mechanism = ?",
+                crate::db_params![
+                    sm_id.to_string(),
+                    issued.token.clone(),
+                    issued.mechanism.clone()
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        Ok(deleted > 0)
+    }
+
     async fn consume(
         &self,
         sm_id: &str,
@@ -421,6 +442,28 @@ mod tests {
             .await
             .expect("consume");
         assert_eq!(replay, IsrConsumeOutcome::Mismatched);
+    }
+
+    #[tokio::test]
+    async fn provisional_revoke_cannot_delete_a_newer_postgres_issue() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(db) = test_db().await else {
+            return;
+        };
+        let store = PostgresIsrTokenStore::new(db);
+        store.ensure_schema().await.expect("ensure isr schema");
+        let sm_id = format!("sm-{}", uuid::Uuid::new_v4());
+        let old = store.issue(&sm_id, "PLAIN").await.expect("old issue");
+        let current = store.issue(&sm_id, "PLAIN").await.expect("new issue");
+
+        assert!(!store
+            .revoke_if_current(&sm_id, &old)
+            .await
+            .expect("stale revoke"));
+        assert!(store
+            .revoke_if_current(&sm_id, &current)
+            .await
+            .expect("exact revoke"));
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/clustering/local_claims.rs
+++ b/server/crates/waddle-server/src/clustering/local_claims.rs
@@ -33,8 +33,9 @@ use waddle_xmpp::muc::RoomRegistry;
 use waddle_xmpp::ownership::{Entity, EntityType};
 use waddle_xmpp::registry::user_actor::HealthCheck as UserHealthCheck;
 use waddle_xmpp::registry::{
-    ConnectionRegistry, DemoteUserActor, ForceDetachOutcome, ForceDetachRequest, GetResources,
-    GetUserForLocalClaim, ListUsers, UserRegistryActor,
+    ConnectionRegistry, DemoteUserActor, DemoteUserActorIfOwner, DemotedUserResource,
+    ForceDetachOutcome, ForceDetachRequest, GetResources, GetUserForLocalClaim, ListUsers,
+    ListUsersOwnedBy, UserRegistryActor,
 };
 use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
 
@@ -98,6 +99,18 @@ impl LocallyClaimedEntities for SmSessionLocalClaims {
             return;
         }
         registry.forget_claim_locally(&entity.id).await;
+    }
+
+    async fn demote_owned_by(&self, owner: &waddle_xmpp::ownership::NodeIdentity) {
+        let Some(registry) = self.registry.get() else {
+            return;
+        };
+        let entities = registry
+            .locally_owned_claim_ids_for_owner(owner)
+            .unwrap_or_default();
+        for stream_id in entities {
+            registry.forget_claim_locally(&stream_id).await;
+        }
     }
 
     async fn health_check(&self, _entity: &Entity) -> bool {
@@ -331,6 +344,28 @@ impl LocallyClaimedEntities for RoomLocalClaims {
         }
     }
 
+    async fn demote_owned_by(&self, owner: &waddle_xmpp::ownership::NodeIdentity) {
+        let Some(registry) = self.registry.get() else {
+            return;
+        };
+        let Ok(room_jids) = registry.list_rooms_owned_by(owner.clone()).await else {
+            return;
+        };
+        for room_jid in room_jids {
+            if registry
+                .demote_room_if_owner(room_jid.clone(), owner.clone())
+                .await
+                .unwrap_or(false)
+            {
+                tracing::warn!(
+                    room = %room_jid,
+                    owner = %owner.node_id,
+                    "post-rotation exact-owner sweep demoted stale RoomActor"
+                );
+            }
+        }
+    }
+
     /// Health-ask the local `RoomActor` (ADR-0017 Phase 3 Slice 3's
     /// owner-veto path, now genuinely applicable to `RoomActor` claims).
     ///
@@ -559,10 +594,41 @@ impl UserLocalClaims {
             );
             return;
         };
-        for jid in resources {
-            let Some(entry) = connection_registry.get_entry(&jid) else {
-                continue;
-            };
+        let entries = resources
+            .into_iter()
+            .filter_map(|jid| {
+                connection_registry
+                    .get_entry(&jid)
+                    .map(|entry| (jid, entry))
+            })
+            .collect();
+        self.force_detach_entries(bare_jid, entries).await;
+    }
+
+    async fn force_detach_exact_resources(
+        &self,
+        bare_jid: &BareJid,
+        resources: Vec<DemotedUserResource>,
+    ) {
+        self.force_detach_entries(
+            bare_jid,
+            resources
+                .into_iter()
+                .map(|resource| (resource.jid, resource.entry))
+                .collect(),
+        )
+        .await;
+    }
+
+    async fn force_detach_entries(
+        &self,
+        bare_jid: &BareJid,
+        entries: Vec<(FullJid, waddle_xmpp::registry::ConnectionEntry)>,
+    ) {
+        let Some(connection_registry) = self.connection_registry.get() else {
+            return;
+        };
+        for (jid, entry) in entries {
             let owner = entry.carbons_handle();
             let (ack, ack_rx) = tokio::sync::oneshot::channel();
             let request = ForceDetachRequest {
@@ -755,6 +821,51 @@ impl LocallyClaimedEntities for UserLocalClaims {
             true
         }
     }
+
+    async fn demote_owned_by(&self, owner: &waddle_xmpp::ownership::NodeIdentity) {
+        let Some(registry) = self.registry.get() else {
+            return;
+        };
+        let users = match registry
+            .ask(ListUsersOwnedBy {
+                owner: owner.clone(),
+            })
+            .mailbox_timeout(USER_HEALTH_CHECK_TIMEOUT)
+            .reply_timeout(USER_HEALTH_CHECK_TIMEOUT)
+            .await
+        {
+            Ok(users) => users,
+            Err(error) => {
+                tracing::warn!(?error, "UserLocalClaims exact-owner listing failed");
+                return;
+            }
+        };
+        for bare_jid in users {
+            match registry
+                .ask(DemoteUserActorIfOwner {
+                    bare_jid: bare_jid.clone(),
+                    owner: owner.clone(),
+                })
+                .mailbox_timeout(USER_HEALTH_CHECK_TIMEOUT)
+                .reply_timeout(USER_HEALTH_CHECK_TIMEOUT)
+                .await
+            {
+                Ok(Some(demoted)) => {
+                    self.force_detach_exact_resources(&bare_jid, demoted.resources)
+                        .await;
+                    tracing::warn!(
+                        jid = %bare_jid,
+                        owner = %owner.node_id,
+                        "post-rotation exact-owner sweep demoted stale UserActor"
+                    );
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::warn!(jid = %bare_jid, ?error, "exact-owner UserActor demotion failed");
+                }
+            }
+        }
+    }
 }
 
 /// Dispatches [`LocallyClaimedEntities`] calls across `SmSession`,
@@ -797,6 +908,12 @@ impl LocallyClaimedEntities for CombinedLocalClaims {
             EntityType::RoomActor => self.room.demote(entity).await,
             EntityType::UserActor => self.user.demote(entity).await,
         }
+    }
+
+    async fn demote_owned_by(&self, owner: &waddle_xmpp::ownership::NodeIdentity) {
+        self.sm.demote_owned_by(owner).await;
+        self.room.demote_owned_by(owner).await;
+        self.user.demote_owned_by(owner).await;
     }
 
     async fn health_check(&self, entity: &Entity) -> bool {

--- a/server/crates/waddle-server/src/clustering/self_fence.rs
+++ b/server/crates/waddle-server/src/clustering/self_fence.rs
@@ -153,6 +153,13 @@ pub trait LocallyClaimedEntities: Send + Sync {
     /// of hard kill, not a `tell`.
     async fn demote(&self, entity: &Entity);
 
+    /// Demote work still recorded under an exact superseded node identity
+    /// after identity rotation has made new admissions distinguishable. Most
+    /// local actor registries do not retain owner identity per entry and use
+    /// the ordinary pre-rotation sweep; typed SM claim fences do, so their
+    /// implementation closes the final inventory-snapshot race precisely.
+    async fn demote_owned_by(&self, _owner: &NodeIdentity) {}
+
     /// Health-ask the local actor owning `entity` (ADR-0017 Phase 3 Slice
     /// 3's owner-veto path): `true` if it answered promptly (the owner may
     /// then clear the entity's steal intent — FIX 1(e): the veto is
@@ -1178,6 +1185,7 @@ pub async fn run_node_lease<L>(
                         let superseded_identity = identity.clone();
                         identity = fresh;
                         live_identity.rotate(identity.clone()).await;
+                        local_claims.demote_owned_by(&superseded_identity).await;
 
                         // What "claim re-acquisition" can mean AT THIS
                         // EXACT POINT: every entity this node owned before
@@ -2055,6 +2063,7 @@ mod tests {
         owned: Vec<Entity>,
         healthy: Arc<AtomicBool>,
         demoted: Arc<std::sync::Mutex<Vec<Entity>>>,
+        exact_demoted_owners: Arc<std::sync::Mutex<Vec<NodeIdentity>>>,
         /// Every entity ever passed to `hydrate_reclaimed`, in call order —
         /// lets FIX 4(b)'s inline-post-fence-reclaim test assert the
         /// targeted-hydration hook actually fires. Defaults are wired via
@@ -2079,6 +2088,13 @@ mod tests {
 
         async fn demote(&self, entity: &Entity) {
             self.demoted.lock().expect("lock").push(entity.clone());
+        }
+
+        async fn demote_owned_by(&self, owner: &NodeIdentity) {
+            self.exact_demoted_owners
+                .lock()
+                .expect("lock")
+                .push(owner.clone());
         }
 
         async fn health_check(&self, _entity: &Entity) -> bool {
@@ -2265,6 +2281,7 @@ mod tests {
             owned: vec![entity.clone()],
             healthy: Arc::new(AtomicBool::new(true)),
             demoted: Arc::clone(&demoted),
+            exact_demoted_owners: Arc::new(std::sync::Mutex::new(Vec::new())),
             hydrated: FakeLocalClaims::unhydrated(),
             live_identity_at_hydration: None,
             stale_hydration_observed: Arc::new(AtomicBool::new(false)),
@@ -2333,6 +2350,7 @@ mod tests {
             // instead of waiting to be stolen from.
             healthy: Arc::new(AtomicBool::new(false)),
             demoted: Arc::clone(&demoted),
+            exact_demoted_owners: Arc::new(std::sync::Mutex::new(Vec::new())),
             hydrated: FakeLocalClaims::unhydrated(),
             live_identity_at_hydration: None,
             stale_hydration_observed: Arc::new(AtomicBool::new(false)),
@@ -2402,6 +2420,7 @@ mod tests {
             owned: vec![entity.clone()],
             healthy: Arc::new(AtomicBool::new(true)),
             demoted: Arc::clone(&demoted),
+            exact_demoted_owners: Arc::new(std::sync::Mutex::new(Vec::new())),
             hydrated: FakeLocalClaims::unhydrated(),
             live_identity_at_hydration: None,
             stale_hydration_observed: Arc::new(AtomicBool::new(false)),
@@ -2474,6 +2493,7 @@ mod tests {
             owned: vec![entity_a.clone(), entity_b.clone()],
             healthy: Arc::new(AtomicBool::new(true)),
             demoted: Arc::clone(&demoted),
+            exact_demoted_owners: Arc::new(std::sync::Mutex::new(Vec::new())),
             hydrated: FakeLocalClaims::unhydrated(),
             live_identity_at_hydration: None,
             stale_hydration_observed: Arc::new(AtomicBool::new(false)),
@@ -2520,6 +2540,68 @@ mod tests {
         assert!(
             !readiness.is_ready(),
             "readiness must flip not-ready before the lease becomes stealable"
+        );
+        stop_token.cancel();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn node_lease_post_rotation_sweeps_the_exact_superseded_owner() {
+        let interval = Duration::from_millis(50);
+        let initial_identity = identity();
+        let live_identity =
+            waddle_xmpp::ownership::SharedNodeIdentity::new(initial_identity.clone());
+        let exact_demoted_owners = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let local_claims = Arc::new(FakeLocalClaims {
+            // Both ordinary inventories are deliberately empty. This models
+            // an admission landing after the final snapshot; the exact-owner
+            // hook must still run after rotation.
+            owned: Vec::new(),
+            healthy: Arc::new(AtomicBool::new(true)),
+            demoted: Arc::new(std::sync::Mutex::new(Vec::new())),
+            exact_demoted_owners: Arc::clone(&exact_demoted_owners),
+            hydrated: FakeLocalClaims::unhydrated(),
+            live_identity_at_hydration: None,
+            stale_hydration_observed: Arc::new(AtomicBool::new(false)),
+        });
+        let stop_token = CancellationToken::new();
+        tokio::spawn(run_node_lease(
+            FakeLease::new(Box::new(|| Ok(false))),
+            initial_identity.clone(),
+            stop_token.clone(),
+            NodeLeaseRunConfig {
+                pod_template_hash: None,
+                lease_config: ClusteringNodeLeaseConfig {
+                    heartbeat_interval: interval,
+                    lease_ttl: Duration::from_secs(10),
+                    claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                },
+                self_fence_config: ClusteringSelfFenceConfig {
+                    isolation_intervals: 1_000,
+                    reregister_backoff_base: Duration::from_millis(10),
+                    reregister_backoff_max: Duration::from_millis(20),
+                },
+                connected_peers: ConnectedPeerCount::new(),
+                local_claims,
+                readiness: ClusteringReadiness::new(),
+                live_identity: live_identity.clone(),
+                peer_id: None,
+                claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
+                claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+            },
+        ));
+
+        advance_until(interval, 20, || {
+            !exact_demoted_owners.lock().expect("lock").is_empty()
+        })
+        .await;
+        assert_eq!(
+            exact_demoted_owners.lock().expect("lock").as_slice(),
+            std::slice::from_ref(&initial_identity)
+        );
+        assert_ne!(
+            live_identity.current(),
+            initial_identity,
+            "exact-owner cleanup must run only after admissions use the fresh identity"
         );
         stop_token.cancel();
     }
@@ -2756,6 +2838,7 @@ mod tests {
             owned: Vec::new(),
             healthy: Arc::new(AtomicBool::new(true)),
             demoted: Arc::new(std::sync::Mutex::new(Vec::new())),
+            exact_demoted_owners: Arc::new(std::sync::Mutex::new(Vec::new())),
             hydrated: Arc::clone(&hydrated),
             live_identity_at_hydration: Some(live_identity.clone()),
             stale_hydration_observed: Arc::clone(&stale_hydration_observed),

--- a/server/crates/waddle-server/src/server/config.rs
+++ b/server/crates/waddle-server/src/server/config.rs
@@ -223,29 +223,22 @@ fn parse_public_websocket_url(raw: Option<&str>, xmpp_domain: &str) -> anyhow::R
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
         .unwrap_or_else(|| format!("ws://{xmpp_domain}/ws"));
-    let url = Url::parse(&configured).with_context(|| {
-        format!("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL='{configured}' is not a valid absolute URL")
-    })?;
+    let url = Url::parse(&configured)
+        .context("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL is not a valid absolute URL")?;
     if !matches!(url.scheme(), "ws" | "wss") {
-        anyhow::bail!(
-            "WADDLE_XMPP_PUBLIC_WEBSOCKET_URL='{configured}' must use the ws or wss scheme"
-        );
+        anyhow::bail!("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL must use the ws or wss scheme");
     }
     if url.host().is_none() {
-        anyhow::bail!("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL='{configured}' must include a host");
+        anyhow::bail!("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL must include a host");
     }
     if !url.username().is_empty() || url.password().is_some() {
-        anyhow::bail!(
-            "WADDLE_XMPP_PUBLIC_WEBSOCKET_URL='{configured}' must not include user information"
-        );
+        anyhow::bail!("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL must not include user information");
     }
     if url.query().is_some() {
-        anyhow::bail!("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL='{configured}' must not include a query");
+        anyhow::bail!("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL must not include a query");
     }
     if url.fragment().is_some() {
-        anyhow::bail!(
-            "WADDLE_XMPP_PUBLIC_WEBSOCKET_URL='{configured}' must not include a fragment"
-        );
+        anyhow::bail!("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL must not include a fragment");
     }
     Ok(url)
 }

--- a/server/crates/waddle-server/src/server/config.rs
+++ b/server/crates/waddle-server/src/server/config.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use jid::{BareJid, DomainPart};
 use std::path::PathBuf;
 use std::str::FromStr;
+use url::Url;
 
 /// XMPP server configuration loaded from environment variables.
 #[derive(Debug, Clone)]
@@ -55,6 +56,11 @@ pub struct XmppConfig {
     pub sm_database_url: Option<String>,
     /// PubSub/PEP database URL (prefers dedicated XMPP DSN, otherwise the main runtime DSN)
     pub pubsub_database_url: Option<String>,
+    /// Trusted public RFC 7395 endpoint used by clients. Its scheme is the
+    /// authoritative source for transport-security decisions such as the
+    /// XEP-0397 TLS-only feature and bearer-token gates; the unrelated HTTP
+    /// application base URL and client-controlled forwarding headers are not.
+    pub public_websocket_url: Url,
     /// Whether native JID authentication is enabled (default: true)
     /// When enabled, users can authenticate with SCRAM-SHA-256 using native credentials.
     pub native_auth_enabled: bool,
@@ -93,6 +99,8 @@ impl Default for XmppConfig {
             pending_delivery_database_url: None,
             sm_database_url: None,
             pubsub_database_url: None,
+            public_websocket_url: Url::parse("ws://localhost:3000/ws")
+                .expect("default public XMPP WebSocket URL is valid"),
             native_auth_enabled: true,
             acme: XmppAcmeConfig {
                 enabled: false,
@@ -155,6 +163,12 @@ impl XmppConfig {
             resolve_xmpp_database_url("WADDLE_XMPP_PENDING_DELIVERY_DATABASE_URL");
         let sm_database_url = resolve_xmpp_database_url("WADDLE_XMPP_SM_DATABASE_URL");
         let pubsub_database_url = resolve_xmpp_database_url("WADDLE_XMPP_PUBSUB_DATABASE_URL");
+        let public_websocket_url = parse_public_websocket_url(
+            std::env::var("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL")
+                .ok()
+                .as_deref(),
+            &domain,
+        )?;
 
         let native_auth_enabled = std::env::var("WADDLE_NATIVE_AUTH_ENABLED")
             .map(|v| v.to_lowercase() != "false" && v != "0")
@@ -186,6 +200,7 @@ impl XmppConfig {
             pending_delivery_database_url,
             sm_database_url,
             pubsub_database_url,
+            public_websocket_url,
             native_auth_enabled,
             acme: XmppAcmeConfig {
                 enabled: acme_enabled,
@@ -195,6 +210,44 @@ impl XmppConfig {
             },
         })
     }
+}
+
+/// Parse the operator-declared public RFC 7395 endpoint. When it is omitted,
+/// derive an explicitly plaintext endpoint so security-sensitive features
+/// fail closed until the deployment declares its TLS-terminated `wss://`
+/// address. Whitespace is normalized here and malformed/HTTP URLs fail
+/// startup instead of silently changing XEP-0397 availability.
+fn parse_public_websocket_url(raw: Option<&str>, xmpp_domain: &str) -> anyhow::Result<Url> {
+    let configured = raw
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("ws://{xmpp_domain}/ws"));
+    let url = Url::parse(&configured).with_context(|| {
+        format!("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL='{configured}' is not a valid absolute URL")
+    })?;
+    if !matches!(url.scheme(), "ws" | "wss") {
+        anyhow::bail!(
+            "WADDLE_XMPP_PUBLIC_WEBSOCKET_URL='{configured}' must use the ws or wss scheme"
+        );
+    }
+    if url.host().is_none() {
+        anyhow::bail!("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL='{configured}' must include a host");
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        anyhow::bail!(
+            "WADDLE_XMPP_PUBLIC_WEBSOCKET_URL='{configured}' must not include user information"
+        );
+    }
+    if url.query().is_some() {
+        anyhow::bail!("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL='{configured}' must not include a query");
+    }
+    if url.fragment().is_some() {
+        anyhow::bail!(
+            "WADDLE_XMPP_PUBLIC_WEBSOCKET_URL='{configured}' must not include a fragment"
+        );
+    }
+    Ok(url)
 }
 
 /// Parse an optional typed env var. Returns `Ok(None)` when the var is

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -221,6 +221,7 @@ pub(crate) async fn create_router(deps: RouterDeps) -> Result<Router> {
     let auth_state = Arc::new(AuthState::new(
         state.clone(),
         &server_config,
+        &xmpp_config.public_websocket_url,
         Some(server_config.session_key.as_bytes()),
     ));
 
@@ -718,8 +719,8 @@ async fn create_websocket_state(
         deps: WebSocketDeps {
             app_state: state.clone(),
             auth_state: auth_state.clone(),
-            transport_security: routes::websocket::TransportSecurity::from_base_url(
-                &server_config.base_url,
+            transport_security: routes::websocket::TransportSecurity::from_public_websocket_url(
+                &xmpp_config.public_websocket_url,
             ),
             service_domains,
             protocol: ProtocolServices {

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -718,6 +718,9 @@ async fn create_websocket_state(
         deps: WebSocketDeps {
             app_state: state.clone(),
             auth_state: auth_state.clone(),
+            transport_security: routes::websocket::TransportSecurity::from_base_url(
+                &server_config.base_url,
+            ),
             service_domains,
             protocol: ProtocolServices {
                 connection_registry,

--- a/server/crates/waddle-server/src/server/routes/auth/state.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/state.rs
@@ -18,6 +18,10 @@ pub struct AuthState {
     pub identity_service: IdentityService,
     pub providers: ProviderRegistry,
     pub base_url: String,
+    /// Trusted public RFC 7395 endpoint advertised to XMPP clients. Kept
+    /// separate from `base_url`, which describes the HTTP application and may
+    /// have a different external scheme/authority behind a TLS terminator.
+    pub public_xmpp_websocket_url: url::Url,
     pub xmpp_domain: String,
     /// Pre-parsed XMPP domain JID for server-issued IQ stanzas
     /// (e.g. XEP-0115 caps disco#info queries). Validated at startup
@@ -42,6 +46,7 @@ impl AuthState {
     pub fn new(
         app_state: Arc<AppState>,
         server_config: &ServerConfig,
+        public_xmpp_websocket_url: &url::Url,
         encryption_key: Option<&[u8]>,
     ) -> Self {
         let session_manager =
@@ -63,6 +68,7 @@ impl AuthState {
             identity_service,
             providers,
             base_url: server_config.base_url.trim_end_matches('/').to_string(),
+            public_xmpp_websocket_url: public_xmpp_websocket_url.clone(),
             xmpp_domain,
             caps_server_domain,
             http_client: reqwest::Client::new(),
@@ -122,26 +128,7 @@ impl AuthState {
     }
 
     pub(crate) fn websocket_url(&self) -> String {
-        let parsed = match url::Url::parse(&self.base_url) {
-            Ok(parsed) => parsed,
-            Err(_) => return "ws://localhost/ws".to_string(),
-        };
-
-        let scheme = match parsed.scheme() {
-            "https" => "wss",
-            _ => "ws",
-        };
-
-        let Some(host) = parsed.host_str() else {
-            return "ws://localhost/ws".to_string();
-        };
-
-        let authority = match parsed.port() {
-            Some(port) => format!("{host}:{port}"),
-            None => host.to_string(),
-        };
-
-        format!("{scheme}://{authority}/ws")
+        self.public_xmpp_websocket_url.as_str().to_string()
     }
 
     pub(super) fn session_cookie_header(&self, session_id: Option<&str>, max_age: i64) -> String {

--- a/server/crates/waddle-server/src/server/routes/auth/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/tests.rs
@@ -11,6 +11,15 @@ use tower::ServiceExt;
 async fn create_test_auth_state(
     server_config: &ServerConfig,
 ) -> (Arc<AuthState>, kameo::actor::ActorRef<DbActor>) {
+    let public_websocket_url =
+        url::Url::parse("ws://localhost:3000/ws").expect("test WebSocket URL");
+    create_test_auth_state_with_websocket_url(server_config, &public_websocket_url).await
+}
+
+async fn create_test_auth_state_with_websocket_url(
+    server_config: &ServerConfig,
+    public_websocket_url: &url::Url,
+) -> (Arc<AuthState>, kameo::actor::ActorRef<DbActor>) {
     let config = DatabaseConfig::default();
     let pool_config = PoolConfig;
     let db_pool = DatabasePool::new(config, pool_config).await.unwrap();
@@ -22,7 +31,12 @@ async fn create_test_auth_state(
 
     let app_state = Arc::new(AppState::new(Arc::new(db_pool)));
     (
-        Arc::new(AuthState::new(app_state, server_config, None)),
+        Arc::new(AuthState::new(
+            app_state,
+            server_config,
+            public_websocket_url,
+            None,
+        )),
         actor,
     )
 }
@@ -79,6 +93,47 @@ async fn session_response_includes_jid_websocket_url_and_link_preview_media_orig
         json["link_preview_media_origin"].as_str(),
         Some("http://localhost:3000")
     );
+}
+
+#[tokio::test]
+async fn session_response_advertises_public_wss_when_app_base_url_is_internal_http() {
+    let mut server_config = ServerConfig::test_homeserver();
+    server_config.base_url = "http://localhost:3000".to_string();
+    let public_websocket_url =
+        url::Url::parse("wss://xmpp.example.com/ws").expect("public WebSocket URL");
+    let (auth_state, actor) =
+        create_test_auth_state_with_websocket_url(&server_config, &public_websocket_url).await;
+    let session = Session::new("alice@example.com", "alice", "alice");
+    auth_state
+        .session_manager
+        .create_session(&session)
+        .await
+        .expect("create session");
+
+    let response = router(auth_state)
+        .oneshot(
+            Request::builder()
+                .uri("/api/auth/session")
+                .header(header::COOKIE, format!("waddle_session={}", session.id))
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("session response");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response
+        .into_body()
+        .collect()
+        .await
+        .expect("body")
+        .to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("session JSON");
+    assert_eq!(
+        json["xmpp_websocket_url"].as_str(),
+        Some("wss://xmpp.example.com/ws")
+    );
+
+    drop(actor);
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/calendar_feed.rs
+++ b/server/crates/waddle-server/src/server/routes/calendar_feed.rs
@@ -697,6 +697,7 @@ mod tests {
         Arc::new(AuthState::new(
             Arc::new(AppState::new(Arc::new(db_pool))),
             &server_config,
+            &url::Url::parse("wss://xmpp.example.com/ws").expect("test WebSocket URL"),
             Some(b"test-session-key"),
         ))
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -298,6 +298,7 @@ pub(super) async fn cleanup_connection_shutdown(
     // occupant slots now belong to the newer connection for this FullJid,
     // and any cleanup we do here would clobber the newcomer.
     if superseded {
+        conn.unpublished_isr_cleanup.take();
         return ConnectionShutdownOutcome::NotPersisted;
     }
     // Note: we deliberately do NOT mirror `conn.phase` Closing into
@@ -309,6 +310,7 @@ pub(super) async fn cleanup_connection_shutdown(
     // the main loop.
 
     let Some(jid) = conn.phase.cleanup_jid().cloned() else {
+        conn.unpublished_isr_cleanup.take();
         return ConnectionShutdownOutcome::NotPersisted;
     };
 
@@ -331,6 +333,7 @@ pub(super) async fn cleanup_connection_shutdown(
             }
         }
         let Some(owner) = conn.registry_owner.as_ref() else {
+            conn.unpublished_isr_cleanup.take();
             debug!(jid = %jid, "Skipped SM detach for connection without registry ownership");
             return ConnectionShutdownOutcome::NotPersisted;
         };
@@ -345,6 +348,7 @@ pub(super) async fn cleanup_connection_shutdown(
             .connection_registry
             .entry_if_owner(&jid, owner)
         else {
+            conn.unpublished_isr_cleanup.take();
             super::stream_management::defer_superseded_sm_claim(state, &conn.sm_state);
             debug!(jid = %jid, "Skipped SM detach for non-owned registry entry");
             return ConnectionShutdownOutcome::NotPersisted;
@@ -496,6 +500,7 @@ pub(super) async fn cleanup_connection_shutdown(
                                 );
                             }
                         }
+                        conn.unpublished_isr_cleanup.take();
                         return ConnectionShutdownOutcome::NotPersisted;
                     }
                     // ADR-0017 Phase 1: prune the actor-tree entry at detach
@@ -547,6 +552,9 @@ pub(super) async fn cleanup_connection_shutdown(
                         stream_id = %stream_id,
                         "SM session detached; awaiting resume"
                     );
+                    if let Some(reservation) = conn.unpublished_isr_cleanup.take() {
+                        reservation.disarm();
+                    }
                     return ConnectionShutdownOutcome::Detached;
                 }
                 Err(err) => {
@@ -586,6 +594,7 @@ pub(super) async fn cleanup_connection_shutdown(
                     if !detach_fail_removed {
                         cleanup_muc_presence(state, &jid).await;
                     }
+                    conn.unpublished_isr_cleanup.take();
                     return ConnectionShutdownOutcome::NotPersisted;
                 }
             }
@@ -632,6 +641,7 @@ pub(super) async fn cleanup_connection_shutdown(
     }
     // Every path reaching here is a non-detach (full-cleanup or no-op)
     // teardown — never a persisted resumable snapshot.
+    conn.unpublished_isr_cleanup.take();
     ConnectionShutdownOutcome::NotPersisted
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -345,6 +345,7 @@ pub(super) async fn cleanup_connection_shutdown(
             .connection_registry
             .entry_if_owner(&jid, owner)
         else {
+            super::stream_management::defer_superseded_sm_claim(state, &conn.sm_state);
             debug!(jid = %jid, "Skipped SM detach for non-owned registry entry");
             return ConnectionShutdownOutcome::NotPersisted;
         };

--- a/server/crates/waddle-server/src/server/routes/websocket/connection.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/connection.rs
@@ -583,6 +583,18 @@ async fn handle_xmpp_websocket(
     // newcomer owns — the same reason the cleanup block below
     // short-circuits.
     if !superseded {
+        if let (Some(jid), Some(owner)) = (conn.phase.bound_jid(), conn.registry_owner.as_ref()) {
+            superseded = state
+                .deps
+                .protocol
+                .connection_registry
+                .entry_if_owner(jid, owner)
+                .is_none();
+        }
+    }
+    if superseded {
+        super::stream_management::defer_superseded_sm_claim(state.as_ref(), &conn.sm_state);
+    } else {
         process_deferred_inbound_after_transport_loss(&domain, state.as_ref(), &mut conn).await;
         drain_ordered_relay_handoffs_before_cleanup(&mut handoff_rx, &mut conn).await;
     }
@@ -770,7 +782,9 @@ async fn handle_inbound_text(
     )
     .await
     {
-        BatchWriteOutcome::Continue => {}
+        BatchWriteOutcome::Continue => {
+            conn.publish_pending_sm_enable(state.as_ref());
+        }
         BatchWriteOutcome::TransportClosed => return false,
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -111,12 +111,7 @@ async fn handle_xmpp_frame_impl(
         InboundFrame::Open => {
             info!("XMPP stream open requested");
             let open_element = websocket_stream_open_xml(domain);
-            let isr_available = state
-                .deps
-                .app_state
-                .clustering_claims
-                .isr_token_store()
-                .is_some();
+            let isr_available = state.deps.isr_available();
             let features_element = build_stream_features_for_phase(phase, isr_available);
             *stream_open_sent = true;
             vec![open_element, features_element]
@@ -360,46 +355,6 @@ pub(super) fn settle_inbound_dispatch(
     }
 }
 
-#[cfg(test)]
-mod inbound_dispatch_tests {
-    use super::*;
-
-    fn enabled_sm() -> waddle_xmpp::stream_management::StreamManagementState {
-        let mut state = waddle_xmpp::stream_management::StreamManagementState::new();
-        state.enable("dispatch-test".to_string(), true, Some(300));
-        state
-    }
-
-    #[test]
-    fn handled_dispatch_advances_h_unless_ordered_relay_owns_completion() {
-        let mut state = enabled_sm();
-        let mut completion =
-            crate::server::routes::interpret::SmInboundCompletionTracker::default();
-        let sequence = completion.reserve(&state);
-
-        settle_inbound_dispatch(
-            InboundDisposition::Handled,
-            false,
-            Some(sequence),
-            &mut completion,
-            &mut state,
-        );
-
-        assert_eq!(state.get_inbound_count(), 1);
-
-        let deferred = completion.reserve(&state);
-        settle_inbound_dispatch(
-            InboundDisposition::Handled,
-            true,
-            Some(deferred),
-            &mut completion,
-            &mut state,
-        );
-        assert_eq!(state.get_inbound_count(), 1);
-        assert!(completion.has_pending());
-    }
-}
-
 #[cfg(feature = "clustering")]
 async fn ordered_relay_origin_for_inbound_stanza(
     state: &WebSocketState,
@@ -583,5 +538,45 @@ mod tests {
                 )
             )
         );
+    }
+}
+
+#[cfg(test)]
+mod inbound_dispatch_tests {
+    use super::*;
+
+    fn enabled_sm() -> waddle_xmpp::stream_management::StreamManagementState {
+        let mut state = waddle_xmpp::stream_management::StreamManagementState::new();
+        state.enable("dispatch-test".to_string(), true, Some(300));
+        state
+    }
+
+    #[test]
+    fn handled_dispatch_advances_h_unless_ordered_relay_owns_completion() {
+        let mut state = enabled_sm();
+        let mut completion =
+            crate::server::routes::interpret::SmInboundCompletionTracker::default();
+        let sequence = completion.reserve(&state);
+
+        settle_inbound_dispatch(
+            InboundDisposition::Handled,
+            false,
+            Some(sequence),
+            &mut completion,
+            &mut state,
+        );
+
+        assert_eq!(state.get_inbound_count(), 1);
+
+        let deferred = completion.reserve(&state);
+        settle_inbound_dispatch(
+            InboundDisposition::Handled,
+            true,
+            Some(deferred),
+            &mut completion,
+            &mut state,
+        );
+        assert_eq!(state.get_inbound_count(), 1);
+        assert!(completion.has_pending());
     }
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/frame.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/frame.rs
@@ -52,6 +52,7 @@ async fn handle_xmpp_frame_impl(
         pending_resume_stream_id,
         pending_resume_h,
         suppress_sm_record_next_batch,
+        pending_sm_enable_commit,
         state_machine,
         stream_open_sent,
         registry_owner,
@@ -79,6 +80,7 @@ async fn handle_xmpp_frame_impl(
                 suppress_sm_record_next_batch,
                 roster_interested,
                 blocklist_interested,
+                pending_sm_enable_commit,
             };
             return handle_sm_stanza(sm, state, ctx).await;
         }
@@ -189,6 +191,7 @@ async fn handle_xmpp_frame_impl(
                 suppress_sm_record_next_batch,
                 roster_interested,
                 blocklist_interested,
+                pending_sm_enable_commit,
             };
             let responses =
                 handle_isr_resume_authenticate(mechanism, initial_response, resume, state, ctx)

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/server_info.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/disco_info/server_info.rs
@@ -52,20 +52,14 @@ pub(super) async fn handle_server_disco_info<'a>(
     let mut features = waddle_xmpp::disco::info::server_features();
     features.push(Feature::new("jabber:iq:search"));
     // ADR-0017 Phase 3 Slice 8 (Q8): XEP-0397 ISR is advertised ONLY when
-    // `clustering.enabled && Postgres` — `isr_token_store().is_some()` is
-    // the single source of truth for that gate (see its doc comment), so
+    // `clustering.enabled && Postgres && configured TLS transport` —
+    // `WebSocketDeps::isr_available()` is the single source of truth, so
     // the advertised capability can never drift from what is actually
     // wired. Corrected premise (FIX 8): before this slice ISR was NOT
     // unadvertised — it was advertised UNCONDITIONALLY and
     // non-conformantly (the wrong namespace, `urn:xmpp:isr:0`, with no
     // gating at all). This slice is what first gates it correctly.
-    if state
-        .deps
-        .app_state
-        .clustering_claims
-        .isr_token_store()
-        .is_some()
-    {
+    if state.deps.isr_available() {
         features.push(Feature::new(waddle_xmpp::isr::ISR_NS));
     }
     features.extend(extension_features_for_disco(state));

--- a/server/crates/waddle-server/src/server/routes/websocket/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/isr_resume.rs
@@ -143,6 +143,14 @@ pub(super) async fn handle_isr_resume_authenticate(
         return vec![sasl2_failure("invalid-mechanism")];
     }
 
+    let isr_stream_id = match SmSessionId::try_from_wire(resume.previd.clone()) {
+        Ok(stream_id) => stream_id,
+        Err(error) => {
+            warn!(%error, "ISR resume rejected: invalid SM session id");
+            return vec![sasl2_failure("not-authorized")];
+        }
+    };
+
     let decoded = match BASE64_STANDARD.decode(initial_response.trim()) {
         Ok(bytes) => bytes,
         Err(error) => {
@@ -330,7 +338,6 @@ pub(super) async fn handle_isr_resume_authenticate(
     };
     let mut identity_guard = Some(identity_guard);
 
-    let isr_stream_id = SmSessionId::new(resume.previd.clone());
     let consume_result = isr_token_store
         .consume(
             &isr_stream_id,

--- a/server/crates/waddle-server/src/server/routes/websocket/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/isr_resume.rs
@@ -117,6 +117,7 @@ pub(super) async fn handle_isr_resume_authenticate(
         suppress_sm_record_next_batch,
         roster_interested,
         blocklist_interested,
+        pending_sm_enable_commit: _,
     } = ctx;
 
     // Q8's gate: ISR is only wired when clustering.enabled && Postgres —

--- a/server/crates/waddle-server/src/server/routes/websocket/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/isr_resume.rs
@@ -64,6 +64,7 @@ use waddle_xmpp::isr::{
     inst_resume_failed_element, inst_resumed_element, IsrConsumeOutcome, ISR_PINNED_MECHANISM,
 };
 use waddle_xmpp::ownership::{resume::verify_resume_identity, Entity, EntityType};
+use waddle_xmpp::pending_delivery::SmSessionId;
 use waddle_xmpp::stream_management::{stamp_replay_delay, SmFailed, SmResumed};
 
 /// Build a bare SASL2 `<failure/>` carrying a single standard SASL
@@ -120,12 +121,16 @@ pub(super) async fn handle_isr_resume_authenticate(
         pending_sm_enable_commit: _,
     } = ctx;
 
-    // Q8's gate: ISR is only wired when clustering.enabled && Postgres —
-    // `isr_token_store()`/`claim_pair()` are `None` under the exact same
-    // conditions the stream feature is unadvertised, so a client that
-    // somehow pipelines this without ever seeing the advertisement (a
-    // stale token from before a topology change, a misbehaving client)
-    // gets a conformant failure rather than a panic on a missing handle.
+    // XEP-0397 requires TLS for the bearer-token authentication itself, not
+    // only for feature advertisement and token issuance. Reuse the exact same
+    // availability gate so a stale token cannot cross a transport-security or
+    // topology configuration change.
+    if !state.deps.isr_available() {
+        return vec![sasl2_failure("invalid-mechanism")];
+    }
+
+    // Keep the individual handle check defensive even though `isr_available`
+    // already establishes the token-store half of this invariant.
     let (Some(isr_token_store), Some((claim_store, node_identity))) = (
         state.deps.app_state.clustering_claims.isr_token_store(),
         state.deps.app_state.clustering_claims.claim_pair(),
@@ -325,9 +330,10 @@ pub(super) async fn handle_isr_resume_authenticate(
     };
     let mut identity_guard = Some(identity_guard);
 
+    let isr_stream_id = SmSessionId::new(resume.previd.clone());
     let consume_result = isr_token_store
         .consume(
-            &resume.previd,
+            &isr_stream_id,
             presented_token.as_bytes(),
             ISR_PINNED_MECHANISM,
             &claim_fence,

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -103,7 +103,7 @@ pub(crate) use cleanup::redrive_remote_muc_cleanup;
 pub use connection::router;
 pub use state::{
     ActiveCallThread, DmCallThreadKey, DmPairKey, DmPinStore, PendingDmCallOffer, ProtocolServices,
-    RemoteMucMemberships, WebSocketDeps, WebSocketState, XmppServiceDomains,
+    RemoteMucMemberships, TransportSecurity, WebSocketDeps, WebSocketState, XmppServiceDomains,
 };
 
 pub(crate) use cleanup::{

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -703,6 +703,10 @@ pub(super) struct WsConnState {
     /// and duplicate queue entries. The main loop resets the flag to
     /// `false` after skipping the record step.
     pub(super) suppress_sm_record_next_batch: bool,
+    /// Post-write `<enable/>` publication. While present, a resumable claim
+    /// remains guarded and SM stays locally disabled; dropping the
+    /// connection or failing the write terminalizes the exact claim.
+    pub(super) pending_sm_enable_commit: Option<super::stream_management::SmEnableCommit>,
     /// Inbound text frames pulled off the socket by the mid-batch ack
     /// drain (issue #1089) that were NOT `<a/>` acks. The batch writer
     /// may only consume acks out of order; everything else must reach
@@ -775,12 +779,30 @@ impl WsConnState {
             pending_resume_h: None,
             registry_owner: None,
             suppress_sm_record_next_batch: false,
+            pending_sm_enable_commit: None,
             deferred_inbound: std::collections::VecDeque::new(),
             send_window_pause_deadline: None,
             send_window_last_request_acked: 0,
             state_machine: None,
             keepalive_config: waddle_xmpp::protocol::KeepaliveConfig::default(),
         }
+    }
+
+    /// Apply the typed `<enable/>` effect after its `<enabled/>` frame has
+    /// been written. This is synchronous by design: no cancellation point
+    /// may exist between transport success, local SM enablement, registry
+    /// publication, and disarming exact-claim cleanup.
+    pub(super) fn publish_pending_sm_enable(&mut self, state: &WebSocketState) {
+        let Some(commit) = self.pending_sm_enable_commit.take() else {
+            return;
+        };
+        let bound_jid = self.phase.bound_jid().cloned();
+        commit.publish(
+            state,
+            &mut self.sm_state,
+            bound_jid.as_ref(),
+            self.registry_owner.as_ref(),
+        );
     }
 
     /// Initialize the per-connection [`XmppStateMachine`] in the

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -459,11 +459,37 @@ pub struct WebSocketState {
     pub deps: WebSocketDeps,
 }
 
+/// Whether the externally configured XMPP WebSocket endpoint is protected by
+/// TLS. This is derived once from the trusted deployment `base_url`; request
+/// headers are deliberately not consulted because an untrusted client can
+/// forge forwarding headers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportSecurity {
+    Unsecured,
+    Tls,
+}
+
+impl TransportSecurity {
+    pub fn from_base_url(base_url: &str) -> Self {
+        match url::Url::parse(base_url) {
+            Ok(url) if url.scheme() == "https" => Self::Tls,
+            _ => Self::Unsecured,
+        }
+    }
+
+    pub const fn is_tls(self) -> bool {
+        matches!(self, Self::Tls)
+    }
+}
+
 pub struct WebSocketDeps {
     /// Core app state for accessing the global and per-waddle databases.
     pub app_state: Arc<AppState>,
     /// Authentication state for session validation.
     pub auth_state: Arc<AuthState>,
+    /// Trusted deployment-level transport security used to enforce the
+    /// XEP-0397 TLS-only advertisement and token-issuance requirements.
+    pub transport_security: TransportSecurity,
     /// Authoritative XMPP component/service JIDs used by this deployment.
     pub service_domains: XmppServiceDomains,
     /// Protocol/runtime services used by the WebSocket C2S path.
@@ -491,6 +517,15 @@ pub struct WebSocketDeps {
     /// observes the stop token to close live sessions with
     /// `<stream:error><system-shutdown/>`.
     pub shutdown: waddle_ecdysis::ShutdownHandle,
+}
+
+impl WebSocketDeps {
+    /// XEP-0397 is available only when both its durable backend exists and
+    /// the externally configured WebSocket endpoint is TLS protected.
+    pub fn isr_available(&self) -> bool {
+        self.transport_security.is_tls()
+            && self.app_state.clustering_claims.isr_token_store().is_some()
+    }
 }
 
 pub struct ProtocolServices {
@@ -707,6 +742,10 @@ pub(super) struct WsConnState {
     /// remains guarded and SM stays locally disabled; dropping the
     /// connection or failing the write terminalizes the exact claim.
     pub(super) pending_sm_enable_commit: Option<super::stream_management::SmEnableCommit>,
+    /// Exact provisional ISR cleanup retained only when `<enabled/>` was
+    /// written but the connection lost the owner-gated publication race.
+    /// Terminal cleanup drops the armed reservation and activates revocation.
+    pub(super) unpublished_isr_cleanup: Option<waddle_xmpp::isr::IsrRevocationReservation>,
     /// Inbound text frames pulled off the socket by the mid-batch ack
     /// drain (issue #1089) that were NOT `<a/>` acks. The batch writer
     /// may only consume acks out of order; everything else must reach
@@ -780,6 +819,7 @@ impl WsConnState {
             registry_owner: None,
             suppress_sm_record_next_batch: false,
             pending_sm_enable_commit: None,
+            unpublished_isr_cleanup: None,
             deferred_inbound: std::collections::VecDeque::new(),
             send_window_pause_deadline: None,
             send_window_last_request_acked: 0,
@@ -797,7 +837,7 @@ impl WsConnState {
             return;
         };
         let bound_jid = self.phase.bound_jid().cloned();
-        commit.publish(
+        self.unpublished_isr_cleanup = commit.publish(
             state,
             &mut self.sm_state,
             bound_jid.as_ref(),

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -460,9 +460,9 @@ pub struct WebSocketState {
 }
 
 /// Whether the externally configured XMPP WebSocket endpoint is protected by
-/// TLS. This is derived once from the trusted deployment `base_url`; request
-/// headers are deliberately not consulted because an untrusted client can
-/// forge forwarding headers.
+/// TLS. This is derived once from the trusted deployment RFC 7395 endpoint;
+/// the unrelated application base URL and request headers are deliberately not
+/// consulted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransportSecurity {
     Unsecured,
@@ -470,10 +470,11 @@ pub enum TransportSecurity {
 }
 
 impl TransportSecurity {
-    pub fn from_base_url(base_url: &str) -> Self {
-        match url::Url::parse(base_url) {
-            Ok(url) if url.scheme() == "https" => Self::Tls,
-            _ => Self::Unsecured,
+    pub fn from_public_websocket_url(public_websocket_url: &url::Url) -> Self {
+        if public_websocket_url.scheme() == "wss" {
+            Self::Tls
+        } else {
+            Self::Unsecured
         }
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -528,7 +528,7 @@ async fn handle_sm_enable(
     if !phase.allows_stream_management_enable() {
         return vec![SmFailed::with_condition("unexpected-request").to_xml()];
     }
-    if sm_state.enabled {
+    if sm_state.enabled || pending_commit.is_some() {
         return vec![SmFailed::with_condition("unexpected-request").to_xml()];
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -6,6 +6,7 @@ const SM_ENABLE_FALLIBLE_AWAIT_TIMEOUT: std::time::Duration = std::time::Duratio
 struct SmEnableClaimGuard {
     registry: std::sync::Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
     stream_id: waddle_xmpp::pending_delivery::SmSessionId,
+    _claim_publication: waddle_xmpp::ownership::CurrentNodeIdentityGuard,
     provisional_isr_token: Option<waddle_xmpp::isr::IsrRevocationReservation>,
     armed: bool,
 }
@@ -76,10 +77,12 @@ impl SmEnableClaimGuard {
     fn new(
         registry: std::sync::Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
         stream_id: waddle_xmpp::pending_delivery::SmSessionId,
+        claim_publication: waddle_xmpp::ownership::CurrentNodeIdentityGuard,
     ) -> Self {
         Self {
             registry,
             stream_id,
+            _claim_publication: claim_publication,
             provisional_isr_token: None,
             armed: true,
         }
@@ -219,17 +222,23 @@ mod enable_claim_guard_tests {
     async fn dropped_prepublication_guard_defers_and_releases_the_exact_claim() {
         let store = Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
         let identity = waddle_xmpp::ownership::NodeIdentity::new("sm-node", "incarnation");
-        let registry = Arc::new(InMemorySmSessionRegistry::new().with_claim_store(
-            store.clone(),
-            waddle_xmpp::ownership::SharedNodeIdentity::new(identity),
-        ));
+        let shared_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(identity);
+        let registry = Arc::new(
+            InMemorySmSessionRegistry::new()
+                .with_claim_store(store.clone(), shared_identity.clone()),
+        );
         let stream_id = "cancelled-before-enabled-publication";
-        assert!(registry.ensure_session_claim(stream_id).await.is_some());
+        let claim_publication = registry
+            .ensure_session_claim(stream_id)
+            .await
+            .expect("claim admission");
 
-        drop(SmEnableClaimGuard::new(
+        let guard = SmEnableClaimGuard::new(
             registry.clone(),
             waddle_xmpp::pending_delivery::SmSessionId::new(stream_id),
-        ));
+            claim_publication,
+        );
+        drop(guard);
 
         assert_eq!(registry.pending_claim_release_count(), 1);
         assert_eq!(registry.retry_pending_claim_releases(1).await, 1);
@@ -239,6 +248,37 @@ mod enable_claim_guard_tests {
             .await
             .expect("claim lookup")
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn prepublication_guard_blocks_self_fence_demotion_until_commit() {
+        let registry = Arc::new(InMemorySmSessionRegistry::new());
+        let stream_id = "enable-publication-vs-self-fence";
+        let claim_publication = registry
+            .ensure_session_claim(stream_id)
+            .await
+            .expect("claim admission");
+        let guard = SmEnableClaimGuard::new(
+            registry.clone(),
+            waddle_xmpp::pending_delivery::SmSessionId::new(stream_id),
+            claim_publication,
+        );
+        let demotion = tokio::spawn({
+            let registry = registry.clone();
+            async move { registry.forget_claim_locally(stream_id).await }
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !demotion.is_finished(),
+            "pending transport publication must block self-fence demotion"
+        );
+
+        assert!(guard.commit(true).is_none());
+        demotion.await.expect("self-fence demotion");
+        assert!(registry
+            .locally_owned_claim_ids()
+            .expect("owned inventory")
+            .is_empty());
     }
 
     #[tokio::test]
@@ -255,12 +295,15 @@ mod enable_claim_guard_tests {
         });
         let stream_id = "cancelled-isr-before-enabled-publication";
         let isr_stream_id = waddle_xmpp::pending_delivery::SmSessionId::new(stream_id);
-        assert!(registry.ensure_session_claim(stream_id).await.is_some());
+        let claim_publication = registry
+            .ensure_session_claim(stream_id)
+            .await
+            .expect("claim admission");
         let issued = token_store
             .issue(&isr_stream_id, "PLAIN")
             .await
             .expect("issue");
-        let mut guard = SmEnableClaimGuard::new(registry, isr_stream_id.clone());
+        let mut guard = SmEnableClaimGuard::new(registry, isr_stream_id.clone(), claim_publication);
         let revocations = waddle_xmpp::isr::IsrRevocationQueue::default();
         assert!(guard.retain_provisional_isr_token(
             &revocations,
@@ -574,17 +617,17 @@ async fn handle_sm_enable(
     } else {
         None
     };
-    let mut claim_guard = enable.resume.then(|| {
+    let mut claim_guard = claim_publication.map(|publication| {
         SmEnableClaimGuard::new(
             state.deps.protocol.sm_session_registry.clone(),
             waddle_xmpp::pending_delivery::SmSessionId::new(stream_id.clone()),
+            publication,
         )
     });
-    // Publishing the armed pre-transport guard transfers exact cleanup
-    // responsibility into the pending commit. Keep identity authority until
-    // that synchronous hand-off is complete; later fallible work and the
-    // socket write must not hold the rotation gate.
-    drop(claim_publication);
+    // The pending commit retains both exact cleanup responsibility and the
+    // identity-publication guard through the `<enabled/>` transport write.
+    // Identity rotation therefore cannot demote the durable claim in the gap
+    // between admission and the state the peer has observed.
     // ADR-0017 Phase 3 Slice 8: XEP-0397 ISR token issuance rides this same
     // `<enable/>`/`<enabled/>` exchange inline (`<isr-enable/>`/
     // `<isr-enabled/>`) — never a standalone IQ (the retired conformance

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -6,13 +6,8 @@ const SM_ENABLE_FALLIBLE_AWAIT_TIMEOUT: std::time::Duration = std::time::Duratio
 struct SmEnableClaimGuard {
     registry: std::sync::Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
     stream_id: String,
-    provisional_isr_token: Option<ProvisionalIsrToken>,
+    provisional_isr_token: Option<waddle_xmpp::isr::IsrRevocationReservation>,
     armed: bool,
-}
-
-struct ProvisionalIsrToken {
-    store: std::sync::Arc<dyn waddle_xmpp::isr::IsrTokenStore>,
-    issued: waddle_xmpp::isr::IssuedIsrToken,
 }
 
 /// Typed post-write effect for `<enable/>`. The resumable claim is acquired
@@ -48,26 +43,34 @@ impl SmEnableCommit {
         bound_jid: Option<&jid::FullJid>,
         registry_owner: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
     ) {
-        let (Some(jid), Some(owner)) = (bound_jid, registry_owner) else {
-            return;
+        let registry_published = match (bound_jid, registry_owner) {
+            (Some(jid), Some(owner)) => state
+                .deps
+                .protocol
+                .connection_registry
+                .set_sm_stream_id_if_owner(
+                    jid,
+                    owner,
+                    Some(waddle_xmpp::pending_delivery::SmSessionId::new(
+                        self.stream_id.clone(),
+                    )),
+                ),
+            _ => false,
         };
-        if !state
-            .deps
-            .protocol
-            .connection_registry
-            .set_sm_stream_id_if_owner(
-                jid,
-                owner,
-                Some(waddle_xmpp::pending_delivery::SmSessionId::new(
-                    self.stream_id.clone(),
-                )),
-            )
-        {
-            return;
-        }
+
+        // The transport has already written `<enabled/>`; XEP-0198 makes
+        // that positive reply the SM-session commit point. A concurrent
+        // same-JID replacement may reject only the shared registry alias,
+        // never roll back the state the peer has already observed.
         sm_state.enable(self.stream_id.clone(), self.resume, Some(self.max));
         if let Some(guard) = self.claim_guard.as_mut() {
             guard.disarm();
+        }
+        if !registry_published {
+            debug!(
+                stream_id = %self.stream_id,
+                "SM enabled after transport commit without publishing a stale registry alias"
+            );
         }
         info!(stream_id = %self.stream_id, resume = self.resume, max = self.max, "SM enabled");
     }
@@ -88,15 +91,22 @@ impl SmEnableClaimGuard {
 
     fn retain_provisional_isr_token(
         &mut self,
+        queue: &waddle_xmpp::isr::IsrRevocationQueue,
         store: std::sync::Arc<dyn waddle_xmpp::isr::IsrTokenStore>,
         issued: waddle_xmpp::isr::IssuedIsrToken,
-    ) {
-        self.provisional_isr_token = Some(ProvisionalIsrToken { store, issued });
+    ) -> bool {
+        let Some(reservation) = queue.reserve(self.stream_id.clone(), store, issued) else {
+            return false;
+        };
+        self.provisional_isr_token = Some(reservation);
+        true
     }
 
     fn disarm(&mut self) {
         self.armed = false;
-        self.provisional_isr_token = None;
+        if let Some(reservation) = self.provisional_isr_token.take() {
+            reservation.disarm();
+        }
     }
 }
 
@@ -114,38 +124,9 @@ impl Drop for SmEnableClaimGuard {
                 "SM enable cancelled before publication but exact claim cleanup could not be inventoried"
             );
         }
-        let Some(provisional) = self.provisional_isr_token.take() else {
-            return;
-        };
-        let stream_id = self.stream_id.clone();
-        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
-            warn!(
-                stream_id,
-                "SM enable cancelled outside a Tokio runtime; provisional ISR token remains for expiry sweep"
-            );
-            return;
-        };
-        runtime.spawn(async move {
-            match tokio::time::timeout(
-                SM_ENABLE_FALLIBLE_AWAIT_TIMEOUT,
-                provisional
-                    .store
-                    .revoke_if_current(&stream_id, &provisional.issued),
-            )
-            .await
-            {
-                Ok(Ok(true)) => {}
-                Ok(Ok(false)) => {
-                    debug!(stream_id, "Provisional ISR token was already superseded or removed");
-                }
-                Ok(Err(error)) => {
-                    warn!(stream_id, %error, "Failed to revoke provisional ISR token; expiry sweep retains cleanup responsibility");
-                }
-                Err(_) => {
-                    warn!(stream_id, "Timed out revoking provisional ISR token; expiry sweep retains cleanup responsibility");
-                }
-            }
-        });
+        // Dropping the armed reservation activates bounded exact revocation.
+        // Its queue retains and redrives responsibility until deletion or a
+        // proven exact-value mismatch shows that this issuance was superseded.
     }
 }
 
@@ -189,13 +170,12 @@ mod enable_claim_guard_tests {
             self.inner.ensure_schema().await
         }
 
-        async fn issue(
+        async fn persist_issued(
             &self,
             sm_id: &str,
-            mechanism: &str,
-        ) -> Result<waddle_xmpp::isr::IssuedIsrToken, waddle_xmpp::isr::IsrTokenStoreError>
-        {
-            self.inner.issue(sm_id, mechanism).await
+            issued: &waddle_xmpp::isr::IssuedIsrToken,
+        ) -> Result<(), waddle_xmpp::isr::IsrTokenStoreError> {
+            self.inner.persist_issued(sm_id, issued).await
         }
 
         async fn revoke_if_current(
@@ -271,7 +251,12 @@ mod enable_claim_guard_tests {
         assert!(registry.ensure_session_claim(stream_id).await.is_some());
         let issued = token_store.issue(stream_id, "PLAIN").await.expect("issue");
         let mut guard = SmEnableClaimGuard::new(registry, stream_id.to_string());
-        guard.retain_provisional_isr_token(token_store.clone(), issued.clone());
+        let revocations = waddle_xmpp::isr::IsrRevocationQueue::default();
+        assert!(guard.retain_provisional_isr_token(
+            &revocations,
+            token_store.clone(),
+            issued.clone()
+        ));
 
         let revoked = token_store.revoked.notified();
         drop(guard);
@@ -619,24 +604,31 @@ async fn handle_sm_enable(
             Some(mechanism) if mechanism == waddle_xmpp::isr::ISR_PINNED_MECHANISM => {
                 match state.deps.app_state.clustering_claims.isr_token_store() {
                     Some(isr_token_store) => {
+                        let issued = waddle_xmpp::isr::IssuedIsrToken::new(mechanism);
+                        let revocations =
+                            waddle_xmpp::isr::revocation_queue_for_store(&isr_token_store);
+                        if claim_guard.as_mut().is_none_or(|guard| {
+                            !guard.retain_provisional_isr_token(
+                                &revocations,
+                                isr_token_store.clone(),
+                                issued.clone(),
+                            )
+                        }) {
+                            warn!(stream_id = %stream_id, "ISR provisional-revocation inventory is full");
+                            return vec![SmFailed::with_condition("resource-constraint").to_xml()];
+                        }
                         match tokio::time::timeout(
                             SM_ENABLE_FALLIBLE_AWAIT_TIMEOUT,
-                            isr_token_store.issue(&stream_id, mechanism),
+                            isr_token_store.persist_issued(&stream_id, &issued),
                         )
                         .await
                         {
-                            Ok(Ok(issued)) => {
-                                if let Some(guard) = claim_guard.as_mut() {
-                                    guard.retain_provisional_isr_token(
-                                        isr_token_store.clone(),
-                                        issued.clone(),
-                                    );
-                                }
-                                Some(issued.token)
-                            }
+                            Ok(Ok(())) => Some(issued.token),
                             Ok(Err(error)) => {
                                 warn!(stream_id = %stream_id, %error, "ISR token issuance failed");
-                                None
+                                return vec![
+                                    SmFailed::with_condition("resource-constraint").to_xml()
+                                ];
                             }
                             Err(_) => {
                                 warn!(stream_id = %stream_id, "ISR token issuance timed out; rejecting SM enable before state commit");

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -42,7 +42,7 @@ impl SmEnableCommit {
         sm_state: &mut StreamManagementState,
         bound_jid: Option<&jid::FullJid>,
         registry_owner: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
-    ) {
+    ) -> Option<waddle_xmpp::isr::IsrRevocationReservation> {
         let registry_published = match (bound_jid, registry_owner) {
             (Some(jid), Some(owner)) => state
                 .deps
@@ -63,9 +63,10 @@ impl SmEnableCommit {
         // same-JID replacement may reject only the shared registry alias,
         // never roll back the state the peer has already observed.
         sm_state.enable(self.stream_id.clone(), self.resume, Some(self.max));
-        if let Some(guard) = self.claim_guard.as_mut() {
-            guard.disarm();
-        }
+        let unpublished_isr_cleanup = self
+            .claim_guard
+            .take()
+            .and_then(|guard| guard.commit(registry_published));
         if !registry_published {
             debug!(
                 stream_id = %self.stream_id,
@@ -73,6 +74,7 @@ impl SmEnableCommit {
             );
         }
         info!(stream_id = %self.stream_id, resume = self.resume, max = self.max, "SM enabled");
+        unpublished_isr_cleanup
     }
 }
 
@@ -102,10 +104,19 @@ impl SmEnableClaimGuard {
         true
     }
 
-    fn disarm(&mut self) {
+    fn commit(
+        mut self,
+        registry_published: bool,
+    ) -> Option<waddle_xmpp::isr::IsrRevocationReservation> {
         self.armed = false;
-        if let Some(reservation) = self.provisional_isr_token.take() {
-            reservation.disarm();
+        let reservation = self.provisional_isr_token.take();
+        if registry_published {
+            if let Some(reservation) = reservation {
+                reservation.disarm();
+            }
+            None
+        } else {
+            reservation
         }
     }
 }
@@ -591,7 +602,12 @@ async fn handle_sm_enable(
     // (gated) advertisement, or without `resume='true'`, simply doesn't
     // get a token, exactly as if the server had never announced the
     // capability.
-    let isr_token = if !enable.resume {
+    let isr_token = if !state.deps.transport_security.is_tls() {
+        if enable.isr_enable_mechanism.is_some() {
+            debug!(stream_id = %stream_id, "ISR enable requested on a non-TLS endpoint; ignoring");
+        }
+        None
+    } else if !enable.resume {
         if enable.isr_enable_mechanism.is_some() {
             debug!(
                 stream_id = %stream_id,

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -5,7 +5,7 @@ const SM_ENABLE_FALLIBLE_AWAIT_TIMEOUT: std::time::Duration = std::time::Duratio
 
 struct SmEnableClaimGuard {
     registry: std::sync::Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
-    stream_id: String,
+    stream_id: waddle_xmpp::pending_delivery::SmSessionId,
     provisional_isr_token: Option<waddle_xmpp::isr::IsrRevocationReservation>,
     armed: bool,
 }
@@ -16,7 +16,7 @@ struct SmEnableClaimGuard {
 /// `<enabled/>` frame was written.
 pub(super) struct SmEnableCommit {
     claim_guard: Option<SmEnableClaimGuard>,
-    stream_id: String,
+    stream_id: waddle_xmpp::pending_delivery::SmSessionId,
     resume: bool,
     max: u32,
 }
@@ -24,7 +24,7 @@ pub(super) struct SmEnableCommit {
 impl SmEnableCommit {
     fn new(
         claim_guard: Option<SmEnableClaimGuard>,
-        stream_id: String,
+        stream_id: waddle_xmpp::pending_delivery::SmSessionId,
         resume: bool,
         max: u32,
     ) -> Self {
@@ -48,13 +48,7 @@ impl SmEnableCommit {
                 .deps
                 .protocol
                 .connection_registry
-                .set_sm_stream_id_if_owner(
-                    jid,
-                    owner,
-                    Some(waddle_xmpp::pending_delivery::SmSessionId::new(
-                        self.stream_id.clone(),
-                    )),
-                ),
+                .set_sm_stream_id_if_owner(jid, owner, Some(self.stream_id.clone())),
             _ => false,
         };
 
@@ -62,7 +56,7 @@ impl SmEnableCommit {
         // that positive reply the SM-session commit point. A concurrent
         // same-JID replacement may reject only the shared registry alias,
         // never roll back the state the peer has already observed.
-        sm_state.enable(self.stream_id.clone(), self.resume, Some(self.max));
+        sm_state.enable(self.stream_id.to_string(), self.resume, Some(self.max));
         let unpublished_isr_cleanup = self
             .claim_guard
             .take()
@@ -81,7 +75,7 @@ impl SmEnableCommit {
 impl SmEnableClaimGuard {
     fn new(
         registry: std::sync::Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
-        stream_id: String,
+        stream_id: waddle_xmpp::pending_delivery::SmSessionId,
     ) -> Self {
         Self {
             registry,
@@ -128,7 +122,7 @@ impl Drop for SmEnableClaimGuard {
         }
         if !self
             .registry
-            .defer_unpublished_enabled_claim_release(&self.stream_id)
+            .defer_unpublished_enabled_claim_release(self.stream_id.as_str())
         {
             warn!(
                 stream_id = %self.stream_id,
@@ -183,7 +177,7 @@ mod enable_claim_guard_tests {
 
         async fn persist_issued(
             &self,
-            sm_id: &str,
+            sm_id: &waddle_xmpp::pending_delivery::SmSessionId,
             issued: &waddle_xmpp::isr::IssuedIsrToken,
         ) -> Result<(), waddle_xmpp::isr::IsrTokenStoreError> {
             self.inner.persist_issued(sm_id, issued).await
@@ -191,9 +185,10 @@ mod enable_claim_guard_tests {
 
         async fn revoke_if_current(
             &self,
-            sm_id: &str,
+            sm_id: &waddle_xmpp::pending_delivery::SmSessionId,
             issued: &waddle_xmpp::isr::IssuedIsrToken,
-        ) -> Result<bool, waddle_xmpp::isr::IsrTokenStoreError> {
+        ) -> Result<waddle_xmpp::isr::IsrRevokeOutcome, waddle_xmpp::isr::IsrTokenStoreError>
+        {
             let revoked = self.inner.revoke_if_current(sm_id, issued).await?;
             self.revoked.notify_one();
             Ok(revoked)
@@ -201,7 +196,7 @@ mod enable_claim_guard_tests {
 
         async fn consume(
             &self,
-            sm_id: &str,
+            sm_id: &waddle_xmpp::pending_delivery::SmSessionId,
             presented_token: &[u8],
             mechanism: &str,
             fence: &SmClaimFence,
@@ -233,7 +228,7 @@ mod enable_claim_guard_tests {
 
         drop(SmEnableClaimGuard::new(
             registry.clone(),
-            stream_id.to_string(),
+            waddle_xmpp::pending_delivery::SmSessionId::new(stream_id),
         ));
 
         assert_eq!(registry.pending_claim_release_count(), 1);
@@ -259,9 +254,13 @@ mod enable_claim_guard_tests {
             revoked: tokio::sync::Notify::new(),
         });
         let stream_id = "cancelled-isr-before-enabled-publication";
+        let isr_stream_id = waddle_xmpp::pending_delivery::SmSessionId::new(stream_id);
         assert!(registry.ensure_session_claim(stream_id).await.is_some());
-        let issued = token_store.issue(stream_id, "PLAIN").await.expect("issue");
-        let mut guard = SmEnableClaimGuard::new(registry, stream_id.to_string());
+        let issued = token_store
+            .issue(&isr_stream_id, "PLAIN")
+            .await
+            .expect("issue");
+        let mut guard = SmEnableClaimGuard::new(registry, isr_stream_id.clone());
         let revocations = waddle_xmpp::isr::IsrRevocationQueue::default();
         assert!(guard.retain_provisional_isr_token(
             &revocations,
@@ -278,7 +277,7 @@ mod enable_claim_guard_tests {
         let fence = SmClaimFence::new(identity, waddle_xmpp::ownership::ClaimEpoch(0));
         assert_eq!(
             token_store
-                .consume(stream_id, issued.token.as_bytes(), "PLAIN", &fence)
+                .consume(&isr_stream_id, issued.token.as_bytes(), "PLAIN", &fence,)
                 .await
                 .expect("consume after cancellation"),
             IsrConsumeOutcome::NoSuchToken
@@ -578,7 +577,7 @@ async fn handle_sm_enable(
     let mut claim_guard = enable.resume.then(|| {
         SmEnableClaimGuard::new(
             state.deps.protocol.sm_session_registry.clone(),
-            stream_id.clone(),
+            waddle_xmpp::pending_delivery::SmSessionId::new(stream_id.clone()),
         )
     });
     // Publishing the armed pre-transport guard transfers exact cleanup
@@ -621,6 +620,8 @@ async fn handle_sm_enable(
                 match state.deps.app_state.clustering_claims.isr_token_store() {
                     Some(isr_token_store) => {
                         let issued = waddle_xmpp::isr::IssuedIsrToken::new(mechanism);
+                        let isr_stream_id =
+                            waddle_xmpp::pending_delivery::SmSessionId::new(stream_id.clone());
                         let revocations =
                             waddle_xmpp::isr::revocation_queue_for_store(&isr_token_store);
                         if claim_guard.as_mut().is_none_or(|guard| {
@@ -635,7 +636,7 @@ async fn handle_sm_enable(
                         }
                         match tokio::time::timeout(
                             SM_ENABLE_FALLIBLE_AWAIT_TIMEOUT,
-                            isr_token_store.persist_issued(&stream_id, &issued),
+                            isr_token_store.persist_issued(&isr_stream_id, &issued),
                         )
                         .await
                         {
@@ -679,7 +680,7 @@ async fn handle_sm_enable(
     }
     *pending_commit = Some(SmEnableCommit::new(
         claim_guard,
-        stream_id,
+        waddle_xmpp::pending_delivery::SmSessionId::new(stream_id),
         enable.resume,
         max,
     ));

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -1,6 +1,158 @@
 use super::transport_xml::{build_handled_count_too_high_stream_error, websocket_stream_close_xml};
 use super::*;
 
+const SM_ENABLE_FALLIBLE_AWAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
+struct SmEnableClaimGuard {
+    registry: std::sync::Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
+    stream_id: String,
+    armed: bool,
+}
+
+/// Typed post-write effect for `<enable/>`. The resumable claim is acquired
+/// before the response is built, but neither local SM state nor connection-
+/// registry publication occurs until the transport confirms that the
+/// `<enabled/>` frame was written.
+pub(super) struct SmEnableCommit {
+    claim_guard: Option<SmEnableClaimGuard>,
+    stream_id: String,
+    resume: bool,
+    max: u32,
+}
+
+impl SmEnableCommit {
+    fn new(
+        claim_guard: Option<SmEnableClaimGuard>,
+        stream_id: String,
+        resume: bool,
+        max: u32,
+    ) -> Self {
+        Self {
+            claim_guard,
+            stream_id,
+            resume,
+            max,
+        }
+    }
+
+    pub(super) fn publish(
+        mut self,
+        state: &WebSocketState,
+        sm_state: &mut StreamManagementState,
+        bound_jid: Option<&jid::FullJid>,
+        registry_owner: Option<&std::sync::Arc<std::sync::atomic::AtomicBool>>,
+    ) {
+        let (Some(jid), Some(owner)) = (bound_jid, registry_owner) else {
+            return;
+        };
+        if !state
+            .deps
+            .protocol
+            .connection_registry
+            .set_sm_stream_id_if_owner(
+                jid,
+                owner,
+                Some(waddle_xmpp::pending_delivery::SmSessionId::new(
+                    self.stream_id.clone(),
+                )),
+            )
+        {
+            return;
+        }
+        sm_state.enable(self.stream_id.clone(), self.resume, Some(self.max));
+        if let Some(guard) = self.claim_guard.as_mut() {
+            guard.disarm();
+        }
+        info!(stream_id = %self.stream_id, resume = self.resume, max = self.max, "SM enabled");
+    }
+}
+
+impl SmEnableClaimGuard {
+    fn new(
+        registry: std::sync::Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
+        stream_id: String,
+    ) -> Self {
+        Self {
+            registry,
+            stream_id,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for SmEnableClaimGuard {
+    fn drop(&mut self) {
+        if self.armed
+            && !self
+                .registry
+                .defer_unpublished_enabled_claim_release(&self.stream_id)
+        {
+            warn!(
+                stream_id = %self.stream_id,
+                "SM enable cancelled before publication but exact claim cleanup could not be inventoried"
+            );
+        }
+    }
+}
+
+pub(super) fn defer_superseded_sm_claim(state: &WebSocketState, sm_state: &StreamManagementState) {
+    if !sm_state.is_resumable() {
+        return;
+    }
+    let Some(stream_id) = sm_state.stream_id.as_deref() else {
+        return;
+    };
+    if !state
+        .deps
+        .protocol
+        .sm_session_registry
+        .defer_superseded_enabled_claim_release(stream_id)
+    {
+        warn!(
+            stream_id,
+            "Superseded SM connection could not inventory its exact terminal claim"
+        );
+    }
+}
+
+#[cfg(test)]
+mod enable_claim_guard_tests {
+    use super::SmEnableClaimGuard;
+    use std::sync::Arc;
+    use waddle_xmpp::ownership::{ClaimStore as _, Entity, EntityType};
+    use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
+
+    #[tokio::test]
+    async fn dropped_prepublication_guard_defers_and_releases_the_exact_claim() {
+        let store = Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+        let identity = waddle_xmpp::ownership::NodeIdentity::new("sm-node", "incarnation");
+        let registry = Arc::new(InMemorySmSessionRegistry::new().with_claim_store(
+            store.clone(),
+            waddle_xmpp::ownership::SharedNodeIdentity::new(identity),
+        ));
+        let stream_id = "cancelled-before-enabled-publication";
+        assert!(registry.ensure_session_claim(stream_id).await.is_some());
+
+        drop(SmEnableClaimGuard::new(
+            registry.clone(),
+            stream_id.to_string(),
+        ));
+
+        assert_eq!(registry.pending_claim_release_count(), 1);
+        assert_eq!(registry.retry_pending_claim_releases(1).await, 1);
+        assert_eq!(registry.pending_claim_release_count(), 0);
+        assert!(store
+            .current_claim(&Entity::new(EntityType::SmSession, stream_id))
+            .await
+            .expect("claim lookup")
+            .is_none());
+    }
+}
+
 mod registration;
 
 pub(super) use registration::{
@@ -86,6 +238,7 @@ pub(super) struct SmCtx<'a> {
     pub(super) suppress_sm_record_next_batch: &'a mut bool,
     pub(super) roster_interested: &'a mut bool,
     pub(super) blocklist_interested: &'a mut bool,
+    pub(super) pending_sm_enable_commit: &'a mut Option<SmEnableCommit>,
 }
 
 /// Dispatch an XEP-0198 control nonza. Isolated helper so the main frame
@@ -98,7 +251,16 @@ pub(super) async fn handle_sm_stanza(
     use waddle_xmpp::stream_management::SmAck;
 
     match sm {
-        SmStanza::Enable(enable) => handle_sm_enable(enable, state, ctx.sm_state, ctx.phase).await,
+        SmStanza::Enable(enable) => {
+            handle_sm_enable(
+                enable,
+                state,
+                ctx.sm_state,
+                ctx.phase,
+                ctx.pending_sm_enable_commit,
+            )
+            .await
+        }
         SmStanza::Request => vec![SmAck::new(ctx.sm_state.get_inbound_count()).to_xml()],
         SmStanza::Ack(ack) => apply_sm_ack(state, ctx.sm_state, ctx.phase, ack.h).await,
         SmStanza::Resume(resume) => handle_sm_resume(resume, state, ctx).await,
@@ -226,6 +388,7 @@ async fn handle_sm_enable(
     state: &WebSocketState,
     sm_state: &mut StreamManagementState,
     phase: &ConnectionPhase,
+    pending_commit: &mut Option<SmEnableCommit>,
 ) -> Vec<String> {
     use waddle_xmpp::stream_management::{SmEnabled, SmFailed};
 
@@ -246,8 +409,8 @@ async fn handle_sm_enable(
         Some(m) => m,
         None => max_resume_secs,
     };
-    // ADR-0017 Phase 3 Slice 6, element 8: ensure this node's `ClaimStore`
-    // claim on this SM session at `<enable/>` time — not only at detach
+    // ADR-0017 Phase 3 Slice 6, element 8: for a resumable enable, ensure
+    // this node's `ClaimStore` claim at `<enable/>` time — not only at detach
     // time (Slice 5's `acquire_claim_store_entry_for_detach`). Without a
     // claim row for a still-live session, a cross-node resume attempt
     // would have nothing to discover: it needs the `clustering_claims` row
@@ -257,37 +420,39 @@ async fn handle_sm_enable(
     // with the detach-time call for the same stream id later in this
     // session's lifetime. No-op in practice for single-node deployments
     // (`InProcessClaimStore`'s bookkeeping, never a foreign conflict).
-    let Some(claim_publication) = state
-        .deps
-        .protocol
-        .sm_session_registry
-        .ensure_session_claim(&stream_id)
-        .await
-    else {
-        warn!(
-            stream_id = %stream_id,
-            "SM enable rejected because exact claim admission did not complete"
-        );
-        return vec![SmFailed::with_condition("resource-constraint").to_xml()];
+    // A non-resumable stream has no `previd`, is never detached, and cannot
+    // be discovered or resumed cross-node. Giving it a durable ownership
+    // claim would retain an entity with no terminal close path, so it does
+    // not participate in clustered SM ownership at all.
+    let claim_publication = if enable.resume {
+        let Some(publication) = state
+            .deps
+            .protocol
+            .sm_session_registry
+            .ensure_session_claim(&stream_id)
+            .await
+        else {
+            warn!(
+                stream_id = %stream_id,
+                "SM enable rejected because exact claim admission did not complete"
+            );
+            return vec![SmFailed::with_condition("resource-constraint").to_xml()];
+        };
+        Some(publication)
+    } else {
+        None
     };
-    sm_state.enable(stream_id.clone(), enable.resume, Some(max));
+    let mut claim_guard = enable.resume.then(|| {
+        SmEnableClaimGuard::new(
+            state.deps.protocol.sm_session_registry.clone(),
+            stream_id.clone(),
+        )
+    });
+    // Publishing the armed pre-transport guard transfers exact cleanup
+    // responsibility into the pending commit. Keep identity authority until
+    // that synchronous hand-off is complete; later fallible work and the
+    // socket write must not hold the rotation gate.
     drop(claim_publication);
-
-    // Publish the stream id onto the registry's ConnectionEntry so
-    // the offline-flush path can claim `pending_delivery` rows under
-    // a session id that's unique to this XEP-0198 session (not just
-    // the resource JID — distinct SM sessions on the same resource
-    // would otherwise share the same key, causing cross-session row
-    // deletion). Locked Q7b SM-ack lifecycle (issue #209).
-    if let Some(jid) = phase.bound_jid() {
-        state.deps.protocol.connection_registry.set_sm_stream_id(
-            jid,
-            Some(waddle_xmpp::pending_delivery::SmSessionId::new(
-                stream_id.clone(),
-            )),
-        );
-    }
-
     // ADR-0017 Phase 3 Slice 8: XEP-0397 ISR token issuance rides this same
     // `<enable/>`/`<enabled/>` exchange inline (`<isr-enable/>`/
     // `<isr-enabled/>`) — never a standalone IQ (the retired conformance
@@ -317,11 +482,22 @@ async fn handle_sm_enable(
             Some(mechanism) if mechanism == waddle_xmpp::isr::ISR_PINNED_MECHANISM => {
                 match state.deps.app_state.clustering_claims.isr_token_store() {
                     Some(isr_token_store) => {
-                        match isr_token_store.issue(&stream_id, mechanism).await {
-                            Ok(issued) => Some(issued.token),
-                            Err(error) => {
+                        match tokio::time::timeout(
+                            SM_ENABLE_FALLIBLE_AWAIT_TIMEOUT,
+                            isr_token_store.issue(&stream_id, mechanism),
+                        )
+                        .await
+                        {
+                            Ok(Ok(issued)) => Some(issued.token),
+                            Ok(Err(error)) => {
                                 warn!(stream_id = %stream_id, %error, "ISR token issuance failed");
                                 None
+                            }
+                            Err(_) => {
+                                warn!(stream_id = %stream_id, "ISR token issuance timed out; rejecting SM enable before state commit");
+                                return vec![
+                                    SmFailed::with_condition("resource-constraint").to_xml()
+                                ];
                             }
                         }
                     }
@@ -340,15 +516,20 @@ async fn handle_sm_enable(
         }
     };
 
-    info!(stream_id = %stream_id, resume = enable.resume, max = max, "SM enabled");
     let mut enabled = if enable.resume {
-        SmEnabled::with_resume(stream_id, max)
+        SmEnabled::with_resume(stream_id.clone(), max)
     } else {
-        SmEnabled::new(stream_id)
+        SmEnabled::new(stream_id.clone())
     };
     if let Some(token) = isr_token {
         enabled = enabled.with_isr_token(token);
     }
+    *pending_commit = Some(SmEnableCommit::new(
+        claim_guard,
+        stream_id,
+        enable.resume,
+        max,
+    ));
     vec![enabled.to_xml()]
 }
 
@@ -485,6 +666,7 @@ async fn handle_sm_resume(resume: SmResume, state: &WebSocketState, ctx: SmCtx<'
         suppress_sm_record_next_batch,
         roster_interested,
         blocklist_interested,
+        pending_sm_enable_commit: _,
     } = ctx;
 
     // Stream resumption is only legal before this transport has established a

--- a/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/stream_management.rs
@@ -6,7 +6,13 @@ const SM_ENABLE_FALLIBLE_AWAIT_TIMEOUT: std::time::Duration = std::time::Duratio
 struct SmEnableClaimGuard {
     registry: std::sync::Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
     stream_id: String,
+    provisional_isr_token: Option<ProvisionalIsrToken>,
     armed: bool,
+}
+
+struct ProvisionalIsrToken {
+    store: std::sync::Arc<dyn waddle_xmpp::isr::IsrTokenStore>,
+    issued: waddle_xmpp::isr::IssuedIsrToken,
 }
 
 /// Typed post-write effect for `<enable/>`. The resumable claim is acquired
@@ -75,27 +81,71 @@ impl SmEnableClaimGuard {
         Self {
             registry,
             stream_id,
+            provisional_isr_token: None,
             armed: true,
         }
     }
 
+    fn retain_provisional_isr_token(
+        &mut self,
+        store: std::sync::Arc<dyn waddle_xmpp::isr::IsrTokenStore>,
+        issued: waddle_xmpp::isr::IssuedIsrToken,
+    ) {
+        self.provisional_isr_token = Some(ProvisionalIsrToken { store, issued });
+    }
+
     fn disarm(&mut self) {
         self.armed = false;
+        self.provisional_isr_token = None;
     }
 }
 
 impl Drop for SmEnableClaimGuard {
     fn drop(&mut self) {
-        if self.armed
-            && !self
-                .registry
-                .defer_unpublished_enabled_claim_release(&self.stream_id)
+        if !self.armed {
+            return;
+        }
+        if !self
+            .registry
+            .defer_unpublished_enabled_claim_release(&self.stream_id)
         {
             warn!(
                 stream_id = %self.stream_id,
                 "SM enable cancelled before publication but exact claim cleanup could not be inventoried"
             );
         }
+        let Some(provisional) = self.provisional_isr_token.take() else {
+            return;
+        };
+        let stream_id = self.stream_id.clone();
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            warn!(
+                stream_id,
+                "SM enable cancelled outside a Tokio runtime; provisional ISR token remains for expiry sweep"
+            );
+            return;
+        };
+        runtime.spawn(async move {
+            match tokio::time::timeout(
+                SM_ENABLE_FALLIBLE_AWAIT_TIMEOUT,
+                provisional
+                    .store
+                    .revoke_if_current(&stream_id, &provisional.issued),
+            )
+            .await
+            {
+                Ok(Ok(true)) => {}
+                Ok(Ok(false)) => {
+                    debug!(stream_id, "Provisional ISR token was already superseded or removed");
+                }
+                Ok(Err(error)) => {
+                    warn!(stream_id, %error, "Failed to revoke provisional ISR token; expiry sweep retains cleanup responsibility");
+                }
+                Err(_) => {
+                    warn!(stream_id, "Timed out revoking provisional ISR token; expiry sweep retains cleanup responsibility");
+                }
+            }
+        });
     }
 }
 
@@ -123,8 +173,61 @@ pub(super) fn defer_superseded_sm_claim(state: &WebSocketState, sm_state: &Strea
 mod enable_claim_guard_tests {
     use super::SmEnableClaimGuard;
     use std::sync::Arc;
+    use waddle_xmpp::isr::{IsrConsumeOutcome, IsrTokenStore as _};
     use waddle_xmpp::ownership::{ClaimStore as _, Entity, EntityType};
+    use waddle_xmpp::stream_management::persistence::SmClaimFence;
     use waddle_xmpp::stream_management::InMemorySmSessionRegistry;
+
+    struct NotifyingIsrTokenStore {
+        inner: waddle_xmpp::isr::InMemoryIsrTokenStore,
+        revoked: tokio::sync::Notify,
+    }
+
+    #[async_trait::async_trait]
+    impl waddle_xmpp::isr::IsrTokenStore for NotifyingIsrTokenStore {
+        async fn ensure_schema(&self) -> Result<(), waddle_xmpp::isr::IsrTokenStoreError> {
+            self.inner.ensure_schema().await
+        }
+
+        async fn issue(
+            &self,
+            sm_id: &str,
+            mechanism: &str,
+        ) -> Result<waddle_xmpp::isr::IssuedIsrToken, waddle_xmpp::isr::IsrTokenStoreError>
+        {
+            self.inner.issue(sm_id, mechanism).await
+        }
+
+        async fn revoke_if_current(
+            &self,
+            sm_id: &str,
+            issued: &waddle_xmpp::isr::IssuedIsrToken,
+        ) -> Result<bool, waddle_xmpp::isr::IsrTokenStoreError> {
+            let revoked = self.inner.revoke_if_current(sm_id, issued).await?;
+            self.revoked.notify_one();
+            Ok(revoked)
+        }
+
+        async fn consume(
+            &self,
+            sm_id: &str,
+            presented_token: &[u8],
+            mechanism: &str,
+            fence: &SmClaimFence,
+        ) -> Result<waddle_xmpp::isr::IsrConsumeOutcome, waddle_xmpp::isr::IsrTokenStoreError>
+        {
+            self.inner
+                .consume(sm_id, presented_token, mechanism, fence)
+                .await
+        }
+
+        async fn sweep_expired(
+            &self,
+            max_age: std::time::Duration,
+        ) -> Result<u64, waddle_xmpp::isr::IsrTokenStoreError> {
+            self.inner.sweep_expired(max_age).await
+        }
+    }
 
     #[tokio::test]
     async fn dropped_prepublication_guard_defers_and_releases_the_exact_claim() {
@@ -150,6 +253,40 @@ mod enable_claim_guard_tests {
             .await
             .expect("claim lookup")
             .is_none());
+    }
+
+    #[tokio::test]
+    async fn dropped_prepublication_guard_revokes_the_exact_provisional_isr_token() {
+        let claim_store = Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+        let identity = waddle_xmpp::ownership::NodeIdentity::new("sm-node", "incarnation");
+        let registry = Arc::new(InMemorySmSessionRegistry::new().with_claim_store(
+            claim_store,
+            waddle_xmpp::ownership::SharedNodeIdentity::new(identity.clone()),
+        ));
+        let token_store = Arc::new(NotifyingIsrTokenStore {
+            inner: waddle_xmpp::isr::InMemoryIsrTokenStore::new(),
+            revoked: tokio::sync::Notify::new(),
+        });
+        let stream_id = "cancelled-isr-before-enabled-publication";
+        assert!(registry.ensure_session_claim(stream_id).await.is_some());
+        let issued = token_store.issue(stream_id, "PLAIN").await.expect("issue");
+        let mut guard = SmEnableClaimGuard::new(registry, stream_id.to_string());
+        guard.retain_provisional_isr_token(token_store.clone(), issued.clone());
+
+        let revoked = token_store.revoked.notified();
+        drop(guard);
+        tokio::time::timeout(std::time::Duration::from_secs(1), revoked)
+            .await
+            .expect("provisional revoke task");
+
+        let fence = SmClaimFence::new(identity, waddle_xmpp::ownership::ClaimEpoch(0));
+        assert_eq!(
+            token_store
+                .consume(stream_id, issued.token.as_bytes(), "PLAIN", &fence)
+                .await
+                .expect("consume after cancellation"),
+            IsrConsumeOutcome::NoSuchToken
+        );
     }
 }
 
@@ -488,7 +625,15 @@ async fn handle_sm_enable(
                         )
                         .await
                         {
-                            Ok(Ok(issued)) => Some(issued.token),
+                            Ok(Ok(issued)) => {
+                                if let Some(guard) = claim_guard.as_mut() {
+                                    guard.retain_provisional_isr_token(
+                                        isr_token_store.clone(),
+                                        issued.clone(),
+                                    );
+                                }
+                                Some(issued.token)
+                            }
                             Ok(Err(error)) => {
                                 warn!(stream_id = %stream_id, %error, "ISR token issuance failed");
                                 None

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -351,7 +351,10 @@ async fn create_test_websocket_state_with_extension_manager(
     let runner = MigrationRunner::global();
     runner.run(db_pool.global()).await.expect("migrations");
 
-    let server_config = ServerConfig::test_homeserver();
+    let mut server_config = ServerConfig::test_homeserver();
+    // XEP-0397 fixtures exercise token advertisement/issuance and therefore
+    // model the TLS-secured production endpoint required by the XEP.
+    server_config.base_url = "https://example.com".to_string();
     let mut app_state_built = AppState::new(Arc::new(db_pool));
     if let Some(clustering) = clustering_override {
         app_state_built.clustering_claims = clustering;
@@ -437,6 +440,9 @@ async fn create_test_websocket_state_with_extension_manager(
             deps: WebSocketDeps {
                 app_state: Arc::clone(&app_state),
                 auth_state,
+                transport_security: super::state::TransportSecurity::from_base_url(
+                    &server_config.base_url,
+                ),
                 service_domains: XmppServiceDomains {
                     muc: "muc.example.com".to_string(),
                     spaces: "spaces.example.com".to_string(),

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -351,10 +351,10 @@ async fn create_test_websocket_state_with_extension_manager(
     let runner = MigrationRunner::global();
     runner.run(db_pool.global()).await.expect("migrations");
 
-    let mut server_config = ServerConfig::test_homeserver();
+    let server_config = ServerConfig::test_homeserver();
     // XEP-0397 fixtures exercise token advertisement/issuance and therefore
-    // model the TLS-secured production endpoint required by the XEP.
-    server_config.base_url = "https://example.com".to_string();
+    // model the TLS-secured public RFC 7395 endpoint required by the XEP.
+    let public_websocket_url = url::Url::parse("wss://example.com/ws").expect("test WebSocket URL");
     let mut app_state_built = AppState::new(Arc::new(db_pool));
     if let Some(clustering) = clustering_override {
         app_state_built.clustering_claims = clustering;
@@ -363,6 +363,7 @@ async fn create_test_websocket_state_with_extension_manager(
     let mut auth_state_inner = AuthState::new(
         app_state.clone(),
         &server_config,
+        &public_websocket_url,
         Some(b"test-encryption-key-32-bytes!!!"),
     );
     // The dispatcher path's bare-JID branch
@@ -440,9 +441,10 @@ async fn create_test_websocket_state_with_extension_manager(
             deps: WebSocketDeps {
                 app_state: Arc::clone(&app_state),
                 auth_state,
-                transport_security: super::state::TransportSecurity::from_base_url(
-                    &server_config.base_url,
-                ),
+                transport_security:
+                    super::state::TransportSecurity::from_public_websocket_url(
+                        &public_websocket_url,
+                    ),
                 service_domains: XmppServiceDomains {
                     muc: "muc.example.com".to_string(),
                     spaces: "spaces.example.com".to_string(),

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -96,6 +96,18 @@ pub(crate) async fn create_test_websocket_state() -> Arc<WebSocketState> {
     .await
 }
 
+pub(crate) async fn create_test_websocket_state_with_sm_registry(
+    sm_session_registry: Arc<InMemorySmSessionRegistry>,
+) -> Arc<WebSocketState> {
+    create_test_websocket_state_with_extension_manager(
+        empty_extension_manager().await,
+        None,
+        None,
+        Some(sm_session_registry),
+    )
+    .await
+}
+
 /// Build a test [`WebSocketState`] with clustering-enabled
 /// [`crate::clustering::ClusteringHandles`] and a caller-supplied SM-session
 /// registry (e.g. one backed by [`crate::sm_persistence_fenced::PostgresFencedSmPersistence`]

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
@@ -29,6 +29,66 @@ use waddle_xmpp::isr::{IsrTokenStore, ISR_NS, ISR_PINNED_MECHANISM};
 use waddle_xmpp::ownership::{ClaimStore, NodeIdentity, SharedNodeIdentity};
 use waddle_xmpp::stream_management::{DetachedSession, SmResume, SmSessionRegistry};
 
+struct HangIssueOnceIsrTokenStore {
+    inner: waddle_xmpp::isr::InMemoryIsrTokenStore,
+    hang_once: std::sync::atomic::AtomicBool,
+}
+
+fn register_isr_publish_owner(
+    state: &super::super::state::WebSocketState,
+    conn: &mut WsConnState,
+    jid: &FullJid,
+) {
+    let (tx, _rx) = tokio::sync::mpsc::channel(1);
+    conn.registry_owner = Some(
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .register(jid.clone(), tx),
+    );
+}
+
+#[async_trait::async_trait]
+impl IsrTokenStore for HangIssueOnceIsrTokenStore {
+    async fn ensure_schema(&self) -> Result<(), waddle_xmpp::isr::IsrTokenStoreError> {
+        self.inner.ensure_schema().await
+    }
+
+    async fn issue(
+        &self,
+        sm_id: &str,
+        mechanism: &str,
+    ) -> Result<waddle_xmpp::isr::IssuedIsrToken, waddle_xmpp::isr::IsrTokenStoreError> {
+        if self
+            .hang_once
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+        {
+            return std::future::pending().await;
+        }
+        self.inner.issue(sm_id, mechanism).await
+    }
+
+    async fn consume(
+        &self,
+        sm_id: &str,
+        presented_token: &[u8],
+        mechanism: &str,
+        fence: &waddle_xmpp::stream_management::persistence::SmClaimFence,
+    ) -> Result<waddle_xmpp::isr::IsrConsumeOutcome, waddle_xmpp::isr::IsrTokenStoreError> {
+        self.inner
+            .consume(sm_id, presented_token, mechanism, fence)
+            .await
+    }
+
+    async fn sweep_expired(
+        &self,
+        max_age: std::time::Duration,
+    ) -> Result<u64, waddle_xmpp::isr::IsrTokenStoreError> {
+        self.inner.sweep_expired(max_age).await
+    }
+}
+
 async fn test_db() -> Option<Database> {
     let url = std::env::var("WADDLE_TEST_POSTGRES_URL").ok()?;
     let db = Database::from_config(
@@ -214,7 +274,8 @@ async fn isr_enable_mints_a_token_when_clustering_and_postgres_are_available() {
 
     let mut conn = WsConnState::new();
     let jid: FullJid = "alice@example.com/web".parse().expect("jid");
-    conn.phase = ConnectionPhase::ready(jid, false);
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_isr_publish_owner(fixture.state.as_ref(), &mut conn, &jid);
 
     let responses = handle_xmpp_frame(
         &format!(
@@ -227,6 +288,7 @@ async fn isr_enable_mints_a_token_when_clustering_and_postgres_are_available() {
         &mut conn,
     )
     .await;
+    conn.publish_pending_sm_enable(fixture.state.as_ref());
 
     assert_eq!(responses.len(), 1);
     let enabled = Element::from_str(&responses[0]).expect("enabled xml");
@@ -241,12 +303,62 @@ async fn isr_enable_mints_a_token_when_clustering_and_postgres_are_available() {
 }
 
 #[tokio::test]
+async fn hung_isr_issue_fails_before_sm_state_commit_and_enable_is_retry_safe() {
+    let claim_store: std::sync::Arc<dyn ClaimStore> =
+        std::sync::Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+    let node_identity = SharedNodeIdentity::new(NodeIdentity::new("sm-node", "incarnation"));
+    let sm_session_registry = Arc::new(
+        InMemorySmSessionRegistry::new()
+            .with_claim_store(claim_store.clone(), node_identity.clone()),
+    );
+    let isr_token_store: Arc<dyn IsrTokenStore> = Arc::new(HangIssueOnceIsrTokenStore {
+        inner: waddle_xmpp::isr::InMemoryIsrTokenStore::new(),
+        hang_once: std::sync::atomic::AtomicBool::new(true),
+    });
+    let state = create_test_websocket_state_with_clustering(
+        ClusteringHandles {
+            claim_store: Some(claim_store),
+            node_identity: Some(node_identity),
+            isr_token_store: Some(isr_token_store),
+            ..ClusteringHandles::default()
+        },
+        sm_session_registry,
+    )
+    .await;
+    let mut conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/web".parse().expect("jid");
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_isr_publish_owner(state.as_ref(), &mut conn, &jid);
+    let enable = format!(
+        "<enable xmlns='urn:xmpp:sm:3' resume='true'>\
+            <isr-enable xmlns='{ISR_NS}' mechanism='PLAIN'/>\
+         </enable>"
+    );
+
+    let failed = handle_xmpp_frame(&enable, "example.com", state.as_ref(), &mut conn).await;
+    let failed = Element::from_str(&failed[0]).expect("failed xml");
+    assert_eq!(failed.name(), "failed");
+    assert!(failed
+        .get_child("resource-constraint", "urn:ietf:params:xml:ns:xmpp-stanzas")
+        .is_some());
+    assert!(!conn.sm_state.enabled);
+
+    let retried = handle_xmpp_frame(&enable, "example.com", state.as_ref(), &mut conn).await;
+    let enabled = Element::from_str(&retried[0]).expect("enabled xml");
+    assert_eq!(enabled.name(), "enabled");
+    conn.publish_pending_sm_enable(state.as_ref());
+    assert!(conn.sm_state.enabled);
+    assert!(enabled.get_child("isr-enabled", ISR_NS).is_some());
+}
+
+#[tokio::test]
 async fn isr_enable_is_silently_ignored_without_clustering() {
     // No clustering/Postgres wired at all — the plain default fixture.
     let state = create_test_websocket_state().await;
     let mut conn = WsConnState::new();
     let jid: FullJid = "alice@example.com/web".parse().expect("jid");
-    conn.phase = ConnectionPhase::ready(jid, false);
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_isr_publish_owner(state.as_ref(), &mut conn, &jid);
 
     let responses = handle_xmpp_frame(
         &format!(
@@ -259,6 +371,7 @@ async fn isr_enable_is_silently_ignored_without_clustering() {
         &mut conn,
     )
     .await;
+    conn.publish_pending_sm_enable(state.as_ref());
 
     let enabled = Element::from_str(&responses[0]).expect("enabled xml");
     assert!(
@@ -282,7 +395,8 @@ async fn isr_enable_is_ignored_when_not_resumable() {
 
     let mut conn = WsConnState::new();
     let jid: FullJid = "grace@example.com/web".parse().expect("jid");
-    conn.phase = ConnectionPhase::ready(jid, false);
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_isr_publish_owner(fixture.state.as_ref(), &mut conn, &jid);
 
     let responses = handle_xmpp_frame(
         &format!(
@@ -295,6 +409,7 @@ async fn isr_enable_is_ignored_when_not_resumable() {
         &mut conn,
     )
     .await;
+    conn.publish_pending_sm_enable(fixture.state.as_ref());
 
     assert_eq!(responses.len(), 1);
     let enabled = Element::from_str(&responses[0]).expect("enabled xml");
@@ -610,6 +725,7 @@ async fn isr_resume_authenticated_but_impossible_wraps_failed_in_success() {
 async fn handle_isr_resume_authenticate_is_a_noop_failure_without_clustering() {
     let state = create_test_websocket_state().await;
     let mut conn = WsConnState::new();
+    let mut pending_sm_enable_commit = None;
     let ctx = SmCtx {
         phase: &mut conn.phase,
         sm_state: &mut conn.sm_state,
@@ -626,6 +742,7 @@ async fn handle_isr_resume_authenticate_is_a_noop_failure_without_clustering() {
         suppress_sm_record_next_batch: &mut conn.suppress_sm_record_next_batch,
         roster_interested: &mut conn.roster_interested,
         blocklist_interested: &mut conn.blocklist_interested,
+        pending_sm_enable_commit: &mut pending_sm_enable_commit,
     };
     let responses = handle_isr_resume_authenticate(
         "PLAIN".to_string(),

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
@@ -1128,6 +1128,25 @@ async fn isr_resume_rejects_unsecured_transport_without_consuming_token() {
     assert!(success.get_child("inst-resumed", ISR_NS).is_some());
 }
 
+#[tokio::test]
+async fn isr_resume_rejects_an_overlong_wire_session_id_before_backend_work() {
+    let fixture = in_memory_isr_fixture().await;
+    let previd = "s".repeat(waddle_xmpp::pending_delivery::SM_SESSION_ID_MAX_LEN + 1);
+    let frame = isr_authenticate_frame("alice@example.com", "unused-token", &previd, 0);
+    let mut conn = WsConnState::new();
+
+    let responses =
+        handle_xmpp_frame(&frame, "example.com", fixture.state.as_ref(), &mut conn).await;
+
+    assert_eq!(responses.len(), 1);
+    let failure = Element::from_str(&responses[0]).expect("failure XML");
+    assert_eq!(failure.name(), "failure");
+    assert!(failure
+        .get_child("not-authorized", waddle_xmpp::ns::SASL)
+        .is_some());
+    assert!(!conn.phase.is_ready());
+}
+
 // Sanity check that the module-level handler is reachable directly too
 // (mirrors how `stream_management.rs` tests call `handle_sm_stanza`
 // directly in a couple of places) — exercised via the SmCtx-taking

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
@@ -505,6 +505,155 @@ async fn dropped_isr_enable_commit_revokes_the_committed_provisional_token() {
 }
 
 #[tokio::test]
+async fn written_isr_enable_that_loses_publication_revokes_on_terminal_cleanup() {
+    let claim_store: std::sync::Arc<dyn ClaimStore> =
+        std::sync::Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+    let node_identity = SharedNodeIdentity::new(NodeIdentity::new("sm-node", "incarnation"));
+    let sm_session_registry = Arc::new(
+        InMemorySmSessionRegistry::new()
+            .with_claim_store(claim_store.clone(), node_identity.clone()),
+    );
+    let revoked = Arc::new(tokio::sync::Notify::new());
+    let isr_token_store = Arc::new(ControlledPersistIsrTokenStore {
+        inner: waddle_xmpp::isr::InMemoryIsrTokenStore::new(),
+        hang_once: std::sync::atomic::AtomicBool::new(false),
+        error_once: std::sync::atomic::AtomicBool::new(false),
+        revoked: Some(revoked.clone()),
+    });
+    let state = create_test_websocket_state_with_clustering(
+        ClusteringHandles {
+            claim_store: Some(claim_store),
+            node_identity: Some(node_identity.clone()),
+            isr_token_store: Some(isr_token_store.clone()),
+            ..ClusteringHandles::default()
+        },
+        sm_session_registry,
+    )
+    .await;
+    let mut conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/publication-race".parse().expect("jid");
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_isr_publish_owner(state.as_ref(), &mut conn, &jid);
+
+    let responses = handle_xmpp_frame(
+        &format!(
+            "<enable xmlns='urn:xmpp:sm:3' resume='true'>\
+                <isr-enable xmlns='{ISR_NS}' mechanism='PLAIN'/>\
+             </enable>"
+        ),
+        "example.com",
+        state.as_ref(),
+        &mut conn,
+    )
+    .await;
+    let enabled = Element::from_str(&responses[0]).expect("enabled xml");
+    let stream_id = enabled.attr("id").expect("stream id").to_string();
+    let token = enabled
+        .get_child("isr-enabled", ISR_NS)
+        .and_then(|element| element.attr("token"))
+        .expect("issued ISR token")
+        .to_string();
+
+    let (replacement_tx, _replacement_rx) = tokio::sync::mpsc::channel(1);
+    state
+        .deps
+        .protocol
+        .connection_registry
+        .register(jid, replacement_tx);
+    conn.publish_pending_sm_enable(state.as_ref());
+    assert!(
+        conn.sm_state.enabled,
+        "written XEP-0198 state remains committed"
+    );
+    assert!(conn.unpublished_isr_cleanup.is_some());
+
+    let revoke_completed = revoked.notified();
+    let (_outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel(1);
+    assert_eq!(
+        super::super::cleanup::cleanup_connection_shutdown(
+            state.as_ref(),
+            &mut outbound_rx,
+            &mut conn,
+            false,
+        )
+        .await,
+        super::super::cleanup::ConnectionShutdownOutcome::NotPersisted
+    );
+    tokio::time::timeout(std::time::Duration::from_secs(1), revoke_completed)
+        .await
+        .expect("terminal cleanup revokes unpublished ISR credential");
+
+    let fence = waddle_xmpp::stream_management::persistence::SmClaimFence::new(
+        node_identity.current(),
+        waddle_xmpp::ownership::ClaimEpoch(0),
+    );
+    assert_eq!(
+        isr_token_store
+            .consume(&stream_id, token.as_bytes(), ISR_PINNED_MECHANISM, &fence)
+            .await
+            .expect("consume after terminal cleanup"),
+        waddle_xmpp::isr::IsrConsumeOutcome::NoSuchToken
+    );
+}
+
+#[tokio::test]
+async fn isr_is_not_advertised_or_issued_for_unsecured_configured_transport() {
+    let claim_store: std::sync::Arc<dyn ClaimStore> =
+        std::sync::Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+    let node_identity = SharedNodeIdentity::new(NodeIdentity::new("sm-node", "incarnation"));
+    let sm_session_registry = Arc::new(
+        InMemorySmSessionRegistry::new()
+            .with_claim_store(claim_store.clone(), node_identity.clone()),
+    );
+    let isr_token_store: Arc<dyn IsrTokenStore> =
+        Arc::new(waddle_xmpp::isr::InMemoryIsrTokenStore::new());
+    let mut state = create_test_websocket_state_with_clustering(
+        ClusteringHandles {
+            claim_store: Some(claim_store),
+            node_identity: Some(node_identity),
+            isr_token_store: Some(isr_token_store),
+            ..ClusteringHandles::default()
+        },
+        sm_session_registry,
+    )
+    .await;
+    Arc::get_mut(&mut state)
+        .expect("fixture state uniquely owned")
+        .deps
+        .transport_security = super::super::state::TransportSecurity::Unsecured;
+    assert!(!state.deps.isr_available());
+
+    let mut conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/insecure".parse().expect("jid");
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_isr_publish_owner(state.as_ref(), &mut conn, &jid);
+    let open_responses = handle_xmpp_frame(
+        "<open xmlns='urn:ietf:params:xml:ns:xmpp-framing' to='example.com' version='1.0'/>",
+        "example.com",
+        state.as_ref(),
+        &mut conn,
+    )
+    .await;
+    let features = Element::from_str(&open_responses[1]).expect("stream features xml");
+    assert!(!features
+        .children()
+        .any(|child| child.name() == "isr" && child.ns() == ISR_NS));
+    let responses = handle_xmpp_frame(
+        &format!(
+            "<enable xmlns='urn:xmpp:sm:3' resume='true'>\
+                <isr-enable xmlns='{ISR_NS}' mechanism='PLAIN'/>\
+             </enable>"
+        ),
+        "example.com",
+        state.as_ref(),
+        &mut conn,
+    )
+    .await;
+    let enabled = Element::from_str(&responses[0]).expect("enabled xml");
+    assert!(enabled.get_child("isr-enabled", ISR_NS).is_none());
+}
+
+#[tokio::test]
 async fn isr_enable_is_silently_ignored_without_clustering() {
     // No clustering/Postgres wired at all — the plain default fixture.
     let state = create_test_websocket_state().await;

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
@@ -25,8 +25,9 @@ use crate::clustering::isr::PostgresIsrTokenStore;
 use crate::clustering::ClusteringHandles;
 use crate::db::{Database, DatabaseConfig, DatabaseDriver};
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use waddle_xmpp::isr::{IsrTokenStore, ISR_NS, ISR_PINNED_MECHANISM};
-use waddle_xmpp::ownership::{ClaimStore, NodeIdentity, SharedNodeIdentity};
+use waddle_xmpp::isr::{InMemoryIsrTokenStore, IsrTokenStore, ISR_NS, ISR_PINNED_MECHANISM};
+use waddle_xmpp::ownership::{ClaimStore, InProcessClaimStore, NodeIdentity, SharedNodeIdentity};
+use waddle_xmpp::pending_delivery::SmSessionId;
 use waddle_xmpp::stream_management::{DetachedSession, SmResume, SmSessionRegistry};
 
 struct ControlledPersistIsrTokenStore {
@@ -59,7 +60,7 @@ impl IsrTokenStore for ControlledPersistIsrTokenStore {
 
     async fn persist_issued(
         &self,
-        sm_id: &str,
+        sm_id: &waddle_xmpp::pending_delivery::SmSessionId,
         issued: &waddle_xmpp::isr::IssuedIsrToken,
     ) -> Result<(), waddle_xmpp::isr::IsrTokenStoreError> {
         if self
@@ -82,9 +83,9 @@ impl IsrTokenStore for ControlledPersistIsrTokenStore {
 
     async fn revoke_if_current(
         &self,
-        sm_id: &str,
+        sm_id: &waddle_xmpp::pending_delivery::SmSessionId,
         issued: &waddle_xmpp::isr::IssuedIsrToken,
-    ) -> Result<bool, waddle_xmpp::isr::IsrTokenStoreError> {
+    ) -> Result<waddle_xmpp::isr::IsrRevokeOutcome, waddle_xmpp::isr::IsrTokenStoreError> {
         let revoked = self.inner.revoke_if_current(sm_id, issued).await?;
         if let Some(notify) = &self.revoked {
             notify.notify_one();
@@ -94,7 +95,7 @@ impl IsrTokenStore for ControlledPersistIsrTokenStore {
 
     async fn consume(
         &self,
-        sm_id: &str,
+        sm_id: &waddle_xmpp::pending_delivery::SmSessionId,
         presented_token: &[u8],
         mechanism: &str,
         fence: &waddle_xmpp::stream_management::persistence::SmClaimFence,
@@ -175,6 +176,44 @@ async fn isr_fixture() -> Option<IsrFixture> {
         state,
         isr_token_store,
     })
+}
+
+/// An always-on ISR fixture for security-boundary tests that do not need to
+/// exercise Postgres fencing itself. The in-process claim/token stores obey
+/// the same claim and single-use token contracts, so CI cannot silently skip
+/// these tests when `WADDLE_TEST_POSTGRES_URL` is absent.
+async fn in_memory_isr_fixture() -> IsrFixture {
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let isr_token_store: Arc<dyn IsrTokenStore> = Arc::new(InMemoryIsrTokenStore::new());
+    let node_identity = SharedNodeIdentity::new(NodeIdentity::new(
+        uuid::Uuid::new_v4().to_string(),
+        uuid::Uuid::new_v4().to_string(),
+    ));
+    let sm_session_registry = Arc::new(
+        InMemorySmSessionRegistry::new()
+            .with_claim_store(Arc::clone(&claim_store), node_identity.clone()),
+    );
+    let clustering = ClusteringHandles {
+        claim_store: Some(claim_store),
+        node_identity: Some(node_identity),
+        local_claims: None,
+        room_local_claims: None,
+        user_local_claims: None,
+        muc_durable_store: None,
+        isr_token_store: Some(Arc::clone(&isr_token_store)),
+        node_lease: None,
+        lease_ttl: None,
+        pod_template_hash: None,
+        resume_bridge: None,
+        ordered_relay_delivery_bridge: None,
+        stop_token: None,
+        resume_handshake_timeout: None,
+    };
+    let state = create_test_websocket_state_with_clustering(clustering, sm_session_registry).await;
+    IsrFixture {
+        state,
+        isr_token_store,
+    }
 }
 
 fn isr_authenticate_frame(bare_jid: &str, token: &str, previd: &str, h: u32) -> String {
@@ -497,7 +536,12 @@ async fn dropped_isr_enable_commit_revokes_the_committed_provisional_token() {
     );
     assert_eq!(
         isr_token_store
-            .consume(&stream_id, token.as_bytes(), ISR_PINNED_MECHANISM, &fence)
+            .consume(
+                &SmSessionId::new(stream_id.clone()),
+                token.as_bytes(),
+                ISR_PINNED_MECHANISM,
+                &fence,
+            )
             .await
             .expect("consume after dropped publication"),
         waddle_xmpp::isr::IsrConsumeOutcome::NoSuchToken
@@ -589,7 +633,12 @@ async fn written_isr_enable_that_loses_publication_revokes_on_terminal_cleanup()
     );
     assert_eq!(
         isr_token_store
-            .consume(&stream_id, token.as_bytes(), ISR_PINNED_MECHANISM, &fence)
+            .consume(
+                &SmSessionId::new(stream_id.clone()),
+                token.as_bytes(),
+                ISR_PINNED_MECHANISM,
+                &fence,
+            )
             .await
             .expect("consume after terminal cleanup"),
         waddle_xmpp::isr::IsrConsumeOutcome::NoSuchToken
@@ -743,7 +792,7 @@ async fn isr_resume_succeeds_matches_token_rotates_and_replays() {
         .expect("seed detached session");
     let issued = fixture
         .isr_token_store
-        .issue(&stream_id, ISR_PINNED_MECHANISM)
+        .issue(&SmSessionId::new(stream_id.clone()), ISR_PINNED_MECHANISM)
         .await
         .expect("issue token");
 
@@ -826,7 +875,7 @@ async fn isr_resume_rejects_wrong_token_with_bare_failure_and_destroys_session()
         .expect("seed detached session");
     fixture
         .isr_token_store
-        .issue(&stream_id, ISR_PINNED_MECHANISM)
+        .issue(&SmSessionId::new(stream_id.clone()), ISR_PINNED_MECHANISM)
         .await
         .expect("issue token");
 
@@ -943,7 +992,7 @@ async fn isr_resume_rejects_identity_mismatch_without_destroying_session() {
         .expect("seed detached session");
     let issued = fixture
         .isr_token_store
-        .issue(&stream_id, ISR_PINNED_MECHANISM)
+        .issue(&SmSessionId::new(stream_id.clone()), ISR_PINNED_MECHANISM)
         .await
         .expect("issue token");
 
@@ -993,7 +1042,7 @@ async fn isr_resume_authenticated_but_impossible_wraps_failed_in_success() {
         .expect("seed detached session");
     let issued = fixture
         .isr_token_store
-        .issue(&stream_id, ISR_PINNED_MECHANISM)
+        .issue(&SmSessionId::new(stream_id.clone()), ISR_PINNED_MECHANISM)
         .await
         .expect("issue token");
 
@@ -1017,6 +1066,66 @@ async fn isr_resume_authenticated_but_impossible_wraps_failed_in_success() {
     assert!(failed.attr("h").is_some());
     // The connection was NOT resumed — it stays in its pre-attempt phase.
     assert!(!conn.phase.is_ready());
+}
+
+#[tokio::test]
+async fn isr_resume_rejects_unsecured_transport_without_consuming_token() {
+    let mut fixture = in_memory_isr_fixture().await;
+
+    Arc::get_mut(&mut fixture.state)
+        .expect("fixture owns its WebSocket state")
+        .deps
+        .transport_security = TransportSecurity::Unsecured;
+
+    let jid: FullJid = "tls-gate@example.com/web".parse().expect("jid");
+    let stream_id = format!("sm-{}", uuid::Uuid::new_v4());
+    fixture
+        .state
+        .deps
+        .protocol
+        .sm_session_registry
+        .store_session(seeded_detached_session(&stream_id, &jid))
+        .await
+        .expect("seed detached session");
+    let issued = fixture
+        .isr_token_store
+        .issue(&SmSessionId::new(stream_id.clone()), ISR_PINNED_MECHANISM)
+        .await
+        .expect("issue token");
+
+    let frame = isr_authenticate_frame(&jid.to_bare().to_string(), &issued.token, &stream_id, 4);
+    let mut unsecured_conn = WsConnState::new();
+    let responses = handle_xmpp_frame(
+        &frame,
+        "example.com",
+        fixture.state.as_ref(),
+        &mut unsecured_conn,
+    )
+    .await;
+    let failure = Element::from_str(&responses[0]).expect("failure XML");
+    assert_eq!(failure.name(), "failure");
+    assert!(failure
+        .get_child("invalid-mechanism", waddle_xmpp::ns::SASL)
+        .is_some());
+
+    // The transport gate runs before session claim or token consumption. Once
+    // the trusted public endpoint is secure, the original token can still
+    // resume the original detached session.
+    Arc::get_mut(&mut fixture.state)
+        .expect("fixture still owns its WebSocket state")
+        .deps
+        .transport_security = TransportSecurity::Tls;
+    let mut secure_conn = WsConnState::new();
+    let resumed = handle_xmpp_frame(
+        &frame,
+        "example.com",
+        fixture.state.as_ref(),
+        &mut secure_conn,
+    )
+    .await;
+    let success = Element::from_str(&resumed[0]).expect("success XML");
+    assert_eq!(success.name(), "success");
+    assert!(success.get_child("inst-resumed", ISR_NS).is_some());
 }
 
 // Sanity check that the module-level handler is reachable directly too
@@ -1122,7 +1231,7 @@ async fn isr_resume_wins_a_cross_node_steal_and_consumes_the_token() {
     let isr_store = PostgresIsrTokenStore::new(db.clone());
     isr_store.ensure_schema().await.expect("ensure isr schema");
     let issued = isr_store
-        .issue(&stream_id, ISR_PINNED_MECHANISM)
+        .issue(&SmSessionId::new(stream_id.clone()), ISR_PINNED_MECHANISM)
         .await
         .expect("issue token");
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
@@ -29,9 +29,10 @@ use waddle_xmpp::isr::{IsrTokenStore, ISR_NS, ISR_PINNED_MECHANISM};
 use waddle_xmpp::ownership::{ClaimStore, NodeIdentity, SharedNodeIdentity};
 use waddle_xmpp::stream_management::{DetachedSession, SmResume, SmSessionRegistry};
 
-struct HangIssueOnceIsrTokenStore {
+struct ControlledPersistIsrTokenStore {
     inner: waddle_xmpp::isr::InMemoryIsrTokenStore,
     hang_once: std::sync::atomic::AtomicBool,
+    error_once: std::sync::atomic::AtomicBool,
     revoked: Option<Arc<tokio::sync::Notify>>,
 }
 
@@ -51,23 +52,32 @@ fn register_isr_publish_owner(
 }
 
 #[async_trait::async_trait]
-impl IsrTokenStore for HangIssueOnceIsrTokenStore {
+impl IsrTokenStore for ControlledPersistIsrTokenStore {
     async fn ensure_schema(&self) -> Result<(), waddle_xmpp::isr::IsrTokenStoreError> {
         self.inner.ensure_schema().await
     }
 
-    async fn issue(
+    async fn persist_issued(
         &self,
         sm_id: &str,
-        mechanism: &str,
-    ) -> Result<waddle_xmpp::isr::IssuedIsrToken, waddle_xmpp::isr::IsrTokenStoreError> {
+        issued: &waddle_xmpp::isr::IssuedIsrToken,
+    ) -> Result<(), waddle_xmpp::isr::IsrTokenStoreError> {
+        if self
+            .error_once
+            .swap(false, std::sync::atomic::Ordering::SeqCst)
+        {
+            return Err(waddle_xmpp::isr::IsrTokenStoreError::Backend(
+                "injected persistence failure".to_string(),
+            ));
+        }
+        self.inner.persist_issued(sm_id, issued).await?;
         if self
             .hang_once
             .swap(false, std::sync::atomic::Ordering::SeqCst)
         {
             return std::future::pending().await;
         }
-        self.inner.issue(sm_id, mechanism).await
+        Ok(())
     }
 
     async fn revoke_if_current(
@@ -316,7 +326,7 @@ async fn isr_enable_mints_a_token_when_clustering_and_postgres_are_available() {
 }
 
 #[tokio::test]
-async fn hung_isr_issue_fails_before_sm_state_commit_and_enable_is_retry_safe() {
+async fn timed_out_isr_persist_revokes_ambiguous_commit_and_enable_is_retry_safe() {
     let claim_store: std::sync::Arc<dyn ClaimStore> =
         std::sync::Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
     let node_identity = SharedNodeIdentity::new(NodeIdentity::new("sm-node", "incarnation"));
@@ -324,10 +334,12 @@ async fn hung_isr_issue_fails_before_sm_state_commit_and_enable_is_retry_safe() 
         InMemorySmSessionRegistry::new()
             .with_claim_store(claim_store.clone(), node_identity.clone()),
     );
-    let isr_token_store: Arc<dyn IsrTokenStore> = Arc::new(HangIssueOnceIsrTokenStore {
+    let revoked = Arc::new(tokio::sync::Notify::new());
+    let isr_token_store: Arc<dyn IsrTokenStore> = Arc::new(ControlledPersistIsrTokenStore {
         inner: waddle_xmpp::isr::InMemoryIsrTokenStore::new(),
         hang_once: std::sync::atomic::AtomicBool::new(true),
-        revoked: None,
+        error_once: std::sync::atomic::AtomicBool::new(false),
+        revoked: Some(revoked.clone()),
     });
     let state = create_test_websocket_state_with_clustering(
         ClusteringHandles {
@@ -349,6 +361,7 @@ async fn hung_isr_issue_fails_before_sm_state_commit_and_enable_is_retry_safe() 
          </enable>"
     );
 
+    let revoke_completed = revoked.notified();
     let failed = handle_xmpp_frame(&enable, "example.com", state.as_ref(), &mut conn).await;
     let failed = Element::from_str(&failed[0]).expect("failed xml");
     assert_eq!(failed.name(), "failed");
@@ -356,6 +369,9 @@ async fn hung_isr_issue_fails_before_sm_state_commit_and_enable_is_retry_safe() 
         .get_child("resource-constraint", "urn:ietf:params:xml:ns:xmpp-stanzas")
         .is_some());
     assert!(!conn.sm_state.enabled);
+    tokio::time::timeout(std::time::Duration::from_secs(1), revoke_completed)
+        .await
+        .expect("exact cleanup of ambiguous committed issuance");
 
     let retried = handle_xmpp_frame(&enable, "example.com", state.as_ref(), &mut conn).await;
     let enabled = Element::from_str(&retried[0]).expect("enabled xml");
@@ -363,6 +379,58 @@ async fn hung_isr_issue_fails_before_sm_state_commit_and_enable_is_retry_safe() 
     conn.publish_pending_sm_enable(state.as_ref());
     assert!(conn.sm_state.enabled);
     assert!(enabled.get_child("isr-enabled", ISR_NS).is_some());
+}
+
+#[tokio::test]
+async fn isr_persist_error_returns_sm_failure_instead_of_tokenless_success() {
+    let claim_store: std::sync::Arc<dyn ClaimStore> =
+        std::sync::Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+    let node_identity = SharedNodeIdentity::new(NodeIdentity::new("sm-node", "incarnation"));
+    let sm_session_registry = Arc::new(
+        InMemorySmSessionRegistry::new()
+            .with_claim_store(claim_store.clone(), node_identity.clone()),
+    );
+    let isr_token_store: Arc<dyn IsrTokenStore> = Arc::new(ControlledPersistIsrTokenStore {
+        inner: waddle_xmpp::isr::InMemoryIsrTokenStore::new(),
+        hang_once: std::sync::atomic::AtomicBool::new(false),
+        error_once: std::sync::atomic::AtomicBool::new(true),
+        revoked: None,
+    });
+    let state = create_test_websocket_state_with_clustering(
+        ClusteringHandles {
+            claim_store: Some(claim_store),
+            node_identity: Some(node_identity),
+            isr_token_store: Some(isr_token_store),
+            ..ClusteringHandles::default()
+        },
+        sm_session_registry,
+    )
+    .await;
+    let mut conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/persist-error".parse().expect("jid");
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_isr_publish_owner(state.as_ref(), &mut conn, &jid);
+
+    let responses = handle_xmpp_frame(
+        &format!(
+            "<enable xmlns='urn:xmpp:sm:3' resume='true'>\
+                <isr-enable xmlns='{ISR_NS}' mechanism='PLAIN'/>\
+             </enable>"
+        ),
+        "example.com",
+        state.as_ref(),
+        &mut conn,
+    )
+    .await;
+
+    assert_eq!(responses.len(), 1);
+    let failed = Element::from_str(&responses[0]).expect("failed xml");
+    assert_eq!(failed.name(), "failed");
+    assert!(failed
+        .get_child("resource-constraint", "urn:ietf:params:xml:ns:xmpp-stanzas")
+        .is_some());
+    assert!(!conn.sm_state.enabled);
+    assert!(conn.pending_sm_enable_commit.is_none());
 }
 
 #[tokio::test]
@@ -375,9 +443,10 @@ async fn dropped_isr_enable_commit_revokes_the_committed_provisional_token() {
             .with_claim_store(claim_store.clone(), node_identity.clone()),
     );
     let revoked = Arc::new(tokio::sync::Notify::new());
-    let isr_token_store = Arc::new(HangIssueOnceIsrTokenStore {
+    let isr_token_store = Arc::new(ControlledPersistIsrTokenStore {
         inner: waddle_xmpp::isr::InMemoryIsrTokenStore::new(),
         hang_once: std::sync::atomic::AtomicBool::new(false),
+        error_once: std::sync::atomic::AtomicBool::new(false),
         revoked: Some(revoked.clone()),
     });
     let state = create_test_websocket_state_with_clustering(

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
@@ -32,6 +32,7 @@ use waddle_xmpp::stream_management::{DetachedSession, SmResume, SmSessionRegistr
 struct HangIssueOnceIsrTokenStore {
     inner: waddle_xmpp::isr::InMemoryIsrTokenStore,
     hang_once: std::sync::atomic::AtomicBool,
+    revoked: Option<Arc<tokio::sync::Notify>>,
 }
 
 fn register_isr_publish_owner(
@@ -67,6 +68,18 @@ impl IsrTokenStore for HangIssueOnceIsrTokenStore {
             return std::future::pending().await;
         }
         self.inner.issue(sm_id, mechanism).await
+    }
+
+    async fn revoke_if_current(
+        &self,
+        sm_id: &str,
+        issued: &waddle_xmpp::isr::IssuedIsrToken,
+    ) -> Result<bool, waddle_xmpp::isr::IsrTokenStoreError> {
+        let revoked = self.inner.revoke_if_current(sm_id, issued).await?;
+        if let Some(notify) = &self.revoked {
+            notify.notify_one();
+        }
+        Ok(revoked)
     }
 
     async fn consume(
@@ -314,6 +327,7 @@ async fn hung_isr_issue_fails_before_sm_state_commit_and_enable_is_retry_safe() 
     let isr_token_store: Arc<dyn IsrTokenStore> = Arc::new(HangIssueOnceIsrTokenStore {
         inner: waddle_xmpp::isr::InMemoryIsrTokenStore::new(),
         hang_once: std::sync::atomic::AtomicBool::new(true),
+        revoked: None,
     });
     let state = create_test_websocket_state_with_clustering(
         ClusteringHandles {
@@ -349,6 +363,76 @@ async fn hung_isr_issue_fails_before_sm_state_commit_and_enable_is_retry_safe() 
     conn.publish_pending_sm_enable(state.as_ref());
     assert!(conn.sm_state.enabled);
     assert!(enabled.get_child("isr-enabled", ISR_NS).is_some());
+}
+
+#[tokio::test]
+async fn dropped_isr_enable_commit_revokes_the_committed_provisional_token() {
+    let claim_store: std::sync::Arc<dyn ClaimStore> =
+        std::sync::Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new());
+    let node_identity = SharedNodeIdentity::new(NodeIdentity::new("sm-node", "incarnation"));
+    let sm_session_registry = Arc::new(
+        InMemorySmSessionRegistry::new()
+            .with_claim_store(claim_store.clone(), node_identity.clone()),
+    );
+    let revoked = Arc::new(tokio::sync::Notify::new());
+    let isr_token_store = Arc::new(HangIssueOnceIsrTokenStore {
+        inner: waddle_xmpp::isr::InMemoryIsrTokenStore::new(),
+        hang_once: std::sync::atomic::AtomicBool::new(false),
+        revoked: Some(revoked.clone()),
+    });
+    let state = create_test_websocket_state_with_clustering(
+        ClusteringHandles {
+            claim_store: Some(claim_store),
+            node_identity: Some(node_identity.clone()),
+            isr_token_store: Some(isr_token_store.clone()),
+            ..ClusteringHandles::default()
+        },
+        sm_session_registry,
+    )
+    .await;
+    let mut conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/web".parse().expect("jid");
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_isr_publish_owner(state.as_ref(), &mut conn, &jid);
+
+    let responses = handle_xmpp_frame(
+        &format!(
+            "<enable xmlns='urn:xmpp:sm:3' resume='true'>\
+                <isr-enable xmlns='{ISR_NS}' mechanism='PLAIN'/>\
+             </enable>"
+        ),
+        "example.com",
+        state.as_ref(),
+        &mut conn,
+    )
+    .await;
+    let enabled = Element::from_str(&responses[0]).expect("enabled xml");
+    let stream_id = enabled.attr("id").expect("stream id").to_string();
+    let token = enabled
+        .get_child("isr-enabled", ISR_NS)
+        .and_then(|element| element.attr("token"))
+        .expect("issued ISR token")
+        .to_string();
+    assert!(!conn.sm_state.enabled);
+    assert!(conn.pending_sm_enable_commit.is_some());
+
+    let revoke_completed = revoked.notified();
+    drop(conn.pending_sm_enable_commit.take());
+    tokio::time::timeout(std::time::Duration::from_secs(1), revoke_completed)
+        .await
+        .expect("bounded provisional revoke");
+
+    let fence = waddle_xmpp::stream_management::persistence::SmClaimFence::new(
+        node_identity.current(),
+        waddle_xmpp::ownership::ClaimEpoch(0),
+    );
+    assert_eq!(
+        isr_token_store
+            .consume(&stream_id, token.as_bytes(), ISR_PINNED_MECHANISM, &fence)
+            .await
+            .expect("consume after dropped publication"),
+        waddle_xmpp::isr::IsrConsumeOutcome::NoSuchToken
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -882,6 +882,50 @@ async fn sm_enable_after_bind_returns_enabled_and_tracks_counters() {
 }
 
 #[tokio::test]
+async fn pipelined_sm_enable_cannot_replace_the_unpublished_commit() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/pipelined-enable".parse().expect("jid");
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_sm_publish_owner(state.as_ref(), &mut conn, &jid);
+
+    let first = handle_xmpp_frame(
+        "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
+        "example.com",
+        state.as_ref(),
+        &mut conn,
+    )
+    .await;
+    let first_enabled = Element::from_str(&first[0]).expect("first enabled xml");
+    let first_stream_id = first_enabled
+        .attr("id")
+        .expect("first stream id")
+        .to_string();
+    assert!(conn.pending_sm_enable_commit.is_some());
+    assert!(!conn.sm_state.enabled);
+
+    let second = handle_xmpp_frame(
+        "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
+        "example.com",
+        state.as_ref(),
+        &mut conn,
+    )
+    .await;
+    let failed = Element::from_str(&second[0]).expect("second failed xml");
+    assert_eq!(failed.name(), "failed");
+    assert!(failed
+        .get_child("unexpected-request", "urn:ietf:params:xml:ns:xmpp-stanzas")
+        .is_some());
+
+    conn.publish_pending_sm_enable(state.as_ref());
+    assert!(conn.sm_state.enabled);
+    assert_eq!(
+        conn.sm_state.stream_id.as_deref(),
+        Some(first_stream_id.as_str())
+    );
+}
+
+#[tokio::test]
 async fn resumable_enable_cancelled_before_write_never_publishes_and_releases_exact_claim() {
     let state = create_test_websocket_state().await;
     let mut conn = WsConnState::new();

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -11,13 +11,14 @@ use super::super::{
 };
 use super::{
     create_test_server_owner_session, create_test_session, create_test_websocket_state,
-    message_frame_xml_with_id, register_test_native_user, scram_client_final_from_challenge,
-    snapshot_room,
+    create_test_websocket_state_with_sm_registry, message_frame_xml_with_id,
+    register_test_native_user, scram_client_final_from_challenge, snapshot_room,
 };
 use crate::auth::Session;
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use jid::{BareJid, FullJid};
 use std::str::FromStr;
+use std::sync::Arc;
 use tokio::sync::mpsc;
 use waddle_xmpp::{
     protocol::{Blocklist, ConnectionPhase, InboundEvent},
@@ -26,6 +27,106 @@ use waddle_xmpp::{
     Stanza,
 };
 use xmpp_parsers::minidom::Element;
+
+struct HangingEnsureClaimStore {
+    inner: waddle_xmpp::ownership::InProcessClaimStore,
+}
+
+fn register_sm_publish_owner(
+    state: &super::super::state::WebSocketState,
+    conn: &mut WsConnState,
+    jid: &FullJid,
+) {
+    let (tx, _rx) = mpsc::channel(1);
+    conn.registry_owner = Some(
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .register(jid.clone(), tx),
+    );
+}
+
+#[async_trait::async_trait]
+impl waddle_xmpp::ownership::ClaimStore for HangingEnsureClaimStore {
+    async fn ensure_schema(&self) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.ensure_schema().await
+    }
+
+    async fn acquire(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner.acquire(entity, me).await
+    }
+
+    async fn ensure_claimed(
+        &self,
+        _entity: &waddle_xmpp::ownership::Entity,
+        _me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        std::future::pending().await
+    }
+
+    async fn steal_stale(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        observed: waddle_xmpp::ownership::ClaimEpoch,
+        staleness: waddle_xmpp::ownership::StalePredicate,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner
+            .steal_stale(entity, observed, staleness, me)
+            .await
+    }
+
+    async fn steal_for_resume(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        observed: waddle_xmpp::ownership::ClaimEpoch,
+        witness: waddle_xmpp::ownership::ResumeIdentityProof,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner
+            .steal_for_resume(entity, observed, witness, me)
+            .await
+    }
+
+    async fn current_claim(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+    ) -> Result<Option<waddle_xmpp::ownership::ClaimSnapshot>, waddle_xmpp::ownership::ClaimError>
+    {
+        self.inner.current_claim(entity).await
+    }
+
+    async fn fence(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+        mine: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> Result<bool, waddle_xmpp::ownership::ClaimError> {
+        self.inner.fence(entity, me, mine).await
+    }
+
+    async fn release(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+        mine: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.release(entity, me, mine).await
+    }
+
+    async fn release_many(
+        &self,
+        entities: &[waddle_xmpp::ownership::Entity],
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.release_many(entities, me).await
+    }
+}
 
 fn resume_frame_xml(stream_id: &str, handled_count: u32) -> String {
     element_to_xml(
@@ -232,6 +333,40 @@ async fn sm_enable_requires_resource_binding() {
     let el = Element::from_str(&responses[0]).expect("xml");
     assert_eq!(el.name(), "failed");
     assert!(!conn.sm_state.enabled);
+}
+
+#[tokio::test]
+async fn sm_enable_claim_timeout_returns_failure_without_enabling_state() {
+    let registry = Arc::new(
+        waddle_xmpp::stream_management::InMemorySmSessionRegistry::new().with_claim_store(
+            Arc::new(HangingEnsureClaimStore {
+                inner: waddle_xmpp::ownership::InProcessClaimStore::new(),
+            }),
+            waddle_xmpp::ownership::SharedNodeIdentity::new(
+                waddle_xmpp::ownership::NodeIdentity::new("sm-node", "incarnation"),
+            ),
+        ),
+    );
+    let state = create_test_websocket_state_with_sm_registry(registry).await;
+    let mut conn = WsConnState::new();
+    conn.phase = ConnectionPhase::ready("alice@example.com/web".parse().expect("bound jid"), false);
+
+    let responses = handle_xmpp_frame(
+        "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
+        "example.com",
+        state.as_ref(),
+        &mut conn,
+    )
+    .await;
+
+    assert_eq!(responses.len(), 1);
+    let failed = Element::from_str(&responses[0]).expect("failed xml");
+    assert_eq!(failed.name(), "failed");
+    assert!(failed
+        .get_child("resource-constraint", "urn:ietf:params:xml:ns:xmpp-stanzas")
+        .is_some());
+    assert!(!conn.sm_state.enabled);
+    assert!(conn.sm_state.stream_id.is_none());
 }
 
 #[tokio::test]
@@ -688,7 +823,8 @@ async fn sm_enable_after_bind_returns_enabled_and_tracks_counters() {
     let state = create_test_websocket_state().await;
     let mut conn = WsConnState::new();
     let jid: FullJid = "alice@example.com/web".parse().expect("jid");
-    conn.phase = ConnectionPhase::ready(jid, false);
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_sm_publish_owner(state.as_ref(), &mut conn, &jid);
 
     let responses = handle_xmpp_frame(
         "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
@@ -702,6 +838,11 @@ async fn sm_enable_after_bind_returns_enabled_and_tracks_counters() {
     assert_eq!(el.name(), "enabled");
     assert_eq!(el.attr("resume"), Some("true"));
     assert!(el.attr("id").filter(|s| !s.is_empty()).is_some());
+    assert!(
+        !conn.sm_state.enabled,
+        "SM must remain unpublished until the <enabled/> write succeeds"
+    );
+    conn.publish_pending_sm_enable(state.as_ref());
     assert!(conn.sm_state.enabled);
     assert!(conn.sm_state.is_resumable());
 
@@ -740,6 +881,193 @@ async fn sm_enable_after_bind_returns_enabled_and_tracks_counters() {
     assert_eq!(ack2_el.attr("h"), Some("1"));
 }
 
+#[tokio::test]
+async fn resumable_enable_cancelled_before_write_never_publishes_and_releases_exact_claim() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/cancelled-enable".parse().expect("jid");
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_sm_publish_owner(state.as_ref(), &mut conn, &jid);
+
+    let responses = handle_xmpp_frame(
+        "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
+        "example.com",
+        state.as_ref(),
+        &mut conn,
+    )
+    .await;
+    let enabled = Element::from_str(&responses[0]).expect("enabled xml");
+    let stream_id = enabled.attr("id").expect("stream id").to_string();
+    assert!(!conn.sm_state.enabled);
+    assert!(conn.pending_sm_enable_commit.is_some());
+
+    drop(conn);
+
+    let registry = &state.deps.protocol.sm_session_registry;
+    assert_eq!(registry.pending_claim_release_count(), 1);
+    assert_eq!(registry.retry_pending_claim_releases(1).await, 1);
+    assert!(
+        !registry
+            .locally_owned_claim_ids()
+            .expect("local ownership inventory")
+            .contains(&stream_id),
+        "an unpublished previd must not retain a resumable claim"
+    );
+}
+
+#[tokio::test]
+async fn replaced_connection_cannot_publish_or_strand_its_post_write_enable_claim() {
+    let state = create_test_websocket_state().await;
+    let mut old_conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/replaced-enable".parse().expect("jid");
+    old_conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_sm_publish_owner(state.as_ref(), &mut old_conn, &jid);
+
+    let responses = handle_xmpp_frame(
+        "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
+        "example.com",
+        state.as_ref(),
+        &mut old_conn,
+    )
+    .await;
+    let enabled = Element::from_str(&responses[0]).expect("enabled xml");
+    let stream_id = waddle_xmpp::pending_delivery::SmSessionId::new(
+        enabled.attr("id").expect("stream id").to_string(),
+    );
+
+    let (replacement_tx, _replacement_rx) = mpsc::channel(1);
+    let _replacement_owner = state
+        .deps
+        .protocol
+        .connection_registry
+        .register(jid.clone(), replacement_tx);
+
+    old_conn.publish_pending_sm_enable(state.as_ref());
+
+    assert!(!old_conn.sm_state.enabled);
+    assert!(old_conn.pending_sm_enable_commit.is_none());
+    assert!(
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .get_entry(&jid)
+            .expect("replacement entry")
+            .sm_stream_id()
+            .is_none(),
+        "stale publication must not stamp the replacement entry"
+    );
+    assert!(
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .sm_stream_owner(&stream_id)
+            .is_none(),
+        "stale publication must not create a reverse-index alias"
+    );
+    let registry = &state.deps.protocol.sm_session_registry;
+    assert_eq!(registry.pending_claim_release_count(), 1);
+    assert_eq!(registry.retry_pending_claim_releases(1).await, 1);
+}
+
+#[tokio::test]
+async fn replacement_after_enable_publication_terminalizes_only_the_old_stream_claim() {
+    let state = create_test_websocket_state().await;
+    let mut old_conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/replaced-after-enable"
+        .parse()
+        .expect("jid");
+    old_conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_sm_publish_owner(state.as_ref(), &mut old_conn, &jid);
+
+    let responses = handle_xmpp_frame(
+        "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
+        "example.com",
+        state.as_ref(),
+        &mut old_conn,
+    )
+    .await;
+    let enabled = Element::from_str(&responses[0]).expect("enabled xml");
+    let old_stream_id = enabled.attr("id").expect("stream id").to_string();
+    old_conn.publish_pending_sm_enable(state.as_ref());
+    assert!(old_conn.sm_state.enabled);
+
+    let (replacement_tx, _replacement_rx) = mpsc::channel(1);
+    let replacement_owner = state
+        .deps
+        .protocol
+        .connection_registry
+        .register(jid.clone(), replacement_tx);
+    let replacement_stream =
+        waddle_xmpp::pending_delivery::SmSessionId::new("replacement-owned-stream".to_string());
+    assert!(state
+        .deps
+        .protocol
+        .connection_registry
+        .set_sm_stream_id_if_owner(&jid, &replacement_owner, Some(replacement_stream.clone()),));
+
+    let (_outbound_tx, mut outbound_rx) = mpsc::channel(1);
+    assert_eq!(
+        cleanup_connection_shutdown(state.as_ref(), &mut outbound_rx, &mut old_conn, false).await,
+        super::super::cleanup::ConnectionShutdownOutcome::NotPersisted
+    );
+
+    assert_eq!(
+        state
+            .deps
+            .protocol
+            .connection_registry
+            .get_entry(&jid)
+            .expect("replacement entry")
+            .sm_stream_id(),
+        Some(replacement_stream),
+        "old-stream cleanup must not alter the replacement entry"
+    );
+    let registry = &state.deps.protocol.sm_session_registry;
+    assert_eq!(registry.pending_claim_release_count(), 1);
+    assert!(registry
+        .locally_owned_claim_ids()
+        .expect("ownership inventory")
+        .contains(&old_stream_id));
+    assert_eq!(registry.retry_pending_claim_releases(1).await, 1);
+}
+
+#[tokio::test]
+async fn non_resumable_sm_enable_does_not_create_cluster_claim() {
+    let state = create_test_websocket_state().await;
+    let mut conn = WsConnState::new();
+    let jid: FullJid = "alice@example.com/non-resumable".parse().expect("jid");
+    conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_sm_publish_owner(state.as_ref(), &mut conn, &jid);
+
+    let responses = handle_xmpp_frame(
+        "<enable xmlns='urn:xmpp:sm:3' resume='false'/>",
+        "example.com",
+        state.as_ref(),
+        &mut conn,
+    )
+    .await;
+    assert_eq!(responses.len(), 1);
+    let enabled = Element::from_str(&responses[0]).expect("enabled xml");
+    assert_eq!(enabled.name(), "enabled");
+    assert_eq!(enabled.attr("resume"), None);
+    let stream_id = enabled.attr("id").expect("SM id");
+    conn.publish_pending_sm_enable(state.as_ref());
+    assert!(conn.sm_state.enabled);
+    assert!(!conn.sm_state.is_resumable());
+    assert!(
+        !state
+            .deps
+            .protocol
+            .sm_session_registry
+            .locally_owned_claim_ids()
+            .expect("local claim snapshot")
+            .contains(&stream_id.to_string()),
+        "non-resumable SM must not retain a clustered ownership claim"
+    );
+}
+
 /// Enable SM on a fresh ready connection and return the negotiated
 /// stream id. Shared setup for the live `<a h='N'/>` validation tests
 /// (issue #1099).
@@ -749,6 +1077,7 @@ async fn enable_sm_for_live_ack_tests(
     jid: &FullJid,
 ) -> String {
     conn.phase = ConnectionPhase::ready(jid.clone(), false);
+    register_sm_publish_owner(state, conn, jid);
     let responses = handle_xmpp_frame(
         "<enable xmlns='urn:xmpp:sm:3' resume='true'/>",
         "example.com",
@@ -758,6 +1087,7 @@ async fn enable_sm_for_live_ack_tests(
     .await;
     let enabled = Element::from_str(&responses[0]).expect("enabled xml");
     assert_eq!(enabled.name(), "enabled");
+    conn.publish_pending_sm_enable(state);
     enabled.attr("id").expect("stream id").to_string()
 }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -916,7 +916,7 @@ async fn resumable_enable_cancelled_before_write_never_publishes_and_releases_ex
 }
 
 #[tokio::test]
-async fn replaced_connection_cannot_publish_or_strand_its_post_write_enable_claim() {
+async fn replaced_connection_commits_written_enable_without_publishing_stale_alias() {
     let state = create_test_websocket_state().await;
     let mut old_conn = WsConnState::new();
     let jid: FullJid = "alice@example.com/replaced-enable".parse().expect("jid");
@@ -944,7 +944,10 @@ async fn replaced_connection_cannot_publish_or_strand_its_post_write_enable_clai
 
     old_conn.publish_pending_sm_enable(state.as_ref());
 
-    assert!(!old_conn.sm_state.enabled);
+    assert!(
+        old_conn.sm_state.enabled,
+        "a successfully written <enabled/> commits local XEP-0198 state"
+    );
     assert!(old_conn.pending_sm_enable_commit.is_none());
     assert!(
         state
@@ -967,6 +970,13 @@ async fn replaced_connection_cannot_publish_or_strand_its_post_write_enable_clai
         "stale publication must not create a reverse-index alias"
     );
     let registry = &state.deps.protocol.sm_session_registry;
+    assert_eq!(registry.pending_claim_release_count(), 0);
+
+    let (_outbound_tx, mut outbound_rx) = mpsc::channel(1);
+    assert_eq!(
+        cleanup_connection_shutdown(state.as_ref(), &mut outbound_rx, &mut old_conn, false).await,
+        super::super::cleanup::ConnectionShutdownOutcome::NotPersisted
+    );
     assert_eq!(registry.pending_claim_release_count(), 1);
     assert_eq!(registry.retry_pending_claim_releases(1).await, 1);
 }

--- a/server/crates/waddle-server/src/server/routes/websocket/transport_xml.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/transport_xml.rs
@@ -271,7 +271,7 @@ pub(super) fn build_conflict_stream_error() -> String {
 
 /// `isr_available` (ADR-0017 Phase 3 Slice 8, Q8): whether XEP-0397 ISR is
 /// advertised — true only when `clustering.enabled && Postgres`
-/// (`ClusteringHandles::isr_token_store().is_some()` is the single source
+/// (`WebSocketDeps::isr_available()` is the single source
 /// of truth for this; see that method's doc comment). Corrected premise
 /// (FIX 8): before this slice ISR was advertised UNCONDITIONALLY and
 /// non-conformantly — the wrong namespace (`urn:xmpp:isr:0`) and a bare

--- a/server/crates/waddle-server/src/server/routes/well_known.rs
+++ b/server/crates/waddle-server/src/server/routes/well_known.rs
@@ -30,15 +30,7 @@ pub fn router(auth_state: Arc<AuthState>) -> Router {
 /// Returns XRD document for XMPP service discovery (XEP-0156).
 /// Used by XMPP clients to discover WebSocket/BOSH endpoints.
 async fn host_meta_xml_handler(State(state): State<Arc<AuthState>>) -> Response {
-    let websocket_url = state.websocket_url();
-
-    let xml = format!(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
-<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
-  <Link rel="{}" href="{}" />
-</XRD>"#,
-        XMPP_ALT_CONNECTIONS_WEBSOCKET_REL, websocket_url
-    );
+    let xml = host_meta_xml(&state.public_xmpp_websocket_url);
 
     (
         StatusCode::OK,
@@ -49,6 +41,25 @@ async fn host_meta_xml_handler(State(state): State<Arc<AuthState>>) -> Response 
         xml,
     )
         .into_response()
+}
+
+fn host_meta_xml(websocket_url: &url::Url) -> String {
+    const XRD_NS: &str = "http://docs.oasis-open.org/ns/xri/xrd-1.0";
+    let xrd = xmpp_parsers::minidom::Element::builder("XRD", XRD_NS)
+        .append(
+            xmpp_parsers::minidom::Element::builder("Link", XRD_NS)
+                .attr(
+                    xmpp_parsers::minidom::rxml::xml_ncname!("rel").to_owned(),
+                    XMPP_ALT_CONNECTIONS_WEBSOCKET_REL,
+                )
+                .attr(
+                    xmpp_parsers::minidom::rxml::xml_ncname!("href").to_owned(),
+                    websocket_url.as_str(),
+                )
+                .build(),
+        )
+        .build();
+    crate::server::routes::websocket::element_to_xml(xrd)
 }
 
 /// GET /.well-known/host-meta.json
@@ -76,7 +87,8 @@ async fn host_meta_json_handler(State(state): State<Arc<AuthState>>) -> Response
 
 #[cfg(test)]
 mod xep0156_host_meta_tests {
-    use super::XMPP_ALT_CONNECTIONS_WEBSOCKET_REL;
+    use super::{host_meta_xml, XMPP_ALT_CONNECTIONS_WEBSOCKET_REL};
+    use std::str::FromStr;
 
     #[test]
     fn xep0156_consistency_uses_single_rel_identifier_constant() {
@@ -84,5 +96,18 @@ mod xep0156_host_meta_tests {
             XMPP_ALT_CONNECTIONS_WEBSOCKET_REL,
             "urn:xmpp:alt-connections:websocket"
         );
+    }
+
+    #[test]
+    fn host_meta_serialization_escapes_url_attributes() {
+        let url =
+            url::Url::parse("wss://xmpp.example.com/ws?one=1&two=2").expect("test WebSocket URL");
+        let xml = host_meta_xml(&url);
+        let xrd = xmpp_parsers::minidom::Element::from_str(&xml).expect("valid XRD XML");
+        let link = xrd
+            .get_child("Link", "http://docs.oasis-open.org/ns/xri/xrd-1.0")
+            .expect("Link child");
+        assert_eq!(link.attr("href"), Some(url.as_str()));
+        assert!(xml.contains("&amp;"));
     }
 }

--- a/server/crates/waddle-server/src/server/routes/well_known.rs
+++ b/server/crates/waddle-server/src/server/routes/well_known.rs
@@ -45,8 +45,9 @@ async fn host_meta_xml_handler(State(state): State<Arc<AuthState>>) -> Response 
 
 fn host_meta_xml(websocket_url: &url::Url) -> String {
     const XRD_NS: &str = "http://docs.oasis-open.org/ns/xri/xrd-1.0";
-    let xrd = xmpp_parsers::minidom::Element::builder("XRD", XRD_NS)
-        .append(
+    let mut xrd = xmpp_parsers::minidom::Element::builder("XRD", XRD_NS);
+    if websocket_url.scheme() == "wss" {
+        xrd = xrd.append(
             xmpp_parsers::minidom::Element::builder("Link", XRD_NS)
                 .attr(
                     xmpp_parsers::minidom::rxml::xml_ncname!("rel").to_owned(),
@@ -57,25 +58,16 @@ fn host_meta_xml(websocket_url: &url::Url) -> String {
                     websocket_url.as_str(),
                 )
                 .build(),
-        )
-        .build();
-    crate::server::routes::websocket::element_to_xml(xrd)
+        );
+    }
+    crate::server::routes::websocket::element_to_xml(xrd.build())
 }
 
 /// GET /.well-known/host-meta.json
 ///
 /// Returns JSON variant of host-meta for XMPP service discovery.
 async fn host_meta_json_handler(State(state): State<Arc<AuthState>>) -> Response {
-    let websocket_url = state.websocket_url();
-
-    let json = serde_json::json!({
-        "links": [
-            {
-                "rel": XMPP_ALT_CONNECTIONS_WEBSOCKET_REL,
-                "href": websocket_url
-            }
-        ]
-    });
+    let json = host_meta_json(&state.public_xmpp_websocket_url);
 
     (
         StatusCode::OK,
@@ -85,9 +77,22 @@ async fn host_meta_json_handler(State(state): State<Arc<AuthState>>) -> Response
         .into_response()
 }
 
+fn host_meta_json(websocket_url: &url::Url) -> serde_json::Value {
+    let links = (websocket_url.scheme() == "wss")
+        .then(|| {
+            serde_json::json!({
+                "rel": XMPP_ALT_CONNECTIONS_WEBSOCKET_REL,
+                "href": websocket_url.as_str()
+            })
+        })
+        .into_iter()
+        .collect::<Vec<_>>();
+    serde_json::json!({ "links": links })
+}
+
 #[cfg(test)]
 mod xep0156_host_meta_tests {
-    use super::{host_meta_xml, XMPP_ALT_CONNECTIONS_WEBSOCKET_REL};
+    use super::{host_meta_json, host_meta_xml, XMPP_ALT_CONNECTIONS_WEBSOCKET_REL};
     use std::str::FromStr;
 
     #[test]
@@ -109,5 +114,28 @@ mod xep0156_host_meta_tests {
             .expect("Link child");
         assert_eq!(link.attr("href"), Some(url.as_str()));
         assert!(xml.contains("&amp;"));
+    }
+
+    #[test]
+    fn xep0156_never_advertises_a_plaintext_websocket_url() {
+        let url = url::Url::parse("ws://xmpp.example.com/ws").expect("test WebSocket URL");
+        let xml = host_meta_xml(&url);
+        let xrd = xmpp_parsers::minidom::Element::from_str(&xml).expect("valid XRD XML");
+        assert!(xrd
+            .get_child("Link", "http://docs.oasis-open.org/ns/xri/xrd-1.0")
+            .is_none());
+        assert_eq!(host_meta_json(&url)["links"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn xep0156_advertises_the_exact_secure_websocket_url() {
+        let url = url::Url::parse("wss://xmpp.waddle.social/ws").expect("production WebSocket URL");
+        let xml = host_meta_xml(&url);
+        let xrd = xmpp_parsers::minidom::Element::from_str(&xml).expect("valid XRD XML");
+        let link = xrd
+            .get_child("Link", "http://docs.oasis-open.org/ns/xri/xrd-1.0")
+            .expect("secure Link child");
+        assert_eq!(link.attr("href"), Some(url.as_str()));
+        assert_eq!(host_meta_json(&url)["links"][0]["href"], url.as_str());
     }
 }

--- a/server/crates/waddle-server/src/server/tests.rs
+++ b/server/crates/waddle-server/src/server/tests.rs
@@ -349,6 +349,7 @@ fn test_xmpp_config_rejects_malformed_public_websocket_url() {
         error.to_string().contains("is not a valid absolute URL"),
         "unexpected error: {error:#}"
     );
+    assert!(!error.to_string().contains("not a URL"));
 
     reset_xmpp_config_env();
 }
@@ -369,6 +370,11 @@ fn test_xmpp_config_rejects_sensitive_or_ambiguous_websocket_urls() {
             error.to_string().contains(expected),
             "unexpected error for {configured}: {error:#}"
         );
+        assert!(
+            !error.to_string().contains(configured),
+            "configuration diagnostics must redact the rejected URL"
+        );
+        assert!(!error.to_string().contains("secret"));
     }
 
     reset_xmpp_config_env();

--- a/server/crates/waddle-server/src/server/tests.rs
+++ b/server/crates/waddle-server/src/server/tests.rs
@@ -293,9 +293,94 @@ fn reset_xmpp_config_env() {
         "WADDLE_XMPP_DOMAIN",
         "WADDLE_SPACES_JID",
         "WADDLE_MUC_DOMAIN",
+        "WADDLE_XMPP_PUBLIC_WEBSOCKET_URL",
     ] {
         std::env::remove_var(key);
     }
+}
+
+#[test]
+fn test_xmpp_config_parses_trimmed_public_websocket_url() {
+    let _guard = env_lock();
+    reset_xmpp_config_env();
+
+    std::env::set_var(
+        "WADDLE_XMPP_PUBLIC_WEBSOCKET_URL",
+        "  wss://xmpp.example.com/ws  ",
+    );
+
+    let config = XmppConfig::from_env().expect("public WebSocket URL parses");
+    assert_eq!(
+        config.public_websocket_url.as_str(),
+        "wss://xmpp.example.com/ws"
+    );
+
+    reset_xmpp_config_env();
+}
+
+#[test]
+fn test_xmpp_config_rejects_non_websocket_public_url() {
+    let _guard = env_lock();
+    reset_xmpp_config_env();
+
+    std::env::set_var(
+        "WADDLE_XMPP_PUBLIC_WEBSOCKET_URL",
+        "https://xmpp.example.com/ws",
+    );
+
+    let error = XmppConfig::from_env().expect_err("HTTP URL must fail startup");
+    assert!(
+        error.to_string().contains("must use the ws or wss scheme"),
+        "unexpected error: {error:#}"
+    );
+
+    reset_xmpp_config_env();
+}
+
+#[test]
+fn test_xmpp_config_rejects_malformed_public_websocket_url() {
+    let _guard = env_lock();
+    reset_xmpp_config_env();
+
+    std::env::set_var("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL", "not a URL");
+
+    let error = XmppConfig::from_env().expect_err("malformed URL must fail startup");
+    assert!(
+        error.to_string().contains("is not a valid absolute URL"),
+        "unexpected error: {error:#}"
+    );
+
+    reset_xmpp_config_env();
+}
+
+#[test]
+fn test_xmpp_config_rejects_sensitive_or_ambiguous_websocket_urls() {
+    let _guard = env_lock();
+    for (configured, expected) in [
+        ("wss://alice:secret@xmpp.example.com/ws", "user information"),
+        ("wss://xmpp.example.com/ws?token=secret", "query"),
+        ("wss://xmpp.example.com/ws#fragment", "fragment"),
+    ] {
+        reset_xmpp_config_env();
+        std::env::set_var("WADDLE_XMPP_PUBLIC_WEBSOCKET_URL", configured);
+
+        let error = XmppConfig::from_env().expect_err("unsafe URL must fail startup");
+        assert!(
+            error.to_string().contains(expected),
+            "unexpected error for {configured}: {error:#}"
+        );
+    }
+
+    reset_xmpp_config_env();
+}
+
+#[test]
+fn transport_security_uses_the_public_websocket_scheme() {
+    let secure = url::Url::parse("wss://xmpp.example.com/ws").expect("secure URL");
+    let unsecured = url::Url::parse("ws://xmpp.example.com/ws").expect("plain URL");
+
+    assert!(routes::websocket::TransportSecurity::from_public_websocket_url(&secure).is_tls());
+    assert!(!routes::websocket::TransportSecurity::from_public_websocket_url(&unsecured).is_tls());
 }
 
 #[test]
@@ -308,6 +393,10 @@ fn test_xmpp_config_defaults_spaces_and_muc_from_xmpp_domain() {
     let config = XmppConfig::from_env().expect("config parses");
     assert_eq!(config.spaces_jid.to_string(), "spaces.waddle.example");
     assert_eq!(config.muc_domain.as_str(), "muc.waddle.example");
+    assert_eq!(
+        config.public_websocket_url.as_str(),
+        "ws://waddle.example/ws"
+    );
 
     reset_xmpp_config_env();
 }

--- a/server/crates/waddle-xmpp/src/isr.rs
+++ b/server/crates/waddle-xmpp/src/isr.rs
@@ -40,7 +40,7 @@ mod wire;
 
 pub use store::{
     revocation_queue_for_store, InMemoryIsrTokenStore, IsrConsumeOutcome, IsrRevocationQueue,
-    IsrRevocationReservation, IsrTokenStore, IsrTokenStoreError, IssuedIsrToken,
+    IsrRevocationReservation, IsrRevokeOutcome, IsrTokenStore, IsrTokenStoreError, IssuedIsrToken,
 };
 pub use wire::{
     inst_resume_failed_element, inst_resumed_element, isr_enabled_element,

--- a/server/crates/waddle-xmpp/src/isr.rs
+++ b/server/crates/waddle-xmpp/src/isr.rs
@@ -39,7 +39,8 @@ mod store;
 mod wire;
 
 pub use store::{
-    InMemoryIsrTokenStore, IsrConsumeOutcome, IsrTokenStore, IsrTokenStoreError, IssuedIsrToken,
+    revocation_queue_for_store, InMemoryIsrTokenStore, IsrConsumeOutcome, IsrRevocationQueue,
+    IsrRevocationReservation, IsrTokenStore, IsrTokenStoreError, IssuedIsrToken,
 };
 pub use wire::{
     inst_resume_failed_element, inst_resumed_element, isr_enabled_element,

--- a/server/crates/waddle-xmpp/src/isr/store.rs
+++ b/server/crates/waddle-xmpp/src/isr/store.rs
@@ -267,6 +267,17 @@ impl IsrRevocationQueue {
         runtime.spawn(async move { queue.run_worker().await });
     }
 
+    fn schedule_worker_restart(&self) {
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let queue = self.clone();
+        runtime.spawn(async move {
+            tokio::time::sleep(REVOCATION_RETRY_DELAY).await;
+            queue.start_worker();
+        });
+    }
+
     async fn run_worker(self) {
         let mut guard = IsrRevocationWorkerGuard {
             queue: self.clone(),
@@ -351,13 +362,22 @@ impl Drop for IsrRevocationWorkerGuard {
         if !self.armed {
             return;
         }
-        if let Ok(mut state) = self.queue.inner.state.lock() {
+        let retained_active = if let Ok(mut state) = self.queue.inner.state.lock() {
             state.worker_running = false;
             for entry in &mut state.entries {
                 if entry.state == IsrRevocationState::InFlight {
                     entry.state = IsrRevocationState::Active;
                 }
             }
+            state
+                .entries
+                .iter()
+                .any(|entry| entry.state == IsrRevocationState::Active)
+        } else {
+            false
+        };
+        if retained_active {
+            self.queue.schedule_worker_restart();
         }
     }
 }
@@ -549,6 +569,63 @@ mod tests {
         revoked: tokio::sync::Notify,
     }
 
+    struct PanicFirstRevokeStore {
+        inner: InMemoryIsrTokenStore,
+        attempts: std::sync::atomic::AtomicUsize,
+        revoked: tokio::sync::Notify,
+    }
+
+    #[async_trait]
+    impl IsrTokenStore for PanicFirstRevokeStore {
+        async fn ensure_schema(&self) -> Result<(), IsrTokenStoreError> {
+            self.inner.ensure_schema().await
+        }
+
+        async fn persist_issued(
+            &self,
+            sm_id: &str,
+            issued: &IssuedIsrToken,
+        ) -> Result<(), IsrTokenStoreError> {
+            self.inner.persist_issued(sm_id, issued).await
+        }
+
+        async fn revoke_if_current(
+            &self,
+            sm_id: &str,
+            issued: &IssuedIsrToken,
+        ) -> Result<bool, IsrTokenStoreError> {
+            if self
+                .attempts
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                == 0
+            {
+                panic!("injected first revoke panic");
+            }
+            let revoked = self.inner.revoke_if_current(sm_id, issued).await?;
+            self.revoked.notify_one();
+            Ok(revoked)
+        }
+
+        async fn consume(
+            &self,
+            sm_id: &str,
+            presented_token: &[u8],
+            mechanism: &str,
+            fence: &SmClaimFence,
+        ) -> Result<IsrConsumeOutcome, IsrTokenStoreError> {
+            self.inner
+                .consume(sm_id, presented_token, mechanism, fence)
+                .await
+        }
+
+        async fn sweep_expired(
+            &self,
+            max_age: std::time::Duration,
+        ) -> Result<u64, IsrTokenStoreError> {
+            self.inner.sweep_expired(max_age).await
+        }
+    }
+
     #[async_trait]
     impl IsrTokenStore for FailFirstRevokeStore {
         async fn ensure_schema(&self) -> Result<(), IsrTokenStoreError> {
@@ -730,6 +807,34 @@ mod tests {
         tokio::time::timeout(std::time::Duration::from_secs(1), revoked)
             .await
             .expect("second revoke succeeds after first failure");
+
+        assert_eq!(store.attempts.load(std::sync::atomic::Ordering::SeqCst), 2);
+        assert_eq!(queue.pending_len(), 0);
+    }
+
+    #[tokio::test]
+    async fn revocation_queue_restarts_after_worker_panic() {
+        let store = Arc::new(PanicFirstRevokeStore {
+            inner: InMemoryIsrTokenStore::new(),
+            attempts: std::sync::atomic::AtomicUsize::new(0),
+            revoked: tokio::sync::Notify::new(),
+        });
+        let issued = IssuedIsrToken::new("PLAIN");
+        store
+            .persist_issued("sm-panic", &issued)
+            .await
+            .expect("persist provisional token");
+        let queue = IsrRevocationQueue::with_capacity(1);
+        let dyn_store: Arc<dyn IsrTokenStore> = store.clone();
+        let reservation = queue
+            .reserve("sm-panic".to_string(), dyn_store, issued)
+            .expect("reserve cleanup capacity");
+        let revoked = store.revoked.notified();
+
+        drop(reservation);
+        tokio::time::timeout(std::time::Duration::from_secs(1), revoked)
+            .await
+            .expect("replacement worker revokes after predecessor panic");
 
         assert_eq!(store.attempts.load(std::sync::atomic::Ordering::SeqCst), 2);
         assert_eq!(queue.pending_len(), 0);

--- a/server/crates/waddle-xmpp/src/isr/store.rs
+++ b/server/crates/waddle-xmpp/src/isr/store.rs
@@ -117,6 +117,16 @@ pub trait IsrTokenStore: Send + Sync {
         mechanism: &str,
     ) -> Result<IssuedIsrToken, IsrTokenStoreError>;
 
+    /// Revoke a provisional issuance only if the row still contains the
+    /// exact token and mechanism returned by [`Self::issue`]. A delayed
+    /// cleanup must never delete a newer issuance or a token rotated by a
+    /// successful resume. Returns whether this exact issuance was removed.
+    async fn revoke_if_current(
+        &self,
+        sm_id: &str,
+        issued: &IssuedIsrToken,
+    ) -> Result<bool, IsrTokenStoreError>;
+
     /// Fenced, single-use, constant-time consume. See the trait-level doc
     /// for the locked spec this must implement exactly.
     async fn consume(
@@ -179,6 +189,25 @@ impl IsrTokenStore for InMemoryIsrTokenStore {
             .map_err(|_| IsrTokenStoreError::Poisoned)?;
         tokens.insert(sm_id.to_string(), issued.clone());
         Ok(issued)
+    }
+
+    async fn revoke_if_current(
+        &self,
+        sm_id: &str,
+        issued: &IssuedIsrToken,
+    ) -> Result<bool, IsrTokenStoreError> {
+        let mut tokens = self
+            .tokens
+            .write()
+            .map_err(|_| IsrTokenStoreError::Poisoned)?;
+        let matches = tokens.get(sm_id).is_some_and(|current| {
+            current.mechanism == issued.mechanism
+                && bool::from(current.token.as_bytes().ct_eq(issued.token.as_bytes()))
+        });
+        if matches {
+            tokens.remove(sm_id);
+        }
+        Ok(matches)
     }
 
     async fn consume(
@@ -315,5 +344,28 @@ mod tests {
             .await
             .expect("consume");
         assert_eq!(outcome, IsrConsumeOutcome::Mismatched);
+    }
+
+    #[tokio::test]
+    async fn provisional_revoke_is_exact_and_cannot_delete_a_newer_issue() {
+        let store = InMemoryIsrTokenStore::new();
+        let old = store.issue("sm-1", "PLAIN").await.expect("old issue");
+        let current = store.issue("sm-1", "PLAIN").await.expect("new issue");
+
+        assert!(!store
+            .revoke_if_current("sm-1", &old)
+            .await
+            .expect("stale revoke"));
+        assert!(store
+            .revoke_if_current("sm-1", &current)
+            .await
+            .expect("exact revoke"));
+        assert_eq!(
+            store
+                .consume("sm-1", current.token.as_bytes(), "PLAIN", &fence())
+                .await
+                .expect("lookup after revoke"),
+            IsrConsumeOutcome::NoSuchToken
+        );
     }
 }

--- a/server/crates/waddle-xmpp/src/isr/store.rs
+++ b/server/crates/waddle-xmpp/src/isr/store.rs
@@ -21,6 +21,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use async_trait::async_trait;
 use subtle::ConstantTimeEq;
 
+use crate::pending_delivery::SmSessionId;
 use crate::stream_management::persistence::SmClaimFence;
 
 /// A freshly issued or rotated ISR token (ADR-0017 Phase 3 Slice 8,
@@ -78,6 +79,21 @@ pub enum IsrConsumeOutcome {
     NoSuchToken,
 }
 
+/// Outcome of exact provisional-token revocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IsrRevokeOutcome {
+    /// The exact provisional issuance was present and removed.
+    Revoked,
+    /// A different issuance is present. The store retained an exact negative
+    /// fence for the provisional value, so a delayed write of that older
+    /// issuance cannot overwrite the current token.
+    Superseded,
+    /// No live row was visible. The store installed an exact negative fence
+    /// atomically with this observation, so a delayed matching write is
+    /// suppressed and consumes the fence instead of publishing a token.
+    Missing,
+}
+
 /// [`IsrTokenStore`] failures. Typed per the repo's typed-payloads hard
 /// rule — never a bare `String` masquerading as structured data.
 #[derive(Debug, thiserror::Error)]
@@ -127,9 +143,10 @@ struct IsrRevocationQueueState {
 
 struct IsrRevocationEntry {
     id: u64,
-    sm_id: String,
+    sm_id: SmSessionId,
     store: Arc<dyn IsrTokenStore>,
     issued: IssuedIsrToken,
+    runtime: tokio::runtime::Handle,
     state: IsrRevocationState,
 }
 
@@ -192,10 +209,11 @@ impl IsrRevocationQueue {
     /// token can be committed without retained cleanup responsibility.
     pub fn reserve(
         &self,
-        sm_id: String,
+        sm_id: SmSessionId,
         store: Arc<dyn IsrTokenStore>,
         issued: IssuedIsrToken,
     ) -> Option<IsrRevocationReservation> {
+        let runtime = tokio::runtime::Handle::try_current().ok()?;
         let mut state = self.inner.state.lock().ok()?;
         if state.entries.len() >= self.inner.capacity {
             return None;
@@ -209,6 +227,7 @@ impl IsrRevocationQueue {
             sm_id,
             store,
             issued,
+            runtime,
             state: IsrRevocationState::Reserved,
         });
         Some(IsrRevocationReservation {
@@ -242,25 +261,24 @@ impl IsrRevocationQueue {
     }
 
     fn start_worker(&self) {
-        let should_start = self.inner.state.lock().is_ok_and(|mut state| {
+        let runtime = self.inner.state.lock().ok().and_then(|mut state| {
             if state.worker_running
                 || !state
                     .entries
                     .iter()
                     .any(|entry| entry.state == IsrRevocationState::Active)
             {
-                return false;
+                return None;
             }
+            let runtime = state
+                .entries
+                .iter()
+                .find(|entry| entry.state == IsrRevocationState::Active)
+                .map(|entry| entry.runtime.clone())?;
             state.worker_running = true;
-            true
+            Some(runtime)
         });
-        if !should_start {
-            return;
-        }
-        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
-            if let Ok(mut state) = self.inner.state.lock() {
-                state.worker_running = false;
-            }
+        let Some(runtime) = runtime else {
             return;
         };
         let queue = self.clone();
@@ -268,7 +286,13 @@ impl IsrRevocationQueue {
     }
 
     fn schedule_worker_restart(&self) {
-        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+        let Some(runtime) = self.inner.state.lock().ok().and_then(|state| {
+            state
+                .entries
+                .iter()
+                .find(|entry| entry.state == IsrRevocationState::Active)
+                .map(|entry| entry.runtime.clone())
+        }) else {
             return;
         };
         let queue = self.clone();
@@ -403,7 +427,7 @@ pub trait IsrTokenStore: Send + Sync {
     /// backend outcome can be followed by [`Self::revoke_if_current`].
     async fn persist_issued(
         &self,
-        sm_id: &str,
+        sm_id: &SmSessionId,
         issued: &IssuedIsrToken,
     ) -> Result<(), IsrTokenStoreError>;
 
@@ -415,7 +439,7 @@ pub trait IsrTokenStore: Send + Sync {
     /// token; rotation is [`consume`](Self::consume)'s job.
     async fn issue(
         &self,
-        sm_id: &str,
+        sm_id: &SmSessionId,
         mechanism: &str,
     ) -> Result<IssuedIsrToken, IsrTokenStoreError> {
         let issued = IssuedIsrToken::new(mechanism);
@@ -426,36 +450,43 @@ pub trait IsrTokenStore: Send + Sync {
     /// Revoke a provisional issuance only if the row still contains the
     /// exact token and mechanism returned by [`Self::issue`]. A delayed
     /// cleanup must never delete a newer issuance or a token rotated by a
-    /// successful resume. Returns whether this exact issuance was removed.
+    /// successful resume. Implementations MUST atomically retain an exact
+    /// negative fence for `issued` when the live value is missing or
+    /// superseded. A later [`Self::persist_issued`] of that exact value MUST
+    /// consume the fence without publishing the token. This makes every
+    /// successful outcome terminal without mistaking temporary absence for
+    /// proof that a timed-out write cannot commit.
     async fn revoke_if_current(
         &self,
-        sm_id: &str,
+        sm_id: &SmSessionId,
         issued: &IssuedIsrToken,
-    ) -> Result<bool, IsrTokenStoreError>;
+    ) -> Result<IsrRevokeOutcome, IsrTokenStoreError>;
 
     /// Fenced, single-use, constant-time consume. See the trait-level doc
     /// for the locked spec this must implement exactly.
     async fn consume(
         &self,
-        sm_id: &str,
+        sm_id: &SmSessionId,
         presented_token: &[u8],
         mechanism: &str,
         fence: &SmClaimFence,
     ) -> Result<IsrConsumeOutcome, IsrTokenStoreError>;
 
     /// Council-adjudicated FIX 4 (ADR-0017 Phase 3 Slice 8): reap token
-    /// rows older than `max_age`. A row is minted per `<isr-enable/>` and
+    /// rows older than `max_age`, together with exact negative revocation
+    /// fences older than the same bound. A row is minted per `<isr-enable/>` and
     /// is never reaped by the ordinary [`consume`](Self::consume) path
     /// alone — a token issued but never resumed (or whose SM session is
     /// later expired/reaped by some other path with no cascade hook back
     /// to this store) would otherwise sit in `clustering_isr_tokens`
-    /// forever. Returns the number of rows deleted.
+    /// forever. Returns the number of live token rows deleted; maintenance of
+    /// expired negative fences is intentionally not included in that count.
     ///
     /// [`InMemoryIsrTokenStore`]'s implementation is a no-op returning `0`:
     /// per this module's own doc comment it is never advertised/exercised
     /// in production (ISR requires `clustering.enabled && Postgres`), so
     /// nothing ever accumulates there worth sweeping, and it tracks no
-    /// issuance timestamp to sweep by in the first place.
+    /// issuance/fence timestamp to sweep by in the first place.
     async fn sweep_expired(&self, max_age: std::time::Duration) -> Result<u64, IsrTokenStoreError>;
 }
 
@@ -464,7 +495,13 @@ pub trait IsrTokenStore: Send + Sync {
 /// kept for trait-contract symmetry and unit testing only.
 #[derive(Debug, Default)]
 pub struct InMemoryIsrTokenStore {
-    tokens: RwLock<HashMap<String, IssuedIsrToken>>,
+    state: RwLock<InMemoryIsrTokenState>,
+}
+
+#[derive(Debug, Default)]
+struct InMemoryIsrTokenState {
+    tokens: HashMap<SmSessionId, IssuedIsrToken>,
+    revocation_fences: HashMap<SmSessionId, Vec<IssuedIsrToken>>,
 }
 
 impl InMemoryIsrTokenStore {
@@ -482,39 +519,63 @@ impl IsrTokenStore for InMemoryIsrTokenStore {
 
     async fn persist_issued(
         &self,
-        sm_id: &str,
+        sm_id: &SmSessionId,
         issued: &IssuedIsrToken,
     ) -> Result<(), IsrTokenStoreError> {
-        let mut tokens = self
-            .tokens
+        let mut state = self
+            .state
             .write()
             .map_err(|_| IsrTokenStoreError::Poisoned)?;
-        tokens.insert(sm_id.to_string(), issued.clone());
+        if let Some(fences) = state.revocation_fences.get_mut(sm_id) {
+            if let Some(index) = fences.iter().position(|fenced| {
+                fenced.mechanism == issued.mechanism
+                    && bool::from(fenced.token.as_bytes().ct_eq(issued.token.as_bytes()))
+            }) {
+                fences.remove(index);
+                if fences.is_empty() {
+                    state.revocation_fences.remove(sm_id);
+                }
+                return Ok(());
+            }
+        }
+        state.tokens.insert(sm_id.clone(), issued.clone());
         Ok(())
     }
 
     async fn revoke_if_current(
         &self,
-        sm_id: &str,
+        sm_id: &SmSessionId,
         issued: &IssuedIsrToken,
-    ) -> Result<bool, IsrTokenStoreError> {
-        let mut tokens = self
-            .tokens
+    ) -> Result<IsrRevokeOutcome, IsrTokenStoreError> {
+        let mut state = self
+            .state
             .write()
             .map_err(|_| IsrTokenStoreError::Poisoned)?;
-        let matches = tokens.get(sm_id).is_some_and(|current| {
+        let matches = state.tokens.get(sm_id).is_some_and(|current| {
             current.mechanism == issued.mechanism
                 && bool::from(current.token.as_bytes().ct_eq(issued.token.as_bytes()))
         });
-        if matches {
-            tokens.remove(sm_id);
+        let outcome = if matches {
+            state.tokens.remove(sm_id);
+            IsrRevokeOutcome::Revoked
+        } else if state.tokens.contains_key(sm_id) {
+            IsrRevokeOutcome::Superseded
+        } else {
+            IsrRevokeOutcome::Missing
+        };
+        let fences = state.revocation_fences.entry(sm_id.clone()).or_default();
+        if !fences.iter().any(|fenced| {
+            fenced.mechanism == issued.mechanism
+                && bool::from(fenced.token.as_bytes().ct_eq(issued.token.as_bytes()))
+        }) {
+            fences.push(issued.clone());
         }
-        Ok(matches)
+        Ok(outcome)
     }
 
     async fn consume(
         &self,
-        sm_id: &str,
+        sm_id: &SmSessionId,
         presented_token: &[u8],
         mechanism: &str,
         // No node-liveness table exists for the single-node case (mirrors
@@ -522,15 +583,15 @@ impl IsrTokenStore for InMemoryIsrTokenStore {
         // so fencing is a no-op here rather than a meaningful check.
         _fence: &SmClaimFence,
     ) -> Result<IsrConsumeOutcome, IsrTokenStoreError> {
-        let mut tokens = self
-            .tokens
+        let mut state = self
+            .state
             .write()
             .map_err(|_| IsrTokenStoreError::Poisoned)?;
         // Council-adjudicated FIX 1/FIX 3: distinguish "no row at all"
         // (never opted in / already consumed) from "a row existed but
         // didn't match" (genuine wrong-token attempt) — mirroring
         // `PostgresIsrTokenStore::consume`'s same guard.
-        let Some(stored) = tokens.remove(sm_id) else {
+        let Some(stored) = state.tokens.remove(sm_id) else {
             return Ok(IsrConsumeOutcome::NoSuchToken);
         };
         // Constant-time comparison (ADR-0017 Phase 3 Slice 8, element 10):
@@ -544,7 +605,7 @@ impl IsrTokenStore for InMemoryIsrTokenStore {
             return Ok(IsrConsumeOutcome::Mismatched);
         }
         let rotated = IssuedIsrToken::new(mechanism);
-        tokens.insert(sm_id.to_string(), rotated.clone());
+        state.tokens.insert(sm_id.clone(), rotated.clone());
         Ok(IsrConsumeOutcome::Matched { rotated })
     }
 
@@ -575,6 +636,63 @@ mod tests {
         revoked: tokio::sync::Notify,
     }
 
+    struct DelayedVisibilityStore {
+        inner: InMemoryIsrTokenStore,
+        attempts: std::sync::atomic::AtomicUsize,
+        observed_missing: tokio::sync::Notify,
+        revoked: tokio::sync::Notify,
+    }
+
+    #[async_trait]
+    impl IsrTokenStore for DelayedVisibilityStore {
+        async fn ensure_schema(&self) -> Result<(), IsrTokenStoreError> {
+            self.inner.ensure_schema().await
+        }
+
+        async fn persist_issued(
+            &self,
+            sm_id: &SmSessionId,
+            issued: &IssuedIsrToken,
+        ) -> Result<(), IsrTokenStoreError> {
+            self.inner.persist_issued(sm_id, issued).await
+        }
+
+        async fn revoke_if_current(
+            &self,
+            sm_id: &SmSessionId,
+            issued: &IssuedIsrToken,
+        ) -> Result<IsrRevokeOutcome, IsrTokenStoreError> {
+            self.attempts
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let outcome = self.inner.revoke_if_current(sm_id, issued).await?;
+            match outcome {
+                IsrRevokeOutcome::Missing => self.observed_missing.notify_one(),
+                IsrRevokeOutcome::Revoked => self.revoked.notify_one(),
+                IsrRevokeOutcome::Superseded => {}
+            }
+            Ok(outcome)
+        }
+
+        async fn consume(
+            &self,
+            sm_id: &SmSessionId,
+            presented_token: &[u8],
+            mechanism: &str,
+            fence: &SmClaimFence,
+        ) -> Result<IsrConsumeOutcome, IsrTokenStoreError> {
+            self.inner
+                .consume(sm_id, presented_token, mechanism, fence)
+                .await
+        }
+
+        async fn sweep_expired(
+            &self,
+            max_age: std::time::Duration,
+        ) -> Result<u64, IsrTokenStoreError> {
+            self.inner.sweep_expired(max_age).await
+        }
+    }
+
     #[async_trait]
     impl IsrTokenStore for PanicFirstRevokeStore {
         async fn ensure_schema(&self) -> Result<(), IsrTokenStoreError> {
@@ -583,7 +701,7 @@ mod tests {
 
         async fn persist_issued(
             &self,
-            sm_id: &str,
+            sm_id: &SmSessionId,
             issued: &IssuedIsrToken,
         ) -> Result<(), IsrTokenStoreError> {
             self.inner.persist_issued(sm_id, issued).await
@@ -591,9 +709,9 @@ mod tests {
 
         async fn revoke_if_current(
             &self,
-            sm_id: &str,
+            sm_id: &SmSessionId,
             issued: &IssuedIsrToken,
-        ) -> Result<bool, IsrTokenStoreError> {
+        ) -> Result<IsrRevokeOutcome, IsrTokenStoreError> {
             if self
                 .attempts
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
@@ -608,7 +726,7 @@ mod tests {
 
         async fn consume(
             &self,
-            sm_id: &str,
+            sm_id: &SmSessionId,
             presented_token: &[u8],
             mechanism: &str,
             fence: &SmClaimFence,
@@ -634,7 +752,7 @@ mod tests {
 
         async fn persist_issued(
             &self,
-            sm_id: &str,
+            sm_id: &SmSessionId,
             issued: &IssuedIsrToken,
         ) -> Result<(), IsrTokenStoreError> {
             self.inner.persist_issued(sm_id, issued).await
@@ -642,9 +760,9 @@ mod tests {
 
         async fn revoke_if_current(
             &self,
-            sm_id: &str,
+            sm_id: &SmSessionId,
             issued: &IssuedIsrToken,
-        ) -> Result<bool, IsrTokenStoreError> {
+        ) -> Result<IsrRevokeOutcome, IsrTokenStoreError> {
             if self
                 .attempts
                 .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
@@ -661,7 +779,7 @@ mod tests {
 
         async fn consume(
             &self,
-            sm_id: &str,
+            sm_id: &SmSessionId,
             presented_token: &[u8],
             mechanism: &str,
             fence: &SmClaimFence,
@@ -686,12 +804,17 @@ mod tests {
         )
     }
 
+    fn sid(value: &str) -> SmSessionId {
+        SmSessionId::new(value)
+    }
+
     #[tokio::test]
     async fn issue_then_consume_with_matching_token_rotates() {
         let store = InMemoryIsrTokenStore::new();
-        let issued = store.issue("sm-1", "PLAIN").await.expect("issue");
+        let stream_id = sid("sm-1");
+        let issued = store.issue(&stream_id, "PLAIN").await.expect("issue");
         let outcome = store
-            .consume("sm-1", issued.token.as_bytes(), "PLAIN", &fence())
+            .consume(&stream_id, issued.token.as_bytes(), "PLAIN", &fence())
             .await
             .expect("consume");
         let IsrConsumeOutcome::Matched { rotated } = outcome else {
@@ -703,9 +826,10 @@ mod tests {
     #[tokio::test]
     async fn consume_with_wrong_token_is_mismatched_and_destroys_the_row() {
         let store = InMemoryIsrTokenStore::new();
-        let issued = store.issue("sm-1", "PLAIN").await.expect("issue");
+        let stream_id = sid("sm-1");
+        let issued = store.issue(&stream_id, "PLAIN").await.expect("issue");
         let outcome = store
-            .consume("sm-1", b"not-the-token", "PLAIN", &fence())
+            .consume(&stream_id, b"not-the-token", "PLAIN", &fence())
             .await
             .expect("consume");
         assert_eq!(outcome, IsrConsumeOutcome::Mismatched);
@@ -714,7 +838,7 @@ mod tests {
         // (correct) token now finds no row at all (FIX 3: distinct from
         // the genuine-mismatch outcome above), proving destruction happened.
         let second = store
-            .consume("sm-1", issued.token.as_bytes(), "PLAIN", &fence())
+            .consume(&stream_id, issued.token.as_bytes(), "PLAIN", &fence())
             .await
             .expect("consume");
         assert_eq!(second, IsrConsumeOutcome::NoSuchToken);
@@ -723,9 +847,10 @@ mod tests {
     #[tokio::test]
     async fn consume_is_single_use() {
         let store = InMemoryIsrTokenStore::new();
-        let issued = store.issue("sm-1", "PLAIN").await.expect("issue");
+        let stream_id = sid("sm-1");
+        let issued = store.issue(&stream_id, "PLAIN").await.expect("issue");
         let first = store
-            .consume("sm-1", issued.token.as_bytes(), "PLAIN", &fence())
+            .consume(&stream_id, issued.token.as_bytes(), "PLAIN", &fence())
             .await
             .expect("consume");
         assert!(matches!(first, IsrConsumeOutcome::Matched { .. }));
@@ -734,7 +859,7 @@ mod tests {
         // exists under the same sm_id — a genuine mismatch (a row DOES
         // exist), not `NoSuchToken`.
         let replay = store
-            .consume("sm-1", issued.token.as_bytes(), "PLAIN", &fence())
+            .consume(&stream_id, issued.token.as_bytes(), "PLAIN", &fence())
             .await
             .expect("consume");
         assert_eq!(replay, IsrConsumeOutcome::Mismatched);
@@ -744,7 +869,7 @@ mod tests {
     async fn consume_with_no_issued_token_is_no_such_token() {
         let store = InMemoryIsrTokenStore::new();
         let outcome = store
-            .consume("no-such-sm-id", b"anything", "PLAIN", &fence())
+            .consume(&sid("no-such-sm-id"), b"anything", "PLAIN", &fence())
             .await
             .expect("consume");
         assert_eq!(outcome, IsrConsumeOutcome::NoSuchToken);
@@ -753,9 +878,15 @@ mod tests {
     #[tokio::test]
     async fn consume_pins_the_mechanism() {
         let store = InMemoryIsrTokenStore::new();
-        let issued = store.issue("sm-1", "PLAIN").await.expect("issue");
+        let stream_id = sid("sm-1");
+        let issued = store.issue(&stream_id, "PLAIN").await.expect("issue");
         let outcome = store
-            .consume("sm-1", issued.token.as_bytes(), "SCRAM-SHA-256", &fence())
+            .consume(
+                &stream_id,
+                issued.token.as_bytes(),
+                "SCRAM-SHA-256",
+                &fence(),
+            )
             .await
             .expect("consume");
         assert_eq!(outcome, IsrConsumeOutcome::Mismatched);
@@ -764,24 +895,91 @@ mod tests {
     #[tokio::test]
     async fn provisional_revoke_is_exact_and_cannot_delete_a_newer_issue() {
         let store = InMemoryIsrTokenStore::new();
-        let old = store.issue("sm-1", "PLAIN").await.expect("old issue");
-        let current = store.issue("sm-1", "PLAIN").await.expect("new issue");
+        let stream_id = sid("sm-1");
+        let old = store.issue(&stream_id, "PLAIN").await.expect("old issue");
+        let current = store.issue(&stream_id, "PLAIN").await.expect("new issue");
 
-        assert!(!store
-            .revoke_if_current("sm-1", &old)
-            .await
-            .expect("stale revoke"));
-        assert!(store
-            .revoke_if_current("sm-1", &current)
-            .await
-            .expect("exact revoke"));
         assert_eq!(
             store
-                .consume("sm-1", current.token.as_bytes(), "PLAIN", &fence())
+                .revoke_if_current(&stream_id, &old)
+                .await
+                .expect("stale revoke"),
+            IsrRevokeOutcome::Superseded
+        );
+        store
+            .persist_issued(&stream_id, &old)
+            .await
+            .expect("late old persistence is suppressed by its exact fence");
+        assert_eq!(
+            store
+                .revoke_if_current(&stream_id, &current)
+                .await
+                .expect("exact revoke"),
+            IsrRevokeOutcome::Revoked
+        );
+        assert_eq!(
+            store
+                .consume(&stream_id, current.token.as_bytes(), "PLAIN", &fence(),)
                 .await
                 .expect("lookup after revoke"),
             IsrConsumeOutcome::NoSuchToken
         );
+    }
+
+    #[tokio::test]
+    async fn revocation_queue_fences_missing_before_a_late_persist_becomes_visible() {
+        let store = Arc::new(DelayedVisibilityStore {
+            inner: InMemoryIsrTokenStore::new(),
+            attempts: std::sync::atomic::AtomicUsize::new(0),
+            observed_missing: tokio::sync::Notify::new(),
+            revoked: tokio::sync::Notify::new(),
+        });
+        let stream_id = sid("sm-late-persist");
+        let issued = IssuedIsrToken::new("PLAIN");
+        let queue = IsrRevocationQueue::with_capacity(1);
+        let dyn_store: Arc<dyn IsrTokenStore> = store.clone();
+        let reservation = queue
+            .reserve(stream_id.clone(), dyn_store.clone(), issued.clone())
+            .expect("reserve cleanup capacity");
+        let observed_missing = store.observed_missing.notified();
+
+        // Model a timed-out persistence future whose database write is not
+        // visible when cancellation cleanup first runs.
+        drop(reservation);
+        tokio::time::timeout(std::time::Duration::from_secs(1), observed_missing)
+            .await
+            .expect("cleanup first observes a missing row");
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while queue.pending_len() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("negative fence makes Missing terminal without leaking capacity");
+
+        store
+            .persist_issued(&stream_id, &issued)
+            .await
+            .expect("late persistence reaches the negative fence");
+        assert_eq!(
+            store
+                .consume(&stream_id, issued.token.as_bytes(), "PLAIN", &fence())
+                .await
+                .expect("lookup after suppressed late persistence"),
+            IsrConsumeOutcome::NoSuchToken
+        );
+
+        assert_eq!(store.attempts.load(std::sync::atomic::Ordering::SeqCst), 1);
+        assert_eq!(queue.pending_len(), 0);
+
+        let next = queue
+            .reserve(
+                sid("sm-after-definite-failure"),
+                dyn_store,
+                IssuedIsrToken::new("PLAIN"),
+            )
+            .expect("definite missing persistence releases bounded capacity");
+        next.disarm();
     }
 
     #[tokio::test]
@@ -792,14 +990,15 @@ mod tests {
             revoked: tokio::sync::Notify::new(),
         });
         let issued = IssuedIsrToken::new("PLAIN");
+        let stream_id = sid("sm-retry");
         store
-            .persist_issued("sm-retry", &issued)
+            .persist_issued(&stream_id, &issued)
             .await
             .expect("persist provisional token");
         let queue = IsrRevocationQueue::with_capacity(1);
         let dyn_store: Arc<dyn IsrTokenStore> = store.clone();
         let reservation = queue
-            .reserve("sm-retry".to_string(), dyn_store, issued)
+            .reserve(stream_id, dyn_store, issued)
             .expect("reserve cleanup capacity");
         let revoked = store.revoked.notified();
 
@@ -820,14 +1019,15 @@ mod tests {
             revoked: tokio::sync::Notify::new(),
         });
         let issued = IssuedIsrToken::new("PLAIN");
+        let stream_id = sid("sm-panic");
         store
-            .persist_issued("sm-panic", &issued)
+            .persist_issued(&stream_id, &issued)
             .await
             .expect("persist provisional token");
         let queue = IsrRevocationQueue::with_capacity(1);
         let dyn_store: Arc<dyn IsrTokenStore> = store.clone();
         let reservation = queue
-            .reserve("sm-panic".to_string(), dyn_store, issued)
+            .reserve(stream_id, dyn_store, issued)
             .expect("reserve cleanup capacity");
         let revoked = store.revoked.notified();
 
@@ -845,17 +1045,51 @@ mod tests {
         let queue = IsrRevocationQueue::with_capacity(1);
         let store: Arc<dyn IsrTokenStore> = Arc::new(InMemoryIsrTokenStore::new());
         let reservation = queue
-            .reserve(
-                "sm-one".to_string(),
-                store.clone(),
-                IssuedIsrToken::new("PLAIN"),
-            )
+            .reserve(sid("sm-one"), store.clone(), IssuedIsrToken::new("PLAIN"))
             .expect("first reservation");
 
         assert!(queue
-            .reserve("sm-two".to_string(), store, IssuedIsrToken::new("PLAIN"),)
+            .reserve(sid("sm-two"), store, IssuedIsrToken::new("PLAIN"),)
             .is_none());
         reservation.disarm();
+        assert_eq!(queue.pending_len(), 0);
+    }
+
+    #[test]
+    fn revocation_queue_uses_captured_runtime_when_reservation_drops_outside_it() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+        let store = Arc::new(FailFirstRevokeStore {
+            inner: InMemoryIsrTokenStore::new(),
+            attempts: std::sync::atomic::AtomicUsize::new(0),
+            revoked: tokio::sync::Notify::new(),
+        });
+        let queue = IsrRevocationQueue::with_capacity(1);
+        let reservation = runtime.block_on(async {
+            let issued = IssuedIsrToken::new("PLAIN");
+            let stream_id = sid("sm-outside-runtime-drop");
+            store
+                .persist_issued(&stream_id, &issued)
+                .await
+                .expect("persist provisional token");
+            let dyn_store: Arc<dyn IsrTokenStore> = store.clone();
+            queue
+                .reserve(stream_id, dyn_store, issued)
+                .expect("reserve cleanup capacity")
+        });
+
+        // There is deliberately no entered Tokio context on this thread.
+        // The reservation must reuse the handle captured by `reserve`.
+        drop(reservation);
+
+        runtime.block_on(async {
+            tokio::time::timeout(std::time::Duration::from_secs(1), store.revoked.notified())
+                .await
+                .expect("captured runtime completes exact revocation");
+        });
+        assert_eq!(store.attempts.load(std::sync::atomic::Ordering::SeqCst), 2);
         assert_eq!(queue.pending_len(), 0);
     }
 }

--- a/server/crates/waddle-xmpp/src/isr/store.rs
+++ b/server/crates/waddle-xmpp/src/isr/store.rs
@@ -214,27 +214,38 @@ impl IsrRevocationQueue {
         issued: IssuedIsrToken,
     ) -> Option<IsrRevocationReservation> {
         let runtime = tokio::runtime::Handle::try_current().ok()?;
-        let mut state = self.inner.state.lock().ok()?;
-        if state.entries.len() >= self.inner.capacity {
-            return None;
-        }
-        let id = self
-            .inner
-            .next_id
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        state.entries.push_back(IsrRevocationEntry {
-            id,
-            sm_id,
-            store,
-            issued,
-            runtime,
-            state: IsrRevocationState::Reserved,
-        });
-        Some(IsrRevocationReservation {
-            queue: self.clone(),
-            id,
-            armed: true,
-        })
+        let reservation = {
+            let mut state = self.inner.state.lock().ok()?;
+            // A reservation can outlive the runtime on which it was created.
+            // Any later live caller lends its runtime to retained active work
+            // before capacity is checked, so a full queue can still recover.
+            for entry in &mut state.entries {
+                entry.runtime = runtime.clone();
+            }
+            if state.entries.len() >= self.inner.capacity {
+                None
+            } else {
+                let id = self
+                    .inner
+                    .next_id
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                state.entries.push_back(IsrRevocationEntry {
+                    id,
+                    sm_id,
+                    store,
+                    issued,
+                    runtime,
+                    state: IsrRevocationState::Reserved,
+                });
+                Some(IsrRevocationReservation {
+                    queue: self.clone(),
+                    id,
+                    armed: true,
+                })
+            }
+        };
+        self.start_worker();
+        reservation
     }
 
     pub fn pending_len(&self) -> usize {
@@ -282,7 +293,14 @@ impl IsrRevocationQueue {
             return;
         };
         let queue = self.clone();
-        runtime.spawn(async move { queue.run_worker().await });
+        // Construct the guard before task admission. If the captured runtime
+        // has already shut down, Tokio drops the never-polled future and this
+        // guard resets `worker_running` instead of permanently wedging it.
+        let guard = IsrRevocationWorkerGuard {
+            queue: self.clone(),
+            armed: true,
+        };
+        runtime.spawn(async move { queue.run_worker(guard).await });
     }
 
     fn schedule_worker_restart(&self) {
@@ -302,11 +320,7 @@ impl IsrRevocationQueue {
         });
     }
 
-    async fn run_worker(self) {
-        let mut guard = IsrRevocationWorkerGuard {
-            queue: self.clone(),
-            armed: true,
-        };
+    async fn run_worker(self, mut guard: IsrRevocationWorkerGuard) {
         loop {
             let work = self.inner.state.lock().ok().and_then(|mut state| {
                 let Some(entry) = state
@@ -641,6 +655,65 @@ mod tests {
         attempts: std::sync::atomic::AtomicUsize,
         observed_missing: tokio::sync::Notify,
         revoked: tokio::sync::Notify,
+    }
+
+    struct HangFirstRevokeStore {
+        inner: InMemoryIsrTokenStore,
+        attempts: std::sync::atomic::AtomicUsize,
+        first_attempt_entered: std::sync::Barrier,
+        revoked: tokio::sync::Notify,
+    }
+
+    #[async_trait]
+    impl IsrTokenStore for HangFirstRevokeStore {
+        async fn ensure_schema(&self) -> Result<(), IsrTokenStoreError> {
+            self.inner.ensure_schema().await
+        }
+
+        async fn persist_issued(
+            &self,
+            sm_id: &SmSessionId,
+            issued: &IssuedIsrToken,
+        ) -> Result<(), IsrTokenStoreError> {
+            self.inner.persist_issued(sm_id, issued).await
+        }
+
+        async fn revoke_if_current(
+            &self,
+            sm_id: &SmSessionId,
+            issued: &IssuedIsrToken,
+        ) -> Result<IsrRevokeOutcome, IsrTokenStoreError> {
+            if self
+                .attempts
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                == 0
+            {
+                self.first_attempt_entered.wait();
+                return std::future::pending().await;
+            }
+            let revoked = self.inner.revoke_if_current(sm_id, issued).await?;
+            self.revoked.notify_one();
+            Ok(revoked)
+        }
+
+        async fn consume(
+            &self,
+            sm_id: &SmSessionId,
+            presented_token: &[u8],
+            mechanism: &str,
+            fence: &SmClaimFence,
+        ) -> Result<IsrConsumeOutcome, IsrTokenStoreError> {
+            self.inner
+                .consume(sm_id, presented_token, mechanism, fence)
+                .await
+        }
+
+        async fn sweep_expired(
+            &self,
+            max_age: std::time::Duration,
+        ) -> Result<u64, IsrTokenStoreError> {
+            self.inner.sweep_expired(max_age).await
+        }
     }
 
     #[async_trait]
@@ -1088,6 +1161,121 @@ mod tests {
             tokio::time::timeout(std::time::Duration::from_secs(1), store.revoked.notified())
                 .await
                 .expect("captured runtime completes exact revocation");
+        });
+        assert_eq!(store.attempts.load(std::sync::atomic::Ordering::SeqCst), 2);
+        assert_eq!(queue.pending_len(), 0);
+    }
+
+    #[test]
+    fn revocation_queue_recovers_when_the_captured_runtime_has_shut_down() {
+        let runtime_a = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build first runtime");
+        let store = Arc::new(FailFirstRevokeStore {
+            inner: InMemoryIsrTokenStore::new(),
+            attempts: std::sync::atomic::AtomicUsize::new(0),
+            revoked: tokio::sync::Notify::new(),
+        });
+        let queue = IsrRevocationQueue::with_capacity(1);
+        let reservation = runtime_a.block_on(async {
+            let issued = IssuedIsrToken::new("PLAIN");
+            let stream_id = sid("sm-dead-runtime");
+            store
+                .persist_issued(&stream_id, &issued)
+                .await
+                .expect("persist provisional token");
+            let dyn_store: Arc<dyn IsrTokenStore> = store.clone();
+            queue
+                .reserve(stream_id, dyn_store, issued)
+                .expect("reserve cleanup capacity")
+        });
+        drop(runtime_a);
+
+        // Activating outside any runtime first tries the now-dead captured
+        // handle. Its never-polled worker must not leave `worker_running` set.
+        drop(reservation);
+        assert_eq!(queue.pending_len(), 1);
+
+        let runtime_b = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build recovery runtime");
+        runtime_b.block_on(async {
+            let dyn_store: Arc<dyn IsrTokenStore> = store.clone();
+            assert!(queue
+                .reserve(
+                    sid("sm-capacity-probe"),
+                    dyn_store,
+                    IssuedIsrToken::new("PLAIN"),
+                )
+                .is_none());
+            tokio::time::timeout(std::time::Duration::from_secs(1), store.revoked.notified())
+                .await
+                .expect("later live runtime recovers retained cleanup");
+            assert_eq!(queue.pending_len(), 0);
+
+            let dyn_store: Arc<dyn IsrTokenStore> = store.clone();
+            queue
+                .reserve(
+                    sid("sm-after-recovery"),
+                    dyn_store,
+                    IssuedIsrToken::new("PLAIN"),
+                )
+                .expect("recovered queue releases capacity")
+                .disarm();
+        });
+    }
+
+    #[test]
+    fn revocation_queue_lends_a_live_runtime_to_in_flight_cleanup() {
+        let runtime_a = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("build first runtime");
+        let runtime_b = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build recovery runtime");
+        let store = Arc::new(HangFirstRevokeStore {
+            inner: InMemoryIsrTokenStore::new(),
+            attempts: std::sync::atomic::AtomicUsize::new(0),
+            first_attempt_entered: std::sync::Barrier::new(2),
+            revoked: tokio::sync::Notify::new(),
+        });
+        let queue = IsrRevocationQueue::with_capacity(1);
+        let reservation = runtime_a.block_on(async {
+            let issued = IssuedIsrToken::new("PLAIN");
+            let stream_id = sid("sm-in-flight-runtime-loss");
+            store
+                .persist_issued(&stream_id, &issued)
+                .await
+                .expect("persist provisional token");
+            let dyn_store: Arc<dyn IsrTokenStore> = store.clone();
+            queue
+                .reserve(stream_id, dyn_store, issued)
+                .expect("reserve cleanup capacity")
+        });
+        drop(reservation);
+        store.first_attempt_entered.wait();
+
+        runtime_b.block_on(async {
+            let dyn_store: Arc<dyn IsrTokenStore> = store.clone();
+            assert!(queue
+                .reserve(
+                    sid("sm-in-flight-capacity-probe"),
+                    dyn_store,
+                    IssuedIsrToken::new("PLAIN"),
+                )
+                .is_none());
+        });
+        runtime_a.shutdown_timeout(std::time::Duration::from_secs(1));
+
+        runtime_b.block_on(async {
+            tokio::time::timeout(std::time::Duration::from_secs(1), store.revoked.notified())
+                .await
+                .expect("in-flight cleanup restarts on the lent live runtime");
         });
         assert_eq!(store.attempts.load(std::sync::atomic::Ordering::SeqCst), 2);
         assert_eq!(queue.pending_len(), 0);

--- a/server/crates/waddle-xmpp/src/isr/store.rs
+++ b/server/crates/waddle-xmpp/src/isr/store.rs
@@ -15,8 +15,8 @@
 //! without a live Postgres instance, not because single-node ISR is a
 //! supported deployment shape.
 
-use std::collections::HashMap;
-use std::sync::RwLock;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex, RwLock};
 
 use async_trait::async_trait;
 use subtle::ConstantTimeEq;
@@ -30,6 +30,18 @@ use crate::stream_management::persistence::SmClaimFence;
 pub struct IssuedIsrToken {
     pub token: String,
     pub mechanism: String,
+}
+
+impl IssuedIsrToken {
+    /// Generate a fresh typed issuance before any fallible persistence await.
+    /// Keeping the exact value in the caller lets cancellation cleanup revoke
+    /// a write whose commit outcome became ambiguous.
+    pub fn new(mechanism: impl Into<String>) -> Self {
+        Self {
+            token: super::generate_isr_token(),
+            mechanism: mechanism.into(),
+        }
+    }
 }
 
 /// Outcome of a fenced [`IsrTokenStore::consume`] attempt.
@@ -89,6 +101,267 @@ pub enum IsrTokenStoreError {
     Poisoned,
 }
 
+const DEFAULT_REVOCATION_CAPACITY: usize = 128;
+const REVOCATION_ATTEMPT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+const REVOCATION_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Bounded process-local responsibility for exact provisional ISR-token
+/// revocation. Capacity is reserved before persistence starts; cancellation
+/// therefore cannot create committed cleanup work that has nowhere to live.
+#[derive(Clone)]
+pub struct IsrRevocationQueue {
+    inner: Arc<IsrRevocationQueueInner>,
+}
+
+struct IsrRevocationQueueInner {
+    state: Mutex<IsrRevocationQueueState>,
+    capacity: usize,
+    next_id: std::sync::atomic::AtomicU64,
+}
+
+#[derive(Default)]
+struct IsrRevocationQueueState {
+    entries: VecDeque<IsrRevocationEntry>,
+    worker_running: bool,
+}
+
+struct IsrRevocationEntry {
+    id: u64,
+    sm_id: String,
+    store: Arc<dyn IsrTokenStore>,
+    issued: IssuedIsrToken,
+    state: IsrRevocationState,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum IsrRevocationState {
+    Reserved,
+    Active,
+    InFlight,
+}
+
+/// A pre-persistence capacity reservation. Dropping an armed reservation
+/// activates exact cleanup; disarming it after the `<enabled/>` write removes
+/// the inventory entry because the token now belongs to the live SM session.
+pub struct IsrRevocationReservation {
+    queue: IsrRevocationQueue,
+    id: u64,
+    armed: bool,
+}
+
+impl Default for IsrRevocationQueue {
+    fn default() -> Self {
+        Self::with_capacity(DEFAULT_REVOCATION_CAPACITY)
+    }
+}
+
+/// Return the bounded revocation inventory associated with this exact store
+/// instance. Weak registry entries avoid extending a store's lifetime when it
+/// has no reserved or active cleanup work.
+pub fn revocation_queue_for_store(store: &Arc<dyn IsrTokenStore>) -> IsrRevocationQueue {
+    static QUEUES: std::sync::OnceLock<
+        Mutex<HashMap<usize, std::sync::Weak<IsrRevocationQueueInner>>>,
+    > = std::sync::OnceLock::new();
+    let key = Arc::as_ptr(store) as *const () as usize;
+    let queues = QUEUES.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut queues = queues
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    queues.retain(|_, queue| queue.strong_count() > 0);
+    if let Some(inner) = queues.get(&key).and_then(std::sync::Weak::upgrade) {
+        return IsrRevocationQueue { inner };
+    }
+    let queue = IsrRevocationQueue::default();
+    queues.insert(key, Arc::downgrade(&queue.inner));
+    queue
+}
+
+impl IsrRevocationQueue {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(IsrRevocationQueueInner {
+                state: Mutex::new(IsrRevocationQueueState::default()),
+                capacity,
+                next_id: std::sync::atomic::AtomicU64::new(1),
+            }),
+        }
+    }
+
+    /// Reserve cleanup capacity before persisting `issued`. Returns `None`
+    /// under backpressure, allowing the caller to reject enablement before a
+    /// token can be committed without retained cleanup responsibility.
+    pub fn reserve(
+        &self,
+        sm_id: String,
+        store: Arc<dyn IsrTokenStore>,
+        issued: IssuedIsrToken,
+    ) -> Option<IsrRevocationReservation> {
+        let mut state = self.inner.state.lock().ok()?;
+        if state.entries.len() >= self.inner.capacity {
+            return None;
+        }
+        let id = self
+            .inner
+            .next_id
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        state.entries.push_back(IsrRevocationEntry {
+            id,
+            sm_id,
+            store,
+            issued,
+            state: IsrRevocationState::Reserved,
+        });
+        Some(IsrRevocationReservation {
+            queue: self.clone(),
+            id,
+            armed: true,
+        })
+    }
+
+    pub fn pending_len(&self) -> usize {
+        self.inner
+            .state
+            .lock()
+            .map(|state| state.entries.len())
+            .unwrap_or(0)
+    }
+
+    fn remove(&self, id: u64) {
+        if let Ok(mut state) = self.inner.state.lock() {
+            state.entries.retain(|entry| entry.id != id);
+        }
+    }
+
+    fn activate(&self, id: u64) {
+        if let Ok(mut state) = self.inner.state.lock() {
+            if let Some(entry) = state.entries.iter_mut().find(|entry| entry.id == id) {
+                entry.state = IsrRevocationState::Active;
+            }
+        }
+        self.start_worker();
+    }
+
+    fn start_worker(&self) {
+        let should_start = self.inner.state.lock().is_ok_and(|mut state| {
+            if state.worker_running
+                || !state
+                    .entries
+                    .iter()
+                    .any(|entry| entry.state == IsrRevocationState::Active)
+            {
+                return false;
+            }
+            state.worker_running = true;
+            true
+        });
+        if !should_start {
+            return;
+        }
+        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+            if let Ok(mut state) = self.inner.state.lock() {
+                state.worker_running = false;
+            }
+            return;
+        };
+        let queue = self.clone();
+        runtime.spawn(async move { queue.run_worker().await });
+    }
+
+    async fn run_worker(self) {
+        let mut guard = IsrRevocationWorkerGuard {
+            queue: self.clone(),
+            armed: true,
+        };
+        loop {
+            let work = self.inner.state.lock().ok().and_then(|mut state| {
+                let Some(entry) = state
+                    .entries
+                    .iter_mut()
+                    .find(|entry| entry.state == IsrRevocationState::Active)
+                else {
+                    state.worker_running = false;
+                    return None;
+                };
+                entry.state = IsrRevocationState::InFlight;
+                Some((
+                    entry.id,
+                    entry.sm_id.clone(),
+                    Arc::clone(&entry.store),
+                    entry.issued.clone(),
+                ))
+            });
+            let Some((id, sm_id, store, issued)) = work else {
+                guard.disarm();
+                return;
+            };
+            let completed = matches!(
+                tokio::time::timeout(
+                    REVOCATION_ATTEMPT_TIMEOUT,
+                    store.revoke_if_current(&sm_id, &issued),
+                )
+                .await,
+                Ok(Ok(_))
+            );
+            if let Ok(mut state) = self.inner.state.lock() {
+                let Some(index) = state.entries.iter().position(|entry| entry.id == id) else {
+                    continue;
+                };
+                if completed {
+                    state.entries.remove(index);
+                } else if let Some(mut entry) = state.entries.remove(index) {
+                    entry.state = IsrRevocationState::Active;
+                    state.entries.push_back(entry);
+                }
+            }
+            if !completed {
+                tokio::time::sleep(REVOCATION_RETRY_DELAY).await;
+            }
+        }
+    }
+}
+
+impl IsrRevocationReservation {
+    pub fn disarm(mut self) {
+        self.queue.remove(self.id);
+        self.armed = false;
+    }
+}
+
+impl Drop for IsrRevocationReservation {
+    fn drop(&mut self) {
+        if self.armed {
+            self.queue.activate(self.id);
+        }
+    }
+}
+
+struct IsrRevocationWorkerGuard {
+    queue: IsrRevocationQueue,
+    armed: bool,
+}
+
+impl IsrRevocationWorkerGuard {
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for IsrRevocationWorkerGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        if let Ok(mut state) = self.queue.inner.state.lock() {
+            state.worker_running = false;
+            for entry in &mut state.entries {
+                if entry.state == IsrRevocationState::InFlight {
+                    entry.state = IsrRevocationState::Active;
+                }
+            }
+        }
+    }
+}
+
 /// Postgres-authoritative, epoch-fenced ISR token storage (ADR-0017 Phase 3
 /// Slice 8, element 10). See the module doc for the trait/impl split
 /// rationale.
@@ -105,6 +378,15 @@ pub trait IsrTokenStore: Send + Sync {
     /// Create the backing schema if it does not exist. Idempotent.
     async fn ensure_schema(&self) -> Result<(), IsrTokenStoreError>;
 
+    /// Persist the exact caller-generated issuance for `sm_id`. The caller
+    /// retains this value across the await so cancellation or an ambiguous
+    /// backend outcome can be followed by [`Self::revoke_if_current`].
+    async fn persist_issued(
+        &self,
+        sm_id: &str,
+        issued: &IssuedIsrToken,
+    ) -> Result<(), IsrTokenStoreError>;
+
     /// Mint and store a fresh token for `sm_id`, pinned to `mechanism`
     /// (XEP-0397's "mechanism pinning", element 10: the entities involved
     /// MUST only use or allow this mechanism when performing ISR with the
@@ -115,7 +397,11 @@ pub trait IsrTokenStore: Send + Sync {
         &self,
         sm_id: &str,
         mechanism: &str,
-    ) -> Result<IssuedIsrToken, IsrTokenStoreError>;
+    ) -> Result<IssuedIsrToken, IsrTokenStoreError> {
+        let issued = IssuedIsrToken::new(mechanism);
+        self.persist_issued(sm_id, &issued).await?;
+        Ok(issued)
+    }
 
     /// Revoke a provisional issuance only if the row still contains the
     /// exact token and mechanism returned by [`Self::issue`]. A delayed
@@ -174,21 +460,17 @@ impl IsrTokenStore for InMemoryIsrTokenStore {
         Ok(())
     }
 
-    async fn issue(
+    async fn persist_issued(
         &self,
         sm_id: &str,
-        mechanism: &str,
-    ) -> Result<IssuedIsrToken, IsrTokenStoreError> {
-        let issued = IssuedIsrToken {
-            token: super::generate_isr_token(),
-            mechanism: mechanism.to_string(),
-        };
+        issued: &IssuedIsrToken,
+    ) -> Result<(), IsrTokenStoreError> {
         let mut tokens = self
             .tokens
             .write()
             .map_err(|_| IsrTokenStoreError::Poisoned)?;
         tokens.insert(sm_id.to_string(), issued.clone());
-        Ok(issued)
+        Ok(())
     }
 
     async fn revoke_if_current(
@@ -241,10 +523,7 @@ impl IsrTokenStore for InMemoryIsrTokenStore {
             // XEP's anti-brute-force MUST.
             return Ok(IsrConsumeOutcome::Mismatched);
         }
-        let rotated = IssuedIsrToken {
-            token: super::generate_isr_token(),
-            mechanism: mechanism.to_string(),
-        };
+        let rotated = IssuedIsrToken::new(mechanism);
         tokens.insert(sm_id.to_string(), rotated.clone());
         Ok(IsrConsumeOutcome::Matched { rotated })
     }
@@ -263,6 +542,65 @@ impl IsrTokenStore for InMemoryIsrTokenStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    struct FailFirstRevokeStore {
+        inner: InMemoryIsrTokenStore,
+        attempts: std::sync::atomic::AtomicUsize,
+        revoked: tokio::sync::Notify,
+    }
+
+    #[async_trait]
+    impl IsrTokenStore for FailFirstRevokeStore {
+        async fn ensure_schema(&self) -> Result<(), IsrTokenStoreError> {
+            self.inner.ensure_schema().await
+        }
+
+        async fn persist_issued(
+            &self,
+            sm_id: &str,
+            issued: &IssuedIsrToken,
+        ) -> Result<(), IsrTokenStoreError> {
+            self.inner.persist_issued(sm_id, issued).await
+        }
+
+        async fn revoke_if_current(
+            &self,
+            sm_id: &str,
+            issued: &IssuedIsrToken,
+        ) -> Result<bool, IsrTokenStoreError> {
+            if self
+                .attempts
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+                == 0
+            {
+                return Err(IsrTokenStoreError::Backend(
+                    "injected first revoke failure".to_string(),
+                ));
+            }
+            let revoked = self.inner.revoke_if_current(sm_id, issued).await?;
+            self.revoked.notify_one();
+            Ok(revoked)
+        }
+
+        async fn consume(
+            &self,
+            sm_id: &str,
+            presented_token: &[u8],
+            mechanism: &str,
+            fence: &SmClaimFence,
+        ) -> Result<IsrConsumeOutcome, IsrTokenStoreError> {
+            self.inner
+                .consume(sm_id, presented_token, mechanism, fence)
+                .await
+        }
+
+        async fn sweep_expired(
+            &self,
+            max_age: std::time::Duration,
+        ) -> Result<u64, IsrTokenStoreError> {
+            self.inner.sweep_expired(max_age).await
+        }
+    }
 
     fn fence() -> SmClaimFence {
         SmClaimFence::new(
@@ -367,5 +705,52 @@ mod tests {
                 .expect("lookup after revoke"),
             IsrConsumeOutcome::NoSuchToken
         );
+    }
+
+    #[tokio::test]
+    async fn revocation_queue_retries_an_exact_issuance_after_transient_failure() {
+        let store = Arc::new(FailFirstRevokeStore {
+            inner: InMemoryIsrTokenStore::new(),
+            attempts: std::sync::atomic::AtomicUsize::new(0),
+            revoked: tokio::sync::Notify::new(),
+        });
+        let issued = IssuedIsrToken::new("PLAIN");
+        store
+            .persist_issued("sm-retry", &issued)
+            .await
+            .expect("persist provisional token");
+        let queue = IsrRevocationQueue::with_capacity(1);
+        let dyn_store: Arc<dyn IsrTokenStore> = store.clone();
+        let reservation = queue
+            .reserve("sm-retry".to_string(), dyn_store, issued)
+            .expect("reserve cleanup capacity");
+        let revoked = store.revoked.notified();
+
+        drop(reservation);
+        tokio::time::timeout(std::time::Duration::from_secs(1), revoked)
+            .await
+            .expect("second revoke succeeds after first failure");
+
+        assert_eq!(store.attempts.load(std::sync::atomic::Ordering::SeqCst), 2);
+        assert_eq!(queue.pending_len(), 0);
+    }
+
+    #[tokio::test]
+    async fn revocation_queue_reserves_capacity_before_persistence() {
+        let queue = IsrRevocationQueue::with_capacity(1);
+        let store: Arc<dyn IsrTokenStore> = Arc::new(InMemoryIsrTokenStore::new());
+        let reservation = queue
+            .reserve(
+                "sm-one".to_string(),
+                store.clone(),
+                IssuedIsrToken::new("PLAIN"),
+            )
+            .expect("first reservation");
+
+        assert!(queue
+            .reserve("sm-two".to_string(), store, IssuedIsrToken::new("PLAIN"),)
+            .is_none());
+        reservation.disarm();
+        assert_eq!(queue.pending_len(), 0);
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -1990,6 +1990,77 @@ impl kameo::message::Message<ListRooms> for RoomRegistryActor {
     }
 }
 
+/// List live or terminal-release room claims belonging to one exact owner.
+pub struct ListRoomsOwnedBy {
+    pub owner: NodeIdentity,
+}
+
+/// Hard-kill and forget a room only while its live entry still belongs to
+/// `owner`. The comparison and mutation share the registry mailbox turn, so
+/// a fresh same-JID replacement cannot be demoted by a stale owner sweep.
+pub struct DemoteRoomIfOwner {
+    pub room_jid: BareJid,
+    pub owner: NodeIdentity,
+}
+
+impl kameo::message::Message<DemoteRoomIfOwner> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: DemoteRoomIfOwner,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let matches = self
+            .rooms
+            .get(&msg.room_jid)
+            .is_some_and(|entry| entry.claim_fence.owner() == msg.owner);
+        if !matches {
+            return false;
+        }
+        let Some(entry) = self.rooms.remove(&msg.room_jid) else {
+            return false;
+        };
+        entry.actor_ref.kill();
+        if let Some(store) = &self.durable_store {
+            store.forget_claim_fence(&msg.room_jid, &entry.claim_fence);
+        }
+        true
+    }
+}
+
+impl kameo::message::Message<ListRoomsOwnedBy> for RoomRegistryActor {
+    type Reply = Result<Vec<BareJid>, RoomRegistryError>;
+
+    async fn handle(
+        &mut self,
+        msg: ListRoomsOwnedBy,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let mut room_jids = self
+            .rooms
+            .iter()
+            .filter(|(_, entry)| entry.claim_fence.owner() == msg.owner)
+            .map(|(jid, _)| jid.clone())
+            .collect::<Vec<_>>();
+        room_jids.extend(
+            self.pending_room_releases
+                .keys()
+                .filter(|(_, fence)| fence.owner() == msg.owner)
+                .map(|(jid, _)| jid.clone()),
+        );
+        room_jids.extend(
+            self.pending_reclaimed_rooms
+                .keys()
+                .filter(|(_, fence)| fence.owner() == msg.owner)
+                .map(|(jid, _)| jid.clone()),
+        );
+        room_jids.sort();
+        room_jids.dedup();
+        Ok(room_jids)
+    }
+}
+
 /// Return the number of active rooms.
 pub struct RoomCount;
 

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -481,6 +481,126 @@ async fn test_list_rooms() {
 }
 
 #[tokio::test]
+async fn list_rooms_owned_by_excludes_fresh_post_rotation_rooms() {
+    let registry = spawn_registry().await;
+    let old = NodeIdentity::new("room-node", "old-incarnation");
+    let fresh = NodeIdentity::new("room-node", "fresh-incarnation");
+    let identity = SharedNodeIdentity::new(old.clone());
+    let claim_store = Arc::new(InProcessClaimStore::new());
+    registry
+        .ask(WireClusteringClaims {
+            claim_store: claim_store.clone(),
+            node_identity: identity.clone(),
+            durable_store: None,
+            rollout_backoff: None,
+        })
+        .await
+        .expect("wire claims");
+
+    registry
+        .ask(CreateRoom {
+            room_jid: test_room_jid("old-owner"),
+            waddle_id: "w-old".to_string(),
+            channel_id: "c-old".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("create old-owner room");
+    identity.rotate(fresh.clone()).await;
+    registry
+        .ask(CreateRoom {
+            room_jid: test_room_jid("fresh-owner"),
+            waddle_id: "w-fresh".to_string(),
+            channel_id: "c-fresh".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("create fresh-owner room");
+
+    assert_eq!(
+        registry
+            .ask(ListRoomsOwnedBy { owner: old })
+            .await
+            .expect("old owner rooms"),
+        vec![test_room_jid("old-owner")]
+    );
+    assert_eq!(
+        registry
+            .ask(ListRoomsOwnedBy { owner: fresh })
+            .await
+            .expect("fresh owner rooms"),
+        vec![test_room_jid("fresh-owner")]
+    );
+}
+
+#[tokio::test]
+async fn stale_exact_owner_demotion_preserves_a_fresh_same_jid_room() {
+    let registry = spawn_registry().await;
+    let old = NodeIdentity::new("room-node", "old-incarnation");
+    let fresh = NodeIdentity::new("room-node", "fresh-incarnation");
+    let identity = SharedNodeIdentity::new(old.clone());
+    let claim_store = Arc::new(InProcessClaimStore::new());
+    registry
+        .ask(WireClusteringClaims {
+            claim_store: claim_store.clone(),
+            node_identity: identity.clone(),
+            durable_store: None,
+            rollout_backoff: None,
+        })
+        .await
+        .expect("wire claims");
+    let room_jid = test_room_jid("same-jid");
+    registry
+        .ask(CreateRoom {
+            room_jid: room_jid.clone(),
+            waddle_id: "w-old".to_string(),
+            channel_id: "c-old".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("create old room");
+    assert!(registry
+        .ask(DemoteRoomIfOwner {
+            room_jid: room_jid.clone(),
+            owner: old.clone(),
+        })
+        .await
+        .expect("demote old room"));
+    claim_store
+        .release(
+            &Entity::new(EntityType::RoomActor, room_jid.to_string()),
+            &old,
+            ClaimEpoch(0),
+        )
+        .await
+        .expect("simulate authoritative old-claim retirement");
+
+    identity.rotate(fresh).await;
+    registry
+        .ask(CreateRoom {
+            room_jid: room_jid.clone(),
+            waddle_id: "w-fresh".to_string(),
+            channel_id: "c-fresh".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("create fresh room");
+
+    assert!(!registry
+        .ask(DemoteRoomIfOwner {
+            room_jid: room_jid.clone(),
+            owner: old,
+        })
+        .await
+        .expect("stale demotion"));
+    assert!(registry
+        .ask(GetRoom { room_jid })
+        .await
+        .expect("fresh room lookup")
+        .is_some());
+}
+
+#[tokio::test]
 async fn test_get_or_create_fails_fast_for_dead_room_until_explicit_destroy() {
     let registry = spawn_registry().await;
     let room_jid = test_room_jid("restart");

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -36,19 +36,19 @@ use super::affiliation::DurableMembershipSource;
 use super::durable::MucDurableStore;
 use super::room_actor::{RoomActor, SealGuard};
 use super::room_registry_actor::{
-    CancelPendingReclaimedRoomReservation, CreateInstantRoom, CreateRoom, DestroyRoom,
-    DestroyRoomIfInactive, DestroyRoomOutcome, DestroyRoomReason, GetOrCreateRoom,
+    CancelPendingReclaimedRoomReservation, CreateInstantRoom, CreateRoom, DemoteRoomIfOwner,
+    DestroyRoom, DestroyRoomIfInactive, DestroyRoomOutcome, DestroyRoomReason, GetOrCreateRoom,
     GetPendingReclaimedRoomBacklog, GetPendingRoomReleaseBacklog, GetRoom,
     IsCurrentIdentityPendingRoomReleaseOnly, IsCurrentRoomPendingRelease, IsMucJid,
     IsPendingRoomReleaseOnly, ListPendingReclaimedRooms, ListPendingRoomReleaseJids, ListRooms,
-    PendingReclaimedRoom, PendingReclaimedRoomBacklog, PendingRoomReleaseBacklog, ReapSealedRoom,
-    ReclaimedRoomOutcome, ReconcileReclaimedRoom, RememberPendingReclaimedRoom,
+    ListRoomsOwnedBy, PendingReclaimedRoom, PendingReclaimedRoomBacklog, PendingRoomReleaseBacklog,
+    ReapSealedRoom, ReclaimedRoomOutcome, ReconcileReclaimedRoom, RememberPendingReclaimedRoom,
     ReservePendingReclaimedRoom, RetryPendingRoomReleases, RoomAcquisition, RoomCount, RoomExists,
     RoomRegistryActor, RoomRegistryError, WireClusteringClaims,
 };
 use super::RoomConfig;
 use crate::metrics;
-use crate::ownership::{ClaimStore, SharedNodeIdentity};
+use crate::ownership::{ClaimStore, NodeIdentity, SharedNodeIdentity};
 use crate::xep::xep0421::OccupantIdSecret;
 
 /// Explicit bounded mailbox capacity for the `RoomRegistryActor`.
@@ -428,6 +428,20 @@ impl RoomRegistry {
         list_rooms() -> Vec<BareJid>,
         "list_rooms",
         ListRooms
+    );
+
+    registry_method!(
+        /// List rooms and pending release work tied to one exact owner.
+        list_rooms_owned_by(owner: NodeIdentity) -> Vec<BareJid>,
+        "list_rooms_owned_by",
+        ListRoomsOwnedBy { owner }
+    );
+
+    registry_method!(
+        /// Demote a live room only if its entry still belongs to `owner`.
+        demote_room_if_owner(room_jid: BareJid, owner: NodeIdentity) -> bool,
+        "demote_room_if_owner",
+        DemoteRoomIfOwner { room_jid, owner }
     );
 
     registry_method!(

--- a/server/crates/waddle-xmpp/src/ownership/mod.rs
+++ b/server/crates/waddle-xmpp/src/ownership/mod.rs
@@ -331,6 +331,15 @@ impl SharedNodeIdentity {
         })
     }
 
+    /// Run a short synchronous demotion transition only after every current
+    /// publication guard has drained. This uses the exclusive side of the
+    /// same gate as identity rotation, so local claim removal cannot race a
+    /// caller publishing state under [`CurrentNodeIdentityGuard`].
+    pub async fn with_publications_blocked<R>(&self, demote: impl FnOnce() -> R) -> R {
+        let _publication_guard = self.rotation_gate.write().await;
+        demote()
+    }
+
     /// Whether `guard` holds the read side of this exact identity source's
     /// rotation gate, not merely an equal node-id/incarnation value.
     pub fn owns_guard(&self, guard: &CurrentNodeIdentityGuard) -> bool {

--- a/server/crates/waddle-xmpp/src/pending_delivery/mod.rs
+++ b/server/crates/waddle-xmpp/src/pending_delivery/mod.rs
@@ -99,20 +99,26 @@ pub struct SmSessionIdTooLong {
 /// stream-id-shaped value on the wire, while every in-process consumer still
 /// only ever sees the typed newtype. `Deserialize` is hand-written (below),
 /// not derived, so it can enforce [`SM_SESSION_ID_MAX_LEN`] — see
-/// [`SM_SESSION_ID_MAX_LEN`]'s own doc comment for why. [`Self::new`] itself
-/// stays unvalidated: every production caller mints server-generated UUIDs
-/// (far under the cap), and validating there too would force every one of
-/// those internal call sites to handle a `Result` for a case that cannot
-/// occur in practice — the wire boundary is where an untrusted length
-/// actually arrives.
+/// [`SM_SESSION_ID_MAX_LEN`]'s own doc comment for why. [`Self::new`] is for
+/// server-minted identifiers; untrusted wire values must enter through
+/// [`Self::try_from_wire`].
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]
 #[serde(transparent)]
 pub struct SmSessionId(String);
 
 impl SmSessionId {
-    /// Wrap a stream-id value.
+    /// Wrap a server-minted stream-id value.
     pub fn new(value: impl Into<String>) -> Self {
         Self(value.into())
+    }
+
+    /// Validate and wrap an untrusted stream-id received from the wire.
+    pub fn try_from_wire(value: impl Into<String>) -> Result<Self, SmSessionIdTooLong> {
+        let value = value.into();
+        if value.len() > SM_SESSION_ID_MAX_LEN {
+            return Err(SmSessionIdTooLong { len: value.len() });
+        }
+        Ok(Self(value))
     }
 
     /// Borrow the underlying string.
@@ -133,12 +139,7 @@ impl<'de> serde::Deserialize<'de> for SmSessionId {
         D: serde::Deserializer<'de>,
     {
         let value = String::deserialize(deserializer)?;
-        if value.len() > SM_SESSION_ID_MAX_LEN {
-            return Err(serde::de::Error::custom(SmSessionIdTooLong {
-                len: value.len(),
-            }));
-        }
-        Ok(Self(value))
+        Self::try_from_wire(value).map_err(serde::de::Error::custom)
     }
 }
 
@@ -288,6 +289,14 @@ mod tests {
             error.to_string().contains("exceeds"),
             "unexpected error message: {error}"
         );
+    }
+
+    #[test]
+    fn sm_session_id_wire_constructor_rejects_one_byte_over_the_cap() {
+        let value = "a".repeat(SM_SESSION_ID_MAX_LEN + 1);
+        let error = SmSessionId::try_from_wire(value)
+            .expect_err("untrusted wire ids must enforce the same bound as serde");
+        assert_eq!(error.len, SM_SESSION_ID_MAX_LEN + 1);
     }
 
     #[test]

--- a/server/crates/waddle-xmpp/src/registry/connection_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/connection_registry.rs
@@ -91,6 +91,31 @@ impl ConnectionRegistry {
         }
     }
 
+    /// Publish an SM stream id only while `owner` still owns the full-JID
+    /// slot. The connection entry guard serializes the ownership check,
+    /// entry update, and reverse-index update against same-JID replacement.
+    pub fn set_sm_stream_id_if_owner(
+        &self,
+        jid: &FullJid,
+        owner: &Arc<AtomicBool>,
+        stream_id: Option<crate::pending_delivery::SmSessionId>,
+    ) -> bool {
+        let Some(entry) = self.connections.get(jid) else {
+            return false;
+        };
+        if !Arc::ptr_eq(&entry.carbons_enabled, owner) {
+            return false;
+        }
+        if let Some(previous) = entry.sm_stream_id() {
+            self.sm_stream_owners.remove(&previous);
+        }
+        entry.set_sm_stream_id(stream_id.clone());
+        if let Some(stream_id) = stream_id {
+            self.sm_stream_owners.insert(stream_id, jid.clone());
+        }
+        true
+    }
+
     /// Look up which full JID currently publishes `stream_id`, if any
     /// (ADR-0017 Phase 3 Slice 6). **Best-effort**: this index is not
     /// proactively swept on every teardown path, so callers MUST re-verify

--- a/server/crates/waddle-xmpp/src/registry/mod.rs
+++ b/server/crates/waddle-xmpp/src/registry/mod.rs
@@ -33,7 +33,8 @@ pub use user_actor::delivery::{
 };
 pub use user_actor::GetResources;
 pub use user_registry::{
-    DemoteUserActor, GetOrCreateUser, GetUser, GetUserForLocalClaim, ListUsers, ReapUserIfEmpty,
+    DemoteUserActor, DemoteUserActorIfOwner, DemotedUserActor, DemotedUserResource,
+    GetOrCreateUser, GetUser, GetUserForLocalClaim, ListUsers, ListUsersOwnedBy, ReapUserIfEmpty,
     RegisterUserResource, RegisterUserResourceIfOwnerOrAbsent, RemoveUser, UnregisterUserResource,
     UserCount, UserRegistryActor, UserRegistryError, WireUserClusteringClaims,
 };

--- a/server/crates/waddle-xmpp/src/registry/user_actor.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_actor.rs
@@ -192,8 +192,14 @@ pub struct UnregisterConnectionAndReportEmpty {
     pub owner: Option<Arc<AtomicBool>>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
+pub struct UnregisterConnectionOutcome {
+    pub removed: bool,
+    pub is_empty: bool,
+}
+
 impl kameo::message::Message<UnregisterConnectionAndReportEmpty> for UserActor {
-    type Reply = bool;
+    type Reply = UnregisterConnectionOutcome;
 
     async fn handle(
         &mut self,
@@ -205,8 +211,11 @@ impl kameo::message::Message<UnregisterConnectionAndReportEmpty> for UserActor {
             bare = %self.bare_jid,
             "Unregistering connection and checking emptiness"
         );
-        self.remove_resource_if_owner(&msg.jid, msg.owner.as_ref());
-        self.connections.is_empty()
+        let removed = self.remove_resource_if_owner(&msg.jid, msg.owner.as_ref());
+        UnregisterConnectionOutcome {
+            removed,
+            is_empty: self.connections.is_empty(),
+        }
     }
 }
 

--- a/server/crates/waddle-xmpp/src/registry/user_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_actor/tests.rs
@@ -165,11 +165,12 @@ async fn test_unregister_and_report_empty_is_atomic_per_user_actor() {
         .await
         .expect("register");
 
-    let is_empty: bool = actor
+    let outcome = actor
         .ask(UnregisterConnectionAndReportEmpty { jid, owner: None })
         .await
         .expect("unregister+check");
-    assert!(is_empty);
+    assert!(outcome.removed);
+    assert!(outcome.is_empty);
 }
 
 /// Owner-gated unregister mirrors the DashMap `unregister_if_owner`: a lagging
@@ -221,7 +222,7 @@ async fn test_unregister_is_owner_gated() {
     );
 
     // The replacement's own teardown (matching token) removes it.
-    let is_empty: bool = actor
+    let outcome = actor
         .ask(UnregisterConnectionAndReportEmpty {
             jid,
             owner: Some(new_owner),
@@ -229,7 +230,7 @@ async fn test_unregister_is_owner_gated() {
         .await
         .expect("owned unregister");
     assert!(
-        is_empty,
+        outcome.removed && outcome.is_empty,
         "matching-owner unregister must remove the resource"
     );
 }

--- a/server/crates/waddle-xmpp/src/registry/user_registry.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_registry.rs
@@ -49,6 +49,10 @@ struct UserClaimLease {
 struct UserEntry {
     actor_ref: ActorRef<UserActor>,
     claim: UserClaimLease,
+    /// Actor-authoritative registration mirror used only for exact hard
+    /// demotion. Keeping the cheap Arc-backed entries here avoids asking a
+    /// potentially wedged child actor before it can be killed.
+    resources: HashMap<FullJid, ConnectionEntry>,
 }
 
 enum UserEntryClaimStatus {
@@ -171,9 +175,23 @@ impl UserRegistryActor {
             UserEntry {
                 actor_ref: actor_ref.clone(),
                 claim,
+                resources: HashMap::new(),
             },
         );
         actor_ref
+    }
+
+    async fn acquire_and_publish_user(
+        &mut self,
+        bare_jid: BareJid,
+    ) -> Result<ActorRef<UserActor>, UserRegistryError> {
+        let claim = self.acquire_user_claim(&bare_jid).await?;
+        let Some(_publication_guard) = self.node_identity.guard_if_current(&claim.owner).await
+        else {
+            self.release_user_claim(&bare_jid, &claim).await;
+            return Err(UserRegistryError::ClaimUnavailable(bare_jid));
+        };
+        Ok(self.spawn_user_actor(bare_jid, claim))
     }
 
     async fn release_user_claim(&self, bare_jid: &BareJid, claim: &UserClaimLease) {
@@ -444,8 +462,7 @@ impl kameo::message::Message<GetOrCreateUser> for UserRegistryActor {
         }
 
         debug!(jid = %msg.bare_jid, "Spawning new UserActor");
-        let claim = self.acquire_user_claim(&msg.bare_jid).await?;
-        let actor_ref = self.spawn_user_actor(msg.bare_jid, claim);
+        let actor_ref = self.acquire_and_publish_user(msg.bare_jid).await?;
         Ok(actor_ref)
     }
 }
@@ -515,6 +532,7 @@ impl kameo::message::Message<RegisterUserResource> for UserRegistryActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let bare_jid = msg.jid.to_bare();
+        let mirrored_entry = msg.entry.clone();
         if self.poisoned_users.contains(&bare_jid) {
             return Err(UserRegistryError::UserActorStateLost(bare_jid));
         }
@@ -525,8 +543,7 @@ impl kameo::message::Message<RegisterUserResource> for UserRegistryActor {
         {
             actor_ref
         } else {
-            let claim = self.acquire_user_claim(&bare_jid).await?;
-            self.spawn_user_actor(bare_jid.clone(), claim)
+            self.acquire_and_publish_user(bare_jid.clone()).await?
         };
 
         match user_actor
@@ -538,7 +555,11 @@ impl kameo::message::Message<RegisterUserResource> for UserRegistryActor {
             .reply_timeout(CHILD_ACTOR_TIMEOUT)
             .await
         {
-            Ok(()) => {}
+            Ok(()) => {
+                if let Some(user) = self.users.get_mut(&bare_jid) {
+                    user.resources.insert(msg.jid.clone(), mirrored_entry);
+                }
+            }
             Err(SendError::MailboxFull(_) | SendError::Timeout(_)) => {
                 return Err(UserRegistryError::UserActorBusy(bare_jid));
             }
@@ -570,6 +591,7 @@ impl kameo::message::Message<RegisterUserResourceIfOwnerOrAbsent> for UserRegist
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let bare_jid = msg.jid.to_bare();
+        let mirrored_entry = msg.entry.clone();
         if self.poisoned_users.contains(&bare_jid) {
             return Err(UserRegistryError::UserActorStateLost(bare_jid));
         }
@@ -580,8 +602,7 @@ impl kameo::message::Message<RegisterUserResourceIfOwnerOrAbsent> for UserRegist
         {
             actor_ref
         } else {
-            let claim = self.acquire_user_claim(&bare_jid).await?;
-            self.spawn_user_actor(bare_jid.clone(), claim)
+            self.acquire_and_publish_user(bare_jid.clone()).await?
         };
 
         match user_actor
@@ -594,7 +615,14 @@ impl kameo::message::Message<RegisterUserResourceIfOwnerOrAbsent> for UserRegist
             .reply_timeout(CHILD_ACTOR_TIMEOUT)
             .await
         {
-            Ok(registered) => Ok(registered),
+            Ok(registered) => {
+                if registered {
+                    if let Some(user) = self.users.get_mut(&bare_jid) {
+                        user.resources.insert(msg.jid.clone(), mirrored_entry);
+                    }
+                }
+                Ok(registered)
+            }
             Err(SendError::MailboxFull(_) | SendError::Timeout(_)) => {
                 Err(UserRegistryError::UserActorBusy(bare_jid))
             }
@@ -622,6 +650,7 @@ impl kameo::message::Message<UnregisterUserResource> for UserRegistryActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let bare_jid = msg.jid.to_bare();
+        let resource_jid = msg.jid.clone();
         if self.poisoned_users.contains(&bare_jid) {
             return Err(UserRegistryError::UserActorStateLost(bare_jid));
         }
@@ -633,7 +662,7 @@ impl kameo::message::Message<UnregisterUserResource> for UserRegistryActor {
             return Err(self.mark_actor_state_lost(&bare_jid).await);
         }
 
-        let is_empty = match entry
+        let unregister = match entry
             .actor_ref
             .ask(UnregisterConnectionAndReportEmpty {
                 jid: msg.jid,
@@ -643,14 +672,20 @@ impl kameo::message::Message<UnregisterUserResource> for UserRegistryActor {
             .reply_timeout(CHILD_ACTOR_TIMEOUT)
             .await
         {
-            Ok(is_empty) => is_empty,
+            Ok(outcome) => outcome,
             Err(SendError::MailboxFull(_) | SendError::Timeout(_)) => {
                 return Err(UserRegistryError::UserActorBusy(bare_jid));
             }
             Err(_) => return Err(self.mark_actor_state_lost(&bare_jid).await),
         };
 
-        if is_empty {
+        if unregister.removed {
+            if let Some(user) = self.users.get_mut(&bare_jid) {
+                user.resources.remove(&resource_jid);
+            }
+        }
+
+        if unregister.is_empty {
             if let Some(entry) = self.users.remove(&bare_jid) {
                 self.release_user_claim(&bare_jid, &entry.claim).await;
             }
@@ -715,6 +750,51 @@ impl kameo::message::Message<DemoteUserActor> for UserRegistryActor {
     }
 }
 
+/// One exact resource removed with an owner-conditional UserActor demotion.
+pub struct DemotedUserResource {
+    pub jid: FullJid,
+    pub entry: ConnectionEntry,
+}
+
+/// Resources that belonged to the exact UserActor entry that was demoted.
+#[derive(kameo::Reply)]
+pub struct DemotedUserActor {
+    pub resources: Vec<DemotedUserResource>,
+}
+
+/// Demote a UserActor only if its immutable claim lease still belongs to
+/// `owner`. Resource capture, owner comparison, removal, and kill share one
+/// registry mailbox turn, preventing a stale sweep from targeting an ABA
+/// same-JID replacement.
+pub struct DemoteUserActorIfOwner {
+    pub bare_jid: BareJid,
+    pub owner: NodeIdentity,
+}
+
+impl kameo::message::Message<DemoteUserActorIfOwner> for UserRegistryActor {
+    type Reply = Option<DemotedUserActor>;
+
+    async fn handle(
+        &mut self,
+        msg: DemoteUserActorIfOwner,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let entry = self.users.get(&msg.bare_jid)?.clone();
+        if entry.claim.owner != msg.owner {
+            return None;
+        }
+        let removed = self.users.remove(&msg.bare_jid)?;
+        removed.actor_ref.kill();
+        Some(DemotedUserActor {
+            resources: removed
+                .resources
+                .into_iter()
+                .map(|(jid, entry)| DemotedUserResource { jid, entry })
+                .collect(),
+        })
+    }
+}
+
 /// List all bare JIDs that currently have a `UserActor`.
 pub struct ListUsers;
 
@@ -727,6 +807,27 @@ impl kameo::message::Message<ListUsers> for UserRegistryActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         self.users.keys().cloned().collect()
+    }
+}
+
+/// List local UserActors whose immutable claim lease belongs to `owner`.
+pub struct ListUsersOwnedBy {
+    pub owner: NodeIdentity,
+}
+
+impl kameo::message::Message<ListUsersOwnedBy> for UserRegistryActor {
+    type Reply = Vec<BareJid>;
+
+    async fn handle(
+        &mut self,
+        msg: ListUsersOwnedBy,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.users
+            .iter()
+            .filter(|(_, entry)| entry.claim.owner == msg.owner)
+            .map(|(jid, _)| jid.clone())
+            .collect()
     }
 }
 

--- a/server/crates/waddle-xmpp/src/registry/user_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_registry/tests.rs
@@ -12,6 +12,23 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
+struct WedgeUserActor {
+    entered: Arc<tokio::sync::Notify>,
+}
+
+impl kameo::message::Message<WedgeUserActor> for UserActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: WedgeUserActor,
+        _ctx: &mut kameo::message::Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        msg.entered.notify_one();
+        std::future::pending().await
+    }
+}
+
 /// A bounded outbound channel for a test registration. Returns the sender to
 /// register and the receiver, which the caller keeps alive so the channel
 /// does not report closed.
@@ -72,6 +89,9 @@ struct RecordingClaimStore {
     release_owners: Mutex<Vec<NodeIdentity>>,
     fence_errors: AtomicBool,
     steal_calls: AtomicUsize,
+    block_ensure: AtomicBool,
+    ensure_entered: tokio::sync::Notify,
+    continue_ensure: tokio::sync::Notify,
 }
 
 impl RecordingClaimStore {
@@ -81,6 +101,9 @@ impl RecordingClaimStore {
             release_owners: Mutex::new(Vec::new()),
             fence_errors: AtomicBool::new(false),
             steal_calls: AtomicUsize::new(0),
+            block_ensure: AtomicBool::new(false),
+            ensure_entered: tokio::sync::Notify::new(),
+            continue_ensure: tokio::sync::Notify::new(),
         }
     }
 
@@ -90,6 +113,9 @@ impl RecordingClaimStore {
             release_owners: Mutex::new(Vec::new()),
             fence_errors: AtomicBool::new(false),
             steal_calls: AtomicUsize::new(0),
+            block_ensure: AtomicBool::new(false),
+            ensure_entered: tokio::sync::Notify::new(),
+            continue_ensure: tokio::sync::Notify::new(),
         }
     }
 
@@ -107,6 +133,10 @@ impl RecordingClaimStore {
 
     fn set_fence_errors(&self, fence_errors: bool) {
         self.fence_errors.store(fence_errors, Ordering::SeqCst);
+    }
+
+    fn block_next_ensure(&self) {
+        self.block_ensure.store(true, Ordering::SeqCst);
     }
 }
 
@@ -131,11 +161,16 @@ impl ClaimStore for RecordingClaimStore {
         me: &NodeIdentity,
     ) -> Result<ClaimEpoch, ClaimError> {
         let existing = self.state.lock().expect("lock").clone();
-        match existing {
+        let result = match existing {
             None => self.acquire(entity, me).await,
             Some((owner, epoch, _)) if owner == *me => Ok(epoch),
             Some(_) => Err(ClaimError::AlreadyClaimed),
+        };
+        if self.block_ensure.swap(false, Ordering::SeqCst) {
+            self.ensure_entered.notify_one();
+            self.continue_ensure.notified().await;
         }
+        result
     }
 
     async fn steal_stale(
@@ -328,6 +363,186 @@ async fn test_get_or_create_acquires_user_actor_claim() {
         .expect("current_claim")
         .expect("user claim should be held after actor spawn");
     assert_eq!(snapshot.owner, this_identity());
+}
+
+#[tokio::test]
+async fn get_or_create_releases_a_claim_if_identity_rotates_after_the_cas() {
+    let registry = spawn_registry().await;
+    let claim_store = Arc::new(RecordingClaimStore::empty());
+    let claim_store_trait: Arc<dyn ClaimStore> = claim_store.clone();
+    let old = this_identity();
+    let fresh = NodeIdentity::new("node-this", "epoch-after-self-fence");
+    let shared_identity = SharedNodeIdentity::new(old);
+    wire_shared_claims(&registry, claim_store_trait, shared_identity.clone()).await;
+    claim_store.block_next_ensure();
+    let bare_jid = bare("post-cas-rotation");
+
+    let creating = tokio::spawn({
+        let registry = registry.clone();
+        let bare_jid = bare_jid.clone();
+        async move { registry.ask(GetOrCreateUser { bare_jid }).await }
+    });
+    claim_store.ensure_entered.notified().await;
+    shared_identity.rotate(fresh).await;
+    claim_store.continue_ensure.notify_one();
+
+    assert!(matches!(
+        creating.await.expect("creation task"),
+        Err(SendError::HandlerError(UserRegistryError::ClaimUnavailable(jid))) if jid == bare_jid
+    ));
+    assert!(registry
+        .ask(ListUsers)
+        .await
+        .expect("list users")
+        .is_empty());
+    assert!(claim_store
+        .current_claim(&user_entity(&bare_jid))
+        .await
+        .expect("claim lookup")
+        .is_none());
+}
+
+#[tokio::test]
+async fn list_users_owned_by_excludes_fresh_post_rotation_users() {
+    let registry = spawn_registry().await;
+    let old = this_identity();
+    let fresh = NodeIdentity::new("node-this", "fresh-incarnation");
+    let shared_identity = SharedNodeIdentity::new(old.clone());
+    wire_shared_claims(
+        &registry,
+        Arc::new(InProcessClaimStore::new()),
+        shared_identity.clone(),
+    )
+    .await;
+    registry
+        .ask(GetOrCreateUser {
+            bare_jid: bare("old-owner-user"),
+        })
+        .await
+        .expect("old user");
+    shared_identity.rotate(fresh.clone()).await;
+    registry
+        .ask(GetOrCreateUser {
+            bare_jid: bare("fresh-owner-user"),
+        })
+        .await
+        .expect("fresh user");
+
+    assert_eq!(
+        registry
+            .ask(ListUsersOwnedBy { owner: old })
+            .await
+            .expect("old-owner users"),
+        vec![bare("old-owner-user")]
+    );
+    assert_eq!(
+        registry
+            .ask(ListUsersOwnedBy { owner: fresh })
+            .await
+            .expect("fresh-owner users"),
+        vec![bare("fresh-owner-user")]
+    );
+}
+
+#[tokio::test]
+async fn stale_exact_owner_demotion_preserves_a_fresh_same_jid_user() {
+    let registry = spawn_registry().await;
+    let old = this_identity();
+    let fresh = NodeIdentity::new("node-this", "fresh-incarnation");
+    let shared_identity = SharedNodeIdentity::new(old.clone());
+    let claim_store = Arc::new(InProcessClaimStore::new());
+    wire_shared_claims(&registry, claim_store.clone(), shared_identity.clone()).await;
+    let bare_jid = bare("same-owner-jid");
+    registry
+        .ask(GetOrCreateUser {
+            bare_jid: bare_jid.clone(),
+        })
+        .await
+        .expect("old user");
+    assert!(registry
+        .ask(DemoteUserActorIfOwner {
+            bare_jid: bare_jid.clone(),
+            owner: old.clone(),
+        })
+        .await
+        .expect("demote old user")
+        .is_some());
+    claim_store
+        .release(&user_entity(&bare_jid), &old, ClaimEpoch(0))
+        .await
+        .expect("simulate authoritative old-claim retirement");
+
+    shared_identity.rotate(fresh).await;
+    registry
+        .ask(GetOrCreateUser {
+            bare_jid: bare_jid.clone(),
+        })
+        .await
+        .expect("fresh user");
+    assert!(registry
+        .ask(DemoteUserActorIfOwner {
+            bare_jid: bare_jid.clone(),
+            owner: old,
+        })
+        .await
+        .expect("stale demotion")
+        .is_none());
+    assert_eq!(
+        registry.ask(ListUsers).await.expect("list users"),
+        vec![bare_jid]
+    );
+}
+
+#[tokio::test]
+async fn exact_owner_demotion_never_waits_on_a_wedged_multi_resource_actor() {
+    let registry = spawn_registry().await;
+    let owner = this_identity();
+    wire_claims(
+        &registry,
+        Arc::new(InProcessClaimStore::new()),
+        owner.clone(),
+    )
+    .await;
+    let bare_jid = bare("wedged-exact-demotion");
+    let mut receivers = Vec::new();
+    for resource in ["one", "two", "three"] {
+        let (sender, receiver) = outbound_channel();
+        receivers.push(receiver);
+        registry
+            .ask(RegisterUserResource {
+                jid: full("wedged-exact-demotion", resource),
+                entry: ConnectionEntry::new(sender),
+            })
+            .await
+            .expect("register resource");
+    }
+    let actor = registry
+        .ask(GetUserForLocalClaim {
+            bare_jid: bare_jid.clone(),
+        })
+        .await
+        .expect("get user")
+        .expect("live user");
+    let entered = Arc::new(tokio::sync::Notify::new());
+    let wedge = tokio::spawn({
+        let actor = actor.clone();
+        let entered = entered.clone();
+        async move { actor.ask(WedgeUserActor { entered }).await }
+    });
+    entered.notified().await;
+
+    let demoted = tokio::time::timeout(
+        Duration::from_millis(100),
+        registry.ask(DemoteUserActorIfOwner { bare_jid, owner }),
+    )
+    .await
+    .expect("exact demotion must not wait on the wedged child")
+    .expect("registry demotion")
+    .expect("matching owner");
+    assert_eq!(demoted.resources.len(), 3);
+    assert!(!actor.is_alive());
+    assert!(wedge.await.expect("wedge task").is_err());
+    drop(receivers);
 }
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/claims.rs
@@ -328,6 +328,65 @@ impl InMemorySmSessionRegistry {
         Some(out)
     }
 
+    /// Snapshot claim responsibilities tied to one immutable node identity.
+    /// Used after self-fence rotation: fresh admissions now carry the new
+    /// identity, while anything returned here is provably stale local work
+    /// that the final pre-rotation inventory may have missed.
+    pub fn locally_owned_claim_ids_for_owner(
+        &self,
+        owner: &crate::ownership::NodeIdentity,
+    ) -> Option<Vec<String>> {
+        let mut out = Vec::new();
+        {
+            let pending = self.pending_claim_acquisitions.read().ok()?;
+            out.extend(
+                pending
+                    .iter()
+                    .filter(|(_, pending_owner, _)| pending_owner == owner)
+                    .map(|(stream_id, _, _)| stream_id.clone()),
+            );
+        }
+        {
+            let lookups = self.pending_reclaimed_claim_lookups.read().ok()?;
+            out.extend(
+                lookups
+                    .keys()
+                    .filter(|(_, pending_owner, _)| pending_owner == owner)
+                    .map(|(stream_id, _, _)| stream_id.clone()),
+            );
+        }
+        {
+            let hydrations = self.pending_reclaimed_hydrations.read().ok()?;
+            out.extend(
+                hydrations
+                    .keys()
+                    .filter(|(_, fence, _)| fence.owner() == owner)
+                    .map(|(stream_id, _, _)| stream_id.clone()),
+            );
+        }
+        {
+            let fences = self.claim_fences.read().ok()?;
+            out.extend(
+                fences
+                    .iter()
+                    .filter(|(_, fence)| fence.owner() == owner)
+                    .map(|(stream_id, _)| stream_id.clone()),
+            );
+        }
+        {
+            let pending = self.pending_claim_releases.read().ok()?;
+            out.extend(
+                pending
+                    .iter()
+                    .filter(|(_, fence)| fence.owner() == owner)
+                    .map(|(stream_id, _)| stream_id.clone()),
+            );
+        }
+        out.sort();
+        out.dedup();
+        Some(out)
+    }
+
     /// Retry exact terminal releases retained after a backend error/timeout.
     /// Entries still represented by a live/detached session are excluded:
     /// those claims remain intentionally held.
@@ -693,7 +752,9 @@ impl InMemorySmSessionRegistry {
             return;
         };
         let _stream_guard = stream_lock.lock().await;
-        self.forget_claim_locally_locked(stream_id, None);
+        self.node_identity
+            .with_publications_blocked(|| self.forget_claim_locally_locked(stream_id, None))
+            .await;
     }
 
     pub(super) fn forget_claim_locally_locked(

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -740,6 +740,73 @@ async fn enable_claim_publication_guard_blocks_identity_rotation_until_caller_pu
 }
 
 #[tokio::test]
+async fn enable_claim_publication_guard_blocks_local_demotion_until_caller_publishes() {
+    let registry = std::sync::Arc::new(InMemorySmSessionRegistry::new());
+    let stream_id = "guarded-enable-demotion";
+    let publication = registry
+        .ensure_session_claim(stream_id)
+        .await
+        .expect("claim admission");
+    let demoting = {
+        let registry = registry.clone();
+        tokio::spawn(async move { registry.forget_claim_locally(stream_id).await })
+    };
+
+    tokio::task::yield_now().await;
+    assert!(
+        !demoting.is_finished(),
+        "self-fence demotion must wait until transport publication completes"
+    );
+    assert_eq!(
+        registry.locally_owned_claim_ids().expect("owned inventory"),
+        vec![stream_id.to_string()]
+    );
+
+    drop(publication);
+    demoting.await.expect("demotion task");
+    assert!(registry
+        .locally_owned_claim_ids()
+        .expect("owned inventory")
+        .is_empty());
+}
+
+#[tokio::test]
+async fn exact_owner_inventory_excludes_fresh_post_rotation_admissions() {
+    let old = crate::ownership::NodeIdentity::new("sm-node", "old-incarnation");
+    let fresh = crate::ownership::NodeIdentity::new("sm-node", "fresh-incarnation");
+    let shared = crate::ownership::SharedNodeIdentity::new(old.clone());
+    let registry = InMemorySmSessionRegistry::new().with_claim_store(
+        std::sync::Arc::new(crate::ownership::InProcessClaimStore::new()),
+        shared.clone(),
+    );
+    let old_publication = registry
+        .ensure_session_claim("old-enable")
+        .await
+        .expect("old claim admission");
+    drop(old_publication);
+
+    shared.rotate(fresh.clone()).await;
+    let fresh_publication = registry
+        .ensure_session_claim("fresh-enable")
+        .await
+        .expect("fresh claim admission");
+    drop(fresh_publication);
+
+    assert_eq!(
+        registry
+            .locally_owned_claim_ids_for_owner(&old)
+            .expect("old-owner inventory"),
+        vec!["old-enable".to_string()]
+    );
+    assert_eq!(
+        registry
+            .locally_owned_claim_ids_for_owner(&fresh)
+            .expect("fresh-owner inventory"),
+        vec!["fresh-enable".to_string()]
+    );
+}
+
+#[tokio::test]
 async fn pending_claim_retry_limit_is_shared_across_acquisitions_and_releases() {
     use crate::ownership::ClaimStore as _;
 


### PR DESCRIPTION
## Scope

- Treat a successfully written XEP-0198 `<enabled/>` response as the local SM commit point.
- Reject pipelined duplicate `<enable/>` requests while a transport commit is pending.
- Publish shared connection aliases only while the connection still owns the exact JID slot.
- Generate ISR credentials before persistence, retain bounded cleanup responsibility, and suppress ambiguous late writes with exact negative fences.
- Serialize ISR publish, consume, and revoke with one per-SM PostgreSQL advisory lock.
- Gate XEP-0397 discovery, issuance, and authentication on a validated trusted public `wss://` endpoint.
- Advertise only secure WebSocket links through XEP-0156 XRD/JRD discovery.
- Keep SM, RoomActor, and UserActor publication/demotion exact across self-fence identity rotation, including same-JID ABA replacements and wedged actors.
- Carry `SmSessionId` through ISR APIs and reject overlong client-supplied `previd` values before registry/backend work.

## Rebase and review fixes

- Rebased onto merged #1332 (`bfb2ab60`).
- Addresses all 20 review threads: public WebSocket transport authority, duplicate pending enable, resume-time TLS gate, typed SM IDs, Drop outside Tokio context, and whitespace/config validation.
- Adds production `xmpp.publicWebsocketUrl: wss://xmpp.waddle.social/ws` so discovery and ISR match the deployed gateway/certificate.
- Redacts rejected URL values from startup diagnostics.
- Captures/lends live Tokio runtime handles so retained ISR cleanup recovers after runtime shutdown, including in-flight work.
- Makes post-rotation cleanup exact-owner and mutation-conditional for SM sessions, rooms, users, and exact connection generations.

## Review boundary

- 42 files; +4,020 / -286 relative to `main`.
- WebSocket transport commit, ISR lifecycle/TLS authority, self-fence publication boundaries, and focused XEP tests.
- General orphan-reaper supervision remains outside this PR.

## Verification

- `cargo test -p waddle-server --lib --all-features`: 1,845 passed.
- `cargo test -p waddle-xmpp --lib --all-features`: 2,529 passed.
- `cargo clippy -p waddle-xmpp -p waddle-server --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- Helm lint/render and production GitOps kustomize render: passed.
- Three independent adversarial passes (TLS/XEP, ISR queue/storage, lifecycle/comment audit): clean.
- PostgreSQL-backed race test bodies compile but require `WADDLE_TEST_POSTGRES_URL`, which is not configured locally; CI remains authoritative for those paths.
