### PR TITLE
fix(server): bump helm chart to 0.4.1 to publish publicWebsocketUrl template

### DIFF
--- a/server/charts/waddle-server/Chart.yaml
+++ b/server/charts/waddle-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: waddle-server
 description: Helm chart for deploying Waddle Social server to Kubernetes.
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "0.1.0"
 # ADR-0017 Phase 0: the graceful-shutdown preStop hook uses the native Sleep
 # lifecycle action (`lifecycle.preStop.sleep`), which is GA in Kubernetes 1.32


### PR DESCRIPTION
## Problem

Since the 2026-07-13 19:33 UTC deploy, fresh logins get no presence and no channels. OIDC login succeeds, but the client immediately loops on `stream-transport-error: websocket transport error` and no `/ws` upgrade ever reaches the pods.

## Root cause

PR #1333 changed `AuthState::websocket_url()` to source the advertised RFC 7395 endpoint from `WADDLE_XMPP_PUBLIC_WEBSOCKET_URL`, with a deliberate fail-closed fallback of `ws://{domain}/ws`. The same PR added the `publicWebsocketUrl` value to the HelmRelease and the configmap template — but did **not** bump the chart version, so the 0.4.1-content chart was never republished and Flux kept rendering the old 0.4.0 template. The live configmap therefore has no `WADDLE_XMPP_PUBLIC_WEBSOCKET_URL`, and `/api/auth/session` returned:

```json
"xmpp_websocket_url": "ws://waddle.social/ws"
```

Browsers on `https://waddle.chat` reject plaintext `ws://` as mixed content, so the XMPP WebSocket never connects — no presence, no channels.

## Fix

Bump the chart to 0.4.1 so helmPush publishes the template that renders `WADDLE_XMPP_PUBLIC_WEBSOCKET_URL` from `.Values.xmpp.publicWebsocketUrl` (already set to `wss://xmpp.waddle.social/ws` in the HelmRelease).

Production was hot-patched with the same configmap key to restore service immediately; this PR makes the rendered state match GitOps.

## Verification plan

- CI green
- After merge + Flux reconcile: `kubectl -n waddle get cm waddle-server-config -o jsonpath='{.data.WADDLE_XMPP_PUBLIC_WEBSOCKET_URL}'` returns `wss://xmpp.waddle.social/ws`
- `/api/auth/session` returns the `wss://` URL; login shows presence and channels

🤖 Generated with [Claude Code](https://claude.com/claude-code)
