### PR TITLE
fix(xmpp): publish restored rooms only under current ownership

### DIFF
--- a/server/crates/waddle-server/src/clustering/local_claims.rs
+++ b/server/crates/waddle-server/src/clustering/local_claims.rs
@@ -1660,6 +1660,14 @@ mod tests {
             Box::pin(async { Ok(None) })
         }
 
+        fn load_room_state_fenced<'a>(
+            &'a self,
+            room_jid: &'a jid::BareJid,
+        ) -> waddle_xmpp::muc::MucDurableFuture<'a, Option<waddle_xmpp::muc::DurableRoomState>>
+        {
+            self.load_room_state(room_jid)
+        }
+
         fn save_config<'a>(
             &'a self,
             _room_jid: &'a jid::BareJid,

--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -273,6 +273,81 @@ impl PostgresMucRoomStore {
             )))
         }
     }
+
+    async fn load_room_state_in_tx(
+        tx: &mut Transaction<'_>,
+        room_jid: &BareJid,
+    ) -> Result<Option<DurableRoomState>, XmppError> {
+        let mut room_rows = tx
+            .query(
+                "SELECT waddle_id, channel_id, config_json, subject_json FROM \
+                 clustering_muc_rooms WHERE room_jid = ?",
+                crate::db_params![room_jid.to_string()],
+            )
+            .await
+            .map_err(db_err)?;
+        let Some(row) = room_rows.next().await.map_err(db_err)? else {
+            return Ok(None);
+        };
+        let waddle_id: String = row.get(0).map_err(db_err)?;
+        let channel_id: String = row.get(1).map_err(db_err)?;
+        let config_json: String = row.get(2).map_err(db_err)?;
+        let subject_json: Option<String> = row.get(3).map_err(db_err)?;
+        let config: RoomConfig = serde_json::from_str(&config_json).map_err(|error| {
+            XmppError::internal(format!("durable room config decode failed: {error}"))
+        })?;
+        let subject: Option<SubjectState> = subject_json
+            .map(|json| serde_json::from_str(&json))
+            .transpose()
+            .map_err(|error| {
+                XmppError::internal(format!("durable room subject decode failed: {error}"))
+            })?;
+
+        let mut affiliation_rows = tx
+            .query(
+                "SELECT member_jid, affiliation, reason FROM \
+                 clustering_muc_room_affiliations WHERE room_jid = ?",
+                crate::db_params![room_jid.to_string()],
+            )
+            .await
+            .map_err(db_err)?;
+        let mut affiliations = Vec::new();
+        while let Some(row) = affiliation_rows.next().await.map_err(db_err)? {
+            let member_jid: String = row.get(0).map_err(db_err)?;
+            let affiliation_str: String = row.get(1).map_err(db_err)?;
+            let reason: Option<String> = row.get(2).map_err(db_err)?;
+            let Ok(jid) = member_jid.parse::<BareJid>() else {
+                tracing::warn!(
+                    room = %room_jid,
+                    member_jid,
+                    "durable affiliation row has an unparseable member JID; skipping"
+                );
+                continue;
+            };
+            let Some(affiliation) = affiliation_from_db_str(&affiliation_str) else {
+                tracing::warn!(
+                    room = %room_jid,
+                    affiliation = affiliation_str,
+                    "durable affiliation row has an unrecognized affiliation tag; skipping"
+                );
+                continue;
+            };
+            affiliations.push(AffiliationEntry {
+                jid,
+                affiliation,
+                granted_at: None,
+                reason,
+            });
+        }
+
+        Ok(Some(DurableRoomState {
+            waddle_id,
+            channel_id,
+            config,
+            subject,
+            affiliations,
+        }))
+    }
 }
 
 impl MucDurableStore for PostgresMucRoomStore {
@@ -281,76 +356,34 @@ impl MucDurableStore for PostgresMucRoomStore {
         room_jid: &'a BareJid,
     ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
         Box::pin(async move {
-            let conn = self.db.guard().await.map_err(db_err)?;
-            let mut room_rows = conn
-                .query(
-                    "SELECT waddle_id, channel_id, config_json, subject_json FROM \
-                     clustering_muc_rooms WHERE room_jid = ?",
-                    crate::db_params![room_jid.to_string()],
-                )
+            let mut tx = self.db.begin().await.map_err(db_err)?;
+            tx.execute(
+                "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
+                (),
+            )
+            .await
+            .map_err(db_err)?;
+            let state = Self::load_room_state_in_tx(&mut tx, room_jid).await?;
+            tx.commit().await.map_err(db_err)?;
+            Ok(state)
+        })
+    }
+
+    fn load_room_state_fenced<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+    ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+        Box::pin(async move {
+            let fence = self.fence_for(room_jid)?;
+            let _identity_guard = self.guard_fence_identity(room_jid, &fence).await?;
+            let mut tx = self.db.begin().await.map_err(db_err)?;
+            tx.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ", ())
                 .await
                 .map_err(db_err)?;
-            let Some(row) = room_rows.next().await.map_err(db_err)? else {
-                return Ok(None);
-            };
-            let waddle_id: String = row.get(0).map_err(db_err)?;
-            let channel_id: String = row.get(1).map_err(db_err)?;
-            let config_json: String = row.get(2).map_err(db_err)?;
-            let subject_json: Option<String> = row.get(3).map_err(db_err)?;
-            let config: RoomConfig = serde_json::from_str(&config_json).map_err(|error| {
-                XmppError::internal(format!("durable room config decode failed: {error}"))
-            })?;
-            let subject: Option<SubjectState> = subject_json
-                .map(|json| serde_json::from_str(&json))
-                .transpose()
-                .map_err(|error| {
-                    XmppError::internal(format!("durable room subject decode failed: {error}"))
-                })?;
-
-            let mut affiliation_rows = conn
-                .query(
-                    "SELECT member_jid, affiliation, reason FROM \
-                     clustering_muc_room_affiliations WHERE room_jid = ?",
-                    crate::db_params![room_jid.to_string()],
-                )
-                .await
-                .map_err(db_err)?;
-            let mut affiliations = Vec::new();
-            while let Some(row) = affiliation_rows.next().await.map_err(db_err)? {
-                let member_jid: String = row.get(0).map_err(db_err)?;
-                let affiliation_str: String = row.get(1).map_err(db_err)?;
-                let reason: Option<String> = row.get(2).map_err(db_err)?;
-                let Ok(jid) = member_jid.parse::<BareJid>() else {
-                    tracing::warn!(
-                        room = %room_jid,
-                        member_jid,
-                        "durable affiliation row has an unparseable member JID; skipping"
-                    );
-                    continue;
-                };
-                let Some(affiliation) = affiliation_from_db_str(&affiliation_str) else {
-                    tracing::warn!(
-                        room = %room_jid,
-                        affiliation = affiliation_str,
-                        "durable affiliation row has an unrecognized affiliation tag; skipping"
-                    );
-                    continue;
-                };
-                affiliations.push(AffiliationEntry {
-                    jid,
-                    affiliation,
-                    granted_at: None,
-                    reason,
-                });
-            }
-
-            Ok(Some(DurableRoomState {
-                waddle_id,
-                channel_id,
-                config,
-                subject,
-                affiliations,
-            }))
+            self.assert_fenced(&mut tx, room_jid, &fence).await?;
+            let state = Self::load_room_state_in_tx(&mut tx, room_jid).await?;
+            tx.commit().await.map_err(db_err)?;
+            Ok(state)
         })
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -1215,16 +1215,26 @@ pub(crate) async fn get_room_actor(
     state: &WebSocketState,
     room_jid: &BareJid,
 ) -> Option<ActorRef<RoomActor>> {
-    match RoomRegistry::wrap(state.deps.protocol.room_registry.clone())
-        .get_room(room_jid.clone())
-        .await
-    {
+    match get_room_actor_result(state, room_jid).await {
         Ok(actor) => actor,
         Err(error) => {
             warn!(room = %room_jid, error = %error, "Failed to get room actor");
             None
         }
     }
+}
+
+/// Typed room lookup for protocol paths where an unpublished restore is not
+/// equivalent to an absent room. Callers must map reconciliation to a
+/// wait-class response or coalesce through `GetOrCreateRoom`; they must never
+/// run room-creation authorization based on that transient state.
+pub(crate) async fn get_room_actor_result(
+    state: &WebSocketState,
+    room_jid: &BareJid,
+) -> Result<Option<ActorRef<RoomActor>>, RoomRegistryError> {
+    RoomRegistry::wrap(state.deps.protocol.room_registry.clone())
+        .get_room(room_jid.clone())
+        .await
 }
 
 /// Get or create the room via the registry. The returned

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/mod.rs
@@ -205,8 +205,8 @@ use vcard_private::{handle_private_storage_iq, handle_vcard_iq};
 pub(super) use super::super::{build_iq_error_xml_typed, build_iq_error_xml_with_payload};
 
 use super::super::{
-    build_iq_result_xml, element_to_xml, get_room_actor, iq_to_xml, is_muc_room_jid, stanza_to_xml,
-    WebSocketState,
+    build_iq_result_xml, element_to_xml, get_room_actor, get_room_actor_result, iq_to_xml,
+    is_muc_room_jid, stanza_to_xml, WebSocketState,
 };
 use super::presence::{
     get_managed_channel_for_room, resolve_muc_room_archive_access,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_admin.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_admin.rs
@@ -163,13 +163,25 @@ pub(super) async fn handle_muc_admin_iq(
         Ok(query) => query,
         Err(error) => return vec![build_xmpp_error_response(&iq_with_from, error)],
     };
-    let Some(room_actor) = get_room_actor(state, &query.room_jid).await else {
-        return vec![build_iq_error_xml_typed(
-            iq.id(),
-            response_from,
-            response_to,
-            item_not_found_iq_error("Requested item not found."),
-        )];
+    let room_actor = match get_room_actor_result(state, &query.room_jid).await {
+        Ok(Some(room_actor)) => room_actor,
+        Ok(None) => {
+            return vec![build_iq_error_xml_typed(
+                iq.id(),
+                response_from,
+                response_to,
+                item_not_found_iq_error("Requested item not found."),
+            )];
+        }
+        Err(error) => {
+            warn!(room = %query.room_jid, %error, "MUC admin room lookup failed");
+            return vec![build_iq_error_xml_typed(
+                iq.id(),
+                response_from,
+                response_to,
+                internal_server_error_iq_error("Internal server error."),
+            )];
+        }
     };
     let _config_guard = if query.is_get {
         None

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
@@ -264,13 +264,25 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
             // alongside the IQ result so it lands on the same socket;
             // others are routed via the connection registry.
             let destroy_request = parse_destroy_request(iq).unwrap_or_default();
-            let Some(room_actor) = get_room_actor(state, &room_jid).await else {
-                return vec![build_iq_error_xml_typed(
-                    id,
-                    response_from,
-                    response_to,
-                    item_not_found_iq_error("Requested item not found."),
-                )];
+            let room_actor = match get_room_actor_result(state, &room_jid).await {
+                Ok(Some(room_actor)) => room_actor,
+                Ok(None) => {
+                    return vec![build_iq_error_xml_typed(
+                        id,
+                        response_from,
+                        response_to,
+                        item_not_found_iq_error("Requested item not found."),
+                    )];
+                }
+                Err(error) => {
+                    warn!(room = %room_jid, %error, "MUC destroy room lookup failed");
+                    return vec![build_iq_error_xml_typed(
+                        id,
+                        response_from,
+                        response_to,
+                        internal_server_error_iq_error("Internal server error."),
+                    )];
+                }
             };
             let Ok(snapshot) = room_actor.ask(GetSnapshot).await else {
                 return vec![build_iq_error_xml_typed(
@@ -483,13 +495,25 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                 bad_request_iq_error("Malformed IQ payload."),
             )];
         };
-        let Some(room_actor) = get_room_actor(state, &room_jid).await else {
-            return vec![build_iq_error_xml_typed(
-                id,
-                response_from,
-                response_to,
-                item_not_found_iq_error("Requested item not found."),
-            )];
+        let room_actor = match get_room_actor_result(state, &room_jid).await {
+            Ok(Some(room_actor)) => room_actor,
+            Ok(None) => {
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    response_from,
+                    response_to,
+                    item_not_found_iq_error("Requested item not found."),
+                )];
+            }
+            Err(error) => {
+                warn!(room = %room_jid, %error, "MUC moderation room lookup failed");
+                return vec![build_iq_error_xml_typed(
+                    id,
+                    response_from,
+                    response_to,
+                    internal_server_error_iq_error("Internal server error."),
+                )];
+            }
         };
         let context = match room_actor
             .ask(GetAdminContext {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/permissions.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/permissions.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::permissions::DeleteTuple;
+use crate::server::routes::websocket::cleanup::get_room_actor_result;
 
 pub(super) fn build_xmpp_error_response(
     request_iq: &xmpp_parsers::iq::Iq,
@@ -399,14 +400,15 @@ pub(super) async fn muc_owner_authorized(
     room_jid: &BareJid,
     sender_jid: &FullJid,
     _session: Option<&Session>,
-) -> Result<bool, String> {
-    let room_actor = get_room_actor(state, room_jid)
+) -> Result<bool, XmppError> {
+    let room_actor = get_room_actor_result(state, room_jid)
         .await
-        .ok_or_else(|| "room actor not found".to_string())?;
+        .map_err(|error| XmppError::internal(format!("room lookup failed: {error}")))?
+        .ok_or_else(|| XmppError::internal("room actor not found"))?;
     let snapshot = room_actor
         .ask(GetSnapshot)
         .await
-        .map_err(|error| format!("snapshot failed: {error:?}"))?;
+        .map_err(|error| XmppError::internal(format!("snapshot failed: {error:?}")))?;
     if matches!(
         snapshot.room.get_affiliation(&sender_jid.to_bare()),
         Affiliation::Owner
@@ -422,17 +424,20 @@ pub(super) async fn build_muc_owner_config_response(
     room_jid: &BareJid,
     id: &str,
     response_to: Option<&str>,
-) -> Result<String, String> {
-    let room_actor = get_room_actor(state, room_jid)
+) -> Result<String, XmppError> {
+    let room_actor = get_room_actor_result(state, room_jid)
         .await
-        .ok_or_else(|| "room actor not found".to_string())?;
+        .map_err(|error| XmppError::internal(format!("room lookup failed: {error}")))?
+        .ok_or_else(|| XmppError::internal("room actor not found"))?;
     let snapshot = room_actor
         .ask(GetSnapshot)
         .await
-        .map_err(|error| format!("snapshot failed: {error:?}"))?;
+        .map_err(|error| XmppError::internal(format!("snapshot failed: {error:?}")))?;
     let mut room = snapshot.room;
     if let Some(channel_type) =
-        super::muc_owner_config::managed_channel_type_for_room(state, room_jid).await?
+        super::muc_owner_config::managed_channel_type_for_room(state, room_jid)
+            .await
+            .map_err(XmppError::internal)?
     {
         super::muc_owner_config::project_channel_type_to_config(&mut room.config, channel_type);
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::server::routes::websocket::cleanup::get_room_actor_result;
 
 mod access;
 mod xml;
@@ -1683,7 +1684,27 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                 )];
             }
         };
-        let existing_room_actor = get_room_actor(state, room_jid).await;
+        let (existing_room_actor, room_preparation_pending) =
+            match get_room_actor_result(state, room_jid).await {
+                Ok(actor) => (actor, false),
+                Err(
+                    waddle_xmpp::muc::room_registry_actor::RoomRegistryError::OwnershipReconciliationPending(_),
+                ) => (None, true),
+                Err(error) => {
+                    warn!(room = %room_jid, %error, "Failed to look up MUC room before join");
+                    return vec![build_muc_presence_error_xml(
+                        room_jid,
+                        &nick,
+                        sender_jid,
+                        StanzaError::new(
+                            ErrorType::Wait,
+                            DefinedCondition::InternalServerError,
+                            "en",
+                            "Failed to look up room before join.",
+                        ),
+                    )];
+                }
+            };
         let existing_room_snapshot = if let Some(actor) = existing_room_actor.as_ref() {
             match actor.ask(GetSnapshot).await {
                 Ok(snapshot) => Some(snapshot),
@@ -1851,6 +1872,7 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
             Some(actor) => (actor, false),
             None => {
                 if managed_channel.is_none()
+                    && !room_preparation_pending
                     && !server_permission_allowed(
                         state,
                         authenticated_session.as_ref(),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -433,6 +433,13 @@ mod resolver_sync_retry_tests {
             Box::pin(async { Ok(None) })
         }
 
+        fn load_room_state_fenced<'a>(
+            &'a self,
+            room_jid: &'a BareJid,
+        ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+            self.load_room_state(room_jid)
+        }
+
         fn save_config<'a>(
             &'a self,
             _room_jid: &'a BareJid,

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -109,7 +109,8 @@ pub use state::{
 };
 
 pub(crate) use cleanup::{
-    destroy_room_actor, get_or_create_room_actor, get_room_actor, is_muc_room_jid,
+    destroy_room_actor, get_or_create_room_actor, get_room_actor, get_room_actor_result,
+    is_muc_room_jid,
 };
 pub(crate) use muc_call_sfu::{
     note_participant_left_by_call_id, note_participant_left_from_webhook,

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -6848,6 +6848,12 @@ async fn xep0045_destroy_wipe_failure_sends_no_destroy_presence() {
         ) -> MucDurableFuture<'a, Option<waddle_xmpp::muc::durable::DurableRoomState>> {
             Box::pin(async { Ok(None) })
         }
+        fn load_room_state_fenced<'a>(
+            &'a self,
+            room_jid: &'a BareJid,
+        ) -> MucDurableFuture<'a, Option<waddle_xmpp::muc::durable::DurableRoomState>> {
+            self.load_room_state(room_jid)
+        }
         fn save_config<'a>(
             &'a self,
             _room_jid: &'a BareJid,

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -158,6 +158,249 @@ async fn muc_join_maps_registry_ownership_deferral_to_retryable_resource_constra
     );
 }
 
+#[tokio::test]
+async fn ordinary_join_coalesces_with_restoring_room_without_create_permission() {
+    use std::sync::Arc;
+
+    use waddle_xmpp::muc::durable::{DurableRoomState, MucDurableFuture, MucDurableStore};
+    use waddle_xmpp::muc::room_registry_actor::WireClusteringClaims;
+    use waddle_xmpp::ownership::{
+        ClaimStore, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
+    };
+
+    struct BlockingExistingRoomStore {
+        started: Arc<tokio::sync::Notify>,
+        allow: Arc<tokio::sync::Notify>,
+        snapshot: DurableRoomState,
+    }
+
+    impl MucDurableStore for BlockingExistingRoomStore {
+        fn load_room_state<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+        ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+            let snapshot = self.snapshot.clone();
+            Box::pin(async move { Ok(Some(snapshot)) })
+        }
+
+        fn load_room_state_fenced<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+        ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+            let started = Arc::clone(&self.started);
+            let allow = Arc::clone(&self.allow);
+            let snapshot = self.snapshot.clone();
+            Box::pin(async move {
+                started.notify_one();
+                allow.notified().await;
+                Ok(Some(snapshot))
+            })
+        }
+
+        fn save_config<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _waddle_id: &'a str,
+            _channel_id: &'a str,
+            _config: &'a waddle_xmpp::muc::RoomConfig,
+        ) -> MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn save_subject<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _subject: Option<&'a waddle_xmpp::muc::SubjectState>,
+        ) -> MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn save_affiliation<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _entry: &'a waddle_xmpp::muc::affiliation::AffiliationEntry,
+        ) -> MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn check_fenced_fanout<'a>(&'a self, _room_jid: &'a BareJid) -> MucDurableFuture<'a, bool> {
+            Box::pin(async { Ok(true) })
+        }
+    }
+
+    let state = create_test_websocket_state().await;
+    let creator_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let ordinary_session = create_test_session(state.as_ref(), "bob").await;
+    let admin_session = create_test_session(state.as_ref(), "carol").await;
+    let room_jid: BareJid = "restoring-existing@muc.example.com"
+        .parse()
+        .expect("room JID");
+    let durable_owner: BareJid = "carol@example.com".parse().expect("owner JID");
+    let started = Arc::new(tokio::sync::Notify::new());
+    let allow = Arc::new(tokio::sync::Notify::new());
+    let store = Arc::new(BlockingExistingRoomStore {
+        started: Arc::clone(&started),
+        allow: Arc::clone(&allow),
+        snapshot: DurableRoomState {
+            waddle_id: "restored-waddle".to_string(),
+            channel_id: "restored-channel".to_string(),
+            config: waddle_xmpp::muc::RoomConfig {
+                name: "Restored room".to_string(),
+                persistent: true,
+                members_only: false,
+                ..Default::default()
+            },
+            subject: None,
+            affiliations: vec![waddle_xmpp::muc::affiliation::AffiliationEntry::new(
+                durable_owner.clone(),
+                Affiliation::Owner,
+            )],
+        },
+    });
+    state
+        .deps
+        .protocol
+        .room_registry
+        .ask(WireClusteringClaims {
+            claim_store: Arc::new(InProcessClaimStore::new()) as Arc<dyn ClaimStore>,
+            node_identity: SharedNodeIdentity::new(NodeIdentity::local()),
+            durable_store: Some(store as Arc<dyn MucDurableStore>),
+            rollout_backoff: None,
+        })
+        .await
+        .expect("wire blocking durable store");
+
+    let creator_state = Arc::clone(&state);
+    let creator_room = room_jid.clone();
+    let creator_jid: FullJid = "alice@example.com/web".parse().expect("creator JID");
+    let creator_join = tokio::spawn(async move {
+        handle_muc_join(
+            creator_state.as_ref(),
+            "example.com",
+            &creator_room,
+            &creator_jid,
+            "alice",
+            None,
+            &Some(creator_session),
+        )
+        .await
+    });
+    tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+        .await
+        .expect("durable restore started");
+
+    let ordinary_state = Arc::clone(&state);
+    let ordinary_room = room_jid.clone();
+    let ordinary_jid: FullJid = "bob@example.com/web".parse().expect("ordinary JID");
+    let ordinary_join = tokio::spawn(async move {
+        handle_muc_join(
+            ordinary_state.as_ref(),
+            "example.com",
+            &ordinary_room,
+            &ordinary_jid,
+            "bob",
+            None,
+            &Some(ordinary_session),
+        )
+        .await
+    });
+    let admin_iq = element_to_xml(
+        Element::builder("iq", waddle_xmpp::ns::JABBER_CLIENT)
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), "restore-admin")
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
+            .attr(
+                minidom::rxml::xml_ncname!("to").to_owned(),
+                room_jid.to_string(),
+            )
+            .append(
+                Element::builder("query", waddle_xmpp::muc::NS_MUC_ADMIN)
+                    .append(
+                        Element::builder("item", waddle_xmpp::muc::NS_MUC_ADMIN)
+                            .attr(
+                                minidom::rxml::xml_ncname!("affiliation").to_owned(),
+                                "owner",
+                            )
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build(),
+    );
+    let admin_state = Arc::clone(&state);
+    let admin_jid: FullJid = "carol@example.com/web".parse().expect("admin JID");
+    let admin_ready = ready_phase(&admin_jid);
+    let admin_lookup = tokio::spawn(async move {
+        handle_iq(
+            &admin_iq,
+            "example.com",
+            "muc.example.com",
+            admin_state.as_ref(),
+            &Some(admin_session),
+            &admin_ready,
+        )
+        .await
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    assert!(
+        !admin_lookup.is_finished(),
+        "admin IQ must coalesce behind the pending durable restore"
+    );
+    allow.notify_one();
+
+    let creator_responses = creator_join.await.expect("creator join task");
+    let ordinary_responses = ordinary_join.await.expect("ordinary join task");
+    let admin_responses = admin_lookup.await.expect("admin lookup task");
+    assert_eq!(
+        admin_responses.len(),
+        1,
+        "admin response: {admin_responses:?}"
+    );
+    assert!(
+        admin_responses[0].contains("type='result'")
+            && !admin_responses[0].contains("item-not-found"),
+        "a restoring room must not appear absent to MUC admin IQ: {admin_responses:?}"
+    );
+    assert!(
+        ordinary_responses
+            .iter()
+            .all(|response| !response.contains("not-allowed")),
+        "a restoring existing room must not run create-room authorization: {ordinary_responses:?}"
+    );
+    for responses in [&creator_responses, &ordinary_responses] {
+        let self_presence = responses
+            .iter()
+            .filter_map(|xml| Element::from_str(xml).ok())
+            .find(|presence| {
+                presence
+                    .get_child("x", waddle_xmpp::muc::presence::NS_MUC_USER)
+                    .is_some_and(|payload| {
+                        payload.children().any(|child| {
+                            child.name() == "status" && child.attr("code") == Some("110")
+                        })
+                    })
+            })
+            .unwrap_or_else(|| panic!("self presence in responses: {responses:?}"));
+        let payload = self_presence
+            .get_child("x", waddle_xmpp::muc::presence::NS_MUC_USER)
+            .expect("MUC user payload");
+        assert!(
+            payload
+                .children()
+                .all(|child| child.name() != "status" || child.attr("code") != Some("201")),
+            "restoring an existing room must not emit creator status 201: {responses:?}"
+        );
+        assert_ne!(
+            payload
+                .get_child("item", waddle_xmpp::muc::presence::NS_MUC_USER)
+                .and_then(|item| item.attr("affiliation")),
+            Some("owner"),
+            "the first post-restore joiner must not receive CreatorOwner"
+        );
+    }
+    let snapshot = snapshot_room(state.as_ref(), &room_jid).await.room;
+    assert_eq!(snapshot.get_affiliation(&durable_owner), Affiliation::Owner);
+}
+
 /// #1107 / XEP-0045 §7.6: a full JID already in the room under nick A
 /// joining as nick B gets `<error type='cancel'><not-acceptable/>`
 /// on the wire (nicknames are locked to identity) and no second

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -692,7 +692,7 @@ pub(crate) fn spawn_orphan_reaper_janitor(
             // another ownership CAS while RoomRegistry cleanup is in flight.
             let pending_room_handoffs = supervisor.shutdown_terminal().await;
             match terminal_room_registry
-                .drain_pending_reclaimed_rooms_for_shutdown(pending_room_handoffs)
+                .drain_room_ownership_for_shutdown(pending_room_handoffs)
                 .await
             {
                 Ok(outcome) if outcome.retained > 0 => {
@@ -1996,7 +1996,7 @@ async fn terminal_shutdown_transfers_a_post_cas_room_handoff_into_registry_drain
     let handoffs = supervisor.shutdown_terminal().await;
     assert_eq!(handoffs.len(), 1);
     let outcome = registry
-        .drain_pending_reclaimed_rooms_for_shutdown(handoffs)
+        .drain_room_ownership_for_shutdown(handoffs)
         .await
         .expect("drain transferred handoff");
 
@@ -2579,7 +2579,7 @@ async fn worker_restart_self_fences_when_an_uncertain_sm_claim_is_unobserved() {
         .await
         .expect("wire room registry");
     room_registry
-        .drain_pending_reclaimed_rooms_for_shutdown(room_handoffs)
+        .drain_room_ownership_for_shutdown(room_handoffs)
         .await
         .expect("drain handoff after failed restart");
     assert!(room_claim_store

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -1826,15 +1826,12 @@ async fn orphan_reaper_kills_one_node_and_hydrates_only_its_orphaned_sessions() 
 /// the steal-intent veto path (Slice 3, element 4's "Unwedge" text) —
 /// proving the veto scan's health-check-fails branch reaches a real
 /// `RoomActor` through `RoomLocalClaims`, not just `self_fence.rs`'s own
-/// `FakeLocalClaims` unit tests. "Genuinely wedged" is produced by wiring
-/// a `MucDurableStore` whose `load_room_state` future never resolves: the
-/// room registry enqueues `RestoreDurableRoomState` as the very first
-/// message in the freshly spawned actor's FIFO mailbox (element 7's
-/// restore-before-join ordering), so the actor's mailbox loop is
-/// genuinely, durably stuck processing it — exactly the "wedged, not
-/// merely slow" precondition the veto scan's health-check-fails branch
-/// requires, reusing this slice's own restore mechanism as the wedge
-/// point rather than a synthetic one.
+/// `FakeLocalClaims` unit tests. "Genuinely wedged" is produced only after
+/// the room has completed durable restore and been published: its next
+/// config persist never resolves, so the actor's mailbox loop is genuinely,
+/// durably stuck processing a production mutation ahead of the health check.
+/// This preserves the "wedged, not merely slow" precondition without asking
+/// the registry to publish an actor whose initial restore never completed.
 ///
 /// No cross-node proxy/production steal-intent reporter exists this phase
 /// (Slice 3's `report_steal_intent` has no production caller until a
@@ -1861,7 +1858,7 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
     use waddle_server::clustering::ClusteringReadiness;
     use waddle_server::config::{ClusteringNodeLeaseConfig, ClusteringSelfFenceConfig};
     use waddle_xmpp::muc::durable::{DurableRoomState, MucDurableFuture, MucDurableStore};
-    use waddle_xmpp::muc::room_actor::HealthCheck;
+    use waddle_xmpp::muc::room_actor::{HealthCheck, UpdateConfig};
     use waddle_xmpp::muc::{RoomConfig, RoomRegistry};
     use waddle_xmpp::ownership::{
         ClaimStore, Entity, EntityType, NodeIdentity, SharedNodeIdentity,
@@ -1882,15 +1879,22 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
         .await
         .expect("clean steal intents");
 
-    // A `MucDurableStore` whose `load_room_state` never resolves — the
-    // wedge point, per this test's own doc comment.
+    // Initial restore succeeds so the room can be published. Its first
+    // durable config mutation is the deliberate post-publication wedge.
     struct HangingDurableStore;
     impl MucDurableStore for HangingDurableStore {
         fn load_room_state<'a>(
             &'a self,
             _room_jid: &'a jid::BareJid,
         ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
-            Box::pin(pending()) as Pin<Box<_>>
+            Box::pin(async { Ok(None) })
+        }
+
+        fn load_room_state_fenced<'a>(
+            &'a self,
+            room_jid: &'a jid::BareJid,
+        ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+            self.load_room_state(room_jid)
         }
 
         fn save_config<'a>(
@@ -1900,7 +1904,7 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
             _channel_id: &'a str,
             _config: &'a RoomConfig,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            Box::pin(pending()) as Pin<Box<_>>
         }
 
         fn save_subject<'a>(
@@ -1963,10 +1967,15 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
         .expect("get_or_create_room genuinely claims and spawns the room")
         .actor_ref;
 
-    // Confirm genuinely wedged before proceeding: a bounded health-ask
-    // must fail to complete (the actor's mailbox loop is stuck processing
-    // `RestoreDurableRoomState`, ahead of `HealthCheck` in its FIFO
-    // mailbox).
+    actor_ref
+        .tell(UpdateConfig {
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("enqueue post-publication mutation wedge");
+
+    // Confirm genuinely wedged before proceeding: the config update is FIFO
+    // ahead of this bounded health ask and cannot finish its durable persist.
     let health = actor_ref
         .ask(HealthCheck)
         .mailbox_timeout(Duration::from_millis(300))

--- a/server/crates/waddle-xmpp/src/muc/affiliation/config.rs
+++ b/server/crates/waddle-xmpp/src/muc/affiliation/config.rs
@@ -110,7 +110,7 @@ impl FederatedPermissionPolicy {
 /// // Give users from a partner domain higher affiliation
 /// config.set_domain_affiliation("partner.example.org", Affiliation::Admin);
 /// ```
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FederatedAffiliationConfig {
     /// Default affiliation for federated users (typically Member or None).
     pub default_affiliation: Affiliation,

--- a/server/crates/waddle-xmpp/src/muc/durable.rs
+++ b/server/crates/waddle-xmpp/src/muc/durable.rs
@@ -134,6 +134,27 @@ pub trait MucDurableStore: Send + Sync {
         room_jid: &'a BareJid,
     ) -> MucDurableFuture<'a, Option<DurableRoomState>>;
 
+    /// Load one authoritative room snapshot while proving that this store's
+    /// recorded claim fence is still current in the same database
+    /// transaction. Implementations must not split the ownership check and
+    /// snapshot read across transactions: a claim steal between those reads
+    /// would let a deposed actor install state owned by its successor.
+    ///
+    /// The default fails closed. Clustered stores must opt in explicitly;
+    /// in-memory test stores may delegate to [`Self::load_room_state`] when
+    /// their ownership model is controlled synchronously by the test.
+    fn load_room_state_fenced<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+    ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+        let _ = room_jid;
+        Box::pin(async {
+            Err(XmppError::internal(
+                "durable store does not implement fenced room-state loading",
+            ))
+        })
+    }
+
     /// Durably upsert the room's configuration (plus the `waddle_id`/
     /// `channel_id` it travels with).
     fn save_config<'a>(

--- a/server/crates/waddle-xmpp/src/muc/room.rs
+++ b/server/crates/waddle-xmpp/src/muc/room.rs
@@ -77,7 +77,7 @@ impl AllowPm {
 /// timestamp) is **not** part of `RoomConfig` because it is mutated by
 /// the XEP-0045 §8.1 message-path, not by the owner-config form
 /// (§10.2). It lives on `MucRoom.subject` as `Option<SubjectState>`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RoomConfig {
     /// Room name (human-readable)
     pub name: String,

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -377,22 +377,38 @@ pub struct RoomActor {
     restore_state: DurableRestoreState,
 }
 
+#[derive(PartialEq)]
+struct AdmissionPolicySnapshot {
+    waddle_id: String,
+    channel_id: String,
+    requires_membership: bool,
+    max_occupants: u32,
+    affiliations: HashMap<BareJid, Affiliation>,
+}
+
 /// ADR-0017 Phase 3 Slice 7 FIX 4 (council-adjudicated): fail-closed
-/// tracking for [`RestoreDurableRoomState`]. `Ready` (the default) means
-/// either no durable store is configured (single-node/non-clustering —
-/// today's behavior, unchanged) or the restore genuinely completed
-/// (`Ok(Some(_))` applied, or `Ok(None)` — a legitimately brand-new room
-/// with nothing to restore). `Pending` means the initial load hit a
+/// tracking for [`RestoreDurableRoomState`]. `Ready(origin)` means either no
+/// durable store is configured (single-node/non-clustering, therefore a new
+/// in-memory room) or the restore genuinely completed. The typed origin
+/// preserves whether the fenced load returned an existing snapshot or proved
+/// that no durable room exists; the registry uses it to keep XEP-0045 creator
+/// ownership and status 201 exclusive to actual room creation. `Pending`
+/// means the initial load hit a
 /// genuine backend error: joins are refused (a typed, recoverable bounce)
 /// until [`RoomActor::ensure_restored_before_join`]'s bounded inline retry
 /// succeeds — never silently served with the caller-supplied defaults,
 /// which would look exactly like a legitimate empty new room while
 /// actually discarding every ban/member/owner grant on record.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DurableRestoreState {
-    #[default]
-    Ready,
+    Ready(DurableRoomOrigin),
     Pending,
+}
+
+impl Default for DurableRestoreState {
+    fn default() -> Self {
+        Self::Ready(DurableRoomOrigin::New)
+    }
 }
 
 /// Why a room actor has stopped accepting admissions.
@@ -511,7 +527,7 @@ impl RoomActor {
             durable_member_recipients: Vec::new(),
             membership_source: None,
             durable_store: None,
-            restore_state: DurableRestoreState::Ready,
+            restore_state: DurableRestoreState::Ready(DurableRoomOrigin::New),
         }
     }
 
@@ -520,33 +536,30 @@ impl RoomActor {
     /// constructor/default state. Subject changes are deliberately excluded:
     /// they do not affect whether or how an occupant may enter.
     fn install_durable_room_state(&mut self, state: super::durable::DurableRoomState) {
-        let previous_admission_state = (
-            self.room.waddle_id.clone(),
-            self.room.channel_id.clone(),
-            self.room.config.clone(),
-            self.room
-                .get_all_affiliations()
-                .into_iter()
-                .map(|entry| (entry.jid, entry.affiliation))
-                .collect::<HashMap<_, _>>(),
-        );
+        let previous_admission_state = self.admission_policy_snapshot();
         self.room.waddle_id = state.waddle_id;
         self.room.channel_id = state.channel_id;
         self.replace_config(state.config);
         self.room.subject = state.subject;
         self.room.restore_affiliations(state.affiliations);
-        let installed_admission_state = (
-            self.room.waddle_id.clone(),
-            self.room.channel_id.clone(),
-            self.room.config.clone(),
-            self.room
+        let installed_admission_state = self.admission_policy_snapshot();
+        if installed_admission_state != previous_admission_state {
+            self.advance_room_admission_revision();
+        }
+    }
+
+    fn admission_policy_snapshot(&self) -> AdmissionPolicySnapshot {
+        AdmissionPolicySnapshot {
+            waddle_id: self.room.waddle_id.clone(),
+            channel_id: self.room.channel_id.clone(),
+            requires_membership: self.room.config.requires_membership(),
+            max_occupants: self.room.config.max_occupants,
+            affiliations: self
+                .room
                 .get_all_affiliations()
                 .into_iter()
                 .map(|entry| (entry.jid, entry.affiliation))
-                .collect::<HashMap<_, _>>(),
-        );
-        if installed_admission_state != previous_admission_state {
-            self.advance_room_admission_revision();
+                .collect(),
         }
     }
 
@@ -631,7 +644,7 @@ impl RoomActor {
 
     /// ADR-0017 Phase 3 Slice 7 FIX 4 (council-adjudicated): the
     /// fail-closed join gate. `Ok(())` when this incarnation's durable
-    /// restore is already known-good (`DurableRestoreState::Ready` — the
+    /// restore is already known-good (`DurableRestoreState::Ready(_)` — the
     /// overwhelmingly common case). When `Pending` (the initial
     /// [`RestoreDurableRoomState`] load failed), runs ONE bounded inline
     /// retry against the same store before deciding: success applies the
@@ -643,7 +656,7 @@ impl RoomActor {
     /// join against defaulted config/affiliations/subject while a
     /// genuine restore failure is unresolved.
     async fn ensure_restored_before_join(&mut self) -> Result<(), RoomActorError> {
-        if self.restore_state == DurableRestoreState::Ready {
+        if matches!(self.restore_state, DurableRestoreState::Ready(_)) {
             return Ok(());
         }
         let Some(store) = self.durable_store.clone() else {
@@ -652,17 +665,17 @@ impl RoomActor {
             // `durable_store = Some(..)` in the same message. Treat a
             // missing store as nothing-to-restore rather than wedging
             // every future join on an invariant violation.
-            self.restore_state = DurableRestoreState::Ready;
+            self.restore_state = DurableRestoreState::Ready(DurableRoomOrigin::New);
             return Ok(());
         };
         match store.load_room_state_fenced(&self.room.room_jid).await {
             Ok(Some(state)) => {
                 self.install_durable_room_state(state);
-                self.restore_state = DurableRestoreState::Ready;
+                self.restore_state = DurableRestoreState::Ready(DurableRoomOrigin::Restored);
                 Ok(())
             }
             Ok(None) => {
-                self.restore_state = DurableRestoreState::Ready;
+                self.restore_state = DurableRestoreState::Ready(DurableRoomOrigin::New);
                 Ok(())
             }
             Err(error) => {
@@ -980,9 +993,17 @@ pub struct RestoreDurableRoomState {
 /// [`RestoreDurableRoomState`] in the same mailbox. A `Ready` reply is
 /// therefore a publication barrier: every caller that can discover the actor
 /// observes the restored config, affiliations, and subject.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DurableRoomOrigin {
+    /// The exact fenced load proved no durable row exists for this room.
+    New,
+    /// An existing durable room snapshot was installed into this actor.
+    Restored,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
 pub enum DurableRestoreReadiness {
-    Ready,
+    Ready(DurableRoomOrigin),
     Pending,
 }
 
@@ -998,7 +1019,7 @@ impl kameo::message::Message<GetDurableRestoreReadiness> for RoomActor {
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         match self.restore_state {
-            DurableRestoreState::Ready => DurableRestoreReadiness::Ready,
+            DurableRestoreState::Ready(origin) => DurableRestoreReadiness::Ready(origin),
             DurableRestoreState::Pending => DurableRestoreReadiness::Pending,
         }
     }
@@ -1015,11 +1036,11 @@ impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
         match msg.store.load_room_state_fenced(&self.room.room_jid).await {
             Ok(Some(state)) => {
                 self.install_durable_room_state(state);
-                self.restore_state = DurableRestoreState::Ready;
+                self.restore_state = DurableRestoreState::Ready(DurableRoomOrigin::Restored);
             }
             Ok(None) => {
                 // No durable row yet — brand new room, nothing to restore.
-                self.restore_state = DurableRestoreState::Ready;
+                self.restore_state = DurableRestoreState::Ready(DurableRoomOrigin::New);
             }
             Err(error) => {
                 // ADR-0017 Phase 3 Slice 7 FIX 4 (council-adjudicated):

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -523,7 +523,7 @@ impl RoomActor {
         let previous_admission_state = (
             self.room.waddle_id.clone(),
             self.room.channel_id.clone(),
-            serde_json::to_value(&self.room.config).ok(),
+            self.room.config.clone(),
             self.room
                 .get_all_affiliations()
                 .into_iter()
@@ -538,7 +538,7 @@ impl RoomActor {
         let installed_admission_state = (
             self.room.waddle_id.clone(),
             self.room.channel_id.clone(),
-            serde_json::to_value(&self.room.config).ok(),
+            self.room.config.clone(),
             self.room
                 .get_all_affiliations()
                 .into_iter()

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -515,6 +515,41 @@ impl RoomActor {
         }
     }
 
+    /// Install one authoritative durable snapshot and advance the room-wide
+    /// admission watermark when the restored policy differs from the
+    /// constructor/default state. Subject changes are deliberately excluded:
+    /// they do not affect whether or how an occupant may enter.
+    fn install_durable_room_state(&mut self, state: super::durable::DurableRoomState) {
+        let previous_admission_state = (
+            self.room.waddle_id.clone(),
+            self.room.channel_id.clone(),
+            serde_json::to_value(&self.room.config).ok(),
+            self.room
+                .get_all_affiliations()
+                .into_iter()
+                .map(|entry| (entry.jid, entry.affiliation))
+                .collect::<HashMap<_, _>>(),
+        );
+        self.room.waddle_id = state.waddle_id;
+        self.room.channel_id = state.channel_id;
+        self.replace_config(state.config);
+        self.room.subject = state.subject;
+        self.room.restore_affiliations(state.affiliations);
+        let installed_admission_state = (
+            self.room.waddle_id.clone(),
+            self.room.channel_id.clone(),
+            serde_json::to_value(&self.room.config).ok(),
+            self.room
+                .get_all_affiliations()
+                .into_iter()
+                .map(|entry| (entry.jid, entry.affiliation))
+                .collect::<HashMap<_, _>>(),
+        );
+        if installed_admission_state != previous_admission_state {
+            self.advance_room_admission_revision();
+        }
+    }
+
     fn advance_room_admission_revision(&mut self) {
         self.admission_revision = self.admission_revision.saturating_add(1);
         self.room_admission_revision = self.admission_revision;
@@ -620,15 +655,9 @@ impl RoomActor {
             self.restore_state = DurableRestoreState::Ready;
             return Ok(());
         };
-        match store.load_room_state(&self.room.room_jid).await {
+        match store.load_room_state_fenced(&self.room.room_jid).await {
             Ok(Some(state)) => {
-                self.room.waddle_id = state.waddle_id;
-                self.room.channel_id = state.channel_id;
-                self.replace_config(state.config);
-                self.room.subject = state.subject;
-                self.room.restore_affiliations(state.affiliations);
-                self.config_revision = self.config_revision.saturating_add(1);
-                self.advance_room_admission_revision();
+                self.install_durable_room_state(state);
                 self.restore_state = DurableRestoreState::Ready;
                 Ok(())
             }
@@ -937,13 +966,42 @@ impl kameo::message::Message<HydrateDurableRecipients> for RoomActor {
 /// guarantee [`HydrateDurableRecipients`]'s own doc comment already
 /// relies on for durable membership.
 ///
-/// Fail-open on load errors (mirrors [`HydrateDurableRecipients`]): a
-/// brand new room with no durable row yet simply keeps the
-/// caller-supplied initial config, matching today's pre-Slice-7 behavior
-/// exactly when no `MucDurableStore` is configured at all (single-node /
-/// non-clustering deployments never send this message).
+/// Load errors fail closed. A successful `None` still means a brand-new room
+/// and keeps the caller-supplied initial config. The ownership proof and
+/// repeatable-read snapshot are one storage transaction so a claim steal
+/// cannot interleave between them.
 pub struct RestoreDurableRoomState {
     pub store: std::sync::Arc<dyn super::durable::MucDurableStore>,
+}
+
+/// Whether this actor's initial durable restore completed successfully.
+///
+/// The room registry sends [`GetDurableRestoreReadiness`] behind
+/// [`RestoreDurableRoomState`] in the same mailbox. A `Ready` reply is
+/// therefore a publication barrier: every caller that can discover the actor
+/// observes the restored config, affiliations, and subject.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
+pub enum DurableRestoreReadiness {
+    Ready,
+    Pending,
+}
+
+/// FIFO publication barrier for a freshly prepared room actor.
+pub struct GetDurableRestoreReadiness;
+
+impl kameo::message::Message<GetDurableRestoreReadiness> for RoomActor {
+    type Reply = DurableRestoreReadiness;
+
+    async fn handle(
+        &mut self,
+        _msg: GetDurableRestoreReadiness,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        match self.restore_state {
+            DurableRestoreState::Ready => DurableRestoreReadiness::Ready,
+            DurableRestoreState::Pending => DurableRestoreReadiness::Pending,
+        }
+    }
 }
 
 impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
@@ -954,13 +1012,9 @@ impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
         msg: RestoreDurableRoomState,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        match msg.store.load_room_state(&self.room.room_jid).await {
+        match msg.store.load_room_state_fenced(&self.room.room_jid).await {
             Ok(Some(state)) => {
-                self.room.waddle_id = state.waddle_id;
-                self.room.channel_id = state.channel_id;
-                self.replace_config(state.config);
-                self.room.subject = state.subject;
-                self.room.restore_affiliations(state.affiliations);
+                self.install_durable_room_state(state);
                 self.restore_state = DurableRestoreState::Ready;
             }
             Ok(None) => {

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -3467,6 +3467,14 @@ impl crate::muc::durable::MucDurableStore for FakeDurableStore {
         Box::pin(async { Ok(None) })
     }
 
+    fn load_room_state_fenced<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+    ) -> crate::muc::durable::MucDurableFuture<'a, Option<crate::muc::durable::DurableRoomState>>
+    {
+        self.load_room_state(room_jid)
+    }
+
     fn save_config<'a>(
         &'a self,
         _room_jid: &'a BareJid,
@@ -3572,6 +3580,14 @@ impl crate::muc::durable::MucDurableStore for FailNthAffiliationSaveStore {
     ) -> crate::muc::durable::MucDurableFuture<'a, Option<crate::muc::durable::DurableRoomState>>
     {
         Box::pin(async { Ok(None) })
+    }
+
+    fn load_room_state_fenced<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+    ) -> crate::muc::durable::MucDurableFuture<'a, Option<crate::muc::durable::DurableRoomState>>
+    {
+        self.load_room_state(room_jid)
     }
 
     fn save_config<'a>(
@@ -3685,6 +3701,14 @@ impl crate::muc::durable::MucDurableStore for FlakyThenRecoveringStore {
                 }))
             }
         })
+    }
+
+    fn load_room_state_fenced<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+    ) -> crate::muc::durable::MucDurableFuture<'a, Option<crate::muc::durable::DurableRoomState>>
+    {
+        self.load_room_state(room_jid)
     }
 
     fn save_config<'a>(

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -46,6 +46,42 @@ async fn current_admission_revision(actor: &ActorRef<RoomActor>) -> u64 {
         .admission_revision
 }
 
+#[test]
+fn durable_restore_only_advances_for_admission_policy_changes() {
+    let mut actor = RoomActor::new(test_room(), test_secret());
+    let cosmetic_config = RoomConfig {
+        name: "Restored room name".to_string(),
+        description: Some("Restored description".to_string()),
+        enable_logging: false,
+        ..RoomConfig::default()
+    };
+    actor.install_durable_room_state(crate::muc::durable::DurableRoomState {
+        waddle_id: "waddle-1".to_string(),
+        channel_id: "channel-1".to_string(),
+        config: cosmetic_config,
+        subject: None,
+        affiliations: Vec::new(),
+    });
+    assert_eq!(
+        actor.admission_revision, 0,
+        "cosmetic restore fields must not invalidate admission work"
+    );
+
+    let mut admission_config = actor.room.config.clone();
+    admission_config.members_only = false;
+    actor.install_durable_room_state(crate::muc::durable::DurableRoomState {
+        waddle_id: "waddle-1".to_string(),
+        channel_id: "channel-1".to_string(),
+        config: admission_config,
+        subject: None,
+        affiliations: Vec::new(),
+    });
+    assert_eq!(
+        actor.admission_revision, 1,
+        "membership policy changes must invalidate admission work"
+    );
+}
+
 async fn spawn_room_actor_with_config(mut config: RoomConfig) -> ActorRef<RoomActor> {
     let room_jid: BareJid = "testroom@muc.example.com".parse().expect("valid jid");
     config.name = "Test Room".to_string();

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -986,9 +986,18 @@ impl RoomRegistryActor {
                 return Err(RoomPreparationError::ActorUnavailable);
             }
         }
+        if self.durable_store.is_none() && self.membership_source.is_none() {
+            return Ok(actor_guard.disarm());
+        }
         // This ask is FIFO behind restore and membership hydration. Never
         // publish constructor defaults after a failed durable read: ungated
         // room operations could otherwise overwrite authoritative policy.
+        // The registry actor intentionally remains serialized during this
+        // bounded wait: publishing through a detached continuation would need
+        // a second pending-room state machine to order lookups, reclaims, and
+        // releases against the eventual result. The child ask is capped by
+        // `ROOM_OWNERSHIP_CALL_TIMEOUT`; the no-work hot path above pays no
+        // actor round-trip.
         match actor_ref
             .ask(GetDurableRestoreReadiness)
             .mailbox_timeout(ROOM_OWNERSHIP_CALL_TIMEOUT)

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -17,8 +17,9 @@ use tracing::{debug, info, warn};
 use super::affiliation::DurableMembershipSource;
 use super::durable::MucDurableStore;
 use super::room_actor::{
-    GetRoomSealState, HydrateDurableRecipients, RestoreDurableRoomState, RoomActor, RoomSealState,
-    SealGuard, SealIfInactive, SealIfInactiveOutcome,
+    DurableRestoreReadiness, GetDurableRestoreReadiness, GetRoomSealState,
+    HydrateDurableRecipients, RestoreDurableRoomState, RoomActor, RoomSealState, SealGuard,
+    SealIfInactive, SealIfInactiveOutcome,
 };
 use super::{MucRoom, RoomConfig};
 use crate::metrics;
@@ -36,6 +37,39 @@ use crate::xep::xep0421::OccupantIdSecret;
 struct RoomEntry {
     actor_ref: ActorRef<RoomActor>,
     claim_fence: super::RoomClaimFenceContext,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RoomPreparationError {
+    RestorePending,
+    ActorUnavailable,
+}
+
+/// Kills a freshly spawned room actor if preparation is cancelled before the
+/// actor is deliberately handed back to the registry. This also covers a
+/// reclaimed-room deadline cancelling the preparation future.
+struct RoomPreparationGuard(Option<ActorRef<RoomActor>>);
+
+impl RoomPreparationGuard {
+    fn new(actor_ref: ActorRef<RoomActor>) -> Self {
+        Self(Some(actor_ref))
+    }
+
+    fn actor_ref(&self) -> &ActorRef<RoomActor> {
+        self.0.as_ref().expect("prepared actor remains armed")
+    }
+
+    fn disarm(mut self) -> ActorRef<RoomActor> {
+        self.0.take().expect("prepared actor remains armed")
+    }
+}
+
+impl Drop for RoomPreparationGuard {
+    fn drop(&mut self) {
+        if let Some(actor_ref) = self.0.take() {
+            actor_ref.kill();
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -849,9 +883,27 @@ impl RoomRegistryActor {
         config: RoomConfig,
         claim_fence: super::RoomClaimFenceContext,
     ) -> Result<ActorRef<RoomActor>, RoomRegistryError> {
-        let actor_ref = self
-            .prepare_room(room_jid.clone(), waddle_id, channel_id, config)
-            .await;
+        let actor_ref = match self
+            .prepare_room(
+                room_jid.clone(),
+                waddle_id,
+                channel_id,
+                config,
+                &claim_fence,
+            )
+            .await
+        {
+            Ok(actor_ref) => actor_ref,
+            Err(error) => {
+                warn!(
+                    room = %room_jid,
+                    ?error,
+                    "room actor preparation failed before publication"
+                );
+                self.release_room_claim(&room_jid, &claim_fence).await;
+                return Err(RoomRegistryError::OwnershipUnavailable(room_jid));
+            }
+        };
         let owner = claim_fence.owner();
         let still_owned = matches!(
             tokio::time::timeout(
@@ -888,9 +940,20 @@ impl RoomRegistryActor {
         waddle_id: String,
         channel_id: String,
         config: RoomConfig,
-    ) -> ActorRef<RoomActor> {
+        claim_fence: &super::RoomClaimFenceContext,
+    ) -> Result<ActorRef<RoomActor>, RoomPreparationError> {
+        // The restore message may run as soon as it is enqueued. Record the
+        // exact won fence before spawning so the store cannot fall back to a
+        // stale or absent ownership context.
+        if let Some(store) = &self.durable_store {
+            store.record_claim_fence(&room_jid, claim_fence.clone());
+        }
         let room = MucRoom::new(room_jid.clone(), waddle_id, channel_id, config);
-        let actor_ref = RoomActor::spawn(RoomActor::new(room, self.occupant_id_secret.clone()));
+        let actor_guard = RoomPreparationGuard::new(RoomActor::spawn(RoomActor::new(
+            room,
+            self.occupant_id_secret.clone(),
+        )));
+        let actor_ref = actor_guard.actor_ref();
         if let Some(store) = &self.durable_store {
             if let Err(error) = actor_ref
                 .tell(RestoreDurableRoomState {
@@ -904,6 +967,7 @@ impl RoomRegistryActor {
                     "failed to enqueue durable room-state restore for freshly \
                      spawned/re-claimed room actor"
                 );
+                return Err(RoomPreparationError::ActorUnavailable);
             }
         }
         if let Some(source) = &self.membership_source {
@@ -919,9 +983,29 @@ impl RoomRegistryActor {
                     "failed to enqueue durable-recipient hydration for \
                      freshly spawned room actor"
                 );
+                return Err(RoomPreparationError::ActorUnavailable);
             }
         }
-        actor_ref
+        // This ask is FIFO behind restore and membership hydration. Never
+        // publish constructor defaults after a failed durable read: ungated
+        // room operations could otherwise overwrite authoritative policy.
+        match actor_ref
+            .ask(GetDurableRestoreReadiness)
+            .mailbox_timeout(ROOM_OWNERSHIP_CALL_TIMEOUT)
+            .reply_timeout(ROOM_OWNERSHIP_CALL_TIMEOUT)
+            .await
+        {
+            Ok(DurableRestoreReadiness::Ready) => Ok(actor_guard.disarm()),
+            Ok(DurableRestoreReadiness::Pending) => Err(RoomPreparationError::RestorePending),
+            Err(error) => {
+                warn!(
+                    room = %room_jid,
+                    ?error,
+                    "durable room restore readiness barrier failed"
+                );
+                Err(RoomPreparationError::ActorUnavailable)
+            }
+        }
     }
 
     fn publish_room(
@@ -1930,14 +2014,27 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
             return ReclaimedRoomOutcome::PendingRetry;
         }
 
-        let actor_ref = self
+        let actor_ref = match self
             .prepare_room(
                 msg.room_jid.clone(),
                 snapshot.waddle_id,
                 snapshot.channel_id,
                 snapshot.config,
+                &claim_fence,
             )
-            .await;
+            .await
+        {
+            Ok(actor_ref) => actor_ref,
+            Err(error) => {
+                debug!(
+                    room = %msg.room_jid,
+                    ?error,
+                    "reclaimed room restore did not become ready; retaining exact epoch"
+                );
+                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+                return ReclaimedRoomOutcome::PendingRetry;
+            }
+        };
         // `prepare_room` awaits both mailbox enqueues. Fence once more at
         // the actual publication boundary so neither an identity change nor
         // an epoch steal during those awaits can install a stale actor.

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -2819,7 +2819,12 @@ impl kameo::message::Message<ReservePendingReclaimedRoom> for RoomRegistryActor 
         if self.terminal_claim_acquisition_disabled {
             return false;
         }
-        if self.pending_reclaimed_reservations.contains(&msg.room_jid) {
+        if self.pending_reclaimed_reservations.contains(&msg.room_jid)
+            || self
+                .pending_reclaimed_rooms
+                .keys()
+                .any(|(room_jid, _)| room_jid == &msg.room_jid)
+        {
             return true;
         }
         if self.pending_reclaimed_rooms.len() + self.pending_reclaimed_reservations.len()

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -194,13 +194,13 @@ struct PendingRoomAcquisitionState {
     first_pending_at: std::time::Instant,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-enum PendingRoomOwnershipResponsibility {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum PendingRoomOwnershipResponsibility<'a> {
     Exact {
-        room_jid: BareJid,
-        claim_fence: super::RoomClaimFenceContext,
+        room_jid: &'a BareJid,
+        claim_fence: &'a super::RoomClaimFenceContext,
     },
-    ReclaimedReservation(BareJid),
+    ReclaimedReservation(&'a BareJid),
 }
 
 /// Actor that owns the mapping from room JIDs to per-room actors.
@@ -361,85 +361,128 @@ impl RoomRegistryActor {
             || (self.pending_room_releases.len() < MAX_PENDING_ROOM_RELEASES
                 && self.can_admit_room_ownership_responsibility(
                     PendingRoomOwnershipResponsibility::Exact {
-                        room_jid: room_jid.clone(),
-                        claim_fence: claim_fence.clone(),
+                        room_jid,
+                        claim_fence,
                     },
                 ))
     }
 
+    fn extend_pending_room_ownership_responsibilities_until_full<'a>(
+        pending: &mut HashSet<PendingRoomOwnershipResponsibility<'a>>,
+        responsibilities: impl IntoIterator<Item = PendingRoomOwnershipResponsibility<'a>>,
+    ) -> bool {
+        if pending.len() >= MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES {
+            return false;
+        }
+        for responsibility in responsibilities {
+            pending.insert(responsibility);
+            if pending.len() >= MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn has_pending_room_ownership_responsibility(
+        &self,
+        candidate: PendingRoomOwnershipResponsibility<'_>,
+    ) -> bool {
+        match candidate {
+            PendingRoomOwnershipResponsibility::Exact {
+                room_jid,
+                claim_fence,
+            } => {
+                let exact_key = ((*room_jid).clone(), (*claim_fence).clone());
+                self.pending_room_preparations
+                    .get(room_jid)
+                    .is_some_and(|pending| pending.claim_fence == *claim_fence)
+                    || self.pending_room_releases.contains_key(&exact_key)
+                    || self.pending_reclaimed_rooms.contains_key(&exact_key)
+                    || self.rooms.get(room_jid).is_some_and(|entry| {
+                        (!entry.actor_ref.is_alive()
+                            || entry.claim_fence.owner != self.node_identity.current())
+                            && entry.claim_fence == *claim_fence
+                    })
+            }
+            PendingRoomOwnershipResponsibility::ReclaimedReservation(room_jid) => {
+                self.pending_reclaimed_reservations.contains(room_jid)
+            }
+        }
+    }
+
     fn pending_room_ownership_responsibilities(
         &self,
-    ) -> HashSet<PendingRoomOwnershipResponsibility> {
-        let mut pending = HashSet::with_capacity(
-            self.pending_room_preparations.len()
-                + self.pending_room_releases.len()
-                + self.pending_reclaimed_rooms.len()
-                + self.pending_reclaimed_reservations.len(),
-        );
-        pending.extend(
-            self.pending_room_preparations
-                .iter()
-                .map(
-                    |(room_jid, preparation)| PendingRoomOwnershipResponsibility::Exact {
-                        room_jid: room_jid.clone(),
-                        claim_fence: preparation.claim_fence.clone(),
-                    },
-                ),
-        );
-        pending.extend(
-            self.pending_room_releases
-                .keys()
-                .map(
-                    |(room_jid, claim_fence)| PendingRoomOwnershipResponsibility::Exact {
-                        room_jid: room_jid.clone(),
-                        claim_fence: claim_fence.clone(),
-                    },
-                ),
-        );
-        pending.extend(
-            self.pending_reclaimed_rooms
-                .keys()
-                .map(
-                    |(room_jid, claim_fence)| PendingRoomOwnershipResponsibility::Exact {
-                        room_jid: room_jid.clone(),
-                        claim_fence: claim_fence.clone(),
-                    },
-                ),
-        );
-        pending.extend(
-            self.pending_reclaimed_reservations
-                .iter()
-                .cloned()
-                .map(PendingRoomOwnershipResponsibility::ReclaimedReservation),
-        );
+    ) -> impl Iterator<Item = PendingRoomOwnershipResponsibility<'_>> {
+        // Keep this lazy and borrowed: capacity checks stop consuming it at
+        // the shared cap instead of cloning every key or walking the rest of
+        // a saturated room inventory inside the registry mailbox turn.
         let current_identity = self.node_identity.current();
-        pending.extend(
-            self.rooms
-                .iter()
-                .filter(|(_, entry)| {
-                    !entry.actor_ref.is_alive() || entry.claim_fence.owner() != current_identity
-                })
-                .map(
-                    |(room_jid, entry)| PendingRoomOwnershipResponsibility::Exact {
-                        room_jid: room_jid.clone(),
-                        claim_fence: entry.claim_fence.clone(),
-                    },
-                ),
-        );
-        pending
+        self.pending_room_preparations
+            .iter()
+            .map(
+                |(room_jid, preparation)| PendingRoomOwnershipResponsibility::Exact {
+                    room_jid,
+                    claim_fence: &preparation.claim_fence,
+                },
+            )
+            .chain(
+                self.pending_room_releases
+                    .keys()
+                    .map(
+                        |(room_jid, claim_fence)| PendingRoomOwnershipResponsibility::Exact {
+                            room_jid,
+                            claim_fence,
+                        },
+                    ),
+            )
+            .chain(
+                self.pending_reclaimed_rooms
+                    .keys()
+                    .map(
+                        |(room_jid, claim_fence)| PendingRoomOwnershipResponsibility::Exact {
+                            room_jid,
+                            claim_fence,
+                        },
+                    ),
+            )
+            .chain(
+                self.pending_reclaimed_reservations
+                    .iter()
+                    .map(PendingRoomOwnershipResponsibility::ReclaimedReservation),
+            )
+            .chain(
+                self.rooms
+                    .iter()
+                    .filter(move |(_, entry)| {
+                        !entry.actor_ref.is_alive() || entry.claim_fence.owner != current_identity
+                    })
+                    .map(
+                        |(room_jid, entry)| PendingRoomOwnershipResponsibility::Exact {
+                            room_jid,
+                            claim_fence: &entry.claim_fence,
+                        },
+                    ),
+            )
+    }
+
+    fn has_room_ownership_responsibility_capacity(&self) -> bool {
+        let mut pending = HashSet::with_capacity(MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES);
+        Self::extend_pending_room_ownership_responsibilities_until_full(
+            &mut pending,
+            self.pending_room_ownership_responsibilities(),
+        )
     }
 
     fn can_admit_room_ownership_responsibility(
         &self,
-        candidate: PendingRoomOwnershipResponsibility,
+        candidate: PendingRoomOwnershipResponsibility<'_>,
     ) -> bool {
-        let pending = self.pending_room_ownership_responsibilities();
-        pending.contains(&candidate) || pending.len() < MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES
+        self.has_pending_room_ownership_responsibility(candidate)
+            || self.has_room_ownership_responsibility_capacity()
     }
 
     fn can_admit_new_room_ownership_responsibility(&self) -> bool {
-        self.pending_room_ownership_responsibilities().len()
-            < MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES
+        self.has_room_ownership_responsibility_capacity()
     }
 
     fn has_pending_preparation_capacity(
@@ -448,9 +491,16 @@ impl RoomRegistryActor {
         claim_fence: &super::RoomClaimFenceContext,
     ) -> bool {
         self.can_admit_room_ownership_responsibility(PendingRoomOwnershipResponsibility::Exact {
-            room_jid: room_jid.clone(),
-            claim_fence: claim_fence.clone(),
+            room_jid,
+            claim_fence,
         })
+    }
+
+    #[cfg(test)]
+    fn pending_room_ownership_responsibility_count_for_test(&self) -> usize {
+        self.pending_room_ownership_responsibilities()
+            .collect::<HashSet<_>>()
+            .len()
     }
 
     fn preparation_waiter_capacity_available(pending: &PendingRoomPreparation) -> bool {
@@ -2775,7 +2825,7 @@ impl kameo::message::Message<ReservePendingReclaimedRoom> for RoomRegistryActor 
         if self.pending_reclaimed_rooms.len() + self.pending_reclaimed_reservations.len()
             >= MAX_PENDING_RECLAIMED_ROOMS
             || !self.can_admit_room_ownership_responsibility(
-                PendingRoomOwnershipResponsibility::ReclaimedReservation(msg.room_jid.clone()),
+                PendingRoomOwnershipResponsibility::ReclaimedReservation(&msg.room_jid),
             )
         {
             return false;

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -194,6 +194,15 @@ struct PendingRoomAcquisitionState {
     first_pending_at: std::time::Instant,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum PendingRoomOwnershipResponsibility {
+    Exact {
+        room_jid: BareJid,
+        claim_fence: super::RoomClaimFenceContext,
+    },
+    ReclaimedReservation(BareJid),
+}
+
 /// Actor that owns the mapping from room JIDs to per-room actors.
 ///
 /// All room creation, lookup, and destruction flows through this actor,
@@ -349,12 +358,99 @@ impl RoomRegistryActor {
     ) -> bool {
         self.pending_room_releases
             .contains_key(&(room_jid.clone(), claim_fence.clone()))
-            || self.pending_room_releases.len() < MAX_PENDING_ROOM_RELEASES
+            || (self.pending_room_releases.len() < MAX_PENDING_ROOM_RELEASES
+                && self.can_admit_room_ownership_responsibility(
+                    PendingRoomOwnershipResponsibility::Exact {
+                        room_jid: room_jid.clone(),
+                        claim_fence: claim_fence.clone(),
+                    },
+                ))
     }
 
-    fn has_pending_preparation_capacity(&self) -> bool {
-        self.pending_room_preparations.len() + self.pending_room_releases.len()
+    fn pending_room_ownership_responsibilities(
+        &self,
+    ) -> HashSet<PendingRoomOwnershipResponsibility> {
+        let mut pending = HashSet::with_capacity(
+            self.pending_room_preparations.len()
+                + self.pending_room_releases.len()
+                + self.pending_reclaimed_rooms.len()
+                + self.pending_reclaimed_reservations.len(),
+        );
+        pending.extend(
+            self.pending_room_preparations
+                .iter()
+                .map(
+                    |(room_jid, preparation)| PendingRoomOwnershipResponsibility::Exact {
+                        room_jid: room_jid.clone(),
+                        claim_fence: preparation.claim_fence.clone(),
+                    },
+                ),
+        );
+        pending.extend(
+            self.pending_room_releases
+                .keys()
+                .map(
+                    |(room_jid, claim_fence)| PendingRoomOwnershipResponsibility::Exact {
+                        room_jid: room_jid.clone(),
+                        claim_fence: claim_fence.clone(),
+                    },
+                ),
+        );
+        pending.extend(
+            self.pending_reclaimed_rooms
+                .keys()
+                .map(
+                    |(room_jid, claim_fence)| PendingRoomOwnershipResponsibility::Exact {
+                        room_jid: room_jid.clone(),
+                        claim_fence: claim_fence.clone(),
+                    },
+                ),
+        );
+        pending.extend(
+            self.pending_reclaimed_reservations
+                .iter()
+                .cloned()
+                .map(PendingRoomOwnershipResponsibility::ReclaimedReservation),
+        );
+        let current_identity = self.node_identity.current();
+        pending.extend(
+            self.rooms
+                .iter()
+                .filter(|(_, entry)| {
+                    !entry.actor_ref.is_alive() || entry.claim_fence.owner() != current_identity
+                })
+                .map(
+                    |(room_jid, entry)| PendingRoomOwnershipResponsibility::Exact {
+                        room_jid: room_jid.clone(),
+                        claim_fence: entry.claim_fence.clone(),
+                    },
+                ),
+        );
+        pending
+    }
+
+    fn can_admit_room_ownership_responsibility(
+        &self,
+        candidate: PendingRoomOwnershipResponsibility,
+    ) -> bool {
+        let pending = self.pending_room_ownership_responsibilities();
+        pending.contains(&candidate) || pending.len() < MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES
+    }
+
+    fn can_admit_new_room_ownership_responsibility(&self) -> bool {
+        self.pending_room_ownership_responsibilities().len()
             < MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES
+    }
+
+    fn has_pending_preparation_capacity(
+        &self,
+        room_jid: &BareJid,
+        claim_fence: &super::RoomClaimFenceContext,
+    ) -> bool {
+        self.can_admit_room_ownership_responsibility(PendingRoomOwnershipResponsibility::Exact {
+            room_jid: room_jid.clone(),
+            claim_fence: claim_fence.clone(),
+        })
     }
 
     fn preparation_waiter_capacity_available(pending: &PendingRoomPreparation) -> bool {
@@ -373,6 +469,10 @@ impl RoomRegistryActor {
     async fn retire_ownership_lost_entry(&mut self, room_jid: &BareJid, entry: RoomEntry) {
         entry.actor_ref.kill();
         if entry.claim_fence.owner() != self.node_identity.current() {
+            self.transfer_exact_responsibility_to_pending_release(
+                room_jid.clone(),
+                entry.claim_fence.clone(),
+            );
             self.release_room_claim(room_jid, &entry.claim_fence).await;
         } else if let Some(store) = &self.durable_store {
             store.forget_claim_fence(room_jid, &entry.claim_fence);
@@ -405,11 +505,11 @@ impl RoomRegistryActor {
         true
     }
 
-    /// Move an already-admitted pending preparation into exact-release
-    /// responsibility. The caller removes the preparation first, so replacing
-    /// it with this release entry cannot increase the combined bounded
-    /// ownership-responsibility inventory.
-    fn transfer_preparation_to_pending_release(
+    /// Move an already-retained exact fence from a preparation or deposed
+    /// room entry into release state. The caller removes the prior
+    /// representation in the same mailbox turn, so the transfer cannot lose
+    /// responsibility even when ordinary release admission is saturated.
+    fn transfer_exact_responsibility_to_pending_release(
         &mut self,
         room_jid: BareJid,
         claim_fence: super::RoomClaimFenceContext,
@@ -1178,7 +1278,7 @@ impl RoomRegistryActor {
         registry_ref: &ActorRef<Self>,
     ) -> Result<DemandRoomPreparation, RoomRegistryError> {
         let has_async_work = self.durable_store.is_some() || self.membership_source.is_some();
-        if has_async_work && !self.has_pending_preparation_capacity() {
+        if has_async_work && !self.can_admit_new_room_ownership_responsibility() {
             return Err(RoomRegistryError::OwnershipReconciliationPending(
                 room_jid.clone(),
             ));
@@ -1316,7 +1416,7 @@ impl RoomRegistryActor {
     ) {
         debug_assert!(
             self.pending_room_preparations.contains_key(&room_jid)
-                || self.has_pending_preparation_capacity(),
+                || self.has_pending_preparation_capacity(&room_jid, &claim_fence),
             "pending room preparation inventory must be reserved before claim acquisition"
         );
         let generation = self.next_preparation_generation();
@@ -1741,7 +1841,10 @@ impl RoomRegistryActor {
         let claim_fence = pending.claim_fence;
         drop(pending.guard);
         self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
-        self.transfer_preparation_to_pending_release(room_jid.clone(), claim_fence.clone());
+        self.transfer_exact_responsibility_to_pending_release(
+            room_jid.clone(),
+            claim_fence.clone(),
+        );
         self.start_detached_room_release(room_jid.clone(), claim_fence, registry_ref);
         Self::reply_preparation_failure(
             &room_jid,
@@ -1777,7 +1880,7 @@ impl RoomRegistryActor {
                         self.rooms.remove(&room_jid);
                     }
                     actor_ref.kill();
-                    self.transfer_preparation_to_pending_release(
+                    self.transfer_exact_responsibility_to_pending_release(
                         room_jid.clone(),
                         claim_fence.clone(),
                     );
@@ -1787,7 +1890,7 @@ impl RoomRegistryActor {
             Err(error) => {
                 let reclaimed_outcome = match origin {
                     RoomPreparationOrigin::Demand { .. } => {
-                        self.transfer_preparation_to_pending_release(
+                        self.transfer_exact_responsibility_to_pending_release(
                             room_jid.clone(),
                             claim_fence.clone(),
                         );
@@ -1808,7 +1911,7 @@ impl RoomRegistryActor {
                         }
                         RoomPublicationError::LocalIdentityChanged => {
                             self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
-                            self.transfer_preparation_to_pending_release(
+                            self.transfer_exact_responsibility_to_pending_release(
                                 room_jid.clone(),
                                 claim_fence.clone(),
                             );
@@ -1985,10 +2088,11 @@ impl kameo::message::Message<CompleteDetachedRoomRelease> for RoomRegistryActor 
 pub const MAX_PENDING_RECLAIMED_ROOMS: usize = 128;
 pub const MAX_PENDING_ROOM_RELEASES: usize = 128;
 pub const MAX_PENDING_ROOM_ACQUISITIONS: usize = 128;
-/// Combined cap for unpublished room preparations and exact terminal-release
-/// responsibilities. Reclaimed-reservation transfers may fill up to two
-/// ordinary release pages, so the shared cap admits that existing bounded
-/// worst case without allowing detached preparations to grow it further.
+/// Combined admission cap for unique unpublished-room, exact terminal, and
+/// unfenced reclaimed-reservation responsibilities. The same exact fence can
+/// temporarily appear in both reclaimed and preparation/release state during
+/// a representation transfer; it consumes one slot, while different fences
+/// remain distinct.
 pub const MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES: usize =
     MAX_PENDING_ROOM_RELEASES + MAX_PENDING_RECLAIMED_ROOMS;
 pub const MAX_ROOM_PREPARATION_WAITERS: usize = 64;
@@ -2369,7 +2473,7 @@ impl RoomRegistryActor {
             );
             drop(pending.guard);
             self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
-            self.transfer_preparation_to_pending_release(room_jid, claim_fence);
+            self.transfer_exact_responsibility_to_pending_release(room_jid, claim_fence);
         }
         for pending in pending_handoffs {
             self.remember_pending_reclaimed_room(
@@ -2670,6 +2774,9 @@ impl kameo::message::Message<ReservePendingReclaimedRoom> for RoomRegistryActor 
         }
         if self.pending_reclaimed_rooms.len() + self.pending_reclaimed_reservations.len()
             >= MAX_PENDING_RECLAIMED_ROOMS
+            || !self.can_admit_room_ownership_responsibility(
+                PendingRoomOwnershipResponsibility::ReclaimedReservation(msg.room_jid.clone()),
+            )
         {
             return false;
         }
@@ -2936,7 +3043,7 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
             return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
         }
 
-        if !self.has_pending_preparation_capacity() {
+        if !self.has_pending_preparation_capacity(&msg.room_jid, &claim_fence) {
             self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
             return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
         }
@@ -2978,7 +3085,7 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
                 }
                 Err(RoomPublicationError::LocalIdentityChanged) => {
                     self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
-                    self.transfer_preparation_to_pending_release(
+                    self.transfer_exact_responsibility_to_pending_release(
                         msg.room_jid.clone(),
                         claim_fence.clone(),
                     );
@@ -3290,7 +3397,10 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
             );
             drop(pending.guard);
             self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
-            self.transfer_preparation_to_pending_release(msg.room_jid.clone(), claim_fence.clone());
+            self.transfer_exact_responsibility_to_pending_release(
+                msg.room_jid.clone(),
+                claim_fence.clone(),
+            );
             self.start_detached_room_release(
                 msg.room_jid.clone(),
                 claim_fence,
@@ -3637,7 +3747,10 @@ impl kameo::message::Message<DemoteRoomIfOwner> for RoomRegistryActor {
             );
             drop(pending.guard);
             self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
-            self.transfer_preparation_to_pending_release(msg.room_jid.clone(), claim_fence.clone());
+            self.transfer_exact_responsibility_to_pending_release(
+                msg.room_jid.clone(),
+                claim_fence.clone(),
+            );
             self.start_detached_room_release(
                 msg.room_jid.clone(),
                 claim_fence,

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -1472,6 +1472,7 @@ impl RoomRegistryActor {
         let generation = self.next_preparation_generation();
         let actor_ref = guard.actor_ref().clone();
         let claim_store = Arc::clone(&self.claim_store);
+        let durable_store = self.durable_store.clone();
         let publication_fence = claim_fence.clone();
         let waiters = waiter.into_iter().collect();
         let replaced = self.pending_room_preparations.insert(
@@ -1486,13 +1487,37 @@ impl RoomRegistryActor {
         );
         debug_assert!(replaced.is_none(), "same-room preparation must coalesce");
         tokio::spawn(async move {
-            let readiness = match actor_ref
+            let first_readiness = actor_ref
                 .ask(GetDurableRestoreReadiness)
                 .mailbox_timeout(ROOM_OWNERSHIP_CALL_TIMEOUT)
                 .reply_timeout(ROOM_OWNERSHIP_CALL_TIMEOUT)
-                .await
-            {
-                Ok(DurableRestoreReadiness::Ready(durable_origin)) => {
+                .await;
+            let readiness = match first_readiness {
+                Ok(DurableRestoreReadiness::Pending) => match durable_store {
+                    Some(store) => {
+                        if actor_ref
+                            .tell(RestoreDurableRoomState { store })
+                            .mailbox_timeout(ROOM_OWNERSHIP_CALL_TIMEOUT)
+                            .await
+                            .is_ok()
+                        {
+                            Some(
+                                actor_ref
+                                    .ask(GetDurableRestoreReadiness)
+                                    .mailbox_timeout(ROOM_OWNERSHIP_CALL_TIMEOUT)
+                                    .reply_timeout(ROOM_OWNERSHIP_CALL_TIMEOUT)
+                                    .await,
+                            )
+                        } else {
+                            None
+                        }
+                    }
+                    None => None,
+                },
+                other => Some(other),
+            };
+            let readiness = match readiness {
+                Some(Ok(DurableRestoreReadiness::Ready(durable_origin))) => {
                     let owner = publication_fence.owner();
                     let publication_fence = match tokio::time::timeout(
                         ROOM_OWNERSHIP_CALL_TIMEOUT,
@@ -1513,8 +1538,8 @@ impl RoomRegistryActor {
                         publication_fence,
                     }
                 }
-                Ok(DurableRestoreReadiness::Pending) => RoomPreparationReadiness::Pending,
-                Err(_) => RoomPreparationReadiness::Unavailable,
+                Some(Ok(DurableRestoreReadiness::Pending)) => RoomPreparationReadiness::Pending,
+                Some(Err(_)) | None => RoomPreparationReadiness::Unavailable,
             };
             let _ = registry_ref
                 .tell(CompleteRoomPreparation {

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -4,20 +4,22 @@
 //! `MucRoomRegistry` with a single-writer actor that owns the room map and
 //! spawns per-room `RoomActor` instances on demand.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
 use jid::BareJid;
 use kameo::actor::{ActorRef, Spawn};
-use kameo::message::Context;
-use kameo::Actor;
+use kameo::error::BoxSendError;
+use kameo::message::{BoxReply, Context};
+use kameo::reply::{DelegatedReply, ReplySender};
+use kameo::{Actor, Reply};
 use thiserror::Error;
 use tracing::{debug, info, warn};
 
 use super::affiliation::DurableMembershipSource;
 use super::durable::MucDurableStore;
 use super::room_actor::{
-    DurableRestoreReadiness, GetDurableRestoreReadiness, GetRoomSealState,
+    DurableRestoreReadiness, DurableRoomOrigin, GetDurableRestoreReadiness, GetRoomSealState,
     HydrateDurableRecipients, RestoreDurableRoomState, RoomActor, RoomSealState, SealGuard,
     SealIfInactive, SealIfInactiveOutcome,
 };
@@ -41,8 +43,15 @@ struct RoomEntry {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RoomPreparationError {
-    RestorePending,
     ActorUnavailable,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RoomPublicationError {
+    ClaimLost,
+    LocalIdentityChanged,
+    OwnershipUnavailable,
+    ReconciliationPending,
 }
 
 /// Kills a freshly spawned room actor if preparation is cancelled before the
@@ -70,6 +79,99 @@ impl Drop for RoomPreparationGuard {
             actor_ref.kill();
         }
     }
+}
+
+enum RoomPreparationWaiter {
+    Lookup {
+        reply: ReplySender<Result<Option<ActorRef<RoomActor>>, RoomRegistryError>>,
+    },
+    Acquisition {
+        reply: ReplySender<Result<RoomAcquisition, RoomRegistryError>>,
+        creation_spec: Arc<RoomCreationSpec>,
+    },
+    ExclusiveCreate {
+        reply: ReplySender<Result<ActorRef<RoomActor>, RoomRegistryError>>,
+        creation_spec: Arc<RoomCreationSpec>,
+    },
+    Reclaimed {
+        reply: ReplySender<ReclaimedRoomOutcome>,
+        success: ReclaimedRoomOutcome,
+    },
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct RoomCreationSpec {
+    waddle_id: String,
+    channel_id: String,
+    config: RoomConfig,
+}
+
+#[derive(Clone)]
+enum RoomPreparationOrigin {
+    Demand {
+        prepared_spec: Arc<RoomCreationSpec>,
+    },
+    Reclaimed {
+        previous_owner: NodeIdentity,
+    },
+}
+
+struct PendingRoomPreparation {
+    generation: u64,
+    claim_fence: super::RoomClaimFenceContext,
+    origin: RoomPreparationOrigin,
+    guard: RoomPreparationGuard,
+    waiters: Vec<RoomPreparationWaiter>,
+}
+
+enum DemandRoomPreparation {
+    Published(ActorRef<RoomActor>),
+    Pending {
+        guard: RoomPreparationGuard,
+        claim_fence: super::RoomClaimFenceContext,
+    },
+}
+
+enum DemandRoomTransition {
+    Existing(ActorRef<RoomActor>),
+    Created(ActorRef<RoomActor>),
+    Pending(Arc<RoomCreationSpec>),
+}
+
+enum RoomPreparationReadiness {
+    Ready {
+        durable_origin: DurableRoomOrigin,
+        publication_fence: Result<(), RoomPublicationError>,
+    },
+    Pending,
+    Unavailable,
+}
+
+struct CompleteRoomPreparation {
+    room_jid: BareJid,
+    generation: u64,
+    readiness: RoomPreparationReadiness,
+}
+
+struct ReadyRoomPublication {
+    room_jid: BareJid,
+    generation: u64,
+    durable_origin: DurableRoomOrigin,
+}
+
+struct PublishNextReadyRoom;
+
+#[derive(Clone, Copy)]
+enum DetachedRoomReleaseOutcome {
+    Released,
+    NotOwned,
+    Retry,
+}
+
+struct CompleteDetachedRoomRelease {
+    room_jid: BareJid,
+    claim_fence: super::RoomClaimFenceContext,
+    outcome: DetachedRoomReleaseOutcome,
 }
 
 #[derive(Clone)]
@@ -123,6 +225,15 @@ pub struct RoomRegistryActor {
     /// the exact fence into actor/release ownership, this inventory remains
     /// responsible for the possibly committed claim.
     pending_room_acquisitions: HashMap<(BareJid, NodeIdentity), PendingRoomAcquisitionState>,
+    /// Unpublished room actors whose restore/hydration mailbox prefix is still
+    /// running. Keeping these out of `rooms` preserves the publication barrier;
+    /// keeping them in registry-owned state lets same-room operations coalesce
+    /// and lets terminal operations cancel the exact generation before a late
+    /// completion can publish it.
+    pending_room_preparations: HashMap<BareJid, PendingRoomPreparation>,
+    ready_room_publications: VecDeque<ReadyRoomPublication>,
+    ready_room_publication_scheduled: bool,
+    next_room_preparation_generation: u64,
     pending_retry_order: u64,
     pending_retry_timer_generation: u64,
     scheduled_pending_retry_generation: Option<u64>,
@@ -213,6 +324,10 @@ impl RoomRegistryActor {
             pending_reclaimed_reservations: HashSet::new(),
             pending_room_releases: HashMap::new(),
             pending_room_acquisitions: HashMap::new(),
+            pending_room_preparations: HashMap::new(),
+            ready_room_publications: VecDeque::new(),
+            ready_room_publication_scheduled: false,
+            next_room_preparation_generation: 0,
             pending_retry_order: 0,
             pending_retry_timer_generation: 0,
             scheduled_pending_retry_generation: None,
@@ -235,6 +350,15 @@ impl RoomRegistryActor {
         self.pending_room_releases
             .contains_key(&(room_jid.clone(), claim_fence.clone()))
             || self.pending_room_releases.len() < MAX_PENDING_ROOM_RELEASES
+    }
+
+    fn has_pending_preparation_capacity(&self) -> bool {
+        self.pending_room_preparations.len() + self.pending_room_releases.len()
+            < MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES
+    }
+
+    fn preparation_waiter_capacity_available(pending: &PendingRoomPreparation) -> bool {
+        pending.waiters.len() < MAX_ROOM_PREPARATION_WAITERS
     }
 
     /// Remove an actor after its own durable fence proved that this exact
@@ -281,6 +405,26 @@ impl RoomRegistryActor {
         true
     }
 
+    /// Move an already-admitted pending preparation into exact-release
+    /// responsibility. The caller removes the preparation first, so replacing
+    /// it with this release entry cannot increase the combined bounded
+    /// ownership-responsibility inventory.
+    fn transfer_preparation_to_pending_release(
+        &mut self,
+        room_jid: BareJid,
+        claim_fence: super::RoomClaimFenceContext,
+    ) {
+        self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+        let retry_order = self.pending_retry_order;
+        self.pending_room_releases
+            .entry((room_jid, claim_fence))
+            .and_modify(|current| current.retry_order = retry_order)
+            .or_insert(PendingRoomReleaseState {
+                retry_order,
+                first_pending_at: std::time::Instant::now(),
+            });
+    }
+
     /// Replace one bounded, bare-JID reclaimed-room reservation with the
     /// exact fence observed for it. This transfer may take the ordinary
     /// release inventory above [`MAX_PENDING_ROOM_RELEASES`], but cannot
@@ -305,6 +449,32 @@ impl RoomRegistryActor {
                 first_pending_at: std::time::Instant::now(),
             });
         self.pending_reclaimed_reservations.remove(&room_jid);
+    }
+
+    /// Replace one already-bounded uncertain acquisition with the exact
+    /// self-owned fence observed after all pending store writes completed.
+    /// Removing the acquisition only after installing the fence preserves
+    /// uninterrupted ownership responsibility across the representation
+    /// change, including during terminal shutdown.
+    fn transfer_pending_room_acquisition_to_pending_release(
+        &mut self,
+        room_jid: BareJid,
+        attempted_owner: NodeIdentity,
+        claim_fence: super::RoomClaimFenceContext,
+    ) {
+        debug_assert!(self
+            .pending_room_acquisitions
+            .contains_key(&(room_jid.clone(), attempted_owner.clone())));
+        self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
+        let retry_order = self.pending_retry_order;
+        self.pending_room_releases
+            .entry((room_jid.clone(), claim_fence))
+            .and_modify(|current| current.retry_order = retry_order)
+            .or_insert(PendingRoomReleaseState {
+                retry_order,
+                first_pending_at: std::time::Instant::now(),
+            });
+        self.clear_pending_room_acquisition(&room_jid, &attempted_owner);
     }
 
     fn reserve_pending_room_acquisition(
@@ -354,6 +524,35 @@ impl RoomRegistryActor {
                 })
                 .send_after(PENDING_ROOM_RETRY_DELAY),
         );
+    }
+
+    fn start_detached_room_release(
+        &self,
+        room_jid: BareJid,
+        claim_fence: super::RoomClaimFenceContext,
+        registry_ref: ActorRef<Self>,
+    ) {
+        let claim_store = Arc::clone(&self.claim_store);
+        tokio::spawn(async move {
+            let owner = claim_fence.owner();
+            let outcome = match tokio::time::timeout(
+                ROOM_OWNERSHIP_CALL_TIMEOUT,
+                claim_store.release_exact(&claim_fence.entity, &owner, claim_fence.epoch),
+            )
+            .await
+            {
+                Ok(Ok(ExactReleaseOutcome::Released)) => DetachedRoomReleaseOutcome::Released,
+                Ok(Ok(ExactReleaseOutcome::NotOwned)) => DetachedRoomReleaseOutcome::NotOwned,
+                Ok(Err(_)) | Err(_) => DetachedRoomReleaseOutcome::Retry,
+            };
+            let _ = registry_ref
+                .tell(CompleteDetachedRoomRelease {
+                    room_jid,
+                    claim_fence,
+                    outcome,
+                })
+                .await;
+        });
     }
 
     async fn reconcile_pending_room_acquisition(
@@ -863,71 +1062,51 @@ impl RoomRegistryActor {
         });
     }
 
-    /// Spawn a `RoomActor` for the given room and insert it into the map.
-    ///
-    /// When a [`MucDurableStore`] is configured, a
-    /// [`RestoreDurableRoomState`] message is enqueued first (element 7:
-    /// restore configuration/affiliations/subject before accepting any
-    /// join), followed by [`HydrateDurableRecipients`] when a
-    /// [`DurableMembershipSource`] is configured — both before the actor
-    /// ref is handed to any caller, so every later message this
-    /// incarnation processes observes fully-hydrated state (#1135's
-    /// established FIFO-mailbox ordering guarantee, extended here).
-    ///
-    /// Returns a reference to the spawned actor.
-    async fn spawn_room(
+    async fn publish_prepared_room(
         &mut self,
         room_jid: BareJid,
-        waddle_id: String,
-        channel_id: String,
-        config: RoomConfig,
+        actor_guard: RoomPreparationGuard,
         claim_fence: super::RoomClaimFenceContext,
-    ) -> Result<ActorRef<RoomActor>, RoomRegistryError> {
-        let actor_ref = match self
-            .prepare_room(
-                room_jid.clone(),
-                waddle_id,
-                channel_id,
-                config,
-                &claim_fence,
-            )
-            .await
-        {
-            Ok(actor_ref) => actor_ref,
-            Err(error) => {
-                warn!(
-                    room = %room_jid,
-                    ?error,
-                    "room actor preparation failed before publication"
-                );
-                self.release_room_claim(&room_jid, &claim_fence).await;
-                return Err(RoomRegistryError::OwnershipUnavailable(room_jid));
-            }
-        };
+    ) -> Result<ActorRef<RoomActor>, RoomPublicationError> {
         let owner = claim_fence.owner();
-        let still_owned = matches!(
-            tokio::time::timeout(
-                ROOM_OWNERSHIP_CALL_TIMEOUT,
-                self.claim_store
-                    .fence(&claim_fence.entity, &owner, claim_fence.epoch),
-            )
-            .await,
-            Ok(Ok(true))
-        );
-        let identity_guard = if still_owned {
-            self.node_identity.guard_if_current(&owner).await
-        } else {
-            None
+        let still_owned = match tokio::time::timeout(
+            ROOM_OWNERSHIP_CALL_TIMEOUT,
+            self.claim_store
+                .fence(&claim_fence.entity, &owner, claim_fence.epoch),
+        )
+        .await
+        {
+            Ok(Ok(held)) => held,
+            Ok(Err(_)) | Err(_) => return Err(RoomPublicationError::OwnershipUnavailable),
         };
-        let Some(_identity_guard) = identity_guard else {
-            actor_ref.kill();
-            self.release_room_claim(&room_jid, &claim_fence).await;
-            return Err(RoomRegistryError::OwnershipUnavailable(room_jid));
-        };
-        if !self.publish_room(room_jid.clone(), actor_ref.clone(), claim_fence) {
-            return Err(RoomRegistryError::OwnershipReconciliationPending(room_jid));
+        if !still_owned {
+            return Err(RoomPublicationError::ClaimLost);
         }
-        Ok(actor_ref)
+        self.publish_prepared_room_after_fence(room_jid, actor_guard, claim_fence)
+            .await
+    }
+
+    async fn publish_prepared_room_after_fence(
+        &mut self,
+        room_jid: BareJid,
+        actor_guard: RoomPreparationGuard,
+        claim_fence: super::RoomClaimFenceContext,
+    ) -> Result<ActorRef<RoomActor>, RoomPublicationError> {
+        let owner = claim_fence.owner();
+        // Acquire the local incarnation guard after the final database fence
+        // and retain it only through the synchronous map insertion. A
+        // rotation that has already started wins writer preference; a later
+        // rotation waits for this exact publication boundary. Never carry
+        // this guard in a mailbox message, where registry backlog could delay
+        // self-fencing indefinitely.
+        let Some(_identity_guard) = self.node_identity.guard_if_current(&owner).await else {
+            return Err(RoomPublicationError::LocalIdentityChanged);
+        };
+        let actor_ref = actor_guard.actor_ref().clone();
+        if !self.publish_room(room_jid.clone(), actor_ref.clone(), claim_fence) {
+            return Err(RoomPublicationError::ReconciliationPending);
+        }
+        Ok(actor_guard.disarm())
     }
 
     /// Spawn and enqueue all durable hydration work without making the actor
@@ -941,7 +1120,7 @@ impl RoomRegistryActor {
         channel_id: String,
         config: RoomConfig,
         claim_fence: &super::RoomClaimFenceContext,
-    ) -> Result<ActorRef<RoomActor>, RoomPreparationError> {
+    ) -> Result<(RoomPreparationGuard, bool), RoomPreparationError> {
         // The restore message may run as soon as it is enqueued. Record the
         // exact won fence before spawning so the store cannot fall back to a
         // stale or absent ownership context.
@@ -986,33 +1165,341 @@ impl RoomRegistryActor {
                 return Err(RoomPreparationError::ActorUnavailable);
             }
         }
-        if self.durable_store.is_none() && self.membership_source.is_none() {
-            return Ok(actor_guard.disarm());
+        let has_async_work = self.durable_store.is_some() || self.membership_source.is_some();
+        Ok((actor_guard, has_async_work))
+    }
+
+    async fn prepare_demand_room(
+        &mut self,
+        room_jid: &BareJid,
+        waddle_id: String,
+        channel_id: String,
+        config: RoomConfig,
+        registry_ref: &ActorRef<Self>,
+    ) -> Result<DemandRoomPreparation, RoomRegistryError> {
+        let has_async_work = self.durable_store.is_some() || self.membership_source.is_some();
+        if has_async_work && !self.has_pending_preparation_capacity() {
+            return Err(RoomRegistryError::OwnershipReconciliationPending(
+                room_jid.clone(),
+            ));
         }
-        // This ask is FIFO behind restore and membership hydration. Never
-        // publish constructor defaults after a failed durable read: ungated
-        // room operations could otherwise overwrite authoritative policy.
-        // The registry actor intentionally remains serialized during this
-        // bounded wait: publishing through a detached continuation would need
-        // a second pending-room state machine to order lookups, reclaims, and
-        // releases against the eventual result. The child ask is capped by
-        // `ROOM_OWNERSHIP_CALL_TIMEOUT`; the no-work hot path above pays no
-        // actor round-trip.
-        match actor_ref
-            .ask(GetDurableRestoreReadiness)
-            .mailbox_timeout(ROOM_OWNERSHIP_CALL_TIMEOUT)
-            .reply_timeout(ROOM_OWNERSHIP_CALL_TIMEOUT)
+        let claim_fence = self.acquire_room_claim(room_jid, registry_ref).await?;
+        self.poisoned_rooms.remove(room_jid);
+        let (guard, has_async_work) = match self
+            .prepare_room(
+                room_jid.clone(),
+                waddle_id,
+                channel_id,
+                config,
+                &claim_fence,
+            )
             .await
         {
-            Ok(DurableRestoreReadiness::Ready) => Ok(actor_guard.disarm()),
-            Ok(DurableRestoreReadiness::Pending) => Err(RoomPreparationError::RestorePending),
+            Ok(prepared) => prepared,
             Err(error) => {
-                warn!(
-                    room = %room_jid,
-                    ?error,
-                    "durable room restore readiness barrier failed"
+                warn!(room = %room_jid, ?error, "room actor preparation failed before publication");
+                self.release_room_claim(room_jid, &claim_fence).await;
+                return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
+            }
+        };
+        if has_async_work {
+            return Ok(DemandRoomPreparation::Pending { guard, claim_fence });
+        }
+        match self
+            .publish_prepared_room(room_jid.clone(), guard, claim_fence.clone())
+            .await
+        {
+            Ok(actor_ref) => Ok(DemandRoomPreparation::Published(actor_ref)),
+            Err(_) => {
+                self.release_room_claim(room_jid, &claim_fence).await;
+                Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()))
+            }
+        }
+    }
+
+    /// Resolve the common demand-side state machine exactly once for every
+    /// public creation API. Reply-shape differences stay in the message
+    /// handlers; claim acquisition, live-room detection, preparation, and
+    /// coalescing cannot drift between them.
+    async fn transition_demand_room(
+        &mut self,
+        room_jid: BareJid,
+        creation_spec: Arc<RoomCreationSpec>,
+        registry_ref: ActorRef<Self>,
+    ) -> Result<DemandRoomTransition, RoomRegistryError> {
+        if let Some(pending) = self.pending_room_preparations.get(&room_jid) {
+            if !Self::preparation_waiter_capacity_available(pending) {
+                return Err(RoomRegistryError::OwnershipReconciliationPending(room_jid));
+            }
+            return Ok(DemandRoomTransition::Pending(creation_spec));
+        }
+        if let Some(actor_ref) = self.live_room(&room_jid).await? {
+            return Ok(DemandRoomTransition::Existing(actor_ref));
+        }
+
+        match self
+            .prepare_demand_room(
+                &room_jid,
+                creation_spec.waddle_id.clone(),
+                creation_spec.channel_id.clone(),
+                creation_spec.config.clone(),
+                &registry_ref,
+            )
+            .await?
+        {
+            DemandRoomPreparation::Published(actor_ref) => {
+                Ok(DemandRoomTransition::Created(actor_ref))
+            }
+            DemandRoomPreparation::Pending { guard, claim_fence } => {
+                self.start_pending_preparation(
+                    room_jid,
+                    claim_fence,
+                    RoomPreparationOrigin::Demand {
+                        prepared_spec: Arc::clone(&creation_spec),
+                    },
+                    guard,
+                    None,
+                    registry_ref,
                 );
-                Err(RoomPreparationError::ActorUnavailable)
+                Ok(DemandRoomTransition::Pending(creation_spec))
+            }
+        }
+    }
+
+    fn attach_preparation_waiter(
+        &mut self,
+        room_jid: &BareJid,
+        waiter: Option<RoomPreparationWaiter>,
+    ) {
+        let Some(waiter) = waiter else {
+            return;
+        };
+        let pending = self
+            .pending_room_preparations
+            .get_mut(room_jid)
+            .expect("pending demand transition must own a preparation entry");
+        debug_assert!(Self::preparation_waiter_capacity_available(pending));
+        pending.waiters.push(waiter);
+    }
+
+    fn next_preparation_generation(&mut self) -> u64 {
+        self.next_room_preparation_generation =
+            self.next_room_preparation_generation.wrapping_add(1);
+        self.next_room_preparation_generation
+    }
+
+    /// Schedule at most one final publication fence at a time. The next
+    /// publication message is appended only after the preceding one
+    /// completes, so unrelated registry work already queued can run between
+    /// bounded database fences instead of sitting behind the whole ready
+    /// preparation backlog.
+    fn schedule_ready_room_publication(&mut self, registry_ref: &ActorRef<Self>) {
+        if self.ready_room_publication_scheduled || self.ready_room_publications.is_empty() {
+            return;
+        }
+        self.ready_room_publication_scheduled = true;
+        std::mem::drop(
+            registry_ref
+                .tell(PublishNextReadyRoom)
+                .send_after(std::time::Duration::ZERO),
+        );
+    }
+
+    fn start_pending_preparation(
+        &mut self,
+        room_jid: BareJid,
+        claim_fence: super::RoomClaimFenceContext,
+        origin: RoomPreparationOrigin,
+        guard: RoomPreparationGuard,
+        waiter: Option<RoomPreparationWaiter>,
+        registry_ref: ActorRef<Self>,
+    ) {
+        debug_assert!(
+            self.pending_room_preparations.contains_key(&room_jid)
+                || self.has_pending_preparation_capacity(),
+            "pending room preparation inventory must be reserved before claim acquisition"
+        );
+        let generation = self.next_preparation_generation();
+        let actor_ref = guard.actor_ref().clone();
+        let claim_store = Arc::clone(&self.claim_store);
+        let publication_fence = claim_fence.clone();
+        let waiters = waiter.into_iter().collect();
+        let replaced = self.pending_room_preparations.insert(
+            room_jid.clone(),
+            PendingRoomPreparation {
+                generation,
+                claim_fence,
+                origin,
+                guard,
+                waiters,
+            },
+        );
+        debug_assert!(replaced.is_none(), "same-room preparation must coalesce");
+        tokio::spawn(async move {
+            let readiness = match actor_ref
+                .ask(GetDurableRestoreReadiness)
+                .mailbox_timeout(ROOM_OWNERSHIP_CALL_TIMEOUT)
+                .reply_timeout(ROOM_OWNERSHIP_CALL_TIMEOUT)
+                .await
+            {
+                Ok(DurableRestoreReadiness::Ready(durable_origin)) => {
+                    let owner = publication_fence.owner();
+                    let publication_fence = match tokio::time::timeout(
+                        ROOM_OWNERSHIP_CALL_TIMEOUT,
+                        claim_store.fence(
+                            &publication_fence.entity,
+                            &owner,
+                            publication_fence.epoch,
+                        ),
+                    )
+                    .await
+                    {
+                        Ok(Ok(true)) => Ok(()),
+                        Ok(Ok(false)) => Err(RoomPublicationError::ClaimLost),
+                        Ok(Err(_)) | Err(_) => Err(RoomPublicationError::OwnershipUnavailable),
+                    };
+                    RoomPreparationReadiness::Ready {
+                        durable_origin,
+                        publication_fence,
+                    }
+                }
+                Ok(DurableRestoreReadiness::Pending) => RoomPreparationReadiness::Pending,
+                Err(_) => RoomPreparationReadiness::Unavailable,
+            };
+            let _ = registry_ref
+                .tell(CompleteRoomPreparation {
+                    room_jid,
+                    generation,
+                    readiness,
+                })
+                .await;
+        });
+    }
+
+    fn reply_preparation_success(
+        room_jid: &BareJid,
+        waiters: Vec<RoomPreparationWaiter>,
+        actor_ref: ActorRef<RoomActor>,
+        durable_origin: DurableRoomOrigin,
+        preparation_origin: &RoomPreparationOrigin,
+    ) -> bool {
+        if durable_origin == DurableRoomOrigin::Restored {
+            for waiter in waiters {
+                match waiter {
+                    RoomPreparationWaiter::Lookup { reply } => {
+                        reply.send(Ok(Some(actor_ref.clone())));
+                    }
+                    RoomPreparationWaiter::Acquisition { reply, .. } => {
+                        reply.send(Ok(RoomAcquisition {
+                            actor_ref: actor_ref.clone(),
+                            creation: RoomCreation::Existing,
+                        }));
+                    }
+                    RoomPreparationWaiter::ExclusiveCreate { reply, .. } => {
+                        reply.send(Err(RoomRegistryError::RoomAlreadyExists(room_jid.clone())));
+                    }
+                    RoomPreparationWaiter::Reclaimed { reply, success } => reply.send(success),
+                }
+            }
+            return true;
+        }
+
+        let RoomPreparationOrigin::Demand { prepared_spec } = preparation_origin else {
+            Self::reply_preparation_failure(room_jid, waiters, ReclaimedRoomOutcome::PendingRetry);
+            return false;
+        };
+        let mut creation_handoff_delivered = false;
+        let mut deferred = Vec::new();
+        for waiter in waiters {
+            match waiter {
+                RoomPreparationWaiter::Acquisition {
+                    reply,
+                    creation_spec,
+                } if !creation_handoff_delivered
+                    && creation_spec.as_ref() == prepared_spec.as_ref() =>
+                {
+                    if Self::try_send_reply(
+                        reply,
+                        Ok(RoomAcquisition {
+                            actor_ref: actor_ref.clone(),
+                            creation: RoomCreation::Created,
+                        }),
+                    ) {
+                        creation_handoff_delivered = true;
+                    }
+                }
+                RoomPreparationWaiter::ExclusiveCreate {
+                    reply,
+                    creation_spec,
+                } if !creation_handoff_delivered
+                    && creation_spec.as_ref() == prepared_spec.as_ref() =>
+                {
+                    if Self::try_send_reply(reply, Ok(actor_ref.clone())) {
+                        creation_handoff_delivered = true;
+                    }
+                }
+                waiter => deferred.push(waiter),
+            }
+        }
+
+        if !creation_handoff_delivered {
+            Self::reply_preparation_failure(room_jid, deferred, ReclaimedRoomOutcome::PendingRetry);
+            return false;
+        }
+        for waiter in deferred {
+            match waiter {
+                RoomPreparationWaiter::Lookup { reply } => {
+                    reply.send(Ok(Some(actor_ref.clone())));
+                }
+                RoomPreparationWaiter::Acquisition { reply, .. } => {
+                    reply.send(Ok(RoomAcquisition {
+                        actor_ref: actor_ref.clone(),
+                        creation: RoomCreation::Existing,
+                    }));
+                }
+                RoomPreparationWaiter::ExclusiveCreate { reply, .. } => {
+                    reply.send(Err(RoomRegistryError::RoomAlreadyExists(room_jid.clone())));
+                }
+                RoomPreparationWaiter::Reclaimed { reply, success } => reply.send(success),
+            }
+        }
+        true
+    }
+
+    fn try_send_reply<R>(reply: ReplySender<R>, value: R) -> bool
+    where
+        R: Reply,
+    {
+        let boxed = value
+            .to_result()
+            .map(|value| Box::new(value) as BoxReply)
+            .map_err(|error| BoxSendError::HandlerError(Box::new(error)));
+        reply.boxed().send(boxed).is_ok()
+    }
+
+    fn reply_preparation_failure(
+        room_jid: &BareJid,
+        waiters: Vec<RoomPreparationWaiter>,
+        reclaimed_outcome: ReclaimedRoomOutcome,
+    ) {
+        for waiter in waiters {
+            match waiter {
+                RoomPreparationWaiter::Lookup { reply } => {
+                    reply.send(Err(RoomRegistryError::OwnershipUnavailable(
+                        room_jid.clone(),
+                    )));
+                }
+                RoomPreparationWaiter::Acquisition { reply, .. } => {
+                    reply.send(Err(RoomRegistryError::OwnershipUnavailable(
+                        room_jid.clone(),
+                    )));
+                }
+                RoomPreparationWaiter::ExclusiveCreate { reply, .. } => {
+                    reply.send(Err(RoomRegistryError::OwnershipUnavailable(
+                        room_jid.clone(),
+                    )));
+                }
+                RoomPreparationWaiter::Reclaimed { reply, .. } => reply.send(reclaimed_outcome),
             }
         }
     }
@@ -1064,6 +1551,11 @@ impl RoomRegistryActor {
     ) -> Result<Option<ActorRef<RoomActor>>, RoomRegistryError> {
         if self.poisoned_rooms.contains(room_jid) {
             return Err(RoomRegistryError::RoomActorStateLost(room_jid.clone()));
+        }
+        if self.pending_room_preparations.contains_key(room_jid) {
+            return Err(RoomRegistryError::OwnershipReconciliationPending(
+                room_jid.clone(),
+            ));
         }
         if let Some(entry) = self.rooms.get(room_jid) {
             if entry.actor_ref.is_alive() {
@@ -1239,9 +1731,267 @@ impl RoomRegistryActor {
     }
 }
 
+impl RoomRegistryActor {
+    fn abandon_preparation_for_terminal(
+        &mut self,
+        room_jid: BareJid,
+        pending: PendingRoomPreparation,
+        registry_ref: ActorRef<Self>,
+    ) {
+        let claim_fence = pending.claim_fence;
+        drop(pending.guard);
+        self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
+        self.transfer_preparation_to_pending_release(room_jid.clone(), claim_fence.clone());
+        self.start_detached_room_release(room_jid.clone(), claim_fence, registry_ref);
+        Self::reply_preparation_failure(
+            &room_jid,
+            pending.waiters,
+            ReclaimedRoomOutcome::PendingRetry,
+        );
+    }
+
+    fn finish_preparation_outcome(
+        &mut self,
+        room_jid: BareJid,
+        claim_fence: super::RoomClaimFenceContext,
+        origin: RoomPreparationOrigin,
+        waiters: Vec<RoomPreparationWaiter>,
+        publication: Result<(ActorRef<RoomActor>, DurableRoomOrigin), RoomPublicationError>,
+        registry_ref: ActorRef<Self>,
+    ) {
+        match publication {
+            Ok((actor_ref, durable_origin)) => {
+                let creation_handoff_delivered = Self::reply_preparation_success(
+                    &room_jid,
+                    waiters,
+                    actor_ref.clone(),
+                    durable_origin,
+                    &origin,
+                );
+                if !creation_handoff_delivered {
+                    let matching_entry = self
+                        .rooms
+                        .get(&room_jid)
+                        .is_some_and(|entry| entry.claim_fence == claim_fence);
+                    if matching_entry {
+                        self.rooms.remove(&room_jid);
+                    }
+                    actor_ref.kill();
+                    self.transfer_preparation_to_pending_release(
+                        room_jid.clone(),
+                        claim_fence.clone(),
+                    );
+                    self.start_detached_room_release(room_jid, claim_fence, registry_ref);
+                }
+            }
+            Err(error) => {
+                let reclaimed_outcome = match origin {
+                    RoomPreparationOrigin::Demand { .. } => {
+                        self.transfer_preparation_to_pending_release(
+                            room_jid.clone(),
+                            claim_fence.clone(),
+                        );
+                        self.start_detached_room_release(
+                            room_jid.clone(),
+                            claim_fence.clone(),
+                            registry_ref,
+                        );
+                        ReclaimedRoomOutcome::PendingRetry
+                    }
+                    RoomPreparationOrigin::Reclaimed { previous_owner } => match error {
+                        RoomPublicationError::ClaimLost => {
+                            if let Some(store) = &self.durable_store {
+                                store.forget_claim_fence(&room_jid, &claim_fence);
+                            }
+                            self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
+                            ReclaimedRoomOutcome::LostRace
+                        }
+                        RoomPublicationError::LocalIdentityChanged => {
+                            self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
+                            self.transfer_preparation_to_pending_release(
+                                room_jid.clone(),
+                                claim_fence.clone(),
+                            );
+                            self.start_detached_room_release(
+                                room_jid.clone(),
+                                claim_fence,
+                                registry_ref,
+                            );
+                            ReclaimedRoomOutcome::PendingRetry
+                        }
+                        RoomPublicationError::OwnershipUnavailable
+                        | RoomPublicationError::ReconciliationPending => {
+                            self.remember_pending_reclaimed_room(
+                                room_jid.clone(),
+                                claim_fence,
+                                previous_owner,
+                            );
+                            ReclaimedRoomOutcome::PendingRetry
+                        }
+                    },
+                };
+                Self::reply_preparation_failure(&room_jid, waiters, reclaimed_outcome);
+            }
+        }
+    }
+}
+
+impl kameo::message::Message<CompleteRoomPreparation> for RoomRegistryActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: CompleteRoomPreparation,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let is_current = self
+            .pending_room_preparations
+            .get(&msg.room_jid)
+            .is_some_and(|pending| pending.generation == msg.generation);
+        if !is_current {
+            return;
+        }
+        if self.terminal_claim_acquisition_disabled {
+            let pending = self
+                .pending_room_preparations
+                .remove(&msg.room_jid)
+                .expect("generation was checked in the same mailbox turn");
+            self.abandon_preparation_for_terminal(msg.room_jid, pending, ctx.actor_ref().clone());
+            return;
+        }
+
+        let failure = match msg.readiness {
+            RoomPreparationReadiness::Ready {
+                durable_origin,
+                publication_fence: Ok(()),
+            } => {
+                self.ready_room_publications
+                    .push_back(ReadyRoomPublication {
+                        room_jid: msg.room_jid,
+                        generation: msg.generation,
+                        durable_origin,
+                    });
+                self.schedule_ready_room_publication(ctx.actor_ref());
+                return;
+            }
+            RoomPreparationReadiness::Ready {
+                publication_fence: Err(error),
+                ..
+            } => error,
+            RoomPreparationReadiness::Pending | RoomPreparationReadiness::Unavailable => {
+                RoomPublicationError::OwnershipUnavailable
+            }
+        };
+        let pending = self
+            .pending_room_preparations
+            .remove(&msg.room_jid)
+            .expect("generation was checked in the same mailbox turn");
+        let claim_fence = pending.claim_fence.clone();
+        let origin = pending.origin.clone();
+        let waiters = pending.waiters;
+        drop(pending.guard);
+        self.finish_preparation_outcome(
+            msg.room_jid,
+            claim_fence,
+            origin,
+            waiters,
+            Err(failure),
+            ctx.actor_ref().clone(),
+        );
+    }
+}
+
+impl kameo::message::Message<PublishNextReadyRoom> for RoomRegistryActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        _msg: PublishNextReadyRoom,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.ready_room_publication_scheduled = false;
+        let Some(ready) = self.ready_room_publications.pop_front() else {
+            return;
+        };
+        let is_current = self
+            .pending_room_preparations
+            .get(&ready.room_jid)
+            .is_some_and(|pending| pending.generation == ready.generation);
+        if is_current {
+            let pending = self
+                .pending_room_preparations
+                .remove(&ready.room_jid)
+                .expect("generation was checked in the same mailbox turn");
+            if self.terminal_claim_acquisition_disabled {
+                self.abandon_preparation_for_terminal(
+                    ready.room_jid,
+                    pending,
+                    ctx.actor_ref().clone(),
+                );
+            } else {
+                let claim_fence = pending.claim_fence.clone();
+                let origin = pending.origin.clone();
+                let waiters = pending.waiters;
+                let publication = self
+                    .publish_prepared_room(
+                        ready.room_jid.clone(),
+                        pending.guard,
+                        claim_fence.clone(),
+                    )
+                    .await
+                    .map(|actor_ref| (actor_ref, ready.durable_origin));
+                self.finish_preparation_outcome(
+                    ready.room_jid,
+                    claim_fence,
+                    origin,
+                    waiters,
+                    publication,
+                    ctx.actor_ref().clone(),
+                );
+            }
+        }
+        self.schedule_ready_room_publication(ctx.actor_ref());
+    }
+}
+
+impl kameo::message::Message<CompleteDetachedRoomRelease> for RoomRegistryActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: CompleteDetachedRoomRelease,
+        ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        if !self
+            .pending_room_releases
+            .contains_key(&(msg.room_jid.clone(), msg.claim_fence.clone()))
+        {
+            return;
+        }
+        match msg.outcome {
+            DetachedRoomReleaseOutcome::Released | DetachedRoomReleaseOutcome::NotOwned => {
+                self.clear_pending_room_release(&msg.room_jid, &msg.claim_fence);
+                if let Some(store) = &self.durable_store {
+                    store.forget_claim_fence(&msg.room_jid, &msg.claim_fence);
+                }
+            }
+            DetachedRoomReleaseOutcome::Retry => {
+                self.schedule_pending_room_retry(ctx.actor_ref());
+            }
+        }
+    }
+}
+
 pub const MAX_PENDING_RECLAIMED_ROOMS: usize = 128;
 pub const MAX_PENDING_ROOM_RELEASES: usize = 128;
 pub const MAX_PENDING_ROOM_ACQUISITIONS: usize = 128;
+/// Combined cap for unpublished room preparations and exact terminal-release
+/// responsibilities. Reclaimed-reservation transfers may fill up to two
+/// ordinary release pages, so the shared cap admits that existing bounded
+/// worst case without allowing detached preparations to grow it further.
+pub const MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES: usize =
+    MAX_PENDING_ROOM_RELEASES + MAX_PENDING_RECLAIMED_ROOMS;
+pub const MAX_ROOM_PREPARATION_WAITERS: usize = 64;
 const PENDING_ROOM_RETRY_BATCH: usize = 16;
 const PENDING_ROOM_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(5);
 
@@ -1463,10 +2213,24 @@ pub struct GetRoom {
 }
 
 impl kameo::message::Message<GetRoom> for RoomRegistryActor {
-    type Reply = Result<Option<ActorRef<RoomActor>>, RoomRegistryError>;
+    type Reply = DelegatedReply<Result<Option<ActorRef<RoomActor>>, RoomRegistryError>>;
 
-    async fn handle(&mut self, msg: GetRoom, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
-        self.live_room(&msg.room_jid).await
+    async fn handle(&mut self, msg: GetRoom, ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
+        if let Some(pending) = self.pending_room_preparations.get_mut(&msg.room_jid) {
+            if !Self::preparation_waiter_capacity_available(pending) {
+                return ctx.reply(Err(RoomRegistryError::OwnershipReconciliationPending(
+                    msg.room_jid,
+                )));
+            }
+            let (delegated, reply) = ctx.reply_sender();
+            if let Some(reply) = reply {
+                pending
+                    .waiters
+                    .push(RoomPreparationWaiter::Lookup { reply });
+            }
+            return delegated;
+        }
+        ctx.reply(self.live_room(&msg.room_jid).await)
     }
 }
 
@@ -1573,62 +2337,126 @@ pub struct GetPendingReclaimedRoomBacklog;
 /// The handler imports those handoffs and disables future room-claim
 /// acquisition in the same mailbox turn, so queued demand cannot race an
 /// out-of-actor release.
-pub struct DrainPendingReclaimedRoomsForShutdown {
+pub struct DrainRoomOwnershipForShutdown {
     pub pending_handoffs: Vec<PendingReclaimedRoom>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
-pub struct PendingReclaimedRoomDrainOutcome {
+pub struct RoomOwnershipDrainOutcome {
     pub released: usize,
     pub preserved_live: usize,
     pub retained: usize,
 }
 
-impl kameo::message::Message<GetPendingReclaimedRoomBacklog> for RoomRegistryActor {
-    type Reply = PendingReclaimedRoomBacklog;
-
-    async fn handle(
-        &mut self,
-        _msg: GetPendingReclaimedRoomBacklog,
-        _ctx: &mut Context<Self, Self::Reply>,
-    ) -> Self::Reply {
-        let oldest_age_ms = self
-            .pending_reclaimed_rooms
-            .values()
-            .map(|pending| pending.first_pending_at.elapsed().as_millis() as u64)
-            .max()
-            .unwrap_or(0);
-        PendingReclaimedRoomBacklog {
-            depth: self.pending_reclaimed_rooms.len() + self.pending_reclaimed_reservations.len(),
-            oldest_age_ms,
-        }
-    }
+struct RoomOwnershipShutdownReconciliation {
+    preserved_live: usize,
+    retained: usize,
+    reservation_owned: Vec<(BareJid, super::RoomClaimFenceContext)>,
 }
 
-impl kameo::message::Message<DrainPendingReclaimedRoomsForShutdown> for RoomRegistryActor {
-    type Reply = PendingReclaimedRoomDrainOutcome;
-
-    async fn handle(
-        &mut self,
-        msg: DrainPendingReclaimedRoomsForShutdown,
-        _ctx: &mut Context<Self, Self::Reply>,
-    ) -> Self::Reply {
+impl RoomRegistryActor {
+    fn begin_room_ownership_shutdown(&mut self, pending_handoffs: Vec<PendingReclaimedRoom>) {
         self.terminal_claim_acquisition_disabled = true;
-        for pending in msg.pending_handoffs {
+        self.ready_room_publications.clear();
+        self.ready_room_publication_scheduled = false;
+        let pending_preparations = std::mem::take(&mut self.pending_room_preparations);
+        for (room_jid, pending) in pending_preparations {
+            let claim_fence = pending.claim_fence.clone();
+            Self::reply_preparation_failure(
+                &room_jid,
+                pending.waiters,
+                ReclaimedRoomOutcome::PendingRetry,
+            );
+            drop(pending.guard);
+            self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
+            self.transfer_preparation_to_pending_release(room_jid, claim_fence);
+        }
+        for pending in pending_handoffs {
             self.remember_pending_reclaimed_room(
                 pending.room_jid,
                 pending.claim_fence,
                 pending.previous_owner,
             );
         }
-        // A steal CAS can commit while cancellation drops its response
-        // future, leaving only the pre-CAS bare-JID reservation. Check those
-        // reservations after acquisition is disabled and while the actor
-        // mailbox excludes demand-side publication. A positive self-owned
-        // snapshot yields an exact fence that can be released or matched to
-        // a live actor. An absent/foreign snapshot is not authoritative: the
-        // dropped CAS may still commit after this read, so its reservation
-        // must survive for node-expiry recovery.
+    }
+
+    /// Resolve demand-side claim CAS calls that may have committed after
+    /// their response future timed out. Terminal shutdown cannot rely on the
+    /// normal retry timer, so this waits behind already-issued writes and
+    /// transfers every observed self-owned epoch into exact release state.
+    async fn reconcile_uncertain_room_acquisitions_for_shutdown(
+        &mut self,
+    ) -> RoomOwnershipShutdownReconciliation {
+        let pending_acquisitions = self
+            .pending_room_acquisitions
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        let claim_store = Arc::clone(&self.claim_store);
+        let acquisition_claims = futures::future::join_all(pending_acquisitions.into_iter().map(
+            |(room_jid, attempted_owner)| {
+                let claim_store = Arc::clone(&claim_store);
+                async move {
+                    let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+                    let current = tokio::time::timeout(
+                        ROOM_OWNERSHIP_CALL_TIMEOUT,
+                        claim_store.current_claim_after_pending_writes(&entity),
+                    )
+                    .await;
+                    (room_jid, attempted_owner, entity, current)
+                }
+            },
+        ))
+        .await;
+
+        let mut preserved_live = 0usize;
+        let mut retained = 0usize;
+        for (room_jid, attempted_owner, entity, current) in acquisition_claims {
+            match current {
+                Ok(Ok(Some(snapshot))) if snapshot.owner == attempted_owner => {
+                    let claim_fence = super::RoomClaimFenceContext::new(
+                        entity,
+                        snapshot.owner,
+                        snapshot.claim_epoch,
+                    );
+                    if self.has_live_room_with_fence(&room_jid, &claim_fence) {
+                        self.clear_pending_room_acquisition(&room_jid, &attempted_owner);
+                        preserved_live += 1;
+                    } else {
+                        self.transfer_pending_room_acquisition_to_pending_release(
+                            room_jid,
+                            attempted_owner,
+                            claim_fence,
+                        );
+                    }
+                }
+                Ok(Ok(_)) => {
+                    self.clear_pending_room_acquisition(&room_jid, &attempted_owner);
+                }
+                Ok(Err(error)) => {
+                    warn!(room = %room_jid, %error, "terminal room-acquisition lookup failed; retaining uncertain acquisition until node expiry");
+                    retained += 1;
+                }
+                Err(_) => {
+                    warn!(room = %room_jid, "terminal room-acquisition lookup timed out; retaining uncertain acquisition until node expiry");
+                    retained += 1;
+                }
+            }
+        }
+        RoomOwnershipShutdownReconciliation {
+            preserved_live,
+            retained,
+            reservation_owned: Vec::new(),
+        }
+    }
+
+    /// Convert ambiguous orphan-reaper reservations into exact fences after
+    /// all already-issued steal writes settle. Unlike demand acquisitions, a
+    /// non-self snapshot stays ambiguous because the dropped steal may still
+    /// be the writer ordered behind that observation.
+    async fn reconcile_reclaimed_room_reservations_for_shutdown(
+        &mut self,
+    ) -> RoomOwnershipShutdownReconciliation {
         let reserved_rooms = self
             .pending_reclaimed_reservations
             .iter()
@@ -1657,10 +2485,9 @@ impl kameo::message::Message<DrainPendingReclaimedRoomsForShutdown> for RoomRegi
         for (room_jid, entity, current) in reservation_claims {
             match current {
                 Ok(Ok(Some(snapshot))) if snapshot.owner.same_incarnation(&owner) => {
-                    let claim_owner = snapshot.owner;
                     let claim_fence = super::RoomClaimFenceContext::new(
                         entity,
-                        claim_owner,
+                        snapshot.owner,
                         snapshot.claim_epoch,
                     );
                     if self.has_live_room_with_fence(&room_jid, &claim_fence) {
@@ -1688,6 +2515,19 @@ impl kameo::message::Message<DrainPendingReclaimedRoomsForShutdown> for RoomRegi
                 }
             }
         }
+        RoomOwnershipShutdownReconciliation {
+            preserved_live,
+            retained,
+            reservation_owned,
+        }
+    }
+
+    /// Drain every exact ordinary/reclaimed release responsibility in one
+    /// concurrent terminal batch after ambiguous state has been reconciled.
+    async fn release_exact_room_ownership_for_shutdown(
+        &mut self,
+        reservation_owned: Vec<(BareJid, super::RoomClaimFenceContext)>,
+    ) -> RoomOwnershipDrainOutcome {
         let duplicate_live = self
             .pending_reclaimed_rooms
             .keys()
@@ -1697,12 +2537,14 @@ impl kameo::message::Message<DrainPendingReclaimedRoomsForShutdown> for RoomRegi
         for (room_jid, claim_fence) in &duplicate_live {
             self.clear_pending_reclaimed_room(room_jid, claim_fence);
         }
-        preserved_live += duplicate_live.len();
+        let preserved_live = duplicate_live.len();
+
         let mut pending = self
-            .pending_reclaimed_rooms
+            .pending_room_releases
             .keys()
             .cloned()
-            .collect::<Vec<_>>();
+            .collect::<HashSet<_>>();
+        pending.extend(self.pending_reclaimed_rooms.keys().cloned());
         pending.extend(reservation_owned);
         let claim_store = Arc::clone(&self.claim_store);
         let outcomes =
@@ -1721,6 +2563,7 @@ impl kameo::message::Message<DrainPendingReclaimedRoomsForShutdown> for RoomRegi
             .await;
 
         let mut released = 0usize;
+        let mut retained = 0usize;
         for (room_jid, claim_fence, outcome) in outcomes {
             match outcome {
                 Ok(Ok(ExactReleaseOutcome::Released | ExactReleaseOutcome::NotOwned)) => {
@@ -1733,20 +2576,65 @@ impl kameo::message::Message<DrainPendingReclaimedRoomsForShutdown> for RoomRegi
                     released += 1;
                 }
                 Ok(Err(error)) => {
-                    warn!(room = %room_jid, %error, "terminal reclaimed-room release failed; retaining exact fence until node expiry");
+                    warn!(room = %room_jid, %error, "terminal room-ownership release failed; retaining exact fence until node expiry");
                     retained += 1;
                 }
                 Err(_) => {
-                    warn!(room = %room_jid, "terminal reclaimed-room release timed out; retaining exact fence until node expiry");
+                    warn!(room = %room_jid, "terminal room-ownership release timed out; retaining exact fence until node expiry");
                     retained += 1;
                 }
             }
         }
-        PendingReclaimedRoomDrainOutcome {
+        RoomOwnershipDrainOutcome {
             released,
             preserved_live,
             retained,
         }
+    }
+}
+
+impl kameo::message::Message<GetPendingReclaimedRoomBacklog> for RoomRegistryActor {
+    type Reply = PendingReclaimedRoomBacklog;
+
+    async fn handle(
+        &mut self,
+        _msg: GetPendingReclaimedRoomBacklog,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let oldest_age_ms = self
+            .pending_reclaimed_rooms
+            .values()
+            .map(|pending| pending.first_pending_at.elapsed().as_millis() as u64)
+            .max()
+            .unwrap_or(0);
+        PendingReclaimedRoomBacklog {
+            depth: self.pending_reclaimed_rooms.len() + self.pending_reclaimed_reservations.len(),
+            oldest_age_ms,
+        }
+    }
+}
+
+impl kameo::message::Message<DrainRoomOwnershipForShutdown> for RoomRegistryActor {
+    type Reply = RoomOwnershipDrainOutcome;
+
+    async fn handle(
+        &mut self,
+        msg: DrainRoomOwnershipForShutdown,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.begin_room_ownership_shutdown(msg.pending_handoffs);
+        let acquisition = self
+            .reconcile_uncertain_room_acquisitions_for_shutdown()
+            .await;
+        let reservations = self
+            .reconcile_reclaimed_room_reservations_for_shutdown()
+            .await;
+        let mut outcome = self
+            .release_exact_room_ownership_for_shutdown(reservations.reservation_owned)
+            .await;
+        outcome.preserved_live += acquisition.preserved_live + reservations.preserved_live;
+        outcome.retained += acquisition.retained + reservations.retained;
+        outcome
     }
 }
 
@@ -1851,30 +2739,49 @@ impl kameo::message::Message<ListPendingReclaimedRooms> for RoomRegistryActor {
 }
 
 impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
-    type Reply = ReclaimedRoomOutcome;
+    type Reply = DelegatedReply<ReclaimedRoomOutcome>;
 
     async fn handle(
         &mut self,
         msg: ReconcileReclaimedRoom,
-        _ctx: &mut Context<Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let entity = Entity::new(EntityType::RoomActor, msg.room_jid.to_string());
         let claim_fence = msg.claim_fence.clone();
         let claim_epoch = claim_fence.epoch;
         let identity = claim_fence.owner();
+        if let Some(pending) = self.pending_room_preparations.get_mut(&msg.room_jid) {
+            if pending.claim_fence == claim_fence {
+                if !Self::preparation_waiter_capacity_available(pending) {
+                    return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
+                }
+                let (delegated, reply) = ctx.reply_sender();
+                if let Some(reply) = reply {
+                    pending.waiters.push(RoomPreparationWaiter::Reclaimed {
+                        reply,
+                        success: ReclaimedRoomOutcome::AlreadyLive,
+                    });
+                }
+                return delegated;
+            }
+            self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+            return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
+        }
         if self.terminal_claim_acquisition_disabled {
             if self.has_live_room_with_fence(&msg.room_jid, &claim_fence) {
                 self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
-                return ReclaimedRoomOutcome::AlreadyLive;
+                return ctx.reply(ReclaimedRoomOutcome::AlreadyLive);
             }
-            return self
-                .release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)
-                .await;
+            return ctx.reply(
+                self.release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)
+                    .await,
+            );
         }
         if self.node_identity.current() != identity {
-            return self
-                .release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)
-                .await;
+            return ctx.reply(
+                self.release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)
+                    .await,
+            );
         }
 
         // A delayed or duplicate reclaimed-room message can name an exact
@@ -1896,7 +2803,7 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
                 }
             }
             self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
-            return ReclaimedRoomOutcome::PendingRetry;
+            return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
         }
 
         // Prove the reaper's exact epoch before touching any local actor.
@@ -1912,12 +2819,12 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
             Ok(Err(error)) => {
                 debug!(room = %msg.room_jid, %error, "reclaimed-room ownership fence failed");
                 self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
-                return ReclaimedRoomOutcome::PendingRetry;
+                return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
             }
             Err(_) => {
                 debug!(room = %msg.room_jid, "reclaimed-room ownership fence timed out");
                 self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
-                return ReclaimedRoomOutcome::PendingRetry;
+                return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
             }
         };
         if !still_owned {
@@ -1934,14 +2841,14 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
                 store.forget_claim_fence(&msg.room_jid, &claim_fence);
             }
             self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
-            return ReclaimedRoomOutcome::LostRace;
+            return ctx.reply(ReclaimedRoomOutcome::LostRace);
         }
 
         if let Some(entry) = self.rooms.get(&msg.room_jid).cloned() {
             if entry.actor_ref.is_alive() {
                 if entry.claim_fence == claim_fence {
                     self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
-                    return ReclaimedRoomOutcome::AlreadyLive;
+                    return ctx.reply(ReclaimedRoomOutcome::AlreadyLive);
                 }
                 // Never transplant a live actor onto a new epoch. An earlier
                 // mailbox mutation may still be running under the old fence;
@@ -1958,9 +2865,10 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
         }
 
         let Some(store) = self.durable_store.clone() else {
-            return self
-                .release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)
-                .await;
+            return ctx.reply(
+                self.release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)
+                    .await,
+            );
         };
         let snapshot = match tokio::time::timeout(
             RECLAIMED_ROOM_STORE_TIMEOUT,
@@ -1970,9 +2878,14 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
         {
             Ok(Ok(Some(snapshot))) => snapshot,
             Ok(Ok(None)) => {
-                return self
-                    .release_reclaimed_room_claim(&msg.room_jid, &claim_fence, &msg.previous_owner)
-                    .await;
+                return ctx.reply(
+                    self.release_reclaimed_room_claim(
+                        &msg.room_jid,
+                        &claim_fence,
+                        &msg.previous_owner,
+                    )
+                    .await,
+                );
             }
             Ok(Err(error)) => {
                 debug!(
@@ -1981,12 +2894,12 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
                     "failed to load proactively reclaimed room state; retaining for retry"
                 );
                 self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
-                return ReclaimedRoomOutcome::PendingRetry;
+                return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
             }
             Err(_) => {
                 debug!(room = %msg.room_jid, "proactively reclaimed room-state load timed out");
                 self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
-                return ReclaimedRoomOutcome::PendingRetry;
+                return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
             }
         };
 
@@ -2004,26 +2917,31 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
             Ok(Ok(false)) => {
                 store.forget_claim_fence(&msg.room_jid, &claim_fence);
                 self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
-                return ReclaimedRoomOutcome::LostRace;
+                return ctx.reply(ReclaimedRoomOutcome::LostRace);
             }
             Ok(Err(error)) => {
                 debug!(room = %msg.room_jid, %error, "final reclaimed-room ownership fence failed");
                 self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
-                return ReclaimedRoomOutcome::PendingRetry;
+                return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
             }
             Err(_) => {
                 debug!(room = %msg.room_jid, "final reclaimed-room ownership fence timed out");
                 self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
-                return ReclaimedRoomOutcome::PendingRetry;
+                return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
             }
         }
 
         if self.node_identity.current() != identity {
             self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
-            return ReclaimedRoomOutcome::PendingRetry;
+            return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
         }
 
-        let actor_ref = match self
+        if !self.has_pending_preparation_capacity() {
+            self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+            return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
+        }
+
+        let (guard, has_async_work) = match self
             .prepare_room(
                 msg.room_jid.clone(),
                 snapshot.waddle_id,
@@ -2033,7 +2951,7 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
             )
             .await
         {
-            Ok(actor_ref) => actor_ref,
+            Ok(prepared) => prepared,
             Err(error) => {
                 debug!(
                     room = %msg.room_jid,
@@ -2041,45 +2959,61 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
                     "reclaimed room restore did not become ready; retaining exact epoch"
                 );
                 self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
-                return ReclaimedRoomOutcome::PendingRetry;
+                return ctx.reply(ReclaimedRoomOutcome::PendingRetry);
             }
-        };
-        // `prepare_room` awaits both mailbox enqueues. Fence once more at
-        // the actual publication boundary so neither an identity change nor
-        // an epoch steal during those awaits can install a stale actor.
-        let publish_owned = tokio::time::timeout(
-            RECLAIMED_ROOM_STORE_TIMEOUT,
-            self.claim_store.fence(&entity, &identity, claim_epoch),
-        )
-        .await;
-        match publish_owned {
-            Ok(Ok(true)) => {}
-            Ok(Ok(false)) => {
-                actor_ref.kill();
-                if let Some(store) = &self.durable_store {
-                    store.forget_claim_fence(&msg.room_jid, &claim_fence);
-                }
-                self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
-                return ReclaimedRoomOutcome::LostRace;
-            }
-            Ok(Err(_)) | Err(_) => {
-                actor_ref.kill();
-                self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
-                return ReclaimedRoomOutcome::PendingRetry;
-            }
-        }
-        let identity_handle = self.node_identity.clone();
-        let Some(_identity_guard) = identity_handle.guard_if_current(&identity).await else {
-            actor_ref.kill();
-            self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
-            return ReclaimedRoomOutcome::PendingRetry;
         };
         self.poisoned_rooms.remove(&msg.room_jid);
-        if !self.publish_room(msg.room_jid.clone(), actor_ref, claim_fence.clone()) {
-            self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
-            return ReclaimedRoomOutcome::PendingRetry;
+        if !has_async_work {
+            return match self
+                .publish_prepared_room(msg.room_jid.clone(), guard, claim_fence.clone())
+                .await
+            {
+                Ok(_) => ctx.reply(ReclaimedRoomOutcome::Hydrated),
+                Err(RoomPublicationError::ClaimLost) => {
+                    if let Some(store) = &self.durable_store {
+                        store.forget_claim_fence(&msg.room_jid, &claim_fence);
+                    }
+                    self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+                    ctx.reply(ReclaimedRoomOutcome::LostRace)
+                }
+                Err(RoomPublicationError::LocalIdentityChanged) => {
+                    self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+                    self.transfer_preparation_to_pending_release(
+                        msg.room_jid.clone(),
+                        claim_fence.clone(),
+                    );
+                    self.start_detached_room_release(
+                        msg.room_jid,
+                        claim_fence,
+                        ctx.actor_ref().clone(),
+                    );
+                    ctx.reply(ReclaimedRoomOutcome::PendingRetry)
+                }
+                Err(_) => {
+                    self.remember_pending_reclaimed_room(
+                        msg.room_jid,
+                        claim_fence,
+                        msg.previous_owner,
+                    );
+                    ctx.reply(ReclaimedRoomOutcome::PendingRetry)
+                }
+            };
         }
-        ReclaimedRoomOutcome::Hydrated
+        let room_jid = msg.room_jid;
+        let previous_owner = msg.previous_owner;
+        let (delegated, reply) = ctx.reply_sender();
+        self.start_pending_preparation(
+            room_jid.clone(),
+            claim_fence,
+            RoomPreparationOrigin::Reclaimed { previous_owner },
+            guard,
+            reply.map(|reply| RoomPreparationWaiter::Reclaimed {
+                reply,
+                success: ReclaimedRoomOutcome::Hydrated,
+            }),
+            ctx.actor_ref().clone(),
+        );
+        delegated
     }
 }
 
@@ -2092,39 +3026,47 @@ pub struct GetOrCreateRoom {
 }
 
 impl kameo::message::Message<GetOrCreateRoom> for RoomRegistryActor {
-    type Reply = Result<RoomAcquisition, RoomRegistryError>;
+    type Reply = DelegatedReply<Result<RoomAcquisition, RoomRegistryError>>;
 
     async fn handle(
         &mut self,
         msg: GetOrCreateRoom,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        if let Some(actor_ref) = self.live_room(&msg.room_jid).await? {
-            debug!(room = %msg.room_jid, "Room already exists");
-            return Ok(RoomAcquisition {
+        let room_jid = msg.room_jid;
+        let creation_spec = Arc::new(RoomCreationSpec {
+            waddle_id: msg.waddle_id,
+            channel_id: msg.channel_id,
+            config: msg.config,
+        });
+        match self
+            .transition_demand_room(room_jid.clone(), creation_spec, ctx.actor_ref().clone())
+            .await
+        {
+            Ok(DemandRoomTransition::Existing(actor_ref)) => {
+                debug!(room = %room_jid, "Room already exists");
+                ctx.reply(Ok(RoomAcquisition {
+                    actor_ref,
+                    creation: RoomCreation::Existing,
+                }))
+            }
+            Ok(DemandRoomTransition::Created(actor_ref)) => ctx.reply(Ok(RoomAcquisition {
                 actor_ref,
-                creation: RoomCreation::Existing,
-            });
+                creation: RoomCreation::Created,
+            })),
+            Ok(DemandRoomTransition::Pending(creation_spec)) => {
+                let (delegated, reply) = ctx.reply_sender();
+                self.attach_preparation_waiter(
+                    &room_jid,
+                    reply.map(|reply| RoomPreparationWaiter::Acquisition {
+                        reply,
+                        creation_spec,
+                    }),
+                );
+                delegated
+            }
+            Err(error) => ctx.reply(Err(error)),
         }
-
-        let claim_fence = self
-            .acquire_room_claim(&msg.room_jid, ctx.actor_ref())
-            .await?;
-        info!(room = %msg.room_jid, "Creating new room via GetOrCreateRoom");
-        self.poisoned_rooms.remove(&msg.room_jid);
-        let actor_ref = self
-            .spawn_room(
-                msg.room_jid,
-                msg.waddle_id,
-                msg.channel_id,
-                msg.config,
-                claim_fence,
-            )
-            .await?;
-        Ok(RoomAcquisition {
-            actor_ref,
-            creation: RoomCreation::Created,
-        })
     }
 }
 
@@ -2134,20 +3076,13 @@ pub struct CreateInstantRoom {
 }
 
 impl kameo::message::Message<CreateInstantRoom> for RoomRegistryActor {
-    type Reply = Result<RoomAcquisition, RoomRegistryError>;
+    type Reply = DelegatedReply<Result<RoomAcquisition, RoomRegistryError>>;
 
     async fn handle(
         &mut self,
         msg: CreateInstantRoom,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        if let Some(actor_ref) = self.live_room(&msg.room_jid).await? {
-            return Ok(RoomAcquisition {
-                actor_ref,
-                creation: RoomCreation::Existing,
-            });
-        }
-
         let room_local = msg
             .room_jid
             .node()
@@ -2161,18 +3096,38 @@ impl kameo::message::Message<CreateInstantRoom> for RoomRegistryActor {
             persistent: false,
             ..RoomConfig::default()
         };
+        let creation_spec = Arc::new(RoomCreationSpec {
+            waddle_id,
+            channel_id,
+            config,
+        });
 
-        let claim_fence = self
-            .acquire_room_claim(&msg.room_jid, ctx.actor_ref())
-            .await?;
-        self.poisoned_rooms.remove(&msg.room_jid);
-        let actor_ref = self
-            .spawn_room(msg.room_jid, waddle_id, channel_id, config, claim_fence)
-            .await?;
-        Ok(RoomAcquisition {
-            actor_ref,
-            creation: RoomCreation::Created,
-        })
+        let room_jid = msg.room_jid;
+        match self
+            .transition_demand_room(room_jid.clone(), creation_spec, ctx.actor_ref().clone())
+            .await
+        {
+            Ok(DemandRoomTransition::Existing(actor_ref)) => ctx.reply(Ok(RoomAcquisition {
+                actor_ref,
+                creation: RoomCreation::Existing,
+            })),
+            Ok(DemandRoomTransition::Created(actor_ref)) => ctx.reply(Ok(RoomAcquisition {
+                actor_ref,
+                creation: RoomCreation::Created,
+            })),
+            Ok(DemandRoomTransition::Pending(creation_spec)) => {
+                let (delegated, reply) = ctx.reply_sender();
+                self.attach_preparation_waiter(
+                    &room_jid,
+                    reply.map(|reply| RoomPreparationWaiter::Acquisition {
+                        reply,
+                        creation_spec,
+                    }),
+                );
+                delegated
+            }
+            Err(error) => ctx.reply(Err(error)),
+        }
     }
 }
 
@@ -2185,32 +3140,40 @@ pub struct CreateRoom {
 }
 
 impl kameo::message::Message<CreateRoom> for RoomRegistryActor {
-    type Reply = Result<ActorRef<RoomActor>, RoomRegistryError>;
+    type Reply = DelegatedReply<Result<ActorRef<RoomActor>, RoomRegistryError>>;
 
     async fn handle(
         &mut self,
         msg: CreateRoom,
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        if self.live_room(&msg.room_jid).await?.is_some() {
-            return Err(RoomRegistryError::RoomAlreadyExists(msg.room_jid));
+        let room_jid = msg.room_jid;
+        let creation_spec = Arc::new(RoomCreationSpec {
+            waddle_id: msg.waddle_id,
+            channel_id: msg.channel_id,
+            config: msg.config,
+        });
+        match self
+            .transition_demand_room(room_jid.clone(), creation_spec, ctx.actor_ref().clone())
+            .await
+        {
+            Ok(DemandRoomTransition::Existing(_)) => {
+                ctx.reply(Err(RoomRegistryError::RoomAlreadyExists(room_jid)))
+            }
+            Ok(DemandRoomTransition::Created(actor_ref)) => ctx.reply(Ok(actor_ref)),
+            Ok(DemandRoomTransition::Pending(creation_spec)) => {
+                let (delegated, reply) = ctx.reply_sender();
+                self.attach_preparation_waiter(
+                    &room_jid,
+                    reply.map(|reply| RoomPreparationWaiter::ExclusiveCreate {
+                        reply,
+                        creation_spec,
+                    }),
+                );
+                delegated
+            }
+            Err(error) => ctx.reply(Err(error)),
         }
-
-        let claim_fence = self
-            .acquire_room_claim(&msg.room_jid, ctx.actor_ref())
-            .await?;
-        info!(room = %msg.room_jid, "Creating new room");
-        self.poisoned_rooms.remove(&msg.room_jid);
-        let actor_ref = self
-            .spawn_room(
-                msg.room_jid,
-                msg.waddle_id,
-                msg.channel_id,
-                msg.config,
-                claim_fence,
-            )
-            .await?;
-        Ok(actor_ref)
     }
 }
 
@@ -2263,17 +3226,23 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
     async fn handle(
         &mut self,
         msg: DestroyRoom,
-        _ctx: &mut Context<Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        if msg.reason != DestroyRoomReason::DeposedEviction
-            && self.rooms.contains_key(&msg.room_jid)
-            && !self
-                .has_pending_release_capacity(&msg.room_jid, &self.rooms[&msg.room_jid].claim_fence)
-        {
-            return DestroyRoomOutcome::ReleaseBacklogFull;
+        if msg.reason != DestroyRoomReason::DeposedEviction {
+            let claim_fence = self
+                .rooms
+                .get(&msg.room_jid)
+                .map(|entry| &entry.claim_fence);
+            if claim_fence.is_some_and(|claim_fence| {
+                !self.has_pending_release_capacity(&msg.room_jid, claim_fence)
+            }) {
+                return DestroyRoomOutcome::ReleaseBacklogFull;
+            }
         }
         let removed_entry = self.rooms.remove(&msg.room_jid);
         let removed_room = removed_entry.is_some();
+        let removed_preparation = self.pending_room_preparations.remove(&msg.room_jid);
+        let removed_pending_room = removed_preparation.is_some();
         let removed_poison = self.poisoned_rooms.remove(&msg.room_jid);
         // XEP-0045 §10.9 (#1261): destroy removes the room "even if it
         // was defined as persistent" — wipe the durable rows (config,
@@ -2287,7 +3256,9 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
         // acknowledges a destruction whose durable state survived.
         // `DeposedEviction` never wipes — the
         // room lives on under its new owner.
-        if (removed_room || removed_poison) && msg.reason == DestroyRoomReason::Destroy {
+        if (removed_room || removed_pending_room || removed_poison)
+            && msg.reason == DestroyRoomReason::Destroy
+        {
             if let Some(store) = &self.durable_store {
                 if let Err(error) = store.delete_room_state(&msg.room_jid).await {
                     warn!(
@@ -2299,12 +3270,32 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
                     if let Some(entry) = removed_entry {
                         self.rooms.insert(msg.room_jid.clone(), entry);
                     }
+                    if let Some(pending) = removed_preparation {
+                        self.pending_room_preparations
+                            .insert(msg.room_jid.clone(), pending);
+                    }
                     if removed_poison {
                         self.poisoned_rooms.insert(msg.room_jid.clone());
                     }
                     return DestroyRoomOutcome::DurableWipeFailed;
                 }
             }
+        }
+        if let Some(pending) = removed_preparation {
+            let claim_fence = pending.claim_fence.clone();
+            Self::reply_preparation_failure(
+                &msg.room_jid,
+                pending.waiters,
+                ReclaimedRoomOutcome::PendingRetry,
+            );
+            drop(pending.guard);
+            self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+            self.transfer_preparation_to_pending_release(msg.room_jid.clone(), claim_fence.clone());
+            self.start_detached_room_release(
+                msg.room_jid.clone(),
+                claim_fence,
+                ctx.actor_ref().clone(),
+            );
         }
         // ADR-0017 Phase 3 Slice 7: release the Postgres claim on every
         // terminal path (explicit destroy, dormancy-eviction sweep) —
@@ -2326,7 +3317,7 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
                     .await;
             }
         }
-        if removed_room || removed_poison {
+        if removed_room || removed_pending_room || removed_poison {
             info!(room = %msg.room_jid, "Destroyed room");
             DestroyRoomOutcome::Destroyed
         } else {
@@ -2369,6 +3360,11 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
         msg: DestroyRoomIfInactive,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        // Preparation is not yet published and therefore cannot have been
+        // observed inactive at the supplied occupancy revision.
+        if self.pending_room_preparations.contains_key(&msg.room_jid) {
+            return false;
+        }
         let Some(entry) = self.rooms.get(&msg.room_jid).cloned() else {
             return false;
         };
@@ -2472,6 +3468,11 @@ impl kameo::message::Message<ReapSealedRoom> for RoomRegistryActor {
         msg: ReapSealedRoom,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        // A stale reap from a previous incarnation must not cancel or race
+        // publication of a newly restoring incarnation.
+        if self.pending_room_preparations.contains_key(&msg.room_jid) {
+            return false;
+        }
         let Some(entry) = self.rooms.get(&msg.room_jid).cloned() else {
             return false;
         };
@@ -2617,8 +3618,33 @@ impl kameo::message::Message<DemoteRoomIfOwner> for RoomRegistryActor {
     async fn handle(
         &mut self,
         msg: DemoteRoomIfOwner,
-        _ctx: &mut Context<Self, Self::Reply>,
+        ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        let pending_matches = self
+            .pending_room_preparations
+            .get(&msg.room_jid)
+            .is_some_and(|pending| pending.claim_fence.owner() == msg.owner);
+        if pending_matches {
+            let pending = self
+                .pending_room_preparations
+                .remove(&msg.room_jid)
+                .expect("pending owner was checked in the same mailbox turn");
+            let claim_fence = pending.claim_fence.clone();
+            Self::reply_preparation_failure(
+                &msg.room_jid,
+                pending.waiters,
+                ReclaimedRoomOutcome::LostRace,
+            );
+            drop(pending.guard);
+            self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+            self.transfer_preparation_to_pending_release(msg.room_jid.clone(), claim_fence.clone());
+            self.start_detached_room_release(
+                msg.room_jid.clone(),
+                claim_fence,
+                ctx.actor_ref().clone(),
+            );
+            return true;
+        }
         let matches = self
             .rooms
             .get(&msg.room_jid)
@@ -2629,10 +3655,7 @@ impl kameo::message::Message<DemoteRoomIfOwner> for RoomRegistryActor {
         let Some(entry) = self.rooms.remove(&msg.room_jid) else {
             return false;
         };
-        entry.actor_ref.kill();
-        if let Some(store) = &self.durable_store {
-            store.forget_claim_fence(&msg.room_jid, &entry.claim_fence);
-        }
+        self.retire_ownership_lost_entry(&msg.room_jid, entry).await;
         true
     }
 }
@@ -2651,6 +3674,12 @@ impl kameo::message::Message<ListRoomsOwnedBy> for RoomRegistryActor {
             .filter(|(_, entry)| entry.claim_fence.owner() == msg.owner)
             .map(|(jid, _)| jid.clone())
             .collect::<Vec<_>>();
+        room_jids.extend(
+            self.pending_room_preparations
+                .iter()
+                .filter(|(_, pending)| pending.claim_fence.owner() == msg.owner)
+                .map(|(jid, _)| jid.clone()),
+        );
         room_jids.extend(
             self.pending_room_releases
                 .keys()
@@ -2702,6 +3731,24 @@ impl kameo::message::Message<HangForever> for RoomRegistryActor {
         // Park forever: the registry's single-consumer loop is blocked here,
         // mirroring a wedged handler. The caller must rely on its reply timeout.
         std::future::pending::<()>().await
+    }
+}
+
+/// Test-only mailbox marker used to prove that queued work runs between
+/// serialized publication-boundary fences.
+#[cfg(test)]
+pub(crate) struct MarkRegistryProgress(pub std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+#[cfg(test)]
+impl kameo::message::Message<MarkRegistryProgress> for RoomRegistryActor {
+    type Reply = ();
+
+    async fn handle(
+        &mut self,
+        msg: MarkRegistryProgress,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        msg.0.store(true, std::sync::atomic::Ordering::SeqCst);
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -1851,6 +1851,32 @@ mod ownership_claims_tests {
             Box::pin(async move { Ok(result) })
         }
 
+        fn load_room_state_fenced<'a>(
+            &'a self,
+            room_jid: &'a BareJid,
+        ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+            if !self
+                .claim_fences
+                .lock()
+                .expect("lock")
+                .contains_key(room_jid)
+            {
+                return Box::pin(async {
+                    Err(crate::XmppError::internal(
+                        "fenced load attempted before exact claim fence was recorded",
+                    ))
+                });
+            }
+            if self.fence_lost.load(Ordering::SeqCst) {
+                return Box::pin(async {
+                    Err(crate::XmppError::internal(
+                        "fenced load rejected after ownership loss",
+                    ))
+                });
+            }
+            self.load_room_state(room_jid)
+        }
+
         fn save_config<'a>(
             &'a self,
             room_jid: &'a BareJid,
@@ -2217,6 +2243,57 @@ mod ownership_claims_tests {
         assert_eq!(affiliation, Affiliation::Owner);
     }
 
+    #[tokio::test]
+    async fn failed_initial_restore_is_never_published_on_demand() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let durable_store = Arc::new(RecordingDurableStore {
+            fence_lost: AtomicBool::new(true),
+            ..RecordingDurableStore::default()
+        });
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let jid = test_room_jid("failed-initial-demand-restore");
+        let result = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "caller-waddle".to_string(),
+                channel_id: "caller-channel".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await;
+        assert!(matches!(
+            result,
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipUnavailable(room)
+            )) if room == jid
+        ));
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("room lookup after failed restore")
+            .is_none());
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup after failed restore")
+            .is_none());
+        assert!(
+            durable_store.current_claim_fence(&jid).is_none(),
+            "a definitively released demand claim must clear its exact durable fence",
+        );
+    }
+
     fn reclaimed_snapshot(name: &str) -> DurableRoomState {
         DurableRoomState {
             waddle_id: "reclaimed-waddle".to_string(),
@@ -2290,6 +2367,59 @@ mod ownership_claims_tests {
             .expect("idempotent reconcile");
         assert_eq!(second, ReclaimedRoomOutcome::AlreadyLive);
         assert_eq!(registry.ask(RoomCount).await.expect("count"), 1);
+    }
+
+    #[tokio::test]
+    async fn failed_initial_reclaimed_restore_is_never_published_and_retains_the_fence() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(5);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        let durable_store = Arc::new(RecordingDurableStore {
+            load_result: Some(reclaimed_snapshot("must remain hidden")),
+            fence_lost: AtomicBool::new(true),
+            ..RecordingDurableStore::default()
+        });
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let jid = test_room_jid("failed-initial-reclaimed-restore");
+        let claim_fence = room_claim_fence(&jid, epoch);
+        let outcome = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: claim_fence.clone(),
+                previous_owner: this_identity(),
+            })
+            .await
+            .expect("reconcile failed restore");
+        assert_eq!(outcome, ReclaimedRoomOutcome::PendingRetry);
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("room lookup after failed restore")
+            .is_none());
+        assert_eq!(
+            registry
+                .ask(GetPendingReclaimedRoomBacklog)
+                .await
+                .expect("pending reclaimed backlog")
+                .depth,
+            1,
+        );
+        assert_eq!(
+            durable_store.current_claim_fence(&jid),
+            Some(claim_fence),
+            "an uncertain reclaimed preparation retains exact-epoch responsibility",
+        );
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -2725,8 +2725,8 @@ mod ownership_claims_tests {
         assert_eq!(pending.len(), MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES);
     }
 
-    #[test]
-    fn saturated_capacity_admits_existing_but_rejects_novel_responsibility() {
+    #[tokio::test]
+    async fn saturated_capacity_admits_existing_but_rejects_novel_responsibility() {
         let mut registry = RoomRegistryActor::new(
             "muc.example.com".to_string(),
             OccupantIdSecret::for_testing(b"test-secret".to_vec()),
@@ -2742,7 +2742,21 @@ mod ownership_claims_tests {
                 },
             );
         }
-        for index in 0..MAX_PENDING_RECLAIMED_ROOMS {
+        let existing_reclaimed_room = test_room_jid("saturated-exact-reclaimed");
+        let existing_reclaimed_fence = room_claim_fence(&existing_reclaimed_room, ClaimEpoch(500));
+        registry.pending_reclaimed_rooms.insert(
+            (
+                existing_reclaimed_room.clone(),
+                existing_reclaimed_fence.clone(),
+            ),
+            PendingReclaimedState {
+                claim_fence: existing_reclaimed_fence,
+                previous_owner: foreign_identity(),
+                retry_order: 0,
+                first_pending_at: std::time::Instant::now(),
+            },
+        );
+        for index in 0..(MAX_PENDING_RECLAIMED_ROOMS - 1) {
             registry
                 .pending_reclaimed_reservations
                 .insert(test_room_jid(&format!("saturated-reservation-{index}")));
@@ -2777,6 +2791,32 @@ mod ownership_claims_tests {
                 claim_fence: &novel_claim_fence,
             }
         ));
+        let registry = RoomRegistryActor::spawn(registry);
+        let backlog_before = registry
+            .ask(GetPendingReclaimedRoomBacklog)
+            .await
+            .expect("reclaimed backlog before duplicate");
+        assert!(registry
+            .ask(ReservePendingReclaimedRoom {
+                room_jid: existing_reclaimed_room,
+            })
+            .await
+            .expect("repeat existing exact reclaimed reservation"));
+        assert_eq!(
+            registry
+                .ask(GetPendingReclaimedRoomBacklog)
+                .await
+                .expect("reclaimed backlog after duplicate"),
+            backlog_before,
+            "an exact reclaimed responsibility must not gain a redundant bare-JID reservation",
+        );
+        assert!(!registry
+            .ask(ReservePendingReclaimedRoom {
+                room_jid: novel_room_jid,
+            })
+            .await
+            .expect("reject novel reclaimed reservation at capacity"));
+        registry.kill();
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -42,6 +42,20 @@ struct PendingPreparationWaitersForTest {
 
 struct PendingPreparationCountForTest;
 
+struct PendingRoomOwnershipResponsibilityCountForTest;
+
+impl kameo::message::Message<PendingRoomOwnershipResponsibilityCountForTest> for RoomRegistryActor {
+    type Reply = usize;
+
+    async fn handle(
+        &mut self,
+        _msg: PendingRoomOwnershipResponsibilityCountForTest,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.pending_room_ownership_responsibilities().len()
+    }
+}
+
 impl kameo::message::Message<PendingPreparationCountForTest> for RoomRegistryActor {
     type Reply = usize;
 
@@ -2734,10 +2748,286 @@ mod ownership_claims_tests {
                 RoomRegistryError::OwnershipReconciliationPending(ref room)
             )) if *room == overflow_jid
         ));
+        assert!(!registry
+            .ask(ReservePendingReclaimedRoom {
+                room_jid: test_room_jid("bounded-reclaimed-overflow"),
+            })
+            .await
+            .expect("reclaimed admission observes the same global bound"));
+        let release_overflow_jid = test_room_jid("bounded-release-overflow");
+        assert!(!registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: release_overflow_jid.clone(),
+                claim_fence: room_claim_fence(&release_overflow_jid, ClaimEpoch(999)),
+            })
+            .await
+            .expect("ordinary release admission observes the same global bound"));
         registry.kill();
         for task in pending {
             task.abort();
         }
+    }
+
+    #[tokio::test]
+    async fn reclaimed_and_release_responsibilities_exhaust_preparation_capacity() {
+        let registry = spawn_registry().await;
+        for index in 0..MAX_PENDING_RECLAIMED_ROOMS {
+            let room_jid = test_room_jid(&format!("bounded-reclaimed-{index}"));
+            assert!(registry
+                .ask(ReservePendingReclaimedRoom {
+                    room_jid: room_jid.clone(),
+                })
+                .await
+                .expect("reserve reclaimed room"));
+            if index % 2 == 0 {
+                registry
+                    .ask(RememberPendingReclaimedRoom {
+                        room_jid: room_jid.clone(),
+                        claim_fence: room_claim_fence(&room_jid, ClaimEpoch(index as i64 + 1)),
+                        previous_owner: foreign_identity(),
+                    })
+                    .await
+                    .expect("replace reservation with exact reclaimed responsibility");
+            }
+        }
+        for index in 0..MAX_PENDING_ROOM_RELEASES {
+            let room_jid = test_room_jid(&format!("bounded-release-{index}"));
+            assert!(registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: room_jid.clone(),
+                    claim_fence: room_claim_fence(&room_jid, ClaimEpoch(index as i64 + 1)),
+                })
+                .await
+                .expect("remember release"));
+        }
+        wire_recording_store(&registry, Arc::new(RecordingDurableStore::default())).await;
+
+        let overflow_jid = test_room_jid("reclaimed-preparation-overflow");
+        assert!(matches!(
+            registry.ask(get_or_create(overflow_jid.clone())).await,
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipReconciliationPending(ref room)
+            )) if *room == overflow_jid
+        ));
+        registry.kill();
+    }
+
+    #[tokio::test]
+    async fn reclaimed_preparation_overlap_counts_each_exact_fence_once() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(301);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        let allow_load = Arc::new(tokio::sync::Notify::new());
+        let durable_store = Arc::new(RecordingDurableStore {
+            load_result: Some(reclaimed_snapshot("bounded-overlap")),
+            block_all_loads: true,
+            allow_load: Some(Arc::clone(&allow_load)),
+            ..RecordingDurableStore::default()
+        });
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: claim_store as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let room_jid = test_room_jid("bounded-overlap");
+        let claim_fence = room_claim_fence(&room_jid, epoch);
+        registry
+            .ask(RememberPendingReclaimedRoom {
+                room_jid: room_jid.clone(),
+                claim_fence: claim_fence.clone(),
+                previous_owner: foreign_identity(),
+            })
+            .await
+            .expect("remember exact reclaimed responsibility");
+
+        let reconcile_registry = registry.clone();
+        let reconcile_jid = room_jid.clone();
+        let reconcile_fence = claim_fence.clone();
+        let reconcile = tokio::spawn(async move {
+            reconcile_registry
+                .ask(ReconcileReclaimedRoom {
+                    room_jid: reconcile_jid,
+                    claim_fence: reconcile_fence,
+                    previous_owner: foreign_identity(),
+                })
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if registry
+                    .ask(PendingPreparationCountForTest)
+                    .await
+                    .expect("preparation count")
+                    == 1
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("reclaimed room reaches blocked preparation");
+        assert_eq!(
+            registry
+                .ask(PendingRoomOwnershipResponsibilityCountForTest)
+                .await
+                .expect("responsibility count"),
+            1,
+            "one exact fence present in reclaimed and preparation state consumes one slot"
+        );
+
+        registry
+            .ask(RememberPendingReclaimedRoom {
+                room_jid: room_jid.clone(),
+                claim_fence: room_claim_fence(&room_jid, ClaimEpoch(epoch.0 + 1)),
+                previous_owner: foreign_identity(),
+            })
+            .await
+            .expect("remember newer exact generation");
+        assert_eq!(
+            registry
+                .ask(PendingRoomOwnershipResponsibilityCountForTest)
+                .await
+                .expect("responsibility count"),
+            2,
+            "different exact fences for one room remain distinct responsibilities"
+        );
+
+        registry.kill();
+        reconcile.abort();
+    }
+
+    async fn saturated_registry_with_deposed_room(
+        name: &str,
+    ) -> (
+        ActorRef<RoomRegistryActor>,
+        Arc<DeadOwnerClaimStore>,
+        SharedNodeIdentity,
+        BareJid,
+        NodeIdentity,
+    ) {
+        let registry = spawn_registry().await;
+        let owner = this_identity();
+        let identity = SharedNodeIdentity::new(owner.clone());
+        let claim_store = Arc::new(DeadOwnerClaimStore::empty());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: identity.clone(),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let room_jid = test_room_jid(name);
+        registry
+            .ask(get_or_create(room_jid.clone()))
+            .await
+            .expect("create room before saturation");
+        for index in 0..MAX_PENDING_ROOM_RELEASES {
+            let release_jid = test_room_jid(&format!("{name}-release-{index}"));
+            assert!(registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: release_jid.clone(),
+                    claim_fence: room_claim_fence(&release_jid, ClaimEpoch(index as i64 + 1),),
+                })
+                .await
+                .expect("fill release inventory"));
+        }
+        for index in 0..MAX_PENDING_RECLAIMED_ROOMS {
+            assert!(registry
+                .ask(ReservePendingReclaimedRoom {
+                    room_jid: test_room_jid(&format!("{name}-reclaimed-{index}")),
+                })
+                .await
+                .expect("fill reclaimed inventory"));
+        }
+        identity.rotate(foreign_identity()).await;
+        claim_store.fail_next_release();
+        assert_eq!(
+            registry
+                .ask(PendingRoomOwnershipResponsibilityCountForTest)
+                .await
+                .expect("saturated responsibility count"),
+            MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES + 1,
+            "identity rotation turns the live old-identity room into one additional retained responsibility"
+        );
+        (registry, claim_store, identity, room_jid, owner)
+    }
+
+    #[tokio::test]
+    async fn saturated_demotion_retains_failed_exact_release() {
+        let (registry, claim_store, _identity, room_jid, owner) =
+            saturated_registry_with_deposed_room("saturated-demotion").await;
+
+        assert!(registry
+            .ask(DemoteRoomIfOwner {
+                room_jid: room_jid.clone(),
+                owner,
+            })
+            .await
+            .expect("demote old-identity room"));
+        assert!(registry
+            .ask(IsPendingRoomReleaseOnly {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("deposed fence remains typed"));
+        assert_eq!(
+            registry
+                .ask(PendingRoomOwnershipResponsibilityCountForTest)
+                .await
+                .expect("post-demotion responsibility count"),
+            MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES + 1,
+            "moving the deposed entry into release state is slot-neutral"
+        );
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, room_jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_some());
+        registry.kill();
+    }
+
+    #[tokio::test]
+    async fn saturated_deposed_eviction_retains_failed_exact_release() {
+        let (registry, claim_store, _identity, room_jid, _owner) =
+            saturated_registry_with_deposed_room("saturated-deposed-eviction").await;
+
+        assert_eq!(
+            registry
+                .ask(DestroyRoom {
+                    room_jid: room_jid.clone(),
+                    reason: DestroyRoomReason::DeposedEviction,
+                })
+                .await
+                .expect("evict deposed room"),
+            DestroyRoomOutcome::Destroyed
+        );
+        assert!(registry
+            .ask(IsPendingRoomReleaseOnly {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("deposed fence remains typed"));
+        assert_eq!(
+            registry
+                .ask(PendingRoomOwnershipResponsibilityCountForTest)
+                .await
+                .expect("post-eviction responsibility count"),
+            MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES + 1,
+            "deposed eviction transfers rather than discards the saturated responsibility"
+        );
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, room_jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_some());
+        registry.kill();
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -2015,6 +2015,7 @@ mod ownership_claims_tests {
     struct RecordingDurableStore {
         load_result: Option<DurableRoomState>,
         fail_load: bool,
+        fail_fenced_loads_remaining: AtomicUsize,
         block_all_loads: bool,
         block_load_for: Option<BareJid>,
         load_started: Option<Arc<tokio::sync::Notify>>,
@@ -2060,6 +2061,19 @@ mod ownership_claims_tests {
                 return Box::pin(async {
                     Err(crate::XmppError::internal(
                         "fenced load attempted before exact claim fence was recorded",
+                    ))
+                });
+            }
+            if self
+                .fail_fenced_loads_remaining
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return Box::pin(async {
+                    Err(crate::XmppError::internal(
+                        "transient fenced load failure from test store",
                     ))
                 });
             }
@@ -3721,6 +3735,59 @@ mod ownership_claims_tests {
             durable_store.current_claim_fence(&jid).is_none(),
             "a definitively released demand claim must clear its exact durable fence",
         );
+        assert_eq!(
+            durable_store.load_calls.load(Ordering::SeqCst),
+            2,
+            "a demand restore gets one bounded retry before the claim is released",
+        );
+    }
+
+    #[tokio::test]
+    async fn transient_initial_demand_restore_recovers_before_publication() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let durable_store = Arc::new(RecordingDurableStore {
+            load_result: Some(reclaimed_snapshot("restored-after-retry")),
+            fail_fenced_loads_remaining: AtomicUsize::new(1),
+            ..RecordingDurableStore::default()
+        });
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let jid = test_room_jid("transient-demand-restore");
+        let acquisition = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "caller-waddle".to_string(),
+                channel_id: "caller-channel".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("transient restore recovers");
+
+        assert_eq!(acquisition.creation, RoomCreation::Existing);
+        assert_eq!(
+            acquisition
+                .actor_ref
+                .ask(GetConfig)
+                .await
+                .expect("restored config")
+                .name,
+            "restored-after-retry",
+        );
+        assert_eq!(durable_store.load_calls.load(Ordering::SeqCst), 2);
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_some());
     }
 
     fn reclaimed_snapshot(name: &str) -> DurableRoomState {

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -36,6 +36,38 @@ impl kameo::message::Message<ReservePendingAcquisitionForTest> for RoomRegistryA
     }
 }
 
+struct PendingPreparationWaitersForTest {
+    room_jid: BareJid,
+}
+
+struct PendingPreparationCountForTest;
+
+impl kameo::message::Message<PendingPreparationCountForTest> for RoomRegistryActor {
+    type Reply = usize;
+
+    async fn handle(
+        &mut self,
+        _msg: PendingPreparationCountForTest,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.pending_room_preparations.len()
+    }
+}
+
+impl kameo::message::Message<PendingPreparationWaitersForTest> for RoomRegistryActor {
+    type Reply = Option<usize>;
+
+    async fn handle(
+        &mut self,
+        msg: PendingPreparationWaitersForTest,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.pending_room_preparations
+            .get(&msg.room_jid)
+            .map(|pending| pending.waiters.len())
+    }
+}
+
 fn test_room_jid(name: &str) -> BareJid {
     format!("{}@muc.example.com", name)
         .parse()
@@ -1283,7 +1315,7 @@ mod ownership_claims_tests {
         let jid = test_room_jid("panics");
         let entity = Entity::new(EntityType::RoomActor, jid.to_string());
 
-        let actor_ref = registry
+        let acquisition = registry
             .ask(GetOrCreateRoom {
                 room_jid: jid.clone(),
                 waddle_id: "w-1".to_string(),
@@ -1291,8 +1323,9 @@ mod ownership_claims_tests {
                 config: RoomConfig::default(),
             })
             .await
-            .expect("get_or_create_room")
-            .actor_ref;
+            .expect("get_or_create_room");
+        assert_eq!(acquisition.creation, RoomCreation::Created);
+        let actor_ref = acquisition.actor_ref;
         assert!(
             claim_store
                 .current_claim(&entity)
@@ -1396,6 +1429,7 @@ mod ownership_claims_tests {
         current_claim_failures: AtomicUsize,
         fence_calls: AtomicUsize,
         fence_fail_on_call: AtomicUsize,
+        fence_lose_claim_on_call: AtomicUsize,
         release_failures: AtomicUsize,
         release_delay_ms: AtomicU64,
         fence_delay_ms: AtomicU64,
@@ -1414,6 +1448,7 @@ mod ownership_claims_tests {
                 current_claim_failures: AtomicUsize::new(0),
                 fence_calls: AtomicUsize::new(0),
                 fence_fail_on_call: AtomicUsize::new(usize::MAX),
+                fence_lose_claim_on_call: AtomicUsize::new(usize::MAX),
                 release_failures: AtomicUsize::new(0),
                 release_delay_ms: AtomicU64::new(0),
                 fence_delay_ms: AtomicU64::new(0),
@@ -1433,6 +1468,10 @@ mod ownership_claims_tests {
 
         fn fail_fence_on_call(&self, call: usize) {
             self.fence_fail_on_call.store(call, Ordering::SeqCst);
+        }
+
+        fn lose_claim_on_fence_call(&self, call: usize) {
+            self.fence_lose_claim_on_call.store(call, Ordering::SeqCst);
         }
 
         fn fail_next_current_claim(&self) {
@@ -1616,6 +1655,10 @@ mod ownership_claims_tests {
             if call == self.fence_fail_on_call.load(Ordering::SeqCst) {
                 return Err(ClaimError::Backend("test final fence failure".to_string()));
             }
+            if call == self.fence_lose_claim_on_call.load(Ordering::SeqCst) {
+                *self.state.lock().expect("lock") =
+                    Some((foreign_identity(), ClaimEpoch(mine.0.saturating_add(1))));
+            }
             Ok(
                 matches!(&*self.state.lock().expect("lock"), Some((owner, epoch)) if owner == me && *epoch == mine),
             )
@@ -1685,6 +1728,138 @@ mod ownership_claims_tests {
                 *state = None;
             }
             Ok(())
+        }
+    }
+
+    /// Multi-entity claim store whose second fence for each room stalls. The
+    /// first fence is the detached readiness preflight; the second is the
+    /// authoritative publication-boundary fence executed by the registry.
+    struct SlowPublicationFenceStore {
+        inner: InProcessClaimStore,
+        fence_counts: Mutex<HashMap<Entity, usize>>,
+        publication_fence_started: tokio::sync::Notify,
+        publication_fences_started: AtomicUsize,
+        mailbox_marker_seen: Arc<AtomicBool>,
+        second_publication_started_before_marker: AtomicBool,
+    }
+
+    impl SlowPublicationFenceStore {
+        fn new(mailbox_marker_seen: Arc<AtomicBool>) -> Self {
+            Self {
+                inner: InProcessClaimStore::new(),
+                fence_counts: Mutex::new(HashMap::new()),
+                publication_fence_started: tokio::sync::Notify::new(),
+                publication_fences_started: AtomicUsize::new(0),
+                mailbox_marker_seen,
+                second_publication_started_before_marker: AtomicBool::new(false),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ClaimStore for SlowPublicationFenceStore {
+        async fn ensure_schema(&self) -> Result<(), ClaimError> {
+            self.inner.ensure_schema().await
+        }
+
+        async fn acquire(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner.acquire(entity, me).await
+        }
+
+        async fn ensure_claimed(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner.ensure_claimed(entity, me).await
+        }
+
+        async fn steal_stale(
+            &self,
+            entity: &Entity,
+            observed: ClaimEpoch,
+            staleness: StalePredicate,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner
+                .steal_stale(entity, observed, staleness, me)
+                .await
+        }
+
+        async fn steal_for_resume(
+            &self,
+            entity: &Entity,
+            observed: ClaimEpoch,
+            witness: ResumeIdentityProof,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner
+                .steal_for_resume(entity, observed, witness, me)
+                .await
+        }
+
+        async fn current_claim(
+            &self,
+            entity: &Entity,
+        ) -> Result<Option<ClaimSnapshot>, ClaimError> {
+            self.inner.current_claim(entity).await
+        }
+
+        async fn fence(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<bool, ClaimError> {
+            let call = {
+                let mut counts = self.fence_counts.lock().expect("lock");
+                let count = counts.entry(entity.clone()).or_default();
+                *count += 1;
+                *count
+            };
+            if call == 2 {
+                let publication_number = self
+                    .publication_fences_started
+                    .fetch_add(1, Ordering::SeqCst)
+                    + 1;
+                if publication_number == 2 && !self.mailbox_marker_seen.load(Ordering::SeqCst) {
+                    self.second_publication_started_before_marker
+                        .store(true, Ordering::SeqCst);
+                }
+                self.publication_fence_started.notify_one();
+                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+            }
+            self.inner.fence(entity, me, mine).await
+        }
+
+        async fn release(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<(), ClaimError> {
+            self.inner.release(entity, me, mine).await
+        }
+
+        async fn release_exact(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<crate::ownership::ExactReleaseOutcome, ClaimError> {
+            self.inner.release_exact(entity, me, mine).await
+        }
+
+        async fn release_many(
+            &self,
+            entities: &[Entity],
+            me: &NodeIdentity,
+        ) -> Result<(), ClaimError> {
+            self.inner.release_many(entities, me).await
         }
     }
 
@@ -1826,6 +2001,12 @@ mod ownership_claims_tests {
     struct RecordingDurableStore {
         load_result: Option<DurableRoomState>,
         fail_load: bool,
+        block_all_loads: bool,
+        block_load_for: Option<BareJid>,
+        load_started: Option<Arc<tokio::sync::Notify>>,
+        allow_load: Option<Arc<tokio::sync::Notify>>,
+        load_calls: AtomicUsize,
+        config_save_calls: AtomicUsize,
         block_next_config_save: AtomicBool,
         config_save_started: Option<Arc<tokio::sync::Notify>>,
         allow_config_save: Option<Arc<tokio::sync::Notify>>,
@@ -1855,6 +2036,7 @@ mod ownership_claims_tests {
             &'a self,
             room_jid: &'a BareJid,
         ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+            self.load_calls.fetch_add(1, Ordering::SeqCst);
             if !self
                 .claim_fences
                 .lock()
@@ -1874,7 +2056,21 @@ mod ownership_claims_tests {
                     ))
                 });
             }
-            self.load_room_state(room_jid)
+            let should_block =
+                self.block_all_loads || self.block_load_for.as_ref() == Some(room_jid);
+            let load_started = self.load_started.clone();
+            let allow_load = self.allow_load.clone();
+            Box::pin(async move {
+                if should_block {
+                    if let Some(started) = load_started {
+                        started.notify_one();
+                    }
+                    if let Some(allow) = allow_load {
+                        allow.notified().await;
+                    }
+                }
+                self.load_room_state(room_jid).await
+            })
         }
 
         fn save_config<'a>(
@@ -1884,6 +2080,7 @@ mod ownership_claims_tests {
             _channel_id: &'a str,
             _config: &'a RoomConfig,
         ) -> MucDurableFuture<'a, ()> {
+            self.config_save_calls.fetch_add(1, Ordering::SeqCst);
             let block = self.block_next_config_save.swap(false, Ordering::SeqCst);
             let config_save_started = self.config_save_started.clone();
             let allow_config_save = self.allow_config_save.clone();
@@ -1986,6 +2183,724 @@ mod ownership_claims_tests {
                 .push((room_jid.to_string(), previous_owner_node_id.to_string()));
             Box::pin(async { Ok(()) })
         }
+    }
+
+    fn blocking_restore_store(
+        room_jid: BareJid,
+    ) -> (
+        Arc<RecordingDurableStore>,
+        Arc<tokio::sync::Notify>,
+        Arc<tokio::sync::Notify>,
+    ) {
+        blocking_restore_store_with_result(room_jid, None)
+    }
+
+    fn blocking_restore_store_with_result(
+        room_jid: BareJid,
+        load_result: Option<DurableRoomState>,
+    ) -> (
+        Arc<RecordingDurableStore>,
+        Arc<tokio::sync::Notify>,
+        Arc<tokio::sync::Notify>,
+    ) {
+        let started = Arc::new(tokio::sync::Notify::new());
+        let allow = Arc::new(tokio::sync::Notify::new());
+        let store = Arc::new(RecordingDurableStore {
+            load_result,
+            block_load_for: Some(room_jid),
+            load_started: Some(Arc::clone(&started)),
+            allow_load: Some(Arc::clone(&allow)),
+            ..RecordingDurableStore::default()
+        });
+        (store, started, allow)
+    }
+
+    fn restored_room_snapshot(name: &str) -> DurableRoomState {
+        DurableRoomState {
+            waddle_id: "restored-waddle".to_string(),
+            channel_id: "restored-channel".to_string(),
+            config: RoomConfig {
+                name: name.to_string(),
+                persistent: true,
+                ..RoomConfig::default()
+            },
+            subject: None,
+            affiliations: vec![AffiliationEntry::new(
+                "owner@example.com".parse().expect("owner JID"),
+                Affiliation::Owner,
+            )],
+        }
+    }
+
+    async fn wire_recording_store(
+        registry: &ActorRef<RoomRegistryActor>,
+        store: Arc<RecordingDurableStore>,
+    ) -> Arc<InProcessClaimStore> {
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(store as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire blocking durable store");
+        claim_store
+    }
+
+    fn get_or_create(room_jid: BareJid) -> GetOrCreateRoom {
+        GetOrCreateRoom {
+            room_jid,
+            waddle_id: "w".to_string(),
+            channel_id: "c".to_string(),
+            config: RoomConfig::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn blocked_restore_coalesces_its_lookup_without_blocking_unrelated_rooms() {
+        let registry = spawn_registry().await;
+        let blocked_jid = test_room_jid("blocked-restore");
+        let unrelated_jid = test_room_jid("unrelated-live");
+        let (store, started, allow) = blocking_restore_store(blocked_jid.clone());
+        wire_recording_store(&registry, Arc::clone(&store)).await;
+
+        registry
+            .ask(get_or_create(unrelated_jid.clone()))
+            .await
+            .expect("create unrelated room");
+        let registry_for_create = registry.clone();
+        let blocked_for_create = blocked_jid.clone();
+        let create = tokio::spawn(async move {
+            registry_for_create
+                .ask(get_or_create(blocked_for_create))
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+            .await
+            .expect("blocked restore started");
+
+        let unrelated = tokio::time::timeout(
+            std::time::Duration::from_millis(200),
+            registry.ask(GetRoom {
+                room_jid: unrelated_jid,
+            }),
+        )
+        .await
+        .expect("unrelated lookup must not wait for restore")
+        .expect("unrelated lookup reply");
+        assert!(unrelated.is_some());
+        let lookup_registry = registry.clone();
+        let lookup_jid = blocked_jid.clone();
+        let lookup = tokio::spawn(async move {
+            lookup_registry
+                .ask(GetRoom {
+                    room_jid: lookup_jid,
+                })
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_millis(200), async {
+            loop {
+                if registry
+                    .ask(PendingPreparationWaitersForTest {
+                        room_jid: blocked_jid.clone(),
+                    })
+                    .await
+                    .expect("waiter count")
+                    == Some(2)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("same-room lookup coalesces behind restore");
+        assert!(!lookup.is_finished());
+
+        allow.notify_one();
+        create
+            .await
+            .expect("create task")
+            .expect("blocked room publishes after restore");
+        assert!(lookup
+            .await
+            .expect("lookup task")
+            .expect("lookup reply")
+            .is_some());
+        assert_eq!(store.load_calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn concurrent_same_room_creations_coalesce_behind_one_restore() {
+        let registry = spawn_registry().await;
+        let room_jid = test_room_jid("coalesced-restore");
+        let (store, started, allow) = blocking_restore_store(room_jid.clone());
+        wire_recording_store(&registry, Arc::clone(&store)).await;
+
+        let first_registry = registry.clone();
+        let first_jid = room_jid.clone();
+        let first = tokio::spawn(async move { first_registry.ask(get_or_create(first_jid)).await });
+        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+            .await
+            .expect("first restore started");
+        let second_registry = registry.clone();
+        let second_jid = room_jid.clone();
+        let second =
+            tokio::spawn(async move { second_registry.ask(get_or_create(second_jid)).await });
+
+        tokio::time::timeout(std::time::Duration::from_millis(200), async {
+            loop {
+                if registry
+                    .ask(PendingPreparationWaitersForTest {
+                        room_jid: room_jid.clone(),
+                    })
+                    .await
+                    .expect("waiter count")
+                    == Some(2)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("duplicate request coalesced");
+        assert_eq!(
+            store.load_calls.load(Ordering::SeqCst),
+            1,
+            "coalescing must spawn only one actor/restore"
+        );
+
+        allow.notify_one();
+        let first = first.await.expect("first task").expect("first creation");
+        let second = second.await.expect("second task").expect("second creation");
+        assert_eq!(first.creation, RoomCreation::Created);
+        assert_eq!(second.creation, RoomCreation::Existing);
+        assert_eq!(first.actor_ref.id(), second.actor_ref.id());
+    }
+
+    #[tokio::test]
+    async fn concurrent_waiters_for_restored_room_are_all_existing() {
+        let registry = spawn_registry().await;
+        let room_jid = test_room_jid("coalesced-restored-room");
+        let (store, started, allow) = blocking_restore_store_with_result(
+            room_jid.clone(),
+            Some(restored_room_snapshot("restored")),
+        );
+        wire_recording_store(&registry, Arc::clone(&store)).await;
+
+        let first_registry = registry.clone();
+        let first_jid = room_jid.clone();
+        let first = tokio::spawn(async move { first_registry.ask(get_or_create(first_jid)).await });
+        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+            .await
+            .expect("restore started");
+        let second_registry = registry.clone();
+        let second_jid = room_jid.clone();
+        let second =
+            tokio::spawn(async move { second_registry.ask(get_or_create(second_jid)).await });
+
+        tokio::time::timeout(std::time::Duration::from_millis(200), async {
+            loop {
+                if registry
+                    .ask(PendingPreparationWaitersForTest {
+                        room_jid: room_jid.clone(),
+                    })
+                    .await
+                    .expect("waiter count")
+                    == Some(2)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("duplicate request coalesced");
+
+        allow.notify_one();
+        let first = first.await.expect("first task").expect("first acquisition");
+        let second = second
+            .await
+            .expect("second task")
+            .expect("second acquisition");
+        assert_eq!(first.creation, RoomCreation::Existing);
+        assert_eq!(second.creation, RoomCreation::Existing);
+        assert_eq!(first.actor_ref.id(), second.actor_ref.id());
+        assert_eq!(store.load_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn exclusive_create_rejects_existing_durable_room() {
+        let registry = spawn_registry().await;
+        let room_jid = test_room_jid("exclusive-restored-room");
+        let store = Arc::new(RecordingDurableStore {
+            load_result: Some(restored_room_snapshot("restored")),
+            ..RecordingDurableStore::default()
+        });
+        wire_recording_store(&registry, store).await;
+
+        assert!(matches!(
+            registry
+                .ask(CreateRoom {
+                    room_jid: room_jid.clone(),
+                    waddle_id: "caller-waddle".to_string(),
+                    channel_id: "caller-channel".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await,
+            Err(SendError::HandlerError(RoomRegistryError::RoomAlreadyExists(ref room)))
+                if *room == room_jid
+        ));
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("restored room lookup")
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn cancelled_fresh_creator_handoff_promotes_next_waiter() {
+        let registry = spawn_registry().await;
+        let room_jid = test_room_jid("cancelled-creator-handoff");
+        let (store, started, allow) = blocking_restore_store(room_jid.clone());
+        wire_recording_store(&registry, store).await;
+
+        let first_registry = registry.clone();
+        let first_jid = room_jid.clone();
+        let first = tokio::spawn(async move { first_registry.ask(get_or_create(first_jid)).await });
+        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+            .await
+            .expect("restore started");
+        first.abort();
+        let second_registry = registry.clone();
+        let second_jid = room_jid.clone();
+        let second =
+            tokio::spawn(async move { second_registry.ask(get_or_create(second_jid)).await });
+
+        tokio::time::timeout(std::time::Duration::from_millis(200), async {
+            loop {
+                if registry
+                    .ask(PendingPreparationWaitersForTest {
+                        room_jid: room_jid.clone(),
+                    })
+                    .await
+                    .expect("waiter count")
+                    == Some(2)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("replacement creator coalesced");
+
+        allow.notify_one();
+        let acquisition = second
+            .await
+            .expect("second task")
+            .expect("replacement creator acquisition");
+        assert_eq!(acquisition.creation, RoomCreation::Created);
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("published room lookup")
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn cancelled_fresh_creator_cannot_handoff_an_incompatible_creation_spec() {
+        let registry = spawn_registry().await;
+        let room_jid = test_room_jid("cancelled-incompatible-creator-handoff");
+        let (store, started, allow) = blocking_restore_store(room_jid.clone());
+        wire_recording_store(&registry, store).await;
+
+        let first_registry = registry.clone();
+        let first_jid = room_jid.clone();
+        let first = tokio::spawn(async move {
+            first_registry
+                .ask(GetOrCreateRoom {
+                    room_jid: first_jid,
+                    waddle_id: "managed-waddle".to_string(),
+                    channel_id: "managed-channel".to_string(),
+                    config: RoomConfig {
+                        name: "Managed room".to_string(),
+                        members_only: true,
+                        persistent: true,
+                        ..RoomConfig::default()
+                    },
+                })
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+            .await
+            .expect("restore started");
+        first.abort();
+
+        let replacement_registry = registry.clone();
+        let replacement_jid = room_jid.clone();
+        let replacement = tokio::spawn(async move {
+            replacement_registry
+                .ask(CreateInstantRoom {
+                    room_jid: replacement_jid,
+                })
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_millis(200), async {
+            loop {
+                if registry
+                    .ask(PendingPreparationWaitersForTest {
+                        room_jid: room_jid.clone(),
+                    })
+                    .await
+                    .expect("waiter count")
+                    == Some(2)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("incompatible replacement coalesced");
+
+        allow.notify_one();
+        assert!(matches!(
+            replacement.await.expect("replacement task"),
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipUnavailable(ref room)
+            )) if *room == room_jid
+        ));
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("unpublished incompatible room lookup")
+            .is_none());
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if registry
+                    .ask(GetPendingRoomReleaseBacklog)
+                    .await
+                    .expect("release backlog")
+                    .depth
+                    == 0
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("canceled preparation claim released");
+
+        let retry_registry = registry.clone();
+        let retry_jid = room_jid.clone();
+        let retry = tokio::spawn(async move {
+            retry_registry
+                .ask(CreateInstantRoom {
+                    room_jid: retry_jid,
+                })
+                .await
+        });
+        allow.notify_one();
+        let acquisition = retry
+            .await
+            .expect("retry task")
+            .expect("instant room retry");
+        assert_eq!(acquisition.creation, RoomCreation::Created);
+    }
+
+    #[tokio::test]
+    async fn same_room_preparation_waiters_are_bounded() {
+        let registry = spawn_registry().await;
+        let room_jid = test_room_jid("bounded-preparation-waiters");
+        let (store, started, _allow) = blocking_restore_store(room_jid.clone());
+        wire_recording_store(&registry, store).await;
+
+        let mut waiters = Vec::with_capacity(MAX_ROOM_PREPARATION_WAITERS);
+        let first_registry = registry.clone();
+        let first_jid = room_jid.clone();
+        waiters.push(tokio::spawn(async move {
+            first_registry.ask(get_or_create(first_jid)).await
+        }));
+        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+            .await
+            .expect("restore started");
+        for _ in 1..MAX_ROOM_PREPARATION_WAITERS {
+            let waiter_registry = registry.clone();
+            let waiter_jid = room_jid.clone();
+            waiters.push(tokio::spawn(async move {
+                waiter_registry.ask(get_or_create(waiter_jid)).await
+            }));
+        }
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if registry
+                    .ask(PendingPreparationWaitersForTest {
+                        room_jid: room_jid.clone(),
+                    })
+                    .await
+                    .expect("waiter count")
+                    == Some(MAX_ROOM_PREPARATION_WAITERS)
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("waiter inventory fills to its bound");
+
+        assert!(matches!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(200),
+                registry.ask(get_or_create(room_jid.clone())),
+            )
+            .await
+            .expect("saturated waiter fails immediately"),
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipReconciliationPending(ref room)
+            )) if *room == room_jid
+        ));
+        registry.kill();
+        for waiter in waiters {
+            waiter.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn preparation_and_release_responsibilities_share_one_bound() {
+        let registry = spawn_registry().await;
+        // Keep the ordinary release backlog below its independent admission
+        // limit so new claims may still enter preparation. The combined limit
+        // must nevertheless cap the two inventories together.
+        let release_count = MAX_PENDING_ROOM_RELEASES / 2;
+        for index in 0..release_count {
+            let release_jid = test_room_jid(&format!("bounded-release-{index}"));
+            assert!(registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: release_jid.clone(),
+                    claim_fence: room_claim_fence(&release_jid, ClaimEpoch(index as i64 + 1)),
+                })
+                .await
+                .expect("remember release"));
+        }
+        let store = Arc::new(RecordingDurableStore {
+            block_all_loads: true,
+            allow_load: Some(Arc::new(tokio::sync::Notify::new())),
+            ..RecordingDurableStore::default()
+        });
+        wire_recording_store(&registry, store).await;
+
+        let preparation_capacity = MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES - release_count;
+        let mut pending = Vec::with_capacity(preparation_capacity);
+        for index in 0..preparation_capacity {
+            let pending_registry = registry.clone();
+            let pending_jid = test_room_jid(&format!("bounded-preparation-{index}"));
+            pending.push(tokio::spawn(async move {
+                pending_registry.ask(get_or_create(pending_jid)).await
+            }));
+        }
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                if registry
+                    .ask(PendingPreparationCountForTest)
+                    .await
+                    .expect("preparation count")
+                    == preparation_capacity
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("combined responsibility inventory reaches its bound");
+
+        let overflow_jid = test_room_jid("bounded-preparation-overflow");
+        assert!(matches!(
+            registry.ask(get_or_create(overflow_jid.clone())).await,
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipReconciliationPending(ref room)
+            )) if *room == overflow_jid
+        ));
+        registry.kill();
+        for task in pending {
+            task.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn terminal_drain_cancels_pending_publication_and_releases_claim() {
+        let registry = spawn_registry().await;
+        let room_jid = test_room_jid("terminal-drain-pending-restore");
+        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        let (store, started, allow) = blocking_restore_store(room_jid.clone());
+        let claim_store = wire_recording_store(&registry, store).await;
+
+        let create_registry = registry.clone();
+        let create_jid = room_jid.clone();
+        let create =
+            tokio::spawn(async move { create_registry.ask(get_or_create(create_jid)).await });
+        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+            .await
+            .expect("restore started");
+
+        let drained = registry
+            .ask(DrainRoomOwnershipForShutdown {
+                pending_handoffs: Vec::new(),
+            })
+            .await
+            .expect("terminal drain");
+        assert_eq!(drained.released, 1);
+        assert_eq!(drained.retained, 0);
+        assert!(matches!(
+            create.await.expect("create task"),
+            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(ref room)))
+                if *room == room_jid
+        ));
+        allow.notify_one();
+        tokio::task::yield_now().await;
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("lookup after terminal drain")
+            .is_none());
+        assert!(claim_store
+            .current_claim(&entity)
+            .await
+            .expect("claim lookup")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn destroy_cancels_pending_read_then_wipes_and_releases_exact_claim() {
+        let registry = spawn_registry().await;
+        let room_jid = test_room_jid("destroy-pending-read");
+        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        let (store, started, allow) = blocking_restore_store_with_result(
+            room_jid.clone(),
+            Some(restored_room_snapshot("destroyed")),
+        );
+        let claim_store = wire_recording_store(&registry, Arc::clone(&store)).await;
+
+        let create_registry = registry.clone();
+        let create_jid = room_jid.clone();
+        let create =
+            tokio::spawn(async move { create_registry.ask(get_or_create(create_jid)).await });
+        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+            .await
+            .expect("restore started");
+
+        assert_eq!(
+            registry
+                .ask(DestroyRoom {
+                    room_jid: room_jid.clone(),
+                    reason: DestroyRoomReason::Destroy,
+                })
+                .await
+                .expect("destroy pending room"),
+            DestroyRoomOutcome::Destroyed,
+        );
+        assert!(matches!(
+            create.await.expect("create task"),
+            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(ref room)))
+                if *room == room_jid
+        ));
+        allow.notify_one();
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("lookup after destroy")
+            .is_none());
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if claim_store
+                    .current_claim(&entity)
+                    .await
+                    .expect("claim lookup")
+                    .is_none()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached exact release completes");
+        assert_eq!(
+            *store.deleted_rooms.lock().expect("deleted rooms"),
+            vec![room_jid.to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn matching_owner_demotion_cancels_pending_publication() {
+        let registry = spawn_registry().await;
+        let room_jid = test_room_jid("demote-pending-restore");
+        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        let (store, started, allow) = blocking_restore_store(room_jid.clone());
+        let claim_store = wire_recording_store(&registry, Arc::clone(&store)).await;
+
+        let create_registry = registry.clone();
+        let create_jid = room_jid.clone();
+        let create =
+            tokio::spawn(async move { create_registry.ask(get_or_create(create_jid)).await });
+        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+            .await
+            .expect("restore started");
+
+        assert!(registry
+            .ask(DemoteRoomIfOwner {
+                room_jid: room_jid.clone(),
+                owner: this_identity(),
+            })
+            .await
+            .expect("demote pending room"));
+        assert!(matches!(
+            create.await.expect("create task"),
+            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(ref room)))
+                if *room == room_jid
+        ));
+        allow.notify_one();
+        tokio::task::yield_now().await;
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("lookup after demotion")
+            .is_none());
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if claim_store
+                    .current_claim(&entity)
+                    .await
+                    .expect("claim lookup")
+                    .is_none()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("demotion releases exact old claim");
+        assert!(store.current_claim_fence(&room_jid).is_none());
     }
 
     #[tokio::test]
@@ -2216,7 +3131,7 @@ mod ownership_claims_tests {
             .expect("wire");
 
         let jid = test_room_jid("restore-me");
-        let actor_ref = registry
+        let acquisition = registry
             .ask(GetOrCreateRoom {
                 room_jid: jid.clone(),
                 waddle_id: "caller-waddle".to_string(),
@@ -2227,8 +3142,9 @@ mod ownership_claims_tests {
                 config: RoomConfig::default(),
             })
             .await
-            .expect("get_or_create_room")
-            .actor_ref;
+            .expect("get_or_create_room");
+        assert_eq!(acquisition.creation, RoomCreation::Existing);
+        let actor_ref = acquisition.actor_ref;
 
         let config = actor_ref.ask(GetConfig).await.expect("ask");
         assert_eq!(config.name, "restored");
@@ -2974,6 +3890,170 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn hung_final_publication_fence_does_not_block_the_registry_mailbox() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(DeadOwnerClaimStore::empty());
+        claim_store.set_fence_delay(std::time::Duration::from_secs(60));
+        let durable_store = Arc::new(RecordingDurableStore::default());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("hung-final-publication-fence");
+        let create_registry = registry.clone();
+        let create = tokio::spawn(async move {
+            create_registry
+                .ask(GetOrCreateRoom {
+                    room_jid: jid,
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await
+        });
+        while claim_store.fence_calls.load(Ordering::SeqCst) == 0 {
+            tokio::task::yield_now().await;
+        }
+
+        let count_registry = registry.clone();
+        let count = tokio::spawn(async move { count_registry.ask(RoomCount).await });
+        for _ in 0..8 {
+            if count.is_finished() {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            count.is_finished(),
+            "the detached final fence must not hold the registry mailbox"
+        );
+        assert_eq!(count.await.expect("count task").expect("room count"), 0);
+
+        tokio::time::advance(ROOM_OWNERSHIP_CALL_TIMEOUT).await;
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            create.await.expect("create task"),
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipUnavailable(_)
+            ))
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn ready_publications_yield_the_mailbox_between_bounded_final_fences() {
+        let registry = spawn_registry().await;
+        let mailbox_marker_seen = Arc::new(AtomicBool::new(false));
+        let claim_store = Arc::new(SlowPublicationFenceStore::new(Arc::clone(
+            &mailbox_marker_seen,
+        )));
+        let durable_store = Arc::new(RecordingDurableStore::default());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        let mut creates = Vec::new();
+        for room in ["ready-fence-one", "ready-fence-two"] {
+            let create_registry = registry.clone();
+            let jid = test_room_jid(room);
+            creates.push(tokio::spawn(async move {
+                create_registry.ask(get_or_create(jid)).await
+            }));
+        }
+        claim_store.publication_fence_started.notified().await;
+
+        let marker_registry = registry.clone();
+        let marker = Arc::clone(&mailbox_marker_seen);
+        let marker_task =
+            tokio::spawn(async move { marker_registry.ask(MarkRegistryProgress(marker)).await });
+        tokio::task::yield_now().await;
+        tokio::time::advance(ROOM_OWNERSHIP_CALL_TIMEOUT).await;
+        tokio::task::yield_now().await;
+        marker_task
+            .await
+            .expect("marker task")
+            .expect("registry marker");
+
+        while claim_store
+            .publication_fences_started
+            .load(Ordering::SeqCst)
+            < 2
+        {
+            tokio::task::yield_now().await;
+        }
+        assert!(mailbox_marker_seen.load(Ordering::SeqCst));
+        assert!(
+            !claim_store
+                .second_publication_started_before_marker
+                .load(Ordering::SeqCst),
+            "unrelated registry work must run between bounded final fences"
+        );
+        tokio::time::advance(ROOM_OWNERSHIP_CALL_TIMEOUT).await;
+        tokio::task::yield_now().await;
+        for create in creates {
+            assert!(matches!(
+                create.await.expect("create task"),
+                Err(SendError::HandlerError(
+                    RoomRegistryError::OwnershipUnavailable(_)
+                ))
+            ));
+        }
+    }
+
+    #[tokio::test]
+    async fn actual_publication_boundary_rejects_claim_lost_after_detached_preflight() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(DeadOwnerClaimStore::empty());
+        claim_store.lose_claim_on_fence_call(2);
+        let durable_store = Arc::new(RecordingDurableStore::default());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("claim-lost-after-publication-preflight");
+
+        assert!(matches!(
+            registry
+                .ask(GetOrCreateRoom {
+                    room_jid: jid.clone(),
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await,
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipUnavailable(ref room)
+            )) if *room == jid
+        ));
+        assert_eq!(
+            claim_store.fence_calls.load(Ordering::SeqCst),
+            2,
+            "publication must re-fence after detached readiness preflight"
+        );
+        assert_eq!(registry.ask(RoomCount).await.expect("room count"), 0);
+        assert!(registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("lost room lookup")
+            .is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn fresh_acquire_commit_before_timeout_is_retained_and_exactly_released() {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(DeadOwnerClaimStore::empty());
@@ -3045,6 +4125,80 @@ mod ownership_claims_tests {
             .await
             .expect("claim lookup")
             .is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn terminal_drain_reconciles_a_fresh_acquire_committed_before_timeout() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(DeadOwnerClaimStore::empty());
+        claim_store.set_ensure_post_commit_delay(std::time::Duration::from_secs(60));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("terminal-fresh-commit-before-timeout");
+        let create_registry = registry.clone();
+        let create_jid = jid.clone();
+        let create = tokio::spawn(async move {
+            create_registry
+                .ask(GetOrCreateRoom {
+                    room_jid: create_jid,
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await
+        });
+        tokio::task::yield_now().await;
+        tokio::time::advance(ROOM_OWNERSHIP_CALL_TIMEOUT).await;
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            create.await.expect("create task"),
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipUnavailable(_)
+            ))
+        ));
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("uncertain acquisition backlog")
+                .depth,
+            1
+        );
+
+        let outcome = registry
+            .ask(DrainRoomOwnershipForShutdown {
+                pending_handoffs: Vec::new(),
+            })
+            .await
+            .expect("terminal drain");
+        assert_eq!(
+            outcome,
+            RoomOwnershipDrainOutcome {
+                released: 1,
+                preserved_live: 0,
+                retained: 0,
+            }
+        );
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_none());
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("drained ownership backlog")
+                .depth,
+            0
+        );
     }
 
     #[tokio::test(start_paused = true)]
@@ -3785,7 +4939,7 @@ mod ownership_claims_tests {
             .expect("seed ambiguously committed claim");
 
         let outcome = registry
-            .ask(DrainPendingReclaimedRoomsForShutdown {
+            .ask(DrainRoomOwnershipForShutdown {
                 pending_handoffs: Vec::new(),
             })
             .await
@@ -3793,7 +4947,7 @@ mod ownership_claims_tests {
 
         assert_eq!(
             outcome,
-            PendingReclaimedRoomDrainOutcome {
+            RoomOwnershipDrainOutcome {
                 released: 1,
                 preserved_live: 0,
                 retained: 0,
@@ -3813,6 +4967,64 @@ mod ownership_claims_tests {
                 depth: 0,
                 oldest_age_ms: 0,
             }
+        );
+    }
+
+    #[tokio::test]
+    async fn terminal_drain_releases_an_already_pending_exact_release() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let owner = this_identity();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("terminal-pending-exact-release");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let epoch = claim_store
+            .acquire(&entity, &owner)
+            .await
+            .expect("seed exact claim");
+        assert!(registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: jid.clone(),
+                claim_fence: RoomClaimFenceContext::new(entity.clone(), owner, epoch),
+            })
+            .await
+            .expect("remember pending exact release"));
+
+        let outcome = registry
+            .ask(DrainRoomOwnershipForShutdown {
+                pending_handoffs: Vec::new(),
+            })
+            .await
+            .expect("terminal drain");
+
+        assert_eq!(
+            outcome,
+            RoomOwnershipDrainOutcome {
+                released: 1,
+                preserved_live: 0,
+                retained: 0,
+            }
+        );
+        assert!(claim_store
+            .current_claim(&entity)
+            .await
+            .expect("read drained claim")
+            .is_none());
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("pending release backlog")
+                .depth,
+            0
         );
     }
 
@@ -3840,14 +5052,14 @@ mod ownership_claims_tests {
             .expect("reserve before steal"));
 
         let before_commit = registry
-            .ask(DrainPendingReclaimedRoomsForShutdown {
+            .ask(DrainRoomOwnershipForShutdown {
                 pending_handoffs: Vec::new(),
             })
             .await
             .expect("terminal drain before late commit");
         assert_eq!(
             before_commit,
-            PendingReclaimedRoomDrainOutcome {
+            RoomOwnershipDrainOutcome {
                 released: 0,
                 preserved_live: 0,
                 retained: 1,
@@ -3868,14 +5080,14 @@ mod ownership_claims_tests {
             .await
             .expect("simulate the dropped steal future committing after the first read");
         let after_commit = registry
-            .ask(DrainPendingReclaimedRoomsForShutdown {
+            .ask(DrainRoomOwnershipForShutdown {
                 pending_handoffs: Vec::new(),
             })
             .await
             .expect("terminal drain after late commit");
         assert_eq!(
             after_commit,
-            PendingReclaimedRoomDrainOutcome {
+            RoomOwnershipDrainOutcome {
                 released: 1,
                 preserved_live: 0,
                 retained: 0,
@@ -3921,14 +5133,14 @@ mod ownership_claims_tests {
             .expect("reserve before steal"));
 
         let outcome = registry
-            .ask(DrainPendingReclaimedRoomsForShutdown {
+            .ask(DrainRoomOwnershipForShutdown {
                 pending_handoffs: Vec::new(),
             })
             .await
             .expect("terminal drain");
         assert_eq!(
             outcome,
-            PendingReclaimedRoomDrainOutcome {
+            RoomOwnershipDrainOutcome {
                 released: 0,
                 preserved_live: 0,
                 retained: 1,
@@ -3991,14 +5203,14 @@ mod ownership_claims_tests {
         identity.disable().await;
 
         let outcome = registry
-            .ask(DrainPendingReclaimedRoomsForShutdown {
+            .ask(DrainRoomOwnershipForShutdown {
                 pending_handoffs: Vec::new(),
             })
             .await
             .expect("terminal drain");
         assert_eq!(
             outcome,
-            PendingReclaimedRoomDrainOutcome {
+            RoomOwnershipDrainOutcome {
                 released: 1,
                 preserved_live: 0,
                 retained: 0,
@@ -4051,14 +5263,14 @@ mod ownership_claims_tests {
             .expect("register won claim");
 
         let outcome = registry
-            .ask(DrainPendingReclaimedRoomsForShutdown {
+            .ask(DrainRoomOwnershipForShutdown {
                 pending_handoffs: vec![handoff],
             })
             .await
             .expect("terminal drain");
         assert_eq!(
             outcome,
-            PendingReclaimedRoomDrainOutcome {
+            RoomOwnershipDrainOutcome {
                 released: 1,
                 preserved_live: 0,
                 retained: 0,
@@ -4125,14 +5337,14 @@ mod ownership_claims_tests {
             .expect("register won claim");
 
         let outcome = registry
-            .ask(DrainPendingReclaimedRoomsForShutdown {
+            .ask(DrainRoomOwnershipForShutdown {
                 pending_handoffs: Vec::new(),
             })
             .await
             .expect("terminal drain");
         assert_eq!(
             outcome,
-            PendingReclaimedRoomDrainOutcome {
+            RoomOwnershipDrainOutcome {
                 released: 0,
                 preserved_live: 0,
                 retained: 1,
@@ -4189,14 +5401,14 @@ mod ownership_claims_tests {
             .expect("reserve ambiguous steal"));
 
         let outcome = registry
-            .ask(DrainPendingReclaimedRoomsForShutdown {
+            .ask(DrainRoomOwnershipForShutdown {
                 pending_handoffs: Vec::new(),
             })
             .await
             .expect("terminal drain");
         assert_eq!(
             outcome,
-            PendingReclaimedRoomDrainOutcome {
+            RoomOwnershipDrainOutcome {
                 released: 0,
                 preserved_live: 1,
                 retained: 0,

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -52,7 +52,7 @@ impl kameo::message::Message<PendingRoomOwnershipResponsibilityCountForTest> for
         _msg: PendingRoomOwnershipResponsibilityCountForTest,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        self.pending_room_ownership_responsibilities().len()
+        self.pending_room_ownership_responsibility_count_for_test()
     }
 }
 
@@ -2690,6 +2690,189 @@ mod ownership_claims_tests {
         for waiter in waiters {
             waiter.abort();
         }
+    }
+
+    #[test]
+    fn ownership_capacity_scan_stops_at_the_shared_cap() {
+        let responsibilities = (0..=MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES)
+            .map(|index| {
+                let room_jid = test_room_jid(&format!("bounded-scan-{index}"));
+                let claim_fence = room_claim_fence(&room_jid, ClaimEpoch(index as i64 + 1));
+                (room_jid, claim_fence)
+            })
+            .collect::<Vec<_>>();
+        let inspected = std::cell::Cell::new(0usize);
+        let mut pending = HashSet::with_capacity(MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES);
+
+        assert!(
+            !RoomRegistryActor::extend_pending_room_ownership_responsibilities_until_full(
+                &mut pending,
+                responsibilities.iter().map(|(room_jid, claim_fence)| {
+                    let next = inspected.get() + 1;
+                    assert!(
+                        next <= MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES,
+                        "capacity scan consumed an entry after reaching the shared cap"
+                    );
+                    inspected.set(next);
+                    PendingRoomOwnershipResponsibility::Exact {
+                        room_jid,
+                        claim_fence,
+                    }
+                }),
+            )
+        );
+        assert_eq!(inspected.get(), MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES);
+        assert_eq!(pending.len(), MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES);
+    }
+
+    #[test]
+    fn saturated_capacity_admits_existing_but_rejects_novel_responsibility() {
+        let mut registry = RoomRegistryActor::new(
+            "muc.example.com".to_string(),
+            OccupantIdSecret::for_testing(b"test-secret".to_vec()),
+        );
+        for index in 0..MAX_PENDING_ROOM_RELEASES {
+            let room_jid = test_room_jid(&format!("saturated-release-{index}"));
+            let claim_fence = room_claim_fence(&room_jid, ClaimEpoch(index as i64 + 1));
+            registry.pending_room_releases.insert(
+                (room_jid, claim_fence),
+                PendingRoomReleaseState {
+                    retry_order: index as u64,
+                    first_pending_at: std::time::Instant::now(),
+                },
+            );
+        }
+        for index in 0..MAX_PENDING_RECLAIMED_ROOMS {
+            registry
+                .pending_reclaimed_reservations
+                .insert(test_room_jid(&format!("saturated-reservation-{index}")));
+        }
+
+        assert!(!registry.can_admit_new_room_ownership_responsibility());
+        let ((existing_room_jid, existing_claim_fence), _) = registry
+            .pending_room_releases
+            .iter()
+            .next()
+            .expect("saturated release inventory is populated");
+        assert!(registry.can_admit_room_ownership_responsibility(
+            PendingRoomOwnershipResponsibility::Exact {
+                room_jid: existing_room_jid,
+                claim_fence: existing_claim_fence,
+            }
+        ));
+        let existing_reservation = registry
+            .pending_reclaimed_reservations
+            .iter()
+            .next()
+            .expect("saturated reservation inventory is populated");
+        assert!(registry.can_admit_room_ownership_responsibility(
+            PendingRoomOwnershipResponsibility::ReclaimedReservation(existing_reservation)
+        ));
+
+        let novel_room_jid = test_room_jid("saturated-novel");
+        let novel_claim_fence = room_claim_fence(&novel_room_jid, ClaimEpoch(999));
+        assert!(!registry.can_admit_room_ownership_responsibility(
+            PendingRoomOwnershipResponsibility::Exact {
+                room_jid: &novel_room_jid,
+                claim_fence: &novel_claim_fence,
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn healthy_rooms_are_excluded_but_foreign_rooms_consume_capacity() {
+        let current_identity = this_identity();
+        let identity = SharedNodeIdentity::new(current_identity.clone());
+        let mut registry = RoomRegistryActor::new(
+            "muc.example.com".to_string(),
+            OccupantIdSecret::for_testing(b"test-secret".to_vec()),
+        );
+        registry.node_identity = identity.clone();
+        for index in 0..=MAX_PENDING_ROOM_OWNERSHIP_RESPONSIBILITIES {
+            let room_jid = test_room_jid(&format!("healthy-capacity-{index}"));
+            let actor_ref = RoomActor::spawn(RoomActor::new(
+                MucRoom::new(
+                    room_jid.clone(),
+                    "waddle".to_string(),
+                    "channel".to_string(),
+                    RoomConfig::default(),
+                ),
+                OccupantIdSecret::for_testing(b"test-secret".to_vec()),
+            ));
+            registry.rooms.insert(
+                room_jid.clone(),
+                RoomEntry {
+                    actor_ref,
+                    claim_fence: RoomClaimFenceContext::new(
+                        Entity::new(EntityType::RoomActor, room_jid.to_string()),
+                        current_identity.clone(),
+                        ClaimEpoch(index as i64 + 1),
+                    ),
+                },
+            );
+        }
+
+        assert!(registry.can_admit_new_room_ownership_responsibility());
+        identity.rotate(foreign_identity()).await;
+        assert!(!registry.can_admit_new_room_ownership_responsibility());
+        for entry in registry.rooms.values() {
+            entry.actor_ref.kill();
+        }
+    }
+
+    #[tokio::test]
+    async fn dead_room_consumes_the_last_ownership_capacity_slot() {
+        let current_identity = this_identity();
+        let mut registry = RoomRegistryActor::new(
+            "muc.example.com".to_string(),
+            OccupantIdSecret::for_testing(b"test-secret".to_vec()),
+        );
+        registry.node_identity = SharedNodeIdentity::new(current_identity.clone());
+        for index in 0..MAX_PENDING_ROOM_RELEASES {
+            let room_jid = test_room_jid(&format!("dead-slot-release-{index}"));
+            registry.pending_room_releases.insert(
+                (
+                    room_jid.clone(),
+                    room_claim_fence(&room_jid, ClaimEpoch(index as i64 + 1)),
+                ),
+                PendingRoomReleaseState {
+                    retry_order: index as u64,
+                    first_pending_at: std::time::Instant::now(),
+                },
+            );
+        }
+        for index in 0..(MAX_PENDING_RECLAIMED_ROOMS - 1) {
+            registry
+                .pending_reclaimed_reservations
+                .insert(test_room_jid(&format!("dead-slot-reservation-{index}")));
+        }
+        let room_jid = test_room_jid("dead-slot-room");
+        let actor_ref = RoomActor::spawn(RoomActor::new(
+            MucRoom::new(
+                room_jid.clone(),
+                "waddle".to_string(),
+                "channel".to_string(),
+                RoomConfig::default(),
+            ),
+            OccupantIdSecret::for_testing(b"test-secret".to_vec()),
+        ));
+        registry.rooms.insert(
+            room_jid.clone(),
+            RoomEntry {
+                actor_ref: actor_ref.clone(),
+                claim_fence: RoomClaimFenceContext::new(
+                    Entity::new(EntityType::RoomActor, room_jid.to_string()),
+                    current_identity,
+                    ClaimEpoch(999),
+                ),
+            },
+        );
+
+        assert!(registry.can_admit_new_room_ownership_responsibility());
+        actor_ref.kill();
+        actor_ref.wait_for_shutdown().await;
+        assert!(!actor_ref.is_alive());
+        assert!(!registry.can_admit_new_room_ownership_responsibility());
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_handle.rs
@@ -38,13 +38,13 @@ use super::room_actor::{RoomActor, SealGuard};
 use super::room_registry_actor::{
     CancelPendingReclaimedRoomReservation, CreateInstantRoom, CreateRoom, DemoteRoomIfOwner,
     DestroyRoom, DestroyRoomIfInactive, DestroyRoomOutcome, DestroyRoomReason,
-    DrainPendingReclaimedRoomsForShutdown, GetOrCreateRoom, GetPendingReclaimedRoomBacklog,
+    DrainRoomOwnershipForShutdown, GetOrCreateRoom, GetPendingReclaimedRoomBacklog,
     GetPendingRoomReleaseBacklog, GetRoom, IsCurrentIdentityPendingRoomReleaseOnly,
     IsCurrentRoomPendingRelease, IsMucJid, IsPendingRoomReleaseOnly, ListPendingReclaimedRooms,
     ListPendingRoomReleaseJids, ListRooms, ListRoomsOwnedBy, PendingReclaimedRoom,
-    PendingReclaimedRoomBacklog, PendingReclaimedRoomDrainOutcome, PendingRoomReleaseBacklog,
-    ReapSealedRoom, ReclaimedRoomOutcome, ReconcileReclaimedRoom, RememberPendingReclaimedRoom,
-    ReservePendingReclaimedRoom, RetryPendingRoomReleases, RoomAcquisition, RoomCount, RoomExists,
+    PendingReclaimedRoomBacklog, PendingRoomReleaseBacklog, ReapSealedRoom, ReclaimedRoomOutcome,
+    ReconcileReclaimedRoom, RememberPendingReclaimedRoom, ReservePendingReclaimedRoom,
+    RetryPendingRoomReleases, RoomAcquisition, RoomCount, RoomExists, RoomOwnershipDrainOutcome,
     RoomRegistryActor, RoomRegistryError, WireClusteringClaims,
 };
 use super::RoomConfig;
@@ -298,11 +298,11 @@ impl RoomRegistry {
     );
 
     registry_method!(
-        drain_pending_reclaimed_rooms_for_shutdown(
+        drain_room_ownership_for_shutdown(
             pending_handoffs: Vec<PendingReclaimedRoom>
-        ) -> PendingReclaimedRoomDrainOutcome,
-        "drain_pending_reclaimed_rooms_for_shutdown",
-        DrainPendingReclaimedRoomsForShutdown { pending_handoffs }
+        ) -> RoomOwnershipDrainOutcome,
+        "drain_room_ownership_for_shutdown",
+        DrainRoomOwnershipForShutdown { pending_handoffs }
     );
 
     registry_method!(

--- a/server/crates/waddle-xmpp/tests/xep0045_room_ownership_actor.rs
+++ b/server/crates/waddle-xmpp/tests/xep0045_room_ownership_actor.rs
@@ -49,6 +49,13 @@ impl MucDurableStore for OwnershipStore {
         Box::pin(async { Ok(None) })
     }
 
+    fn load_room_state_fenced<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+    ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+        self.load_room_state(room_jid)
+    }
+
     fn save_config<'a>(
         &'a self,
         _room_jid: &'a BareJid,

--- a/server/crates/waddle-xmpp/tests/xep0045_room_ownership_actor.rs
+++ b/server/crates/waddle-xmpp/tests/xep0045_room_ownership_actor.rs
@@ -17,7 +17,12 @@ use waddle_xmpp::muc::room_actor::{
     ResolverAffiliationSyncOutcome, RestoreDurableRoomState, RoomActor, RoomActorError,
     SyncResolverAffiliation,
 };
+use waddle_xmpp::muc::room_registry_actor::{
+    CreateRoom, GetOrCreateRoom, RoomCreation, RoomRegistryActor, RoomRegistryError,
+    WireClusteringClaims,
+};
 use waddle_xmpp::muc::{MucRoom, RoomConfig, SubjectState};
+use waddle_xmpp::ownership::{ClaimStore, InProcessClaimStore, NodeIdentity, SharedNodeIdentity};
 use waddle_xmpp::xep::xep0421::{OccupantIdSecret, OCCUPANT_ID_SECRET_MIN_BYTES};
 use waddle_xmpp::{Affiliation, Role, XmppError};
 
@@ -27,12 +32,21 @@ const UNCERTAIN: u8 = 2;
 
 struct OwnershipStore {
     state: AtomicU8,
+    restore: Option<DurableRoomState>,
 }
 
 impl OwnershipStore {
     fn new() -> Self {
         Self {
             state: AtomicU8::new(OWNED),
+            restore: None,
+        }
+    }
+
+    fn restoring(state: DurableRoomState) -> Self {
+        Self {
+            state: AtomicU8::new(OWNED),
+            restore: Some(state),
         }
     }
 
@@ -46,7 +60,8 @@ impl MucDurableStore for OwnershipStore {
         &'a self,
         _room_jid: &'a BareJid,
     ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
-        Box::pin(async { Ok(None) })
+        let restore = self.restore.clone();
+        Box::pin(async move { Ok(restore) })
     }
 
     fn load_room_state_fenced<'a>(
@@ -271,4 +286,94 @@ async fn uncertain_room_returns_typed_resolver_sync_outcome() {
             .expect("affiliation"),
         Affiliation::None,
     );
+}
+
+fn durable_existing_room() -> DurableRoomState {
+    DurableRoomState {
+        waddle_id: "durable-waddle".to_string(),
+        channel_id: "durable-channel".to_string(),
+        config: RoomConfig {
+            name: "Existing durable room".to_string(),
+            persistent: true,
+            ..RoomConfig::default()
+        },
+        subject: None,
+        affiliations: vec![AffiliationEntry::new(
+            "owner@example.com".parse().expect("owner JID"),
+            Affiliation::Owner,
+        )],
+    }
+}
+
+async fn spawn_restore_registry(store: Arc<OwnershipStore>) -> ActorRef<RoomRegistryActor> {
+    let secret = OccupantIdSecret::new(vec![7; OCCUPANT_ID_SECRET_MIN_BYTES])
+        .expect("valid occupant-id secret");
+    let registry = RoomRegistryActor::spawn(RoomRegistryActor::new(
+        "muc.example.com".to_string(),
+        secret,
+    ));
+    registry
+        .ask(WireClusteringClaims {
+            claim_store: Arc::new(InProcessClaimStore::new()) as Arc<dyn ClaimStore>,
+            node_identity: SharedNodeIdentity::new(NodeIdentity::local()),
+            durable_store: Some(store as Arc<dyn MucDurableStore>),
+            rollout_backoff: None,
+        })
+        .await
+        .expect("wire durable restore store");
+    registry
+}
+
+fn demand_room(room_jid: BareJid) -> GetOrCreateRoom {
+    GetOrCreateRoom {
+        room_jid,
+        waddle_id: "caller-waddle".to_string(),
+        channel_id: "caller-channel".to_string(),
+        config: RoomConfig::default(),
+    }
+}
+
+#[tokio::test]
+async fn xep0045_creator_classification_requires_absent_durable_room() {
+    let fresh_registry = spawn_restore_registry(Arc::new(OwnershipStore::new())).await;
+    let fresh_jid: BareJid = "fresh@muc.example.com".parse().expect("fresh room JID");
+    let fresh = fresh_registry
+        .ask(demand_room(fresh_jid))
+        .await
+        .expect("fresh acquisition");
+    assert_eq!(fresh.creation, RoomCreation::Created);
+
+    let restored_registry =
+        spawn_restore_registry(Arc::new(OwnershipStore::restoring(durable_existing_room()))).await;
+    let restored_jid: BareJid = "restored@muc.example.com"
+        .parse()
+        .expect("restored room JID");
+    let restored = restored_registry
+        .ask(demand_room(restored_jid))
+        .await
+        .expect("restored acquisition");
+    assert_eq!(restored.creation, RoomCreation::Existing);
+}
+
+#[tokio::test]
+async fn xep0045_exclusive_create_rejects_durable_existing_room() {
+    let registry =
+        spawn_restore_registry(Arc::new(OwnershipStore::restoring(durable_existing_room()))).await;
+    let room_jid: BareJid = "exclusive-existing@muc.example.com"
+        .parse()
+        .expect("room JID");
+
+    assert!(matches!(
+        registry
+            .ask(CreateRoom {
+                room_jid: room_jid.clone(),
+                waddle_id: "caller-waddle".to_string(),
+                channel_id: "caller-channel".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await,
+        Err(SendError::HandlerError(
+            RoomRegistryError::RoomAlreadyExists(ref existing)
+        )) if *existing == room_jid
+    ));
 }


### PR DESCRIPTION
## Summary

This is the first prerequisite slice for #1289. It turns durable MUC restoration into a serialized, exact-fenced publication protocol: a claimed `RoomActor` remains undiscoverable until its durable state is restored, the exact room-claim fence is still current at publication, and the local node still has publication authority.

This PR intentionally does not implement the mediated-invite journal, grant, rollback, or coordinator. It also does not close #1289.

## Completed work

- Load room config, subject, and affiliations only inside an exact-fenced durable read.
- Keep prepared actors unpublished and coalesce same-room demand behind one bounded preparation.
- Distinguish restored rooms from genuinely new rooms before returning creator semantics.
- Recheck the exact claim at the serialized publication boundary so a replacement actor cannot inherit stale authority.
- Retain uncertain acquisitions and releases across timeout, cancellation, identity rotation, demotion, destroy, and shutdown.
- Bound unique ownership responsibilities across preparation, release, reclaimed, and dead/deposed room state without double-counting representation transfers.
- Make reclaimed reservations idempotent and retain demand claims through one transient restore failure.
- Route join, owner, admin, permission, and cleanup callers through typed registry outcomes.
- Preserve restored-room policy during ordinary joins: no create authorization, false status 201, false creator grant, and no transient item-not-found caused by an in-progress restore.

## XEP review

Reviewed against the vendored XEP-0045 text. No new wire shape or custom namespace is introduced. The change preserves status 201 and initial-owner semantics for genuinely new rooms while preventing durable existing rooms from becoming observable with constructor-default state.

## Verification at exact head `7c3663d459ce3d7c5c91433a86d84601f7305eee`

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p waddle-xmpp --all-targets --all-features -- -D warnings`
- Full `RoomRegistryActor` suite: 107/107
- Dedicated XEP-0045 room-ownership suite
- Focused transient/persistent restore-failure regressions
- GitHub CI is green except for the two still-running jobs shown on the PR.
- Qodo exact-head review: 0 bugs, 0 rule violations, 0 requirement gaps.
- Greptile exact-head review: passing.

## Stack and follow-up

This PR may merge independently and becomes a foundation for #1352 and the remaining #1289 slices. PR #1350 follows #1352 because its strict durable-state constraints build on the explicit creator lifecycle.

Remaining #1289 slices cover typed durable invite operations, atomic journal/affiliation transactions, actor lifecycle and supersession, managed-affiliation CAS, ordinary MUC coordination, and the group-DM adapter. Do not mark #1289 or the Lane J follow-up complete from this prerequisite alone.

Related: #1289, #1350, #1352