### PR TITLE
fix(server): make RoomActor ownership exact across node incarnations

### DIFF
--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -3387,13 +3387,18 @@ async fn run_delete(state: &AppState, args: &ChannelsDeleteArgs) -> Result<(), A
             waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::Destroyed
             | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::NotRegistered,
         ) => None,
-        Ok(
-            waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed
-            | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ReleaseBacklogFull,
-        ) => Some(internal_err(format!(
-            "room destroy refused for {}: durable room-state wipe failed",
-            args.channel_jid
-        ))),
+        Ok(waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed) => {
+            Some(internal_err(format!(
+                "room destroy refused for {}: durable room-state wipe failed",
+                args.channel_jid
+            )))
+        }
+        Ok(waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ReleaseBacklogFull) => {
+            Some(internal_err(format!(
+                "room destroy refused for {}: exact-release retry backlog is full; retry deletion",
+                args.channel_jid
+            )))
+        }
         Err(error) => Some(send_err("room_registry ask DestroyRoom")(error)),
     };
     if let Some(error) = failure {

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -31,7 +31,8 @@ use kameo::actor::ActorRef;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use waddle_xmpp::commands::{CommandContext, CommandResult};
 use waddle_xmpp::muc::room_registry_actor::{
-    CreateRoom, DestroyRoom, DestroyRoomReason, GetOrCreateRoom, GetRoom, ListRooms,
+    CreateRoom, DestroyRoom, DestroyRoomOutcome, DestroyRoomReason, GetOrCreateRoom, GetRoom,
+    ListRooms, RetryPendingRoomReleases,
 };
 use waddle_xmpp::muc::{
     affiliation::FederatedAffiliationConfig,
@@ -514,6 +515,47 @@ fn unavailable(text: impl Into<String>) -> AdminErr {
     Box::new(CommandResult::Error(XmppError::service_unavailable(Some(
         text.into(),
     ))))
+}
+
+async fn destroy_room_for_rollback(
+    state: &AppState,
+    room_jid: &BareJid,
+    rollback_context: &str,
+) -> Result<(), AdminErr> {
+    let mut outcome = state
+        .room_registry
+        .ask(DestroyRoom {
+            room_jid: room_jid.clone(),
+            reason: DestroyRoomReason::Destroy,
+        })
+        .await
+        .map_err(send_err("room_registry ask DestroyRoom during rollback"))?;
+    if outcome == DestroyRoomOutcome::ReleaseBacklogFull {
+        state
+            .room_registry
+            .ask(RetryPendingRoomReleases { limit: 1 })
+            .await
+            .map_err(send_err(
+                "room_registry ask RetryPendingRoomReleases during rollback",
+            ))?;
+        outcome = state
+            .room_registry
+            .ask(DestroyRoom {
+                room_jid: room_jid.clone(),
+                reason: DestroyRoomReason::Destroy,
+            })
+            .await
+            .map_err(send_err("room_registry retry DestroyRoom during rollback"))?;
+    }
+    match outcome {
+        DestroyRoomOutcome::Destroyed | DestroyRoomOutcome::NotRegistered => Ok(()),
+        DestroyRoomOutcome::DurableWipeFailed => Err(internal_err(format!(
+            "{rollback_context}: durable room-state wipe failed for {room_jid}; rollback is incomplete"
+        ))),
+        DestroyRoomOutcome::ReleaseBacklogFull => Err(internal_err(format!(
+            "{rollback_context}: exact-release retry backlog is still full for {room_jid} after bounded redrive; room remains registered and rollback must be retried"
+        ))),
+    }
 }
 
 async fn handle_list(ctx: CommandContext, state: Arc<AppState>) -> CommandResult {
@@ -1871,13 +1913,7 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
 
     if let Err(error) = upsert_channel_catalog(state, &localpart, &config, args.channel_type).await
     {
-        let _ = state
-            .room_registry
-            .ask(DestroyRoom {
-                room_jid: channel_jid.clone(),
-                reason: DestroyRoomReason::Destroy,
-            })
-            .await;
+        destroy_room_for_rollback(state, &channel_jid, "channel catalog creation failed").await?;
         return Err(error);
     }
 
@@ -1899,13 +1935,12 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
             Ok(created) => created,
             Err(error) => {
                 let _ = delete_xmpp_channel(state.db_pool.global_actor().clone(), &localpart).await;
-                let _ = state
-                    .room_registry
-                    .ask(DestroyRoom {
-                        room_jid: channel_jid.clone(),
-                        reason: DestroyRoomReason::Destroy,
-                    })
-                    .await;
+                destroy_room_for_rollback(
+                    state,
+                    &channel_jid,
+                    "channel-space bookmark creation failed",
+                )
+                .await?;
                 return Err(error);
             }
         };
@@ -1944,13 +1979,12 @@ async fn run_create(state: &AppState, args: &ChannelsCreateArgs) -> Result<Chann
                         let _ =
                             delete_xmpp_channel(state.db_pool.global_actor().clone(), &localpart)
                                 .await;
-                        let _ = state
-                            .room_registry
-                            .ask(DestroyRoom {
-                                room_jid: channel_jid.clone(),
-                                reason: DestroyRoomReason::Destroy,
-                            })
-                            .await;
+                        destroy_room_for_rollback(
+                            state,
+                            &channel_jid,
+                            "channel-space link creation failed",
+                        )
+                        .await?;
                     }
                     Err(retract_error) => {
                         if parent_tuple_created {
@@ -2016,13 +2050,7 @@ async fn run_group_dm_create(
         .map_err(send_err("room_registry ask CreateRoom"))?;
 
     if let Err(error) = upsert_group_dm_catalog(state, &localpart, &config).await {
-        let _ = state
-            .room_registry
-            .ask(DestroyRoom {
-                room_jid: room_jid.clone(),
-                reason: DestroyRoomReason::Destroy,
-            })
-            .await;
+        destroy_room_for_rollback(state, &room_jid, "group-DM catalog creation failed").await?;
         return Err(error);
     }
 
@@ -2033,7 +2061,7 @@ async fn run_group_dm_create(
     let mut persisted_members: Vec<BareJid> = Vec::with_capacity(members.len());
     for member_jid in members {
         if let Err(error) = persist_group_dm_member_tuple(state, &localpart, &member_jid).await {
-            rollback_group_dm_create(state, &localpart, &room_jid, &persisted_members).await;
+            rollback_group_dm_create(state, &localpart, &room_jid, &persisted_members).await?;
             return Err(Box::new(CommandResult::Error(error)));
         }
         persisted_members.push(member_jid.clone());
@@ -2044,13 +2072,13 @@ async fn run_group_dm_create(
             })
             .await
         {
-            rollback_group_dm_create(state, &localpart, &room_jid, &persisted_members).await;
+            rollback_group_dm_create(state, &localpart, &room_jid, &persisted_members).await?;
             return Err(send_err("room actor ChangeAffiliation")(error));
         }
         if let Err(error) =
             publish_group_dm_bookmark(state, &member_jid, &room_jid, Some(&args.name)).await
         {
-            rollback_group_dm_create(state, &localpart, &room_jid, &persisted_members).await;
+            rollback_group_dm_create(state, &localpart, &room_jid, &persisted_members).await?;
             return Err(error);
         }
     }
@@ -2760,19 +2788,13 @@ async fn rollback_group_dm_create(
     group_dm_id: &str,
     room_jid: &BareJid,
     persisted_members: &[BareJid],
-) {
+) -> Result<(), AdminErr> {
     for persisted_member in persisted_members {
         let _ = retract_group_dm_bookmark(state, persisted_member, room_jid).await;
         let _ = delete_group_dm_member_tuple(state, group_dm_id, persisted_member).await;
     }
     let _ = delete_xmpp_channel(state.db_pool.global_actor().clone(), group_dm_id).await;
-    let _ = state
-        .room_registry
-        .ask(DestroyRoom {
-            room_jid: room_jid.clone(),
-            reason: DestroyRoomReason::Destroy,
-        })
-        .await;
+    destroy_room_for_rollback(state, room_jid, "group-DM creation failed").await
 }
 
 pub(crate) async fn persist_group_dm_member_tuple(

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -3387,12 +3387,13 @@ async fn run_delete(state: &AppState, args: &ChannelsDeleteArgs) -> Result<(), A
             waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::Destroyed
             | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::NotRegistered,
         ) => None,
-        Ok(waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed) => {
-            Some(internal_err(format!(
-                "room destroy refused for {}: durable room-state wipe failed",
-                args.channel_jid
-            )))
-        }
+        Ok(
+            waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed
+            | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ReleaseBacklogFull,
+        ) => Some(internal_err(format!(
+            "room destroy refused for {}: durable room-state wipe failed",
+            args.channel_jid
+        ))),
         Err(error) => Some(send_err("room_registry ask DestroyRoom")(error)),
     };
     if let Some(error) = failure {

--- a/server/crates/waddle-server/src/admin/spaces.rs
+++ b/server/crates/waddle-server/src/admin/spaces.rs
@@ -1315,12 +1315,16 @@ async fn run_delete(state: &AppState, args: &SpacesDeleteArgs) -> Result<(), Adm
                 waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::Destroyed
                 | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::NotRegistered,
             ) => None,
-            Ok(
-                waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed
-                | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ReleaseBacklogFull,
-            ) => Some(format!(
+            Ok(waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed) => {
+                Some(format!(
                 "cascade destroy refused for room {room_jid}: durable room-state wipe failed"
-            )),
+            ))
+            }
+            Ok(waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ReleaseBacklogFull) => {
+                Some(format!(
+                    "cascade destroy refused for room {room_jid}: exact-release retry backlog is full; retry deletion"
+                ))
+            }
             Err(error) => Some(format!(
                 "cascade destroy failed for room {room_jid}: {error}"
             )),

--- a/server/crates/waddle-server/src/admin/spaces.rs
+++ b/server/crates/waddle-server/src/admin/spaces.rs
@@ -1317,17 +1317,15 @@ async fn run_delete(state: &AppState, args: &SpacesDeleteArgs) -> Result<(), Adm
             ) => None,
             Ok(waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed) => {
                 Some(format!(
-                "cascade destroy refused for room {room_jid}: durable room-state wipe failed"
-            ))
+                    "cascade destroy refused for room {room_jid}: durable room-state wipe failed"
+                ))
             }
             Ok(waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ReleaseBacklogFull) => {
                 Some(format!(
                     "cascade destroy refused for room {room_jid}: exact-release retry backlog is full; retry deletion"
                 ))
             }
-            Err(error) => Some(format!(
-                "cascade destroy failed for room {room_jid}: {error}"
-            )),
+            Err(error) => Some(format!("cascade destroy failed for room {room_jid}: {error}")),
         };
         if let Some(message) = failure {
             let failed_restores =

--- a/server/crates/waddle-server/src/admin/spaces.rs
+++ b/server/crates/waddle-server/src/admin/spaces.rs
@@ -1315,11 +1315,12 @@ async fn run_delete(state: &AppState, args: &SpacesDeleteArgs) -> Result<(), Adm
                 waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::Destroyed
                 | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::NotRegistered,
             ) => None,
-            Ok(waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed) => {
-                Some(format!(
-                    "cascade destroy refused for room {room_jid}: durable room-state wipe failed"
-                ))
-            }
+            Ok(
+                waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed
+                | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ReleaseBacklogFull,
+            ) => Some(format!(
+                "cascade destroy refused for room {room_jid}: durable room-state wipe failed"
+            )),
             Err(error) => Some(format!(
                 "cascade destroy failed for room {room_jid}: {error}"
             )),

--- a/server/crates/waddle-server/src/clustering/claims.rs
+++ b/server/crates/waddle-server/src/clustering/claims.rs
@@ -872,6 +872,35 @@ impl ClaimStore for PostgresClaimStore {
         Ok(())
     }
 
