### PR TITLE
fix(xmpp): fence room recovery and serialize admission repair

### DIFF
--- a/server/crates/waddle-server/src/clustering/metrics.rs
+++ b/server/crates/waddle-server/src/clustering/metrics.rs
@@ -253,7 +253,7 @@ pub fn record_claims_abandoned_on_drain(count: u64) {
 
 /// Count bounded proactive `RoomActor` orphan-reconciliation outcomes.
 /// `outcome` is one of `hydrated`, `released`, `already_live`,
-/// `adopted_local`, `pending_retry`, `lost_race`, or `failed`; callers
+/// `pending_retry`, `lost_race`, or `failed`; callers
 /// aggregate a whole sweep before recording, avoiding per-room warning noise
 /// after a node loss.
 pub fn record_room_orphan_reconciliation(outcome: &'static str, count: u64) {

--- a/server/crates/waddle-server/src/server/http.rs
+++ b/server/crates/waddle-server/src/server/http.rs
@@ -755,6 +755,9 @@ async fn create_websocket_state(
                 remote_muc_memberships: Arc::new(
                     crate::server::routes::websocket::RemoteMucMemberships::default(),
                 ),
+                resolver_affiliation_syncs: Arc::new(
+                    crate::server::routes::websocket::ResolverAffiliationSyncScheduler::default(),
+                ),
                 dm_call_threads: Arc::new(dashmap::DashMap::new()),
                 dm_pin_store: Arc::new(crate::server::routes::websocket::DmPinStore::default()),
                 dm_call_thread_projections: Arc::new(dashmap::DashSet::new()),

--- a/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/cleanup.rs
@@ -1252,11 +1252,15 @@ pub(crate) async fn get_or_create_room_actor(
         .get_or_create_room(room_jid.clone(), waddle_id, channel_id, config)
         .await
         .inspect_err(|error| {
-            if matches!(error, RoomRegistryError::ClaimHeldByAnotherNode(_)) {
+            if matches!(
+                error,
+                RoomRegistryError::ClaimHeldByAnotherNode(_)
+                    | RoomRegistryError::OwnershipReconciliationPending(_)
+            ) {
                 debug!(
                     room = %room_jid,
                     %error,
-                    "Room actor is owned by another live node"
+                    "Room actor ownership is not locally available"
                 );
             } else {
                 warn!(room = %room_jid, %error, "Failed to get or create room actor");

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -98,9 +98,30 @@ const RESOLVER_SYNC_MAX_ATTEMPTS: usize = 3;
 const RESOLVER_SYNC_MAILBOX_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(250);
 const RESOLVER_SYNC_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis(50);
 
+#[cfg(test)]
 fn sync_resolver_affiliation_on_rejection(
     existing_room_actor: Option<&kameo::actor::ActorRef<waddle_xmpp::muc::room_actor::RoomActor>>,
     scheduler: &std::sync::Arc<crate::server::routes::websocket::ResolverAffiliationSyncScheduler>,
+    room_jid: &BareJid,
+    jid: BareJid,
+    affiliation: Affiliation,
+    expected_admission_revision: u64,
+) {
+    sync_resolver_affiliation_on_rejection_with_registry(
+        existing_room_actor,
+        scheduler,
+        None,
+        room_jid,
+        jid,
+        affiliation,
+        expected_admission_revision,
+    );
+}
+
+fn sync_resolver_affiliation_on_rejection_with_registry(
+    existing_room_actor: Option<&kameo::actor::ActorRef<waddle_xmpp::muc::room_actor::RoomActor>>,
+    scheduler: &std::sync::Arc<crate::server::routes::websocket::ResolverAffiliationSyncScheduler>,
+    room_registry: Option<RoomRegistry>,
     room_jid: &BareJid,
     jid: BareJid,
     affiliation: Affiliation,
@@ -158,12 +179,17 @@ fn sync_resolver_affiliation_on_rejection(
     // Reusing the captured revision makes every delayed attempt harmless once
     // a newer admission or affiliation mutation has landed.
     tokio::spawn(run_resolver_affiliation_sync_worker(
-        actor, room_jid, jid, *worker,
+        actor,
+        room_registry,
+        room_jid,
+        jid,
+        *worker,
     ));
 }
 
 async fn run_resolver_affiliation_sync_worker(
     actor: kameo::actor::ActorRef<waddle_xmpp::muc::room_actor::RoomActor>,
+    room_registry: Option<RoomRegistry>,
     room_jid: BareJid,
     jid: BareJid,
     mut worker: crate::server::routes::websocket::state::ResolverAffiliationSyncWorker,
@@ -209,6 +235,33 @@ async fn run_resolver_affiliation_sync_worker(
                     outcome = ?outcome,
                     "Skipped resolver affiliation sync on rejected join"
                 );
+                if outcome
+                    == waddle_xmpp::muc::room_actor::ResolverAffiliationSyncOutcome::RoomSealed
+                {
+                    // This actor incarnation is permanently unable to accept
+                    // any queued repair. Release the bounded scheduler slot
+                    // before the registry ask, whose mailbox/reply timeout is
+                    // intentionally much longer than the repair fast path.
+                    worker.close_actor_terminal();
+                    if let Some(registry) = room_registry.as_ref() {
+                        match registry.reap_sealed_room(room_jid.clone()).await {
+                            Ok(true) => debug!(
+                                room = %room_jid,
+                                "Reaped deposed room after rejected-join affiliation repair"
+                            ),
+                            Ok(false) => debug!(
+                                room = %room_jid,
+                                "Rejected-join repair observed a room already absent or replaced"
+                            ),
+                            Err(error) => warn!(
+                                room = %room_jid,
+                                %error,
+                                "Failed to reap deposed room after rejected-join affiliation repair"
+                            ),
+                        }
+                    }
+                    return;
+                }
                 let disposition = if outcome
                     == waddle_xmpp::muc::room_actor::ResolverAffiliationSyncOutcome::OwnershipUnavailable
                 {
@@ -301,6 +354,7 @@ mod resolver_sync_retry_tests {
     use super::*;
 
     struct SequencedOwnershipStore {
+        ownership_held: bool,
         failures_remaining: AtomicUsize,
         blocks_remaining: AtomicUsize,
         block_at_check: AtomicUsize,
@@ -313,6 +367,7 @@ mod resolver_sync_retry_tests {
     impl SequencedOwnershipStore {
         fn new(failures: usize) -> Arc<Self> {
             Arc::new(Self {
+                ownership_held: true,
                 failures_remaining: AtomicUsize::new(failures),
                 blocks_remaining: AtomicUsize::new(0),
                 block_at_check: AtomicUsize::new(0),
@@ -325,6 +380,7 @@ mod resolver_sync_retry_tests {
 
         fn hanging() -> Arc<Self> {
             Arc::new(Self {
+                ownership_held: true,
                 failures_remaining: AtomicUsize::new(0),
                 blocks_remaining: AtomicUsize::new(1),
                 block_at_check: AtomicUsize::new(0),
@@ -337,6 +393,7 @@ mod resolver_sync_retry_tests {
 
         fn always_hanging() -> Arc<Self> {
             Arc::new(Self {
+                ownership_held: true,
                 failures_remaining: AtomicUsize::new(0),
                 blocks_remaining: AtomicUsize::new(0),
                 block_at_check: AtomicUsize::new(0),
@@ -345,6 +402,14 @@ mod resolver_sync_retry_tests {
                 check_started: tokio::sync::Notify::new(),
                 release_blocked_check: tokio::sync::Notify::new(),
             })
+        }
+
+        fn not_owner() -> Arc<Self> {
+            let mut store = Self::new(0);
+            Arc::get_mut(&mut store)
+                .expect("new ownership store is uniquely held")
+                .ownership_held = false;
+            store
         }
 
         fn checks(&self) -> usize {
@@ -420,7 +485,7 @@ mod resolver_sync_retry_tests {
                         "transient ownership check failure",
                     ))
                 } else {
-                    Ok(true)
+                    Ok(self.ownership_held)
                 }
             })
         }
@@ -485,6 +550,26 @@ mod resolver_sync_retry_tests {
         expected_admission_revision: u64,
         scheduler: Arc<crate::server::routes::websocket::ResolverAffiliationSyncScheduler>,
     ) -> tokio::task::JoinHandle<()> {
+        spawn_sync_worker_with_scheduler_and_registry(
+            actor,
+            room_jid,
+            member,
+            affiliation,
+            expected_admission_revision,
+            scheduler,
+            None,
+        )
+    }
+
+    fn spawn_sync_worker_with_scheduler_and_registry(
+        actor: kameo::actor::ActorRef<RoomActor>,
+        room_jid: BareJid,
+        member: BareJid,
+        affiliation: Affiliation,
+        expected_admission_revision: u64,
+        scheduler: Arc<crate::server::routes::websocket::ResolverAffiliationSyncScheduler>,
+        room_registry: Option<RoomRegistry>,
+    ) -> tokio::task::JoinHandle<()> {
         let work = crate::server::routes::websocket::ResolverAffiliationSyncWork {
             affiliation,
             expected_admission_revision,
@@ -495,7 +580,11 @@ mod resolver_sync_retry_tests {
             panic!("new scheduler starts one worker");
         };
         tokio::spawn(run_resolver_affiliation_sync_worker(
-            actor, room_jid, member, *worker,
+            actor,
+            room_registry,
+            room_jid,
+            member,
+            *worker,
         ))
     }
 
@@ -524,6 +613,55 @@ mod resolver_sync_retry_tests {
                 .await
                 .expect("affiliation"),
             Affiliation::Member,
+        );
+    }
+
+    #[tokio::test]
+    async fn resolver_sync_reaps_actor_after_ownership_loss() {
+        let room_jid: BareJid = "resolver-sync@muc.example.com".parse().expect("room JID");
+        let member: BareJid = "deposed@example.com".parse().expect("member JID");
+        let secret = OccupantIdSecret::new(vec![7; OCCUPANT_ID_SECRET_MIN_BYTES])
+            .expect("occupant-id secret");
+        let registry = RoomRegistry::spawn("muc.example.com".to_string(), secret, None);
+        let actor = registry
+            .get_or_create_room(
+                room_jid.clone(),
+                "waddle-1".to_string(),
+                "channel-1".to_string(),
+                RoomConfig::default(),
+            )
+            .await
+            .expect("create registered room")
+            .actor_ref;
+        let store = SequencedOwnershipStore::not_owner();
+        actor
+            .ask(RestoreDurableRoomState {
+                store: Arc::clone(&store) as Arc<dyn MucDurableStore>,
+            })
+            .await
+            .expect("install deposed ownership store");
+        let scheduler =
+            Arc::new(crate::server::routes::websocket::ResolverAffiliationSyncScheduler::default());
+
+        spawn_sync_worker_with_scheduler_and_registry(
+            actor,
+            room_jid.clone(),
+            member,
+            Affiliation::None,
+            0,
+            scheduler,
+            Some(registry.clone()),
+        )
+        .await
+        .expect("sealed repair worker");
+
+        assert!(
+            registry
+                .get_room(room_jid)
+                .await
+                .expect("inspect registry")
+                .is_none(),
+            "the rejected-join repair must evict the deposed actor"
         );
     }
 
@@ -1622,9 +1760,12 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                     // otherwise linger on the room's affiliation list
                     // until eviction. Explicit bans are untouched by the
                     // provenance-aware sync.
-                    sync_resolver_affiliation_on_rejection(
+                    sync_resolver_affiliation_on_rejection_with_registry(
                         existing_room_actor.as_ref(),
                         &state.deps.protocol.resolver_affiliation_syncs,
+                        Some(RoomRegistry::wrap(
+                            state.deps.protocol.room_registry.clone(),
+                        )),
                         room_jid,
                         // Room affiliations are keyed by the joiner's
                         // bare JID (`JoinWithAffiliation` uses
@@ -1654,9 +1795,12 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                         // `Resolver(None)` write never reaches a live
                         // actor — clear any stale resolver-derived
                         // affiliation from before the revocation here.
-                        sync_resolver_affiliation_on_rejection(
+                        sync_resolver_affiliation_on_rejection_with_registry(
                             existing_room_actor.as_ref(),
                             &state.deps.protocol.resolver_affiliation_syncs,
+                            Some(RoomRegistry::wrap(
+                                state.deps.protocol.room_registry.clone(),
+                            )),
                             room_jid,
                             // Same key as `JoinWithAffiliation`:
                             // `sender_jid.to_bare()`.

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -784,7 +784,7 @@ mod resolver_sync_retry_tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn resolver_sync_unrelated_mutation_invalidates_post_close_chain() {
+    async fn resolver_sync_unrelated_mutation_preserves_post_close_chain() {
         let store = SequencedOwnershipStore::new(0);
         let member: BareJid = "stale-chain@example.com".parse().expect("member JID");
         let unrelated: BareJid = "unrelated@example.com".parse().expect("member JID");
@@ -829,8 +829,8 @@ mod resolver_sync_retry_tests {
                 .ask(GetAffiliation { jid: member })
                 .await
                 .expect("affiliation after stale chained repair"),
-            Affiliation::None,
-            "an unrelated admission mutation must invalidate the carried revision"
+            Affiliation::Outcast,
+            "an unrelated member mutation must not invalidate the carried revision"
         );
         assert_eq!(store.checks(), 3);
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -969,6 +969,24 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                 if matches!(
                     &error,
                     kameo::error::SendError::HandlerError(
+                        waddle_xmpp::muc::room_actor::RoomActorError::OwnershipUnavailable
+                    )
+                ) {
+                    return vec![build_muc_presence_error_xml(
+                        room_jid,
+                        &nick,
+                        sender_jid,
+                        StanzaError::new(
+                            ErrorType::Wait,
+                            DefinedCondition::ResourceConstraint,
+                            "en",
+                            "This room's ownership is being reconciled; please retry.",
+                        ),
+                    )];
+                }
+                if matches!(
+                    &error,
+                    kameo::error::SendError::HandlerError(
                         waddle_xmpp::muc::room_actor::RoomActorError::RoomFull
                     )
                 ) {

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -819,16 +819,18 @@ mod resolver_sync_retry_tests {
         )
         .await
         .expect("newer-source worker records its completion chain");
-        spawn_sync_worker_with_scheduler(
-            actor.clone(),
-            room_jid.clone(),
-            member.clone(),
-            Affiliation::Member,
-            0,
-            Arc::clone(&scheduler),
-        )
-        .await
-        .expect("out-of-order stale worker terminates");
+        assert!(matches!(
+            scheduler.schedule(
+                &room_jid,
+                &member,
+                actor.id(),
+                crate::server::routes::websocket::ResolverAffiliationSyncWork {
+                    affiliation: Affiliation::Member,
+                    expected_admission_revision: 0,
+                },
+            ),
+            crate::server::routes::websocket::ResolverAffiliationSyncSchedule::Stale
+        ));
         spawn_sync_worker_with_scheduler(
             actor.clone(),
             room_jid,
@@ -848,7 +850,11 @@ mod resolver_sync_retry_tests {
             Affiliation::Outcast,
             "stale-source work must not erase a newer completion chain"
         );
-        assert_eq!(store.checks(), 4);
+        assert_eq!(
+            store.checks(),
+            3,
+            "stale work must not consume ownership-check or worker capacity"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -95,11 +95,12 @@ pub async fn handle_muc_join_with_ordered_relay(
 /// between, so a delayed sync can never clear a live occupant's fresh
 /// affiliation.
 const RESOLVER_SYNC_MAX_ATTEMPTS: usize = 3;
-const RESOLVER_SYNC_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(250);
+const RESOLVER_SYNC_MAILBOX_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(250);
 const RESOLVER_SYNC_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis(50);
 
 fn sync_resolver_affiliation_on_rejection(
     existing_room_actor: Option<&kameo::actor::ActorRef<waddle_xmpp::muc::room_actor::RoomActor>>,
+    scheduler: &std::sync::Arc<crate::server::routes::websocket::ResolverAffiliationSyncScheduler>,
     room_jid: &BareJid,
     jid: BareJid,
     affiliation: Affiliation,
@@ -108,6 +109,39 @@ fn sync_resolver_affiliation_on_rejection(
     let Some(actor) = existing_room_actor else {
         return;
     };
+    let work = crate::server::routes::websocket::ResolverAffiliationSyncWork {
+        affiliation,
+        expected_admission_revision,
+    };
+    let worker = match scheduler.schedule(room_jid, &jid, actor.id(), work) {
+        crate::server::routes::websocket::ResolverAffiliationSyncSchedule::Started(worker) => {
+            worker
+        }
+        crate::server::routes::websocket::ResolverAffiliationSyncSchedule::Updated => {
+            debug!(
+                room = %room_jid,
+                %jid,
+                "Updated the in-flight resolver affiliation repair with a newer verdict"
+            );
+            return;
+        }
+        crate::server::routes::websocket::ResolverAffiliationSyncSchedule::Coalesced => {
+            debug!(
+                room = %room_jid,
+                %jid,
+                "Coalesced an identical resolver affiliation repair"
+            );
+            return;
+        }
+        crate::server::routes::websocket::ResolverAffiliationSyncSchedule::AtCapacity => {
+            debug!(
+                room = %room_jid,
+                %jid,
+                "Skipped resolver affiliation repair because the bounded scheduler is full"
+            );
+            return;
+        }
+    };
     let actor = actor.clone();
     let room_jid = room_jid.clone();
     // This repair must not extend the rejected stanza path. The cloned
@@ -115,34 +149,43 @@ fn sync_resolver_affiliation_on_rejection(
     // they never consult the registry and therefore cannot create a room.
     // Reusing the captured revision makes every delayed attempt harmless once
     // a newer admission or affiliation mutation has landed.
-    tokio::spawn(run_resolver_affiliation_sync_retries(
-        actor,
-        room_jid,
-        jid,
-        affiliation,
-        expected_admission_revision,
+    tokio::spawn(run_resolver_affiliation_sync_worker(
+        actor, room_jid, jid, *worker,
     ));
 }
 
-async fn run_resolver_affiliation_sync_retries(
+async fn run_resolver_affiliation_sync_worker(
     actor: kameo::actor::ActorRef<waddle_xmpp::muc::room_actor::RoomActor>,
     room_jid: BareJid,
     jid: BareJid,
-    affiliation: Affiliation,
-    expected_admission_revision: u64,
+    mut worker: crate::server::routes::websocket::state::ResolverAffiliationSyncWorker,
 ) {
-    for attempt in 1..=RESOLVER_SYNC_MAX_ATTEMPTS {
+    let mut work = worker.current();
+    let mut effective_admission_revision = worker.effective_admission_revision();
+    let mut attempt = 1usize;
+    loop {
         let result = actor
             .ask(waddle_xmpp::muc::room_actor::SyncResolverAffiliation {
                 jid: jid.clone(),
-                affiliation,
-                expected_admission_revision,
+                affiliation: work.affiliation,
+                expected_admission_revision: effective_admission_revision,
             })
-            .mailbox_timeout(RESOLVER_SYNC_REPLY_TIMEOUT)
-            .reply_timeout(RESOLVER_SYNC_REPLY_TIMEOUT)
+            // Bound work that has not reached the actor. Once delivered, keep
+            // the scheduler guard until the handler actually completes so a
+            // slow ownership fence cannot accumulate duplicate mailbox work.
+            .mailbox_timeout(RESOLVER_SYNC_MAILBOX_TIMEOUT)
             .await;
         match result {
-            Ok(waddle_xmpp::muc::room_actor::ResolverAffiliationSyncOutcome::Applied) => return,
+            Ok(waddle_xmpp::muc::room_actor::ResolverAffiliationSyncOutcome::Applied {
+                admission_revision,
+            }) => {
+                let Some(next) = worker.finish_applied_or_take_update(admission_revision) else {
+                    return;
+                };
+                work = next;
+                effective_admission_revision = worker.effective_admission_revision();
+                attempt = 1;
+            }
             Ok(
                 waddle_xmpp::muc::room_actor::ResolverAffiliationSyncOutcome::OwnershipUnavailable,
             ) if attempt < RESOLVER_SYNC_MAX_ATTEMPTS => {}
@@ -157,7 +200,20 @@ async fn run_resolver_affiliation_sync_retries(
                     outcome = ?outcome,
                     "Skipped resolver affiliation sync on rejected join"
                 );
-                return;
+                let disposition = if outcome
+                    == waddle_xmpp::muc::room_actor::ResolverAffiliationSyncOutcome::OwnershipUnavailable
+                {
+                    crate::server::routes::websocket::state::ResolverAffiliationSyncTerminalDisposition::NonMutatingExhaustion
+                } else {
+                    crate::server::routes::websocket::state::ResolverAffiliationSyncTerminalDisposition::InvalidatingOutcome
+                };
+                let Some(next) = worker.finish_terminal_or_take_update(disposition) else {
+                    return;
+                };
+                work = next;
+                effective_admission_revision = worker.effective_admission_revision();
+                attempt = 1;
+                continue;
             }
             Err(
                 error @ (kameo::error::SendError::MailboxFull(_)
@@ -170,16 +226,25 @@ async fn run_resolver_affiliation_sync_retries(
                     "Resolver affiliation sync was not delivered; retrying"
                 );
             }
-            Err(kameo::error::SendError::Timeout(None)) => {
-                // Reply timeout starts only after mailbox delivery. The
-                // handler can still complete, so another send would queue a
-                // duplicate behind the same slow ownership check.
-                debug!(
+            Err(
+                error @ (kameo::error::SendError::MailboxFull(_)
+                | kameo::error::SendError::Timeout(Some(_))),
+            ) => {
+                warn!(
                     room = %room_jid,
                     attempt,
-                    "Resolver affiliation sync reply timed out after delivery; leaving the in-flight repair authoritative"
+                    error = ?error,
+                    "Resolver affiliation sync retries exhausted"
                 );
-                return;
+                let Some(next) = worker.finish_terminal_or_take_update(
+                    crate::server::routes::websocket::state::ResolverAffiliationSyncTerminalDisposition::NonMutatingExhaustion,
+                ) else {
+                    return;
+                };
+                work = next;
+                effective_admission_revision = worker.effective_admission_revision();
+                attempt = 1;
+                continue;
             }
             Err(error) => {
                 warn!(
@@ -188,10 +253,25 @@ async fn run_resolver_affiliation_sync_retries(
                     error = ?error,
                     "Resolver affiliation sync retries exhausted"
                 );
-                return;
+                let Some(next) = worker.finish_terminal_or_take_update(
+                    crate::server::routes::websocket::state::ResolverAffiliationSyncTerminalDisposition::InvalidatingOutcome,
+                ) else {
+                    return;
+                };
+                work = next;
+                effective_admission_revision = worker.effective_admission_revision();
+                attempt = 1;
+                continue;
             }
         }
         tokio::time::sleep(RESOLVER_SYNC_RETRY_BACKOFF).await;
+        if let Some(next) = worker.take_update() {
+            work = next;
+            effective_admission_revision = worker.effective_admission_revision();
+            attempt = 1;
+        } else {
+            attempt += 1;
+        }
     }
 }
 
@@ -203,7 +283,9 @@ mod resolver_sync_retry_tests {
     use kameo::actor::Spawn;
     use waddle_xmpp::muc::affiliation::AffiliationEntry;
     use waddle_xmpp::muc::durable::{DurableRoomState, MucDurableFuture, MucDurableStore};
-    use waddle_xmpp::muc::room_actor::{GetAffiliation, RestoreDurableRoomState, RoomActor};
+    use waddle_xmpp::muc::room_actor::{
+        ChangeAffiliation, GetAffiliation, RestoreDurableRoomState, RoomActor,
+    };
     use waddle_xmpp::muc::{MucRoom, RoomConfig, SubjectState};
     use waddle_xmpp::xep::xep0421::{OccupantIdSecret, OCCUPANT_ID_SECRET_MIN_BYTES};
 
@@ -211,9 +293,11 @@ mod resolver_sync_retry_tests {
 
     struct SequencedOwnershipStore {
         failures_remaining: AtomicUsize,
+        blocks_remaining: AtomicUsize,
+        block_at_check: AtomicUsize,
+        block_every_check: bool,
         checks: AtomicUsize,
-        hang: bool,
-        blocked_check_started: tokio::sync::Notify,
+        check_started: tokio::sync::Notify,
         release_blocked_check: tokio::sync::Notify,
     }
 
@@ -221,9 +305,11 @@ mod resolver_sync_retry_tests {
         fn new(failures: usize) -> Arc<Self> {
             Arc::new(Self {
                 failures_remaining: AtomicUsize::new(failures),
+                blocks_remaining: AtomicUsize::new(0),
+                block_at_check: AtomicUsize::new(0),
+                block_every_check: false,
                 checks: AtomicUsize::new(0),
-                hang: false,
-                blocked_check_started: tokio::sync::Notify::new(),
+                check_started: tokio::sync::Notify::new(),
                 release_blocked_check: tokio::sync::Notify::new(),
             })
         }
@@ -231,15 +317,37 @@ mod resolver_sync_retry_tests {
         fn hanging() -> Arc<Self> {
             Arc::new(Self {
                 failures_remaining: AtomicUsize::new(0),
+                blocks_remaining: AtomicUsize::new(1),
+                block_at_check: AtomicUsize::new(0),
+                block_every_check: false,
                 checks: AtomicUsize::new(0),
-                hang: true,
-                blocked_check_started: tokio::sync::Notify::new(),
+                check_started: tokio::sync::Notify::new(),
+                release_blocked_check: tokio::sync::Notify::new(),
+            })
+        }
+
+        fn always_hanging() -> Arc<Self> {
+            Arc::new(Self {
+                failures_remaining: AtomicUsize::new(0),
+                blocks_remaining: AtomicUsize::new(0),
+                block_at_check: AtomicUsize::new(0),
+                block_every_check: true,
+                checks: AtomicUsize::new(0),
+                check_started: tokio::sync::Notify::new(),
                 release_blocked_check: tokio::sync::Notify::new(),
             })
         }
 
         fn checks(&self) -> usize {
             self.checks.load(Ordering::SeqCst)
+        }
+
+        fn fail_next(&self, failures: usize) {
+            self.failures_remaining.store(failures, Ordering::SeqCst);
+        }
+
+        fn block_check(&self, check: usize) {
+            self.block_at_check.store(check, Ordering::SeqCst);
         }
     }
 
@@ -278,8 +386,15 @@ mod resolver_sync_retry_tests {
         }
 
         fn check_fenced_fanout<'a>(&'a self, _room_jid: &'a BareJid) -> MucDurableFuture<'a, bool> {
-            self.checks.fetch_add(1, Ordering::SeqCst);
-            let hang = self.hang;
+            let check = self.checks.fetch_add(1, Ordering::SeqCst) + 1;
+            let should_block = self.block_every_check
+                || self.block_at_check.load(Ordering::SeqCst) == check
+                || self
+                    .blocks_remaining
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                        remaining.checked_sub(1)
+                    })
+                    .is_ok();
             let should_fail = self
                 .failures_remaining
                 .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
@@ -287,8 +402,8 @@ mod resolver_sync_retry_tests {
                 })
                 .is_ok();
             Box::pin(async move {
-                if hang {
-                    self.blocked_check_started.notify_one();
+                self.check_started.notify_one();
+                if should_block {
                     self.release_blocked_check.notified().await;
                 }
                 if should_fail {
@@ -305,13 +420,23 @@ mod resolver_sync_retry_tests {
     async fn spawn_sync_test_room(
         store: Arc<SequencedOwnershipStore>,
     ) -> (kameo::actor::ActorRef<RoomActor>, BareJid) {
+        spawn_sync_test_room_with_seed(store, None).await
+    }
+
+    async fn spawn_sync_test_room_with_seed(
+        store: Arc<SequencedOwnershipStore>,
+        seed: Option<(BareJid, Affiliation)>,
+    ) -> (kameo::actor::ActorRef<RoomActor>, BareJid) {
         let room_jid: BareJid = "resolver-sync@muc.example.com".parse().expect("room JID");
-        let room = MucRoom::new(
+        let mut room = MucRoom::new(
             room_jid.clone(),
             "waddle-1".to_string(),
             "channel-1".to_string(),
             RoomConfig::default(),
         );
+        if let Some((jid, affiliation)) = seed {
+            room.update_affiliation_from_resolver(jid, affiliation);
+        }
         let secret = OccupantIdSecret::new(vec![7; OCCUPANT_ID_SECRET_MIN_BYTES])
             .expect("occupant-id secret");
         let actor = RoomActor::spawn(RoomActor::new(room, secret));
@@ -324,18 +449,59 @@ mod resolver_sync_retry_tests {
         (actor, room_jid)
     }
 
+    fn spawn_sync_worker(
+        actor: kameo::actor::ActorRef<RoomActor>,
+        room_jid: BareJid,
+        member: BareJid,
+        affiliation: Affiliation,
+        expected_admission_revision: u64,
+    ) -> tokio::task::JoinHandle<()> {
+        let scheduler =
+            Arc::new(crate::server::routes::websocket::ResolverAffiliationSyncScheduler::default());
+        spawn_sync_worker_with_scheduler(
+            actor,
+            room_jid,
+            member,
+            affiliation,
+            expected_admission_revision,
+            scheduler,
+        )
+    }
+
+    fn spawn_sync_worker_with_scheduler(
+        actor: kameo::actor::ActorRef<RoomActor>,
+        room_jid: BareJid,
+        member: BareJid,
+        affiliation: Affiliation,
+        expected_admission_revision: u64,
+        scheduler: Arc<crate::server::routes::websocket::ResolverAffiliationSyncScheduler>,
+    ) -> tokio::task::JoinHandle<()> {
+        let work = crate::server::routes::websocket::ResolverAffiliationSyncWork {
+            affiliation,
+            expected_admission_revision,
+        };
+        let crate::server::routes::websocket::ResolverAffiliationSyncSchedule::Started(worker) =
+            scheduler.schedule(&room_jid, &member, actor.id(), work)
+        else {
+            panic!("new scheduler starts one worker");
+        };
+        tokio::spawn(run_resolver_affiliation_sync_worker(
+            actor, room_jid, member, *worker,
+        ))
+    }
+
     #[tokio::test(start_paused = true)]
     async fn resolver_sync_retries_transient_ownership_then_applies() {
         let store = SequencedOwnershipStore::new(1);
         let (actor, room_jid) = spawn_sync_test_room(Arc::clone(&store)).await;
         let member: BareJid = "member@example.com".parse().expect("member JID");
-        let retry = tokio::spawn(run_resolver_affiliation_sync_retries(
+        let retry = spawn_sync_worker(
             actor.clone(),
             room_jid,
             member.clone(),
             Affiliation::Member,
             0,
-        ));
+        );
 
         tokio::task::yield_now().await;
         assert_eq!(store.checks(), 1, "first ownership check must fail once");
@@ -357,13 +523,13 @@ mod resolver_sync_retry_tests {
         let store = SequencedOwnershipStore::new(RESOLVER_SYNC_MAX_ATTEMPTS);
         let (actor, room_jid) = spawn_sync_test_room(Arc::clone(&store)).await;
         let member: BareJid = "member@example.com".parse().expect("member JID");
-        let retry = tokio::spawn(run_resolver_affiliation_sync_retries(
+        let retry = spawn_sync_worker(
             actor.clone(),
             room_jid,
             member.clone(),
             Affiliation::Member,
             0,
-        ));
+        );
 
         for expected_checks in 1..=RESOLVER_SYNC_MAX_ATTEMPTS {
             tokio::task::yield_now().await;
@@ -385,22 +551,28 @@ mod resolver_sync_retry_tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn resolver_sync_does_not_duplicate_after_delivered_reply_timeout() {
+    async fn resolver_sync_waits_for_the_intrinsically_bounded_handler() {
         let store = SequencedOwnershipStore::hanging();
         let (actor, room_jid) = spawn_sync_test_room(Arc::clone(&store)).await;
         let member: BareJid = "member@example.com".parse().expect("member JID");
-        let retry = tokio::spawn(run_resolver_affiliation_sync_retries(
+        let retry = spawn_sync_worker(
             actor.clone(),
             room_jid,
             member.clone(),
             Affiliation::Member,
             0,
-        ));
+        );
 
-        store.blocked_check_started.notified().await;
-        tokio::time::advance(RESOLVER_SYNC_REPLY_TIMEOUT).await;
-        retry.await.expect("reply timeout ends the retry task");
+        store.check_started.notified().await;
+        tokio::time::advance(RESOLVER_SYNC_MAILBOX_TIMEOUT * 4).await;
+        tokio::task::yield_now().await;
+        assert!(
+            !retry.is_finished(),
+            "delivery transfers completion ownership to the actor handler"
+        );
         store.release_blocked_check.notify_one();
+        tokio::time::advance(RESOLVER_SYNC_RETRY_BACKOFF).await;
+        retry.await.expect("delivered repair completes");
 
         assert_eq!(
             actor
@@ -411,9 +583,512 @@ mod resolver_sync_retry_tests {
         );
         assert_eq!(
             store.checks(),
-            1,
-            "a reply timeout must not enqueue duplicate repair messages"
+            2,
+            "the timed-out handler is retried once without an independent worker"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resolver_sync_scheduler_coalesces_identical_work_past_the_mailbox_timeout() {
+        let store = SequencedOwnershipStore::hanging();
+        let (actor, room_jid) = spawn_sync_test_room(Arc::clone(&store)).await;
+        let scheduler =
+            Arc::new(crate::server::routes::websocket::ResolverAffiliationSyncScheduler::default());
+        let member: BareJid = "coalesced@example.com".parse().expect("member JID");
+
+        sync_resolver_affiliation_on_rejection(
+            Some(&actor),
+            &scheduler,
+            &room_jid,
+            member.clone(),
+            Affiliation::Member,
+            0,
+        );
+        store.check_started.notified().await;
+        sync_resolver_affiliation_on_rejection(
+            Some(&actor),
+            &scheduler,
+            &room_jid,
+            member.clone(),
+            Affiliation::Member,
+            0,
+        );
+
+        tokio::time::advance(RESOLVER_SYNC_MAILBOX_TIMEOUT * 4).await;
+        tokio::task::yield_now().await;
+        sync_resolver_affiliation_on_rejection(
+            Some(&actor),
+            &scheduler,
+            &room_jid,
+            member.clone(),
+            Affiliation::Member,
+            0,
+        );
+        store.release_blocked_check.notify_one();
+        tokio::time::advance(RESOLVER_SYNC_RETRY_BACKOFF).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            actor
+                .ask(GetAffiliation { jid: member })
+                .await
+                .expect("coalesced repair completes"),
+            Affiliation::Member,
+        );
+        assert_eq!(
+            store.checks(),
+            2,
+            "duplicates must stay coalesced after the old reply-timeout boundary"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resolver_sync_scheduler_applies_the_latest_same_revision_verdict() {
+        let store = SequencedOwnershipStore::hanging();
+        let member: BareJid = "revision@example.com".parse().expect("member JID");
+        let (actor, room_jid) = spawn_sync_test_room_with_seed(
+            Arc::clone(&store),
+            Some((member.clone(), Affiliation::Member)),
+        )
+        .await;
+        let scheduler =
+            Arc::new(crate::server::routes::websocket::ResolverAffiliationSyncScheduler::default());
+
+        sync_resolver_affiliation_on_rejection(
+            Some(&actor),
+            &scheduler,
+            &room_jid,
+            member.clone(),
+            Affiliation::None,
+            0,
+        );
+        store.check_started.notified().await;
+        sync_resolver_affiliation_on_rejection(
+            Some(&actor),
+            &scheduler,
+            &room_jid,
+            member.clone(),
+            Affiliation::Outcast,
+            0,
+        );
+        tokio::task::yield_now().await;
+
+        store.release_blocked_check.notify_one();
+        store.check_started.notified().await;
+        assert_eq!(store.checks(), 2, "both distinct states must be delivered");
+        assert_eq!(
+            actor
+                .ask(GetAffiliation { jid: member })
+                .await
+                .expect("both distinct repairs drain"),
+            Affiliation::Outcast,
+            "the newer same-snapshot verdict must supersede the first repair's own revision bump"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resolver_sync_post_close_same_base_later_verdict_wins() {
+        let store = SequencedOwnershipStore::new(0);
+        let member: BareJid = "post-close@example.com".parse().expect("member JID");
+        let (actor, room_jid) = spawn_sync_test_room_with_seed(
+            Arc::clone(&store),
+            Some((member.clone(), Affiliation::Member)),
+        )
+        .await;
+        let scheduler =
+            Arc::new(crate::server::routes::websocket::ResolverAffiliationSyncScheduler::default());
+
+        spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid.clone(),
+            member.clone(),
+            Affiliation::None,
+            0,
+            Arc::clone(&scheduler),
+        )
+        .await
+        .expect("first worker closes after applying its repair");
+        spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid,
+            member.clone(),
+            Affiliation::Outcast,
+            0,
+            scheduler,
+        )
+        .await
+        .expect("later same-snapshot worker drains");
+
+        assert_eq!(
+            actor
+                .ask(GetAffiliation { jid: member })
+                .await
+                .expect("post-close repair result"),
+            Affiliation::Outcast,
+            "the later verdict must chain from the exact revision produced before worker closure"
+        );
+        assert_eq!(store.checks(), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resolver_sync_unrelated_mutation_invalidates_post_close_chain() {
+        let store = SequencedOwnershipStore::new(0);
+        let member: BareJid = "stale-chain@example.com".parse().expect("member JID");
+        let unrelated: BareJid = "unrelated@example.com".parse().expect("member JID");
+        let (actor, room_jid) = spawn_sync_test_room_with_seed(
+            Arc::clone(&store),
+            Some((member.clone(), Affiliation::Member)),
+        )
+        .await;
+        let scheduler =
+            Arc::new(crate::server::routes::websocket::ResolverAffiliationSyncScheduler::default());
+
+        spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid.clone(),
+            member.clone(),
+            Affiliation::None,
+            0,
+            Arc::clone(&scheduler),
+        )
+        .await
+        .expect("first worker closes after applying its repair");
+        actor
+            .ask(ChangeAffiliation {
+                jid: unrelated,
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .expect("unrelated mutation succeeds");
+        spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid,
+            member.clone(),
+            Affiliation::Outcast,
+            0,
+            scheduler,
+        )
+        .await
+        .expect("stale chained worker terminates");
+
+        assert_eq!(
+            actor
+                .ask(GetAffiliation { jid: member })
+                .await
+                .expect("affiliation after stale chained repair"),
+            Affiliation::None,
+            "an unrelated admission mutation must invalidate the carried revision"
+        );
+        assert_eq!(store.checks(), 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resolver_sync_out_of_order_stale_work_preserves_newer_completion_chain() {
+        let store = SequencedOwnershipStore::new(0);
+        let member: BareJid = "out-of-order@example.com".parse().expect("member JID");
+        let unrelated: BareJid = "revision-source@example.com".parse().expect("member JID");
+        let (actor, room_jid) = spawn_sync_test_room_with_seed(
+            Arc::clone(&store),
+            Some((member.clone(), Affiliation::Member)),
+        )
+        .await;
+        let scheduler =
+            Arc::new(crate::server::routes::websocket::ResolverAffiliationSyncScheduler::default());
+
+        actor
+            .ask(ChangeAffiliation {
+                jid: unrelated,
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .expect("establish source revision one");
+        spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid.clone(),
+            member.clone(),
+            Affiliation::None,
+            1,
+            Arc::clone(&scheduler),
+        )
+        .await
+        .expect("newer-source worker records its completion chain");
+        spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid.clone(),
+            member.clone(),
+            Affiliation::Member,
+            0,
+            Arc::clone(&scheduler),
+        )
+        .await
+        .expect("out-of-order stale worker terminates");
+        spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid,
+            member.clone(),
+            Affiliation::Outcast,
+            1,
+            scheduler,
+        )
+        .await
+        .expect("matching newer-source worker consumes the preserved chain");
+
+        assert_eq!(
+            actor
+                .ask(GetAffiliation { jid: member })
+                .await
+                .expect("affiliation after out-of-order repair"),
+            Affiliation::Outcast,
+            "stale-source work must not erase a newer completion chain"
+        );
+        assert_eq!(store.checks(), 4);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resolver_sync_retry_update_preserves_post_close_chain_revision() {
+        let store = SequencedOwnershipStore::new(0);
+        let member: BareJid = "retry-chain@example.com".parse().expect("member JID");
+        let (actor, room_jid) = spawn_sync_test_room_with_seed(
+            Arc::clone(&store),
+            Some((member.clone(), Affiliation::Member)),
+        )
+        .await;
+        let scheduler =
+            Arc::new(crate::server::routes::websocket::ResolverAffiliationSyncScheduler::default());
+
+        spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid.clone(),
+            member.clone(),
+            Affiliation::None,
+            0,
+            Arc::clone(&scheduler),
+        )
+        .await
+        .expect("first worker closes after recording its revision chain");
+        store.check_started.notified().await;
+        store.fail_next(1);
+
+        let retry = spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid.clone(),
+            member.clone(),
+            Affiliation::Member,
+            0,
+            Arc::clone(&scheduler),
+        );
+        store.check_started.notified().await;
+        sync_resolver_affiliation_on_rejection(
+            Some(&actor),
+            &scheduler,
+            &room_jid,
+            member.clone(),
+            Affiliation::Outcast,
+            0,
+        );
+        tokio::task::yield_now().await;
+        tokio::time::advance(RESOLVER_SYNC_RETRY_BACKOFF).await;
+        retry.await.expect("same-source retry update drains");
+
+        assert_eq!(
+            actor
+                .ask(GetAffiliation { jid: member })
+                .await
+                .expect("affiliation after retry update"),
+            Affiliation::Outcast,
+            "a transient retry must retain the completion-chain revision for a newer same-source verdict"
+        );
+        assert_eq!(store.checks(), 3);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resolver_sync_exhaustion_preserves_chain_for_pending_same_source_update() {
+        let store = SequencedOwnershipStore::new(0);
+        let member: BareJid = "exhausted-chain@example.com".parse().expect("member JID");
+        let (actor, room_jid) = spawn_sync_test_room_with_seed(
+            Arc::clone(&store),
+            Some((member.clone(), Affiliation::Member)),
+        )
+        .await;
+        let scheduler =
+            Arc::new(crate::server::routes::websocket::ResolverAffiliationSyncScheduler::default());
+
+        spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid.clone(),
+            member.clone(),
+            Affiliation::None,
+            0,
+            Arc::clone(&scheduler),
+        )
+        .await
+        .expect("first worker records source-zero to revision-one chain");
+        store.check_started.notified().await;
+        store.fail_next(RESOLVER_SYNC_MAX_ATTEMPTS);
+        store.block_check(4);
+
+        let exhausted = spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid.clone(),
+            member.clone(),
+            Affiliation::Member,
+            0,
+            Arc::clone(&scheduler),
+        );
+        for expected_check in 2..=3 {
+            store.check_started.notified().await;
+            assert_eq!(store.checks(), expected_check);
+            tokio::task::yield_now().await;
+            tokio::time::advance(RESOLVER_SYNC_RETRY_BACKOFF).await;
+        }
+        store.check_started.notified().await;
+        assert_eq!(store.checks(), 4, "third failed ownership check is blocked");
+        sync_resolver_affiliation_on_rejection(
+            Some(&actor),
+            &scheduler,
+            &room_jid,
+            member.clone(),
+            Affiliation::Outcast,
+            0,
+        );
+        store.release_blocked_check.notify_one();
+        exhausted
+            .await
+            .expect("pending same-source verdict drains after exhaustion");
+
+        assert_eq!(
+            actor
+                .ask(GetAffiliation { jid: member })
+                .await
+                .expect("affiliation after ownership exhaustion"),
+            Affiliation::Outcast,
+            "non-mutating exhaustion must preserve the effective revision for pending same-source work"
+        );
+        assert_eq!(store.checks(), 5);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resolver_sync_intrinsic_timeout_releases_global_worker_capacity() {
+        let blocked_store = SequencedOwnershipStore::always_hanging();
+        let (blocked_actor, blocked_room_jid) =
+            spawn_sync_test_room(Arc::clone(&blocked_store)).await;
+        let ready_store = SequencedOwnershipStore::new(0);
+        let (ready_actor, ready_room_jid) = spawn_sync_test_room(Arc::clone(&ready_store)).await;
+        let scheduler = Arc::new(
+            crate::server::routes::websocket::ResolverAffiliationSyncScheduler::with_capacity(1),
+        );
+        let blocked_member: BareJid = "blocked@example.com".parse().expect("member JID");
+        let ready_member: BareJid = "ready@example.com".parse().expect("member JID");
+
+        sync_resolver_affiliation_on_rejection(
+            Some(&blocked_actor),
+            &scheduler,
+            &blocked_room_jid,
+            blocked_member,
+            Affiliation::Member,
+            0,
+        );
+        blocked_store.check_started.notified().await;
+        sync_resolver_affiliation_on_rejection(
+            Some(&ready_actor),
+            &scheduler,
+            &ready_room_jid,
+            ready_member.clone(),
+            Affiliation::Member,
+            0,
+        );
+        tokio::task::yield_now().await;
+        assert_eq!(
+            ready_actor
+                .ask(GetAffiliation {
+                    jid: ready_member.clone(),
+                })
+                .await
+                .expect("capacity-rejected actor remains responsive"),
+            Affiliation::None,
+        );
+
+        for attempt in 1..=RESOLVER_SYNC_MAX_ATTEMPTS {
+            tokio::time::advance(std::time::Duration::from_secs(1)).await;
+            tokio::task::yield_now().await;
+            if attempt < RESOLVER_SYNC_MAX_ATTEMPTS {
+                tokio::time::advance(RESOLVER_SYNC_RETRY_BACKOFF).await;
+                tokio::task::yield_now().await;
+            }
+        }
+        assert_eq!(blocked_store.checks(), RESOLVER_SYNC_MAX_ATTEMPTS);
+        for _ in 0..4 {
+            tokio::task::yield_now().await;
+        }
+
+        sync_resolver_affiliation_on_rejection(
+            Some(&ready_actor),
+            &scheduler,
+            &ready_room_jid,
+            ready_member.clone(),
+            Affiliation::Member,
+            0,
+        );
+        tokio::task::yield_now().await;
+        assert_eq!(
+            ready_actor
+                .ask(GetAffiliation { jid: ready_member })
+                .await
+                .expect("released capacity admits the next worker"),
+            Affiliation::Member,
+        );
+        assert_eq!(ready_store.checks(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resolver_sync_scheduler_isolates_replacement_actor_incarnations() {
+        let old_store = SequencedOwnershipStore::hanging();
+        let (old_actor, room_jid) = spawn_sync_test_room(Arc::clone(&old_store)).await;
+        let new_store = SequencedOwnershipStore::new(0);
+        let (new_actor, new_room_jid) = spawn_sync_test_room(Arc::clone(&new_store)).await;
+        assert_eq!(room_jid, new_room_jid);
+        let scheduler =
+            Arc::new(crate::server::routes::websocket::ResolverAffiliationSyncScheduler::default());
+        let member: BareJid = "replacement@example.com".parse().expect("member JID");
+
+        sync_resolver_affiliation_on_rejection(
+            Some(&old_actor),
+            &scheduler,
+            &room_jid,
+            member.clone(),
+            Affiliation::Member,
+            0,
+        );
+        old_store.check_started.notified().await;
+        sync_resolver_affiliation_on_rejection(
+            Some(&new_actor),
+            &scheduler,
+            &room_jid,
+            member.clone(),
+            Affiliation::Member,
+            0,
+        );
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            new_actor
+                .ask(GetAffiliation {
+                    jid: member.clone(),
+                })
+                .await
+                .expect("replacement actor repair drains"),
+            Affiliation::Member,
+        );
+        assert_eq!(new_store.checks(), 1);
+
+        old_store.release_blocked_check.notify_one();
+        assert_eq!(
+            old_actor
+                .ask(GetAffiliation { jid: member })
+                .await
+                .expect("old actor repair drains independently"),
+            Affiliation::Member,
+        );
+        assert_eq!(old_store.checks(), 1);
     }
 }
 
@@ -822,6 +1497,7 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                     // provenance-aware sync.
                     sync_resolver_affiliation_on_rejection(
                         existing_room_actor.as_ref(),
+                        &state.deps.protocol.resolver_affiliation_syncs,
                         room_jid,
                         // Room affiliations are keyed by the joiner's
                         // bare JID (`JoinWithAffiliation` uses
@@ -853,6 +1529,7 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                         // affiliation from before the revocation here.
                         sync_resolver_affiliation_on_rejection(
                             existing_room_actor.as_ref(),
+                            &state.deps.protocol.resolver_affiliation_syncs,
                             room_jid,
                             // Same key as `JoinWithAffiliation`:
                             // `sender_jid.to_bare()`.
@@ -1039,6 +1716,21 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                                 "en",
                                 "This room's ownership is currently held by another node; \
                                  please retry.",
+                            ),
+                        )];
+                    }
+                    Err(
+                        waddle_xmpp::muc::room_registry_actor::RoomRegistryError::OwnershipReconciliationPending(_),
+                    ) => {
+                        return vec![build_muc_presence_error_xml(
+                            room_jid,
+                            &nick,
+                            sender_jid,
+                            StanzaError::new(
+                                ErrorType::Wait,
+                                DefinedCondition::ResourceConstraint,
+                                "en",
+                                "This room's ownership is being reconciled; please retry.",
                             ),
                         )];
                     }

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -133,6 +133,14 @@ fn sync_resolver_affiliation_on_rejection(
             );
             return;
         }
+        crate::server::routes::websocket::ResolverAffiliationSyncSchedule::Stale => {
+            debug!(
+                room = %room_jid,
+                %jid,
+                "Ignored a stale resolver affiliation repair because a newer revision is queued"
+            );
+            return;
+        }
         crate::server::routes::websocket::ResolverAffiliationSyncSchedule::AtCapacity => {
             debug!(
                 room = %room_jid,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -94,7 +94,11 @@ pub async fn handle_muc_join_with_ordered_relay(
 /// change (e.g. the re-granted user's successful join) landed in
 /// between, so a delayed sync can never clear a live occupant's fresh
 /// affiliation.
-async fn sync_resolver_affiliation_on_rejection(
+const RESOLVER_SYNC_MAX_ATTEMPTS: usize = 3;
+const RESOLVER_SYNC_REPLY_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(250);
+const RESOLVER_SYNC_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_millis(50);
+
+fn sync_resolver_affiliation_on_rejection(
     existing_room_actor: Option<&kameo::actor::ActorRef<waddle_xmpp::muc::room_actor::RoomActor>>,
     room_jid: &BareJid,
     jid: BareJid,
@@ -104,32 +108,312 @@ async fn sync_resolver_affiliation_on_rejection(
     let Some(actor) = existing_room_actor else {
         return;
     };
-    match actor
-        .ask(waddle_xmpp::muc::room_actor::SyncResolverAffiliation {
-            jid,
-            affiliation,
-            expected_admission_revision,
-        })
-        .await
-    {
-        Ok(waddle_xmpp::muc::room_actor::ResolverAffiliationSyncOutcome::Applied) => {}
-        Ok(outcome) => {
-            // Best-effort staleness repair only: a refused sync means the
-            // room's admission state already moved on (or the actor is
-            // sealed) — the newer state wins.
-            debug!(
-                room = %room_jid,
-                outcome = ?outcome,
-                "Skipped resolver affiliation sync on rejected join"
-            );
+    let actor = actor.clone();
+    let room_jid = room_jid.clone();
+    // This repair must not extend the rejected stanza path. The cloned
+    // ActorRef also guarantees retries target the same existing incarnation:
+    // they never consult the registry and therefore cannot create a room.
+    // Reusing the captured revision makes every delayed attempt harmless once
+    // a newer admission or affiliation mutation has landed.
+    tokio::spawn(run_resolver_affiliation_sync_retries(
+        actor,
+        room_jid,
+        jid,
+        affiliation,
+        expected_admission_revision,
+    ));
+}
+
+async fn run_resolver_affiliation_sync_retries(
+    actor: kameo::actor::ActorRef<waddle_xmpp::muc::room_actor::RoomActor>,
+    room_jid: BareJid,
+    jid: BareJid,
+    affiliation: Affiliation,
+    expected_admission_revision: u64,
+) {
+    for attempt in 1..=RESOLVER_SYNC_MAX_ATTEMPTS {
+        let result = actor
+            .ask(waddle_xmpp::muc::room_actor::SyncResolverAffiliation {
+                jid: jid.clone(),
+                affiliation,
+                expected_admission_revision,
+            })
+            .mailbox_timeout(RESOLVER_SYNC_REPLY_TIMEOUT)
+            .reply_timeout(RESOLVER_SYNC_REPLY_TIMEOUT)
+            .await;
+        match result {
+            Ok(waddle_xmpp::muc::room_actor::ResolverAffiliationSyncOutcome::Applied) => return,
+            Ok(
+                waddle_xmpp::muc::room_actor::ResolverAffiliationSyncOutcome::OwnershipUnavailable,
+            ) if attempt < RESOLVER_SYNC_MAX_ATTEMPTS => {}
+            Ok(outcome) => {
+                // Stale revision, sealing, and invite compensation are
+                // terminal for this captured rejection decision. A final
+                // OwnershipUnavailable is also bounded here rather than
+                // keeping a detached task alive indefinitely.
+                debug!(
+                    room = %room_jid,
+                    attempt,
+                    outcome = ?outcome,
+                    "Skipped resolver affiliation sync on rejected join"
+                );
+                return;
+            }
+            Err(
+                error @ (kameo::error::SendError::MailboxFull(_)
+                | kameo::error::SendError::Timeout(Some(_))),
+            ) if attempt < RESOLVER_SYNC_MAX_ATTEMPTS => {
+                debug!(
+                    room = %room_jid,
+                    attempt,
+                    error = ?error,
+                    "Resolver affiliation sync was not delivered; retrying"
+                );
+            }
+            Err(kameo::error::SendError::Timeout(None)) => {
+                // Reply timeout starts only after mailbox delivery. The
+                // handler can still complete, so another send would queue a
+                // duplicate behind the same slow ownership check.
+                debug!(
+                    room = %room_jid,
+                    attempt,
+                    "Resolver affiliation sync reply timed out after delivery; leaving the in-flight repair authoritative"
+                );
+                return;
+            }
+            Err(error) => {
+                warn!(
+                    room = %room_jid,
+                    attempt,
+                    error = ?error,
+                    "Resolver affiliation sync retries exhausted"
+                );
+                return;
+            }
         }
-        Err(error) => {
-            warn!(
-                room = %room_jid,
-                error = ?error,
-                "Failed to sync resolver affiliation into live room actor on rejected join"
-            );
+        tokio::time::sleep(RESOLVER_SYNC_RETRY_BACKOFF).await;
+    }
+}
+
+#[cfg(test)]
+mod resolver_sync_retry_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use kameo::actor::Spawn;
+    use waddle_xmpp::muc::affiliation::AffiliationEntry;
+    use waddle_xmpp::muc::durable::{DurableRoomState, MucDurableFuture, MucDurableStore};
+    use waddle_xmpp::muc::room_actor::{GetAffiliation, RestoreDurableRoomState, RoomActor};
+    use waddle_xmpp::muc::{MucRoom, RoomConfig, SubjectState};
+    use waddle_xmpp::xep::xep0421::{OccupantIdSecret, OCCUPANT_ID_SECRET_MIN_BYTES};
+
+    use super::*;
+
+    struct SequencedOwnershipStore {
+        failures_remaining: AtomicUsize,
+        checks: AtomicUsize,
+        hang: bool,
+        blocked_check_started: tokio::sync::Notify,
+        release_blocked_check: tokio::sync::Notify,
+    }
+
+    impl SequencedOwnershipStore {
+        fn new(failures: usize) -> Arc<Self> {
+            Arc::new(Self {
+                failures_remaining: AtomicUsize::new(failures),
+                checks: AtomicUsize::new(0),
+                hang: false,
+                blocked_check_started: tokio::sync::Notify::new(),
+                release_blocked_check: tokio::sync::Notify::new(),
+            })
         }
+
+        fn hanging() -> Arc<Self> {
+            Arc::new(Self {
+                failures_remaining: AtomicUsize::new(0),
+                checks: AtomicUsize::new(0),
+                hang: true,
+                blocked_check_started: tokio::sync::Notify::new(),
+                release_blocked_check: tokio::sync::Notify::new(),
+            })
+        }
+
+        fn checks(&self) -> usize {
+            self.checks.load(Ordering::SeqCst)
+        }
+    }
+
+    impl MucDurableStore for SequencedOwnershipStore {
+        fn load_room_state<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+        ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+            Box::pin(async { Ok(None) })
+        }
+
+        fn save_config<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _waddle_id: &'a str,
+            _channel_id: &'a str,
+            _config: &'a RoomConfig,
+        ) -> MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn save_subject<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _subject: Option<&'a SubjectState>,
+        ) -> MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn save_affiliation<'a>(
+            &'a self,
+            _room_jid: &'a BareJid,
+            _entry: &'a AffiliationEntry,
+        ) -> MucDurableFuture<'a, ()> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn check_fenced_fanout<'a>(&'a self, _room_jid: &'a BareJid) -> MucDurableFuture<'a, bool> {
+            self.checks.fetch_add(1, Ordering::SeqCst);
+            let hang = self.hang;
+            let should_fail = self
+                .failures_remaining
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok();
+            Box::pin(async move {
+                if hang {
+                    self.blocked_check_started.notify_one();
+                    self.release_blocked_check.notified().await;
+                }
+                if should_fail {
+                    Err(waddle_xmpp::XmppError::internal(
+                        "transient ownership check failure",
+                    ))
+                } else {
+                    Ok(true)
+                }
+            })
+        }
+    }
+
+    async fn spawn_sync_test_room(
+        store: Arc<SequencedOwnershipStore>,
+    ) -> (kameo::actor::ActorRef<RoomActor>, BareJid) {
+        let room_jid: BareJid = "resolver-sync@muc.example.com".parse().expect("room JID");
+        let room = MucRoom::new(
+            room_jid.clone(),
+            "waddle-1".to_string(),
+            "channel-1".to_string(),
+            RoomConfig::default(),
+        );
+        let secret = OccupantIdSecret::new(vec![7; OCCUPANT_ID_SECRET_MIN_BYTES])
+            .expect("occupant-id secret");
+        let actor = RoomActor::spawn(RoomActor::new(room, secret));
+        actor
+            .ask(RestoreDurableRoomState {
+                store: Arc::clone(&store) as Arc<dyn MucDurableStore>,
+            })
+            .await
+            .expect("install durable store");
+        (actor, room_jid)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resolver_sync_retries_transient_ownership_then_applies() {
+        let store = SequencedOwnershipStore::new(1);
+        let (actor, room_jid) = spawn_sync_test_room(Arc::clone(&store)).await;
+        let member: BareJid = "member@example.com".parse().expect("member JID");
+        let retry = tokio::spawn(run_resolver_affiliation_sync_retries(
+            actor.clone(),
+            room_jid,
+            member.clone(),
+            Affiliation::Member,
+            0,
+        ));
+
+        tokio::task::yield_now().await;
+        assert_eq!(store.checks(), 1, "first ownership check must fail once");
+        tokio::time::advance(RESOLVER_SYNC_RETRY_BACKOFF).await;
+        retry.await.expect("bounded retry task");
+
+        assert_eq!(store.checks(), 2, "second ownership check must retry");
+        assert_eq!(
+            actor
+                .ask(GetAffiliation { jid: member })
+                .await
+                .expect("affiliation"),
+            Affiliation::Member,
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resolver_sync_stops_after_bounded_persistent_ownership_errors() {
+        let store = SequencedOwnershipStore::new(RESOLVER_SYNC_MAX_ATTEMPTS);
+        let (actor, room_jid) = spawn_sync_test_room(Arc::clone(&store)).await;
+        let member: BareJid = "member@example.com".parse().expect("member JID");
+        let retry = tokio::spawn(run_resolver_affiliation_sync_retries(
+            actor.clone(),
+            room_jid,
+            member.clone(),
+            Affiliation::Member,
+            0,
+        ));
+
+        for expected_checks in 1..=RESOLVER_SYNC_MAX_ATTEMPTS {
+            tokio::task::yield_now().await;
+            assert_eq!(store.checks(), expected_checks);
+            if expected_checks < RESOLVER_SYNC_MAX_ATTEMPTS {
+                tokio::time::advance(RESOLVER_SYNC_RETRY_BACKOFF).await;
+            }
+        }
+        retry.await.expect("bounded retry task");
+
+        assert_eq!(store.checks(), RESOLVER_SYNC_MAX_ATTEMPTS);
+        assert_eq!(
+            actor
+                .ask(GetAffiliation { jid: member })
+                .await
+                .expect("affiliation"),
+            Affiliation::None,
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resolver_sync_does_not_duplicate_after_delivered_reply_timeout() {
+        let store = SequencedOwnershipStore::hanging();
+        let (actor, room_jid) = spawn_sync_test_room(Arc::clone(&store)).await;
+        let member: BareJid = "member@example.com".parse().expect("member JID");
+        let retry = tokio::spawn(run_resolver_affiliation_sync_retries(
+            actor.clone(),
+            room_jid,
+            member.clone(),
+            Affiliation::Member,
+            0,
+        ));
+
+        store.blocked_check_started.notified().await;
+        tokio::time::advance(RESOLVER_SYNC_REPLY_TIMEOUT).await;
+        retry.await.expect("reply timeout ends the retry task");
+        store.release_blocked_check.notify_one();
+
+        assert_eq!(
+            actor
+                .ask(GetAffiliation { jid: member })
+                .await
+                .expect("affiliation after the delivered repair completes"),
+            Affiliation::Member,
+        );
+        assert_eq!(
+            store.checks(),
+            1,
+            "a reply timeout must not enqueue duplicate repair messages"
+        );
     }
 }
 
@@ -546,8 +830,7 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                         sender_jid.to_bare(),
                         Affiliation::Outcast,
                         admission_revision,
-                    )
-                    .await;
+                    );
                     return vec![build_muc_presence_error_xml(
                         room_jid,
                         &nick,
@@ -576,8 +859,7 @@ async fn handle_muc_join_unlocked(state: &WebSocketState, request: MucJoinWork<'
                             sender_jid.to_bare(),
                             Affiliation::None,
                             admission_revision,
-                        )
-                        .await;
+                        );
                         return vec![build_muc_presence_error_xml(
                             room_jid,
                             &nick,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -967,6 +967,73 @@ mod resolver_sync_retry_tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn resolver_sync_exhausted_worker_retains_chain_for_later_same_source_work() {
+        let store = SequencedOwnershipStore::new(0);
+        let member: BareJid = "closed-exhaustion@example.com".parse().expect("member JID");
+        let (actor, room_jid) = spawn_sync_test_room_with_seed(
+            Arc::clone(&store),
+            Some((member.clone(), Affiliation::Member)),
+        )
+        .await;
+        let scheduler =
+            Arc::new(crate::server::routes::websocket::ResolverAffiliationSyncScheduler::default());
+
+        spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid.clone(),
+            member.clone(),
+            Affiliation::None,
+            0,
+            Arc::clone(&scheduler),
+        )
+        .await
+        .expect("first worker records source-zero to revision-one chain");
+        store.check_started.notified().await;
+        store.fail_next(RESOLVER_SYNC_MAX_ATTEMPTS);
+
+        let exhausted = spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid.clone(),
+            member.clone(),
+            Affiliation::Member,
+            0,
+            Arc::clone(&scheduler),
+        );
+        for expected_check in 2..=4 {
+            store.check_started.notified().await;
+            assert_eq!(store.checks(), expected_check);
+            if expected_check < 4 {
+                tokio::task::yield_now().await;
+                tokio::time::advance(RESOLVER_SYNC_RETRY_BACKOFF).await;
+            }
+        }
+        exhausted
+            .await
+            .expect("exhausted worker closes without pending work");
+
+        spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid,
+            member.clone(),
+            Affiliation::Outcast,
+            0,
+            scheduler,
+        )
+        .await
+        .expect("later same-source work consumes the retained chain");
+
+        assert_eq!(
+            actor
+                .ask(GetAffiliation { jid: member })
+                .await
+                .expect("affiliation after exhausted worker closure"),
+            Affiliation::Outcast,
+            "non-mutating exhaustion must retain authorization after the worker closes"
+        );
+        assert_eq!(store.checks(), 5);
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn resolver_sync_intrinsic_timeout_releases_global_worker_capacity() {
         let blocked_store = SequencedOwnershipStore::always_hanging();
         let (blocked_actor, blocked_room_jid) =

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -193,6 +193,7 @@ async fn run_resolver_affiliation_sync_worker(
                 work = next;
                 effective_admission_revision = worker.effective_admission_revision();
                 attempt = 1;
+                continue;
             }
             Ok(
                 waddle_xmpp::muc::room_actor::ResolverAffiliationSyncOutcome::OwnershipUnavailable,
@@ -690,6 +691,51 @@ mod resolver_sync_retry_tests {
                 .expect("both distinct repairs drain"),
             Affiliation::Outcast,
             "the newer same-snapshot verdict must supersede the first repair's own revision bump"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn resolver_sync_chained_update_receives_the_full_retry_budget() {
+        let store = SequencedOwnershipStore::hanging();
+        let member: BareJid = "chained-retry@example.com".parse().expect("member JID");
+        let (actor, room_jid) = spawn_sync_test_room_with_seed(
+            Arc::clone(&store),
+            Some((member.clone(), Affiliation::Member)),
+        )
+        .await;
+        let scheduler =
+            Arc::new(crate::server::routes::websocket::ResolverAffiliationSyncScheduler::default());
+
+        let worker = spawn_sync_worker_with_scheduler(
+            actor.clone(),
+            room_jid.clone(),
+            member.clone(),
+            Affiliation::None,
+            0,
+            Arc::clone(&scheduler),
+        );
+        store.check_started.notified().await;
+        sync_resolver_affiliation_on_rejection(
+            Some(&actor),
+            &scheduler,
+            &room_jid,
+            member,
+            Affiliation::Outcast,
+            0,
+        );
+        store.fail_next(RESOLVER_SYNC_MAX_ATTEMPTS);
+        store.release_blocked_check.notify_one();
+
+        for _ in 0..=RESOLVER_SYNC_MAX_ATTEMPTS {
+            tokio::task::yield_now().await;
+            tokio::time::advance(RESOLVER_SYNC_RETRY_BACKOFF).await;
+        }
+        worker.await.expect("bounded chained worker");
+
+        assert_eq!(
+            store.checks(),
+            1 + RESOLVER_SYNC_MAX_ATTEMPTS,
+            "queued work adopted after a successful repair must receive its own full retry budget"
         );
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/mod.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/mod.rs
@@ -103,7 +103,9 @@ pub(crate) use cleanup::redrive_remote_muc_cleanup;
 pub use connection::router;
 pub use state::{
     ActiveCallThread, DmCallThreadKey, DmPairKey, DmPinStore, PendingDmCallOffer, ProtocolServices,
-    RemoteMucMemberships, TransportSecurity, WebSocketDeps, WebSocketState, XmppServiceDomains,
+    RemoteMucMemberships, ResolverAffiliationSyncSchedule, ResolverAffiliationSyncScheduler,
+    ResolverAffiliationSyncWork, TransportSecurity, WebSocketDeps, WebSocketState,
+    XmppServiceDomains,
 };
 
 pub(crate) use cleanup::{

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -146,6 +146,8 @@ pub enum ResolverAffiliationSyncSchedule {
     Updated,
     /// The existing worker already owns an identical latest verdict.
     Coalesced,
+    /// A newer source snapshot is already retained for this worker.
+    Stale,
     /// All global worker slots are occupied by other logical keys.
     AtCapacity,
 }
@@ -209,6 +211,9 @@ impl ResolverAffiliationSyncScheduler {
         };
         let mut state = self.state.lock().expect("resolver sync scheduler lock");
         if let Some(slot) = state.workers.get_mut(&key) {
+            if work.expected_admission_revision < slot.latest.expected_admission_revision {
+                return ResolverAffiliationSyncSchedule::Stale;
+            }
             if slot.latest == work {
                 return ResolverAffiliationSyncSchedule::Coalesced;
             }
@@ -458,6 +463,45 @@ mod resolver_affiliation_sync_scheduler_tests {
             scheduler.schedule(&room, &bob, actor_a, initial),
             ResolverAffiliationSyncSchedule::Started(_)
         ));
+    }
+
+    #[test]
+    fn scheduler_rejects_a_stale_update_when_a_newer_revision_is_queued() {
+        let scheduler = Arc::new(ResolverAffiliationSyncScheduler::default());
+        let room: BareJid = "room@muc.example.com".parse().expect("room JID");
+        let member: BareJid = "member@example.com".parse().expect("member JID");
+        let actor_id = kameo::actor::ActorId::new(1);
+        let initial = ResolverAffiliationSyncWork {
+            affiliation: waddle_xmpp::Affiliation::None,
+            expected_admission_revision: 0,
+        };
+        let newer = ResolverAffiliationSyncWork {
+            affiliation: waddle_xmpp::Affiliation::Member,
+            expected_admission_revision: 2,
+        };
+        let stale = ResolverAffiliationSyncWork {
+            affiliation: waddle_xmpp::Affiliation::Outcast,
+            expected_admission_revision: 1,
+        };
+
+        let ResolverAffiliationSyncSchedule::Started(mut worker) =
+            scheduler.schedule(&room, &member, actor_id, initial)
+        else {
+            panic!("first repair starts a worker");
+        };
+        assert!(matches!(
+            scheduler.schedule(&room, &member, actor_id, newer),
+            ResolverAffiliationSyncSchedule::Updated
+        ));
+        assert!(matches!(
+            scheduler.schedule(&room, &member, actor_id, stale),
+            ResolverAffiliationSyncSchedule::Stale
+        ));
+        assert_eq!(
+            worker.take_update(),
+            Some(newer),
+            "out-of-order stale completion must not replace the newer queued verdict"
+        );
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -97,6 +97,16 @@ fn take_completion_revision(
         .then_some(completion.resulting_admission_revision)
 }
 
+fn has_newer_completion(
+    state: &ResolverAffiliationSyncState,
+    key: &ResolverAffiliationSyncWorkerKey,
+    source_admission_revision: u64,
+) -> bool {
+    state.recent_completions.iter().any(|completion| {
+        completion.key == *key && completion.source_admission_revision > source_admission_revision
+    })
+}
+
 fn clear_completion_through(
     state: &mut ResolverAffiliationSyncState,
     key: &ResolverAffiliationSyncWorkerKey,
@@ -223,6 +233,9 @@ impl ResolverAffiliationSyncScheduler {
                 .checked_add(1)
                 .expect("resolver sync worker version overflow");
             return ResolverAffiliationSyncSchedule::Updated;
+        }
+        if has_newer_completion(&state, &key, work.expected_admission_revision) {
+            return ResolverAffiliationSyncSchedule::Stale;
         }
         if state.workers.len() >= state.max_workers {
             waddle_xmpp::prometheus::increment_resolver_affiliation_sync_capacity_drop();
@@ -595,7 +608,7 @@ mod resolver_affiliation_sync_scheduler_tests {
     }
 
     #[test]
-    fn scheduler_stale_worker_drop_preserves_a_newer_completion() {
+    fn scheduler_rejects_stale_work_without_consuming_a_newer_completion() {
         let scheduler = Arc::new(ResolverAffiliationSyncScheduler::with_capacity(1));
         let room: BareJid = "room@muc.example.com".parse().expect("room JID");
         let member: BareJid = "member@example.com".parse().expect("member JID");
@@ -616,13 +629,10 @@ mod resolver_affiliation_sync_scheduler_tests {
         };
         assert_eq!(newer_worker.finish_applied_or_take_update(2), None);
 
-        let ResolverAffiliationSyncSchedule::Started(stale_worker) =
-            scheduler.schedule(&room, &member, actor_id, stale)
-        else {
-            panic!("out-of-order stale repair starts independently");
-        };
-        assert_eq!(stale_worker.effective_admission_revision(), 0);
-        drop(stale_worker);
+        assert!(matches!(
+            scheduler.schedule(&room, &member, actor_id, stale),
+            ResolverAffiliationSyncSchedule::Stale
+        ));
 
         let ResolverAffiliationSyncSchedule::Started(chained_worker) =
             scheduler.schedule(&room, &member, actor_id, newer)
@@ -632,7 +642,7 @@ mod resolver_affiliation_sync_scheduler_tests {
         assert_eq!(
             chained_worker.effective_admission_revision(),
             2,
-            "stale worker cleanup must preserve a newer source revision chain"
+            "rejecting stale work must preserve the newer source revision chain"
         );
     }
 

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -329,8 +329,10 @@ impl ResolverAffiliationSyncWorker {
         None
     }
 
-    /// Atomically adopt a pending update or close without preserving a
-    /// revision chain. A non-applied outcome cannot authorize later rebasing.
+    /// Atomically adopt a pending update or close with disposition-specific
+    /// revision handling. Non-mutating exhaustion retains only the exact
+    /// revision already authorized for this worker; invalidating outcomes
+    /// clear that chain.
     pub fn finish_terminal_or_take_update(
         &mut self,
         disposition: ResolverAffiliationSyncTerminalDisposition,

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -365,11 +365,23 @@ impl ResolverAffiliationSyncWorker {
             return Some(self.current);
         }
         state.workers.remove(&self.key);
-        clear_completion_through(
-            &mut state,
-            &self.key,
-            self.current.expected_admission_revision,
-        );
+        match disposition {
+            ResolverAffiliationSyncTerminalDisposition::NonMutatingExhaustion => {
+                retain_completion(
+                    &mut state,
+                    &self.key,
+                    self.current.expected_admission_revision,
+                    self.effective_admission_revision,
+                );
+            }
+            ResolverAffiliationSyncTerminalDisposition::InvalidatingOutcome => {
+                clear_completion_through(
+                    &mut state,
+                    &self.key,
+                    self.current.expected_admission_revision,
+                );
+            }
+        }
         self.closed = true;
         None
     }

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -36,6 +36,581 @@ impl DmCallThreadKey {
     }
 }
 
+const MAX_RESOLVER_AFFILIATION_SYNC_WORKERS: usize = 128;
+const MAX_RECENT_RESOLVER_AFFILIATION_SYNC_COMPLETIONS: usize = 128;
+
+/// One resolver verdict captured from a rejected join.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolverAffiliationSyncWork {
+    pub affiliation: waddle_xmpp::Affiliation,
+    pub expected_admission_revision: u64,
+}
+
+/// Logical worker identity. Every verdict for this actor incarnation and
+/// member is serialized through one latest-wins worker.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ResolverAffiliationSyncWorkerKey {
+    room_jid: BareJid,
+    jid: BareJid,
+    actor_id: kameo::actor::ActorId,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ResolverAffiliationSyncSlot {
+    latest: ResolverAffiliationSyncWork,
+    version: u64,
+}
+
+#[derive(Debug, Clone)]
+struct ResolverAffiliationSyncCompletion {
+    key: ResolverAffiliationSyncWorkerKey,
+    source_admission_revision: u64,
+    resulting_admission_revision: u64,
+}
+
+#[derive(Debug)]
+struct ResolverAffiliationSyncState {
+    workers:
+        std::collections::HashMap<ResolverAffiliationSyncWorkerKey, ResolverAffiliationSyncSlot>,
+    recent_completions: std::collections::VecDeque<ResolverAffiliationSyncCompletion>,
+    max_workers: usize,
+}
+
+fn take_completion_revision(
+    state: &mut ResolverAffiliationSyncState,
+    key: &ResolverAffiliationSyncWorkerKey,
+    source_admission_revision: u64,
+) -> Option<u64> {
+    let position = state
+        .recent_completions
+        .iter()
+        .position(|completion| completion.key == *key)?;
+    let completion = &state.recent_completions[position];
+    if completion.source_admission_revision > source_admission_revision {
+        return None;
+    }
+    let completion = state
+        .recent_completions
+        .remove(position)
+        .expect("resolver sync completion position");
+    (completion.source_admission_revision == source_admission_revision)
+        .then_some(completion.resulting_admission_revision)
+}
+
+fn clear_completion_through(
+    state: &mut ResolverAffiliationSyncState,
+    key: &ResolverAffiliationSyncWorkerKey,
+    source_admission_revision: u64,
+) {
+    if let Some(position) = state.recent_completions.iter().position(|completion| {
+        completion.key == *key && completion.source_admission_revision <= source_admission_revision
+    }) {
+        state.recent_completions.remove(position);
+    }
+}
+
+fn retain_completion(
+    state: &mut ResolverAffiliationSyncState,
+    key: &ResolverAffiliationSyncWorkerKey,
+    source_admission_revision: u64,
+    resulting_admission_revision: u64,
+) {
+    if let Some(position) = state
+        .recent_completions
+        .iter()
+        .position(|completion| completion.key == *key)
+    {
+        if state.recent_completions[position].source_admission_revision > source_admission_revision
+        {
+            return;
+        }
+        state.recent_completions.remove(position);
+    }
+    if state.recent_completions.len() >= MAX_RECENT_RESOLVER_AFFILIATION_SYNC_COMPLETIONS {
+        state.recent_completions.pop_front();
+    }
+    state
+        .recent_completions
+        .push_back(ResolverAffiliationSyncCompletion {
+            key: key.clone(),
+            source_admission_revision,
+            resulting_admission_revision,
+        });
+}
+
+/// Result of offering a resolver verdict to the bounded scheduler.
+pub enum ResolverAffiliationSyncSchedule {
+    /// A new logical worker owns this key and must be spawned by the caller.
+    Started(Box<ResolverAffiliationSyncWorker>),
+    /// An existing worker atomically retained this newer verdict.
+    Updated,
+    /// The existing worker already owns an identical latest verdict.
+    Coalesced,
+    /// All global worker slots are occupied by other logical keys.
+    AtCapacity,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolverAffiliationSyncTerminalDisposition {
+    /// No actor admission state changed, so pending same-source work retains
+    /// the effective revision already authorized for this worker.
+    NonMutatingExhaustion,
+    /// The actor outcome invalidated the current chain; pending work must
+    /// establish its own source revision or consume another retained chain.
+    InvalidatingOutcome,
+}
+
+/// Bounds detached resolver-affiliation repair to one latest-wins worker per
+/// `(actor incarnation, room, member)`. The worker table and close/update
+/// handshake share one mutex, so a verdict cannot land between a worker's
+/// final empty check and removal.
+#[derive(Debug)]
+pub struct ResolverAffiliationSyncScheduler {
+    state: std::sync::Mutex<ResolverAffiliationSyncState>,
+}
+
+pub struct ResolverAffiliationSyncWorker {
+    scheduler: Arc<ResolverAffiliationSyncScheduler>,
+    key: ResolverAffiliationSyncWorkerKey,
+    current: ResolverAffiliationSyncWork,
+    effective_admission_revision: u64,
+    version: u64,
+    closed: bool,
+}
+
+impl Default for ResolverAffiliationSyncScheduler {
+    fn default() -> Self {
+        Self::with_capacity(MAX_RESOLVER_AFFILIATION_SYNC_WORKERS)
+    }
+}
+
+impl ResolverAffiliationSyncScheduler {
+    pub(crate) fn with_capacity(max_workers: usize) -> Self {
+        Self {
+            state: std::sync::Mutex::new(ResolverAffiliationSyncState {
+                workers: std::collections::HashMap::new(),
+                recent_completions: std::collections::VecDeque::new(),
+                max_workers,
+            }),
+        }
+    }
+
+    pub fn schedule(
+        self: &Arc<Self>,
+        room_jid: &BareJid,
+        jid: &BareJid,
+        actor_id: kameo::actor::ActorId,
+        work: ResolverAffiliationSyncWork,
+    ) -> ResolverAffiliationSyncSchedule {
+        let key = ResolverAffiliationSyncWorkerKey {
+            room_jid: room_jid.clone(),
+            jid: jid.clone(),
+            actor_id,
+        };
+        let mut state = self.state.lock().expect("resolver sync scheduler lock");
+        if let Some(slot) = state.workers.get_mut(&key) {
+            if slot.latest == work {
+                return ResolverAffiliationSyncSchedule::Coalesced;
+            }
+            slot.latest = work;
+            slot.version = slot
+                .version
+                .checked_add(1)
+                .expect("resolver sync worker version overflow");
+            return ResolverAffiliationSyncSchedule::Updated;
+        }
+        if state.workers.len() >= state.max_workers {
+            waddle_xmpp::prometheus::increment_resolver_affiliation_sync_capacity_drop();
+            return ResolverAffiliationSyncSchedule::AtCapacity;
+        }
+        let effective_admission_revision =
+            take_completion_revision(&mut state, &key, work.expected_admission_revision)
+                .unwrap_or(work.expected_admission_revision);
+        let version = 0;
+        state.workers.insert(
+            key.clone(),
+            ResolverAffiliationSyncSlot {
+                latest: work,
+                version,
+            },
+        );
+        ResolverAffiliationSyncSchedule::Started(Box::new(ResolverAffiliationSyncWorker {
+            scheduler: Arc::clone(self),
+            key,
+            current: work,
+            effective_admission_revision,
+            version,
+            closed: false,
+        }))
+    }
+}
+
+impl ResolverAffiliationSyncWorker {
+    pub fn current(&self) -> ResolverAffiliationSyncWork {
+        self.current
+    }
+
+    pub fn effective_admission_revision(&self) -> u64 {
+        self.effective_admission_revision
+    }
+
+    /// Adopt the most recent verdict when one arrived while the current
+    /// verdict was running. Leaves the worker registered when unchanged.
+    pub fn take_update(&mut self) -> Option<ResolverAffiliationSyncWork> {
+        let mut state = self
+            .scheduler
+            .state
+            .lock()
+            .expect("resolver sync scheduler lock");
+        let slot = *state
+            .workers
+            .get(&self.key)
+            .expect("live resolver sync worker slot");
+        if slot.version == self.version {
+            return None;
+        }
+        let previous_source_admission_revision = self.current.expected_admission_revision;
+        self.version = slot.version;
+        self.current = slot.latest;
+        if self.current.expected_admission_revision != previous_source_admission_revision {
+            self.effective_admission_revision = take_completion_revision(
+                &mut state,
+                &self.key,
+                self.current.expected_admission_revision,
+            )
+            .unwrap_or(self.current.expected_admission_revision);
+        }
+        Some(self.current)
+    }
+
+    /// Atomically adopt an update or retain this applied repair's exact
+    /// revision chain for one later worker with the same source snapshot.
+    /// A concurrent `schedule` call must run before or after this lock, so it
+    /// can never publish into a slot after the worker decided to exit.
+    pub fn finish_applied_or_take_update(
+        &mut self,
+        resulting_admission_revision: u64,
+    ) -> Option<ResolverAffiliationSyncWork> {
+        let mut state = self
+            .scheduler
+            .state
+            .lock()
+            .expect("resolver sync scheduler lock");
+        let slot = *state
+            .workers
+            .get(&self.key)
+            .expect("live resolver sync worker slot");
+        if slot.version != self.version {
+            let completed_source_admission_revision = self.current.expected_admission_revision;
+            self.version = slot.version;
+            self.current = slot.latest;
+            self.effective_admission_revision = if self.current.expected_admission_revision
+                == completed_source_admission_revision
+            {
+                resulting_admission_revision
+            } else {
+                take_completion_revision(
+                    &mut state,
+                    &self.key,
+                    self.current.expected_admission_revision,
+                )
+                .unwrap_or(self.current.expected_admission_revision)
+            };
+            return Some(self.current);
+        }
+        state.workers.remove(&self.key);
+        retain_completion(
+            &mut state,
+            &self.key,
+            self.current.expected_admission_revision,
+            resulting_admission_revision,
+        );
+        self.closed = true;
+        None
+    }
+
+    /// Atomically adopt a pending update or close without preserving a
+    /// revision chain. A non-applied outcome cannot authorize later rebasing.
+    pub fn finish_terminal_or_take_update(
+        &mut self,
+        disposition: ResolverAffiliationSyncTerminalDisposition,
+    ) -> Option<ResolverAffiliationSyncWork> {
+        let mut state = self
+            .scheduler
+            .state
+            .lock()
+            .expect("resolver sync scheduler lock");
+        let slot = *state
+            .workers
+            .get(&self.key)
+            .expect("live resolver sync worker slot");
+        if slot.version != self.version {
+            let completed_source_admission_revision = self.current.expected_admission_revision;
+            let completed_effective_admission_revision = self.effective_admission_revision;
+            self.version = slot.version;
+            self.current = slot.latest;
+            self.effective_admission_revision = if disposition
+                == ResolverAffiliationSyncTerminalDisposition::NonMutatingExhaustion
+                && self.current.expected_admission_revision == completed_source_admission_revision
+            {
+                completed_effective_admission_revision
+            } else {
+                take_completion_revision(
+                    &mut state,
+                    &self.key,
+                    self.current.expected_admission_revision,
+                )
+                .unwrap_or(self.current.expected_admission_revision)
+            };
+            return Some(self.current);
+        }
+        state.workers.remove(&self.key);
+        clear_completion_through(
+            &mut state,
+            &self.key,
+            self.current.expected_admission_revision,
+        );
+        self.closed = true;
+        None
+    }
+}
+
+impl Drop for ResolverAffiliationSyncWorker {
+    fn drop(&mut self) {
+        if self.closed {
+            return;
+        }
+        let mut state = self
+            .scheduler
+            .state
+            .lock()
+            .expect("resolver sync scheduler lock");
+        state.workers.remove(&self.key);
+        clear_completion_through(
+            &mut state,
+            &self.key,
+            self.current.expected_admission_revision,
+        );
+    }
+}
+
+#[cfg(test)]
+mod resolver_affiliation_sync_scheduler_tests {
+    use super::*;
+
+    #[test]
+    fn scheduler_keeps_one_worker_and_replaces_its_pending_verdict() {
+        let scheduler = Arc::new(ResolverAffiliationSyncScheduler::default());
+        let room: BareJid = "room@muc.example.com".parse().expect("room JID");
+        let alice: BareJid = "alice@example.com".parse().expect("member JID");
+        let bob: BareJid = "bob@example.com".parse().expect("member JID");
+        let actor_a = kameo::actor::ActorId::new(1);
+        let actor_b = kameo::actor::ActorId::new(2);
+        let initial = ResolverAffiliationSyncWork {
+            affiliation: waddle_xmpp::Affiliation::None,
+            expected_admission_revision: 7,
+        };
+        let newer = ResolverAffiliationSyncWork {
+            affiliation: waddle_xmpp::Affiliation::Outcast,
+            expected_admission_revision: 7,
+        };
+
+        let ResolverAffiliationSyncSchedule::Started(mut alice_worker) =
+            scheduler.schedule(&room, &alice, actor_a, initial)
+        else {
+            panic!("first repair starts a worker");
+        };
+        assert!(
+            matches!(
+                scheduler.schedule(&room, &alice, actor_a, initial),
+                ResolverAffiliationSyncSchedule::Coalesced
+            ),
+            "identical latest work must coalesce"
+        );
+        assert!(
+            matches!(
+                scheduler.schedule(&room, &alice, actor_a, newer),
+                ResolverAffiliationSyncSchedule::Updated
+            ),
+            "a conflicting verdict updates the existing worker"
+        );
+        assert_eq!(alice_worker.take_update(), Some(newer));
+
+        assert!(matches!(
+            scheduler.schedule(&room, &alice, actor_b, initial),
+            ResolverAffiliationSyncSchedule::Started(_)
+        ));
+        assert!(matches!(
+            scheduler.schedule(&room, &bob, actor_a, initial),
+            ResolverAffiliationSyncSchedule::Started(_)
+        ));
+    }
+
+    #[test]
+    fn scheduler_close_atomically_adopts_an_update_or_releases_capacity() {
+        let scheduler = Arc::new(ResolverAffiliationSyncScheduler::with_capacity(1));
+        let room: BareJid = "room@muc.example.com".parse().expect("room JID");
+        let alice: BareJid = "alice@example.com".parse().expect("member JID");
+        let bob: BareJid = "bob@example.com".parse().expect("member JID");
+        let actor_id = kameo::actor::ActorId::new(1);
+        let initial = ResolverAffiliationSyncWork {
+            affiliation: waddle_xmpp::Affiliation::None,
+            expected_admission_revision: 0,
+        };
+        let newer = ResolverAffiliationSyncWork {
+            affiliation: waddle_xmpp::Affiliation::Outcast,
+            expected_admission_revision: 0,
+        };
+
+        let ResolverAffiliationSyncSchedule::Started(mut worker) =
+            scheduler.schedule(&room, &alice, actor_id, initial)
+        else {
+            panic!("first repair starts a worker");
+        };
+        assert!(matches!(
+            scheduler.schedule(&room, &bob, actor_id, initial),
+            ResolverAffiliationSyncSchedule::AtCapacity
+        ));
+        assert!(matches!(
+            scheduler.schedule(&room, &alice, actor_id, newer),
+            ResolverAffiliationSyncSchedule::Updated
+        ));
+        assert_eq!(worker.finish_applied_or_take_update(1), Some(newer));
+        assert_eq!(worker.finish_applied_or_take_update(2), None);
+
+        let ResolverAffiliationSyncSchedule::Started(chained_worker) =
+            scheduler.schedule(&room, &alice, actor_id, initial)
+        else {
+            panic!("a later same-snapshot repair starts a worker");
+        };
+        assert_eq!(
+            chained_worker.effective_admission_revision(),
+            2,
+            "a completed repair carries its exact resulting revision across worker closure"
+        );
+        drop(chained_worker);
+
+        assert!(
+            matches!(
+                scheduler.schedule(&room, &bob, actor_id, initial),
+                ResolverAffiliationSyncSchedule::Started(_)
+            ),
+            "atomic close must release the global worker slot"
+        );
+    }
+
+    #[test]
+    fn scheduler_bounds_recent_completion_chains_independently() {
+        let scheduler = Arc::new(ResolverAffiliationSyncScheduler::with_capacity(1));
+        let room: BareJid = "room@muc.example.com".parse().expect("room JID");
+        let actor_id = kameo::actor::ActorId::new(1);
+        let work = ResolverAffiliationSyncWork {
+            affiliation: waddle_xmpp::Affiliation::Member,
+            expected_admission_revision: 0,
+        };
+
+        for index in 0..=MAX_RECENT_RESOLVER_AFFILIATION_SYNC_COMPLETIONS {
+            let member: BareJid = format!("member-{index}@example.com")
+                .parse()
+                .expect("member JID");
+            let ResolverAffiliationSyncSchedule::Started(mut worker) =
+                scheduler.schedule(&room, &member, actor_id, work)
+            else {
+                panic!("active capacity is reusable while completions accumulate");
+            };
+            assert_eq!(worker.finish_applied_or_take_update(1), None);
+        }
+
+        let state = scheduler
+            .state
+            .lock()
+            .expect("resolver sync scheduler lock");
+        assert!(state.workers.is_empty());
+        assert_eq!(
+            state.recent_completions.len(),
+            MAX_RECENT_RESOLVER_AFFILIATION_SYNC_COMPLETIONS,
+        );
+        assert!(state
+            .recent_completions
+            .iter()
+            .all(|completion| { completion.key.jid.as_str() != "member-0@example.com" }));
+    }
+
+    #[test]
+    fn scheduler_stale_worker_drop_preserves_a_newer_completion() {
+        let scheduler = Arc::new(ResolverAffiliationSyncScheduler::with_capacity(1));
+        let room: BareJid = "room@muc.example.com".parse().expect("room JID");
+        let member: BareJid = "member@example.com".parse().expect("member JID");
+        let actor_id = kameo::actor::ActorId::new(1);
+        let newer = ResolverAffiliationSyncWork {
+            affiliation: waddle_xmpp::Affiliation::None,
+            expected_admission_revision: 1,
+        };
+        let stale = ResolverAffiliationSyncWork {
+            affiliation: waddle_xmpp::Affiliation::Member,
+            expected_admission_revision: 0,
+        };
+
+        let ResolverAffiliationSyncSchedule::Started(mut newer_worker) =
+            scheduler.schedule(&room, &member, actor_id, newer)
+        else {
+            panic!("newer repair starts a worker");
+        };
+        assert_eq!(newer_worker.finish_applied_or_take_update(2), None);
+
+        let ResolverAffiliationSyncSchedule::Started(stale_worker) =
+            scheduler.schedule(&room, &member, actor_id, stale)
+        else {
+            panic!("out-of-order stale repair starts independently");
+        };
+        assert_eq!(stale_worker.effective_admission_revision(), 0);
+        drop(stale_worker);
+
+        let ResolverAffiliationSyncSchedule::Started(chained_worker) =
+            scheduler.schedule(&room, &member, actor_id, newer)
+        else {
+            panic!("matching newer repair starts after the stale worker drops");
+        };
+        assert_eq!(
+            chained_worker.effective_admission_revision(),
+            2,
+            "stale worker cleanup must preserve a newer source revision chain"
+        );
+    }
+
+    #[tokio::test]
+    async fn scheduler_capacity_drop_is_exported_as_a_counter() {
+        let _metrics_guard = waddle_xmpp::prometheus::metrics_test_lock().lock().await;
+        let before = waddle_xmpp::prometheus::resolver_affiliation_sync_capacity_drop_count();
+        let scheduler = Arc::new(ResolverAffiliationSyncScheduler::with_capacity(1));
+        let room: BareJid = "room@muc.example.com".parse().expect("room JID");
+        let alice: BareJid = "alice@example.com".parse().expect("member JID");
+        let bob: BareJid = "bob@example.com".parse().expect("member JID");
+        let actor_id = kameo::actor::ActorId::new(1);
+        let work = ResolverAffiliationSyncWork {
+            affiliation: waddle_xmpp::Affiliation::None,
+            expected_admission_revision: 0,
+        };
+
+        let ResolverAffiliationSyncSchedule::Started(_worker) =
+            scheduler.schedule(&room, &alice, actor_id, work)
+        else {
+            panic!("first repair occupies the only worker slot");
+        };
+        assert!(matches!(
+            scheduler.schedule(&room, &bob, actor_id, work),
+            ResolverAffiliationSyncSchedule::AtCapacity
+        ));
+
+        assert!(
+            waddle_xmpp::prometheus::resolver_affiliation_sync_capacity_drop_count() > before,
+            "capacity rejection must increment the exported counter"
+        );
+        assert!(waddle_xmpp::prometheus::render_metrics()
+            .contains("waddle_resolver_affiliation_sync_capacity_drop_total "));
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct PendingDmCallOffer {
     pub media: waddle_xmpp::xep::CallThreadMedia,
@@ -650,6 +1225,9 @@ pub struct ProtocolServices {
     /// presence to the authoritative remote RoomActor even though no local
     /// RoomActor exists to discover by registry scan.
     pub remote_muc_memberships: Arc<RemoteMucMemberships>,
+    /// At most one detached resolver-affiliation repair per room/member pair.
+    /// Rejected joins coalesce here instead of spawning unbounded retry tasks.
+    pub resolver_affiliation_syncs: Arc<ResolverAffiliationSyncScheduler>,
     /// Active 1:1 call-thread anchors keyed by the two bare peers plus
     /// JMI/Jingle sid. `proceed` creates the anchor; `finish` later
     /// consumes the entry to stamp the ended summary.

--- a/server/crates/waddle-server/src/server/routes/websocket/state.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/state.rs
@@ -272,6 +272,23 @@ impl ResolverAffiliationSyncWorker {
         self.effective_admission_revision
     }
 
+    /// Close all repair state for an actor incarnation that can no longer
+    /// accept mutations. Pending verdicts and retained revision chains are
+    /// obsolete once the actor is sealed, so release global capacity before
+    /// any potentially slow registry cleanup.
+    pub fn close_actor_terminal(&mut self) {
+        let mut state = self
+            .scheduler
+            .state
+            .lock()
+            .expect("resolver sync scheduler lock");
+        state.workers.remove(&self.key);
+        state
+            .recent_completions
+            .retain(|completion| completion.key != self.key);
+        self.closed = true;
+    }
+
     /// Adopt the most recent verdict when one arrived while the current
     /// verdict was running. Leaves the worker registered when unchanged.
     pub fn take_update(&mut self) -> Option<ResolverAffiliationSyncWork> {
@@ -568,6 +585,51 @@ mod resolver_affiliation_sync_scheduler_tests {
             ),
             "atomic close must release the global worker slot"
         );
+    }
+
+    #[test]
+    fn scheduler_actor_terminal_close_discards_updates_and_releases_capacity() {
+        let scheduler = Arc::new(ResolverAffiliationSyncScheduler::with_capacity(1));
+        let room: BareJid = "room@muc.example.com".parse().expect("room JID");
+        let alice: BareJid = "alice@example.com".parse().expect("member JID");
+        let bob: BareJid = "bob@example.com".parse().expect("member JID");
+        let actor_id = kameo::actor::ActorId::new(1);
+        let initial = ResolverAffiliationSyncWork {
+            affiliation: waddle_xmpp::Affiliation::None,
+            expected_admission_revision: 0,
+        };
+        let queued = ResolverAffiliationSyncWork {
+            affiliation: waddle_xmpp::Affiliation::Outcast,
+            expected_admission_revision: 1,
+        };
+
+        let ResolverAffiliationSyncSchedule::Started(mut worker) =
+            scheduler.schedule(&room, &alice, actor_id, initial)
+        else {
+            panic!("first repair starts a worker");
+        };
+        assert!(matches!(
+            scheduler.schedule(&room, &alice, actor_id, queued),
+            ResolverAffiliationSyncSchedule::Updated
+        ));
+
+        worker.close_actor_terminal();
+
+        let ResolverAffiliationSyncSchedule::Started(_bob_worker) =
+            scheduler.schedule(&room, &bob, actor_id, initial)
+        else {
+            panic!("actor-terminal close releases capacity for Bob");
+        };
+        let state = scheduler
+            .state
+            .lock()
+            .expect("resolver sync scheduler lock");
+        assert_eq!(state.workers.len(), 1, "only Bob's worker remains");
+        assert!(
+            state.workers.keys().all(|key| key.jid == bob),
+            "queued work for the sealed actor/member was discarded"
+        );
+        assert!(state.recent_completions.is_empty());
     }
 
     #[test]

--- a/server/crates/waddle-server/src/server/routes/websocket/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests.rs
@@ -519,6 +519,9 @@ async fn create_test_websocket_state_with_extension_manager(
                     pep_feed_bridge: Arc::new(crate::pep_feed_bridge::PepFeedBridge::new()),
                     call_threads: Arc::new(dashmap::DashMap::new()),
                     remote_muc_memberships: Arc::new(super::RemoteMucMemberships::default()),
+                    resolver_affiliation_syncs: Arc::new(
+                        super::ResolverAffiliationSyncScheduler::default(),
+                    ),
                     dm_call_threads: Arc::new(dashmap::DashMap::new()),
                     dm_pin_store: Arc::new(crate::server::routes::websocket::DmPinStore::default()),
                     dm_call_thread_projections: Arc::new(dashmap::DashSet::new()),

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -111,6 +111,53 @@ async fn muc_join_after_guarded_dormancy_eviction_respawns_room() {
     );
 }
 
+#[tokio::test]
+async fn muc_join_maps_registry_ownership_deferral_to_retryable_resource_constraint() {
+    use waddle_xmpp::muc::room_registry_actor::ReservePendingReclaimedRoom;
+
+    let state = create_test_websocket_state().await;
+    let owner_session = create_test_server_owner_session(state.as_ref(), "alice").await;
+    let room_jid: BareJid = "ownership-reconciling@muc.example.com"
+        .parse()
+        .expect("room JID");
+    let sender_jid: FullJid = "alice@example.com/web".parse().expect("sender JID");
+
+    state
+        .deps
+        .protocol
+        .room_registry
+        .ask(ReservePendingReclaimedRoom {
+            room_jid: room_jid.clone(),
+        })
+        .await
+        .expect("reserve reclaimed-room reconciliation");
+
+    let responses = handle_muc_join(
+        state.as_ref(),
+        "example.com",
+        &room_jid,
+        &sender_jid,
+        "alice",
+        None,
+        &Some(owner_session),
+    )
+    .await;
+
+    assert_eq!(responses.len(), 1, "one retryable error presence");
+    let presence = Element::from_str(&responses[0]).expect("error presence XML");
+    assert_eq!(presence.attr("type"), Some("error"));
+    let error = presence
+        .get_child("error", waddle_xmpp::parser::ns::JABBER_CLIENT)
+        .expect("typed stanza error");
+    assert_eq!(error.attr("type"), Some("wait"));
+    assert!(
+        error
+            .get_child("resource-constraint", "urn:ietf:params:xml:ns:xmpp-stanzas",)
+            .is_some(),
+        "ownership reconciliation must remain retryable: {responses:?}"
+    );
+}
+
 /// #1107 / XEP-0045 §7.6: a full JID already in the room under nick A
 /// joining as nick B gets `<error type='cancel'><not-acceptable/>`
 /// on the wire (nicknames are locked to identity) and no second
@@ -894,7 +941,11 @@ async fn rejected_members_only_join_clears_stale_resolver_affiliation_in_live_ac
         .expect("seed stale resolver-derived member");
     assert_eq!(
         seeded,
-        waddle_xmpp::muc::room_actor::ResolverAffiliationSyncOutcome::Applied,
+        waddle_xmpp::muc::room_actor::ResolverAffiliationSyncOutcome::Applied {
+            admission_revision: snapshot_room(state.as_ref(), &room_jid)
+                .await
+                .admission_revision,
+        },
         "seeding the stale member must apply"
     );
 
@@ -915,7 +966,17 @@ async fn rejected_members_only_join_clears_stale_resolver_affiliation_in_live_ac
         "revoked user's members-only join must be refused: {denied:?}"
     );
 
-    let room = snapshot_room(state.as_ref(), &room_jid).await.room;
+    let room = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+        loop {
+            let room = snapshot_room(state.as_ref(), &room_jid).await.room;
+            if room.get_affiliation(&sender_jid.to_bare()) == waddle_xmpp::Affiliation::None {
+                break room;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("detached resolver repair must complete within the test deadline");
     assert_eq!(
         room.get_affiliation(&sender_jid.to_bare()),
         waddle_xmpp::Affiliation::None,

--- a/server/crates/waddle-server/src/server/session_janitors.rs
+++ b/server/crates/waddle-server/src/server/session_janitors.rs
@@ -3406,7 +3406,6 @@ async fn run_orphan_reaper_sweep_with_workers(
     let mut room_hydrated = 0u64;
     let mut room_released = 0u64;
     let mut room_already_live = 0u64;
-    let mut room_adopted_local = 0u64;
     let mut room_pending_retry = 0u64;
     let mut room_lost_race = 0u64;
     let mut room_failed = 0u64;
@@ -3445,9 +3444,6 @@ async fn run_orphan_reaper_sweep_with_workers(
                     Ok(
                         waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AlreadyLive,
                     ) => room_already_live += 1,
-                    Ok(
-                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal,
-                    ) => room_adopted_local += 1,
                     Ok(
                         waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::PendingRetry,
                     ) => {
@@ -3629,8 +3625,7 @@ async fn run_orphan_reaper_sweep_with_workers(
                 .await;
                 let notify_previous_owner = !matches!(
                     reconciliation,
-                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal)
-                        | Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace)
+                    Ok(waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::LostRace)
                         | Err(_)
                 );
                 if notify_previous_owner {
@@ -3662,9 +3657,6 @@ async fn run_orphan_reaper_sweep_with_workers(
                     Ok(
                         waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AlreadyLive,
                     ) => room_already_live += 1,
-                    Ok(
-                        waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::AdoptedLocal,
-                    ) => room_adopted_local += 1,
                     Ok(
                         waddle_xmpp::muc::room_registry_actor::ReclaimedRoomOutcome::PendingRetry,
                     ) => room_pending_retry += 1,
@@ -3721,7 +3713,6 @@ async fn run_orphan_reaper_sweep_with_workers(
         ("hydrated", room_hydrated),
         ("released", room_released),
         ("already_live", room_already_live),
-        ("adopted_local", room_adopted_local),
         ("pending_retry", room_pending_retry),
         ("lost_race", room_lost_race),
         ("failed", room_failed),
@@ -3730,13 +3721,12 @@ async fn run_orphan_reaper_sweep_with_workers(
             crate::clustering::metrics::record_room_orphan_reconciliation(outcome, count);
         }
     }
-    let room_reconciled = room_hydrated + room_released + room_already_live + room_adopted_local;
+    let room_reconciled = room_hydrated + room_released + room_already_live;
     if room_pending_retry > 0 || room_failed > 0 {
         warn!(
             hydrated = room_hydrated,
             released = room_released,
             already_live = room_already_live,
-            adopted_local = room_adopted_local,
             pending_retry = room_pending_retry,
             lost_race = room_lost_race,
             failed = room_failed,
@@ -3748,7 +3738,6 @@ async fn run_orphan_reaper_sweep_with_workers(
             hydrated = room_hydrated,
             released = room_released,
             already_live = room_already_live,
-            adopted_local = room_adopted_local,
             pending_retry = room_pending_retry,
             lost_race = room_lost_race,
             failed = room_failed,

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -22,6 +22,11 @@ use crate::types::{Affiliation, Role};
 pub(crate) const JOIN_OWNERSHIP_CHECK_TIMEOUT: std::time::Duration =
     std::time::Duration::from_secs(1);
 
+/// Maximum exact per-JID freshness watermarks retained by one room actor.
+/// Overflow compacts safely into the room-wide watermark, trading only
+/// cross-JID liveness for bounded memory while never accepting stale work.
+const MAX_MEMBER_ADMISSION_REVISIONS: usize = 128;
+
 mod admin_handlers;
 mod mediated_invites;
 mod occupancy_handlers;
@@ -313,7 +318,16 @@ impl OccupantInfo {
 pub struct RoomActor {
     room: MucRoom,
     config_revision: u64,
+    /// Monotonic sequence used to timestamp admission-relevant snapshots.
+    /// Scope-specific watermarks below decide whether a snapshot is stale;
+    /// an unrelated member mutation may advance this sequence without
+    /// invalidating another member's pending resolver repair.
     admission_revision: u64,
+    /// Latest admission revision that changed room-wide admission policy.
+    room_admission_revision: u64,
+    /// Latest admission revision that changed each bare JID's admission or
+    /// affiliation state.
+    member_admission_revisions: HashMap<BareJid, u64>,
     invite_operations: HashMap<MediatedInviteOperationId, MediatedInviteOperationRecord>,
     invite_operation_by_invitee: HashMap<BareJid, MediatedInviteOperationId>,
     /// Monotonically increasing counter bumped on every successful
@@ -487,6 +501,8 @@ impl RoomActor {
             room,
             config_revision: 0,
             admission_revision: 0,
+            room_admission_revision: 0,
+            member_admission_revisions: HashMap::new(),
             invite_operations: HashMap::new(),
             invite_operation_by_invitee: HashMap::new(),
             occupancy_revision: 0,
@@ -497,6 +513,38 @@ impl RoomActor {
             durable_store: None,
             restore_state: DurableRestoreState::Ready,
         }
+    }
+
+    fn advance_room_admission_revision(&mut self) {
+        self.admission_revision = self.admission_revision.saturating_add(1);
+        self.room_admission_revision = self.admission_revision;
+        self.member_admission_revisions.clear();
+    }
+
+    fn advance_member_admission_revision(&mut self, jid: &BareJid) {
+        self.admission_revision = self.admission_revision.saturating_add(1);
+        if !self.member_admission_revisions.contains_key(jid)
+            && self.member_admission_revisions.len() >= MAX_MEMBER_ADMISSION_REVISIONS
+        {
+            // Promote the new sequence value to a conservative room-wide
+            // fence before discarding exact member watermarks. Every older
+            // snapshot remains stale; only unrelated pending work may retry.
+            self.room_admission_revision = self.admission_revision;
+            self.member_admission_revisions.clear();
+        }
+        self.member_admission_revisions
+            .insert(jid.clone(), self.admission_revision);
+    }
+
+    fn admission_revision_is_current(&self, jid: &BareJid, revision: u64) -> bool {
+        let member_revision = self
+            .member_admission_revisions
+            .get(jid)
+            .copied()
+            .unwrap_or(0);
+        revision <= self.admission_revision
+            && revision >= self.room_admission_revision
+            && revision >= member_revision
     }
 
     /// ADR-0017 Phase 3 Slice 7 FIX 2 (council-adjudicated): the
@@ -552,8 +600,9 @@ impl RoomActor {
     /// overwhelmingly common case). When `Pending` (the initial
     /// [`RestoreDurableRoomState`] load failed), runs ONE bounded inline
     /// retry against the same store before deciding: success applies the
-    /// restored state (if any) and flips back to `Ready`, letting this
-    /// join proceed; a repeated failure returns
+    /// restored state (if any), flips back to `Ready`, and advances the
+    /// room-wide admission fence so this join re-snapshots the recovered
+    /// policy; a repeated failure returns
     /// `Err(RoomActorError::RestorePending)` and leaves the state
     /// `Pending` for the next join attempt to retry again. Never serves a
     /// join against defaulted config/affiliations/subject while a
@@ -578,6 +627,8 @@ impl RoomActor {
                 self.replace_config(state.config);
                 self.room.subject = state.subject;
                 self.room.restore_affiliations(state.affiliations);
+                self.config_revision = self.config_revision.saturating_add(1);
+                self.advance_room_admission_revision();
                 self.restore_state = DurableRestoreState::Ready;
                 Ok(())
             }
@@ -1092,7 +1143,7 @@ impl kameo::message::Message<UpdateConfig> for RoomActor {
         self.gate_mutation().await?;
         self.replace_config(msg.config);
         self.config_revision = self.config_revision.saturating_add(1);
-        self.admission_revision = self.admission_revision.saturating_add(1);
+        self.advance_room_admission_revision();
         self.persist_config().await?;
         Ok(self.config_revision)
     }
@@ -1120,7 +1171,7 @@ impl kameo::message::Message<RollbackConfigIfRevision> for RoomActor {
         self.gate_mutation().await?;
         self.replace_config(msg.config);
         self.config_revision = self.config_revision.saturating_add(1);
-        self.admission_revision = self.admission_revision.saturating_add(1);
+        self.advance_room_admission_revision();
         self.persist_config().await?;
         Ok(true)
     }
@@ -1202,7 +1253,7 @@ impl kameo::message::Message<UpdateGroupDmConfigByMember> for RoomActor {
         config.group_dm = true;
         self.replace_config(config);
         self.config_revision = self.config_revision.saturating_add(1);
-        self.admission_revision = self.admission_revision.saturating_add(1);
+        self.advance_room_admission_revision();
         self.persist_config().await?;
         Ok(RoomSnapshot {
             room: self.room.clone(),
@@ -1312,7 +1363,7 @@ impl kameo::message::Message<ChangeAffiliation> for RoomActor {
             .set_affiliation(msg.jid.clone(), msg.affiliation)
             .is_some()
         {
-            self.admission_revision = self.admission_revision.saturating_add(1);
+            self.advance_member_admission_revision(&msg.jid);
             self.persist_affiliation(&msg.jid, msg.affiliation).await?;
         }
         if needs_rehydration {

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -446,6 +446,11 @@ pub enum RoomActorError {
     /// ownership-gap bounce.
     #[error("durable room-state restore has not yet completed; retry")]
     RestorePending,
+    /// An admission could not prove that this actor still owns the room.
+    /// The caller should return a wait-class error and retry via the registry
+    /// rather than admitting into an uncertain incarnation.
+    #[error("room ownership could not be confirmed; retry")]
+    OwnershipUnavailable,
 }
 
 impl RoomActor {
@@ -557,6 +562,31 @@ impl RoomActor {
                      join attempt (fail-closed, FIX 4)"
                 );
                 Err(RoomActorError::RestorePending)
+            }
+        }
+    }
+
+    /// A join does not naturally pass through the mutation fence before it
+    /// admits an occupant. Fail closed here to keep a deposed but
+    /// still-referenced actor from admitting either a returning occupant or
+    /// the creator whose registry acquisition raced an ownership change.
+    async fn gate_join_ownership(&mut self) -> Result<(), RoomActorError> {
+        let Some(store) = self.durable_store.clone() else {
+            return Ok(());
+        };
+        match store.check_fenced_fanout(&self.room.room_jid).await {
+            Ok(true) => Ok(()),
+            Ok(false) => {
+                self.sealed = true;
+                Err(RoomActorError::RoomSealed)
+            }
+            Err(error) => {
+                tracing::warn!(
+                    room = %self.room.room_jid,
+                    %error,
+                    "join ownership gate failed; refusing admission"
+                );
+                Err(RoomActorError::OwnershipUnavailable)
             }
         }
     }

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -899,6 +899,13 @@ impl kameo::message::Message<Join> for RoomActor {
         if self.sealed {
             return Err(RoomActorError::RoomSealed);
         }
+        // `Join` predates the resolver-aware admission message, but it is
+        // still reachable by internal callers holding an ActorRef. Apply the
+        // same fail-closed restore and ownership gates as
+        // `JoinWithAffiliation`; otherwise a stale reference could admit an
+        // occupant after this room's durable claim moved to another node.
+        self.ensure_restored_before_join().await?;
+        self.gate_join_ownership().await?;
         if self.invite_rollback_pending(&msg.real_jid.to_bare()) {
             return Err(RoomActorError::InviteRollbackPending);
         }

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -17,6 +17,11 @@ use super::room_registry::RoomInfo;
 use super::{MucRoom, RoomConfig, RoomSubjectTexts, SubjectState};
 use crate::types::{Affiliation, Role};
 
+/// A join-path ownership proof is fail-closed, but it must not monopolize the
+/// room actor forever when the durable backend stops responding.
+pub(crate) const JOIN_OWNERSHIP_CHECK_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(1);
+
 mod admin_handlers;
 mod mediated_invites;
 mod occupancy_handlers;
@@ -319,12 +324,12 @@ pub struct RoomActor {
     /// makes the probe's revision stale, closing the probe→destroy
     /// TOCTOU that orphaned freshly-admitted occupants.
     occupancy_revision: u64,
-    /// Set by [`SealIfInactive`] immediately before the registry
-    /// removes this actor from its map (#1108). A sealed actor refuses
-    /// further admissions with [`RoomActorError::RoomSealed`] so a
-    /// caller holding a stale `ActorRef` retries through the registry
-    /// (which respawns the room) instead of joining a destroyed room.
-    sealed: bool,
+    /// Why this actor refuses further admissions. Keeping the reason typed
+    /// lets the registry distinguish an ordinary inactivity seal, whose
+    /// removal must retain exact-release backlog fencing, from a definitive
+    /// ownership-loss seal, whose deposed local actor must be evicted even
+    /// when that backlog is full.
+    seal_state: RoomSealState,
     occupant_id_secret: crate::xep::xep0421::OccupantIdSecret,
     /// Durable membership hydrated from the deployment's membership
     /// source at spawn (#1135). Kept separate from
@@ -374,6 +379,24 @@ enum DurableRestoreState {
     #[default]
     Ready,
     Pending,
+}
+
+/// Why a room actor has stopped accepting admissions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, kameo::Reply)]
+pub enum RoomSealState {
+    /// The actor is live and may accept admissions.
+    #[default]
+    Open,
+    /// The registry sealed an inactive actor before a terminal local removal.
+    Inactive,
+    /// The durable ownership gate proved this incarnation is deposed.
+    OwnershipLost,
+}
+
+impl RoomSealState {
+    fn is_sealed(self) -> bool {
+        self != Self::Open
+    }
 }
 
 /// Why a join was refused, so the presence-error mapping can pick the
@@ -467,7 +490,7 @@ impl RoomActor {
             invite_operations: HashMap::new(),
             invite_operation_by_invitee: HashMap::new(),
             occupancy_revision: 0,
-            sealed: false,
+            seal_state: RoomSealState::Open,
             occupant_id_secret,
             durable_member_recipients: Vec::new(),
             membership_source: None,
@@ -490,13 +513,21 @@ impl RoomActor {
     /// does" rule) — only a definitive fencing failure blocks the
     /// mutation; an unreachable Postgres must not itself wedge every
     /// mutating admin action.
-    async fn gate_mutation(&self) -> Result<(), RoomMutationError> {
+    async fn gate_mutation(&mut self) -> Result<(), RoomMutationError> {
+        // A definitive ownership-loss observation is monotonic for this
+        // actor incarnation. Do not let a later transient store failure
+        // override that proof through the ordinary fail-open path while the
+        // registry is still converging the deposed actor's removal.
+        if self.seal_state == RoomSealState::OwnershipLost {
+            return Err(RoomMutationError::NotOwner);
+        }
         let Some(store) = self.durable_store.clone() else {
             return Ok(());
         };
         match store.check_fenced_fanout(&self.room.room_jid).await {
             Ok(true) => Ok(()),
             Ok(false) => {
+                self.seal_state = RoomSealState::OwnershipLost;
                 tracing::warn!(
                     room = %self.room.room_jid,
                     "mutation gate observed ownership loss; refusing to mutate"
@@ -574,19 +605,50 @@ impl RoomActor {
         let Some(store) = self.durable_store.clone() else {
             return Ok(());
         };
-        match store.check_fenced_fanout(&self.room.room_jid).await {
-            Ok(true) => Ok(()),
-            Ok(false) => {
-                self.sealed = true;
+        match tokio::time::timeout(
+            JOIN_OWNERSHIP_CHECK_TIMEOUT,
+            store.check_fenced_fanout(&self.room.room_jid),
+        )
+        .await
+        {
+            Ok(Ok(true)) => Ok(()),
+            Ok(Ok(false)) => {
+                self.seal_state = RoomSealState::OwnershipLost;
                 Err(RoomActorError::RoomSealed)
             }
-            Err(error) => {
+            Ok(Err(error)) => {
                 tracing::warn!(
                     room = %self.room.room_jid,
                     %error,
                     "join ownership gate failed; refusing admission"
                 );
                 Err(RoomActorError::OwnershipUnavailable)
+            }
+            Err(_) => {
+                tracing::warn!(
+                    room = %self.room.room_jid,
+                    timeout_ms = JOIN_OWNERSHIP_CHECK_TIMEOUT.as_millis(),
+                    "join ownership gate timed out; refusing admission"
+                );
+                Err(RoomActorError::OwnershipUnavailable)
+            }
+        }
+    }
+
+    /// Refuse admission through an already sealed actor while allowing an
+    /// inactivity seal to strengthen into a definitive ownership-loss seal.
+    ///
+    /// The ownership probe's result never makes an inactive actor joinable:
+    /// it only preserves the stronger cause for the registry's reaper. A
+    /// transient probe failure therefore still returns `RoomSealed` and
+    /// leaves the original inactivity seal intact.
+    async fn reject_sealed_join(&mut self) -> Result<(), RoomActorError> {
+        match self.seal_state {
+            RoomSealState::Open => Ok(()),
+            RoomSealState::OwnershipLost => Err(RoomActorError::RoomSealed),
+            RoomSealState::Inactive => {
+                let _ = self.gate_join_ownership().await;
+                Err(RoomActorError::RoomSealed)
             }
         }
     }
@@ -896,9 +958,7 @@ impl kameo::message::Message<Join> for RoomActor {
     type Reply = Result<(), RoomActorError>;
 
     async fn handle(&mut self, msg: Join, _ctx: &mut Context<Self, Self::Reply>) -> Self::Reply {
-        if self.sealed {
-            return Err(RoomActorError::RoomSealed);
-        }
+        self.reject_sealed_join().await?;
         // `Join` predates the resolver-aware admission message, but it is
         // still reachable by internal callers holding an ActorRef. Apply the
         // same fail-closed restore and ownership gates as
@@ -1399,7 +1459,7 @@ impl kameo::message::Message<IsDormant> for RoomActor {
             // compensation responsibility and must survive both lifecycle
             // guards (the Dormant guard is also protected by the explicit
             // Member affiliation itself).
-            dormant: self.sealed
+            dormant: self.seal_state.is_sealed()
                 || (self.room.is_dormant() && !self.has_lifecycle_fenced_invite_operation()),
             occupancy_revision: self.occupancy_revision,
         }
@@ -1419,7 +1479,25 @@ impl kameo::message::Message<IsSealed> for RoomActor {
         _msg: IsSealed,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        self.sealed
+        self.seal_state.is_sealed()
+    }
+}
+
+/// Return the typed admission seal state used by the registry's reaper.
+///
+/// Unlike [`IsSealed`], this preserves whether the actor was sealed by an
+/// inactivity transition or by a definitive ownership-loss fence.
+pub struct GetRoomSealState;
+
+impl kameo::message::Message<GetRoomSealState> for RoomActor {
+    type Reply = RoomSealState;
+
+    async fn handle(
+        &mut self,
+        _msg: GetRoomSealState,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.seal_state
     }
 }
 
@@ -1452,19 +1530,34 @@ pub struct SealIfInactive {
     pub guard: SealGuard,
 }
 
+/// Typed result of an inactivity-seal attempt.
+///
+/// The registry must retain the distinction between ordinary inactivity and
+/// a prior ownership-loss seal: both refuse admission, but only the latter
+/// requires immediate deposed-actor teardown without releasing a claim this
+/// incarnation has already proven it does not own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
+pub enum SealIfInactiveOutcome {
+    Refused,
+    Inactive,
+    OwnershipLost,
+}
+
 impl kameo::message::Message<SealIfInactive> for RoomActor {
-    type Reply = bool;
+    type Reply = SealIfInactiveOutcome;
 
     async fn handle(
         &mut self,
         msg: SealIfInactive,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        if self.sealed {
-            return true;
+        match self.seal_state {
+            RoomSealState::OwnershipLost => return SealIfInactiveOutcome::OwnershipLost,
+            RoomSealState::Inactive => return SealIfInactiveOutcome::Inactive,
+            RoomSealState::Open => {}
         }
         if self.occupancy_revision != msg.expected_occupancy_revision {
-            return false;
+            return SealIfInactiveOutcome::Refused;
         }
         let inactive = !self.has_lifecycle_fenced_invite_operation()
             && match msg.guard {
@@ -1474,9 +1567,11 @@ impl kameo::message::Message<SealIfInactive> for RoomActor {
                 }
             };
         if inactive {
-            self.sealed = true;
+            self.seal_state = RoomSealState::Inactive;
+            SealIfInactiveOutcome::Inactive
+        } else {
+            SealIfInactiveOutcome::Refused
         }
-        inactive
     }
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/admin_handlers.rs
@@ -604,7 +604,7 @@ impl kameo::message::Message<ApplyAdminItems> for RoomActor {
                 needs_rehydration |=
                     self.prune_durable_recipient_if_removed(&target_jid, new_affiliation);
                 if target_current_affiliation != new_affiliation {
-                    self.admission_revision = self.admission_revision.saturating_add(1);
+                    self.advance_member_admission_revision(&target_jid);
                     if let Err(error) = self.persist_affiliation(&target_jid, new_affiliation).await
                     {
                         persist_failure.get_or_insert(error);
@@ -665,7 +665,7 @@ impl kameo::message::Message<ApplyAffiliationChange> for RoomActor {
         )?;
         let needs_rehydration = self.prune_durable_recipient_if_removed(&msg.jid, msg.affiliation);
         if previous_affiliation != msg.affiliation {
-            self.admission_revision = self.admission_revision.saturating_add(1);
+            self.advance_member_admission_revision(&msg.jid);
             self.persist_affiliation(&msg.jid, msg.affiliation).await?;
         }
         if needs_rehydration {
@@ -732,7 +732,7 @@ impl kameo::message::Message<EnforceMembersOnlyAffiliations> for RoomActor {
                 .set_affiliation(jid.clone(), affiliation)
                 .is_some()
             {
-                self.admission_revision = self.admission_revision.saturating_add(1);
+                self.advance_member_admission_revision(&jid);
                 if let Err(error) = self.persist_affiliation(&jid, affiliation).await {
                     persist_failure.get_or_insert(error);
                 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/authorization.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/authorization.rs
@@ -81,7 +81,7 @@ impl kameo::message::Message<AuthorizeMediatedInvite> for RoomActor {
                 .room
                 .set_affiliation(msg.invitee.clone(), Affiliation::Member);
             debug_assert!(changed.is_some(), "a below-Member affiliation must change");
-            self.admission_revision = self.admission_revision.saturating_add(1);
+            self.advance_member_admission_revision(&msg.invitee);
             MediatedInviteAuthorized {
                 grant: Some(InviteMembershipGrant {
                     operation_id: msg.operation_id,

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/authorization.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/authorization.rs
@@ -21,7 +21,7 @@ impl kameo::message::Message<AuthorizeMediatedInvite> for RoomActor {
                 Err(MediatedInviteGrantError::OperationMismatch)
             };
         }
-        if self.sealed {
+        if self.seal_state.is_sealed() {
             return Err(MediatedInviteGrantError::RoomSealed);
         }
         self.gate_mutation().await?;

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/rollback.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/rollback.rs
@@ -117,7 +117,7 @@ impl kameo::message::Message<CommitMediatedInviteGrantRollback> for RoomActor {
         .expect("invite rollback restores only a below-Member affiliation");
         let needs_rehydration = self
             .prune_durable_recipient_if_removed(&msg.grant.invitee, msg.grant.previous_affiliation);
-        self.admission_revision = self.admission_revision.saturating_add(1);
+        self.advance_member_admission_revision(&msg.grant.invitee);
         if needs_rehydration {
             self.refresh_durable_recipients_from_source().await;
         }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -57,6 +57,7 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
         // unresolved (a genuine backend failure, not a legitimate brand
         // -new room) — see `RoomActor::ensure_restored_before_join`.
         self.ensure_restored_before_join().await?;
+        self.gate_join_ownership().await?;
         if self.invite_rollback_pending(&msg.sender_jid.to_bare()) {
             return Err(RoomActorError::InviteRollbackPending);
         }
@@ -626,6 +627,9 @@ pub enum ResolverAffiliationSyncOutcome {
     StaleAdmissionRevision,
     /// The actor is sealed pending destruction (#1108); nothing to sync.
     RoomSealed,
+    /// Exact room ownership could not be proven, so the resolver result was
+    /// not allowed to mutate this actor's affiliation memory.
+    OwnershipUnavailable,
     /// An invite compensation owns the invitee affiliation until its
     /// terminal result is acknowledged.
     InviteRollbackPending,
@@ -641,6 +645,13 @@ impl kameo::message::Message<SyncResolverAffiliation> for RoomActor {
     ) -> Self::Reply {
         if self.sealed {
             return ResolverAffiliationSyncOutcome::RoomSealed;
+        }
+        match self.gate_join_ownership().await {
+            Ok(()) => {}
+            Err(RoomActorError::RoomSealed) => {
+                return ResolverAffiliationSyncOutcome::RoomSealed;
+            }
+            Err(_) => return ResolverAffiliationSyncOutcome::OwnershipUnavailable,
         }
         if self.invite_rollback_pending(&msg.jid) {
             return ResolverAffiliationSyncOutcome::InviteRollbackPending;

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -59,7 +59,8 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
         if self.invite_rollback_pending(&msg.sender_jid.to_bare()) {
             return Err(RoomActorError::InviteRollbackPending);
         }
-        if msg.admission_revision != self.admission_revision {
+        let joining_bare_jid = msg.sender_jid.to_bare();
+        if !self.admission_revision_is_current(&joining_bare_jid, msg.admission_revision) {
             return Err(RoomActorError::StaleAdmissionRevision);
         }
 
@@ -88,7 +89,7 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
                     .is_some()
                 {
                     self.invalidate_invite_grant(&msg.sender_jid.to_bare());
-                    self.admission_revision = self.admission_revision.saturating_add(1);
+                    self.advance_member_admission_revision(&joining_bare_jid);
                     resolver_join_advanced_admission_revision = true;
                 }
             }
@@ -197,7 +198,7 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
             // boundary, even when the affiliation was already identical. A
             // delayed rejection repair captured before this join must not
             // retain the same revision and demote the occupant just admitted.
-            self.admission_revision = self.admission_revision.saturating_add(1);
+            self.advance_member_admission_revision(&joining_bare_jid);
         }
         // #1108: every successful admission bumps the occupancy
         // revision so a dormancy probe taken before this join can no
@@ -599,6 +600,8 @@ impl kameo::message::Message<ReconcileChannelBackedRoom> for RoomActor {
         self.room.waddle_id = msg.waddle_id;
         self.room.channel_id = msg.channel_id;
         self.replace_config(desired_config);
+        self.config_revision = self.config_revision.saturating_add(1);
+        self.advance_room_admission_revision();
         self.persist_config().await?;
         Ok(())
     }
@@ -619,11 +622,10 @@ pub struct SyncResolverAffiliation {
     pub affiliation: Affiliation,
     /// The `admission_revision` the caller's rejection decision was
     /// computed against (the room snapshot of that same join attempt).
-    /// The sync applies only while the room is still at that revision:
-    /// any interleaved admission/affiliation change — including a later
-    /// successful join of the re-granted user — invalidates this
-    /// delayed sync instead of letting it clear a live occupant's
-    /// freshly re-derived affiliation.
+    /// The sync applies only while neither room-wide admission policy nor
+    /// this JID's admission/affiliation state has changed. A later successful
+    /// join of the re-granted user therefore invalidates this delayed sync,
+    /// while an unrelated occupant's join does not strand the repair.
     pub expected_admission_revision: u64,
 }
 
@@ -634,8 +636,8 @@ pub enum ResolverAffiliationSyncOutcome {
     Applied {
         /// Exact actor revision after this repair. A single ordered worker
         /// may use it for a newer verdict computed from the same original
-        /// snapshot; any unrelated mutation changes the actor revision again
-        /// and keeps the follow-up fail-closed.
+        /// snapshot. Scope-aware actor watermarks decide whether a follow-up
+        /// remains fresh when another member mutates in between.
         admission_revision: u64,
     },
     /// The room's admission state changed since the caller snapshotted
@@ -672,7 +674,7 @@ impl kameo::message::Message<SyncResolverAffiliation> for RoomActor {
         if self.invite_rollback_pending(&msg.jid) {
             return ResolverAffiliationSyncOutcome::InviteRollbackPending;
         }
-        if msg.expected_admission_revision != self.admission_revision {
+        if !self.admission_revision_is_current(&msg.jid, msg.expected_admission_revision) {
             return ResolverAffiliationSyncOutcome::StaleAdmissionRevision;
         }
         // An applied change is itself an admission-relevant affiliation
@@ -684,7 +686,7 @@ impl kameo::message::Message<SyncResolverAffiliation> for RoomActor {
             .is_some()
         {
             self.invalidate_invite_grant(&msg.jid);
-            self.admission_revision = self.admission_revision.saturating_add(1);
+            self.advance_member_admission_revision(&msg.jid);
         }
         ResolverAffiliationSyncOutcome::Applied {
             admission_revision: self.admission_revision,

--- a/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/occupancy_handlers.rs
@@ -46,12 +46,10 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
         msg: JoinWithAffiliation,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        if self.sealed {
-            // #1108: the registry sealed this actor for destruction; a
-            // caller holding a stale ActorRef must retry through the
-            // registry, which respawns the room.
-            return Err(RoomActorError::RoomSealed);
-        }
+        // #1108: a caller holding a stale ActorRef must retry through the
+        // registry. For an inactivity seal this also re-checks ownership so
+        // the seal can strengthen to OwnershipLost before the reaper runs.
+        self.reject_sealed_join().await?;
         // ADR-0017 Phase 3 Slice 7 FIX 4 (council-adjudicated): refuse to
         // admit a join while this incarnation's durable restore is
         // unresolved (a genuine backend failure, not a legitimate brand
@@ -65,6 +63,7 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
             return Err(RoomActorError::StaleAdmissionRevision);
         }
 
+        let mut resolver_join_advanced_admission_revision = false;
         match msg.affiliation_grant {
             JoinAffiliationGrant::Unaffiliated => {}
             JoinAffiliationGrant::Resolver(affiliation) => {
@@ -76,8 +75,9 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
                 // resolver writes over explicit grants (bans survive)
                 // and removes the map entry on a None write.
                 //
-                // An applied change bumps the admission revision (like
-                // `ChangeAffiliation`): a delayed
+                // An applied change bumps the admission revision immediately
+                // (like `ChangeAffiliation`). If the resolver value is already
+                // identical, a successful admission bumps it below: a delayed
                 // `SyncResolverAffiliation` from an earlier rejected
                 // join of this user carries the pre-change revision and
                 // must be refused, or it would clear the affiliation
@@ -89,6 +89,7 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
                 {
                     self.invalidate_invite_grant(&msg.sender_jid.to_bare());
                     self.admission_revision = self.admission_revision.saturating_add(1);
+                    resolver_join_advanced_admission_revision = true;
                 }
             }
             JoinAffiliationGrant::CreatorOwner => {
@@ -189,6 +190,15 @@ impl kameo::message::Message<JoinWithAffiliation> for RoomActor {
         let new_occupant_role = new_occupant.role;
         let occupant_count = self.room.occupant_count();
         let room_jid = self.room.room_jid.clone();
+        if matches!(msg.affiliation_grant, JoinAffiliationGrant::Resolver(_))
+            && !resolver_join_advanced_admission_revision
+        {
+            // A successful resolver-backed admission is itself a freshness
+            // boundary, even when the affiliation was already identical. A
+            // delayed rejection repair captured before this join must not
+            // retain the same revision and demote the occupant just admitted.
+            self.admission_revision = self.admission_revision.saturating_add(1);
+        }
         // #1108: every successful admission bumps the occupancy
         // revision so a dormancy probe taken before this join can no
         // longer authorize a destroy.
@@ -621,7 +631,13 @@ pub struct SyncResolverAffiliation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
 pub enum ResolverAffiliationSyncOutcome {
     /// The resolver verdict was applied (or was already in effect).
-    Applied,
+    Applied {
+        /// Exact actor revision after this repair. A single ordered worker
+        /// may use it for a newer verdict computed from the same original
+        /// snapshot; any unrelated mutation changes the actor revision again
+        /// and keeps the follow-up fail-closed.
+        admission_revision: u64,
+    },
     /// The room's admission state changed since the caller snapshotted
     /// it; the stale sync was refused.
     StaleAdmissionRevision,
@@ -643,7 +659,7 @@ impl kameo::message::Message<SyncResolverAffiliation> for RoomActor {
         msg: SyncResolverAffiliation,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        if self.sealed {
+        if self.reject_sealed_join().await.is_err() {
             return ResolverAffiliationSyncOutcome::RoomSealed;
         }
         match self.gate_join_ownership().await {
@@ -670,6 +686,8 @@ impl kameo::message::Message<SyncResolverAffiliation> for RoomActor {
             self.invalidate_invite_grant(&msg.jid);
             self.admission_revision = self.admission_revision.saturating_add(1);
         }
-        ResolverAffiliationSyncOutcome::Applied
+        ResolverAffiliationSyncOutcome::Applied {
+            admission_revision: self.admission_revision,
+        }
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -954,6 +954,42 @@ async fn stale_admission_revision_returns_retryable_error_without_joining() {
 }
 
 #[tokio::test]
+async fn channel_reconciliation_invalidates_pre_policy_change_repairs() {
+    let actor = spawn_room_actor().await;
+    let stale_revision = current_admission_revision(&actor).await;
+
+    actor
+        .ask(ReconcileChannelBackedRoom {
+            room_jid: "testroom@muc.example.com".parse().expect("room JID"),
+            waddle_id: "waddle-2".to_string(),
+            channel_id: "channel-2".to_string(),
+            desired_config: RoomConfig {
+                members_only: true,
+                ..RoomConfig::default()
+            },
+        })
+        .await
+        .expect("reconcile channel-backed room");
+
+    let snapshot = actor.ask(GetSnapshot).await.expect("room snapshot");
+    assert!(snapshot.room.config.members_only);
+    assert_eq!(snapshot.config_revision, 1);
+    assert_eq!(snapshot.admission_revision, stale_revision + 1);
+    assert_eq!(
+        actor
+            .ask(SyncResolverAffiliation {
+                jid: "alice@example.com".parse().expect("bare JID"),
+                affiliation: Affiliation::None,
+                expected_admission_revision: stale_revision,
+            })
+            .await
+            .expect("pre-reconcile resolver repair"),
+        ResolverAffiliationSyncOutcome::StaleAdmissionRevision,
+        "room-wide policy changes must reject repairs from older snapshots"
+    );
+}
+
+#[tokio::test]
 async fn role_none_kick_notifies_same_nick_sibling_sessions() {
     let actor = spawn_room_actor().await;
     let alice_laptop = test_full_jid_resource("alice", "laptop");
@@ -3638,7 +3674,7 @@ impl crate::muc::durable::MucDurableStore for FlakyThenRecoveringStore {
                     waddle_id: "waddle-1".to_string(),
                     channel_id: "channel-1".to_string(),
                     config: RoomConfig {
-                        members_only: false,
+                        members_only: true,
                         ..RoomConfig::default()
                     },
                     subject: None,
@@ -3716,12 +3752,30 @@ async fn join_is_refused_while_restore_is_pending_then_succeeds_once_recovered_w
     );
     assert_eq!(store.call_count(), 2);
 
-    // Second join attempt: the inline retry (call 2) succeeds — the join
-    // proceeds AND the ban restored from Postgres is genuinely in effect
-    // (not silently lost across the two earlier failures).
-    let banned_attempt = actor
+    // Second join attempt: the inline retry (call 2) succeeds. Applying the
+    // recovered state advances the room-wide fence, so the join must
+    // re-snapshot instead of proceeding with resolver input computed against
+    // the pre-restore config.
+    let recovering_attempt = actor
         .ask(test_join_msg("banned-nick", test_full_jid("banned")))
         .await;
+    assert!(
+        matches!(
+            recovering_attempt,
+            Err(SendError::HandlerError(
+                RoomActorError::StaleAdmissionRevision
+            ))
+        ),
+        "the join that recovered durable state must re-snapshot, got: \
+         {recovering_attempt:?}"
+    );
+    assert_eq!(store.call_count(), 3);
+
+    // The retry uses the recovered snapshot and enforces the restored ban.
+    let recovered_revision = current_admission_revision(&actor).await;
+    let mut banned_join = test_join_msg("banned-nick", test_full_jid("banned"));
+    banned_join.admission_revision = recovered_revision;
+    let banned_attempt = actor.ask(banned_join).await;
     assert!(
         matches!(
             banned_attempt,
@@ -3729,14 +3783,15 @@ async fn join_is_refused_while_restore_is_pending_then_succeeds_once_recovered_w
                 RoomActorError::JoinForbidden { .. }
             ))
         ),
-        "the restored ban must be enforced on the very join that recovered \
-         the restore, got: {banned_attempt:?}"
+        "the restored ban must be enforced after re-snapshot, got: {banned_attempt:?}"
     );
-    assert_eq!(store.call_count(), 3);
 
     // A different, never-banned sender can now join normally too.
+    let mut carol_join = test_join_msg("carol", test_full_jid("carol"));
+    carol_join.admission_revision = recovered_revision;
+    carol_join.affiliation_grant = JoinAffiliationGrant::Resolver(Affiliation::Member);
     actor
-        .ask(test_join_msg("carol", test_full_jid("carol")))
+        .ask(carol_join)
         .await
         .expect("a non-banned sender joins normally once restore has recovered");
 }
@@ -4353,6 +4408,145 @@ async fn stale_sync_does_not_clear_readmitted_member_when_resolver_grant_is_iden
             .affiliation,
         Affiliation::Member,
         "the delayed repair must not demote the live occupant",
+    );
+}
+
+/// A successful resolver-backed join must fence delayed repairs only for the
+/// joining bare JID. Bob's identical Member grant must not make Alice's
+/// already-queued revocation stale and leave her old Member entry behind.
+#[tokio::test]
+async fn resolver_join_does_not_invalidate_another_members_repair() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: true,
+        ..RoomConfig::default()
+    })
+    .await;
+    let alice = test_full_jid("alice");
+    let alice_bare = alice.to_bare();
+    let bob = test_full_jid("bob");
+    let bob_bare = bob.to_bare();
+
+    for jid in [&alice_bare, &bob_bare] {
+        let outcome = actor
+            .ask(SyncResolverAffiliation {
+                jid: jid.clone(),
+                affiliation: Affiliation::Member,
+                expected_admission_revision: current_admission_revision(&actor).await,
+            })
+            .await
+            .expect("seed resolver-derived member");
+        assert!(matches!(
+            outcome,
+            ResolverAffiliationSyncOutcome::Applied { .. }
+        ));
+    }
+    let alice_repair_revision = current_admission_revision(&actor).await;
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: bob.clone(),
+            nick: "bob".to_string(),
+            affiliation_grant: JoinAffiliationGrant::Resolver(Affiliation::Member),
+            local_domain: "example.com".to_string(),
+            admission_revision: alice_repair_revision,
+        })
+        .await
+        .expect("bob joins with an identical resolver grant");
+
+    let outcome = actor
+        .ask(SyncResolverAffiliation {
+            jid: alice_bare.clone(),
+            affiliation: Affiliation::None,
+            expected_admission_revision: alice_repair_revision,
+        })
+        .await
+        .expect("apply Alice's queued revocation");
+    assert!(matches!(
+        outcome,
+        ResolverAffiliationSyncOutcome::Applied { .. }
+    ));
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid: alice_bare })
+            .await
+            .expect("Alice affiliation after repair"),
+        Affiliation::None,
+    );
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid: bob_bare })
+            .await
+            .expect("Bob affiliation after Alice repair"),
+        Affiliation::Member,
+    );
+    assert!(
+        actor
+            .ask(GetOccupantByJid { jid: bob })
+            .await
+            .expect("Bob occupant lookup")
+            .is_some(),
+        "Alice's repair must not disturb Bob's successful admission"
+    );
+}
+
+struct GetMemberAdmissionRevisionCount;
+
+impl kameo::message::Message<GetMemberAdmissionRevisionCount> for RoomActor {
+    type Reply = usize;
+
+    async fn handle(
+        &mut self,
+        _msg: GetMemberAdmissionRevisionCount,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        self.member_admission_revisions.len()
+    }
+}
+
+#[tokio::test]
+async fn member_admission_watermarks_compact_without_accepting_stale_work() {
+    let actor = spawn_room_actor().await;
+    let stale_revision = current_admission_revision(&actor).await;
+
+    for index in 0..=MAX_MEMBER_ADMISSION_REVISIONS {
+        let jid: BareJid = format!("historical-{index}@example.com")
+            .parse()
+            .expect("bare JID");
+        actor
+            .ask(ChangeAffiliation {
+                jid: jid.clone(),
+                affiliation: Affiliation::Member,
+            })
+            .await
+            .expect("add historical member");
+        actor
+            .ask(ChangeAffiliation {
+                jid,
+                affiliation: Affiliation::None,
+            })
+            .await
+            .expect("remove historical member");
+    }
+
+    assert!(
+        actor
+            .ask(GetMemberAdmissionRevisionCount)
+            .await
+            .expect("watermark count")
+            <= MAX_MEMBER_ADMISSION_REVISIONS,
+        "historical JIDs must not grow the per-room tracker without bound"
+    );
+    assert_eq!(
+        actor
+            .ask(SyncResolverAffiliation {
+                jid: "pending@example.com".parse().expect("bare JID"),
+                affiliation: Affiliation::None,
+                expected_admission_revision: stale_revision,
+            })
+            .await
+            .expect("stale post-compaction repair"),
+        ResolverAffiliationSyncOutcome::StaleAdmissionRevision,
+        "compaction must retain a conservative fence for discarded entries"
     );
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -3416,6 +3416,10 @@ impl FakeDurableStore {
     fn saved_affiliations(&self) -> Vec<(BareJid, BareJid, Affiliation)> {
         self.saved_affiliations.lock().expect("lock").clone()
     }
+
+    fn set_fenced(&self, fenced: Option<bool>) {
+        *self.fenced.lock().expect("lock") = fenced;
+    }
 }
 
 impl crate::muc::durable::MucDurableStore for FakeDurableStore {
@@ -3739,7 +3743,8 @@ async fn join_is_refused_while_restore_is_pending_then_succeeds_once_recovered_w
 
 #[tokio::test]
 async fn update_config_gate_blocks_the_mutation_when_deposed() {
-    let actor = spawn_room_actor_with_store(FakeDurableStore::deposed()).await;
+    let store = FakeDurableStore::deposed();
+    let actor = spawn_room_actor_with_store(store.clone()).await;
     let original = actor.ask(GetConfig).await.expect("ask").members_only;
 
     let mut new_config = actor.ask(GetConfig).await.expect("ask");
@@ -3757,6 +3762,22 @@ async fn update_config_gate_blocks_the_mutation_when_deposed() {
     assert_eq!(
         after, original,
         "a gated-out mutation must never have applied in-memory"
+    );
+
+    store.set_fenced(None);
+    let mut retry_config = actor.ask(GetConfig).await.expect("retry config");
+    retry_config.members_only = !original;
+    let retry = actor
+        .ask(UpdateConfig {
+            config: retry_config,
+        })
+        .await;
+    assert!(
+        matches!(
+            retry,
+            Err(SendError::HandlerError(RoomMutationError::NotOwner))
+        ),
+        "a definitive mutation-gate loss must remain terminal across later uncertainty"
     );
 }
 
@@ -3793,6 +3814,79 @@ async fn update_config_gate_fails_open_on_a_transient_fencing_error() {
     assert_ne!(
         after, original,
         "fail-open means the mutation still applies despite the transient error"
+    );
+}
+
+#[tokio::test]
+async fn inactive_seal_strengthens_to_ownership_lost_on_join() {
+    let store = FakeDurableStore::owned();
+    let actor = spawn_room_actor_with_store(store.clone()).await;
+    let probe = actor.ask(IsDormant).await.expect("dormancy probe");
+    assert_eq!(
+        actor
+            .ask(SealIfInactive {
+                expected_occupancy_revision: probe.occupancy_revision,
+                guard: SealGuard::Dormant,
+            })
+            .await
+            .expect("seal inactive room"),
+        SealIfInactiveOutcome::Inactive,
+    );
+
+    store.set_fenced(Some(false));
+    let join = actor
+        .ask(test_join_msg("alice", test_full_jid("alice")))
+        .await;
+    assert!(matches!(
+        join,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert_eq!(
+        actor.ask(GetRoomSealState).await.expect("typed seal state"),
+        RoomSealState::OwnershipLost,
+        "an inactivity seal must retain the stronger ownership-loss proof"
+    );
+}
+
+#[tokio::test]
+async fn ownership_lost_seal_blocks_a_later_fail_open_mutation() {
+    let store = FakeDurableStore::owned();
+    let actor = spawn_room_actor_with_store(store.clone()).await;
+    let original = actor.ask(GetConfig).await.expect("config");
+
+    store.set_fenced(Some(false));
+    let join = actor
+        .ask(test_join_msg("alice", test_full_jid("alice")))
+        .await;
+    assert!(matches!(
+        join,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+
+    // The ordinary mutation gate intentionally fails open on a transient
+    // backend error, but a prior definitive loss must remain terminal for
+    // this actor incarnation.
+    store.set_fenced(None);
+    let mut changed = original.clone();
+    changed.members_only = !changed.members_only;
+    let update = actor.ask(UpdateConfig { config: changed }).await;
+    assert!(matches!(
+        update,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert_eq!(
+        actor
+            .ask(GetConfig)
+            .await
+            .expect("unchanged config")
+            .members_only,
+        original.members_only,
+        "a definitive ownership-loss seal must dominate later uncertainty"
+    );
+    assert_eq!(
+        store.save_call_count(),
+        0,
+        "the rejected mutation must not attempt a durable write"
     );
 }
 
@@ -4069,7 +4163,9 @@ async fn sync_resolver_affiliation_clears_stale_resolver_derived_member() {
         .expect("sync resolver affiliation");
     assert_eq!(
         outcome,
-        ResolverAffiliationSyncOutcome::Applied,
+        ResolverAffiliationSyncOutcome::Applied {
+            admission_revision: current_admission_revision(&actor).await,
+        },
         "a sync at the current admission revision must apply"
     );
 
@@ -4182,6 +4278,84 @@ async fn stale_sync_resolver_affiliation_does_not_clear_readmitted_member() {
     );
 }
 
+/// The re-granted affiliation can already be present in actor memory when
+/// join B arrives: rejection A has not delivered its delayed resolver sync
+/// yet. The successful resolver-backed admission must still advance the
+/// revision even though writing Member is a no-op, or A's stale None repair
+/// can demote the live occupant after admission.
+#[tokio::test]
+async fn stale_sync_does_not_clear_readmitted_member_when_resolver_grant_is_identical() {
+    let actor = spawn_room_actor_with_config(RoomConfig {
+        members_only: true,
+        ..RoomConfig::default()
+    })
+    .await;
+    let alice = test_full_jid("alice");
+    let alice_bare = alice.to_bare();
+
+    let seeded = actor
+        .ask(SyncResolverAffiliation {
+            jid: alice_bare.clone(),
+            affiliation: Affiliation::Member,
+            expected_admission_revision: current_admission_revision(&actor).await,
+        })
+        .await
+        .expect("seed resolver-derived member");
+    assert!(matches!(
+        seeded,
+        ResolverAffiliationSyncOutcome::Applied { .. }
+    ));
+    let stale_revision = current_admission_revision(&actor).await;
+
+    actor
+        .ask(JoinWithAffiliation {
+            sender_jid: alice.clone(),
+            nick: "alice".to_string(),
+            affiliation_grant: JoinAffiliationGrant::Resolver(Affiliation::Member),
+            local_domain: "example.com".to_string(),
+            admission_revision: stale_revision,
+        })
+        .await
+        .expect("already-derived member rejoins successfully");
+    assert_eq!(
+        current_admission_revision(&actor).await,
+        stale_revision.saturating_add(1),
+        "successful resolver-backed admission must invalidate older rejection repairs even when the affiliation write is identical"
+    );
+
+    let outcome = actor
+        .ask(SyncResolverAffiliation {
+            jid: alice_bare.clone(),
+            affiliation: Affiliation::None,
+            expected_admission_revision: stale_revision,
+        })
+        .await
+        .expect("deliver delayed rejection repair");
+    assert_eq!(
+        outcome,
+        ResolverAffiliationSyncOutcome::StaleAdmissionRevision,
+    );
+    assert_eq!(
+        actor
+            .ask(GetAffiliation {
+                jid: alice_bare.clone(),
+            })
+            .await
+            .expect("affiliation after stale repair"),
+        Affiliation::Member,
+    );
+    assert_eq!(
+        actor
+            .ask(GetOccupantByJid { jid: alice })
+            .await
+            .expect("live occupant lookup")
+            .expect("member remains admitted")
+            .affiliation,
+        Affiliation::Member,
+        "the delayed repair must not demote the live occupant",
+    );
+}
+
 /// A sealed actor (#1108) is pending destruction; a delayed rejection
 /// sync must be refused instead of mutating state the registry already
 /// decided to drop.
@@ -4213,7 +4387,11 @@ async fn sync_resolver_affiliation_refuses_sealed_actor() {
         })
         .await
         .expect("seal");
-    assert!(sealed, "empty non-persistent room must seal");
+    assert_eq!(
+        sealed,
+        crate::muc::room_actor::SealIfInactiveOutcome::Inactive,
+        "empty non-persistent room must seal"
+    );
 
     let outcome = actor
         .ask(SyncResolverAffiliation {
@@ -4293,7 +4471,11 @@ async fn sealed_room_reports_dormant_so_the_sweep_converges() {
         })
         .await
         .expect("seal");
-    assert!(sealed, "empty non-persistent room must seal");
+    assert_eq!(
+        sealed,
+        crate::muc::room_actor::SealIfInactiveOutcome::Inactive,
+        "empty non-persistent room must seal"
+    );
 
     let status = actor
         .ask(crate::muc::room_actor::IsDormant)

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/affiliation_fencing.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/affiliation_fencing.rs
@@ -576,7 +576,9 @@ async fn refused_resolver_affiliation_writes_preserve_invite_rollback_authority(
             })
             .await
             .expect("resolver sync"),
-        ResolverAffiliationSyncOutcome::Applied,
+        ResolverAffiliationSyncOutcome::Applied {
+            admission_revision: current_admission_revision(&sync_actor).await,
+        },
     );
     assert_eq!(
         sync_actor

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/durability.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/durability.rs
@@ -67,14 +67,15 @@ async fn unacknowledged_rollback_blocks_dormancy_and_both_seal_guards() {
         "unacknowledged rollback output must block dormancy"
     );
     for guard in [SealGuard::Dormant, SealGuard::EmptyNonPersistent] {
-        assert!(
-            !actor
+        assert_eq!(
+            actor
                 .ask(SealIfInactive {
                     expected_occupancy_revision: probe.occupancy_revision,
                     guard,
                 })
                 .await
                 .expect("seal verdict"),
+            SealIfInactiveOutcome::Refused,
             "unacknowledged rollback output must block {guard:?} sealing",
         );
     }
@@ -320,14 +321,15 @@ async fn rollback_persist_failure_retains_the_exact_token_and_reservation_for_re
         .await
         .expect("leave while rollback remains prepared");
     let probe = actor.ask(IsDormant).await.expect("dormancy probe");
-    assert!(
-        !actor
+    assert_eq!(
+        actor
             .ask(SealIfInactive {
                 expected_occupancy_revision: probe.occupancy_revision,
                 guard: SealGuard::EmptyNonPersistent,
             })
             .await
             .expect("empty-room seal verdict"),
+        SealIfInactiveOutcome::Refused,
         "a prepared rollback must survive empty non-persistent room cleanup",
     );
     let expected_grant = grant.clone();

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/lifecycle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/lifecycle.rs
@@ -542,7 +542,7 @@ async fn no_grant_operation_does_not_pin_an_otherwise_dormant_room() {
 
     let probe = actor.ask(IsDormant).await.expect("dormancy probe");
     assert!(probe.dormant, "no-grant replay state must not pin the room");
-    assert!(
+    assert_eq!(
         actor
             .ask(SealIfInactive {
                 expected_occupancy_revision: probe.occupancy_revision,
@@ -550,6 +550,7 @@ async fn no_grant_operation_does_not_pin_an_otherwise_dormant_room() {
             })
             .await
             .expect("seal dormant room"),
+        SealIfInactiveOutcome::Inactive,
         "no-grant replay state must not block guarded sealing",
     );
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/lifecycle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/lifecycle.rs
@@ -672,7 +672,8 @@ async fn capacity_never_evicts_live_grants_or_persists_an_overflow_grant() {
 async fn invite_grant_and_rollback_advance_the_admission_fence() {
     let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
     let before_grant = current_admission_revision(&actor).await;
-    let grant = authorize_invite_grant(&actor, inviter, invitee).await;
+    let grant = authorize_invite_grant(&actor, inviter, invitee.clone()).await;
+    let operation_id = grant.operation_id();
     assert_eq!(
         current_admission_revision(&actor).await,
         before_grant + 1,
@@ -680,17 +681,14 @@ async fn invite_grant_and_rollback_advance_the_admission_fence() {
     );
     assert!(matches!(
         actor
-            .ask(JoinWithAffiliation {
-                sender_jid: test_full_jid("stale"),
-                nick: "stale".to_string(),
-                affiliation_grant: JoinAffiliationGrant::Unaffiliated,
-                local_domain: "example.com".to_string(),
-                admission_revision: before_grant,
+            .ask(SyncResolverAffiliation {
+                jid: "unrelated@example.com".parse().expect("bare JID"),
+                affiliation: Affiliation::None,
+                expected_admission_revision: before_grant,
             })
-            .await,
-        Err(SendError::HandlerError(
-            RoomActorError::StaleAdmissionRevision
-        ))
+            .await
+            .expect("unrelated resolver repair"),
+        ResolverAffiliationSyncOutcome::Applied { .. }
     ));
 
     actor
@@ -703,9 +701,25 @@ async fn invite_grant_and_rollback_advance_the_admission_fence() {
         .ask(CommitMediatedInviteGrantRollback { grant })
         .await
         .expect("commit rollback");
+    actor
+        .ask(AcknowledgeMediatedInviteOperation { operation_id })
+        .await
+        .expect("acknowledge rollback");
     assert_eq!(
         current_admission_revision(&actor).await,
         before_grant + 2,
         "restoring the prior affiliation changes admission state again",
+    );
+    assert_eq!(
+        actor
+            .ask(SyncResolverAffiliation {
+                jid: invitee,
+                affiliation: Affiliation::None,
+                expected_admission_revision: before_grant,
+            })
+            .await
+            .expect("stale invitee repair"),
+        ResolverAffiliationSyncOutcome::StaleAdmissionRevision,
+        "grant and rollback must invalidate pre-grant work for the invitee",
     );
 }

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -371,6 +371,58 @@ impl RoomRegistryActor {
         true
     }
 
+    /// Resolve every exact terminal-release responsibility for this room
+    /// before attempting a new demand claim. A timed-out release can commit
+    /// after its future is dropped; self-reacquiring that still-present exact
+    /// epoch would let the late delete remove a newly published actor's claim.
+    /// Only typed `Released`/`NotOwned` outcomes clear these entries.
+    async fn converge_pending_room_releases_before_acquire(&mut self, room_jid: &BareJid) -> bool {
+        let pending = self
+            .pending_room_releases
+            .keys()
+            .filter(|(pending_room, _)| pending_room == room_jid)
+            .map(|(_, claim_fence)| claim_fence.clone())
+            .collect::<Vec<_>>();
+        for claim_fence in pending {
+            self.release_room_claim(room_jid, &claim_fence).await;
+        }
+        !self
+            .pending_room_releases
+            .keys()
+            .any(|(pending_room, _)| pending_room == room_jid)
+    }
+
+    /// Reclaimed epochs use a separate bounded retry inventory because they
+    /// arrive from the dead-owner sweeper. They carry the same late-delete
+    /// hazard as ordinary releases, so demand must converge every exact
+    /// generation for this room before acquiring a fresh claim. A bare-JID
+    /// reservation has no exact epoch to fence and therefore blocks demand
+    /// until the reaper replaces it with typed state.
+    async fn converge_pending_reclaimed_before_acquire(&mut self, room_jid: &BareJid) -> bool {
+        if self.pending_reclaimed_reservations.contains(room_jid) {
+            return false;
+        }
+        let pending = self
+            .pending_reclaimed_rooms
+            .iter()
+            .filter(|((pending_room, _), _)| pending_room == room_jid)
+            .map(|((_, claim_fence), state)| (claim_fence.clone(), state.previous_owner.clone()))
+            .collect::<Vec<_>>();
+        for (claim_fence, previous_owner) in pending {
+            let outcome = self
+                .release_reclaimed_room_claim(room_jid, &claim_fence, &previous_owner)
+                .await;
+            if outcome == ReclaimedRoomOutcome::PendingRetry {
+                return false;
+            }
+        }
+        !self.pending_reclaimed_reservations.contains(room_jid)
+            && !self
+                .pending_reclaimed_rooms
+                .keys()
+                .any(|(pending_room, _)| pending_room == room_jid)
+    }
+
     async fn retry_pending_room_work(&mut self, limit: usize) -> usize {
         enum RetryWork {
             Acquisition(BareJid, NodeIdentity),
@@ -482,6 +534,16 @@ impl RoomRegistryActor {
         actor_ref: &ActorRef<Self>,
     ) -> Result<super::RoomClaimFenceContext, RoomRegistryError> {
         if self.terminal_claim_acquisition_disabled {
+            return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
+        }
+        if !self
+            .converge_pending_reclaimed_before_acquire(room_jid)
+            .await
+            || !self
+                .converge_pending_room_releases_before_acquire(room_jid)
+                .await
+        {
+            warn!(room = %room_jid, "room claim acquisition deferred until exact-release ambiguity converges");
             return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
         }
         // A newly acquired generation can require an exact terminal-release
@@ -739,13 +801,6 @@ impl RoomRegistryActor {
         claim_fence: super::RoomClaimFenceContext,
     ) {
         self.clear_pending_room_acquisition(&room_jid, &claim_fence.owner());
-        // A timed-out release may not have committed, so a later demand can
-        // self-reacquire and publish this identical owner+epoch fence. Once
-        // the fence backs a live actor it is no longer a terminal-release
-        // responsibility; leaving it queued would let a stale retry delete
-        // the live claim. Cancel only the exact match so ABA-distinct
-        // generations for this room remain independently retryable.
-        self.clear_pending_room_release(&room_jid, &claim_fence);
         if let Some(store) = &self.durable_store {
             store.record_claim_fence(&room_jid, claim_fence.clone());
         }
@@ -1170,9 +1225,6 @@ pub enum ReclaimedRoomOutcome {
     /// Demand-side creation already installed a live actor under this exact
     /// fenced epoch; no duplicate was spawned.
     AlreadyLive,
-    /// A live local actor from this process's prior node identity adopted
-    /// the newly fenced epoch in place, preserving its in-memory room state.
-    AdoptedLocal,
     /// No durable room state existed, so the otherwise-unusable orphan claim
     /// was released for ordinary demand-side recreation.
     Released,
@@ -1559,6 +1611,9 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
             }
         };
         if !still_owned {
+            if let Some(store) = &self.durable_store {
+                store.forget_claim_fence(&msg.room_jid, &claim_fence);
+            }
             self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
             return ReclaimedRoomOutcome::LostRace;
         }
@@ -1569,64 +1624,12 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
                     self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
                     return ReclaimedRoomOutcome::AlreadyLive;
                 }
-                if entry.claim_fence.owner() == msg.previous_owner {
-                    // The actor is exactly the one whose claim the reaper
-                    // observed and replaced. It may safely adopt the new
-                    // epoch without discarding its in-memory state. Recheck
-                    // after the earlier fence await and immediately before
-                    // mutating the live map.
-                    if self.node_identity.current() != identity {
-                        self.remember_pending_reclaimed_room(
-                            msg.room_jid,
-                            claim_fence,
-                            msg.previous_owner,
-                        );
-                        return ReclaimedRoomOutcome::PendingRetry;
-                    }
-                    match tokio::time::timeout(
-                        RECLAIMED_ROOM_STORE_TIMEOUT,
-                        self.claim_store.fence(&entity, &identity, claim_epoch),
-                    )
-                    .await
-                    {
-                        Ok(Ok(true)) => {}
-                        Ok(Ok(false)) => {
-                            self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
-                            return ReclaimedRoomOutcome::LostRace;
-                        }
-                        Ok(Err(_)) | Err(_) => {
-                            self.remember_pending_reclaimed_room(
-                                msg.room_jid,
-                                claim_fence,
-                                msg.previous_owner,
-                            );
-                            return ReclaimedRoomOutcome::PendingRetry;
-                        }
-                    }
-                    let identity_handle = self.node_identity.clone();
-                    let Some(_identity_guard) = identity_handle.guard_if_current(&identity).await
-                    else {
-                        self.remember_pending_reclaimed_room(
-                            msg.room_jid,
-                            claim_fence,
-                            msg.previous_owner,
-                        );
-                        return ReclaimedRoomOutcome::PendingRetry;
-                    };
-                    if let Some(current) = self.rooms.get_mut(&msg.room_jid) {
-                        current.claim_fence = claim_fence.clone();
-                    }
-                    if let Some(store) = &self.durable_store {
-                        store.record_claim_fence(&msg.room_jid, claim_fence.clone());
-                    }
-                    self.clear_pending_room_release(&msg.room_jid, &claim_fence);
-                    self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
-                    return ReclaimedRoomOutcome::AdoptedLocal;
-                }
-
-                // Another owner intervened after this local actor was
-                // created. Its state is stale relative to the durable
-                // snapshot, so never transplant it onto the won epoch.
+                // Never transplant a live actor onto a new epoch. An earlier
+                // mailbox mutation may still be running under the old fence;
+                // changing only the registry/store fence would let that actor
+                // retain memory which was never durably authorized under the
+                // new owner. Replace it and hydrate a clean actor from a
+                // freshly fenced durable snapshot instead.
                 entry.actor_ref.kill();
             }
             self.rooms.remove(&msg.room_jid);
@@ -1680,6 +1683,7 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
         {
             Ok(Ok(true)) => {}
             Ok(Ok(false)) => {
+                store.forget_claim_fence(&msg.room_jid, &claim_fence);
                 self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
                 return ReclaimedRoomOutcome::LostRace;
             }
@@ -1720,6 +1724,9 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
             Ok(Ok(true)) => {}
             Ok(Ok(false)) => {
                 actor_ref.kill();
+                if let Some(store) = &self.durable_store {
+                    store.forget_claim_fence(&msg.room_jid, &claim_fence);
+                }
                 self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
                 return ReclaimedRoomOutcome::LostRace;
             }
@@ -1973,6 +1980,13 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
         // lease is what it takes to look stale (bounded residual gap,
         // same class as FIX 6e's fail-open-detach gap).
         if let Some(entry) = removed_entry {
+            if msg.reason == DestroyRoomReason::DeposedEviction {
+                // Removal from the registry is not itself a terminal signal
+                // to a RoomActor. A caller may still hold an ActorRef and the
+                // best-effort Demote notification may never arrive, so kill
+                // the deposed incarnation before dropping our last entry.
+                entry.actor_ref.kill();
+            }
             self.release_room_claim(&msg.room_jid, &entry.claim_fence)
                 .await;
         }

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -376,7 +376,11 @@ impl RoomRegistryActor {
     /// after its future is dropped; self-reacquiring that still-present exact
     /// epoch would let the late delete remove a newly published actor's claim.
     /// Only typed `Released`/`NotOwned` outcomes clear these entries.
-    async fn converge_pending_room_releases_before_acquire(&mut self, room_jid: &BareJid) -> bool {
+    async fn converge_pending_room_releases_before_acquire(
+        &mut self,
+        room_jid: &BareJid,
+        deadline: tokio::time::Instant,
+    ) -> bool {
         let pending = self
             .pending_room_releases
             .keys()
@@ -384,7 +388,23 @@ impl RoomRegistryActor {
             .map(|(_, claim_fence)| claim_fence.clone())
             .collect::<Vec<_>>();
         for claim_fence in pending {
-            self.release_room_claim(room_jid, &claim_fence).await;
+            let Some(remaining) = deadline.checked_duration_since(tokio::time::Instant::now())
+            else {
+                return false;
+            };
+            self.release_room_claim_with_timeout(
+                room_jid,
+                &claim_fence,
+                remaining.min(ROOM_OWNERSHIP_CALL_TIMEOUT),
+                ClaimReleaseContext::PreAcquire,
+            )
+            .await;
+            if self
+                .pending_room_releases
+                .contains_key(&(room_jid.clone(), claim_fence))
+            {
+                return false;
+            }
         }
         !self
             .pending_room_releases
@@ -398,7 +418,11 @@ impl RoomRegistryActor {
     /// generation for this room before acquiring a fresh claim. A bare-JID
     /// reservation has no exact epoch to fence and therefore blocks demand
     /// until the reaper replaces it with typed state.
-    async fn converge_pending_reclaimed_before_acquire(&mut self, room_jid: &BareJid) -> bool {
+    async fn converge_pending_reclaimed_before_acquire(
+        &mut self,
+        room_jid: &BareJid,
+        deadline: tokio::time::Instant,
+    ) -> bool {
         if self.pending_reclaimed_reservations.contains(room_jid) {
             return false;
         }
@@ -409,8 +433,17 @@ impl RoomRegistryActor {
             .map(|((_, claim_fence), state)| (claim_fence.clone(), state.previous_owner.clone()))
             .collect::<Vec<_>>();
         for (claim_fence, previous_owner) in pending {
+            let Some(remaining) = deadline.checked_duration_since(tokio::time::Instant::now())
+            else {
+                return false;
+            };
             let outcome = self
-                .release_reclaimed_room_claim(room_jid, &claim_fence, &previous_owner)
+                .release_reclaimed_room_claim_with_timeout(
+                    room_jid,
+                    &claim_fence,
+                    &previous_owner,
+                    remaining.min(RECLAIMED_ROOM_RELEASE_TIMEOUT),
+                )
                 .await;
             if outcome == ReclaimedRoomOutcome::PendingRetry {
                 return false;
@@ -536,14 +569,15 @@ impl RoomRegistryActor {
         if self.terminal_claim_acquisition_disabled {
             return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
         }
+        let convergence_deadline = tokio::time::Instant::now() + PRE_ACQUIRE_CONVERGENCE_BUDGET;
         if !self
-            .converge_pending_reclaimed_before_acquire(room_jid)
+            .converge_pending_reclaimed_before_acquire(room_jid, convergence_deadline)
             .await
             || !self
-                .converge_pending_room_releases_before_acquire(room_jid)
+                .converge_pending_room_releases_before_acquire(room_jid, convergence_deadline)
                 .await
         {
-            warn!(room = %room_jid, "room claim acquisition deferred until exact-release ambiguity converges");
+            debug!(room = %room_jid, "room claim acquisition deferred until exact-release ambiguity converges");
             return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
         }
         // A newly acquired generation can require an exact terminal-release
@@ -879,9 +913,25 @@ impl RoomRegistryActor {
         room_jid: &BareJid,
         claim_fence: &super::RoomClaimFenceContext,
     ) {
+        self.release_room_claim_with_timeout(
+            room_jid,
+            claim_fence,
+            ROOM_OWNERSHIP_CALL_TIMEOUT,
+            ClaimReleaseContext::Operational,
+        )
+        .await;
+    }
+
+    async fn release_room_claim_with_timeout(
+        &mut self,
+        room_jid: &BareJid,
+        claim_fence: &super::RoomClaimFenceContext,
+        timeout: std::time::Duration,
+        context: ClaimReleaseContext,
+    ) {
         let owner = claim_fence.owner();
         match tokio::time::timeout(
-            ROOM_OWNERSHIP_CALL_TIMEOUT,
+            timeout,
             self.claim_store
                 .release_exact(&claim_fence.entity, &owner, claim_fence.epoch),
         )
@@ -894,13 +944,27 @@ impl RoomRegistryActor {
                 }
             }
             Ok(Err(error)) => {
-                warn!(room = %room_jid, %error, "failed to release room ownership claim");
+                match context {
+                    ClaimReleaseContext::Operational => {
+                        warn!(room = %room_jid, %error, "failed to release room ownership claim");
+                    }
+                    ClaimReleaseContext::PreAcquire => {
+                        debug!(room = %room_jid, %error, "room claim release remains pending before acquisition");
+                    }
+                }
                 if !self.remember_pending_room_release(room_jid.clone(), claim_fence.clone()) {
                     tracing::error!(room = %room_jid, "exact-release retry backlog saturated despite pre-admission guard; claim remains fenced for node-expiry recovery");
                 }
             }
             Err(_) => {
-                warn!(room = %room_jid, "timed out releasing room ownership claim; retaining exact fence for a later retry");
+                match context {
+                    ClaimReleaseContext::Operational => {
+                        warn!(room = %room_jid, "timed out releasing room ownership claim; retaining exact fence for a later retry");
+                    }
+                    ClaimReleaseContext::PreAcquire => {
+                        debug!(room = %room_jid, "room claim release timed out before acquisition; retaining exact fence for background retry");
+                    }
+                }
                 if !self.remember_pending_room_release(room_jid.clone(), claim_fence.clone()) {
                     tracing::error!(room = %room_jid, "exact-release retry backlog saturated despite pre-admission guard; claim remains fenced for node-expiry recovery");
                 }
@@ -918,9 +982,25 @@ impl RoomRegistryActor {
         claim_fence: &super::RoomClaimFenceContext,
         previous_owner: &NodeIdentity,
     ) -> ReclaimedRoomOutcome {
+        self.release_reclaimed_room_claim_with_timeout(
+            room_jid,
+            claim_fence,
+            previous_owner,
+            RECLAIMED_ROOM_RELEASE_TIMEOUT,
+        )
+        .await
+    }
+
+    async fn release_reclaimed_room_claim_with_timeout(
+        &mut self,
+        room_jid: &BareJid,
+        claim_fence: &super::RoomClaimFenceContext,
+        previous_owner: &NodeIdentity,
+        timeout: std::time::Duration,
+    ) -> ReclaimedRoomOutcome {
         let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
         match tokio::time::timeout(
-            RECLAIMED_ROOM_RELEASE_TIMEOUT,
+            timeout,
             self.claim_store
                 .release_exact(&entity, &claim_fence.owner(), claim_fence.epoch),
         )
@@ -1253,6 +1333,17 @@ pub struct ReconcileReclaimedRoom {
 const RECLAIMED_ROOM_STORE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 const RECLAIMED_ROOM_RELEASE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
 const ROOM_OWNERSHIP_CALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+/// Demand-side convergence gets one shared mailbox budget across reclaimed
+/// and ordinary exact fences. Background retries keep the full per-call
+/// timeout; admission returns retryably well before the five-second public
+/// registry ask timeout.
+const PRE_ACQUIRE_CONVERGENCE_BUDGET: std::time::Duration = std::time::Duration::from_millis(250);
+
+#[derive(Clone, Copy)]
+enum ClaimReleaseContext {
+    Operational,
+    PreAcquire,
+}
 
 /// One typed pending entry returned to the reaper for retry.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1611,6 +1702,15 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
             }
         };
         if !still_owned {
+            if self
+                .rooms
+                .get(&msg.room_jid)
+                .is_some_and(|entry| entry.claim_fence == claim_fence)
+            {
+                if let Some(entry) = self.rooms.remove(&msg.room_jid) {
+                    entry.actor_ref.kill();
+                }
+            }
             if let Some(store) = &self.durable_store {
                 store.forget_claim_fence(&msg.room_jid, &claim_fence);
             }

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -17,13 +17,13 @@ use tracing::{debug, info, warn};
 use super::affiliation::DurableMembershipSource;
 use super::durable::MucDurableStore;
 use super::room_actor::{
-    HydrateDurableRecipients, IsSealed, RestoreDurableRoomState, RoomActor, SealGuard,
-    SealIfInactive,
+    GetRoomSealState, HydrateDurableRecipients, RestoreDurableRoomState, RoomActor, RoomSealState,
+    SealGuard, SealIfInactive, SealIfInactiveOutcome,
 };
 use super::{MucRoom, RoomConfig};
 use crate::metrics;
 use crate::ownership::{
-    ClaimEpoch, ClaimError, ClaimStore, Entity, EntityType, ExactReleaseOutcome,
+    ClaimEpoch, ClaimError, ClaimSnapshot, ClaimStore, Entity, EntityType, ExactReleaseOutcome,
     InProcessClaimStore, NodeIdentity, RolloutBackoff, SharedNodeIdentity, StalePredicate,
 };
 use crate::xep::xep0421::OccupantIdSecret;
@@ -151,6 +151,11 @@ pub enum RoomRegistryError {
     Unavailable,
     #[error("room {0}'s ownership store is unavailable")]
     OwnershipUnavailable(BareJid),
+    /// A prior exact room-ownership generation is still converging. Unlike
+    /// [`RoomRegistryError::OwnershipUnavailable`], this is an expected,
+    /// bounded demand-side deferral rather than a claim-store failure.
+    #[error("room {0}'s prior ownership generation is still reconciling")]
+    OwnershipReconciliationPending(BareJid),
     /// ADR-0017 Phase 3 Slice 7: `entity`'s Postgres claim is held by
     /// another, currently-live node, and this slice does not wire
     /// cross-node MUC message/join proxying (the ADR's own text names it
@@ -196,6 +201,30 @@ impl RoomRegistryActor {
         self.pending_room_releases
             .contains_key(&(room_jid.clone(), claim_fence.clone()))
             || self.pending_room_releases.len() < MAX_PENDING_ROOM_RELEASES
+    }
+
+    /// Remove an actor after its own durable fence proved that this exact
+    /// incarnation no longer owns the room.
+    ///
+    /// A same-identity negative database fence is terminal, so releasing it
+    /// would only create a possible late-delete responsibility. A different
+    /// local identity is special: the durable gate rejects the cached old
+    /// fence before querying the claim store, so the old exact row can still
+    /// exist and must receive one safe best-effort release. That old owner can
+    /// never match a claim acquired by the current identity.
+    async fn retire_ownership_lost_entry(&mut self, room_jid: &BareJid, entry: RoomEntry) {
+        entry.actor_ref.kill();
+        if entry.claim_fence.owner() != self.node_identity.current() {
+            self.release_room_claim(room_jid, &entry.claim_fence).await;
+        } else if let Some(store) = &self.durable_store {
+            store.forget_claim_fence(room_jid, &entry.claim_fence);
+        }
+    }
+
+    async fn evict_ownership_lost_room(&mut self, room_jid: &BareJid, entry: RoomEntry) {
+        self.rooms.remove(room_jid);
+        self.poisoned_rooms.remove(room_jid);
+        self.retire_ownership_lost_entry(room_jid, entry).await;
     }
 
     fn remember_pending_room_release(
@@ -578,7 +607,9 @@ impl RoomRegistryActor {
                 .await
         {
             debug!(room = %room_jid, "room claim acquisition deferred until exact-release ambiguity converges");
-            return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
+            return Err(RoomRegistryError::OwnershipReconciliationPending(
+                room_jid.clone(),
+            ));
         }
         // A newly acquired generation can require an exact terminal-release
         // retry if identity rotates or actor preparation loses its final
@@ -623,7 +654,9 @@ impl RoomRegistryActor {
         if self.node_identity.current() != identity {
             let claim_fence = super::RoomClaimFenceContext::new(entity, identity, epoch);
             self.release_room_claim(room_jid, &claim_fence).await;
-            return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()));
+            return Err(RoomRegistryError::OwnershipReconciliationPending(
+                room_jid.clone(),
+            ));
         }
         Ok(super::RoomClaimFenceContext::new(entity, identity, epoch))
     }
@@ -644,9 +677,16 @@ impl RoomRegistryActor {
         .await
         {
             Ok(Ok(Some(snapshot))) => snapshot,
-            Ok(Ok(None)) | Ok(Err(_)) => {
+            Ok(Ok(None)) => {
                 self.clear_pending_room_acquisition(room_jid, identity);
-                return Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()));
+                return Err(RoomRegistryError::OwnershipReconciliationPending(
+                    room_jid.clone(),
+                ));
+            }
+            Ok(Err(error)) => {
+                self.clear_pending_room_acquisition(room_jid, identity);
+                warn!(room = %room_jid, %error, "room claim lookup failed during ownership steal");
+                return Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone()));
             }
             Err(_) => {
                 self.clear_pending_room_acquisition(room_jid, identity);
@@ -692,10 +732,64 @@ impl RoomRegistryActor {
             }
             Ok(Err(ClaimError::Conflict | ClaimError::AlreadyClaimed)) => {
                 self.clear_pending_room_acquisition(room_jid, identity);
-                Err(RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone()))
+                Err(self
+                    .classify_claim_after_steal_conflict(entity, room_jid, identity, &snapshot)
+                    .await)
             }
             Ok(Err(_)) => Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone())),
             Err(_) => Err(RoomRegistryError::OwnershipUnavailable(room_jid.clone())),
+        }
+    }
+
+    /// Classify a lost stale-owner CAS from a fresh claim-store read. The CAS
+    /// contract folds several zero-row causes into `Conflict`: another owner
+    /// may have renewed, the claim may have disappeared or changed generation,
+    /// or this node's own lease may no longer authorize acquisition. Only the
+    /// same observed foreign owner/epoch becoming fresh proves remote
+    /// ownership; every other successful read is a retryable convergence race.
+    async fn classify_claim_after_steal_conflict(
+        &self,
+        entity: &Entity,
+        room_jid: &BareJid,
+        identity: &NodeIdentity,
+        observed: &ClaimSnapshot,
+    ) -> RoomRegistryError {
+        match tokio::time::timeout(
+            ROOM_OWNERSHIP_CALL_TIMEOUT,
+            self.claim_store.current_claim(entity),
+        )
+        .await
+        {
+            Ok(Ok(Some(current)))
+                if current.owner_lease_fresh
+                    && current.owner != *identity
+                    && current.owner == observed.owner
+                    && current.claim_epoch == observed.claim_epoch =>
+            {
+                RoomRegistryError::ClaimHeldByAnotherNode(room_jid.clone())
+            }
+            Ok(Ok(_)) => {
+                debug!(
+                    room = %room_jid,
+                    "room claim changed while stealing stale ownership; deferring acquisition"
+                );
+                RoomRegistryError::OwnershipReconciliationPending(room_jid.clone())
+            }
+            Ok(Err(error)) => {
+                warn!(
+                    room = %room_jid,
+                    %error,
+                    "room claim lookup failed after stale-owner steal conflict"
+                );
+                RoomRegistryError::OwnershipUnavailable(room_jid.clone())
+            }
+            Err(_) => {
+                warn!(
+                    room = %room_jid,
+                    "room claim lookup timed out after stale-owner steal conflict"
+                );
+                RoomRegistryError::OwnershipUnavailable(room_jid.clone())
+            }
         }
     }
 
@@ -2085,10 +2179,11 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
                 // to a RoomActor. A caller may still hold an ActorRef and the
                 // best-effort Demote notification may never arrive, so kill
                 // the deposed incarnation before dropping our last entry.
-                entry.actor_ref.kill();
+                self.retire_ownership_lost_entry(&msg.room_jid, entry).await;
+            } else {
+                self.release_room_claim(&msg.room_jid, &entry.claim_fence)
+                    .await;
             }
-            self.release_room_claim(&msg.room_jid, &entry.claim_fence)
-                .await;
         }
         if removed_room || removed_poison {
             info!(room = %msg.room_jid, "Destroyed room");
@@ -2137,8 +2232,31 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
             return false;
         };
         if !self.has_pending_release_capacity(&msg.room_jid, &entry.claim_fence) {
-            warn!(room = %msg.room_jid, "Skipping inactive-room seal because exact-release retry backlog is full");
-            return false;
+            // Ordinary inactivity must remain open when there is nowhere to
+            // retain an uncertain release. A previously deposed actor is
+            // different: its negative fence is already terminal, so evict it
+            // without issuing another release even under saturation.
+            let seal_state = entry
+                .actor_ref
+                .ask(GetRoomSealState)
+                .mailbox_timeout(SEAL_ASK_TIMEOUT)
+                .reply_timeout(SEAL_ASK_TIMEOUT)
+                .await;
+            return match seal_state {
+                Ok(RoomSealState::OwnershipLost) => {
+                    self.evict_ownership_lost_room(&msg.room_jid, entry).await;
+                    info!(room = %msg.room_jid, "Evicted deposed room during inactive-room cleanup");
+                    true
+                }
+                Ok(RoomSealState::Open | RoomSealState::Inactive) => {
+                    warn!(room = %msg.room_jid, "Skipping inactive-room seal because exact-release retry backlog is full");
+                    false
+                }
+                Err(error) => {
+                    warn!(room = %msg.room_jid, error = ?error, "Could not classify room seal while exact-release retry backlog is full");
+                    false
+                }
+            };
         }
         let sealed = entry
             .actor_ref
@@ -2150,7 +2268,12 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
             .reply_timeout(SEAL_ASK_TIMEOUT)
             .await;
         match sealed {
-            Ok(true) => {
+            Ok(SealIfInactiveOutcome::OwnershipLost) => {
+                self.evict_ownership_lost_room(&msg.room_jid, entry).await;
+                info!(room = %msg.room_jid, "Evicted deposed room during inactive-room cleanup");
+                true
+            }
+            Ok(SealIfInactiveOutcome::Inactive) => {
                 self.rooms.remove(&msg.room_jid);
                 self.poisoned_rooms.remove(&msg.room_jid);
                 // ADR-0017 Phase 3 Slice 7: this is a terminal removal from
@@ -2163,7 +2286,7 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
                 info!(room = %msg.room_jid, "Destroyed inactive room (guarded)");
                 true
             }
-            Ok(false) => {
+            Ok(SealIfInactiveOutcome::Refused) => {
                 debug!(
                     room = %msg.room_jid,
                     "Guarded destroy refused: room no longer inactive at expected revision"
@@ -2224,14 +2347,27 @@ impl kameo::message::Message<ReapSealedRoom> for RoomRegistryActor {
             info!(room = %msg.room_jid, "Reaped dead room actor during sealed-room purge");
             return true;
         }
-        let sealed = entry
+        let seal_state = entry
             .actor_ref
-            .ask(IsSealed)
+            .ask(GetRoomSealState)
             .mailbox_timeout(SEAL_ASK_TIMEOUT)
             .reply_timeout(SEAL_ASK_TIMEOUT)
             .await;
-        match sealed {
-            Ok(true) => {
+        match seal_state {
+            Ok(RoomSealState::OwnershipLost) => {
+                // A definitive join fence proved this actor is deposed. Its
+                // local registration is no longer safe to serve. Remove and
+                // kill locally, preserve durable room state, and do not issue
+                // a redundant release that could become an untracked late
+                // delete while the retry inventory is saturated.
+                self.evict_ownership_lost_room(&msg.room_jid, entry).await;
+                info!(
+                    room = %msg.room_jid,
+                    "Evicted room actor after join fence proved ownership loss"
+                );
+                true
+            }
+            Ok(RoomSealState::Inactive) => {
                 if !self.has_pending_release_capacity(&msg.room_jid, &entry.claim_fence) {
                     return false;
                 }
@@ -2247,7 +2383,7 @@ impl kameo::message::Message<ReapSealedRoom> for RoomRegistryActor {
                 );
                 true
             }
-            Ok(false) => false,
+            Ok(RoomSealState::Open) => false,
             Err(error) => {
                 warn!(
                     room = %msg.room_jid,

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -77,11 +77,11 @@ pub struct RoomRegistryActor {
     /// Ordinary terminal removals whose exact claim release was uncertain.
     /// Multiple owner+epoch generations for one room are intentional. A
     /// timed-out release may have deleted the row, after which another owner
-    /// can recreate it with a reset epoch; numeric epoch ordering therefore
-    /// cannot identify a newest generation across delete/recreate ABA.
-    /// Retaining every exact fence lets out-of-order retries prove each
-    /// responsibility independently, while the global bound prevents churn
-    /// from growing this inventory without limit.
+    /// can recreate it with a fresh globally monotonic epoch. Retaining every
+    /// exact fence still matters because each timed-out delete can commit out
+    /// of order and must reach its own typed outcome before the registry drops
+    /// that release responsibility. The global bound prevents churn from
+    /// growing this inventory without limit.
     pending_room_releases:
         HashMap<(BareJid, super::RoomClaimFenceContext), PendingRoomReleaseState>,
     /// Claim CAS calls whose timeout/backend error left commit status
@@ -872,7 +872,9 @@ impl RoomRegistryActor {
             self.release_room_claim(&room_jid, &claim_fence).await;
             return Err(RoomRegistryError::OwnershipUnavailable(room_jid));
         };
-        self.publish_room(room_jid, actor_ref.clone(), claim_fence);
+        if !self.publish_room(room_jid.clone(), actor_ref.clone(), claim_fence) {
+            return Err(RoomRegistryError::OwnershipReconciliationPending(room_jid));
+        }
         Ok(actor_ref)
     }
 
@@ -927,7 +929,14 @@ impl RoomRegistryActor {
         room_jid: BareJid,
         actor_ref: ActorRef<RoomActor>,
         claim_fence: super::RoomClaimFenceContext,
-    ) {
+    ) -> bool {
+        if self
+            .pending_room_releases
+            .contains_key(&(room_jid.clone(), claim_fence.clone()))
+        {
+            actor_ref.kill();
+            return false;
+        }
         self.clear_pending_room_acquisition(&room_jid, &claim_fence.owner());
         if let Some(store) = &self.durable_store {
             store.record_claim_fence(&room_jid, claim_fence.clone());
@@ -940,6 +949,7 @@ impl RoomRegistryActor {
             },
         );
         self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
+        true
     }
 
     /// ADR-0017 Phase 3 Slice 7 FIX 3 (council-adjudicated): `async` (not
@@ -1774,6 +1784,28 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
                 .await;
         }
 
+        // A delayed or duplicate reclaimed-room message can name an exact
+        // generation whose terminal release already timed out. Its database
+        // delete may still commit after the caller future was dropped, so
+        // never make that same generation live again. Retain both retry
+        // responsibilities until the exact release reaches a typed outcome.
+        if self
+            .pending_room_releases
+            .contains_key(&(msg.room_jid.clone(), claim_fence.clone()))
+        {
+            if self
+                .rooms
+                .get(&msg.room_jid)
+                .is_some_and(|entry| entry.claim_fence == claim_fence)
+            {
+                if let Some(entry) = self.rooms.remove(&msg.room_jid) {
+                    entry.actor_ref.kill();
+                }
+            }
+            self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+            return ReclaimedRoomOutcome::PendingRetry;
+        }
+
         // Prove the reaper's exact epoch before touching any local actor.
         // A stale adoption message must never depose a newer demand-side
         // actor, and a backend error is uncertainty, not permission.
@@ -1937,7 +1969,10 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
             return ReclaimedRoomOutcome::PendingRetry;
         };
         self.poisoned_rooms.remove(&msg.room_jid);
-        self.publish_room(msg.room_jid, actor_ref, claim_fence);
+        if !self.publish_room(msg.room_jid.clone(), actor_ref, claim_fence.clone()) {
+            self.remember_pending_reclaimed_room(msg.room_jid, claim_fence, msg.previous_owner);
+            return ReclaimedRoomOutcome::PendingRetry;
+        }
         ReclaimedRoomOutcome::Hydrated
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -993,7 +993,10 @@ mod ownership_claims_tests {
     use crate::muc::durable::{
         DurableRoomState, MucDurableFuture, MucDurableStore, RoomClaimFenceContext,
     };
-    use crate::muc::room_actor::{GetAffiliation, GetConfig};
+    use crate::muc::room_actor::{
+        GetAffiliation, GetConfig, JoinAffiliationGrant, JoinWithAffiliation,
+        ResolverAffiliationSyncOutcome, SyncResolverAffiliation, UpdateConfig,
+    };
     use crate::muc::subject::SubjectState;
     use crate::ownership::{
         ClaimEpoch, ClaimError, ClaimSnapshot, ClaimStore, Entity, EntityType, InProcessClaimStore,
@@ -1001,7 +1004,7 @@ mod ownership_claims_tests {
     };
     use crate::types::Affiliation;
     use async_trait::async_trait;
-    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
     use std::sync::Mutex;
 
     fn foreign_identity() -> NodeIdentity {
@@ -1192,7 +1195,7 @@ mod ownership_claims_tests {
             .expect("wire");
 
         let jid = test_room_jid("deposed-evict");
-        registry
+        let stale_actor = registry
             .ask(GetOrCreateRoom {
                 room_jid: jid.clone(),
                 waddle_id: "w-1".to_string(),
@@ -1200,7 +1203,8 @@ mod ownership_claims_tests {
                 config: RoomConfig::default(),
             })
             .await
-            .expect("get_or_create_room");
+            .expect("get_or_create_room")
+            .actor_ref;
 
         for index in 0..MAX_PENDING_ROOM_RELEASES {
             let pending_jid = test_room_jid(&format!("deposed-backlog-{index}"));
@@ -1231,6 +1235,12 @@ mod ownership_claims_tests {
             "a deposed eviction must never delete the room's durable state"
         );
         assert_eq!(registry.ask(RoomCount).await.expect("room count"), 0);
+        stale_actor.wait_for_shutdown().await;
+        assert!(!stale_actor.is_alive());
+        assert!(
+            stale_actor.ask(crate::muc::room_actor::IsDormant).await.is_err(),
+            "a stale ActorRef must be unusable even if the best-effort Demote notification never arrives"
+        );
         assert!(
             claim_store
                 .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
@@ -1642,16 +1652,153 @@ mod ownership_claims_tests {
         }
     }
 
+    /// The first exact release starts a detached database-side delete and
+    /// then never completes its caller future. This models a driver/backend
+    /// operation that is not cancellation-safe: the registry times out, but
+    /// the original delete can still commit later.
+    struct NonCancelSafeReleaseStore {
+        inner: Arc<InProcessClaimStore>,
+        release_calls: AtomicUsize,
+        late_release_started: Arc<tokio::sync::Notify>,
+        allow_late_release: Arc<tokio::sync::Notify>,
+        late_release_completed: Arc<tokio::sync::Notify>,
+    }
+
+    impl NonCancelSafeReleaseStore {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(InProcessClaimStore::new()),
+                release_calls: AtomicUsize::new(0),
+                late_release_started: Arc::new(tokio::sync::Notify::new()),
+                allow_late_release: Arc::new(tokio::sync::Notify::new()),
+                late_release_completed: Arc::new(tokio::sync::Notify::new()),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl ClaimStore for NonCancelSafeReleaseStore {
+        async fn ensure_schema(&self) -> Result<(), ClaimError> {
+            Ok(())
+        }
+
+        async fn acquire(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner.acquire(entity, me).await
+        }
+
+        async fn ensure_claimed(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner.ensure_claimed(entity, me).await
+        }
+
+        async fn steal_stale(
+            &self,
+            entity: &Entity,
+            observed: ClaimEpoch,
+            staleness: StalePredicate,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner
+                .steal_stale(entity, observed, staleness, me)
+                .await
+        }
+
+        async fn steal_for_resume(
+            &self,
+            entity: &Entity,
+            observed: ClaimEpoch,
+            witness: ResumeIdentityProof,
+            me: &NodeIdentity,
+        ) -> Result<ClaimEpoch, ClaimError> {
+            self.inner
+                .steal_for_resume(entity, observed, witness, me)
+                .await
+        }
+
+        async fn current_claim(
+            &self,
+            entity: &Entity,
+        ) -> Result<Option<ClaimSnapshot>, ClaimError> {
+            self.inner.current_claim(entity).await
+        }
+
+        async fn fence(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<bool, ClaimError> {
+            self.inner.fence(entity, me, mine).await
+        }
+
+        async fn release(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<(), ClaimError> {
+            self.inner.release(entity, me, mine).await
+        }
+
+        async fn release_exact(
+            &self,
+            entity: &Entity,
+            me: &NodeIdentity,
+            mine: ClaimEpoch,
+        ) -> Result<crate::ownership::ExactReleaseOutcome, ClaimError> {
+            if self.release_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                let inner = Arc::clone(&self.inner);
+                let entity = entity.clone();
+                let me = me.clone();
+                let started = Arc::clone(&self.late_release_started);
+                let allow = Arc::clone(&self.allow_late_release);
+                let completed = Arc::clone(&self.late_release_completed);
+                tokio::spawn(async move {
+                    started.notify_one();
+                    allow.notified().await;
+                    inner
+                        .release_exact(&entity, &me, mine)
+                        .await
+                        .expect("detached late release");
+                    completed.notify_one();
+                });
+                std::future::pending().await
+            } else {
+                self.inner.release_exact(entity, me, mine).await
+            }
+        }
+
+        async fn release_many(
+            &self,
+            entities: &[Entity],
+            me: &NodeIdentity,
+        ) -> Result<(), ClaimError> {
+            self.inner.release_many(entities, me).await
+        }
+    }
+
     /// A [`MucDurableStore`] fake recording `notify_previous_owner_demoted`
     /// calls and returning a fixed `load_room_state` result.
     #[derive(Default)]
     struct RecordingDurableStore {
         load_result: Option<DurableRoomState>,
         fail_load: bool,
+        block_next_config_save: AtomicBool,
+        config_save_started: Option<Arc<tokio::sync::Notify>>,
+        allow_config_save: Option<Arc<tokio::sync::Notify>>,
+        stale_config_save_rejected: Arc<AtomicBool>,
+        fence_lost: AtomicBool,
         demote_notifications: Mutex<Vec<(String, String)>>,
         deleted_rooms: Mutex<Vec<String>>,
         fail_deletes: bool,
-        claim_fences: Mutex<HashMap<BareJid, RoomClaimFenceContext>>,
+        claim_fences: Arc<Mutex<HashMap<BareJid, RoomClaimFenceContext>>>,
     }
 
     impl MucDurableStore for RecordingDurableStore {
@@ -1670,12 +1817,47 @@ mod ownership_claims_tests {
 
         fn save_config<'a>(
             &'a self,
-            _room_jid: &'a BareJid,
+            room_jid: &'a BareJid,
             _waddle_id: &'a str,
             _channel_id: &'a str,
             _config: &'a RoomConfig,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            let block = self.block_next_config_save.swap(false, Ordering::SeqCst);
+            let config_save_started = self.config_save_started.clone();
+            let allow_config_save = self.allow_config_save.clone();
+            let starting_fence = self
+                .claim_fences
+                .lock()
+                .expect("lock")
+                .get(room_jid)
+                .cloned();
+            Box::pin(async move {
+                if block {
+                    let claim_fences = Arc::clone(&self.claim_fences);
+                    let stale_rejected = Arc::clone(&self.stale_config_save_rejected);
+                    let room_jid = room_jid.clone();
+                    tokio::spawn(async move {
+                        if let Some(started) = config_save_started {
+                            started.notify_one();
+                        }
+                        if let Some(allow) = allow_config_save {
+                            allow.notified().await;
+                        }
+                        let current_fence =
+                            claim_fences.lock().expect("lock").get(&room_jid).cloned();
+                        if current_fence != starting_fence {
+                            stale_rejected.store(true, Ordering::SeqCst);
+                        }
+                    });
+                    std::future::pending().await
+                }
+                Ok(())
+            })
+        }
+
+        fn check_fenced_fanout<'a>(&'a self, _room_jid: &'a BareJid) -> MucDurableFuture<'a, bool> {
+            let owned = !self.fence_lost.load(Ordering::SeqCst);
+            Box::pin(async move { Ok(owned) })
         }
 
         fn save_subject<'a>(
@@ -1828,11 +2010,7 @@ mod ownership_claims_tests {
                     Affiliation::Owner,
                 )],
             }),
-            fail_load: false,
-            demote_notifications: Mutex::new(Vec::new()),
-            deleted_rooms: Mutex::new(Vec::new()),
-            fail_deletes: false,
-            claim_fences: Mutex::new(HashMap::new()),
+            ..RecordingDurableStore::default()
         });
         registry
             .ask(WireClusteringClaims {
@@ -2377,7 +2555,10 @@ mod ownership_claims_tests {
             .current_claim_fence(&jid)
             .expect("new fence cached");
         assert_eq!(new_fence.owner(), new_owner);
-        assert!(new_fence.epoch > old_epoch);
+        assert_ne!(
+            new_fence, old_fence,
+            "owner identity plus epoch identifies the exact generation even when a recreated in-memory claim resets its numeric epoch"
+        );
 
         assert_eq!(
             registry
@@ -2575,13 +2756,15 @@ mod ownership_claims_tests {
         let old_epoch = ClaimEpoch(30);
         let new_epoch = ClaimEpoch(31);
         let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), old_epoch));
+        let durable_store = Arc::new(RecordingDurableStore {
+            load_result: Some(reclaimed_snapshot("clean retry snapshot")),
+            ..RecordingDurableStore::default()
+        });
         registry
             .ask(WireClusteringClaims {
                 claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
                 node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(
-                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
-                ),
+                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
                 rollout_backoff: None,
             })
             .await
@@ -2597,9 +2780,9 @@ mod ownership_claims_tests {
             .await
             .expect("spawn old-epoch actor");
         *claim_store.state.lock().expect("claim state") = Some((this_identity(), new_epoch));
-        // Let the initial authorization pass, then make the fence adjacent
-        // to the live-map epoch mutation uncertain.
-        claim_store.fail_fence_on_call(2);
+        // Make the initial exact proof uncertain. The old actor must remain
+        // untouched until a later retry proves the new generation.
+        claim_store.fail_fence_on_call(claim_store.fence_calls.load(Ordering::SeqCst) + 1);
 
         let uncertain = registry
             .ask(ReconcileReclaimedRoom {
@@ -2639,7 +2822,23 @@ mod ownership_claims_tests {
             })
             .await
             .expect("retry with exact proof");
-        assert_eq!(retried, ReclaimedRoomOutcome::AdoptedLocal);
+        assert_eq!(retried, ReclaimedRoomOutcome::Hydrated);
+        let replacement = registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("get replacement")
+            .expect("replacement actor");
+        assert_ne!(replacement.id(), original.actor_ref.id());
+        assert_eq!(
+            replacement
+                .ask(GetConfig)
+                .await
+                .expect("replacement config")
+                .name,
+            "clean retry snapshot"
+        );
         assert!(registry
             .ask(ListPendingReclaimedRooms { limit: 8 })
             .await
@@ -2804,91 +3003,6 @@ mod ownership_claims_tests {
             2,
             "A/41 and recreated B/0 are distinct exact release responsibilities"
         );
-    }
-
-    #[tokio::test]
-    async fn publishing_reacquired_exact_fence_cancels_matching_terminal_release() {
-        let registry = spawn_registry().await;
-        let claim_store = Arc::new(crate::ownership::InProcessClaimStore::new());
-        let identity = this_identity();
-        let jid = test_room_jid("reacquired-release-cancel");
-        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
-        let epoch = claim_store
-            .ensure_claimed(&entity, &identity)
-            .await
-            .expect("seed self-owned claim");
-        let fence = RoomClaimFenceContext::new(entity.clone(), identity.clone(), epoch);
-        let aba_distinct_fence = RoomClaimFenceContext::new(
-            entity.clone(),
-            foreign_identity(),
-            ClaimEpoch(epoch.0.saturating_add(1)),
-        );
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(identity.clone()),
-                durable_store: None,
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
-        registry
-            .ask(RememberOrdinaryReleaseForTest {
-                room_jid: jid.clone(),
-                claim_fence: fence.clone(),
-            })
-            .await
-            .expect("remember ambiguous release");
-        registry
-            .ask(RememberOrdinaryReleaseForTest {
-                room_jid: jid.clone(),
-                claim_fence: aba_distinct_fence,
-            })
-            .await
-            .expect("remember ABA-distinct release");
-
-        registry
-            .ask(GetOrCreateRoom {
-                room_jid: jid.clone(),
-                waddle_id: "w".to_string(),
-                channel_id: "c".to_string(),
-                config: RoomConfig::default(),
-            })
-            .await
-            .expect("publish actor under reacquired fence");
-
-        assert_eq!(
-            registry
-                .ask(GetPendingRoomReleaseBacklog)
-                .await
-                .expect("pending release backlog")
-                .depth,
-            1,
-            "publishing cancels only the exact live fence, not another ABA generation"
-        );
-        assert!(!registry
-            .ask(IsCurrentRoomPendingRelease {
-                room_jid: jid.clone(),
-            })
-            .await
-            .expect("current-fence pending query"));
-        assert!(!registry
-            .ask(IsPendingRoomReleaseOnly {
-                room_jid: jid.clone(),
-            })
-            .await
-            .expect("pending-only query"));
-        assert_eq!(
-            registry
-                .ask(RetryPendingRoomReleases { limit: 8 })
-                .await
-                .expect("retry backlog"),
-            1
-        );
-        assert!(claim_store
-            .fence(&entity, &identity, epoch)
-            .await
-            .expect("live claim fence"));
     }
 
     #[tokio::test]
@@ -3784,6 +3898,175 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn late_non_cancel_safe_release_cannot_delete_a_new_live_claim() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(NonCancelSafeReleaseStore::new());
+        let identity = this_identity();
+        let jid = test_room_jid("late-release-before-reacquire");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let epoch = claim_store
+            .ensure_claimed(&entity, &identity)
+            .await
+            .expect("seed self-owned claim");
+        let fence = RoomClaimFenceContext::new(entity.clone(), identity.clone(), epoch);
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(identity.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: jid.clone(),
+                claim_fence: fence,
+            })
+            .await
+            .expect("remember ambiguous release");
+
+        assert_eq!(
+            registry
+                .ask(RetryPendingRoomReleases { limit: 1 })
+                .await
+                .expect("time out first non-cancel-safe release"),
+            1,
+        );
+        claim_store.late_release_started.notified().await;
+
+        let acquisition = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("converge old release then publish fresh actor");
+        let live = claim_store
+            .current_claim(&entity)
+            .await
+            .expect("current claim")
+            .expect("fresh claim exists");
+        assert!(
+            live.claim_epoch > epoch,
+            "demand must acquire a fresh epoch"
+        );
+
+        claim_store.allow_late_release.notify_one();
+        claim_store.late_release_completed.notified().await;
+        assert!(claim_store
+            .fence(&entity, &identity, live.claim_epoch)
+            .await
+            .expect("fresh claim survives late old delete"));
+        assert!(acquisition.actor_ref.is_alive());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn reclaimed_late_release_is_converged_before_demand_reacquires() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(NonCancelSafeReleaseStore::new());
+        let identity = this_identity();
+        let jid = test_room_jid("late-reclaimed-release-before-reacquire");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let epoch = claim_store
+            .ensure_claimed(&entity, &identity)
+            .await
+            .expect("seed reclaimed self-owned claim");
+        let fence = RoomClaimFenceContext::new(entity.clone(), identity.clone(), epoch);
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(identity.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+
+        assert_eq!(
+            registry
+                .ask(ReconcileReclaimedRoom {
+                    room_jid: jid.clone(),
+                    claim_fence: fence,
+                    previous_owner: foreign_identity(),
+                })
+                .await
+                .expect("first reclaimed release times out"),
+            ReclaimedRoomOutcome::PendingRetry,
+        );
+        claim_store.late_release_started.notified().await;
+
+        let acquisition = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("converge reclaimed release then publish fresh actor");
+        let live = claim_store
+            .current_claim(&entity)
+            .await
+            .expect("current claim")
+            .expect("fresh claim exists");
+        assert!(
+            live.claim_epoch > epoch,
+            "demand must acquire a fresh epoch"
+        );
+
+        claim_store.allow_late_release.notify_one();
+        claim_store.late_release_completed.notified().await;
+        assert!(claim_store
+            .fence(&entity, &identity, live.claim_epoch)
+            .await
+            .expect("fresh claim survives late reclaimed delete"));
+        assert!(acquisition.actor_ref.is_alive());
+    }
+
+    #[tokio::test]
+    async fn bare_reclaimed_reservation_blocks_demand_claim_acquisition() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("reserved-reclaimed-blocks-demand");
+        assert!(registry
+            .ask(ReservePendingReclaimedRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("reserve reclaimed room"));
+
+        assert!(matches!(
+            registry
+                .ask(GetOrCreateRoom {
+                    room_jid: jid.clone(),
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await,
+            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(blocked)))
+                if blocked == jid
+        ));
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn timed_out_release_is_cancelled_and_retried_without_wedging_registry() {
         let registry = spawn_registry().await;
         let epoch = ClaimEpoch(50);
@@ -3900,18 +4183,28 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test]
-    async fn locally_live_old_epoch_actor_is_adopted_without_state_loss() {
+    async fn in_flight_old_epoch_mutation_is_replaced_by_clean_fenced_hydration() {
         let registry = spawn_registry().await;
+        let old_owner = this_identity();
+        let new_owner = foreign_identity();
         let old_epoch = ClaimEpoch(20);
         let new_epoch = ClaimEpoch(21);
-        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), old_epoch));
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner.clone(), old_epoch));
+        let node_identity = SharedNodeIdentity::new(old_owner.clone());
+        let config_save_started = Arc::new(tokio::sync::Notify::new());
+        let allow_config_save = Arc::new(tokio::sync::Notify::new());
+        let durable_store = Arc::new(RecordingDurableStore {
+            load_result: Some(reclaimed_snapshot("authoritative rehydrated config")),
+            block_next_config_save: AtomicBool::new(false),
+            config_save_started: Some(Arc::clone(&config_save_started)),
+            allow_config_save: Some(Arc::clone(&allow_config_save)),
+            ..RecordingDurableStore::default()
+        });
         registry
             .ask(WireClusteringClaims {
                 claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(
-                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
-                ),
+                node_identity: node_identity.clone(),
+                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
                 rollout_backoff: None,
             })
             .await
@@ -3927,27 +4220,169 @@ mod ownership_claims_tests {
             .await
             .expect("create local actor");
 
+        durable_store
+            .block_next_config_save
+            .store(true, Ordering::SeqCst);
+        let original_actor = original.actor_ref.clone();
+        let mutation = tokio::spawn(async move {
+            original_actor
+                .ask(UpdateConfig {
+                    config: RoomConfig {
+                        name: "old-epoch in-memory mutation".to_string(),
+                        ..RoomConfig::default()
+                    },
+                })
+                .await
+        });
+        config_save_started.notified().await;
+
         // Stand in for the dead-node reaper's exact CAS after this process
-        // refreshed its node identity while the local actor remained live.
-        *claim_store.state.lock().expect("claim state lock") = Some((this_identity(), new_epoch));
+        // refreshed its node identity while the old actor still has a
+        // mutation blocked in its mailbox handler.
+        node_identity.rotate(new_owner.clone()).await;
+        *claim_store.state.lock().expect("claim state lock") = Some((new_owner.clone(), new_epoch));
         let outcome = registry
             .ask(ReconcileReclaimedRoom {
                 room_jid: jid.clone(),
-                claim_fence: room_claim_fence(&jid, new_epoch),
-                previous_owner: this_identity(),
+                claim_fence: RoomClaimFenceContext::new(
+                    Entity::new(EntityType::RoomActor, jid.to_string()),
+                    new_owner,
+                    new_epoch,
+                ),
+                previous_owner: old_owner,
             })
             .await
-            .expect("adopt new epoch");
-        assert_eq!(outcome, ReclaimedRoomOutcome::AdoptedLocal);
-        let adopted = registry
+            .expect("replace old epoch");
+        assert_eq!(outcome, ReclaimedRoomOutcome::Hydrated);
+        let restored = registry
             .ask(GetRoom { room_jid: jid })
             .await
-            .expect("get adopted actor")
-            .expect("actor remains registered");
-        assert_eq!(
-            adopted.id(),
+            .expect("get replacement actor")
+            .expect("replacement remains registered");
+        assert_ne!(
+            restored.id(),
             original.actor_ref.id(),
-            "epoch adoption must preserve the locally live RoomActor"
+            "an actor with old-epoch work in flight must never be adopted in place"
+        );
+        assert_eq!(
+            restored.ask(GetConfig).await.expect("restored config").name,
+            "authoritative rehydrated config",
+            "only the newly fenced durable snapshot may seed replacement memory"
+        );
+        allow_config_save.notify_waiters();
+        let mutation = mutation.await.expect("mutation task");
+        assert!(
+            mutation.is_err(),
+            "the in-flight old-fence mutation must not report durable success"
+        );
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !durable_store
+                .stale_config_save_rejected
+                .load(Ordering::SeqCst)
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("detached old-fence save reached its fence check");
+        assert!(
+            durable_store
+                .stale_config_save_rejected
+                .load(Ordering::SeqCst),
+            "the durable fake must observe and reject the old generation after identity rotation"
+        );
+        assert_eq!(
+            restored.ask(GetConfig).await.expect("restored config").name,
+            "authoritative rehydrated config",
+            "the rejected old-fence write must not alter the replacement actor"
+        );
+    }
+
+    #[tokio::test]
+    async fn deposed_actor_ref_refuses_resolver_granted_join() {
+        let registry = spawn_registry().await;
+        let durable_store = Arc::new(RecordingDurableStore::default());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::new(InProcessClaimStore::new()),
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: test_room_jid("deposed-resolver-join"),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create room")
+            .actor_ref;
+        durable_store.fence_lost.store(true, Ordering::SeqCst);
+
+        let join = actor
+            .ask(JoinWithAffiliation {
+                sender_jid: "member@example.com/web".parse().expect("full JID"),
+                nick: "member".to_string(),
+                affiliation_grant: JoinAffiliationGrant::Resolver(Affiliation::Member),
+                local_domain: "example.com".to_string(),
+                admission_revision: 0,
+            })
+            .await;
+        assert!(matches!(
+            join,
+            Err(SendError::HandlerError(
+                crate::muc::room_actor::RoomActorError::RoomSealed
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn deposed_actor_ref_refuses_resolver_affiliation_sync() {
+        let registry = spawn_registry().await;
+        let durable_store = Arc::new(RecordingDurableStore::default());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::new(InProcessClaimStore::new()),
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: test_room_jid("deposed-resolver-sync"),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create room")
+            .actor_ref;
+        durable_store.fence_lost.store(true, Ordering::SeqCst);
+        let jid: BareJid = "member@example.com".parse().expect("bare JID");
+
+        assert_eq!(
+            actor
+                .ask(SyncResolverAffiliation {
+                    jid: jid.clone(),
+                    affiliation: Affiliation::Member,
+                    expected_admission_revision: 0,
+                })
+                .await
+                .expect("sync reply"),
+            ResolverAffiliationSyncOutcome::RoomSealed,
+        );
+        assert_eq!(
+            actor
+                .ask(GetAffiliation { jid })
+                .await
+                .expect("affiliation query"),
+            Affiliation::None,
         );
     }
 

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -4192,6 +4192,89 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn reclaimed_reconcile_cannot_republish_a_fence_with_a_late_release_pending() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(NonCancelSafeReleaseStore::new());
+        let identity = this_identity();
+        let jid = test_room_jid("reclaimed-publish-with-late-release");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let epoch = claim_store
+            .ensure_claimed(&entity, &identity)
+            .await
+            .expect("seed self-owned claim");
+        let fence = RoomClaimFenceContext::new(entity.clone(), identity.clone(), epoch);
+        let durable_store = Arc::new(RecordingDurableStore {
+            load_result: Some(reclaimed_snapshot("must-not-republish")),
+            ..RecordingDurableStore::default()
+        });
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(identity),
+                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        registry
+            .ask(RememberOrdinaryReleaseForTest {
+                room_jid: jid.clone(),
+                claim_fence: fence.clone(),
+            })
+            .await
+            .expect("remember ambiguous release");
+
+        assert_eq!(
+            registry
+                .ask(RetryPendingRoomReleases { limit: 1 })
+                .await
+                .expect("time out first non-cancel-safe release"),
+            1,
+        );
+        claim_store.late_release_started.notified().await;
+
+        assert_eq!(
+            registry
+                .ask(ReconcileReclaimedRoom {
+                    room_jid: jid.clone(),
+                    claim_fence: fence,
+                    previous_owner: foreign_identity(),
+                })
+                .await
+                .expect("reconcile while exact release is pending"),
+            ReclaimedRoomOutcome::PendingRetry,
+        );
+        assert!(
+            registry
+                .ask(GetRoom {
+                    room_jid: jid.clone(),
+                })
+                .await
+                .expect("room lookup")
+                .is_none(),
+            "an exact fence with a non-cancel-safe delete in flight must never be republished"
+        );
+
+        claim_store.allow_late_release.notify_one();
+        claim_store.late_release_completed.notified().await;
+        registry
+            .ask(RetryPendingRoomReleases { limit: 1 })
+            .await
+            .expect("converge completed late release");
+        assert_eq!(
+            registry
+                .ask(ReconcileReclaimedRoom {
+                    room_jid: jid.clone(),
+                    claim_fence: room_claim_fence(&jid, epoch),
+                    previous_owner: foreign_identity(),
+                })
+                .await
+                .expect("reconcile released fence"),
+            ReclaimedRoomOutcome::LostRace,
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn pre_acquire_convergence_uses_one_short_budget_and_releases_the_mailbox() {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(NonCancelSafeReleaseStore::new());

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -3964,6 +3964,81 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test(start_paused = true)]
+    async fn pre_acquire_convergence_uses_one_short_budget_and_releases_the_mailbox() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(NonCancelSafeReleaseStore::new());
+        let identity = this_identity();
+        let jid = test_room_jid("bounded-pre-acquire-convergence");
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(identity.clone()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        for epoch in 1..=6 {
+            registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: jid.clone(),
+                    claim_fence: RoomClaimFenceContext::new(
+                        Entity::new(EntityType::RoomActor, jid.to_string()),
+                        identity.clone(),
+                        ClaimEpoch(epoch),
+                    ),
+                })
+                .await
+                .expect("remember ambiguous release");
+        }
+
+        let create_registry = registry.clone();
+        let create_jid = jid.clone();
+        let create = tokio::spawn(async move {
+            create_registry
+                .ask(GetOrCreateRoom {
+                    room_jid: create_jid,
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await
+        });
+        claim_store.late_release_started.notified().await;
+        let count_registry = registry.clone();
+        let unrelated = tokio::spawn(async move { count_registry.ask(RoomCount).await });
+
+        tokio::time::advance(PRE_ACQUIRE_CONVERGENCE_BUDGET).await;
+        assert!(matches!(
+            create.await.expect("create task"),
+            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(ref room)))
+                if *room == jid
+        ));
+        assert_eq!(
+            unrelated
+                .await
+                .expect("unrelated task")
+                .expect("registry count"),
+            0,
+            "unrelated mailbox work must resume after the short shared budget"
+        );
+        assert_eq!(
+            claim_store.release_calls.load(Ordering::SeqCst),
+            1,
+            "convergence must stop on the first exact fence that stays pending"
+        );
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("pending backlog")
+                .depth,
+            6,
+            "unattempted exact fences must remain for background retry"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
     async fn reclaimed_late_release_is_converged_before_demand_reacquires() {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(NonCancelSafeReleaseStore::new());
@@ -4180,6 +4255,64 @@ mod ownership_claims_tests {
             .expect("get after stale adoption")
             .expect("live actor survives");
         assert_eq!(still_registered.id(), demand.actor_ref.id());
+    }
+
+    #[tokio::test]
+    async fn lost_exact_reclaimed_fence_evicts_the_matching_live_actor() {
+        let registry = spawn_registry().await;
+        let owner = this_identity();
+        let epoch = ClaimEpoch(12);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(owner.clone(), epoch));
+        let durable_store = Arc::new(RecordingDurableStore::default());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(owner),
+                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("lost-live-reclaimed-fence");
+        let live = registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("publish exact live actor")
+            .actor_ref;
+        let fence = durable_store
+            .current_claim_fence(&jid)
+            .expect("published fence cache");
+
+        *claim_store.state.lock().expect("claim state") =
+            Some((foreign_identity(), ClaimEpoch(epoch.0 + 1)));
+        assert_eq!(
+            registry
+                .ask(ReconcileReclaimedRoom {
+                    room_jid: jid.clone(),
+                    claim_fence: fence,
+                    previous_owner: foreign_identity(),
+                })
+                .await
+                .expect("lost-race reconciliation"),
+            ReclaimedRoomOutcome::LostRace,
+        );
+        assert!(
+            registry
+                .ask(GetRoom {
+                    room_jid: jid.clone(),
+                })
+                .await
+                .expect("registry lookup")
+                .is_none(),
+            "an unfenced live actor must not remain registered"
+        );
+        assert!(!live.is_alive(), "the stale ActorRef must be killed");
+        assert_eq!(durable_store.current_claim_fence(&jid), None);
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -994,7 +994,7 @@ mod ownership_claims_tests {
         DurableRoomState, MucDurableFuture, MucDurableStore, RoomClaimFenceContext,
     };
     use crate::muc::room_actor::{
-        GetAffiliation, GetConfig, JoinAffiliationGrant, JoinWithAffiliation,
+        GetAffiliation, GetConfig, IsSealed, JoinAffiliationGrant, JoinWithAffiliation,
         ResolverAffiliationSyncOutcome, SyncResolverAffiliation, UpdateConfig,
     };
     use crate::muc::subject::SubjectState;
@@ -1393,6 +1393,7 @@ mod ownership_claims_tests {
     struct DeadOwnerClaimStore {
         state: Mutex<Option<(NodeIdentity, ClaimEpoch)>>,
         steal_calls: AtomicUsize,
+        current_claim_failures: AtomicUsize,
         fence_calls: AtomicUsize,
         fence_fail_on_call: AtomicUsize,
         release_failures: AtomicUsize,
@@ -1401,6 +1402,8 @@ mod ownership_claims_tests {
         ensure_delay_ms: AtomicU64,
         ensure_post_commit_delay_ms: AtomicU64,
         steal_post_commit_delay_ms: AtomicU64,
+        force_next_steal_conflict: AtomicBool,
+        drop_claim_on_forced_steal_conflict: AtomicBool,
     }
 
     impl DeadOwnerClaimStore {
@@ -1408,6 +1411,7 @@ mod ownership_claims_tests {
             Self {
                 state: Mutex::new(Some((owner, epoch))),
                 steal_calls: AtomicUsize::new(0),
+                current_claim_failures: AtomicUsize::new(0),
                 fence_calls: AtomicUsize::new(0),
                 fence_fail_on_call: AtomicUsize::new(usize::MAX),
                 release_failures: AtomicUsize::new(0),
@@ -1416,6 +1420,8 @@ mod ownership_claims_tests {
                 ensure_delay_ms: AtomicU64::new(0),
                 ensure_post_commit_delay_ms: AtomicU64::new(0),
                 steal_post_commit_delay_ms: AtomicU64::new(0),
+                force_next_steal_conflict: AtomicBool::new(false),
+                drop_claim_on_forced_steal_conflict: AtomicBool::new(false),
             }
         }
 
@@ -1427,6 +1433,10 @@ mod ownership_claims_tests {
 
         fn fail_fence_on_call(&self, call: usize) {
             self.fence_fail_on_call.store(call, Ordering::SeqCst);
+        }
+
+        fn fail_next_current_claim(&self) {
+            self.current_claim_failures.store(1, Ordering::SeqCst);
         }
 
         fn fail_next_release(&self) {
@@ -1466,6 +1476,12 @@ mod ownership_claims_tests {
                 u64::try_from(delay.as_millis()).unwrap_or(u64::MAX),
                 Ordering::SeqCst,
             );
+        }
+
+        fn conflict_next_steal(&self, drop_claim: bool) {
+            self.drop_claim_on_forced_steal_conflict
+                .store(drop_claim, Ordering::SeqCst);
+            self.force_next_steal_conflict.store(true, Ordering::SeqCst);
         }
     }
 
@@ -1520,6 +1536,15 @@ mod ownership_claims_tests {
             me: &NodeIdentity,
         ) -> Result<ClaimEpoch, ClaimError> {
             self.steal_calls.fetch_add(1, Ordering::SeqCst);
+            if self.force_next_steal_conflict.swap(false, Ordering::SeqCst) {
+                if self
+                    .drop_claim_on_forced_steal_conflict
+                    .swap(false, Ordering::SeqCst)
+                {
+                    *self.state.lock().expect("lock") = None;
+                }
+                return Err(ClaimError::Conflict);
+            }
             let result = {
                 let mut state = self.state.lock().expect("lock");
                 match &*state {
@@ -1554,6 +1579,17 @@ mod ownership_claims_tests {
             &self,
             _entity: &Entity,
         ) -> Result<Option<ClaimSnapshot>, ClaimError> {
+            if self
+                .current_claim_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return Err(ClaimError::Backend(
+                    "test current-claim failure".to_string(),
+                ));
+            }
             Ok(self
                 .state
                 .lock()
@@ -1924,6 +1960,137 @@ mod ownership_claims_tests {
                 .push((room_jid.to_string(), previous_owner_node_id.to_string()));
             Box::pin(async { Ok(()) })
         }
+    }
+
+    #[tokio::test]
+    async fn claim_lookup_failure_is_not_misclassified_as_a_remote_owner() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(
+            foreign_identity(),
+            ClaimEpoch(3),
+        ));
+        claim_store.fail_next_current_claim();
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("claim-lookup-error");
+
+        assert!(matches!(
+            registry
+                .ask(GetOrCreateRoom {
+                    room_jid: jid.clone(),
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await,
+            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(ref room)))
+                if *room == jid
+        ));
+        assert!(registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("room lookup")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn claim_disappearing_during_stale_owner_steal_is_reconciliation_pending() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(
+            foreign_identity(),
+            ClaimEpoch(3),
+        ));
+        claim_store.conflict_next_steal(true);
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("claim-gone-during-steal");
+
+        assert!(matches!(
+            registry
+                .ask(GetOrCreateRoom {
+                    room_jid: jid.clone(),
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await,
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipReconciliationPending(ref room)
+            )) if *room == jid
+        ));
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("room lookup")
+            .is_none());
+
+        registry
+            .ask(GetOrCreateRoom {
+                room_jid: jid,
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("next attempt acquires the now-unclaimed room");
+    }
+
+    #[tokio::test]
+    async fn invalid_local_stealer_conflict_is_not_misclassified_as_a_remote_owner() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(
+            foreign_identity(),
+            ClaimEpoch(3),
+        ));
+        // Postgres returns the same catch-all Conflict when the stale-owner
+        // predicate matched but this node's own lease is missing, expired, or
+        // draining. Preserve the stale foreign claim to model that branch.
+        claim_store.conflict_next_steal(false);
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("local-stealer-invalid");
+
+        assert!(matches!(
+            registry
+                .ask(GetOrCreateRoom {
+                    room_jid: jid.clone(),
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await,
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipReconciliationPending(ref room)
+            )) if *room == jid
+        ));
+        assert!(registry
+            .ask(GetRoom { room_jid: jid })
+            .await
+            .expect("room lookup")
+            .is_none());
     }
 
     #[tokio::test]
@@ -2424,6 +2591,67 @@ mod ownership_claims_tests {
             .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
             .await
             .expect("claim lookup")
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn identity_rotation_during_claim_acquisition_is_not_a_remote_owner() {
+        let registry = spawn_registry().await;
+        let old_owner = this_identity();
+        let identity = SharedNodeIdentity::new(old_owner.clone());
+        let claim_store = Arc::new(DeadOwnerClaimStore::empty());
+        claim_store.set_ensure_post_commit_delay(std::time::Duration::from_millis(100));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: identity.clone(),
+                durable_store: None,
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire");
+        let jid = test_room_jid("rotate-during-claim-acquire");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let create_registry = registry.clone();
+        let create_jid = jid.clone();
+        let create = tokio::spawn(async move {
+            create_registry
+                .ask(GetOrCreateRoom {
+                    room_jid: create_jid,
+                    waddle_id: "w".to_string(),
+                    channel_id: "c".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await
+        });
+
+        while claim_store
+            .current_claim(&entity)
+            .await
+            .expect("claim lookup")
+            .is_none()
+        {
+            tokio::task::yield_now().await;
+        }
+        identity.rotate(foreign_identity()).await;
+
+        assert!(matches!(
+            create.await.expect("create task"),
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipReconciliationPending(ref room)
+            )) if *room == jid
+        ));
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("room lookup")
+            .is_none());
+        assert!(claim_store
+            .current_claim(&entity)
+            .await
+            .expect("released old claim")
             .is_none());
     }
 
@@ -4011,7 +4239,9 @@ mod ownership_claims_tests {
         tokio::time::advance(PRE_ACQUIRE_CONVERGENCE_BUDGET).await;
         assert!(matches!(
             create.await.expect("create task"),
-            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(ref room)))
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipReconciliationPending(ref room)
+            ))
                 if *room == jid
         ));
         assert_eq!(
@@ -4131,7 +4361,9 @@ mod ownership_claims_tests {
                     config: RoomConfig::default(),
                 })
                 .await,
-            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(blocked)))
+            Err(SendError::HandlerError(
+                RoomRegistryError::OwnershipReconciliationPending(blocked)
+            ))
                 if blocked == jid
         ));
         assert!(claim_store
@@ -4588,6 +4820,304 @@ mod ownership_claims_tests {
             "owner B durable config"
         );
     }
+
+    #[tokio::test]
+    async fn inactive_destroy_hard_kills_a_previously_deposed_actor() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(NonCancelSafeReleaseStore::new());
+        let durable_store = Arc::new(RecordingDurableStore::default());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire clustering");
+
+        let room_jid = test_room_jid("deposed-before-inactive-destroy");
+        let actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: room_jid.clone(),
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-1".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create room")
+            .actor_ref;
+        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        let claim = claim_store
+            .inner
+            .current_claim(&entity)
+            .await
+            .expect("read claim")
+            .expect("room is initially claimed");
+        assert_eq!(
+            claim_store
+                .inner
+                .release_exact(&entity, &claim.owner, claim.claim_epoch)
+                .await
+                .expect("remove claim"),
+            crate::ownership::ExactReleaseOutcome::Released,
+        );
+        durable_store.fence_lost.store(true, Ordering::SeqCst);
+
+        assert!(matches!(
+            actor
+                .ask(JoinWithAffiliation {
+                    sender_jid: "alice@example.com/device".parse().expect("full JID"),
+                    nick: "alice".to_string(),
+                    affiliation_grant: JoinAffiliationGrant::Unaffiliated,
+                    local_domain: "example.com".to_string(),
+                    admission_revision: 0,
+                })
+                .await,
+            Err(SendError::HandlerError(
+                crate::muc::room_actor::RoomActorError::RoomSealed
+            ))
+        ));
+
+        assert!(registry
+            .ask(DestroyRoomIfInactive {
+                room_jid: room_jid.clone(),
+                expected_occupancy_revision: 0,
+                guard: SealGuard::Dormant,
+            })
+            .await
+            .expect("typed inactive destroy"));
+        actor.wait_for_shutdown().await;
+        assert!(
+            !actor.is_alive(),
+            "the deposed ActorRef must be hard-killed"
+        );
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("room lookup")
+            .is_none());
+        assert_eq!(claim_store.release_calls.load(Ordering::SeqCst), 0);
+        assert!(durable_store.current_claim_fence(&room_jid).is_none());
+        assert!(durable_store.deleted_rooms.lock().expect("lock").is_empty());
+    }
+
+    /// A join fence can be the first component to prove that this actor's
+    /// durable ownership moved. That seal is materially different from an
+    /// inactivity seal: the deposed actor must leave the registry even when
+    /// the bounded exact-release inventory is already full, while the ordinary
+    /// seal must retain its capacity guard.
+    #[tokio::test]
+    async fn reap_sealed_room_forces_deposed_eviction_without_weakening_inactive_fence() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(NonCancelSafeReleaseStore::new());
+        let durable_store = Arc::new(RecordingDurableStore::default());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: SharedNodeIdentity::new(this_identity()),
+                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire clustering");
+
+        let inactive_jid = test_room_jid("inactive-seal-full-backlog");
+        let inactive_actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: inactive_jid.clone(),
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-inactive".to_string(),
+                config: RoomConfig {
+                    persistent: false,
+                    ..RoomConfig::default()
+                },
+            })
+            .await
+            .expect("create inactive target")
+            .actor_ref;
+        assert_eq!(
+            inactive_actor
+                .ask(crate::muc::room_actor::SealIfInactive {
+                    expected_occupancy_revision: 0,
+                    guard: crate::muc::room_actor::SealGuard::EmptyNonPersistent,
+                })
+                .await
+                .expect("seal inactive target"),
+            crate::muc::room_actor::SealIfInactiveOutcome::Inactive,
+        );
+
+        let deposed_jid = test_room_jid("deposed-seal-full-backlog");
+        let deposed_actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: deposed_jid.clone(),
+                waddle_id: "w-1".to_string(),
+                channel_id: "c-deposed".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create deposed target")
+            .actor_ref;
+        let deposed_entity = Entity::new(EntityType::RoomActor, deposed_jid.to_string());
+        let deposed_claim = claim_store
+            .inner
+            .current_claim(&deposed_entity)
+            .await
+            .expect("read deposed claim")
+            .expect("deposed room is initially claimed");
+        assert_eq!(
+            claim_store
+                .inner
+                .release_exact(
+                    &deposed_entity,
+                    &deposed_claim.owner,
+                    deposed_claim.claim_epoch,
+                )
+                .await
+                .expect("remove claim before the actor fence observes loss"),
+            crate::ownership::ExactReleaseOutcome::Released,
+        );
+
+        for index in 0..MAX_PENDING_ROOM_RELEASES {
+            let pending_jid = test_room_jid(&format!("sealed-reap-backlog-{index}"));
+            assert!(registry
+                .ask(RememberOrdinaryReleaseForTest {
+                    room_jid: pending_jid.clone(),
+                    claim_fence: room_claim_fence(&pending_jid, ClaimEpoch(index as i64)),
+                })
+                .await
+                .expect("fill exact-release backlog"));
+        }
+
+        assert!(!registry
+            .ask(ReapSealedRoom {
+                room_jid: inactive_jid.clone(),
+            })
+            .await
+            .expect("ordinary reaper remains fenced"));
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: inactive_jid,
+            })
+            .await
+            .expect("get inactive target")
+            .is_some());
+
+        durable_store.fence_lost.store(true, Ordering::SeqCst);
+        let join = deposed_actor
+            .ask(JoinWithAffiliation {
+                sender_jid: "alice@example.com/device".parse().expect("full JID"),
+                nick: "alice".to_string(),
+                affiliation_grant: JoinAffiliationGrant::Unaffiliated,
+                local_domain: "example.com".to_string(),
+                admission_revision: 0,
+            })
+            .await;
+        assert!(matches!(
+            join,
+            Err(SendError::HandlerError(
+                crate::muc::room_actor::RoomActorError::RoomSealed
+            ))
+        ));
+
+        assert!(registry
+            .ask(ReapSealedRoom {
+                room_jid: deposed_jid.clone(),
+            })
+            .await
+            .expect("deposed reaper bypasses backlog"));
+        deposed_actor.wait_for_shutdown().await;
+        assert!(!deposed_actor.is_alive());
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: deposed_jid.clone(),
+            })
+            .await
+            .expect("get deposed target")
+            .is_none());
+        assert!(durable_store.deleted_rooms.lock().expect("lock").is_empty());
+        assert_eq!(
+            claim_store.release_calls.load(Ordering::SeqCst),
+            0,
+            "definitive ownership loss must not issue a redundant, potentially late release"
+        );
+        assert!(
+            durable_store.current_claim_fence(&deposed_jid).is_none(),
+            "deposed eviction forgets only the local cached fence"
+        );
+        assert_eq!(
+            registry
+                .ask(GetPendingRoomReleaseBacklog)
+                .await
+                .expect("bounded backlog")
+                .depth,
+            MAX_PENDING_ROOM_RELEASES,
+            "deposed eviction must not grow a saturated release inventory"
+        );
+    }
+
+    #[tokio::test]
+    async fn reaping_an_identity_rotated_actor_releases_its_old_exact_claim() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let durable_store = Arc::new(RecordingDurableStore::default());
+        let identity = SharedNodeIdentity::new(this_identity());
+        registry
+            .ask(WireClusteringClaims {
+                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+                node_identity: identity.clone(),
+                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire clustering");
+        let room_jid = test_room_jid("identity-rotated-sealed-reap");
+        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        let actor = registry
+            .ask(GetOrCreateRoom {
+                room_jid: room_jid.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create room")
+            .actor_ref;
+
+        identity.rotate(foreign_identity()).await;
+        durable_store.fence_lost.store(true, Ordering::SeqCst);
+        assert!(matches!(
+            actor
+                .ask(JoinWithAffiliation {
+                    sender_jid: "alice@example.com/device".parse().expect("full JID"),
+                    nick: "alice".to_string(),
+                    affiliation_grant: JoinAffiliationGrant::Unaffiliated,
+                    local_domain: "example.com".to_string(),
+                    admission_revision: 0,
+                })
+                .await,
+            Err(SendError::HandlerError(
+                crate::muc::room_actor::RoomActorError::RoomSealed
+            ))
+        ));
+
+        assert!(registry
+            .ask(ReapSealedRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("reap identity-rotated actor"));
+        actor.wait_for_shutdown().await;
+        assert!(!actor.is_alive());
+        assert!(claim_store
+            .current_claim(&entity)
+            .await
+            .expect("old exact claim lookup")
+            .is_none());
+        assert!(durable_store.current_claim_fence(&room_jid).is_none());
+    }
 }
 
 /// gpt-5.5 review follow-up to #1108: when the registry's seal ask
@@ -4620,7 +5150,11 @@ async fn reap_sealed_room_purges_a_sealed_but_registered_actor() {
         })
         .await
         .expect("seal");
-    assert!(sealed, "fresh empty instant room must seal");
+    assert_eq!(
+        sealed,
+        crate::muc::room_actor::SealIfInactiveOutcome::Inactive,
+        "fresh empty instant room must seal"
+    );
 
     let reaped: bool = registry
         .ask(ReapSealedRoom {

--- a/server/crates/waddle-xmpp/src/prometheus.rs
+++ b/server/crates/waddle-xmpp/src/prometheus.rs
@@ -39,6 +39,13 @@ static DELIVERY_TERMINAL_ERROR_DROP: AtomicU64 = AtomicU64::new(0);
 // occupant roster may be stale until their next rejoin/resync.
 static DELIVERY_RETRY_EXHAUSTED_DROP: AtomicU64 = AtomicU64::new(0);
 
+// Rejected-join resolver-affiliation repairs dropped because the bounded
+// process-wide scheduler already had its maximum number of active worker
+// keys. A non-zero value means the authoritative join decision was still
+// enforced, but a live RoomActor may retain a stale resolver-derived
+// affiliation until a later repair or eviction.
+static RESOLVER_AFFILIATION_SYNC_CAPACITY_DROP: AtomicU64 = AtomicU64::new(0);
+
 // ADR-0017 Phase 1 Slice 2: empty `UserActor`s reaped by the periodic reaper
 // after `try_deliver`'s closed-channel eviction removed their last resource
 // without the explicit unregister-prune path running. A non-zero value is the
@@ -419,6 +426,15 @@ pub fn increment_delivery_retry_exhausted_drop() {
     DELIVERY_RETRY_EXHAUSTED_DROP.fetch_add(1, Ordering::Relaxed);
 }
 
+pub fn increment_resolver_affiliation_sync_capacity_drop() {
+    RESOLVER_AFFILIATION_SYNC_CAPACITY_DROP.fetch_add(1, Ordering::Relaxed);
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+pub fn resolver_affiliation_sync_capacity_drop_count() -> u64 {
+    RESOLVER_AFFILIATION_SYNC_CAPACITY_DROP.load(Ordering::Relaxed)
+}
+
 #[cfg(any(test, feature = "test-utils"))]
 pub fn delivery_retry_exhausted_drop_count() -> u64 {
     DELIVERY_RETRY_EXHAUSTED_DROP.load(Ordering::Relaxed)
@@ -620,6 +636,7 @@ pub fn reset_metrics_for_test() {
     BROADCAST_DROPPED_CLOSED.store(0, Ordering::Release);
     DELIVERY_TERMINAL_ERROR_DROP.store(0, Ordering::Release);
     DELIVERY_RETRY_EXHAUSTED_DROP.store(0, Ordering::Release);
+    RESOLVER_AFFILIATION_SYNC_CAPACITY_DROP.store(0, Ordering::Release);
     USER_ACTOR_REAPED.store(0, Ordering::Release);
     SM_UNACKED_EVICTED.store(0, Ordering::Release);
     PENDING_DELIVERY_QUOTA_EXCEEDED.store(0, Ordering::Release);
@@ -664,6 +681,8 @@ pub fn render_metrics() -> String {
     let broadcast_dropped_closed = BROADCAST_DROPPED_CLOSED.load(Ordering::Relaxed);
     let delivery_terminal_error_drop = DELIVERY_TERMINAL_ERROR_DROP.load(Ordering::Relaxed);
     let delivery_retry_exhausted_drop = DELIVERY_RETRY_EXHAUSTED_DROP.load(Ordering::Relaxed);
+    let resolver_affiliation_sync_capacity_drop =
+        RESOLVER_AFFILIATION_SYNC_CAPACITY_DROP.load(Ordering::Relaxed);
     let user_actor_reaped = USER_ACTOR_REAPED.load(Ordering::Relaxed);
     let sm_unacked_evicted = SM_UNACKED_EVICTED.load(Ordering::Relaxed);
     let pending_quota_exceeded = PENDING_DELIVERY_QUOTA_EXCEEDED.load(Ordering::Relaxed);
@@ -722,6 +741,9 @@ pub fn render_metrics() -> String {
             "# HELP waddle_delivery_retry_exhausted_drop_total Frames dropped because the recipient's outbound channel was STILL full after the bounded in-line DroppedFull retries (#1263) — groupchat reflections, MUC presence fan-out, and actor-path full-JID deliveries. A non-zero value means a live recipient missed a stanza under sustained backpressure.\n",
             "# TYPE waddle_delivery_retry_exhausted_drop_total counter\n",
             "waddle_delivery_retry_exhausted_drop_total {delivery_retry_exhausted_drop}\n",
+            "# HELP waddle_resolver_affiliation_sync_capacity_drop_total Rejected-join resolver-affiliation repairs dropped because the bounded scheduler had no free worker slot. The join decision remains authoritative, but the live room affiliation projection may stay stale until a later repair or eviction.\n",
+            "# TYPE waddle_resolver_affiliation_sync_capacity_drop_total counter\n",
+            "waddle_resolver_affiliation_sync_capacity_drop_total {resolver_affiliation_sync_capacity_drop}\n",
             "# HELP waddle_user_actor_reaped_total Empty UserActors reaped by the periodic reaper after delivery-path closed-channel eviction removed their last resource without the explicit unregister-prune path running.\n",
             "# TYPE waddle_user_actor_reaped_total counter\n",
             "waddle_user_actor_reaped_total {user_actor_reaped}\n",
@@ -806,6 +828,7 @@ pub fn render_metrics() -> String {
         broadcast_dropped_closed = broadcast_dropped_closed,
         delivery_terminal_error_drop = delivery_terminal_error_drop,
         delivery_retry_exhausted_drop = delivery_retry_exhausted_drop,
+        resolver_affiliation_sync_capacity_drop = resolver_affiliation_sync_capacity_drop,
         user_actor_reaped = user_actor_reaped,
         sm_unacked_evicted = sm_unacked_evicted,
         pending_quota_exceeded = pending_quota_exceeded,

--- a/server/crates/waddle-xmpp/tests/xep0045_room_ownership_actor.rs
+++ b/server/crates/waddle-xmpp/tests/xep0045_room_ownership_actor.rs
@@ -1,0 +1,232 @@
+//! XEP-0045 §7.2 admission fencing for a deposed room actor.
+//!
+//! A room incarnation whose durable ownership cannot be proven must not
+//! admit an occupant or apply resolver-derived affiliation state. Otherwise
+//! two owners could independently authorize the same XEP-0045 room.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
+
+use jid::BareJid;
+use kameo::actor::{ActorRef, Spawn};
+use kameo::error::SendError;
+use waddle_xmpp::muc::affiliation::AffiliationEntry;
+use waddle_xmpp::muc::durable::{DurableRoomState, MucDurableFuture, MucDurableStore};
+use waddle_xmpp::muc::room_actor::{
+    GetAffiliation, JoinAffiliationGrant, JoinWithAffiliation, OccupantCount,
+    ResolverAffiliationSyncOutcome, RestoreDurableRoomState, RoomActor, RoomActorError,
+    SyncResolverAffiliation,
+};
+use waddle_xmpp::muc::{MucRoom, RoomConfig, SubjectState};
+use waddle_xmpp::xep::xep0421::{OccupantIdSecret, OCCUPANT_ID_SECRET_MIN_BYTES};
+use waddle_xmpp::{Affiliation, XmppError};
+
+const OWNED: u8 = 0;
+const DEPOSED: u8 = 1;
+const UNCERTAIN: u8 = 2;
+
+struct OwnershipStore {
+    state: AtomicU8,
+}
+
+impl OwnershipStore {
+    fn new() -> Self {
+        Self {
+            state: AtomicU8::new(OWNED),
+        }
+    }
+
+    fn set(&self, state: u8) {
+        self.state.store(state, Ordering::SeqCst);
+    }
+}
+
+impl MucDurableStore for OwnershipStore {
+    fn load_room_state<'a>(
+        &'a self,
+        _room_jid: &'a BareJid,
+    ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+        Box::pin(async { Ok(None) })
+    }
+
+    fn save_config<'a>(
+        &'a self,
+        _room_jid: &'a BareJid,
+        _waddle_id: &'a str,
+        _channel_id: &'a str,
+        _config: &'a RoomConfig,
+    ) -> MucDurableFuture<'a, ()> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn save_subject<'a>(
+        &'a self,
+        _room_jid: &'a BareJid,
+        _subject: Option<&'a SubjectState>,
+    ) -> MucDurableFuture<'a, ()> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn save_affiliation<'a>(
+        &'a self,
+        _room_jid: &'a BareJid,
+        _entry: &'a AffiliationEntry,
+    ) -> MucDurableFuture<'a, ()> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn check_fenced_fanout<'a>(&'a self, _room_jid: &'a BareJid) -> MucDurableFuture<'a, bool> {
+        let state = self.state.load(Ordering::SeqCst);
+        Box::pin(async move {
+            match state {
+                OWNED => Ok(true),
+                DEPOSED => Ok(false),
+                UNCERTAIN => Err(XmppError::internal("ownership proof unavailable")),
+                _ => unreachable!("test ownership state"),
+            }
+        })
+    }
+}
+
+async fn spawn_fenced_room() -> (ActorRef<RoomActor>, Arc<OwnershipStore>) {
+    let room_jid = "ownership@muc.example.com".parse().expect("valid room JID");
+    let room = MucRoom::new(
+        room_jid,
+        "waddle-1".to_string(),
+        "channel-1".to_string(),
+        RoomConfig::default(),
+    );
+    let secret = OccupantIdSecret::new(vec![7; OCCUPANT_ID_SECRET_MIN_BYTES])
+        .expect("valid occupant-id secret");
+    let actor = RoomActor::spawn(RoomActor::new(room, secret));
+    let store = Arc::new(OwnershipStore::new());
+    actor
+        .ask(RestoreDurableRoomState {
+            store: Arc::clone(&store) as Arc<dyn MucDurableStore>,
+        })
+        .await
+        .expect("install durable ownership store");
+    (actor, store)
+}
+
+fn resolver_join() -> JoinWithAffiliation {
+    JoinWithAffiliation {
+        sender_jid: "member@example.com/web".parse().expect("full JID"),
+        nick: "member".to_string(),
+        affiliation_grant: JoinAffiliationGrant::Resolver(Affiliation::Member),
+        local_domain: "example.com".to_string(),
+        admission_revision: 0,
+    }
+}
+
+fn creator_join() -> JoinWithAffiliation {
+    JoinWithAffiliation {
+        sender_jid: "creator@example.com/web".parse().expect("full JID"),
+        nick: "creator".to_string(),
+        affiliation_grant: JoinAffiliationGrant::CreatorOwner,
+        local_domain: "example.com".to_string(),
+        admission_revision: 0,
+    }
+}
+
+#[tokio::test]
+async fn deposed_room_refuses_xep0045_resolver_join() {
+    let (actor, store) = spawn_fenced_room().await;
+    store.set(DEPOSED);
+
+    assert!(matches!(
+        actor.ask(resolver_join()).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert_eq!(actor.ask(OccupantCount).await.expect("occupant count"), 0);
+}
+
+#[tokio::test]
+async fn uncertain_room_refuses_xep0045_resolver_join() {
+    let (actor, store) = spawn_fenced_room().await;
+    store.set(UNCERTAIN);
+
+    assert!(matches!(
+        actor.ask(resolver_join()).await,
+        Err(SendError::HandlerError(
+            RoomActorError::OwnershipUnavailable
+        ))
+    ));
+    assert_eq!(actor.ask(OccupantCount).await.expect("occupant count"), 0);
+}
+
+#[tokio::test]
+async fn deposed_room_refuses_xep0045_creator_join() {
+    let (actor, store) = spawn_fenced_room().await;
+    store.set(DEPOSED);
+
+    assert!(matches!(
+        actor.ask(creator_join()).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+}
+
+#[tokio::test]
+async fn uncertain_room_refuses_xep0045_creator_join() {
+    let (actor, store) = spawn_fenced_room().await;
+    store.set(UNCERTAIN);
+
+    assert!(matches!(
+        actor.ask(creator_join()).await,
+        Err(SendError::HandlerError(
+            RoomActorError::OwnershipUnavailable
+        ))
+    ));
+}
+
+#[tokio::test]
+async fn deposed_room_refuses_resolver_affiliation_sync() {
+    let (actor, store) = spawn_fenced_room().await;
+    store.set(DEPOSED);
+    let jid: BareJid = "member@example.com".parse().expect("bare JID");
+
+    assert_eq!(
+        actor
+            .ask(SyncResolverAffiliation {
+                jid: jid.clone(),
+                affiliation: Affiliation::Member,
+                expected_admission_revision: 0,
+            })
+            .await
+            .expect("sync outcome"),
+        ResolverAffiliationSyncOutcome::RoomSealed,
+    );
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid })
+            .await
+            .expect("affiliation"),
+        Affiliation::None,
+    );
+}
+
+#[tokio::test]
+async fn uncertain_room_returns_typed_resolver_sync_outcome() {
+    let (actor, store) = spawn_fenced_room().await;
+    store.set(UNCERTAIN);
+    let jid: BareJid = "member@example.com".parse().expect("bare JID");
+
+    assert_eq!(
+        actor
+            .ask(SyncResolverAffiliation {
+                jid: jid.clone(),
+                affiliation: Affiliation::Member,
+                expected_admission_revision: 0,
+            })
+            .await
+            .expect("sync outcome"),
+        ResolverAffiliationSyncOutcome::OwnershipUnavailable,
+    );
+    assert_eq!(
+        actor
+            .ask(GetAffiliation { jid })
+            .await
+            .expect("affiliation"),
+        Affiliation::None,
+    );
+}

--- a/server/crates/waddle-xmpp/tests/xep0045_room_ownership_actor.rs
+++ b/server/crates/waddle-xmpp/tests/xep0045_room_ownership_actor.rs
@@ -13,13 +13,13 @@ use kameo::error::SendError;
 use waddle_xmpp::muc::affiliation::AffiliationEntry;
 use waddle_xmpp::muc::durable::{DurableRoomState, MucDurableFuture, MucDurableStore};
 use waddle_xmpp::muc::room_actor::{
-    GetAffiliation, JoinAffiliationGrant, JoinWithAffiliation, OccupantCount,
+    GetAffiliation, Join, JoinAffiliationGrant, JoinWithAffiliation, OccupantCount,
     ResolverAffiliationSyncOutcome, RestoreDurableRoomState, RoomActor, RoomActorError,
     SyncResolverAffiliation,
 };
 use waddle_xmpp::muc::{MucRoom, RoomConfig, SubjectState};
 use waddle_xmpp::xep::xep0421::{OccupantIdSecret, OCCUPANT_ID_SECRET_MIN_BYTES};
-use waddle_xmpp::{Affiliation, XmppError};
+use waddle_xmpp::{Affiliation, Role, XmppError};
 
 const OWNED: u8 = 0;
 const DEPOSED: u8 = 1;
@@ -129,6 +129,15 @@ fn creator_join() -> JoinWithAffiliation {
     }
 }
 
+fn legacy_join() -> Join {
+    Join {
+        real_jid: "legacy@example.com/web".parse().expect("full JID"),
+        nick: "legacy".to_string(),
+        role: Role::Participant,
+        affiliation: Affiliation::Member,
+    }
+}
+
 #[tokio::test]
 async fn deposed_room_refuses_xep0045_resolver_join() {
     let (actor, store) = spawn_fenced_room().await;
@@ -177,6 +186,32 @@ async fn uncertain_room_refuses_xep0045_creator_join() {
             RoomActorError::OwnershipUnavailable
         ))
     ));
+}
+
+#[tokio::test]
+async fn deposed_room_refuses_legacy_xep0045_join() {
+    let (actor, store) = spawn_fenced_room().await;
+    store.set(DEPOSED);
+
+    assert!(matches!(
+        actor.ask(legacy_join()).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert_eq!(actor.ask(OccupantCount).await.expect("occupant count"), 0);
+}
+
+#[tokio::test]
+async fn uncertain_room_refuses_legacy_xep0045_join() {
+    let (actor, store) = spawn_fenced_room().await;
+    store.set(UNCERTAIN);
+
+    assert!(matches!(
+        actor.ask(legacy_join()).await,
+        Err(SendError::HandlerError(
+            RoomActorError::OwnershipUnavailable
+        ))
+    ));
+    assert_eq!(actor.ask(OccupantCount).await.expect("occupant count"), 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fence MUC room recovery and admission against stale/deposed actor incarnations, then serialize rejected-join resolver repair so transient ownership failures cannot create unbounded, stale, out-of-order, or cross-occupant-invalidated background work.

This is a prerequisite for draft PR #1343. The durable destroy state machine and MAM epoch remain in draft PR #1306.

## What changed

- Demand acquisition blocks on same-room reclaimed reservations and converges exact-release responsibility under one 250 ms budget.
- Reclaimed generations replace and rehydrate actors instead of adopting live old-fence memory.
- Delayed or duplicate reclaimed reconciliation cannot republish an exact fence while a non-cancel-safe release remains pending; publication fails closed and retains bounded retry responsibility.
- Creator, unaffiliated, resolver-derived, and legacy joins prove durable ownership before admission.
- Ownership-loss seals are monotonic and deposed actors are hard-killed even when ordinary release inventory is saturated.
- Pre-acquire reconciliation deferrals use a typed retryable error; backend ownership failures remain internal errors.
- Stale-owner steal conflicts are re-read and classified as remote ownership only when a fresh foreign owner is actually proven.
- Rejected-join resolver repair uses a bounded latest-wins scheduler: 128 active actor-incarnation/member keys and 128 bounded recent completion chains.
- Lower admission revisions cannot overwrite a newer queued verdict or start a worker after a newer completion is retained; equal-revision conflicting verdicts remain intentional latest-arrival-wins.
- Exact admission revisions survive safe worker handoffs, transient retries, and worker closure; every adopted queued verdict receives its own full bounded retry budget.
- Admission freshness uses room-wide and per-bare-JID watermarks: another occupant's join no longer strands a repair, while same-user re-admission still rejects stale work.
- Per-JID watermark storage is capped at 128 entries; overflow conservatively promotes the current sequence into a room-wide fence before compaction.
- Room policy reconciliation and successful inline durable-state recovery advance the room-wide fence, forcing joins and repairs to re-snapshot recovered policy.
- A rejected-join repair that proves ownership loss atomically discards obsolete queued work, releases scheduler capacity, and asks the registry to reap the sealed actor.
- Scheduler capacity drops are exported as `waddle_resolver_affiliation_sync_capacity_drop_total`.

## Correctness invariants

- A room generation is never published while a destructive exact release for that same fence can still commit.
- Memory created under an old fence is never authoritative under a new generation.
- Lost ownership permanently seals that actor incarnation; later transient checks cannot reopen mutation.
- Only confirmed fresh foreign ownership enters remote-owner routing.
- At most one resolver repair worker exists per `(room, member, actor incarnation)`, with a process-wide bound.
- A lower source revision never replaces a higher queued repair or consumes capacity while a newer completion is retained; later same-revision verdicts still win.
- Each distinct queued verdict receives attempts 1 through `RESOLVER_SYNC_MAX_ATTEMPTS`; only failed attempts enter retry backoff.
- A member-scoped mutation fences stale work for that bare JID without invalidating unrelated occupants; room-wide policy changes fence every older snapshot.
- Watermark compaction never accepts discarded stale work: it may conservatively require unrelated work to retry, but retained memory stays bounded.
- A sealed actor's repair key releases global capacity before registry cleanup; the old worker cannot delete a newly scheduled same-key worker.
- XMPP ownership reconciliation remains retryable via wait-class `<resource-constraint/>`; no custom namespace or non-XMPP control API is introduced.

## Review feedback resolved

- Unbounded detached resolver-sync retry tasks.
- Deposed actors blocked behind a full exact-release backlog.
- Pre-acquire ownership deferrals returned as internal errors.
- Legacy join fence bypass and lost-fence actors left registered.
- Sequential convergence exceeding registry ask budgets.
- Transient resolver repair drops, close-boundary races, retry-exhaustion rebasing, out-of-order completion-chain loss, and chained retry-budget loss.
- Lower-revision resolver work replacing a newer queued verdict or consuming capacity after a newer retained completion.
- Delayed reclaimed reconciliation republishing a fence with a late exact delete in flight.
- Stale-owner CAS conflicts misclassified as live remote ownership.
- Invisible bounded-scheduler saturation.
- Room-global admission revisions invalidating another occupant's pending repair.
- Unbounded historical per-JID watermark retention.
- Config reconciliation and inline durable recovery failing to invalidate pre-policy snapshots.
- Rejected joins leaving a deposed actor registered, and registry reaping retaining scarce scheduler capacity.

## Verification on final diff `6ebca6b5`

- `cargo fmt --all -- --check` and `git diff --check`: passed.
- Strict `cargo clippy -p waddle-xmpp -p waddle-server --all-targets --all-features -- -D warnings`: passed.
- Room-actor focused suite: 152 passed.
- Resolver repair worker suite: 15 passed; terminal-close capacity and ownership-loss registry-reap regressions passed.
- Full `cargo test -p waddle-xmpp --all-features`: 2,599 library tests plus all integration, custom XEP, and doc targets passed before the final narrow server-only follow-up.
- Full `cargo test -p waddle-server --all-features`: 1,925 library tests plus all binary, integration, and doc targets passed before the final narrow server-only follow-up.
- Three exact-diff adversarial personas covering seal/ownership, revision tracking, scheduler capacity, and XEP-visible races: clean after every actionable finding was fixed.
- XEP-0045 reviewed; the change adds no wire shape or namespace and preserves wait-class retry behavior.
- Exact-head GitHub CI: all 21 checks passed or skipped as expected, including `nixTest`, `nixXmppServerTests`, `nixXmppXepIntegration`, strict clippy, fmt, and CodeQL.
- Qodo, Greptile, and Codex reviewed exact head `6ebca6b5`: clean; 0 unresolved review threads.

## Scope boundary

- No mediated-invite journal schema change.
- No durable room-destroy coordinator or MAM epoch change; those remain in #1306.
- No new XMPP namespace or out-of-band control API.

## Merge gate

Satisfied on exact head `6ebca6b5`: full CI is green, Qodo/Greptile/Codex are clean, and every actionable review thread is resolved.
