### PR TITLE
fix(server): move OIDC auth handshake state to shared DB (#1336)

### DIFF
--- a/server/crates/waddle-server/src/db/migrations/global.rs
+++ b/server/crates/waddle-server/src/db/migrations/global.rs
@@ -600,60 +600,65 @@ CREATE INDEX IF NOT EXISTS idx_link_preview_media_refs_message
 /// callback / token / device endpoints (#1336). Entries are single-use
 /// JSON payloads keyed by their opaque secret; `expires_at_ms` (unix
 /// epoch milliseconds) exists purely for the janitor's SQL prune.
+///
+/// `IF NOT EXISTS` throughout: the migration runner has no cross-node
+/// lock, so two replicas starting concurrently can both attempt this
+/// DDL; idempotent statements make the loser a no-op instead of a
+/// startup crash-loop.
 pub const V0009_AUTH_HANDSHAKE_STATE: &str = r#"
-CREATE TABLE pending_auth (
+CREATE TABLE IF NOT EXISTS pending_auth (
     state TEXT PRIMARY KEY,
     payload TEXT NOT NULL,
     expires_at_ms INTEGER NOT NULL
 );
 
-CREATE INDEX idx_pending_auth_expires_at ON pending_auth(expires_at_ms);
+CREATE INDEX IF NOT EXISTS idx_pending_auth_expires_at ON pending_auth(expires_at_ms);
 
-CREATE TABLE device_auth (
+CREATE TABLE IF NOT EXISTS device_auth (
     device_code TEXT PRIMARY KEY,
     user_code TEXT NOT NULL,
     payload TEXT NOT NULL,
     expires_at_ms INTEGER NOT NULL
 );
 
-CREATE INDEX idx_device_auth_user_code ON device_auth(user_code);
-CREATE INDEX idx_device_auth_expires_at ON device_auth(expires_at_ms);
+CREATE INDEX IF NOT EXISTS idx_device_auth_user_code ON device_auth(user_code);
+CREATE INDEX IF NOT EXISTS idx_device_auth_expires_at ON device_auth(expires_at_ms);
 
-CREATE TABLE xmpp_auth_codes (
+CREATE TABLE IF NOT EXISTS xmpp_auth_codes (
     code TEXT PRIMARY KEY,
     payload TEXT NOT NULL,
     expires_at_ms INTEGER NOT NULL
 );
 
-CREATE INDEX idx_xmpp_auth_codes_expires_at ON xmpp_auth_codes(expires_at_ms);
+CREATE INDEX IF NOT EXISTS idx_xmpp_auth_codes_expires_at ON xmpp_auth_codes(expires_at_ms);
 "#;
 
 pub const V0009_AUTH_HANDSHAKE_STATE_POSTGRES: &str = r#"
-CREATE TABLE pending_auth (
+CREATE TABLE IF NOT EXISTS pending_auth (
     state TEXT PRIMARY KEY,
     payload TEXT NOT NULL,
     expires_at_ms BIGINT NOT NULL
 );
 
-CREATE INDEX idx_pending_auth_expires_at ON pending_auth(expires_at_ms);
+CREATE INDEX IF NOT EXISTS idx_pending_auth_expires_at ON pending_auth(expires_at_ms);
 
-CREATE TABLE device_auth (
+CREATE TABLE IF NOT EXISTS device_auth (
     device_code TEXT PRIMARY KEY,
     user_code TEXT NOT NULL,
     payload TEXT NOT NULL,
     expires_at_ms BIGINT NOT NULL
 );
 
-CREATE INDEX idx_device_auth_user_code ON device_auth(user_code);
-CREATE INDEX idx_device_auth_expires_at ON device_auth(expires_at_ms);
+CREATE INDEX IF NOT EXISTS idx_device_auth_user_code ON device_auth(user_code);
+CREATE INDEX IF NOT EXISTS idx_device_auth_expires_at ON device_auth(expires_at_ms);
 
-CREATE TABLE xmpp_auth_codes (
+CREATE TABLE IF NOT EXISTS xmpp_auth_codes (
     code TEXT PRIMARY KEY,
     payload TEXT NOT NULL,
     expires_at_ms BIGINT NOT NULL
 );
 
-CREATE INDEX idx_xmpp_auth_codes_expires_at ON xmpp_auth_codes(expires_at_ms);
+CREATE INDEX IF NOT EXISTS idx_xmpp_auth_codes_expires_at ON xmpp_auth_codes(expires_at_ms);
 "#;
 
 /// Get all global migrations in order

--- a/server/crates/waddle-server/src/db/migrations/global.rs
+++ b/server/crates/waddle-server/src/db/migrations/global.rs
@@ -622,7 +622,7 @@ CREATE TABLE IF NOT EXISTS device_auth (
     expires_at_ms INTEGER NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_device_auth_user_code ON device_auth(user_code);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_device_auth_user_code ON device_auth(user_code);
 CREATE INDEX IF NOT EXISTS idx_device_auth_expires_at ON device_auth(expires_at_ms);
 
 CREATE TABLE IF NOT EXISTS xmpp_auth_codes (
@@ -651,7 +651,7 @@ CREATE TABLE IF NOT EXISTS device_auth (
     expires_at_ms BIGINT NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_device_auth_user_code ON device_auth(user_code);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_device_auth_user_code ON device_auth(user_code);
 CREATE INDEX IF NOT EXISTS idx_device_auth_expires_at ON device_auth(expires_at_ms);
 
 CREATE TABLE IF NOT EXISTS xmpp_auth_codes (

--- a/server/crates/waddle-server/src/db/migrations/global.rs
+++ b/server/crates/waddle-server/src/db/migrations/global.rs
@@ -596,6 +596,66 @@ CREATE INDEX IF NOT EXISTS idx_link_preview_media_refs_message
     ON link_preview_media_refs(archive_jid, message_id);
 "#;
 
+/// Durable OIDC/OAuth handshake state so any replica can serve the
+/// callback / token / device endpoints (#1336). Entries are single-use
+/// JSON payloads keyed by their opaque secret; `expires_at_ms` (unix
+/// epoch milliseconds) exists purely for the janitor's SQL prune.
+pub const V0009_AUTH_HANDSHAKE_STATE: &str = r#"
+CREATE TABLE pending_auth (
+    state TEXT PRIMARY KEY,
+    payload TEXT NOT NULL,
+    expires_at_ms INTEGER NOT NULL
+);
+
+CREATE INDEX idx_pending_auth_expires_at ON pending_auth(expires_at_ms);
+
+CREATE TABLE device_auth (
+    device_code TEXT PRIMARY KEY,
+    user_code TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    expires_at_ms INTEGER NOT NULL
+);
+
+CREATE INDEX idx_device_auth_user_code ON device_auth(user_code);
+CREATE INDEX idx_device_auth_expires_at ON device_auth(expires_at_ms);
+
+CREATE TABLE xmpp_auth_codes (
+    code TEXT PRIMARY KEY,
+    payload TEXT NOT NULL,
+    expires_at_ms INTEGER NOT NULL
+);
+
+CREATE INDEX idx_xmpp_auth_codes_expires_at ON xmpp_auth_codes(expires_at_ms);
+"#;
+
+pub const V0009_AUTH_HANDSHAKE_STATE_POSTGRES: &str = r#"
+CREATE TABLE pending_auth (
+    state TEXT PRIMARY KEY,
+    payload TEXT NOT NULL,
+    expires_at_ms BIGINT NOT NULL
+);
+
+CREATE INDEX idx_pending_auth_expires_at ON pending_auth(expires_at_ms);
+
+CREATE TABLE device_auth (
+    device_code TEXT PRIMARY KEY,
+    user_code TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    expires_at_ms BIGINT NOT NULL
+);
+
+CREATE INDEX idx_device_auth_user_code ON device_auth(user_code);
+CREATE INDEX idx_device_auth_expires_at ON device_auth(expires_at_ms);
+
+CREATE TABLE xmpp_auth_codes (
+    code TEXT PRIMARY KEY,
+    payload TEXT NOT NULL,
+    expires_at_ms BIGINT NOT NULL
+);
+
+CREATE INDEX idx_xmpp_auth_codes_expires_at ON xmpp_auth_codes(expires_at_ms);
+"#;
+
 /// Get all global migrations in order
 pub fn all() -> Vec<Migration> {
     vec![
@@ -649,6 +709,12 @@ pub fn all() -> Vec<Migration> {
             description: "Repair missing global tables after migration drift".to_string(),
             sql_sqlite: V0008_REPAIR_GLOBAL_SCHEMA_DRIFT,
             sql_postgres: V0008_REPAIR_GLOBAL_SCHEMA_DRIFT_POSTGRES,
+        },
+        Migration {
+            version: 9,
+            description: "Durable OIDC/OAuth handshake state shared across replicas".to_string(),
+            sql_sqlite: V0009_AUTH_HANDSHAKE_STATE,
+            sql_postgres: V0009_AUTH_HANDSHAKE_STATE_POSTGRES,
         },
     ]
 }

--- a/server/crates/waddle-server/src/db/migrations/global.rs
+++ b/server/crates/waddle-server/src/db/migrations/global.rs
@@ -617,6 +617,7 @@ CREATE INDEX IF NOT EXISTS idx_pending_auth_expires_at ON pending_auth(expires_a
 CREATE TABLE IF NOT EXISTS device_auth (
     device_code TEXT PRIMARY KEY,
     user_code TEXT NOT NULL,
+    status TEXT NOT NULL,
     payload TEXT NOT NULL,
     expires_at_ms INTEGER NOT NULL
 );
@@ -645,6 +646,7 @@ CREATE INDEX IF NOT EXISTS idx_pending_auth_expires_at ON pending_auth(expires_a
 CREATE TABLE IF NOT EXISTS device_auth (
     device_code TEXT PRIMARY KEY,
     user_code TEXT NOT NULL,
+    status TEXT NOT NULL,
     payload TEXT NOT NULL,
     expires_at_ms BIGINT NOT NULL
 );

--- a/server/crates/waddle-server/src/db/migrations/runner.rs
+++ b/server/crates/waddle-server/src/db/migrations/runner.rs
@@ -147,9 +147,14 @@ impl MigrationRunner {
                 ))
             })?;
 
-            // Record the migration
+            // Record the migration. `ON CONFLICT DO NOTHING`: there is
+            // no cross-node lock (#1338), so two replicas booting
+            // concurrently can both pass the applied-versions check and
+            // race this insert; the loser must not crash-loop on the
+            // duplicate primary key after (idempotent) DDL succeeded.
             conn.execute(
-                "INSERT INTO _migrations (version, description) VALUES (?, ?)",
+                "INSERT INTO _migrations (version, description) VALUES (?, ?) \
+                 ON CONFLICT (version) DO NOTHING",
                 (migration.version, migration.description.as_str()),
             )
             .await

--- a/server/crates/waddle-server/src/db/migrations/tests.rs
+++ b/server/crates/waddle-server/src/db/migrations/tests.rs
@@ -241,7 +241,7 @@ async fn test_global_v0004_adds_policy_digest_to_existing_v0003_schema() {
     let applied = runner.run(&db).await.unwrap();
     assert_eq!(
         applied,
-        vec![4, 5, 6, 7, 8, 1001, 1002, 1003, 1004, 1005, 1006, 1007]
+        vec![4, 5, 6, 7, 8, 9, 1001, 1002, 1003, 1004, 1005, 1006, 1007]
     );
 
     // Column exists.
@@ -355,7 +355,7 @@ async fn test_incompatible_history_forces_hard_cut_reapply() {
     let applied = runner.run(&db).await.unwrap();
     assert_eq!(
         applied,
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 1001, 1002, 1003, 1004, 1005, 1006, 1007]
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 1001, 1002, 1003, 1004, 1005, 1006, 1007]
     );
 
     let applied_again = runner.run(&db).await.unwrap();
@@ -409,7 +409,7 @@ async fn test_incompatible_history_recreates_existing_owned_tables() {
     let applied = runner.run(&db).await.unwrap();
     assert_eq!(
         applied,
-        vec![1, 2, 3, 4, 5, 6, 7, 8, 1001, 1002, 1003, 1004, 1005, 1006, 1007]
+        vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 1001, 1002, 1003, 1004, 1005, 1006, 1007]
     );
 
     let conn = db.guard().await.unwrap();
@@ -630,7 +630,7 @@ async fn postgres_v0006_widens_existing_upload_slot_size_bytes() {
         .expect("run global migration");
     assert_eq!(
         applied,
-        vec![6, 7, 8, 1001, 1002, 1003, 1004, 1005, 1006, 1007]
+        vec![6, 7, 8, 9, 1001, 1002, 1003, 1004, 1005, 1006, 1007]
     );
     assert_postgres_column_type(&db, "upload_slots", "size_bytes", "bigint").await;
 
@@ -698,7 +698,7 @@ async fn sqlite_v0007_tracks_link_preview_media_refs() {
     let applied = MigrationRunner::global().run(&db).await.unwrap();
     assert_eq!(
         applied,
-        vec![7, 8, 1001, 1002, 1003, 1004, 1005, 1006, 1007]
+        vec![7, 8, 9, 1001, 1002, 1003, 1004, 1005, 1006, 1007]
     );
 
     let conn = db.guard().await.unwrap();
@@ -811,7 +811,7 @@ async fn sqlite_v0008_repairs_marked_but_missing_global_tables() {
     drop(conn);
 
     let applied = MigrationRunner::global().run(&db).await.unwrap();
-    assert_eq!(applied, vec![8]);
+    assert_eq!(applied, vec![8, 9]);
 
     let conn = db.guard().await.unwrap();
     for table in ["provider_webhook_deliveries", "link_preview_media_refs"] {
@@ -891,7 +891,7 @@ async fn postgres_v0007_tracks_link_preview_media_refs() {
         .expect("run global migration");
     assert_eq!(
         applied,
-        vec![7, 8, 1001, 1002, 1003, 1004, 1005, 1006, 1007]
+        vec![7, 8, 9, 1001, 1002, 1003, 1004, 1005, 1006, 1007]
     );
 
     let conn = db.guard().await.expect("postgres guard");
@@ -1029,7 +1029,7 @@ async fn postgres_v0008_repairs_marked_but_missing_global_tables() {
         .run(&db)
         .await
         .expect("run global migration");
-    assert_eq!(applied, vec![8]);
+    assert_eq!(applied, vec![8, 9]);
 
     let conn = db.guard().await.expect("postgres guard");
     for table in ["provider_webhook_deliveries", "link_preview_media_refs"] {

--- a/server/crates/waddle-server/src/server/routes/auth.rs
+++ b/server/crates/waddle-server/src/server/routes/auth.rs
@@ -39,12 +39,14 @@ use tracing::{error, instrument, warn};
 use uuid::Uuid;
 
 mod callback;
+mod handshake;
 mod state;
 
 use callback::callback_handler;
+pub use handshake::AuthHandshakeStore;
 pub use state::{AuthState, ProfilePublishHook};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PendingAuthorization {
     pub state: String,
     pub provider_id: String,
@@ -60,12 +62,16 @@ pub struct PendingAuthorization {
 }
 
 impl PendingAuthorization {
+    pub fn expires_at(&self) -> DateTime<Utc> {
+        self.created_at + Duration::minutes(10)
+    }
+
     pub fn is_expired(&self) -> bool {
-        Utc::now() > self.created_at + Duration::minutes(10)
+        Utc::now() > self.expires_at()
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum PendingFlow {
     Browser {
         next: Option<String>,
@@ -81,7 +87,7 @@ pub enum PendingFlow {
     },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BrowserSessionTransport {
     Cookie,
     Fragment,
@@ -99,7 +105,7 @@ impl BrowserSessionTransport {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeviceAuthorization {
     pub device_code: String,
     pub user_code: String,
@@ -115,14 +121,14 @@ impl DeviceAuthorization {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DeviceAuthStatus {
     Pending,
     InProgress,
     Approved,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct XmppAuthCode {
     pub session_id: String,
     pub redirect_uri: String,
@@ -131,8 +137,12 @@ pub struct XmppAuthCode {
 }
 
 impl XmppAuthCode {
+    pub fn expires_at(&self) -> DateTime<Utc> {
+        self.created_at + Duration::minutes(10)
+    }
+
     pub fn is_expired(&self) -> bool {
-        Utc::now() > self.created_at + Duration::minutes(10)
+        Utc::now() > self.expires_at()
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/auth.rs
+++ b/server/crates/waddle-server/src/server/routes/auth.rs
@@ -66,8 +66,11 @@ impl PendingAuthorization {
         self.created_at + Duration::minutes(10)
     }
 
+    /// Inclusive boundary (`>=`) to match the store's SQL gates
+    /// (`expires_at_ms > now` to act, `<= now` to prune), so an entry
+    /// can never pass this check yet be rejected by the database.
     pub fn is_expired(&self) -> bool {
-        Utc::now() > self.expires_at()
+        Utc::now() >= self.expires_at()
     }
 }
 
@@ -116,8 +119,9 @@ pub struct DeviceAuthorization {
 }
 
 impl DeviceAuthorization {
+    /// Inclusive boundary (`>=`) — see `PendingAuthorization::is_expired`.
     pub fn is_expired(&self) -> bool {
-        Utc::now() > self.expires_at
+        Utc::now() >= self.expires_at
     }
 }
 
@@ -141,8 +145,9 @@ impl XmppAuthCode {
         self.created_at + Duration::minutes(10)
     }
 
+    /// Inclusive boundary (`>=`) — see `PendingAuthorization::is_expired`.
     pub fn is_expired(&self) -> bool {
-        Utc::now() > self.expires_at()
+        Utc::now() >= self.expires_at()
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/auth/callback.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/callback.rs
@@ -288,16 +288,32 @@ pub(super) async fn callback_handler(
             response
         }
         PendingFlow::Device { device_code } => {
-            match state.auth_handshake.get_device(&device_code).await {
+            // The approval must actually land on the device row: if the
+            // grant expired and was pruned mid-callback, reporting
+            // "Device authorized" would strand the poller forever and
+            // leak the session we just created — so roll it back and
+            // surface the expiry instead.
+            let approved = match state.auth_handshake.get_device(&device_code).await {
                 Ok(Some(mut entry)) => {
                     entry.status = DeviceAuthStatus::Approved;
                     entry.session_id = Some(session.id.clone());
-                    if let Err(err) = state.auth_handshake.update_device(&entry).await {
-                        return auth_error_to_response(err).into_response();
+                    match state.auth_handshake.update_device(&entry).await {
+                        Ok(approved) => approved,
+                        Err(err) => return auth_error_to_response(err).into_response(),
                     }
                 }
-                Ok(None) => {}
+                Ok(None) => false,
                 Err(err) => return auth_error_to_response(err).into_response(),
+            };
+
+            if !approved {
+                if let Err(err) = state.session_manager.delete_session(&session.id).await {
+                    warn!(error = %err, "Failed to roll back session for expired device grant");
+                }
+                return auth_error_to_response(AuthError::InvalidRequest(
+                    "device authorization expired; restart the device login".to_string(),
+                ))
+                .into_response();
             }
 
             (

--- a/server/crates/waddle-server/src/server/routes/auth/callback.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/callback.rs
@@ -18,9 +18,10 @@ pub(super) async fn callback_handler(
             .into_response();
     };
 
-    let pending = match state.pending_auth.remove(&state_key) {
-        Some((_, pending)) => pending,
-        None => return auth_error_to_response(AuthError::InvalidState).into_response(),
+    let pending = match state.auth_handshake.take_pending(&state_key).await {
+        Ok(Some(pending)) => pending,
+        Ok(None) => return auth_error_to_response(AuthError::InvalidState).into_response(),
+        Err(err) => return auth_error_to_response(err).into_response(),
     };
 
     if pending.is_expired() {
@@ -287,9 +288,16 @@ pub(super) async fn callback_handler(
             response
         }
         PendingFlow::Device { device_code } => {
-            if let Some(mut entry) = state.device_auth.get_mut(&device_code) {
-                entry.status = DeviceAuthStatus::Approved;
-                entry.session_id = Some(session.id.clone());
+            match state.auth_handshake.get_device(&device_code).await {
+                Ok(Some(mut entry)) => {
+                    entry.status = DeviceAuthStatus::Approved;
+                    entry.session_id = Some(session.id.clone());
+                    if let Err(err) = state.auth_handshake.update_device(&entry).await {
+                        return auth_error_to_response(err).into_response();
+                    }
+                }
+                Ok(None) => {}
+                Err(err) => return auth_error_to_response(err).into_response(),
             }
 
             (
@@ -304,15 +312,21 @@ pub(super) async fn callback_handler(
             client_code_challenge,
         } => {
             let auth_code = Uuid::new_v4().to_string();
-            state.xmpp_auth_codes.insert(
-                auth_code.clone(),
-                XmppAuthCode {
-                    session_id: session.id,
-                    redirect_uri: client_redirect_uri.clone(),
-                    code_challenge: client_code_challenge,
-                    created_at: Utc::now(),
-                },
-            );
+            if let Err(err) = state
+                .auth_handshake
+                .insert_xmpp_code(
+                    &auth_code,
+                    &XmppAuthCode {
+                        session_id: session.id,
+                        redirect_uri: client_redirect_uri.clone(),
+                        code_challenge: client_code_challenge,
+                        created_at: Utc::now(),
+                    },
+                )
+                .await
+            {
+                return auth_error_to_response(err).into_response();
+            }
 
             let mut redirect = match url::Url::parse(&client_redirect_uri) {
                 Ok(v) => v,

--- a/server/crates/waddle-server/src/server/routes/auth/callback.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/callback.rs
@@ -295,11 +295,22 @@ pub(super) async fn callback_handler(
             // surface the expiry instead.
             let approved = match state.auth_handshake.get_device(&device_code).await {
                 Ok(Some(mut entry)) => {
-                    entry.status = DeviceAuthStatus::Approved;
-                    entry.session_id = Some(session.id.clone());
-                    match state.auth_handshake.update_device(&entry).await {
-                        Ok(approved) => approved,
-                        Err(err) => return auth_error_to_response(err).into_response(),
+                    if entry.is_expired() {
+                        // The IdP round-trip outlived the device-code
+                        // window. `update_device` is also time-gated in
+                        // SQL, so this is belt-and-braces plus eager
+                        // cleanup of the dead row.
+                        if let Err(err) = state.auth_handshake.remove_device(&device_code).await {
+                            warn!(error = %err, "Failed to remove expired device authorization");
+                        }
+                        false
+                    } else {
+                        entry.status = DeviceAuthStatus::Approved;
+                        entry.session_id = Some(session.id.clone());
+                        match state.auth_handshake.update_device(&entry).await {
+                            Ok(approved) => approved,
+                            Err(err) => return auth_error_to_response(err).into_response(),
+                        }
                     }
                 }
                 Ok(None) => false,
@@ -333,7 +344,7 @@ pub(super) async fn callback_handler(
                 .insert_xmpp_code(
                     &auth_code,
                     &XmppAuthCode {
-                        session_id: session.id,
+                        session_id: session.id.clone(),
                         redirect_uri: client_redirect_uri.clone(),
                         code_challenge: client_code_challenge,
                         created_at: Utc::now(),
@@ -341,6 +352,11 @@ pub(super) async fn callback_handler(
                 )
                 .await
             {
+                // No code ever reaches the client, so the session just
+                // created would be a live 30-day orphan — roll it back.
+                if let Err(rollback_err) = state.session_manager.delete_session(&session.id).await {
+                    warn!(error = %rollback_err, "Failed to roll back session for failed xmpp code insert");
+                }
                 return auth_error_to_response(err).into_response();
             }
 

--- a/server/crates/waddle-server/src/server/routes/auth/callback.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/callback.rs
@@ -293,6 +293,16 @@ pub(super) async fn callback_handler(
             // "Device authorized" would strand the poller forever and
             // leak the session we just created — so roll it back and
             // surface the expiry instead.
+            // The session is already committed; any exit from this
+            // block that can't hand it to the device poller must roll
+            // it back or it lives as a 30-day orphan.
+            let rollback_session = |err: AuthError| async {
+                if let Err(rollback_err) = state.session_manager.delete_session(&session.id).await {
+                    warn!(error = %rollback_err, "Failed to roll back session for failed device approval");
+                }
+                auth_error_to_response(err).into_response()
+            };
+
             let approved = match state.auth_handshake.get_device(&device_code).await {
                 Ok(Some(mut entry)) => {
                     if entry.is_expired() {
@@ -309,12 +319,12 @@ pub(super) async fn callback_handler(
                         entry.session_id = Some(session.id.clone());
                         match state.auth_handshake.update_device(&entry).await {
                             Ok(approved) => approved,
-                            Err(err) => return auth_error_to_response(err).into_response(),
+                            Err(err) => return rollback_session(err).await,
                         }
                     }
                 }
                 Ok(None) => false,
-                Err(err) => return auth_error_to_response(err).into_response(),
+                Err(err) => return rollback_session(err).await,
             };
 
             if !approved {

--- a/server/crates/waddle-server/src/server/routes/auth/handshake.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/handshake.rs
@@ -1,0 +1,582 @@
+//! Durable OIDC/OAuth handshake state (#1336).
+//!
+//! `pending_auth`, `device_auth`, and `xmpp_auth_codes` used to live in
+//! per-process `DashMap`s, which breaks behind a load balancer: the pod
+//! that mints a `state`/code is not necessarily the pod that redeems
+//! it. This store keeps the same entries in the shared global database
+//! (via the `DbActor`, like `SessionManager`) so any replica can serve
+//! the callback / token / device endpoints.
+//!
+//! Redemption is single-use across replicas: `take_*` gates on the
+//! rows-affected count of the `DELETE`, so exactly one caller wins even
+//! when two pods race on the same key.
+
+use super::*;
+
+use crate::auth::AuthError;
+use crate::db::actor::{DbActor, DbExecute, DbQueryOne};
+use crate::db::{row_value, ValueExt};
+
+/// Per-sweep counts returned by [`AuthHandshakeStore::sweep_expired`].
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct AuthSweepCounts {
+    pub pending_pruned: usize,
+    pub device_pruned: usize,
+    pub xmpp_pruned: usize,
+    pub pending_remaining: usize,
+    pub device_remaining: usize,
+    pub xmpp_remaining: usize,
+}
+
+/// Row counts for the state inventory snapshot.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct AuthHandshakeCounts {
+    pub pending_auth: usize,
+    pub device_auth: usize,
+    pub xmpp_auth_codes: usize,
+}
+
+#[derive(Clone)]
+pub struct AuthHandshakeStore {
+    actor: ActorRef<DbActor>,
+}
+
+impl AuthHandshakeStore {
+    pub fn new(actor: ActorRef<DbActor>) -> Self {
+        Self { actor }
+    }
+
+    fn ask_err(e: impl std::fmt::Display) -> AuthError {
+        AuthError::DatabaseError(e.to_string())
+    }
+
+    fn encode<T: Serialize>(entry: &T) -> Result<String, AuthError> {
+        serde_json::to_string(entry)
+            .map_err(|e| AuthError::DatabaseError(format!("failed to encode payload: {e}")))
+    }
+
+    fn decode<T: serde::de::DeserializeOwned>(payload: &str) -> Result<T, AuthError> {
+        serde_json::from_str(payload)
+            .map_err(|e| AuthError::DatabaseError(format!("failed to decode payload: {e}")))
+    }
+
+    async fn select_payload(
+        &self,
+        sql: &'static str,
+        key: &str,
+    ) -> Result<Option<String>, AuthError> {
+        let row = self
+            .actor
+            .ask(DbQueryOne {
+                sql: sql.to_string(),
+                params: vec![crate::db::Value::from(key)],
+            })
+            .await
+            .map_err(Self::ask_err)?;
+
+        match row {
+            Some(values) => {
+                let payload = row_value(&values, 0)
+                    .and_then(ValueExt::as_string)
+                    .map_err(|e| AuthError::DatabaseError(format!("failed to get payload: {e}")))?;
+                Ok(Some(payload))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// SELECT the payload, then DELETE gated on rows-affected. Exactly
+    /// one concurrent caller observes `rows_affected == 1`; every other
+    /// racer gets `None`, which makes redemption single-use across
+    /// replicas without needing driver-specific `RETURNING` support.
+    async fn take_payload(
+        &self,
+        select_sql: &'static str,
+        delete_sql: &'static str,
+        key: &str,
+    ) -> Result<Option<String>, AuthError> {
+        let Some(payload) = self.select_payload(select_sql, key).await? else {
+            return Ok(None);
+        };
+
+        let deleted = self
+            .actor
+            .ask(DbExecute {
+                sql: delete_sql.to_string(),
+                params: vec![crate::db::Value::from(key)],
+            })
+            .await
+            .map_err(Self::ask_err)?;
+
+        if deleted == 1 {
+            Ok(Some(payload))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub async fn insert_pending(&self, pending: &PendingAuthorization) -> Result<(), AuthError> {
+        let payload = Self::encode(pending)?;
+        self.actor
+            .ask(DbExecute {
+                sql: "INSERT INTO pending_auth (state, payload, expires_at_ms) VALUES (?, ?, ?)"
+                    .to_string(),
+                params: vec![
+                    crate::db::Value::from(&pending.state),
+                    crate::db::Value::from(payload),
+                    crate::db::Value::from(pending.expires_at().timestamp_millis()),
+                ],
+            })
+            .await
+            .map_err(Self::ask_err)?;
+        Ok(())
+    }
+
+    pub async fn take_pending(
+        &self,
+        state: &str,
+    ) -> Result<Option<PendingAuthorization>, AuthError> {
+        self.take_payload(
+            "SELECT payload FROM pending_auth WHERE state = ? LIMIT 1",
+            "DELETE FROM pending_auth WHERE state = ?",
+            state,
+        )
+        .await?
+        .map(|payload| Self::decode(&payload))
+        .transpose()
+    }
+
+    pub async fn insert_xmpp_code(
+        &self,
+        code: &str,
+        entry: &XmppAuthCode,
+    ) -> Result<(), AuthError> {
+        let payload = Self::encode(entry)?;
+        self.actor
+            .ask(DbExecute {
+                sql: "INSERT INTO xmpp_auth_codes (code, payload, expires_at_ms) VALUES (?, ?, ?)"
+                    .to_string(),
+                params: vec![
+                    crate::db::Value::from(code),
+                    crate::db::Value::from(payload),
+                    crate::db::Value::from(entry.expires_at().timestamp_millis()),
+                ],
+            })
+            .await
+            .map_err(Self::ask_err)?;
+        Ok(())
+    }
+
+    pub async fn take_xmpp_code(&self, code: &str) -> Result<Option<XmppAuthCode>, AuthError> {
+        self.take_payload(
+            "SELECT payload FROM xmpp_auth_codes WHERE code = ? LIMIT 1",
+            "DELETE FROM xmpp_auth_codes WHERE code = ?",
+            code,
+        )
+        .await?
+        .map(|payload| Self::decode(&payload))
+        .transpose()
+    }
+
+    pub async fn insert_device(&self, entry: &DeviceAuthorization) -> Result<(), AuthError> {
+        let payload = Self::encode(entry)?;
+        self.actor
+            .ask(DbExecute {
+                sql: "INSERT INTO device_auth (device_code, user_code, payload, expires_at_ms) \
+                      VALUES (?, ?, ?, ?)"
+                    .to_string(),
+                params: vec![
+                    crate::db::Value::from(&entry.device_code),
+                    crate::db::Value::from(&entry.user_code),
+                    crate::db::Value::from(payload),
+                    crate::db::Value::from(entry.expires_at.timestamp_millis()),
+                ],
+            })
+            .await
+            .map_err(Self::ask_err)?;
+        Ok(())
+    }
+
+    pub async fn get_device(
+        &self,
+        device_code: &str,
+    ) -> Result<Option<DeviceAuthorization>, AuthError> {
+        self.select_payload(
+            "SELECT payload FROM device_auth WHERE device_code = ? LIMIT 1",
+            device_code,
+        )
+        .await?
+        .map(|payload| Self::decode(&payload))
+        .transpose()
+    }
+
+    pub async fn find_device_by_user_code(
+        &self,
+        user_code: &str,
+    ) -> Result<Option<DeviceAuthorization>, AuthError> {
+        self.select_payload(
+            "SELECT payload FROM device_auth WHERE user_code = ? LIMIT 1",
+            user_code,
+        )
+        .await?
+        .map(|payload| Self::decode(&payload))
+        .transpose()
+    }
+
+    /// Persist a device-flow state transition (Pending → InProgress →
+    /// Approved / session attach). Returns `false` when the row is gone
+    /// (expired-and-pruned or redeemed by another replica).
+    pub async fn update_device(&self, entry: &DeviceAuthorization) -> Result<bool, AuthError> {
+        let payload = Self::encode(entry)?;
+        let updated = self
+            .actor
+            .ask(DbExecute {
+                sql: "UPDATE device_auth SET payload = ?, expires_at_ms = ? WHERE device_code = ?"
+                    .to_string(),
+                params: vec![
+                    crate::db::Value::from(payload),
+                    crate::db::Value::from(entry.expires_at.timestamp_millis()),
+                    crate::db::Value::from(&entry.device_code),
+                ],
+            })
+            .await
+            .map_err(Self::ask_err)?;
+        Ok(updated == 1)
+    }
+
+    pub async fn remove_device(&self, device_code: &str) -> Result<(), AuthError> {
+        self.actor
+            .ask(DbExecute {
+                sql: "DELETE FROM device_auth WHERE device_code = ?".to_string(),
+                params: vec![crate::db::Value::from(device_code)],
+            })
+            .await
+            .map_err(Self::ask_err)?;
+        Ok(())
+    }
+
+    async fn delete_expired(&self, table: &str, now_ms: i64) -> Result<u64, AuthError> {
+        self.actor
+            .ask(DbExecute {
+                sql: format!("DELETE FROM {table} WHERE expires_at_ms <= ?"),
+                params: vec![crate::db::Value::from(now_ms)],
+            })
+            .await
+            .map_err(Self::ask_err)
+    }
+
+    async fn count_rows(&self, table: &str) -> Result<usize, AuthError> {
+        let row = self
+            .actor
+            .ask(DbQueryOne {
+                sql: format!("SELECT COUNT(*) FROM {table}"),
+                params: vec![],
+            })
+            .await
+            .map_err(Self::ask_err)?;
+
+        match row {
+            Some(values) => {
+                let value = row_value(&values, 0).map_err(|e| {
+                    AuthError::DatabaseError(format!("failed to get row count: {e}"))
+                })?;
+                match value {
+                    crate::db::Value::Integer(count) => Ok(usize::try_from(*count).unwrap_or(0)),
+                    other => Err(AuthError::DatabaseError(format!(
+                        "expected integer row count, got {other:?}"
+                    ))),
+                }
+            }
+            None => Ok(0),
+        }
+    }
+
+    /// Delete every entry whose validity window has passed. Used by the
+    /// auth-state janitor; any replica may run it since expiry is
+    /// derived from the stored `expires_at_ms`, not process state.
+    pub async fn sweep_expired(&self, now: DateTime<Utc>) -> Result<AuthSweepCounts, AuthError> {
+        let now_ms = now.timestamp_millis();
+        let pending_pruned = self.delete_expired("pending_auth", now_ms).await?;
+        let device_pruned = self.delete_expired("device_auth", now_ms).await?;
+        let xmpp_pruned = self.delete_expired("xmpp_auth_codes", now_ms).await?;
+        let counts = self.counts().await?;
+        Ok(AuthSweepCounts {
+            pending_pruned: usize::try_from(pending_pruned).unwrap_or(usize::MAX),
+            device_pruned: usize::try_from(device_pruned).unwrap_or(usize::MAX),
+            xmpp_pruned: usize::try_from(xmpp_pruned).unwrap_or(usize::MAX),
+            pending_remaining: counts.pending_auth,
+            device_remaining: counts.device_auth,
+            xmpp_remaining: counts.xmpp_auth_codes,
+        })
+    }
+
+    pub async fn counts(&self) -> Result<AuthHandshakeCounts, AuthError> {
+        Ok(AuthHandshakeCounts {
+            pending_auth: self.count_rows("pending_auth").await?,
+            device_auth: self.count_rows("device_auth").await?,
+            xmpp_auth_codes: self.count_rows("xmpp_auth_codes").await?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{actor::DbActor, Database, MigrationRunner};
+    use kameo::actor::Spawn;
+
+    async fn create_store(db_name: &str) -> AuthHandshakeStore {
+        let db = Database::in_memory(db_name).await.expect("in-memory db");
+        MigrationRunner::single()
+            .run(&db)
+            .await
+            .expect("migrations");
+        AuthHandshakeStore::new(DbActor::spawn(DbActor::new(db)))
+    }
+
+    fn make_pending(state: &str, created_minutes_ago: i64) -> PendingAuthorization {
+        PendingAuthorization {
+            state: state.to_string(),
+            provider_id: "p".to_string(),
+            nonce: "n".to_string(),
+            code_verifier: "cv".to_string(),
+            redirect_uri: "https://example.test/cb".to_string(),
+            client_id: "cid".to_string(),
+            client_secret: "secret".to_string(),
+            token_endpoint_auth_method: AuthProviderTokenEndpointAuthMethod::ClientSecretPost,
+            require_dpop: false,
+            flow: PendingFlow::Browser {
+                next: Some("/chat".to_string()),
+                session_transport: BrowserSessionTransport::Fragment,
+            },
+            created_at: Utc::now() - Duration::minutes(created_minutes_ago),
+        }
+    }
+
+    #[tokio::test]
+    async fn pending_round_trips_through_the_store() {
+        let store = create_store("handshake-pending-roundtrip").await;
+        let pending = make_pending("state-abc", 0);
+
+        store.insert_pending(&pending).await.expect("insert");
+        let loaded = store
+            .take_pending("state-abc")
+            .await
+            .expect("take")
+            .expect("entry exists");
+
+        assert_eq!(loaded.state, "state-abc");
+        assert_eq!(loaded.provider_id, "p");
+        assert_eq!(loaded.code_verifier, "cv");
+        assert_eq!(loaded.client_secret, "secret");
+        assert_eq!(
+            loaded.token_endpoint_auth_method,
+            AuthProviderTokenEndpointAuthMethod::ClientSecretPost
+        );
+        match loaded.flow {
+            PendingFlow::Browser {
+                next,
+                session_transport,
+            } => {
+                assert_eq!(next.as_deref(), Some("/chat"));
+                assert_eq!(session_transport, BrowserSessionTransport::Fragment);
+            }
+            other => panic!("expected browser flow, got {other:?}"),
+        }
+        assert_eq!(loaded.created_at, pending.created_at);
+    }
+
+    #[tokio::test]
+    async fn pending_take_is_single_use() {
+        let store = create_store("handshake-pending-single-use").await;
+        store
+            .insert_pending(&make_pending("state-once", 0))
+            .await
+            .expect("insert");
+
+        assert!(store
+            .take_pending("state-once")
+            .await
+            .expect("first take")
+            .is_some());
+        assert!(store
+            .take_pending("state-once")
+            .await
+            .expect("second take")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn pending_take_of_unknown_state_returns_none() {
+        let store = create_store("handshake-pending-unknown").await;
+        assert!(store
+            .take_pending("never-inserted")
+            .await
+            .expect("take")
+            .is_none());
+    }
+
+    fn make_xmpp_code(session_id: &str, created_minutes_ago: i64) -> XmppAuthCode {
+        XmppAuthCode {
+            session_id: session_id.to_string(),
+            redirect_uri: "waddle://auth/callback".to_string(),
+            code_challenge: Some("challenge".to_string()),
+            created_at: Utc::now() - Duration::minutes(created_minutes_ago),
+        }
+    }
+
+    #[tokio::test]
+    async fn xmpp_code_round_trips_and_is_single_use() {
+        let store = create_store("handshake-xmpp-roundtrip").await;
+        store
+            .insert_xmpp_code("code-1", &make_xmpp_code("session-9", 0))
+            .await
+            .expect("insert");
+
+        let loaded = store
+            .take_xmpp_code("code-1")
+            .await
+            .expect("take")
+            .expect("entry exists");
+        assert_eq!(loaded.session_id, "session-9");
+        assert_eq!(loaded.redirect_uri, "waddle://auth/callback");
+        assert_eq!(loaded.code_challenge.as_deref(), Some("challenge"));
+
+        assert!(store
+            .take_xmpp_code("code-1")
+            .await
+            .expect("second take")
+            .is_none());
+    }
+
+    fn make_device(code: &str, expires_minutes_from_now: i64) -> DeviceAuthorization {
+        DeviceAuthorization {
+            device_code: code.to_string(),
+            user_code: format!("USER-{code}"),
+            provider_id: "p".to_string(),
+            expires_at: Utc::now() + Duration::minutes(expires_minutes_from_now),
+            status: DeviceAuthStatus::Pending,
+            session_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn device_state_transitions_persist_across_lookups() {
+        let store = create_store("handshake-device-transitions").await;
+        let mut device = make_device("dev-1", 15);
+        store.insert_device(&device).await.expect("insert");
+
+        let by_user_code = store
+            .find_device_by_user_code("USER-dev-1")
+            .await
+            .expect("find")
+            .expect("entry exists");
+        assert_eq!(by_user_code.device_code, "dev-1");
+        assert_eq!(by_user_code.status, DeviceAuthStatus::Pending);
+
+        device.status = DeviceAuthStatus::Approved;
+        device.session_id = Some("session-42".to_string());
+        assert!(store.update_device(&device).await.expect("update"));
+
+        let reloaded = store
+            .get_device("dev-1")
+            .await
+            .expect("get")
+            .expect("entry exists");
+        assert_eq!(reloaded.status, DeviceAuthStatus::Approved);
+        assert_eq!(reloaded.session_id.as_deref(), Some("session-42"));
+
+        store.remove_device("dev-1").await.expect("remove");
+        assert!(store.get_device("dev-1").await.expect("get").is_none());
+        assert!(!store.update_device(&device).await.expect("update gone"));
+    }
+
+    #[tokio::test]
+    async fn sweep_removes_only_expired_entries() {
+        let store = create_store("handshake-sweep").await;
+
+        store
+            .insert_pending(&make_pending("fresh", 1))
+            .await
+            .expect("insert");
+        store
+            .insert_pending(&make_pending("stale", 30))
+            .await
+            .expect("insert");
+        store
+            .insert_device(&make_device("live", 5))
+            .await
+            .expect("insert");
+        store
+            .insert_device(&make_device("dead", -1))
+            .await
+            .expect("insert");
+        store
+            .insert_xmpp_code("fresh-code", &make_xmpp_code("s", 2))
+            .await
+            .expect("insert");
+        store
+            .insert_xmpp_code("stale-code", &make_xmpp_code("s", 20))
+            .await
+            .expect("insert");
+
+        let counts = store.sweep_expired(Utc::now()).await.expect("sweep");
+
+        assert_eq!(counts.pending_pruned, 1);
+        assert_eq!(counts.device_pruned, 1);
+        assert_eq!(counts.xmpp_pruned, 1);
+        assert_eq!(counts.pending_remaining, 1);
+        assert_eq!(counts.device_remaining, 1);
+        assert_eq!(counts.xmpp_remaining, 1);
+
+        assert!(store.take_pending("fresh").await.expect("take").is_some());
+        assert!(store.take_pending("stale").await.expect("take").is_none());
+        assert!(store.get_device("live").await.expect("get").is_some());
+        assert!(store.get_device("dead").await.expect("get").is_none());
+        assert!(store
+            .take_xmpp_code("fresh-code")
+            .await
+            .expect("take")
+            .is_some());
+        assert!(store
+            .take_xmpp_code("stale-code")
+            .await
+            .expect("take")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn two_stores_sharing_one_database_behave_like_two_pods() {
+        // Two `AuthHandshakeStore`s over the same database simulate two
+        // replicas behind the load balancer: pod A mints the state on
+        // /api/auth/start, pod B redeems it on /api/auth/callback.
+        let db = Database::in_memory("handshake-two-pods")
+            .await
+            .expect("in-memory db");
+        MigrationRunner::single()
+            .run(&db)
+            .await
+            .expect("migrations");
+        let pod_a = AuthHandshakeStore::new(DbActor::spawn(DbActor::new(db.clone())));
+        let pod_b = AuthHandshakeStore::new(DbActor::spawn(DbActor::new(db)));
+
+        pod_a
+            .insert_pending(&make_pending("cross-pod-state", 0))
+            .await
+            .expect("insert on pod A");
+
+        let redeemed = pod_b
+            .take_pending("cross-pod-state")
+            .await
+            .expect("take on pod B")
+            .expect("pod B sees the state pod A minted");
+        assert_eq!(redeemed.code_verifier, "cv");
+
+        // Single-use holds across pods too: pod A can no longer redeem.
+        assert!(pod_a
+            .take_pending("cross-pod-state")
+            .await
+            .expect("re-take on pod A")
+            .is_none());
+    }
+}

--- a/server/crates/waddle-server/src/server/routes/auth/handshake.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/handshake.rs
@@ -178,16 +178,29 @@ impl AuthHandshakeStore {
         .transpose()
     }
 
+    /// Wire value for the `device_auth.status` column. The column is
+    /// authoritative only for the anti-downgrade guard in
+    /// [`Self::update_device`]; readers decode the JSON payload.
+    fn device_status_str(status: &DeviceAuthStatus) -> &'static str {
+        match status {
+            DeviceAuthStatus::Pending => "pending",
+            DeviceAuthStatus::InProgress => "in_progress",
+            DeviceAuthStatus::Approved => "approved",
+        }
+    }
+
     pub async fn insert_device(&self, entry: &DeviceAuthorization) -> Result<(), AuthError> {
         let payload = Self::encode(entry)?;
         self.actor
             .ask(DbExecute {
-                sql: "INSERT INTO device_auth (device_code, user_code, payload, expires_at_ms) \
-                      VALUES (?, ?, ?, ?)"
+                sql: "INSERT INTO device_auth \
+                      (device_code, user_code, status, payload, expires_at_ms) \
+                      VALUES (?, ?, ?, ?, ?)"
                     .to_string(),
                 params: vec![
                     crate::db::Value::from(&entry.device_code),
                     crate::db::Value::from(&entry.user_code),
+                    crate::db::Value::from(Self::device_status_str(&entry.status)),
                     crate::db::Value::from(payload),
                     crate::db::Value::from(entry.expires_at.timestamp_millis()),
                 ],
@@ -225,18 +238,27 @@ impl AuthHandshakeStore {
 
     /// Persist a device-flow state transition (Pending → InProgress →
     /// Approved / session attach). Returns `false` when the row is gone
-    /// (expired-and-pruned or redeemed by another replica).
+    /// (expired-and-pruned or redeemed by another replica) or when the
+    /// write lost to an approval: a non-approved write can never
+    /// overwrite an `approved` row, so a delayed duplicate
+    /// verify-submit cannot clobber the callback's approval and wipe
+    /// its `session_id` (read-modify-write here holds no row lock
+    /// between replicas).
     pub async fn update_device(&self, entry: &DeviceAuthorization) -> Result<bool, AuthError> {
         let payload = Self::encode(entry)?;
+        let status = Self::device_status_str(&entry.status);
         let updated = self
             .actor
             .ask(DbExecute {
-                sql: "UPDATE device_auth SET payload = ?, expires_at_ms = ? WHERE device_code = ?"
+                sql: "UPDATE device_auth SET payload = ?, status = ?, expires_at_ms = ? \
+                      WHERE device_code = ? AND (status <> 'approved' OR ? = 'approved')"
                     .to_string(),
                 params: vec![
                     crate::db::Value::from(payload),
+                    crate::db::Value::from(status),
                     crate::db::Value::from(entry.expires_at.timestamp_millis()),
                     crate::db::Value::from(&entry.device_code),
+                    crate::db::Value::from(status),
                 ],
             })
             .await
@@ -489,6 +511,36 @@ mod tests {
         store.remove_device("dev-1").await.expect("remove");
         assert!(store.get_device("dev-1").await.expect("get").is_none());
         assert!(!store.update_device(&device).await.expect("update gone"));
+    }
+
+    #[tokio::test]
+    async fn stale_write_cannot_downgrade_an_approved_device() {
+        let store = create_store("handshake-device-no-downgrade").await;
+        let device = make_device("dev-race", 15);
+        store.insert_device(&device).await.expect("insert");
+
+        // Callback approves and attaches the session.
+        let mut approved = device.clone();
+        approved.status = DeviceAuthStatus::Approved;
+        approved.session_id = Some("session-77".to_string());
+        assert!(store.update_device(&approved).await.expect("approve"));
+
+        // A delayed duplicate verify-submit still holds the stale
+        // InProgress view and tries to write it back.
+        let mut stale = device.clone();
+        stale.status = DeviceAuthStatus::InProgress;
+        assert!(!store.update_device(&stale).await.expect("stale write"));
+
+        let reloaded = store
+            .get_device("dev-race")
+            .await
+            .expect("get")
+            .expect("entry exists");
+        assert_eq!(reloaded.status, DeviceAuthStatus::Approved);
+        assert_eq!(reloaded.session_id.as_deref(), Some("session-77"));
+
+        // Re-asserting the approval (idempotent write) still succeeds.
+        assert!(store.update_device(&approved).await.expect("re-approve"));
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/auth/handshake.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/handshake.rs
@@ -13,8 +13,7 @@
 
 use super::*;
 
-use crate::auth::AuthError;
-use crate::db::actor::{DbActor, DbExecute, DbQueryOne};
+use crate::db::actor::DbActor;
 use crate::db::{row_value, ValueExt};
 
 /// Per-sweep counts returned by [`AuthHandshakeStore::sweep_expired`].
@@ -189,13 +188,19 @@ impl AuthHandshakeStore {
         }
     }
 
-    pub async fn insert_device(&self, entry: &DeviceAuthorization) -> Result<(), AuthError> {
+    /// Returns `false` when the insert lost to a `device_code` /
+    /// `user_code` uniqueness conflict (`ON CONFLICT DO NOTHING`) —
+    /// the caller regenerates both codes and retries, which is what
+    /// guarantees a `user_code` maps to exactly one active grant.
+    pub async fn insert_device(&self, entry: &DeviceAuthorization) -> Result<bool, AuthError> {
         let payload = Self::encode(entry)?;
-        self.actor
+        let inserted = self
+            .actor
             .ask(DbExecute {
                 sql: "INSERT INTO device_auth \
                       (device_code, user_code, status, payload, expires_at_ms) \
-                      VALUES (?, ?, ?, ?, ?)"
+                      VALUES (?, ?, ?, ?, ?) \
+                      ON CONFLICT DO NOTHING"
                     .to_string(),
                 params: vec![
                     crate::db::Value::from(&entry.device_code),
@@ -207,7 +212,7 @@ impl AuthHandshakeStore {
             })
             .await
             .map_err(Self::ask_err)?;
-        Ok(())
+        Ok(inserted == 1)
     }
 
     pub async fn get_device(
@@ -237,13 +242,15 @@ impl AuthHandshakeStore {
     }
 
     /// Persist a device-flow state transition (Pending → InProgress →
-    /// Approved / session attach). Returns `false` when the row is gone
-    /// (expired-and-pruned or redeemed by another replica) or when the
-    /// write lost to an approval: a non-approved write can never
-    /// overwrite an `approved` row, so a delayed duplicate
-    /// verify-submit cannot clobber the callback's approval and wipe
-    /// its `session_id` (read-modify-write here holds no row lock
-    /// between replicas).
+    /// Approved / session attach). Returns `false` when the write did
+    /// not land, which happens when the row is gone (pruned or
+    /// redeemed by another replica), when the grant's validity window
+    /// has passed (an expired grant must not be approvable even if the
+    /// janitor hasn't pruned it yet), or when the write lost to an
+    /// approval: a non-approved write can never overwrite an
+    /// `approved` row, so a delayed duplicate verify-submit cannot
+    /// clobber the callback's approval and wipe its `session_id`
+    /// (read-modify-write here holds no row lock between replicas).
     pub async fn update_device(&self, entry: &DeviceAuthorization) -> Result<bool, AuthError> {
         let payload = Self::encode(entry)?;
         let status = Self::device_status_str(&entry.status);
@@ -251,7 +258,9 @@ impl AuthHandshakeStore {
             .actor
             .ask(DbExecute {
                 sql: "UPDATE device_auth SET payload = ?, status = ?, expires_at_ms = ? \
-                      WHERE device_code = ? AND (status <> 'approved' OR ? = 'approved')"
+                      WHERE device_code = ? \
+                        AND (status <> 'approved' OR ? = 'approved') \
+                        AND expires_at_ms > ?"
                     .to_string(),
                 params: vec![
                     crate::db::Value::from(payload),
@@ -259,6 +268,7 @@ impl AuthHandshakeStore {
                     crate::db::Value::from(entry.expires_at.timestamp_millis()),
                     crate::db::Value::from(&entry.device_code),
                     crate::db::Value::from(status),
+                    crate::db::Value::from(Utc::now().timestamp_millis()),
                 ],
             })
             .await
@@ -511,6 +521,43 @@ mod tests {
         store.remove_device("dev-1").await.expect("remove");
         assert!(store.get_device("dev-1").await.expect("get").is_none());
         assert!(!store.update_device(&device).await.expect("update gone"));
+    }
+
+    #[tokio::test]
+    async fn expired_device_grant_cannot_be_approved() {
+        let store = create_store("handshake-device-expired-approve").await;
+        let mut device = make_device("dev-late", -1);
+        assert!(store.insert_device(&device).await.expect("insert"));
+
+        device.status = DeviceAuthStatus::Approved;
+        device.session_id = Some("session-late".to_string());
+        assert!(
+            !store.update_device(&device).await.expect("update"),
+            "approval must not land on a grant past its validity window"
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_user_code_insert_is_rejected_not_silently_merged() {
+        let store = create_store("handshake-device-user-code-unique").await;
+        let first = make_device("dev-a", 15);
+        assert!(store.insert_device(&first).await.expect("insert"));
+
+        let mut clash = make_device("dev-b", 15);
+        clash.user_code = first.user_code.clone();
+        assert!(
+            !store.insert_device(&clash).await.expect("insert clash"),
+            "second grant with the same user_code must lose the insert"
+        );
+
+        // The surviving row is the first grant, so the verify page can
+        // never approve the wrong device.
+        let resolved = store
+            .find_device_by_user_code(&first.user_code)
+            .await
+            .expect("find")
+            .expect("entry exists");
+        assert_eq!(resolved.device_code, "dev-a");
     }
 
     #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/auth/state.rs
+++ b/server/crates/waddle-server/src/server/routes/auth/state.rs
@@ -29,9 +29,12 @@ pub struct AuthState {
     /// `WADDLE_XMPP_DOMAIN` value at runtime.
     pub caps_server_domain: crate::server::caps_resolution::ServerDomainJid,
     pub http_client: reqwest::Client,
-    pub pending_auth: Arc<DashMap<String, PendingAuthorization>>,
-    pub device_auth: Arc<DashMap<String, DeviceAuthorization>>,
-    pub xmpp_auth_codes: Arc<DashMap<String, XmppAuthCode>>,
+    /// Durable OIDC/OAuth handshake state (`pending_auth`,
+    /// `device_auth`, `xmpp_auth_codes`) shared across replicas via the
+    /// global database — see #1336. Never cache these entries in
+    /// process memory: the pod that mints a state/code is not
+    /// necessarily the pod that redeems it.
+    pub auth_handshake: AuthHandshakeStore,
     pub dynamic_oidc_clients: Arc<DashMap<String, oidc::DynamicClientRegistration>>,
     pub dynamic_oidc_client_locks: Arc<DashMap<String, Arc<Mutex<()>>>>,
     pub permission_actor: ActorRef<PermissionActor>,
@@ -72,9 +75,7 @@ impl AuthState {
             xmpp_domain,
             caps_server_domain,
             http_client: reqwest::Client::new(),
-            pending_auth: Arc::new(DashMap::new()),
-            device_auth: Arc::new(DashMap::new()),
-            xmpp_auth_codes: Arc::new(DashMap::new()),
+            auth_handshake: AuthHandshakeStore::new(app_state.db_pool.global_actor().clone()),
             dynamic_oidc_clients: Arc::new(DashMap::new()),
             dynamic_oidc_client_locks: Arc::new(DashMap::new()),
             permission_actor: app_state.permission_actor.clone(),
@@ -248,9 +249,8 @@ impl AuthState {
             qp.append_pair("nonce", &nonce);
         }
 
-        self.pending_auth.insert(
-            state.clone(),
-            PendingAuthorization {
+        self.auth_handshake
+            .insert_pending(&PendingAuthorization {
                 state,
                 provider_id: provider.id.clone(),
                 nonce,
@@ -262,8 +262,8 @@ impl AuthState {
                 require_dpop: provider.require_dpop,
                 flow,
                 created_at: Utc::now(),
-            },
-        );
+            })
+            .await?;
 
         Ok(url.to_string())
     }

--- a/server/crates/waddle-server/src/server/routes/device.rs
+++ b/server/crates/waddle-server/src/server/routes/device.rs
@@ -166,7 +166,13 @@ pub async fn device_start_handler(
     let user_code = auth.user_code.clone();
     let expires_in = (auth.expires_at - Utc::now()).num_seconds() as u32;
 
-    state.device_auth.insert(device_code.clone(), auth);
+    if let Err(err) = state.auth_handshake.insert_device(&auth).await {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new("server_error", &err.to_string())),
+        )
+            .into_response();
+    }
 
     let verification_uri = format!("{}/api/auth/device/verify", state.base_url);
 
@@ -189,9 +195,9 @@ pub async fn device_poll_handler(
     State(state): State<Arc<AuthState>>,
     Json(request): Json<DevicePollRequest>,
 ) -> impl IntoResponse {
-    let auth = match state.device_auth.get(&request.device_code) {
-        Some(v) => v.clone(),
-        None => {
+    let auth = match state.auth_handshake.get_device(&request.device_code).await {
+        Ok(Some(v)) => v,
+        Ok(None) => {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(
@@ -201,10 +207,23 @@ pub async fn device_poll_handler(
             )
                 .into_response();
         }
+        Err(err) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("server_error", &err.to_string())),
+            )
+                .into_response();
+        }
     };
 
     if auth.is_expired() {
-        state.device_auth.remove(&request.device_code);
+        if let Err(err) = state
+            .auth_handshake
+            .remove_device(&request.device_code)
+            .await
+        {
+            warn!(error = %err, "Failed to remove expired device authorization");
+        }
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse::new(
@@ -299,52 +318,43 @@ pub async fn device_verify_submit_handler(
 ) -> impl IntoResponse {
     let normalized = request.user_code.trim().to_uppercase();
 
-    let selected = state
-        .device_auth
-        .iter()
-        .find(|entry| entry.value().user_code == normalized)
-        .map(|entry| entry.key().clone());
-
-    let Some(device_code) = selected else {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse::new("invalid_user_code", "Invalid user code")),
-        )
-            .into_response();
-    };
-
+    let mut auth = match state
+        .auth_handshake
+        .find_device_by_user_code(&normalized)
+        .await
     {
-        let mut auth = match state.device_auth.get_mut(&device_code) {
-            Some(v) => v,
-            None => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorResponse::new(
-                        "invalid_device_code",
-                        "Device code no longer exists",
-                    )),
-                )
-                    .into_response();
-            }
-        };
-
-        if auth.is_expired() {
+        Ok(Some(v)) => v,
+        Ok(None) => {
             return (
                 StatusCode::BAD_REQUEST,
-                Json(ErrorResponse::new(
-                    "expired_token",
-                    "Device code has expired",
-                )),
+                Json(ErrorResponse::new("invalid_user_code", "Invalid user code")),
             )
                 .into_response();
         }
+        Err(err) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("server_error", &err.to_string())),
+            )
+                .into_response();
+        }
+    };
 
-        auth.status = DeviceAuthStatus::InProgress;
+    if auth.is_expired() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse::new(
+                "expired_token",
+                "Device code has expired",
+            )),
+        )
+            .into_response();
     }
 
-    let provider_id = match state.device_auth.get(&device_code) {
-        Some(v) => v.provider_id.clone(),
-        None => {
+    auth.status = DeviceAuthStatus::InProgress;
+    match state.auth_handshake.update_device(&auth).await {
+        Ok(true) => {}
+        Ok(false) => {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(
@@ -354,7 +364,17 @@ pub async fn device_verify_submit_handler(
             )
                 .into_response();
         }
-    };
+        Err(err) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("server_error", &err.to_string())),
+            )
+                .into_response();
+        }
+    }
+
+    let device_code = auth.device_code.clone();
+    let provider_id = auth.provider_id.clone();
 
     let provider = match state.providers.get(&provider_id) {
         Some(v) => v,

--- a/server/crates/waddle-server/src/server/routes/device.rs
+++ b/server/crates/waddle-server/src/server/routes/device.rs
@@ -153,26 +153,52 @@ pub async fn device_start_handler(
             .into_response();
     }
 
-    let auth = DeviceAuthorization {
-        device_code: generate_device_code(),
-        user_code: generate_user_code(),
-        provider_id: request.provider,
-        expires_at: Utc::now() + Duration::minutes(15),
-        status: DeviceAuthStatus::Pending,
-        session_id: None,
+    // `user_code` is unique in the store; regenerate both codes on a
+    // collision with another active grant (the insert is ON CONFLICT
+    // DO NOTHING, so a loss is reported as `false`, not an error).
+    const INSERT_ATTEMPTS: usize = 5;
+    let mut auth = None;
+    for _ in 0..INSERT_ATTEMPTS {
+        let candidate = DeviceAuthorization {
+            device_code: generate_device_code(),
+            user_code: generate_user_code(),
+            provider_id: request.provider.clone(),
+            expires_at: Utc::now() + Duration::minutes(15),
+            status: DeviceAuthStatus::Pending,
+            session_id: None,
+        };
+
+        match state.auth_handshake.insert_device(&candidate).await {
+            Ok(true) => {
+                auth = Some(candidate);
+                break;
+            }
+            Ok(false) => continue,
+            Err(err) => {
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorResponse::new("server_error", &err.to_string())),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    let Some(auth) = auth else {
+        warn!("Device flow could not allocate a unique user_code after retries");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse::new(
+                "server_error",
+                "Could not allocate a device code; try again",
+            )),
+        )
+            .into_response();
     };
 
     let device_code = auth.device_code.clone();
     let user_code = auth.user_code.clone();
     let expires_in = (auth.expires_at - Utc::now()).num_seconds() as u32;
-
-    if let Err(err) = state.auth_handshake.insert_device(&auth).await {
-        return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse::new("server_error", &err.to_string())),
-        )
-            .into_response();
-    }
 
     let verification_uri = format!("{}/api/auth/device/verify", state.base_url);
 

--- a/server/crates/waddle-server/src/server/routes/xmpp_oauth.rs
+++ b/server/crates/waddle-server/src/server/routes/xmpp_oauth.rs
@@ -189,15 +189,22 @@ pub async fn xmpp_token_handler(
             .into_response();
     }
 
-    let code = match state.xmpp_auth_codes.remove(&request.code) {
-        Some((_, code)) => code,
-        None => {
+    let code = match state.auth_handshake.take_xmpp_code(&request.code).await {
+        Ok(Some(code)) => code,
+        Ok(None) => {
             return (
                 StatusCode::BAD_REQUEST,
                 Json(ErrorResponse::new(
                     "invalid_grant",
                     "Invalid or expired code",
                 )),
+            )
+                .into_response();
+        }
+        Err(err) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse::new("server_error", &err.to_string())),
             )
                 .into_response();
         }

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -2051,69 +2051,17 @@ pub(crate) fn spawn_graceful_shutdown_drain(
     });
 }
 
-/// Per-sweep counts returned by [`sweep_auth_state_once`]. Exposed for
-/// the unit tests that exercise the sweep without the live tokio
-/// ticker.
-#[derive(Debug, Default, PartialEq, Eq)]
-pub(crate) struct AuthSweepCounts {
-    pub pending_pruned: usize,
-    pub device_pruned: usize,
-    pub xmpp_pruned: usize,
-    pub pending_remaining: usize,
-    pub device_remaining: usize,
-    pub xmpp_remaining: usize,
-}
-
-/// Walk the three auth-state DashMaps and remove every entry whose
-/// `is_expired()` reports `true`. Pure helper so the long-running
-/// janitor in [`spawn_auth_state_janitor`] and the unit tests share
-/// the same eviction logic.
-pub(crate) fn sweep_auth_state_once(
-    pending_auth: &dashmap::DashMap<String, crate::server::routes::auth::PendingAuthorization>,
-    device_auth: &dashmap::DashMap<String, crate::server::routes::auth::DeviceAuthorization>,
-    xmpp_auth_codes: &dashmap::DashMap<String, crate::server::routes::auth::XmppAuthCode>,
-) -> AuthSweepCounts {
-    let mut counts = AuthSweepCounts::default();
-    pending_auth.retain(|_, entry| {
-        if entry.is_expired() {
-            counts.pending_pruned += 1;
-            false
-        } else {
-            true
-        }
-    });
-    device_auth.retain(|_, entry| {
-        if entry.is_expired() {
-            counts.device_pruned += 1;
-            false
-        } else {
-            true
-        }
-    });
-    xmpp_auth_codes.retain(|_, entry| {
-        if entry.is_expired() {
-            counts.xmpp_pruned += 1;
-            false
-        } else {
-            true
-        }
-    });
-    counts.pending_remaining = pending_auth.len();
-    counts.device_remaining = device_auth.len();
-    counts.xmpp_remaining = xmpp_auth_codes.len();
-    counts
-}
-
-/// Sweep expired entries from the auth-state DashMaps (`pending_auth`,
-/// `device_auth`, `xmpp_auth_codes`).
+/// Sweep expired entries from the durable auth handshake tables
+/// (`pending_auth`, `device_auth`, `xmpp_auth_codes`).
 ///
-/// These maps grow on every started OAuth / device / XMPP-OAuth flow
+/// These tables grow on every started OAuth / device / XMPP-OAuth flow
 /// and are removed only on the success path. Abandoned flows (network
-/// flake, tab close, user typo) leave entries behind. Each carries an
-/// `is_expired()` and the OAuth specs already bound the validity
-/// window (10 minutes for `PendingAuthorization` / `XmppAuthCode`,
-/// `device_auth.expires_at` for `DeviceAuthorization`), so the
-/// janitor just consults that and removes anything past its window.
+/// flake, tab close, user typo) leave entries behind. The OAuth specs
+/// already bound the validity window (10 minutes for
+/// `PendingAuthorization` / `XmppAuthCode`, `device_auth.expires_at`
+/// for `DeviceAuthorization`); each row carries that deadline as
+/// `expires_at_ms`, so the sweep is a plain SQL delete and any replica
+/// may run it (see `AuthHandshakeStore::sweep_expired`).
 ///
 /// Runs on a 60 s ticker. Skips the first immediate tick so a fresh
 /// process doesn't sweep before any auth flow has started.
@@ -2127,9 +2075,19 @@ pub(crate) fn spawn_auth_state_janitor(websocket_state: &Arc<WebSocketState>) {
             let Some(state) = weak_state.upgrade() else {
                 break;
             };
-            let auth = &state.deps.auth_state;
-            let counts =
-                sweep_auth_state_once(&auth.pending_auth, &auth.device_auth, &auth.xmpp_auth_codes);
+            let counts = match state
+                .deps
+                .auth_state
+                .auth_handshake
+                .sweep_expired(chrono::Utc::now())
+                .await
+            {
+                Ok(counts) => counts,
+                Err(error) => {
+                    warn!(error = %error, "auth janitor: sweep failed; will retry next tick");
+                    continue;
+                }
+            };
             let total = counts.pending_pruned + counts.device_pruned + counts.xmpp_pruned;
             if total > 0 {
                 info!(
@@ -2433,109 +2391,6 @@ pub(crate) fn spawn_user_actor_reaper(websocket_state: &Arc<WebSocketState>) {
             }
         }
     });
-}
-
-#[cfg(test)]
-mod auth_janitor_tests {
-    use super::sweep_auth_state_once;
-    use crate::auth::providers::AuthProviderTokenEndpointAuthMethod;
-    use crate::server::routes::auth::{
-        BrowserSessionTransport, DeviceAuthStatus, DeviceAuthorization, PendingAuthorization,
-        PendingFlow, XmppAuthCode,
-    };
-    use chrono::{Duration, Utc};
-    use dashmap::DashMap;
-
-    fn make_pending(state: &str, created_minutes_ago: i64) -> PendingAuthorization {
-        PendingAuthorization {
-            state: state.to_string(),
-            provider_id: "p".to_string(),
-            nonce: "n".to_string(),
-            code_verifier: "cv".to_string(),
-            redirect_uri: "https://example.test/cb".to_string(),
-            client_id: "cid".to_string(),
-            client_secret: String::new(),
-            token_endpoint_auth_method: AuthProviderTokenEndpointAuthMethod::NoAuthentication,
-            require_dpop: false,
-            flow: PendingFlow::Browser {
-                next: None,
-                session_transport: BrowserSessionTransport::Cookie,
-            },
-            created_at: Utc::now() - Duration::minutes(created_minutes_ago),
-        }
-    }
-
-    fn make_device(code: &str, expires_minutes_from_now: i64) -> DeviceAuthorization {
-        DeviceAuthorization {
-            device_code: code.to_string(),
-            user_code: "user".to_string(),
-            provider_id: "p".to_string(),
-            expires_at: Utc::now() + Duration::minutes(expires_minutes_from_now),
-            status: DeviceAuthStatus::Pending,
-            session_id: None,
-        }
-    }
-
-    fn make_xmpp_code(session_id: &str, created_minutes_ago: i64) -> XmppAuthCode {
-        XmppAuthCode {
-            session_id: session_id.to_string(),
-            redirect_uri: "xmpp://example.test/cb".to_string(),
-            code_challenge: None,
-            created_at: Utc::now() - Duration::minutes(created_minutes_ago),
-        }
-    }
-
-    #[test]
-    fn sweep_removes_only_expired_entries() {
-        let pending: DashMap<String, PendingAuthorization> = DashMap::new();
-        // PendingAuthorization expires 10 minutes after creation.
-        pending.insert("fresh".to_string(), make_pending("fresh", 1));
-        pending.insert("stale".to_string(), make_pending("stale", 30));
-
-        let device: DashMap<String, DeviceAuthorization> = DashMap::new();
-        device.insert("live".to_string(), make_device("live", 5));
-        device.insert("dead".to_string(), make_device("dead", -1));
-
-        let xmpp: DashMap<String, XmppAuthCode> = DashMap::new();
-        // XmppAuthCode expires 10 minutes after creation.
-        xmpp.insert("fresh".to_string(), make_xmpp_code("fresh", 2));
-        xmpp.insert("stale".to_string(), make_xmpp_code("stale", 20));
-
-        let counts = sweep_auth_state_once(&pending, &device, &xmpp);
-
-        assert_eq!(counts.pending_pruned, 1);
-        assert_eq!(counts.device_pruned, 1);
-        assert_eq!(counts.xmpp_pruned, 1);
-        assert_eq!(counts.pending_remaining, 1);
-        assert_eq!(counts.device_remaining, 1);
-        assert_eq!(counts.xmpp_remaining, 1);
-
-        assert!(pending.contains_key("fresh"));
-        assert!(!pending.contains_key("stale"));
-        assert!(device.contains_key("live"));
-        assert!(!device.contains_key("dead"));
-        assert!(xmpp.contains_key("fresh"));
-        assert!(!xmpp.contains_key("stale"));
-    }
-
-    #[test]
-    fn sweep_is_noop_when_all_entries_are_fresh() {
-        let pending: DashMap<String, PendingAuthorization> = DashMap::new();
-        pending.insert("a".to_string(), make_pending("a", 0));
-        let device: DashMap<String, DeviceAuthorization> = DashMap::new();
-        device.insert("b".to_string(), make_device("b", 30));
-        let xmpp: DashMap<String, XmppAuthCode> = DashMap::new();
-        xmpp.insert("c".to_string(), make_xmpp_code("c", 0));
-
-        let counts = sweep_auth_state_once(&pending, &device, &xmpp);
-
-        assert_eq!(counts.pending_pruned, 0);
-        assert_eq!(counts.device_pruned, 0);
-        assert_eq!(counts.xmpp_pruned, 0);
-        assert_eq!(counts.pending_remaining, 1);
-        assert_eq!(counts.device_remaining, 1);
-        assert_eq!(counts.xmpp_remaining, 1);
-    }
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-server/src/server/state_inventory.rs
+++ b/server/crates/waddle-server/src/server/state_inventory.rs
@@ -128,11 +128,23 @@ pub async fn collect_snapshot(ws: &WebSocketState) -> StateInventorySnapshot {
         }
     }
 
+    // Handshake entries live in the shared database (#1336), so the
+    // counts are DB-wide rather than per-process; a query failure is
+    // reported as zeros rather than dropping the whole snapshot.
+    let handshake_counts = auth_state
+        .auth_handshake
+        .counts()
+        .await
+        .unwrap_or_else(|error| {
+            tracing::warn!(error = %error, "state inventory: auth handshake counts unavailable");
+            Default::default()
+        });
+
     StateInventorySnapshot {
         auth: AuthInventory {
-            pending_auth: auth_state.pending_auth.len(),
-            device_auth: auth_state.device_auth.len(),
-            xmpp_auth_codes: auth_state.xmpp_auth_codes.len(),
+            pending_auth: handshake_counts.pending_auth,
+            device_auth: handshake_counts.device_auth,
+            xmpp_auth_codes: handshake_counts.xmpp_auth_codes,
             dynamic_oidc_clients: auth_state.dynamic_oidc_clients.len(),
             dynamic_oidc_client_locks: auth_state.dynamic_oidc_client_locks.len(),
         },


### PR DESCRIPTION
Fixes #1336.

## Problem

OIDC login failed ~50% of the time in prod with `{"error":"invalid_state"}`: the whole auth handshake state (`pending_auth`, `xmpp_auth_codes`, `device_auth`) lived in per-process `DashMap`s, but prod runs 2 waddle-server replicas. `/api/auth/start` mints the `state` on pod A; the IdP callback lands on pod B, which has never seen it. Grafana confirmed the signature: both pods repeatedly pruning orphaned `pending_auth` entries (`pending_auth_pruned=1`) — states minted but never redeemed. The same defect broke the XMPP client token exchange (`xmpp_auth_codes`) and the device flow (`device_auth`), and made every login straddling a deploy fail.

## Fix

Move the handshake state into the shared global database so any replica can serve the callback / token / device endpoints:

- **Migration v9 (global):** `pending_auth`, `device_auth`, `xmpp_auth_codes` tables — key column, JSON payload, `expires_at_ms` (epoch millis) for SQL pruning; sqlite + postgres variants. `device_auth` also carries an indexed `user_code` column for the verify-page lookup.
- **`AuthHandshakeStore`** (`server/routes/auth/handshake.rs`, over `DbActor` like `SessionManager`):
  - `take_pending` / `take_xmpp_code` are **single-use across replicas**: SELECT, then `DELETE` gated on rows-affected — exactly one racer wins, no driver-specific `RETURNING` needed.
  - `insert_device` / `get_device` / `find_device_by_user_code` / `update_device` / `remove_device` persist device-flow transitions (Pending → InProgress → Approved) so poll and approve can hit different pods.
  - `sweep_expired` gives the auth janitor a SQL prune; `counts()` feeds the state-inventory metrics (now DB-wide `COUNT(*)` instead of per-process map sizes).
- **Wired through** `start_authorization`, the OIDC callback, `/api/auth/token` (XMPP), the device routes, the auth-state janitor, and the state inventory. The 10-minute validity windows and `is_expired()` read-time checks are unchanged.

Left in-memory on purpose: `dynamic_oidc_clients` — a per-pod cache; `PendingAuthorization` carries the resolved client credentials to the callback pod, so a miss only costs a re-registration.

## Tests

- Store round-trips for all three entry kinds (flow enum, PKCE verifier, client secret survive the DB round-trip).
- Single-use redemption (second `take` → `None`; unknown key → `None`).
- Device state transitions persist across lookups; `update_device` returns `false` once the row is gone.
- Janitor sweep removes only expired rows and reports pruned/remaining counts.
- **Two-pods test:** two `AuthHandshakeStore`s over one database — the state minted by "pod A" is redeemed by "pod B", and single-use holds across both.
- Migration version-list assertions updated for v9 (sqlite + postgres).

## Adversarial review rounds

Four independent reviewers (3 personas + gpt-5.5/codex) attacked the diff; confirmed sound: cross-pod single-use arbitration via the DB row (Postgres row lock / SQLite single-writer), `?`→`$N` placeholder rewriting, i64 epoch-millis bindings, migration ordering across all deployment shapes, no DB-failure→auth-bypass path, and no secrets-hashing regression (handshake values must be replayed to the IdP, so they cannot be hashed like session tokens).

Actionable findings fixed in follow-up commits:
- **v9 made idempotent** (`IF NOT EXISTS`): the migration runner has no cross-node lock, so concurrent replica startup could race the DDL. Runner-level advisory locking filed as #1338.
- **Device-auth anti-downgrade guard:** `update_device` now writes an authoritative `status` column and refuses to overwrite an `approved` row with a non-approved write, so a delayed duplicate verify-submit can't clobber the callback's approval and wipe `session_id`.
- **Callback no longer lies on a lost device grant:** if the device row vanished (expired + pruned) mid-callback, the freshly created session is rolled back and an expiry error is returned instead of "Device authorized" with a poller stranded forever.

Assessed non-blocking, filed as optional hardening: encrypting persisted handshake payloads at rest (#1339).

Bot-review round (Qodo/Greptile/Codex, all fixed in `861b17ab`): expired device grants can no longer be approved (`is_expired` check + SQL time gate on `update_device`); the XMPP branch rolls back its session when the code insert fails; `user_code` is now UNIQUE with a regenerate-and-retry insert so the verify page can never bind to the wrong grant; `_migrations` recording is `ON CONFLICT DO NOTHING` so concurrent replica boot can't crash-loop on the duplicate version row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
