### PR TITLE
fix(server): bound and fail closed claim recovery

### DIFF
--- a/server/crates/waddle-server/src/clustering/claims.rs
+++ b/server/crates/waddle-server/src/clustering/claims.rs
@@ -279,6 +279,44 @@ impl PostgresClaimStore {
         Self { db }
     }
 
+    async fn load_sm_orphan_reaper_cursor(&self) -> Result<Option<SmOrphanScanCursor>, ClaimError> {
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let mut rows = conn
+            .query(
+                "SELECT cursor_entity FROM clustering_orphan_reaper_cursors WHERE lane = ?",
+                crate::db_params![EntityType::SmSession.as_db_str().to_string()],
+            )
+            .await
+            .map_err(db_err)?;
+        match rows.next().await.map_err(db_err)? {
+            Some(row) => row
+                .get::<Option<String>>(0)
+                .map(|cursor| cursor.map(SmOrphanScanCursor::from_raw))
+                .map_err(db_err),
+            None => Ok(None),
+        }
+    }
+
+    async fn load_room_orphan_reaper_cursor(
+        &self,
+    ) -> Result<Option<RoomOrphanScanCursor>, ClaimError> {
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let mut rows = conn
+            .query(
+                "SELECT cursor_entity FROM clustering_orphan_reaper_cursors WHERE lane = ?",
+                crate::db_params![EntityType::RoomActor.as_db_str().to_string()],
+            )
+            .await
+            .map_err(db_err)?;
+        match rows.next().await.map_err(db_err)? {
+            Some(row) => row
+                .get::<Option<String>>(0)
+                .map(|cursor| cursor.map(RoomOrphanScanCursor::from_raw))
+                .map_err(db_err),
+            None => Ok(None),
+        }
+    }
+
     /// Remove one exact stale SM claim discovered by the advisory orphan
     /// scan. A claim classified as claim-only is deleted only if its durable
     /// row is still absent in this transaction. That current-state predicate
@@ -1445,19 +1483,21 @@ pub trait NodeLeaseStore: Send + Sync {
     /// should override this so the bound is enforced by the query itself.
     async fn list_orphaned_sm_session_claims_page(
         &self,
-        after: Option<String>,
+        after: Option<SmOrphanScanCursor>,
         limit: usize,
     ) -> Result<OrphanedSmSessionClaimPage, ClaimError> {
         let mut candidates = self.list_orphaned_sm_session_claims().await?;
-        candidates.sort_by(|left, right| left.entity.id.cmp(&right.entity.id));
-        if let Some(after) = after.as_deref() {
-            candidates.retain(|candidate| candidate.entity.id.as_str() > after);
+        candidates.sort_by_key(|candidate| entity_key(&candidate.entity));
+        if let Some(after) = after.as_ref() {
+            candidates.retain(|candidate| {
+                entity_key(&candidate.entity).as_str() > after.raw_key.as_str()
+            });
         }
         let has_more = candidates.len() > limit;
         candidates.truncate(limit);
         let next_cursor = candidates
             .last()
-            .map(|candidate| candidate.entity.id.clone());
+            .map(|candidate| SmOrphanScanCursor::from_raw(entity_key(&candidate.entity)));
         Ok(OrphanedSmSessionClaimPage {
             candidates,
             next_cursor,
@@ -1466,17 +1506,12 @@ pub trait NodeLeaseStore: Send + Sync {
         })
     }
 
-    /// Durable advisory cursor for raw orphan-integrity scans. Defaults are
-    /// process-local/no-op for fakes; production persists one cursor per
-    /// entity lane so restarts cannot starve high-key claims indefinitely.
-    async fn orphan_reaper_cursor(&self, _lane: EntityType) -> Result<Option<String>, ClaimError> {
-        Ok(None)
-    }
-
+    /// Persist one lane-typed advisory cursor after a complete page. The
+    /// update enum carries its lane even when resetting to `None`, making
+    /// cross-lane cursor writes unrepresentable at this public boundary.
     async fn persist_orphan_reaper_cursor(
         &self,
-        _lane: EntityType,
-        _cursor: Option<String>,
+        _update: OrphanReaperCursorUpdate,
     ) -> Result<(), ClaimError> {
         Ok(())
     }
@@ -1542,28 +1577,9 @@ pub trait NodeLeaseStore: Send + Sync {
     /// budget instead of forcing an unbounded predicate scan before LIMIT.
     async fn list_orphaned_room_actor_claims_page(
         &self,
-        after: Option<String>,
+        after: Option<RoomOrphanScanCursor>,
         limit: usize,
-    ) -> Result<OrphanedRoomActorClaimPage, ClaimError> {
-        let mut candidates = self
-            .list_orphaned_room_actor_claims(limit.saturating_add(1))
-            .await?;
-        candidates.sort_by(|left, right| left.entity.id.cmp(&right.entity.id));
-        if let Some(after) = after.as_deref() {
-            candidates.retain(|candidate| candidate.entity.id.as_str() > after);
-        }
-        let has_more = candidates.len() > limit;
-        candidates.truncate(limit);
-        let next_cursor = candidates
-            .last()
-            .map(|candidate| candidate.entity.id.clone());
-        Ok(OrphanedRoomActorClaimPage {
-            candidates,
-            next_cursor,
-            has_more,
-            quarantined: 0,
-        })
-    }
+    ) -> Result<OrphanedRoomActorClaimPage, ClaimError>;
 
     /// Reaper-only stale-owner steal for a `RoomActor`. The production
     /// implementation binds both the observed claim epoch and the sweeping
@@ -1606,9 +1622,30 @@ pub struct OrphanedSmSessionClaim {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrphanedSmSessionClaimPage {
     pub candidates: Vec<OrphanedSmSessionClaim>,
-    pub next_cursor: Option<String>,
+    pub next_cursor: Option<SmOrphanScanCursor>,
     pub has_more: bool,
     pub quarantined: usize,
+}
+
+/// Opaque ordering checkpoint for the raw `sm_session` claim-key lane.
+///
+/// The private value intentionally remains the database key rather than a
+/// parsed `SmSessionId`: malformed keys must still advance the integrity
+/// scan so one poison row cannot pin every later claim forever.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SmOrphanScanCursor {
+    raw_key: String,
+}
+
+impl SmOrphanScanCursor {
+    pub(crate) fn from_raw(raw_key: String) -> Self {
+        Self { raw_key }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn as_raw(&self) -> &str {
+        &self.raw_key
+    }
 }
 
 /// A bounded-scan candidate for proactive `RoomActor` reconciliation.
@@ -1624,9 +1661,45 @@ pub struct OrphanedRoomActorClaim {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrphanedRoomActorClaimPage {
     pub candidates: Vec<OrphanedRoomActorClaim>,
-    pub next_cursor: Option<String>,
+    pub next_cursor: Option<RoomOrphanScanCursor>,
     pub has_more: bool,
     pub quarantined: usize,
+}
+
+/// Opaque ordering checkpoint for the raw `room_actor` claim-key lane.
+/// The raw key is private because this is a storage cursor, not a room JID;
+/// malformed keys must remain representable for forward progress.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoomOrphanScanCursor {
+    raw_key: String,
+}
+
+impl RoomOrphanScanCursor {
+    pub(crate) fn from_raw(raw_key: String) -> Self {
+        Self { raw_key }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn as_raw(&self) -> &str {
+        &self.raw_key
+    }
+}
+
+/// Lane-safe durable cursor write. `None` is a typed reset for exactly one
+/// lane rather than an untyped `(EntityType, Option<String>)` pair.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OrphanReaperCursorUpdate {
+    SmSession(Option<SmOrphanScanCursor>),
+    RoomActor(Option<RoomOrphanScanCursor>),
+}
+
+impl OrphanReaperCursorUpdate {
+    fn into_db_parts(self) -> (EntityType, Option<String>) {
+        match self {
+            Self::SmSession(cursor) => (EntityType::SmSession, cursor.map(|cursor| cursor.raw_key)),
+            Self::RoomActor(cursor) => (EntityType::RoomActor, cursor.map(|cursor| cursor.raw_key)),
+        }
+    }
 }
 
 async fn register_node(
@@ -2107,7 +2180,7 @@ impl NodeLeaseStore for PostgresClaimStore {
 
     async fn list_orphaned_sm_session_claims_page(
         &self,
-        after: Option<String>,
+        after: Option<SmOrphanScanCursor>,
         limit: usize,
     ) -> Result<OrphanedSmSessionClaimPage, ClaimError> {
         if limit == 0 {
@@ -2120,10 +2193,11 @@ impl NodeLeaseStore for PostgresClaimStore {
         }
         let scan_limit = limit.saturating_add(1);
         let cursor = match after {
-            Some(cursor) => cursor,
+            Some(cursor) => cursor.raw_key,
             None => self
-                .orphan_reaper_cursor(EntityType::SmSession)
+                .load_sm_orphan_reaper_cursor()
                 .await?
+                .map(|cursor| cursor.raw_key)
                 .unwrap_or_default(),
         };
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
@@ -2179,7 +2253,7 @@ impl NodeLeaseStore for PostgresClaimStore {
             let claim_epoch: i64 = row.get(3).map_err(db_err)?;
             let owner_stale: i64 = row.get(4).map_err(db_err)?;
             let has_durable: i64 = row.get(5).map_err(db_err)?;
-            next_cursor = Some(encoded.clone());
+            next_cursor = Some(SmOrphanScanCursor::from_raw(encoded.clone()));
             if owner_stale != 1 {
                 continue;
             }
@@ -2233,26 +2307,11 @@ impl NodeLeaseStore for PostgresClaimStore {
         })
     }
 
-    async fn orphan_reaper_cursor(&self, lane: EntityType) -> Result<Option<String>, ClaimError> {
-        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        let mut rows = conn
-            .query(
-                "SELECT cursor_entity FROM clustering_orphan_reaper_cursors WHERE lane = ?",
-                crate::db_params![lane.as_db_str().to_string()],
-            )
-            .await
-            .map_err(db_err)?;
-        match rows.next().await.map_err(db_err)? {
-            Some(row) => row.get::<Option<String>>(0).map_err(db_err),
-            None => Ok(None),
-        }
-    }
-
     async fn persist_orphan_reaper_cursor(
         &self,
-        lane: EntityType,
-        cursor: Option<String>,
+        update: OrphanReaperCursorUpdate,
     ) -> Result<(), ClaimError> {
+        let (lane, cursor) = update.into_db_parts();
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
         conn.execute(
             "INSERT INTO clustering_orphan_reaper_cursors (lane, cursor_entity) VALUES (?, ?) \
@@ -2401,7 +2460,7 @@ impl NodeLeaseStore for PostgresClaimStore {
 
     async fn list_orphaned_room_actor_claims_page(
         &self,
-        after: Option<String>,
+        after: Option<RoomOrphanScanCursor>,
         limit: usize,
     ) -> Result<OrphanedRoomActorClaimPage, ClaimError> {
         if limit == 0 {
@@ -2414,10 +2473,11 @@ impl NodeLeaseStore for PostgresClaimStore {
         }
         let scan_limit = limit.saturating_add(1);
         let cursor = match after {
-            Some(cursor) => cursor,
+            Some(cursor) => cursor.raw_key,
             None => self
-                .orphan_reaper_cursor(EntityType::RoomActor)
+                .load_room_orphan_reaper_cursor()
                 .await?
+                .map(|cursor| cursor.raw_key)
                 .unwrap_or_default(),
         };
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
@@ -2465,7 +2525,7 @@ impl NodeLeaseStore for PostgresClaimStore {
             let node_epoch: String = row.get(2).map_err(db_err)?;
             let claim_epoch: i64 = row.get(3).map_err(db_err)?;
             let owner_stale: i64 = row.get(4).map_err(db_err)?;
-            next_cursor = Some(encoded.clone());
+            next_cursor = Some(RoomOrphanScanCursor::from_raw(encoded.clone()));
             if owner_stale != 1 {
                 continue;
             }
@@ -2649,6 +2709,35 @@ mod tests {
         Entity::new(EntityType::SmSession, id.to_string())
     }
 
+    #[test]
+    fn orphan_reaper_cursor_updates_preserve_their_lane_when_set_or_reset() {
+        let sm = SmOrphanScanCursor::from_raw("sm_session:page-064".to_string());
+        let room =
+            RoomOrphanScanCursor::from_raw("room_actor:page-064@muc.example.com".to_string());
+        assert_eq!(
+            OrphanReaperCursorUpdate::SmSession(Some(sm)).into_db_parts(),
+            (
+                EntityType::SmSession,
+                Some("sm_session:page-064".to_string())
+            )
+        );
+        assert_eq!(
+            OrphanReaperCursorUpdate::RoomActor(Some(room)).into_db_parts(),
+            (
+                EntityType::RoomActor,
+                Some("room_actor:page-064@muc.example.com".to_string())
+            )
+        );
+        assert_eq!(
+            OrphanReaperCursorUpdate::SmSession(None).into_db_parts(),
+            (EntityType::SmSession, None)
+        );
+        assert_eq!(
+            OrphanReaperCursorUpdate::RoomActor(None).into_db_parts(),
+            (EntityType::RoomActor, None)
+        );
+    }
+
     async fn clean_store() -> Option<PostgresClaimStore> {
         let url = std::env::var("WADDLE_TEST_POSTGRES_URL").ok()?;
         let db = Database::from_config(
@@ -2684,6 +2773,59 @@ mod tests {
             .await
             .expect("clean steal intents");
         Some(store)
+    }
+
+    #[tokio::test]
+    async fn durable_orphan_reaper_cursors_are_lane_typed_and_reset_independently() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let sm = SmOrphanScanCursor::from_raw("sm_session:durable-064".to_string());
+        let room =
+            RoomOrphanScanCursor::from_raw("room_actor:durable-064@muc.example.com".to_string());
+        store
+            .persist_orphan_reaper_cursor(OrphanReaperCursorUpdate::SmSession(Some(sm.clone())))
+            .await
+            .expect("persist SM cursor");
+        store
+            .persist_orphan_reaper_cursor(OrphanReaperCursorUpdate::RoomActor(Some(room.clone())))
+            .await
+            .expect("persist room cursor");
+
+        assert_eq!(
+            store
+                .load_sm_orphan_reaper_cursor()
+                .await
+                .expect("load SM cursor"),
+            Some(sm)
+        );
+        assert_eq!(
+            store
+                .load_room_orphan_reaper_cursor()
+                .await
+                .expect("load room cursor"),
+            Some(room.clone())
+        );
+
+        store
+            .persist_orphan_reaper_cursor(OrphanReaperCursorUpdate::SmSession(None))
+            .await
+            .expect("reset SM cursor");
+        assert_eq!(
+            store
+                .load_sm_orphan_reaper_cursor()
+                .await
+                .expect("load reset SM cursor"),
+            None
+        );
+        assert_eq!(
+            store
+                .load_room_orphan_reaper_cursor()
+                .await
+                .expect("room cursor survives SM reset"),
+            Some(room)
+        );
     }
 
     /// Seed a `clustering_nodes` row directly with a caller-chosen `expired`
@@ -4390,11 +4532,23 @@ mod tests {
             .await
             .expect("valid claim");
 
-        let candidates = store
-            .list_orphaned_room_actor_claims(64)
+        let first = store
+            .list_orphaned_room_actor_claims_page(None, 64)
             .await
-            .expect("bounded scan");
-        assert!(candidates.iter().any(|candidate| candidate.entity == valid));
+            .expect("first bounded scan");
+        assert!(first.candidates.is_empty());
+        assert!(first.has_more);
+        assert_eq!(first.quarantined, 64);
+        let second = store
+            .list_orphaned_room_actor_claims_page(first.next_cursor, 64)
+            .await
+            .expect("second bounded scan");
+        assert!(second
+            .candidates
+            .iter()
+            .any(|candidate| candidate.entity == valid));
+        assert_eq!(second.quarantined, 1);
+        assert!(!second.has_more);
         for entity in [
             malformed.first().expect("first"),
             malformed.last().expect("last"),
@@ -5379,7 +5533,12 @@ mod tests {
         .expect("seed malformed claim");
         drop(conn);
         let malformed_page = store
-            .list_orphaned_sm_session_claims_page(Some("sm_session:paged-999".to_string()), 64)
+            .list_orphaned_sm_session_claims_page(
+                Some(SmOrphanScanCursor::from_raw(
+                    "sm_session:paged-999".to_string(),
+                )),
+                64,
+            )
             .await
             .expect("malformed page");
         assert_eq!(malformed_page.quarantined, 1);

--- a/server/crates/waddle-server/src/clustering/claims.rs
+++ b/server/crates/waddle-server/src/clustering/claims.rs
@@ -154,6 +154,9 @@ fn entity_key(entity: &Entity) -> String {
 fn decode_entity(encoded: &str, entity_type: EntityType) -> Option<Entity> {
     let prefix = format!("{}:", entity_type.as_db_str());
     let id = encoded.strip_prefix(&prefix)?;
+    if id.len() > waddle_xmpp::ownership::ENTITY_ID_MAX_LEN {
+        return None;
+    }
     Some(Entity::new(entity_type, id))
 }
 
@@ -195,12 +198,16 @@ mod entity_key_tests {
 
     #[test]
     fn decode_entity_round_trips_entity_key_including_ids_with_colons() {
-        let cases = [
+        let long_valid_room: jid::BareJid = format!("{}@muc.example.com", "a".repeat(129))
+            .parse()
+            .expect("valid room JID longer than the old 128-byte wire bound");
+        let cases = vec![
             Entity::new(EntityType::UserActor, "42"),
             Entity::new(EntityType::RoomActor, "room_actor:42"),
             Entity::new(EntityType::SmSession, "sm_session:sm_session:x"),
             Entity::new(EntityType::UserActor, ""),
             Entity::new(EntityType::RoomActor, ":"),
+            Entity::new(EntityType::RoomActor, long_valid_room.to_string()),
         ];
         for entity in cases {
             let encoded = entity_key(&entity);
@@ -233,9 +240,125 @@ pub struct PostgresClaimStore {
     db: Database,
 }
 
+struct OrphanedSmClaimCleanup {
+    encoded: String,
+    owner: NodeIdentity,
+    claim_epoch: ClaimEpoch,
+    durable_stream_id: Option<String>,
+    malformed: bool,
+}
+
 impl PostgresClaimStore {
     pub fn new(db: Database) -> Self {
         Self { db }
+    }
+
+    /// Remove one exact stale SM claim discovered by the advisory orphan
+    /// scan. A claim classified as claim-only is deleted only if its durable
+    /// row is still absent in this transaction. That current-state predicate
+    /// closes the scan/delete window in which a paused owner can finish a
+    /// fenced detach write before this DELETE obtains the claim-row lock.
+    async fn cleanup_orphaned_sm_claim(
+        &self,
+        cleanup: OrphanedSmClaimCleanup,
+    ) -> Result<bool, ClaimError> {
+        let mut tx = self.db.begin().await.map_err(db_err)?;
+        // Serialize with every fenced SM writer before evaluating durable-row
+        // absence. Under Postgres READ COMMITTED, putting `NOT EXISTS` in the
+        // same DELETE that waits on a writer's `FOR SHARE` lock is not enough:
+        // that statement's snapshot can predate the writer's commit. Taking
+        // the exact claim lock in this first statement makes the DELETE below
+        // start with a fresh statement snapshot after any in-flight writer has
+        // committed or rolled back.
+        let mut locked = tx
+            .query(
+                r#"
+                /* orphan_sm_cleanup_exact_lock */
+                SELECT 1 FROM clustering_claims
+                WHERE entity = ? AND entity_type = ? AND node_id = ? AND node_epoch = ?
+                  AND claim_epoch = ?
+                FOR UPDATE
+                "#,
+                crate::db_params![
+                    cleanup.encoded.clone(),
+                    EntityType::SmSession.as_db_str().to_string(),
+                    cleanup.owner.node_id.clone(),
+                    cleanup.owner.node_epoch.clone(),
+                    cleanup.claim_epoch.0,
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        let exact_claim_locked = locked.next().await.map_err(db_err)?.is_some();
+        drop(locked);
+        if !exact_claim_locked {
+            tx.commit().await.map_err(db_err)?;
+            return Ok(false);
+        }
+        let params = crate::db_params![
+            cleanup.encoded.clone(),
+            EntityType::SmSession.as_db_str().to_string(),
+            cleanup.owner.node_id,
+            cleanup.owner.node_epoch,
+            cleanup.claim_epoch.0,
+        ];
+        let affected = if cleanup.durable_stream_id.is_some() {
+            tx.execute(
+                r#"
+                DELETE FROM clustering_claims
+                WHERE entity = ? AND entity_type = ? AND node_id = ? AND node_epoch = ?
+                  AND claim_epoch = ?
+                  AND NOT EXISTS (
+                    SELECT 1 FROM clustering_nodes n
+                    WHERE n.node_id = clustering_claims.node_id
+                      AND NOT n.expired
+                      AND n.node_epoch = clustering_claims.node_epoch
+                  )
+                "#,
+                params,
+            )
+            .await
+            .map_err(db_err)?
+        } else {
+            tx.execute(
+                r#"
+                DELETE FROM clustering_claims
+                WHERE entity = ? AND entity_type = ? AND node_id = ? AND node_epoch = ?
+                  AND claim_epoch = ?
+                  AND NOT EXISTS (
+                    SELECT 1 FROM clustering_nodes n
+                    WHERE n.node_id = clustering_claims.node_id
+                      AND NOT n.expired
+                      AND n.node_epoch = clustering_claims.node_epoch
+                  )
+                  AND NOT EXISTS (
+                    SELECT 1 FROM sm_sessions s
+                    WHERE clustering_claims.entity = ('sm_session:' || s.stream_id)
+                  )
+                "#,
+                params,
+            )
+            .await
+            .map_err(db_err)?
+        };
+        if affected == 1 {
+            if let Some(stream_id) = cleanup.durable_stream_id {
+                tx.execute(
+                    "DELETE FROM sm_unacked WHERE stream_id = ?",
+                    crate::db_params![stream_id.clone()],
+                )
+                .await
+                .map_err(db_err)?;
+                tx.execute(
+                    "DELETE FROM sm_sessions WHERE stream_id = ?",
+                    crate::db_params![stream_id],
+                )
+                .await
+                .map_err(db_err)?;
+            }
+        }
+        tx.commit().await.map_err(db_err)?;
+        Ok(affected == 1 && cleanup.malformed)
     }
 }
 
@@ -359,6 +482,19 @@ impl ClaimStore for PostgresClaimStore {
             r#"
             CREATE INDEX IF NOT EXISTS clustering_claims_node_id_node_epoch
                 ON clustering_claims (node_id, node_epoch)
+            "#,
+            (),
+        )
+        .await
+        .map_err(db_err)?;
+        // Supports bounded per-entity-type orphan scans without walking the
+        // much larger mixed claim table (SM sessions dominate in modeled
+        // deployments). `entity` also satisfies the room scan's stable
+        // ordering before its LIMIT.
+        conn.execute(
+            r#"
+            CREATE INDEX IF NOT EXISTS clustering_claims_entity_type_entity
+                ON clustering_claims (entity_type, entity)
             "#,
             (),
         )
@@ -874,9 +1010,14 @@ impl ClaimStore for PostgresClaimStore {
             .query(
                 r#"
                 SELECT 1 FROM clustering_claims
-                WHERE entity = ? AND node_id = ? AND claim_epoch = ?
+                WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ?
                 "#,
-                crate::db_params![entity_key(entity), me.node_id.clone(), mine.0],
+                crate::db_params![
+                    entity_key(entity),
+                    me.node_id.clone(),
+                    me.node_epoch.clone(),
+                    mine.0,
+                ],
             )
             .await
             .map_err(db_err)?;
@@ -890,33 +1031,20 @@ impl ClaimStore for PostgresClaimStore {
         mine: ClaimEpoch,
     ) -> Result<(), ClaimError> {
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        // Epoch-gated release: best-effort. A claim already stolen out
-        // from under `me` (0 rows affected) is a no-op, not an error —
-        // graceful drain releases whatever it still owns and does not
-        // treat a lost race as a failure.
-        let affected = conn
-            .execute(
-                r#"
+        conn.execute(
+            r#"
                 DELETE FROM clustering_claims
                 WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ?
                 "#,
-                crate::db_params![
-                    entity_key(entity),
-                    me.node_id.clone(),
-                    me.node_epoch.clone(),
-                    mine.0,
-                ],
-            )
-            .await
-            .map_err(db_err)?;
-        if affected == 0 {
-            tracing::debug!(
-                entity = %entity.id,
-                node_id = %me.node_id,
-                claim_epoch = mine.0,
-                "release: claim already gone (stolen or already released)"
-            );
-        }
+            crate::db_params![
+                entity_key(entity),
+                me.node_id.clone(),
+                me.node_epoch.clone(),
+                mine.0,
+            ],
+        )
+        .await
+        .map_err(db_err)?;
         Ok(())
     }
 
@@ -1232,10 +1360,9 @@ pub trait NodeLeaseStore: Send + Sync {
     /// candidate list only; the reaper's subsequent `expire` +
     /// `ClaimStore::steal_stale(OwnerStale)` calls are the actual
     /// authority, exactly like every other candidate-then-CAS pattern in
-    /// this store). Scoped to `sm_session` only: `UserActor`/`RoomActor`
-    /// claim acquisition is out of this slice's scope (see
-    /// `clustering::local_claims`'s module doc), so there is nothing of
-    /// either other type to scan for yet.
+    /// this store). Scoped to `sm_session` only because RoomActor recovery
+    /// has its own bounded scan/adoption path below, while UserActor claims
+    /// remain demand-created and carry no durable actor state to hydrate.
     ///
     /// A row whose `entity` key does not decode cleanly against its own
     /// `entity_type` column (the same data-integrity anomaly
@@ -1245,6 +1372,32 @@ pub trait NodeLeaseStore: Send + Sync {
     async fn list_orphaned_sm_session_claims(
         &self,
     ) -> Result<Vec<OrphanedSmSessionClaim>, ClaimError>;
+
+    /// Ordered, bounded cursor page used by the periodic orphan reaper. The
+    /// default keeps test/dummy stores source-compatible; durable stores
+    /// should override this so the bound is enforced by the query itself.
+    async fn list_orphaned_sm_session_claims_page(
+        &self,
+        after: Option<String>,
+        limit: usize,
+    ) -> Result<OrphanedSmSessionClaimPage, ClaimError> {
+        let mut candidates = self.list_orphaned_sm_session_claims().await?;
+        candidates.sort_by(|left, right| left.entity.id.cmp(&right.entity.id));
+        if let Some(after) = after.as_deref() {
+            candidates.retain(|candidate| candidate.entity.id.as_str() > after);
+        }
+        let has_more = candidates.len() > limit;
+        candidates.truncate(limit);
+        let next_cursor = candidates
+            .last()
+            .map(|candidate| candidate.entity.id.clone());
+        Ok(OrphanedSmSessionClaimPage {
+            candidates,
+            next_cursor,
+            has_more,
+            quarantined: 0,
+        })
+    }
 
     /// Reaper-only stale-owner steal for detached SM-session claims. Unlike
     /// [`ClaimStore::steal_stale`]'s generic owner-stale CAS, this binds the
@@ -1262,8 +1415,9 @@ pub trait NodeLeaseStore: Send + Sync {
     }
 
     /// Bounded advisory scan for `RoomActor` claims whose recorded owner
-    /// lease is committed-stale. The subsequent epoch-fenced steal is the
-    /// authority; this candidate list is read-only.
+    /// lease is committed-stale. The returned snapshot never authorizes a
+    /// takeover: callers must still expire the owner and win
+    /// [`Self::steal_orphaned_room_actor_claim`]'s epoch-fenced CAS.
     async fn list_orphaned_room_actor_claims(
         &self,
         _limit: usize,
@@ -1271,8 +1425,10 @@ pub trait NodeLeaseStore: Send + Sync {
         Ok(Vec::new())
     }
 
-    /// Reaper-only stale-owner steal for a `RoomActor`, bound to both the
-    /// observed claim epoch and the sweeping node's fresh lease.
+    /// Reaper-only stale-owner steal for a `RoomActor`. The production
+    /// implementation binds both the observed claim epoch and the sweeping
+    /// node's own fresh, non-draining lease into one statement, so neither a
+    /// renewed owner nor a stale sweeper can win a candidate-scan race.
     async fn steal_orphaned_room_actor_claim(
         &self,
         _entity: &Entity,
@@ -1307,6 +1463,17 @@ pub struct OrphanedSmSessionClaim {
     pub owner: NodeIdentity,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrphanedSmSessionClaimPage {
+    pub candidates: Vec<OrphanedSmSessionClaim>,
+    pub next_cursor: Option<String>,
+    pub has_more: bool,
+    pub quarantined: usize,
+}
+
+/// A bounded-scan candidate for proactive `RoomActor` reconciliation.
+/// Its fields are only an observation; the reaper's subsequent CAS is the
+/// authority over whether the claim can move.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrphanedRoomActorClaim {
     pub entity: Entity,
@@ -1702,7 +1869,7 @@ impl NodeLeaseStore for PostgresClaimStore {
                 r#"
                 WITH fenced AS (
                     SELECT 1 FROM clustering_claims
-                    WHERE entity = ? AND node_id = ? AND claim_epoch = ?
+                    WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ?
                     FOR SHARE
                 )
                 DELETE FROM clustering_steal_intents
@@ -1712,6 +1879,7 @@ impl NodeLeaseStore for PostgresClaimStore {
                 crate::db_params![
                     entity_key(entity),
                     me.node_id.clone(),
+                    me.node_epoch.clone(),
                     mine.0,
                     entity_key(entity),
                 ],
@@ -1789,6 +1957,120 @@ impl NodeLeaseStore for PostgresClaimStore {
         Ok(out)
     }
 
+    async fn list_orphaned_sm_session_claims_page(
+        &self,
+        after: Option<String>,
+        limit: usize,
+    ) -> Result<OrphanedSmSessionClaimPage, ClaimError> {
+        if limit == 0 {
+            return Ok(OrphanedSmSessionClaimPage {
+                candidates: Vec::new(),
+                next_cursor: after,
+                has_more: false,
+                quarantined: 0,
+            });
+        }
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let scan_limit = limit.saturating_mul(4).saturating_add(1);
+        let cursor = after.unwrap_or_default();
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT entity, node_id, node_epoch, claim_epoch,
+                       CASE WHEN EXISTS (
+                         SELECT 1 FROM sm_sessions s
+                         WHERE clustering_claims.entity = ('sm_session:' || s.stream_id)
+                       ) THEN 1 ELSE 0 END AS has_durable
+                FROM clustering_claims
+                WHERE entity_type = ?
+                  AND entity > ?
+                  AND NOT EXISTS (
+                    SELECT 1 FROM clustering_nodes n
+                    WHERE n.node_id = clustering_claims.node_id
+                      AND NOT n.expired
+                      AND n.node_epoch = clustering_claims.node_epoch
+                  )
+                ORDER BY entity
+                LIMIT ?
+                "#,
+                crate::db_params![
+                    EntityType::SmSession.as_db_str().to_string(),
+                    cursor,
+                    i64::try_from(scan_limit).unwrap_or(i64::MAX),
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        let mut out = Vec::new();
+        // Exact stale-owner snapshot plus an optional durable suffix. The
+        // cleanup transaction revalidates claim-only absence; this scan-time
+        // classification is never destructive authority by itself.
+        let mut cleanup = Vec::new();
+        let mut next_cursor = None;
+        let mut observed_extra = false;
+        let mut scanned = 0usize;
+        while let Some(row) = rows.next().await.map_err(db_err)? {
+            scanned += 1;
+            let encoded: String = row.get(0).map_err(db_err)?;
+            let node_id: String = row.get(1).map_err(db_err)?;
+            let node_epoch: String = row.get(2).map_err(db_err)?;
+            let claim_epoch: i64 = row.get(3).map_err(db_err)?;
+            let has_durable: i64 = row.get(4).map_err(db_err)?;
+            if out.len() == limit {
+                observed_extra = true;
+                break;
+            }
+            next_cursor = Some(encoded.clone());
+            let Some(entity) = decode_entity(&encoded, EntityType::SmSession) else {
+                // Only malformed keys in the canonical namespace may name
+                // matching poison durable rows. Wrong-prefix keys can never
+                // authorize deleting session state.
+                let durable_suffix = encoded
+                    .strip_prefix("sm_session:")
+                    .filter(|_| has_durable == 1)
+                    .map(str::to_string);
+                cleanup.push(OrphanedSmClaimCleanup {
+                    encoded,
+                    owner: NodeIdentity::new(node_id, node_epoch),
+                    claim_epoch: ClaimEpoch(claim_epoch),
+                    durable_stream_id: durable_suffix,
+                    malformed: true,
+                });
+                continue;
+            };
+            if has_durable != 1 {
+                // A committed stale owner cannot still be in the live
+                // claim-before-detach window. Remove only the exact stale
+                // claim; never manufacture a durable session or steal it.
+                cleanup.push(OrphanedSmClaimCleanup {
+                    encoded,
+                    owner: NodeIdentity::new(node_id, node_epoch),
+                    claim_epoch: ClaimEpoch(claim_epoch),
+                    durable_stream_id: None,
+                    malformed: false,
+                });
+                continue;
+            }
+            out.push(OrphanedSmSessionClaim {
+                entity,
+                epoch: ClaimEpoch(claim_epoch),
+                owner: NodeIdentity::new(node_id, node_epoch),
+            });
+        }
+        drop(rows);
+        drop(conn);
+        let mut quarantined = 0usize;
+        for cleanup in cleanup {
+            quarantined += usize::from(self.cleanup_orphaned_sm_claim(cleanup).await?);
+        }
+        Ok(OrphanedSmSessionClaimPage {
+            has_more: observed_extra || out.len() == limit || scanned == scan_limit,
+            candidates: out,
+            next_cursor,
+            quarantined,
+        })
+    }
+
     async fn steal_orphaned_sm_session_claim(
         &self,
         entity: &Entity,
@@ -1854,6 +2136,8 @@ impl NodeLeaseStore for PostgresClaimStore {
             return Ok(Vec::new());
         }
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        // Over-fetch a bounded page so malformed rows can be quarantined
+        // without occupying every user-visible slot in the page.
         let scan_limit = limit.saturating_mul(4);
         let mut rows = conn
             .query(
@@ -1888,7 +2172,12 @@ impl NodeLeaseStore for PostgresClaimStore {
                 malformed.push((encoded, node_id, node_epoch, claim_epoch));
                 continue;
             };
-            if entity.id.parse::<jid::BareJid>().is_err() {
+            // XEP-0045 Business Rules / Addresses requires a non-empty Room
+            // ID (the node portion); a domain-only BareJid is not a room JID.
+            if !matches!(
+                entity.id.parse::<jid::BareJid>(),
+                Ok(room_jid) if room_jid.node().is_some()
+            ) {
                 malformed.push((encoded, node_id, node_epoch, claim_epoch));
                 continue;
             }
@@ -2565,7 +2854,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn release_is_epoch_gated_and_idempotent() {
+    async fn release_is_idempotent_and_exact_release_requires_owner_incarnation_and_epoch() {
         let _guard = clustering_control_plane_table_lock().lock().await;
         let Some(store) = clean_store().await else {
             return;
@@ -2574,12 +2863,31 @@ mod tests {
         let entity = sm_entity("stream-1");
         let epoch0 = store.acquire(&entity, &owner).await.expect("acquire");
 
-        // Releasing under the wrong epoch is a silent no-op — the claim
-        // must survive.
         store
             .release(&entity, &owner, ClaimEpoch(99))
             .await
-            .expect("release under wrong epoch is a no-op");
+            .expect("idempotent stale release");
+        assert_eq!(
+            store
+                .release_exact(&entity, &owner, ClaimEpoch(99))
+                .await
+                .expect("exact stale release"),
+            waddle_xmpp::ownership::ExactReleaseOutcome::NotOwned
+        );
+        assert!(store.fence(&entity, &owner, epoch0).await.expect("fence"));
+
+        let replacement = NodeIdentity::new(owner.node_id.clone(), "replacement-incarnation");
+        assert!(!store
+            .fence(&entity, &replacement, epoch0)
+            .await
+            .expect("replacement fence"));
+        assert_eq!(
+            store
+                .release_exact(&entity, &replacement, epoch0)
+                .await
+                .expect("exact release"),
+            waddle_xmpp::ownership::ExactReleaseOutcome::NotOwned
+        );
         assert!(store.fence(&entity, &owner, epoch0).await.expect("fence"));
 
         store
@@ -2591,11 +2899,10 @@ mod tests {
             .await
             .expect("fence after release"));
 
-        // Releasing again (already gone) is still not an error.
         store
             .release(&entity, &owner, epoch0)
             .await
-            .expect("re-release is a no-op, not an error");
+            .expect("repeat release is idempotent");
     }
 
     #[tokio::test]
@@ -2820,8 +3127,13 @@ mod tests {
         let mut fencing_tx = store.db.begin().await.expect("begin fencing tx");
         let held = fencing_tx
             .query(
-                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND claim_epoch = ? FOR SHARE",
-                crate::db_params![entity_key(&entity), owner.node_id.clone(), epoch0.0],
+                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
+                crate::db_params![
+                    entity_key(&entity),
+                    owner.node_id.clone(),
+                    owner.node_epoch.clone(),
+                    epoch0.0,
+                ],
             )
             .await
             .expect("fencing select")
@@ -3561,6 +3873,235 @@ mod tests {
             .await
             .expect("a heartbeat-fresh stealer can reclaim the orphaned SM session claim");
         assert!(epoch1.0 > epoch0.0);
+    }
+
+    #[tokio::test]
+    async fn room_orphan_scan_and_steal_are_bounded_and_fenced_against_races() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let store = Arc::new(store);
+        let dead_owner = node_identity();
+        seed_node(&store.db, &dead_owner, true).await;
+        let first = room_entity("a-orphan@muc.example.com");
+        let renewed = room_entity("b-renewed@muc.example.com");
+        let concurrent = room_entity("c-concurrent@muc.example.com");
+        let first_epoch = store
+            .acquire(&first, &dead_owner)
+            .await
+            .expect("first claim");
+        let renewed_epoch = store
+            .acquire(&renewed, &dead_owner)
+            .await
+            .expect("renewed claim");
+        let concurrent_epoch = store
+            .acquire(&concurrent, &dead_owner)
+            .await
+            .expect("concurrent claim");
+
+        let bounded = store
+            .list_orphaned_room_actor_claims(2)
+            .await
+            .expect("bounded room scan");
+        assert_eq!(bounded.len(), 2, "the SQL LIMIT must bound each sweep");
+        assert_eq!(bounded[0].entity, first);
+        assert_eq!(bounded[1].entity, renewed);
+
+        let live_stealer = node_identity();
+        store
+            .register(&live_stealer, None)
+            .await
+            .expect("register live stealer");
+        let won = store
+            .steal_orphaned_room_actor_claim(&first, first_epoch, &live_stealer, NODE_LEASE_TTL)
+            .await
+            .expect("fresh sweeper wins");
+        assert!(
+            won > concurrent_epoch,
+            "a room-claim steal must allocate a generation newer than every earlier claim"
+        );
+        let claimed = store
+            .current_claim(&first)
+            .await
+            .expect("read stolen room claim")
+            .expect("stolen room remains claimed");
+        assert_eq!(claimed.owner, live_stealer);
+        assert_eq!(claimed.claim_epoch, won);
+
+        // Candidate discovery was advisory. If the owner renews before the
+        // CAS, the stale snapshot cannot displace it.
+        store
+            .register(&dead_owner, None)
+            .await
+            .expect("owner renews its exact lease identity");
+        assert!(matches!(
+            store
+                .steal_orphaned_room_actor_claim(
+                    &renewed,
+                    renewed_epoch,
+                    &live_stealer,
+                    NODE_LEASE_TTL,
+                )
+                .await,
+            Err(ClaimError::Conflict)
+        ));
+
+        // Make the owner stale again, then race two sweepers against the
+        // same observed epoch. Exactly one can bump it once.
+        backdate_heartbeat(&store.db, &dead_owner).await;
+        assert!(store
+            .expire(&dead_owner, NODE_LEASE_TTL)
+            .await
+            .expect("commit the renewed owner as expired"));
+        let second_stealer = node_identity();
+        store
+            .register(&second_stealer, None)
+            .await
+            .expect("register second stealer");
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+        let task_a = {
+            let store = Arc::clone(&store);
+            let entity = concurrent.clone();
+            let stealer = live_stealer.clone();
+            let barrier = Arc::clone(&barrier);
+            tokio::spawn(async move {
+                barrier.wait().await;
+                store
+                    .steal_orphaned_room_actor_claim(
+                        &entity,
+                        concurrent_epoch,
+                        &stealer,
+                        NODE_LEASE_TTL,
+                    )
+                    .await
+            })
+        };
+        let task_b = {
+            let store = Arc::clone(&store);
+            let entity = concurrent.clone();
+            let stealer = second_stealer.clone();
+            let barrier = Arc::clone(&barrier);
+            tokio::spawn(async move {
+                barrier.wait().await;
+                store
+                    .steal_orphaned_room_actor_claim(
+                        &entity,
+                        concurrent_epoch,
+                        &stealer,
+                        NODE_LEASE_TTL,
+                    )
+                    .await
+            })
+        };
+        let (a, b) = tokio::join!(task_a, task_b);
+        let results = [a.expect("task a"), b.expect("task b")];
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            results
+                .iter()
+                .filter(|result| matches!(result, Err(ClaimError::Conflict)))
+                .count(),
+            1
+        );
+
+        // A heartbeat-stale (but not yet committed-expired) sweeper is
+        // fenced inside the same CAS statement.
+        let stale_sweeper = node_identity();
+        store
+            .register(&stale_sweeper, None)
+            .await
+            .expect("register stale sweeper");
+        backdate_heartbeat(&store.db, &stale_sweeper).await;
+        let another = room_entity("d-stale-sweeper@muc.example.com");
+        let another_epoch = store
+            .acquire(&another, &dead_owner)
+            .await
+            .expect("another orphan");
+        assert!(matches!(
+            store
+                .steal_orphaned_room_actor_claim(
+                    &another,
+                    another_epoch,
+                    &stale_sweeper,
+                    NODE_LEASE_TTL,
+                )
+                .await,
+            Err(ClaimError::Conflict)
+        ));
+    }
+
+    #[tokio::test]
+    async fn orphan_scan_preserves_valid_room_jids_longer_than_128_bytes() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let dead_owner = node_identity();
+        seed_node(&store.db, &dead_owner, true).await;
+        let long_room_jid: jid::BareJid = format!("{}@muc.example.com", "a".repeat(129))
+            .parse()
+            .expect("valid long room JID");
+        let entity = room_entity(long_room_jid.as_str());
+        store
+            .acquire(&entity, &dead_owner)
+            .await
+            .expect("long room claim");
+
+        let candidates = store
+            .list_orphaned_room_actor_claims(1)
+            .await
+            .expect("orphan scan");
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].entity, entity);
+        assert!(
+            store
+                .current_claim(&entity)
+                .await
+                .expect("claim lookup")
+                .is_some(),
+            "a valid long room claim must be returned for adoption, not quarantined"
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_room_claims_are_quarantined_without_starving_valid_page() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let dead_owner = node_identity();
+        seed_node(&store.db, &dead_owner, true).await;
+        let mut malformed = Vec::new();
+        for index in 0..65 {
+            let entity = Entity::new(EntityType::RoomActor, format!("000-invalid-{index:02}"));
+            store
+                .acquire(&entity, &dead_owner)
+                .await
+                .expect("malformed claim");
+            malformed.push(entity);
+        }
+        let valid = room_entity("zzz-valid@muc.example.com");
+        store
+            .acquire(&valid, &dead_owner)
+            .await
+            .expect("valid claim");
+
+        let candidates = store
+            .list_orphaned_room_actor_claims(64)
+            .await
+            .expect("bounded scan");
+        assert!(candidates.iter().any(|candidate| candidate.entity == valid));
+        for entity in [
+            malformed.first().expect("first"),
+            malformed.last().expect("last"),
+        ] {
+            assert!(store
+                .current_claim(entity)
+                .await
+                .expect("claim lookup")
+                .is_none());
+        }
     }
 
     // --- ADR-0017 Phase 3 Slice 10: current_generation (Q5's mechanism) --
@@ -4450,6 +4991,363 @@ mod tests {
             candidates_after.is_empty(),
             "the reclaimed claim (now owned by a fresh, registered node) must no longer \
              be reported as orphaned"
+        );
+    }
+
+    #[tokio::test]
+    async fn orphaned_sm_pages_advance_past_sixty_four_and_quarantine_malformed_rows() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let stale_owner = node_identity();
+        seed_node(&store.db, &stale_owner, true).await;
+        for index in 0..70 {
+            let entity = sm_entity(&format!("paged-{index:03}"));
+            seed_sm_session_row(&store.db, &entity.id).await;
+            store
+                .acquire(&entity, &stale_owner)
+                .await
+                .expect("acquire paged claim");
+        }
+
+        let first = store
+            .list_orphaned_sm_session_claims_page(None, 64)
+            .await
+            .expect("first page");
+        assert_eq!(first.candidates.len(), 64);
+        assert!(first.has_more);
+        let second = store
+            .list_orphaned_sm_session_claims_page(first.next_cursor, 64)
+            .await
+            .expect("second page");
+        assert_eq!(
+            second.candidates.len(),
+            6,
+            "cursor must expose rows beyond the first 64"
+        );
+
+        // An over-limit typed entity can exist only through direct database
+        // corruption. It still satisfies the durable-row join, so the scan
+        // must exact-owner/epoch quarantine it instead of re-WARN forever.
+        let malformed_id = "z".repeat(waddle_xmpp::ownership::ENTITY_ID_MAX_LEN + 1);
+        seed_sm_session_row(&store.db, &malformed_id).await;
+        let encoded = format!("{}:{malformed_id}", EntityType::SmSession.as_db_str());
+        let conn = store.db.guard().await.expect("guard");
+        conn.execute(
+            r#"INSERT INTO clustering_claims
+               (entity, entity_type, node_id, node_epoch, claim_epoch)
+               VALUES (?, ?, ?, ?, 0)"#,
+            crate::db_params![
+                encoded.clone(),
+                EntityType::SmSession.as_db_str().to_string(),
+                stale_owner.node_id.clone(),
+                stale_owner.node_epoch.clone(),
+            ],
+        )
+        .await
+        .expect("seed malformed claim");
+        drop(conn);
+        let malformed_page = store
+            .list_orphaned_sm_session_claims_page(Some("sm_session:paged-999".to_string()), 64)
+            .await
+            .expect("malformed page");
+        assert_eq!(malformed_page.quarantined, 1);
+        let conn = store.db.guard().await.expect("guard");
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM clustering_claims WHERE entity = ?",
+                crate::db_params![encoded],
+            )
+            .await
+            .expect("count quarantined row");
+        let count: i64 = rows
+            .next()
+            .await
+            .expect("row")
+            .expect("row")
+            .get(0)
+            .expect("count");
+        assert_eq!(count, 0);
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM sm_sessions WHERE stream_id = ?",
+                crate::db_params![malformed_id],
+            )
+            .await
+            .expect("count quarantined durable row");
+        let durable_count: i64 = rows
+            .next()
+            .await
+            .expect("row")
+            .expect("row")
+            .get(0)
+            .expect("count");
+        assert_eq!(durable_count, 0);
+    }
+
+    #[tokio::test]
+    async fn orphaned_sm_page_classifies_claim_only_and_wrong_prefix_rows_safely() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let stale_owner = node_identity();
+        seed_node(&store.db, &stale_owner, true).await;
+
+        let claim_only = sm_entity("claim-only-cleanup");
+        store
+            .acquire(&claim_only, &stale_owner)
+            .await
+            .expect("seed valid claim without durable state");
+        let wrong_prefix = "wrong-prefix:must-not-touch-durable";
+        let conn = store.db.guard().await.expect("guard");
+        conn.execute(
+            r#"INSERT INTO clustering_claims
+               (entity, entity_type, node_id, node_epoch, claim_epoch)
+               VALUES (?, ?, ?, ?, 0)"#,
+            crate::db_params![
+                wrong_prefix,
+                EntityType::SmSession.as_db_str().to_string(),
+                stale_owner.node_id.clone(),
+                stale_owner.node_epoch.clone(),
+            ],
+        )
+        .await
+        .expect("seed wrong-prefix claim");
+        drop(conn);
+        // A similarly named durable row proves wrong-prefix cleanup cannot
+        // derive a suffix and delete persistence state.
+        seed_sm_session_row(&store.db, "must-not-touch-durable").await;
+
+        let page = store
+            .list_orphaned_sm_session_claims_page(None, 64)
+            .await
+            .expect("classify stale rows");
+        assert!(page.candidates.is_empty());
+        assert_eq!(page.quarantined, 1, "only the malformed key is quarantine");
+
+        let conn = store.db.guard().await.expect("guard");
+        for encoded in [claim_only.to_string(), wrong_prefix.to_string()] {
+            let mut rows = conn
+                .query(
+                    "SELECT COUNT(*) FROM clustering_claims WHERE entity = ?",
+                    crate::db_params![encoded],
+                )
+                .await
+                .expect("count claim");
+            let count: i64 = rows
+                .next()
+                .await
+                .expect("row")
+                .expect("row")
+                .get(0)
+                .expect("count");
+            assert_eq!(count, 0);
+        }
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM sm_sessions WHERE stream_id = ?",
+                crate::db_params!["must-not-touch-durable"],
+            )
+            .await
+            .expect("count protected durable row");
+        let durable_count: i64 = rows
+            .next()
+            .await
+            .expect("row")
+            .expect("row")
+            .get(0)
+            .expect("count");
+        assert_eq!(durable_count, 1);
+    }
+
+    #[tokio::test]
+    async fn claim_only_cleanup_rechecks_durable_absence_after_scan_classification() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let stale_owner = node_identity();
+        seed_node(&store.db, &stale_owner, true).await;
+        let entity = sm_entity("claim-only-raced-by-detach");
+        let claim_epoch = store
+            .acquire(&entity, &stale_owner)
+            .await
+            .expect("seed stale claim without durable state");
+
+        // This cleanup value is the exact classification the unlocked page
+        // scan produced while no sm_sessions row existed. A paused owner can
+        // finish its already-fenced detach before cleanup locks the claim.
+        let cleanup = OrphanedSmClaimCleanup {
+            encoded: entity_key(&entity),
+            owner: stale_owner.clone(),
+            claim_epoch,
+            durable_stream_id: None,
+            malformed: false,
+        };
+        seed_sm_session_row(&store.db, &entity.id).await;
+
+        assert!(!store
+            .cleanup_orphaned_sm_claim(cleanup)
+            .await
+            .expect("cleanup transaction"));
+        let snapshot = store
+            .current_claim(&entity)
+            .await
+            .expect("read claim after cleanup");
+        assert_eq!(
+            snapshot.as_ref().map(|claim| (&claim.owner, claim.claim_epoch)),
+            Some((&stale_owner, claim_epoch)),
+            "a durable row appearing after scan classification must retain its exact claim for a later steal"
+        );
+        let conn = store.db.guard().await.expect("guard");
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM sm_sessions WHERE stream_id = ?",
+                crate::db_params![entity.id],
+            )
+            .await
+            .expect("count durable row");
+        let durable_count: i64 = rows
+            .next()
+            .await
+            .expect("row")
+            .expect("row")
+            .get(0)
+            .expect("count");
+        assert_eq!(durable_count, 1);
+    }
+
+    #[tokio::test]
+    async fn claim_only_cleanup_observes_detach_committed_while_waiting_for_claim_lock() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let store = Arc::new(store);
+        let stale_owner = node_identity();
+        seed_node(&store.db, &stale_owner, true).await;
+        let entity = sm_entity("claim-only-in-flight-detach");
+        let claim_epoch = store
+            .acquire(&entity, &stale_owner)
+            .await
+            .expect("seed stale claim without durable state");
+
+        // Model a real fenced detach: hold FOR SHARE on the exact claim and
+        // stage the durable row without committing it yet.
+        let mut writer = store.db.begin().await.expect("begin detach writer");
+        let mut fenced = writer
+            .query(
+                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
+                crate::db_params![
+                    entity_key(&entity),
+                    stale_owner.node_id.clone(),
+                    stale_owner.node_epoch.clone(),
+                    claim_epoch.0,
+                ],
+            )
+            .await
+            .expect("lock exact claim for detach");
+        assert!(fenced.next().await.expect("read fence").is_some());
+        drop(fenced);
+        writer
+            .execute(
+                r#"
+                INSERT INTO sm_sessions (
+                    stream_id, user_id, full_jid, inbound_count, outbound_count,
+                    last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms,
+                    carbons_enabled, roster_interested, blocklist_interested,
+                    presence_available, presence_priority
+                ) VALUES (?, ?, ?, 0, 0, 0, NULL, 0, 60000, 0, 0, 0, 0, 0)
+                "#,
+                crate::db_params![
+                    entity.id.clone(),
+                    "alice".to_string(),
+                    "alice@example.com/web".to_string(),
+                ],
+            )
+            .await
+            .expect("stage durable detach row");
+
+        let cleanup = OrphanedSmClaimCleanup {
+            encoded: entity_key(&entity),
+            owner: stale_owner.clone(),
+            claim_epoch,
+            durable_stream_id: None,
+            malformed: false,
+        };
+        let cleanup_store = Arc::clone(&store);
+        let cleanup_task =
+            tokio::spawn(async move { cleanup_store.cleanup_orphaned_sm_claim(cleanup).await });
+
+        // Do not release the writer until Postgres confirms the cleanup's
+        // exact FOR UPDATE statement is waiting on that writer's share lock.
+        let monitor = store.db.guard().await.expect("monitor guard");
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let mut rows = monitor
+                    .query(
+                        r#"
+                        SELECT COUNT(*) FROM pg_stat_activity
+                        WHERE pid <> pg_backend_pid()
+                          AND query LIKE '%orphan_sm_cleanup_exact_lock%'
+                          AND wait_event_type = 'Lock'
+                        "#,
+                        (),
+                    )
+                    .await
+                    .expect("inspect blocked cleanup");
+                let blocked = rows
+                    .next()
+                    .await
+                    .expect("read blocked cleanup count")
+                    .expect("blocked cleanup count row")
+                    .get::<i64>(0)
+                    .expect("blocked cleanup count");
+                if blocked > 0 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cleanup reached exact claim lock");
+        drop(monitor);
+
+        writer.commit().await.expect("commit durable detach");
+        cleanup_task
+            .await
+            .expect("cleanup task joined")
+            .expect("cleanup transaction");
+
+        let snapshot = store
+            .current_claim(&entity)
+            .await
+            .expect("read claim after cleanup");
+        assert_eq!(
+            snapshot
+                .as_ref()
+                .map(|claim| (&claim.owner, claim.claim_epoch)),
+            Some((&stale_owner, claim_epoch)),
+            "cleanup must preserve the exact claim once the blocked detach commits durable state"
+        );
+        let conn = store.db.guard().await.expect("guard");
+        let mut rows = conn
+            .query(
+                "SELECT COUNT(*) FROM sm_sessions WHERE stream_id = ?",
+                crate::db_params![entity.id],
+            )
+            .await
+            .expect("count durable row");
+        assert_eq!(
+            rows.next()
+                .await
+                .expect("row")
+                .expect("row")
+                .get::<i64>(0)
+                .expect("count"),
+            1
         );
     }
 }

--- a/server/crates/waddle-server/src/clustering/claims.rs
+++ b/server/crates/waddle-server/src/clustering/claims.rs
@@ -1100,6 +1100,55 @@ impl ClaimStore for PostgresClaimStore {
         }
     }
 
+    async fn current_claim_after_pending_writes(
+        &self,
+        entity: &Entity,
+    ) -> Result<Option<waddle_xmpp::ownership::ClaimSnapshot>, ClaimError> {
+        // Terminal orphan recovery can arrive here after its caller dropped
+        // a steal future. Locking the claim row makes this SELECT wait behind
+        // that detached UPDATE, so the returned version is post-commit (or
+        // post-rollback) rather than the unlocked pre-CAS snapshot. A stale
+        // room steal only updates an existing row, so the absent-row gap does
+        // not need predicate/range locking.
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let mut rows = conn
+            .query(
+                r#"
+                /* terminal_claim_reconciliation_lock */
+                SELECT
+                    c.node_id,
+                    c.node_epoch,
+                    c.claim_epoch,
+                    EXISTS (
+                        SELECT 1 FROM clustering_nodes n
+                        WHERE n.node_id = c.node_id
+                          AND NOT n.expired
+                          AND n.node_epoch = c.node_epoch
+                    ) AS owner_lease_fresh
+                FROM clustering_claims c
+                WHERE c.entity = ?
+                FOR UPDATE
+                "#,
+                crate::db_params![entity_key(entity)],
+            )
+            .await
+            .map_err(db_err)?;
+        match rows.next().await.map_err(db_err)? {
+            Some(row) => {
+                let node_id: String = row.get(0).map_err(db_err)?;
+                let node_epoch: String = row.get(1).map_err(db_err)?;
+                let claim_epoch: i64 = row.get(2).map_err(db_err)?;
+                let owner_lease_fresh: bool = row.get(3).map_err(db_err)?;
+                Ok(Some(waddle_xmpp::ownership::ClaimSnapshot {
+                    owner: NodeIdentity::new(node_id, node_epoch),
+                    claim_epoch: ClaimEpoch(claim_epoch),
+                    owner_lease_fresh,
+                }))
+            }
+            None => Ok(None),
+        }
+    }
+
     async fn fence(
         &self,
         entity: &Entity,
@@ -4109,6 +4158,100 @@ mod tests {
 
     fn room_entity(id: &str) -> Entity {
         Entity::new(EntityType::RoomActor, id.to_string())
+    }
+
+    #[tokio::test]
+    async fn terminal_claim_lookup_waits_for_an_in_flight_steal_update() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let previous_owner = node_identity();
+        let new_owner = node_identity();
+        seed_node(&store.db, &previous_owner, true).await;
+        seed_node(&store.db, &new_owner, false).await;
+        let entity = room_entity("terminal-barrier@muc.example.com");
+        store
+            .acquire(&entity, &previous_owner)
+            .await
+            .expect("seed previous claim");
+
+        let mut steal = store.db.begin().await.expect("begin detached steal");
+        let mut rows = steal
+            .query(
+                r#"
+                UPDATE clustering_claims
+                SET node_id = ?, node_epoch = ?,
+                    claim_epoch = nextval('clustering_claim_epoch_seq'::regclass)
+                WHERE entity = ?
+                RETURNING claim_epoch
+                "#,
+                crate::db_params![
+                    new_owner.node_id.clone(),
+                    new_owner.node_epoch.clone(),
+                    entity_key(&entity),
+                ],
+            )
+            .await
+            .expect("stage steal update");
+        let committed_epoch = ClaimEpoch(
+            rows.next()
+                .await
+                .expect("read staged update")
+                .expect("updated claim")
+                .get::<i64>(0)
+                .expect("claim epoch"),
+        );
+        drop(rows);
+
+        let barrier_store = PostgresClaimStore::new(store.db.clone());
+        let barrier_entity = entity.clone();
+        let barrier = tokio::spawn(async move {
+            barrier_store
+                .current_claim_after_pending_writes(&barrier_entity)
+                .await
+        });
+
+        let monitor = store.db.guard().await.expect("monitor guard");
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let mut rows = monitor
+                    .query(
+                        r#"
+                        SELECT COUNT(*) FROM pg_stat_activity
+                        WHERE pid <> pg_backend_pid()
+                          AND query LIKE '%terminal_claim_reconciliation_lock%'
+                          AND wait_event_type = 'Lock'
+                        "#,
+                        (),
+                    )
+                    .await
+                    .expect("inspect blocked terminal lookup");
+                let blocked = rows
+                    .next()
+                    .await
+                    .expect("read blocked lookup count")
+                    .expect("blocked lookup count row")
+                    .get::<i64>(0)
+                    .expect("blocked lookup count");
+                if blocked > 0 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("terminal lookup reached the claim-row barrier");
+        drop(monitor);
+
+        steal.commit().await.expect("commit detached steal");
+        let snapshot = barrier
+            .await
+            .expect("terminal lookup joined")
+            .expect("terminal lookup")
+            .expect("claim remains present");
+        assert_eq!(snapshot.owner, new_owner);
+        assert_eq!(snapshot.claim_epoch, committed_epoch);
     }
 
     // --- ADR-0017 Phase 3 Slice 10: the acquire-side draining gate -------

--- a/server/crates/waddle-server/src/clustering/claims.rs
+++ b/server/crates/waddle-server/src/clustering/claims.rs
@@ -65,6 +65,7 @@ use waddle_xmpp::ownership::{
     ClaimEpoch, ClaimError, ClaimStore, Entity, EntityType, NodeIdentity, ResumeIdentityProof,
     StalePredicate,
 };
+use waddle_xmpp::pending_delivery::SmSessionId;
 
 use crate::db::{Database, DatabaseError};
 
@@ -160,9 +161,19 @@ fn decode_entity(encoded: &str, entity_type: EntityType) -> Option<Entity> {
     Some(Entity::new(entity_type, id))
 }
 
+/// Decode a persisted SM claim and enforce the SM protocol boundary's
+/// narrower wire limit. [`Entity`] deliberately permits longer ids for room
+/// JIDs and other entity kinds, so `decode_entity` alone cannot establish
+/// that a database value is a valid [`SmSessionId`].
+fn decode_sm_session_entity(encoded: &str) -> Option<Entity> {
+    let entity = decode_entity(encoded, EntityType::SmSession)?;
+    SmSessionId::try_from_wire(entity.id.clone()).ok()?;
+    Some(entity)
+}
+
 #[cfg(test)]
 mod entity_key_tests {
-    use super::entity_key;
+    use super::{decode_sm_session_entity, entity_key};
     use waddle_xmpp::ownership::{Entity, EntityType};
 
     /// Pure unit test (no Postgres required): `entity_key` must be
@@ -231,6 +242,21 @@ mod entity_key_tests {
             super::decode_entity("not-even-tagged", EntityType::UserActor),
             None
         );
+    }
+
+    #[test]
+    fn sm_session_decode_enforces_the_sm_specific_wire_bound() {
+        let valid = Entity::new(
+            EntityType::SmSession,
+            "s".repeat(waddle_xmpp::pending_delivery::SM_SESSION_ID_MAX_LEN),
+        );
+        assert_eq!(decode_sm_session_entity(&entity_key(&valid)), Some(valid));
+
+        let overlong = Entity::new(
+            EntityType::SmSession,
+            "s".repeat(waddle_xmpp::pending_delivery::SM_SESSION_ID_MAX_LEN + 1),
+        );
+        assert_eq!(decode_sm_session_entity(&entity_key(&overlong)), None);
     }
 }
 
@@ -487,6 +513,15 @@ impl ClaimStore for PostgresClaimStore {
         )
         .await
         .map_err(db_err)?;
+        conn.execute(
+            r#"
+            CREATE INDEX IF NOT EXISTS clustering_claims_owner_type_entity
+                ON clustering_claims (node_id, node_epoch, entity_type, entity)
+            "#,
+            (),
+        )
+        .await
+        .map_err(db_err)?;
         // Supports bounded per-entity-type orphan scans without walking the
         // much larger mixed claim table (SM sessions dominate in modeled
         // deployments). `entity` also satisfies the room scan's stable
@@ -500,6 +535,26 @@ impl ClaimStore for PostgresClaimStore {
         )
         .await
         .map_err(db_err)?;
+        conn.execute(
+            r#"
+            CREATE TABLE IF NOT EXISTS clustering_orphan_reaper_cursors (
+                lane          TEXT PRIMARY KEY,
+                cursor_entity TEXT
+            )
+            "#,
+            (),
+        )
+        .await
+        .map_err(db_err)?;
+        for lane in [EntityType::SmSession, EntityType::RoomActor] {
+            conn.execute(
+                "INSERT INTO clustering_orphan_reaper_cursors (lane) VALUES (?) \
+                 ON CONFLICT (lane) DO NOTHING",
+                crate::db_params![lane.as_db_str().to_string()],
+            )
+            .await
+            .map_err(db_err)?;
+        }
         // ADR-0017 Phase 3 Slice 3: steal-intents unwedge/owner-veto path
         // (element 4's "Unwedge" text, quoted verbatim in the phase plan).
         // `UNIQUE (entity, reporter_node)` + the upsert in
@@ -538,6 +593,9 @@ impl ClaimStore for PostgresClaimStore {
     }
 
     async fn acquire(&self, entity: &Entity, me: &NodeIdentity) -> Result<ClaimEpoch, ClaimError> {
+        if !me.is_active() {
+            return Err(ClaimError::AuthorityDisabled);
+        }
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
         // Acquire CAS (element 4): a fresh claim only inserts; a
         // still-live claim on the same entity leaves the row untouched and
@@ -624,6 +682,9 @@ impl ClaimStore for PostgresClaimStore {
         entity: &Entity,
         me: &NodeIdentity,
     ) -> Result<ClaimEpoch, ClaimError> {
+        if !me.is_active() {
+            return Err(ClaimError::AuthorityDisabled);
+        }
         // FIX 1: try the real CAS first — the common, uncontended case (a
         // brand-new entity, or a genuine conflict with another node) needs
         // nothing beyond `acquire` itself.
@@ -693,6 +754,9 @@ impl ClaimStore for PostgresClaimStore {
         staleness: StalePredicate,
         me: &NodeIdentity,
     ) -> Result<ClaimEpoch, ClaimError> {
+        if !me.is_active() {
+            return Err(ClaimError::AuthorityDisabled);
+        }
         // FIX 5: an exhaustive `match`, not an `if let ... else` fallthrough
         // — so the compiler forces this function to be revisited the
         // moment a third `StalePredicate` variant is added, rather than
@@ -914,6 +978,9 @@ impl ClaimStore for PostgresClaimStore {
         _witness: ResumeIdentityProof,
         me: &NodeIdentity,
     ) -> Result<ClaimEpoch, ClaimError> {
+        if !me.is_active() {
+            return Err(ClaimError::AuthorityDisabled);
+        }
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
         // Consent/epoch-only steal CAS (element 4's third variant): no
         // staleness predicate at all — authorized exclusively by the
@@ -1399,6 +1466,35 @@ pub trait NodeLeaseStore: Send + Sync {
         })
     }
 
+    /// Durable advisory cursor for raw orphan-integrity scans. Defaults are
+    /// process-local/no-op for fakes; production persists one cursor per
+    /// entity lane so restarts cannot starve high-key claims indefinitely.
+    async fn orphan_reaper_cursor(&self, _lane: EntityType) -> Result<Option<String>, ClaimError> {
+        Ok(None)
+    }
+
+    async fn persist_orphan_reaper_cursor(
+        &self,
+        _lane: EntityType,
+        _cursor: Option<String>,
+    ) -> Result<(), ClaimError> {
+        Ok(())
+    }
+
+    /// Bounded inline-recovery scan for one identity this process has just
+    /// superseded. Production stores override with an owner-indexed query;
+    /// the default keeps fakes source-compatible.
+    async fn list_orphaned_sm_session_claims_for_owner(
+        &self,
+        owner: &NodeIdentity,
+        limit: usize,
+    ) -> Result<Vec<OrphanedSmSessionClaim>, ClaimError> {
+        let mut candidates = self.list_orphaned_sm_session_claims().await?;
+        candidates.retain(|candidate| candidate.owner == *owner);
+        candidates.truncate(limit);
+        Ok(candidates)
+    }
+
     /// Reaper-only stale-owner steal for detached SM-session claims. Unlike
     /// [`ClaimStore::steal_stale`]'s generic owner-stale CAS, this binds the
     /// stealer's own heartbeat freshness into the same SQL statement because
@@ -1414,6 +1510,22 @@ pub trait NodeLeaseStore: Send + Sync {
         Err(ClaimError::Conflict)
     }
 
+    /// Inline counterpart used immediately after re-registration. Durable
+    /// Postgres stores override this to bind the fresh stealer's heartbeat
+    /// into the CAS; fakes delegate to their supplied claim store.
+    async fn steal_own_expired_sm_session_claim(
+        &self,
+        claim_store: &dyn ClaimStore,
+        entity: &Entity,
+        observed: ClaimEpoch,
+        me: &NodeIdentity,
+        _lease_ttl: Duration,
+    ) -> Result<ClaimEpoch, ClaimError> {
+        claim_store
+            .steal_stale(entity, observed, StalePredicate::OwnerStale, me)
+            .await
+    }
+
     /// Bounded advisory scan for `RoomActor` claims whose recorded owner
     /// lease is committed-stale. The returned snapshot never authorizes a
     /// takeover: callers must still expire the owner and win
@@ -1423,6 +1535,34 @@ pub trait NodeLeaseStore: Send + Sync {
         _limit: usize,
     ) -> Result<Vec<OrphanedRoomActorClaim>, ClaimError> {
         Ok(Vec::new())
+    }
+
+    /// Raw-key cursor page for RoomActor recovery. Durable stores override
+    /// this so live-owner and malformed rows still consume the fixed scan
+    /// budget instead of forcing an unbounded predicate scan before LIMIT.
+    async fn list_orphaned_room_actor_claims_page(
+        &self,
+        after: Option<String>,
+        limit: usize,
+    ) -> Result<OrphanedRoomActorClaimPage, ClaimError> {
+        let mut candidates = self
+            .list_orphaned_room_actor_claims(limit.saturating_add(1))
+            .await?;
+        candidates.sort_by(|left, right| left.entity.id.cmp(&right.entity.id));
+        if let Some(after) = after.as_deref() {
+            candidates.retain(|candidate| candidate.entity.id.as_str() > after);
+        }
+        let has_more = candidates.len() > limit;
+        candidates.truncate(limit);
+        let next_cursor = candidates
+            .last()
+            .map(|candidate| candidate.entity.id.clone());
+        Ok(OrphanedRoomActorClaimPage {
+            candidates,
+            next_cursor,
+            has_more,
+            quarantined: 0,
+        })
     }
 
     /// Reaper-only stale-owner steal for a `RoomActor`. The production
@@ -1479,6 +1619,14 @@ pub struct OrphanedRoomActorClaim {
     pub entity: Entity,
     pub epoch: ClaimEpoch,
     pub owner: NodeIdentity,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrphanedRoomActorClaimPage {
+    pub candidates: Vec<OrphanedRoomActorClaim>,
+    pub next_cursor: Option<String>,
+    pub has_more: bool,
+    pub quarantined: usize,
 }
 
 async fn register_node(
@@ -1940,11 +2088,11 @@ impl NodeLeaseStore for PostgresClaimStore {
             let node_id: String = row.get(1).map_err(db_err)?;
             let node_epoch: String = row.get(2).map_err(db_err)?;
             let claim_epoch: i64 = row.get(3).map_err(db_err)?;
-            let Some(entity) = decode_entity(&encoded, EntityType::SmSession) else {
+            let Some(entity) = decode_sm_session_entity(&encoded) else {
                 tracing::warn!(
                     encoded_entity = %encoded,
-                    "list_orphaned_sm_session_claims: row's entity key does not decode \
-                     against the sm_session tag; skipping (data-integrity anomaly)"
+                    "list_orphaned_sm_session_claims: row's entity key is not a valid \
+                     bounded SM-session id; skipping (data-integrity anomaly)"
                 );
                 continue;
             };
@@ -1970,28 +2118,38 @@ impl NodeLeaseStore for PostgresClaimStore {
                 quarantined: 0,
             });
         }
+        let scan_limit = limit.saturating_add(1);
+        let cursor = match after {
+            Some(cursor) => cursor,
+            None => self
+                .orphan_reaper_cursor(EntityType::SmSession)
+                .await?
+                .unwrap_or_default(),
+        };
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        let scan_limit = limit.saturating_mul(4).saturating_add(1);
-        let cursor = after.unwrap_or_default();
         let mut rows = conn
             .query(
                 r#"
+                WITH raw_claims AS (
+                    SELECT entity, node_id, node_epoch, claim_epoch
+                    FROM clustering_claims
+                    WHERE entity_type = ? AND entity > ?
+                    ORDER BY entity
+                    LIMIT ?
+                )
                 SELECT entity, node_id, node_epoch, claim_epoch,
+                       CASE WHEN NOT EXISTS (
+                         SELECT 1 FROM clustering_nodes n
+                         WHERE n.node_id = raw_claims.node_id
+                           AND NOT n.expired
+                           AND n.node_epoch = raw_claims.node_epoch
+                       ) THEN 1 ELSE 0 END AS owner_stale,
                        CASE WHEN EXISTS (
                          SELECT 1 FROM sm_sessions s
-                         WHERE clustering_claims.entity = ('sm_session:' || s.stream_id)
+                         WHERE raw_claims.entity = ('sm_session:' || s.stream_id)
                        ) THEN 1 ELSE 0 END AS has_durable
-                FROM clustering_claims
-                WHERE entity_type = ?
-                  AND entity > ?
-                  AND NOT EXISTS (
-                    SELECT 1 FROM clustering_nodes n
-                    WHERE n.node_id = clustering_claims.node_id
-                      AND NOT n.expired
-                      AND n.node_epoch = clustering_claims.node_epoch
-                  )
+                FROM raw_claims
                 ORDER BY entity
-                LIMIT ?
                 "#,
                 crate::db_params![
                     EntityType::SmSession.as_db_str().to_string(),
@@ -2010,18 +2168,22 @@ impl NodeLeaseStore for PostgresClaimStore {
         let mut observed_extra = false;
         let mut scanned = 0usize;
         while let Some(row) = rows.next().await.map_err(db_err)? {
+            if scanned == limit {
+                observed_extra = true;
+                break;
+            }
             scanned += 1;
             let encoded: String = row.get(0).map_err(db_err)?;
             let node_id: String = row.get(1).map_err(db_err)?;
             let node_epoch: String = row.get(2).map_err(db_err)?;
             let claim_epoch: i64 = row.get(3).map_err(db_err)?;
-            let has_durable: i64 = row.get(4).map_err(db_err)?;
-            if out.len() == limit {
-                observed_extra = true;
-                break;
-            }
+            let owner_stale: i64 = row.get(4).map_err(db_err)?;
+            let has_durable: i64 = row.get(5).map_err(db_err)?;
             next_cursor = Some(encoded.clone());
-            let Some(entity) = decode_entity(&encoded, EntityType::SmSession) else {
+            if owner_stale != 1 {
+                continue;
+            }
+            let Some(entity) = decode_sm_session_entity(&encoded) else {
                 // Only malformed keys in the canonical namespace may name
                 // matching poison durable rows. Wrong-prefix keys can never
                 // authorize deleting session state.
@@ -2064,11 +2226,98 @@ impl NodeLeaseStore for PostgresClaimStore {
             quarantined += usize::from(self.cleanup_orphaned_sm_claim(cleanup).await?);
         }
         Ok(OrphanedSmSessionClaimPage {
-            has_more: observed_extra || out.len() == limit || scanned == scan_limit,
+            has_more: observed_extra,
             candidates: out,
             next_cursor,
             quarantined,
         })
+    }
+
+    async fn orphan_reaper_cursor(&self, lane: EntityType) -> Result<Option<String>, ClaimError> {
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let mut rows = conn
+            .query(
+                "SELECT cursor_entity FROM clustering_orphan_reaper_cursors WHERE lane = ?",
+                crate::db_params![lane.as_db_str().to_string()],
+            )
+            .await
+            .map_err(db_err)?;
+        match rows.next().await.map_err(db_err)? {
+            Some(row) => row.get::<Option<String>>(0).map_err(db_err),
+            None => Ok(None),
+        }
+    }
+
+    async fn persist_orphan_reaper_cursor(
+        &self,
+        lane: EntityType,
+        cursor: Option<String>,
+    ) -> Result<(), ClaimError> {
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        conn.execute(
+            "INSERT INTO clustering_orphan_reaper_cursors (lane, cursor_entity) VALUES (?, ?) \
+             ON CONFLICT (lane) DO UPDATE SET cursor_entity = EXCLUDED.cursor_entity",
+            crate::db_params![lane.as_db_str().to_string(), cursor],
+        )
+        .await
+        .map_err(db_err)?;
+        Ok(())
+    }
+
+    async fn list_orphaned_sm_session_claims_for_owner(
+        &self,
+        owner: &NodeIdentity,
+        limit: usize,
+    ) -> Result<Vec<OrphanedSmSessionClaim>, ClaimError> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let conn = self.db.control_plane_guard().await.map_err(db_err)?;
+        let mut rows = conn
+            .query(
+                r#"
+                WITH raw_claims AS (
+                    SELECT entity, claim_epoch
+                    FROM clustering_claims
+                    WHERE node_id = ? AND node_epoch = ? AND entity_type = ?
+                    ORDER BY entity
+                    LIMIT ?
+                )
+                SELECT entity, claim_epoch,
+                       CASE WHEN EXISTS (
+                         SELECT 1 FROM sm_sessions s
+                         WHERE raw_claims.entity = ('sm_session:' || s.stream_id)
+                       ) THEN 1 ELSE 0 END AS has_durable
+                FROM raw_claims
+                ORDER BY entity
+                "#,
+                crate::db_params![
+                    owner.node_id.clone(),
+                    owner.node_epoch.clone(),
+                    EntityType::SmSession.as_db_str().to_string(),
+                    i64::try_from(limit).unwrap_or(i64::MAX),
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        let mut candidates = Vec::new();
+        while let Some(row) = rows.next().await.map_err(db_err)? {
+            let encoded: String = row.get(0).map_err(db_err)?;
+            let claim_epoch: i64 = row.get(1).map_err(db_err)?;
+            let has_durable: i64 = row.get(2).map_err(db_err)?;
+            if has_durable != 1 {
+                continue;
+            }
+            let Some(entity) = decode_sm_session_entity(&encoded) else {
+                continue;
+            };
+            candidates.push(OrphanedSmSessionClaim {
+                entity,
+                epoch: ClaimEpoch(claim_epoch),
+                owner: owner.clone(),
+            });
+        }
+        Ok(candidates)
     }
 
     async fn steal_orphaned_sm_session_claim(
@@ -2128,34 +2377,73 @@ impl NodeLeaseStore for PostgresClaimStore {
         }
     }
 
+    async fn steal_own_expired_sm_session_claim(
+        &self,
+        _claim_store: &dyn ClaimStore,
+        entity: &Entity,
+        observed: ClaimEpoch,
+        me: &NodeIdentity,
+        lease_ttl: Duration,
+    ) -> Result<ClaimEpoch, ClaimError> {
+        self.steal_orphaned_sm_session_claim(entity, observed, me, lease_ttl)
+            .await
+    }
+
     async fn list_orphaned_room_actor_claims(
         &self,
         limit: usize,
     ) -> Result<Vec<OrphanedRoomActorClaim>, ClaimError> {
+        Ok(self
+            .list_orphaned_room_actor_claims_page(None, limit)
+            .await?
+            .candidates)
+    }
+
+    async fn list_orphaned_room_actor_claims_page(
+        &self,
+        after: Option<String>,
+        limit: usize,
+    ) -> Result<OrphanedRoomActorClaimPage, ClaimError> {
         if limit == 0 {
-            return Ok(Vec::new());
+            return Ok(OrphanedRoomActorClaimPage {
+                candidates: Vec::new(),
+                next_cursor: after,
+                has_more: false,
+                quarantined: 0,
+            });
         }
+        let scan_limit = limit.saturating_add(1);
+        let cursor = match after {
+            Some(cursor) => cursor,
+            None => self
+                .orphan_reaper_cursor(EntityType::RoomActor)
+                .await?
+                .unwrap_or_default(),
+        };
         let conn = self.db.control_plane_guard().await.map_err(db_err)?;
-        // Over-fetch a bounded page so malformed rows can be quarantined
-        // without occupying every user-visible slot in the page.
-        let scan_limit = limit.saturating_mul(4);
         let mut rows = conn
             .query(
                 r#"
-                SELECT entity, node_id, node_epoch, claim_epoch
-                FROM clustering_claims
-                WHERE entity_type = ?
-                  AND NOT EXISTS (
-                    SELECT 1 FROM clustering_nodes n
-                    WHERE n.node_id = clustering_claims.node_id
-                      AND NOT n.expired
-                      AND n.node_epoch = clustering_claims.node_epoch
-                  )
+                WITH raw_claims AS (
+                    SELECT entity, node_id, node_epoch, claim_epoch
+                    FROM clustering_claims
+                    WHERE entity_type = ? AND entity > ?
+                    ORDER BY entity
+                    LIMIT ?
+                )
+                SELECT entity, node_id, node_epoch, claim_epoch,
+                       CASE WHEN NOT EXISTS (
+                         SELECT 1 FROM clustering_nodes n
+                         WHERE n.node_id = raw_claims.node_id
+                           AND NOT n.expired
+                           AND n.node_epoch = raw_claims.node_epoch
+                       ) THEN 1 ELSE 0 END AS owner_stale
+                FROM raw_claims
                 ORDER BY entity
-                LIMIT ?
                 "#,
                 crate::db_params![
                     EntityType::RoomActor.as_db_str().to_string(),
+                    cursor,
                     i64::try_from(scan_limit).unwrap_or(i64::MAX),
                 ],
             )
@@ -2163,11 +2451,24 @@ impl NodeLeaseStore for PostgresClaimStore {
             .map_err(db_err)?;
         let mut out = Vec::new();
         let mut malformed = Vec::new();
+        let mut next_cursor = None;
+        let mut scanned = 0usize;
+        let mut has_more = false;
         while let Some(row) = rows.next().await.map_err(db_err)? {
+            if scanned == limit {
+                has_more = true;
+                break;
+            }
+            scanned += 1;
             let encoded: String = row.get(0).map_err(db_err)?;
             let node_id: String = row.get(1).map_err(db_err)?;
             let node_epoch: String = row.get(2).map_err(db_err)?;
             let claim_epoch: i64 = row.get(3).map_err(db_err)?;
+            let owner_stale: i64 = row.get(4).map_err(db_err)?;
+            next_cursor = Some(encoded.clone());
+            if owner_stale != 1 {
+                continue;
+            }
             let Some(entity) = decode_entity(&encoded, EntityType::RoomActor) else {
                 malformed.push((encoded, node_id, node_epoch, claim_epoch));
                 continue;
@@ -2186,9 +2487,6 @@ impl NodeLeaseStore for PostgresClaimStore {
                 epoch: ClaimEpoch(claim_epoch),
                 owner: NodeIdentity::new(node_id, node_epoch),
             });
-            if out.len() == limit {
-                break;
-            }
         }
         drop(rows);
         let mut quarantined = 0usize;
@@ -2224,7 +2522,12 @@ impl NodeLeaseStore for PostgresClaimStore {
                 "quarantined malformed stale RoomActor claim rows"
             );
         }
-        Ok(out)
+        Ok(OrphanedRoomActorClaimPage {
+            candidates: out,
+            next_cursor,
+            has_more,
+            quarantined,
+        })
     }
 
     async fn steal_orphaned_room_actor_claim(
@@ -4995,6 +5298,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn legacy_orphaned_sm_scan_skips_ids_above_the_sm_wire_limit() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(store) = clean_store().await else {
+            return;
+        };
+        let stale_owner = node_identity();
+        seed_node(&store.db, &stale_owner, true).await;
+        let malformed_id = "z".repeat(waddle_xmpp::pending_delivery::SM_SESSION_ID_MAX_LEN + 1);
+        let malformed = sm_entity(&malformed_id);
+        seed_sm_session_row(&store.db, &malformed_id).await;
+        store
+            .acquire(&malformed, &stale_owner)
+            .await
+            .expect("seed overlong SM claim");
+
+        let candidates = store
+            .list_orphaned_sm_session_claims()
+            .await
+            .expect("legacy orphan scan");
+        assert!(
+            candidates.is_empty(),
+            "the legacy scan must not construct a typed orphan candidate from an overlong SM id"
+        );
+    }
+
+    #[tokio::test]
     async fn orphaned_sm_pages_advance_past_sixty_four_and_quarantine_malformed_rows() {
         let _guard = clustering_control_plane_table_lock().lock().await;
         let Some(store) = clean_store().await else {
@@ -5027,10 +5356,11 @@ mod tests {
             "cursor must expose rows beyond the first 64"
         );
 
-        // An over-limit typed entity can exist only through direct database
-        // corruption. It still satisfies the durable-row join, so the scan
-        // must exact-owner/epoch quarantine it instead of re-WARN forever.
-        let malformed_id = "z".repeat(waddle_xmpp::ownership::ENTITY_ID_MAX_LEN + 1);
+        // An id above the SM wire limit can still fit the deliberately wider
+        // generic Entity bound, but it is not a valid typed SmSessionId. It
+        // satisfies the durable-row join, so the scan must exact-owner/epoch
+        // quarantine it instead of re-WARN forever.
+        let malformed_id = "z".repeat(waddle_xmpp::pending_delivery::SM_SESSION_ID_MAX_LEN + 1);
         seed_sm_session_row(&store.db, &malformed_id).await;
         let encoded = format!("{}:{malformed_id}", EntityType::SmSession.as_db_str());
         let conn = store.db.guard().await.expect("guard");

--- a/server/crates/waddle-server/src/clustering/claims.rs
+++ b/server/crates/waddle-server/src/clustering/claims.rs
@@ -2815,6 +2815,9 @@ mod tests {
         conn.execute("DELETE FROM clustering_claims", ())
             .await
             .expect("clean claims");
+        conn.execute("DELETE FROM clustering_orphan_reaper_cursors", ())
+            .await
+            .expect("clean orphan reaper cursors");
         conn.execute("DELETE FROM clustering_nodes", ())
             .await
             .expect("clean nodes");

--- a/server/crates/waddle-server/src/clustering/drain.rs
+++ b/server/crates/waddle-server/src/clustering/drain.rs
@@ -269,6 +269,19 @@ mod tests {
 
     #[async_trait]
     impl NodeLeaseStore for NoopLease {
+        async fn list_orphaned_room_actor_claims_page(
+            &self,
+            _after: Option<crate::clustering::claims::RoomOrphanScanCursor>,
+            _limit: usize,
+        ) -> Result<crate::clustering::claims::OrphanedRoomActorClaimPage, ClaimError> {
+            Ok(crate::clustering::claims::OrphanedRoomActorClaimPage {
+                candidates: Vec::new(),
+                next_cursor: None,
+                has_more: false,
+                quarantined: 0,
+            })
+        }
+
         async fn register(
             &self,
             _me: &NodeIdentity,

--- a/server/crates/waddle-server/src/clustering/isr.rs
+++ b/server/crates/waddle-server/src/clustering/isr.rs
@@ -82,6 +82,11 @@ use waddle_xmpp::pending_delivery::SmSessionId;
 
 use crate::db::{Database, DatabaseError};
 
+/// Keep each TTL pass short enough that cleanup cannot monopolize the ISR
+/// tables. Repeated janitor ticks make monotonic progress in oldest-first
+/// order.
+const ISR_SWEEP_BATCH_SIZE: i64 = 64;
+
 /// Convert a backend database failure into the upstream
 /// [`IsrTokenStoreError`]. Mirrors [`super::claims::db_err`] one type over
 /// — a human-facing `Display` conversion, not a structured payload (see
@@ -155,6 +160,15 @@ impl IsrTokenStore for PostgresIsrTokenStore {
         .map_err(db_err)?;
         conn.execute(
             r#"
+            CREATE INDEX IF NOT EXISTS clustering_isr_tokens_created_at_sm_id
+                ON clustering_isr_tokens (created_at, sm_id)
+            "#,
+            (),
+        )
+        .await
+        .map_err(db_err)?;
+        conn.execute(
+            r#"
             CREATE TABLE IF NOT EXISTS clustering_isr_revocation_fences (
                 sm_id      TEXT NOT NULL,
                 token      TEXT NOT NULL,
@@ -163,6 +177,34 @@ impl IsrTokenStore for PostgresIsrTokenStore {
                 PRIMARY KEY (sm_id, token, mechanism)
             )
             "#,
+            (),
+        )
+        .await
+        .map_err(db_err)?;
+        conn.execute(
+            r#"
+            CREATE INDEX IF NOT EXISTS clustering_isr_revocation_fences_created_at_identity
+                ON clustering_isr_revocation_fences (created_at, sm_id, token, mechanism)
+            "#,
+            (),
+        )
+        .await
+        .map_err(db_err)?;
+        conn.execute(
+            r#"
+            CREATE TABLE IF NOT EXISTS clustering_isr_sweep_state (
+                singleton         BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton),
+                cursor_created_at TIMESTAMPTZ,
+                cursor_sm_id      TEXT
+            )
+            "#,
+            (),
+        )
+        .await
+        .map_err(db_err)?;
+        conn.execute(
+            "INSERT INTO clustering_isr_sweep_state (singleton) VALUES (TRUE) \
+             ON CONFLICT (singleton) DO NOTHING",
             (),
         )
         .await
@@ -431,31 +473,134 @@ impl IsrTokenStore for PostgresIsrTokenStore {
         // deliberately avoids. Age alone is not terminal authority: an SM
         // stream can remain live for longer than this backstop and its ISR
         // token must remain valid throughout that lifetime. Reap only an old
-        // token whose typed SM-session claim is absent. Mirrors
+        // token whose typed SM-session claim and durable detached-session row
+        // are both absent. A persisted session is still resumable even while
+        // its former node's exact claim is being recovered, so deleting its
+        // ISR credential would turn a recoverable node loss into permanent
+        // resume failure. Mirrors
         // `lease.rs`'s own `(? || ' milliseconds')::interval`
         // TTL-comparison idiom.
-        let conn = self.db.guard().await.map_err(db_err)?;
-        let deleted_tokens = conn
-            .execute(
-                "DELETE FROM clustering_isr_tokens AS token \
-                 WHERE token.created_at < now() - (? || ' milliseconds')::interval \
-                   AND NOT EXISTS ( \
-                     SELECT 1 FROM clustering_claims AS claim \
-                     WHERE claim.entity = (? || ':' || token.sm_id) \
-                       AND claim.entity_type = ? \
-                   )",
+        let mut tx = self.db.begin().await.map_err(db_err)?;
+        let mut cursor_rows = tx
+            .query(
+                "SELECT COALESCE(cursor_created_at::text, '0001-01-01 00:00:00+00'), \
+                        COALESCE(cursor_sm_id, '') \
+                 FROM clustering_isr_sweep_state WHERE singleton = TRUE FOR UPDATE",
+                (),
+            )
+            .await
+            .map_err(db_err)?;
+        let cursor_row =
+            cursor_rows.next().await.map_err(db_err)?.ok_or_else(|| {
+                IsrTokenStoreError::Backend("missing ISR sweep cursor row".into())
+            })?;
+        let raw_after_created_at: String = cursor_row.get(0).map_err(db_err)?;
+        let raw_after_sm_id: String = cursor_row.get(1).map_err(db_err)?;
+        drop(cursor_rows);
+        let raw_limit = ISR_SWEEP_BATCH_SIZE.saturating_add(1);
+        let mut raw_rows = tx
+            .query(
+                r#"
+                SELECT created_at::text, sm_id
+                FROM clustering_isr_tokens
+                WHERE created_at < now() - (? || ' milliseconds')::interval
+                  AND (created_at, sm_id) > (CAST(? AS TIMESTAMPTZ), ?)
+                ORDER BY created_at, sm_id
+                LIMIT ?
+                FOR UPDATE SKIP LOCKED
+                "#,
                 crate::db_params![
                     max_age.as_millis().to_string(),
-                    EntityType::SmSession.as_db_str().to_string(),
-                    EntityType::SmSession.as_db_str().to_string(),
+                    raw_after_created_at,
+                    raw_after_sm_id,
+                    raw_limit,
                 ],
             )
             .await
             .map_err(db_err)?;
+        let mut raw_tokens = Vec::new();
+        while let Some(row) = raw_rows.next().await.map_err(db_err)? {
+            raw_tokens.push((
+                row.get::<String>(0).map_err(db_err)?,
+                row.get::<String>(1).map_err(db_err)?,
+            ));
+        }
+        drop(raw_rows);
+
+        let batch_size = usize::try_from(ISR_SWEEP_BATCH_SIZE).unwrap_or(64);
+        let has_more = raw_tokens.len() > batch_size;
+        raw_tokens.truncate(batch_size);
+        let mut deleted_tokens = 0u64;
+        for (_, sm_id) in &raw_tokens {
+            deleted_tokens = deleted_tokens.saturating_add(
+                tx.execute(
+                    r#"
+                    DELETE FROM clustering_isr_tokens AS token
+                    WHERE token.sm_id = ?
+                      AND token.created_at < now() - (? || ' milliseconds')::interval
+                      AND NOT EXISTS (
+                        SELECT 1 FROM clustering_claims AS claim
+                        WHERE claim.entity = (? || ':' || token.sm_id)
+                          AND claim.entity_type = ?
+                      )
+                      AND NOT EXISTS (
+                        SELECT 1 FROM sm_sessions AS session
+                        WHERE session.stream_id = token.sm_id
+                      )
+                    "#,
+                    crate::db_params![
+                        sm_id.clone(),
+                        max_age.as_millis().to_string(),
+                        EntityType::SmSession.as_db_str().to_string(),
+                        EntityType::SmSession.as_db_str().to_string(),
+                    ],
+                )
+                .await
+                .map_err(db_err)?,
+            );
+        }
+        if has_more {
+            let (created_at, sm_id) = raw_tokens
+                .last()
+                .expect("a page with an extra row has a retained cursor row");
+            tx.execute(
+                "UPDATE clustering_isr_sweep_state \
+                 SET cursor_created_at = CAST(? AS TIMESTAMPTZ), cursor_sm_id = ? \
+                 WHERE singleton = TRUE",
+                crate::db_params![created_at.clone(), sm_id.clone()],
+            )
+            .await
+            .map_err(db_err)?;
+        } else {
+            tx.execute(
+                "UPDATE clustering_isr_sweep_state \
+                 SET cursor_created_at = NULL, cursor_sm_id = NULL \
+                 WHERE singleton = TRUE",
+                (),
+            )
+            .await
+            .map_err(db_err)?;
+        }
+        tx.commit().await.map_err(db_err)?;
+
+        let conn = self.db.guard().await.map_err(db_err)?;
         conn.execute(
-            "DELETE FROM clustering_isr_revocation_fences \
-                 WHERE created_at < now() - (? || ' milliseconds')::interval",
-            crate::db_params![max_age.as_millis().to_string()],
+            r#"
+            WITH expired_fences AS (
+                SELECT fence.sm_id, fence.token, fence.mechanism
+                FROM clustering_isr_revocation_fences AS fence
+                WHERE fence.created_at < now() - (? || ' milliseconds')::interval
+                ORDER BY fence.created_at, fence.sm_id, fence.token, fence.mechanism
+                LIMIT ?
+                FOR UPDATE OF fence SKIP LOCKED
+            )
+            DELETE FROM clustering_isr_revocation_fences AS fence
+            USING expired_fences AS expired
+            WHERE fence.sm_id = expired.sm_id
+              AND fence.token = expired.token
+              AND fence.mechanism = expired.mechanism
+            "#,
+            crate::db_params![max_age.as_millis().to_string(), ISR_SWEEP_BATCH_SIZE],
         )
         .await
         .map_err(db_err)?;
@@ -468,7 +613,10 @@ mod tests {
     use super::*;
     use crate::clustering::claims::{clustering_control_plane_table_lock, PostgresClaimStore};
     use crate::db::{DatabaseConfig, DatabaseDriver};
-    use waddle_xmpp::ownership::{ClaimEpoch, ClaimStore, Entity, NodeIdentity};
+    use std::sync::Arc;
+    use waddle_xmpp::ownership::{
+        ClaimEpoch, ClaimStore, Entity, NodeIdentity, SharedNodeIdentity,
+    };
     use waddle_xmpp::stream_management::persistence::SmClaimFence;
 
     fn node_identity() -> NodeIdentity {
@@ -513,6 +661,72 @@ mod tests {
             .acquire(&entity, me)
             .await
             .expect("acquire sm_session claim")
+    }
+
+    async fn ensure_sm_persistence_schema(db: &Database) {
+        let claim_store = Arc::new(PostgresClaimStore::new(db.clone()));
+        claim_store
+            .ensure_schema()
+            .await
+            .expect("ensure claims schema");
+        crate::sm_persistence_fenced::PostgresFencedSmPersistence::open(
+            db.clone(),
+            claim_store,
+            SharedNodeIdentity::new(node_identity()),
+        )
+        .await
+        .expect("ensure SM persistence schema");
+    }
+
+    async fn clean_sweep_tables(db: &Database) {
+        let conn = db.guard().await.expect("guard");
+        conn.execute("DELETE FROM sm_unacked", ())
+            .await
+            .expect("clean sm_unacked");
+        conn.execute("DELETE FROM sm_sessions", ())
+            .await
+            .expect("clean sm_sessions");
+        conn.execute("DELETE FROM clustering_isr_tokens", ())
+            .await
+            .expect("clean ISR tokens");
+        conn.execute("DELETE FROM clustering_isr_revocation_fences", ())
+            .await
+            .expect("clean ISR revocation fences");
+        conn.execute(
+            "UPDATE clustering_isr_sweep_state \
+             SET cursor_created_at = NULL, cursor_sm_id = NULL \
+             WHERE singleton = TRUE",
+            (),
+        )
+        .await
+        .expect("reset ISR sweep cursor");
+        conn.execute("DELETE FROM clustering_claims", ())
+            .await
+            .expect("clean claims");
+        conn.execute("DELETE FROM clustering_nodes", ())
+            .await
+            .expect("clean nodes");
+    }
+
+    async fn seed_sm_session_row(db: &Database, sm_id: &SmSessionId) {
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            r#"
+            INSERT INTO sm_sessions (
+                stream_id, user_id, full_jid, inbound_count, outbound_count,
+                last_acked, max_resume_secs, detached_at_ms, max_resume_duration_ms,
+                carbons_enabled, roster_interested, blocklist_interested,
+                presence_available, presence_priority
+            ) VALUES (?, ?, ?, 0, 0, 0, NULL, 0, 60000, 0, 0, 0, 0, 0)
+            "#,
+            crate::db_params![
+                sm_id.to_string(),
+                "alice".to_string(),
+                "alice@example.com/web".to_string(),
+            ],
+        )
+        .await
+        .expect("seed durable SM session");
     }
 
     #[tokio::test]
@@ -702,22 +916,25 @@ mod tests {
         assert!(!bool::from(stored.ct_eq(mismatch_at_last_byte)));
     }
 
-    /// Council-adjudicated FIX 4: `sweep_expired` reaps an old orphan but
-    /// preserves both a fresh token and an old token whose live/detached SM
-    /// ownership claim still exists. Token age starts at SM enable, not at
-    /// disconnect, so age alone must never invalidate a long-lived stream.
+    /// Council-adjudicated FIX 4: `sweep_expired` reaps an old terminal row
+    /// but preserves fresh, exactly claimed, and durably persisted sessions.
+    /// Token age starts at SM enable, not at disconnect, so age alone must
+    /// never invalidate a live or recoverable stream.
     #[tokio::test]
-    async fn sweep_expired_reaps_only_old_tokens_without_an_sm_claim() {
+    async fn sweep_expired_requires_both_claim_and_durable_session_to_be_absent() {
         let _guard = clustering_control_plane_table_lock().lock().await;
         let Some(db) = test_db().await else {
             return;
         };
         let store = PostgresIsrTokenStore::new(db.clone());
         store.ensure_schema().await.expect("ensure isr schema");
+        ensure_sm_persistence_schema(&db).await;
+        clean_sweep_tables(&db).await;
 
         let fresh_sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
         let claimed_stale_sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
-        let orphaned_stale_sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
+        let persisted_stale_sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
+        let terminal_stale_sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
         store
             .issue(&fresh_sm_id, "PLAIN")
             .await
@@ -727,22 +944,28 @@ mod tests {
             .await
             .expect("issue claimed stale token");
         store
-            .issue(&orphaned_stale_sm_id, "PLAIN")
+            .issue(&persisted_stale_sm_id, "PLAIN")
             .await
-            .expect("issue orphaned stale token");
+            .expect("issue persisted stale token");
+        store
+            .issue(&terminal_stale_sm_id, "PLAIN")
+            .await
+            .expect("issue terminal stale token");
 
         let me = node_identity();
         let claimed_stale_epoch = claim_sm_session(&db, &claimed_stale_sm_id, &me).await;
+        seed_sm_session_row(&db, &persisted_stale_sm_id).await;
 
-        // Backdate both old rows directly. Only the unclaimed one is an
-        // orphan eligible for the TTL backstop.
+        // Backdate all non-fresh rows directly. Only the row with neither
+        // exact ownership nor durable resume state is terminal.
         let conn = db.guard().await.expect("guard");
         conn.execute(
             "UPDATE clustering_isr_tokens SET created_at = now() - interval '1 day' \
-             WHERE sm_id IN (?, ?)",
+             WHERE sm_id IN (?, ?, ?)",
             crate::db_params![
                 claimed_stale_sm_id.to_string(),
-                orphaned_stale_sm_id.to_string()
+                persisted_stale_sm_id.to_string(),
+                terminal_stale_sm_id.to_string()
             ],
         )
         .await
@@ -752,25 +975,24 @@ mod tests {
             .sweep_expired(std::time::Duration::from_secs(3600))
             .await
             .expect("sweep_expired");
-        assert!(
-            deleted >= 1,
-            "the backdated unclaimed row must be reaped (the shared test database may contain older orphans)"
-        );
+        assert_eq!(deleted, 1, "only the terminal token may be reaped");
 
-        // The fresh row survives by age. The old claimed row survives by
-        // ownership. Only the old orphan is gone.
+        // The fresh row survives by age. The two old recoverable rows survive
+        // by ownership and persistence respectively. Only the terminal row
+        // is gone.
         let fresh_epoch = claim_sm_session(&db, &fresh_sm_id, &me).await;
-        let orphaned_stale_epoch = claim_sm_session(&db, &orphaned_stale_sm_id, &me).await;
-        let orphaned_stale_outcome = store
+        let persisted_stale_epoch = claim_sm_session(&db, &persisted_stale_sm_id, &me).await;
+        let terminal_stale_epoch = claim_sm_session(&db, &terminal_stale_sm_id, &me).await;
+        let terminal_stale_outcome = store
             .consume(
-                &orphaned_stale_sm_id,
+                &terminal_stale_sm_id,
                 b"anything",
                 "PLAIN",
-                &fence(&me, orphaned_stale_epoch),
+                &fence(&me, terminal_stale_epoch),
             )
             .await
-            .expect("consume orphaned stale");
-        assert_eq!(orphaned_stale_outcome, IsrConsumeOutcome::NoSuchToken);
+            .expect("consume terminal stale");
+        assert_eq!(terminal_stale_outcome, IsrConsumeOutcome::NoSuchToken);
         let claimed_stale_outcome = store
             .consume(
                 &claimed_stale_sm_id,
@@ -784,6 +1006,20 @@ mod tests {
             claimed_stale_outcome,
             IsrConsumeOutcome::Mismatched,
             "an old token with a live SM claim must not be swept"
+        );
+        let persisted_stale_outcome = store
+            .consume(
+                &persisted_stale_sm_id,
+                b"wrong-token-but-row-must-exist",
+                "PLAIN",
+                &fence(&me, persisted_stale_epoch),
+            )
+            .await
+            .expect("consume persisted stale");
+        assert_eq!(
+            persisted_stale_outcome,
+            IsrConsumeOutcome::Mismatched,
+            "an old token with durable resumable state must not be swept while its claim is absent"
         );
         let fresh_outcome = store
             .consume(
@@ -799,6 +1035,120 @@ mod tests {
             IsrConsumeOutcome::Mismatched,
             "fresh row must still exist (Mismatched, not NoSuchToken) — only wrong-token, \
              not swept"
+        );
+    }
+
+    #[tokio::test]
+    async fn sweep_expired_deletes_ordered_batches_until_both_tables_are_empty() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some(db) = test_db().await else {
+            return;
+        };
+        let store = PostgresIsrTokenStore::new(db.clone());
+        store.ensure_schema().await.expect("ensure isr schema");
+        ensure_sm_persistence_schema(&db).await;
+        clean_sweep_tables(&db).await;
+
+        let row_count = usize::try_from(ISR_SWEEP_BATCH_SIZE).expect("positive batch") + 3;
+        for index in 0..row_count {
+            let token_id = SmSessionId::new(format!("batch-token-{index:03}"));
+            store
+                .issue(&token_id, "PLAIN")
+                .await
+                .expect("seed token row");
+
+            let fence_id = SmSessionId::new(format!("batch-fence-{index:03}"));
+            let issued = store
+                .issue(&fence_id, "PLAIN")
+                .await
+                .expect("seed fence source");
+            assert_eq!(
+                store
+                    .revoke_if_current(&fence_id, &issued)
+                    .await
+                    .expect("turn token into revocation fence"),
+                IsrRevokeOutcome::Revoked
+            );
+        }
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "UPDATE clustering_isr_tokens SET created_at = now() - interval '1 day'",
+            (),
+        )
+        .await
+        .expect("backdate token batch");
+        conn.execute(
+            "UPDATE clustering_isr_revocation_fences SET created_at = now() - interval '1 day'",
+            (),
+        )
+        .await
+        .expect("backdate fence batch");
+        drop(conn);
+
+        assert_eq!(
+            store
+                .sweep_expired(std::time::Duration::from_secs(3600))
+                .await
+                .expect("first bounded sweep"),
+            u64::try_from(ISR_SWEEP_BATCH_SIZE).expect("positive batch"),
+            "the first pass must report only its bounded token deletion count"
+        );
+        let conn = db.guard().await.expect("guard");
+        for table in ["clustering_isr_tokens", "clustering_isr_revocation_fences"] {
+            let query = match table {
+                "clustering_isr_tokens" => "SELECT COUNT(*) FROM clustering_isr_tokens",
+                _ => "SELECT COUNT(*) FROM clustering_isr_revocation_fences",
+            };
+            let mut rows = conn
+                .query(query, ())
+                .await
+                .expect("count rows after first pass");
+            assert_eq!(
+                rows.next()
+                    .await
+                    .expect("count result")
+                    .expect("count row")
+                    .get::<i64>(0)
+                    .expect("count"),
+                3,
+                "first pass must leave the ordered tail in {table}"
+            );
+        }
+        drop(conn);
+
+        assert_eq!(
+            store
+                .sweep_expired(std::time::Duration::from_secs(3600))
+                .await
+                .expect("second bounded sweep"),
+            3,
+            "the next pass must make monotonic progress through the tail"
+        );
+        assert_eq!(
+            store
+                .sweep_expired(std::time::Duration::from_secs(3600))
+                .await
+                .expect("empty sweep"),
+            0,
+            "once drained, subsequent passes must be stable"
+        );
+        let conn = db.guard().await.expect("guard");
+        let mut rows = conn
+            .query(
+                "SELECT (SELECT COUNT(*) FROM clustering_isr_tokens) + \
+                        (SELECT COUNT(*) FROM clustering_isr_revocation_fences)",
+                (),
+            )
+            .await
+            .expect("count final rows");
+        assert_eq!(
+            rows.next()
+                .await
+                .expect("count result")
+                .expect("count row")
+                .get::<i64>(0)
+                .expect("count"),
+            0
         );
     }
 

--- a/server/crates/waddle-server/src/clustering/isr.rs
+++ b/server/crates/waddle-server/src/clustering/isr.rs
@@ -428,18 +428,27 @@ impl IsrTokenStore for PostgresIsrTokenStore {
         // SM session registry (`waddle-xmpp`, cross-node-generic) to know
         // about ISR (`waddle-server`-local, Postgres-only) at all — the
         // exact coupling `ClaimStore`/`IsrTokenStore`'s trait split
-        // deliberately avoids. `created_at` already exists on this table
-        // (the schema this module's own `ensure_schema` creates), so a
-        // bounded sweep over it, run at the same cadence as
-        // `session_janitors.rs`'s orphan-reaper sweep, is the smaller
-        // correct option. Mirrors `lease.rs`'s own
-        // `(? || ' milliseconds')::interval` TTL-comparison idiom.
+        // deliberately avoids. Age alone is not terminal authority: an SM
+        // stream can remain live for longer than this backstop and its ISR
+        // token must remain valid throughout that lifetime. Reap only an old
+        // token whose typed SM-session claim is absent. Mirrors
+        // `lease.rs`'s own `(? || ' milliseconds')::interval`
+        // TTL-comparison idiom.
         let conn = self.db.guard().await.map_err(db_err)?;
         let deleted_tokens = conn
             .execute(
-                "DELETE FROM clustering_isr_tokens \
-                 WHERE created_at < now() - (? || ' milliseconds')::interval",
-                crate::db_params![max_age.as_millis().to_string()],
+                "DELETE FROM clustering_isr_tokens AS token \
+                 WHERE token.created_at < now() - (? || ' milliseconds')::interval \
+                   AND NOT EXISTS ( \
+                     SELECT 1 FROM clustering_claims AS claim \
+                     WHERE claim.entity = (? || ':' || token.sm_id) \
+                       AND claim.entity_type = ? \
+                   )",
+                crate::db_params![
+                    max_age.as_millis().to_string(),
+                    EntityType::SmSession.as_db_str().to_string(),
+                    EntityType::SmSession.as_db_str().to_string(),
+                ],
             )
             .await
             .map_err(db_err)?;
@@ -693,12 +702,12 @@ mod tests {
         assert!(!bool::from(stored.ct_eq(mismatch_at_last_byte)));
     }
 
-    /// Council-adjudicated FIX 4: `sweep_expired` reaps only rows whose
-    /// `created_at` predates the TTL — a token issued moments ago survives
-    /// a short-TTL sweep; a token backdated (via a direct UPDATE, standing
-    /// in for one that has genuinely aged past the TTL) is reaped.
+    /// Council-adjudicated FIX 4: `sweep_expired` reaps an old orphan but
+    /// preserves both a fresh token and an old token whose live/detached SM
+    /// ownership claim still exists. Token age starts at SM enable, not at
+    /// disconnect, so age alone must never invalidate a long-lived stream.
     #[tokio::test]
-    async fn sweep_expired_reaps_only_rows_older_than_max_age() {
+    async fn sweep_expired_reaps_only_old_tokens_without_an_sm_claim() {
         let _guard = clustering_control_plane_table_lock().lock().await;
         let Some(db) = test_db().await else {
             return;
@@ -707,24 +716,34 @@ mod tests {
         store.ensure_schema().await.expect("ensure isr schema");
 
         let fresh_sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
-        let stale_sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
+        let claimed_stale_sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
+        let orphaned_stale_sm_id = SmSessionId::new(format!("sm-{}", uuid::Uuid::new_v4()));
         store
             .issue(&fresh_sm_id, "PLAIN")
             .await
             .expect("issue fresh token");
         store
-            .issue(&stale_sm_id, "PLAIN")
+            .issue(&claimed_stale_sm_id, "PLAIN")
             .await
-            .expect("issue stale token");
+            .expect("issue claimed stale token");
+        store
+            .issue(&orphaned_stale_sm_id, "PLAIN")
+            .await
+            .expect("issue orphaned stale token");
 
-        // Backdate the "stale" row directly — standing in for a token that
-        // has genuinely aged past the TTL without needing the test to
-        // actually sleep.
+        let me = node_identity();
+        let claimed_stale_epoch = claim_sm_session(&db, &claimed_stale_sm_id, &me).await;
+
+        // Backdate both old rows directly. Only the unclaimed one is an
+        // orphan eligible for the TTL backstop.
         let conn = db.guard().await.expect("guard");
         conn.execute(
             "UPDATE clustering_isr_tokens SET created_at = now() - interval '1 day' \
-             WHERE sm_id = ?",
-            crate::db_params![stale_sm_id.to_string()],
+             WHERE sm_id IN (?, ?)",
+            crate::db_params![
+                claimed_stale_sm_id.to_string(),
+                orphaned_stale_sm_id.to_string()
+            ],
         )
         .await
         .expect("backdate stale row");
@@ -733,18 +752,39 @@ mod tests {
             .sweep_expired(std::time::Duration::from_secs(3600))
             .await
             .expect("sweep_expired");
-        assert_eq!(deleted, 1, "exactly the backdated row must be reaped");
+        assert!(
+            deleted >= 1,
+            "the backdated unclaimed row must be reaped (the shared test database may contain older orphans)"
+        );
 
-        // The fresh row survives; the stale one is gone (a subsequent
-        // consume for it finds no row at all).
-        let me = node_identity();
+        // The fresh row survives by age. The old claimed row survives by
+        // ownership. Only the old orphan is gone.
         let fresh_epoch = claim_sm_session(&db, &fresh_sm_id, &me).await;
-        let stale_epoch = claim_sm_session(&db, &stale_sm_id, &me).await;
-        let stale_outcome = store
-            .consume(&stale_sm_id, b"anything", "PLAIN", &fence(&me, stale_epoch))
+        let orphaned_stale_epoch = claim_sm_session(&db, &orphaned_stale_sm_id, &me).await;
+        let orphaned_stale_outcome = store
+            .consume(
+                &orphaned_stale_sm_id,
+                b"anything",
+                "PLAIN",
+                &fence(&me, orphaned_stale_epoch),
+            )
             .await
-            .expect("consume stale");
-        assert_eq!(stale_outcome, IsrConsumeOutcome::NoSuchToken);
+            .expect("consume orphaned stale");
+        assert_eq!(orphaned_stale_outcome, IsrConsumeOutcome::NoSuchToken);
+        let claimed_stale_outcome = store
+            .consume(
+                &claimed_stale_sm_id,
+                b"wrong-token-but-row-must-exist",
+                "PLAIN",
+                &fence(&me, claimed_stale_epoch),
+            )
+            .await
+            .expect("consume claimed stale");
+        assert_eq!(
+            claimed_stale_outcome,
+            IsrConsumeOutcome::Mismatched,
+            "an old token with a live SM claim must not be swept"
+        );
         let fresh_outcome = store
             .consume(
                 &fresh_sm_id,

--- a/server/crates/waddle-server/src/clustering/metrics.rs
+++ b/server/crates/waddle-server/src/clustering/metrics.rs
@@ -291,7 +291,7 @@ pub fn record_room_orphan_pending_backlog(depth: usize, oldest_age_ms: u64) {
 }
 
 /// Report the bounded orphan-reaper work queues. `queue` is the stable
-/// low-cardinality value `sm_hydration` or `room_release`.
+/// low-cardinality value `sm_hydration`, `room_release`, or `room_handoff`.
 pub fn record_orphan_work_queue_depth(queue: &'static str, depth: usize) {
     static G: OnceLock<Gauge<u64>> = OnceLock::new();
     G.get_or_init(|| {

--- a/server/crates/waddle-server/src/clustering/metrics.rs
+++ b/server/crates/waddle-server/src/clustering/metrics.rs
@@ -307,9 +307,11 @@ pub fn record_orphan_work_queue_depth(queue: &'static str, depth: usize) {
     );
 }
 
-/// Count work rejected by a bounded orphan-reaper queue. A nonzero value
-/// means ownership remains fenced-safe but recovery is deferred to a later
-/// sweep or node-incarnation expiry.
+/// Count work rejected by a bounded orphan-reaper queue or reservation gate.
+/// `queue` is one of the stable low-cardinality values `sm_hydration`,
+/// `room_release`, or `room_adoption`. A nonzero value means ownership
+/// remains fenced-safe but recovery is deferred to a later sweep or
+/// node-incarnation expiry.
 pub fn record_orphan_work_queue_backpressure(queue: &'static str) {
     static C: OnceLock<Counter<u64>> = OnceLock::new();
     C.get_or_init(|| {

--- a/server/crates/waddle-server/src/clustering/metrics.rs
+++ b/server/crates/waddle-server/src/clustering/metrics.rs
@@ -250,3 +250,120 @@ pub fn record_claims_abandoned_on_drain(count: u64) {
     })
     .add(count, &[]);
 }
+
+/// Count bounded proactive `RoomActor` orphan-reconciliation outcomes.
+/// `outcome` is one of `hydrated`, `released`, `already_live`,
+/// `adopted_local`, `pending_retry`, `lost_race`, or `failed`; callers
+/// aggregate a whole sweep before recording, avoiding per-room warning noise
+/// after a node loss.
+pub fn record_room_orphan_reconciliation(outcome: &'static str, count: u64) {
+    static C: OnceLock<Counter<u64>> = OnceLock::new();
+    C.get_or_init(|| {
+        meter()
+            .u64_counter("waddle.clustering.room_orphan_reconciliations")
+            .with_description("Proactive RoomActor orphan-claim reconciliation outcomes")
+            .with_unit("claim")
+            .build()
+    })
+    .add(count, &[opentelemetry::KeyValue::new("outcome", outcome)]);
+}
+
+pub fn record_room_orphan_pending_backlog(depth: usize, oldest_age_ms: u64) {
+    static DEPTH: OnceLock<Gauge<u64>> = OnceLock::new();
+    DEPTH
+        .get_or_init(|| {
+            meter()
+                .u64_gauge("waddle.clustering.room_orphan_pending_depth")
+                .with_description("Reclaimed room epochs awaiting adoption or release")
+                .with_unit("claim")
+                .build()
+        })
+        .record(depth as u64, &[]);
+    static AGE: OnceLock<Gauge<u64>> = OnceLock::new();
+    AGE.get_or_init(|| {
+        meter()
+            .u64_gauge("waddle.clustering.room_orphan_pending_oldest_age_ms")
+            .with_description("Age of the oldest pending reclaimed room epoch")
+            .with_unit("ms")
+            .build()
+    })
+    .record(oldest_age_ms, &[]);
+}
+
+/// Report the bounded orphan-reaper work queues. `queue` is the stable
+/// low-cardinality value `sm_hydration` or `room_release`.
+pub fn record_orphan_work_queue_depth(queue: &'static str, depth: usize) {
+    static G: OnceLock<Gauge<u64>> = OnceLock::new();
+    G.get_or_init(|| {
+        meter()
+            .u64_gauge("waddle.clustering.orphan_work_queue_depth")
+            .with_description("Current deduplicated orphan-reaper work queue depth")
+            .with_unit("item")
+            .build()
+    })
+    .record(
+        depth as u64,
+        &[opentelemetry::KeyValue::new("queue", queue)],
+    );
+}
+
+/// Count work rejected by a bounded orphan-reaper queue. A nonzero value
+/// means ownership remains fenced-safe but recovery is deferred to a later
+/// sweep or node-incarnation expiry.
+pub fn record_orphan_work_queue_backpressure(queue: &'static str) {
+    static C: OnceLock<Counter<u64>> = OnceLock::new();
+    C.get_or_init(|| {
+        meter()
+            .u64_counter("waddle.clustering.orphan_work_queue_backpressure")
+            .with_description("Orphan-reaper work rejected because its bounded queue was full")
+            .with_unit("item")
+            .build()
+    })
+    .add(1, &[opentelemetry::KeyValue::new("queue", queue)]);
+}
+
+pub fn record_orphan_worker_failure(worker: &'static str, reason: &'static str) {
+    static C: OnceLock<Counter<u64>> = OnceLock::new();
+    C.get_or_init(|| {
+        meter()
+            .u64_counter("waddle.clustering.orphan_worker_failures")
+            .with_description("Orphan-reaper worker tasks that exited unexpectedly")
+            .with_unit("failure")
+            .build()
+    })
+    .add(
+        1,
+        &[
+            opentelemetry::KeyValue::new("worker", worker),
+            opentelemetry::KeyValue::new("reason", reason),
+        ],
+    );
+}
+
+/// Report each bounded SM candidate page, including whether another page was
+/// visible at scan time and how many malformed stale rows were quarantined.
+pub fn record_sm_orphan_candidate_page(candidates: usize, has_more: bool, quarantined: usize) {
+    static H: OnceLock<Histogram<u64>> = OnceLock::new();
+    H.get_or_init(|| {
+        meter()
+            .u64_histogram("waddle.clustering.sm_orphan_candidate_page_size")
+            .with_description("Bounded SM orphan candidates returned per cursor page")
+            .with_unit("claim")
+            .build()
+    })
+    .record(
+        candidates as u64,
+        &[opentelemetry::KeyValue::new("has_more", has_more)],
+    );
+    if quarantined > 0 {
+        static C: OnceLock<Counter<u64>> = OnceLock::new();
+        C.get_or_init(|| {
+            meter()
+                .u64_counter("waddle.clustering.sm_orphan_malformed_quarantined")
+                .with_description("Malformed stale SM claim rows quarantined by the bounded scan")
+                .with_unit("claim")
+                .build()
+        })
+        .add(quarantined as u64, &[]);
+    }
+}

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -168,27 +168,51 @@ pub(crate) fn keypair_slot_table_lock() -> &'static tokio::sync::Mutex<()> {
 /// `clustering.enabled = false`) never flips it, so it stays ready forever
 /// — today's behavior, unchanged.
 #[derive(Clone)]
-pub struct ClusteringReadiness(std::sync::Arc<std::sync::atomic::AtomicBool>);
+pub struct ClusteringReadiness {
+    ready: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    fatal_fence: CancellationToken,
+}
 
 impl ClusteringReadiness {
     pub fn new() -> Self {
-        Self(std::sync::Arc::new(std::sync::atomic::AtomicBool::new(
-            true,
-        )))
+        Self {
+            ready: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            fatal_fence: CancellationToken::new(),
+        }
     }
 
     pub fn is_ready(&self) -> bool {
-        self.0.load(std::sync::atomic::Ordering::Acquire)
+        self.ready.load(std::sync::atomic::Ordering::Acquire) && !self.fatal_fence.is_cancelled()
     }
 
     pub fn set_ready(&self, ready: bool) {
-        self.0.store(ready, std::sync::atomic::Ordering::Release);
+        self.ready
+            .store(ready, std::sync::atomic::Ordering::Release);
+    }
+
+    pub(crate) fn fatal_fence_token(&self) -> CancellationToken {
+        self.fatal_fence.clone()
     }
 }
 
 impl Default for ClusteringReadiness {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod readiness_tests {
+    use super::ClusteringReadiness;
+
+    #[test]
+    fn fatal_latch_immediately_overrides_a_ready_flag() {
+        let readiness = ClusteringReadiness::new();
+        assert!(readiness.is_ready());
+        readiness.fatal_fence_token().cancel();
+        assert!(!readiness.is_ready());
+        readiness.set_ready(true);
+        assert!(!readiness.is_ready());
     }
 }
 
@@ -410,6 +434,12 @@ pub struct ClusteringHandles {
     /// Phase 3 Slice 6's `RelayHandle` cancellation-safety paydown).
     #[cfg(feature = "clustering")]
     pub stop_token: Option<CancellationToken>,
+    /// One-shot fatal fencing signal for clustering workers that discover
+    /// ambiguous post-CAS ownership state. Unlike `stop_token`, firing this
+    /// signal drives the node-lease loop through its demote/not-ready fence
+    /// path before clustering shuts down.
+    #[cfg(feature = "clustering")]
+    pub fatal_fence: Option<CancellationToken>,
     /// The resolved `ClusteringResumeHandshakeConfig::timeout` (ADR-0017
     /// Phase 3 Slice 6) — the cross-node resume path's held-response retry
     /// budget. Carried here (rather than threading `ServerConfig` itself)
@@ -588,6 +618,7 @@ pub async fn start_if_enabled(
         // node-lease/self-fence loop) is driven off this child, never the
         // raw process-wide `stop_token` — see `clustering_scope_token`.
         let clustering_stop = clustering_scope_token(stop_token);
+        let fatal_fence = readiness.fatal_fence_token();
         // ADR-0017 Phase 3 Slice 6: constructed empty (the `ConnectionRegistry`
         // doesn't exist yet at this point in startup) and wired to it later by
         // `server/http.rs::create_sm_session_registry` — the same
@@ -739,6 +770,7 @@ pub async fn start_if_enabled(
             resume_bridge: Some(resume_bridge),
             ordered_relay_delivery_bridge: Some(ordered_relay_delivery_bridge),
             stop_token: Some(clustering_stop.clone()),
+            fatal_fence: Some(fatal_fence.clone()),
             resume_handshake_timeout: Some(config.resume_handshake.timeout),
         };
 

--- a/server/crates/waddle-server/src/clustering/mod.rs
+++ b/server/crates/waddle-server/src/clustering/mod.rs
@@ -689,8 +689,8 @@ pub async fn start_if_enabled(
         let node_lease_handle: Arc<dyn claims::NodeLeaseStore> =
             Arc::new(claims::PostgresClaimStore::new(db.clone()));
         // ADR-0017 Phase 3 Slice 7: the durable MUC room store. Built here
-        // (not deferred to `server/mod.rs`) because it only needs `db`/
-        // `live_identity`/`clustering_stop` — all already in scope — unlike
+        // (not deferred to `server/mod.rs`) because it only needs `db` and
+        // `clustering_stop` — both already in scope — unlike
         // `room_local_claims` above, which genuinely must wait for the room
         // registry to exist.
         //

--- a/server/crates/waddle-server/src/clustering/relay.rs
+++ b/server/crates/waddle-server/src/clustering/relay.rs
@@ -1795,6 +1795,19 @@ mod tests {
 
     #[async_trait]
     impl NodeLeaseStore for NoopNodeLease {
+        async fn list_orphaned_room_actor_claims_page(
+            &self,
+            _after: Option<crate::clustering::claims::RoomOrphanScanCursor>,
+            _limit: usize,
+        ) -> Result<crate::clustering::claims::OrphanedRoomActorClaimPage, ClaimError> {
+            Ok(crate::clustering::claims::OrphanedRoomActorClaimPage {
+                candidates: Vec::new(),
+                next_cursor: None,
+                has_more: false,
+                quarantined: 0,
+            })
+        }
+
         async fn register(
             &self,
             _me: &NodeIdentity,

--- a/server/crates/waddle-server/src/clustering/route_bridge.rs
+++ b/server/crates/waddle-server/src/clustering/route_bridge.rs
@@ -4801,6 +4801,19 @@ mod tests {
 
     #[async_trait::async_trait]
     impl NodeLeaseStore for StaticNodeLease {
+        async fn list_orphaned_room_actor_claims_page(
+            &self,
+            _after: Option<crate::clustering::claims::RoomOrphanScanCursor>,
+            _limit: usize,
+        ) -> Result<crate::clustering::claims::OrphanedRoomActorClaimPage, ClaimError> {
+            Ok(crate::clustering::claims::OrphanedRoomActorClaimPage {
+                candidates: Vec::new(),
+                next_cursor: None,
+                has_more: false,
+                quarantined: 0,
+            })
+        }
+
         async fn register(
             &self,
             _me: &NodeIdentity,

--- a/server/crates/waddle-server/src/clustering/self_fence.rs
+++ b/server/crates/waddle-server/src/clustering/self_fence.rs
@@ -28,7 +28,7 @@ use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
 
 use waddle_xmpp::ownership::{
-    ClaimEpoch, ClaimError, ClaimStore, Entity, NodeIdentity, StalePredicate,
+    ClaimEpoch, ClaimError, ClaimStore, Entity, NodeIdentity, SharedNodeIdentity,
 };
 
 use super::claims::NodeLeaseStore;
@@ -489,14 +489,10 @@ where
 /// FIX 4(b) (ADR-0017 Phase 3 Slice 5 corrigenda, council-adjudicated):
 /// reclaim `old_identity`'s own orphaned `sm_session` claims inline, under
 /// `fresh`, rather than waiting for the general orphan reaper's
-/// independent cadence to notice them. `list_orphaned_sm_session_claims`
-/// returns candidates cluster-wide (any node's dead claims); this function
-/// filters to exactly `old_identity` — this node's own just-superseded
-/// identity, provably dead because THIS loop is the one that just
-/// re-registered past it — so it never touches another node's genuinely
-/// dead claims (the general reaper remains the sole mechanism for those,
-/// preserving the "backstop for other nodes" carried-risk boundary FIX 4's
-/// own doc note names honestly).
+/// independent cadence to notice them. The scan is owner-indexed and capped
+/// to one raw page, so other nodes' orphan populations cannot inflate this
+/// re-registration critical path. The general reaper remains the backstop
+/// for overflow and every other dead owner.
 ///
 /// Caller bounds this whole call against `config.lease_ttl` (mirroring
 /// every other control-plane call in [`run_node_lease`]); this function
@@ -510,31 +506,27 @@ async fn reclaim_own_expired_claims<L>(
     old_identity: &NodeIdentity,
     fresh: &NodeIdentity,
     local_claims: &dyn LocallyClaimedEntities,
+    lease_ttl: Duration,
 ) where
     L: NodeLeaseStore + Send + Sync,
 {
-    let candidates = match lease.list_orphaned_sm_session_claims().await {
+    const INLINE_RECLAIM_LIMIT: usize = 64;
+    let candidates = match lease
+        .list_orphaned_sm_session_claims_for_owner(old_identity, INLINE_RECLAIM_LIMIT)
+        .await
+    {
         Ok(candidates) => candidates,
         Err(error) => {
             tracing::warn!(
                 %error,
                 node_id = %old_identity.node_id,
-                "clustering: inline post-fence reclaim: list_orphaned_sm_session_claims failed"
+                "clustering: inline post-fence owner-scoped SM scan failed"
             );
             return;
         }
     };
 
     for candidate in candidates {
-        if candidate.owner != *old_identity {
-            // Another node's genuinely dead claim — not this node's own
-            // just-superseded identity. Left for the general orphan
-            // reaper, exactly as element 9 describes; naming that
-            // boundary honestly (rather than silently widening this
-            // node's own inline reclaim to cover it) is the point of FIX
-            // 4's "residual window" carried-risk note.
-            continue;
-        }
         let Some(reservation_token) =
             local_claims.reserve_reclaimed_claim_capacity(&candidate.entity)
         else {
@@ -546,12 +538,13 @@ async fn reclaim_own_expired_claims<L>(
             fresh.clone(),
             reservation_token,
         );
-        match claim_store
-            .steal_stale(
+        match lease
+            .steal_own_expired_sm_session_claim(
+                claim_store,
                 &candidate.entity,
                 candidate.epoch,
-                StalePredicate::OwnerStale,
                 fresh,
+                lease_ttl,
             )
             .await
         {
@@ -809,6 +802,143 @@ pub(super) async fn run_shutdown_drain_with_heartbeat<L>(
 /// callers only ever expire an identity this loop or the reaper has
 /// independently proven dead, never the identity a phantom-row retry would
 /// have minted.)
+struct TerminalFenceContext<'a, L> {
+    lease: &'a L,
+    live_identity: &'a SharedNodeIdentity,
+    local_claims: &'a Arc<dyn LocallyClaimedEntities>,
+    readiness: &'a ClusteringReadiness,
+    stop_token: &'a CancellationToken,
+    fatal_fence: &'a CancellationToken,
+    control_plane_budget: Duration,
+}
+
+impl<L> TerminalFenceContext<'_, L>
+where
+    L: NodeLeaseStore + Send + Sync,
+{
+    async fn shutdown(
+        &self,
+        claim_store: &Arc<dyn ClaimStore>,
+        identity: &NodeIdentity,
+        claim_release_budget: Duration,
+        lease_ttl: Duration,
+    ) {
+        // The clustering scope can be stopped independently of axum. Stop
+        // admitting traffic and NEW claims first, but keep the current
+        // identity authoritative while mailbox seal barriers complete the
+        // final fenced writes for already-owned rooms.
+        self.readiness.set_ready(false);
+        if self.fatal_fence.is_cancelled() {
+            self.finish(identity, identity).await;
+            return;
+        }
+
+        let mark_draining = std::pin::pin!(mark_draining_bounded(
+            self.lease,
+            identity,
+            self.control_plane_budget,
+        ));
+        tokio::select! {
+            biased;
+            _ = self.fatal_fence.cancelled() => {
+                self.finish(identity, identity).await;
+                return;
+            }
+            _ = mark_draining => {}
+        }
+
+        let drain = std::pin::pin!(run_shutdown_drain_with_heartbeat(
+            self.lease,
+            claim_store,
+            identity,
+            self.local_claims,
+            claim_release_budget,
+            lease_ttl,
+        ));
+        tokio::select! {
+            biased;
+            _ = self.fatal_fence.cancelled() => {
+                self.finish(identity, identity).await;
+                return;
+            }
+            _ = drain => {}
+        }
+
+        // Only after every successful seal has been released may the
+        // publication barrier reject the remaining identity. Exact demotion
+        // retires anything the bounded drain deliberately abandoned.
+        self.live_identity.disable().await;
+        self.local_claims.demote_owned_by(identity).await;
+        for entity in self.local_claims.owned().await {
+            self.local_claims.demote(&entity).await;
+        }
+    }
+
+    async fn finish(&self, prior_identity: &NodeIdentity, registered_identity: &NodeIdentity) {
+        self.readiness.set_ready(false);
+        self.stop_token.cancel();
+
+        // A registration call is deliberately allowed to finish instead of
+        // being cancellation-dropped: once it returns, rotate through a
+        // publication barrier and retire both identities that might own work.
+        // Disabled is a typed terminal state: publication guards and claim
+        // stores both reject it for the rest of this clustering lifetime.
+        self.live_identity.disable().await;
+        self.local_claims.demote_owned_by(prior_identity).await;
+        if registered_identity != prior_identity {
+            self.local_claims.demote_owned_by(registered_identity).await;
+        }
+        for entity in self.local_claims.owned().await {
+            self.local_claims.demote(&entity).await;
+        }
+        mark_draining_bounded(self.lease, prior_identity, self.control_plane_budget).await;
+        if registered_identity != prior_identity {
+            mark_draining_bounded(self.lease, registered_identity, self.control_plane_budget).await;
+        }
+    }
+}
+
+async fn run_pre_ready_heartbeat<L>(
+    lease: Arc<L>,
+    identity: NodeIdentity,
+    cancel: CancellationToken,
+    fatal_fence: CancellationToken,
+    heartbeat_interval: Duration,
+    lease_ttl: Duration,
+) where
+    L: NodeLeaseStore + Send + Sync + 'static,
+{
+    let mut timer = tokio::time::interval(heartbeat_interval);
+    timer.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    timer.tick().await;
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return,
+            _ = fatal_fence.cancelled() => return,
+            _ = timer.tick() => {
+                let renewal = std::pin::pin!(tokio::time::timeout(
+                    lease_ttl,
+                    lease.heartbeat(&identity, lease_ttl),
+                ));
+                let result = tokio::select! {
+                    biased;
+                    _ = cancel.cancelled() => return,
+                    _ = fatal_fence.cancelled() => return,
+                    result = renewal => result,
+                };
+                match result {
+                    Ok(Ok(true)) => {}
+                    Ok(Ok(false)) | Ok(Err(_)) | Err(_) => {
+                        fatal_fence.cancel();
+                        return;
+                    }
+                }
+            }
+        }
+    }
+}
+
 pub async fn run_node_lease<L>(
     lease: L,
     mut identity: NodeIdentity,
@@ -829,6 +959,17 @@ pub async fn run_node_lease<L>(
         claim_store,
         claim_release_budget,
     } = run_config;
+    let lease = Arc::new(lease);
+    let fatal_fence = readiness.fatal_fence_token();
+    let terminal_fence_context = TerminalFenceContext {
+        lease: lease.as_ref(),
+        live_identity: &live_identity,
+        local_claims: &local_claims,
+        readiness: &readiness,
+        stop_token: &stop_token,
+        fatal_fence: &fatal_fence,
+        control_plane_budget: config.heartbeat_interval,
+    };
     // Seed the shared handle with the identity this loop starts under —
     // see `live_identity`'s doc comment and the `identity = fresh;`
     // reassignment below, which keeps it current across every
@@ -841,6 +982,7 @@ pub async fn run_node_lease<L>(
     );
 
     'registered: loop {
+        let mut terminal_fence = false;
         let mut timer = tokio::time::interval_at(
             tokio::time::Instant::now() + config.heartbeat_interval,
             config.heartbeat_interval,
@@ -861,8 +1003,12 @@ pub async fn run_node_lease<L>(
             tokio::select! {
                 biased;
                 _ = stop_token.cancelled() => {
-                    run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                    terminal_fence_context.shutdown(&claim_store, &identity, claim_release_budget, config.lease_ttl).await;
                     return;
+                }
+                _ = fatal_fence.cancelled() => {
+                    terminal_fence = true;
+                    break;
                 }
                 _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
                     break;
@@ -877,8 +1023,12 @@ pub async fn run_node_lease<L>(
             let renewed = tokio::select! {
                 biased;
                 _ = stop_token.cancelled() => {
-                    run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                    terminal_fence_context.shutdown(&claim_store, &identity, claim_release_budget, config.lease_ttl).await;
                     return;
+                }
+                _ = fatal_fence.cancelled() => {
+                    terminal_fence = true;
+                    break;
                 }
                 _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
                     break;
@@ -920,8 +1070,12 @@ pub async fn run_node_lease<L>(
             let other_live_result = tokio::select! {
                 biased;
                 _ = stop_token.cancelled() => {
-                    run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                    terminal_fence_context.shutdown(&claim_store, &identity, claim_release_budget, config.lease_ttl).await;
                     return;
+                }
+                _ = fatal_fence.cancelled() => {
+                    terminal_fence = true;
+                    break;
                 }
                 _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
                     break;
@@ -946,13 +1100,32 @@ pub async fn run_node_lease<L>(
                 break;
             }
 
-            let owned = local_claims.owned().await;
+            let owned_future = std::pin::pin!(local_claims.owned());
+            let owned = tokio::select! {
+                biased;
+                _ = stop_token.cancelled() => {
+                    terminal_fence_context.shutdown(&claim_store, &identity, claim_release_budget, config.lease_ttl).await;
+                    return;
+                }
+                _ = fatal_fence.cancelled() => {
+                    terminal_fence = true;
+                    break;
+                }
+                _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
+                    break;
+                }
+                owned = owned_future => owned,
+            };
             let reconcile_future = std::pin::pin!(lease.reconcile(&identity, &owned));
             let reconcile_result = tokio::select! {
                 biased;
                 _ = stop_token.cancelled() => {
-                    run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                    terminal_fence_context.shutdown(&claim_store, &identity, claim_release_budget, config.lease_ttl).await;
                     return;
+                }
+                _ = fatal_fence.cancelled() => {
+                    terminal_fence = true;
+                    break;
                 }
                 _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
                     break;
@@ -986,8 +1159,12 @@ pub async fn run_node_lease<L>(
             let intents_result = tokio::select! {
                 biased;
                 _ = stop_token.cancelled() => {
-                    run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                    terminal_fence_context.shutdown(&claim_store, &identity, claim_release_budget, config.lease_ttl).await;
                     return;
+                }
+                _ = fatal_fence.cancelled() => {
+                    terminal_fence = true;
+                    break;
                 }
                 _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
                     break;
@@ -1009,8 +1186,12 @@ pub async fn run_node_lease<L>(
                         let healthy = tokio::select! {
                             biased;
                             _ = stop_token.cancelled() => {
-                                run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                                terminal_fence_context.shutdown(&claim_store, &identity, claim_release_budget, config.lease_ttl).await;
                                 return;
+                            }
+                            _ = fatal_fence.cancelled() => {
+                                terminal_fence = true;
+                                break 'tick;
                             }
                             _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
                                 break 'tick;
@@ -1023,8 +1204,12 @@ pub async fn run_node_lease<L>(
                             let cleared = tokio::select! {
                                 biased;
                                 _ = stop_token.cancelled() => {
-                                    run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                                    terminal_fence_context.shutdown(&claim_store, &identity, claim_release_budget, config.lease_ttl).await;
                                     return;
+                                }
+                                _ = fatal_fence.cancelled() => {
+                                    terminal_fence = true;
+                                    break 'tick;
                                 }
                                 _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
                                     break 'tick;
@@ -1057,8 +1242,12 @@ pub async fn run_node_lease<L>(
                                     tokio::select! {
                                         biased;
                                         _ = stop_token.cancelled() => {
-                                            run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                                            terminal_fence_context.shutdown(&claim_store, &identity, claim_release_budget, config.lease_ttl).await;
                                             return;
+                                        }
+                                        _ = fatal_fence.cancelled() => {
+                                            terminal_fence = true;
+                                            break 'tick;
                                         }
                                         _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
                                             break 'tick;
@@ -1091,8 +1280,12 @@ pub async fn run_node_lease<L>(
                             tokio::select! {
                                 biased;
                                 _ = stop_token.cancelled() => {
-                                    run_shutdown_drain_with_heartbeat(&lease, &claim_store, &identity, &local_claims, claim_release_budget, config.lease_ttl).await;
+                                    terminal_fence_context.shutdown(&claim_store, &identity, claim_release_budget, config.lease_ttl).await;
                                     return;
+                                }
+                                _ = fatal_fence.cancelled() => {
+                                    terminal_fence = true;
+                                    break 'tick;
                                 }
                                 _ = tokio::time::sleep_until(last_success + config.lease_ttl) => {
                                     break 'tick;
@@ -1108,6 +1301,21 @@ pub async fn run_node_lease<L>(
             }
         }
 
+        // Fatal recovery ambiguity is terminal for this clustering lifetime.
+        // Disable the shared identity before taking the final ownership
+        // snapshot: `rotate` waits for every old-identity publication guard,
+        // then rejects any later SM/RoomActor publication under that owner.
+        // This is the quiescence barrier that makes the following one-shot
+        // demotion sweep complete even while recovery workers are winding
+        // down.
+        if terminal_fence {
+            readiness.set_ready(false);
+            stop_token.cancel();
+            let superseded_identity = identity.clone();
+            live_identity.disable().await;
+            local_claims.demote_owned_by(&superseded_identity).await;
+        }
+
         // Self-fenced (either trigger): stop serving before the lease
         // becomes stealable, then flip client-facing readiness.
         for entity in local_claims.owned().await {
@@ -1120,7 +1328,11 @@ pub async fn run_node_lease<L>(
         // draining, bounded — narrows how long other nodes keep counting
         // it as live (FIX 1(c) already excludes draining rows regardless
         // of heartbeat freshness).
-        mark_draining_bounded(&lease, &identity, config.heartbeat_interval).await;
+        mark_draining_bounded(lease.as_ref(), &identity, config.heartbeat_interval).await;
+
+        if terminal_fence {
+            return;
+        }
 
         // FIX 1(a): mint the fresh re-registration identity ONCE per
         // fence — every retry below (including hysteresis-rejected ones)
@@ -1136,26 +1348,83 @@ pub async fn run_node_lease<L>(
             tokio::select! {
                 biased;
                 _ = stop_token.cancelled() => {
-                    // FIX 3: `fresh` may already be live in
-                    // `clustering_nodes` from an earlier hysteresis-rejected
-                    // retry in this same fence (or may not exist yet at
-                    // all, in which case this is a harmless no-op) — mark
-                    // it draining too before returning on ordinary
-                    // shutdown.
-                    mark_draining_bounded(&lease, &fresh, config.heartbeat_interval).await;
+                    terminal_fence_context.finish(&identity, &fresh).await;
+                    return;
+                }
+                _ = fatal_fence.cancelled() => {
+                    terminal_fence_context.finish(&identity, &fresh).await;
                     return;
                 }
                 _ = tokio::time::sleep(backoff.next_delay()) => {}
             }
-            match lease
-                .register_with_peer_id(&fresh, pod_template_hash.clone(), peer_id.clone())
-                .await
-            {
+            let registration_lease = Arc::clone(&lease);
+            let registration_identity = fresh.clone();
+            let registration_fatal = fatal_fence.clone();
+            let registration_stop = stop_token.clone();
+            let registration_hash = pod_template_hash.clone();
+            let registration_peer_id = peer_id.clone();
+            let control_plane_budget = config.heartbeat_interval;
+            let mut registration = tokio::spawn(async move {
+                let result = registration_lease
+                    .register_with_peer_id(
+                        &registration_identity,
+                        registration_hash,
+                        registration_peer_id,
+                    )
+                    .await;
+                if registration_fatal.is_cancelled() || registration_stop.is_cancelled() {
+                    mark_draining_bounded(
+                        registration_lease.as_ref(),
+                        &registration_identity,
+                        control_plane_budget,
+                    )
+                    .await;
+                }
+                result
+            });
+            let registration_result = tokio::select! {
+                biased;
+                _ = fatal_fence.cancelled() => {
+                    terminal_fence_context.finish(&identity, &fresh).await;
+                    return;
+                }
+                _ = stop_token.cancelled() => {
+                    terminal_fence_context.finish(&identity, &fresh).await;
+                    return;
+                }
+                joined = &mut registration => match joined {
+                    Ok(result) => result,
+                    Err(error) => Err(ClaimError::Backend(format!(
+                        "node re-registration task failed: {error}"
+                    ))),
+                }
+            };
+            match registration_result {
                 Ok(()) => {
-                    let other_live = lease
-                        .count_other_live_nodes(&fresh, config.lease_ttl)
-                        .await
-                        .unwrap_or(usize::MAX);
+                    if fatal_fence.is_cancelled() {
+                        terminal_fence_context.finish(&identity, &fresh).await;
+                        return;
+                    }
+                    let count_identity = fresh.clone();
+                    let count_future = std::pin::pin!(
+                        lease.count_other_live_nodes(&count_identity, config.lease_ttl)
+                    );
+                    let other_live = tokio::select! {
+                        biased;
+                        _ = fatal_fence.cancelled() => {
+                            terminal_fence_context.finish(&identity, &fresh).await;
+                            return;
+                        }
+                        _ = stop_token.cancelled() => {
+                            terminal_fence_context.finish(&identity, &fresh).await;
+                            return;
+                        }
+                        result = count_future => result.unwrap_or(usize::MAX),
+                    };
+                    if fatal_fence.is_cancelled() {
+                        terminal_fence_context.finish(&identity, &fresh).await;
+                        return;
+                    }
                     let reachable = usize::try_from(connected_peers.get().max(0)).unwrap_or(0);
                     if can_reacquire_claims(other_live, reachable) {
                         // ADR-0017 Phase 3 Slice 5 (plan deviation #19,
@@ -1178,14 +1447,55 @@ pub async fn run_node_lease<L>(
                         // snapshot missed it entirely. Re-running the sweep
                         // here catches anything acquired during that window
                         // before this node ever claims to be ready again.
-                        for entity in local_claims.owned().await {
+                        let owned_future = std::pin::pin!(local_claims.owned());
+                        let owned = tokio::select! {
+                            biased;
+                            _ = fatal_fence.cancelled() => {
+                                terminal_fence_context.finish(&identity, &fresh).await;
+                                return;
+                            }
+                            _ = stop_token.cancelled() => {
+                                terminal_fence_context.finish(&identity, &fresh).await;
+                                return;
+                            }
+                            owned = owned_future => owned,
+                        };
+                        for entity in owned {
                             local_claims.demote(&entity).await;
                         }
 
                         let superseded_identity = identity.clone();
                         identity = fresh;
                         live_identity.rotate(identity.clone()).await;
-                        local_claims.demote_owned_by(&superseded_identity).await;
+                        let recovery_heartbeat_cancel = CancellationToken::new();
+                        let mut recovery_heartbeat = tokio::spawn(run_pre_ready_heartbeat(
+                            Arc::clone(&lease),
+                            identity.clone(),
+                            recovery_heartbeat_cancel.clone(),
+                            fatal_fence.clone(),
+                            config.heartbeat_interval,
+                            config.lease_ttl,
+                        ));
+                        let exact_demote =
+                            std::pin::pin!(local_claims.demote_owned_by(&superseded_identity));
+                        tokio::select! {
+                            biased;
+                            _ = fatal_fence.cancelled() => {
+                                recovery_heartbeat_cancel.cancel();
+                                recovery_heartbeat.abort();
+                                let _ = (&mut recovery_heartbeat).await;
+                                terminal_fence_context.finish(&superseded_identity, &identity).await;
+                                return;
+                            }
+                            _ = stop_token.cancelled() => {
+                                recovery_heartbeat_cancel.cancel();
+                                recovery_heartbeat.abort();
+                                let _ = (&mut recovery_heartbeat).await;
+                                terminal_fence_context.finish(&superseded_identity, &identity).await;
+                                return;
+                            }
+                            _ = exact_demote => {}
+                        }
 
                         // What "claim re-acquisition" can mean AT THIS
                         // EXACT POINT: every entity this node owned before
@@ -1201,7 +1511,29 @@ pub async fn run_node_lease<L>(
                         // just-superseded identity is genuinely dead — so it
                         // commits that knowledge to Postgres immediately
                         // via `NodeLeaseStore::expire`.
-                        expire_bounded(&lease, &superseded_identity, config.lease_ttl).await;
+                        let expire_future = std::pin::pin!(expire_bounded(
+                            lease.as_ref(),
+                            &superseded_identity,
+                            config.lease_ttl,
+                        ));
+                        tokio::select! {
+                            biased;
+                            _ = fatal_fence.cancelled() => {
+                                recovery_heartbeat_cancel.cancel();
+                                recovery_heartbeat.abort();
+                                let _ = (&mut recovery_heartbeat).await;
+                                terminal_fence_context.finish(&superseded_identity, &identity).await;
+                                return;
+                            }
+                            _ = stop_token.cancelled() => {
+                                recovery_heartbeat_cancel.cancel();
+                                recovery_heartbeat.abort();
+                                let _ = (&mut recovery_heartbeat).await;
+                                terminal_fence_context.finish(&superseded_identity, &identity).await;
+                                return;
+                            }
+                            _ = expire_future => {}
+                        }
 
                         // FIX 4(b), council-adjudicated: rather than
                         // leaving every one of this node's own dropped
@@ -1216,15 +1548,35 @@ pub async fn run_node_lease<L>(
                         // `reclaim_own_expired_claims`'s owner filter).
                         let reclaim_timed_out = {
                             let reclaim_future = std::pin::pin!(reclaim_own_expired_claims(
-                                &lease,
+                                lease.as_ref(),
                                 claim_store.as_ref(),
                                 &superseded_identity,
                                 &identity,
                                 local_claims.as_ref(),
+                                config.lease_ttl,
                             ));
-                            tokio::time::timeout(config.lease_ttl, reclaim_future)
-                                .await
-                                .is_err()
+                            let reclaim = std::pin::pin!(tokio::time::timeout(
+                                config.lease_ttl,
+                                reclaim_future
+                            ));
+                            tokio::select! {
+                                biased;
+                                _ = fatal_fence.cancelled() => {
+                                    recovery_heartbeat_cancel.cancel();
+                                    recovery_heartbeat.abort();
+                                    let _ = (&mut recovery_heartbeat).await;
+                                    terminal_fence_context.finish(&superseded_identity, &identity).await;
+                                    return;
+                                }
+                                _ = stop_token.cancelled() => {
+                                    recovery_heartbeat_cancel.cancel();
+                                    recovery_heartbeat.abort();
+                                    let _ = (&mut recovery_heartbeat).await;
+                                    terminal_fence_context.finish(&superseded_identity, &identity).await;
+                                    return;
+                                }
+                                result = reclaim => result.is_err(),
+                            }
                         };
                         if reclaim_timed_out {
                             tracing::warn!(
@@ -1235,8 +1587,69 @@ pub async fn run_node_lease<L>(
                             );
                         }
 
+                        recovery_heartbeat_cancel.cancel();
+                        let _ = (&mut recovery_heartbeat).await;
+
+                        if fatal_fence.is_cancelled() {
+                            terminal_fence_context
+                                .finish(&superseded_identity, &identity)
+                                .await;
+                            return;
+                        }
+
+                        // The background heartbeat keeps the fresh row live
+                        // during recovery; prove it once more immediately
+                        // before readiness so no stale fresh identity can be
+                        // published as serving.
+                        let final_heartbeat = std::pin::pin!(tokio::time::timeout(
+                            config.lease_ttl,
+                            lease.heartbeat(&identity, config.lease_ttl),
+                        ));
+                        let heartbeat_is_fresh = tokio::select! {
+                            biased;
+                            _ = fatal_fence.cancelled() => false,
+                            _ = stop_token.cancelled() => false,
+                            result = final_heartbeat => matches!(result, Ok(Ok(true))),
+                        };
+                        if !heartbeat_is_fresh {
+                            fatal_fence.cancel();
+                            terminal_fence_context
+                                .finish(&superseded_identity, &identity)
+                                .await;
+                            return;
+                        }
+
                         backoff.reset();
+                        if stop_token.is_cancelled() {
+                            terminal_fence_context
+                                .shutdown(
+                                    &claim_store,
+                                    &identity,
+                                    claim_release_budget,
+                                    config.lease_ttl,
+                                )
+                                .await;
+                            return;
+                        }
                         readiness.set_ready(true);
+                        if fatal_fence.is_cancelled() {
+                            readiness.set_ready(false);
+                            terminal_fence_context
+                                .finish(&superseded_identity, &identity)
+                                .await;
+                            return;
+                        }
+                        if stop_token.is_cancelled() {
+                            terminal_fence_context
+                                .shutdown(
+                                    &claim_store,
+                                    &identity,
+                                    claim_release_budget,
+                                    config.lease_ttl,
+                                )
+                                .await;
+                            return;
+                        }
                         tracing::info!(
                             node_id = %identity.node_id,
                             "clustering node re-registered; readiness restored"
@@ -1401,6 +1814,8 @@ mod tests {
         clear_reports_zero_rows: Arc<AtomicBool>,
         orphaned_sm_claims:
             Arc<std::sync::Mutex<Vec<crate::clustering::claims::OrphanedSmSessionClaim>>>,
+        registration_entered: Option<Arc<tokio::sync::Notify>>,
+        registration_release: Option<Arc<tokio::sync::Notify>>,
     }
 
     impl FakeLease {
@@ -1417,6 +1832,8 @@ mod tests {
                 cleared_intents: Arc::new(std::sync::Mutex::new(Vec::new())),
                 clear_reports_zero_rows: Arc::new(AtomicBool::new(false)),
                 orphaned_sm_claims: Arc::new(std::sync::Mutex::new(Vec::new())),
+                registration_entered: None,
+                registration_release: None,
             }
         }
     }
@@ -1433,6 +1850,12 @@ mod tests {
                 .lock()
                 .expect("lock")
                 .insert(me.node_id.clone());
+            if let Some(entered) = &self.registration_entered {
+                entered.notify_one();
+            }
+            if let Some(release) = &self.registration_release {
+                release.notified().await;
+            }
             Ok(())
         }
         async fn heartbeat(
@@ -1650,7 +2073,8 @@ mod tests {
         let draining_calls = Arc::clone(&lease.draining_calls);
         let readiness = ClusteringReadiness::new();
         let stop_token = CancellationToken::new();
-        tokio::spawn(run_node_lease(
+        let live_identity = waddle_xmpp::ownership::SharedNodeIdentity::new(identity());
+        let task = tokio::spawn(run_node_lease(
             lease,
             identity(),
             stop_token.clone(),
@@ -1669,7 +2093,7 @@ mod tests {
                 connected_peers: ConnectedPeerCount::new(),
                 local_claims: Arc::new(NoLocallyClaimedEntities),
                 readiness: readiness.clone(),
-                live_identity: waddle_xmpp::ownership::SharedNodeIdentity::new(identity()),
+                live_identity: live_identity.clone(),
                 peer_id: None,
                 claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
                 claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
@@ -1694,6 +2118,15 @@ mod tests {
             "the fenced identity must be marked draining before re-registration"
         );
         stop_token.cancel();
+        task.await.expect("node lease exits after shutdown drain");
+        assert!(
+            !readiness.is_ready(),
+            "clustering shutdown must revoke readiness even after re-registration"
+        );
+        assert!(
+            !live_identity.current().is_active(),
+            "clustering shutdown must revoke publication authority"
+        );
     }
 
     // FIX 1(a): the row-leak wedge regression test. With `other_live_nodes`
@@ -2147,6 +2580,39 @@ mod tests {
         deferred: std::sync::Mutex<Vec<Entity>>,
     }
 
+    struct BlockingSealLocalClaims {
+        entity: Entity,
+        seal_started: Arc<tokio::sync::Notify>,
+        seal_release: Arc<tokio::sync::Notify>,
+        exact_demoted_owners: Arc<std::sync::Mutex<Vec<NodeIdentity>>>,
+    }
+
+    #[async_trait]
+    impl LocallyClaimedEntities for BlockingSealLocalClaims {
+        async fn owned(&self) -> Vec<Entity> {
+            vec![self.entity.clone()]
+        }
+
+        async fn demote(&self, _entity: &Entity) {}
+
+        async fn demote_owned_by(&self, owner: &NodeIdentity) {
+            self.exact_demoted_owners
+                .lock()
+                .expect("lock")
+                .push(owner.clone());
+        }
+
+        async fn health_check(&self, _entity: &Entity) -> bool {
+            true
+        }
+
+        async fn seal_before_release(&self, _entity: &Entity) -> bool {
+            self.seal_started.notify_one();
+            self.seal_release.notified().await;
+            true
+        }
+    }
+
     #[async_trait]
     impl LocallyClaimedEntities for RejectingHydrationLocalClaims {
         async fn owned(&self) -> Vec<Entity> {
@@ -2545,6 +3011,304 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn fatal_orphan_recovery_fence_demotes_every_claim_before_clustering_stops() {
+        let interval = Duration::from_millis(50);
+        let lease_ttl = Duration::from_secs(10);
+        let lease = FakeLease::new(Box::new(|| Ok(true)));
+        let entities = vec![
+            user_actor_entity("fatal-fence-user"),
+            waddle_xmpp::ownership::Entity::new(
+                waddle_xmpp::ownership::EntityType::RoomActor,
+                "fatal-fence-room",
+            ),
+            waddle_xmpp::ownership::Entity::new(
+                waddle_xmpp::ownership::EntityType::SmSession,
+                "fatal-fence-sm",
+            ),
+        ];
+        let demoted = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let exact_demoted_owners = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let local_claims = Arc::new(FakeLocalClaims {
+            owned: entities.clone(),
+            healthy: Arc::new(AtomicBool::new(true)),
+            demoted: Arc::clone(&demoted),
+            exact_demoted_owners: Arc::clone(&exact_demoted_owners),
+            hydrated: FakeLocalClaims::unhydrated(),
+            live_identity_at_hydration: None,
+            stale_hydration_observed: Arc::new(AtomicBool::new(false)),
+        });
+        let readiness = ClusteringReadiness::new();
+        let fatal_fence = readiness.fatal_fence_token();
+        let stop_token = CancellationToken::new();
+        let initial_identity = identity();
+        let live_identity =
+            waddle_xmpp::ownership::SharedNodeIdentity::new(initial_identity.clone());
+        let task = tokio::spawn(run_node_lease(
+            lease,
+            initial_identity.clone(),
+            stop_token.clone(),
+            NodeLeaseRunConfig {
+                pod_template_hash: None,
+                lease_config: ClusteringNodeLeaseConfig {
+                    heartbeat_interval: interval,
+                    lease_ttl,
+                    claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                },
+                self_fence_config: ClusteringSelfFenceConfig {
+                    isolation_intervals: 1_000,
+                    reregister_backoff_base: Duration::from_millis(10),
+                    reregister_backoff_max: Duration::from_millis(20),
+                },
+                connected_peers: ConnectedPeerCount::new(),
+                local_claims,
+                readiness: readiness.clone(),
+                live_identity: live_identity.clone(),
+                peer_id: None,
+                claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
+                claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        fatal_fence.cancel();
+        task.await.expect("node lease exits after terminal fence");
+
+        let mut demoted_entities = demoted.lock().expect("lock").clone();
+        demoted_entities.sort_by(|a, b| a.id.cmp(&b.id));
+        let mut expected = entities;
+        expected.sort_by(|a, b| a.id.cmp(&b.id));
+        assert_eq!(demoted_entities, expected);
+        assert!(!readiness.is_ready());
+        assert_ne!(
+            live_identity.current(),
+            initial_identity,
+            "fatal fencing must enter a terminally disabled publication state"
+        );
+        assert_eq!(
+            exact_demoted_owners.lock().expect("lock").as_slice(),
+            std::slice::from_ref(&initial_identity),
+            "all work published under the superseded identity must be demoted"
+        );
+        assert!(
+            stop_token.is_cancelled(),
+            "sibling clustering tasks stop only after local authority is demoted"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fatal_fence_latched_during_reregistration_cannot_restore_readiness() {
+        let interval = Duration::from_millis(50);
+        let mut lease = FakeLease::new(Box::new(|| Ok(false)));
+        let registration_entered = Arc::new(tokio::sync::Notify::new());
+        let registration_release = Arc::new(tokio::sync::Notify::new());
+        lease.registration_entered = Some(Arc::clone(&registration_entered));
+        lease.registration_release = Some(Arc::clone(&registration_release));
+
+        let initial_identity = identity();
+        let live_identity =
+            waddle_xmpp::ownership::SharedNodeIdentity::new(initial_identity.clone());
+        let exact_demoted_owners = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let local_claims = Arc::new(FakeLocalClaims {
+            owned: Vec::new(),
+            healthy: Arc::new(AtomicBool::new(true)),
+            demoted: Arc::new(std::sync::Mutex::new(Vec::new())),
+            exact_demoted_owners: Arc::clone(&exact_demoted_owners),
+            hydrated: FakeLocalClaims::unhydrated(),
+            live_identity_at_hydration: None,
+            stale_hydration_observed: Arc::new(AtomicBool::new(false)),
+        });
+        let readiness = ClusteringReadiness::new();
+        let fatal_fence = readiness.fatal_fence_token();
+        let stop_token = CancellationToken::new();
+        let task = tokio::spawn(run_node_lease(
+            lease,
+            initial_identity.clone(),
+            stop_token.clone(),
+            NodeLeaseRunConfig {
+                pod_template_hash: None,
+                lease_config: ClusteringNodeLeaseConfig {
+                    heartbeat_interval: interval,
+                    lease_ttl: Duration::from_secs(10),
+                    claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                },
+                self_fence_config: ClusteringSelfFenceConfig {
+                    isolation_intervals: 1_000,
+                    reregister_backoff_base: Duration::from_millis(10),
+                    reregister_backoff_max: Duration::from_millis(20),
+                },
+                connected_peers: ConnectedPeerCount::new(),
+                local_claims,
+                readiness: readiness.clone(),
+                live_identity: live_identity.clone(),
+                peer_id: None,
+                claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
+                claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(interval + Duration::from_millis(20)).await;
+        registration_entered.notified().await;
+        fatal_fence.cancel();
+        registration_release.notify_one();
+        task.await
+            .expect("terminal latch exits after registration returns");
+
+        assert!(!readiness.is_ready());
+        assert!(stop_token.is_cancelled());
+        let published = live_identity.current();
+        assert_ne!(published, initial_identity);
+        let exact = exact_demoted_owners.lock().expect("lock");
+        assert!(exact.contains(&initial_identity));
+        assert_eq!(
+            exact.len(),
+            2,
+            "both pre-fence and freshly registered owners retire"
+        );
+        assert!(
+            exact.iter().all(|owner| owner != &published),
+            "the live identity must be terminally disabled, not either retired owner"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_during_reregistration_disables_the_superseded_identity() {
+        let interval = Duration::from_millis(50);
+        let mut lease = FakeLease::new(Box::new(|| Ok(false)));
+        let registration_entered = Arc::new(tokio::sync::Notify::new());
+        let registration_release = Arc::new(tokio::sync::Notify::new());
+        lease.registration_entered = Some(Arc::clone(&registration_entered));
+        lease.registration_release = Some(Arc::clone(&registration_release));
+
+        let initial_identity = identity();
+        let live_identity =
+            waddle_xmpp::ownership::SharedNodeIdentity::new(initial_identity.clone());
+        let exact_demoted_owners = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let local_claims = Arc::new(FakeLocalClaims {
+            owned: Vec::new(),
+            healthy: Arc::new(AtomicBool::new(true)),
+            demoted: Arc::new(std::sync::Mutex::new(Vec::new())),
+            exact_demoted_owners: Arc::clone(&exact_demoted_owners),
+            hydrated: FakeLocalClaims::unhydrated(),
+            live_identity_at_hydration: None,
+            stale_hydration_observed: Arc::new(AtomicBool::new(false)),
+        });
+        let readiness = ClusteringReadiness::new();
+        let stop_token = CancellationToken::new();
+        let task = tokio::spawn(run_node_lease(
+            lease,
+            initial_identity.clone(),
+            stop_token.clone(),
+            NodeLeaseRunConfig {
+                pod_template_hash: None,
+                lease_config: ClusteringNodeLeaseConfig {
+                    heartbeat_interval: interval,
+                    lease_ttl: Duration::from_secs(10),
+                    claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                },
+                self_fence_config: ClusteringSelfFenceConfig {
+                    isolation_intervals: 1_000,
+                    reregister_backoff_base: Duration::from_millis(10),
+                    reregister_backoff_max: Duration::from_millis(20),
+                },
+                connected_peers: ConnectedPeerCount::new(),
+                local_claims,
+                readiness: readiness.clone(),
+                live_identity: live_identity.clone(),
+                peer_id: None,
+                claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
+                claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(interval + Duration::from_millis(20)).await;
+        registration_entered.notified().await;
+        stop_token.cancel();
+        registration_release.notify_one();
+        task.await
+            .expect("shutdown exits after terminally disabling publication");
+
+        assert!(!readiness.is_ready());
+        assert!(!live_identity.current().is_active());
+        let exact = exact_demoted_owners.lock().expect("lock");
+        assert!(exact.contains(&initial_identity));
+        assert_eq!(
+            exact.len(),
+            2,
+            "both pre-fence and potentially registered owners retire"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn fatal_fence_preempts_an_in_progress_graceful_drain() {
+        let interval = Duration::from_millis(50);
+        let initial_identity = identity();
+        let live_identity =
+            waddle_xmpp::ownership::SharedNodeIdentity::new(initial_identity.clone());
+        let seal_started = Arc::new(tokio::sync::Notify::new());
+        let seal_release = Arc::new(tokio::sync::Notify::new());
+        let exact_demoted_owners = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let local_claims = Arc::new(BlockingSealLocalClaims {
+            entity: waddle_xmpp::ownership::Entity::new(
+                waddle_xmpp::ownership::EntityType::RoomActor,
+                "fatal-during-drain",
+            ),
+            seal_started: Arc::clone(&seal_started),
+            seal_release,
+            exact_demoted_owners: Arc::clone(&exact_demoted_owners),
+        });
+        let readiness = ClusteringReadiness::new();
+        let fatal_fence = readiness.fatal_fence_token();
+        let stop_token = CancellationToken::new();
+        let task = tokio::spawn(run_node_lease(
+            FakeLease::new(Box::new(|| Ok(true))),
+            initial_identity.clone(),
+            stop_token.clone(),
+            NodeLeaseRunConfig {
+                pod_template_hash: None,
+                lease_config: ClusteringNodeLeaseConfig {
+                    heartbeat_interval: interval,
+                    lease_ttl: Duration::from_secs(10),
+                    claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+                },
+                self_fence_config: ClusteringSelfFenceConfig {
+                    isolation_intervals: 1_000,
+                    reregister_backoff_base: Duration::from_millis(10),
+                    reregister_backoff_max: Duration::from_millis(20),
+                },
+                connected_peers: ConnectedPeerCount::new(),
+                local_claims,
+                readiness: readiness.clone(),
+                live_identity: live_identity.clone(),
+                peer_id: None,
+                claim_store: Arc::new(waddle_xmpp::ownership::InProcessClaimStore::new()),
+                claim_release_budget: TEST_CLAIM_RELEASE_BUDGET,
+            },
+        ));
+
+        tokio::task::yield_now().await;
+        stop_token.cancel();
+        seal_started.notified().await;
+        assert!(
+            live_identity.current().is_active(),
+            "ordinary drain keeps authority active through the seal barrier"
+        );
+
+        fatal_fence.cancel();
+        task.await
+            .expect("fatal ambiguity interrupts the blocked graceful drain");
+
+        assert!(!readiness.is_ready());
+        assert!(!live_identity.current().is_active());
+        assert_eq!(
+            exact_demoted_owners.lock().expect("lock").as_slice(),
+            std::slice::from_ref(&initial_identity),
+            "fatal preemption exact-demotes the active identity once"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn node_lease_post_rotation_sweeps_the_exact_superseded_owner() {
         let interval = Duration::from_millis(50);
         let initial_identity = identity();
@@ -2564,8 +3328,12 @@ mod tests {
             stale_hydration_observed: Arc::new(AtomicBool::new(false)),
         });
         let stop_token = CancellationToken::new();
+        let mut heartbeat_calls = 0usize;
         tokio::spawn(run_node_lease(
-            FakeLease::new(Box::new(|| Ok(false))),
+            FakeLease::new(Box::new(move || {
+                heartbeat_calls += 1;
+                Ok(heartbeat_calls > 1)
+            })),
             initial_identity.clone(),
             stop_token.clone(),
             NodeLeaseRunConfig {
@@ -2647,7 +3415,15 @@ mod tests {
             hydrated: std::sync::Mutex::new(Vec::new()),
         };
 
-        reclaim_own_expired_claims(&lease, &store, &old, &fresh, &local).await;
+        reclaim_own_expired_claims(
+            &lease,
+            &store,
+            &old,
+            &fresh,
+            &local,
+            Duration::from_secs(10),
+        )
+        .await;
 
         assert_eq!(local.admission_attempts.load(Ordering::SeqCst), 2);
         assert_eq!(
@@ -2708,6 +3484,7 @@ mod tests {
                 &reclaim_old,
                 &reclaim_fresh,
                 reclaim_local.as_ref(),
+                Duration::from_secs(10),
             )
             .await;
         });
@@ -2752,7 +3529,15 @@ mod tests {
             deferred: std::sync::Mutex::new(Vec::new()),
         };
 
-        reclaim_own_expired_claims(&lease, &store, &old, &fresh, &local).await;
+        reclaim_own_expired_claims(
+            &lease,
+            &store,
+            &old,
+            &fresh,
+            &local,
+            Duration::from_secs(10),
+        )
+        .await;
 
         assert_eq!(
             store

--- a/server/crates/waddle-server/src/clustering/self_fence.rs
+++ b/server/crates/waddle-server/src/clustering/self_fence.rs
@@ -1840,6 +1840,19 @@ mod tests {
 
     #[async_trait]
     impl NodeLeaseStore for FakeLease {
+        async fn list_orphaned_room_actor_claims_page(
+            &self,
+            _after: Option<crate::clustering::claims::RoomOrphanScanCursor>,
+            _limit: usize,
+        ) -> Result<crate::clustering::claims::OrphanedRoomActorClaimPage, ClaimError> {
+            Ok(crate::clustering::claims::OrphanedRoomActorClaimPage {
+                candidates: Vec::new(),
+                next_cursor: None,
+                has_more: false,
+                quarantined: 0,
+            })
+        }
+
         async fn register(
             &self,
             me: &NodeIdentity,

--- a/server/crates/waddle-server/src/pending_delivery/database.rs
+++ b/server/crates/waddle-server/src/pending_delivery/database.rs
@@ -133,9 +133,10 @@ fn claim_error_to_pending_storage_error(error: ClaimError, entity: Entity) -> Pe
         // `Draining`, will not become) the owner, so the caller should
         // treat it exactly like any other ownership loss, never a
         // transient backend error.
-        ClaimError::AlreadyClaimed | ClaimError::Conflict | ClaimError::Draining => {
-            PendingStorageError::NotOwner { entity }
-        }
+        ClaimError::AlreadyClaimed
+        | ClaimError::Conflict
+        | ClaimError::Draining
+        | ClaimError::AuthorityDisabled => PendingStorageError::NotOwner { entity },
         ClaimError::Backend(_) | ClaimError::Poisoned => {
             PendingStorageError::Other(error.to_string())
         }

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/isr_resume.rs
@@ -168,6 +168,7 @@ async fn isr_fixture() -> Option<IsrFixture> {
         resume_bridge: None,
         ordered_relay_delivery_bridge: None,
         stop_token: None,
+        fatal_fence: None,
         resume_handshake_timeout: None,
     };
 
@@ -207,6 +208,7 @@ async fn in_memory_isr_fixture() -> IsrFixture {
         resume_bridge: None,
         ordered_relay_delivery_bridge: None,
         stop_token: None,
+        fatal_fence: None,
         resume_handshake_timeout: None,
     };
     let state = create_test_websocket_state_with_clustering(clustering, sm_session_registry).await;
@@ -1290,6 +1292,7 @@ async fn isr_resume_wins_a_cross_node_steal_and_consumes_the_token() {
         ordered_relay_delivery_bridge: None,
         resume_bridge: None,
         stop_token: None,
+        fatal_fence: None,
         // FIX 2: a real handshake budget — node B's cross-node steal must
         // actually reach branch 1 (`current_claim` finds node A's foreign
         // claim; a persisted snapshot already exists too), never

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/stream_management.rs
@@ -3821,6 +3821,7 @@ mod fix3_shutdown_race {
             resume_bridge: None,
             ordered_relay_delivery_bridge: None,
             stop_token: None,
+            fatal_fence: None,
             resume_handshake_timeout: Some(handshake_budget),
         };
 
@@ -4152,6 +4153,7 @@ mod fix_a_post_cas_shutdown {
             resume_bridge: None,
             ordered_relay_delivery_bridge: None,
             stop_token: None,
+            fatal_fence: None,
             resume_handshake_timeout: Some(handshake_budget),
         };
 

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -628,6 +628,8 @@ pub(crate) fn spawn_orphan_reaper_janitor(
         };
         let room_registry_actor = websocket_state.deps.protocol.room_registry.clone();
         tokio::spawn(async move {
+            let terminal_room_registry =
+                waddle_xmpp::muc::RoomRegistry::wrap(room_registry_actor.clone());
             let registry_lifetime_watch = spawn_room_registry_lifetime_watch(
                 room_registry_actor,
                 stop.clone(),
@@ -646,11 +648,15 @@ pub(crate) fn spawn_orphan_reaper_janitor(
             loop {
                 tokio::select! {
                     _ = stop.cancelled() => break,
+                    _ = supervisor.workers.fatal_fence.cancelled() => break,
                     _ = ticker.tick() => {}
                 }
                 if !supervisor.is_healthy() {
                     error!("orphan reaper worker exited; restarting workers with retained work");
                     supervisor = supervisor.restarted(registry.clone(), stop.clone()).await;
+                    if supervisor.workers.fatal_fence.is_cancelled() {
+                        break;
+                    }
                 }
                 let Some(state) = weak_state.upgrade() else {
                     break;
@@ -676,9 +682,33 @@ pub(crate) fn spawn_orphan_reaper_janitor(
                 if !supervisor.is_healthy() {
                     error!("orphan reaper worker exited during sweep; restarting workers with retained work");
                     supervisor = supervisor.restarted(registry.clone(), stop.clone()).await;
+                    if supervisor.workers.fatal_fence.is_cancelled() {
+                        break;
+                    }
                 }
             }
+            // Snapshot and stop SM/release workers before any other terminal
+            // await. A fatal fence must not leave a live worker able to start
+            // another ownership CAS while RoomRegistry cleanup is in flight.
             supervisor.shutdown_terminal().await;
+            match terminal_room_registry
+                .drain_pending_reclaimed_rooms_for_shutdown()
+                .await
+            {
+                Ok(outcome) if outcome.retained > 0 => {
+                    error!(released = outcome.released, preserved_live = outcome.preserved_live, retained = outcome.retained, "orphan reaper: terminal RoomRegistry claim drain retained exact fences for node-expiry recovery");
+                }
+                Ok(outcome) => {
+                    debug!(
+                        released = outcome.released,
+                        preserved_live = outcome.preserved_live,
+                        "orphan reaper: terminal RoomRegistry claim drain completed"
+                    );
+                }
+                Err(error) => {
+                    error!(%error, "orphan reaper: terminal RoomRegistry claim drain failed; node-expiry recovery remains authoritative");
+                }
+            }
             let _ = registry_lifetime_watch.await;
         });
     }
@@ -714,6 +744,7 @@ where
     tokio::select! {
         biased;
         _ = cancel.cancelled() => OrphanSweepOutcome::Cancelled,
+        _ = fatal_fence.cancelled() => OrphanSweepOutcome::Cancelled,
         result = tokio::time::timeout(timeout, sweep) => match result {
             Ok(()) => OrphanSweepOutcome::Completed,
             Err(_) => {
@@ -762,6 +793,28 @@ mod orphan_sweep_supervision_tests {
 
         assert_eq!(outcome, OrphanSweepOutcome::Cancelled);
         assert!(!fatal_fence.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn fatal_fence_cancels_a_sweep_before_it_can_make_progress() {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let fatal_fence = tokio_util::sync::CancellationToken::new();
+        fatal_fence.cancel();
+        let entered = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let entered_by_sweep = Arc::clone(&entered);
+
+        let outcome = supervise_orphan_reaper_sweep(
+            &cancel,
+            &fatal_fence,
+            Duration::from_secs(1),
+            async move {
+                entered_by_sweep.store(true, std::sync::atomic::Ordering::SeqCst);
+            },
+        )
+        .await;
+
+        assert_eq!(outcome, OrphanSweepOutcome::Cancelled);
+        assert!(!entered.load(std::sync::atomic::Ordering::SeqCst));
     }
 }
 
@@ -943,8 +996,8 @@ struct OrphanReaperWorkers {
     hydration_pending: Arc<std::sync::Mutex<std::collections::HashMap<String, PendingSmHydration>>>,
     release_pending:
         Arc<std::sync::Mutex<std::collections::HashMap<ExactReleaseKey, ExactReleaseWork>>>,
-    room_cursor: Arc<std::sync::Mutex<Option<String>>>,
-    sm_cursor: Arc<std::sync::Mutex<Option<String>>>,
+    room_cursor: Arc<std::sync::Mutex<Option<crate::clustering::claims::RoomOrphanScanCursor>>>,
+    sm_cursor: Arc<std::sync::Mutex<Option<crate::clustering::claims::SmOrphanScanCursor>>>,
     cancel: tokio_util::sync::CancellationToken,
     fatal_fence: tokio_util::sync::CancellationToken,
 }
@@ -1159,25 +1212,25 @@ impl OrphanReaperWorkers {
             .collect()
     }
 
-    fn sm_cursor(&self) -> Option<String> {
+    fn sm_cursor(&self) -> Option<crate::clustering::claims::SmOrphanScanCursor> {
         self.sm_cursor
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .clone()
     }
 
-    fn set_sm_cursor(&self, cursor: Option<String>) {
+    fn set_sm_cursor(&self, cursor: Option<crate::clustering::claims::SmOrphanScanCursor>) {
         *self.sm_cursor.lock().unwrap_or_else(|e| e.into_inner()) = cursor;
     }
 
-    fn room_cursor(&self) -> Option<String> {
+    fn room_cursor(&self) -> Option<crate::clustering::claims::RoomOrphanScanCursor> {
         self.room_cursor
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .clone()
     }
 
-    fn set_room_cursor(&self, cursor: Option<String>) {
+    fn set_room_cursor(&self, cursor: Option<crate::clustering::claims::RoomOrphanScanCursor>) {
         *self.room_cursor.lock().unwrap_or_else(|e| e.into_inner()) = cursor;
     }
 }
@@ -1434,20 +1487,34 @@ impl OrphanReaperSupervisor {
         let fatal_fence = self.workers.fatal_fence.clone();
         let previous_registry = self.registry.clone();
         self.shutdown_for_restart().await;
-        futures::future::join_all(unwon_reservations.into_iter().map(
+        let retirement_results = futures::future::join_all(unwon_reservations.into_iter().map(
             |(entity, attempted_owner, reservation)| {
                 let registry = previous_registry.clone();
                 async move {
-                    let _ = registry
+                    let entity_id = entity.id.clone();
+                    let result = registry
                         .retire_uncertain_reclaimed_claim(&entity, &attempted_owner, reservation)
                         .await;
+                    (entity_id, result)
                 }
             },
         ))
         .await;
+        let mut retirement_failed = false;
+        for (entity_id, result) in retirement_results {
+            if let Err(error) = result {
+                error!(%error, %entity_id, "orphan reaper: uncertain SM claim could not be retired during worker restart; self-fencing node");
+                fatal_fence.cancel();
+                retirement_failed = true;
+            }
+        }
         let next = Self::new_with_fatal_fence(registry, parent_cancel, fatal_fence);
         next.workers.set_room_cursor(room_cursor);
         next.workers.set_sm_cursor(sm_cursor);
+        if retirement_failed {
+            next.workers.cancel.cancel();
+            return next;
+        }
         for work in hydration {
             if !next
                 .workers
@@ -1496,17 +1563,24 @@ impl OrphanReaperSupervisor {
                 error!(worker, %error, "orphan reaper worker failed");
             }
         }
-        futures::future::join_all(unwon_reservations.into_iter().map(
+        let retirement_results = futures::future::join_all(unwon_reservations.into_iter().map(
             |(entity, attempted_owner, reservation)| {
                 let registry = self.registry.clone();
                 async move {
-                    let _ = registry
+                    let entity_id = entity.id.clone();
+                    let result = registry
                         .retire_uncertain_reclaimed_claim(&entity, &attempted_owner, reservation)
                         .await;
+                    (entity_id, result)
                 }
             },
         ))
         .await;
+        for (entity_id, result) in retirement_results {
+            if let Err(error) = result {
+                error!(%error, %entity_id, "orphan reaper: terminal uncertain SM claim cleanup failed; retaining capacity reservation until process teardown");
+            }
+        }
         futures::future::join_all(hydrations.into_iter().map(|work| {
             let registry = self.registry.clone();
             async move {
@@ -2142,7 +2216,7 @@ async fn hung_sm_hydration_does_not_block_completed_room_lane() {
 
 #[cfg(all(test, feature = "clustering"))]
 #[tokio::test]
-async fn terminal_shutdown_retires_a_pre_steal_sm_reservation() {
+async fn terminal_shutdown_retains_an_unobserved_uncertain_sm_reservation() {
     use waddle_xmpp::ownership::{Entity, EntityType, NodeIdentity};
 
     let registry =
@@ -2167,7 +2241,38 @@ async fn terminal_shutdown_retires_a_pre_steal_sm_reservation() {
 
     assert!(registry
         .reserve_reclaimed_claim_capacity(&replacement)
-        .is_some());
+        .is_none());
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn worker_restart_self_fences_when_an_uncertain_sm_claim_is_unobserved() {
+    use waddle_xmpp::ownership::{Entity, EntityType, NodeIdentity};
+
+    let registry =
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::with_capacity(1));
+    let entity = Entity::new(EntityType::SmSession, "unobserved-during-restart");
+    let replacement = Entity::new(EntityType::SmSession, "replacement-after-restart");
+    let reservation = registry
+        .reserve_reclaimed_claim_capacity(&entity)
+        .expect("initial reservation");
+    let parent_cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(registry.clone(), parent_cancel.clone());
+    let fatal_fence = supervisor.workers.fatal_fence.clone();
+    assert!(supervisor.workers.reserve_hydration(
+        &entity,
+        &NodeIdentity::new("sweeper", "incarnation"),
+        reservation,
+    ));
+
+    let restarted = supervisor.restarted(registry.clone(), parent_cancel).await;
+
+    assert!(fatal_fence.is_cancelled());
+    assert!(restarted.workers.cancel.is_cancelled());
+    assert!(registry
+        .reserve_reclaimed_claim_capacity(&replacement)
+        .is_none());
+    restarted.shutdown_terminal().await;
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -2692,12 +2797,14 @@ async fn supervisor_restart_preserves_orphan_scan_cursors() {
         Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
         parent_cancel.clone(),
     );
-    supervisor
-        .workers
-        .set_sm_cursor(Some("sm_session:page-064".to_string()));
-    supervisor
-        .workers
-        .set_room_cursor(Some("room_actor:page-064@muc.example.com".to_string()));
+    supervisor.workers.set_sm_cursor(Some(
+        crate::clustering::claims::SmOrphanScanCursor::from_raw("sm_session:page-064".to_string()),
+    ));
+    supervisor.workers.set_room_cursor(Some(
+        crate::clustering::claims::RoomOrphanScanCursor::from_raw(
+            "room_actor:page-064@muc.example.com".to_string(),
+        ),
+    ));
 
     let restarted = supervisor
         .restarted(
@@ -2707,11 +2814,19 @@ async fn supervisor_restart_preserves_orphan_scan_cursors() {
         .await;
 
     assert_eq!(
-        restarted.workers.sm_cursor().as_deref(),
+        restarted
+            .workers
+            .sm_cursor()
+            .as_ref()
+            .map(|cursor| cursor.as_raw()),
         Some("sm_session:page-064")
     );
     assert_eq!(
-        restarted.workers.room_cursor().as_deref(),
+        restarted
+            .workers
+            .room_cursor()
+            .as_ref()
+            .map(|cursor| cursor.as_raw()),
         Some("room_actor:page-064@muc.example.com")
     );
     restarted.shutdown().await;
@@ -3162,8 +3277,7 @@ async fn run_orphan_reaper_sweep_with_workers(
         workers.set_room_cursor(committed_cursor.clone());
         if let Err(error) = node_lease
             .persist_orphan_reaper_cursor(
-                waddle_xmpp::ownership::EntityType::RoomActor,
-                committed_cursor,
+                crate::clustering::claims::OrphanReaperCursorUpdate::RoomActor(committed_cursor),
             )
             .await
         {
@@ -3381,8 +3495,7 @@ async fn run_orphan_reaper_sweep_with_workers(
         workers.set_sm_cursor(committed_cursor.clone());
         if let Err(error) = node_lease
             .persist_orphan_reaper_cursor(
-                waddle_xmpp::ownership::EntityType::SmSession,
-                committed_cursor,
+                crate::clustering::claims::OrphanReaperCursorUpdate::SmSession(committed_cursor),
             )
             .await
         {

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -690,9 +690,9 @@ pub(crate) fn spawn_orphan_reaper_janitor(
             // Snapshot and stop SM/release workers before any other terminal
             // await. A fatal fence must not leave a live worker able to start
             // another ownership CAS while RoomRegistry cleanup is in flight.
-            supervisor.shutdown_terminal().await;
+            let pending_room_handoffs = supervisor.shutdown_terminal().await;
             match terminal_room_registry
-                .drain_pending_reclaimed_rooms_for_shutdown()
+                .drain_pending_reclaimed_rooms_for_shutdown(pending_room_handoffs)
                 .await
             {
                 Ok(outcome) if outcome.retained > 0 => {
@@ -996,6 +996,18 @@ struct OrphanReaperWorkers {
     hydration_pending: Arc<std::sync::Mutex<std::collections::HashMap<String, PendingSmHydration>>>,
     release_pending:
         Arc<std::sync::Mutex<std::collections::HashMap<ExactReleaseKey, ExactReleaseWork>>>,
+    /// Exact RoomActor epochs observed as won but not yet accepted into the
+    /// registry actor's pending inventory. This synchronous bridge closes the
+    /// cancellation gap between the steal CAS returning and the first
+    /// subsequent mailbox await.
+    room_handoff_pending: Arc<
+        std::sync::Mutex<
+            std::collections::HashMap<
+                (jid::BareJid, waddle_xmpp::muc::RoomClaimFenceContext),
+                waddle_xmpp::muc::room_registry_actor::PendingReclaimedRoom,
+            >,
+        >,
+    >,
     room_cursor: Arc<std::sync::Mutex<Option<crate::clustering::claims::RoomOrphanScanCursor>>>,
     sm_cursor: Arc<std::sync::Mutex<Option<crate::clustering::claims::SmOrphanScanCursor>>>,
     cancel: tokio_util::sync::CancellationToken,
@@ -1212,6 +1224,51 @@ impl OrphanReaperWorkers {
             .collect()
     }
 
+    fn remember_room_handoff(
+        &self,
+        pending: waddle_xmpp::muc::room_registry_actor::PendingReclaimedRoom,
+    ) {
+        let key = (pending.room_jid.clone(), pending.claim_fence.clone());
+        let mut handoffs = self
+            .room_handoff_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if handoffs.contains_key(&key) {
+            return;
+        }
+        // Every entry consumes a RoomRegistry reservation admitted under the
+        // same bound before the steal. Keep the post-CAS transition
+        // infallible: once ownership is observed as won, dropping the exact
+        // fence would be worse than violating a defensive debug assertion.
+        debug_assert!(handoffs.len() < ORPHAN_WORK_QUEUE_CAPACITY);
+        handoffs.insert(key, pending);
+        crate::clustering::metrics::record_orphan_work_queue_depth("room_handoff", handoffs.len());
+    }
+
+    fn forget_room_handoff(
+        &self,
+        room_jid: &jid::BareJid,
+        claim_fence: &waddle_xmpp::muc::RoomClaimFenceContext,
+    ) {
+        let mut handoffs = self
+            .room_handoff_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        handoffs.remove(&(room_jid.clone(), claim_fence.clone()));
+        crate::clustering::metrics::record_orphan_work_queue_depth("room_handoff", handoffs.len());
+    }
+
+    fn pending_room_handoffs(
+        &self,
+    ) -> Vec<waddle_xmpp::muc::room_registry_actor::PendingReclaimedRoom> {
+        self.room_handoff_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .cloned()
+            .collect()
+    }
+
     fn sm_cursor(&self) -> Option<crate::clustering::claims::SmOrphanScanCursor> {
         self.sm_cursor
             .lock()
@@ -1260,11 +1317,14 @@ impl OrphanReaperSupervisor {
         let (release_tx, mut release_rx) = tokio::sync::mpsc::channel(ORPHAN_WORK_QUEUE_CAPACITY);
         let hydration_pending = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
         let release_pending = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let room_handoff_pending =
+            Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
         let workers = OrphanReaperWorkers {
             hydration_tx,
             release_tx,
             hydration_pending: hydration_pending.clone(),
             release_pending: release_pending.clone(),
+            room_handoff_pending,
             room_cursor: Arc::new(std::sync::Mutex::new(None)),
             sm_cursor: Arc::new(std::sync::Mutex::new(None)),
             cancel: cancel.clone(),
@@ -1482,6 +1542,7 @@ impl OrphanReaperSupervisor {
         let hydration = self.workers.pending_hydrations();
         let unwon_reservations = self.workers.pending_unwon_hydration_reservations();
         let releases = self.workers.pending_releases();
+        let room_handoffs = self.workers.pending_room_handoffs();
         let room_cursor = self.workers.room_cursor();
         let sm_cursor = self.workers.sm_cursor();
         let fatal_fence = self.workers.fatal_fence.clone();
@@ -1511,6 +1572,9 @@ impl OrphanReaperSupervisor {
         let next = Self::new_with_fatal_fence(registry, parent_cancel, fatal_fence);
         next.workers.set_room_cursor(room_cursor);
         next.workers.set_sm_cursor(sm_cursor);
+        for handoff in room_handoffs {
+            next.workers.remember_room_handoff(handoff);
+        }
         if retirement_failed {
             next.workers.cancel.cancel();
             return next;
@@ -1547,10 +1611,13 @@ impl OrphanReaperSupervisor {
         }
     }
 
-    async fn shutdown_terminal(mut self) {
+    async fn shutdown_terminal(
+        mut self,
+    ) -> Vec<waddle_xmpp::muc::room_registry_actor::PendingReclaimedRoom> {
         let hydrations = self.workers.pending_hydrations();
         let unwon_reservations = self.workers.pending_unwon_hydration_reservations();
         let releases = self.workers.pending_releases();
+        let room_handoffs = self.workers.pending_room_handoffs();
         self.cancel.cancel();
         for (worker, task) in self.tasks.drain(..) {
             if let Err(error) = task.await {
@@ -1623,6 +1690,8 @@ impl OrphanReaperSupervisor {
             }
         }))
         .await;
+        crate::clustering::metrics::record_orphan_work_queue_depth("room_handoff", 0);
+        room_handoffs
     }
 
     #[cfg(test)]
@@ -1645,28 +1714,23 @@ struct ReclaimedRegistrationContext<'a> {
     workers: &'a OrphanReaperWorkers,
     room_registry: &'a waddle_xmpp::muc::RoomRegistry,
     claim_store: &'a Arc<dyn waddle_xmpp::ownership::ClaimStore>,
-    previous_owner: &'a waddle_xmpp::ownership::NodeIdentity,
     me: &'a waddle_xmpp::ownership::NodeIdentity,
 }
 
 #[cfg(feature = "clustering")]
 async fn register_reclaimed_epoch_or_cleanup(
     context: ReclaimedRegistrationContext<'_>,
-    entity: &waddle_xmpp::ownership::Entity,
-    room_jid: &jid::BareJid,
-    claim_epoch: waddle_xmpp::ownership::ClaimEpoch,
+    pending: waddle_xmpp::muc::room_registry_actor::PendingReclaimedRoom,
 ) -> ReclaimedRegistration {
+    let room_jid = &pending.room_jid;
+    let claim_fence = &pending.claim_fence;
     loop {
         let registration = context
             .room_registry
             .remember_pending_reclaimed_room(
                 room_jid.clone(),
-                waddle_xmpp::muc::RoomClaimFenceContext::new(
-                    entity.clone(),
-                    context.me.clone(),
-                    claim_epoch,
-                ),
-                context.previous_owner.clone(),
+                claim_fence.clone(),
+                pending.previous_owner.clone(),
             )
             .await;
         if registration.is_ok() {
@@ -1688,14 +1752,16 @@ async fn register_reclaimed_epoch_or_cleanup(
         ORPHANED_ROOM_RELEASE_TIMEOUT,
         context
             .claim_store
-            .release_exact(entity, context.me, claim_epoch),
+            .release_exact(&claim_fence.entity, context.me, claim_fence.epoch),
     )
     .await;
     match release {
         Ok(Ok(waddle_xmpp::ownership::ExactReleaseOutcome::Released)) => {
+            context.workers.forget_room_handoff(room_jid, claim_fence);
             ReclaimedRegistration::Released
         }
         Ok(Ok(waddle_xmpp::ownership::ExactReleaseOutcome::NotOwned)) => {
+            context.workers.forget_room_handoff(room_jid, claim_fence);
             ReclaimedRegistration::LostRace
         }
         Ok(Err(error)) => {
@@ -1705,12 +1771,13 @@ async fn register_reclaimed_epoch_or_cleanup(
                     .workers
                     .enqueue_release(ExactReleaseWork {
                         claim_store: context.claim_store.clone(),
-                        entity: entity.clone(),
+                        entity: claim_fence.entity.clone(),
                         owner: context.me.clone(),
-                        epoch: claim_epoch,
+                        epoch: claim_fence.epoch,
                     })
                     .is_accepted()
                 {
+                    context.workers.forget_room_handoff(room_jid, claim_fence);
                     break ReclaimedRegistration::CleanupScheduled;
                 }
                 tokio::time::sleep(Duration::from_millis(10)).await;
@@ -1721,12 +1788,13 @@ async fn register_reclaimed_epoch_or_cleanup(
                 .workers
                 .enqueue_release(ExactReleaseWork {
                     claim_store: context.claim_store.clone(),
-                    entity: entity.clone(),
+                    entity: claim_fence.entity.clone(),
                     owner: context.me.clone(),
-                    epoch: claim_epoch,
+                    epoch: claim_fence.epoch,
                 })
                 .is_accepted()
             {
+                context.workers.forget_room_handoff(room_jid, claim_fence);
                 break ReclaimedRegistration::CleanupScheduled;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
@@ -1746,15 +1814,17 @@ async fn reconcile_registered_room_or_self_fence(
     waddle_xmpp::muc::RoomRegistryError,
 > {
     let result = room_registry
-        .reconcile_reclaimed_room(room_jid, claim_fence, previous_owner)
+        .reconcile_reclaimed_room(room_jid.clone(), claim_fence.clone(), previous_owner)
         .await;
-    if result.is_err() {
-        // Mailbox acceptance is not handler completion. If this uncertain
-        // handoff cannot produce a typed outcome, actor-local retry state may
-        // disappear while this node still owns the won claim. Stop the node's
-        // lease lifecycle so another node can reclaim it after expiry; never
-        // guess whether an exact release is safe after possible publication.
-        workers.fatal_fence.cancel();
+    match &result {
+        Ok(_) => workers.forget_room_handoff(&room_jid, &claim_fence),
+        Err(_) => {
+            // Mailbox acceptance is not handler completion. If this uncertain
+            // handoff cannot produce a typed outcome, retain the supervisor's
+            // exact fence for terminal transfer and stop this node's lease
+            // lifecycle so another incarnation can recover after expiry.
+            workers.fatal_fence.cancel();
+        }
     }
     result
 }
@@ -1784,17 +1854,24 @@ async fn stopped_registry_after_steal_exactly_releases_the_won_claim() {
         Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
         tokio_util::sync::CancellationToken::new(),
     );
+    let pending = waddle_xmpp::muc::room_registry_actor::PendingReclaimedRoom {
+        room_jid: room_jid.clone(),
+        claim_fence: waddle_xmpp::muc::RoomClaimFenceContext::new(
+            entity.clone(),
+            me.clone(),
+            epoch,
+        ),
+        previous_owner: previous.clone(),
+    };
+    supervisor.workers.remember_room_handoff(pending.clone());
     let outcome = register_reclaimed_epoch_or_cleanup(
         ReclaimedRegistrationContext {
             workers: &supervisor.workers,
             room_registry: &registry,
             claim_store: &claim_store,
-            previous_owner: &previous,
             me: &me,
         },
-        &entity,
-        &room_jid,
-        epoch,
+        pending,
     )
     .await;
     assert_eq!(outcome, ReclaimedRegistration::Released);
@@ -1807,6 +1884,74 @@ async fn stopped_registry_after_steal_exactly_releases_the_won_claim() {
         "a stopped registry cannot adopt the won claim, so exact cleanup must not strand it"
     );
     supervisor.shutdown().await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn terminal_shutdown_transfers_a_post_cas_room_handoff_into_registry_drain() {
+    use waddle_xmpp::ownership::{ClaimStore, Entity, EntityType, InProcessClaimStore};
+
+    let registry = waddle_xmpp::muc::RoomRegistry::spawn(
+        "muc.example.com".to_string(),
+        waddle_xmpp::xep::xep0421::OccupantIdSecret::new(
+            b"test-occupant-id-secret-32-bytes-long".to_vec(),
+        )
+        .expect("secret"),
+        None,
+    );
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let me = waddle_xmpp::ownership::NodeIdentity::new("sweeper", "incarnation");
+    let previous = waddle_xmpp::ownership::NodeIdentity::new("dead", "old");
+    registry
+        .actor_ref()
+        .ask(
+            waddle_xmpp::muc::room_registry_actor::WireClusteringClaims {
+                claim_store: claim_store.clone(),
+                node_identity: waddle_xmpp::ownership::SharedNodeIdentity::new(me.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            },
+        )
+        .await
+        .expect("wire registry claim store");
+    let room_jid: jid::BareJid = "cancelled-before-remember@muc.example.com"
+        .parse()
+        .expect("room");
+    assert!(registry
+        .reserve_pending_reclaimed_room(room_jid.clone())
+        .await
+        .expect("reserve adoption"));
+    let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+    let epoch = claim_store.acquire(&entity, &me).await.expect("won epoch");
+    let supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        tokio_util::sync::CancellationToken::new(),
+    );
+    supervisor.workers.remember_room_handoff(
+        waddle_xmpp::muc::room_registry_actor::PendingReclaimedRoom {
+            room_jid: room_jid.clone(),
+            claim_fence: waddle_xmpp::muc::RoomClaimFenceContext::new(entity.clone(), me, epoch),
+            previous_owner: previous,
+        },
+    );
+
+    let handoffs = supervisor.shutdown_terminal().await;
+    assert_eq!(handoffs.len(), 1);
+    let outcome = registry
+        .drain_pending_reclaimed_rooms_for_shutdown(handoffs)
+        .await
+        .expect("drain transferred handoff");
+
+    assert_eq!(outcome.released, 1);
+    assert_eq!(outcome.retained, 0);
+    assert!(claim_store
+        .current_claim(&entity)
+        .await
+        .expect("claim")
+        .is_none());
+
+    registry.actor_ref().kill();
+    registry.actor_ref().wait_for_shutdown().await;
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -1825,6 +1970,18 @@ async fn cancelled_after_known_steal_still_registers_the_exact_room_fence() {
     let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
     let me = waddle_xmpp::ownership::NodeIdentity::new("sweeper", "incarnation");
     let previous = waddle_xmpp::ownership::NodeIdentity::new("dead", "old");
+    registry
+        .actor_ref()
+        .ask(
+            waddle_xmpp::muc::room_registry_actor::WireClusteringClaims {
+                claim_store: claim_store.clone(),
+                node_identity: waddle_xmpp::ownership::SharedNodeIdentity::new(me.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            },
+        )
+        .await
+        .expect("wire registry claim store");
     let room_jid: jid::BareJid = "cancelled-registration@muc.example.com"
         .parse()
         .expect("room");
@@ -1837,17 +1994,25 @@ async fn cancelled_after_known_steal_still_registers_the_exact_room_fence() {
     );
     cancel.cancel();
 
+    let pending = waddle_xmpp::muc::room_registry_actor::PendingReclaimedRoom {
+        room_jid: room_jid.clone(),
+        claim_fence: waddle_xmpp::muc::RoomClaimFenceContext::new(
+            entity.clone(),
+            me.clone(),
+            epoch,
+        ),
+        previous_owner: previous.clone(),
+    };
+    supervisor.workers.remember_room_handoff(pending.clone());
+
     let outcome = register_reclaimed_epoch_or_cleanup(
         ReclaimedRegistrationContext {
             workers: &supervisor.workers,
             room_registry: &registry,
             claim_store: &claim_store,
-            previous_owner: &previous,
             me: &me,
         },
-        &entity,
-        &room_jid,
-        epoch,
+        pending,
     )
     .await;
     assert_eq!(outcome, ReclaimedRegistration::Registered);
@@ -1864,6 +2029,31 @@ async fn cancelled_after_known_steal_still_registers_the_exact_room_fence() {
             .is_some(),
         "known post-CAS ownership must stay actor-serialized while the registry is live"
     );
+
+    assert_eq!(
+        supervisor.workers.pending_room_handoffs().len(),
+        1,
+        "mailbox acceptance alone must not retire supervisor ownership"
+    );
+    let reconciliation = reconcile_registered_room_or_self_fence(
+        &supervisor.workers,
+        &registry,
+        room_jid.clone(),
+        waddle_xmpp::muc::RoomClaimFenceContext::new(entity.clone(), me, epoch),
+        previous,
+    )
+    .await
+    .expect("typed reconciliation");
+    assert_eq!(
+        reconciliation,
+        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Released
+    );
+    assert!(supervisor.workers.pending_room_handoffs().is_empty());
+    assert!(claim_store
+        .current_claim(&entity)
+        .await
+        .expect("claim after typed reconciliation")
+        .is_none());
 
     registry.actor_ref().kill();
     registry.actor_ref().wait_for_shutdown().await;
@@ -1899,6 +2089,16 @@ async fn registry_death_after_mailbox_acceptance_self_fences_the_node() {
         tokio_util::sync::CancellationToken::new(),
         fatal_fence.clone(),
     );
+    let pending = waddle_xmpp::muc::room_registry_actor::PendingReclaimedRoom {
+        room_jid: room_jid.clone(),
+        claim_fence: waddle_xmpp::muc::RoomClaimFenceContext::new(
+            entity.clone(),
+            me.clone(),
+            epoch,
+        ),
+        previous_owner: previous.clone(),
+    };
+    supervisor.workers.remember_room_handoff(pending.clone());
 
     assert_eq!(
         register_reclaimed_epoch_or_cleanup(
@@ -1906,12 +2106,9 @@ async fn registry_death_after_mailbox_acceptance_self_fences_the_node() {
                 workers: &supervisor.workers,
                 room_registry: &registry,
                 claim_store: &claim_store,
-                previous_owner: &previous,
                 me: &me,
             },
-            &entity,
-            &room_jid,
-            epoch,
+            pending,
         )
         .await,
         ReclaimedRegistration::Registered
@@ -1937,8 +2134,12 @@ async fn registry_death_after_mailbox_acceptance_self_fences_the_node() {
             .is_some(),
         "uncertain post-accept handoff must self-fence, not guess that release is safe"
     );
-
-    supervisor.shutdown().await;
+    let handoffs = supervisor.shutdown_terminal().await;
+    assert_eq!(
+        handoffs.len(),
+        1,
+        "failed reconciliation must retain the exact supervisor handoff"
+    );
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -2247,7 +2448,9 @@ async fn terminal_shutdown_retains_an_unobserved_uncertain_sm_reservation() {
 #[cfg(all(test, feature = "clustering"))]
 #[tokio::test]
 async fn worker_restart_self_fences_when_an_uncertain_sm_claim_is_unobserved() {
-    use waddle_xmpp::ownership::{Entity, EntityType, NodeIdentity};
+    use waddle_xmpp::ownership::{
+        ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
+    };
 
     let registry =
         Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::with_capacity(1));
@@ -2264,6 +2467,28 @@ async fn worker_restart_self_fences_when_an_uncertain_sm_claim_is_unobserved() {
         &NodeIdentity::new("sweeper", "incarnation"),
         reservation,
     ));
+    let room_claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let room_owner = NodeIdentity::new("sweeper", "room-incarnation");
+    let previous_room_owner = NodeIdentity::new("dead", "room-incarnation");
+    let room_jid: jid::BareJid = "handoff-across-failed-restart@muc.example.com"
+        .parse()
+        .expect("room");
+    let room_entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+    let room_epoch = room_claim_store
+        .acquire(&room_entity, &room_owner)
+        .await
+        .expect("room claim");
+    supervisor.workers.remember_room_handoff(
+        waddle_xmpp::muc::room_registry_actor::PendingReclaimedRoom {
+            room_jid: room_jid.clone(),
+            claim_fence: waddle_xmpp::muc::RoomClaimFenceContext::new(
+                room_entity.clone(),
+                room_owner.clone(),
+                room_epoch,
+            ),
+            previous_owner: previous_room_owner,
+        },
+    );
 
     let restarted = supervisor.restarted(registry.clone(), parent_cancel).await;
 
@@ -2272,7 +2497,40 @@ async fn worker_restart_self_fences_when_an_uncertain_sm_claim_is_unobserved() {
     assert!(registry
         .reserve_reclaimed_claim_capacity(&replacement)
         .is_none());
-    restarted.shutdown_terminal().await;
+    let room_handoffs = restarted.shutdown_terminal().await;
+    assert_eq!(room_handoffs.len(), 1);
+
+    let room_registry = waddle_xmpp::muc::RoomRegistry::spawn(
+        "muc.example.com".to_string(),
+        waddle_xmpp::xep::xep0421::OccupantIdSecret::new(
+            b"test-occupant-id-secret-32-bytes-long".to_vec(),
+        )
+        .expect("secret"),
+        None,
+    );
+    room_registry
+        .actor_ref()
+        .ask(
+            waddle_xmpp::muc::room_registry_actor::WireClusteringClaims {
+                claim_store: room_claim_store.clone(),
+                node_identity: SharedNodeIdentity::new(room_owner),
+                durable_store: None,
+                rollout_backoff: None,
+            },
+        )
+        .await
+        .expect("wire room registry");
+    room_registry
+        .drain_pending_reclaimed_rooms_for_shutdown(room_handoffs)
+        .await
+        .expect("drain handoff after failed restart");
+    assert!(room_claim_store
+        .current_claim(&room_entity)
+        .await
+        .expect("room claim after drain")
+        .is_none());
+    room_registry.actor_ref().kill();
+    room_registry.actor_ref().wait_for_shutdown().await;
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -2546,6 +2804,9 @@ fn hydration_reservations_do_not_overcommit_a_127_of_128_queue() {
                 .collect(),
         )),
         release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        room_handoff_pending: Arc::new(std::sync::Mutex::new(
+            std::collections::HashMap::new(),
+        )),
         room_cursor: Arc::new(std::sync::Mutex::new(None)),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
@@ -2588,6 +2849,7 @@ async fn full_hydration_channel_retains_and_redrives_pending_work() {
             [("existing".to_string(), PendingSmHydration::Won(existing))].into(),
         )),
         release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        room_handoff_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         room_cursor: Arc::new(std::sync::Mutex::new(None)),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
@@ -2642,6 +2904,7 @@ fn closed_hydration_channel_retains_restart_inventory() {
         release_tx,
         hydration_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        room_handoff_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         room_cursor: Arc::new(std::sync::Mutex::new(None)),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
@@ -2718,6 +2981,7 @@ async fn full_release_channel_retains_and_redrives_pending_work() {
         release_pending: Arc::new(std::sync::Mutex::new(
             [(existing_key.clone(), existing)].into(),
         )),
+        room_handoff_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         room_cursor: Arc::new(std::sync::Mutex::new(None)),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
@@ -2765,6 +3029,7 @@ fn closed_release_channel_retains_restart_inventory() {
         release_tx,
         hydration_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        room_handoff_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         room_cursor: Arc::new(std::sync::Mutex::new(None)),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
@@ -3154,17 +3419,28 @@ async fn run_orphan_reaper_sweep_with_workers(
             .await
         {
             Ok(new_epoch) => {
+                let pending_handoff = waddle_xmpp::muc::room_registry_actor::PendingReclaimedRoom {
+                    room_jid: room_jid.clone(),
+                    claim_fence: waddle_xmpp::muc::RoomClaimFenceContext::new(
+                        candidate.entity.clone(),
+                        me.clone(),
+                        new_epoch,
+                    ),
+                    previous_owner: candidate.owner.clone(),
+                };
+                // This must remain the first operation after observing the
+                // steal CAS succeed. It is synchronous, so cancellation of
+                // the outer sweep cannot drop the exact won epoch before
+                // terminal shutdown can transfer it into RoomRegistry.
+                workers.remember_room_handoff(pending_handoff.clone());
                 match register_reclaimed_epoch_or_cleanup(
                     ReclaimedRegistrationContext {
                         workers,
                         room_registry: &room_registry,
                         claim_store: &claim_store,
-                        previous_owner: &candidate.owner,
                         me: &me,
                     },
-                    &candidate.entity,
-                    &room_jid,
-                    new_epoch,
+                    pending_handoff.clone(),
                 )
                 .await
                 {
@@ -3186,11 +3462,7 @@ async fn run_orphan_reaper_sweep_with_workers(
                     workers,
                     &room_registry,
                     room_jid.clone(),
-                    waddle_xmpp::muc::RoomClaimFenceContext::new(
-                        candidate.entity.clone(),
-                        me.clone(),
-                        new_epoch,
-                    ),
+                    pending_handoff.claim_fence,
                     candidate.owner.clone(),
                 )
                 .await;

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -617,11 +617,27 @@ pub(crate) fn spawn_orphan_reaper_janitor(
             // process-wide shutdown token.
             return;
         };
+        let Some(fatal_fence) = websocket_state
+            .deps
+            .app_state
+            .clustering_claims
+            .fatal_fence
+            .clone()
+        else {
+            return;
+        };
         let room_registry_actor = websocket_state.deps.protocol.room_registry.clone();
         tokio::spawn(async move {
-            let registry_lifetime_watch =
-                spawn_room_registry_lifetime_watch(room_registry_actor, stop.clone());
-            let mut supervisor = OrphanReaperSupervisor::new(registry.clone(), stop.clone());
+            let registry_lifetime_watch = spawn_room_registry_lifetime_watch(
+                room_registry_actor,
+                stop.clone(),
+                fatal_fence.clone(),
+            );
+            let mut supervisor = OrphanReaperSupervisor::new_with_fatal_fence(
+                registry.clone(),
+                stop.clone(),
+                fatal_fence,
+            );
             let mut ticker = tokio::time::interval(interval);
             // Skip the first (immediate) tick, mirroring the other janitors
             // — no need to sweep before the node-lease loop has even
@@ -641,7 +657,7 @@ pub(crate) fn spawn_orphan_reaper_janitor(
                 };
                 match supervise_orphan_reaper_sweep(
                     &supervisor.workers.cancel,
-                    &supervisor.workers.node_cancel,
+                    &supervisor.workers.fatal_fence,
                     ORPHAN_REAPER_SWEEP_TIMEOUT,
                     run_orphan_reaper_sweep_with_workers(&state, &supervisor.workers),
                 )
@@ -662,8 +678,7 @@ pub(crate) fn spawn_orphan_reaper_janitor(
                     supervisor = supervisor.restarted(registry.clone(), stop.clone()).await;
                 }
             }
-            stop.cancel();
-            supervisor.shutdown().await;
+            supervisor.shutdown_terminal().await;
             let _ = registry_lifetime_watch.await;
         });
     }
@@ -689,7 +704,7 @@ enum OrphanSweepOutcome {
 #[cfg(feature = "clustering")]
 async fn supervise_orphan_reaper_sweep<F>(
     cancel: &tokio_util::sync::CancellationToken,
-    node_cancel: &tokio_util::sync::CancellationToken,
+    fatal_fence: &tokio_util::sync::CancellationToken,
     timeout: Duration,
     sweep: F,
 ) -> OrphanSweepOutcome
@@ -702,7 +717,7 @@ where
         result = tokio::time::timeout(timeout, sweep) => match result {
             Ok(()) => OrphanSweepOutcome::Completed,
             Err(_) => {
-                node_cancel.cancel();
+                fatal_fence.cancel();
                 crate::clustering::metrics::record_orphan_worker_failure("sweep", "timeout");
                 OrphanSweepOutcome::TimedOut
             }
@@ -717,36 +732,36 @@ mod orphan_sweep_supervision_tests {
     #[tokio::test]
     async fn timed_out_outer_sweep_self_fences_uncertain_claim_handoffs() {
         let cancel = tokio_util::sync::CancellationToken::new();
-        let node_cancel = tokio_util::sync::CancellationToken::new();
+        let fatal_fence = tokio_util::sync::CancellationToken::new();
 
         let outcome = supervise_orphan_reaper_sweep(
             &cancel,
-            &node_cancel,
+            &fatal_fence,
             Duration::from_millis(1),
             std::future::pending(),
         )
         .await;
 
         assert_eq!(outcome, OrphanSweepOutcome::TimedOut);
-        assert!(node_cancel.is_cancelled());
+        assert!(fatal_fence.is_cancelled());
     }
 
     #[tokio::test]
     async fn ordinary_sweep_cancellation_does_not_invent_a_new_self_fence() {
         let cancel = tokio_util::sync::CancellationToken::new();
-        let node_cancel = tokio_util::sync::CancellationToken::new();
+        let fatal_fence = tokio_util::sync::CancellationToken::new();
         cancel.cancel();
 
         let outcome = supervise_orphan_reaper_sweep(
             &cancel,
-            &node_cancel,
+            &fatal_fence,
             Duration::from_secs(1),
             std::future::pending(),
         )
         .await;
 
         assert_eq!(outcome, OrphanSweepOutcome::Cancelled);
-        assert!(!node_cancel.is_cancelled());
+        assert!(!fatal_fence.is_cancelled());
     }
 }
 
@@ -775,18 +790,19 @@ async fn clustering_disabled_orphan_reaper_does_not_bind_process_shutdown() {
 #[cfg(feature = "clustering")]
 fn spawn_room_registry_lifetime_watch(
     room_registry: kameo::actor::ActorRef<waddle_xmpp::muc::room_registry_actor::RoomRegistryActor>,
-    node_cancel: tokio_util::sync::CancellationToken,
+    stop: tokio_util::sync::CancellationToken,
+    fatal_fence: tokio_util::sync::CancellationToken,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         tokio::select! {
             biased;
-            _ = node_cancel.cancelled() => {}
+            _ = stop.cancelled() => {}
             _ = room_registry.wait_for_shutdown() => {
                 // Room ownership retry state is actor-local. Losing the
                 // registry while this node's lease remains fresh can strand
                 // every retained exact fence, even while idle, so registry
                 // lifetime is clustering-critical.
-                node_cancel.cancel();
+                fatal_fence.cancel();
             }
         }
     })
@@ -866,8 +882,27 @@ struct SmHydrationWork {
 
 #[cfg(feature = "clustering")]
 #[derive(Clone)]
+enum PendingSmHydration {
+    Reserved {
+        entity: waddle_xmpp::ownership::Entity,
+        attempted_owner: waddle_xmpp::ownership::NodeIdentity,
+        reservation: waddle_xmpp::stream_management::ReclaimedClaimReservation,
+    },
+    Won(SmHydrationWork),
+}
+
+#[cfg(feature = "clustering")]
+#[derive(Clone)]
 struct ExactReleaseWork {
     claim_store: Arc<dyn waddle_xmpp::ownership::ClaimStore>,
+    entity: waddle_xmpp::ownership::Entity,
+    owner: waddle_xmpp::ownership::NodeIdentity,
+    epoch: waddle_xmpp::ownership::ClaimEpoch,
+}
+
+#[cfg(feature = "clustering")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ExactReleaseKey {
     entity: waddle_xmpp::ownership::Entity,
     owner: waddle_xmpp::ownership::NodeIdentity,
     epoch: waddle_xmpp::ownership::ClaimEpoch,
@@ -905,16 +940,18 @@ impl WorkEnqueueOutcome {
 struct OrphanReaperWorkers {
     hydration_tx: tokio::sync::mpsc::Sender<SmHydrationWork>,
     release_tx: tokio::sync::mpsc::Sender<ExactReleaseWork>,
-    hydration_pending:
-        Arc<std::sync::Mutex<std::collections::HashMap<String, Option<SmHydrationWork>>>>,
-    release_pending: Arc<std::sync::Mutex<std::collections::HashMap<String, ExactReleaseWork>>>,
+    hydration_pending: Arc<std::sync::Mutex<std::collections::HashMap<String, PendingSmHydration>>>,
+    release_pending:
+        Arc<std::sync::Mutex<std::collections::HashMap<ExactReleaseKey, ExactReleaseWork>>>,
+    room_cursor: Arc<std::sync::Mutex<Option<String>>>,
     sm_cursor: Arc<std::sync::Mutex<Option<String>>>,
     cancel: tokio_util::sync::CancellationToken,
-    node_cancel: tokio_util::sync::CancellationToken,
+    fatal_fence: tokio_util::sync::CancellationToken,
 }
 
 #[cfg(feature = "clustering")]
 struct OrphanReaperSupervisor {
+    registry: Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
     workers: OrphanReaperWorkers,
     cancel: tokio_util::sync::CancellationToken,
     tasks: Vec<(&'static str, tokio::task::JoinHandle<()>)>,
@@ -926,7 +963,12 @@ impl OrphanReaperWorkers {
         work.entity.id.clone()
     }
 
-    fn reserve_hydration(&self, entity: &waddle_xmpp::ownership::Entity) -> bool {
+    fn reserve_hydration(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        attempted_owner: &waddle_xmpp::ownership::NodeIdentity,
+        reservation: waddle_xmpp::stream_management::ReclaimedClaimReservation,
+    ) -> bool {
         let mut pending = self
             .hydration_pending
             .lock()
@@ -938,7 +980,14 @@ impl OrphanReaperWorkers {
             crate::clustering::metrics::record_orphan_work_queue_backpressure("sm_hydration");
             return false;
         }
-        pending.insert(entity.id.clone(), None);
+        pending.insert(
+            entity.id.clone(),
+            PendingSmHydration::Reserved {
+                entity: entity.clone(),
+                attempted_owner: attempted_owner.clone(),
+                reservation,
+            },
+        );
         crate::clustering::metrics::record_orphan_work_queue_depth("sm_hydration", pending.len());
         true
     }
@@ -967,7 +1016,7 @@ impl OrphanReaperWorkers {
         self.hydration_pending
             .lock()
             .unwrap_or_else(|e| e.into_inner())
-            .insert(key.clone(), Some(work.clone()));
+            .insert(key.clone(), PendingSmHydration::Won(work.clone()));
         match self.hydration_tx.try_send(work) {
             Ok(()) => WorkEnqueueOutcome::Enqueued,
             Err(tokio::sync::mpsc::error::TrySendError::Full(work)) => {
@@ -987,11 +1036,12 @@ impl OrphanReaperWorkers {
         }
     }
 
-    fn release_key(work: &ExactReleaseWork) -> String {
-        format!(
-            "{}:{}:{}:{}",
-            work.entity.id, work.owner.node_id, work.owner.node_epoch, work.epoch.0
-        )
+    fn release_key(work: &ExactReleaseWork) -> ExactReleaseKey {
+        ExactReleaseKey {
+            entity: work.entity.clone(),
+            owner: work.owner.clone(),
+            epoch: work.epoch,
+        }
     }
 
     fn has_release_capacity(&self) -> bool {
@@ -1021,7 +1071,7 @@ impl OrphanReaperWorkers {
         {
             return WorkEnqueueOutcome::AlreadyTracked;
         }
-        if !self.reserve_hydration(&work.entity) {
+        if !self.reserve_hydration(&work.entity, work.fence.owner(), work.reservation) {
             return WorkEnqueueOutcome::Rejected;
         }
         self.enqueue_reserved_hydration(work.entity, work.fence, work.reservation)
@@ -1071,7 +1121,32 @@ impl OrphanReaperWorkers {
             .lock()
             .unwrap_or_else(|e| e.into_inner())
             .values()
-            .filter_map(Clone::clone)
+            .filter_map(|pending| match pending {
+                PendingSmHydration::Won(work) => Some(work.clone()),
+                PendingSmHydration::Reserved { .. } => None,
+            })
+            .collect()
+    }
+
+    fn pending_unwon_hydration_reservations(
+        &self,
+    ) -> Vec<(
+        waddle_xmpp::ownership::Entity,
+        waddle_xmpp::ownership::NodeIdentity,
+        waddle_xmpp::stream_management::ReclaimedClaimReservation,
+    )> {
+        self.hydration_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .filter_map(|pending| match pending {
+                PendingSmHydration::Reserved {
+                    entity,
+                    attempted_owner,
+                    reservation,
+                } => Some((entity.clone(), attempted_owner.clone(), *reservation)),
+                PendingSmHydration::Won(_) => None,
+            })
             .collect()
     }
 
@@ -1094,13 +1169,37 @@ impl OrphanReaperWorkers {
     fn set_sm_cursor(&self, cursor: Option<String>) {
         *self.sm_cursor.lock().unwrap_or_else(|e| e.into_inner()) = cursor;
     }
+
+    fn room_cursor(&self) -> Option<String> {
+        self.room_cursor
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    fn set_room_cursor(&self, cursor: Option<String>) {
+        *self.room_cursor.lock().unwrap_or_else(|e| e.into_inner()) = cursor;
+    }
 }
 
 #[cfg(feature = "clustering")]
 impl OrphanReaperSupervisor {
+    #[cfg(test)]
     fn new(
         registry: Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
         parent_cancel: tokio_util::sync::CancellationToken,
+    ) -> Self {
+        Self::new_with_fatal_fence(
+            registry,
+            parent_cancel,
+            tokio_util::sync::CancellationToken::new(),
+        )
+    }
+
+    fn new_with_fatal_fence(
+        registry: Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
+        parent_cancel: tokio_util::sync::CancellationToken,
+        fatal_fence: tokio_util::sync::CancellationToken,
     ) -> Self {
         let cancel = parent_cancel.child_token();
         let (hydration_tx, mut hydration_rx) =
@@ -1113,12 +1212,14 @@ impl OrphanReaperSupervisor {
             release_tx,
             hydration_pending: hydration_pending.clone(),
             release_pending: release_pending.clone(),
+            room_cursor: Arc::new(std::sync::Mutex::new(None)),
             sm_cursor: Arc::new(std::sync::Mutex::new(None)),
             cancel: cancel.clone(),
-            node_cancel: parent_cancel.clone(),
+            fatal_fence,
         };
 
         let hydration_cancel = cancel.clone();
+        let hydration_registry = registry.clone();
         let hydration_task = tokio::spawn(async move {
             let mut queue = std::collections::VecDeque::new();
             loop {
@@ -1138,7 +1239,7 @@ impl OrphanReaperSupervisor {
                     _ = hydration_cancel.cancelled() => break,
                     result = tokio::time::timeout(
                         ORPHAN_WORK_ATTEMPT_TIMEOUT,
-                        registry.hydrate_reclaimed_typed(
+                        hydration_registry.hydrate_reclaimed_typed(
                             &work.entity,
                             &work.fence,
                             work.reservation,
@@ -1169,7 +1270,7 @@ impl OrphanReaperSupervisor {
                             _ = hydration_cancel.cancelled() => break,
                             result = tokio::time::timeout(
                                 ORPHAN_WORK_ATTEMPT_TIMEOUT,
-                                registry.release_reclaimed_claim(
+                                hydration_registry.release_reclaimed_claim(
                                     &work.entity,
                                     &work.fence,
                                     work.reservation,
@@ -1204,7 +1305,7 @@ impl OrphanReaperSupervisor {
                     )) => {
                         let cleanup = tokio::time::timeout(
                             ORPHAN_WORK_ATTEMPT_TIMEOUT,
-                            registry.release_reclaimed_claim(
+                            hydration_registry.release_reclaimed_claim(
                                 &work.entity,
                                 &work.fence,
                                 work.reservation,
@@ -1306,6 +1407,7 @@ impl OrphanReaperSupervisor {
             crate::clustering::metrics::record_orphan_work_queue_depth("room_release", 0);
         });
         Self {
+            registry,
             workers,
             cancel,
             tasks: vec![
@@ -1325,10 +1427,26 @@ impl OrphanReaperSupervisor {
         parent_cancel: tokio_util::sync::CancellationToken,
     ) -> Self {
         let hydration = self.workers.pending_hydrations();
+        let unwon_reservations = self.workers.pending_unwon_hydration_reservations();
         let releases = self.workers.pending_releases();
+        let room_cursor = self.workers.room_cursor();
         let sm_cursor = self.workers.sm_cursor();
-        self.shutdown().await;
-        let next = Self::new(registry, parent_cancel);
+        let fatal_fence = self.workers.fatal_fence.clone();
+        let previous_registry = self.registry.clone();
+        self.shutdown_for_restart().await;
+        futures::future::join_all(unwon_reservations.into_iter().map(
+            |(entity, attempted_owner, reservation)| {
+                let registry = previous_registry.clone();
+                async move {
+                    let _ = registry
+                        .retire_uncertain_reclaimed_claim(&entity, &attempted_owner, reservation)
+                        .await;
+                }
+            },
+        ))
+        .await;
+        let next = Self::new_with_fatal_fence(registry, parent_cancel, fatal_fence);
+        next.workers.set_room_cursor(room_cursor);
         next.workers.set_sm_cursor(sm_cursor);
         for work in hydration {
             if !next
@@ -1347,7 +1465,7 @@ impl OrphanReaperSupervisor {
         next
     }
 
-    async fn shutdown(mut self) {
+    async fn shutdown_for_restart(mut self) {
         self.cancel.cancel();
         for (worker, task) in self.tasks.drain(..) {
             if let Err(error) = task.await {
@@ -1361,6 +1479,82 @@ impl OrphanReaperSupervisor {
             }
         }
     }
+
+    async fn shutdown_terminal(mut self) {
+        let hydrations = self.workers.pending_hydrations();
+        let unwon_reservations = self.workers.pending_unwon_hydration_reservations();
+        let releases = self.workers.pending_releases();
+        self.cancel.cancel();
+        for (worker, task) in self.tasks.drain(..) {
+            if let Err(error) = task.await {
+                let reason = if error.is_panic() {
+                    "panic"
+                } else {
+                    "cancelled"
+                };
+                crate::clustering::metrics::record_orphan_worker_failure(worker, reason);
+                error!(worker, %error, "orphan reaper worker failed");
+            }
+        }
+        futures::future::join_all(unwon_reservations.into_iter().map(
+            |(entity, attempted_owner, reservation)| {
+                let registry = self.registry.clone();
+                async move {
+                    let _ = registry
+                        .retire_uncertain_reclaimed_claim(&entity, &attempted_owner, reservation)
+                        .await;
+                }
+            },
+        ))
+        .await;
+        futures::future::join_all(hydrations.into_iter().map(|work| {
+            let registry = self.registry.clone();
+            async move {
+                match tokio::time::timeout(
+                    ORPHAN_WORK_ATTEMPT_TIMEOUT,
+                    registry.release_reclaimed_claim(
+                        &work.entity,
+                        &work.fence,
+                        work.reservation,
+                    ),
+                )
+                .await
+                {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(error)) => {
+                        debug!(%error, entity_id = %work.entity.id, "orphan reaper: terminal SM cleanup failed");
+                    }
+                    Err(_) => {
+                        debug!(entity_id = %work.entity.id, "orphan reaper: terminal SM cleanup timed out");
+                    }
+                }
+            }
+        }))
+        .await;
+        futures::future::join_all(releases.into_iter().map(|work| async move {
+            match tokio::time::timeout(
+                ORPHANED_ROOM_RELEASE_TIMEOUT,
+                work.claim_store
+                    .release_exact(&work.entity, &work.owner, work.epoch),
+            )
+            .await
+            {
+                Ok(Ok(_)) => {}
+                Ok(Err(error)) => {
+                    debug!(%error, entity_id = %work.entity.id, "orphan reaper: terminal exact cleanup failed");
+                }
+                Err(_) => {
+                    debug!(entity_id = %work.entity.id, "orphan reaper: terminal exact cleanup timed out");
+                }
+            }
+        }))
+        .await;
+    }
+
+    #[cfg(test)]
+    async fn shutdown(self) {
+        self.shutdown_terminal().await;
+    }
 }
 
 #[cfg(feature = "clustering")]
@@ -1370,7 +1564,6 @@ enum ReclaimedRegistration {
     Released,
     LostRace,
     CleanupScheduled,
-    ShutdownDeferred,
 }
 
 #[cfg(feature = "clustering")]
@@ -1390,12 +1583,9 @@ async fn register_reclaimed_epoch_or_cleanup(
     claim_epoch: waddle_xmpp::ownership::ClaimEpoch,
 ) -> ReclaimedRegistration {
     loop {
-        let registration = tokio::select! {
-            biased;
-            _ = context.workers.cancel.cancelled() => {
-                return ReclaimedRegistration::ShutdownDeferred;
-            }
-            result = context.room_registry.remember_pending_reclaimed_room(
+        let registration = context
+            .room_registry
+            .remember_pending_reclaimed_room(
                 room_jid.clone(),
                 waddle_xmpp::muc::RoomClaimFenceContext::new(
                     entity.clone(),
@@ -1403,8 +1593,8 @@ async fn register_reclaimed_epoch_or_cleanup(
                     claim_epoch,
                 ),
                 context.previous_owner.clone(),
-            ) => result,
-        };
+            )
+            .await;
         if registration.is_ok() {
             return ReclaimedRegistration::Registered;
         }
@@ -1414,28 +1604,19 @@ async fn register_reclaimed_epoch_or_cleanup(
         // The registry reservation was established before the steal, so
         // demand remains serialized while mailbox backpressure clears. Do
         // not cancel it or release outside the actor while the actor is live.
-        tokio::select! {
-            biased;
-            _ = context.workers.cancel.cancelled() => {
-                return ReclaimedRegistration::ShutdownDeferred;
-            }
-            _ = tokio::time::sleep(Duration::from_millis(10)) => {}
-        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
     }
 
     // A stopped registry cannot create or publish a replacement actor, so
     // exact cleanup can no longer race demand on this registry. Release the
     // won generation now; retain failures in the bounded supervised worker.
-    let release = tokio::select! {
-        biased;
-        _ = context.workers.cancel.cancelled() => {
-            return ReclaimedRegistration::ShutdownDeferred;
-        }
-        result = tokio::time::timeout(
-            ORPHANED_ROOM_RELEASE_TIMEOUT,
-            context.claim_store.release_exact(entity, context.me, claim_epoch),
-        ) => result,
-    };
+    let release = tokio::time::timeout(
+        ORPHANED_ROOM_RELEASE_TIMEOUT,
+        context
+            .claim_store
+            .release_exact(entity, context.me, claim_epoch),
+    )
+    .await;
     match release {
         Ok(Ok(waddle_xmpp::ownership::ExactReleaseOutcome::Released)) => {
             ReclaimedRegistration::Released
@@ -1458,13 +1639,7 @@ async fn register_reclaimed_epoch_or_cleanup(
                 {
                     break ReclaimedRegistration::CleanupScheduled;
                 }
-                tokio::select! {
-                    biased;
-                    _ = context.workers.cancel.cancelled() => {
-                        break ReclaimedRegistration::ShutdownDeferred;
-                    }
-                    _ = tokio::time::sleep(Duration::from_millis(10)) => {}
-                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
             }
         }
         Err(_) => loop {
@@ -1480,13 +1655,7 @@ async fn register_reclaimed_epoch_or_cleanup(
             {
                 break ReclaimedRegistration::CleanupScheduled;
             }
-            tokio::select! {
-                biased;
-                _ = context.workers.cancel.cancelled() => {
-                    break ReclaimedRegistration::ShutdownDeferred;
-                }
-                _ = tokio::time::sleep(Duration::from_millis(10)) => {}
-            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
         },
     }
 }
@@ -1511,7 +1680,7 @@ async fn reconcile_registered_room_or_self_fence(
         // disappear while this node still owns the won claim. Stop the node's
         // lease lifecycle so another node can reclaim it after expiry; never
         // guess whether an exact release is safe after possible publication.
-        workers.node_cancel.cancel();
+        workers.fatal_fence.cancel();
     }
     result
 }
@@ -1568,7 +1737,7 @@ async fn stopped_registry_after_steal_exactly_releases_the_won_claim() {
 
 #[cfg(all(test, feature = "clustering"))]
 #[tokio::test]
-async fn cancelled_registration_retry_returns_without_releasing_a_live_registry_claim() {
+async fn cancelled_after_known_steal_still_registers_the_exact_room_fence() {
     use waddle_xmpp::ownership::{ClaimStore, Entity, EntityType, InProcessClaimStore};
 
     let registry = waddle_xmpp::muc::RoomRegistry::spawn(
@@ -1607,14 +1776,19 @@ async fn cancelled_registration_retry_returns_without_releasing_a_live_registry_
         epoch,
     )
     .await;
-    assert_eq!(outcome, ReclaimedRegistration::ShutdownDeferred);
+    assert_eq!(outcome, ReclaimedRegistration::Registered);
+    let pending = registry
+        .list_pending_reclaimed_rooms(1)
+        .await
+        .expect("list retained exact room fence");
+    assert_eq!(pending.len(), 1);
     assert!(
         claim_store
             .current_claim(&entity)
             .await
             .expect("claim")
             .is_some(),
-        "shutdown must not release outside a still-live registry"
+        "known post-CAS ownership must stay actor-serialized while the registry is live"
     );
 
     registry.actor_ref().kill();
@@ -1645,10 +1819,11 @@ async fn registry_death_after_mailbox_acceptance_self_fences_the_node() {
         .reserve_pending_reclaimed_room(room_jid.clone())
         .await
         .expect("reserve adoption"));
-    let node_cancel = tokio_util::sync::CancellationToken::new();
-    let supervisor = OrphanReaperSupervisor::new(
+    let fatal_fence = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new_with_fatal_fence(
         Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
-        node_cancel.clone(),
+        tokio_util::sync::CancellationToken::new(),
+        fatal_fence.clone(),
     );
 
     assert_eq!(
@@ -1679,7 +1854,7 @@ async fn registry_death_after_mailbox_acceptance_self_fences_the_node() {
     )
     .await;
     assert!(result.is_err());
-    assert!(node_cancel.is_cancelled());
+    assert!(fatal_fence.is_cancelled());
     assert!(
         claim_store
             .current_claim(&entity)
@@ -1703,13 +1878,14 @@ async fn idle_room_registry_death_self_fences_the_node() {
         .expect("secret"),
         None,
     );
-    let node_cancel = tokio_util::sync::CancellationToken::new();
+    let stop = tokio_util::sync::CancellationToken::new();
+    let fatal_fence = tokio_util::sync::CancellationToken::new();
     let watcher =
-        spawn_room_registry_lifetime_watch(registry.actor_ref().clone(), node_cancel.clone());
+        spawn_room_registry_lifetime_watch(registry.actor_ref().clone(), stop, fatal_fence.clone());
 
     registry.actor_ref().kill();
     registry.actor_ref().wait_for_shutdown().await;
-    tokio::time::timeout(Duration::from_secs(1), node_cancel.cancelled())
+    tokio::time::timeout(Duration::from_secs(1), fatal_fence.cancelled())
         .await
         .expect("registry lifetime watcher must cancel the node promptly");
     watcher.await.expect("registry lifetime watcher");
@@ -1966,6 +2142,131 @@ async fn hung_sm_hydration_does_not_block_completed_room_lane() {
 
 #[cfg(all(test, feature = "clustering"))]
 #[tokio::test]
+async fn terminal_shutdown_retires_a_pre_steal_sm_reservation() {
+    use waddle_xmpp::ownership::{Entity, EntityType, NodeIdentity};
+
+    let registry =
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::with_capacity(1));
+    let entity = Entity::new(EntityType::SmSession, "reserved-before-steal");
+    let replacement = Entity::new(EntityType::SmSession, "replacement-after-fence");
+    let reservation = registry
+        .reserve_reclaimed_claim_capacity(&entity)
+        .expect("initial reservation");
+    let supervisor =
+        OrphanReaperSupervisor::new(registry.clone(), tokio_util::sync::CancellationToken::new());
+    assert!(supervisor.workers.reserve_hydration(
+        &entity,
+        &NodeIdentity::new("sweeper", "incarnation"),
+        reservation,
+    ));
+    assert!(registry
+        .reserve_reclaimed_claim_capacity(&replacement)
+        .is_none());
+
+    supervisor.shutdown_terminal().await;
+
+    assert!(registry
+        .reserve_reclaimed_claim_capacity(&replacement)
+        .is_some());
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn terminal_shutdown_reconciles_an_unknown_sm_steal_result_read_only() {
+    use waddle_xmpp::ownership::{
+        ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
+    };
+
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let attempted_owner = NodeIdentity::new("sweeper", "uncertain-incarnation");
+    let registry = Arc::new(
+        waddle_xmpp::stream_management::InMemorySmSessionRegistry::with_capacity(1)
+            .with_claim_store(
+                claim_store.clone(),
+                SharedNodeIdentity::new(attempted_owner.clone()),
+            ),
+    );
+    let entity = Entity::new(EntityType::SmSession, "uncertain-steal");
+    let replacement = Entity::new(EntityType::SmSession, "replacement-after-reconcile");
+    let reservation = registry
+        .reserve_reclaimed_claim_capacity(&entity)
+        .expect("initial reservation");
+    let supervisor =
+        OrphanReaperSupervisor::new(registry.clone(), tokio_util::sync::CancellationToken::new());
+    assert!(supervisor
+        .workers
+        .reserve_hydration(&entity, &attempted_owner, reservation,));
+    claim_store
+        .acquire(&entity, &attempted_owner)
+        .await
+        .expect("simulate an ambiguously committed steal");
+
+    supervisor.shutdown_terminal().await;
+
+    assert!(
+        claim_store
+            .current_claim(&entity)
+            .await
+            .expect("read reconciled claim")
+            .is_none(),
+        "read-only reconciliation must discover and terminally release the won claim"
+    );
+    assert!(registry
+        .reserve_reclaimed_claim_capacity(&replacement)
+        .is_some());
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn worker_restart_preserves_hung_sm_reservation_until_terminal_shutdown() {
+    use waddle_xmpp::ownership::{
+        ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
+    };
+
+    let storage = Arc::new(HangingSmReadPersistence::default());
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let me = NodeIdentity::new("sweeper", "restart-incarnation");
+    let registry = Arc::new(
+        waddle_xmpp::stream_management::InMemorySmSessionRegistry::with_capacity(1)
+            .with_persistence(storage.clone())
+            .with_claim_store(claim_store.clone(), SharedNodeIdentity::new(me.clone())),
+    );
+    let entity = Entity::new(EntityType::SmSession, "hung-across-restart");
+    let replacement = Entity::new(EntityType::SmSession, "replacement-after-shutdown");
+    let epoch = claim_store.acquire(&entity, &me).await.expect("claim");
+    let reservation = registry
+        .reserve_reclaimed_claim_capacity(&entity)
+        .expect("initial reservation");
+    let parent_cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(registry.clone(), parent_cancel.clone());
+    assert!(supervisor
+        .workers
+        .enqueue_hydration(
+            entity,
+            waddle_xmpp::stream_management::persistence::SmClaimFence::new(me, epoch),
+            reservation,
+        )
+        .is_accepted());
+    tokio::time::timeout(Duration::from_secs(1), storage.read_started.notified())
+        .await
+        .expect("first worker reaches the hung read");
+
+    let restarted = supervisor.restarted(registry.clone(), parent_cancel).await;
+    assert!(
+        registry
+            .reserve_reclaimed_claim_capacity(&replacement)
+            .is_none(),
+        "worker restart must retain the exact existing reservation"
+    );
+
+    restarted.shutdown_terminal().await;
+    assert!(registry
+        .reserve_reclaimed_claim_capacity(&replacement)
+        .is_some());
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
 async fn sm_rotation_before_hydration_worker_releases_the_exact_old_fence() {
     use waddle_xmpp::ownership::{
         ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
@@ -2117,7 +2418,7 @@ async fn hung_exact_release_worker_is_cancelled_and_joined() {
 #[cfg(all(test, feature = "clustering"))]
 #[test]
 fn hydration_reservations_do_not_overcommit_a_127_of_128_queue() {
-    use waddle_xmpp::ownership::{Entity, EntityType};
+    use waddle_xmpp::ownership::{Entity, EntityType, NodeIdentity};
     let (hydration_tx, _hydration_rx) = tokio::sync::mpsc::channel(ORPHAN_WORK_QUEUE_CAPACITY);
     let (release_tx, _release_rx) = tokio::sync::mpsc::channel(ORPHAN_WORK_QUEUE_CAPACITY);
     let workers = OrphanReaperWorkers {
@@ -2125,20 +2426,35 @@ fn hydration_reservations_do_not_overcommit_a_127_of_128_queue() {
         release_tx,
         hydration_pending: Arc::new(std::sync::Mutex::new(
             (0..127)
-                .map(|index| (format!("existing-{index}"), None))
+                .map(|index| {
+                    let entity =
+                        Entity::new(EntityType::SmSession, format!("existing-{index}"));
+                    (
+                        entity.id.clone(),
+                        PendingSmHydration::Reserved {
+                            entity,
+                            attempted_owner: NodeIdentity::new("sweeper", "incarnation"),
+                            reservation: waddle_xmpp::stream_management::ReclaimedClaimReservation::from_generation(index + 1),
+                        },
+                    )
+                })
                 .collect(),
         )),
         release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        room_cursor: Arc::new(std::sync::Mutex::new(None)),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
-        node_cancel: tokio_util::sync::CancellationToken::new(),
+        fatal_fence: tokio_util::sync::CancellationToken::new(),
     };
     let reserved = (0..64)
         .filter(|index| {
-            workers.reserve_hydration(&Entity::new(
-                EntityType::SmSession,
-                format!("candidate-{index}"),
-            ))
+            workers.reserve_hydration(
+                &Entity::new(EntityType::SmSession, format!("candidate-{index}")),
+                &NodeIdentity::new("sweeper", "incarnation"),
+                waddle_xmpp::stream_management::ReclaimedClaimReservation::from_generation(
+                    index + 128,
+                ),
+            )
         })
         .count();
     assert_eq!(reserved, 1);
@@ -2164,12 +2480,13 @@ async fn full_hydration_channel_retains_and_redrives_pending_work() {
         hydration_tx,
         release_tx,
         hydration_pending: Arc::new(std::sync::Mutex::new(
-            [("existing".to_string(), Some(existing))].into(),
+            [("existing".to_string(), PendingSmHydration::Won(existing))].into(),
         )),
         release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        room_cursor: Arc::new(std::sync::Mutex::new(None)),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
-        node_cancel: tokio_util::sync::CancellationToken::new(),
+        fatal_fence: tokio_util::sync::CancellationToken::new(),
     };
     let candidate = Entity::new(EntityType::SmSession, "candidate");
 
@@ -2220,9 +2537,10 @@ fn closed_hydration_channel_retains_restart_inventory() {
         release_tx,
         hydration_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        room_cursor: Arc::new(std::sync::Mutex::new(None)),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
-        node_cancel: tokio_util::sync::CancellationToken::new(),
+        fatal_fence: tokio_util::sync::CancellationToken::new(),
     };
     let candidate = Entity::new(EntityType::SmSession, "candidate");
 
@@ -2239,6 +2557,33 @@ fn closed_hydration_channel_retains_restart_inventory() {
         .lock()
         .expect("hydration pending")
         .contains_key(&candidate.id));
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[test]
+fn exact_release_keys_are_structural_when_components_contain_colons() {
+    use waddle_xmpp::ownership::{
+        ClaimEpoch, Entity, EntityType, InProcessClaimStore, NodeIdentity,
+    };
+
+    let left = ExactReleaseWork {
+        claim_store: Arc::new(InProcessClaimStore::new()),
+        entity: Entity::new(EntityType::RoomActor, "room:part"),
+        owner: NodeIdentity::new("node", "epoch"),
+        epoch: ClaimEpoch(1),
+    };
+    let right = ExactReleaseWork {
+        claim_store: Arc::new(InProcessClaimStore::new()),
+        entity: Entity::new(EntityType::RoomActor, "room"),
+        owner: NodeIdentity::new("part:node", "epoch"),
+        epoch: ClaimEpoch(1),
+    };
+
+    assert_ne!(
+        OrphanReaperWorkers::release_key(&left),
+        OrphanReaperWorkers::release_key(&right),
+        "field boundaries must remain part of the deduplication identity"
+    );
 }
 
 #[cfg(all(test, feature = "clustering"))]
@@ -2268,9 +2613,10 @@ async fn full_release_channel_retains_and_redrives_pending_work() {
         release_pending: Arc::new(std::sync::Mutex::new(
             [(existing_key.clone(), existing)].into(),
         )),
+        room_cursor: Arc::new(std::sync::Mutex::new(None)),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
-        node_cancel: tokio_util::sync::CancellationToken::new(),
+        fatal_fence: tokio_util::sync::CancellationToken::new(),
     };
     let candidate = ExactReleaseWork {
         claim_store: Arc::new(InProcessClaimStore::new()),
@@ -2314,9 +2660,10 @@ fn closed_release_channel_retains_restart_inventory() {
         release_tx,
         hydration_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
         release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        room_cursor: Arc::new(std::sync::Mutex::new(None)),
         sm_cursor: Arc::new(std::sync::Mutex::new(None)),
         cancel: tokio_util::sync::CancellationToken::new(),
-        node_cancel: tokio_util::sync::CancellationToken::new(),
+        fatal_fence: tokio_util::sync::CancellationToken::new(),
     };
     let candidate = ExactReleaseWork {
         claim_store: Arc::new(InProcessClaimStore::new()),
@@ -2339,7 +2686,7 @@ fn closed_release_channel_retains_restart_inventory() {
 
 #[cfg(all(test, feature = "clustering"))]
 #[tokio::test]
-async fn supervisor_restart_preserves_the_sm_scan_cursor() {
+async fn supervisor_restart_preserves_orphan_scan_cursors() {
     let parent_cancel = tokio_util::sync::CancellationToken::new();
     let supervisor = OrphanReaperSupervisor::new(
         Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
@@ -2348,6 +2695,9 @@ async fn supervisor_restart_preserves_the_sm_scan_cursor() {
     supervisor
         .workers
         .set_sm_cursor(Some("sm_session:page-064".to_string()));
+    supervisor
+        .workers
+        .set_room_cursor(Some("room_actor:page-064@muc.example.com".to_string()));
 
     let restarted = supervisor
         .restarted(
@@ -2359,6 +2709,10 @@ async fn supervisor_restart_preserves_the_sm_scan_cursor() {
     assert_eq!(
         restarted.workers.sm_cursor().as_deref(),
         Some("sm_session:page-064")
+    );
+    assert_eq!(
+        restarted.workers.room_cursor().as_deref(),
+        Some("room_actor:page-064@muc.example.com")
     );
     restarted.shutdown().await;
 }
@@ -2570,7 +2924,7 @@ async fn run_orphan_reaper_sweep_with_workers(
         }
         Err(error) => {
             debug!(%error, "orphan reaper: pending RoomActor listing failed");
-            workers.node_cancel.cancel();
+            workers.fatal_fence.cancel();
             return;
         }
     }
@@ -2591,26 +2945,41 @@ async fn run_orphan_reaper_sweep_with_workers(
     // The serialized registry adoption below therefore either hydrates the
     // exact won epoch, observes demand-side creation already did so, or
     // releases the unusable claim.
-    let room_candidates = match node_lease
-        .list_orphaned_room_actor_claims(ORPHANED_ROOM_CANDIDATE_LIMIT)
-        .await
-    {
-        Ok(candidates) => candidates,
-        Err(error) => {
-            warn!(%error, "orphan reaper: list_orphaned_room_actor_claims failed");
-            Vec::new()
-        }
-    };
+    let (room_candidates, room_page_next_cursor, room_page_has_more, room_scan_succeeded) =
+        match node_lease
+            .list_orphaned_room_actor_claims_page(
+                workers.room_cursor(),
+                ORPHANED_ROOM_CANDIDATE_LIMIT,
+            )
+            .await
+        {
+            Ok(page) => {
+                if page.quarantined > 0 {
+                    debug!(
+                        quarantined = page.quarantined,
+                        "orphan reaper: quarantined malformed stale RoomActor claims"
+                    );
+                }
+                (page.candidates, page.next_cursor, page.has_more, true)
+            }
+            Err(error) => {
+                warn!(%error, "orphan reaper: list_orphaned_room_actor_claims_page failed");
+                (Vec::new(), workers.room_cursor(), false, false)
+            }
+        };
+    let mut room_page_processed = true;
     for candidate in room_candidates {
         if workers.cancel.is_cancelled() {
             return;
         }
         if !workers.has_release_capacity() {
+            room_page_processed = false;
             crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
             warn!("orphan reaper: pausing RoomActor steals because exact-release cleanup capacity is exhausted");
             break;
         }
         let Ok(room_jid) = candidate.entity.id.parse::<jid::BareJid>() else {
+            room_page_processed = false;
             room_failed += 1;
             debug!(
                 entity_id = %candidate.entity.id,
@@ -2624,11 +2993,13 @@ async fn run_orphan_reaper_sweep_with_workers(
         {
             Ok(true) => {}
             Ok(false) => {
+                room_page_processed = false;
                 crate::clustering::metrics::record_orphan_work_queue_backpressure("room_adoption");
                 warn!("orphan reaper: pausing RoomActor steals because adoption capacity is exhausted");
                 break;
             }
             Err(error) => {
+                room_page_processed = false;
                 room_failed += 1;
                 debug!(room = %room_jid, %error, "orphan reaper: room adoption reservation failed");
                 break;
@@ -2642,6 +3013,7 @@ async fn run_orphan_reaper_sweep_with_workers(
             return;
         }
         if let Err(error) = node_lease.expire(&candidate.owner, lease_ttl).await {
+            room_page_processed = false;
             let _ = room_registry
                 .cancel_pending_reclaimed_room_reservation(room_jid.clone())
                 .await;
@@ -2693,9 +3065,6 @@ async fn run_orphan_reaper_sweep_with_workers(
                     ReclaimedRegistration::CleanupScheduled => {
                         room_failed += 1;
                         continue;
-                    }
-                    ReclaimedRegistration::ShutdownDeferred => {
-                        return;
                     }
                 }
                 let reconciliation = reconcile_registered_room_or_self_fence(
@@ -2771,6 +3140,7 @@ async fn run_orphan_reaper_sweep_with_workers(
                     .await;
             }
             Err(error) => {
+                room_page_processed = false;
                 room_failed += 1;
                 let _ = room_registry
                     .cancel_pending_reclaimed_room_reservation(room_jid.clone())
@@ -2781,6 +3151,23 @@ async fn run_orphan_reaper_sweep_with_workers(
                     "orphan reaper: RoomActor claim steal failed"
                 );
             }
+        }
+    }
+    if room_scan_succeeded && room_page_processed {
+        let committed_cursor = if room_page_has_more {
+            room_page_next_cursor
+        } else {
+            None
+        };
+        workers.set_room_cursor(committed_cursor.clone());
+        if let Err(error) = node_lease
+            .persist_orphan_reaper_cursor(
+                waddle_xmpp::ownership::EntityType::RoomActor,
+                committed_cursor,
+            )
+            .await
+        {
+            warn!(%error, "orphan reaper: failed to persist RoomActor scan cursor");
         }
     }
     for (outcome, count) in [
@@ -2864,16 +3251,11 @@ async fn run_orphan_reaper_sweep_with_workers(
         page.has_more,
         page.quarantined,
     );
-    if scan_succeeded {
-        if page.has_more {
-            workers.set_sm_cursor(page.next_cursor.clone());
-        } else {
-            // Wrap on the next successful end-of-scan observation.
-            workers.set_sm_cursor(None);
-        }
-    }
+    let page_has_more = page.has_more;
+    let page_next_cursor = page.next_cursor.clone();
     let candidates = page.candidates;
     let mut stolen = 0usize;
+    let mut page_processed = true;
     for candidate in candidates {
         let Some(reservation) = state
             .deps
@@ -2881,15 +3263,17 @@ async fn run_orphan_reaper_sweep_with_workers(
             .sm_session_registry
             .reserve_reclaimed_claim_capacity(&candidate.entity)
         else {
+            page_processed = false;
             break;
         };
-        if !workers.reserve_hydration(&candidate.entity) {
+        if !workers.reserve_hydration(&candidate.entity, &me, reservation) {
             state
                 .deps
                 .protocol
                 .sm_session_registry
                 .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
             warn!("orphan reaper: pausing SM steals because hydration capacity is exhausted");
+            page_processed = false;
             break;
         }
         if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-candidate")
@@ -2908,6 +3292,7 @@ async fn run_orphan_reaper_sweep_with_workers(
         // just means the steal below is also likely to lose (the owner
         // row is not yet committed-expired), retried next sweep.
         if let Err(error) = node_lease.expire(&candidate.owner, lease_ttl).await {
+            page_processed = false;
             workers.cancel_hydration_reservation(&candidate.entity);
             debug!(
                 entity_id = %candidate.entity.id,
@@ -2972,6 +3357,7 @@ async fn run_orphan_reaper_sweep_with_workers(
                 // renewed concurrently — safe, no-op.
             }
             Err(error) => {
+                page_processed = false;
                 workers.cancel_hydration_reservation(&candidate.entity);
                 state
                     .deps
@@ -2984,6 +3370,23 @@ async fn run_orphan_reaper_sweep_with_workers(
                     "orphan reaper: steal_orphaned_sm_session_claim failed"
                 );
             }
+        }
+    }
+    if scan_succeeded && page_processed {
+        let committed_cursor = if page_has_more {
+            page_next_cursor
+        } else {
+            None
+        };
+        workers.set_sm_cursor(committed_cursor.clone());
+        if let Err(error) = node_lease
+            .persist_orphan_reaper_cursor(
+                waddle_xmpp::ownership::EntityType::SmSession,
+                committed_cursor,
+            )
+            .await
+        {
+            warn!(%error, "orphan reaper: failed to persist SM-session scan cursor");
         }
     }
     if stolen > 0 {
@@ -3328,6 +3731,7 @@ mod orphan_reaper_sweep_tests {
             resume_bridge: None,
             ordered_relay_delivery_bridge: None,
             stop_token: None,
+            fatal_fence: None,
             resume_handshake_timeout: None,
         };
 
@@ -4113,12 +4517,23 @@ pub(crate) fn spawn_graceful_shutdown_drain(
                     break;
                 }
             };
-            websocket_state
-                .deps
-                .protocol
-                .sm_session_registry
-                .retry_pending_claim_releases(64)
-                .await;
+            let release_retry_budget =
+                drain_deadline.saturating_duration_since(std::time::Instant::now());
+            if tokio::time::timeout(
+                release_retry_budget,
+                websocket_state
+                    .deps
+                    .protocol
+                    .sm_session_registry
+                    .retry_pending_claim_releases(64),
+            )
+            .await
+            .is_err()
+            {
+                // Re-enter at the deadline check so timeout telemetry and
+                // abandonment accounting stay centralized above.
+                continue;
+            }
             if drained.is_empty() {
                 empty_passes += 1;
                 if empty_passes >= QUIET_WINDOW_PASSES {

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -37,9 +37,11 @@ const REAPER_ASK_TIMEOUT: Duration = Duration::from_secs(5);
 /// minted per `<isr-enable/>` and only ever reaped by an ordinary
 /// `consume` (match or mismatch); one that's issued and never resumed
 /// (client never reconnects, or the SM session is later expired/reaped by
-/// [`run_orphan_reaper_sweep`] itself) would otherwise sit forever. 24h is
-/// generous relative to any realistic resume window, while still bounding
-/// the table.
+/// [`run_orphan_reaper_sweep`] itself) would otherwise sit forever. Age is
+/// only a backstop after the corresponding typed SM-session claim is absent;
+/// a live or detached claimed stream retains its token regardless of age.
+/// 24h bounds genuinely orphaned rows without shortening a stream's resume
+/// lifetime.
 #[cfg(feature = "clustering")]
 const ISR_TOKEN_SWEEP_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
 
@@ -56,6 +58,32 @@ const ISR_TOKEN_SWEEP_TIMEOUT: Duration = Duration::from_secs(5);
 #[cfg(feature = "clustering")]
 const STALE_NODE_WATCHDOG_CANDIDATE_LIMIT: usize = 64;
 
+/// Per-sweep bound for proactive `RoomActor` orphan reconciliation. Room
+/// claims are cheap rows but adoption can hydrate durable state, so the
+/// janitor deliberately amortizes a large node loss across sweeps.
+#[cfg(feature = "clustering")]
+const ORPHANED_ROOM_CANDIDATE_LIMIT: usize = 64;
+
+#[cfg(feature = "clustering")]
+const ORPHANED_ROOM_RELEASE_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[cfg(feature = "clustering")]
+const ORPHANED_SM_SCAN_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[cfg(feature = "clustering")]
+const ORPHAN_WORK_QUEUE_CAPACITY: usize = 128;
+
+#[cfg(feature = "clustering")]
+const ORPHAN_WORK_ATTEMPT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Hard wall-clock bound for one outer orphan-reconciliation pass. Individual
+/// hydration and release jobs have their own tighter deadlines, but the sweep
+/// also awaits lease-store and RoomRegistry operations. If any of those
+/// dependencies wedges after a claim steal, continuing to advertise this
+/// node's lease could strand authority with no retained actor responsibility.
+/// Self-fence on expiry so another node can recover the exact claim.
+#[cfg(feature = "clustering")]
+const ORPHAN_REAPER_SWEEP_TIMEOUT: Duration = Duration::from_secs(60);
 fn pending_delivery_max_age_days_from_env() -> u32 {
     const DEFAULT_DAYS: u32 = 30;
     const MIN_DAYS: u32 = 1;
@@ -575,19 +603,68 @@ pub(crate) fn spawn_orphan_reaper_janitor(
     #[cfg(feature = "clustering")]
     {
         let weak_state = Arc::downgrade(websocket_state);
+        let registry = websocket_state.deps.protocol.sm_session_registry.clone();
+        let Some(stop) = websocket_state
+            .deps
+            .app_state
+            .clustering_claims
+            .stop_token
+            .clone()
+        else {
+            // The binary may include clustering support while runtime
+            // clustering is disabled. In that configuration no clustering
+            // supervisor or registry-lifetime watcher may be attached to the
+            // process-wide shutdown token.
+            return;
+        };
+        let room_registry_actor = websocket_state.deps.protocol.room_registry.clone();
         tokio::spawn(async move {
+            let registry_lifetime_watch =
+                spawn_room_registry_lifetime_watch(room_registry_actor, stop.clone());
+            let mut supervisor = OrphanReaperSupervisor::new(registry.clone(), stop.clone());
             let mut ticker = tokio::time::interval(interval);
             // Skip the first (immediate) tick, mirroring the other janitors
             // — no need to sweep before the node-lease loop has even
             // registered this node.
             ticker.tick().await;
             loop {
-                ticker.tick().await;
+                tokio::select! {
+                    _ = stop.cancelled() => break,
+                    _ = ticker.tick() => {}
+                }
+                if !supervisor.is_healthy() {
+                    error!("orphan reaper worker exited; restarting workers with retained work");
+                    supervisor = supervisor.restarted(registry.clone(), stop.clone()).await;
+                }
                 let Some(state) = weak_state.upgrade() else {
                     break;
                 };
-                run_orphan_reaper_sweep(&state).await;
+                match supervise_orphan_reaper_sweep(
+                    &supervisor.workers.cancel,
+                    &supervisor.workers.node_cancel,
+                    ORPHAN_REAPER_SWEEP_TIMEOUT,
+                    run_orphan_reaper_sweep_with_workers(&state, &supervisor.workers),
+                )
+                .await
+                {
+                    OrphanSweepOutcome::Completed => {}
+                    OrphanSweepOutcome::Cancelled => break,
+                    OrphanSweepOutcome::TimedOut => {
+                        error!(
+                            timeout = ?ORPHAN_REAPER_SWEEP_TIMEOUT,
+                            "orphan reaper sweep timed out; self-fencing node because claim handoff state may be uncertain"
+                        );
+                        break;
+                    }
+                }
+                if !supervisor.is_healthy() {
+                    error!("orphan reaper worker exited during sweep; restarting workers with retained work");
+                    supervisor = supervisor.restarted(registry.clone(), stop.clone()).await;
+                }
             }
+            stop.cancel();
+            supervisor.shutdown().await;
+            let _ = registry_lifetime_watch.await;
         });
     }
     #[cfg(not(feature = "clustering"))]
@@ -595,6 +672,124 @@ pub(crate) fn spawn_orphan_reaper_janitor(
         let _ = websocket_state;
         let _ = interval;
     }
+}
+
+#[cfg(feature = "clustering")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum OrphanSweepOutcome {
+    Completed,
+    Cancelled,
+    TimedOut,
+}
+
+/// Bound and cancellation-arm the complete outer sweep, not only its worker
+/// jobs. A timeout can occur after a fenced steal but before the typed actor
+/// handoff returns; in that uncertain state the only safe generic recovery is
+/// to stop this node's lease lifecycle and let another incarnation reclaim it.
+#[cfg(feature = "clustering")]
+async fn supervise_orphan_reaper_sweep<F>(
+    cancel: &tokio_util::sync::CancellationToken,
+    node_cancel: &tokio_util::sync::CancellationToken,
+    timeout: Duration,
+    sweep: F,
+) -> OrphanSweepOutcome
+where
+    F: std::future::Future<Output = ()>,
+{
+    tokio::select! {
+        biased;
+        _ = cancel.cancelled() => OrphanSweepOutcome::Cancelled,
+        result = tokio::time::timeout(timeout, sweep) => match result {
+            Ok(()) => OrphanSweepOutcome::Completed,
+            Err(_) => {
+                node_cancel.cancel();
+                crate::clustering::metrics::record_orphan_worker_failure("sweep", "timeout");
+                OrphanSweepOutcome::TimedOut
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "clustering"))]
+mod orphan_sweep_supervision_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn timed_out_outer_sweep_self_fences_uncertain_claim_handoffs() {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let node_cancel = tokio_util::sync::CancellationToken::new();
+
+        let outcome = supervise_orphan_reaper_sweep(
+            &cancel,
+            &node_cancel,
+            Duration::from_millis(1),
+            std::future::pending(),
+        )
+        .await;
+
+        assert_eq!(outcome, OrphanSweepOutcome::TimedOut);
+        assert!(node_cancel.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn ordinary_sweep_cancellation_does_not_invent_a_new_self_fence() {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let node_cancel = tokio_util::sync::CancellationToken::new();
+        cancel.cancel();
+
+        let outcome = supervise_orphan_reaper_sweep(
+            &cancel,
+            &node_cancel,
+            Duration::from_secs(1),
+            std::future::pending(),
+        )
+        .await;
+
+        assert_eq!(outcome, OrphanSweepOutcome::Cancelled);
+        assert!(!node_cancel.is_cancelled());
+    }
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn clustering_disabled_orphan_reaper_does_not_bind_process_shutdown() {
+    let state =
+        crate::server::routes::websocket::tests::create_test_websocket_state_with_clustering(
+            crate::clustering::ClusteringHandles::default(),
+            Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        )
+        .await;
+    let shutdown = state.deps.shutdown.stop_token();
+
+    spawn_orphan_reaper_janitor(&state, Duration::from_millis(1));
+    state.deps.protocol.room_registry.kill();
+    state.deps.protocol.room_registry.wait_for_shutdown().await;
+    tokio::task::yield_now().await;
+
+    assert!(
+        !shutdown.is_cancelled(),
+        "runtime-disabled clustering must not turn RoomRegistry death into process shutdown"
+    );
+}
+
+#[cfg(feature = "clustering")]
+fn spawn_room_registry_lifetime_watch(
+    room_registry: kameo::actor::ActorRef<waddle_xmpp::muc::room_registry_actor::RoomRegistryActor>,
+    node_cancel: tokio_util::sync::CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        tokio::select! {
+            biased;
+            _ = node_cancel.cancelled() => {}
+            _ = room_registry.wait_for_shutdown() => {
+                // Room ownership retry state is actor-local. Losing the
+                // registry while this node's lease remains fresh can strand
+                // every retained exact fence, even while idle, so registry
+                // lifetime is clustering-critical.
+                node_cancel.cancel();
+            }
+        }
+    })
 }
 
 #[cfg(feature = "clustering")]
@@ -647,12 +842,1571 @@ async fn orphan_reaper_self_lease_is_fresh(
 /// running server — it hydrates exactly (and only) the entities this sweep
 /// just reclaimed, without needing this function to duplicate the
 /// codec/expiry logic `hydrate_reclaimed` already owns.
+#[cfg(all(test, feature = "clustering"))]
+fn orphaned_sm_candidates_or_empty(
+    result: Result<
+        Vec<crate::clustering::claims::OrphanedSmSessionClaim>,
+        waddle_xmpp::ownership::ClaimError,
+    >,
+) -> Vec<crate::clustering::claims::OrphanedSmSessionClaim> {
+    result
+        .inspect_err(|error| {
+            debug!(%error, "orphan reaper: SM-session candidate scan failed; continuing other orphan lanes")
+        })
+        .unwrap_or_default()
+}
+
 #[cfg(feature = "clustering")]
-async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
+#[derive(Clone)]
+struct SmHydrationWork {
+    entity: waddle_xmpp::ownership::Entity,
+    fence: waddle_xmpp::stream_management::persistence::SmClaimFence,
+    reservation: waddle_xmpp::stream_management::ReclaimedClaimReservation,
+}
+
+#[cfg(feature = "clustering")]
+#[derive(Clone)]
+struct ExactReleaseWork {
+    claim_store: Arc<dyn waddle_xmpp::ownership::ClaimStore>,
+    entity: waddle_xmpp::ownership::Entity,
+    owner: waddle_xmpp::ownership::NodeIdentity,
+    epoch: waddle_xmpp::ownership::ClaimEpoch,
+}
+
+#[cfg(feature = "clustering")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WorkEnqueueOutcome {
+    Enqueued,
+    AlreadyTracked,
+    /// Receiver exited, but the exact work remains in the supervisor's
+    /// restart inventory and will be requeued by the replacement worker.
+    RetainedForRestart,
+    /// The bounded channel was full. The exact work remains in the pending
+    /// inventory and a bounded background sender is actively redriving it.
+    RetainedForRedrive,
+    Rejected,
+}
+
+#[cfg(feature = "clustering")]
+impl WorkEnqueueOutcome {
+    const fn is_accepted(self) -> bool {
+        matches!(
+            self,
+            Self::Enqueued
+                | Self::AlreadyTracked
+                | Self::RetainedForRestart
+                | Self::RetainedForRedrive
+        )
+    }
+}
+
+#[cfg(feature = "clustering")]
+#[derive(Clone)]
+struct OrphanReaperWorkers {
+    hydration_tx: tokio::sync::mpsc::Sender<SmHydrationWork>,
+    release_tx: tokio::sync::mpsc::Sender<ExactReleaseWork>,
+    hydration_pending:
+        Arc<std::sync::Mutex<std::collections::HashMap<String, Option<SmHydrationWork>>>>,
+    release_pending: Arc<std::sync::Mutex<std::collections::HashMap<String, ExactReleaseWork>>>,
+    sm_cursor: Arc<std::sync::Mutex<Option<String>>>,
+    cancel: tokio_util::sync::CancellationToken,
+    node_cancel: tokio_util::sync::CancellationToken,
+}
+
+#[cfg(feature = "clustering")]
+struct OrphanReaperSupervisor {
+    workers: OrphanReaperWorkers,
+    cancel: tokio_util::sync::CancellationToken,
+    tasks: Vec<(&'static str, tokio::task::JoinHandle<()>)>,
+}
+
+#[cfg(feature = "clustering")]
+impl OrphanReaperWorkers {
+    fn hydration_key(work: &SmHydrationWork) -> String {
+        work.entity.id.clone()
+    }
+
+    fn reserve_hydration(&self, entity: &waddle_xmpp::ownership::Entity) -> bool {
+        let mut pending = self
+            .hydration_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if pending.contains_key(&entity.id) {
+            return false;
+        }
+        if pending.len() >= ORPHAN_WORK_QUEUE_CAPACITY {
+            crate::clustering::metrics::record_orphan_work_queue_backpressure("sm_hydration");
+            return false;
+        }
+        pending.insert(entity.id.clone(), None);
+        crate::clustering::metrics::record_orphan_work_queue_depth("sm_hydration", pending.len());
+        true
+    }
+
+    fn cancel_hydration_reservation(&self, entity: &waddle_xmpp::ownership::Entity) {
+        let mut pending = self
+            .hydration_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        pending.remove(&entity.id);
+        crate::clustering::metrics::record_orphan_work_queue_depth("sm_hydration", pending.len());
+    }
+
+    fn enqueue_reserved_hydration(
+        &self,
+        entity: waddle_xmpp::ownership::Entity,
+        fence: waddle_xmpp::stream_management::persistence::SmClaimFence,
+        reservation: waddle_xmpp::stream_management::ReclaimedClaimReservation,
+    ) -> WorkEnqueueOutcome {
+        let work = SmHydrationWork {
+            entity,
+            fence,
+            reservation,
+        };
+        let key = Self::hydration_key(&work);
+        self.hydration_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(key.clone(), Some(work.clone()));
+        match self.hydration_tx.try_send(work) {
+            Ok(()) => WorkEnqueueOutcome::Enqueued,
+            Err(tokio::sync::mpsc::error::TrySendError::Full(work)) => {
+                crate::clustering::metrics::record_orphan_work_queue_backpressure("sm_hydration");
+                let tx = self.hydration_tx.clone();
+                tokio::spawn(async move {
+                    let _ = tx.send(work).await;
+                });
+                WorkEnqueueOutcome::RetainedForRedrive
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                // The supervisor snapshots this map when it replaces a dead
+                // worker. Retain the exact work so restart can requeue it.
+                crate::clustering::metrics::record_orphan_work_queue_backpressure("sm_hydration");
+                WorkEnqueueOutcome::RetainedForRestart
+            }
+        }
+    }
+
+    fn release_key(work: &ExactReleaseWork) -> String {
+        format!(
+            "{}:{}:{}:{}",
+            work.entity.id, work.owner.node_id, work.owner.node_epoch, work.epoch.0
+        )
+    }
+
+    fn has_release_capacity(&self) -> bool {
+        self.release_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .len()
+            < ORPHAN_WORK_QUEUE_CAPACITY
+    }
+
+    fn enqueue_hydration(
+        &self,
+        entity: waddle_xmpp::ownership::Entity,
+        fence: waddle_xmpp::stream_management::persistence::SmClaimFence,
+        reservation: waddle_xmpp::stream_management::ReclaimedClaimReservation,
+    ) -> WorkEnqueueOutcome {
+        let work = SmHydrationWork {
+            entity,
+            fence,
+            reservation,
+        };
+        if self
+            .hydration_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .contains_key(&Self::hydration_key(&work))
+        {
+            return WorkEnqueueOutcome::AlreadyTracked;
+        }
+        if !self.reserve_hydration(&work.entity) {
+            return WorkEnqueueOutcome::Rejected;
+        }
+        self.enqueue_reserved_hydration(work.entity, work.fence, work.reservation)
+    }
+
+    fn enqueue_release(&self, work: ExactReleaseWork) -> WorkEnqueueOutcome {
+        let key = Self::release_key(&work);
+        let mut pending = self
+            .release_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        if pending.contains_key(&key) {
+            return WorkEnqueueOutcome::AlreadyTracked;
+        }
+        if pending.len() >= ORPHAN_WORK_QUEUE_CAPACITY {
+            crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
+            return WorkEnqueueOutcome::Rejected;
+        }
+        pending.insert(key.clone(), work.clone());
+        match self.release_tx.try_send(work) {
+            Ok(()) => {
+                crate::clustering::metrics::record_orphan_work_queue_depth(
+                    "room_release",
+                    pending.len(),
+                );
+                WorkEnqueueOutcome::Enqueued
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Full(work)) => {
+                crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
+                let tx = self.release_tx.clone();
+                tokio::spawn(async move {
+                    let _ = tx.send(work).await;
+                });
+                WorkEnqueueOutcome::RetainedForRedrive
+            }
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                // A closed receiver means the supervisor must restart the
+                // worker. Keep this exact fence in its restart inventory.
+                crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
+                WorkEnqueueOutcome::RetainedForRestart
+            }
+        }
+    }
+
+    fn pending_hydrations(&self) -> Vec<SmHydrationWork> {
+        self.hydration_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .filter_map(Clone::clone)
+            .collect()
+    }
+
+    fn pending_releases(&self) -> Vec<ExactReleaseWork> {
+        self.release_pending
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    fn sm_cursor(&self) -> Option<String> {
+        self.sm_cursor
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    fn set_sm_cursor(&self, cursor: Option<String>) {
+        *self.sm_cursor.lock().unwrap_or_else(|e| e.into_inner()) = cursor;
+    }
+}
+
+#[cfg(feature = "clustering")]
+impl OrphanReaperSupervisor {
+    fn new(
+        registry: Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
+        parent_cancel: tokio_util::sync::CancellationToken,
+    ) -> Self {
+        let cancel = parent_cancel.child_token();
+        let (hydration_tx, mut hydration_rx) =
+            tokio::sync::mpsc::channel(ORPHAN_WORK_QUEUE_CAPACITY);
+        let (release_tx, mut release_rx) = tokio::sync::mpsc::channel(ORPHAN_WORK_QUEUE_CAPACITY);
+        let hydration_pending = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let release_pending = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+        let workers = OrphanReaperWorkers {
+            hydration_tx,
+            release_tx,
+            hydration_pending: hydration_pending.clone(),
+            release_pending: release_pending.clone(),
+            sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+            cancel: cancel.clone(),
+            node_cancel: parent_cancel.clone(),
+        };
+
+        let hydration_cancel = cancel.clone();
+        let hydration_task = tokio::spawn(async move {
+            let mut queue = std::collections::VecDeque::new();
+            loop {
+                if queue.is_empty() {
+                    tokio::select! {
+                        _ = hydration_cancel.cancelled() => break,
+                        work = hydration_rx.recv() => match work { Some(work) => queue.push_back(work), None => break },
+                    }
+                }
+                while let Ok(work) = hydration_rx.try_recv() {
+                    queue.push_back(work);
+                }
+                let Some(work) = queue.pop_front() else {
+                    continue;
+                };
+                let result = tokio::select! {
+                    _ = hydration_cancel.cancelled() => break,
+                    result = tokio::time::timeout(
+                        ORPHAN_WORK_ATTEMPT_TIMEOUT,
+                        registry.hydrate_reclaimed_typed(
+                            &work.entity,
+                            &work.fence,
+                            work.reservation,
+                        ),
+                    ) => result,
+                };
+                match result {
+                    Ok(Ok(
+                        waddle_xmpp::stream_management::ReclaimedHydrationOutcome::Hydrated
+                        | waddle_xmpp::stream_management::ReclaimedHydrationOutcome::AlreadyPresent
+                        | waddle_xmpp::stream_management::ReclaimedHydrationOutcome::LostClaim,
+                    )) => {
+                        let key = OrphanReaperWorkers::hydration_key(&work);
+                        let mut pending =
+                            hydration_pending.lock().unwrap_or_else(|e| e.into_inner());
+                        pending.remove(&key);
+                        crate::clustering::metrics::record_orphan_work_queue_depth(
+                            "sm_hydration",
+                            pending.len(),
+                        );
+                        info!("orphan reaper: targeted hydration work complete");
+                    }
+                    Ok(Ok(
+                        waddle_xmpp::stream_management::ReclaimedHydrationOutcome::MissingDurable
+                        | waddle_xmpp::stream_management::ReclaimedHydrationOutcome::PoisonReleased,
+                    )) => {
+                        let cleanup = tokio::select! {
+                            _ = hydration_cancel.cancelled() => break,
+                            result = tokio::time::timeout(
+                                ORPHAN_WORK_ATTEMPT_TIMEOUT,
+                                registry.release_reclaimed_claim(
+                                    &work.entity,
+                                    &work.fence,
+                                    work.reservation,
+                                ),
+                            ) => result,
+                        };
+                        match cleanup {
+                            Ok(Ok(_)) => {
+                                let key = OrphanReaperWorkers::hydration_key(&work);
+                                let mut pending =
+                                    hydration_pending.lock().unwrap_or_else(|e| e.into_inner());
+                                pending.remove(&key);
+                                crate::clustering::metrics::record_orphan_work_queue_depth(
+                                    "sm_hydration",
+                                    pending.len(),
+                                );
+                            }
+                            Ok(Err(error)) => {
+                                debug!(%error, "orphan reaper: missing/poison SM exact release failed; retrying");
+                                queue.push_back(work);
+                            }
+                            Err(_) => queue.push_back(work),
+                        }
+                    }
+                    Ok(Ok(
+                        waddle_xmpp::stream_management::ReclaimedHydrationOutcome::TransientFailure,
+                    )) => {
+                        queue.push_back(work);
+                    }
+                    Ok(Ok(
+                        waddle_xmpp::stream_management::ReclaimedHydrationOutcome::StaleIdentity,
+                    )) => {
+                        let cleanup = tokio::time::timeout(
+                            ORPHAN_WORK_ATTEMPT_TIMEOUT,
+                            registry.release_reclaimed_claim(
+                                &work.entity,
+                                &work.fence,
+                                work.reservation,
+                            ),
+                        )
+                        .await;
+                        match cleanup {
+                            Ok(Ok(_)) => {
+                                let key = OrphanReaperWorkers::hydration_key(&work);
+                                let mut pending =
+                                    hydration_pending.lock().unwrap_or_else(|e| e.into_inner());
+                                pending.remove(&key);
+                                crate::clustering::metrics::record_orphan_work_queue_depth(
+                                    "sm_hydration",
+                                    pending.len(),
+                                );
+                            }
+                            Ok(Err(_)) | Err(_) => queue.push_back(work),
+                        }
+                    }
+                    Ok(Err(error)) => {
+                        debug!(%error, "orphan reaper: targeted hydration failed; retaining bounded retry");
+                        queue.push_back(work);
+                    }
+                    Err(_) => {
+                        debug!(
+                            "orphan reaper: targeted hydration timed out; retaining bounded retry"
+                        );
+                        queue.push_back(work);
+                    }
+                }
+                if !queue.is_empty() {
+                    tokio::select! {
+                        _ = hydration_cancel.cancelled() => break,
+                        _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                    }
+                }
+            }
+            hydration_pending
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clear();
+            crate::clustering::metrics::record_orphan_work_queue_depth("sm_hydration", 0);
+        });
+
+        let release_cancel = cancel.clone();
+        let release_task = tokio::spawn(async move {
+            let mut queue = std::collections::VecDeque::new();
+            loop {
+                if queue.is_empty() {
+                    tokio::select! {
+                        _ = release_cancel.cancelled() => break,
+                        work = release_rx.recv() => match work { Some(work) => queue.push_back(work), None => break },
+                    }
+                }
+                while let Ok(work) = release_rx.try_recv() {
+                    queue.push_back(work);
+                }
+                let Some(work) = queue.pop_front() else {
+                    continue;
+                };
+                let result = tokio::select! {
+                    _ = release_cancel.cancelled() => break,
+                    result = tokio::time::timeout(
+                        ORPHANED_ROOM_RELEASE_TIMEOUT,
+                        work.claim_store.release_exact(&work.entity, &work.owner, work.epoch),
+                    ) => result,
+                };
+                match result {
+                    Ok(Ok(_)) => {
+                        let key = OrphanReaperWorkers::release_key(&work);
+                        let mut pending = release_pending.lock().unwrap_or_else(|e| e.into_inner());
+                        pending.remove(&key);
+                        crate::clustering::metrics::record_orphan_work_queue_depth(
+                            "room_release",
+                            pending.len(),
+                        );
+                    }
+                    Ok(Err(error)) => {
+                        debug!(%error, entity_id = %work.entity.id, "orphan reaper: exact cleanup retry failed");
+                        queue.push_back(work);
+                    }
+                    Err(_) => {
+                        debug!(entity_id = %work.entity.id, "orphan reaper: exact cleanup retry timed out");
+                        queue.push_back(work);
+                    }
+                }
+                if !queue.is_empty() {
+                    tokio::select! {
+                        _ = release_cancel.cancelled() => break,
+                        _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+                    }
+                }
+            }
+            release_pending
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .clear();
+            crate::clustering::metrics::record_orphan_work_queue_depth("room_release", 0);
+        });
+        Self {
+            workers,
+            cancel,
+            tasks: vec![
+                ("sm_hydration", hydration_task),
+                ("room_release", release_task),
+            ],
+        }
+    }
+
+    fn is_healthy(&self) -> bool {
+        self.tasks.iter().all(|(_, task)| !task.is_finished())
+    }
+
+    async fn restarted(
+        self,
+        registry: Arc<waddle_xmpp::stream_management::InMemorySmSessionRegistry>,
+        parent_cancel: tokio_util::sync::CancellationToken,
+    ) -> Self {
+        let hydration = self.workers.pending_hydrations();
+        let releases = self.workers.pending_releases();
+        let sm_cursor = self.workers.sm_cursor();
+        self.shutdown().await;
+        let next = Self::new(registry, parent_cancel);
+        next.workers.set_sm_cursor(sm_cursor);
+        for work in hydration {
+            if !next
+                .workers
+                .enqueue_hydration(work.entity, work.fence, work.reservation)
+                .is_accepted()
+            {
+                error!("orphan reaper: failed to requeue hydration after worker restart");
+            }
+        }
+        for work in releases {
+            if !next.workers.enqueue_release(work).is_accepted() {
+                error!("orphan reaper: failed to requeue exact release after worker restart");
+            }
+        }
+        next
+    }
+
+    async fn shutdown(mut self) {
+        self.cancel.cancel();
+        for (worker, task) in self.tasks.drain(..) {
+            if let Err(error) = task.await {
+                let reason = if error.is_panic() {
+                    "panic"
+                } else {
+                    "cancelled"
+                };
+                crate::clustering::metrics::record_orphan_worker_failure(worker, reason);
+                error!(worker, %error, "orphan reaper worker failed");
+            }
+        }
+    }
+}
+
+#[cfg(feature = "clustering")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReclaimedRegistration {
+    Registered,
+    Released,
+    LostRace,
+    CleanupScheduled,
+    ShutdownDeferred,
+}
+
+#[cfg(feature = "clustering")]
+struct ReclaimedRegistrationContext<'a> {
+    workers: &'a OrphanReaperWorkers,
+    room_registry: &'a waddle_xmpp::muc::RoomRegistry,
+    claim_store: &'a Arc<dyn waddle_xmpp::ownership::ClaimStore>,
+    previous_owner: &'a waddle_xmpp::ownership::NodeIdentity,
+    me: &'a waddle_xmpp::ownership::NodeIdentity,
+}
+
+#[cfg(feature = "clustering")]
+async fn register_reclaimed_epoch_or_cleanup(
+    context: ReclaimedRegistrationContext<'_>,
+    entity: &waddle_xmpp::ownership::Entity,
+    room_jid: &jid::BareJid,
+    claim_epoch: waddle_xmpp::ownership::ClaimEpoch,
+) -> ReclaimedRegistration {
+    loop {
+        let registration = tokio::select! {
+            biased;
+            _ = context.workers.cancel.cancelled() => {
+                return ReclaimedRegistration::ShutdownDeferred;
+            }
+            result = context.room_registry.remember_pending_reclaimed_room(
+                room_jid.clone(),
+                waddle_xmpp::muc::RoomClaimFenceContext::new(
+                    entity.clone(),
+                    context.me.clone(),
+                    claim_epoch,
+                ),
+                context.previous_owner.clone(),
+            ) => result,
+        };
+        if registration.is_ok() {
+            return ReclaimedRegistration::Registered;
+        }
+        if !context.room_registry.actor_ref().is_alive() {
+            break;
+        }
+        // The registry reservation was established before the steal, so
+        // demand remains serialized while mailbox backpressure clears. Do
+        // not cancel it or release outside the actor while the actor is live.
+        tokio::select! {
+            biased;
+            _ = context.workers.cancel.cancelled() => {
+                return ReclaimedRegistration::ShutdownDeferred;
+            }
+            _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+        }
+    }
+
+    // A stopped registry cannot create or publish a replacement actor, so
+    // exact cleanup can no longer race demand on this registry. Release the
+    // won generation now; retain failures in the bounded supervised worker.
+    let release = tokio::select! {
+        biased;
+        _ = context.workers.cancel.cancelled() => {
+            return ReclaimedRegistration::ShutdownDeferred;
+        }
+        result = tokio::time::timeout(
+            ORPHANED_ROOM_RELEASE_TIMEOUT,
+            context.claim_store.release_exact(entity, context.me, claim_epoch),
+        ) => result,
+    };
+    match release {
+        Ok(Ok(waddle_xmpp::ownership::ExactReleaseOutcome::Released)) => {
+            ReclaimedRegistration::Released
+        }
+        Ok(Ok(waddle_xmpp::ownership::ExactReleaseOutcome::NotOwned)) => {
+            ReclaimedRegistration::LostRace
+        }
+        Ok(Err(error)) => {
+            debug!(room = %room_jid, %error, "orphan reaper: stopped-registry exact cleanup failed; retaining supervised retry");
+            loop {
+                if context
+                    .workers
+                    .enqueue_release(ExactReleaseWork {
+                        claim_store: context.claim_store.clone(),
+                        entity: entity.clone(),
+                        owner: context.me.clone(),
+                        epoch: claim_epoch,
+                    })
+                    .is_accepted()
+                {
+                    break ReclaimedRegistration::CleanupScheduled;
+                }
+                tokio::select! {
+                    biased;
+                    _ = context.workers.cancel.cancelled() => {
+                        break ReclaimedRegistration::ShutdownDeferred;
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+                }
+            }
+        }
+        Err(_) => loop {
+            if context
+                .workers
+                .enqueue_release(ExactReleaseWork {
+                    claim_store: context.claim_store.clone(),
+                    entity: entity.clone(),
+                    owner: context.me.clone(),
+                    epoch: claim_epoch,
+                })
+                .is_accepted()
+            {
+                break ReclaimedRegistration::CleanupScheduled;
+            }
+            tokio::select! {
+                biased;
+                _ = context.workers.cancel.cancelled() => {
+                    break ReclaimedRegistration::ShutdownDeferred;
+                }
+                _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+            }
+        },
+    }
+}
+
+#[cfg(feature = "clustering")]
+async fn reconcile_registered_room_or_self_fence(
+    workers: &OrphanReaperWorkers,
+    room_registry: &waddle_xmpp::muc::RoomRegistry,
+    room_jid: jid::BareJid,
+    claim_fence: waddle_xmpp::muc::RoomClaimFenceContext,
+    previous_owner: waddle_xmpp::ownership::NodeIdentity,
+) -> Result<
+    waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome,
+    waddle_xmpp::muc::RoomRegistryError,
+> {
+    let result = room_registry
+        .reconcile_reclaimed_room(room_jid, claim_fence, previous_owner)
+        .await;
+    if result.is_err() {
+        // Mailbox acceptance is not handler completion. If this uncertain
+        // handoff cannot produce a typed outcome, actor-local retry state may
+        // disappear while this node still owns the won claim. Stop the node's
+        // lease lifecycle so another node can reclaim it after expiry; never
+        // guess whether an exact release is safe after possible publication.
+        workers.node_cancel.cancel();
+    }
+    result
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn stopped_registry_after_steal_exactly_releases_the_won_claim() {
+    use waddle_xmpp::ownership::{ClaimStore, Entity, EntityType, InProcessClaimStore};
+
+    let registry = waddle_xmpp::muc::RoomRegistry::spawn(
+        "muc.example.com".to_string(),
+        waddle_xmpp::xep::xep0421::OccupantIdSecret::new(
+            b"test-occupant-id-secret-32-bytes-long".to_vec(),
+        )
+        .expect("secret"),
+        None,
+    );
+    registry.actor_ref().kill();
+    registry.actor_ref().wait_for_shutdown().await;
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let me = waddle_xmpp::ownership::NodeIdentity::new("sweeper", "incarnation");
+    let previous = waddle_xmpp::ownership::NodeIdentity::new("dead", "old");
+    let room_jid: jid::BareJid = "stopped-registry@muc.example.com".parse().expect("room");
+    let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+    let epoch = claim_store.acquire(&entity, &me).await.expect("won epoch");
+    let supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        tokio_util::sync::CancellationToken::new(),
+    );
+    let outcome = register_reclaimed_epoch_or_cleanup(
+        ReclaimedRegistrationContext {
+            workers: &supervisor.workers,
+            room_registry: &registry,
+            claim_store: &claim_store,
+            previous_owner: &previous,
+            me: &me,
+        },
+        &entity,
+        &room_jid,
+        epoch,
+    )
+    .await;
+    assert_eq!(outcome, ReclaimedRegistration::Released);
+    assert!(
+        claim_store
+            .current_claim(&entity)
+            .await
+            .expect("claim")
+            .is_none(),
+        "a stopped registry cannot adopt the won claim, so exact cleanup must not strand it"
+    );
+    supervisor.shutdown().await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn cancelled_registration_retry_returns_without_releasing_a_live_registry_claim() {
+    use waddle_xmpp::ownership::{ClaimStore, Entity, EntityType, InProcessClaimStore};
+
+    let registry = waddle_xmpp::muc::RoomRegistry::spawn(
+        "muc.example.com".to_string(),
+        waddle_xmpp::xep::xep0421::OccupantIdSecret::new(
+            b"test-occupant-id-secret-32-bytes-long".to_vec(),
+        )
+        .expect("secret"),
+        None,
+    );
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let me = waddle_xmpp::ownership::NodeIdentity::new("sweeper", "incarnation");
+    let previous = waddle_xmpp::ownership::NodeIdentity::new("dead", "old");
+    let room_jid: jid::BareJid = "cancelled-registration@muc.example.com"
+        .parse()
+        .expect("room");
+    let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+    let epoch = claim_store.acquire(&entity, &me).await.expect("won epoch");
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        cancel.clone(),
+    );
+    cancel.cancel();
+
+    let outcome = register_reclaimed_epoch_or_cleanup(
+        ReclaimedRegistrationContext {
+            workers: &supervisor.workers,
+            room_registry: &registry,
+            claim_store: &claim_store,
+            previous_owner: &previous,
+            me: &me,
+        },
+        &entity,
+        &room_jid,
+        epoch,
+    )
+    .await;
+    assert_eq!(outcome, ReclaimedRegistration::ShutdownDeferred);
+    assert!(
+        claim_store
+            .current_claim(&entity)
+            .await
+            .expect("claim")
+            .is_some(),
+        "shutdown must not release outside a still-live registry"
+    );
+
+    registry.actor_ref().kill();
+    registry.actor_ref().wait_for_shutdown().await;
+    supervisor.shutdown().await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn registry_death_after_mailbox_acceptance_self_fences_the_node() {
+    use waddle_xmpp::ownership::{ClaimStore, Entity, EntityType, InProcessClaimStore};
+
+    let registry = waddle_xmpp::muc::RoomRegistry::spawn(
+        "muc.example.com".to_string(),
+        waddle_xmpp::xep::xep0421::OccupantIdSecret::new(
+            b"test-occupant-id-secret-32-bytes-long".to_vec(),
+        )
+        .expect("secret"),
+        None,
+    );
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let me = waddle_xmpp::ownership::NodeIdentity::new("sweeper", "incarnation");
+    let previous = waddle_xmpp::ownership::NodeIdentity::new("dead", "old");
+    let room_jid: jid::BareJid = "accepted-then-dead@muc.example.com".parse().expect("room");
+    let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+    let epoch = claim_store.acquire(&entity, &me).await.expect("won epoch");
+    assert!(registry
+        .reserve_pending_reclaimed_room(room_jid.clone())
+        .await
+        .expect("reserve adoption"));
+    let node_cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        node_cancel.clone(),
+    );
+
+    assert_eq!(
+        register_reclaimed_epoch_or_cleanup(
+            ReclaimedRegistrationContext {
+                workers: &supervisor.workers,
+                room_registry: &registry,
+                claim_store: &claim_store,
+                previous_owner: &previous,
+                me: &me,
+            },
+            &entity,
+            &room_jid,
+            epoch,
+        )
+        .await,
+        ReclaimedRegistration::Registered
+    );
+    registry.actor_ref().kill();
+    registry.actor_ref().wait_for_shutdown().await;
+
+    let result = reconcile_registered_room_or_self_fence(
+        &supervisor.workers,
+        &registry,
+        room_jid,
+        waddle_xmpp::muc::RoomClaimFenceContext::new(entity.clone(), me, epoch),
+        previous,
+    )
+    .await;
+    assert!(result.is_err());
+    assert!(node_cancel.is_cancelled());
+    assert!(
+        claim_store
+            .current_claim(&entity)
+            .await
+            .expect("claim")
+            .is_some(),
+        "uncertain post-accept handoff must self-fence, not guess that release is safe"
+    );
+
+    supervisor.shutdown().await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn idle_room_registry_death_self_fences_the_node() {
+    let registry = waddle_xmpp::muc::RoomRegistry::spawn(
+        "muc.example.com".to_string(),
+        waddle_xmpp::xep::xep0421::OccupantIdSecret::new(
+            b"test-occupant-id-secret-32-bytes-long".to_vec(),
+        )
+        .expect("secret"),
+        None,
+    );
+    let node_cancel = tokio_util::sync::CancellationToken::new();
+    let watcher =
+        spawn_room_registry_lifetime_watch(registry.actor_ref().clone(), node_cancel.clone());
+
+    registry.actor_ref().kill();
+    registry.actor_ref().wait_for_shutdown().await;
+    tokio::time::timeout(Duration::from_secs(1), node_cancel.cancelled())
+        .await
+        .expect("registry lifetime watcher must cancel the node promptly");
+    watcher.await.expect("registry lifetime watcher");
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[derive(Default)]
+struct HangingSmReadPersistence {
+    inner: waddle_xmpp::stream_management::persistence::InMemorySmPersistence,
+    read_started: tokio::sync::Notify,
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[async_trait::async_trait]
+impl waddle_xmpp::stream_management::persistence::SmPersistenceStorage
+    for HangingSmReadPersistence
+{
+    async fn upsert_session(
+        &self,
+        session: waddle_xmpp::stream_management::persistence::PersistedSession,
+    ) -> Result<(), waddle_xmpp::stream_management::persistence::SmPersistenceError> {
+        self.inner.upsert_session(session).await
+    }
+
+    async fn get_session(
+        &self,
+        _stream_id: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<
+        Option<waddle_xmpp::stream_management::persistence::PersistedSession>,
+        waddle_xmpp::stream_management::persistence::SmPersistenceError,
+    > {
+        self.read_started.notify_one();
+        std::future::pending().await
+    }
+
+    async fn delete_session(
+        &self,
+        stream_id: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<(), waddle_xmpp::stream_management::persistence::SmPersistenceError> {
+        self.inner.delete_session(stream_id).await
+    }
+
+    async fn append_unacked(
+        &self,
+        stanza: waddle_xmpp::stream_management::persistence::PersistedUnackedStanza,
+    ) -> Result<(), waddle_xmpp::stream_management::persistence::SmPersistenceError> {
+        self.inner.append_unacked(stanza).await
+    }
+
+    async fn ack_through(
+        &self,
+        stream_id: &waddle_xmpp::pending_delivery::SmSessionId,
+        up_to_sequence: u32,
+    ) -> Result<u64, waddle_xmpp::stream_management::persistence::SmPersistenceError> {
+        self.inner.ack_through(stream_id, up_to_sequence).await
+    }
+
+    async fn delete_unacked(
+        &self,
+        stream_id: &waddle_xmpp::pending_delivery::SmSessionId,
+        sequences: &[u32],
+    ) -> Result<u64, waddle_xmpp::stream_management::persistence::SmPersistenceError> {
+        self.inner.delete_unacked(stream_id, sequences).await
+    }
+
+    async fn list_unacked(
+        &self,
+        stream_id: &waddle_xmpp::pending_delivery::SmSessionId,
+    ) -> Result<
+        Vec<waddle_xmpp::stream_management::persistence::PersistedUnackedStanza>,
+        waddle_xmpp::stream_management::persistence::SmPersistenceError,
+    > {
+        self.inner.list_unacked(stream_id).await
+    }
+
+    async fn list_expired_sessions(
+        &self,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> Result<
+        Vec<waddle_xmpp::stream_management::persistence::PersistedSession>,
+        waddle_xmpp::stream_management::persistence::SmPersistenceError,
+    > {
+        self.inner.list_expired_sessions(now).await
+    }
+
+    async fn list_all_sessions(
+        &self,
+    ) -> Result<
+        Vec<waddle_xmpp::stream_management::persistence::PersistedSession>,
+        waddle_xmpp::stream_management::persistence::SmPersistenceError,
+    > {
+        self.inner.list_all_sessions().await
+    }
+}
+
+#[cfg(all(test, feature = "clustering"))]
+struct HangingExactReleaseStore {
+    inner: waddle_xmpp::ownership::InProcessClaimStore,
+    release_started: tokio::sync::Notify,
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[async_trait::async_trait]
+impl waddle_xmpp::ownership::ClaimStore for HangingExactReleaseStore {
+    async fn ensure_schema(&self) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.ensure_schema().await
+    }
+    async fn acquire(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner.acquire(entity, me).await
+    }
+    async fn ensure_claimed(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner.ensure_claimed(entity, me).await
+    }
+    async fn steal_stale(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        observed: waddle_xmpp::ownership::ClaimEpoch,
+        staleness: waddle_xmpp::ownership::StalePredicate,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner
+            .steal_stale(entity, observed, staleness, me)
+            .await
+    }
+    async fn steal_for_resume(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        observed: waddle_xmpp::ownership::ClaimEpoch,
+        witness: waddle_xmpp::ownership::ResumeIdentityProof,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<waddle_xmpp::ownership::ClaimEpoch, waddle_xmpp::ownership::ClaimError> {
+        self.inner
+            .steal_for_resume(entity, observed, witness, me)
+            .await
+    }
+    async fn current_claim(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+    ) -> Result<Option<waddle_xmpp::ownership::ClaimSnapshot>, waddle_xmpp::ownership::ClaimError>
+    {
+        self.inner.current_claim(entity).await
+    }
+    async fn fence(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+        mine: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> Result<bool, waddle_xmpp::ownership::ClaimError> {
+        self.inner.fence(entity, me, mine).await
+    }
+    async fn release(
+        &self,
+        entity: &waddle_xmpp::ownership::Entity,
+        me: &waddle_xmpp::ownership::NodeIdentity,
+        mine: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.release(entity, me, mine).await
+    }
+    async fn release_exact(
+        &self,
+        _entity: &waddle_xmpp::ownership::Entity,
+        _me: &waddle_xmpp::ownership::NodeIdentity,
+        _mine: waddle_xmpp::ownership::ClaimEpoch,
+    ) -> Result<waddle_xmpp::ownership::ExactReleaseOutcome, waddle_xmpp::ownership::ClaimError>
+    {
+        self.release_started.notify_one();
+        std::future::pending().await
+    }
+    async fn release_many(
+        &self,
+        entities: &[waddle_xmpp::ownership::Entity],
+        me: &waddle_xmpp::ownership::NodeIdentity,
+    ) -> Result<(), waddle_xmpp::ownership::ClaimError> {
+        self.inner.release_many(entities, me).await
+    }
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn hung_sm_hydration_does_not_block_completed_room_lane() {
+    use waddle_xmpp::ownership::{
+        ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
+    };
+
+    let storage = Arc::new(HangingSmReadPersistence::default());
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let me = NodeIdentity::new("sweeper", "incarnation");
+    let registry = Arc::new(
+        waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()
+            .with_persistence(storage.clone())
+            .with_claim_store(claim_store.clone(), SharedNodeIdentity::new(me.clone())),
+    );
+    let entity = Entity::new(EntityType::SmSession, "hung-session");
+    let epoch = claim_store.acquire(&entity, &me).await.expect("claim");
+
+    // Production completes the bounded RoomActor lane before scheduling
+    // this detached SM hydration. A storage read that never returns must
+    // therefore neither undo nor delay that room progress.
+    let room_lane_completed = true;
+    let reservation = registry
+        .reserve_reclaimed_claim_capacity(&entity)
+        .expect("hung hydration reservation");
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(registry, cancel.clone());
+    supervisor.workers.enqueue_hydration(
+        entity,
+        waddle_xmpp::stream_management::persistence::SmClaimFence::new(me.clone(), epoch),
+        reservation,
+    );
+
+    tokio::time::timeout(Duration::from_secs(1), storage.read_started.notified())
+        .await
+        .expect("detached hydration should reach the deliberately hung SM read");
+    assert!(room_lane_completed);
+    for index in 1..ORPHAN_WORK_QUEUE_CAPACITY {
+        assert!(supervisor
+            .workers
+            .enqueue_hydration(
+                Entity::new(EntityType::SmSession, format!("queued-{index}")),
+                waddle_xmpp::stream_management::persistence::SmClaimFence::new(
+                    me.clone(),
+                    waddle_xmpp::ownership::ClaimEpoch(index as i64),
+                ),
+                waddle_xmpp::stream_management::ReclaimedClaimReservation::from_generation(
+                    index as u64 + 1,
+                ),
+            )
+            .is_accepted());
+    }
+    assert_eq!(
+        supervisor.workers.enqueue_hydration(
+            Entity::new(EntityType::SmSession, "queue-overflow"),
+            waddle_xmpp::stream_management::persistence::SmClaimFence::new(
+                me,
+                waddle_xmpp::ownership::ClaimEpoch(999),
+            ),
+            waddle_xmpp::stream_management::ReclaimedClaimReservation::from_generation(999),
+        ),
+        WorkEnqueueOutcome::Rejected
+    );
+    cancel.cancel();
+    tokio::time::timeout(Duration::from_secs(1), supervisor.shutdown())
+        .await
+        .expect("hung hydration worker must cancel and join");
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn sm_rotation_before_hydration_worker_releases_the_exact_old_fence() {
+    use waddle_xmpp::ownership::{
+        ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
+    };
+
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let old_owner = NodeIdentity::new("sweeper", "old-incarnation");
+    let new_owner = NodeIdentity::new("sweeper", "new-incarnation");
+    let identity = SharedNodeIdentity::new(old_owner.clone());
+    let entity = Entity::new(EntityType::SmSession, "rotate-before-worker");
+    let epoch = claim_store
+        .acquire(&entity, &old_owner)
+        .await
+        .expect("seed old claim");
+    let registry = Arc::new(
+        waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()
+            .with_claim_store(claim_store.clone(), identity.clone()),
+    );
+    let reservation = registry
+        .reserve_reclaimed_claim_capacity(&entity)
+        .expect("stale hydration reservation");
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(registry, cancel.clone());
+
+    identity.rotate(new_owner).await;
+    assert!(supervisor
+        .workers
+        .enqueue_hydration(
+            entity.clone(),
+            waddle_xmpp::stream_management::persistence::SmClaimFence::new(old_owner, epoch),
+            reservation,
+        )
+        .is_accepted());
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            if claim_store
+                .current_claim(&entity)
+                .await
+                .expect("read claim")
+                .is_none()
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("stale worker must release the exact old fence");
+    assert!(supervisor.workers.pending_hydrations().is_empty());
+
+    cancel.cancel();
+    supervisor.shutdown().await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test(start_paused = true)]
+async fn sm_rotation_between_hydration_retries_releases_the_exact_old_fence() {
+    use waddle_xmpp::ownership::{
+        ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
+    };
+
+    let storage = Arc::new(HangingSmReadPersistence::default());
+    let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
+    let old_owner = NodeIdentity::new("sweeper", "old-incarnation");
+    let new_owner = NodeIdentity::new("sweeper", "new-incarnation");
+    let identity = SharedNodeIdentity::new(old_owner.clone());
+    let entity = Entity::new(EntityType::SmSession, "rotate-between-retries");
+    let epoch = claim_store
+        .acquire(&entity, &old_owner)
+        .await
+        .expect("seed old claim");
+    let registry = Arc::new(
+        waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()
+            .with_persistence(storage.clone())
+            .with_claim_store(claim_store.clone(), identity.clone()),
+    );
+    let reservation = registry
+        .reserve_reclaimed_claim_capacity(&entity)
+        .expect("retry hydration reservation");
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(registry, cancel.clone());
+    assert!(supervisor
+        .workers
+        .enqueue_hydration(
+            entity.clone(),
+            waddle_xmpp::stream_management::persistence::SmClaimFence::new(old_owner, epoch),
+            reservation,
+        )
+        .is_accepted());
+
+    storage.read_started.notified().await;
+    identity.rotate(new_owner).await;
+    tokio::time::advance(ORPHAN_WORK_ATTEMPT_TIMEOUT).await;
+    tokio::task::yield_now().await;
+    tokio::time::advance(Duration::from_secs(1)).await;
+    for _ in 0..100 {
+        if claim_store
+            .current_claim(&entity)
+            .await
+            .expect("read claim")
+            .is_none()
+        {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    assert!(claim_store
+        .current_claim(&entity)
+        .await
+        .expect("read final claim")
+        .is_none());
+    assert!(supervisor.workers.pending_hydrations().is_empty());
+
+    cancel.cancel();
+    supervisor.shutdown().await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn hung_exact_release_worker_is_cancelled_and_joined() {
+    use waddle_xmpp::ownership::{Entity, EntityType, NodeIdentity};
+
+    let store = Arc::new(HangingExactReleaseStore {
+        inner: waddle_xmpp::ownership::InProcessClaimStore::new(),
+        release_started: tokio::sync::Notify::new(),
+    });
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        cancel.clone(),
+    );
+    supervisor.workers.enqueue_release(ExactReleaseWork {
+        claim_store: store.clone(),
+        entity: Entity::new(EntityType::RoomActor, "cancel@muc.example.com"),
+        owner: NodeIdentity::new("sweeper", "incarnation"),
+        epoch: waddle_xmpp::ownership::ClaimEpoch(1),
+    });
+    tokio::time::timeout(Duration::from_secs(1), store.release_started.notified())
+        .await
+        .expect("release worker started");
+    cancel.cancel();
+    tokio::time::timeout(Duration::from_secs(1), supervisor.shutdown())
+        .await
+        .expect("hung exact-release worker must cancel and join");
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[test]
+fn hydration_reservations_do_not_overcommit_a_127_of_128_queue() {
+    use waddle_xmpp::ownership::{Entity, EntityType};
+    let (hydration_tx, _hydration_rx) = tokio::sync::mpsc::channel(ORPHAN_WORK_QUEUE_CAPACITY);
+    let (release_tx, _release_rx) = tokio::sync::mpsc::channel(ORPHAN_WORK_QUEUE_CAPACITY);
+    let workers = OrphanReaperWorkers {
+        hydration_tx,
+        release_tx,
+        hydration_pending: Arc::new(std::sync::Mutex::new(
+            (0..127)
+                .map(|index| (format!("existing-{index}"), None))
+                .collect(),
+        )),
+        release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+        cancel: tokio_util::sync::CancellationToken::new(),
+        node_cancel: tokio_util::sync::CancellationToken::new(),
+    };
+    let reserved = (0..64)
+        .filter(|index| {
+            workers.reserve_hydration(&Entity::new(
+                EntityType::SmSession,
+                format!("candidate-{index}"),
+            ))
+        })
+        .count();
+    assert_eq!(reserved, 1);
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn full_hydration_channel_retains_and_redrives_pending_work() {
+    use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
+    use waddle_xmpp::stream_management::persistence::SmClaimFence;
+
+    let (hydration_tx, mut hydration_rx) = tokio::sync::mpsc::channel(1);
+    let (release_tx, _release_rx) = tokio::sync::mpsc::channel(1);
+    let existing = SmHydrationWork {
+        entity: Entity::new(EntityType::SmSession, "existing"),
+        fence: SmClaimFence::new(NodeIdentity::new("node", "incarnation"), ClaimEpoch(1)),
+        reservation: waddle_xmpp::stream_management::ReclaimedClaimReservation::from_generation(1),
+    };
+    hydration_tx
+        .try_send(existing.clone())
+        .expect("prefill hydration channel");
+    let workers = OrphanReaperWorkers {
+        hydration_tx,
+        release_tx,
+        hydration_pending: Arc::new(std::sync::Mutex::new(
+            [("existing".to_string(), Some(existing))].into(),
+        )),
+        release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+        cancel: tokio_util::sync::CancellationToken::new(),
+        node_cancel: tokio_util::sync::CancellationToken::new(),
+    };
+    let candidate = Entity::new(EntityType::SmSession, "candidate");
+
+    assert_eq!(
+        workers.enqueue_hydration(
+            candidate.clone(),
+            SmClaimFence::new(NodeIdentity::new("node", "incarnation"), ClaimEpoch(2)),
+            waddle_xmpp::stream_management::ReclaimedClaimReservation::from_generation(2),
+        ),
+        WorkEnqueueOutcome::RetainedForRedrive
+    );
+    assert!(workers
+        .hydration_pending
+        .lock()
+        .expect("hydration pending")
+        .contains_key(&candidate.id));
+    assert_eq!(
+        hydration_rx
+            .recv()
+            .await
+            .expect("existing hydration")
+            .entity
+            .id,
+        "existing"
+    );
+    assert_eq!(
+        hydration_rx
+            .recv()
+            .await
+            .expect("redriven hydration")
+            .entity
+            .id,
+        candidate.id
+    );
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[test]
+fn closed_hydration_channel_retains_restart_inventory() {
+    use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
+    use waddle_xmpp::stream_management::persistence::SmClaimFence;
+
+    let (hydration_tx, hydration_rx) = tokio::sync::mpsc::channel(1);
+    drop(hydration_rx);
+    let (release_tx, _release_rx) = tokio::sync::mpsc::channel(1);
+    let workers = OrphanReaperWorkers {
+        hydration_tx,
+        release_tx,
+        hydration_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+        cancel: tokio_util::sync::CancellationToken::new(),
+        node_cancel: tokio_util::sync::CancellationToken::new(),
+    };
+    let candidate = Entity::new(EntityType::SmSession, "candidate");
+
+    assert_eq!(
+        workers.enqueue_hydration(
+            candidate.clone(),
+            SmClaimFence::new(NodeIdentity::new("node", "incarnation"), ClaimEpoch(2)),
+            waddle_xmpp::stream_management::ReclaimedClaimReservation::from_generation(2),
+        ),
+        WorkEnqueueOutcome::RetainedForRestart
+    );
+    assert!(workers
+        .hydration_pending
+        .lock()
+        .expect("hydration pending")
+        .contains_key(&candidate.id));
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn full_release_channel_retains_and_redrives_pending_work() {
+    use waddle_xmpp::ownership::{
+        ClaimEpoch, Entity, EntityType, InProcessClaimStore, NodeIdentity,
+    };
+
+    let (hydration_tx, _hydration_rx) = tokio::sync::mpsc::channel(1);
+    let (release_tx, mut release_rx) = tokio::sync::mpsc::channel(1);
+    let owner = NodeIdentity::new("node", "incarnation");
+    let existing = ExactReleaseWork {
+        claim_store: Arc::new(InProcessClaimStore::new()),
+        entity: Entity::new(EntityType::RoomActor, "existing@muc.example.com"),
+        owner: owner.clone(),
+        epoch: ClaimEpoch(1),
+    };
+    release_tx
+        .try_send(existing.clone())
+        .expect("prefill release channel");
+    let existing_key = OrphanReaperWorkers::release_key(&existing);
+    let workers = OrphanReaperWorkers {
+        hydration_tx,
+        release_tx,
+        hydration_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        release_pending: Arc::new(std::sync::Mutex::new(
+            [(existing_key.clone(), existing)].into(),
+        )),
+        sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+        cancel: tokio_util::sync::CancellationToken::new(),
+        node_cancel: tokio_util::sync::CancellationToken::new(),
+    };
+    let candidate = ExactReleaseWork {
+        claim_store: Arc::new(InProcessClaimStore::new()),
+        entity: Entity::new(EntityType::RoomActor, "candidate@muc.example.com"),
+        owner,
+        epoch: ClaimEpoch(2),
+    };
+    let candidate_key = OrphanReaperWorkers::release_key(&candidate);
+
+    assert_eq!(
+        workers.enqueue_release(candidate),
+        WorkEnqueueOutcome::RetainedForRedrive
+    );
+    assert!(workers
+        .release_pending
+        .lock()
+        .expect("release pending")
+        .contains_key(&candidate_key));
+    assert_eq!(
+        OrphanReaperWorkers::release_key(&release_rx.recv().await.expect("existing release")),
+        existing_key
+    );
+    assert_eq!(
+        OrphanReaperWorkers::release_key(&release_rx.recv().await.expect("redriven release")),
+        candidate_key
+    );
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[test]
+fn closed_release_channel_retains_restart_inventory() {
+    use waddle_xmpp::ownership::{
+        ClaimEpoch, Entity, EntityType, InProcessClaimStore, NodeIdentity,
+    };
+
+    let (hydration_tx, _hydration_rx) = tokio::sync::mpsc::channel(1);
+    let (release_tx, release_rx) = tokio::sync::mpsc::channel(1);
+    drop(release_rx);
+    let workers = OrphanReaperWorkers {
+        hydration_tx,
+        release_tx,
+        hydration_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        release_pending: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        sm_cursor: Arc::new(std::sync::Mutex::new(None)),
+        cancel: tokio_util::sync::CancellationToken::new(),
+        node_cancel: tokio_util::sync::CancellationToken::new(),
+    };
+    let candidate = ExactReleaseWork {
+        claim_store: Arc::new(InProcessClaimStore::new()),
+        entity: Entity::new(EntityType::RoomActor, "candidate@muc.example.com"),
+        owner: NodeIdentity::new("node", "incarnation"),
+        epoch: ClaimEpoch(2),
+    };
+    let candidate_key = OrphanReaperWorkers::release_key(&candidate);
+
+    assert_eq!(
+        workers.enqueue_release(candidate),
+        WorkEnqueueOutcome::RetainedForRestart
+    );
+    assert!(workers
+        .release_pending
+        .lock()
+        .expect("release pending")
+        .contains_key(&candidate_key));
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn supervisor_restart_preserves_the_sm_scan_cursor() {
+    let parent_cancel = tokio_util::sync::CancellationToken::new();
+    let supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        parent_cancel.clone(),
+    );
+    supervisor
+        .workers
+        .set_sm_cursor(Some("sm_session:page-064".to_string()));
+
+    let restarted = supervisor
+        .restarted(
+            Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+            parent_cancel,
+        )
+        .await;
+
+    assert_eq!(
+        restarted.workers.sm_cursor().as_deref(),
+        Some("sm_session:page-064")
+    );
+    restarted.shutdown().await;
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[tokio::test]
+async fn supervisor_detects_and_reports_a_panicked_worker() {
+    let mut supervisor = OrphanReaperSupervisor::new(
+        Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        tokio_util::sync::CancellationToken::new(),
+    );
+    supervisor.tasks.push((
+        "panic-regression",
+        tokio::spawn(async { panic!("injected worker panic") }),
+    ));
+    tokio::task::yield_now().await;
+    assert!(!supervisor.is_healthy());
+    tokio::time::timeout(Duration::from_secs(1), supervisor.shutdown())
+        .await
+        .expect("shutdown observes the panicked JoinHandle");
+}
+
+#[cfg(all(test, feature = "clustering"))]
+#[test]
+fn failed_sm_candidate_scan_is_an_empty_batch_not_a_sweep_abort() {
+    let candidates = orphaned_sm_candidates_or_empty(Err(
+        waddle_xmpp::ownership::ClaimError::Backend("scan failed".to_string()),
+    ));
+    assert!(candidates.is_empty());
+
+    // The caller continues directly into the RoomActor lane after iterating
+    // this empty batch; preserve that control-flow contract explicitly.
+    let room_lane_ran = {
+        for _ in candidates {}
+        true
+    };
+    assert!(room_lane_ran);
+}
+
+#[cfg(feature = "clustering")]
+async fn run_orphan_reaper_sweep_with_workers(
+    state: &Arc<WebSocketState>,
+    workers: &OrphanReaperWorkers,
+) {
     use waddle_xmpp::ownership::ClaimError;
 
     let clustering = &state.deps.app_state.clustering_claims;
-    let Some((_claim_store, identity_handle)) = clustering.claim_pair() else {
+    let Some((claim_store, identity_handle)) = clustering.claim_pair() else {
         return;
     };
     let Some(node_lease) = clustering.node_lease.clone() else {
@@ -733,17 +2487,6 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
         return;
     }
 
-    let candidates = match node_lease.list_orphaned_sm_session_claims().await {
-        Ok(candidates) => candidates,
-        Err(error) => {
-            warn!(%error, "orphan reaper: list_orphaned_sm_session_claims failed");
-            return;
-        }
-    };
-    if candidates.is_empty() {
-        return;
-    }
-
     // ADR-0017 Phase 3 Slice 10 (Q5's rollout-aware placement rule): an
     // old-generation node backs off before racing a matching/newer
     // -generation node for a just-orphaned claim, so each entity moves
@@ -763,6 +2506,373 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
         }
     };
 
+    let room_registry =
+        waddle_xmpp::muc::RoomRegistry::wrap(state.deps.protocol.room_registry.clone());
+    let mut room_hydrated = 0u64;
+    let mut room_released = 0u64;
+    let mut room_already_live = 0u64;
+    let mut room_adopted_local = 0u64;
+    let mut room_pending_retry = 0u64;
+    let mut room_lost_race = 0u64;
+    let mut room_failed = 0u64;
+
+    // Ordinary destroy/dead-actor/eviction releases use the same orphan
+    // reaper cadence, but retry one exact fence per sweep so a slow ownership
+    // backend cannot monopolize the registry mailbox.
+    if let Err(error) = room_registry.retry_pending_room_releases(1).await {
+        debug!(%error, "orphan reaper: pending ordinary RoomActor release retry failed");
+    }
+
+    // Retry epochs won on an earlier sweep before discovering new work.
+    // Each retry is its own bounded registry ask, so a slow store operation
+    // cannot monopolize the registry actor as one large batch handler.
+    match room_registry
+        .list_pending_reclaimed_rooms(ORPHANED_ROOM_CANDIDATE_LIMIT)
+        .await
+    {
+        Ok(pending) => {
+            for pending_room in pending {
+                match reconcile_registered_room_or_self_fence(
+                    workers,
+                    &room_registry,
+                    pending_room.room_jid,
+                    pending_room.claim_fence,
+                    pending_room.previous_owner,
+                )
+                .await
+                {
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Hydrated) => {
+                        room_hydrated += 1;
+                    }
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Released) => {
+                        room_released += 1;
+                    }
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AlreadyLive,
+                    ) => room_already_live += 1,
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal,
+                    ) => room_adopted_local += 1,
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::PendingRetry,
+                    ) => {
+                        room_pending_retry += 1;
+                    }
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace) => {
+                        room_lost_race += 1;
+                    }
+                    Err(error) => {
+                        debug!(%error, "orphan reaper: pending RoomActor retry ask failed");
+                        return;
+                    }
+                }
+            }
+        }
+        Err(error) => {
+            debug!(%error, "orphan reaper: pending RoomActor listing failed");
+            workers.node_cancel.cancel();
+            return;
+        }
+    }
+    if let Ok(mut backlog) = room_registry.pending_reclaimed_room_backlog().await {
+        if let Ok(releases) = room_registry.pending_room_release_backlog().await {
+            backlog.depth = backlog.depth.saturating_add(releases.depth);
+            backlog.oldest_age_ms = backlog.oldest_age_ms.max(releases.oldest_age_ms);
+        }
+        crate::clustering::metrics::record_room_orphan_pending_backlog(
+            backlog.depth,
+            backlog.oldest_age_ms,
+        );
+    }
+
+    // RoomActor counterpart: proactively move a bounded set of claims off
+    // committed-dead owners. Unlike detached SM sessions, a room claim may
+    // have no durable state at all (for example an ephemeral instant room).
+    // The serialized registry adoption below therefore either hydrates the
+    // exact won epoch, observes demand-side creation already did so, or
+    // releases the unusable claim.
+    let room_candidates = match node_lease
+        .list_orphaned_room_actor_claims(ORPHANED_ROOM_CANDIDATE_LIMIT)
+        .await
+    {
+        Ok(candidates) => candidates,
+        Err(error) => {
+            warn!(%error, "orphan reaper: list_orphaned_room_actor_claims failed");
+            Vec::new()
+        }
+    };
+    for candidate in room_candidates {
+        if workers.cancel.is_cancelled() {
+            return;
+        }
+        if !workers.has_release_capacity() {
+            crate::clustering::metrics::record_orphan_work_queue_backpressure("room_release");
+            warn!("orphan reaper: pausing RoomActor steals because exact-release cleanup capacity is exhausted");
+            break;
+        }
+        let Ok(room_jid) = candidate.entity.id.parse::<jid::BareJid>() else {
+            room_failed += 1;
+            debug!(
+                entity_id = %candidate.entity.id,
+                "orphan reaper: RoomActor claim id is not a bare JID; leaving stale claim for repair"
+            );
+            continue;
+        };
+        match room_registry
+            .reserve_pending_reclaimed_room(room_jid.clone())
+            .await
+        {
+            Ok(true) => {}
+            Ok(false) => {
+                crate::clustering::metrics::record_orphan_work_queue_backpressure("room_adoption");
+                warn!("orphan reaper: pausing RoomActor steals because adoption capacity is exhausted");
+                break;
+            }
+            Err(error) => {
+                room_failed += 1;
+                debug!(room = %room_jid, %error, "orphan reaper: room adoption reservation failed");
+                break;
+            }
+        }
+        if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-room").await
+        {
+            let _ = room_registry
+                .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+                .await;
+            return;
+        }
+        if let Err(error) = node_lease.expire(&candidate.owner, lease_ttl).await {
+            let _ = room_registry
+                .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+                .await;
+            room_failed += 1;
+            debug!(
+                entity_id = %candidate.entity.id,
+                %error,
+                "orphan reaper: room owner's expire CAS failed"
+            );
+            continue;
+        }
+        if !backoff_delay.is_zero() {
+            tokio::time::sleep(backoff_delay).await;
+        }
+        if workers.cancel.is_cancelled() {
+            let _ = room_registry
+                .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+                .await;
+            return;
+        }
+        match node_lease
+            .steal_orphaned_room_actor_claim(&candidate.entity, candidate.epoch, &me, lease_ttl)
+            .await
+        {
+            Ok(new_epoch) => {
+                match register_reclaimed_epoch_or_cleanup(
+                    ReclaimedRegistrationContext {
+                        workers,
+                        room_registry: &room_registry,
+                        claim_store: &claim_store,
+                        previous_owner: &candidate.owner,
+                        me: &me,
+                    },
+                    &candidate.entity,
+                    &room_jid,
+                    new_epoch,
+                )
+                .await
+                {
+                    ReclaimedRegistration::Registered => {}
+                    ReclaimedRegistration::Released => {
+                        room_released += 1;
+                        continue;
+                    }
+                    ReclaimedRegistration::LostRace => {
+                        room_lost_race += 1;
+                        continue;
+                    }
+                    ReclaimedRegistration::CleanupScheduled => {
+                        room_failed += 1;
+                        continue;
+                    }
+                    ReclaimedRegistration::ShutdownDeferred => {
+                        return;
+                    }
+                }
+                let reconciliation = reconcile_registered_room_or_self_fence(
+                    workers,
+                    &room_registry,
+                    room_jid.clone(),
+                    waddle_xmpp::muc::RoomClaimFenceContext::new(
+                        candidate.entity.clone(),
+                        me.clone(),
+                        new_epoch,
+                    ),
+                    candidate.owner.clone(),
+                )
+                .await;
+                let notify_previous_owner = !matches!(
+                    reconciliation,
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal)
+                        | Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace)
+                        | Err(_)
+                );
+                if notify_previous_owner {
+                    if let Some(store) = clustering.muc_durable_store.as_ref() {
+                        if let Err(error) = store
+                            .notify_previous_owner_demoted(
+                                &room_jid,
+                                &candidate.owner.node_id,
+                                &candidate.owner.node_epoch,
+                                new_epoch,
+                            )
+                            .await
+                        {
+                            debug!(
+                                room = %room_jid,
+                                %error,
+                                "orphan reaper: best-effort room demotion notification failed"
+                            );
+                        }
+                    }
+                }
+                match reconciliation {
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Hydrated) => {
+                        room_hydrated += 1;
+                    }
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::Released) => {
+                        room_released += 1;
+                    }
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AlreadyLive,
+                    ) => room_already_live += 1,
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal,
+                    ) => room_adopted_local += 1,
+                    Ok(
+                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::PendingRetry,
+                    ) => room_pending_retry += 1,
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace) => {
+                        room_lost_race += 1;
+                    }
+                    Err(error) => {
+                        debug!(
+                            room = %room_jid,
+                            %error,
+                            "orphan reaper: reclaimed-room registry adoption ask failed; node self-fenced"
+                        );
+                        return;
+                    }
+                }
+            }
+            Err(ClaimError::Conflict) => {
+                room_lost_race += 1;
+                let _ = room_registry
+                    .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+                    .await;
+            }
+            Err(error) => {
+                room_failed += 1;
+                let _ = room_registry
+                    .cancel_pending_reclaimed_room_reservation(room_jid.clone())
+                    .await;
+                debug!(
+                    entity_id = %candidate.entity.id,
+                    %error,
+                    "orphan reaper: RoomActor claim steal failed"
+                );
+            }
+        }
+    }
+    for (outcome, count) in [
+        ("hydrated", room_hydrated),
+        ("released", room_released),
+        ("already_live", room_already_live),
+        ("adopted_local", room_adopted_local),
+        ("pending_retry", room_pending_retry),
+        ("lost_race", room_lost_race),
+        ("failed", room_failed),
+    ] {
+        if count > 0 {
+            crate::clustering::metrics::record_room_orphan_reconciliation(outcome, count);
+        }
+    }
+    let room_reconciled = room_hydrated + room_released + room_already_live + room_adopted_local;
+    if room_pending_retry > 0 || room_failed > 0 {
+        warn!(
+            hydrated = room_hydrated,
+            released = room_released,
+            already_live = room_already_live,
+            adopted_local = room_adopted_local,
+            pending_retry = room_pending_retry,
+            lost_race = room_lost_race,
+            failed = room_failed,
+            limit = ORPHANED_ROOM_CANDIDATE_LIMIT,
+            "orphan reaper: RoomActor reconciliation completed with pending work"
+        );
+    } else if room_reconciled > 0 {
+        info!(
+            hydrated = room_hydrated,
+            released = room_released,
+            already_live = room_already_live,
+            adopted_local = room_adopted_local,
+            pending_retry = room_pending_retry,
+            lost_race = room_lost_race,
+            failed = room_failed,
+            limit = ORPHANED_ROOM_CANDIDATE_LIMIT,
+            "orphan reaper: reconciled orphaned RoomActor claims"
+        );
+    }
+    let (page, scan_succeeded) = match tokio::time::timeout(
+        ORPHANED_SM_SCAN_TIMEOUT,
+        node_lease.list_orphaned_sm_session_claims_page(
+            workers.sm_cursor(),
+            STALE_NODE_WATCHDOG_CANDIDATE_LIMIT,
+        ),
+    )
+    .await
+    {
+        Ok(Ok(page)) => (page, true),
+        Ok(Err(error)) => {
+            debug!(%error, "orphan reaper: SM-session candidate page failed; room lane already completed");
+            (
+                crate::clustering::claims::OrphanedSmSessionClaimPage {
+                    candidates: Vec::new(),
+                    next_cursor: workers.sm_cursor(),
+                    has_more: false,
+                    quarantined: 0,
+                },
+                false,
+            )
+        }
+        Err(_) => {
+            debug!(
+                "orphan reaper: SM-session candidate scan timed out; room lane already completed"
+            );
+            (
+                crate::clustering::claims::OrphanedSmSessionClaimPage {
+                    candidates: Vec::new(),
+                    next_cursor: workers.sm_cursor(),
+                    has_more: false,
+                    quarantined: 0,
+                },
+                false,
+            )
+        }
+    };
+    crate::clustering::metrics::record_sm_orphan_candidate_page(
+        page.candidates.len(),
+        page.has_more,
+        page.quarantined,
+    );
+    if scan_succeeded {
+        if page.has_more {
+            workers.set_sm_cursor(page.next_cursor.clone());
+        } else {
+            // Wrap on the next successful end-of-scan observation.
+            workers.set_sm_cursor(None);
+        }
+    }
+    let candidates = page.candidates;
     let mut stolen = 0usize;
     for candidate in candidates {
         let Some(reservation) = state
@@ -773,9 +2883,19 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
         else {
             break;
         };
+        if !workers.reserve_hydration(&candidate.entity) {
+            state
+                .deps
+                .protocol
+                .sm_session_registry
+                .cancel_reclaimed_claim_capacity(&candidate.entity, reservation);
+            warn!("orphan reaper: pausing SM steals because hydration capacity is exhausted");
+            break;
+        }
         if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-candidate")
             .await
         {
+            workers.cancel_hydration_reservation(&candidate.entity);
             state
                 .deps
                 .protocol
@@ -788,6 +2908,7 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
         // just means the steal below is also likely to lose (the owner
         // row is not yet committed-expired), retried next sweep.
         if let Err(error) = node_lease.expire(&candidate.owner, lease_ttl).await {
+            workers.cancel_hydration_reservation(&candidate.entity);
             debug!(
                 entity_id = %candidate.entity.id,
                 %error,
@@ -810,6 +2931,7 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
         if !orphan_reaper_self_lease_is_fresh(node_lease.as_ref(), &me, lease_ttl, "pre-steal")
             .await
         {
+            workers.cancel_hydration_reservation(&candidate.entity);
             state
                 .deps
                 .protocol
@@ -823,30 +2945,22 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
         {
             Ok(new_epoch) => {
                 stolen += 1;
-                let fence = waddle_xmpp::stream_management::persistence::SmClaimFence::new(
-                    me.clone(),
-                    new_epoch,
-                );
-                if let Ok(
-                    waddle_xmpp::stream_management::ReclaimedHydrationOutcome::MissingDurable
-                    | waddle_xmpp::stream_management::ReclaimedHydrationOutcome::PoisonReleased
-                    | waddle_xmpp::stream_management::ReclaimedHydrationOutcome::StaleIdentity,
-                ) = state
-                    .deps
-                    .protocol
-                    .sm_session_registry
-                    .hydrate_reclaimed_typed(&candidate.entity, &fence, reservation)
-                    .await
-                {
-                    let _ = state
-                        .deps
-                        .protocol
-                        .sm_session_registry
-                        .release_reclaimed_claim(&candidate.entity, &fence, reservation)
-                        .await;
+                match workers.enqueue_reserved_hydration(
+                    candidate.entity,
+                    waddle_xmpp::stream_management::persistence::SmClaimFence::new(
+                        me.clone(),
+                        new_epoch,
+                    ),
+                    reservation,
+                ) {
+                    WorkEnqueueOutcome::Enqueued | WorkEnqueueOutcome::AlreadyTracked => {}
+                    WorkEnqueueOutcome::RetainedForRestart => debug!("orphan reaper: hydration worker stopped after steal; responsibility retained for supervisor restart"),
+                    WorkEnqueueOutcome::RetainedForRedrive => debug!("orphan reaper: hydration channel full after steal; responsibility retained for active redrive"),
+                    WorkEnqueueOutcome::Rejected => debug!("orphan reaper: reserved hydration channel rejected work after steal; claim remains fenced until node expiry"),
                 }
             }
             Err(ClaimError::Conflict) => {
+                workers.cancel_hydration_reservation(&candidate.entity);
                 state
                     .deps
                     .protocol
@@ -858,6 +2972,7 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
                 // renewed concurrently — safe, no-op.
             }
             Err(error) => {
+                workers.cancel_hydration_reservation(&candidate.entity);
                 state
                     .deps
                     .protocol
@@ -912,6 +3027,36 @@ async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
     }
 }
 
+#[cfg(all(test, feature = "clustering"))]
+async fn run_orphan_reaper_sweep(state: &Arc<WebSocketState>) {
+    let supervisor = OrphanReaperSupervisor::new(
+        state.deps.protocol.sm_session_registry.clone(),
+        tokio_util::sync::CancellationToken::new(),
+    );
+    run_orphan_reaper_sweep_with_workers(state, &supervisor.workers).await;
+    let workers = supervisor.workers.clone();
+    let _ = tokio::time::timeout(Duration::from_secs(10), async move {
+        loop {
+            let hydration_empty = workers
+                .hydration_pending
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_empty();
+            let release_empty = workers
+                .release_pending
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .is_empty();
+            if hydration_empty && release_empty {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await;
+    supervisor.shutdown().await;
+}
+
 /// Postgres-gated end-to-end test for [`run_orphan_reaper_sweep`]
 /// (ADR-0017 Phase 3 Slice 5 corrigenda, council-adjudicated review): seeds
 /// a stale-owner `sm_session` claim plus its durably persisted session,
@@ -931,9 +3076,13 @@ mod orphan_reaper_sweep_tests {
     };
     use crate::clustering::ClusteringHandles;
     use crate::db::{Database, DatabaseConfig, DatabaseDriver, DEFAULT_CONTROL_PLANE_POOL_SIZE};
+    use crate::muc_durable::PostgresMucRoomStore;
     use crate::server::routes::websocket::tests::create_test_websocket_state_with_clustering;
     use crate::sm_persistence_fenced::PostgresFencedSmPersistence;
     use chrono::{TimeZone, Utc};
+    use waddle_xmpp::muc::room_actor::GetConfig;
+    use waddle_xmpp::muc::room_registry_actor::WireClusteringClaims;
+    use waddle_xmpp::muc::{MucDurableStore, RoomConfig, RoomRegistry};
     use waddle_xmpp::ownership::{
         ClaimStore, Entity, EntityType, NodeIdentity, SharedNodeIdentity,
     };
@@ -1143,6 +3292,27 @@ mod orphan_reaper_sweep_tests {
                     sweeper_identity_handle.clone(),
                 ),
         );
+        let muc_store = Arc::new(
+            PostgresMucRoomStore::open(
+                db.clone(),
+                tokio_util::sync::CancellationToken::new(),
+                sweeper_identity_handle.clone(),
+            )
+            .await
+            .expect("open fenced MUC durable store"),
+        );
+        {
+            let conn = db.guard().await.expect("guard");
+            for statement in [
+                "DELETE FROM clustering_muc_room_affiliations",
+                "DELETE FROM clustering_muc_rooms",
+            ] {
+                conn.execute(statement, ())
+                    .await
+                    .expect("clean MUC durable table");
+            }
+        }
+        let muc_store_dyn: Arc<dyn MucDurableStore> = muc_store.clone();
 
         let clustering = ClusteringHandles {
             claim_store: Some(Arc::clone(&sweeper_claim_store)),
@@ -1150,7 +3320,7 @@ mod orphan_reaper_sweep_tests {
             local_claims: None,
             room_local_claims: None,
             user_local_claims: None,
-            muc_durable_store: None,
+            muc_durable_store: Some(Arc::clone(&muc_store_dyn)),
             isr_token_store: None,
             node_lease: Some(sweeper_node_lease),
             lease_ttl: Some(lease_ttl),
@@ -1166,6 +3336,18 @@ mod orphan_reaper_sweep_tests {
             Arc::clone(&sm_session_registry),
         )
         .await;
+        state
+            .deps
+            .protocol
+            .room_registry
+            .tell(WireClusteringClaims {
+                claim_store: Arc::clone(&sweeper_claim_store),
+                node_identity: sweeper_identity_handle.clone(),
+                durable_store: Some(muc_store_dyn),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire test room registry to clustering stores");
 
         // ============ Leg 1: single-sweep steal + targeted hydrate ============
         let dead_owner = node_identity();
@@ -1256,7 +3438,91 @@ mod orphan_reaper_sweep_tests {
              concurrent sweeps"
         );
 
-        // ============ Leg 3: a heartbeat-stale sweeper cannot steal or hydrate ============
+        // ============ Leg 3: durable RoomActor hydrate + ephemeral release ==========
+        let dead_room_owner = node_identity();
+        register_and_backdate_dead_owner(&claim_store, &db, &dead_room_owner).await;
+        let durable_room: jid::BareJid =
+            "durable-orphan@muc.example.com".parse().expect("room JID");
+        let durable_room_entity = Entity::new(EntityType::RoomActor, durable_room.to_string());
+        let durable_room_epoch = claim_store
+            .acquire(&durable_room_entity, &dead_room_owner)
+            .await
+            .expect("dead node owns durable room claim");
+        let restored_config = RoomConfig {
+            name: "restored by room orphan reaper".to_string(),
+            persistent: true,
+            ..RoomConfig::default()
+        };
+        {
+            let conn = db.guard().await.expect("guard");
+            conn.execute(
+                r#"
+                INSERT INTO clustering_muc_rooms
+                    (room_jid, waddle_id, channel_id, config_json, subject_json)
+                VALUES (?, ?, ?, ?, NULL)
+                ON CONFLICT (room_jid) DO UPDATE SET
+                    waddle_id = EXCLUDED.waddle_id,
+                    channel_id = EXCLUDED.channel_id,
+                    config_json = EXCLUDED.config_json,
+                    subject_json = NULL
+                "#,
+                crate::db_params![
+                    durable_room.to_string(),
+                    "w-reclaimed".to_string(),
+                    "c-reclaimed".to_string(),
+                    serde_json::to_string(&restored_config).expect("serialize config"),
+                ],
+            )
+            .await
+            .expect("seed durable room state");
+        }
+
+        let ephemeral_room: jid::BareJid = "ephemeral-orphan@muc.example.com"
+            .parse()
+            .expect("room JID");
+        let ephemeral_room_entity = Entity::new(EntityType::RoomActor, ephemeral_room.to_string());
+        claim_store
+            .acquire(&ephemeral_room_entity, &dead_room_owner)
+            .await
+            .expect("dead node owns ephemeral room claim");
+
+        run_orphan_reaper_sweep(&state).await;
+
+        let durable_room_claim = claim_store
+            .current_claim(&durable_room_entity)
+            .await
+            .expect("durable room claim lookup")
+            .expect("durable room remains claimed after recovery");
+        assert_eq!(durable_room_claim.owner, sweeper_identity);
+        assert_ne!(durable_room_claim.claim_epoch, durable_room_epoch);
+        let room_registry = RoomRegistry::wrap(state.deps.protocol.room_registry.clone());
+        let restored_actor = room_registry
+            .get_room(durable_room.clone())
+            .await
+            .expect("registry lookup")
+            .expect("durable room proactively hydrated");
+        assert_eq!(
+            restored_actor.ask(GetConfig).await.expect("config").name,
+            restored_config.name
+        );
+        assert!(
+            claim_store
+                .current_claim(&ephemeral_room_entity)
+                .await
+                .expect("ephemeral claim lookup")
+                .is_none(),
+            "a room with no durable state must be released for demand-side recreation"
+        );
+        assert!(
+            room_registry
+                .get_room(ephemeral_room)
+                .await
+                .expect("registry lookup")
+                .is_none(),
+            "the reaper must not invent a RoomActor with default state"
+        );
+
+        // ============ Leg 4: a heartbeat-stale sweeper cannot steal or hydrate ============
         {
             let conn = db.guard().await.expect("guard");
             conn.execute(
@@ -1847,6 +4113,12 @@ pub(crate) fn spawn_graceful_shutdown_drain(
                     break;
                 }
             };
+            websocket_state
+                .deps
+                .protocol
+                .sm_session_registry
+                .retry_pending_claim_releases(64)
+                .await;
             if drained.is_empty() {
                 empty_passes += 1;
                 if empty_passes >= QUIET_WINDOW_PASSES {

--- a/server/crates/waddle-server/src/sm_persistence.rs
+++ b/server/crates/waddle-server/src/sm_persistence.rs
@@ -512,9 +512,10 @@ impl SmPersistenceStorage for DatabaseSmPersistence {
 /// (`clustering::ClusteringHandles::claim_pair`); it is `None` whenever
 /// clustering is disabled, this binary lacks the `clustering` feature, or
 /// (defensively) the subsystem started without producing handles. Any of
-/// those cases — or `clustering_enabled` being false, or the database URL
-/// not being a `postgres://`/`postgresql://` URL — falls back to the
-/// portable implementation, exactly today's behavior.
+/// those cases when clustering is disabled. When clustering is enabled,
+/// Postgres co-location and live claim handles are mandatory: falling back
+/// to portable persistence would make the claim reaper query a different
+/// (or nonexistent) `sm_sessions` table and violate ownership fencing.
 ///
 /// `global_db` is the same [`Database`] handle `clustering::start_if_enabled`
 /// itself received (`db_pool.global()`) — FIX 4: the fenced impl is
@@ -538,9 +539,14 @@ pub async fn open_for_cluster_mode(
 ) -> Result<Arc<dyn SmPersistenceStorage>, SmPersistenceError> {
     #[cfg(feature = "clustering")]
     {
-        let resolved_sm_url = database_url
-            .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"));
-        if let (true, Some(resolved_sm_url)) = (clustering_enabled, resolved_sm_url) {
+        if clustering_enabled {
+            let resolved_sm_url = database_url
+                .filter(|url| url.starts_with("postgres://") || url.starts_with("postgresql://"))
+                .ok_or_else(|| SmPersistenceError::ClusterRequiresPostgres {
+                    sm_database_url: database_url
+                        .map(crate::db::redact_database_url)
+                        .unwrap_or_else(|| "<unset>".to_string()),
+                })?;
             // FIX 4 — co-location invariant, checked before anything else
             // in this branch runs: clustered SM persistence and the
             // clustering claims tables must live in the same Postgres
@@ -554,27 +560,23 @@ pub async fn open_for_cluster_mode(
                     global_database_url: crate::db::redact_database_url(global_db.database_url()),
                 });
             }
-            if let Some((claim_store, node_identity)) = claim_pair {
-                let fenced = crate::sm_persistence_fenced::PostgresFencedSmPersistence::open(
-                    global_db.clone(),
-                    claim_store,
-                    node_identity,
-                )
-                .await?;
-                return Ok(Arc::new(fenced));
-            }
-            tracing::warn!(
-                "clustering.enabled with a Postgres SM database URL, but the clustering \
-                 subsystem produced no live ClaimStore/NodeIdentity handles; falling back to \
-                 the portable (unfenced) SmPersistenceStorage. This should only happen if \
-                 clustering startup itself failed before this point (which fails the server \
-                 boot), so seeing this warning indicates a wiring bug."
-            );
+            let (claim_store, node_identity) =
+                claim_pair.ok_or(SmPersistenceError::ClusterClaimHandlesUnavailable)?;
+            let fenced = crate::sm_persistence_fenced::PostgresFencedSmPersistence::open(
+                global_db.clone(),
+                claim_store,
+                node_identity,
+            )
+            .await?;
+            return Ok(Arc::new(fenced));
         }
     }
     #[cfg(not(feature = "clustering"))]
     {
-        let _ = (clustering_enabled, claim_pair, global_db);
+        let _ = (claim_pair, global_db);
+        if clustering_enabled {
+            return Err(SmPersistenceError::ClusterClaimHandlesUnavailable);
+        }
     }
     Ok(Arc::new(DatabaseSmPersistence::open(database_url).await?))
 }

--- a/server/crates/waddle-server/src/sm_persistence/tests.rs
+++ b/server/crates/waddle-server/src/sm_persistence/tests.rs
@@ -46,6 +46,22 @@ fn fixture_unacked(stream_id: &str, sequence: u32) -> PersistedUnackedStanza {
     }
 }
 
+#[cfg(feature = "clustering")]
+#[tokio::test]
+async fn clustering_refuses_portable_sm_persistence() {
+    let global_db = crate::db::Database::in_memory("cluster-sm-portable-rejected")
+        .await
+        .expect("in-memory global database");
+    let error = match open_for_cluster_mode(None, true, None, &global_db).await {
+        Ok(_) => panic!("cluster mode must never fall back to unfenced portable persistence"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error,
+        SmPersistenceError::ClusterRequiresPostgres { .. }
+    ));
+}
+
 #[tokio::test]
 async fn round_trip_session_preserves_every_field() {
     let storage = DatabaseSmPersistence::open(None).await.unwrap();

--- a/server/crates/waddle-server/src/sm_persistence_fenced.rs
+++ b/server/crates/waddle-server/src/sm_persistence_fenced.rs
@@ -181,9 +181,10 @@ fn claim_error_to_sm_persistence_error(error: ClaimError, entity: Entity) -> SmP
         // `AlreadyClaimed`/`Conflict` — this node is not, and for
         // `Draining` will not become, the owner, so the caller should treat
         // it exactly like any other ownership loss.
-        ClaimError::AlreadyClaimed | ClaimError::Conflict | ClaimError::Draining => {
-            SmPersistenceError::NotOwner { entity }
-        }
+        ClaimError::AlreadyClaimed
+        | ClaimError::Conflict
+        | ClaimError::Draining
+        | ClaimError::AuthorityDisabled => SmPersistenceError::NotOwner { entity },
         ClaimError::Backend(_) | ClaimError::Poisoned => {
             SmPersistenceError::Other(error.to_string())
         }

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -92,6 +92,9 @@ pub struct RoomRegistryActor {
     pending_retry_order: u64,
     pending_retry_timer_generation: u64,
     scheduled_pending_retry_generation: Option<u64>,
+    /// Terminal shutdown has begun. Once set inside the actor mailbox, no
+    /// later demand or orphan-reaper message may acquire fresh room authority.
+    terminal_claim_acquisition_disabled: bool,
     muc_domain: String,
     /// Per-deployment XEP-0421 occupant-id HMAC key. Forwarded to every
     /// `RoomActor` at spawn so all rooms in this deployment share the
@@ -174,6 +177,7 @@ impl RoomRegistryActor {
             pending_retry_order: 0,
             pending_retry_timer_generation: 0,
             scheduled_pending_retry_generation: None,
+            terminal_claim_acquisition_disabled: false,
             muc_domain,
             occupant_id_secret,
             membership_source: None,
@@ -427,6 +431,16 @@ impl RoomRegistryActor {
             .remove(&(room_jid.clone(), claim_fence.clone()));
     }
 
+    fn has_live_room_with_fence(
+        &self,
+        room_jid: &BareJid,
+        claim_fence: &super::RoomClaimFenceContext,
+    ) -> bool {
+        self.rooms
+            .get(room_jid)
+            .is_some_and(|entry| entry.actor_ref.is_alive() && entry.claim_fence == *claim_fence)
+    }
+
     /// Acquire this room's Postgres claim (ADR-0017 Phase 3 Slice 7),
     /// stealing from a dead owner (re-election) when the current owner's
     /// own node lease is no longer fresh. Returns the epoch this node now
@@ -441,6 +455,9 @@ impl RoomRegistryActor {
         room_jid: &BareJid,
         actor_ref: &ActorRef<Self>,
     ) -> Result<super::RoomClaimFenceContext, RoomRegistryError> {
+        if self.terminal_claim_acquisition_disabled {
+            return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
+        }
         // A newly acquired generation can require an exact terminal-release
         // retry if identity rotates or actor preparation loses its final
         // fence. Refuse acquisition while the bounded retry inventory is
@@ -1184,6 +1201,19 @@ pub struct PendingReclaimedRoomBacklog {
 
 pub struct GetPendingReclaimedRoomBacklog;
 
+/// Terminally release every won-but-unserved room epoch currently registered
+/// in this actor. The handler disables future room-claim acquisition before
+/// taking its snapshot, so queued demand cannot recreate authority after the
+/// drain and before the node lease is fenced.
+pub struct DrainPendingReclaimedRoomsForShutdown;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
+pub struct PendingReclaimedRoomDrainOutcome {
+    pub released: usize,
+    pub preserved_live: usize,
+    pub retained: usize,
+}
+
 impl kameo::message::Message<GetPendingReclaimedRoomBacklog> for RoomRegistryActor {
     type Reply = PendingReclaimedRoomBacklog;
 
@@ -1201,6 +1231,75 @@ impl kameo::message::Message<GetPendingReclaimedRoomBacklog> for RoomRegistryAct
         PendingReclaimedRoomBacklog {
             depth: self.pending_reclaimed_rooms.len() + self.pending_reclaimed_reservations.len(),
             oldest_age_ms,
+        }
+    }
+}
+
+impl kameo::message::Message<DrainPendingReclaimedRoomsForShutdown> for RoomRegistryActor {
+    type Reply = PendingReclaimedRoomDrainOutcome;
+
+    async fn handle(
+        &mut self,
+        _msg: DrainPendingReclaimedRoomsForShutdown,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.terminal_claim_acquisition_disabled = true;
+        let duplicate_live = self
+            .pending_reclaimed_rooms
+            .keys()
+            .filter(|(room_jid, claim_fence)| self.has_live_room_with_fence(room_jid, claim_fence))
+            .cloned()
+            .collect::<Vec<_>>();
+        for (room_jid, claim_fence) in &duplicate_live {
+            self.clear_pending_reclaimed_room(room_jid, claim_fence);
+        }
+        let preserved_live = duplicate_live.len();
+        let pending = self
+            .pending_reclaimed_rooms
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        let claim_store = Arc::clone(&self.claim_store);
+        let outcomes =
+            futures::future::join_all(pending.into_iter().map(|(room_jid, claim_fence)| {
+                let claim_store = Arc::clone(&claim_store);
+                async move {
+                    let owner = claim_fence.owner();
+                    let outcome = tokio::time::timeout(
+                        RECLAIMED_ROOM_RELEASE_TIMEOUT,
+                        claim_store.release_exact(&claim_fence.entity, &owner, claim_fence.epoch),
+                    )
+                    .await;
+                    (room_jid, claim_fence, outcome)
+                }
+            }))
+            .await;
+
+        let mut released = 0usize;
+        let mut retained = 0usize;
+        for (room_jid, claim_fence, outcome) in outcomes {
+            match outcome {
+                Ok(Ok(ExactReleaseOutcome::Released | ExactReleaseOutcome::NotOwned)) => {
+                    self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
+                    if let Some(store) = &self.durable_store {
+                        store.forget_claim_fence(&room_jid, &claim_fence);
+                    }
+                    released += 1;
+                }
+                Ok(Err(error)) => {
+                    warn!(room = %room_jid, %error, "terminal reclaimed-room release failed; retaining exact fence until node expiry");
+                    retained += 1;
+                }
+                Err(_) => {
+                    warn!(room = %room_jid, "terminal reclaimed-room release timed out; retaining exact fence until node expiry");
+                    retained += 1;
+                }
+            }
+        }
+        PendingReclaimedRoomDrainOutcome {
+            released,
+            preserved_live,
+            retained,
         }
     }
 }
@@ -1229,6 +1328,9 @@ impl kameo::message::Message<ReservePendingReclaimedRoom> for RoomRegistryActor 
         msg: ReservePendingReclaimedRoom,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        if self.terminal_claim_acquisition_disabled {
+            return false;
+        }
         if self.pending_reclaimed_reservations.contains(&msg.room_jid) {
             return true;
         }
@@ -1314,6 +1416,15 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
         let claim_fence = msg.claim_fence.clone();
         let claim_epoch = claim_fence.epoch;
         let identity = claim_fence.owner();
+        if self.terminal_claim_acquisition_disabled {
+            if self.has_live_room_with_fence(&msg.room_jid, &claim_fence) {
+                self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+                return ReclaimedRoomOutcome::AlreadyLive;
+            }
+            return self
+                .release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)
+                .await;
+        }
         if self.node_identity.current() != identity {
             return self
                 .release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -218,6 +218,32 @@ impl RoomRegistryActor {
         true
     }
 
+    /// Replace one bounded, bare-JID reclaimed-room reservation with the
+    /// exact fence observed for it. This transfer may take the ordinary
+    /// release inventory above [`MAX_PENDING_ROOM_RELEASES`], but cannot
+    /// increase the combined number of responsibilities: the reservation
+    /// was already admitted under [`MAX_PENDING_RECLAIMED_ROOMS`]. Keeping
+    /// the typed fence in actor state before awaiting release prevents a
+    /// terminal backend failure from degrading exact ownership back to an
+    /// ambiguous room JID.
+    fn transfer_reclaimed_reservation_to_pending_release(
+        &mut self,
+        room_jid: BareJid,
+        claim_fence: super::RoomClaimFenceContext,
+    ) {
+        debug_assert!(self.pending_reclaimed_reservations.contains(&room_jid));
+        self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+        let retry_order = self.pending_retry_order;
+        self.pending_room_releases
+            .entry((room_jid.clone(), claim_fence))
+            .and_modify(|current| current.retry_order = retry_order)
+            .or_insert(PendingRoomReleaseState {
+                retry_order,
+                first_pending_at: std::time::Instant::now(),
+            });
+        self.pending_reclaimed_reservations.remove(&room_jid);
+    }
+
     fn reserve_pending_room_acquisition(
         &mut self,
         room_jid: &BareJid,
@@ -1202,10 +1228,14 @@ pub struct PendingReclaimedRoomBacklog {
 pub struct GetPendingReclaimedRoomBacklog;
 
 /// Terminally release every won-but-unserved room epoch currently registered
-/// in this actor. The handler disables future room-claim acquisition before
-/// taking its snapshot, so queued demand cannot recreate authority after the
-/// drain and before the node lease is fenced.
-pub struct DrainPendingReclaimedRoomsForShutdown;
+/// in this actor, including exact post-CAS handoffs retained by the orphan
+/// reaper supervisor when its sweep was cancelled before mailbox delivery.
+/// The handler imports those handoffs and disables future room-claim
+/// acquisition in the same mailbox turn, so queued demand cannot race an
+/// out-of-actor release.
+pub struct DrainPendingReclaimedRoomsForShutdown {
+    pub pending_handoffs: Vec<PendingReclaimedRoom>,
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
 pub struct PendingReclaimedRoomDrainOutcome {
@@ -1240,10 +1270,84 @@ impl kameo::message::Message<DrainPendingReclaimedRoomsForShutdown> for RoomRegi
 
     async fn handle(
         &mut self,
-        _msg: DrainPendingReclaimedRoomsForShutdown,
+        msg: DrainPendingReclaimedRoomsForShutdown,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         self.terminal_claim_acquisition_disabled = true;
+        for pending in msg.pending_handoffs {
+            self.remember_pending_reclaimed_room(
+                pending.room_jid,
+                pending.claim_fence,
+                pending.previous_owner,
+            );
+        }
+        // A steal CAS can commit while cancellation drops its response
+        // future, leaving only the pre-CAS bare-JID reservation. Check those
+        // reservations after acquisition is disabled and while the actor
+        // mailbox excludes demand-side publication. A positive self-owned
+        // snapshot yields an exact fence that can be released or matched to
+        // a live actor. An absent/foreign snapshot is not authoritative: the
+        // dropped CAS may still commit after this read, so its reservation
+        // must survive for node-expiry recovery.
+        let reserved_rooms = self
+            .pending_reclaimed_reservations
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        let owner = self.node_identity.current();
+        let claim_store = Arc::clone(&self.claim_store);
+        let reservation_claims =
+            futures::future::join_all(reserved_rooms.into_iter().map(|room_jid| {
+                let claim_store = Arc::clone(&claim_store);
+                async move {
+                    let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+                    let current = tokio::time::timeout(
+                        ROOM_OWNERSHIP_CALL_TIMEOUT,
+                        claim_store.current_claim_after_pending_writes(&entity),
+                    )
+                    .await;
+                    (room_jid, entity, current)
+                }
+            }))
+            .await;
+
+        let mut preserved_live = 0usize;
+        let mut retained = 0usize;
+        let mut reservation_owned = Vec::new();
+        for (room_jid, entity, current) in reservation_claims {
+            match current {
+                Ok(Ok(Some(snapshot))) if snapshot.owner.same_incarnation(&owner) => {
+                    let claim_owner = snapshot.owner;
+                    let claim_fence = super::RoomClaimFenceContext::new(
+                        entity,
+                        claim_owner,
+                        snapshot.claim_epoch,
+                    );
+                    if self.has_live_room_with_fence(&room_jid, &claim_fence) {
+                        self.pending_reclaimed_reservations.remove(&room_jid);
+                        preserved_live += 1;
+                    } else {
+                        self.transfer_reclaimed_reservation_to_pending_release(
+                            room_jid.clone(),
+                            claim_fence.clone(),
+                        );
+                        reservation_owned.push((room_jid, claim_fence));
+                    }
+                }
+                Ok(Ok(_)) => {
+                    warn!(room = %room_jid, "terminal reclaimed-room reservation remains ambiguous after a non-self snapshot; retaining for node-expiry recovery");
+                    retained += 1;
+                }
+                Ok(Err(error)) => {
+                    warn!(room = %room_jid, %error, "terminal reclaimed-room reservation lookup failed; retaining for node-expiry recovery");
+                    retained += 1;
+                }
+                Err(_) => {
+                    warn!(room = %room_jid, "terminal reclaimed-room reservation lookup timed out; retaining for node-expiry recovery");
+                    retained += 1;
+                }
+            }
+        }
         let duplicate_live = self
             .pending_reclaimed_rooms
             .keys()
@@ -1253,12 +1357,13 @@ impl kameo::message::Message<DrainPendingReclaimedRoomsForShutdown> for RoomRegi
         for (room_jid, claim_fence) in &duplicate_live {
             self.clear_pending_reclaimed_room(room_jid, claim_fence);
         }
-        let preserved_live = duplicate_live.len();
-        let pending = self
+        preserved_live += duplicate_live.len();
+        let mut pending = self
             .pending_reclaimed_rooms
             .keys()
             .cloned()
             .collect::<Vec<_>>();
+        pending.extend(reservation_owned);
         let claim_store = Arc::clone(&self.claim_store);
         let outcomes =
             futures::future::join_all(pending.into_iter().map(|(room_jid, claim_fence)| {
@@ -1276,11 +1381,12 @@ impl kameo::message::Message<DrainPendingReclaimedRoomsForShutdown> for RoomRegi
             .await;
 
         let mut released = 0usize;
-        let mut retained = 0usize;
         for (room_jid, claim_fence, outcome) in outcomes {
             match outcome {
                 Ok(Ok(ExactReleaseOutcome::Released | ExactReleaseOutcome::NotOwned)) => {
                     self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
+                    self.clear_pending_room_release(&room_jid, &claim_fence);
+                    self.pending_reclaimed_reservations.remove(&room_jid);
                     if let Some(store) = &self.durable_store {
                         store.forget_claim_fence(&room_jid, &claim_fence);
                     }

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -3286,6 +3286,264 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test]
+    async fn terminal_drain_resolves_a_won_reservation_without_an_exact_handoff() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let owner = this_identity();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("terminal-reservation-handoff");
+        assert!(registry
+            .ask(ReservePendingReclaimedRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("reserve before steal"));
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        claim_store
+            .acquire(&entity, &owner)
+            .await
+            .expect("seed ambiguously committed claim");
+
+        let outcome = registry
+            .ask(DrainPendingReclaimedRoomsForShutdown {
+                pending_handoffs: Vec::new(),
+            })
+            .await
+            .expect("terminal drain");
+
+        assert_eq!(
+            outcome,
+            PendingReclaimedRoomDrainOutcome {
+                released: 1,
+                preserved_live: 0,
+                retained: 0,
+            }
+        );
+        assert!(claim_store
+            .current_claim(&entity)
+            .await
+            .expect("read drained claim")
+            .is_none());
+        assert_eq!(
+            registry
+                .ask(GetPendingReclaimedRoomBacklog)
+                .await
+                .expect("terminal backlog"),
+            PendingReclaimedRoomBacklog {
+                depth: 0,
+                oldest_age_ms: 0,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_drain_retains_a_reservation_until_a_late_steal_commit_is_observed() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let owner = this_identity();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("terminal-late-steal-commit");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        assert!(registry
+            .ask(ReservePendingReclaimedRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("reserve before steal"));
+
+        let before_commit = registry
+            .ask(DrainPendingReclaimedRoomsForShutdown {
+                pending_handoffs: Vec::new(),
+            })
+            .await
+            .expect("terminal drain before late commit");
+        assert_eq!(
+            before_commit,
+            PendingReclaimedRoomDrainOutcome {
+                released: 0,
+                preserved_live: 0,
+                retained: 1,
+            },
+            "an absent snapshot cannot prove that a canceled steal CAS will not commit later"
+        );
+        assert_eq!(
+            registry
+                .ask(GetPendingReclaimedRoomBacklog)
+                .await
+                .expect("ambiguous reservation backlog")
+                .depth,
+            1
+        );
+
+        claim_store
+            .acquire(&entity, &owner)
+            .await
+            .expect("simulate the dropped steal future committing after the first read");
+        let after_commit = registry
+            .ask(DrainPendingReclaimedRoomsForShutdown {
+                pending_handoffs: Vec::new(),
+            })
+            .await
+            .expect("terminal drain after late commit");
+        assert_eq!(
+            after_commit,
+            PendingReclaimedRoomDrainOutcome {
+                released: 1,
+                preserved_live: 0,
+                retained: 0,
+            }
+        );
+        assert!(claim_store
+            .current_claim(&entity)
+            .await
+            .expect("read drained late claim")
+            .is_none());
+        assert_eq!(
+            registry
+                .ask(GetPendingReclaimedRoomBacklog)
+                .await
+                .expect("resolved reservation backlog")
+                .depth,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_drain_keeps_a_discovered_reservation_fence_typed_on_release_failure() {
+        let registry = spawn_registry().await;
+        let owner = this_identity();
+        let epoch = ClaimEpoch(74);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(owner.clone(), epoch));
+        claim_store.fail_next_release();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("terminal-reservation-release-failure");
+        assert!(registry
+            .ask(ReservePendingReclaimedRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("reserve before steal"));
+
+        let outcome = registry
+            .ask(DrainPendingReclaimedRoomsForShutdown {
+                pending_handoffs: Vec::new(),
+            })
+            .await
+            .expect("terminal drain");
+        assert_eq!(
+            outcome,
+            PendingReclaimedRoomDrainOutcome {
+                released: 0,
+                preserved_live: 0,
+                retained: 1,
+            }
+        );
+        assert!(registry
+            .ask(IsCurrentIdentityPendingRoomReleaseOnly {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("typed exact-release inventory"));
+        assert_eq!(
+            registry
+                .ask(GetPendingReclaimedRoomBacklog)
+                .await
+                .expect("bare reservation transferred to exact inventory")
+                .depth,
+            0
+        );
+        assert_eq!(
+            registry
+                .ask(RetryPendingRoomReleases { limit: 1 })
+                .await
+                .expect("retry exact release"),
+            1
+        );
+        assert!(!registry
+            .ask(IsPendingRoomReleaseOnly { room_jid: jid })
+            .await
+            .expect("exact fence cleared after successful retry"));
+    }
+
+    #[tokio::test]
+    async fn terminal_drain_releases_the_active_snapshot_after_local_authority_is_disabled() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let owner = this_identity();
+        let identity = SharedNodeIdentity::new(owner.clone());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: identity.clone(),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("terminal-disabled-identity");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        claim_store
+            .acquire(&entity, &owner)
+            .await
+            .expect("seed active claim");
+        assert!(registry
+            .ask(ReservePendingReclaimedRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("reserve before terminal fencing"));
+        identity.disable().await;
+
+        let outcome = registry
+            .ask(DrainPendingReclaimedRoomsForShutdown {
+                pending_handoffs: Vec::new(),
+            })
+            .await
+            .expect("terminal drain");
+        assert_eq!(
+            outcome,
+            PendingReclaimedRoomDrainOutcome {
+                released: 1,
+                preserved_live: 0,
+                retained: 0,
+            }
+        );
+        assert!(claim_store
+            .current_claim(&entity)
+            .await
+            .expect("read drained claim")
+            .is_none());
+        assert!(!registry
+            .ask(IsPendingRoomReleaseOnly { room_jid: jid })
+            .await
+            .expect("typed release cleared"));
+    }
+
+    #[tokio::test]
     async fn terminal_drain_releases_registered_reclaimed_epochs_and_disables_acquisition() {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(InProcessClaimStore::new());
@@ -3306,17 +3564,24 @@ mod ownership_claims_tests {
             .await
             .expect("seed won claim");
         let fence = RoomClaimFenceContext::new(entity.clone(), owner.clone(), epoch);
+        let handoff = PendingReclaimedRoom {
+            room_jid: jid.clone(),
+            claim_fence: fence.clone(),
+            previous_owner: foreign_identity(),
+        };
         registry
             .ask(RememberPendingReclaimedRoom {
                 room_jid: jid.clone(),
                 claim_fence: fence,
-                previous_owner: foreign_identity(),
+                previous_owner: handoff.previous_owner.clone(),
             })
             .await
             .expect("register won claim");
 
         let outcome = registry
-            .ask(DrainPendingReclaimedRoomsForShutdown)
+            .ask(DrainPendingReclaimedRoomsForShutdown {
+                pending_handoffs: vec![handoff],
+            })
             .await
             .expect("terminal drain");
         assert_eq!(
@@ -3388,7 +3653,9 @@ mod ownership_claims_tests {
             .expect("register won claim");
 
         let outcome = registry
-            .ask(DrainPendingReclaimedRoomsForShutdown)
+            .ask(DrainPendingReclaimedRoomsForShutdown {
+                pending_handoffs: Vec::new(),
+            })
             .await
             .expect("terminal drain");
         assert_eq!(
@@ -3413,7 +3680,7 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test]
-    async fn terminal_drain_preserves_a_live_room_with_the_same_registered_fence() {
+    async fn terminal_drain_preserves_a_live_room_with_the_same_reserved_claim() {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(InProcessClaimStore::new());
         let owner = this_identity();
@@ -3442,18 +3709,17 @@ mod ownership_claims_tests {
             .await
             .expect("read live claim")
             .expect("live claim exists");
-        let fence = RoomClaimFenceContext::new(entity.clone(), owner.clone(), snapshot.claim_epoch);
-        registry
-            .ask(RememberPendingReclaimedRoom {
+        assert!(registry
+            .ask(ReservePendingReclaimedRoom {
                 room_jid: jid.clone(),
-                claim_fence: fence.clone(),
-                previous_owner: foreign_identity(),
             })
             .await
-            .expect("register delayed duplicate");
+            .expect("reserve ambiguous steal"));
 
         let outcome = registry
-            .ask(DrainPendingReclaimedRoomsForShutdown)
+            .ask(DrainPendingReclaimedRoomsForShutdown {
+                pending_handoffs: Vec::new(),
+            })
             .await
             .expect("terminal drain");
         assert_eq!(

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -3286,6 +3286,203 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test]
+    async fn terminal_drain_releases_registered_reclaimed_epochs_and_disables_acquisition() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let owner = this_identity();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("terminal-reclaimed-drain");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let epoch = claim_store
+            .acquire(&entity, &owner)
+            .await
+            .expect("seed won claim");
+        let fence = RoomClaimFenceContext::new(entity.clone(), owner.clone(), epoch);
+        registry
+            .ask(RememberPendingReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: fence,
+                previous_owner: foreign_identity(),
+            })
+            .await
+            .expect("register won claim");
+
+        let outcome = registry
+            .ask(DrainPendingReclaimedRoomsForShutdown)
+            .await
+            .expect("terminal drain");
+        assert_eq!(
+            outcome,
+            PendingReclaimedRoomDrainOutcome {
+                released: 1,
+                preserved_live: 0,
+                retained: 0,
+            }
+        );
+        assert!(claim_store
+            .current_claim(&entity)
+            .await
+            .expect("read drained claim")
+            .is_none());
+        assert!(registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("pending after drain")
+            .is_empty());
+        assert!(!registry
+            .ask(ReservePendingReclaimedRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("terminal reservation refusal"));
+
+        let demand = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w-terminal".to_string(),
+                channel_id: "c-terminal".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await;
+        assert!(matches!(
+            demand,
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipUnavailable(room)
+            )) if room == jid
+        ));
+    }
+
+    #[tokio::test]
+    async fn terminal_drain_retains_registered_epoch_when_exact_release_fails() {
+        let registry = spawn_registry().await;
+        let owner = this_identity();
+        let epoch = ClaimEpoch(73);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(owner.clone(), epoch));
+        claim_store.fail_next_release();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("terminal-reclaimed-retained");
+        let fence = room_claim_fence(&jid, epoch);
+        registry
+            .ask(RememberPendingReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: fence.clone(),
+                previous_owner: foreign_identity(),
+            })
+            .await
+            .expect("register won claim");
+
+        let outcome = registry
+            .ask(DrainPendingReclaimedRoomsForShutdown)
+            .await
+            .expect("terminal drain");
+        assert_eq!(
+            outcome,
+            PendingReclaimedRoomDrainOutcome {
+                released: 0,
+                preserved_live: 0,
+                retained: 1,
+            }
+        );
+        assert_eq!(
+            registry
+                .ask(ListPendingReclaimedRooms { limit: 8 })
+                .await
+                .expect("retained pending claim"),
+            vec![PendingReclaimedRoom {
+                room_jid: jid,
+                claim_fence: fence,
+                previous_owner: foreign_identity(),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_drain_preserves_a_live_room_with_the_same_registered_fence() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let owner = this_identity();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("terminal-live-duplicate");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w-live".to_string(),
+                channel_id: "c-live".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("publish live room");
+        let snapshot = claim_store
+            .current_claim(&entity)
+            .await
+            .expect("read live claim")
+            .expect("live claim exists");
+        let fence = RoomClaimFenceContext::new(entity.clone(), owner.clone(), snapshot.claim_epoch);
+        registry
+            .ask(RememberPendingReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: fence.clone(),
+                previous_owner: foreign_identity(),
+            })
+            .await
+            .expect("register delayed duplicate");
+
+        let outcome = registry
+            .ask(DrainPendingReclaimedRoomsForShutdown)
+            .await
+            .expect("terminal drain");
+        assert_eq!(
+            outcome,
+            PendingReclaimedRoomDrainOutcome {
+                released: 0,
+                preserved_live: 1,
+                retained: 0,
+            }
+        );
+        assert!(claim_store
+            .fence(&entity, &owner, snapshot.claim_epoch)
+            .await
+            .expect("fence live claim"));
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("get live room")
+            .is_some());
+        assert!(registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("pending after live duplicate cleanup")
+            .is_empty());
+    }
+
+    #[tokio::test]
     async fn pending_retry_page_rotates_past_a_persistent_full_prefix() {
         let registry = spawn_registry().await;
         let previous_owner = foreign_identity();

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -298,9 +298,11 @@ impl RoomRegistry {
     );
 
     registry_method!(
-        drain_pending_reclaimed_rooms_for_shutdown() -> PendingReclaimedRoomDrainOutcome,
+        drain_pending_reclaimed_rooms_for_shutdown(
+            pending_handoffs: Vec<PendingReclaimedRoom>
+        ) -> PendingReclaimedRoomDrainOutcome,
         "drain_pending_reclaimed_rooms_for_shutdown",
-        DrainPendingReclaimedRoomsForShutdown
+        DrainPendingReclaimedRoomsForShutdown { pending_handoffs }
     );
 
     registry_method!(

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -37,11 +37,12 @@ use super::durable::MucDurableStore;
 use super::room_actor::{RoomActor, SealGuard};
 use super::room_registry_actor::{
     CancelPendingReclaimedRoomReservation, CreateInstantRoom, CreateRoom, DemoteRoomIfOwner,
-    DestroyRoom, DestroyRoomIfInactive, DestroyRoomOutcome, DestroyRoomReason, GetOrCreateRoom,
-    GetPendingReclaimedRoomBacklog, GetPendingRoomReleaseBacklog, GetRoom,
-    IsCurrentIdentityPendingRoomReleaseOnly, IsCurrentRoomPendingRelease, IsMucJid,
-    IsPendingRoomReleaseOnly, ListPendingReclaimedRooms, ListPendingRoomReleaseJids, ListRooms,
-    ListRoomsOwnedBy, PendingReclaimedRoom, PendingReclaimedRoomBacklog, PendingRoomReleaseBacklog,
+    DestroyRoom, DestroyRoomIfInactive, DestroyRoomOutcome, DestroyRoomReason,
+    DrainPendingReclaimedRoomsForShutdown, GetOrCreateRoom, GetPendingReclaimedRoomBacklog,
+    GetPendingRoomReleaseBacklog, GetRoom, IsCurrentIdentityPendingRoomReleaseOnly,
+    IsCurrentRoomPendingRelease, IsMucJid, IsPendingRoomReleaseOnly, ListPendingReclaimedRooms,
+    ListPendingRoomReleaseJids, ListRooms, ListRoomsOwnedBy, PendingReclaimedRoom,
+    PendingReclaimedRoomBacklog, PendingReclaimedRoomDrainOutcome, PendingRoomReleaseBacklog,
     ReapSealedRoom, ReclaimedRoomOutcome, ReconcileReclaimedRoom, RememberPendingReclaimedRoom,
     ReservePendingReclaimedRoom, RetryPendingRoomReleases, RoomAcquisition, RoomCount, RoomExists,
     RoomRegistryActor, RoomRegistryError, WireClusteringClaims,
@@ -294,6 +295,12 @@ impl RoomRegistry {
         pending_reclaimed_room_backlog() -> PendingReclaimedRoomBacklog,
         "pending_reclaimed_room_backlog",
         GetPendingReclaimedRoomBacklog
+    );
+
+    registry_method!(
+        drain_pending_reclaimed_rooms_for_shutdown() -> PendingReclaimedRoomDrainOutcome,
+        "drain_pending_reclaimed_rooms_for_shutdown",
+        DrainPendingReclaimedRoomsForShutdown
     );
 
     registry_method!(

--- a/server/crates/waddle-xmpp/src/ownership/in_process.rs
+++ b/server/crates/waddle-xmpp/src/ownership/in_process.rs
@@ -79,6 +79,9 @@ impl ClaimStore for InProcessClaimStore {
     }
 
     async fn acquire(&self, entity: &Entity, me: &NodeIdentity) -> Result<ClaimEpoch, ClaimError> {
+        if !me.is_active() {
+            return Err(ClaimError::AuthorityDisabled);
+        }
         let mut state = self.lock()?;
         // Same contract as `PostgresClaimStore::acquire` (INSERT ... ON
         // CONFLICT DO NOTHING): a fresh claim only succeeds when the
@@ -106,6 +109,9 @@ impl ClaimStore for InProcessClaimStore {
         entity: &Entity,
         me: &NodeIdentity,
     ) -> Result<ClaimEpoch, ClaimError> {
+        if !me.is_active() {
+            return Err(ClaimError::AuthorityDisabled);
+        }
         // FIX 1: same observable contract as `PostgresClaimStore::ensure_claimed`
         // — a fresh acquire, or (on conflict) a self-reacquire iff the
         // existing row's owner is exactly `me`. Implemented directly against
@@ -137,6 +143,9 @@ impl ClaimStore for InProcessClaimStore {
         _staleness: StalePredicate,
         me: &NodeIdentity,
     ) -> Result<ClaimEpoch, ClaimError> {
+        if !me.is_active() {
+            return Err(ClaimError::AuthorityDisabled);
+        }
         // Real epoch-fenced CAS, mirroring `PostgresClaimStore::steal_stale`'s
         // `WHERE entity=$e AND claim_epoch=$observed` gate exactly (ADR-0017
         // Phase 3 Slice 6 fix: the previous unconditional-overwrite shape

--- a/server/crates/waddle-xmpp/src/ownership/mod.rs
+++ b/server/crates/waddle-xmpp/src/ownership/mod.rs
@@ -218,6 +218,13 @@ pub struct ClaimEpoch(pub i64);
 pub struct NodeIdentity {
     pub node_id: String,
     pub node_epoch: String,
+    authority: NodeAuthority,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum NodeAuthority {
+    Active,
+    TerminallyDisabled,
 }
 
 impl NodeIdentity {
@@ -225,6 +232,7 @@ impl NodeIdentity {
         Self {
             node_id: node_id.into(),
             node_epoch: node_epoch.into(),
+            authority: NodeAuthority::Active,
         }
     }
 
@@ -233,6 +241,10 @@ impl NodeIdentity {
     /// node identity is not a meaningful concept (there is only one node).
     pub fn local() -> Self {
         Self::new("local", "local")
+    }
+
+    pub fn is_active(&self) -> bool {
+        self.authority == NodeAuthority::Active
     }
 }
 
@@ -324,7 +336,7 @@ impl SharedNodeIdentity {
     ) -> Option<CurrentNodeIdentityGuard> {
         let rotation_guard = self.rotation_gate.clone().read_owned().await;
         let identity = self.current();
-        (identity == *expected).then_some(CurrentNodeIdentityGuard {
+        (identity.is_active() && identity == *expected).then_some(CurrentNodeIdentityGuard {
             identity,
             rotation_gate: self.rotation_gate.clone(),
             _rotation_guard: rotation_guard,
@@ -354,6 +366,18 @@ impl SharedNodeIdentity {
             .identity
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner) = identity;
+    }
+
+    /// Permanently revoke publication authority for this clustering
+    /// lifetime after every in-flight guarded publication has drained.
+    /// The last identity remains inspectable for diagnostics, but compares
+    /// unequal to its former active value and cannot pass a claim acquire.
+    pub async fn disable(&self) {
+        let _rotation_guard = self.rotation_gate.write().await;
+        self.identity
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .authority = NodeAuthority::TerminallyDisabled;
     }
 }
 
@@ -436,6 +460,12 @@ pub enum ClaimError {
     /// refused.
     #[error("this node is draining and refuses to acquire a new claim")]
     Draining,
+
+    /// The process terminally revoked its shared node identity after a
+    /// fatal ownership ambiguity. No new or self-reacquired claim may be
+    /// published under that identity.
+    #[error("this node identity is terminally disabled")]
+    AuthorityDisabled,
 }
 
 /// Result of an ownership- and epoch-exact release attempt.
@@ -708,6 +738,25 @@ mod tests {
 
         assert_eq!(clone.current(), NodeIdentity::new("node-a", "epoch-1"));
         assert_eq!(shared.current(), NodeIdentity::new("node-a", "epoch-1"));
+    }
+
+    #[tokio::test]
+    async fn terminally_disabled_identity_rejects_guards_and_claim_acquisition() {
+        let active = NodeIdentity::new("node-a", "epoch-0");
+        let shared = SharedNodeIdentity::new(active.clone());
+        shared.disable().await;
+
+        let disabled = shared.current();
+        assert!(!disabled.is_active());
+        assert_ne!(disabled, active);
+        assert!(shared.guard_if_current(&disabled).await.is_none());
+
+        let store = InProcessClaimStore::new();
+        let entity = Entity::new(EntityType::SmSession, "disabled-owner");
+        assert!(matches!(
+            store.acquire(&entity, &disabled).await,
+            Err(ClaimError::AuthorityDisabled)
+        ));
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/ownership/mod.rs
+++ b/server/crates/waddle-xmpp/src/ownership/mod.rs
@@ -246,6 +246,15 @@ impl NodeIdentity {
     pub fn is_active(&self) -> bool {
         self.authority == NodeAuthority::Active
     }
+
+    /// Whether both values identify the same process incarnation, regardless
+    /// of this process's current publication authority. Terminal cleanup may
+    /// still need to recognize and release rows written by the active form of
+    /// an identity after [`SharedNodeIdentity::disable`] has revoked any new
+    /// claim or publication authority.
+    pub fn same_incarnation(&self, other: &Self) -> bool {
+        self.node_id == other.node_id && self.node_epoch == other.node_epoch
+    }
 }
 
 /// A live, shared view of this process's current [`NodeIdentity`].
@@ -585,6 +594,22 @@ pub trait ClaimStore: Send + Sync {
     /// call.
     async fn current_claim(&self, entity: &Entity) -> Result<Option<ClaimSnapshot>, ClaimError>;
 
+    /// Observe a claim only after any detached write already mutating that
+    /// claim row has committed or rolled back. Terminal recovery uses this
+    /// as an ordering barrier after cancellation may have dropped a steal
+    /// future while its backend statement remained in flight.
+    ///
+    /// In-process stores execute claim mutations synchronously and therefore
+    /// need no stronger operation than [`Self::current_claim`]. Stores that
+    /// can outlive a dropped future must override this method with a row-lock
+    /// or equivalent serialization barrier.
+    async fn current_claim_after_pending_writes(
+        &self,
+        entity: &Entity,
+    ) -> Result<Option<ClaimSnapshot>, ClaimError> {
+        self.current_claim(entity).await
+    }
+
     /// Advisory, own-transaction check: does `me` still hold `entity` under
     /// epoch `mine` right now? See the trait-level doc for why this is
     /// never the write-path fencing mechanism.
@@ -749,6 +774,8 @@ mod tests {
         let disabled = shared.current();
         assert!(!disabled.is_active());
         assert_ne!(disabled, active);
+        assert!(disabled.same_incarnation(&active));
+        assert!(!disabled.same_incarnation(&NodeIdentity::new("node-a", "epoch-1")));
         assert!(shared.guard_if_current(&disabled).await.is_none());
 
         let store = InProcessClaimStore::new();

--- a/server/crates/waddle-xmpp/src/stream_management/persistence.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/persistence.rs
@@ -127,6 +127,18 @@ pub enum SmPersistenceError {
         sm_database_url: String,
         global_database_url: String,
     },
+
+    /// Clustering cannot use the portable SQLite/in-memory persistence
+    /// implementation because its ownership fence lives in Postgres.
+    #[error(
+        "clustered SM persistence requires a postgres:// or postgresql:// database URL; got {sm_database_url}"
+    )]
+    ClusterRequiresPostgres { sm_database_url: String },
+
+    /// Startup wiring enabled clustering without providing the live claim
+    /// store and rotating node identity needed by fenced persistence.
+    #[error("clustered SM persistence started without live claim-store handles")]
+    ClusterClaimHandlesUnavailable,
 }
 
 /// A durable record of an XEP-0198 detached session.

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
@@ -1844,9 +1844,10 @@ impl InMemorySmSessionRegistry {
     /// Resolve an ownership CAS whose result was dropped without ever
     /// hydrating the session locally. This is the terminal self-fence path:
     /// a read-only claim lookup discovers whether `attempted_owner` won, and
-    /// an exact release retires only that observed generation. Lookup failure
-    /// cancels the local capacity reservation; the already self-fenced node's
-    /// lease expiry remains the durable recovery backstop.
+    /// an exact release retires only that observed generation. Until that
+    /// generation is observed, the CAS may still commit after the lookup, so
+    /// every lookup failure or non-matching snapshot keeps the local capacity
+    /// reservation and forces the caller to remain self-fenced.
     pub async fn retire_uncertain_reclaimed_claim(
         &self,
         entity: &Entity,
@@ -1865,21 +1866,22 @@ impl InMemorySmSessionRegistry {
         {
             Ok(Ok(snapshot)) => snapshot,
             Ok(Err(error)) => {
-                self.cancel_reclaimed_claim_fence_reservation(&entity.id, reservation);
                 return Err(SmRegistryError::Internal(format!(
                     "retire_uncertain_reclaimed_claim: exact owner lookup failed: {error}"
                 )));
             }
             Err(_) => {
-                self.cancel_reclaimed_claim_fence_reservation(&entity.id, reservation);
                 return Err(SmRegistryError::Internal(
                     "retire_uncertain_reclaimed_claim: exact owner lookup timed out".to_string(),
                 ));
             }
         };
         let Some(snapshot) = snapshot.filter(|snapshot| snapshot.owner == *attempted_owner) else {
-            self.cancel_reclaimed_claim_fence_reservation(&entity.id, reservation);
-            return Ok(crate::ownership::ExactReleaseOutcome::NotOwned);
+            return Err(SmRegistryError::Internal(
+                "retire_uncertain_reclaimed_claim: attempted owner not yet observable; \
+                 reservation retained because the ownership CAS may still commit"
+                    .to_string(),
+            ));
         };
         let fence = super::super::persistence::SmClaimFence::new(
             attempted_owner.clone(),

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/core.rs
@@ -1840,6 +1840,54 @@ impl InMemorySmSessionRegistry {
         self.clear_pending_reclaimed_hydration(entity, fence, reservation);
         Ok(outcome)
     }
+
+    /// Resolve an ownership CAS whose result was dropped without ever
+    /// hydrating the session locally. This is the terminal self-fence path:
+    /// a read-only claim lookup discovers whether `attempted_owner` won, and
+    /// an exact release retires only that observed generation. Lookup failure
+    /// cancels the local capacity reservation; the already self-fenced node's
+    /// lease expiry remains the durable recovery backstop.
+    pub async fn retire_uncertain_reclaimed_claim(
+        &self,
+        entity: &Entity,
+        attempted_owner: &NodeIdentity,
+        reservation: ReclaimedClaimReservation,
+    ) -> Result<crate::ownership::ExactReleaseOutcome, SmRegistryError> {
+        if entity.entity_type != EntityType::SmSession {
+            self.cancel_reclaimed_claim_fence_reservation(&entity.id, reservation);
+            return Ok(crate::ownership::ExactReleaseOutcome::NotOwned);
+        }
+        let snapshot = match tokio::time::timeout(
+            CLAIM_CALL_UNDER_SHARD_LOCK_TIMEOUT,
+            self.claim_store.current_claim(entity),
+        )
+        .await
+        {
+            Ok(Ok(snapshot)) => snapshot,
+            Ok(Err(error)) => {
+                self.cancel_reclaimed_claim_fence_reservation(&entity.id, reservation);
+                return Err(SmRegistryError::Internal(format!(
+                    "retire_uncertain_reclaimed_claim: exact owner lookup failed: {error}"
+                )));
+            }
+            Err(_) => {
+                self.cancel_reclaimed_claim_fence_reservation(&entity.id, reservation);
+                return Err(SmRegistryError::Internal(
+                    "retire_uncertain_reclaimed_claim: exact owner lookup timed out".to_string(),
+                ));
+            }
+        };
+        let Some(snapshot) = snapshot.filter(|snapshot| snapshot.owner == *attempted_owner) else {
+            self.cancel_reclaimed_claim_fence_reservation(&entity.id, reservation);
+            return Ok(crate::ownership::ExactReleaseOutcome::NotOwned);
+        };
+        let fence = super::super::persistence::SmClaimFence::new(
+            attempted_owner.clone(),
+            snapshot.claim_epoch,
+        );
+        self.release_reclaimed_claim(entity, &fence, reservation)
+            .await
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
+++ b/server/crates/waddle-xmpp/src/stream_management/session_registry/tests.rs
@@ -298,6 +298,39 @@ async fn hung_claim_release_is_bounded_and_retains_exact_fence() {
         .contains_key(stream_id));
 }
 
+#[tokio::test]
+async fn uncertain_reclaimed_claim_without_observed_owner_retains_capacity() {
+    let attempted_owner = crate::ownership::NodeIdentity::new("sweeper", "uncertain");
+    let store: std::sync::Arc<dyn crate::ownership::ClaimStore> =
+        std::sync::Arc::new(crate::ownership::InProcessClaimStore::new());
+    let registry = InMemorySmSessionRegistry::with_capacity(1).with_claim_store(
+        store,
+        crate::ownership::SharedNodeIdentity::new(attempted_owner.clone()),
+    );
+    let entity = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        "unobserved-uncertain-claim",
+    );
+    let replacement = crate::ownership::Entity::new(
+        crate::ownership::EntityType::SmSession,
+        "replacement-after-uncertain-claim",
+    );
+    let reservation = registry
+        .reserve_reclaimed_claim_capacity(&entity)
+        .expect("reserve uncertain claim capacity");
+
+    assert!(registry
+        .retire_uncertain_reclaimed_claim(&entity, &attempted_owner, reservation)
+        .await
+        .is_err());
+    assert!(
+        registry
+            .reserve_reclaimed_claim_capacity(&replacement)
+            .is_none(),
+        "a missing snapshot is not proof that the in-flight ownership CAS cannot still commit"
+    );
+}
+
 #[tokio::test(start_paused = true)]
 async fn claim_session_commit_before_timeout_retains_acquisition_for_reconciliation() {
     use crate::ownership::ClaimStore as _;


### PR DESCRIPTION
Closes #1284

## Implementation plan

- Supervise RoomActor and SM orphan-recovery workers without losing exact ownership responsibility across cancellation, full queues, worker failure, or restart.
- Keep RoomActor and SM scans raw-bounded and restart-safe with persisted lane-typed cursors; keep ISR cleanup age-indexed, transactionally serialized, and restart-safe with its own durable cursor.
- Reserve bounded local capacity before SM ownership changes and retain it while a dropped ownership CAS can still commit.
- Drain won-but-unserved RoomActor epochs inside the serialized RoomRegistry mailbox while preserving claims that already back live room actors.
- Fail closed when clustered persistence, claim handles, node authority, readiness, post-recovery fencing, or uncertain-retirement reconciliation cannot be proven safe.
- Preserve the graceful-drain seal-before-release contract while allowing fatal recovery ambiguity to preempt the drain with immediate terminal fencing.

## Rebase and review boundary

- Rebased onto current `main` after merged PRs #1332, #1333, and #1334.
- The obsolete stacked dependency history remains removed; this PR contains five PR-only commits.
- Twenty-three files are changed (approximately +7,150 / -273), concentrated in claim storage, orphan/ISR janitors, node-lease supervision, SM persistence, RoomRegistry ownership cleanup, and ownership authority.
- No transport-publication implementation is duplicated from #1333.
- Qodo and Greptile follow-up findings were addressed: lane-specific cursor types cross every public/storage boundary, ambiguous SM retirement retains capacity and self-fences restarts, and exact RoomActor handoffs survive cancellation, worker restart, mailbox delivery, disabled local authority, and terminal release failure.

## Correctness invariants

- Cursor advancement is committed only after a complete raw-bounded page has been accepted and processed; restarts and multi-node sweeps may duplicate safe work but cannot skip ownership candidates.
- Ownership-changing CAS operations are never blindly replayed after cancellation; exact owner, epoch, and durable state are revalidated before cleanup or hydration.
- A missing, foreign, failed, or timed-out claim lookup is not treated as proof that an in-flight CAS lost; its capacity reservation remains held through teardown.
- Terminal RoomRegistry cleanup disables new room-claim acquisition, imports supervisor-owned exact handoffs, serializes PostgreSQL observation behind detached steal writes, retains ambiguous or failed cleanup for node-expiry recovery, and never releases the exact fence of a live room actor.
- Fatal retirement failure stops replacement workers and future sweeps before another ownership CAS can begin.
- Ordinary shutdown first marks the node not-ready and draining, seals/releases while the current identity remains authoritative, then disables publication and exact-demotes leftovers.
- Fatal ambiguity disables publication first, exact-demotes every possibly responsible identity, and permanently overrides readiness.
- Clustered SM persistence requires PostgreSQL, the same configured DSN as the control plane, and live claim handles.

## Protocol constraints

- No XMPP wire shape is added or changed.
- XEP-0198 SM IDs remain bounded, opaque typed identifiers.
- XEP-0397 ISR tokens remain valid only while their exact SM-session claim or durable session still exists.

## Verification

- `cargo test -p waddle-server --all-features`: 1,890 unit tests plus all server integration and conformance tests passed.
- PostgreSQL-backed cursor persistence, lane isolation/reset, malformed-room quarantine pagination, and orphan-recovery tests passed locally.
- The complete `waddle-xmpp` unit suite passed: 2,538 tests, including terminal handoff, late-steal observation, disabled-identity cleanup, live-fence preservation, and typed release-retention regressions.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- PostgreSQL test fixtures reset durable lane cursors with claims/leases, preventing release-suite ordering from contaminating later orphan scans.
- Repeated independent adversarial lifecycle reviews are clean after the final PostgreSQL ordering-barrier, typed handoff, restart, capacity, and disabled-authority fixes.