+    async fn release_exact(
+        &self,
+        entity: &Entity,
+        me: &NodeIdentity,
+        mine: ClaimEpoch,
+    ) -> Result<waddle_xmpp::ownership::ExactReleaseOutcome, ClaimError> {
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let affected = conn
+            .execute(
+                r#"
+                DELETE FROM clustering_claims
+                WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ?
+                "#,
+                crate::db_params![
+                    entity_key(entity),
+                    me.node_id.clone(),
+                    me.node_epoch.clone(),
+                    mine.0,
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        if affected == 1 {
+            Ok(waddle_xmpp::ownership::ExactReleaseOutcome::Released)
+        } else {
+            Ok(waddle_xmpp::ownership::ExactReleaseOutcome::NotOwned)
+        }
+    }
+
     async fn release_many(&self, entities: &[Entity], me: &NodeIdentity) -> Result<(), ClaimError> {
         if entities.is_empty() {
             return Ok(());
@@ -1184,6 +1213,28 @@ pub trait NodeLeaseStore: Send + Sync {
         Err(ClaimError::Conflict)
     }
 
+    /// Bounded advisory scan for `RoomActor` claims whose recorded owner
+    /// lease is committed-stale. The subsequent epoch-fenced steal is the
+    /// authority; this candidate list is read-only.
+    async fn list_orphaned_room_actor_claims(
+        &self,
+        _limit: usize,
+    ) -> Result<Vec<OrphanedRoomActorClaim>, ClaimError> {
+        Ok(Vec::new())
+    }
+
+    /// Reaper-only stale-owner steal for a `RoomActor`, bound to both the
+    /// observed claim epoch and the sweeping node's fresh lease.
+    async fn steal_orphaned_room_actor_claim(
+        &self,
+        _entity: &Entity,
+        _observed: ClaimEpoch,
+        _me: &NodeIdentity,
+        _lease_ttl: Duration,
+    ) -> Result<ClaimEpoch, ClaimError> {
+        Err(ClaimError::Conflict)
+    }
+
     /// The current deployment generation's `pod_template_hash` (ADR-0017
     /// Phase 3 Slice 10, Q5's operational definition): the hash stamped on
     /// the non-expired `clustering_nodes` row with the greatest
@@ -1203,6 +1254,13 @@ pub trait NodeLeaseStore: Send + Sync {
 /// [`NodeLeaseStore::list_orphaned_sm_session_claims`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrphanedSmSessionClaim {
+    pub entity: Entity,
+    pub epoch: ClaimEpoch,
+    pub owner: NodeIdentity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrphanedRoomActorClaim {
     pub entity: Entity,
     pub epoch: ClaimEpoch,
     pub owner: NodeIdentity,
@@ -1727,6 +1785,154 @@ impl NodeLeaseStore for PostgresClaimStore {
                     EntityType::SmSession.as_db_str().to_string(),
                     observed.0,
                     EntityType::SmSession.as_db_str().to_string(),
+                    me.node_id.clone(),
+                    me.node_epoch.clone(),
+                    lease_ttl.as_millis().to_string(),
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        if affected == 1 {
+            Ok(ClaimEpoch(next_epoch))
+        } else {
+            Err(ClaimError::Conflict)
+        }
+    }
+
+    async fn list_orphaned_room_actor_claims(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<OrphanedRoomActorClaim>, ClaimError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let scan_limit = limit.saturating_mul(4);
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT entity, node_id, node_epoch, claim_epoch
+                FROM clustering_claims
+                WHERE entity_type = ?
+                  AND NOT EXISTS (
+                    SELECT 1 FROM clustering_nodes n
+                    WHERE n.node_id = clustering_claims.node_id
+                      AND NOT n.expired
+                      AND n.node_epoch = clustering_claims.node_epoch
+                  )
+                ORDER BY entity
+                LIMIT ?
+                "#,
+                crate::db_params![
+                    EntityType::RoomActor.as_db_str().to_string(),
+                    i64::try_from(scan_limit).unwrap_or(i64::MAX),
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        let mut out = Vec::new();
+        let mut malformed = Vec::new();
+        while let Some(row) = rows.next().await.map_err(db_err)? {
+            let encoded: String = row.get(0).map_err(db_err)?;
+            let node_id: String = row.get(1).map_err(db_err)?;
+            let node_epoch: String = row.get(2).map_err(db_err)?;
+            let claim_epoch: i64 = row.get(3).map_err(db_err)?;
+            let Some(entity) = decode_entity(&encoded, EntityType::RoomActor) else {
+                malformed.push((encoded, node_id, node_epoch, claim_epoch));
+                continue;
+            };
+            if entity.id.parse::<jid::BareJid>().is_err() {
+                malformed.push((encoded, node_id, node_epoch, claim_epoch));
+                continue;
+            }
+            out.push(OrphanedRoomActorClaim {
+                entity,
+                epoch: ClaimEpoch(claim_epoch),
+                owner: NodeIdentity::new(node_id, node_epoch),
+            });
+            if out.len() == limit {
+                break;
+            }
+        }
+        drop(rows);
+        let mut quarantined = 0usize;
+        for (encoded, node_id, node_epoch, claim_epoch) in malformed {
+            let affected = conn
+                .execute(
+                    r#"
+                    DELETE FROM clustering_claims
+                    WHERE entity = ? AND entity_type = ? AND node_id = ? AND node_epoch = ?
+                      AND claim_epoch = ?
+                      AND NOT EXISTS (
+                        SELECT 1 FROM clustering_nodes n
+                        WHERE n.node_id = clustering_claims.node_id
+                          AND NOT n.expired
+                          AND n.node_epoch = clustering_claims.node_epoch
+                      )
+                    "#,
+                    crate::db_params![
+                        encoded,
+                        EntityType::RoomActor.as_db_str().to_string(),
+                        node_id,
+                        node_epoch,
+                        claim_epoch,
+                    ],
+                )
+                .await
+                .map_err(db_err)?;
+            quarantined += usize::from(affected == 1);
+        }
+        if quarantined > 0 {
+            tracing::debug!(
+                quarantined,
+                "quarantined malformed stale RoomActor claim rows"
+            );
+        }
+        Ok(out)
+    }
+
+    async fn steal_orphaned_room_actor_claim(
+        &self,
+        entity: &Entity,
+        observed: ClaimEpoch,
+        me: &NodeIdentity,
+        lease_ttl: Duration,
+    ) -> Result<ClaimEpoch, ClaimError> {
+        if entity.entity_type != EntityType::RoomActor {
+            return Err(ClaimError::Conflict);
+        }
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let next_epoch = observed.0 + 1;
+        let affected = conn
+            .execute(
+                r#"
+                UPDATE clustering_claims
+                SET node_id = ?, node_epoch = ?, claim_epoch = ?
+                WHERE entity = ?
+                  AND entity_type = ?
+                  AND claim_epoch = ?
+                  AND NOT EXISTS (
+                    SELECT 1 FROM clustering_nodes n
+                    WHERE n.node_id = clustering_claims.node_id
+                      AND NOT n.expired
+                      AND n.node_epoch = clustering_claims.node_epoch
+                  )
+                  AND EXISTS (
+                    SELECT 1 FROM clustering_nodes
+                    WHERE node_id = ?
+                      AND node_epoch = ?
+                      AND NOT expired
+                      AND NOT draining
+                      AND heartbeat >= now() - (? || ' milliseconds')::interval
+                  )
+                "#,
+                crate::db_params![
+                    me.node_id.clone(),
+                    me.node_epoch.clone(),
+                    next_epoch,
+                    entity_key(entity),
+                    EntityType::RoomActor.as_db_str().to_string(),
+                    observed.0,
                     me.node_id.clone(),
                     me.node_epoch.clone(),
                     lease_ttl.as_millis().to_string(),

--- a/server/crates/waddle-server/src/clustering/claims.rs
+++ b/server/crates/waddle-server/src/clustering/claims.rs
@@ -291,20 +291,70 @@ impl ClaimStore for PostgresClaimStore {
         )
         .await
         .map_err(db_err)?;
-        conn.execute(
+        // Claim generations must never repeat after a row is deleted and
+        // recreated. Bootstrap the sequence under a transaction-scoped
+        // advisory lock so concurrent startup migrations cannot race their
+        // `setval`, then lock the claims table while advancing the sequence
+        // past every generation already present in a pre-sequence schema.
+        // The table lock also excludes concurrent INSERT/UPDATE statements
+        // until the new default and sequence floor commit together.
+        let mut tx = self.db.begin().await.map_err(db_err)?;
+        tx.query("SELECT pg_advisory_xact_lock(6841445497037937991)", ())
+            .await
+            .map_err(db_err)?;
+        tx.execute(
+            r#"
+            CREATE SEQUENCE IF NOT EXISTS clustering_claim_epoch_seq
+                AS BIGINT MINVALUE 0 START WITH 1
+            "#,
+            (),
+        )
+        .await
+        .map_err(db_err)?;
+        tx.execute(
             r#"
             CREATE TABLE IF NOT EXISTS clustering_claims (
                 entity      TEXT PRIMARY KEY,
                 entity_type TEXT NOT NULL,
                 node_id     TEXT NOT NULL,
                 node_epoch  TEXT NOT NULL,
-                claim_epoch BIGINT NOT NULL DEFAULT 0
+                claim_epoch BIGINT NOT NULL
+                    DEFAULT nextval('clustering_claim_epoch_seq'::regclass)
             )
             "#,
             (),
         )
         .await
         .map_err(db_err)?;
+        tx.execute("LOCK TABLE clustering_claims IN ACCESS EXCLUSIVE MODE", ())
+            .await
+            .map_err(db_err)?;
+        tx.execute(
+            r#"
+            ALTER TABLE clustering_claims
+            ALTER COLUMN claim_epoch
+            SET DEFAULT nextval('clustering_claim_epoch_seq'::regclass)
+            "#,
+            (),
+        )
+        .await
+        .map_err(db_err)?;
+        tx.query(
+            r#"
+            SELECT setval(
+                'clustering_claim_epoch_seq',
+                GREATEST(
+                    (SELECT COALESCE(MAX(claim_epoch), 0) FROM clustering_claims),
+                    (SELECT last_value FROM clustering_claim_epoch_seq)
+                ),
+                true
+            )
+            "#,
+            (),
+        )
+        .await
+        .map_err(db_err)?;
+        tx.commit().await.map_err(db_err)?;
         conn.execute(
             r#"
             CREATE INDEX IF NOT EXISTS clustering_claims_node_id_node_epoch
@@ -368,16 +418,17 @@ impl ClaimStore for PostgresClaimStore {
         // every subsequent `acquire`/`steal_stale` call under ordinary
         // READ COMMITTED semantics by the time this node's drain loop
         // itself proceeds to iterate owned entities.
-        let affected = conn
-            .execute(
+        let mut inserted = conn
+            .query(
                 r#"
                 INSERT INTO clustering_claims (entity, entity_type, node_id, node_epoch, claim_epoch)
-                SELECT ?, ?, ?, ?, 0
+                SELECT ?, ?, ?, ?, nextval('clustering_claim_epoch_seq'::regclass)
                 WHERE NOT EXISTS (
                     SELECT 1 FROM clustering_nodes
                     WHERE node_id = ? AND node_epoch = ? AND draining
                 )
                 ON CONFLICT (entity) DO NOTHING
+                RETURNING claim_epoch
                 "#,
                 crate::db_params![
                     entity_key(entity),
@@ -390,8 +441,8 @@ impl ClaimStore for PostgresClaimStore {
             )
             .await
             .map_err(db_err)?;
-        if affected == 1 {
-            return Ok(ClaimEpoch(0));
+        if let Some(row) = inserted.next().await.map_err(db_err)? {
+            return Ok(ClaimEpoch(row.get::<i64>(0).map_err(db_err)?));
         }
         // Zero rows affected: either a genuine conflict (someone already
         // holds this entity) or this node's own draining gate blocked the
@@ -526,7 +577,6 @@ impl ClaimStore for PostgresClaimStore {
                     return Err(ClaimError::SmSessionExcludedFromStealIntent);
                 }
                 let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-                let next_epoch = observed.0 + 1;
                 // FIX 1(a) — council-adjudicated redesign closing the veto
                 // race (write skew under READ COMMITTED between this CAS
                 // and `clear_steal_intent`'s DELETE, both previously gated
@@ -599,8 +649,8 @@ impl ClaimStore for PostgresClaimStore {
                 // missing, expired, or draining local lease must not be able
                 // to acquire a new claim merely because it won this CAS after
                 // another node's watchdog expired it.
-                let affected = conn
-                    .execute(
+                let mut rows = conn
+                    .query(
                         r#"
                         WITH live_stealer AS (
                             SELECT 1 FROM clustering_nodes
@@ -621,11 +671,13 @@ impl ClaimStore for PostgresClaimStore {
                             RETURNING 1
                         )
                         UPDATE clustering_claims
-                        SET node_id = ?, node_epoch = ?, claim_epoch = ?
+                        SET node_id = ?, node_epoch = ?,
+                            claim_epoch = nextval('clustering_claim_epoch_seq'::regclass)
                         WHERE entity = ?
                           AND claim_epoch = ?
                           AND EXISTS (SELECT 1 FROM consumed)
                           AND EXISTS (SELECT 1 FROM live_stealer)
+                        RETURNING claim_epoch
                         "#,
                         crate::db_params![
                             me.node_id.clone(),
@@ -636,7 +688,6 @@ impl ClaimStore for PostgresClaimStore {
                             observed.0,
                             me.node_id.clone(),
                             me.node_epoch.clone(),
-                            next_epoch,
                             entity_key(entity),
                             observed.0,
                         ],
@@ -650,15 +701,13 @@ impl ClaimStore for PostgresClaimStore {
                         );
                         db_err(error)
                     })?;
-                if affected == 1 {
-                    Ok(ClaimEpoch(next_epoch))
-                } else {
-                    Err(ClaimError::Conflict)
+                match rows.next().await.map_err(db_err)? {
+                    Some(row) => Ok(ClaimEpoch(row.get::<i64>(0).map_err(db_err)?)),
+                    None => Err(ClaimError::Conflict),
                 }
             }
             StalePredicate::OwnerStale => {
                 let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-                let next_epoch = observed.0 + 1;
                 // Owner-stale steal CAS (element 4): the `NOT EXISTS`
                 // correlated subquery realizes the ADR's "LEFT JOIN"
                 // predicate (`nodes.node_id IS NULL OR nodes.expired OR
@@ -680,11 +729,12 @@ impl ClaimStore for PostgresClaimStore {
                 // live-stealer predicate, not just "not draining". A node
                 // whose own row is missing or committed expired is not allowed
                 // to win orphaned claims under its dead identity.
-                let affected = conn
-                    .execute(
+                let mut rows = conn
+                    .query(
                         r#"
                         UPDATE clustering_claims
-                        SET node_id = ?, node_epoch = ?, claim_epoch = ?
+                        SET node_id = ?, node_epoch = ?,
+                            claim_epoch = nextval('clustering_claim_epoch_seq'::regclass)
                         WHERE entity = ?
                           AND claim_epoch = ?
                           AND NOT EXISTS (
@@ -700,11 +750,11 @@ impl ClaimStore for PostgresClaimStore {
                               AND NOT expired
                               AND NOT draining
                           )
+                        RETURNING claim_epoch
                         "#,
                         crate::db_params![
                             me.node_id.clone(),
                             me.node_epoch.clone(),
-                            next_epoch,
                             entity_key(entity),
                             observed.0,
                             me.node_id.clone(),
@@ -713,10 +763,9 @@ impl ClaimStore for PostgresClaimStore {
                     )
                     .await
                     .map_err(db_err)?;
-                if affected == 1 {
-                    Ok(ClaimEpoch(next_epoch))
-                } else {
-                    Err(ClaimError::Conflict)
+                match rows.next().await.map_err(db_err)? {
+                    Some(row) => Ok(ClaimEpoch(row.get::<i64>(0).map_err(db_err)?)),
+                    None => Err(ClaimError::Conflict),
                 }
             }
         }
@@ -730,32 +779,31 @@ impl ClaimStore for PostgresClaimStore {
         me: &NodeIdentity,
     ) -> Result<ClaimEpoch, ClaimError> {
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        let next_epoch = observed.0 + 1;
         // Consent/epoch-only steal CAS (element 4's third variant): no
         // staleness predicate at all — authorized exclusively by the
         // caller already holding a `ResumeIdentityProof`, which only
         // `ownership::resume::verify_resume_identity` can mint.
-        let affected = conn
-            .execute(
+        let mut rows = conn
+            .query(
                 r#"
                 UPDATE clustering_claims
-                SET node_id = ?, node_epoch = ?, claim_epoch = ?
+                SET node_id = ?, node_epoch = ?,
+                    claim_epoch = nextval('clustering_claim_epoch_seq'::regclass)
                 WHERE entity = ? AND claim_epoch = ?
+                RETURNING claim_epoch
                 "#,
                 crate::db_params![
                     me.node_id.clone(),
                     me.node_epoch.clone(),
-                    next_epoch,
                     entity_key(entity),
                     observed.0,
                 ],
             )
             .await
             .map_err(db_err)?;
-        if affected == 1 {
-            Ok(ClaimEpoch(next_epoch))
-        } else {
-            Err(ClaimError::Conflict)
+        match rows.next().await.map_err(db_err)? {
+            Some(row) => Ok(ClaimEpoch(row.get::<i64>(0).map_err(db_err)?)),
+            None => Err(ClaimError::Conflict),
         }
     }
 
@@ -1749,12 +1797,12 @@ impl NodeLeaseStore for PostgresClaimStore {
         lease_ttl: Duration,
     ) -> Result<ClaimEpoch, ClaimError> {
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        let next_epoch = observed.0 + 1;
-        let affected = conn
-            .execute(
+        let mut rows = conn
+            .query(
                 r#"
                 UPDATE clustering_claims
-                SET node_id = ?, node_epoch = ?, claim_epoch = ?
+                SET node_id = ?, node_epoch = ?,
+                    claim_epoch = nextval('clustering_claim_epoch_seq'::regclass)
                 WHERE entity = ?
                   AND entity_type = ?
                   AND claim_epoch = ?
@@ -1776,11 +1824,11 @@ impl NodeLeaseStore for PostgresClaimStore {
                       AND NOT draining
                       AND heartbeat >= now() - (? || ' milliseconds')::interval
                   )
+                RETURNING claim_epoch
                 "#,
                 crate::db_params![
                     me.node_id.clone(),
                     me.node_epoch.clone(),
-                    next_epoch,
                     entity_key(entity),
                     EntityType::SmSession.as_db_str().to_string(),
                     observed.0,
@@ -1792,10 +1840,9 @@ impl NodeLeaseStore for PostgresClaimStore {
             )
             .await
             .map_err(db_err)?;
-        if affected == 1 {
-            Ok(ClaimEpoch(next_epoch))
-        } else {
-            Err(ClaimError::Conflict)
+        match rows.next().await.map_err(db_err)? {
+            Some(row) => Ok(ClaimEpoch(row.get::<i64>(0).map_err(db_err)?)),
+            None => Err(ClaimError::Conflict),
         }
     }
 
@@ -1902,12 +1949,12 @@ impl NodeLeaseStore for PostgresClaimStore {
             return Err(ClaimError::Conflict);
         }
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        let next_epoch = observed.0 + 1;
-        let affected = conn
-            .execute(
+        let mut rows = conn
+            .query(
                 r#"
                 UPDATE clustering_claims
-                SET node_id = ?, node_epoch = ?, claim_epoch = ?
+                SET node_id = ?, node_epoch = ?,
+                    claim_epoch = nextval('clustering_claim_epoch_seq'::regclass)
                 WHERE entity = ?
                   AND entity_type = ?
                   AND claim_epoch = ?
@@ -1925,11 +1972,11 @@ impl NodeLeaseStore for PostgresClaimStore {
                       AND NOT draining
                       AND heartbeat >= now() - (? || ' milliseconds')::interval
                   )
+                RETURNING claim_epoch
                 "#,
                 crate::db_params![
                     me.node_id.clone(),
                     me.node_epoch.clone(),
-                    next_epoch,
                     entity_key(entity),
                     EntityType::RoomActor.as_db_str().to_string(),
                     observed.0,
@@ -1940,10 +1987,9 @@ impl NodeLeaseStore for PostgresClaimStore {
             )
             .await
             .map_err(db_err)?;
-        if affected == 1 {
-            Ok(ClaimEpoch(next_epoch))
-        } else {
-            Err(ClaimError::Conflict)
+        match rows.next().await.map_err(db_err)? {
+            Some(row) => Ok(ClaimEpoch(row.get::<i64>(0).map_err(db_err)?)),
+            None => Err(ClaimError::Conflict),
         }
     }
 
@@ -2123,7 +2169,7 @@ mod tests {
         let me = node_identity();
         let entity = sm_entity("stream-1");
         let epoch = store.acquire(&entity, &me).await.expect("first acquire");
-        assert_eq!(epoch, ClaimEpoch(0));
+        assert!(store.fence(&entity, &me, epoch).await.expect("fence"));
 
         let other = node_identity();
         let err = store
@@ -2147,7 +2193,7 @@ mod tests {
             .ensure_claimed(&entity, &me)
             .await
             .expect("ensure_claimed acquires fresh");
-        assert_eq!(epoch, ClaimEpoch(0));
+        assert!(store.fence(&entity, &me, epoch).await.expect("fence"));
     }
 
     /// FIX 1: a second `ensure_claimed` call under the exact same
@@ -2173,7 +2219,6 @@ mod tests {
             .await
             .expect("second ensure_claimed under the same identity self-reacquires");
         assert_eq!(first, second);
-        assert_eq!(second, ClaimEpoch(0));
     }
 
     /// FIX 1: `ensure_claimed` under a genuinely different node/epoch than
@@ -2279,47 +2324,47 @@ mod tests {
         let room_entity = Entity::new(EntityType::RoomActor, "42");
         let sm_entity_same_id = Entity::new(EntityType::SmSession, "42");
 
-        store
+        let user_epoch = store
             .acquire(&user_entity, &me)
             .await
             .expect("acquire user_actor:42");
-        store
+        let room_epoch = store
             .acquire(&room_entity, &me)
             .await
             .expect("acquire room_actor:42 must not collide with user_actor:42");
-        store
+        let sm_epoch = store
             .acquire(&sm_entity_same_id, &me)
             .await
             .expect("acquire sm_session:42 must not collide with either of the above");
 
         assert!(store
-            .fence(&user_entity, &me, ClaimEpoch(0))
+            .fence(&user_entity, &me, user_epoch)
             .await
             .expect("fence user_actor:42"));
         assert!(store
-            .fence(&room_entity, &me, ClaimEpoch(0))
+            .fence(&room_entity, &me, room_epoch)
             .await
             .expect("fence room_actor:42"));
         assert!(store
-            .fence(&sm_entity_same_id, &me, ClaimEpoch(0))
+            .fence(&sm_entity_same_id, &me, sm_epoch)
             .await
             .expect("fence sm_session:42"));
 
         // Releasing one must not affect the others.
         store
-            .release(&user_entity, &me, ClaimEpoch(0))
+            .release(&user_entity, &me, user_epoch)
             .await
             .expect("release user_actor:42");
         assert!(!store
-            .fence(&user_entity, &me, ClaimEpoch(0))
+            .fence(&user_entity, &me, user_epoch)
             .await
             .expect("fence user_actor:42 after release"));
         assert!(store
-            .fence(&room_entity, &me, ClaimEpoch(0))
+            .fence(&room_entity, &me, room_epoch)
             .await
             .expect("room_actor:42 untouched by user_actor:42's release"));
         assert!(store
-            .fence(&sm_entity_same_id, &me, ClaimEpoch(0))
+            .fence(&sm_entity_same_id, &me, sm_epoch)
             .await
             .expect("sm_session:42 untouched by user_actor:42's release"));
     }
@@ -2368,7 +2413,7 @@ mod tests {
             .steal_stale(&entity, epoch0, StalePredicate::OwnerStale, &stealer)
             .await
             .expect("steal succeeds once the owner is committed-expired");
-        assert_eq!(epoch1, ClaimEpoch(1));
+        assert!(epoch1.0 > epoch0.0);
         assert!(store.fence(&entity, &stealer, epoch1).await.expect("fence"));
     }
 
@@ -2391,7 +2436,7 @@ mod tests {
             .steal_stale(&entity, epoch0, StalePredicate::OwnerStale, &stealer)
             .await
             .expect("steal from a node with no nodes-row succeeds");
-        assert_eq!(epoch1, ClaimEpoch(1));
+        assert!(epoch1.0 > epoch0.0);
     }
 
     #[tokio::test]
@@ -2473,7 +2518,7 @@ mod tests {
             .steal_for_resume(&entity, epoch0, proof, &stealer)
             .await
             .expect("consent CAS steals from a fresh owner");
-        assert_eq!(epoch1, ClaimEpoch(1));
+        assert!(epoch1.0 > epoch0.0);
     }
 
     #[tokio::test]
@@ -2554,6 +2599,99 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_and_recreate_never_reuses_a_claim_generation() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let owner = node_identity();
+        let entity = room_entity("generation-recreate@muc.example.com");
+        let first = store.acquire(&entity, &owner).await.expect("first acquire");
+        assert_eq!(
+            store
+                .release_exact(&entity, &owner, first)
+                .await
+                .expect("exact release"),
+            waddle_xmpp::ownership::ExactReleaseOutcome::Released
+        );
+
+        let recreated = store
+            .acquire(&entity, &owner)
+            .await
+            .expect("recreate under the same node incarnation");
+        assert!(recreated.0 > first.0);
+        assert_eq!(
+            store
+                .release_exact(&entity, &owner, first)
+                .await
+                .expect("stale exact release"),
+            waddle_xmpp::ownership::ExactReleaseOutcome::NotOwned
+        );
+        assert!(store
+            .fence(&entity, &owner, recreated)
+            .await
+            .expect("recreated claim remains held"));
+    }
+
+    #[tokio::test]
+    async fn concurrent_schema_setup_advances_sequence_past_existing_generations() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let conn = store.db.guard().await.expect("guard");
+        let mut rows = conn
+            .query("SELECT last_value FROM clustering_claim_epoch_seq", ())
+            .await
+            .expect("sequence value");
+        let last = rows
+            .next()
+            .await
+            .expect("sequence row")
+            .expect("sequence row present")
+            .get::<i64>(0)
+            .expect("last_value");
+        let legacy_epoch = last.checked_add(1_000).expect("test sequence headroom");
+        let legacy = room_entity("legacy-generation@muc.example.com");
+        let owner = node_identity();
+        conn.execute(
+            r#"
+            INSERT INTO clustering_claims
+                (entity, entity_type, node_id, node_epoch, claim_epoch)
+            VALUES (?, ?, ?, ?, ?)
+            "#,
+            crate::db_params![
+                entity_key(&legacy),
+                EntityType::RoomActor.as_db_str().to_string(),
+                owner.node_id.clone(),
+                owner.node_epoch.clone(),
+                legacy_epoch,
+            ],
+        )
+        .await
+        .expect("seed pre-sequence generation");
+
+        let store_a = PostgresClaimStore::new(store.db.clone());
+        let store_b = PostgresClaimStore::new(store.db.clone());
+        let (a, b) = tokio::join!(store_a.ensure_schema(), store_b.ensure_schema());
+        a.expect("first concurrent schema setup");
+        b.expect("second concurrent schema setup");
+
+        conn.execute(
+            "DELETE FROM clustering_claims WHERE entity = ?",
+            crate::db_params![entity_key(&legacy)],
+        )
+        .await
+        .expect("remove legacy row");
+        let fresh = room_entity("post-migration-generation@muc.example.com");
+        let fresh_epoch = store
+            .acquire(&fresh, &owner)
+            .await
+            .expect("acquire after schema migration");
+        assert!(fresh_epoch.0 > legacy_epoch);
+    }
+
+    #[tokio::test]
     async fn release_many_clears_every_owned_entity_in_one_round_trip() {
         let _guard = clustering_control_plane_table_lock().lock().await;
         let Some(store) = clean_store().await else {
@@ -2563,27 +2701,21 @@ mod tests {
         let a = sm_entity("stream-a");
         let b = sm_entity("stream-b");
         let c = sm_entity("stream-c");
-        store.acquire(&a, &owner).await.expect("acquire a");
-        store.acquire(&b, &owner).await.expect("acquire b");
+        let a_epoch = store.acquire(&a, &owner).await.expect("acquire a");
+        let b_epoch = store.acquire(&b, &owner).await.expect("acquire b");
         // c is owned by someone else — release_many must not touch it.
         let other = node_identity();
-        store.acquire(&c, &other).await.expect("acquire c");
+        let c_epoch = store.acquire(&c, &other).await.expect("acquire c");
 
         store
             .release_many(&[a.clone(), b.clone(), c.clone()], &owner)
             .await
             .expect("release_many");
 
-        assert!(!store
-            .fence(&a, &owner, ClaimEpoch(0))
-            .await
-            .expect("fence a"));
-        assert!(!store
-            .fence(&b, &owner, ClaimEpoch(0))
-            .await
-            .expect("fence b"));
+        assert!(!store.fence(&a, &owner, a_epoch).await.expect("fence a"));
+        assert!(!store.fence(&b, &owner, b_epoch).await.expect("fence b"));
         assert!(store
-            .fence(&c, &other, ClaimEpoch(0))
+            .fence(&c, &other, c_epoch)
             .await
             .expect("fence c: untouched, still owned by other"));
     }
@@ -2642,13 +2774,13 @@ mod tests {
             .steal_for_resume(&entity, epoch0, proof, &me)
             .await
             .expect("same-node resume steal succeeds (no staleness required)");
-        assert_eq!(epoch1, ClaimEpoch(1), "epoch bumped by the resume steal");
+        assert!(epoch1.0 > epoch0.0, "epoch bumped by the resume steal");
         assert!(
             store
                 .fence(&entity, &me, epoch1)
                 .await
                 .expect("fence check"),
-            "the entity is genuinely, freshly re-claimed under epoch 1"
+            "the entity is genuinely, freshly re-claimed under a new generation"
         );
 
         // The stale batch entry's `release_many` call is blind to that
@@ -2720,7 +2852,7 @@ mod tests {
             .await
             .expect("steal task join")
             .expect("steal succeeds once the FOR SHARE lock is released");
-        assert_eq!(stolen_epoch, ClaimEpoch(1));
+        assert!(stolen_epoch.0 > epoch0.0);
 
         // The original owner's fencing check against its old epoch now
         // observes zero rows — it has been fenced out.
@@ -3380,7 +3512,7 @@ mod tests {
             .steal_stale(&entity, epoch0, StalePredicate::OwnerStale, &live_stealer)
             .await
             .expect("a live stealer can still reclaim the dead owner's claim");
-        assert_eq!(epoch1, ClaimEpoch(epoch0.0 + 1));
+        assert!(epoch1.0 > epoch0.0);
     }
 
     #[tokio::test]
@@ -3428,7 +3560,7 @@ mod tests {
             .steal_orphaned_sm_session_claim(&entity, epoch0, &live_stealer, NODE_LEASE_TTL)
             .await
             .expect("a heartbeat-fresh stealer can reclaim the orphaned SM session claim");
-        assert_eq!(epoch1, ClaimEpoch(epoch0.0 + 1));
+        assert!(epoch1.0 > epoch0.0);
     }
 
     // --- ADR-0017 Phase 3 Slice 10: current_generation (Q5's mechanism) --
@@ -3753,7 +3885,7 @@ mod tests {
             )
             .await
             .expect("an uncleared, aged-out intent makes the entity stealable");
-        assert_eq!(epoch1, ClaimEpoch(1));
+        assert!(epoch1.0 > epoch0.0);
     }
 
     #[tokio::test]
@@ -3829,7 +3961,7 @@ mod tests {
             )
             .await
             .expect("a live stealer can consume and win the aged intent");
-        assert_eq!(epoch1, ClaimEpoch(epoch0.0 + 1));
+        assert!(epoch1.0 > epoch0.0);
     }
 
     #[tokio::test]
@@ -3978,7 +4110,7 @@ mod tests {
             )
             .await
             .expect("current-epoch stealer wins on the surviving intent");
-        assert_eq!(epoch2, ClaimEpoch(epoch1.0 + 1));
+        assert!(epoch2.0 > epoch1.0);
         let consumed = store
             .owner_steal_intents(&real_stealer)
             .await

--- a/server/crates/waddle-server/src/clustering/drain.rs
+++ b/server/crates/waddle-server/src/clustering/drain.rs
@@ -538,8 +538,9 @@ mod tests {
         let entities: Vec<Entity> = (0..5)
             .map(|i| room(&format!("room-{i}@muc.example.com")))
             .collect();
+        let mut epochs = Vec::with_capacity(entities.len());
         for entity in &entities {
-            claim_store.acquire(entity, &me).await.expect("acquire");
+            epochs.push(claim_store.acquire(entity, &me).await.expect("acquire"));
         }
         let seal_calls = Arc::new(Mutex::new(Vec::new()));
         let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(FakeLocalClaims {
@@ -564,12 +565,9 @@ mod tests {
             entities.len(),
             "every owned room must have had its seal attempted exactly once"
         );
-        for entity in &entities {
+        for (entity, epoch) in entities.iter().zip(epochs) {
             assert!(
-                !claim_store
-                    .fence(entity, &me, ClaimEpoch(0))
-                    .await
-                    .unwrap_or(true),
+                !claim_store.fence(entity, &me, epoch).await.unwrap_or(true),
                 "every successfully-sealed entity must end up released"
             );
         }
@@ -630,16 +628,16 @@ mod tests {
         let mut entities = Vec::with_capacity(MODELED_ENTITY_COUNT);
         for i in 0..MODELED_ENTITY_COUNT {
             let entity = room(&format!("room-{i}@muc.example.com"));
-            claim_store_typed
+            let epoch = claim_store_typed
                 .acquire(&entity, &me)
                 .await
                 .expect("acquire");
-            entities.push(entity);
+            entities.push((entity, epoch));
         }
         let claim_store: Arc<dyn ClaimStore> = Arc::new(claim_store_typed);
 
         let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(FakeLocalClaims {
-            owned: entities.clone(),
+            owned: entities.iter().map(|(entity, _)| entity.clone()).collect(),
             outcome: SealOutcome::Succeed,
             seal_calls: Arc::new(Mutex::new(Vec::new())),
             demote_calls: Arc::new(AtomicU32::new(0)),
@@ -662,12 +660,9 @@ mod tests {
 
         // Spot-check a sample: genuinely released, not merely "didn't
         // time out."
-        for entity in entities.iter().step_by(200) {
+        for (entity, epoch) in entities.iter().step_by(200) {
             assert!(
-                !claim_store
-                    .fence(entity, &me, ClaimEpoch(0))
-                    .await
-                    .unwrap_or(true),
+                !claim_store.fence(entity, &me, *epoch).await.unwrap_or(true),
                 "entity {entity} must have been released by the modeled-scale drain"
             );
         }

--- a/server/crates/waddle-server/src/clustering/drain.rs
+++ b/server/crates/waddle-server/src/clustering/drain.rs
@@ -412,15 +412,15 @@ mod tests {
         let room_a = room("room-a@muc.example.com");
         let room_b = room("room-b@muc.example.com");
         let sm_c = sm("stream-c");
-        claim_store
+        let room_a_epoch = claim_store
             .acquire(&room_a, &me)
             .await
             .expect("acquire room a");
-        claim_store
+        let room_b_epoch = claim_store
             .acquire(&room_b, &me)
             .await
             .expect("acquire room b");
-        claim_store.acquire(&sm_c, &me).await.expect("acquire sm c");
+        let sm_c_epoch = claim_store.acquire(&sm_c, &me).await.expect("acquire sm c");
 
         let local_claims: Arc<dyn LocallyClaimedEntities> = Arc::new(FakeLocalClaims {
             owned: vec![room_a.clone(), room_b.clone(), sm_c.clone()],
@@ -440,21 +440,21 @@ mod tests {
 
         assert!(
             !claim_store
-                .fence(&room_a, &me, ClaimEpoch(0))
+                .fence(&room_a, &me, room_a_epoch)
                 .await
                 .unwrap_or(true),
             "room_a's claim must be released by the drain"
         );
         assert!(
             !claim_store
-                .fence(&room_b, &me, ClaimEpoch(0))
+                .fence(&room_b, &me, room_b_epoch)
                 .await
                 .unwrap_or(true),
             "room_b's claim must be released by the drain"
         );
         assert!(
             claim_store
-                .fence(&sm_c, &me, ClaimEpoch(0))
+                .fence(&sm_c, &me, sm_c_epoch)
                 .await
                 .unwrap_or(false),
             "the sm_session entity must be left untouched by the generic drain loop \

--- a/server/crates/waddle-server/src/clustering/local_claims.rs
+++ b/server/crates/waddle-server/src/clustering/local_claims.rs
@@ -208,10 +208,16 @@ impl LocallyClaimedEntities for RoomLocalClaims {
         // `CreateInstantRoom` acquire the claim before spawning), so this
         // enumeration is exactly the owned-entity set.
         match registry.list_rooms().await {
-            Ok(jids) => jids
-                .into_iter()
-                .map(|jid| Entity::new(EntityType::RoomActor, jid.to_string()))
-                .collect(),
+            Ok(mut jids) => {
+                if let Ok(pending) = registry.list_pending_room_release_jids().await {
+                    jids.extend(pending);
+                    jids.sort();
+                    jids.dedup();
+                }
+                jids.into_iter()
+                    .map(|jid| Entity::new(EntityType::RoomActor, jid.to_string()))
+                    .collect()
+            }
             Err(error) => {
                 tracing::warn!(
                     %error,
@@ -279,6 +285,13 @@ impl LocallyClaimedEntities for RoomLocalClaims {
         let Some(room_jid) = Self::room_jid(entity) else {
             return true;
         };
+        if registry
+            .is_current_room_pending_release(room_jid.clone())
+            .await
+            .unwrap_or(false)
+        {
+            return false;
+        }
         let Ok(Some(actor_ref)) = registry.get_room(room_jid).await else {
             tracing::warn!(
                 %entity,
@@ -328,6 +341,13 @@ impl LocallyClaimedEntities for RoomLocalClaims {
         let Some(room_jid) = Self::room_jid(entity) else {
             return true;
         };
+        if registry
+            .is_current_identity_pending_room_release_only(room_jid.clone())
+            .await
+            .unwrap_or(false)
+        {
+            return true;
+        }
         let Ok(Some(actor_ref)) = registry.get_room(room_jid).await else {
             tracing::warn!(
                 %entity,

--- a/server/crates/waddle-server/src/clustering/metrics.rs
+++ b/server/crates/waddle-server/src/clustering/metrics.rs
@@ -250,38 +250,3 @@ pub fn record_claims_abandoned_on_drain(count: u64) {
     })
     .add(count, &[]);
 }
-
-/// Count bounded proactive `RoomActor` orphan-reconciliation outcomes.
-pub fn record_room_orphan_reconciliation(outcome: &'static str, count: u64) {
-    static C: OnceLock<Counter<u64>> = OnceLock::new();
-    C.get_or_init(|| {
-        meter()
-            .u64_counter("waddle.clustering.room_orphan_reconciliations")
-            .with_description("Proactive RoomActor orphan-claim reconciliation outcomes")
-            .with_unit("claim")
-            .build()
-    })
-    .add(count, &[opentelemetry::KeyValue::new("outcome", outcome)]);
-}
-
-pub fn record_room_orphan_pending_backlog(depth: usize, oldest_age_ms: u64) {
-    static DEPTH: OnceLock<Gauge<u64>> = OnceLock::new();
-    DEPTH
-        .get_or_init(|| {
-            meter()
-                .u64_gauge("waddle.clustering.room_orphan_pending_depth")
-                .with_description("Reclaimed room epochs awaiting adoption or release")
-                .with_unit("claim")
-                .build()
-        })
-        .record(depth as u64, &[]);
-    static AGE: OnceLock<Gauge<u64>> = OnceLock::new();
-    AGE.get_or_init(|| {
-        meter()
-            .u64_gauge("waddle.clustering.room_orphan_pending_oldest_age_ms")
-            .with_description("Age of the oldest pending reclaimed room epoch")
-            .with_unit("ms")
-            .build()
-    })
-    .record(oldest_age_ms, &[]);
-}

--- a/server/crates/waddle-server/src/clustering/metrics.rs
+++ b/server/crates/waddle-server/src/clustering/metrics.rs
@@ -250,3 +250,38 @@ pub fn record_claims_abandoned_on_drain(count: u64) {
     })
     .add(count, &[]);
 }
+
+/// Count bounded proactive `RoomActor` orphan-reconciliation outcomes.
+pub fn record_room_orphan_reconciliation(outcome: &'static str, count: u64) {
+    static C: OnceLock<Counter<u64>> = OnceLock::new();
+    C.get_or_init(|| {
+        meter()
+            .u64_counter("waddle.clustering.room_orphan_reconciliations")
+            .with_description("Proactive RoomActor orphan-claim reconciliation outcomes")
+            .with_unit("claim")
+            .build()
+    })
+    .add(count, &[opentelemetry::KeyValue::new("outcome", outcome)]);
+}
+
+pub fn record_room_orphan_pending_backlog(depth: usize, oldest_age_ms: u64) {
+    static DEPTH: OnceLock<Gauge<u64>> = OnceLock::new();
+    DEPTH
+        .get_or_init(|| {
+            meter()
+                .u64_gauge("waddle.clustering.room_orphan_pending_depth")
+                .with_description("Reclaimed room epochs awaiting adoption or release")
+                .with_unit("claim")
+                .build()
+        })
+        .record(depth as u64, &[]);
+    static AGE: OnceLock<Gauge<u64>> = OnceLock::new();
+    AGE.get_or_init(|| {
+        meter()
+            .u64_gauge("waddle.clustering.room_orphan_pending_oldest_age_ms")
+            .with_description("Age of the oldest pending reclaimed room epoch")
+            .with_unit("ms")
+            .build()
+    })
+    .record(oldest_age_ms, &[]);
+}

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -705,8 +705,8 @@ pub async fn start_if_enabled(
         let muc_durable_store: Arc<dyn waddle_xmpp::muc::MucDurableStore> = Arc::new(
             crate::muc_durable::PostgresMucRoomStore::open(
                 db.clone(),
-                live_identity.clone(),
                 clustering_stop.clone(),
+                live_identity.clone(),
             )
             .await
             .map_err(ClusteringError::MucDurableStoreInit)?,

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -5036,8 +5036,33 @@ mod tests {
         envelope
     }
 
-    fn signed_envelope(keypair: &Keypair) -> RemoteStanzaEnvelope {
-        sign_envelope(envelope(), keypair)
+    async fn envelope_for_services(
+        services: &OrderedRelayDeliveryServices,
+    ) -> RemoteStanzaEnvelope {
+        async fn epoch_for(services: &OrderedRelayDeliveryServices, entity: &Entity) -> ClaimEpoch {
+            services
+                .claim_store
+                .current_claim(entity)
+                .await
+                .expect("claim lookup")
+                .expect("seeded claim")
+                .claim_epoch
+        }
+
+        let mut envelope = envelope();
+        envelope.origin_claim.epoch = epoch_for(services, &origin_entity()).await;
+        envelope.sender_claim.epoch = epoch_for(services, &sender_entity()).await;
+        let target_epoch = epoch_for(services, &target_entity()).await;
+        envelope.target_claim.epoch = target_epoch;
+        envelope.channel.target_epoch = target_epoch;
+        envelope
+    }
+
+    async fn signed_envelope_for_services(
+        services: &OrderedRelayDeliveryServices,
+        keypair: &Keypair,
+    ) -> RemoteStanzaEnvelope {
+        sign_envelope(envelope_for_services(services).await, keypair)
     }
 
     fn test_peer_id() -> String {
@@ -5127,7 +5152,8 @@ mod tests {
         )
         .await;
 
-        let err = validate_claims(&services, &signed_envelope(&keypair))
+        let envelope = signed_envelope_for_services(&services, &keypair).await;
+        let err = validate_claims(&services, &envelope)
             .await
             .expect_err("foreign target owner is not this relay");
 
@@ -5150,7 +5176,8 @@ mod tests {
         )
         .await;
 
-        validate_claims(&services, &signed_envelope(&keypair))
+        let envelope = signed_envelope_for_services(&services, &keypair).await;
+        validate_claims(&services, &envelope)
             .await
             .expect("claims match origin and receiver");
     }
@@ -5165,7 +5192,7 @@ mod tests {
             keypair.public().to_peer_id().to_string(),
         )
         .await;
-        let mut envelope = envelope();
+        let mut envelope = envelope_for_services(&services).await;
         envelope.sender_claim.epoch = ClaimEpoch(99);
         let envelope = sign_envelope(envelope, &keypair);
 
@@ -5262,10 +5289,10 @@ mod tests {
             CancellationToken::new(),
             &ClusteringMessagingConfig::default(),
         );
-        bridge.wire(Arc::new(services));
-        let mut envelope = envelope();
+        let mut envelope = envelope_for_services(&services).await;
         envelope.payload = iq_payload();
         let envelope = sign_envelope(envelope, &keypair);
+        bridge.wire(Arc::new(services));
 
         let err = bridge
             .deliver_reserved(&envelope)
@@ -5298,10 +5325,10 @@ mod tests {
             CancellationToken::new(),
             &ClusteringMessagingConfig::default(),
         );
-        bridge.wire(Arc::new(services));
-        let mut envelope = envelope();
+        let mut envelope = envelope_for_services(&services).await;
         envelope.payload = iq_payload();
         let envelope = sign_envelope(envelope, &keypair);
+        bridge.wire(Arc::new(services));
 
         bridge
             .deliver_reserved(&envelope)
@@ -5494,8 +5521,8 @@ mod tests {
             CancellationToken::new(),
             &ClusteringMessagingConfig::default(),
         );
+        let envelope = sign_envelope(envelope_for_services(&services).await, &keypair);
         bridge.wire(Arc::new(services));
-        let envelope = sign_envelope(envelope(), &keypair);
 
         let err = bridge
             .deliver_reserved(&envelope)

--- a/server/crates/waddle-server/src/clustering/self_fence.rs
+++ b/server/crates/waddle-server/src/clustering/self_fence.rs
@@ -350,7 +350,7 @@ pub struct NodeLeaseRunConfig {
     pub claim_store: Arc<dyn ClaimStore>,
     /// Live, shared view of this node's current identity (ADR-0017 Phase 3
     /// Slice 4 follow-up plumbing note): [`run_node_lease`] calls
-    /// [`waddle_xmpp::ownership::SharedNodeIdentity::set`] on it every
+    /// [`waddle_xmpp::ownership::SharedNodeIdentity::rotate`] on it every
     /// time it mints a fresh identity (initial value and every post-fence
     /// re-registration), so any other holder of a clone — e.g. the
     /// Postgres-fenced `SmPersistenceStorage`'s claim-acquire calls —
@@ -705,7 +705,7 @@ pub async fn run_node_lease<L>(
     // see `live_identity`'s doc comment and the `identity = fresh;`
     // reassignment below, which keeps it current across every
     // re-registration.
-    live_identity.set(identity.clone());
+    live_identity.rotate(identity.clone()).await;
     let mut isolation = IsolationTracker::new();
     let mut backoff = ReregistrationBackoff::new(
         self_fence_cfg.reregister_backoff_base,
@@ -1048,7 +1048,7 @@ pub async fn run_node_lease<L>(
                         // `acquire_claim_store_entry_for_detach`) during
                         // the retry window did so under `live_identity`'s
                         // STALE, pre-fence value (this loop only calls
-                        // `live_identity.set(fresh)` a few lines below, once
+                        // `live_identity.rotate(fresh)` a few lines below, once
                         // re-registration itself succeeds), so that
                         // snapshot missed it entirely. Re-running the sweep
                         // here catches anything acquired during that window
@@ -1113,7 +1113,7 @@ pub async fn run_node_lease<L>(
                         }
 
                         identity = fresh;
-                        live_identity.set(identity.clone());
+                        live_identity.rotate(identity.clone()).await;
                         backoff.reset();
                         readiness.set_ready(true);
                         tracing::info!(

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -168,7 +168,7 @@ pub struct ClusteringConfig {
     /// dials seed peers, picking up pod churn
     /// (`WADDLE_CLUSTERING_DIAL_INTERVAL_MS`).
     pub dial_interval: Duration,
-    /// Cadence for the orphan reaper's `sm_session` claim sweep (ADR-0017
+    /// Cadence for the orphan reaper's `sm_session` and `RoomActor` claim sweep (ADR-0017
     /// Phase 3 Slice 5, element 9) — `WADDLE_CLUSTERING_ORPHAN_REAPER_INTERVAL_MS`.
     /// The only cluster timer that, prior to ADR-0017 Phase 3 Slice 11's
     /// corrigenda (deviation 111), had no env override at all (every

--- a/server/crates/waddle-server/src/config.rs
+++ b/server/crates/waddle-server/src/config.rs
@@ -168,7 +168,7 @@ pub struct ClusteringConfig {
     /// dials seed peers, picking up pod churn
     /// (`WADDLE_CLUSTERING_DIAL_INTERVAL_MS`).
     pub dial_interval: Duration,
-    /// Cadence for the orphan reaper's `sm_session` and `RoomActor` claim sweep (ADR-0017
+    /// Cadence for the orphan reaper's `sm_session` claim sweep (ADR-0017
     /// Phase 3 Slice 5, element 9) — `WADDLE_CLUSTERING_ORPHAN_REAPER_INTERVAL_MS`.
     /// The only cluster timer that, prior to ADR-0017 Phase 3 Slice 11's
     /// corrigenda (deviation 111), had no env override at all (every

--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -61,7 +61,9 @@ use waddle_xmpp::muc::{
     DurableRoomState, MucDurableFuture, MucDurableStore, RoomClaimFenceContext, RoomConfig,
     SubjectState,
 };
-use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, SharedNodeIdentity};
+use waddle_xmpp::ownership::{
+    ClaimEpoch, CurrentNodeIdentityGuard, Entity, EntityType, SharedNodeIdentity,
+};
 use waddle_xmpp::{Affiliation, XmppError};
 
 use crate::clustering::relay::RelayHandle;
@@ -216,6 +218,21 @@ impl PostgresMucRoomStore {
         Ok(fence)
     }
 
+    async fn guard_fence_identity(
+        &self,
+        room_jid: &BareJid,
+        fence: &RoomClaimFenceContext,
+    ) -> Result<CurrentNodeIdentityGuard, XmppError> {
+        self.node_identity
+            .guard_if_current(&fence.owner)
+            .await
+            .ok_or_else(|| {
+                XmppError::internal(format!(
+                    "durable write for room {room_jid} aborted during node identity rotation"
+                ))
+            })
+    }
+
     /// Take the fencing lock inside `tx` — the exact `SELECT ... FOR SHARE`
     /// shape `sm_persistence_fenced::assert_fenced` already established —
     /// for `room_jid` at `epoch`. See that function's doc comment for the
@@ -346,6 +363,7 @@ impl MucDurableStore for PostgresMucRoomStore {
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
             let fence = self.fence_for(room_jid)?;
+            let _identity_guard = self.guard_fence_identity(room_jid, &fence).await?;
             let config_json = serde_json::to_string(config).map_err(|error| {
                 XmppError::internal(format!("durable room config encode failed: {error}"))
             })?;
@@ -382,6 +400,7 @@ impl MucDurableStore for PostgresMucRoomStore {
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
             let fence = self.fence_for(room_jid)?;
+            let _identity_guard = self.guard_fence_identity(room_jid, &fence).await?;
             let subject_json = subject
                 .map(serde_json::to_string)
                 .transpose()
@@ -422,6 +441,7 @@ impl MucDurableStore for PostgresMucRoomStore {
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
             let fence = self.fence_for(room_jid)?;
+            let _identity_guard = self.guard_fence_identity(room_jid, &fence).await?;
             let mut tx = self.db.begin().await.map_err(db_err)?;
             self.assert_fenced(&mut tx, room_jid, &fence).await?;
             if entry.affiliation == Affiliation::None {
@@ -463,6 +483,7 @@ impl MucDurableStore for PostgresMucRoomStore {
     fn delete_room_state<'a>(&'a self, room_jid: &'a BareJid) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
             let fence = self.fence_for(room_jid)?;
+            let _identity_guard = self.guard_fence_identity(room_jid, &fence).await?;
             let mut tx = self.db.begin().await.map_err(db_err)?;
             self.assert_fenced(&mut tx, room_jid, &fence).await?;
             tx.execute(
@@ -631,7 +652,7 @@ mod tests {
         );
         assert!(store.current_claim_fence(&jid).is_some());
 
-        live_identity.set(node_identity());
+        live_identity.rotate(node_identity()).await;
 
         assert!(
             !store

--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -923,6 +923,9 @@ mod tests {
         let message = ArchivedMessage {
             id: first_id.clone(),
             body: Some("hello, fenced world".to_string()),
+            origin_id: Some(waddle_xmpp_core::xep0359::OriginId::new(
+                uuid::Uuid::new_v4().to_string(),
+            )),
             message_type: xmpp_parsers::message::MessageType::Groupchat,
             ..ArchivedMessage::for_test(
                 format!("{jid}/alice").parse().expect("valid full jid"),
@@ -949,6 +952,14 @@ mod tests {
             .steal_stale(&entity, epoch, StalePredicate::OwnerStale, &stealer)
             .await
             .expect("steal succeeds against a dead-owner claim");
+
+        let duplicate_result = mam_storage
+            .store_message_fenced(&jid, &message, &fence)
+            .await;
+        assert!(
+            matches!(duplicate_result, Err(MamStorageError::NotOwner { .. })),
+            "origin-id dedup must not bypass the deposed owner's fence: {duplicate_result:?}"
+        );
 
         let second_message = ArchivedMessage {
             id: second_id.clone(),

--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -32,8 +32,8 @@
 //! same [`crate::db::Database::begin`] transaction as the write it guards,
 //! on the **main pool**, never the control-plane pool (the Slice 0/4/7
 //! pool-assignment rule). The epoch bound into that check comes from a
-//! per-room cache ([`PostgresMucRoomStore::claim_epochs`]) populated by the
-//! room registry calling [`Self::record_claim_epoch`] immediately after a
+//! per-room cache ([`PostgresMucRoomStore::claim_fences`]) populated by the
+//! room registry calling [`Self::record_claim_fence`] immediately after a
 //! successful claim acquire/steal — never re-derived here, mirroring
 //! `PostgresFencedSmPersistence`'s own "epoch side channel" design note.
 //!
@@ -113,6 +113,9 @@ fn affiliation_from_db_str(value: &str) -> Option<Affiliation> {
 /// code-research correction.
 pub struct PostgresMucRoomStore {
     db: Database,
+    /// Live process incarnation. Cached room fences remain immutable; every
+    /// use must still match this handle so a self-fenced old incarnation
+    /// cannot write merely because its old claim row remains in Postgres.
     node_identity: SharedNodeIdentity,
     /// This node's clustering-scope cancellation token, threaded into the
     /// `RelayHandle` [`Self::notify_previous_owner_demoted`] constructs
@@ -120,7 +123,15 @@ pub struct PostgresMucRoomStore {
     /// identical "fresh `RelayHandle` per ask" pattern).
     stop_token: CancellationToken,
     /// Per-room claim epoch cache — see the module doc's fencing section.
-    claim_epochs: DashMap<BareJid, ClaimEpoch>,
+    claim_fences: DashMap<BareJid, RoomClaimFenceContext>,
+}
+
+fn remove_room_claim_fence_if(
+    claim_fences: &DashMap<BareJid, RoomClaimFenceContext>,
+    room_jid: &BareJid,
+    expected: &RoomClaimFenceContext,
+) {
+    claim_fences.remove_if(room_jid, |_, current| current == expected);
 }
 
 impl PostgresMucRoomStore {
@@ -131,14 +142,14 @@ impl PostgresMucRoomStore {
     /// which lives there).
     pub async fn open(
         db: Database,
-        node_identity: SharedNodeIdentity,
         stop_token: CancellationToken,
+        node_identity: SharedNodeIdentity,
     ) -> Result<Self, XmppError> {
         let store = Self {
             db,
             node_identity,
             stop_token,
-            claim_epochs: DashMap::new(),
+            claim_fences: DashMap::new(),
         };
         store.ensure_schema().await.map_err(db_err)?;
         Ok(store)
@@ -185,16 +196,24 @@ impl PostgresMucRoomStore {
         Ok(())
     }
 
-    fn epoch_for(&self, room_jid: &BareJid) -> Result<ClaimEpoch, XmppError> {
-        self.claim_epochs
+    fn fence_for(&self, room_jid: &BareJid) -> Result<RoomClaimFenceContext, XmppError> {
+        let fence = self
+            .claim_fences
             .get(room_jid)
-            .map(|entry| *entry)
+            .map(|entry| entry.clone())
             .ok_or_else(|| {
                 XmppError::internal(format!(
                     "no claim epoch recorded for room {room_jid}; durable write skipped \
-                 (the room registry must call record_claim_epoch before any write)"
+                 (the room registry must call record_claim_fence before any write)"
                 ))
-            })
+            })?;
+        if self.node_identity.current() != fence.owner {
+            remove_room_claim_fence_if(&self.claim_fences, room_jid, &fence);
+            return Err(XmppError::internal(format!(
+                "durable write for room {room_jid} aborted: cached claim belongs to a stale node incarnation"
+            )));
+        }
+        Ok(fence)
     }
 
     /// Take the fencing lock inside `tx` — the exact `SELECT ... FOR SHARE`
@@ -205,22 +224,32 @@ impl PostgresMucRoomStore {
         &self,
         tx: &mut Transaction<'_>,
         room_jid: &BareJid,
-        epoch: ClaimEpoch,
+        fence: &RoomClaimFenceContext,
     ) -> Result<(), XmppError> {
-        let identity = self.node_identity.current();
+        if self.node_identity.current() != fence.owner {
+            remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
+            return Err(XmppError::internal(format!(
+                "durable write for room {room_jid} aborted: claim fence belongs to a stale node incarnation"
+            )));
+        }
         let key = room_entity_key(room_jid);
         let mut rows = tx
             .query(
-                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                crate::db_params![key, identity.node_id.clone(), epoch.0],
+                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
+                crate::db_params![
+                    key,
+                    fence.owner.node_id.clone(),
+                    fence.owner.node_epoch.clone(),
+                    fence.epoch.0
+                ],
             )
             .await
             .map_err(db_err)?;
         let held = rows.next().await.map_err(db_err)?.is_some();
-        if held {
+        if held && self.node_identity.current() == fence.owner {
             Ok(())
         } else {
-            self.claim_epochs.remove(room_jid);
+            remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
             Err(XmppError::internal(format!(
                 "durable write for room {room_jid} aborted: this node no longer holds the \
                  room's ownership claim (0 rows from the fencing SELECT)"
@@ -316,12 +345,12 @@ impl MucDurableStore for PostgresMucRoomStore {
         config: &'a RoomConfig,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let epoch = self.epoch_for(room_jid)?;
+            let fence = self.fence_for(room_jid)?;
             let config_json = serde_json::to_string(config).map_err(|error| {
                 XmppError::internal(format!("durable room config encode failed: {error}"))
             })?;
             let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, epoch).await?;
+            self.assert_fenced(&mut tx, room_jid, &fence).await?;
             tx.execute(
                 r#"
                 INSERT INTO clustering_muc_rooms (room_jid, waddle_id, channel_id, config_json, updated_at)
@@ -352,7 +381,7 @@ impl MucDurableStore for PostgresMucRoomStore {
         subject: Option<&'a SubjectState>,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let epoch = self.epoch_for(room_jid)?;
+            let fence = self.fence_for(room_jid)?;
             let subject_json = subject
                 .map(serde_json::to_string)
                 .transpose()
@@ -360,7 +389,7 @@ impl MucDurableStore for PostgresMucRoomStore {
                     XmppError::internal(format!("durable room subject encode failed: {error}"))
                 })?;
             let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, epoch).await?;
+            self.assert_fenced(&mut tx, room_jid, &fence).await?;
             // The room row must already exist (a subject can only be set on
             // an already-spawned room, which always durably writes its
             // config at spawn-adjacent points first) — an UPDATE-only
@@ -392,9 +421,9 @@ impl MucDurableStore for PostgresMucRoomStore {
         entry: &'a AffiliationEntry,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let epoch = self.epoch_for(room_jid)?;
+            let fence = self.fence_for(room_jid)?;
             let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, epoch).await?;
+            self.assert_fenced(&mut tx, room_jid, &fence).await?;
             if entry.affiliation == Affiliation::None {
                 tx.execute(
                     "DELETE FROM clustering_muc_room_affiliations WHERE room_jid = ? AND member_jid = ?",
@@ -433,9 +462,9 @@ impl MucDurableStore for PostgresMucRoomStore {
     /// rows.
     fn delete_room_state<'a>(&'a self, room_jid: &'a BareJid) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let epoch = self.epoch_for(room_jid)?;
+            let fence = self.fence_for(room_jid)?;
             let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, epoch).await?;
+            self.assert_fenced(&mut tx, room_jid, &fence).await?;
             tx.execute(
                 "DELETE FROM clustering_muc_room_affiliations WHERE room_jid = ?",
                 crate::db_params![room_jid.to_string()],
@@ -453,12 +482,12 @@ impl MucDurableStore for PostgresMucRoomStore {
         })
     }
 
-    fn record_claim_epoch(&self, room_jid: &BareJid, epoch: ClaimEpoch) {
-        self.claim_epochs.insert(room_jid.clone(), epoch);
+    fn record_claim_fence(&self, room_jid: &BareJid, fence: RoomClaimFenceContext) {
+        self.claim_fences.insert(room_jid.clone(), fence);
     }
 
-    fn forget_claim_epoch(&self, room_jid: &BareJid) {
-        self.claim_epochs.remove(room_jid);
+    fn forget_claim_fence(&self, room_jid: &BareJid, expected: &RoomClaimFenceContext) {
+        remove_room_claim_fence_if(&self.claim_fences, room_jid, expected);
     }
 
     /// The guaranteed demotion backstop (element 7): a fenced,
@@ -468,34 +497,54 @@ impl MucDurableStore for PostgresMucRoomStore {
     /// lands, unconditionally (both archiving-on and archiving-off).
     fn check_fenced_fanout<'a>(&'a self, room_jid: &'a BareJid) -> MucDurableFuture<'a, bool> {
         Box::pin(async move {
-            let epoch = self.epoch_for(room_jid)?;
-            let identity = self.node_identity.current();
+            let fence = self
+                .claim_fences
+                .get(room_jid)
+                .map(|entry| entry.clone())
+                .ok_or_else(|| {
+                    XmppError::internal(format!(
+                        "no claim epoch recorded for room {room_jid}; fenced fan-out skipped"
+                    ))
+                })?;
+            // Identity rotation is a definitive local ownership loss, not a
+            // transient storage failure. Return `Ok(false)` so fan-out and
+            // mutation gates fail closed instead of taking their transient
+            // error path (which intentionally fails open).
+            if self.node_identity.current() != fence.owner {
+                remove_room_claim_fence_if(&self.claim_fences, room_jid, &fence);
+                return Ok(false);
+            }
             let key = room_entity_key(room_jid);
             let conn = self.db.guard().await.map_err(db_err)?;
             let mut rows = conn
                 .query(
-                    "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                    crate::db_params![key, identity.node_id.clone(), epoch.0],
+                    "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
+                    crate::db_params![
+                        key,
+                        fence.owner.node_id.clone(),
+                        fence.owner.node_epoch.clone(),
+                        fence.epoch.0
+                    ],
                 )
                 .await
                 .map_err(db_err)?;
-            Ok(rows.next().await.map_err(db_err)?.is_some())
+            let held = rows.next().await.map_err(db_err)?.is_some();
+            if held && self.node_identity.current() == fence.owner {
+                Ok(true)
+            } else {
+                remove_room_claim_fence_if(&self.claim_fences, room_jid, &fence);
+                Ok(false)
+            }
         })
     }
 
     /// ADR-0017 Phase 3 Slice 7 FIX 1: exposes the exact `(Entity,
     /// ClaimEpoch, node_id)` triple [`Self::check_fenced_fanout`]/
-    /// [`Self::assert_fenced`] already resolve from `self.claim_epochs`, so
+    /// [`Self::assert_fenced`] already resolve from `self.claim_fences`, so
     /// `groupchat_archive.rs`'s MAM fenced write can bind the identical
     /// typed context rather than re-deriving it from a second mechanism.
     fn current_claim_fence(&self, room_jid: &BareJid) -> Option<RoomClaimFenceContext> {
-        let epoch = self.claim_epochs.get(room_jid).map(|entry| *entry)?;
-        let identity = self.node_identity.current();
-        Some(RoomClaimFenceContext {
-            entity: Entity::new(EntityType::RoomActor, room_jid.to_string()),
-            epoch,
-            node_id: identity.node_id,
-        })
+        self.fence_for(room_jid).ok()
     }
 
     fn notify_previous_owner_demoted<'a>(
@@ -558,12 +607,54 @@ mod tests {
             .expect("valid test room JID")
     }
 
+    #[tokio::test]
+    async fn identity_rotation_invalidates_cached_room_fence_before_database_access() {
+        let original = node_identity();
+        let live_identity = SharedNodeIdentity::new(original.clone());
+        let db = Database::from_config(
+            "muc-identity-rotation-test",
+            &DatabaseConfig::new(DatabaseDriver::Sqlite, "sqlite::memory:"),
+        )
+        .await
+        .expect("open in-memory database");
+        let store = PostgresMucRoomStore {
+            db,
+            node_identity: live_identity.clone(),
+            stop_token: CancellationToken::new(),
+            claim_fences: DashMap::new(),
+        };
+        let jid = room_jid("identity-rotation");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        store.record_claim_fence(
+            &jid,
+            RoomClaimFenceContext::new(entity, original, ClaimEpoch(7)),
+        );
+        assert!(store.current_claim_fence(&jid).is_some());
+
+        live_identity.set(node_identity());
+
+        assert!(
+            !store
+                .check_fenced_fanout(&jid)
+                .await
+                .expect("identity rotation is definitive ownership loss"),
+            "a rotated cached fence must return false, never a transient error that callers fail open"
+        );
+        assert!(store.current_claim_fence(&jid).is_none());
+        assert!(store.claim_fences.get(&jid).is_none());
+    }
+
     /// Open a clean `PostgresMucRoomStore` alongside a `PostgresClaimStore`
     /// sharing the same `Database`/tables, wiping every row this module's
     /// tests touch first. `None` (test skipped) when
     /// `WADDLE_TEST_POSTGRES_URL` is unset, mirroring every other
     /// Postgres-gated test in this workspace.
-    async fn clean_store() -> Option<(PostgresMucRoomStore, Arc<PostgresClaimStore>, Database)> {
+    async fn clean_store() -> Option<(
+        PostgresMucRoomStore,
+        Arc<PostgresClaimStore>,
+        Database,
+        NodeIdentity,
+    )> {
         let url = std::env::var("WADDLE_TEST_POSTGRES_URL").ok()?;
         let db = Database::from_config(
             "muc-durable-test",
@@ -577,10 +668,11 @@ mod tests {
             .ensure_schema()
             .await
             .expect("ensure claim schema");
+        let me = node_identity();
         let store = PostgresMucRoomStore::open(
             db.clone(),
-            SharedNodeIdentity::new(node_identity()),
             CancellationToken::new(),
+            SharedNodeIdentity::new(me.clone()),
         )
         .await
         .expect("open muc durable store");
@@ -597,23 +689,25 @@ mod tests {
         conn.execute("DELETE FROM clustering_muc_room_affiliations", ())
             .await
             .expect("clean affiliations");
-        Some((store, claim_store, db))
+        Some((store, claim_store, db, me))
     }
 
     #[tokio::test]
     async fn save_and_load_round_trips_config_subject_and_affiliations() {
         let _guard = clustering_control_plane_table_lock().lock().await;
-        let Some((store, claim_store, _db)) = clean_store().await else {
+        let Some((store, claim_store, _db, me)) = clean_store().await else {
             return;
         };
         let jid = room_jid("round-trip");
         let entity = Entity::new(EntityType::RoomActor, jid.to_string());
-        let me = store.node_identity.current();
         let epoch = claim_store
             .ensure_claimed(&entity, &me)
             .await
             .expect("claim");
-        store.record_claim_epoch(&jid, epoch);
+        store.record_claim_fence(
+            &jid,
+            RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch),
+        );
 
         let config = RoomConfig {
             name: "test room".to_string(),
@@ -664,17 +758,19 @@ mod tests {
     #[tokio::test]
     async fn save_affiliation_none_deletes_the_row() {
         let _guard = clustering_control_plane_table_lock().lock().await;
-        let Some((store, claim_store, _db)) = clean_store().await else {
+        let Some((store, claim_store, _db, me)) = clean_store().await else {
             return;
         };
         let jid = room_jid("affiliation-removal");
         let entity = Entity::new(EntityType::RoomActor, jid.to_string());
-        let me = store.node_identity.current();
         let epoch = claim_store
             .ensure_claimed(&entity, &me)
             .await
             .expect("claim");
-        store.record_claim_epoch(&jid, epoch);
+        store.record_claim_fence(
+            &jid,
+            RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch),
+        );
         store
             .save_config(&jid, "waddle-1", "chan-1", &RoomConfig::default())
             .await
@@ -713,17 +809,19 @@ mod tests {
     #[tokio::test]
     async fn check_fenced_fanout_returns_false_immediately_after_a_steal_commits() {
         let _guard = clustering_control_plane_table_lock().lock().await;
-        let Some((store, claim_store, db)) = clean_store().await else {
+        let Some((store, claim_store, db, me)) = clean_store().await else {
             return;
         };
         let jid = room_jid("deposed");
         let entity = Entity::new(EntityType::RoomActor, jid.to_string());
-        let me = store.node_identity.current();
         let epoch = claim_store
             .ensure_claimed(&entity, &me)
             .await
             .expect("claim");
-        store.record_claim_epoch(&jid, epoch);
+        store.record_claim_fence(
+            &jid,
+            RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch),
+        );
 
         assert!(
             store
@@ -766,17 +864,19 @@ mod tests {
         use waddle_xmpp_core::mam::ArchivedMessage;
 
         let _guard = clustering_control_plane_table_lock().lock().await;
-        let Some((store, claim_store, db)) = clean_store().await else {
+        let Some((store, claim_store, db, me)) = clean_store().await else {
             return;
         };
         let jid = room_jid("mam-fenced");
         let entity = Entity::new(EntityType::RoomActor, jid.to_string());
-        let me = store.node_identity.current();
         let epoch = claim_store
             .ensure_claimed(&entity, &me)
             .await
             .expect("claim");
-        store.record_claim_epoch(&jid, epoch);
+        store.record_claim_fence(
+            &jid,
+            RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch),
+        );
 
         let mam_storage = SqlxMamStorage::open(db.database_url())
             .await
@@ -794,10 +894,10 @@ mod tests {
 
         let fence = store
             .current_claim_fence(&jid)
-            .expect("current_claim_fence must resolve immediately after record_claim_epoch");
+            .expect("current_claim_fence must resolve immediately after record_claim_fence");
         assert_eq!(fence.entity, entity);
         assert_eq!(fence.epoch, epoch);
-        assert_eq!(fence.node_id, me.node_id);
+        assert_eq!(fence.owner, me);
 
         let message = ArchivedMessage {
             id: first_id.clone(),
@@ -857,5 +957,20 @@ mod tests {
             should_be_absent.is_none(),
             "a rejected fenced write must not have committed any row"
         );
+    }
+
+    #[test]
+    fn stale_muc_cache_failure_does_not_evict_new_generation() {
+        let jid = room_jid("old-a-new-b");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let owner = node_identity();
+        let fence_a = RoomClaimFenceContext::new(entity.clone(), owner.clone(), ClaimEpoch(1));
+        let fence_b = RoomClaimFenceContext::new(entity, owner, ClaimEpoch(2));
+        let cache = DashMap::new();
+        cache.insert(jid.clone(), fence_b.clone());
+
+        remove_room_claim_fence_if(&cache, &jid, &fence_a);
+
+        assert_eq!(cache.get(&jid).as_deref(), Some(&fence_b));
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/archive_groupchat_event.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/archive_groupchat_event.rs
@@ -42,13 +42,13 @@ pub(super) async fn archive_groupchat_event(
     // ADR-0017 Phase 3 Slice 7 FIX 1: resolve the SAME typed fencing
     // context `dispatch_to_room`'s own pre-fan-out check reads, so the
     // fenced archive write below agrees with it by construction.
-    let fence = resolve_room_claim_fence(deps, &room);
+    let fence = resolve_room_claim_fence(deps, &room).await;
     let archive_id = match archive_groupchat_message(
         mam_storage,
         &room,
         &message,
         sender_nickname_generation,
-        fence.as_ref(),
+        &fence,
         sender_item.as_ref(),
     )
     .await

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -1,6 +1,20 @@
 use super::*;
 use waddle_xmpp::mam::MamStorageError;
 use waddle_xmpp::muc::RoomClaimFenceContext;
+use waddle_xmpp::ownership::{CurrentNodeIdentityGuard, SharedNodeIdentity};
+
+/// Archive fencing authority resolved for one room write. `Guarded` owns
+/// the identity-rotation read guard through the archive transaction, while
+/// `OwnershipLost` distinguishes a configured clustered room with no valid
+/// fence from a genuinely unclustered `Unfenced` deployment.
+pub(super) enum RoomArchiveFence {
+    Unfenced,
+    Guarded {
+        context: RoomClaimFenceContext,
+        _identity_guard: CurrentNodeIdentityGuard,
+    },
+    OwnershipLost,
+}
 
 /// Outcome of a groupchat archive write attempt (ADR-0017 Phase 3 Slice 7
 /// FIX 1, council-adjudicated). `OwnershipLost` is the fenced backstop
@@ -24,31 +38,46 @@ pub(super) enum ArchiveGroupchatOutcome {
 /// node_id)` fencing context for `room`, the SAME mechanism
 /// `dispatch_to_room`'s own `check_fenced_fanout` pre-fan-out check reads
 /// from — threaded here rather than re-derived from a second, independent
-/// source. `None` whenever clustering is disabled, this binary lacks the
-/// `clustering` Cargo feature, or no durable store is configured for this
-/// room (matches `check_fenced_fanout`'s own `None`-means-unfenced
-/// contract): callers fall back to the portable, unfenced
-/// `MamStorage::store_message` path, byte-identical to pre-Slice-7
-/// behavior.
-pub(super) fn resolve_room_claim_fence(
-    deps: &Deps<'_>,
-    room: &BareJid,
-) -> Option<RoomClaimFenceContext> {
+/// source. A genuinely unclustered deployment resolves to `Unfenced` and
+/// retains the portable `MamStorage::store_message` path. Once a clustered
+/// durable store is configured, a missing, stale, or rotated fence resolves
+/// to `OwnershipLost`; it can never silently become an unfenced write.
+pub(super) async fn resolve_room_claim_fence(deps: &Deps<'_>, room: &BareJid) -> RoomArchiveFence {
     #[cfg(feature = "clustering")]
     {
-        let state = deps.web_socket_state?;
-        let store = state
-            .deps
-            .app_state
-            .clustering_claims
-            .muc_durable_store
-            .as_ref()?;
-        store.current_claim_fence(room)
+        let Some(state) = deps.web_socket_state else {
+            return RoomArchiveFence::Unfenced;
+        };
+        let clustering = &state.deps.app_state.clustering_claims;
+        let Some(store) = clustering.muc_durable_store.as_ref() else {
+            return RoomArchiveFence::Unfenced;
+        };
+        guard_clustered_room_claim_fence(
+            store.current_claim_fence(room),
+            clustering.node_identity.as_ref(),
+        )
+        .await
     }
     #[cfg(not(feature = "clustering"))]
     {
         let _ = (deps, room);
-        None
+        RoomArchiveFence::Unfenced
+    }
+}
+
+async fn guard_clustered_room_claim_fence(
+    fence: Option<RoomClaimFenceContext>,
+    node_identity: Option<&SharedNodeIdentity>,
+) -> RoomArchiveFence {
+    let (Some(context), Some(node_identity)) = (fence, node_identity) else {
+        return RoomArchiveFence::OwnershipLost;
+    };
+    let Some(identity_guard) = node_identity.guard_if_current(&context.owner).await else {
+        return RoomArchiveFence::OwnershipLost;
+    };
+    RoomArchiveFence::Guarded {
+        context,
+        _identity_guard: identity_guard,
     }
 }
 
@@ -57,9 +86,12 @@ pub(super) async fn archive_groupchat_message(
     room: &BareJid,
     message: &Message,
     sender_nickname_generation: u64,
-    fence: Option<&RoomClaimFenceContext>,
+    fence: &RoomArchiveFence,
     sender_item: Option<&waddle_xmpp_core::mam::ArchivedMucSender>,
 ) -> ArchiveGroupchatOutcome {
+    if matches!(fence, RoomArchiveFence::OwnershipLost) {
+        return ArchiveGroupchatOutcome::OwnershipLost;
+    }
     // XEP-0313 §MUC Archives: for non-anonymous rooms the *archived*
     // copy carries a room-authored `<x xmlns='muc#user'><item
     // jid='real-jid' affiliation role/></x>` disclosing the sender's
@@ -126,7 +158,7 @@ pub(super) async fn finish_archive_groupchat_message(
     archive_clone: Message,
     archive_id: String,
     sender_nickname_generation: u64,
-    fence: Option<&RoomClaimFenceContext>,
+    fence: &RoomArchiveFence,
     sender_item: Option<&waddle_xmpp_core::mam::ArchivedMucSender>,
 ) -> ArchiveGroupchatOutcome {
     // RFC 6121 §5.2.3: `<body>` is optional. Preserve the
@@ -193,12 +225,13 @@ pub(super) async fn finish_archive_groupchat_message(
     // running the `SELECT ... FOR SHARE` INSIDE the same transaction as
     // this insert.
     let store_result = match fence {
-        Some(fence) => {
+        RoomArchiveFence::Guarded { context, .. } => {
             mam_storage
-                .store_message_fenced(room, &archived, fence)
+                .store_message_fenced(room, &archived, context)
                 .await
         }
-        None => mam_storage.store_message(room, &archived).await,
+        RoomArchiveFence::Unfenced => mam_storage.store_message(room, &archived).await,
+        RoomArchiveFence::OwnershipLost => return ArchiveGroupchatOutcome::OwnershipLost,
     };
     match store_result {
         Ok(stored_id) => ArchiveGroupchatOutcome::Stored(ArchiveStoreResult {
@@ -226,6 +259,66 @@ pub(super) async fn finish_archive_groupchat_message(
             );
             ArchiveGroupchatOutcome::Skipped
         }
+    }
+}
+
+#[cfg(all(test, feature = "clustering"))]
+mod room_archive_fence_tests {
+    use super::*;
+    use std::time::Duration;
+    use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
+
+    fn fence(owner: NodeIdentity) -> RoomClaimFenceContext {
+        RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, "room@muc.example.com"),
+            owner,
+            ClaimEpoch(7),
+        )
+    }
+
+    #[tokio::test]
+    async fn configured_cluster_without_a_room_fence_fails_closed() {
+        let identity = SharedNodeIdentity::new(NodeIdentity::new("node-a", "epoch-a"));
+        assert!(matches!(
+            guard_clustered_room_claim_fence(None, Some(&identity)).await,
+            RoomArchiveFence::OwnershipLost
+        ));
+    }
+
+    #[tokio::test]
+    async fn stale_room_fence_fails_closed_after_identity_rotation() {
+        let old = NodeIdentity::new("node-a", "epoch-a");
+        let identity = SharedNodeIdentity::new(NodeIdentity::new("node-a", "epoch-b"));
+        assert!(matches!(
+            guard_clustered_room_claim_fence(Some(fence(old)), Some(&identity)).await,
+            RoomArchiveFence::OwnershipLost
+        ));
+    }
+
+    #[tokio::test]
+    async fn guarded_room_fence_blocks_rotation_through_the_archive_boundary() {
+        let old = NodeIdentity::new("node-a", "epoch-a");
+        let replacement = NodeIdentity::new("node-a", "epoch-b");
+        let identity = SharedNodeIdentity::new(old.clone());
+        let guarded = guard_clustered_room_claim_fence(Some(fence(old)), Some(&identity)).await;
+        assert!(matches!(guarded, RoomArchiveFence::Guarded { .. }));
+
+        let rotating_identity = identity.clone();
+        let mut rotation = tokio::spawn(async move {
+            rotating_identity.rotate(replacement).await;
+        });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(25), &mut rotation)
+                .await
+                .is_err(),
+            "identity rotation must wait while the MAM fence authority is live"
+        );
+
+        drop(guarded);
+        tokio::time::timeout(Duration::from_secs(1), rotation)
+            .await
+            .expect("rotation unblocks when archive authority drops")
+            .expect("rotation task completes");
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
@@ -225,16 +225,31 @@ pub(super) async fn dispatch_to_room(
                     "DispatchToRoom: fenced ownership check observed 0 rows; this node has \
                      been deposed — evicting the local room actor and bouncing the sender"
                 );
-                let _ = room_registry
+                match room_registry
                     .ask(DestroyRoom {
                         room_jid: room_jid.clone(),
                         // Eviction, not destruction: the room now lives
                         // on the stealing node — its durable rows MUST
                         // survive this local teardown.
-                        reason:
-                            waddle_xmpp::muc::room_registry_actor::DestroyRoomReason::LocalEviction,
+                        reason: waddle_xmpp::muc::room_registry_actor::DestroyRoomReason::DeposedEviction,
                     })
-                    .await;
+                    .await
+                {
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::Destroyed
+                        | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::NotRegistered,
+                    ) => {}
+                    Ok(outcome) => warn!(
+                        room = %room_jid,
+                        ?outcome,
+                        "DispatchToRoom: deposed local actor eviction was unexpectedly refused"
+                    ),
+                    Err(error) => warn!(
+                        room = %room_jid,
+                        %error,
+                        "DispatchToRoom: failed to ask registry to evict deposed local actor"
+                    ),
+                }
                 let reply = build_message_error_reply(
                     &incoming,
                     &room_jid,

--- a/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
@@ -107,11 +107,10 @@ pub(super) async fn broadcast_room_system_message_event(
     // `ArchiveGroupchat` event arm), so an early return here is the exact
     // "not archived, not fanned out" contract.
     if let Some(mam_storage) = deps.mam_storage {
-        let fence = resolve_room_claim_fence(deps, &room);
+        let fence = resolve_room_claim_fence(deps, &room).await;
         // Room-authored system messages have no occupant sender, so
         // there is no real-JID `<x xmlns='muc#user'/>` to disclose.
-        match archive_groupchat_message(mam_storage, &room, &message, 0, fence.as_ref(), None).await
-        {
+        match archive_groupchat_message(mam_storage, &room, &message, 0, &fence, None).await {
             ArchiveGroupchatOutcome::Stored(result) => debug!(
                 room = %room,
                 stanza_id = %result.stored_id,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
@@ -299,7 +299,8 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                 // atomically restored the room — nothing was torn down, so
                 // answer retryable, never a false success.
                 Ok(
-                    waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed,
+                    waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::DurableWipeFailed
+                    | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::ReleaseBacklogFull,
                 ) => {
                     return vec![build_iq_error_xml_typed(
                         id,

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -808,7 +808,7 @@ mod orphan_reaper_sweep_tests {
     use crate::sm_persistence_fenced::PostgresFencedSmPersistence;
     use chrono::{TimeZone, Utc};
     use waddle_xmpp::ownership::{
-        ClaimEpoch, ClaimStore, Entity, EntityType, NodeIdentity, SharedNodeIdentity,
+        ClaimStore, Entity, EntityType, NodeIdentity, SharedNodeIdentity,
     };
     use waddle_xmpp::pending_delivery::SmSessionId;
     use waddle_xmpp::stream_management::persistence::{PersistedSession, SmPersistenceStorage};
@@ -1058,14 +1058,14 @@ mod orphan_reaper_sweep_tests {
             expired_flag(&db, &dead_owner.node_id).await,
             "the stale-node watchdog must commit dead owner's clustering_nodes row expired"
         );
-        let steal_landed = claim_store
-            .fence(&entity, &sweeper_identity, ClaimEpoch(orphan_epoch.0 + 1))
+        let reclaimed = claim_store
+            .current_claim(&entity)
             .await
-            .expect("fence call");
+            .expect("claim lookup")
+            .expect("reclaimed claim remains present");
         assert!(
-            steal_landed,
-            "steal must land: the sweeping node must now own the entity at the \
-             bumped epoch"
+            reclaimed.owner == sweeper_identity && reclaimed.claim_epoch.0 > orphan_epoch.0,
+            "steal must land under the sweeping node at a fresh monotonic generation"
         );
         let hydrated = sm_session_registry
             .peek_session(stream_id)
@@ -1100,19 +1100,16 @@ mod orphan_reaper_sweep_tests {
             expired_flag(&db, &dead_owner_2.node_id).await,
             "dead owner 2's clustering_nodes row must be committed-expired"
         );
-        let steal_landed_exactly_once = claim_store
-            .fence(
-                &entity_2,
-                &sweeper_identity,
-                ClaimEpoch(orphan_epoch_2.0 + 1),
-            )
+        let reclaimed_once = claim_store
+            .current_claim(&entity_2)
             .await
-            .expect("fence call");
+            .expect("claim lookup")
+            .expect("reclaimed claim remains present");
         assert!(
-            steal_landed_exactly_once,
-            "exactly one of the two concurrent sweeps must have won the steal — the \
-             epoch must be bumped by exactly 1, not 2 (a double-steal would fence at \
-             +1 as false, since the epoch would actually be +2)"
+            reclaimed_once.owner == sweeper_identity
+                && reclaimed_once.claim_epoch.0 > orphan_epoch_2.0,
+            "exactly one concurrent sweep must win the observed-epoch CAS and leave the \
+             claim under the live sweeper at a fresh monotonic generation"
         );
         let hydrated_2 = sm_session_registry
             .peek_session(stream_id_2)
@@ -1157,24 +1154,13 @@ mod orphan_reaper_sweep_tests {
 
         run_orphan_reaper_sweep(&state).await;
 
-        assert!(
-            claim_store
-                .fence(&entity_3, &dead_owner_3, orphan_epoch_3)
-                .await
-                .expect("fence dead-owner claim after heartbeat-stale sweeper"),
-            "a heartbeat-stale sweeping node must not steal the orphaned claim"
-        );
-        assert!(
-            !claim_store
-                .fence(
-                    &entity_3,
-                    &sweeper_identity,
-                    ClaimEpoch(orphan_epoch_3.0 + 1)
-                )
-                .await
-                .expect("fence heartbeat-stale sweeper after failed steal"),
-            "the heartbeat-stale sweeping node must not own the bumped claim epoch"
-        );
+        let unchanged = claim_store
+            .current_claim(&entity_3)
+            .await
+            .expect("claim lookup")
+            .expect("dead-owner claim remains present");
+        assert_eq!(unchanged.owner, dead_owner_3);
+        assert_eq!(unchanged.claim_epoch, orphan_epoch_3);
         let not_hydrated = sm_session_registry
             .peek_session(stream_id_3)
             .await

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -56,9 +56,6 @@ const ISR_TOKEN_SWEEP_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(feature = "clustering")]
 const STALE_NODE_WATCHDOG_CANDIDATE_LIMIT: usize = 64;
 
-#[cfg(feature = "clustering")]
-const ORPHANED_ROOM_CANDIDATE_LIMIT: usize = 64;
-
 fn pending_delivery_max_age_days_from_env() -> u32 {
     const DEFAULT_DAYS: u32 = 30;
     const MIN_DAYS: u32 = 1;
@@ -487,34 +484,19 @@ pub(crate) fn spawn_orphan_reaper_janitor(
     #[cfg(feature = "clustering")]
     {
         let weak_state = Arc::downgrade(websocket_state);
-        let Some(stop) = websocket_state
-            .deps
-            .app_state
-            .clustering_claims
-            .stop_token
-            .clone()
-        else {
-            return;
-        };
-        let room_registry = websocket_state.deps.protocol.room_registry.clone();
         tokio::spawn(async move {
-            let registry_watch = spawn_room_registry_lifetime_watch(room_registry, stop.clone());
             let mut ticker = tokio::time::interval(interval);
             // Skip the first (immediate) tick, mirroring the other janitors
             // — no need to sweep before the node-lease loop has even
             // registered this node.
             ticker.tick().await;
             loop {
-                tokio::select! {
-                    _ = stop.cancelled() => break,
-                    _ = ticker.tick() => {}
-                }
+                ticker.tick().await;
                 let Some(state) = weak_state.upgrade() else {
                     break;
                 };
                 run_orphan_reaper_sweep(&state).await;
             }
-            let _ = registry_watch.await;
         });
     }
     #[cfg(not(feature = "clustering"))]
@@ -522,20 +504,6 @@ pub(crate) fn spawn_orphan_reaper_janitor(
         let _ = websocket_state;
         let _ = interval;
     }
-}
-
-#[cfg(feature = "clustering")]
-fn spawn_room_registry_lifetime_watch(
-    room_registry: kameo::actor::ActorRef<waddle_xmpp::muc::room_registry_actor::RoomRegistryActor>,
-    node_cancel: tokio_util::sync::CancellationToken,
-) -> tokio::task::JoinHandle<()> {
-    tokio::spawn(async move {
-        tokio::select! {
-            biased;
-            _ = node_cancel.cancelled() => {}
-            _ = room_registry.wait_for_shutdown() => node_cancel.cancel(),
-        }
-    })
 }
 
 #[cfg(feature = "clustering")]
@@ -678,9 +646,12 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
         Ok(candidates) => candidates,
         Err(error) => {
             warn!(%error, "orphan reaper: list_orphaned_sm_session_claims failed");
-            Vec::new()
+            return;
         }
     };
+    if candidates.is_empty() {
+        return;
+    }
 
     // ADR-0017 Phase 3 Slice 10 (Q5's rollout-aware placement rule): an
     // old-generation node backs off before racing a matching/newer
@@ -777,217 +748,6 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
                     "orphan reaper: hydrate_reclaimed (post-steal targeted hydrate) failed"
                 );
             }
-        }
-    }
-
-    let room_registry =
-        waddle_xmpp::muc::RoomRegistry::wrap(state.deps.protocol.room_registry.clone());
-    let mut room_hydrated = 0u64;
-    let mut room_released = 0u64;
-    let mut room_already_live = 0u64;
-    let mut room_adopted_local = 0u64;
-    let mut room_pending_retry = 0u64;
-    let mut room_lost_race = 0u64;
-    let mut room_failed = 0u64;
-
-    if let Err(error) = room_registry.retry_pending_room_releases(1).await {
-        debug!(%error, "orphan reaper: pending ordinary RoomActor release retry failed");
-    }
-    match room_registry
-        .list_pending_reclaimed_rooms(ORPHANED_ROOM_CANDIDATE_LIMIT)
-        .await
-    {
-        Ok(pending) => {
-            for pending_room in pending {
-                match room_registry
-                    .reconcile_reclaimed_room(
-                        pending_room.room_jid,
-                        pending_room.claim_fence,
-                        pending_room.previous_owner,
-                    )
-                    .await
-                {
-                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Hydrated) => {
-                        room_hydrated += 1
-                    }
-                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Released) => {
-                        room_released += 1
-                    }
-                    Ok(
-                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AlreadyLive,
-                    ) => room_already_live += 1,
-                    Ok(
-                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal,
-                    ) => room_adopted_local += 1,
-                    Ok(
-                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::PendingRetry,
-                    ) => room_pending_retry += 1,
-                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace) => {
-                        room_lost_race += 1
-                    }
-                    Err(error) => {
-                        debug!(%error, "orphan reaper: pending RoomActor retry ask failed");
-                        return;
-                    }
-                }
-            }
-        }
-        Err(error) => {
-            debug!(%error, "orphan reaper: pending RoomActor listing failed");
-            return;
-        }
-    }
-    if let Ok(mut backlog) = room_registry.pending_reclaimed_room_backlog().await {
-        if let Ok(releases) = room_registry.pending_room_release_backlog().await {
-            backlog.depth = backlog.depth.saturating_add(releases.depth);
-            backlog.oldest_age_ms = backlog.oldest_age_ms.max(releases.oldest_age_ms);
-        }
-        crate::clustering::metrics::record_room_orphan_pending_backlog(
-            backlog.depth,
-            backlog.oldest_age_ms,
-        );
-    }
-
-    let room_candidates = match node_lease
-        .list_orphaned_room_actor_claims(ORPHANED_ROOM_CANDIDATE_LIMIT)
-        .await
-    {
-        Ok(candidates) => candidates,
-        Err(error) => {
-            warn!(%error, "orphan reaper: list_orphaned_room_actor_claims failed");
-            Vec::new()
-        }
-    };
-    for candidate in room_candidates {
-        let Ok(room_jid) = candidate.entity.id.parse::<jid::BareJid>() else {
-            room_failed += 1;
-            continue;
-        };
-        match room_registry
-            .reserve_pending_reclaimed_room(room_jid.clone())
-            .await
-        {
-            Ok(true) => {}
-            Ok(false) => break,
-            Err(error) => {
-                debug!(room = %room_jid, %error, "orphan reaper: room adoption reservation failed");
-                break;
-            }
-        }
-        if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-room").await
-        {
-            let _ = room_registry
-                .cancel_pending_reclaimed_room_reservation(room_jid)
-                .await;
-            return;
-        }
-        if let Err(error) = node_lease.expire(&candidate.owner, lease_ttl).await {
-            let _ = room_registry
-                .cancel_pending_reclaimed_room_reservation(room_jid)
-                .await;
-            room_failed += 1;
-            debug!(entity_id = %candidate.entity.id, %error, "orphan reaper: room owner expire failed");
-            continue;
-        }
-        if !backoff_delay.is_zero() {
-            tokio::time::sleep(backoff_delay).await;
-        }
-        match node_lease
-            .steal_orphaned_room_actor_claim(&candidate.entity, candidate.epoch, &me, lease_ttl)
-            .await
-        {
-            Ok(new_epoch) => {
-                let fence = waddle_xmpp::muc::RoomClaimFenceContext::new(
-                    candidate.entity.clone(),
-                    me.clone(),
-                    new_epoch,
-                );
-                if room_registry
-                    .remember_pending_reclaimed_room(
-                        room_jid.clone(),
-                        fence.clone(),
-                        candidate.owner.clone(),
-                    )
-                    .await
-                    .is_err()
-                {
-                    let _ = room_registry
-                        .cancel_pending_reclaimed_room_reservation(room_jid)
-                        .await;
-                    room_failed += 1;
-                    continue;
-                }
-                let result = room_registry
-                    .reconcile_reclaimed_room(room_jid.clone(), fence, candidate.owner.clone())
-                    .await;
-                if let Some(store) = clustering.muc_durable_store.as_ref() {
-                    if !matches!(
-                        result,
-                        Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal)
-                            | Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace)
-                            | Err(_)
-                    ) {
-                        let _ = store
-                            .notify_previous_owner_demoted(
-                                &room_jid,
-                                &candidate.owner.node_id,
-                                &candidate.owner.node_epoch,
-                                new_epoch,
-                            )
-                            .await;
-                    }
-                }
-                match result {
-                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Hydrated) => {
-                        room_hydrated += 1
-                    }
-                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Released) => {
-                        room_released += 1
-                    }
-                    Ok(
-                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AlreadyLive,
-                    ) => room_already_live += 1,
-                    Ok(
-                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal,
-                    ) => room_adopted_local += 1,
-                    Ok(
-                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::PendingRetry,
-                    ) => room_pending_retry += 1,
-                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace) => {
-                        room_lost_race += 1
-                    }
-                    Err(error) => {
-                        debug!(room = %room_jid, %error, "orphan reaper: reclaimed room adoption ask failed");
-                        return;
-                    }
-                }
-            }
-            Err(ClaimError::Conflict) => {
-                room_lost_race += 1;
-                let _ = room_registry
-                    .cancel_pending_reclaimed_room_reservation(room_jid)
-                    .await;
-            }
-            Err(error) => {
-                room_failed += 1;
-                let _ = room_registry
-                    .cancel_pending_reclaimed_room_reservation(room_jid)
-                    .await;
-                debug!(entity_id = %candidate.entity.id, %error, "orphan reaper: RoomActor steal failed");
-            }
-        }
-    }
-    for (outcome, count) in [
-        ("hydrated", room_hydrated),
-        ("released", room_released),
-        ("already_live", room_already_live),
-        ("adopted_local", room_adopted_local),
-        ("pending_retry", room_pending_retry),
-        ("lost_race", room_lost_race),
-        ("failed", room_failed),
-    ] {
-        if count > 0 {
-            crate::clustering::metrics::record_room_orphan_reconciliation(outcome, count);
         }
     }
 

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -56,6 +56,9 @@ const ISR_TOKEN_SWEEP_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(feature = "clustering")]
 const STALE_NODE_WATCHDOG_CANDIDATE_LIMIT: usize = 64;
 
+#[cfg(feature = "clustering")]
+const ORPHANED_ROOM_CANDIDATE_LIMIT: usize = 64;
+
 fn pending_delivery_max_age_days_from_env() -> u32 {
     const DEFAULT_DAYS: u32 = 30;
     const MIN_DAYS: u32 = 1;
@@ -484,19 +487,34 @@ pub(crate) fn spawn_orphan_reaper_janitor(
     #[cfg(feature = "clustering")]
     {
         let weak_state = Arc::downgrade(websocket_state);
+        let Some(stop) = websocket_state
+            .deps
+            .app_state
+            .clustering_claims
+            .stop_token
+            .clone()
+        else {
+            return;
+        };
+        let room_registry = websocket_state.deps.protocol.room_registry.clone();
         tokio::spawn(async move {
+            let registry_watch = spawn_room_registry_lifetime_watch(room_registry, stop.clone());
             let mut ticker = tokio::time::interval(interval);
             // Skip the first (immediate) tick, mirroring the other janitors
             // — no need to sweep before the node-lease loop has even
             // registered this node.
             ticker.tick().await;
             loop {
-                ticker.tick().await;
+                tokio::select! {
+                    _ = stop.cancelled() => break,
+                    _ = ticker.tick() => {}
+                }
                 let Some(state) = weak_state.upgrade() else {
                     break;
                 };
                 run_orphan_reaper_sweep(&state).await;
             }
+            let _ = registry_watch.await;
         });
     }
     #[cfg(not(feature = "clustering"))]
@@ -504,6 +522,20 @@ pub(crate) fn spawn_orphan_reaper_janitor(
         let _ = websocket_state;
         let _ = interval;
     }
+}
+
+#[cfg(feature = "clustering")]
+fn spawn_room_registry_lifetime_watch(
+    room_registry: kameo::actor::ActorRef<waddle_xmpp::muc::room_registry_actor::RoomRegistryActor>,
+    node_cancel: tokio_util::sync::CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        tokio::select! {
+            biased;
+            _ = node_cancel.cancelled() => {}
+            _ = room_registry.wait_for_shutdown() => node_cancel.cancel(),
+        }
+    })
 }
 
 #[cfg(feature = "clustering")]
@@ -646,12 +678,9 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
         Ok(candidates) => candidates,
         Err(error) => {
             warn!(%error, "orphan reaper: list_orphaned_sm_session_claims failed");
-            return;
+            Vec::new()
         }
     };
-    if candidates.is_empty() {
-        return;
-    }
 
     // ADR-0017 Phase 3 Slice 10 (Q5's rollout-aware placement rule): an
     // old-generation node backs off before racing a matching/newer
@@ -748,6 +777,217 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
                     "orphan reaper: hydrate_reclaimed (post-steal targeted hydrate) failed"
                 );
             }
+        }
+    }
+
+    let room_registry =
+        waddle_xmpp::muc::RoomRegistry::wrap(state.deps.protocol.room_registry.clone());
+    let mut room_hydrated = 0u64;
+    let mut room_released = 0u64;
+    let mut room_already_live = 0u64;
+    let mut room_adopted_local = 0u64;
+    let mut room_pending_retry = 0u64;
+    let mut room_lost_race = 0u64;
+    let mut room_failed = 0u64;
+
+    if let Err(error) = room_registry.retry_pending_room_releases(1).await {
+        debug!(%error, "orphan reaper: pending ordinary RoomActor release retry failed");
+    }
+    match room_registry
+        .list_pending_reclaimed_rooms(ORPHANED_ROOM_CANDIDATE_LIMIT)
+        .await
+    {
+        Ok(pending) => {
+            for pending_room in pending {
+                match room_registry
+                    .reconcile_reclaimed_room(
+                        pending_room.room_jid,
+                        pending_room.claim_fence,
+                        pending_room.previous_owner,
+                    )
+                    .await
+                {
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Hydrated) => {
+                        room_hydrated += 1
+                    }
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Released) => {
+                        room_released += 1
+                    }
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AlreadyLive,
+                    ) => room_already_live += 1,
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal,
+                    ) => room_adopted_local += 1,
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::PendingRetry,
+                    ) => room_pending_retry += 1,
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace) => {
+                        room_lost_race += 1
+                    }
+                    Err(error) => {
+                        debug!(%error, "orphan reaper: pending RoomActor retry ask failed");
+                        return;
+                    }
+                }
+            }
+        }
+        Err(error) => {
+            debug!(%error, "orphan reaper: pending RoomActor listing failed");
+            return;
+        }
+    }
+    if let Ok(mut backlog) = room_registry.pending_reclaimed_room_backlog().await {
+        if let Ok(releases) = room_registry.pending_room_release_backlog().await {
+            backlog.depth = backlog.depth.saturating_add(releases.depth);
+            backlog.oldest_age_ms = backlog.oldest_age_ms.max(releases.oldest_age_ms);
+        }
+        crate::clustering::metrics::record_room_orphan_pending_backlog(
+            backlog.depth,
+            backlog.oldest_age_ms,
+        );
+    }
+
+    let room_candidates = match node_lease
+        .list_orphaned_room_actor_claims(ORPHANED_ROOM_CANDIDATE_LIMIT)
+        .await
+    {
+        Ok(candidates) => candidates,
+        Err(error) => {
+            warn!(%error, "orphan reaper: list_orphaned_room_actor_claims failed");
+            Vec::new()
+        }
+    };
+    for candidate in room_candidates {
+        let Ok(room_jid) = candidate.entity.id.parse::<jid::BareJid>() else {
+            room_failed += 1;
+            continue;
+        };
+        match room_registry
+            .reserve_pending_reclaimed_room(room_jid.clone())
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => break,
+            Err(error) => {
+                debug!(room = %room_jid, %error, "orphan reaper: room adoption reservation failed");
+                break;
+            }
+        }
+        if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-room").await
+        {
+            let _ = room_registry
+                .cancel_pending_reclaimed_room_reservation(room_jid)
+                .await;
+            return;
+        }
+        if let Err(error) = node_lease.expire(&candidate.owner, lease_ttl).await {
+            let _ = room_registry
+                .cancel_pending_reclaimed_room_reservation(room_jid)
+                .await;
+            room_failed += 1;
+            debug!(entity_id = %candidate.entity.id, %error, "orphan reaper: room owner expire failed");
+            continue;
+        }
+        if !backoff_delay.is_zero() {
+            tokio::time::sleep(backoff_delay).await;
+        }
+        match node_lease
+            .steal_orphaned_room_actor_claim(&candidate.entity, candidate.epoch, &me, lease_ttl)
+            .await
+        {
+            Ok(new_epoch) => {
+                let fence = waddle_xmpp::muc::RoomClaimFenceContext::new(
+                    candidate.entity.clone(),
+                    me.clone(),
+                    new_epoch,
+                );
+                if room_registry
+                    .remember_pending_reclaimed_room(
+                        room_jid.clone(),
+                        fence.clone(),
+                        candidate.owner.clone(),
+                    )
+                    .await
+                    .is_err()
+                {
+                    let _ = room_registry
+                        .cancel_pending_reclaimed_room_reservation(room_jid)
+                        .await;
+                    room_failed += 1;
+                    continue;
+                }
+                let result = room_registry
+                    .reconcile_reclaimed_room(room_jid.clone(), fence, candidate.owner.clone())
+                    .await;
+                if let Some(store) = clustering.muc_durable_store.as_ref() {
+                    if !matches!(
+                        result,
+                        Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal)
+                            | Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace)
+                            | Err(_)
+                    ) {
+                        let _ = store
+                            .notify_previous_owner_demoted(
+                                &room_jid,
+                                &candidate.owner.node_id,
+                                &candidate.owner.node_epoch,
+                                new_epoch,
+                            )
+                            .await;
+                    }
+                }
+                match result {
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Hydrated) => {
+                        room_hydrated += 1
+                    }
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Released) => {
+                        room_released += 1
+                    }
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AlreadyLive,
+                    ) => room_already_live += 1,
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal,
+                    ) => room_adopted_local += 1,
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::PendingRetry,
+                    ) => room_pending_retry += 1,
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace) => {
+                        room_lost_race += 1
+                    }
+                    Err(error) => {
+                        debug!(room = %room_jid, %error, "orphan reaper: reclaimed room adoption ask failed");
+                        return;
+                    }
+                }
+            }
+            Err(ClaimError::Conflict) => {
+                room_lost_race += 1;
+                let _ = room_registry
+                    .cancel_pending_reclaimed_room_reservation(room_jid)
+                    .await;
+            }
+            Err(error) => {
+                room_failed += 1;
+                let _ = room_registry
+                    .cancel_pending_reclaimed_room_reservation(room_jid)
+                    .await;
+                debug!(entity_id = %candidate.entity.id, %error, "orphan reaper: RoomActor steal failed");
+            }
+        }
+    }
+    for (outcome, count) in [
+        ("hydrated", room_hydrated),
+        ("released", room_released),
+        ("already_live", room_already_live),
+        ("adopted_local", room_adopted_local),
+        ("pending_retry", room_pending_retry),
+        ("lost_race", room_lost_race),
+        ("failed", room_failed),
+    ] {
+        if count > 0 {
+            crate::clustering::metrics::record_room_orphan_reconciliation(outcome, count);
         }
     }
 

--- a/server/crates/waddle-server/src/sm_persistence_fenced/tests.rs
+++ b/server/crates/waddle-server/src/sm_persistence_fenced/tests.rs
@@ -87,6 +87,16 @@ async fn live_stealer(db: &Database) -> NodeIdentity {
     stealer
 }
 
+async fn current_claim_epoch(fixture: &Fixture, entity: &Entity) -> ClaimEpoch {
+    fixture
+        .claims
+        .current_claim(entity)
+        .await
+        .expect("claim lookup")
+        .expect("fenced write established a claim")
+        .claim_epoch
+}
+
 struct Fixture {
     fenced: PostgresFencedSmPersistence,
     /// A second `ClaimStore` handle onto the same underlying Postgres
@@ -434,15 +444,16 @@ async fn delete_session_aborts_before_any_write_once_the_claim_is_stolen() {
     f.fenced
         .upsert_session(fixture_session("stream-stolen"))
         .await
-        .expect("upsert_session establishes the claim at epoch 0");
+        .expect("upsert_session establishes the claim");
 
     // Make the current owner's node row stale, then steal the entity to a
-    // different node — the fenced impl's cached epoch (0) is now invalid.
+    // different node — the fenced impl's cached generation is now invalid.
     seed_node(&f.claims_db, &f.identity, true).await;
     let entity = Entity::new(EntityType::SmSession, "stream-stolen".to_string());
+    let owner_epoch = current_claim_epoch(&f, &entity).await;
     let stealer = live_stealer(&f.claims_db).await;
     f.claims
-        .steal_stale(&entity, ClaimEpoch(0), StalePredicate::OwnerStale, &stealer)
+        .steal_stale(&entity, owner_epoch, StalePredicate::OwnerStale, &stealer)
         .await
         .expect("steal succeeds against a stale owner");
 
@@ -470,13 +481,14 @@ async fn record_promotion_failure_aborts_before_any_write_once_the_claim_is_stol
     f.fenced
         .upsert_session(fixture_session("stream-promo-stolen"))
         .await
-        .expect("upsert_session establishes the claim at epoch 0");
+        .expect("upsert_session establishes the claim");
 
     seed_node(&f.claims_db, &f.identity, true).await;
     let entity = Entity::new(EntityType::SmSession, "stream-promo-stolen".to_string());
+    let owner_epoch = current_claim_epoch(&f, &entity).await;
     let stealer = live_stealer(&f.claims_db).await;
     f.claims
-        .steal_stale(&entity, ClaimEpoch(0), StalePredicate::OwnerStale, &stealer)
+        .steal_stale(&entity, owner_epoch, StalePredicate::OwnerStale, &stealer)
         .await
         .expect("steal succeeds against a stale owner");
 
@@ -544,12 +556,13 @@ async fn concurrent_steal_vs_delete_session_never_produces_torn_state() {
     seed_node(&f.claims_db, &f.identity, true).await;
 
     let entity = Entity::new(EntityType::SmSession, "stream-race".to_string());
+    let owner_epoch = current_claim_epoch(&f, &entity).await;
     let stealer = live_stealer(&f.claims_db).await;
 
     let delete_result = f.fenced.delete_session(&stream_id);
     let steal_result =
         f.claims
-            .steal_stale(&entity, ClaimEpoch(0), StalePredicate::OwnerStale, &stealer);
+            .steal_stale(&entity, owner_epoch, StalePredicate::OwnerStale, &stealer);
     let (delete_outcome, _steal_outcome) = tokio::join!(delete_result, steal_result);
 
     // Whichever statement's transaction actually committed first, the
@@ -600,7 +613,7 @@ async fn store_session_atomic_aborts_before_any_write_once_the_claim_is_stolen()
     f.fenced
         .upsert_session(fixture_session("stream-atomic-stolen"))
         .await
-        .expect("upsert_session establishes the claim at epoch 0");
+        .expect("upsert_session establishes the claim");
     f.fenced
         .append_unacked(fixture_unacked("stream-atomic-stolen", 1))
         .await
@@ -608,9 +621,10 @@ async fn store_session_atomic_aborts_before_any_write_once_the_claim_is_stolen()
 
     seed_node(&f.claims_db, &f.identity, true).await;
     let entity = Entity::new(EntityType::SmSession, "stream-atomic-stolen".to_string());
+    let owner_epoch = current_claim_epoch(&f, &entity).await;
     let stealer = live_stealer(&f.claims_db).await;
     f.claims
-        .steal_stale(&entity, ClaimEpoch(0), StalePredicate::OwnerStale, &stealer)
+        .steal_stale(&entity, owner_epoch, StalePredicate::OwnerStale, &stealer)
         .await
         .expect("steal succeeds against a stale owner");
 
@@ -667,6 +681,7 @@ async fn concurrent_steal_vs_store_session_atomic_never_produces_torn_state() {
     seed_node(&f.claims_db, &f.identity, true).await;
 
     let entity = Entity::new(EntityType::SmSession, "stream-atomic-race".to_string());
+    let owner_epoch = current_claim_epoch(&f, &entity).await;
     let stealer = live_stealer(&f.claims_db).await;
 
     let mut new_session = fixture_session("stream-atomic-race");
@@ -676,7 +691,7 @@ async fn concurrent_steal_vs_store_session_atomic_never_produces_torn_state() {
     let store_result = f.fenced.store_session_atomic(new_session, new_unacked);
     let steal_result =
         f.claims
-            .steal_stale(&entity, ClaimEpoch(0), StalePredicate::OwnerStale, &stealer);
+            .steal_stale(&entity, owner_epoch, StalePredicate::OwnerStale, &stealer);
     let (store_outcome, _steal_outcome) = tokio::join!(store_result, steal_result);
 
     let loaded = f
@@ -728,12 +743,13 @@ async fn concurrent_steal_vs_record_promotion_failure_never_produces_torn_state(
     seed_node(&f.claims_db, &f.identity, true).await;
 
     let entity = Entity::new(EntityType::SmSession, "stream-promo-race".to_string());
+    let owner_epoch = current_claim_epoch(&f, &entity).await;
     let stealer = live_stealer(&f.claims_db).await;
 
     let promo_result = f.fenced.record_promotion_failure(&stream_id);
     let steal_result =
         f.claims
-            .steal_stale(&entity, ClaimEpoch(0), StalePredicate::OwnerStale, &stealer);
+            .steal_stale(&entity, owner_epoch, StalePredicate::OwnerStale, &stealer);
     let (promo_outcome, _steal_outcome) = tokio::join!(promo_result, steal_result);
 
     let conn = f.claims_db.guard().await.expect("guard");

--- a/server/crates/waddle-server/tests/xep0198_cross_node_resume.rs
+++ b/server/crates/waddle-server/tests/xep0198_cross_node_resume.rs
@@ -716,12 +716,20 @@ async fn resume_retransmit_race_against_the_same_new_node_dedups_without_double_
     };
     let (bare, full) = alice_jid();
     let (registry_a, _identity_a) = node_registry(&db, node_identity(), None).await;
-    let (registry_b, _identity_b) = node_registry(&db, node_identity(), None).await;
+    let (registry_b, identity_b) = node_registry(&db, node_identity(), None).await;
 
     registry_a
         .store_session(detached_session("stream-retransmit", &full))
         .await
         .expect("node A stores the detached session");
+
+    let entity = Entity::new(EntityType::SmSession, "stream-retransmit".to_string());
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(PostgresClaimStore::new(db.clone()));
+    let before = claim_store
+        .current_claim(&entity)
+        .await
+        .expect("current_claim before resume race")
+        .expect("detached session has an ownership claim");
 
     // Two concurrent attempts on the SAME registry_b — modeling a client
     // that retransmits `<resume/>` (or opens a second connection) against
@@ -764,18 +772,22 @@ async fn resume_retransmit_race_against_the_same_new_node_dedups_without_double_
         "no stray claimable copy should survive the dedup'd retransmit race"
     );
 
-    // The claim epoch advanced by exactly one steal, not two.
-    let entity = Entity::new(EntityType::SmSession, "stream-retransmit".to_string());
-    let claim_store: Arc<dyn ClaimStore> = Arc::new(PostgresClaimStore::new(db.clone()));
+    // The single winner replaced node A's claim with a fresh monotonic
+    // generation owned by node B. Generations are globally allocated, so
+    // neither their initial value nor adjacency is deterministic.
     let after = claim_store
         .current_claim(&entity)
         .await
         .expect("current_claim")
         .expect("claim still exists (held by the winner via claimed_sessions)");
+    assert!(
+        after.claim_epoch > before.claim_epoch,
+        "the winning steal_for_resume must allocate a newer claim generation"
+    );
     assert_eq!(
-        after.claim_epoch,
-        waddle_xmpp::ownership::ClaimEpoch(1),
-        "exactly one steal_for_resume CAS committed, not two"
+        after.owner,
+        identity_b.current(),
+        "the sole successful resume CAS must leave node B as the exact owner"
     );
 }
 

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -232,10 +232,11 @@ pub(super) async fn store_message_fenced(
         fence.entity.id
     );
     let held = sqlx::query(
-        "SELECT 1 FROM clustering_claims WHERE entity = $1 AND node_id = $2 AND claim_epoch = $3 FOR SHARE",
+        "SELECT 1 FROM clustering_claims WHERE entity = $1 AND node_id = $2 AND node_epoch = $3 AND claim_epoch = $4 FOR SHARE",
     )
     .bind(&entity_key)
-    .bind(&fence.node_id)
+    .bind(&fence.owner.node_id)
+    .bind(&fence.owner.node_epoch)
     .bind(fence.epoch.0)
     .fetch_optional(&mut *tx)
     .await?

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -4,7 +4,7 @@ use jid::{BareJid, Jid};
 use sha2::{Digest, Sha256};
 use sqlx::postgres::PgRow;
 use sqlx::sqlite::SqliteRow;
-use sqlx::{Postgres, QueryBuilder, Row, Sqlite};
+use sqlx::{Postgres, QueryBuilder, Row, Sqlite, Transaction};
 use tracing::{debug, warn};
 use uuid::Uuid;
 use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedRichMessage, ArchivedRichPayload};
@@ -164,13 +164,12 @@ pub(super) async fn store_message(
 /// standalone pre-fan-out check and this write can never land a phantom
 /// archived row under a claim this node no longer holds.
 ///
-/// The origin-id dedup pre-check (idempotency for retried sends) runs
-/// against the plain pool, exactly as [`store_message`] already does it —
-/// it only ever reads already-committed rows, so it needs no transactional
-/// isolation from this write; only the fencing-check-then-insert pair needs
-/// one-transaction atomicity, which this function provides. Postgres-only:
-/// fencing is never enabled for a SQLite backend (clustering is
-/// Postgres-only per ADR-0017 element 1 — see
+/// Origin-id deduplication runs only after the claim check and inside the
+/// same transaction. An idempotent retry is still an ownership-sensitive
+/// archive operation: returning an existing row to a deposed actor would
+/// otherwise authorize its subsequent fan-out without proving the room
+/// claim. Postgres-only: fencing is never enabled for a SQLite backend
+/// (clustering is Postgres-only per ADR-0017 element 1 — see
 /// `SqlxMamStorage::with_cluster_fencing`), so the non-Postgres arm here is
 /// defensive only.
 pub(super) async fn store_message_fenced(
@@ -188,18 +187,6 @@ pub(super) async fn store_message_fenced(
         .origin_id
         .as_ref()
         .map(|_| origin_dedup_fingerprint(message));
-
-    if let Some(existing_archive_id) = find_existing_origin_id_match(
-        backend,
-        archive_jid,
-        message,
-        rich_payload.as_deref(),
-        origin_dedup_fingerprint.as_deref(),
-    )
-    .await?
-    {
-        return Ok(existing_archive_id);
-    }
 
     let archive_id = if message.id.is_empty() {
         Uuid::now_v7().to_string()
@@ -226,22 +213,7 @@ pub(super) async fn store_message_fenced(
     // `insert_fenced` already establish — the first statement inside this
     // transaction, on the SAME connection as the write it guards. A failed
     // check rolls back BEFORE any write.
-    let entity_key = format!(
-        "{}:{}",
-        fence.entity.entity_type.as_db_str(),
-        fence.entity.id
-    );
-    let held = sqlx::query(
-        "SELECT 1 FROM clustering_claims WHERE entity = $1 AND node_id = $2 AND node_epoch = $3 AND claim_epoch = $4 FOR SHARE",
-    )
-    .bind(&entity_key)
-    .bind(&fence.owner.node_id)
-    .bind(&fence.owner.node_epoch)
-    .bind(fence.epoch.0)
-    .fetch_optional(&mut *tx)
-    .await?
-    .is_some();
-    if !held {
+    if !claim_fence_is_held(&mut tx, fence).await? {
         // Roll back explicitly rather than relying on drop — the fencing
         // failure is the expected, correctness-critical path here, not an
         // error worth masking behind an implicit rollback-on-drop.
@@ -249,6 +221,18 @@ pub(super) async fn store_message_fenced(
         return Err(MamStorageError::NotOwner {
             entity: fence.entity.clone(),
         });
+    }
+    if let Some(existing_archive_id) = find_existing_origin_id_match_postgres_tx(
+        &mut tx,
+        archive_jid,
+        message,
+        rich_payload.as_deref(),
+        origin_dedup_fingerprint.as_deref(),
+    )
+    .await?
+    {
+        tx.commit().await?;
+        return Ok(existing_archive_id);
     }
 
     let mut query = QueryBuilder::<Postgres>::new(
@@ -282,15 +266,27 @@ pub(super) async fn store_message_fenced(
     });
     if let Err(error) = query.build().execute(&mut *tx).await {
         let _ = tx.rollback().await;
-        if let Some(existing_archive_id) = find_existing_origin_id_match(
-            backend,
+        // A concurrent origin-id insert can still win after our pre-check.
+        // Re-prove ownership in a fresh transaction before accepting its
+        // row as the idempotent result; never fall back to a pool-level
+        // dedup read that could bypass fencing after a claim transfer.
+        let mut dedup_tx = pool.begin().await?;
+        if !claim_fence_is_held(&mut dedup_tx, fence).await? {
+            let _ = dedup_tx.rollback().await;
+            return Err(MamStorageError::NotOwner {
+                entity: fence.entity.clone(),
+            });
+        }
+        let existing_archive_id = find_existing_origin_id_match_postgres_tx(
+            &mut dedup_tx,
             archive_jid,
             message,
             rich_payload.as_deref(),
             origin_dedup_fingerprint.as_deref(),
         )
-        .await?
-        {
+        .await?;
+        dedup_tx.commit().await?;
+        if let Some(existing_archive_id) = existing_archive_id {
             return Ok(existing_archive_id);
         }
         return Err(error.into());
@@ -299,6 +295,61 @@ pub(super) async fn store_message_fenced(
 
     debug!(archive_id = %archive_id, "Message stored in MAM archive (fenced)");
     Ok(archive_id)
+}
+
+async fn claim_fence_is_held(
+    tx: &mut Transaction<'_, Postgres>,
+    fence: &RoomClaimFenceContext,
+) -> Result<bool, MamStorageError> {
+    let entity_key = format!(
+        "{}:{}",
+        fence.entity.entity_type.as_db_str(),
+        fence.entity.id
+    );
+    Ok(sqlx::query(
+        "SELECT 1 FROM clustering_claims WHERE entity = $1 AND node_id = $2 AND node_epoch = $3 AND claim_epoch = $4 FOR SHARE",
+    )
+    .bind(&entity_key)
+    .bind(&fence.owner.node_id)
+    .bind(&fence.owner.node_epoch)
+    .bind(fence.epoch.0)
+    .fetch_optional(&mut **tx)
+    .await?
+    .is_some())
+}
+
+async fn find_existing_origin_id_match_postgres_tx(
+    tx: &mut Transaction<'_, Postgres>,
+    archive_jid: &BareJid,
+    message: &ArchivedMessage,
+    incoming_rich_payload: Option<&str>,
+    origin_dedup_fingerprint: Option<&str>,
+) -> Result<Option<String>, MamStorageError> {
+    let Some(origin_id) = message.origin_id.as_ref() else {
+        return Ok(None);
+    };
+    let archive_jid_str = archive_jid.to_string();
+    let mut builder = QueryBuilder::<Postgres>::new(
+        "SELECT id, from_jid, to_jid, body, thread_id, parent_thread_id, \
+         reply_to_id, reply_to_jid, message_type, rich_payload, nickname_generation \
+         FROM mam_messages WHERE room_jid = ",
+    );
+    push_origin_dedup_filter(
+        &mut builder,
+        archive_jid_str.as_str(),
+        origin_id.as_str(),
+        origin_dedup_fingerprint,
+    );
+    let rows: Vec<PgRow> = builder.build().fetch_all(&mut **tx).await?;
+    for row in rows {
+        let Some(existing) = OriginDedupRow::from_postgres(&row) else {
+            continue;
+        };
+        if existing.matches(message, incoming_rich_payload) {
+            return Ok(Some(existing.id));
+        }
+    }
+    Ok(None)
 }
 
 async fn find_existing_origin_id_match(

--- a/server/crates/waddle-xmpp/src/muc/durable.rs
+++ b/server/crates/waddle-xmpp/src/muc/durable.rs
@@ -36,7 +36,7 @@ use jid::BareJid;
 
 use super::affiliation::AffiliationEntry;
 use super::{RoomConfig, SubjectState};
-use crate::ownership::{ClaimEpoch, Entity};
+use crate::ownership::{ClaimEpoch, Entity, NodeIdentity};
 use crate::XmppError;
 
 /// Boxed future returned by every [`MucDurableStore`] method, mirroring
@@ -46,18 +46,32 @@ pub type MucDurableFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, XmppErr
 
 /// Typed fencing context for a room's currently-recorded Postgres claim
 /// (ADR-0017 Phase 3 Slice 7 FIX 1, council-adjudicated): the same
-/// `(Entity, ClaimEpoch, node_id)` triple [`MucDurableStore::check_fenced_fanout`]
-/// resolves internally via [`MucDurableStore::record_claim_epoch`]'s cache,
+/// `(Entity, ClaimEpoch, NodeIdentity)` tuple [`MucDurableStore::check_fenced_fanout`]
+/// resolves internally via [`MucDurableStore::record_claim_fence`]'s cache,
 /// exposed here so a caller that needs to run its OWN fenced write against a
 /// DIFFERENT store (MAM's `store_message_fenced`, which cannot share a SQL
 /// transaction with this store's own `assert_fenced`) can bind the identical
 /// typed values into its own `SELECT ... FOR SHARE` check, rather than
 /// re-deriving them from a second, independent source of truth.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RoomClaimFenceContext {
     pub entity: Entity,
     pub epoch: ClaimEpoch,
-    pub node_id: String,
+    pub owner: NodeIdentity,
+}
+
+impl RoomClaimFenceContext {
+    pub fn new(entity: Entity, owner: NodeIdentity, epoch: ClaimEpoch) -> Self {
+        Self {
+            entity,
+            epoch,
+            owner,
+        }
+    }
+
+    pub fn owner(&self) -> NodeIdentity {
+        self.owner.clone()
+    }
 }
 
 /// Full durable snapshot of a room's long-lived state: configuration,
@@ -76,7 +90,7 @@ pub struct DurableRoomState {
 /// Durable backing store for MUC room ownership (ADR-0017 Phase 3 Slice 7).
 ///
 /// Every write is epoch-fenced against this node's currently-recorded claim
-/// on the room's `RoomActor` entity (see [`Self::record_claim_epoch`]) —
+/// on the room's `RoomActor` entity (see [`Self::record_claim_fence`]) —
 /// "epoch-fenced like all claimed-entity writes" per element 7.
 ///
 /// **Fail-open contract, revised (ADR-0017 Phase 3 Slice 7 FIX 2,
@@ -168,20 +182,20 @@ pub trait MucDurableStore: Send + Sync {
     /// fencing SQL. Default no-op: single-node/non-clustering deployments
     /// never configure a `MucDurableStore` at all, so this is never
     /// called there.
-    fn record_claim_epoch(&self, room_jid: &BareJid, epoch: ClaimEpoch) {
-        let _ = (room_jid, epoch);
+    fn record_claim_fence(&self, room_jid: &BareJid, fence: RoomClaimFenceContext) {
+        let _ = (room_jid, fence);
     }
 
     /// Best-effort cache hygiene on claim release (dormancy eviction /
     /// explicit destroy): forget the recorded epoch so a stale cache
     /// entry cannot linger past this node's ownership. Default no-op.
-    fn forget_claim_epoch(&self, room_jid: &BareJid) {
-        let _ = room_jid;
+    fn forget_claim_fence(&self, room_jid: &BareJid, expected: &RoomClaimFenceContext) {
+        let _ = (room_jid, expected);
     }
 
     /// The two-part demotion protocol's guaranteed backstop (element 7): a
     /// fenced `SELECT ... FOR SHARE` against this room's claim (at the
-    /// epoch [`Self::record_claim_epoch`] last recorded), run before every
+    /// fence [`Self::record_claim_fence`] last recorded), run before every
     /// local fan-out. `Ok(true)` iff this node still holds the claim;
     /// `Ok(false)` means a steal has committed and the caller must demote
     /// locally and not deliver. Default `Ok(true)` (never demotes):
@@ -201,7 +215,7 @@ pub trait MucDurableStore: Send + Sync {
     /// cannot share a transaction with this store) can bind them into an
     /// equivalent `SELECT ... FOR SHARE` check without re-deriving them from
     /// a second, independent mechanism. `None` when no epoch is cached for
-    /// this room (this node has never claimed it, or `forget_claim_epoch`
+    /// this room (this node has never claimed it, or `forget_claim_fence`
     /// ran) — callers treat that exactly like a fencing failure. Default
     /// `None`: single-node/non-clustering deployments never configure a
     /// `MucDurableStore` at all, so this default only matters for tests

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -23,8 +23,8 @@ use super::room_actor::{
 use super::{MucRoom, RoomConfig};
 use crate::metrics;
 use crate::ownership::{
-    ClaimEpoch, ClaimError, ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity,
-    RolloutBackoff, SharedNodeIdentity, StalePredicate,
+    ClaimEpoch, ClaimError, ClaimStore, Entity, EntityType, ExactReleaseOutcome,
+    InProcessClaimStore, NodeIdentity, RolloutBackoff, SharedNodeIdentity, StalePredicate,
 };
 use crate::xep::xep0421::OccupantIdSecret;
 
@@ -35,7 +35,22 @@ use crate::xep::xep0421::OccupantIdSecret;
 #[derive(Clone)]
 struct RoomEntry {
     actor_ref: ActorRef<RoomActor>,
-    claim_epoch: ClaimEpoch,
+    claim_fence: super::RoomClaimFenceContext,
+}
+
+#[derive(Clone)]
+struct PendingReclaimedState {
+    claim_fence: super::RoomClaimFenceContext,
+    previous_owner: NodeIdentity,
+    retry_order: u64,
+    first_pending_at: std::time::Instant,
+}
+
+#[derive(Clone)]
+struct PendingRoomReleaseState {
+    claim_fence: super::RoomClaimFenceContext,
+    retry_order: u64,
+    first_pending_at: std::time::Instant,
 }
 
 /// Actor that owns the mapping from room JIDs to per-room actors.
@@ -46,6 +61,25 @@ struct RoomEntry {
 pub struct RoomRegistryActor {
     rooms: HashMap<BareJid, RoomEntry>,
     poisoned_rooms: HashSet<BareJid>,
+    /// Reclaimed epochs that are neither served by a local actor nor
+    /// confirmed released yet. The orphan reaper asks for a bounded page on
+    /// later sweeps and retries each through the same serialized adoption
+    /// path; this prevents a transient store failure from stranding a fresh
+    /// claim forever.
+    pending_reclaimed_rooms:
+        HashMap<(BareJid, super::RoomClaimFenceContext), PendingReclaimedState>,
+    pending_reclaimed_reservations: HashSet<BareJid>,
+    /// Ordinary terminal removals whose exact claim release was uncertain.
+    /// Multiple owner+epoch generations for one room are intentional. A
+    /// timed-out release may have deleted the row, after which another owner
+    /// can recreate it with a reset epoch; numeric epoch ordering therefore
+    /// cannot identify a newest generation across delete/recreate ABA.
+    /// Retaining every exact fence lets out-of-order retries prove each
+    /// responsibility independently, while the global bound prevents churn
+    /// from growing this inventory without limit.
+    pending_room_releases:
+        HashMap<(BareJid, super::RoomClaimFenceContext), PendingRoomReleaseState>,
+    pending_retry_order: u64,
     muc_domain: String,
     /// Per-deployment XEP-0421 occupant-id HMAC key. Forwarded to every
     /// `RoomActor` at spawn so all rooms in this deployment share the
@@ -100,6 +134,8 @@ pub enum RoomRegistryError {
     /// request never entered processing.
     #[error("room registry unavailable")]
     Unavailable,
+    #[error("room {0}'s ownership store is unavailable")]
+    OwnershipUnavailable(BareJid),
     /// ADR-0017 Phase 3 Slice 7: `entity`'s Postgres claim is held by
     /// another, currently-live node, and this slice does not wire
     /// cross-node MUC message/join proxying (the ADR's own text names it
@@ -119,6 +155,10 @@ impl RoomRegistryActor {
         Self {
             rooms: HashMap::new(),
             poisoned_rooms: HashSet::new(),
+            pending_reclaimed_rooms: HashMap::new(),
+            pending_reclaimed_reservations: HashSet::new(),
+            pending_room_releases: HashMap::new(),
+            pending_retry_order: 0,
             muc_domain,
             occupant_id_secret,
             membership_source: None,
@@ -129,12 +169,94 @@ impl RoomRegistryActor {
         }
     }
 
+    fn has_pending_release_capacity(
+        &self,
+        room_jid: &BareJid,
+        claim_fence: &super::RoomClaimFenceContext,
+    ) -> bool {
+        self.pending_room_releases
+            .contains_key(&(room_jid.clone(), claim_fence.clone()))
+            || self.pending_room_releases.len() < MAX_PENDING_ROOM_RELEASES
+    }
+
+    fn remember_pending_room_release(
+        &mut self,
+        room_jid: BareJid,
+        claim_fence: super::RoomClaimFenceContext,
+    ) -> bool {
+        if !self.has_pending_release_capacity(&room_jid, &claim_fence) {
+            return false;
+        }
+        self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+        let retry_order = self.pending_retry_order;
+        self.pending_room_releases
+            .entry((room_jid, claim_fence.clone()))
+            .and_modify(|current| current.retry_order = retry_order)
+            .or_insert(PendingRoomReleaseState {
+                claim_fence: claim_fence.clone(),
+                retry_order,
+                first_pending_at: std::time::Instant::now(),
+            });
+        true
+    }
+
+    fn clear_pending_room_release(
+        &mut self,
+        room_jid: &BareJid,
+        claim_fence: &super::RoomClaimFenceContext,
+    ) {
+        self.pending_room_releases
+            .remove(&(room_jid.clone(), claim_fence.clone()));
+    }
+
+    async fn retry_oldest_pending_room_release(&mut self) -> bool {
+        let Some((room_jid, claim_fence)) = self
+            .pending_room_releases
+            .iter()
+            .min_by_key(|(_, state)| state.retry_order)
+            .map(|((room_jid, claim_fence), _)| (room_jid.clone(), claim_fence.clone()))
+        else {
+            return false;
+        };
+        self.release_room_claim(&room_jid, &claim_fence).await;
+        true
+    }
+
     /// Attach a durable membership source so every spawned `RoomActor`
     /// hydrates its durable-recipient set before serving snapshots (#1135).
     #[must_use]
     pub fn with_membership_source(mut self, source: Arc<dyn DurableMembershipSource>) -> Self {
         self.membership_source = Some(source);
         self
+    }
+
+    fn remember_pending_reclaimed_room(
+        &mut self,
+        room_jid: BareJid,
+        claim_fence: super::RoomClaimFenceContext,
+        previous_owner: NodeIdentity,
+    ) {
+        self.pending_reclaimed_reservations.remove(&room_jid);
+        self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+        let retry_order = self.pending_retry_order;
+        self.pending_reclaimed_rooms
+            .entry((room_jid, claim_fence.clone()))
+            .and_modify(|current| current.retry_order = retry_order)
+            .or_insert(PendingReclaimedState {
+                claim_fence: claim_fence.clone(),
+                previous_owner,
+                retry_order,
+                first_pending_at: std::time::Instant::now(),
+            });
+    }
+
+    fn clear_pending_reclaimed_room(
+        &mut self,
+        room_jid: &BareJid,
+        claim_fence: &super::RoomClaimFenceContext,
+    ) {
+        self.pending_reclaimed_rooms
+            .remove(&(room_jid.clone(), claim_fence.clone()));
     }
 
     /// Acquire this room's Postgres claim (ADR-0017 Phase 3 Slice 7),
@@ -147,22 +269,43 @@ impl RoomRegistryActor {
     /// attempted via any cross-node proxy — see that variant's doc
     /// comment for why that is out of this slice's scope.
     async fn acquire_room_claim(
-        &self,
+        &mut self,
         room_jid: &BareJid,
-    ) -> Result<ClaimEpoch, RoomRegistryError> {
+    ) -> Result<super::RoomClaimFenceContext, RoomRegistryError> {
+        // A newly acquired generation can require an exact terminal-release
+        // retry if identity rotates or actor preparation loses its final
+        // fence. Refuse acquisition while the bounded retry inventory is
+        // saturated; acquiring first would create responsibility that the
+        // registry has nowhere bounded to retain.
+        if self.pending_room_releases.len() >= MAX_PENDING_ROOM_RELEASES {
+            warn!(room = %room_jid, "room claim acquisition refused: exact-release retry backlog is full");
+            return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
+        }
         let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
         let identity = self.node_identity.current();
-        match self.claim_store.ensure_claimed(&entity, &identity).await {
-            Ok(epoch) => Ok(epoch),
-            Err(ClaimError::AlreadyClaimed) => {
+        let epoch = match tokio::time::timeout(
+            ROOM_OWNERSHIP_CALL_TIMEOUT,
+            self.claim_store.ensure_claimed(&entity, &identity),
+        )
+        .await
+        {
+            Ok(Ok(epoch)) => epoch,
+            Ok(Err(ClaimError::AlreadyClaimed)) => {
                 self.steal_from_dead_owner(&entity, room_jid, &identity)
-                    .await
+                    .await?
             }
-            Err(error) => {
+            Ok(Err(error)) => {
                 warn!(room = %room_jid, %error, "room claim acquisition failed");
-                Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()))
+                return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()));
             }
+            Err(_) => return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone())),
+        };
+        if self.node_identity.current() != identity {
+            let claim_fence = super::RoomClaimFenceContext::new(entity, identity, epoch);
+            self.release_room_claim(room_jid, &claim_fence).await;
+            return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()));
         }
+        Ok(super::RoomClaimFenceContext::new(entity, identity, epoch))
     }
 
     /// The re-election path: `entity`'s claim is held by another node —
@@ -174,11 +317,17 @@ impl RoomRegistryActor {
         room_jid: &BareJid,
         identity: &NodeIdentity,
     ) -> Result<ClaimEpoch, RoomRegistryError> {
-        let snapshot = match self.claim_store.current_claim(entity).await {
-            Ok(Some(snapshot)) => snapshot,
-            Ok(None) | Err(_) => {
+        let snapshot = match tokio::time::timeout(
+            ROOM_OWNERSHIP_CALL_TIMEOUT,
+            self.claim_store.current_claim(entity),
+        )
+        .await
+        {
+            Ok(Ok(Some(snapshot))) => snapshot,
+            Ok(Ok(None)) | Ok(Err(_)) => {
                 return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()))
             }
+            Err(_) => return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone())),
         };
         if snapshot.owner_lease_fresh {
             return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()));
@@ -195,17 +344,18 @@ impl RoomRegistryActor {
                 tokio::time::sleep(delay).await;
             }
         }
-        match self
-            .claim_store
-            .steal_stale(
+        match tokio::time::timeout(
+            ROOM_OWNERSHIP_CALL_TIMEOUT,
+            self.claim_store.steal_stale(
                 entity,
                 snapshot.claim_epoch,
                 StalePredicate::OwnerStale,
                 identity,
-            )
-            .await
+            ),
+        )
+        .await
         {
-            Ok(new_epoch) => {
+            Ok(Ok(new_epoch)) => {
                 info!(
                     room = %room_jid,
                     previous_owner = %snapshot.owner.node_id,
@@ -214,7 +364,8 @@ impl RoomRegistryActor {
                 self.notify_previous_owner_demoted(room_jid, &snapshot.owner, new_epoch);
                 Ok(new_epoch)
             }
-            Err(_) => Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone())),
+            Ok(Err(_)) => Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone())),
+            Err(_) => Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone())),
         }
     }
 
@@ -272,12 +423,48 @@ impl RoomRegistryActor {
         waddle_id: String,
         channel_id: String,
         config: RoomConfig,
-        claim_epoch: ClaimEpoch,
+        claim_fence: super::RoomClaimFenceContext,
+    ) -> Result<ActorRef<RoomActor>, RoomRegistryError> {
+        let actor_ref = self
+            .prepare_room(room_jid.clone(), waddle_id, channel_id, config)
+            .await;
+        let still_owned = self.node_identity.current() == claim_fence.owner()
+            && matches!(
+                tokio::time::timeout(
+                    ROOM_OWNERSHIP_CALL_TIMEOUT,
+                    self.claim_store.fence(
+                        &claim_fence.entity,
+                        &claim_fence.owner(),
+                        claim_fence.epoch,
+                    ),
+                )
+                .await,
+                Ok(Ok(true))
+            )
+            && self.node_identity.current() == claim_fence.owner();
+        if !still_owned {
+            actor_ref.kill();
+            self.release_room_claim(&room_jid, &claim_fence).await;
+            return Err(RoomRegistryError::OwnershipUnavailable(room_jid));
+        }
+        self.publish_room(room_jid, actor_ref.clone(), claim_fence);
+        Ok(actor_ref)
+    }
+
+    /// Spawn and enqueue all durable hydration work without making the actor
+    /// discoverable through the registry. Reclaimed rooms use this split so
+    /// ownership can be re-fenced after every enqueue await and immediately
+    /// before publication.
+    async fn prepare_room(
+        &self,
+        room_jid: BareJid,
+        waddle_id: String,
+        channel_id: String,
+        config: RoomConfig,
     ) -> ActorRef<RoomActor> {
         let room = MucRoom::new(room_jid.clone(), waddle_id, channel_id, config);
         let actor_ref = RoomActor::spawn(RoomActor::new(room, self.occupant_id_secret.clone()));
         if let Some(store) = &self.durable_store {
-            store.record_claim_epoch(&room_jid, claim_epoch);
             if let Err(error) = actor_ref
                 .tell(RestoreDurableRoomState {
                     store: Arc::clone(store),
@@ -307,14 +494,33 @@ impl RoomRegistryActor {
                 );
             }
         }
+        actor_ref
+    }
+
+    fn publish_room(
+        &mut self,
+        room_jid: BareJid,
+        actor_ref: ActorRef<RoomActor>,
+        claim_fence: super::RoomClaimFenceContext,
+    ) {
+        // A timed-out release may not have committed, so a later demand can
+        // self-reacquire and publish this identical owner+epoch fence. Once
+        // the fence backs a live actor it is no longer a terminal-release
+        // responsibility; leaving it queued would let a stale retry delete
+        // the live claim. Cancel only the exact match so ABA-distinct
+        // generations for this room remain independently retryable.
+        self.clear_pending_room_release(&room_jid, &claim_fence);
+        if let Some(store) = &self.durable_store {
+            store.record_claim_fence(&room_jid, claim_fence.clone());
+        }
         self.rooms.insert(
-            room_jid,
+            room_jid.clone(),
             RoomEntry {
                 actor_ref: actor_ref.clone(),
-                claim_epoch,
+                claim_fence: claim_fence.clone(),
             },
         );
-        actor_ref
+        self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
     }
 
     /// ADR-0017 Phase 3 Slice 7 FIX 3 (council-adjudicated): `async` (not
@@ -341,7 +547,19 @@ impl RoomRegistryActor {
             if entry.actor_ref.is_alive() {
                 return Ok(Some(entry.actor_ref.clone()));
             }
-            let claim_epoch = entry.claim_epoch;
+            let claim_fence = entry.claim_fence.clone();
+            if !self.has_pending_release_capacity(room_jid, &claim_fence) {
+                // Saturation must not make a dead map entry immortal. Give
+                // the oldest exact responsibility one bounded retry; a
+                // successful/NotOwned result frees the slot needed to retire
+                // this actor, while persistent backend failure remains
+                // bounded and simply defers this dead entry to a later call.
+                self.retry_oldest_pending_room_release().await;
+                if !self.has_pending_release_capacity(room_jid, &claim_fence) {
+                    debug!(room = %room_jid, "Cannot retire dead RoomActor yet: exact-release retry backlog remains full after bounded redrive");
+                    return Err(RoomRegistryError::RoomActorStateLost(room_jid.clone()));
+                }
+            }
             self.rooms.remove(room_jid);
             self.poisoned_rooms.insert(room_jid.clone());
             warn!(
@@ -354,7 +572,7 @@ impl RoomRegistryActor {
             // claim (this node holds it in Postgres but has no way left
             // to act on it), not merely a "fail fast and let the caller
             // retry" situation.
-            self.release_room_claim(room_jid, claim_epoch).await;
+            self.release_room_claim(room_jid, &claim_fence).await;
             return Err(RoomRegistryError::RoomActorStateLost(room_jid.clone()));
         }
         Ok(None)
@@ -363,21 +581,246 @@ impl RoomRegistryActor {
     /// Best-effort release of `room_jid`'s Postgres claim (dormancy
     /// eviction / explicit destroy, element 7's "graceful release").
     /// Epoch-gated and best-effort per [`ClaimStore::release`]'s own
-    /// contract — a claim already stolen out from under this node is a
-    /// no-op, not an error.
-    async fn release_room_claim(&self, room_jid: &BareJid, claim_epoch: ClaimEpoch) {
-        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
-        let identity = self.node_identity.current();
-        if let Err(error) = self
-            .claim_store
-            .release(&entity, &identity, claim_epoch)
-            .await
+    /// idempotent contract. A claim already stolen out from under this node
+    /// is a successful no-op.
+    async fn release_room_claim(
+        &mut self,
+        room_jid: &BareJid,
+        claim_fence: &super::RoomClaimFenceContext,
+    ) {
+        let owner = claim_fence.owner();
+        match tokio::time::timeout(
+            ROOM_OWNERSHIP_CALL_TIMEOUT,
+            self.claim_store
+                .release_exact(&claim_fence.entity, &owner, claim_fence.epoch),
+        )
+        .await
         {
-            warn!(room = %room_jid, %error, "failed to release room ownership claim");
+            Ok(Ok(ExactReleaseOutcome::Released | ExactReleaseOutcome::NotOwned)) => {
+                self.clear_pending_room_release(room_jid, claim_fence);
+                if let Some(store) = &self.durable_store {
+                    store.forget_claim_fence(room_jid, claim_fence);
+                }
+            }
+            Ok(Err(error)) => {
+                warn!(room = %room_jid, %error, "failed to release room ownership claim");
+                if !self.remember_pending_room_release(room_jid.clone(), claim_fence.clone()) {
+                    tracing::error!(room = %room_jid, "exact-release retry backlog saturated despite pre-admission guard; claim remains fenced for node-expiry recovery");
+                }
+            }
+            Err(_) => {
+                warn!(room = %room_jid, "timed out releasing room ownership claim; retaining exact fence for a later retry");
+                if !self.remember_pending_room_release(room_jid.clone(), claim_fence.clone()) {
+                    tracing::error!(room = %room_jid, "exact-release retry backlog saturated despite pre-admission guard; claim remains fenced for node-expiry recovery");
+                }
+            }
         }
-        if let Some(store) = &self.durable_store {
-            store.forget_claim_epoch(room_jid);
+    }
+
+    /// Bounded, observable release for a proactively reclaimed epoch. A
+    /// backend error or timeout retains the exact epoch in the pending map;
+    /// only a typed confirmation clears the durable fence cache and reports
+    /// release or a lost race.
+    async fn release_reclaimed_room_claim(
+        &mut self,
+        room_jid: &BareJid,
+        claim_fence: &super::RoomClaimFenceContext,
+        previous_owner: &NodeIdentity,
+    ) -> ReclaimedRoomOutcome {
+        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        match tokio::time::timeout(
+            RECLAIMED_ROOM_RELEASE_TIMEOUT,
+            self.claim_store
+                .release_exact(&entity, &claim_fence.owner(), claim_fence.epoch),
+        )
+        .await
+        {
+            Ok(Ok(ExactReleaseOutcome::Released)) => {
+                self.clear_pending_reclaimed_room(room_jid, claim_fence);
+                if let Some(store) = &self.durable_store {
+                    store.forget_claim_fence(room_jid, claim_fence);
+                }
+                ReclaimedRoomOutcome::Released
+            }
+            Ok(Ok(ExactReleaseOutcome::NotOwned)) => {
+                self.clear_pending_reclaimed_room(room_jid, claim_fence);
+                if let Some(store) = &self.durable_store {
+                    store.forget_claim_fence(room_jid, claim_fence);
+                }
+                ReclaimedRoomOutcome::LostRace
+            }
+            Ok(Err(error)) => {
+                debug!(room = %room_jid, %error, "reclaimed-room claim release failed; retaining for retry");
+                self.remember_pending_reclaimed_room(
+                    room_jid.clone(),
+                    claim_fence.clone(),
+                    previous_owner.clone(),
+                );
+                ReclaimedRoomOutcome::PendingRetry
+            }
+            Err(_) => {
+                debug!(room = %room_jid, "reclaimed-room claim release timed out; retaining for retry");
+                self.remember_pending_reclaimed_room(
+                    room_jid.clone(),
+                    claim_fence.clone(),
+                    previous_owner.clone(),
+                );
+                ReclaimedRoomOutcome::PendingRetry
+            }
         }
+    }
+}
+
+pub const MAX_PENDING_RECLAIMED_ROOMS: usize = 128;
+pub const MAX_PENDING_ROOM_RELEASES: usize = 128;
+
+pub struct RetryPendingRoomReleases {
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
+pub struct PendingRoomReleaseBacklog {
+    pub depth: usize,
+    pub oldest_age_ms: u64,
+}
+
+pub struct GetPendingRoomReleaseBacklog;
+pub struct ListPendingRoomReleaseJids;
+pub struct IsCurrentRoomPendingRelease {
+    pub room_jid: BareJid,
+}
+pub struct IsPendingRoomReleaseOnly {
+    pub room_jid: BareJid,
+}
+pub struct IsCurrentIdentityPendingRoomReleaseOnly {
+    pub room_jid: BareJid,
+}
+
+impl kameo::message::Message<ListPendingRoomReleaseJids> for RoomRegistryActor {
+    type Reply = Vec<BareJid>;
+
+    async fn handle(
+        &mut self,
+        _msg: ListPendingRoomReleaseJids,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let mut room_jids = self
+            .pending_room_releases
+            .keys()
+            .map(|(room_jid, _)| room_jid.clone())
+            .collect::<Vec<_>>();
+        room_jids.sort();
+        room_jids.dedup();
+        room_jids
+    }
+}
+
+impl kameo::message::Message<IsCurrentRoomPendingRelease> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: IsCurrentRoomPendingRelease,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let Some(entry) = self.rooms.get(&msg.room_jid) else {
+            return false;
+        };
+        self.pending_room_releases
+            .contains_key(&(msg.room_jid, entry.claim_fence.clone()))
+    }
+}
+
+impl kameo::message::Message<IsPendingRoomReleaseOnly> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: IsPendingRoomReleaseOnly,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.rooms
+            .get(&msg.room_jid)
+            .is_none_or(|entry| !entry.actor_ref.is_alive())
+            && self
+                .pending_room_releases
+                .keys()
+                .any(|(room_jid, _)| room_jid == &msg.room_jid)
+    }
+}
+
+impl kameo::message::Message<IsCurrentIdentityPendingRoomReleaseOnly> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: IsCurrentIdentityPendingRoomReleaseOnly,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self
+            .rooms
+            .get(&msg.room_jid)
+            .is_some_and(|entry| entry.actor_ref.is_alive())
+        {
+            return false;
+        }
+        let current_identity = self.node_identity.current();
+        let mut pending = self
+            .pending_room_releases
+            .keys()
+            .filter(|(room_jid, _)| room_jid == &msg.room_jid)
+            .peekable();
+        pending.peek().is_some()
+            && pending.all(|(_, claim_fence)| claim_fence.owner() == current_identity)
+    }
+}
+
+impl kameo::message::Message<GetPendingRoomReleaseBacklog> for RoomRegistryActor {
+    type Reply = PendingRoomReleaseBacklog;
+
+    async fn handle(
+        &mut self,
+        _msg: GetPendingRoomReleaseBacklog,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        PendingRoomReleaseBacklog {
+            depth: self.pending_room_releases.len(),
+            oldest_age_ms: self
+                .pending_room_releases
+                .values()
+                .map(|pending| pending.first_pending_at.elapsed().as_millis() as u64)
+                .max()
+                .unwrap_or(0),
+        }
+    }
+}
+
+impl kameo::message::Message<RetryPendingRoomReleases> for RoomRegistryActor {
+    type Reply = usize;
+
+    async fn handle(
+        &mut self,
+        msg: RetryPendingRoomReleases,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let mut pending: Vec<_> = self
+            .pending_room_releases
+            .iter()
+            .map(|((room_jid, claim_fence), state)| {
+                (room_jid.clone(), claim_fence.clone(), state.clone())
+            })
+            .collect();
+        pending.sort_by_key(|(_, _, state)| state.retry_order);
+        pending.truncate(msg.limit);
+        let attempted = pending.len();
+        for (room_jid, claim_fence, state) in pending {
+            self.release_room_claim(&room_jid, &state.claim_fence).await;
+            self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+            if let Some(current) = self.pending_room_releases.get_mut(&(room_jid, claim_fence)) {
+                current.retry_order = self.pending_retry_order;
+            }
+        }
+        attempted
     }
 }
 
@@ -441,7 +884,7 @@ impl kameo::message::Message<GetRoom> for RoomRegistryActor {
 /// mailbox guarantees exactly one caller per room lifetime observes
 /// [`RoomCreation::Created`] — that caller is the XEP-0045 §10.1.1
 /// room creator and the only one entitled to the creator Owner grant.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
 pub enum RoomCreation {
     /// This request spawned the room actor: the caller created the room.
     Created,
@@ -455,6 +898,398 @@ pub enum RoomCreation {
 pub struct RoomAcquisition {
     pub actor_ref: ActorRef<RoomActor>,
     pub creation: RoomCreation,
+}
+
+/// Result of reconciling a `RoomActor` claim proactively reclaimed by the
+/// dead-node sweeper. This is intentionally typed and low-cardinality so the
+/// caller can aggregate telemetry without logging once per room.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
+pub enum ReclaimedRoomOutcome {
+    /// Durable room state existed and a local actor was spawned at the won
+    /// claim epoch.
+    Hydrated,
+    /// Demand-side creation already installed a live actor under this exact
+    /// fenced epoch; no duplicate was spawned.
+    AlreadyLive,
+    /// A live local actor from this process's prior node identity adopted
+    /// the newly fenced epoch in place, preserving its in-memory room state.
+    AdoptedLocal,
+    /// No durable room state existed, so the otherwise-unusable orphan claim
+    /// was released for ordinary demand-side recreation.
+    Released,
+    /// The won epoch was no longer owned by this node when the registry
+    /// serialized the adoption request.
+    LostRace,
+    /// This node may still own the epoch, but neither actor installation nor
+    /// claim release was confirmed. The registry retained it for a bounded
+    /// retry on a later orphan-reaper sweep.
+    PendingRetry,
+}
+
+/// Adopt or release one exact `RoomActor` epoch won by the dead-node reaper.
+/// Keeping this operation inside the registry actor serializes it against
+/// every demand-side `GetOrCreateRoom` and prevents duplicate local actors.
+pub struct ReconcileReclaimedRoom {
+    pub room_jid: BareJid,
+    pub claim_fence: super::RoomClaimFenceContext,
+    pub previous_owner: NodeIdentity,
+}
+
+/// Internal budget for each durable/claim-store read in proactive room
+/// adoption. It is shorter than the registry handle's five-second outer
+/// reply timeout so the handler completes (including its release fallback)
+/// before a caller can abandon an operation that is still mutating state.
+const RECLAIMED_ROOM_STORE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+const RECLAIMED_ROOM_RELEASE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+const ROOM_OWNERSHIP_CALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// One typed pending entry returned to the reaper for retry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingReclaimedRoom {
+    pub room_jid: BareJid,
+    pub claim_fence: super::RoomClaimFenceContext,
+    pub previous_owner: NodeIdentity,
+}
+
+/// List a bounded page of won-but-unserved epochs. Selection rotates the
+/// returned entries to the back of the retry order so a permanently failing
+/// full page cannot starve later rooms. The caller retries each item through
+/// [`ReconcileReclaimedRoom`] as a separate mailbox message so no batch can
+/// monopolize the registry actor.
+pub struct ListPendingReclaimedRooms {
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
+pub struct PendingReclaimedRoomBacklog {
+    pub depth: usize,
+    pub oldest_age_ms: u64,
+}
+
+pub struct GetPendingReclaimedRoomBacklog;
+
+impl kameo::message::Message<GetPendingReclaimedRoomBacklog> for RoomRegistryActor {
+    type Reply = PendingReclaimedRoomBacklog;
+
+    async fn handle(
+        &mut self,
+        _msg: GetPendingReclaimedRoomBacklog,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let oldest_age_ms = self
+            .pending_reclaimed_rooms
+            .values()
+            .map(|pending| pending.first_pending_at.elapsed().as_millis() as u64)
+            .max()
+            .unwrap_or(0);
+        PendingReclaimedRoomBacklog {
+            depth: self.pending_reclaimed_rooms.len() + self.pending_reclaimed_reservations.len(),
+            oldest_age_ms,
+        }
+    }
+}
+
+/// Record a newly won epoch before starting any fallible adoption work.
+/// Idempotent for repeated delivery of the same `(room, epoch)`.
+pub struct RememberPendingReclaimedRoom {
+    pub room_jid: BareJid,
+    pub claim_fence: super::RoomClaimFenceContext,
+    pub previous_owner: NodeIdentity,
+}
+
+pub struct ReservePendingReclaimedRoom {
+    pub room_jid: BareJid,
+}
+
+pub struct CancelPendingReclaimedRoomReservation {
+    pub room_jid: BareJid,
+}
+
+impl kameo::message::Message<ReservePendingReclaimedRoom> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: ReservePendingReclaimedRoom,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self.pending_reclaimed_reservations.contains(&msg.room_jid) {
+            return true;
+        }
+        if self.pending_reclaimed_rooms.len() + self.pending_reclaimed_reservations.len()
+            >= MAX_PENDING_RECLAIMED_ROOMS
+        {
+            return false;
+        }
+        self.pending_reclaimed_reservations.insert(msg.room_jid);
+        true
+    }
+}
+
+impl kameo::message::Message<CancelPendingReclaimedRoomReservation> for RoomRegistryActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: CancelPendingReclaimedRoomReservation,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) {
+        self.pending_reclaimed_reservations.remove(&msg.room_jid);
+    }
+}
+
+impl kameo::message::Message<RememberPendingReclaimedRoom> for RoomRegistryActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: RememberPendingReclaimedRoom,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.remember_pending_reclaimed_room(msg.room_jid, msg.claim_fence, msg.previous_owner);
+    }
+}
+
+impl kameo::message::Message<ListPendingReclaimedRooms> for RoomRegistryActor {
+    type Reply = Vec<PendingReclaimedRoom>;
+
+    async fn handle(
+        &mut self,
+        msg: ListPendingReclaimedRooms,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let mut entries: Vec<_> = self
+            .pending_reclaimed_rooms
+            .iter()
+            .map(|((room_jid, claim_fence), pending)| {
+                (room_jid.clone(), claim_fence.clone(), pending.clone())
+            })
+            .collect();
+        entries.sort_by_key(|(_, _, pending)| pending.retry_order);
+        entries.truncate(msg.limit);
+        let mut selected = Vec::with_capacity(entries.len());
+        for (room_jid, claim_fence, pending) in entries {
+            self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+            if let Some(current) = self
+                .pending_reclaimed_rooms
+                .get_mut(&(room_jid.clone(), claim_fence))
+            {
+                current.retry_order = self.pending_retry_order;
+            }
+            selected.push(PendingReclaimedRoom {
+                room_jid: room_jid.clone(),
+                claim_fence: pending.claim_fence,
+                previous_owner: pending.previous_owner,
+            });
+        }
+        selected
+    }
+}
+
+impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
+    type Reply = ReclaimedRoomOutcome;
+
+    async fn handle(
+        &mut self,
+        msg: ReconcileReclaimedRoom,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let entity = Entity::new(EntityType::RoomActor, msg.room_jid.to_string());
+        let claim_fence = msg.claim_fence.clone();
+        let claim_epoch = claim_fence.epoch;
+        let identity = claim_fence.owner();
+        if self.node_identity.current() != identity {
+            return self
+                .release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)
+                .await;
+        }
+
+        // Prove the reaper's exact epoch before touching any local actor.
+        // A stale adoption message must never depose a newer demand-side
+        // actor, and a backend error is uncertainty, not permission.
+        let still_owned = match tokio::time::timeout(
+            RECLAIMED_ROOM_STORE_TIMEOUT,
+            self.claim_store.fence(&entity, &identity, claim_epoch),
+        )
+        .await
+        {
+            Ok(Ok(held)) => held,
+            Ok(Err(error)) => {
+                debug!(room = %msg.room_jid, %error, "reclaimed-room ownership fence failed");
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+            Err(_) => {
+                debug!(room = %msg.room_jid, "reclaimed-room ownership fence timed out");
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+        };
+        if !still_owned {
+            self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+            return ReclaimedRoomOutcome::LostRace;
+        }
+
+        if let Some(entry) = self.rooms.get(&msg.room_jid).cloned() {
+            if entry.actor_ref.is_alive() {
+                if entry.claim_fence == claim_fence {
+                    self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+                    return ReclaimedRoomOutcome::AlreadyLive;
+                }
+                if entry.claim_fence.owner() == msg.previous_owner {
+                    // The actor is exactly the one whose claim the reaper
+                    // observed and replaced. It may safely adopt the new
+                    // epoch without discarding its in-memory state. Recheck
+                    // after the earlier fence await and immediately before
+                    // mutating the live map.
+                    if self.node_identity.current() != identity {
+                        self.remember_pending_reclaimed_room(
+                            msg.room_jid,
+                            claim_fence,
+                            msg.previous_owner,
+                        );
+                        return ReclaimedRoomOutcome::PendingRetry;
+                    }
+                    match tokio::time::timeout(
+                        RECLAIMED_ROOM_STORE_TIMEOUT,
+                        self.claim_store.fence(&entity, &identity, claim_epoch),
+                    )
+                    .await
+                    {
+                        Ok(Ok(true)) if self.node_identity.current() == identity => {}
+                        Ok(Ok(false)) => {
+                            self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+                            return ReclaimedRoomOutcome::LostRace;
+                        }
+                        Ok(Ok(true)) | Ok(Err(_)) | Err(_) => {
+                            self.remember_pending_reclaimed_room(
+                                msg.room_jid,
+                                claim_fence,
+                                msg.previous_owner,
+                            );
+                            return ReclaimedRoomOutcome::PendingRetry;
+                        }
+                    }
+                    if let Some(current) = self.rooms.get_mut(&msg.room_jid) {
+                        current.claim_fence = claim_fence.clone();
+                    }
+                    if let Some(store) = &self.durable_store {
+                        store.record_claim_fence(&msg.room_jid, claim_fence.clone());
+                    }
+                    self.clear_pending_room_release(&msg.room_jid, &claim_fence);
+                    self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+                    return ReclaimedRoomOutcome::AdoptedLocal;
+                }
+
+                // Another owner intervened after this local actor was
+                // created. Its state is stale relative to the durable
+                // snapshot, so never transplant it onto the won epoch.
+                entry.actor_ref.kill();
+            }
+            self.rooms.remove(&msg.room_jid);
+            if let Some(store) = &self.durable_store {
+                store.forget_claim_fence(&msg.room_jid, &entry.claim_fence);
+            }
+        }
+
+        let Some(store) = self.durable_store.clone() else {
+            return self
+                .release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)
+                .await;
+        };
+        let snapshot = match tokio::time::timeout(
+            RECLAIMED_ROOM_STORE_TIMEOUT,
+            store.load_room_state(&msg.room_jid),
+        )
+        .await
+        {
+            Ok(Ok(Some(snapshot))) => snapshot,
+            Ok(Ok(None)) => {
+                return self
+                    .release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)
+                    .await;
+            }
+            Ok(Err(error)) => {
+                debug!(
+                    room = %msg.room_jid,
+                    %error,
+                    "failed to load proactively reclaimed room state; retaining for retry"
+                );
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+            Err(_) => {
+                debug!(room = %msg.room_jid, "proactively reclaimed room-state load timed out");
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+        };
+
+        // The durable read above is an await point long enough for another
+        // node to expire this node and steal the epoch. Re-prove exact
+        // ownership immediately before publishing a live actor; the earlier
+        // fence only authorized reading the snapshot, not a later install.
+        match tokio::time::timeout(
+            RECLAIMED_ROOM_STORE_TIMEOUT,
+            self.claim_store.fence(&entity, &identity, claim_epoch),
+        )
+        .await
+        {
+            Ok(Ok(true)) => {}
+            Ok(Ok(false)) => {
+                self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+                return ReclaimedRoomOutcome::LostRace;
+            }
+            Ok(Err(error)) => {
+                debug!(room = %msg.room_jid, %error, "final reclaimed-room ownership fence failed");
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+            Err(_) => {
+                debug!(room = %msg.room_jid, "final reclaimed-room ownership fence timed out");
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+        }
+
+        if self.node_identity.current() != identity {
+            self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+            return ReclaimedRoomOutcome::PendingRetry;
+        }
+
+        let actor_ref = self
+            .prepare_room(
+                msg.room_jid.clone(),
+                snapshot.waddle_id,
+                snapshot.channel_id,
+                snapshot.config,
+            )
+            .await;
+        // `prepare_room` awaits both mailbox enqueues. Fence once more at
+        // the actual publication boundary so neither an identity change nor
+        // an epoch steal during those awaits can install a stale actor.
+        let publish_owned = tokio::time::timeout(
+            RECLAIMED_ROOM_STORE_TIMEOUT,
+            self.claim_store.fence(&entity, &identity, claim_epoch),
+        )
+        .await;
+        match publish_owned {
+            Ok(Ok(true)) if self.node_identity.current() == identity => {}
+            Ok(Ok(false)) => {
+                actor_ref.kill();
+                self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+                return ReclaimedRoomOutcome::LostRace;
+            }
+            Ok(Ok(true)) | Ok(Err(_)) | Err(_) => {
+                actor_ref.kill();
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+        }
+        self.poisoned_rooms.remove(&msg.room_jid);
+        self.publish_room(msg.room_jid, actor_ref, claim_fence);
+        ReclaimedRoomOutcome::Hydrated
+    }
 }
 
 /// Get an existing room or create one if it does not exist.
@@ -481,7 +1316,7 @@ impl kameo::message::Message<GetOrCreateRoom> for RoomRegistryActor {
             });
         }
 
-        let claim_epoch = self.acquire_room_claim(&msg.room_jid).await?;
+        let claim_fence = self.acquire_room_claim(&msg.room_jid).await?;
         info!(room = %msg.room_jid, "Creating new room via GetOrCreateRoom");
         self.poisoned_rooms.remove(&msg.room_jid);
         let actor_ref = self
@@ -490,9 +1325,9 @@ impl kameo::message::Message<GetOrCreateRoom> for RoomRegistryActor {
                 msg.waddle_id,
                 msg.channel_id,
                 msg.config,
-                claim_epoch,
+                claim_fence,
             )
-            .await;
+            .await?;
         Ok(RoomAcquisition {
             actor_ref,
             creation: RoomCreation::Created,
@@ -534,11 +1369,11 @@ impl kameo::message::Message<CreateInstantRoom> for RoomRegistryActor {
             ..RoomConfig::default()
         };
 
-        let claim_epoch = self.acquire_room_claim(&msg.room_jid).await?;
+        let claim_fence = self.acquire_room_claim(&msg.room_jid).await?;
         self.poisoned_rooms.remove(&msg.room_jid);
         let actor_ref = self
-            .spawn_room(msg.room_jid, waddle_id, channel_id, config, claim_epoch)
-            .await;
+            .spawn_room(msg.room_jid, waddle_id, channel_id, config, claim_fence)
+            .await?;
         Ok(RoomAcquisition {
             actor_ref,
             creation: RoomCreation::Created,
@@ -566,7 +1401,7 @@ impl kameo::message::Message<CreateRoom> for RoomRegistryActor {
             return Err(RoomRegistryError::RoomAlreadyExists(msg.room_jid));
         }
 
-        let claim_epoch = self.acquire_room_claim(&msg.room_jid).await?;
+        let claim_fence = self.acquire_room_claim(&msg.room_jid).await?;
         info!(room = %msg.room_jid, "Creating new room");
         self.poisoned_rooms.remove(&msg.room_jid);
         let actor_ref = self
@@ -575,9 +1410,9 @@ impl kameo::message::Message<CreateRoom> for RoomRegistryActor {
                 msg.waddle_id,
                 msg.channel_id,
                 msg.config,
-                claim_epoch,
+                claim_fence,
             )
-            .await;
+            .await?;
         Ok(actor_ref)
     }
 }
@@ -614,6 +1449,9 @@ pub enum DestroyRoomOutcome {
     /// The epoch-fenced durable delete failed; the registry entry was
     /// restored and nothing was destroyed.
     DurableWipeFailed,
+    /// The bounded exact-release retry set is full, so the registry kept the
+    /// actor and claim intact rather than losing responsibility for the fence.
+    ReleaseBacklogFull,
 }
 
 /// Destroy a room, removing it from the registry.
@@ -630,6 +1468,12 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
         msg: DestroyRoom,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        if self.rooms.contains_key(&msg.room_jid)
+            && !self
+                .has_pending_release_capacity(&msg.room_jid, &self.rooms[&msg.room_jid].claim_fence)
+        {
+            return DestroyRoomOutcome::ReleaseBacklogFull;
+        }
         let removed_entry = self.rooms.remove(&msg.room_jid);
         let removed_room = removed_entry.is_some();
         let removed_poison = self.poisoned_rooms.remove(&msg.room_jid);
@@ -673,7 +1517,7 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
         // lease is what it takes to look stale (bounded residual gap,
         // same class as FIX 6e's fail-open-detach gap).
         if let Some(entry) = removed_entry {
-            self.release_room_claim(&msg.room_jid, entry.claim_epoch)
+            self.release_room_claim(&msg.room_jid, &entry.claim_fence)
                 .await;
         }
         if removed_room || removed_poison {
@@ -722,6 +1566,10 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
         let Some(entry) = self.rooms.get(&msg.room_jid).cloned() else {
             return false;
         };
+        if !self.has_pending_release_capacity(&msg.room_jid, &entry.claim_fence) {
+            warn!(room = %msg.room_jid, "Skipping inactive-room seal because exact-release retry backlog is full");
+            return false;
+        }
         let sealed = entry
             .actor_ref
             .ask(SealIfInactive {
@@ -740,7 +1588,7 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
                 // Postgres claim here too, or every guarded dormancy-evicted
                 // room leaks its claim until this node's own liveness lease
                 // looks stale to another node's `OwnerStale` steal.
-                self.release_room_claim(&msg.room_jid, entry.claim_epoch)
+                self.release_room_claim(&msg.room_jid, &entry.claim_fence)
                     .await;
                 info!(room = %msg.room_jid, "Destroyed inactive room (guarded)");
                 true
@@ -794,11 +1642,14 @@ impl kameo::message::Message<ReapSealedRoom> for RoomRegistryActor {
             return false;
         };
         if !entry.actor_ref.is_alive() {
+            if !self.has_pending_release_capacity(&msg.room_jid, &entry.claim_fence) {
+                return false;
+            }
             self.rooms.remove(&msg.room_jid);
             self.poisoned_rooms.remove(&msg.room_jid);
             // ADR-0017 Phase 3 Slice 7: same terminal-removal claim release
             // as the `live_room` dead-actor path and `DestroyRoom`.
-            self.release_room_claim(&msg.room_jid, entry.claim_epoch)
+            self.release_room_claim(&msg.room_jid, &entry.claim_fence)
                 .await;
             info!(room = %msg.room_jid, "Reaped dead room actor during sealed-room purge");
             return true;
@@ -811,11 +1662,14 @@ impl kameo::message::Message<ReapSealedRoom> for RoomRegistryActor {
             .await;
         match sealed {
             Ok(true) => {
+                if !self.has_pending_release_capacity(&msg.room_jid, &entry.claim_fence) {
+                    return false;
+                }
                 self.rooms.remove(&msg.room_jid);
                 self.poisoned_rooms.remove(&msg.room_jid);
                 // ADR-0017 Phase 3 Slice 7: same terminal-removal claim
                 // release as the guarded-destroy path above.
-                self.release_room_claim(&msg.room_jid, entry.claim_epoch)
+                self.release_room_claim(&msg.room_jid, &entry.claim_fence)
                     .await;
                 info!(
                     room = %msg.room_jid,

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -48,7 +48,12 @@ struct PendingReclaimedState {
 
 #[derive(Clone)]
 struct PendingRoomReleaseState {
-    claim_fence: super::RoomClaimFenceContext,
+    retry_order: u64,
+    first_pending_at: std::time::Instant,
+}
+
+#[derive(Clone)]
+struct PendingRoomAcquisitionState {
     retry_order: u64,
     first_pending_at: std::time::Instant,
 }
@@ -79,6 +84,11 @@ pub struct RoomRegistryActor {
     /// from growing this inventory without limit.
     pending_room_releases:
         HashMap<(BareJid, super::RoomClaimFenceContext), PendingRoomReleaseState>,
+    /// Claim CAS calls whose timeout/backend error left commit status
+    /// uncertain. Until a read proves the row missing/foreign or transfers
+    /// the exact fence into actor/release ownership, this inventory remains
+    /// responsible for the possibly committed claim.
+    pending_room_acquisitions: HashMap<(BareJid, NodeIdentity), PendingRoomAcquisitionState>,
     pending_retry_order: u64,
     muc_domain: String,
     /// Per-deployment XEP-0421 occupant-id HMAC key. Forwarded to every
@@ -158,6 +168,7 @@ impl RoomRegistryActor {
             pending_reclaimed_rooms: HashMap::new(),
             pending_reclaimed_reservations: HashSet::new(),
             pending_room_releases: HashMap::new(),
+            pending_room_acquisitions: HashMap::new(),
             pending_retry_order: 0,
             muc_domain,
             occupant_id_secret,
@@ -193,11 +204,87 @@ impl RoomRegistryActor {
             .entry((room_jid, claim_fence.clone()))
             .and_modify(|current| current.retry_order = retry_order)
             .or_insert(PendingRoomReleaseState {
-                claim_fence: claim_fence.clone(),
                 retry_order,
                 first_pending_at: std::time::Instant::now(),
             });
         true
+    }
+
+    fn reserve_pending_room_acquisition(
+        &mut self,
+        room_jid: &BareJid,
+        owner: &NodeIdentity,
+    ) -> bool {
+        let key = (room_jid.clone(), owner.clone());
+        if self.pending_room_acquisitions.contains_key(&key) {
+            return true;
+        }
+        if self.pending_room_acquisitions.len() >= MAX_PENDING_ROOM_ACQUISITIONS {
+            return false;
+        }
+        self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+        self.pending_room_acquisitions.insert(
+            key,
+            PendingRoomAcquisitionState {
+                retry_order: self.pending_retry_order,
+                first_pending_at: std::time::Instant::now(),
+            },
+        );
+        true
+    }
+
+    fn clear_pending_room_acquisition(&mut self, room_jid: &BareJid, owner: &NodeIdentity) {
+        self.pending_room_acquisitions
+            .remove(&(room_jid.clone(), owner.clone()));
+    }
+
+    async fn reconcile_pending_room_acquisition(
+        &mut self,
+        room_jid: &BareJid,
+        owner: &NodeIdentity,
+    ) {
+        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        let snapshot = tokio::time::timeout(
+            ROOM_OWNERSHIP_CALL_TIMEOUT,
+            self.claim_store.current_claim(&entity),
+        )
+        .await;
+        let snapshot = match snapshot {
+            Ok(Ok(snapshot)) => snapshot,
+            Ok(Err(_)) | Err(_) => {
+                self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+                if let Some(pending) = self
+                    .pending_room_acquisitions
+                    .get_mut(&(room_jid.clone(), owner.clone()))
+                {
+                    pending.retry_order = self.pending_retry_order;
+                }
+                return;
+            }
+        };
+        let Some(snapshot) = snapshot else {
+            self.clear_pending_room_acquisition(room_jid, owner);
+            return;
+        };
+        if snapshot.owner != *owner {
+            self.clear_pending_room_acquisition(room_jid, owner);
+            return;
+        }
+        let claim_fence =
+            super::RoomClaimFenceContext::new(entity, owner.clone(), snapshot.claim_epoch);
+        if self
+            .rooms
+            .get(room_jid)
+            .is_some_and(|entry| entry.actor_ref.is_alive() && entry.claim_fence == claim_fence)
+        {
+            self.clear_pending_room_acquisition(room_jid, owner);
+            return;
+        }
+        if !self.has_pending_release_capacity(room_jid, &claim_fence) {
+            return;
+        }
+        self.release_room_claim(room_jid, &claim_fence).await;
+        self.clear_pending_room_acquisition(room_jid, owner);
     }
 
     fn clear_pending_room_release(
@@ -283,20 +370,27 @@ impl RoomRegistryActor {
         }
         let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
         let identity = self.node_identity.current();
+        if !self.reserve_pending_room_acquisition(room_jid, &identity) {
+            warn!(room = %room_jid, "room claim acquisition refused: uncertain-acquisition backlog is full");
+            return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
+        }
         let epoch = match tokio::time::timeout(
             ROOM_OWNERSHIP_CALL_TIMEOUT,
             self.claim_store.ensure_claimed(&entity, &identity),
         )
         .await
         {
-            Ok(Ok(epoch)) => epoch,
+            Ok(Ok(epoch)) => {
+                self.clear_pending_room_acquisition(room_jid, &identity);
+                epoch
+            }
             Ok(Err(ClaimError::AlreadyClaimed)) => {
                 self.steal_from_dead_owner(&entity, room_jid, &identity)
                     .await?
             }
             Ok(Err(error)) => {
                 warn!(room = %room_jid, %error, "room claim acquisition failed");
-                return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()));
+                return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
             }
             Err(_) => return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone())),
         };
@@ -312,7 +406,7 @@ impl RoomRegistryActor {
     /// steal it if (and only if) that node's own liveness lease is no
     /// longer fresh (element 7's "steal after owner death").
     async fn steal_from_dead_owner(
-        &self,
+        &mut self,
         entity: &Entity,
         room_jid: &BareJid,
         identity: &NodeIdentity,
@@ -325,11 +419,16 @@ impl RoomRegistryActor {
         {
             Ok(Ok(Some(snapshot))) => snapshot,
             Ok(Ok(None)) | Ok(Err(_)) => {
-                return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()))
+                self.clear_pending_room_acquisition(room_jid, identity);
+                return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()));
             }
-            Err(_) => return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone())),
+            Err(_) => {
+                self.clear_pending_room_acquisition(room_jid, identity);
+                return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
+            }
         };
         if snapshot.owner_lease_fresh {
+            self.clear_pending_room_acquisition(room_jid, identity);
             return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()));
         }
         // ADR-0017 Phase 3 Slice 10 (Q5's rollout-aware placement rule): an
@@ -356,6 +455,7 @@ impl RoomRegistryActor {
         .await
         {
             Ok(Ok(new_epoch)) => {
+                self.clear_pending_room_acquisition(room_jid, identity);
                 info!(
                     room = %room_jid,
                     previous_owner = %snapshot.owner.node_id,
@@ -364,7 +464,11 @@ impl RoomRegistryActor {
                 self.notify_previous_owner_demoted(room_jid, &snapshot.owner, new_epoch);
                 Ok(new_epoch)
             }
-            Ok(Err(_)) => Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone())),
+            Ok(Err(ClaimError::Conflict | ClaimError::AlreadyClaimed)) => {
+                self.clear_pending_room_acquisition(room_jid, identity);
+                Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()))
+            }
+            Ok(Err(_)) => Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone())),
             Err(_) => Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone())),
         }
     }
@@ -503,6 +607,7 @@ impl RoomRegistryActor {
         actor_ref: ActorRef<RoomActor>,
         claim_fence: super::RoomClaimFenceContext,
     ) {
+        self.clear_pending_room_acquisition(&room_jid, &claim_fence.owner());
         // A timed-out release may not have committed, so a later demand can
         // self-reacquire and publish this identical owner+epoch fence. Once
         // the fence backs a live actor it is no longer a terminal-release
@@ -673,6 +778,7 @@ impl RoomRegistryActor {
 
 pub const MAX_PENDING_RECLAIMED_ROOMS: usize = 128;
 pub const MAX_PENDING_ROOM_RELEASES: usize = 128;
+pub const MAX_PENDING_ROOM_ACQUISITIONS: usize = 128;
 
 pub struct RetryPendingRoomReleases {
     pub limit: usize,
@@ -784,11 +890,19 @@ impl kameo::message::Message<GetPendingRoomReleaseBacklog> for RoomRegistryActor
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         PendingRoomReleaseBacklog {
-            depth: self.pending_room_releases.len(),
+            depth: self
+                .pending_room_releases
+                .len()
+                .saturating_add(self.pending_room_acquisitions.len()),
             oldest_age_ms: self
                 .pending_room_releases
                 .values()
                 .map(|pending| pending.first_pending_at.elapsed().as_millis() as u64)
+                .chain(
+                    self.pending_room_acquisitions
+                        .values()
+                        .map(|pending| pending.first_pending_at.elapsed().as_millis() as u64),
+                )
                 .max()
                 .unwrap_or(0),
         }
@@ -803,21 +917,49 @@ impl kameo::message::Message<RetryPendingRoomReleases> for RoomRegistryActor {
         msg: RetryPendingRoomReleases,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        let mut pending: Vec<_> = self
-            .pending_room_releases
+        enum RetryWork {
+            Acquisition(BareJid, NodeIdentity),
+            Release(BareJid, super::RoomClaimFenceContext),
+        }
+
+        let mut pending = self
+            .pending_room_acquisitions
             .iter()
-            .map(|((room_jid, claim_fence), state)| {
-                (room_jid.clone(), claim_fence.clone(), state.clone())
+            .map(|((room_jid, owner), state)| {
+                (
+                    state.retry_order,
+                    RetryWork::Acquisition(room_jid.clone(), owner.clone()),
+                )
             })
-            .collect();
-        pending.sort_by_key(|(_, _, state)| state.retry_order);
+            .chain(
+                self.pending_room_releases
+                    .iter()
+                    .map(|((room_jid, claim_fence), state)| {
+                        (
+                            state.retry_order,
+                            RetryWork::Release(room_jid.clone(), claim_fence.clone()),
+                        )
+                    }),
+            )
+            .collect::<Vec<_>>();
+        pending.sort_by_key(|(retry_order, _)| *retry_order);
         pending.truncate(msg.limit);
         let attempted = pending.len();
-        for (room_jid, claim_fence, state) in pending {
-            self.release_room_claim(&room_jid, &state.claim_fence).await;
-            self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
-            if let Some(current) = self.pending_room_releases.get_mut(&(room_jid, claim_fence)) {
-                current.retry_order = self.pending_retry_order;
+        for (_, work) in pending {
+            match work {
+                RetryWork::Acquisition(room_jid, owner) => {
+                    self.reconcile_pending_room_acquisition(&room_jid, &owner)
+                        .await;
+                }
+                RetryWork::Release(room_jid, claim_fence) => {
+                    self.release_room_claim(&room_jid, &claim_fence).await;
+                    self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+                    if let Some(current) =
+                        self.pending_room_releases.get_mut(&(room_jid, claim_fence))
+                    {
+                        current.retry_order = self.pending_retry_order;
+                    }
+                }
             }
         }
         attempted

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -90,6 +90,8 @@ pub struct RoomRegistryActor {
     /// responsible for the possibly committed claim.
     pending_room_acquisitions: HashMap<(BareJid, NodeIdentity), PendingRoomAcquisitionState>,
     pending_retry_order: u64,
+    pending_retry_timer_generation: u64,
+    scheduled_pending_retry_generation: Option<u64>,
     muc_domain: String,
     /// Per-deployment XEP-0421 occupant-id HMAC key. Forwarded to every
     /// `RoomActor` at spawn so all rooms in this deployment share the
@@ -170,6 +172,8 @@ impl RoomRegistryActor {
             pending_room_releases: HashMap::new(),
             pending_room_acquisitions: HashMap::new(),
             pending_retry_order: 0,
+            pending_retry_timer_generation: 0,
+            scheduled_pending_retry_generation: None,
             muc_domain,
             occupant_id_secret,
             membership_source: None,
@@ -238,6 +242,27 @@ impl RoomRegistryActor {
             .remove(&(room_jid.clone(), owner.clone()));
     }
 
+    fn has_pending_room_retry_work(&self) -> bool {
+        !self.pending_room_acquisitions.is_empty() || !self.pending_room_releases.is_empty()
+    }
+
+    fn schedule_pending_room_retry(&mut self, actor_ref: &ActorRef<Self>) {
+        if self.scheduled_pending_retry_generation.is_some() {
+            return;
+        }
+        self.pending_retry_timer_generation = self.pending_retry_timer_generation.wrapping_add(1);
+        let generation = self.pending_retry_timer_generation;
+        self.scheduled_pending_retry_generation = Some(generation);
+        std::mem::drop(
+            actor_ref
+                .tell(RetryPendingRoomWork {
+                    generation,
+                    limit: PENDING_ROOM_RETRY_BATCH,
+                })
+                .send_after(PENDING_ROOM_RETRY_DELAY),
+        );
+    }
+
     async fn reconcile_pending_room_acquisition(
         &mut self,
         room_jid: &BareJid,
@@ -281,6 +306,13 @@ impl RoomRegistryActor {
             return;
         }
         if !self.has_pending_release_capacity(room_jid, &claim_fence) {
+            self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+            if let Some(pending) = self
+                .pending_room_acquisitions
+                .get_mut(&(room_jid.clone(), owner.clone()))
+            {
+                pending.retry_order = self.pending_retry_order;
+            }
             return;
         }
         self.release_room_claim(room_jid, &claim_fence).await;
@@ -307,6 +339,55 @@ impl RoomRegistryActor {
         };
         self.release_room_claim(&room_jid, &claim_fence).await;
         true
+    }
+
+    async fn retry_pending_room_work(&mut self, limit: usize) -> usize {
+        enum RetryWork {
+            Acquisition(BareJid, NodeIdentity),
+            Release(BareJid, super::RoomClaimFenceContext),
+        }
+
+        let mut pending = self
+            .pending_room_acquisitions
+            .iter()
+            .map(|((room_jid, owner), state)| {
+                (
+                    state.retry_order,
+                    RetryWork::Acquisition(room_jid.clone(), owner.clone()),
+                )
+            })
+            .chain(
+                self.pending_room_releases
+                    .iter()
+                    .map(|((room_jid, claim_fence), state)| {
+                        (
+                            state.retry_order,
+                            RetryWork::Release(room_jid.clone(), claim_fence.clone()),
+                        )
+                    }),
+            )
+            .collect::<Vec<_>>();
+        pending.sort_by_key(|(retry_order, _)| *retry_order);
+        pending.truncate(limit);
+        let attempted = pending.len();
+        for (_, work) in pending {
+            match work {
+                RetryWork::Acquisition(room_jid, owner) => {
+                    self.reconcile_pending_room_acquisition(&room_jid, &owner)
+                        .await;
+                }
+                RetryWork::Release(room_jid, claim_fence) => {
+                    self.release_room_claim(&room_jid, &claim_fence).await;
+                    self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+                    if let Some(current) =
+                        self.pending_room_releases.get_mut(&(room_jid, claim_fence))
+                    {
+                        current.retry_order = self.pending_retry_order;
+                    }
+                }
+            }
+        }
+        attempted
     }
 
     /// Attach a durable membership source so every spawned `RoomActor`
@@ -358,6 +439,7 @@ impl RoomRegistryActor {
     async fn acquire_room_claim(
         &mut self,
         room_jid: &BareJid,
+        actor_ref: &ActorRef<Self>,
     ) -> Result<super::RoomClaimFenceContext, RoomRegistryError> {
         // A newly acquired generation can require an exact terminal-release
         // retry if identity rotates or actor preparation loses its final
@@ -374,6 +456,11 @@ impl RoomRegistryActor {
             warn!(room = %room_jid, "room claim acquisition refused: uncertain-acquisition backlog is full");
             return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
         }
+        // The reservation represents responsibility for a possibly
+        // committed claim. Drive reconciliation from the actor itself so a
+        // transient backend outage cannot fill the bounded inventory and
+        // permanently refuse unrelated future room acquisitions.
+        self.schedule_pending_room_retry(actor_ref);
         let epoch = match tokio::time::timeout(
             ROOM_OWNERSHIP_CALL_TIMEOUT,
             self.claim_store.ensure_claimed(&entity, &identity),
@@ -780,9 +867,16 @@ impl RoomRegistryActor {
 pub const MAX_PENDING_RECLAIMED_ROOMS: usize = 128;
 pub const MAX_PENDING_ROOM_RELEASES: usize = 128;
 pub const MAX_PENDING_ROOM_ACQUISITIONS: usize = 128;
+const PENDING_ROOM_RETRY_BATCH: usize = 16;
+const PENDING_ROOM_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
 
 pub struct RetryPendingRoomReleases {
     pub limit: usize,
+}
+
+struct RetryPendingRoomWork {
+    generation: u64,
+    limit: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
@@ -916,52 +1010,31 @@ impl kameo::message::Message<RetryPendingRoomReleases> for RoomRegistryActor {
     async fn handle(
         &mut self,
         msg: RetryPendingRoomReleases,
-        _ctx: &mut Context<Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        enum RetryWork {
-            Acquisition(BareJid, NodeIdentity),
-            Release(BareJid, super::RoomClaimFenceContext),
+        let attempted = self.retry_pending_room_work(msg.limit).await;
+        if self.has_pending_room_retry_work() {
+            self.schedule_pending_room_retry(ctx.actor_ref());
         }
+        attempted
+    }
+}
 
-        let mut pending = self
-            .pending_room_acquisitions
-            .iter()
-            .map(|((room_jid, owner), state)| {
-                (
-                    state.retry_order,
-                    RetryWork::Acquisition(room_jid.clone(), owner.clone()),
-                )
-            })
-            .chain(
-                self.pending_room_releases
-                    .iter()
-                    .map(|((room_jid, claim_fence), state)| {
-                        (
-                            state.retry_order,
-                            RetryWork::Release(room_jid.clone(), claim_fence.clone()),
-                        )
-                    }),
-            )
-            .collect::<Vec<_>>();
-        pending.sort_by_key(|(retry_order, _)| *retry_order);
-        pending.truncate(msg.limit);
-        let attempted = pending.len();
-        for (_, work) in pending {
-            match work {
-                RetryWork::Acquisition(room_jid, owner) => {
-                    self.reconcile_pending_room_acquisition(&room_jid, &owner)
-                        .await;
-                }
-                RetryWork::Release(room_jid, claim_fence) => {
-                    self.release_room_claim(&room_jid, &claim_fence).await;
-                    self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
-                    if let Some(current) =
-                        self.pending_room_releases.get_mut(&(room_jid, claim_fence))
-                    {
-                        current.retry_order = self.pending_retry_order;
-                    }
-                }
-            }
+impl kameo::message::Message<RetryPendingRoomWork> for RoomRegistryActor {
+    type Reply = usize;
+
+    async fn handle(
+        &mut self,
+        msg: RetryPendingRoomWork,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if self.scheduled_pending_retry_generation != Some(msg.generation) {
+            return 0;
+        }
+        self.scheduled_pending_retry_generation = None;
+        let attempted = self.retry_pending_room_work(msg.limit).await;
+        if self.has_pending_room_retry_work() {
+            self.schedule_pending_room_retry(ctx.actor_ref());
         }
         attempted
     }
@@ -1465,7 +1538,7 @@ impl kameo::message::Message<GetOrCreateRoom> for RoomRegistryActor {
     async fn handle(
         &mut self,
         msg: GetOrCreateRoom,
-        _ctx: &mut Context<Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         if let Some(actor_ref) = self.live_room(&msg.room_jid).await? {
             debug!(room = %msg.room_jid, "Room already exists");
@@ -1475,7 +1548,9 @@ impl kameo::message::Message<GetOrCreateRoom> for RoomRegistryActor {
             });
         }
 
-        let claim_fence = self.acquire_room_claim(&msg.room_jid).await?;
+        let claim_fence = self
+            .acquire_room_claim(&msg.room_jid, ctx.actor_ref())
+            .await?;
         info!(room = %msg.room_jid, "Creating new room via GetOrCreateRoom");
         self.poisoned_rooms.remove(&msg.room_jid);
         let actor_ref = self
@@ -1505,7 +1580,7 @@ impl kameo::message::Message<CreateInstantRoom> for RoomRegistryActor {
     async fn handle(
         &mut self,
         msg: CreateInstantRoom,
-        _ctx: &mut Context<Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         if let Some(actor_ref) = self.live_room(&msg.room_jid).await? {
             return Ok(RoomAcquisition {
@@ -1528,7 +1603,9 @@ impl kameo::message::Message<CreateInstantRoom> for RoomRegistryActor {
             ..RoomConfig::default()
         };
 
-        let claim_fence = self.acquire_room_claim(&msg.room_jid).await?;
+        let claim_fence = self
+            .acquire_room_claim(&msg.room_jid, ctx.actor_ref())
+            .await?;
         self.poisoned_rooms.remove(&msg.room_jid);
         let actor_ref = self
             .spawn_room(msg.room_jid, waddle_id, channel_id, config, claim_fence)
@@ -1554,13 +1631,15 @@ impl kameo::message::Message<CreateRoom> for RoomRegistryActor {
     async fn handle(
         &mut self,
         msg: CreateRoom,
-        _ctx: &mut Context<Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         if self.live_room(&msg.room_jid).await?.is_some() {
             return Err(RoomRegistryError::RoomAlreadyExists(msg.room_jid));
         }
 
-        let claim_fence = self.acquire_room_claim(&msg.room_jid).await?;
+        let claim_fence = self
+            .acquire_room_claim(&msg.room_jid, ctx.actor_ref())
+            .await?;
         info!(room = %msg.room_jid, "Creating new room");
         self.poisoned_rooms.remove(&msg.room_jid);
         let actor_ref = self

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -532,25 +532,26 @@ impl RoomRegistryActor {
         let actor_ref = self
             .prepare_room(room_jid.clone(), waddle_id, channel_id, config)
             .await;
-        let still_owned = self.node_identity.current() == claim_fence.owner()
-            && matches!(
-                tokio::time::timeout(
-                    ROOM_OWNERSHIP_CALL_TIMEOUT,
-                    self.claim_store.fence(
-                        &claim_fence.entity,
-                        &claim_fence.owner(),
-                        claim_fence.epoch,
-                    ),
-                )
-                .await,
-                Ok(Ok(true))
+        let owner = claim_fence.owner();
+        let still_owned = matches!(
+            tokio::time::timeout(
+                ROOM_OWNERSHIP_CALL_TIMEOUT,
+                self.claim_store
+                    .fence(&claim_fence.entity, &owner, claim_fence.epoch),
             )
-            && self.node_identity.current() == claim_fence.owner();
-        if !still_owned {
+            .await,
+            Ok(Ok(true))
+        );
+        let identity_guard = if still_owned {
+            self.node_identity.guard_if_current(&owner).await
+        } else {
+            None
+        };
+        let Some(_identity_guard) = identity_guard else {
             actor_ref.kill();
             self.release_room_claim(&room_jid, &claim_fence).await;
             return Err(RoomRegistryError::OwnershipUnavailable(room_jid));
-        }
+        };
         self.publish_room(room_jid, actor_ref.clone(), claim_fence);
         Ok(actor_ref)
     }
@@ -1298,12 +1299,12 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
                     )
                     .await
                     {
-                        Ok(Ok(true)) if self.node_identity.current() == identity => {}
+                        Ok(Ok(true)) => {}
                         Ok(Ok(false)) => {
                             self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
                             return ReclaimedRoomOutcome::LostRace;
                         }
-                        Ok(Ok(true)) | Ok(Err(_)) | Err(_) => {
+                        Ok(Err(_)) | Err(_) => {
                             self.remember_pending_reclaimed_room(
                                 msg.room_jid,
                                 claim_fence,
@@ -1312,6 +1313,16 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
                             return ReclaimedRoomOutcome::PendingRetry;
                         }
                     }
+                    let identity_handle = self.node_identity.clone();
+                    let Some(_identity_guard) = identity_handle.guard_if_current(&identity).await
+                    else {
+                        self.remember_pending_reclaimed_room(
+                            msg.room_jid,
+                            claim_fence,
+                            msg.previous_owner,
+                        );
+                        return ReclaimedRoomOutcome::PendingRetry;
+                    };
                     if let Some(current) = self.rooms.get_mut(&msg.room_jid) {
                         current.claim_fence = claim_fence.clone();
                     }
@@ -1416,18 +1427,24 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
         )
         .await;
         match publish_owned {
-            Ok(Ok(true)) if self.node_identity.current() == identity => {}
+            Ok(Ok(true)) => {}
             Ok(Ok(false)) => {
                 actor_ref.kill();
                 self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
                 return ReclaimedRoomOutcome::LostRace;
             }
-            Ok(Ok(true)) | Ok(Err(_)) | Err(_) => {
+            Ok(Err(_)) | Err(_) => {
                 actor_ref.kill();
                 self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
                 return ReclaimedRoomOutcome::PendingRetry;
             }
         }
+        let identity_handle = self.node_identity.clone();
+        let Some(_identity_guard) = identity_handle.guard_if_current(&identity).await else {
+            actor_ref.kill();
+            self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+            return ReclaimedRoomOutcome::PendingRetry;
+        };
         self.poisoned_rooms.remove(&msg.room_jid);
         self.publish_room(msg.room_jid, actor_ref, claim_fence);
         ReclaimedRoomOutcome::Hydrated

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -1663,15 +1663,15 @@ pub enum DestroyRoomReason {
     /// ceases to exist, so its durable rows (config, subject,
     /// affiliations incl. bans) are deleted with it.
     Destroy,
-    /// This node merely lost the room (fenced ownership check saw a
-    /// steal): evict the LOCAL actor only. The room lives on under its
-    /// new owner — its durable rows MUST survive. Without this split,
-    /// a same-node re-claim racing the queued eviction could pass the
-    /// write fence and wipe a legitimately re-claimed room's state.
-    LocalEviction,
+    /// A write-adjacent fence proved this process can no longer serve the
+    /// room, either because the database claim moved or the local node
+    /// identity rotated. Bypass release-backlog admission so the deposed
+    /// actor cannot remain registered, preserve durable state, and still
+    /// attempt exact release of the old fence.
+    DeposedEviction,
 }
 
-/// Outcome of a [`DestroyRoom`] ask. Split three ways because callers
+/// Outcome of a [`DestroyRoom`] ask. Split four ways because callers
 /// must distinguish "the room simply was not registered" (fine for
 /// admin deletion of a dormant room) from "the fenced durable wipe
 /// failed and the room was deliberately kept alive for a retry"
@@ -1706,7 +1706,8 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
         msg: DestroyRoom,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        if self.rooms.contains_key(&msg.room_jid)
+        if msg.reason != DestroyRoomReason::DeposedEviction
+            && self.rooms.contains_key(&msg.room_jid)
             && !self
                 .has_pending_release_capacity(&msg.room_jid, &self.rooms[&msg.room_jid].claim_fence)
         {
@@ -1725,7 +1726,7 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
         // owner's rows). A failed delete FAILS the destroy: the entry
         // is restored and `false` returned, so a caller never
         // acknowledges a destruction whose durable state survived.
-        // `LocalEviction` (deposed-node teardown) never wipes — the
+        // `DeposedEviction` never wipes — the
         // room lives on under its new owner.
         if (removed_room || removed_poison) && msg.reason == DestroyRoomReason::Destroy {
             if let Some(store) = &self.durable_store {

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -1217,6 +1217,8 @@ mod ownership_claims_tests {
         release_delay_ms: AtomicU64,
         fence_delay_ms: AtomicU64,
         ensure_delay_ms: AtomicU64,
+        ensure_post_commit_delay_ms: AtomicU64,
+        steal_post_commit_delay_ms: AtomicU64,
     }
 
     impl DeadOwnerClaimStore {
@@ -1230,7 +1232,15 @@ mod ownership_claims_tests {
                 release_delay_ms: AtomicU64::new(0),
                 fence_delay_ms: AtomicU64::new(0),
                 ensure_delay_ms: AtomicU64::new(0),
+                ensure_post_commit_delay_ms: AtomicU64::new(0),
+                steal_post_commit_delay_ms: AtomicU64::new(0),
             }
+        }
+
+        fn empty() -> Self {
+            let mut store = Self::seeded(this_identity(), ClaimEpoch(0));
+            *store.state.get_mut().expect("lock") = None;
+            store
         }
 
         fn fail_fence_on_call(&self, call: usize) {
@@ -1257,6 +1267,20 @@ mod ownership_claims_tests {
 
         fn set_ensure_delay(&self, delay: std::time::Duration) {
             self.ensure_delay_ms.store(
+                u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+                Ordering::SeqCst,
+            );
+        }
+
+        fn set_ensure_post_commit_delay(&self, delay: std::time::Duration) {
+            self.ensure_post_commit_delay_ms.store(
+                u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+                Ordering::SeqCst,
+            );
+        }
+
+        fn set_steal_post_commit_delay(&self, delay: std::time::Duration) {
+            self.steal_post_commit_delay_ms.store(
                 u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
                 Ordering::SeqCst,
             );
@@ -1292,11 +1316,18 @@ mod ownership_claims_tests {
                 tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
             }
             let existing = self.state.lock().expect("lock").clone();
-            match existing {
+            let result = match existing {
                 None => self.acquire(entity, me).await,
                 Some((owner, epoch)) if owner == *me => Ok(epoch),
                 Some(_) => Err(ClaimError::AlreadyClaimed),
+            };
+            if result.is_ok() {
+                let delay_ms = self.ensure_post_commit_delay_ms.load(Ordering::SeqCst);
+                if delay_ms > 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                }
             }
+            result
         }
 
         async fn steal_stale(
@@ -1307,15 +1338,24 @@ mod ownership_claims_tests {
             me: &NodeIdentity,
         ) -> Result<ClaimEpoch, ClaimError> {
             self.steal_calls.fetch_add(1, Ordering::SeqCst);
-            let mut state = self.state.lock().expect("lock");
-            match &*state {
-                Some((_, epoch)) if *epoch == observed => {
-                    let new_epoch = ClaimEpoch(epoch.0 + 1);
-                    *state = Some((me.clone(), new_epoch));
-                    Ok(new_epoch)
+            let result = {
+                let mut state = self.state.lock().expect("lock");
+                match &*state {
+                    Some((_, epoch)) if *epoch == observed => {
+                        let new_epoch = ClaimEpoch(epoch.0 + 1);
+                        *state = Some((me.clone(), new_epoch));
+                        Ok(new_epoch)
+                    }
+                    _ => Err(ClaimError::Conflict),
                 }
-                _ => Err(ClaimError::Conflict),
+            };
+            if result.is_ok() {
+                let delay_ms = self.steal_post_commit_delay_ms.load(Ordering::SeqCst);
+                if delay_ms > 0 {
+                    tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+                }
             }
+            result
         }
 
         async fn steal_for_resume(
@@ -2149,6 +2189,125 @@ mod ownership_claims_tests {
             registry.ask(RoomCount).await.expect("registry responsive"),
             0
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fresh_acquire_commit_before_timeout_is_retained_and_exactly_released() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(DeadOwnerClaimStore::empty());
+        claim_store.set_ensure_post_commit_delay(std::time::Duration::from_secs(60));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("fresh-commit-before-timeout");
+        let registry_for_create = registry.clone();
+        let jid_for_create = jid.clone();
+        let create = tokio::spawn(async move {
+            registry_for_create
+                .ask(GetOrCreateRoom {
+                    room_jid: jid_for_create,
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(ROOM_OWNERSHIP_CALL_TIMEOUT).await;
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            create.await.expect("join create"),
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipUnavailable(_)
+            ))
+        ));
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("pending acquisition")
+                .depth,
+            1
+        );
+        assert_eq!(
+            registry
+                .ask(RetryPendingRoomReleases { limit: 8 })
+                .await
+                .expect("reconcile acquisition"),
+            1
+        );
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stale_owner_steal_commit_before_timeout_is_retained_and_exactly_released() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(
+            foreign_identity(),
+            ClaimEpoch(70),
+        ));
+        claim_store.set_steal_post_commit_delay(std::time::Duration::from_secs(60));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("steal-commit-before-timeout");
+        let registry_for_create = registry.clone();
+        let jid_for_create = jid.clone();
+        let create = tokio::spawn(async move {
+            registry_for_create
+                .ask(GetOrCreateRoom {
+                    room_jid: jid_for_create,
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(ROOM_OWNERSHIP_CALL_TIMEOUT).await;
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            create.await.expect("join create"),
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipUnavailable(_)
+            ))
+        ));
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("pending acquisition")
+                .depth,
+            1
+        );
+        assert_eq!(
+            registry
+                .ask(RetryPendingRoomReleases { limit: 8 })
+                .await
+                .expect("reconcile acquisition"),
+            1
+        );
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_none());
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -19,6 +19,23 @@ impl kameo::message::Message<RememberOrdinaryReleaseForTest> for RoomRegistryAct
     }
 }
 
+struct ReservePendingAcquisitionForTest {
+    room_jid: BareJid,
+    owner: NodeIdentity,
+}
+
+impl kameo::message::Message<ReservePendingAcquisitionForTest> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: ReservePendingAcquisitionForTest,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.reserve_pending_room_acquisition(&msg.room_jid, &msg.owner)
+    }
+}
+
 fn test_room_jid(name: &str) -> BareJid {
     format!("{}@muc.example.com", name)
         .parse()
@@ -2306,12 +2323,28 @@ mod ownership_claims_tests {
                 .depth,
             1
         );
+        claim_store.fail_next_release();
+        tokio::time::advance(PENDING_ROOM_RETRY_DELAY).await;
+        tokio::task::yield_now().await;
         assert_eq!(
             registry
-                .ask(RetryPendingRoomReleases { limit: 8 })
+                .ask(GetPendingRoomReleaseBacklog)
                 .await
-                .expect("reconcile acquisition"),
-            1
+                .expect("failed release remains scheduled")
+                .depth,
+            1,
+            "a failed exact release must transfer responsibility without losing the retry loop"
+        );
+        tokio::time::advance(PENDING_ROOM_RETRY_DELAY).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("automatic acquisition reconciliation")
+                .depth,
+            0,
+            "the actor must redrive transferred release responsibility without an external janitor"
         );
         assert!(claim_store
             .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
@@ -2817,6 +2850,74 @@ mod ownership_claims_tests {
                 .expect("bounded backlog")
                 .depth,
             MAX_PENDING_ROOM_RELEASES
+        );
+    }
+
+    #[tokio::test]
+    async fn blocked_acquisitions_cannot_starve_release_retries() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let owner = this_identity();
+        for index in 0..PENDING_ROOM_RETRY_BATCH {
+            let jid = test_room_jid(&format!("fair-acquisition-{index}"));
+            claim_store
+                .acquire(&Entity::new(EntityType::RoomActor, jid.to_string()), &owner)
+                .await
+                .expect("seed current-owner claim");
+            assert!(registry
+                .ask(ReservePendingAcquisitionForTest {
+                    room_jid: jid,
+                    owner: owner.clone(),
+                })
+                .await
+                .expect("reserve acquisition"));
+        }
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire seeded claim store");
+        for index in 0..MAX_PENDING_ROOM_RELEASES {
+            let jid = test_room_jid(&format!("fair-release-{index}"));
+            assert!(registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: jid.clone(),
+                    claim_fence: room_claim_fence(&jid, ClaimEpoch(index as i64)),
+                })
+                .await
+                .expect("fill release backlog"));
+        }
+
+        assert_eq!(
+            registry
+                .ask(RetryPendingRoomReleases {
+                    limit: PENDING_ROOM_RETRY_BATCH,
+                })
+                .await
+                .expect("defer blocked acquisitions"),
+            PENDING_ROOM_RETRY_BATCH
+        );
+        assert_eq!(
+            registry
+                .ask(RetryPendingRoomReleases {
+                    limit: PENDING_ROOM_RETRY_BATCH,
+                })
+                .await
+                .expect("release retry gets a fair turn"),
+            PENDING_ROOM_RETRY_BATCH
+        );
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("backlog after fair release batch")
+                .depth,
+            MAX_PENDING_ROOM_RELEASES,
+            "the second batch must clear releases instead of selecting the same blocked acquisitions forever"
         );
     }
 

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -2,6 +2,23 @@ use super::*;
 use kameo::actor::Spawn;
 use kameo::error::SendError;
 
+struct RememberOrdinaryReleaseForTest {
+    room_jid: BareJid,
+    claim_fence: crate::muc::RoomClaimFenceContext,
+}
+
+impl kameo::message::Message<RememberOrdinaryReleaseForTest> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: RememberOrdinaryReleaseForTest,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.remember_pending_room_release(msg.room_jid, msg.claim_fence)
+    }
+}
+
 fn test_room_jid(name: &str) -> BareJid {
     format!("{}@muc.example.com", name)
         .parse()
@@ -836,7 +853,9 @@ async fn offline_durable_member_gets_inbox_projection_after_actor_respawn() {
 mod ownership_claims_tests {
     use super::*;
     use crate::muc::affiliation::AffiliationEntry;
-    use crate::muc::durable::{DurableRoomState, MucDurableFuture, MucDurableStore};
+    use crate::muc::durable::{
+        DurableRoomState, MucDurableFuture, MucDurableStore, RoomClaimFenceContext,
+    };
     use crate::muc::room_actor::{GetAffiliation, GetConfig};
     use crate::muc::subject::SubjectState;
     use crate::ownership::{
@@ -845,7 +864,7 @@ mod ownership_claims_tests {
     };
     use crate::types::Affiliation;
     use async_trait::async_trait;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
     use std::sync::Mutex;
 
     fn foreign_identity() -> NodeIdentity {
@@ -1192,6 +1211,12 @@ mod ownership_claims_tests {
     struct DeadOwnerClaimStore {
         state: Mutex<Option<(NodeIdentity, ClaimEpoch)>>,
         steal_calls: AtomicUsize,
+        fence_calls: AtomicUsize,
+        fence_fail_on_call: AtomicUsize,
+        release_failures: AtomicUsize,
+        release_delay_ms: AtomicU64,
+        fence_delay_ms: AtomicU64,
+        ensure_delay_ms: AtomicU64,
     }
 
     impl DeadOwnerClaimStore {
@@ -1199,7 +1224,42 @@ mod ownership_claims_tests {
             Self {
                 state: Mutex::new(Some((owner, epoch))),
                 steal_calls: AtomicUsize::new(0),
+                fence_calls: AtomicUsize::new(0),
+                fence_fail_on_call: AtomicUsize::new(usize::MAX),
+                release_failures: AtomicUsize::new(0),
+                release_delay_ms: AtomicU64::new(0),
+                fence_delay_ms: AtomicU64::new(0),
+                ensure_delay_ms: AtomicU64::new(0),
             }
+        }
+
+        fn fail_fence_on_call(&self, call: usize) {
+            self.fence_fail_on_call.store(call, Ordering::SeqCst);
+        }
+
+        fn fail_next_release(&self) {
+            self.release_failures.store(1, Ordering::SeqCst);
+        }
+
+        fn set_release_delay(&self, delay: std::time::Duration) {
+            self.release_delay_ms.store(
+                u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+                Ordering::SeqCst,
+            );
+        }
+
+        fn set_fence_delay(&self, delay: std::time::Duration) {
+            self.fence_delay_ms.store(
+                u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+                Ordering::SeqCst,
+            );
+        }
+
+        fn set_ensure_delay(&self, delay: std::time::Duration) {
+            self.ensure_delay_ms.store(
+                u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
+                Ordering::SeqCst,
+            );
         }
     }
 
@@ -1227,6 +1287,10 @@ mod ownership_claims_tests {
             entity: &Entity,
             me: &NodeIdentity,
         ) -> Result<ClaimEpoch, ClaimError> {
+            let delay_ms = self.ensure_delay_ms.load(Ordering::SeqCst);
+            if delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            }
             let existing = self.state.lock().expect("lock").clone();
             match existing {
                 None => self.acquire(entity, me).await,
@@ -1286,6 +1350,14 @@ mod ownership_claims_tests {
             me: &NodeIdentity,
             mine: ClaimEpoch,
         ) -> Result<bool, ClaimError> {
+            let call = self.fence_calls.fetch_add(1, Ordering::SeqCst) + 1;
+            let delay_ms = self.fence_delay_ms.load(Ordering::SeqCst);
+            if delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            }
+            if call == self.fence_fail_on_call.load(Ordering::SeqCst) {
+                return Err(ClaimError::Backend("test final fence failure".to_string()));
+            }
             Ok(
                 matches!(&*self.state.lock().expect("lock"), Some((owner, epoch)) if owner == me && *epoch == mine),
             )
@@ -1297,11 +1369,52 @@ mod ownership_claims_tests {
             me: &NodeIdentity,
             mine: ClaimEpoch,
         ) -> Result<(), ClaimError> {
+            let delay_ms = self.release_delay_ms.load(Ordering::SeqCst);
+            if delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            }
+            if self
+                .release_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return Err(ClaimError::Backend("test release failure".to_string()));
+            }
             let mut state = self.state.lock().expect("lock");
             if matches!(&*state, Some((owner, epoch)) if owner == me && *epoch == mine) {
                 *state = None;
             }
             Ok(())
+        }
+
+        async fn release_exact(
+            &self,
+            _entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<crate::ownership::ExactReleaseOutcome, ClaimError> {
+            let delay_ms = self.release_delay_ms.load(Ordering::SeqCst);
+            if delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+            }
+            if self
+                .release_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return Err(ClaimError::Backend("test release failure".to_string()));
+            }
+            let mut state = self.state.lock().expect("lock");
+            if matches!(&*state, Some((owner, epoch)) if owner == me && *epoch == mine) {
+                *state = None;
+                Ok(crate::ownership::ExactReleaseOutcome::Released)
+            } else {
+                Ok(crate::ownership::ExactReleaseOutcome::NotOwned)
+            }
         }
 
         async fn release_many(
@@ -1322,9 +1435,11 @@ mod ownership_claims_tests {
     #[derive(Default)]
     struct RecordingDurableStore {
         load_result: Option<DurableRoomState>,
+        fail_load: bool,
         demote_notifications: Mutex<Vec<(String, String)>>,
         deleted_rooms: Mutex<Vec<String>>,
         fail_deletes: bool,
+        claim_fences: Mutex<HashMap<BareJid, RoomClaimFenceContext>>,
     }
 
     impl MucDurableStore for RecordingDurableStore {
@@ -1332,6 +1447,11 @@ mod ownership_claims_tests {
             &'a self,
             _room_jid: &'a BareJid,
         ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+            if self.fail_load {
+                return Box::pin(async {
+                    Err(crate::XmppError::internal("load refused by test store"))
+                });
+            }
             let result = self.load_result.clone();
             Box::pin(async move { Ok(result) })
         }
@@ -1373,6 +1493,28 @@ mod ownership_claims_tests {
                 .expect("lock")
                 .push(room_jid.to_string());
             Box::pin(async { Ok(()) })
+        }
+
+        fn record_claim_fence(&self, room_jid: &BareJid, fence: RoomClaimFenceContext) {
+            self.claim_fences
+                .lock()
+                .expect("lock")
+                .insert(room_jid.clone(), fence);
+        }
+
+        fn forget_claim_fence(&self, room_jid: &BareJid, expected: &RoomClaimFenceContext) {
+            let mut fences = self.claim_fences.lock().expect("lock");
+            if fences.get(room_jid) == Some(expected) {
+                fences.remove(room_jid);
+            }
+        }
+
+        fn current_claim_fence(&self, room_jid: &BareJid) -> Option<RoomClaimFenceContext> {
+            self.claim_fences
+                .lock()
+                .expect("lock")
+                .get(room_jid)
+                .cloned()
         }
 
         fn notify_previous_owner_demoted<'a>(
@@ -1474,9 +1616,11 @@ mod ownership_claims_tests {
                     Affiliation::Owner,
                 )],
             }),
+            fail_load: false,
             demote_notifications: Mutex::new(Vec::new()),
             deleted_rooms: Mutex::new(Vec::new()),
             fail_deletes: false,
+            claim_fences: Mutex::new(HashMap::new()),
         });
         registry
             .ask(WireClusteringClaims {
@@ -1514,6 +1658,1418 @@ mod ownership_claims_tests {
             .await
             .expect("ask");
         assert_eq!(affiliation, Affiliation::Owner);
+    }
+
+    fn reclaimed_snapshot(name: &str) -> DurableRoomState {
+        DurableRoomState {
+            waddle_id: "reclaimed-waddle".to_string(),
+            channel_id: "reclaimed-channel".to_string(),
+            config: RoomConfig {
+                name: name.to_string(),
+                persistent: true,
+                ..RoomConfig::default()
+            },
+            subject: None,
+            affiliations: Vec::new(),
+        }
+    }
+
+    fn room_claim_fence(room_jid: &BareJid, epoch: ClaimEpoch) -> RoomClaimFenceContext {
+        RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, room_jid.to_string()),
+            this_identity(),
+            epoch,
+        )
+    }
+
+    #[tokio::test]
+    async fn reclaimed_room_hydrates_once_at_the_exact_won_epoch() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(4);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        let durable_store = Arc::new(RecordingDurableStore {
+            load_result: Some(reclaimed_snapshot("proactively restored")),
+            ..RecordingDurableStore::default()
+        });
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let jid = test_room_jid("proactive");
+        let first = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("reconcile");
+        assert_eq!(first, ReclaimedRoomOutcome::Hydrated);
+        let actor = registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("get hydrated room")
+            .expect("room exists");
+        assert_eq!(
+            actor.ask(GetConfig).await.expect("config").name,
+            "proactively restored"
+        );
+
+        let second = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("idempotent reconcile");
+        assert_eq!(second, ReclaimedRoomOutcome::AlreadyLive);
+        assert_eq!(registry.ask(RoomCount).await.expect("count"), 1);
+    }
+
+    #[tokio::test]
+    async fn reclaimed_room_final_fence_uncertainty_never_installs_actor() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(40);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        // Initial authorization, post-load authorization, then the exact
+        // publication fence after durable hydration messages are enqueued.
+        claim_store.fail_fence_on_call(3);
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(Arc::new(RecordingDurableStore {
+                    load_result: Some(reclaimed_snapshot("must-not-install")),
+                    ..RecordingDurableStore::default()
+                }) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let jid = test_room_jid("final-fence");
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("reconcile");
+        assert_eq!(outcome, ReclaimedRoomOutcome::PendingRetry);
+        assert!(registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("get")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn reclaimed_room_without_durable_state_releases_for_demand_recreation() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(8);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(
+                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
+                ),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let jid = test_room_jid("ephemeral-orphan");
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("reconcile");
+        assert_eq!(outcome, ReclaimedRoomOutcome::Released);
+        assert!(
+            claim_store
+                .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+                .await
+                .expect("claim lookup")
+                .is_none(),
+            "an unhydratable room claim must not remain owned by a fresh node"
+        );
+    }
+
+    #[tokio::test]
+    async fn reclaimed_room_load_failure_retains_exact_epoch_for_retry() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(9);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(Arc::new(RecordingDurableStore {
+                    fail_load: true,
+                    ..RecordingDurableStore::default()
+                }) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let jid = test_room_jid("load-failure");
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("reconcile");
+        assert_eq!(outcome, ReclaimedRoomOutcome::PendingRetry);
+        assert!(
+            claim_store
+                .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+                .await
+                .expect("claim lookup")
+                .is_some(),
+            "a transient hydrate failure must retain the exact won epoch"
+        );
+        assert_eq!(
+            registry
+                .ask(ListPendingReclaimedRooms { limit: 8 })
+                .await
+                .expect("pending retry")
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn identity_rotation_before_room_worker_releases_the_exact_old_fence() {
+        let registry = spawn_registry().await;
+        let old_owner = this_identity();
+        let identity = SharedNodeIdentity::new(old_owner.clone());
+        let epoch = ClaimEpoch(10);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner.clone(), epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: identity.clone(),
+                durable_store: Some(Arc::new(RecordingDurableStore {
+                    load_result: Some(reclaimed_snapshot("must not hydrate")),
+                    ..RecordingDurableStore::default()
+                }) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("rotate-before-worker");
+        let fence = RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            old_owner,
+            epoch,
+        );
+
+        identity.set(foreign_identity());
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: fence,
+                previous_owner: foreign_identity(),
+            })
+            .await
+            .expect("reconcile rotated work");
+
+        assert_eq!(outcome, ReclaimedRoomOutcome::Released);
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_none());
+        assert!(registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("room lookup")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn identity_rotation_between_room_retries_releases_the_exact_old_fence() {
+        let registry = spawn_registry().await;
+        let old_owner = this_identity();
+        let identity = SharedNodeIdentity::new(old_owner.clone());
+        let epoch = ClaimEpoch(11);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner.clone(), epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: identity.clone(),
+                durable_store: Some(Arc::new(RecordingDurableStore {
+                    fail_load: true,
+                    ..RecordingDurableStore::default()
+                }) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("rotate-between-retries");
+        let fence = RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            old_owner,
+            epoch,
+        );
+
+        let first = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: fence.clone(),
+                previous_owner: foreign_identity(),
+            })
+            .await
+            .expect("first reconcile");
+        assert_eq!(first, ReclaimedRoomOutcome::PendingRetry);
+
+        identity.set(foreign_identity());
+        let retried = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: fence,
+                previous_owner: foreign_identity(),
+            })
+            .await
+            .expect("retry after rotation");
+
+        assert_eq!(retried, ReclaimedRoomOutcome::Released);
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_none());
+        assert!(registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("pending retries")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn identity_rotation_during_demand_publication_never_installs_old_fence() {
+        let registry = spawn_registry().await;
+        let old_owner = this_identity();
+        let identity = SharedNodeIdentity::new(old_owner.clone());
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner, ClaimEpoch(20)));
+        claim_store.set_fence_delay(std::time::Duration::from_millis(100));
+        claim_store.fail_next_release();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: identity.clone(),
+                durable_store: Some(
+                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
+                ),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("rotate-at-demand-publish");
+        let registry_for_create = registry.clone();
+        let jid_for_create = jid.clone();
+        let create = tokio::spawn(async move {
+            registry_for_create
+                .ask(GetOrCreateRoom {
+                    room_jid: jid_for_create,
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await
+        });
+        while claim_store.fence_calls.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+        identity.set(foreign_identity());
+
+        let result = create.await.expect("join create");
+        assert!(matches!(
+            result,
+            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(ref room)))
+                if *room == jid
+        ));
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("lookup")
+            .is_none());
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("pending exact cleanup")
+                .depth,
+            1,
+            "failed post-hydration cleanup must retain its exact fence"
+        );
+        assert_eq!(
+            registry
+                .ask(RetryPendingRoomReleases { limit: 8 })
+                .await
+                .expect("retry exact cleanup"),
+            1
+        );
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn stale_selected_retry_cannot_evict_newer_published_fence_cache() {
+        let registry = spawn_registry().await;
+        let old_owner = this_identity();
+        let new_owner = foreign_identity();
+        let identity = SharedNodeIdentity::new(old_owner.clone());
+        let old_epoch = ClaimEpoch(30);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner.clone(), old_epoch));
+        claim_store.fail_fence_on_call(1);
+        let durable_store = Arc::new(RecordingDurableStore::default());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: identity.clone(),
+                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("stale-retry-cache");
+        let old_fence = RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            old_owner.clone(),
+            old_epoch,
+        );
+        assert_eq!(
+            registry
+                .ask(ReconcileReclaimedRoom {
+                    room_jid: jid.clone(),
+                    claim_fence: old_fence.clone(),
+                    previous_owner: old_owner.clone(),
+                })
+                .await
+                .expect("seed pending"),
+            ReclaimedRoomOutcome::PendingRetry
+        );
+        let selected = registry
+            .ask(ListPendingReclaimedRooms { limit: 1 })
+            .await
+            .expect("select old retry")
+            .pop()
+            .expect("pending old retry");
+
+        identity.set(new_owner.clone());
+        registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "new-w".to_string(),
+                channel_id: "new-c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("publish newer demand actor");
+        let new_fence = durable_store
+            .current_claim_fence(&jid)
+            .expect("new fence cached");
+        assert_eq!(new_fence.owner(), new_owner);
+        assert!(new_fence.epoch > old_epoch);
+
+        assert_eq!(
+            registry
+                .ask(ReconcileReclaimedRoom {
+                    room_jid: selected.room_jid,
+                    claim_fence: selected.claim_fence,
+                    previous_owner: selected.previous_owner,
+                })
+                .await
+                .expect("deliver stale selected retry"),
+            ReclaimedRoomOutcome::LostRace
+        );
+        assert_eq!(durable_store.current_claim_fence(&jid), Some(new_fence));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn hung_demand_claim_store_call_is_bounded_inside_registry_actor() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), ClaimEpoch(40)));
+        claim_store.set_ensure_delay(std::time::Duration::from_secs(60));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: claim_store as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("hung-ordinary-claim");
+        let registry_for_create = registry.clone();
+        let create = tokio::spawn(async move {
+            registry_for_create
+                .ask(GetOrCreateRoom {
+                    room_jid: jid,
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(ROOM_OWNERSHIP_CALL_TIMEOUT).await;
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            create.await.expect("join create"),
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipUnavailable(_)
+            ))
+        ));
+        assert_eq!(
+            registry.ask(RoomCount).await.expect("registry responsive"),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn fence_uncertainty_with_live_old_epoch_actor_is_pending_until_exact_proof() {
+        let registry = spawn_registry().await;
+        let old_epoch = ClaimEpoch(30);
+        let new_epoch = ClaimEpoch(31);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), old_epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(
+                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
+                ),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("uncertain-old-epoch");
+        let original = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("spawn old-epoch actor");
+        *claim_store.state.lock().expect("claim state") = Some((this_identity(), new_epoch));
+        // Let the initial authorization pass, then make the fence adjacent
+        // to the live-map epoch mutation uncertain.
+        claim_store.fail_fence_on_call(2);
+
+        let uncertain = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, new_epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("uncertain reconcile");
+        assert_eq!(uncertain, ReclaimedRoomOutcome::PendingRetry);
+        let pending = registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("list pending");
+        assert_eq!(
+            pending,
+            vec![PendingReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, new_epoch),
+                previous_owner: this_identity(),
+            }]
+        );
+        let still_local = registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("get local")
+            .expect("actor retained while proof is uncertain");
+        assert_eq!(still_local.id(), original.actor_ref.id());
+
+        let retried = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, new_epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("retry with exact proof");
+        assert_eq!(retried, ReclaimedRoomOutcome::AdoptedLocal);
+        assert!(registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("list pending after adoption")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn failed_release_retains_epoch_until_a_retry_confirms_release() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(40);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        claim_store.fail_next_release();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("release-failure");
+
+        let first = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("first reconcile");
+        assert_eq!(first, ReclaimedRoomOutcome::PendingRetry);
+        assert!(
+            claim_store
+                .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+                .await
+                .expect("claim")
+                .is_some(),
+            "a failed release must retain the won epoch"
+        );
+        assert_eq!(
+            registry
+                .ask(ListPendingReclaimedRooms { limit: 8 })
+                .await
+                .expect("pending")
+                .len(),
+            1
+        );
+
+        let retried = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("retry");
+        assert_eq!(retried, ReclaimedRoomOutcome::Released);
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim after retry")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn ordinary_destroy_release_failure_is_deduped_and_retried_exactly() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(41);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("ordinary-release-retry");
+        registry
+            .ask(CreateInstantRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("create room");
+
+        claim_store.fail_next_release();
+        assert_eq!(
+            registry
+                .ask(DestroyRoom {
+                    room_jid: jid.clone(),
+                    reason: DestroyRoomReason::LocalEviction,
+                })
+                .await
+                .expect("destroy"),
+            DestroyRoomOutcome::Destroyed
+        );
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("backlog")
+                .depth,
+            1
+        );
+
+        assert_eq!(
+            registry
+                .ask(RetryPendingRoomReleases { limit: 1 })
+                .await
+                .expect("retry"),
+            1
+        );
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("cleared backlog")
+                .depth,
+            0
+        );
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn pending_release_generations_survive_claim_epoch_aba() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("release-aba");
+        let owner_a = this_identity();
+        let owner_b = foreign_identity();
+        let fence_a = crate::muc::RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            owner_a,
+            ClaimEpoch(41),
+        );
+        let fence_b = crate::muc::RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            owner_b,
+            ClaimEpoch(0),
+        );
+        for fence in [fence_a, fence_b] {
+            registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: jid.clone(),
+                    claim_fence: fence,
+                })
+                .await
+                .expect("remember exact release");
+        }
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("backlog")
+                .depth,
+            2,
+            "A/41 and recreated B/0 are distinct exact release responsibilities"
+        );
+    }
+
+    #[tokio::test]
+    async fn publishing_reacquired_exact_fence_cancels_matching_terminal_release() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(crate::ownership::InProcessClaimStore::new());
+        let identity = this_identity();
+        let jid = test_room_jid("reacquired-release-cancel");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let epoch = claim_store
+            .ensure_claimed(&entity, &identity)
+            .await
+            .expect("seed self-owned claim");
+        let fence = RoomClaimFenceContext::new(entity.clone(), identity.clone(), epoch);
+        let aba_distinct_fence = RoomClaimFenceContext::new(
+            entity.clone(),
+            foreign_identity(),
+            ClaimEpoch(epoch.0.saturating_add(1)),
+        );
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(identity.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: jid.clone(),
+                claim_fence: fence.clone(),
+            })
+            .await
+            .expect("remember ambiguous release");
+        registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: jid.clone(),
+                claim_fence: aba_distinct_fence,
+            })
+            .await
+            .expect("remember ABA-distinct release");
+
+        registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("publish actor under reacquired fence");
+
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("pending release backlog")
+                .depth,
+            1,
+            "publishing cancels only the exact live fence, not another ABA generation"
+        );
+        assert!(!registry
+            .ask(IsCurrentRoomPendingRelease {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("current-fence pending query"));
+        assert!(!registry
+            .ask(IsPendingRoomReleaseOnly {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("pending-only query"));
+        assert_eq!(
+            registry
+                .ask(RetryPendingRoomReleases { limit: 8 })
+                .await
+                .expect("retry backlog"),
+            1
+        );
+        assert!(claim_store
+            .fence(&entity, &identity, epoch)
+            .await
+            .expect("live claim fence"));
+    }
+
+    #[tokio::test]
+    async fn pending_reclaimed_generations_survive_claim_epoch_aba() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("reclaimed-aba");
+        let fence_a = crate::muc::RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            this_identity(),
+            ClaimEpoch(41),
+        );
+        let fence_c = crate::muc::RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            foreign_identity(),
+            ClaimEpoch(1),
+        );
+        for (fence, previous_owner) in [
+            (fence_a.clone(), foreign_identity()),
+            (fence_c.clone(), this_identity()),
+        ] {
+            registry
+                .ask(RememberPendingReclaimedRoom {
+                    room_jid: jid.clone(),
+                    claim_fence: fence,
+                    previous_owner,
+                })
+                .await
+                .expect("remember reclaimed generation");
+        }
+        let pending = registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("pending generations");
+        assert_eq!(pending.len(), 2);
+        assert!(pending.iter().any(|entry| entry.claim_fence == fence_a));
+        assert!(pending.iter().any(|entry| entry.claim_fence == fence_c));
+    }
+
+    #[tokio::test]
+    async fn full_release_backlog_does_not_seal_inactive_room() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("must-remain-open");
+        let acquisition = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create target before saturating cleanup inventory");
+        for index in 0..MAX_PENDING_ROOM_RELEASES {
+            let jid = test_room_jid(&format!("backlog-{index}"));
+            registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: jid.clone(),
+                    claim_fence: room_claim_fence(&jid, ClaimEpoch(index as i64)),
+                })
+                .await
+                .expect("fill backlog");
+        }
+        assert!(!registry
+            .ask(DestroyRoomIfInactive {
+                room_jid: jid,
+                expected_occupancy_revision: 0,
+                guard: SealGuard::Dormant,
+            })
+            .await
+            .expect("capacity refusal"));
+        assert!(!acquisition
+            .actor_ref
+            .ask(IsSealed)
+            .await
+            .expect("sealed probe"));
+    }
+
+    #[tokio::test]
+    async fn full_release_backlog_refuses_new_claim_and_never_grows() {
+        let registry = spawn_registry().await;
+        for index in 0..MAX_PENDING_ROOM_RELEASES {
+            let jid = test_room_jid(&format!("bounded-backlog-{index}"));
+            assert!(registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: jid.clone(),
+                    claim_fence: room_claim_fence(&jid, ClaimEpoch(index as i64)),
+                })
+                .await
+                .expect("fill backlog"));
+        }
+        let overflow_jid = test_room_jid("bounded-overflow");
+        assert!(!registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: overflow_jid.clone(),
+                claim_fence: room_claim_fence(&overflow_jid, ClaimEpoch(999)),
+            })
+            .await
+            .expect("bounded insertion outcome"));
+        assert!(matches!(
+            registry
+                .ask(GetOrCreateRoom {
+                    room_jid: overflow_jid.clone(),
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await,
+            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(ref room)))
+                if *room == overflow_jid
+        ));
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("bounded backlog")
+                .depth,
+            MAX_PENDING_ROOM_RELEASES
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_only_room_is_shutdown_sealable_but_not_current_live_generation() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("pending-only");
+        assert!(registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, ClaimEpoch(7)),
+            })
+            .await
+            .expect("remember pending-only generation"));
+
+        assert!(!registry
+            .ask(IsCurrentRoomPendingRelease {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("generation-scoped live query"));
+        assert!(registry
+            .ask(IsPendingRoomReleaseOnly { room_jid: jid })
+            .await
+            .expect("shutdown pending-only query"));
+        assert!(!registry
+            .ask(IsCurrentIdentityPendingRoomReleaseOnly {
+                room_jid: test_room_jid("pending-only"),
+            })
+            .await
+            .expect("current-identity shutdown query"));
+    }
+
+    #[tokio::test]
+    async fn shutdown_batches_only_pending_room_fences_from_current_identity() {
+        let registry = spawn_registry().await;
+        let current_jid = test_room_jid("pending-current-identity");
+        let stale_jid = test_room_jid("pending-stale-identity");
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::new(InProcessClaimStore::new()),
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire current identity");
+        assert!(registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: current_jid.clone(),
+                claim_fence: room_claim_fence(&current_jid, ClaimEpoch(8)),
+            })
+            .await
+            .expect("remember current fence"));
+        assert!(registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: stale_jid.clone(),
+                claim_fence: RoomClaimFenceContext::new(
+                    Entity::new(EntityType::RoomActor, stale_jid.to_string()),
+                    foreign_identity(),
+                    ClaimEpoch(9),
+                ),
+            })
+            .await
+            .expect("remember stale fence"));
+
+        assert!(registry
+            .ask(IsCurrentIdentityPendingRoomReleaseOnly {
+                room_jid: current_jid,
+            })
+            .await
+            .expect("current fence query"));
+        assert!(!registry
+            .ask(IsCurrentIdentityPendingRoomReleaseOnly {
+                room_jid: stale_jid,
+            })
+            .await
+            .expect("stale fence query"));
+    }
+
+    #[tokio::test]
+    async fn pending_release_with_dead_map_entry_is_shutdown_sealable() {
+        let registry = spawn_registry().await;
+        let jid = test_room_jid("pending-dead-entry");
+        let actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create room")
+            .actor_ref;
+        assert!(registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, ClaimEpoch(77)),
+            })
+            .await
+            .expect("remember exact pending responsibility"));
+        actor.kill();
+        actor.wait_for_shutdown().await;
+
+        assert!(registry
+            .ask(IsPendingRoomReleaseOnly { room_jid: jid })
+            .await
+            .expect("dead-entry pending-only query"));
+    }
+
+    #[tokio::test]
+    async fn dead_actor_redrives_oldest_release_when_backlog_is_full() {
+        let registry = spawn_registry().await;
+        let target = test_room_jid("dead-under-saturation");
+        let actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: target.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create target")
+            .actor_ref;
+        actor.kill();
+        actor.wait_for_shutdown().await;
+        for index in 0..MAX_PENDING_ROOM_RELEASES {
+            let jid = test_room_jid(&format!("dead-progress-{index}"));
+            assert!(registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: jid.clone(),
+                    claim_fence: room_claim_fence(&jid, ClaimEpoch(index as i64 + 100)),
+                })
+                .await
+                .expect("fill backlog"));
+        }
+
+        assert!(matches!(
+            registry
+                .ask(GetRoom {
+                    room_jid: target.clone(),
+                })
+                .await,
+            Err(SendError::HandlerError(RoomRegistryError::RoomActorStateLost(ref room)))
+                if *room == target
+        ));
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("backlog after opportunistic redrive")
+                .depth,
+            MAX_PENDING_ROOM_RELEASES - 1,
+            "one stale exact release is confirmed NotOwned, freeing capacity so the dead actor can retire"
+        );
+        assert_eq!(registry.ask(RoomCount).await.expect("room count"), 0);
+    }
+
+    #[tokio::test]
+    async fn stale_pending_messages_cannot_regress_or_clear_a_newer_epoch() {
+        let registry = spawn_registry().await;
+        let current_epoch = ClaimEpoch(61);
+        let stale_epoch = ClaimEpoch(60);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), current_epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: claim_store as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("monotonic-pending");
+        registry
+            .ask(RememberPendingReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, current_epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("remember current");
+        registry
+            .ask(RememberPendingReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, stale_epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("late stale remember");
+        let stale = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, stale_epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("stale reconcile");
+        assert_eq!(stale, ReclaimedRoomOutcome::LostRace);
+        assert_eq!(
+            registry
+                .ask(ListPendingReclaimedRooms { limit: 8 })
+                .await
+                .expect("pending"),
+            vec![PendingReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, current_epoch),
+                previous_owner: this_identity(),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn pending_retry_page_rotates_past_a_persistent_full_prefix() {
+        let registry = spawn_registry().await;
+        let previous_owner = foreign_identity();
+        let mut rooms = Vec::new();
+        for index in 0..65 {
+            let room_jid = test_room_jid(&format!("fair-retry-{index:02}"));
+            registry
+                .ask(RememberPendingReclaimedRoom {
+                    room_jid: room_jid.clone(),
+                    claim_fence: room_claim_fence(&room_jid, ClaimEpoch(70)),
+                    previous_owner: previous_owner.clone(),
+                })
+                .await
+                .expect("remember pending room");
+            rooms.push(room_jid);
+        }
+
+        let first = registry
+            .ask(ListPendingReclaimedRooms { limit: 64 })
+            .await
+            .expect("first page");
+        assert_eq!(first.len(), 64);
+        assert!(!first.iter().any(|entry| entry.room_jid == rooms[64]));
+
+        let second = registry
+            .ask(ListPendingReclaimedRooms { limit: 64 })
+            .await
+            .expect("rotated page");
+        assert!(
+            second.iter().any(|entry| entry.room_jid == rooms[64]),
+            "an entry behind a permanently failing full page must receive a retry"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timed_out_release_is_cancelled_and_retried_without_wedging_registry() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(50);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        claim_store.set_release_delay(std::time::Duration::from_secs(60));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("release-timeout");
+
+        let first = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("bounded reconcile");
+        assert_eq!(first, ReclaimedRoomOutcome::PendingRetry);
+        assert!(registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("registry remains responsive after timeout")
+            .iter()
+            .any(|entry| entry.room_jid == jid && entry.claim_fence.epoch == epoch));
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim retained")
+            .is_some());
+
+        claim_store.set_release_delay(std::time::Duration::ZERO);
+        let retried = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("release retry");
+        assert_eq!(retried, ReclaimedRoomOutcome::Released);
+    }
+
+    #[tokio::test]
+    async fn demand_side_creation_winning_before_reconcile_is_not_duplicated() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(12);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: claim_store as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(
+                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
+                ),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let jid = test_room_jid("demand-race");
+        let demand = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "demand-waddle".to_string(),
+                channel_id: "demand-channel".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("demand-side creation");
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("reconcile after demand");
+        assert_eq!(outcome, ReclaimedRoomOutcome::AlreadyLive);
+        let registered = registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("get")
+            .expect("room exists");
+        assert_eq!(registered.id(), demand.actor_ref.id());
+        assert_eq!(registry.ask(RoomCount).await.expect("count"), 1);
+
+        let stale = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: test_room_jid("demand-race"),
+                claim_fence: room_claim_fence(
+                    &test_room_jid("demand-race"),
+                    ClaimEpoch(epoch.0 - 1),
+                ),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("stale reconciliation message");
+        assert_eq!(stale, ReclaimedRoomOutcome::LostRace);
+        let still_registered = registry
+            .ask(GetRoom {
+                room_jid: test_room_jid("demand-race"),
+            })
+            .await
+            .expect("get after stale adoption")
+            .expect("live actor survives");
+        assert_eq!(still_registered.id(), demand.actor_ref.id());
+    }
+
+    #[tokio::test]
+    async fn locally_live_old_epoch_actor_is_adopted_without_state_loss() {
+        let registry = spawn_registry().await;
+        let old_epoch = ClaimEpoch(20);
+        let new_epoch = ClaimEpoch(21);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), old_epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(
+                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
+                ),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("local-old-epoch");
+        let original = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "local-waddle".to_string(),
+                channel_id: "local-channel".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create local actor");
+
+        // Stand in for the dead-node reaper's exact CAS after this process
+        // refreshed its node identity while the local actor remained live.
+        *claim_store.state.lock().expect("claim state lock") = Some((this_identity(), new_epoch));
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: room_claim_fence(&jid, new_epoch),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("adopt new epoch");
+        assert_eq!(outcome, ReclaimedRoomOutcome::AdoptedLocal);
+        let adopted = registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("get adopted actor")
+            .expect("actor remains registered");
+        assert_eq!(
+            adopted.id(),
+            original.actor_ref.id(),
+            "epoch adoption must preserve the locally live RoomActor"
+        );
+    }
+
+    #[tokio::test]
+    async fn intervening_owner_prevents_stale_local_actor_adoption() {
+        let registry = spawn_registry().await;
+        let owner_a = NodeIdentity::new("node-a", "incarnation-a");
+        let owner_b = NodeIdentity::new("node-b", "incarnation-b");
+        let owner_c = NodeIdentity::new("node-c", "incarnation-c");
+        let old_epoch = ClaimEpoch(80);
+        let won_epoch = ClaimEpoch(82);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(owner_a.clone(), old_epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner_a),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire owner A");
+        let jid = test_room_jid("intervening-owner");
+        let stale_actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "owner-a".to_string(),
+                channel_id: "owner-a-channel".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("spawn owner A actor")
+            .actor_ref;
+
+        let durable_store = Arc::new(RecordingDurableStore {
+            load_result: Some(reclaimed_snapshot("owner B durable config")),
+            ..RecordingDurableStore::default()
+        });
+        *claim_store.state.lock().expect("claim state") = Some((owner_c.clone(), won_epoch));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: claim_store as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner_c.clone()),
+                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire owner C");
+
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: RoomClaimFenceContext::new(
+                    Entity::new(EntityType::RoomActor, jid.to_string()),
+                    owner_c,
+                    won_epoch,
+                ),
+                previous_owner: owner_b,
+            })
+            .await
+            .expect("reconcile after intervening owner");
+        assert_eq!(outcome, ReclaimedRoomOutcome::Hydrated);
+        let restored = registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("get restored room")
+            .expect("restored actor exists");
+        assert_ne!(restored.id(), stale_actor.id());
+        assert_eq!(
+            restored.ask(GetConfig).await.expect("restored config").name,
+            "owner B durable config"
+        );
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -1051,19 +1051,20 @@ mod ownership_claims_tests {
 
     /// The deposed-node eviction path (fenced fan-out check observed a
     /// steal) evicts the LOCAL actor only — the room lives on under
-    /// its new owner, so `DestroyRoomReason::LocalEviction` MUST NOT
+    /// its new owner, so `DestroyRoomReason::DeposedEviction` MUST NOT
     /// wipe the durable rows. Without the split, a same-node re-claim
     /// racing the queued eviction could pass the write fence and wipe
     /// a legitimately re-claimed room's config/subject/ban list.
     #[tokio::test]
-    async fn local_eviction_does_not_delete_durable_room_state() {
+    async fn deposed_eviction_bypasses_release_backlog_without_deleting_durable_state() {
         let registry = spawn_registry().await;
         let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
         let durable_store = Arc::new(RecordingDurableStore::default());
+        let identity = SharedNodeIdentity::new(this_identity());
         registry
             .ask(WireClusteringClaims {
                 claim_store: Arc::clone(&claim_store),
-                node_identity: SharedNodeIdentity::new(this_identity()),
+                node_identity: identity.clone(),
                 durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
                 rollout_backoff: None,
             })
@@ -1081,17 +1082,51 @@ mod ownership_claims_tests {
             .await
             .expect("get_or_create_room");
 
-        registry
+        for index in 0..MAX_PENDING_ROOM_RELEASES {
+            let pending_jid = test_room_jid(&format!("deposed-backlog-{index}"));
+            assert!(registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: pending_jid.clone(),
+                    claim_fence: room_claim_fence(&pending_jid, ClaimEpoch(index as i64)),
+                })
+                .await
+                .expect("fill exact-release backlog"));
+        }
+        identity.rotate(foreign_identity()).await;
+
+        assert_eq!(
+            registry
             .ask(DestroyRoom {
                 room_jid: jid.clone(),
-                reason: DestroyRoomReason::LocalEviction,
+                reason: DestroyRoomReason::DeposedEviction,
             })
             .await
-            .expect("evict");
+            .expect("evict"),
+            DestroyRoomOutcome::Destroyed,
+            "a serve-fence-proven deposed actor must be evicted even when local release capacity is full"
+        );
 
         assert!(
             durable_store.deleted_rooms.lock().expect("lock").is_empty(),
-            "a local eviction must never delete the room's durable state"
+            "a deposed eviction must never delete the room's durable state"
+        );
+        assert_eq!(registry.ask(RoomCount).await.expect("room count"), 0);
+        assert!(
+            claim_store
+                .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+                .await
+                .expect("claim lookup")
+                .is_none(),
+            "deposed eviction must still attempt exact release for identity-rotation cases"
+        );
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("bounded backlog")
+                .depth,
+            MAX_PENDING_ROOM_RELEASES,
+            "deposed eviction must never grow the saturated retry inventory"
         );
     }
 
@@ -2578,7 +2613,7 @@ mod ownership_claims_tests {
             registry
                 .ask(DestroyRoom {
                     room_jid: jid.clone(),
-                    reason: DestroyRoomReason::LocalEviction,
+                    reason: DestroyRoomReason::Destroy,
                 })
                 .await
                 .expect("destroy"),

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -1922,7 +1922,7 @@ mod ownership_claims_tests {
             epoch,
         );
 
-        identity.set(foreign_identity());
+        identity.rotate(foreign_identity()).await;
         let outcome = registry
             .ask(ReconcileReclaimedRoom {
                 room_jid: jid.clone(),
@@ -1981,7 +1981,7 @@ mod ownership_claims_tests {
             .expect("first reconcile");
         assert_eq!(first, ReclaimedRoomOutcome::PendingRetry);
 
-        identity.set(foreign_identity());
+        identity.rotate(foreign_identity()).await;
         let retried = registry
             .ask(ReconcileReclaimedRoom {
                 room_jid: jid.clone(),
@@ -2039,7 +2039,7 @@ mod ownership_claims_tests {
         while claim_store.fence_calls.load(Ordering::SeqCst) == 0 {
             tokio::task::yield_now().await;
         }
-        identity.set(foreign_identity());
+        identity.rotate(foreign_identity()).await;
 
         let result = create.await.expect("join create");
         assert!(matches!(
@@ -2070,6 +2070,77 @@ mod ownership_claims_tests {
                 .expect("retry exact cleanup"),
             1
         );
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn queued_rotation_wins_before_the_final_publication_guard() {
+        let registry = spawn_registry().await;
+        let old_owner = this_identity();
+        let identity = SharedNodeIdentity::new(old_owner.clone());
+        let boundary_blocker = identity
+            .guard_if_current(&old_owner)
+            .await
+            .expect("old identity starts current");
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(
+            old_owner.clone(),
+            ClaimEpoch(21),
+        ));
+        claim_store.set_fence_delay(std::time::Duration::from_millis(100));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: identity.clone(),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("queued-rotation-at-publish-boundary");
+        let registry_for_create = registry.clone();
+        let jid_for_create = jid.clone();
+        let create = tokio::spawn(async move {
+            registry_for_create
+                .ask(GetOrCreateRoom {
+                    room_jid: jid_for_create,
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await
+        });
+        while claim_store.fence_calls.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+
+        let rotating_identity = identity.clone();
+        let rotation = tokio::spawn(async move {
+            rotating_identity.rotate(foreign_identity()).await;
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !rotation.is_finished(),
+            "the synthetic boundary guard must hold rotation before publication"
+        );
+        drop(boundary_blocker);
+        rotation.await.expect("rotation task");
+
+        assert!(matches!(
+            create.await.expect("join create"),
+            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(ref room)))
+                if *room == jid
+        ));
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("lookup")
+            .is_none());
         assert!(claim_store
             .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
             .await
@@ -2120,7 +2191,7 @@ mod ownership_claims_tests {
             .pop()
             .expect("pending old retry");
 
-        identity.set(new_owner.clone());
+        identity.rotate(new_owner.clone()).await;
         registry
             .ask(GetOrCreateRoom {
                 room_jid: jid.clone(),

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -36,10 +36,15 @@ use super::affiliation::DurableMembershipSource;
 use super::durable::MucDurableStore;
 use super::room_actor::{RoomActor, SealGuard};
 use super::room_registry_actor::{
-    CreateInstantRoom, CreateRoom, DestroyRoom, DestroyRoomIfInactive, DestroyRoomOutcome,
-    DestroyRoomReason, GetOrCreateRoom, GetRoom, IsMucJid, ListRooms, ReapSealedRoom,
-    RoomAcquisition, RoomCount, RoomExists, RoomRegistryActor, RoomRegistryError,
-    WireClusteringClaims,
+    CancelPendingReclaimedRoomReservation, CreateInstantRoom, CreateRoom, DestroyRoom,
+    DestroyRoomIfInactive, DestroyRoomOutcome, DestroyRoomReason, GetOrCreateRoom,
+    GetPendingReclaimedRoomBacklog, GetPendingRoomReleaseBacklog, GetRoom,
+    IsCurrentIdentityPendingRoomReleaseOnly, IsCurrentRoomPendingRelease, IsMucJid,
+    IsPendingRoomReleaseOnly, ListPendingReclaimedRooms, ListPendingRoomReleaseJids, ListRooms,
+    PendingReclaimedRoom, PendingReclaimedRoomBacklog, PendingRoomReleaseBacklog, ReapSealedRoom,
+    ReclaimedRoomOutcome, ReconcileReclaimedRoom, RememberPendingReclaimedRoom,
+    ReservePendingReclaimedRoom, RetryPendingRoomReleases, RoomAcquisition, RoomCount, RoomExists,
+    RoomRegistryActor, RoomRegistryError, WireClusteringClaims,
 };
 use super::RoomConfig;
 use crate::metrics;
@@ -280,6 +285,60 @@ impl RoomRegistry {
     );
 
     registry_method!(
+        reserve_pending_reclaimed_room(room_jid: BareJid) -> bool,
+        "reserve_pending_reclaimed_room",
+        ReservePendingReclaimedRoom { room_jid }
+    );
+
+    registry_method!(
+        pending_reclaimed_room_backlog() -> PendingReclaimedRoomBacklog,
+        "pending_reclaimed_room_backlog",
+        GetPendingReclaimedRoomBacklog
+    );
+
+    registry_method!(
+        pending_room_release_backlog() -> PendingRoomReleaseBacklog,
+        "pending_room_release_backlog",
+        GetPendingRoomReleaseBacklog
+    );
+
+    registry_method!(
+        retry_pending_room_releases(limit: usize) -> usize,
+        "retry_pending_room_releases",
+        RetryPendingRoomReleases { limit }
+    );
+
+    registry_method!(
+        list_pending_room_release_jids() -> Vec<BareJid>,
+        "list_pending_room_release_jids",
+        ListPendingRoomReleaseJids
+    );
+
+    registry_method!(
+        is_current_room_pending_release(room_jid: BareJid) -> bool,
+        "is_current_room_pending_release",
+        IsCurrentRoomPendingRelease { room_jid }
+    );
+
+    registry_method!(
+        is_pending_room_release_only(room_jid: BareJid) -> bool,
+        "is_pending_room_release_only",
+        IsPendingRoomReleaseOnly { room_jid }
+    );
+
+    registry_method!(
+        is_current_identity_pending_room_release_only(room_jid: BareJid) -> bool,
+        "is_current_identity_pending_room_release_only",
+        IsCurrentIdentityPendingRoomReleaseOnly { room_jid }
+    );
+
+    registry_method!(
+        cancel_pending_reclaimed_room_reservation(room_jid: BareJid) -> (),
+        "cancel_pending_reclaimed_room_reservation",
+        CancelPendingReclaimedRoomReservation { room_jid }
+    );
+
+    registry_method!(
         /// Get an existing room or create one if absent. The reply's
         /// [`RoomAcquisition::creation`] bit is authoritative for the
         /// XEP-0045 §10.1.1 creator Owner grant (#1134).
@@ -377,6 +436,57 @@ impl RoomRegistry {
         "room_count",
         RoomCount
     );
+
+    registry_method!(
+        /// Serialize proactive orphan-claim adoption against demand-side
+        /// room creation, hydrating durable rooms and releasing claims that
+        /// have no restorable state.
+        reconcile_reclaimed_room(
+            room_jid: BareJid,
+            claim_fence: super::RoomClaimFenceContext,
+            previous_owner: crate::ownership::NodeIdentity
+        ) -> ReclaimedRoomOutcome,
+        "reconcile_reclaimed_room",
+        ReconcileReclaimedRoom { room_jid, claim_fence, previous_owner }
+    );
+
+    registry_method!(
+        /// Return a bounded page of reclaimed epochs awaiting actor
+        /// installation or confirmed release. Each item is retried through
+        /// `reconcile_reclaimed_room` as its own mailbox message.
+        list_pending_reclaimed_rooms(limit: usize) -> Vec<PendingReclaimedRoom>,
+        "list_pending_reclaimed_rooms",
+        ListPendingReclaimedRooms { limit }
+    );
+
+    /// Enqueue a newly won epoch in the registry's idempotent retry set before
+    /// beginning fallible adoption work. This intentionally waits only for
+    /// mailbox acceptance, not a handler reply: an `ask` reply timeout is an
+    /// uncertain commit and must never trigger concurrent exact release.
+    pub async fn remember_pending_reclaimed_room(
+        &self,
+        room_jid: BareJid,
+        claim_fence: super::RoomClaimFenceContext,
+        previous_owner: crate::ownership::NodeIdentity,
+    ) -> Result<(), RoomRegistryError> {
+        self.inner
+            .tell(RememberPendingReclaimedRoom {
+                room_jid,
+                claim_fence,
+                previous_owner,
+            })
+            .mailbox_timeout(ROOM_REGISTRY_MAILBOX_TIMEOUT)
+            .await
+            .map_err(|error| {
+                metrics::record_actor_request_dropped(
+                    ACTOR_LABEL,
+                    "remember_pending_reclaimed_room",
+                    "tell",
+                    send_error_reason(&error),
+                );
+                RoomRegistryError::Unavailable
+            })
+    }
 
     /// Wire the real clustering-backed claim store/identity/durable store
     /// into this already-spawned registry (ADR-0017 Phase 3 Slice 7). See

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::muc::RoomClaimFenceContext;
 use crate::xep::xep0421::OccupantIdSecret;
 use std::time::Duration;
 
@@ -33,6 +34,29 @@ async fn idle_mailbox_depth_is_zero() {
     );
     // A freshly-spawned, idle registry has drained its mailbox: depth 0.
     assert_eq!(registry.mailbox_depth(), Some(0));
+}
+
+#[tokio::test]
+async fn reclaimed_room_reservations_are_bounded() {
+    let registry = test_registry();
+    for index in 0..crate::muc::room_registry_actor::MAX_PENDING_RECLAIMED_ROOMS {
+        assert!(registry
+            .reserve_pending_reclaimed_room(test_room_jid(&format!("pending-{index}")))
+            .await
+            .expect("reservation ask"));
+    }
+    assert!(!registry
+        .reserve_pending_reclaimed_room(test_room_jid("overflow"))
+        .await
+        .expect("overflow reservation ask"));
+    let backlog = registry
+        .pending_reclaimed_room_backlog()
+        .await
+        .expect("backlog");
+    assert_eq!(
+        backlog.depth,
+        crate::muc::room_registry_actor::MAX_PENDING_RECLAIMED_ROOMS
+    );
 }
 
 #[tokio::test]
@@ -71,6 +95,27 @@ async fn wedged_request_maps_to_typed_timeout_error() {
 
     let result = pending.await;
     assert_eq!(result, Err(RoomRegistryError::Timeout));
+
+    // Pending-reclaim registration is mailbox-acknowledged, not reply-
+    // acknowledged. Even though the actor remains wedged in the handler
+    // above, successful enqueue is definitive and cannot be mistaken for an
+    // uncertain commit followed by concurrent exact release.
+    let queued_room = test_room_jid("queued-reclaim");
+    let accepted = registry
+        .remember_pending_reclaimed_room(
+            queued_room.clone(),
+            RoomClaimFenceContext::new(
+                crate::ownership::Entity::new(
+                    crate::ownership::EntityType::RoomActor,
+                    queued_room.to_string(),
+                ),
+                crate::ownership::NodeIdentity::new("current", "incarnation"),
+                crate::ownership::ClaimEpoch(7),
+            ),
+            crate::ownership::NodeIdentity::new("dead", "incarnation"),
+        )
+        .await;
+    assert_eq!(accepted, Ok(()));
 }
 
 #[tokio::test]

--- a/server/crates/waddle-xmpp/src/ownership/in_process.rs
+++ b/server/crates/waddle-xmpp/src/ownership/in_process.rs
@@ -39,10 +39,26 @@ struct ClaimRecord {
     epoch: ClaimEpoch,
 }
 
+#[derive(Default)]
+struct ClaimState {
+    claims: HashMap<Entity, ClaimRecord>,
+    next_generation: i64,
+}
+
+impl ClaimState {
+    fn allocate_generation(&mut self) -> Result<ClaimEpoch, ClaimError> {
+        let generation = self.next_generation;
+        self.next_generation = self.next_generation.checked_add(1).ok_or_else(|| {
+            ClaimError::Backend("in-process claim generation exhausted".to_string())
+        })?;
+        Ok(ClaimEpoch(generation))
+    }
+}
+
 /// In-memory claim bookkeeping for the single-node case.
 #[derive(Default)]
 pub struct InProcessClaimStore {
-    claims: Mutex<HashMap<Entity, ClaimRecord>>,
+    state: Mutex<ClaimState>,
 }
 
 impl InProcessClaimStore {
@@ -50,8 +66,8 @@ impl InProcessClaimStore {
         Self::default()
     }
 
-    fn lock(&self) -> Result<std::sync::MutexGuard<'_, HashMap<Entity, ClaimRecord>>, ClaimError> {
-        self.claims.lock().map_err(|_| ClaimError::Poisoned)
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, ClaimState>, ClaimError> {
+        self.state.lock().map_err(|_| ClaimError::Poisoned)
     }
 }
 
@@ -63,7 +79,7 @@ impl ClaimStore for InProcessClaimStore {
     }
 
     async fn acquire(&self, entity: &Entity, me: &NodeIdentity) -> Result<ClaimEpoch, ClaimError> {
-        let mut claims = self.lock()?;
+        let mut state = self.lock()?;
         // Same contract as `PostgresClaimStore::acquire` (INSERT ... ON
         // CONFLICT DO NOTHING): a fresh claim only succeeds when the
         // entity is currently unclaimed. A second acquire against an
@@ -71,17 +87,18 @@ impl ClaimStore for InProcessClaimStore {
         // would against the real CAS — this is same-node contention
         // (e.g. two connections racing to claim the same SM session),
         // which is real and must be enforced, not idempotent-Ok'd away.
-        if claims.contains_key(entity) {
+        if state.claims.contains_key(entity) {
             return Err(ClaimError::AlreadyClaimed);
         }
-        claims.insert(
+        let epoch = state.allocate_generation()?;
+        state.claims.insert(
             entity.clone(),
             ClaimRecord {
                 owner: me.clone(),
-                epoch: ClaimEpoch(0),
+                epoch,
             },
         );
-        Ok(ClaimEpoch(0))
+        Ok(epoch)
     }
 
     async fn ensure_claimed(
@@ -95,17 +112,18 @@ impl ClaimStore for InProcessClaimStore {
         // the lock rather than by calling `acquire` and re-locking on
         // conflict, since this store already holds everything it needs
         // under one lock acquisition.
-        let mut claims = self.lock()?;
-        match claims.get(entity) {
+        let mut state = self.lock()?;
+        match state.claims.get(entity) {
             None => {
-                claims.insert(
+                let epoch = state.allocate_generation()?;
+                state.claims.insert(
                     entity.clone(),
                     ClaimRecord {
                         owner: me.clone(),
-                        epoch: ClaimEpoch(0),
+                        epoch,
                     },
                 );
-                Ok(ClaimEpoch(0))
+                Ok(epoch)
             }
             Some(record) if record.owner == *me => Ok(record.epoch),
             Some(_) => Err(ClaimError::AlreadyClaimed),
@@ -131,11 +149,11 @@ impl ClaimStore for InProcessClaimStore {
         // so `_staleness` is accepted but not consulted — same simplification
         // the "trivial single node" module doc already makes for every other
         // method.
-        let mut claims = self.lock()?;
-        match claims.get(entity) {
+        let mut state = self.lock()?;
+        match state.claims.get(entity) {
             Some(record) if record.epoch == observed => {
-                let new_epoch = ClaimEpoch(record.epoch.0 + 1);
-                claims.insert(
+                let new_epoch = state.allocate_generation()?;
+                state.claims.insert(
                     entity.clone(),
                     ClaimRecord {
                         owner: me.clone(),
@@ -171,8 +189,8 @@ impl ClaimStore for InProcessClaimStore {
         &self,
         entity: &Entity,
     ) -> Result<Option<super::ClaimSnapshot>, ClaimError> {
-        let claims = self.lock()?;
-        Ok(claims.get(entity).map(|record| super::ClaimSnapshot {
+        let state = self.lock()?;
+        Ok(state.claims.get(entity).map(|record| super::ClaimSnapshot {
             owner: record.owner.clone(),
             claim_epoch: record.epoch,
             // No node-liveness table in this single-node store (see this
@@ -187,9 +205,9 @@ impl ClaimStore for InProcessClaimStore {
         me: &NodeIdentity,
         mine: ClaimEpoch,
     ) -> Result<bool, ClaimError> {
-        let claims = self.lock()?;
+        let state = self.lock()?;
         Ok(
-            matches!(claims.get(entity), Some(record) if record.owner == *me && record.epoch == mine),
+            matches!(state.claims.get(entity), Some(record) if record.owner == *me && record.epoch == mine),
         )
     }
 
@@ -199,10 +217,10 @@ impl ClaimStore for InProcessClaimStore {
         me: &NodeIdentity,
         mine: ClaimEpoch,
     ) -> Result<(), ClaimError> {
-        let mut claims = self.lock()?;
-        if matches!(claims.get(entity), Some(record) if record.owner == *me && record.epoch == mine)
+        let mut state = self.lock()?;
+        if matches!(state.claims.get(entity), Some(record) if record.owner == *me && record.epoch == mine)
         {
-            claims.remove(entity);
+            state.claims.remove(entity);
         }
         Ok(())
     }
@@ -213,10 +231,10 @@ impl ClaimStore for InProcessClaimStore {
         me: &NodeIdentity,
         mine: ClaimEpoch,
     ) -> Result<crate::ownership::ExactReleaseOutcome, ClaimError> {
-        let mut claims = self.lock()?;
-        if matches!(claims.get(entity), Some(record) if record.owner == *me && record.epoch == mine)
+        let mut state = self.lock()?;
+        if matches!(state.claims.get(entity), Some(record) if record.owner == *me && record.epoch == mine)
         {
-            claims.remove(entity);
+            state.claims.remove(entity);
             Ok(crate::ownership::ExactReleaseOutcome::Released)
         } else {
             Ok(crate::ownership::ExactReleaseOutcome::NotOwned)
@@ -230,9 +248,9 @@ impl ClaimStore for InProcessClaimStore {
     ) -> Result<(), ClaimError> {
         // Claim-epoch-blind by the trait contract (the node-identity gate
         // is trivially satisfied here: this store *is* the one node).
-        let mut claims = self.lock()?;
+        let mut state = self.lock()?;
         for entity in entities {
-            claims.remove(entity);
+            state.claims.remove(entity);
         }
         Ok(())
     }
@@ -269,14 +287,40 @@ mod tests {
             .expect_err("second acquire against a still-held entity loses the race");
         assert!(matches!(err, ClaimError::AlreadyClaimed));
 
-        // Once released, the entity is claimable again from epoch 0 —
-        // mirroring a fresh Postgres `INSERT` after the row is deleted.
+        // Once released, the entity is claimable again under a generation
+        // that can never alias the deleted claim.
         store.release(&e, &me(), first).await.expect("release");
         let reacquired = store
             .acquire(&e, &me())
             .await
             .expect("re-acquire after release");
-        assert_eq!(reacquired, ClaimEpoch(0));
+        assert!(reacquired.0 > first.0);
+        assert_eq!(
+            store
+                .release_exact(&e, &me(), first)
+                .await
+                .expect("stale exact release"),
+            crate::ownership::ExactReleaseOutcome::NotOwned
+        );
+        assert!(store
+            .fence(&e, &me(), reacquired)
+            .await
+            .expect("recreated generation remains held"));
+    }
+
+    #[tokio::test]
+    async fn generations_are_monotonic_across_entities_and_steals() {
+        let store = InProcessClaimStore::new();
+        let a = entity("generation-a");
+        let b = entity("generation-b");
+        let a0 = store.acquire(&a, &me()).await.expect("acquire a");
+        let b0 = store.acquire(&b, &me()).await.expect("acquire b");
+        let a1 = store
+            .steal_stale(&a, a0, StalePredicate::OwnerStale, &me())
+            .await
+            .expect("steal a");
+
+        assert!(a0.0 < b0.0 && b0.0 < a1.0);
     }
 
     #[tokio::test]
@@ -529,21 +573,15 @@ mod tests {
         let store = InProcessClaimStore::new();
         let a = entity("stream-a");
         let b = entity("stream-b");
-        store.acquire(&a, &me()).await.expect("acquire a");
-        store.acquire(&b, &me()).await.expect("acquire b");
+        let a_epoch = store.acquire(&a, &me()).await.expect("acquire a");
+        let b_epoch = store.acquire(&b, &me()).await.expect("acquire b");
 
         store
             .release_many(&[a.clone(), b.clone()], &me())
             .await
             .expect("release_many");
 
-        assert!(!store
-            .fence(&a, &me(), ClaimEpoch(0))
-            .await
-            .expect("fence a"));
-        assert!(!store
-            .fence(&b, &me(), ClaimEpoch(0))
-            .await
-            .expect("fence b"));
+        assert!(!store.fence(&a, &me(), a_epoch).await.expect("fence a"));
+        assert!(!store.fence(&b, &me(), b_epoch).await.expect("fence b"));
     }
 }

--- a/server/crates/waddle-xmpp/src/ownership/in_process.rs
+++ b/server/crates/waddle-xmpp/src/ownership/in_process.rs
@@ -241,16 +241,15 @@ impl ClaimStore for InProcessClaimStore {
         }
     }
 
-    async fn release_many(
-        &self,
-        entities: &[Entity],
-        _me: &NodeIdentity,
-    ) -> Result<(), ClaimError> {
-        // Claim-epoch-blind by the trait contract (the node-identity gate
-        // is trivially satisfied here: this store *is* the one node).
+    async fn release_many(&self, entities: &[Entity], me: &NodeIdentity) -> Result<(), ClaimError> {
+        // Claim-epoch-blind by the trait contract, but still exact-owner
+        // gated so an old process incarnation cannot drain claims acquired
+        // by a replacement sharing the same stable node id.
         let mut state = self.lock()?;
         for entity in entities {
-            state.claims.remove(entity);
+            if matches!(state.claims.get(entity), Some(record) if record.owner == *me) {
+                state.claims.remove(entity);
+            }
         }
         Ok(())
     }
@@ -583,5 +582,39 @@ mod tests {
 
         assert!(!store.fence(&a, &me(), a_epoch).await.expect("fence a"));
         assert!(!store.fence(&b, &me(), b_epoch).await.expect("fence b"));
+    }
+
+    #[tokio::test]
+    async fn release_many_only_removes_claims_owned_by_the_exact_incarnation() {
+        let store = InProcessClaimStore::new();
+        let old_identity = NodeIdentity::new("stable-node", "epoch-a");
+        let current_identity = NodeIdentity::new("stable-node", "epoch-b");
+        let old_entity = entity("old-incarnation");
+        let current_entity = entity("current-incarnation");
+        let old_epoch = store
+            .acquire(&old_entity, &old_identity)
+            .await
+            .expect("old incarnation acquires claim");
+        let current_epoch = store
+            .acquire(&current_entity, &current_identity)
+            .await
+            .expect("current incarnation acquires claim");
+
+        store
+            .release_many(
+                &[old_entity.clone(), current_entity.clone()],
+                &current_identity,
+            )
+            .await
+            .expect("current incarnation drains its claims");
+
+        assert!(store
+            .fence(&old_entity, &old_identity, old_epoch)
+            .await
+            .expect("old claim remains fenced"));
+        assert!(!store
+            .fence(&current_entity, &current_identity, current_epoch)
+            .await
+            .expect("current claim was released"));
     }
 }

--- a/server/crates/waddle-xmpp/src/ownership/in_process.rs
+++ b/server/crates/waddle-xmpp/src/ownership/in_process.rs
@@ -184,27 +184,43 @@ impl ClaimStore for InProcessClaimStore {
     async fn fence(
         &self,
         entity: &Entity,
-        _me: &NodeIdentity,
+        me: &NodeIdentity,
         mine: ClaimEpoch,
     ) -> Result<bool, ClaimError> {
         let claims = self.lock()?;
-        Ok(claims.get(entity).map(|record| record.epoch) == Some(mine))
+        Ok(
+            matches!(claims.get(entity), Some(record) if record.owner == *me && record.epoch == mine),
+        )
     }
 
     async fn release(
         &self,
         entity: &Entity,
-        _me: &NodeIdentity,
+        me: &NodeIdentity,
         mine: ClaimEpoch,
     ) -> Result<(), ClaimError> {
         let mut claims = self.lock()?;
-        // Epoch-gated exactly like `PostgresClaimStore`'s CAS: a losing
-        // epoch is a no-op (the claim was re-issued since the caller
-        // observed `mine`), and releasing an absent claim is idempotent.
-        if claims.get(entity).map(|record| record.epoch) == Some(mine) {
+        if matches!(claims.get(entity), Some(record) if record.owner == *me && record.epoch == mine)
+        {
             claims.remove(entity);
         }
         Ok(())
+    }
+
+    async fn release_exact(
+        &self,
+        entity: &Entity,
+        me: &NodeIdentity,
+        mine: ClaimEpoch,
+    ) -> Result<crate::ownership::ExactReleaseOutcome, ClaimError> {
+        let mut claims = self.lock()?;
+        if matches!(claims.get(entity), Some(record) if record.owner == *me && record.epoch == mine)
+        {
+            claims.remove(entity);
+            Ok(crate::ownership::ExactReleaseOutcome::Released)
+        } else {
+            Ok(crate::ownership::ExactReleaseOutcome::NotOwned)
+        }
     }
 
     async fn release_many(
@@ -264,11 +280,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn release_is_epoch_gated_and_idempotent() {
-        // Mirrors `PostgresClaimStore`'s `release_is_epoch_gated_and_idempotent`
-        // (`waddle-server/src/clustering/claims.rs`): a losing epoch is a
-        // no-op — the claim survives — and releasing an absent claim is
-        // not an error.
+    async fn release_is_idempotent_and_exact_release_reports_ownership() {
         let store = InProcessClaimStore::new();
         let e = entity("stream-1");
         let epoch0 = store.acquire(&e, &me()).await.expect("acquire");
@@ -281,7 +293,7 @@ mod tests {
         store
             .release(&e, &me(), epoch0)
             .await
-            .expect("stale release is a no-op, not an error");
+            .expect("stale release is an idempotent no-op");
         let err = store
             .acquire(&e, &me())
             .await
@@ -298,6 +310,39 @@ mod tests {
             .acquire(&e, &me())
             .await
             .expect("entity claimable again after a current-epoch release");
+
+        assert_eq!(
+            store
+                .release_exact(&e, &me(), ClaimEpoch(99))
+                .await
+                .expect("exact release"),
+            crate::ownership::ExactReleaseOutcome::NotOwned
+        );
+    }
+
+    #[tokio::test]
+    async fn same_node_id_from_another_incarnation_cannot_fence_or_release() {
+        let store = InProcessClaimStore::new();
+        let entity = entity("incarnation-fence");
+        let owner = NodeIdentity::new("same-node", "epoch-a");
+        let replacement = NodeIdentity::new("same-node", "epoch-b");
+        let claim_epoch = store.acquire(&entity, &owner).await.expect("acquire");
+
+        assert!(!store
+            .fence(&entity, &replacement, claim_epoch)
+            .await
+            .expect("fence"));
+        assert_eq!(
+            store
+                .release_exact(&entity, &replacement, claim_epoch)
+                .await
+                .expect("exact release"),
+            crate::ownership::ExactReleaseOutcome::NotOwned
+        );
+        assert!(store
+            .fence(&entity, &owner, claim_epoch)
+            .await
+            .expect("original owner remains"));
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/ownership/mod.rs
+++ b/server/crates/waddle-xmpp/src/ownership/mod.rs
@@ -248,7 +248,7 @@ impl NodeIdentity {
 /// would silently keep acquiring/fencing claims under a `node_epoch` that
 /// stopped being current the moment this node last self-fenced (ADR-0017
 /// Phase 3 plan, Slice 4 follow-up plumbing note). This type is that
-/// shared, updatable view: `self_fence::run_node_lease` calls [`Self::set`]
+/// shared, updatable view: `self_fence::run_node_lease` calls [`Self::rotate`]
 /// every time it mints a fresh identity, and any other holder of a clone
 /// calls [`Self::current`] to read the latest value at the moment it
 /// actually needs it (never earlier, never cached across an `.await`).
@@ -260,11 +260,30 @@ impl NodeIdentity {
 /// Slice 4) that only ever reads it, without forcing the reader to depend
 /// on the `clustering` Cargo feature.
 #[derive(Clone)]
-pub struct SharedNodeIdentity(std::sync::Arc<std::sync::RwLock<NodeIdentity>>);
+pub struct SharedNodeIdentity {
+    identity: std::sync::Arc<std::sync::RwLock<NodeIdentity>>,
+    rotation_gate: std::sync::Arc<tokio::sync::RwLock<()>>,
+}
+
+/// Shared authority to use one node identity at a publication or commit
+/// boundary. Identity rotation takes the exclusive side of the same gate.
+pub struct CurrentNodeIdentityGuard {
+    identity: NodeIdentity,
+    _rotation_guard: tokio::sync::OwnedRwLockReadGuard<()>,
+}
+
+impl CurrentNodeIdentityGuard {
+    pub fn identity(&self) -> &NodeIdentity {
+        &self.identity
+    }
+}
 
 impl SharedNodeIdentity {
     pub fn new(initial: NodeIdentity) -> Self {
-        Self(std::sync::Arc::new(std::sync::RwLock::new(initial)))
+        Self {
+            identity: std::sync::Arc::new(std::sync::RwLock::new(initial)),
+            rotation_gate: std::sync::Arc::new(tokio::sync::RwLock::new(())),
+        }
     }
 
     /// The identity this node currently believes it holds, cloned out
@@ -272,24 +291,39 @@ impl SharedNodeIdentity {
     /// across an `.await`.
     ///
     /// A poisoned lock (a panicking holder) still yields a usable
-    /// identity: `NodeIdentity` has no invariant `set` can partially
+    /// identity: `NodeIdentity` has no invariant `rotate` can partially
     /// break (both fields are plain, independently-assigned `String`s),
     /// so recovering via the poison error's inner guard is safe and keeps
     /// one panicking holder from cascading into every future
     /// claim-fencing call this process ever makes.
     pub fn current(&self) -> NodeIdentity {
-        self.0
+        self.identity
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
     }
 
-    /// Replace the current identity. Called by `self_fence::run_node_lease`
-    /// every time this node mints a fresh identity (initial registration
-    /// and every post-fence re-registration).
-    pub fn set(&self, identity: NodeIdentity) {
+    /// Acquire authority to use `expected`. Once returned, rotation cannot
+    /// complete until the guard is dropped. Writer preference also prevents
+    /// a new stale guard from passing a rotation that has already started.
+    pub async fn guard_if_current(
+        &self,
+        expected: &NodeIdentity,
+    ) -> Option<CurrentNodeIdentityGuard> {
+        let rotation_guard = self.rotation_gate.clone().read_owned().await;
+        let identity = self.current();
+        (identity == *expected).then_some(CurrentNodeIdentityGuard {
+            identity,
+            _rotation_guard: rotation_guard,
+        })
+    }
+
+    /// Replace the current identity only after every in-flight guarded
+    /// publication or transaction has completed.
+    pub async fn rotate(&self, identity: NodeIdentity) {
+        let _rotation_guard = self.rotation_gate.write().await;
         *self
-            .0
+            .identity
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = identity;
     }
@@ -636,15 +670,42 @@ mod tests {
         assert!(ClaimEpoch(0) < ClaimEpoch(1));
     }
 
-    #[test]
-    fn shared_node_identity_set_is_visible_through_every_clone() {
+    #[tokio::test]
+    async fn shared_node_identity_rotation_is_visible_through_every_clone() {
         let shared = SharedNodeIdentity::new(NodeIdentity::new("node-a", "epoch-0"));
         let clone = shared.clone();
         assert_eq!(clone.current(), NodeIdentity::new("node-a", "epoch-0"));
 
-        shared.set(NodeIdentity::new("node-a", "epoch-1"));
+        shared.rotate(NodeIdentity::new("node-a", "epoch-1")).await;
 
         assert_eq!(clone.current(), NodeIdentity::new("node-a", "epoch-1"));
         assert_eq!(shared.current(), NodeIdentity::new("node-a", "epoch-1"));
+    }
+
+    #[tokio::test]
+    async fn guarded_identity_boundary_delays_rotation_until_use_completes() {
+        let old = NodeIdentity::new("node-a", "epoch-0");
+        let new = NodeIdentity::new("node-a", "epoch-1");
+        let shared = SharedNodeIdentity::new(old.clone());
+        let guard = shared
+            .guard_if_current(&old)
+            .await
+            .expect("old identity starts current");
+        let rotating = shared.clone();
+        let rotation = tokio::spawn(async move {
+            rotating.rotate(new).await;
+        });
+
+        tokio::task::yield_now().await;
+        assert!(
+            !rotation.is_finished(),
+            "rotation must wait at the exact post-check/use boundary"
+        );
+        assert_eq!(guard.identity(), &old);
+        drop(guard);
+
+        rotation.await.expect("rotation task");
+        assert_eq!(shared.current(), NodeIdentity::new("node-a", "epoch-1"));
+        assert!(shared.guard_if_current(&old).await.is_none());
     }
 }

--- a/server/crates/waddle-xmpp/src/ownership/mod.rs
+++ b/server/crates/waddle-xmpp/src/ownership/mod.rs
@@ -88,13 +88,15 @@ impl EntityType {
 
 /// Wire length bound on [`Entity::id`] (ADR-0017 Phase 3 Slice 7 FIX 9,
 /// council-adjudicated). Mirrors
-/// [`crate::pending_delivery::SM_SESSION_ID_MAX_LEN`]'s exact rationale one
+/// [`crate::pending_delivery::SM_SESSION_ID_MAX_LEN`]'s defensive rationale one
 /// type over: `Entity` now travels wire-typed on the MUC Demote relay ask
 /// (deviation 60), which is NOT a stanza and so never passes through the
 /// bounded XML stanza codec — without a field-level bound of its own, a
 /// malicious (or buggy) allowlisted peer could ship a multi-MB `id`.
-/// Production ids are bare JIDs or room JIDs, far under this cap.
-pub const ENTITY_ID_MAX_LEN: usize = 128;
+/// RFC 7622 section 3.1 permits 1023 octets in each bare-JID part, plus
+/// the `@` separator, so the bound must admit every valid 2047-octet bare
+/// JID used for `UserActor` and `RoomActor` ownership.
+pub const ENTITY_ID_MAX_LEN: usize = 2047;
 
 /// [`Entity::id`] exceeded [`ENTITY_ID_MAX_LEN`] at deserialization.
 #[derive(Debug, Clone, thiserror::Error)]
@@ -109,11 +111,10 @@ pub struct EntityIdTooLong {
 /// `Serialize`/`Deserialize` (ADR-0017 Phase 3 Slice 7) so this type can
 /// travel wire-typed on the MUC Demote relay ask. `Deserialize` is
 /// hand-written (below), not derived, so it can enforce [`ENTITY_ID_MAX_LEN`]
-/// on the `id` field — mirroring [`crate::pending_delivery::SmSessionId`]'s
-/// identical hand-written bound exactly, one type over (FIX 9). [`Self::new`]
-/// itself stays unvalidated, for the same reason `SmSessionId::new` does: every
-/// production caller mints ids far under the cap, and the wire boundary is
-/// where an untrusted length actually arrives.
+/// on the `id` field — applying [`crate::pending_delivery::SmSessionId`]'s
+/// same boundary defense one type over (FIX 9). [`Self::new`]
+/// itself stays unvalidated, for the same reason `SmSessionId::new` does: the
+/// wire boundary is where an untrusted length actually arrives.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize)]
 pub struct Entity {
     pub entity_type: EntityType,
@@ -203,7 +204,7 @@ pub struct ClaimSnapshot {
 /// write. `Serialize`/`Deserialize` (ADR-0017 Phase 3 Slice 7) so this type
 /// can travel wire-typed on the MUC Demote relay ask.
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
 pub struct ClaimEpoch(pub i64);
 
@@ -335,7 +336,7 @@ pub enum ClaimError {
     #[error("entity already claimed by another node")]
     AlreadyClaimed,
 
-    /// A `steal_stale` / `steal_for_resume` / `release` CAS affected zero
+    /// A `steal_stale` / `steal_for_resume` CAS affected zero
     /// rows: the observed epoch was stale, the staleness predicate was not
     /// satisfied (the owner is not actually stale), or the claim no longer
     /// exists.
@@ -373,6 +374,13 @@ pub enum ClaimError {
     /// refused.
     #[error("this node is draining and refuses to acquire a new claim")]
     Draining,
+}
+
+/// Result of an ownership- and epoch-exact release attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExactReleaseOutcome {
+    Released,
+    NotOwned,
 }
 
 /// Entity ownership claims: which node currently owns a given `UserActor`/
@@ -495,14 +503,29 @@ pub trait ClaimStore: Send + Sync {
         mine: ClaimEpoch,
     ) -> Result<bool, ClaimError>;
 
-    /// Release a held claim (epoch-gated, best-effort: releasing a claim
-    /// already stolen out from under `me` is a no-op, not an error).
+    /// Best-effort, idempotent release of a held claim. A missing, stolen,
+    /// foreign-incarnation, or stale-epoch row is already terminal cleanup
+    /// and therefore succeeds.
     async fn release(
         &self,
         entity: &Entity,
         me: &NodeIdentity,
         mine: ClaimEpoch,
     ) -> Result<(), ClaimError>;
+
+    /// Release only the exact owner incarnation and epoch, reporting whether
+    /// a row was actually deleted. Recovery workflows use this when a zero-row
+    /// no-op must not be mistaken for confirmed ownership cleanup.
+    async fn release_exact(
+        &self,
+        _entity: &Entity,
+        _me: &NodeIdentity,
+        _mine: ClaimEpoch,
+    ) -> Result<ExactReleaseOutcome, ClaimError> {
+        Err(ClaimError::Backend(
+            "exact release outcome is not implemented by this claim store".to_string(),
+        ))
+    }
 
     /// Batched release for graceful drain (~18k modeled claims, ADR-0017
     /// Phase 3 Slice 10) — one round-trip, not one-at-a-time. Releases every

--- a/server/crates/waddle-xmpp/src/registry/user_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/registry/user_registry/tests.rs
@@ -386,7 +386,9 @@ async fn test_remove_user_releases_with_the_acquisition_identity_after_identity_
         .await
         .expect("get_or_create");
 
-    shared_identity.set(NodeIdentity::new("node-this", "epoch-after-self-fence"));
+    shared_identity
+        .rotate(NodeIdentity::new("node-this", "epoch-after-self-fence"))
+        .await;
 
     let removed = registry
         .ask(RemoveUser {
@@ -557,7 +559,9 @@ async fn test_register_after_identity_rotation_reclaims_before_reusing_stale_use
         .await
         .expect("create");
 
-    shared_identity.set(NodeIdentity::new("node-this", "epoch-after-self-fence"));
+    shared_identity
+        .rotate(NodeIdentity::new("node-this", "epoch-after-self-fence"))
+        .await;
     claim_store.set_owner_lease_fresh(false);
 
     let (tx, _rx) = outbound_channel();
@@ -636,7 +640,9 @@ async fn test_register_after_identity_rotation_force_detaches_stale_actor_resour
         .expect("get old")
         .expect("old actor");
 
-    shared_identity.set(NodeIdentity::new("node-this", "epoch-after-self-fence"));
+    shared_identity
+        .rotate(NodeIdentity::new("node-this", "epoch-after-self-fence"))
+        .await;
     claim_store.set_owner_lease_fresh(false);
 
     let force_detach_task = tokio::spawn({


### PR DESCRIPTION
Part of #1284

## Scope

- Make RoomActor claims exact across node incarnations and globally non-reusable claim generations.
- Retain ambiguous room acquire and stale-owner-steal outcomes in bounded actor-local reconciliation.
- Supervise uncertain acquisition/release cleanup with one bounded, fair, generation-tagged actor retry stream.
- Serialize identity rotation with final actor publication, reclaimed adoption, PostgreSQL MUC durable commits, and clustered MAM archive transactions.
- Fail closed when a configured clustered room has a missing, stale, or rotated archive fence; origin-ID deduplication cannot bypass ownership proof.
- Keep terminal release, durable fencing, shutdown, and caller behavior ABA-safe.
- Make every production room-destroy caller handle cleanup refusal explicitly; bounded-redrive owned rollback cleanup once and force deposed actors out even when the release backlog is saturated.
- Report exact-release backlog saturation separately from durable room-state wipe failures.

## Stack

1. This PR: shared claim generations and RoomActor ownership.
2. #1332: exact SM ownership and bounded local reconciliation.
3. #1333: transport-committed SM/ISR publication.
4. #1335: supervised orphan recovery and observability.

Supersedes the RoomActor portion of closed #1311. The original monolith remains on `codex/1311-monolith-backup`.

## Review boundary

- 26 files; approximately +4,647 / -525.
- No SM registry, pending-delivery, ISR publication, or general reaper-supervision changes.
- Local XEP-0045/XEP-0313 review found no wire-shape changes; fail-closed archive behavior prevents stale-owner phantom history.
- Addressed all five initial automated review threads: clustered MAM fail-open, identity-rotation fencing, exact in-process batch release, and the two admin backlog diagnostics.
- Addressed the acquisition-backlog follow-up with internally supervised cleanup, release fairness, and timer de-duplication.
- Addressed the cleanup-refusal follow-up by exhaustively handling `DestroyRoomOutcome`, bounded-redriving rollback cleanup, and separating deposed eviction from owned destruction.
- Adversarial follow-ups found and closed an origin-ID dedup fencing bypass, two retry-loop fairness/timer defects, and retry/error-class mistakes in the cleanup-refusal patch; the final pass reported no actionable blockers.

## Verification

- RoomRegistryActor: 57 passed, including saturated-backlog deposed eviction.
- RoomRegistry handle: 6 passed.
- Full clustering server library: 1,798 passed before review follow-ups.
- Clustering MUC durable: 6 passed before review follow-ups; PostgreSQL duplicate-origin claim-transfer regression added.
- Focused archive authority tests: 3 passed.
- Exact-incarnation in-process batch release regression: 1 passed.
- Automatic uncertain-acquisition to exact-release redrive regression passed.
- Saturated release-backlog fairness regression passed.
- `cargo check -p waddle-server --all-targets --all-features` passed.
- `cargo check -p waddle-xmpp --all-targets --all-features` passed.
- `cargo clippy -p waddle-server -p waddle-xmpp --all-targets --all-features -- -D warnings` passed.
- `cargo fmt --all -- --check` and `git diff --check` passed.
- PostgreSQL-backed test bodies are exercised by `nixTest` CI.
