### PR TITLE
test(server): prove stanza timeout metric export

### DIFF
--- a/server/crates/waddle-server/Cargo.toml
+++ b/server/crates/waddle-server/Cargo.toml
@@ -131,6 +131,7 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 # A separate library crate so per-test-binary `dead_code` lints cannot
 # fire on helpers a given binary does not use.
 waddle-ws-test-support = { path = "../waddle-ws-test-support" }
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 tokio-test = "0.4"
 wiremock = "0.6"
 # `image` is already a regular dependency; integration tests reach

--- a/server/crates/waddle-server/tests/stanza_handler_timeout_metrics.rs
+++ b/server/crates/waddle-server/tests/stanza_handler_timeout_metrics.rs
@@ -1,9 +1,9 @@
 //! Export contract for the stanza-handler wedge-backstop metric.
 //!
-//! The frame-backstop tests prove that an elapsed IQ/message/presence dispatch
-//! calls `record_stanza_handler_timeout`. This test pins what that production
-//! helper hands to the OpenTelemetry SDK before the OTLP collector translates
-//! the instrument into a Prometheus series.
+//! A narrow source-contract regression pins the timeout arm to the production
+//! `record_stanza_handler_timeout` helper. The exporter regression then pins
+//! what that helper hands to the OpenTelemetry SDK before the OTLP collector
+//! translates the instrument into a Prometheus series.
 
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::metrics::{
@@ -12,6 +12,20 @@ use opentelemetry_sdk::metrics::{
 };
 
 const INSTRUMENT_NAME: &str = "xmpp.stanza.handler.timeout";
+const FRAME_BACKSTOP_SOURCE: &str =
+    include_str!("../src/server/routes/websocket/frame_backstop.rs");
+
+#[test]
+fn frame_backstop_timeout_arm_records_the_production_metric_helper() {
+    let timeout_arm = FRAME_BACKSTOP_SOURCE
+        .split("fn on_timeout(self) -> StanzaTimeout {")
+        .nth(1)
+        .and_then(|source| source.split("self.span.record").next())
+        .expect("StanzaBackstop::on_timeout source before span recording");
+
+    assert!(timeout_arm
+        .contains("metrics::record_stanza_handler_timeout(self.kind, &self.payload_ns);"));
+}
 
 #[test]
 fn stanza_handler_timeout_exports_the_canonical_counter_and_attributes() {
@@ -21,7 +35,8 @@ fn stanza_handler_timeout_exports_the_canonical_counter_and_attributes() {
         .build();
     opentelemetry::global::set_meter_provider(provider.clone());
 
-    waddle_xmpp::metrics::record_stanza_handler_timeout("message", "urn:test:wedged");
+    waddle_xmpp::metrics::record_stanza_handler_timeout("iq", "urn:test:wedged");
+    waddle_xmpp::metrics::record_stanza_handler_timeout("message", "");
     provider
         .force_flush()
         .expect("timeout metric should flush to the configured exporter");
@@ -47,16 +62,28 @@ fn stanza_handler_timeout_exports_the_canonical_counter_and_attributes() {
     };
     assert!(sum.is_monotonic(), "timeout counter must be monotonic");
 
-    let points: Vec<_> = sum.data_points().collect();
-    assert_eq!(points.len(), 1, "one label set should produce one series");
-    assert_eq!(points[0].value(), 1);
-
-    let attributes: Vec<_> = points[0].attributes().cloned().collect();
     assert_eq!(
-        attributes.len(),
+        sum.data_points().count(),
         2,
-        "timeout cardinality must stay limited to the two documented axes"
+        "the two reachable label sets should produce distinct series"
     );
-    assert!(attributes.contains(&KeyValue::new("kind", "message")));
-    assert!(attributes.contains(&KeyValue::new("payload_ns", "urn:test:wedged")));
+    for (kind, payload_ns) in [("iq", "urn:test:wedged"), ("message", "")] {
+        let point = sum
+            .data_points()
+            .find(|point| {
+                point
+                    .attributes()
+                    .any(|attribute| attribute == &KeyValue::new("kind", kind))
+                    && point
+                        .attributes()
+                        .any(|attribute| attribute == &KeyValue::new("payload_ns", payload_ns))
+            })
+            .expect("reachable stanza timeout label set should be exported");
+        assert_eq!(point.value(), 1);
+        assert_eq!(
+            point.attributes().count(),
+            2,
+            "timeout attribute schema must stay limited to the documented axes"
+        );
+    }
 }

--- a/server/crates/waddle-server/tests/stanza_handler_timeout_metrics.rs
+++ b/server/crates/waddle-server/tests/stanza_handler_timeout_metrics.rs
@@ -23,8 +23,13 @@ fn frame_backstop_timeout_arm_records_the_production_metric_helper() {
         .and_then(|source| source.split("self.span.record").next())
         .expect("StanzaBackstop::on_timeout source before span recording");
 
-    assert!(timeout_arm
-        .contains("metrics::record_stanza_handler_timeout(self.kind, &self.payload_ns);"));
+    let executable_calls = timeout_arm
+        .lines()
+        .filter(|line| {
+            line.trim() == "metrics::record_stanza_handler_timeout(self.kind, &self.payload_ns);"
+        })
+        .count();
+    assert_eq!(executable_calls, 1, "timeout arm must record exactly once");
 }
 
 #[test]

--- a/server/crates/waddle-server/tests/stanza_handler_timeout_metrics.rs
+++ b/server/crates/waddle-server/tests/stanza_handler_timeout_metrics.rs
@@ -1,0 +1,62 @@
+//! Export contract for the stanza-handler wedge-backstop metric.
+//!
+//! The frame-backstop tests prove that an elapsed IQ/message/presence dispatch
+//! calls `record_stanza_handler_timeout`. This test pins what that production
+//! helper hands to the OpenTelemetry SDK before the OTLP collector translates
+//! the instrument into a Prometheus series.
+
+use opentelemetry::KeyValue;
+use opentelemetry_sdk::metrics::{
+    data::{AggregatedMetrics, MetricData},
+    InMemoryMetricExporter, SdkMeterProvider,
+};
+
+const INSTRUMENT_NAME: &str = "xmpp.stanza.handler.timeout";
+
+#[test]
+fn stanza_handler_timeout_exports_the_canonical_counter_and_attributes() {
+    let exporter = InMemoryMetricExporter::default();
+    let provider = SdkMeterProvider::builder()
+        .with_periodic_exporter(exporter.clone())
+        .build();
+    opentelemetry::global::set_meter_provider(provider.clone());
+
+    waddle_xmpp::metrics::record_stanza_handler_timeout("message", "urn:test:wedged");
+    provider
+        .force_flush()
+        .expect("timeout metric should flush to the configured exporter");
+
+    let resource_metrics = exporter
+        .get_finished_metrics()
+        .expect("timeout metric should be available from the exporter");
+    let metric = resource_metrics
+        .iter()
+        .flat_map(|resource| resource.scope_metrics())
+        .flat_map(|scope| scope.metrics())
+        .find(|metric| metric.name() == INSTRUMENT_NAME)
+        .expect("canonical stanza-handler timeout instrument should be exported");
+
+    assert_eq!(
+        metric.description(),
+        "Inbound stanza handlers that exceeded the per-connection wedge backstop"
+    );
+    assert_eq!(metric.unit(), "stanza");
+
+    let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data() else {
+        panic!("stanza-handler timeout must export as a u64 sum");
+    };
+    assert!(sum.is_monotonic(), "timeout counter must be monotonic");
+
+    let points: Vec<_> = sum.data_points().collect();
+    assert_eq!(points.len(), 1, "one label set should produce one series");
+    assert_eq!(points[0].value(), 1);
+
+    let attributes: Vec<_> = points[0].attributes().cloned().collect();
+    assert_eq!(
+        attributes.len(),
+        2,
+        "timeout cardinality must stay limited to the two documented axes"
+    );
+    assert!(attributes.contains(&KeyValue::new("kind", "message")));
+    assert!(attributes.contains(&KeyValue::new("payload_ns", "urn:test:wedged")));
+}


### PR DESCRIPTION
## Why

Issue #1136 found that `xmpp.stanza.handler.timeout` is recorded but its canonical exported series was not found in the configured Prometheus/Grafana backend. This slice proves the existing OpenTelemetry signal before any pipeline change or duplicate metric is considered.

## Plan

1. Add an isolated Rust exporter test that records a stanza-handler timeout through the production helper and asserts the exact instrument name, count, and `kind`/`payload_ns` attributes.
2. Keep the real frame-backstop tests as the proof that IQ/message/presence timeout arms call that helper; strengthen them only if the current evidence is indirect.
3. Run the dedicated XEP-0198 suite, server tests, formatting, and strict all-feature clippy.
4. Trigger a synthetic timeout against the configured deployment and query the actual Grafana/Mimir translation. Record the verified canonical series/query in the observability documentation.
5. If the signal does not arrive, repair only the existing OTLP/collector/export path and add configuration coverage; do not add a duplicate counter.

## Scope

This is the timeout-metric proof slice of #1136. The separately coordinated dead legacy registry/message metrics deletion remains a follow-up and will land after #1343 to avoid overlapping room-actor files. The verified series will be consumed by #1163 alerts-as-code.

Relates to #1136.
Blocks the handler-timeout alert slice of #1163.