### PR TITLE
feat(server): rustls websocket TLS + Android toolchain enablement for the upcoming Android app

### DIFF
--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
@@ -509,7 +509,11 @@ fileprivate struct FfiConverterString: FfiConverter {
             return String()
         }
         let bytes = UnsafeBufferPointer<UInt8>(start: value.data!, count: Int(value.len))
-        return String(bytes: bytes, encoding: String.Encoding.utf8)!
+        // Use Swift's native UTF-8 decoder; `String(bytes:encoding:.utf8)` goes
+        // through Foundation's NSString and silently strips a leading U+FEFF BOM.
+        // Invalid UTF-8 substitutes U+FFFD instead of trapping (unreachable
+        // given Rust's `String` invariant).
+        return String(decoding: bytes, as: UTF8.self)
     }
 
     public static func lower(_ value: String) -> RustBuffer {
@@ -525,7 +529,8 @@ fileprivate struct FfiConverterString: FfiConverter {
 
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> String {
         let len: Int32 = try readInt(&buf)
-        return String(bytes: try readBytes(&buf, count: Int(len)), encoding: String.Encoding.utf8)!
+        // See `lift` above for why we avoid Foundation's NSString-backed decoder here.
+        return String(decoding: try readBytes(&buf, count: Int(len)), as: UTF8.self)
     }
 
     public static func write(_ value: String, into buf: inout [UInt8]) {
@@ -4550,7 +4555,11 @@ fileprivate struct UniffiCallbackInterfaceWaddleEventListener {
 
     // Rust stores this pointer for future callback invocations, so it must live
     // for the process lifetime (not just for the init function call).
-    static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceWaddleEventListener> = {
+    //
+    // `nonisolated(unsafe)` is needed under Swift 6 strict concurrency.
+    // This is safe because the pointee is initialized once during static init
+    // and never mutated by either side of the FFI.  Its fields are C function pointers.
+    nonisolated(unsafe) static let vtablePtr: UnsafePointer<UniffiVTableCallbackInterfaceWaddleEventListener> = {
         let ptr = UnsafeMutablePointer<UniffiVTableCallbackInterfaceWaddleEventListener>.allocate(capacity: 1)
         ptr.initialize(to: vtable)
         return UnsafePointer(ptr)

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -135,7 +135,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -146,7 +146,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1093,7 +1093,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2070,7 +2070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2924,7 +2924,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4262,7 +4262,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5242,7 +5242,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5281,7 +5281,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -5742,7 +5742,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5849,7 +5849,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6337,7 +6337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6706,10 +6706,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6930,9 +6930,13 @@ dependencies = [
  "futures-util",
  "log",
  "native-tls",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -7292,6 +7296,8 @@ dependencies = [
  "log",
  "native-tls",
  "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
  "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
@@ -7379,9 +7385,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uniffi"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5f2297ee5b893405bed1a6929faec4713a061df158ecf5198089f23910d470"
+checksum = "46eefd5468602930da46b1f49d3448c6dfc2e81295f93120f23f8174fd70267f"
 dependencies = [
  "anyhow",
  "camino",
@@ -7396,9 +7402,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc0c60a9607e7ab77a2ad47ec5530178015014839db25af7512447d2238016c"
+checksum = "c4a0c9b375d32e1365cdb2bdd7cb495eecf6fac851ddbad077412b4ee1888514"
 dependencies = [
  "anyhow",
  "askama",
@@ -7422,9 +7428,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c39413c43b955e4aa8a4e2b34bbd1b6b5ff6bd85532b52f9eb92fbe88c14458"
+checksum = "744fe15bcd3e2b1712a4573a45ce749af19cf28d69027ca5789619014955668c"
 dependencies = [
  "anyhow",
  "camino",
@@ -7433,9 +7439,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77baf5d539fe2e1ad6805e942dbc5dbdeb2b83eb5f2b3a6535d422ca4b02a12f"
+checksum = "eec017b112701681f6fbbe5d92014b5c468eb0b177a94389de03ceec40665095"
 dependencies = [
  "anyhow",
  "async-compat",
@@ -7446,9 +7452,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_internal_macros"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b42137524f4be6400fcaca9d02c1d4ecb6ad917e4013c0b93235526d8396e5"
+checksum = "4641669b48fefbc5e80ff08c5004d9c7617fb91232131a6734ab6712779cb04c"
 dependencies = [
  "anyhow",
  "indexmap 2.14.0",
@@ -7459,9 +7465,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9273ec45330d8fe9a3701b7b983cea7a4e218503359831967cb95d26b873561"
+checksum = "eeb8617ee814de22caf7417bf514715ba0b3f46bd9d5a5d794413fd8282cb737"
 dependencies = [
  "camino",
  "fs-err",
@@ -7476,9 +7482,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "431d2f443e7828a6c29d188de98b6771a6491ee98bba2d4372643bf93f988a18"
+checksum = "58d5b94fc92803d21b2928bd15c6f06e57609b95caf98ea561c99cda1b6d2a25"
 dependencies = [
  "anyhow",
  "siphasher",
@@ -7488,9 +7494,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_pipeline"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761ef74f6175e15603d0424cc5f98854c5baccfe7bf4ccb08e5816f9ab8af689"
+checksum = "032739b3ec725576914c15899dedaf080163ced86b6934566c20ec2b20ce90ca"
 dependencies = [
  "anyhow",
  "heck",
@@ -7501,9 +7507,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.31.1"
+version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68773ec0e1c067b6505a73bbf6a5782f31a7f9209333a0df97b87565c46bf370"
+checksum = "fc0a1d0a0252ce1af9e8ce78ba67ac0d8937fb2bedaf10cbddd43d3614d06ec6"
 dependencies = [
  "anyhow",
  "textwrap",
@@ -7831,11 +7837,13 @@ dependencies = [
  "jid",
  "js-sys",
  "minidom",
- "reqwest 0.13.3",
+ "rcgen",
+ "rustls",
  "serde",
  "sha1 0.11.0",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tokio-tungstenite",
  "tracing",
  "url",
@@ -7844,6 +7852,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 0.26.11",
  "xmpp-parsers",
 ]
 
@@ -8640,7 +8649,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/server/crates/waddle-server/tests/admin_users_list_command_ws.rs
+++ b/server/crates/waddle-server/tests/admin_users_list_command_ws.rs
@@ -257,12 +257,13 @@ async fn pagination_cursor_round_trips() {
 /// enough for the test surface; if the response shape ever changes
 /// this will break loudly.
 fn extract_cursor(frame: &str) -> Option<String> {
-    let needle = if let Some(idx) = frame.find(r#"var='next_cursor'"#) {
-        idx + r#"var='next_cursor'"#.len()
-    } else if let Some(idx) = frame.find(r#"var='next_cursor'"#) {
-        idx + r#"var='next_cursor'"#.len()
+    const DOUBLE_QUOTED: &str = r#"var="next_cursor""#;
+    const SINGLE_QUOTED: &str = r#"var='next_cursor'"#;
+    let needle = if let Some(idx) = frame.find(DOUBLE_QUOTED) {
+        idx + DOUBLE_QUOTED.len()
     } else {
-        return None;
+        let idx = frame.find(SINGLE_QUOTED)?;
+        idx + SINGLE_QUOTED.len()
     };
     let rest = &frame[needle..];
     let open = rest.find("<value>")?;

--- a/server/crates/waddle-xmpp-client-ffi/uniffi.toml
+++ b/server/crates/waddle-xmpp-client-ffi/uniffi.toml
@@ -1,0 +1,4 @@
+[bindings.kotlin]
+package_name = "social.waddle.client.ffi"
+android = true
+android_cleaner = true

--- a/server/crates/waddle-xmpp-client/Cargo.toml
+++ b/server/crates/waddle-xmpp-client/Cargo.toml
@@ -9,7 +9,13 @@ description = "Native XMPP client scaffold for Waddle"
 
 [features]
 default = ["native"]
-native = ["dep:futures", "dep:reqwest", "dep:tokio", "dep:tokio-tungstenite"]
+native = [
+    "dep:futures",
+    "dep:tokio",
+    "dep:tokio-tungstenite",
+    "dep:rustls",
+    "dep:webpki-roots",
+]
 wasm = ["dep:futures", "dep:getrandom", "dep:js-sys", "dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:web-sys"]
 
 [dependencies]
@@ -33,6 +39,33 @@ waddle-xmpp-core = { path = "../waddle-xmpp-core" }
 xmpp-parsers = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-reqwest = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
-tokio-tungstenite = { workspace = true, optional = true }
+# Deliberately NOT the workspace dependency: the workspace pins the
+# `native-tls` feature (OpenSSL on Android, Security.framework on Apple),
+# which cannot be cross-compiled for the Android NDK without vendoring
+# OpenSSL. The client uses rustls with bundled webpki roots on every
+# native platform instead; `transport/native.rs` passes an explicit
+# `Connector::Rustls` so whole-workspace feature unification with
+# `native-tls` consumers can never silently select the wrong TLS stack.
+tokio-tungstenite = { version = "0.29", default-features = false, features = [
+    "connect",
+    "handshake",
+    "rustls-tls-webpki-roots",
+], optional = true }
+# `default-features = false` keeps rustls' default `aws-lc-rs` provider
+# (cmake/bindgen requirements in NDK cross-builds) out of the graph; the
+# transport constructs its config with the `ring` provider explicitly.
+rustls = { version = "0.23", default-features = false, features = [
+    "ring",
+    "std",
+    "tls12",
+    "logging",
+], optional = true }
+webpki-roots = { version = "0.26", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+# Test-only TLS server pieces for the certificate-rejection transport test.
+# Both pin `ring` explicitly so dev builds never pull rustls' default
+# `aws-lc-rs` provider into the workspace graph.
+rcgen = { version = "0.13", default-features = false, features = ["crypto", "ring"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }

--- a/server/crates/waddle-xmpp-client/src/error.rs
+++ b/server/crates/waddle-xmpp-client/src/error.rs
@@ -63,6 +63,9 @@ pub enum ClientError {
     #[error("websocket transport failed")]
     #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
     WebSocket(#[source] Box<tokio_tungstenite::tungstenite::Error>),
+    #[error("websocket TLS configuration could not be built")]
+    #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
+    WebSocketTlsConfig(#[source] rustls::Error),
     #[error("websocket transport received an empty XMPP frame")]
     EmptyTransportFrame,
     #[error("websocket transport frame exceeds the maximum size of {max} bytes")]

--- a/server/crates/waddle-xmpp-client/src/transport/native.rs
+++ b/server/crates/waddle-xmpp-client/src/transport/native.rs
@@ -2,12 +2,15 @@ use futures::future::BoxFuture;
 use futures::stream::{SplitSink, SplitStream};
 use futures::{SinkExt, StreamExt};
 use std::collections::VecDeque;
+use std::sync::Arc;
 use tokio::net::TcpStream;
 use tokio::time::timeout;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
 use tokio_tungstenite::tungstenite::http::Request;
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
+use tokio_tungstenite::{
+    connect_async_tls_with_config, Connector, MaybeTlsStream, WebSocketStream,
+};
 
 use crate::config::ClientConfig;
 use crate::error::{ClientError, ClientResult};
@@ -55,12 +58,16 @@ impl WebSocketTransportFactory for DefaultTransportFactory {
     ) -> BoxFuture<'a, ClientResult<Box<dyn WebSocketTransport>>> {
         Box::pin(async move {
             let request = websocket_request(config)?;
+            let connector = rustls_connector()?;
             let connect_timeout = config.transport.connect_timeout;
-            let (socket, _) = timeout(connect_timeout, connect_async(request))
-                .await
-                .map_err(|_| ClientError::WebSocketConnectTimeout {
-                    timeout: connect_timeout,
-                })??;
+            let (socket, _) = timeout(
+                connect_timeout,
+                connect_async_tls_with_config(request, None, false, Some(connector)),
+            )
+            .await
+            .map_err(|_| ClientError::WebSocketConnectTimeout {
+                timeout: connect_timeout,
+            })??;
 
             Ok(Box::new(ConnectedWebSocketTransport::new(socket)) as Box<dyn WebSocketTransport>)
         })
@@ -201,6 +208,28 @@ impl WebSocketTransport for ConnectedWebSocketTransport {
             Ok(())
         })
     }
+}
+
+/// Builds the TLS connector for `wss://` endpoints (ignored for `ws://`).
+///
+/// The connector is always rustls with the bundled webpki (Mozilla) roots and
+/// the `ring` crypto provider. Passing it explicitly — instead of relying on
+/// tokio-tungstenite's auto-connector — is load-bearing: in whole-workspace
+/// builds cargo unions our rustls features with the `native-tls` feature other
+/// workspace members enable, and the auto-connector would then prefer
+/// native-tls, silently diverging from the Android/iOS builds.
+pub(super) fn rustls_connector() -> ClientResult<Connector> {
+    let mut roots = rustls::RootCertStore::empty();
+    roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let config = rustls::ClientConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .map_err(ClientError::WebSocketTlsConfig)?
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+    Ok(Connector::Rustls(Arc::new(config)))
 }
 
 fn websocket_request(config: &ClientConfig) -> ClientResult<Request<()>> {

--- a/server/crates/waddle-xmpp-client/src/transport/native.rs
+++ b/server/crates/waddle-xmpp-client/src/transport/native.rs
@@ -2,7 +2,7 @@ use futures::future::BoxFuture;
 use futures::stream::{SplitSink, SplitStream};
 use futures::{SinkExt, StreamExt};
 use std::collections::VecDeque;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use tokio::net::TcpStream;
 use tokio::time::timeout;
 use tokio_tungstenite::tungstenite::handshake::client::generate_key;
@@ -218,18 +218,32 @@ impl WebSocketTransport for ConnectedWebSocketTransport {
 /// builds cargo unions our rustls features with the `native-tls` feature other
 /// workspace members enable, and the auto-connector would then prefer
 /// native-tls, silently diverging from the Android/iOS builds.
+///
+/// The config is process-cached: parsing the ~150 webpki roots on every
+/// reconnect is wasted work on mobile, where reconnects are frequent. Two
+/// racing first callers may build it twice; `get_or_init` keeps one.
 pub(super) fn rustls_connector() -> ClientResult<Connector> {
+    static TLS_CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+
+    if let Some(config) = TLS_CONFIG.get() {
+        return Ok(Connector::Rustls(Arc::clone(config)));
+    }
+
     let mut roots = rustls::RootCertStore::empty();
     roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
 
     let provider = Arc::new(rustls::crypto::ring::default_provider());
-    let config = rustls::ClientConfig::builder_with_provider(provider)
-        .with_safe_default_protocol_versions()
-        .map_err(ClientError::WebSocketTlsConfig)?
-        .with_root_certificates(roots)
-        .with_no_client_auth();
+    let config = Arc::new(
+        rustls::ClientConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .map_err(ClientError::WebSocketTlsConfig)?
+            .with_root_certificates(roots)
+            .with_no_client_auth(),
+    );
 
-    Ok(Connector::Rustls(Arc::new(config)))
+    Ok(Connector::Rustls(Arc::clone(
+        TLS_CONFIG.get_or_init(|| config),
+    )))
 }
 
 fn websocket_request(config: &ClientConfig) -> ClientResult<Request<()>> {

--- a/server/crates/waddle-xmpp-client/src/transport/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/transport/tests.rs
@@ -249,3 +249,62 @@ async fn concrete_transport_connects_and_emits_typed_frames() {
 
     server.await.unwrap();
 }
+
+#[cfg(all(feature = "native", not(target_arch = "wasm32")))]
+#[test]
+fn transport_pins_the_rustls_connector() {
+    use tokio_tungstenite::Connector;
+
+    // Guards against regressing to tokio-tungstenite's auto-connector: with
+    // whole-workspace feature unification the auto-connector would prefer
+    // `native-tls` (OpenSSL on Android) whenever another workspace member
+    // enables it.
+    let connector = super::native::rustls_connector().unwrap();
+    assert!(matches!(connector, Connector::Rustls(_)));
+}
+
+#[cfg(all(feature = "native", not(target_arch = "wasm32")))]
+#[tokio::test(flavor = "current_thread")]
+async fn concrete_transport_rejects_self_signed_tls_certificates() {
+    use std::sync::Arc;
+    use tokio_rustls::TlsAcceptor;
+
+    let certified = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+    let cert_der = certified.cert.der().clone();
+    let key_der = rustls::pki_types::PrivateKeyDer::from(
+        rustls::pki_types::PrivatePkcs8KeyDer::from(certified.key_pair.serialize_der()),
+    );
+
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let server_config = rustls::ServerConfig::builder_with_provider(provider)
+        .with_safe_default_protocol_versions()
+        .unwrap()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert_der], key_der)
+        .unwrap();
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let acceptor = TlsAcceptor::from(Arc::new(server_config));
+
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.unwrap();
+        // The TLS handshake must fail: the client rejects the untrusted
+        // self-signed certificate against its bundled webpki roots.
+        assert!(acceptor.accept(stream).await.is_err());
+    });
+
+    let mut live_config = config();
+    live_config.transport = WebSocketConfig::new(
+        Url::parse(&format!("wss://localhost:{}/xmpp", address.port())).unwrap(),
+    )
+    .unwrap();
+
+    let error = match DefaultTransportFactory.connect(&live_config).await {
+        Err(error) => error,
+        Ok(_) => panic!("expected certificate verification to fail"),
+    };
+    assert!(matches!(error, ClientError::WebSocket(_)));
+
+    server.await.unwrap();
+}

--- a/server/rust-toolchain.toml
+++ b/server/rust-toolchain.toml
@@ -2,4 +2,9 @@
 channel = "stable"
 profile = "minimal"
 components = ["rustfmt", "clippy"]
-targets = ["wasm32-wasip2", "wasm32-unknown-unknown"]
+targets = [
+    "wasm32-wasip2",
+    "wasm32-unknown-unknown",
+    "aarch64-linux-android",
+    "x86_64-linux-android",
+]


### PR DESCRIPTION
PR-1 of the Android app program ([full plan](#plan) below): unblock Android builds of the shared Rust XMPP client and stage the toolchain for `apps/android`.

## What

- **rustls switch for the native websocket transport.** `waddle-xmpp-client` no longer inherits the workspace `tokio-tungstenite` (pinned to `native-tls` → OpenSSL on Android, unbuildable for the NDK without vendoring). It now declares its own dep with `rustls-tls-webpki-roots`, and `transport/native.rs` passes an **explicit `Connector::Rustls`** (ring provider + bundled webpki roots). The explicit connector is load-bearing: whole-workspace builds union our rustls features with other members' `native-tls`, and tokio-tungstenite's auto-connector would silently prefer native-tls on hosts.
  - Root store: webpki (Mozilla) bundled roots — waddle servers use public ACME certs; deterministic across Android/iOS/macOS/Linux, no Android `Context`/JNI init.
  - Crypto provider: ring — keeps `aws-lc-rs` (cmake/bindgen in NDK cross-builds) out of the graph. Verified: `cargo tree -p waddle-xmpp-client-ffi --target aarch64-linux-android` contains no `aws-lc`, `openssl`, or `native-tls`.
  - Apple builds move from Security.framework to the same rustls stack (public-CA validation unchanged; one TLS stack across all native platforms).
- **Android toolchain enablement**: `rust-toolchain.toml` gains `aarch64-linux-android` + `x86_64-linux-android` (flows into the nix flake toolchain automatically); new `waddle-xmpp-client-ffi/uniffi.toml` with the Kotlin bindings config (`social.waddle.client.ffi`, `android = true`) — Swift output untouched.
- **uniffi 0.31.1 → 0.31.2** (fixes an Android JNA signedness bug, mozilla/uniffi-rs#2897). Regenerated Swift bindings committed; `scripts/check-xmpp-client-ffi-bindings.sh` passes.
- Dropped the declared-but-unused optional `reqwest` dependency from `waddle-xmpp-client`.
- Drive-by: `extract_cursor` in `admin_users_list_command_ws.rs` had two identical single-quoted branches; the first now matches the double-quoted form the doc comment promised (also satisfies clippy 1.97's expanded `question_mark` lint).

## Tests

- New `transport_pins_the_rustls_connector` — guards against regressing to the auto-connector.
- New `concrete_transport_rejects_self_signed_tls_certificates` — real TLS listener with an rcgen self-signed cert; the client must reject it against the bundled webpki roots (proves rustls verification is active).
- Existing `concrete_transport_connects_and_emits_typed_frames` now exercises the `ws://` passthrough through the new connector path.
- `cargo fmt --check` ✓, `cargo clippy --all-targets --all-features -- -D warnings` ✓, `cargo test --workspace --all-targets --locked` ✓ except `notification_outbox::suppression::t1_xep0492_never_records_typed_suppressed_reason`, which is a **pre-existing flake** (fails identically on unmodified `main` when the suite runs in parallel, passes in isolation — metrics-registry test interference, untouched by this PR).
- wasm crate still builds (`cargo check -p waddle-xmpp-client-wasm --target wasm32-unknown-unknown`) ✓.

## Plan

This is PR-1 of the 3-track Android plan:
1. **PR-1 (this)**: rustls + Android targets + uniffi.toml + uniffi 0.31.2.
2. PR-2: migrate `WaddleEventListener` to a single `on_event(WaddleClientEvent)` enum callback + record parity (reactions/edits/moderation/chat-states/markers/markup/mentions/carbons/presence extras) + XEP-0198 resume plumbing (`WaddleSmResumeState` + `WaddleConfig.resume_state`), with the Apple `_EventListener` updated in the same PR.
3. Android app PR: greenfield `apps/android` (Kotlin, Compose, Navigation 3, Hilt, cuenv CI, CLI-only) consuming the UniFFI client via cargo-ndk + committed Kotlin bindings, milestones M0 (on-device uniffi spike) → M5 (LiveKit calls) as commit boundaries.
4. FFI-parity PRs land as the app milestones need them (each with its dedicated XEP test suite, Apple kept green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
