### PR TITLE
fix(server): reject corrupt MUC durable state

### DIFF
--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -21,7 +21,9 @@
 //!   `channel_id` plus the JSON-serialized `RoomConfig`/`SubjectState`
 //!   (both already `Serialize`/`Deserialize` for exactly this purpose).
 //! - `clustering_muc_room_affiliations` — one row per `(room_jid, member_jid)`
-//!   affiliation grant. `affiliation` is stored via a small
+//!   affiliation grant, foreign-keyed to the parent room with cascading
+//!   deletion so a grant cannot outlive its room. `affiliation` is stored via
+//!   a small
 //!   `affiliation_to_db_str`/`affiliation_from_db_str` pair, mirroring
 //!   `EntityType::as_db_str`/`from_db_str`'s exact convention, rather than a
 //!   JSON blob for a five-variant closed enum.
@@ -55,6 +57,7 @@
 
 use dashmap::DashMap;
 use jid::BareJid;
+use std::collections::HashSet;
 use tokio_util::sync::CancellationToken;
 use waddle_xmpp::muc::affiliation::AffiliationEntry;
 use waddle_xmpp::muc::{
@@ -68,12 +71,35 @@ use waddle_xmpp::{Affiliation, XmppError};
 
 use crate::clustering::relay::RelayHandle;
 use crate::clustering::NodeId;
-use crate::db::{Database, DatabaseError, Transaction};
+use crate::db::{ConnectionGuard, Database, DatabaseError, Transaction};
+
+const AFFILIATION_CHECK_CONSTRAINT: &str = "clustering_muc_room_affiliations_value_check";
+const AFFILIATION_ROOM_FK_CONSTRAINT: &str = "clustering_muc_room_affiliations_room_fk";
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RoomDeleteStep {
+    Parent,
+    LegacyOrphanAffiliations,
+}
+
+impl RoomDeleteStep {
+    const fn sql(self) -> &'static str {
+        match self {
+            Self::Parent => "DELETE FROM clustering_muc_rooms WHERE room_jid = ?",
+            Self::LegacyOrphanAffiliations => {
+                "DELETE FROM clustering_muc_room_affiliations WHERE room_jid = ?"
+            }
+        }
+    }
+}
+
+const ROOM_DELETE_STEPS: [RoomDeleteStep; 2] = [
+    RoomDeleteStep::Parent,
+    RoomDeleteStep::LegacyOrphanAffiliations,
+];
 
 fn db_err(error: DatabaseError) -> XmppError {
     XmppError::internal(format!("MUC durable store backend error: {error}"))
 }
-
 /// Injective `(entity_type, id) -> TEXT` encoding for the
 /// `clustering_claims.entity` primary key, mirroring
 /// `clustering::claims::entity_key`/`sm_persistence_fenced::
@@ -108,6 +134,29 @@ fn affiliation_from_db_str(value: &str) -> Option<Affiliation> {
         "owner" => Some(Affiliation::Owner),
         _ => None,
     }
+}
+
+fn affiliation_check_matches_expected(definition: &str) -> bool {
+    const EXPECTED: &str = "check((affiliation=any(array['outcast'::text,'member'::text,'admin'::text,'owner'::text])))";
+
+    let mut compact = String::with_capacity(definition.len());
+    let mut characters = definition.chars().peekable();
+    let mut in_literal = false;
+    while let Some(character) = characters.next() {
+        if character == '\'' {
+            compact.push(character);
+            if in_literal && characters.peek() == Some(&'\'') {
+                compact.push(characters.next().expect("peeked SQL quote"));
+            } else {
+                in_literal = !in_literal;
+            }
+        } else if in_literal {
+            compact.push(character);
+        } else if !character.is_whitespace() {
+            compact.push(character.to_ascii_lowercase());
+        }
+    }
+    compact.strip_suffix("notvalid").unwrap_or(&compact) == EXPECTED
 }
 
 /// Postgres-backed [`MucDurableStore`] (ADR-0017 Phase 3 Slice 7). See the
@@ -181,12 +230,59 @@ impl PostgresMucRoomStore {
                 affiliation TEXT NOT NULL,
                 reason      TEXT,
                 granted_at  TIMESTAMPTZ,
-                PRIMARY KEY (room_jid, member_jid)
+                PRIMARY KEY (room_jid, member_jid),
+                CONSTRAINT clustering_muc_room_affiliations_room_fk
+                    FOREIGN KEY (room_jid)
+                    REFERENCES clustering_muc_rooms (room_jid)
+                    ON DELETE CASCADE,
+                CONSTRAINT clustering_muc_room_affiliations_value_check
+                    CHECK (affiliation IN ('outcast', 'member', 'admin', 'owner'))
             )
             "#,
             (),
         )
         .await?;
+        conn.execute(
+            r#"
+            DO $muc_schema$
+            BEGIN
+                ALTER TABLE clustering_muc_room_affiliations
+                    ADD CONSTRAINT clustering_muc_room_affiliations_value_check
+                    CHECK (affiliation IN ('outcast', 'member', 'admin', 'owner'))
+                    NOT VALID;
+            EXCEPTION
+                WHEN duplicate_object THEN NULL;
+            END
+            $muc_schema$
+            "#,
+            (),
+        )
+        .await?;
+        // Existing deployments created the affiliation table before it had a
+        // parent-room foreign key. `NOT VALID` leaves any legacy corruption
+        // available for the fail-closed loader to diagnose while PostgreSQL
+        // still enforces the relationship for every new insert/update. The
+        // duplicate-object handler makes concurrent/idempotent startup safe;
+        // new installs already received the same named constraint inline.
+        conn.execute(
+            r#"
+            DO $muc_schema$
+            BEGIN
+                ALTER TABLE clustering_muc_room_affiliations
+                    ADD CONSTRAINT clustering_muc_room_affiliations_room_fk
+                    FOREIGN KEY (room_jid)
+                    REFERENCES clustering_muc_rooms (room_jid)
+                    ON DELETE CASCADE
+                    NOT VALID;
+            EXCEPTION
+                WHEN duplicate_object THEN NULL;
+            END
+            $muc_schema$
+            "#,
+            (),
+        )
+        .await?;
+        Self::verify_affiliation_constraints(&conn).await?;
         conn.execute(
             r#"
             CREATE INDEX IF NOT EXISTS clustering_muc_room_affiliations_room_jid_idx
@@ -195,6 +291,78 @@ impl PostgresMucRoomStore {
             (),
         )
         .await?;
+        Ok(())
+    }
+
+    async fn verify_affiliation_constraints(conn: &ConnectionGuard) -> Result<(), DatabaseError> {
+        let mut check_rows = conn
+            .query(
+                r#"
+                SELECT pg_get_constraintdef(c.oid)
+                FROM pg_constraint AS c
+                JOIN pg_attribute AS a
+                  ON a.attrelid = c.conrelid
+                 AND a.attname = 'affiliation'
+                WHERE c.conrelid = 'clustering_muc_room_affiliations'::regclass
+                  AND c.conname = ?
+                  AND c.contype = 'c'
+                  AND c.conkey = ARRAY[a.attnum]::int2[]
+                "#,
+                crate::db_params![AFFILIATION_CHECK_CONSTRAINT],
+            )
+            .await?;
+        let definition = check_rows
+            .next()
+            .await?
+            .ok_or_else(|| {
+                DatabaseError::QueryFailed(format!(
+                    "MUC affiliation schema is missing the required {AFFILIATION_CHECK_CONSTRAINT} constraint"
+                ))
+            })?
+            .get::<String>(0)?;
+        if check_rows.next().await?.is_some() || !affiliation_check_matches_expected(&definition) {
+            return Err(DatabaseError::QueryFailed(format!(
+                "MUC affiliation constraint {AFFILIATION_CHECK_CONSTRAINT} has an unexpected definition: {definition}"
+            )));
+        }
+
+        let mut fk_rows = conn
+            .query(
+                r#"
+                SELECT count(*)
+                FROM pg_constraint AS c
+                JOIN pg_attribute AS child_column
+                  ON child_column.attrelid = c.conrelid
+                 AND child_column.attname = 'room_jid'
+                JOIN pg_attribute AS parent_column
+                  ON parent_column.attrelid = c.confrelid
+                 AND parent_column.attname = 'room_jid'
+                WHERE c.conrelid = 'clustering_muc_room_affiliations'::regclass
+                  AND c.conname = ?
+                  AND c.contype = 'f'
+                  AND c.confrelid = 'clustering_muc_rooms'::regclass
+                  AND c.conkey = ARRAY[child_column.attnum]::int2[]
+                  AND c.confkey = ARRAY[parent_column.attnum]::int2[]
+                  AND c.confdeltype = 'c'
+                  AND NOT c.condeferrable
+                "#,
+                crate::db_params![AFFILIATION_ROOM_FK_CONSTRAINT],
+            )
+            .await?;
+        let matching_fk_count = fk_rows
+            .next()
+            .await?
+            .ok_or_else(|| {
+                DatabaseError::QueryFailed(
+                    "MUC affiliation FK verification returned no count row".to_string(),
+                )
+            })?
+            .get::<i64>(0)?;
+        if matching_fk_count != 1 {
+            return Err(DatabaseError::QueryFailed(format!(
+                "MUC affiliation constraint {AFFILIATION_ROOM_FK_CONSTRAINT} must be a non-deferrable room_jid FK with ON DELETE CASCADE"
+            )));
+        }
         Ok(())
     }
 
@@ -260,8 +428,8 @@ impl PostgresMucRoomStore {
                     fence.epoch.0
                 ],
             )
-            .await
-            .map_err(db_err)?;
+        .await
+        .map_err(db_err)?;
         let held = rows.next().await.map_err(db_err)?.is_some();
         if held && self.node_identity.current() == fence.owner {
             Ok(())
@@ -273,6 +441,113 @@ impl PostgresMucRoomStore {
             )))
         }
     }
+
+    async fn load_room_state_in_tx(
+        tx: &mut Transaction<'_>,
+        room_jid: &BareJid,
+    ) -> Result<Option<DurableRoomState>, XmppError> {
+        let mut room_rows = tx
+            .query(
+                "SELECT waddle_id, channel_id, config_json, subject_json FROM \
+                 clustering_muc_rooms WHERE room_jid = ?",
+                crate::db_params![room_jid.to_string()],
+            )
+            .await
+            .map_err(db_err)?;
+        let Some(row) = room_rows.next().await.map_err(db_err)? else {
+            let mut orphan_rows = tx
+                .query(
+                    "SELECT member_jid FROM clustering_muc_room_affiliations \
+                     WHERE room_jid = ? LIMIT 1",
+                    crate::db_params![room_jid.to_string()],
+                )
+                .await
+                .map_err(db_err)?;
+            if let Some(orphan) = orphan_rows.next().await.map_err(db_err)? {
+                let member_jid: String = orphan.get(0).map_err(db_err)?;
+                return Err(XmppError::internal(format!(
+                    "durable room state is corrupt: affiliation for {member_jid} references \
+                     missing room {room_jid}"
+                )));
+            }
+            return Ok(None);
+        };
+        let waddle_id: String = row.get(0).map_err(db_err)?;
+        let channel_id: String = row.get(1).map_err(db_err)?;
+        let config_json: String = row.get(2).map_err(db_err)?;
+        let subject_json: Option<String> = row.get(3).map_err(db_err)?;
+        let config: RoomConfig = serde_json::from_str(&config_json).map_err(|error| {
+            XmppError::internal(format!("durable room config decode failed: {error}"))
+        })?;
+        let subject: Option<SubjectState> = subject_json
+            .map(|json| serde_json::from_str(&json))
+            .transpose()
+            .map_err(|error| {
+                XmppError::internal(format!("durable room subject decode failed: {error}"))
+            })?;
+        let mut affiliation_rows = tx
+            .query(
+                "SELECT member_jid, affiliation, reason FROM \
+                 clustering_muc_room_affiliations WHERE room_jid = ?",
+                crate::db_params![room_jid.to_string()],
+            )
+            .await
+            .map_err(db_err)?;
+        let mut affiliations = Vec::new();
+        let mut affiliation_jids = HashSet::new();
+        while let Some(row) = affiliation_rows.next().await.map_err(db_err)? {
+            let member_jid: String = row.get(0).map_err(db_err)?;
+            let affiliation_str: String = row.get(1).map_err(db_err)?;
+            let reason: Option<String> = row.get(2).map_err(db_err)?;
+            let jid = member_jid.parse::<BareJid>().map_err(|error| {
+                XmppError::internal(format!(
+                    "durable room state is corrupt: affiliation member JID {member_jid:?} \
+                     for room {room_jid} is invalid: {error}"
+                ))
+            })?;
+            let canonical_jid = jid.to_string();
+            if member_jid != canonical_jid {
+                return Err(XmppError::internal(format!(
+                    "durable room state is corrupt: affiliation member JID {member_jid:?} \
+                     for room {room_jid} is non-canonical; canonical form is {canonical_jid:?}"
+                )));
+            }
+            if !affiliation_jids.insert(jid.clone()) {
+                return Err(XmppError::internal(format!(
+                    "durable room state is corrupt: duplicate normalized affiliation member \
+                     JID {canonical_jid} for room {room_jid}"
+                )));
+            }
+            let affiliation = match affiliation_from_db_str(&affiliation_str) {
+                Some(Affiliation::None) => {
+                    return Err(XmppError::internal(format!(
+                        "durable room state is corrupt: affiliation tag 'none' for member \
+                         {member_jid} in room {room_jid} must be represented by no row"
+                    )));
+                }
+                Some(affiliation) => affiliation,
+                None => {
+                    return Err(XmppError::internal(format!(
+                        "durable room state is corrupt: affiliation tag {affiliation_str:?} \
+                         for member {member_jid} in room {room_jid} is invalid"
+                    )));
+                }
+            };
+            affiliations.push(AffiliationEntry {
+                jid,
+                affiliation,
+                granted_at: None,
+                reason,
+            });
+        }
+        Ok(Some(DurableRoomState {
+            waddle_id,
+            channel_id,
+            config,
+            subject,
+            affiliations,
+        }))
+    }
 }
 
 impl MucDurableStore for PostgresMucRoomStore {
@@ -281,76 +556,16 @@ impl MucDurableStore for PostgresMucRoomStore {
         room_jid: &'a BareJid,
     ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
         Box::pin(async move {
-            let conn = self.db.guard().await.map_err(db_err)?;
-            let mut room_rows = conn
-                .query(
-                    "SELECT waddle_id, channel_id, config_json, subject_json FROM \
-                     clustering_muc_rooms WHERE room_jid = ?",
-                    crate::db_params![room_jid.to_string()],
-                )
-                .await
-                .map_err(db_err)?;
-            let Some(row) = room_rows.next().await.map_err(db_err)? else {
-                return Ok(None);
-            };
-            let waddle_id: String = row.get(0).map_err(db_err)?;
-            let channel_id: String = row.get(1).map_err(db_err)?;
-            let config_json: String = row.get(2).map_err(db_err)?;
-            let subject_json: Option<String> = row.get(3).map_err(db_err)?;
-            let config: RoomConfig = serde_json::from_str(&config_json).map_err(|error| {
-                XmppError::internal(format!("durable room config decode failed: {error}"))
-            })?;
-            let subject: Option<SubjectState> = subject_json
-                .map(|json| serde_json::from_str(&json))
-                .transpose()
-                .map_err(|error| {
-                    XmppError::internal(format!("durable room subject decode failed: {error}"))
-                })?;
-
-            let mut affiliation_rows = conn
-                .query(
-                    "SELECT member_jid, affiliation, reason FROM \
-                     clustering_muc_room_affiliations WHERE room_jid = ?",
-                    crate::db_params![room_jid.to_string()],
-                )
-                .await
-                .map_err(db_err)?;
-            let mut affiliations = Vec::new();
-            while let Some(row) = affiliation_rows.next().await.map_err(db_err)? {
-                let member_jid: String = row.get(0).map_err(db_err)?;
-                let affiliation_str: String = row.get(1).map_err(db_err)?;
-                let reason: Option<String> = row.get(2).map_err(db_err)?;
-                let Ok(jid) = member_jid.parse::<BareJid>() else {
-                    tracing::warn!(
-                        room = %room_jid,
-                        member_jid,
-                        "durable affiliation row has an unparseable member JID; skipping"
-                    );
-                    continue;
-                };
-                let Some(affiliation) = affiliation_from_db_str(&affiliation_str) else {
-                    tracing::warn!(
-                        room = %room_jid,
-                        affiliation = affiliation_str,
-                        "durable affiliation row has an unrecognized affiliation tag; skipping"
-                    );
-                    continue;
-                };
-                affiliations.push(AffiliationEntry {
-                    jid,
-                    affiliation,
-                    granted_at: None,
-                    reason,
-                });
-            }
-
-            Ok(Some(DurableRoomState {
-                waddle_id,
-                channel_id,
-                config,
-                subject,
-                affiliations,
-            }))
+            let mut tx = self.db.begin().await.map_err(db_err)?;
+            tx.execute(
+                "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
+                (),
+            )
+            .await
+            .map_err(db_err)?;
+            let state = Self::load_room_state_in_tx(&mut tx, room_jid).await?;
+            tx.commit().await.map_err(db_err)?;
+            Ok(state)
         })
     }
 
@@ -369,7 +584,7 @@ impl MucDurableStore for PostgresMucRoomStore {
             })?;
             let mut tx = self.db.begin().await.map_err(db_err)?;
             self.assert_fenced(&mut tx, room_jid, &fence).await?;
-            tx.execute(
+            let affected = tx.execute(
                 r#"
                 INSERT INTO clustering_muc_rooms (room_jid, waddle_id, channel_id, config_json, updated_at)
                 VALUES (?, ?, ?, ?, now())
@@ -388,6 +603,11 @@ impl MucDurableStore for PostgresMucRoomStore {
             )
             .await
             .map_err(db_err)?;
+            if affected != 1 {
+                return Err(XmppError::internal(format!(
+                    "durable room config persist for {room_jid} affected {affected} rows; expected 1"
+                )));
+            }
             tx.commit().await.map_err(db_err)?;
             Ok(())
         })
@@ -423,11 +643,9 @@ impl MucDurableStore for PostgresMucRoomStore {
                 .await
                 .map_err(db_err)?;
             if affected == 0 {
-                tracing::warn!(
-                    room = %room_jid,
-                    "durable subject persist skipped: no durable room row exists yet \
-                     (config has not been durably written for this room)"
-                );
+                return Err(XmppError::internal(format!(
+                    "durable subject persist refused: room {room_jid} has no durable config row"
+                )));
             }
             tx.commit().await.map_err(db_err)?;
             Ok(())
@@ -444,6 +662,18 @@ impl MucDurableStore for PostgresMucRoomStore {
             let _identity_guard = self.guard_fence_identity(room_jid, &fence).await?;
             let mut tx = self.db.begin().await.map_err(db_err)?;
             self.assert_fenced(&mut tx, room_jid, &fence).await?;
+            let mut parent_rows = tx
+                .query(
+                    "SELECT 1 FROM clustering_muc_rooms WHERE room_jid = ? FOR KEY SHARE",
+                    crate::db_params![room_jid.to_string()],
+                )
+                .await
+                .map_err(db_err)?;
+            if parent_rows.next().await.map_err(db_err)?.is_none() {
+                return Err(XmppError::internal(format!(
+                    "durable affiliation persist refused: room {room_jid} has no durable config row"
+                )));
+            }
             if entry.affiliation == Affiliation::None {
                 tx.execute(
                     "DELETE FROM clustering_muc_room_affiliations WHERE room_jid = ? AND member_jid = ?",
@@ -452,24 +682,30 @@ impl MucDurableStore for PostgresMucRoomStore {
                 .await
                 .map_err(db_err)?;
             } else {
-                tx.execute(
-                    r#"
-                    INSERT INTO clustering_muc_room_affiliations
-                        (room_jid, member_jid, affiliation, reason)
-                    VALUES (?, ?, ?, ?)
-                    ON CONFLICT (room_jid, member_jid) DO UPDATE SET
-                        affiliation = excluded.affiliation,
-                        reason = excluded.reason
-                    "#,
-                    crate::db_params![
-                        room_jid.to_string(),
-                        entry.jid.to_string(),
-                        affiliation_to_db_str(entry.affiliation).to_string(),
-                        entry.reason.clone(),
-                    ],
-                )
-                .await
-                .map_err(db_err)?;
+                let affected = tx
+                    .execute(
+                        r#"
+                        INSERT INTO clustering_muc_room_affiliations
+                            (room_jid, member_jid, affiliation, reason)
+                        VALUES (?, ?, ?, ?)
+                        ON CONFLICT (room_jid, member_jid) DO UPDATE SET
+                            affiliation = excluded.affiliation,
+                            reason = excluded.reason
+                        "#,
+                        crate::db_params![
+                            room_jid.to_string(),
+                            entry.jid.to_string(),
+                            affiliation_to_db_str(entry.affiliation).to_string(),
+                            entry.reason.clone(),
+                        ],
+                    )
+                    .await
+                    .map_err(db_err)?;
+                if affected != 1 {
+                    return Err(XmppError::internal(format!(
+                        "durable affiliation persist refused: room {room_jid} has no durable config row"
+                    )));
+                }
             }
             tx.commit().await.map_err(db_err)?;
             Ok(())
@@ -486,18 +722,20 @@ impl MucDurableStore for PostgresMucRoomStore {
             let _identity_guard = self.guard_fence_identity(room_jid, &fence).await?;
             let mut tx = self.db.begin().await.map_err(db_err)?;
             self.assert_fenced(&mut tx, room_jid, &fence).await?;
-            tx.execute(
-                "DELETE FROM clustering_muc_room_affiliations WHERE room_jid = ?",
-                crate::db_params![room_jid.to_string()],
-            )
-            .await
-            .map_err(db_err)?;
-            tx.execute(
-                "DELETE FROM clustering_muc_rooms WHERE room_jid = ?",
-                crate::db_params![room_jid.to_string()],
-            )
-            .await
-            .map_err(db_err)?;
+            // Parent-first ordering matches `save_affiliation`, which locks
+            // the parent before touching a child row. The enforced FK owns
+            // child deletion through ON DELETE CASCADE; manually deleting a
+            // child first would invert that lock order and deadlock against a
+            // concurrent affiliation update/removal.
+            // The ordered step list is also the regression seam: production
+            // executes exactly this parent-first sequence, while the unit test
+            // pins the order. The second step removes legacy NOT VALID orphans;
+            // for valid rooms the FK cascade already removed every child.
+            for step in ROOM_DELETE_STEPS {
+                tx.execute(step.sql(), crate::db_params![room_jid.to_string()])
+                    .await
+                    .map_err(db_err)?;
+            }
             tx.commit().await.map_err(db_err)?;
             Ok(())
         })
@@ -628,6 +866,226 @@ mod tests {
             .expect("valid test room JID")
     }
 
+    #[test]
+    fn affiliation_check_matcher_requires_the_exact_closed_set_and_shape() {
+        let expected = "CHECK ((affiliation = ANY (ARRAY['outcast'::text, 'member'::text, 'admin'::text, 'owner'::text]))) NOT VALID";
+        assert!(affiliation_check_matches_expected(expected));
+        assert!(!affiliation_check_matches_expected(
+            "CHECK ((affiliation = ANY (ARRAY['outcast'::text, 'member'::text, 'admin'::text, 'owner'::text, 'superowner'::text])))"
+        ));
+        assert!(!affiliation_check_matches_expected(
+            "CHECK (((affiliation = ANY (ARRAY['outcast'::text, 'member'::text, 'admin'::text, 'owner'::text])) OR true))"
+        ));
+        assert!(!affiliation_check_matches_expected(
+            "CHECK ((affiliation = ANY (ARRAY['outcast'::text, 'member'::text, 'admin'::text, 'owner'::text, NULL::text])))"
+        ));
+        assert!(!affiliation_check_matches_expected(
+            "CHECK ((affiliation = ANY (ARRAY['OUTCAST'::text, 'MEMBER'::text, 'ADMIN'::text, 'OWNER'::text])))"
+        ));
+    }
+
+    #[test]
+    fn room_delete_keeps_parent_before_legacy_orphan_cleanup() {
+        assert_eq!(
+            ROOM_DELETE_STEPS,
+            [
+                RoomDeleteStep::Parent,
+                RoomDeleteStep::LegacyOrphanAffiliations,
+            ]
+        );
+        assert_eq!(
+            ROOM_DELETE_STEPS.map(RoomDeleteStep::sql),
+            [
+                "DELETE FROM clustering_muc_rooms WHERE room_jid = ?",
+                "DELETE FROM clustering_muc_room_affiliations WHERE room_jid = ?",
+            ]
+        );
+    }
+
+    async fn legacy_corruption_db(name: &str) -> Database {
+        let mut config = DatabaseConfig::new(DatabaseDriver::Sqlite, "sqlite::memory:");
+        // An in-memory SQLite database is per connection. Pinning this test
+        // fixture to one pooled connection keeps the deliberately legacy
+        // schema visible to the later transaction deterministically.
+        config.pool_size = 1;
+        let db = Database::from_config(name, &config)
+            .await
+            .expect("open in-memory database");
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            r#"
+            CREATE TABLE clustering_muc_rooms (
+                room_jid TEXT PRIMARY KEY,
+                waddle_id TEXT NOT NULL,
+                channel_id TEXT NOT NULL,
+                config_json TEXT NOT NULL,
+                subject_json TEXT
+            )
+            "#,
+            (),
+        )
+        .await
+        .expect("create rooms table");
+        // Deliberately model the pre-hardening schema so corruption can be
+        // seeded without the new FK rejecting it at write time.
+        conn.execute(
+            r#"
+            CREATE TABLE clustering_muc_room_affiliations (
+                room_jid TEXT NOT NULL,
+                member_jid TEXT NOT NULL,
+                affiliation TEXT NOT NULL,
+                reason TEXT,
+                PRIMARY KEY (room_jid, member_jid)
+            )
+            "#,
+            (),
+        )
+        .await
+        .expect("create legacy affiliations table");
+        drop(conn);
+        db
+    }
+
+    async fn seed_room_and_affiliation(
+        db: &Database,
+        jid: &BareJid,
+        member_jid: &str,
+        affiliation: &str,
+    ) {
+        let config_json = serde_json::to_string(&RoomConfig::default()).expect("encode config");
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "INSERT INTO clustering_muc_rooms \
+             (room_jid, waddle_id, channel_id, config_json) VALUES (?, ?, ?, ?)",
+            crate::db_params![
+                jid.to_string(),
+                "waddle-1".to_string(),
+                "channel-1".to_string(),
+                config_json,
+            ],
+        )
+        .await
+        .expect("seed room");
+        conn.execute(
+            "INSERT INTO clustering_muc_room_affiliations \
+             (room_jid, member_jid, affiliation) VALUES (?, ?, ?)",
+            crate::db_params![
+                jid.to_string(),
+                member_jid.to_string(),
+                affiliation.to_string(),
+            ],
+        )
+        .await
+        .expect("seed affiliation");
+    }
+
+    #[tokio::test]
+    async fn load_errors_on_legacy_orphan_affiliation_row() {
+        let db = legacy_corruption_db("muc-orphan-affiliation-test").await;
+        let jid = room_jid("orphan");
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "INSERT INTO clustering_muc_room_affiliations \
+             (room_jid, member_jid, affiliation) VALUES (?, ?, ?)",
+            crate::db_params![
+                jid.to_string(),
+                "alice@example.com".to_string(),
+                "member".to_string(),
+            ],
+        )
+        .await
+        .expect("seed orphan affiliation");
+        drop(conn);
+
+        let mut tx = db.begin().await.expect("begin");
+        let error = PostgresMucRoomStore::load_room_state_in_tx(&mut tx, &jid)
+            .await
+            .expect_err("orphan affiliation must fail closed");
+        assert!(
+            error.to_string().contains("references missing room"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_errors_on_malformed_affiliation_member_jid() {
+        let db = legacy_corruption_db("muc-malformed-affiliation-jid-test").await;
+        let jid = room_jid("malformed-member");
+        seed_room_and_affiliation(&db, &jid, "@broken", "member").await;
+
+        let mut tx = db.begin().await.expect("begin");
+        let error = PostgresMucRoomStore::load_room_state_in_tx(&mut tx, &jid)
+            .await
+            .expect_err("malformed member JID must fail closed");
+        assert!(
+            error.to_string().contains("member JID") && error.to_string().contains("is invalid"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_errors_on_unknown_affiliation_tag() {
+        let db = legacy_corruption_db("muc-malformed-affiliation-tag-test").await;
+        let jid = room_jid("malformed-tag");
+        seed_room_and_affiliation(&db, &jid, "alice@example.com", "superowner").await;
+
+        let mut tx = db.begin().await.expect("begin");
+        let error = PostgresMucRoomStore::load_room_state_in_tx(&mut tx, &jid)
+            .await
+            .expect_err("unknown affiliation tag must fail closed");
+        assert!(
+            error.to_string().contains("affiliation tag")
+                && error.to_string().contains("is invalid"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_errors_on_conflicting_canonical_affiliation_aliases() {
+        let db = legacy_corruption_db("muc-canonical-affiliation-alias-test").await;
+        let jid = room_jid("canonical-alias");
+        seed_room_and_affiliation(&db, &jid, "ßA@IX.test", "owner").await;
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "INSERT INTO clustering_muc_room_affiliations \
+             (room_jid, member_jid, affiliation) VALUES (?, ?, ?)",
+            crate::db_params![
+                jid.to_string(),
+                "ssa@ix.test".to_string(),
+                "outcast".to_string(),
+            ],
+        )
+        .await
+        .expect("seed conflicting canonical alias");
+        drop(conn);
+
+        let mut tx = db.begin().await.expect("begin");
+        let error = PostgresMucRoomStore::load_room_state_in_tx(&mut tx, &jid)
+            .await
+            .expect_err("canonical aliases must fail closed instead of resolving by row order");
+        assert!(
+            error.to_string().contains("non-canonical")
+                && error.to_string().contains("ssa@ix.test"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_errors_on_persisted_none_affiliation() {
+        let db = legacy_corruption_db("muc-persisted-none-affiliation-test").await;
+        let jid = room_jid("persisted-none");
+        seed_room_and_affiliation(&db, &jid, "alice@example.com", "none").await;
+
+        let mut tx = db.begin().await.expect("begin");
+        let error = PostgresMucRoomStore::load_room_state_in_tx(&mut tx, &jid)
+            .await
+            .expect_err("a persisted none row must fail closed");
+        assert!(
+            error.to_string().contains("must be represented by no row"),
+            "unexpected error: {error}"
+        );
+    }
+
     #[tokio::test]
     async fn identity_rotation_invalidates_cached_room_fence_before_database_access() {
         let original = node_identity();
@@ -704,13 +1162,385 @@ mod tests {
         conn.execute("DELETE FROM clustering_nodes", ())
             .await
             .expect("clean nodes");
-        conn.execute("DELETE FROM clustering_muc_rooms", ())
-            .await
-            .expect("clean rooms");
         conn.execute("DELETE FROM clustering_muc_room_affiliations", ())
             .await
             .expect("clean affiliations");
+        conn.execute("DELETE FROM clustering_muc_rooms", ())
+            .await
+            .expect("clean rooms");
         Some((store, claim_store, db, me))
+    }
+
+    #[tokio::test]
+    async fn ensure_schema_upgrades_legacy_affiliation_constraints_idempotently() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, _claim_store, db, _me)) = clean_store().await else {
+            return;
+        };
+        let legacy_room = room_jid("legacy-orphan");
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             DROP CONSTRAINT IF EXISTS clustering_muc_room_affiliations_room_fk",
+            (),
+        )
+        .await
+        .expect("drop room FK to model the legacy schema");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             DROP CONSTRAINT IF EXISTS clustering_muc_room_affiliations_value_check",
+            (),
+        )
+        .await
+        .expect("drop affiliation check to model the legacy schema");
+        conn.execute(
+            "INSERT INTO clustering_muc_room_affiliations \
+             (room_jid, member_jid, affiliation) VALUES (?, ?, ?)",
+            crate::db_params![
+                legacy_room.to_string(),
+                "legacy@example.com".to_string(),
+                "none".to_string(),
+            ],
+        )
+        .await
+        .expect("seed legacy corruption before NOT VALID constraints exist");
+        drop(conn);
+
+        store.ensure_schema().await.expect("upgrade legacy schema");
+        store
+            .ensure_schema()
+            .await
+            .expect("schema upgrade is idempotent");
+
+        let conn = db.guard().await.expect("guard");
+        for constraint in [
+            "clustering_muc_room_affiliations_room_fk",
+            "clustering_muc_room_affiliations_value_check",
+        ] {
+            let mut rows = conn
+                .query(
+                    "SELECT convalidated FROM pg_constraint \
+                     WHERE conrelid = 'clustering_muc_room_affiliations'::regclass \
+                       AND conname = ?",
+                    crate::db_params![constraint.to_string()],
+                )
+                .await
+                .expect("inspect upgraded constraint");
+            let row = rows
+                .next()
+                .await
+                .expect("read constraint row")
+                .expect("upgraded constraint exists");
+            let validated: bool = row.get(0).expect("read validation state");
+            assert!(
+                !validated,
+                "legacy constraint {constraint} must remain NOT VALID so strict loading can diagnose existing corruption"
+            );
+        }
+
+        let new_orphan = room_jid("new-orphan");
+        assert!(
+            conn.execute(
+                "INSERT INTO clustering_muc_room_affiliations \
+                 (room_jid, member_jid, affiliation) VALUES (?, ?, ?)",
+                crate::db_params![
+                    new_orphan.to_string(),
+                    "alice@example.com".to_string(),
+                    "member".to_string(),
+                ],
+            )
+            .await
+            .is_err(),
+            "the upgraded FK must reject new orphan rows"
+        );
+
+        let parent = room_jid("constraint-parent");
+        let config_json = serde_json::to_string(&RoomConfig::default()).expect("encode config");
+        conn.execute(
+            "INSERT INTO clustering_muc_rooms \
+             (room_jid, waddle_id, channel_id, config_json) VALUES (?, ?, ?, ?)",
+            crate::db_params![
+                parent.to_string(),
+                "waddle-1".to_string(),
+                "channel-1".to_string(),
+                config_json,
+            ],
+        )
+        .await
+        .expect("seed parent room");
+        assert!(
+            conn.execute(
+                "INSERT INTO clustering_muc_room_affiliations \
+                 (room_jid, member_jid, affiliation) VALUES (?, ?, ?)",
+                crate::db_params![
+                    parent.to_string(),
+                    "invalid@example.com".to_string(),
+                    "none".to_string(),
+                ],
+            )
+            .await
+            .is_err(),
+            "the upgraded check must reject new none rows"
+        );
+        conn.execute(
+            "INSERT INTO clustering_muc_room_affiliations \
+             (room_jid, member_jid, affiliation) VALUES (?, ?, ?)",
+            crate::db_params![
+                parent.to_string(),
+                "member@example.com".to_string(),
+                "member".to_string(),
+            ],
+        )
+        .await
+        .expect("seed valid child row");
+        conn.execute(
+            "DELETE FROM clustering_muc_rooms WHERE room_jid = ?",
+            crate::db_params![parent.to_string()],
+        )
+        .await
+        .expect("delete parent room");
+        let mut child_rows = conn
+            .query(
+                "SELECT 1 FROM clustering_muc_room_affiliations WHERE room_jid = ?",
+                crate::db_params![parent.to_string()],
+            )
+            .await
+            .expect("query cascaded child");
+        assert!(
+            child_rows.next().await.expect("read child row").is_none(),
+            "deleting a parent must cascade to its affiliations"
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_schema_rejects_same_named_wrong_affiliation_constraints() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, _claim_store, db, _me)) = clean_store().await else {
+            return;
+        };
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             DROP CONSTRAINT clustering_muc_room_affiliations_value_check",
+            (),
+        )
+        .await
+        .expect("drop canonical CHECK");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             ADD CONSTRAINT clustering_muc_room_affiliations_value_check \
+             CHECK (affiliation <> '') NOT VALID",
+            (),
+        )
+        .await
+        .expect("install same-named wrong CHECK");
+        drop(conn);
+
+        let check_error = store
+            .ensure_schema()
+            .await
+            .expect_err("same-named wrong CHECK must fail startup");
+        assert!(
+            check_error.to_string().contains("unexpected definition"),
+            "unexpected error: {check_error}"
+        );
+
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             DROP CONSTRAINT clustering_muc_room_affiliations_value_check",
+            (),
+        )
+        .await
+        .expect("drop wrong CHECK");
+        drop(conn);
+        store
+            .ensure_schema()
+            .await
+            .expect("restore canonical CHECK");
+
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             DROP CONSTRAINT clustering_muc_room_affiliations_value_check",
+            (),
+        )
+        .await
+        .expect("drop canonical CHECK before uppercase fixture");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             ADD CONSTRAINT clustering_muc_room_affiliations_value_check \
+             CHECK (affiliation IN ('OUTCAST', 'MEMBER', 'ADMIN', 'OWNER')) NOT VALID",
+            (),
+        )
+        .await
+        .expect("install same-named uppercase CHECK");
+        drop(conn);
+
+        let uppercase_error = store
+            .ensure_schema()
+            .await
+            .expect_err("uppercase affiliation literals must fail startup");
+        assert!(
+            uppercase_error
+                .to_string()
+                .contains("unexpected definition"),
+            "unexpected error: {uppercase_error}"
+        );
+
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             DROP CONSTRAINT clustering_muc_room_affiliations_value_check",
+            (),
+        )
+        .await
+        .expect("drop uppercase CHECK");
+        drop(conn);
+        store
+            .ensure_schema()
+            .await
+            .expect("restore canonical CHECK after uppercase fixture");
+
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             DROP CONSTRAINT clustering_muc_room_affiliations_value_check",
+            (),
+        )
+        .await
+        .expect("drop canonical CHECK before nullable fixture");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             ADD CONSTRAINT clustering_muc_room_affiliations_value_check \
+             CHECK (affiliation = ANY (ARRAY[\
+                 'outcast'::text, 'member'::text, 'admin'::text, 'owner'::text, NULL::text\
+             ])) NOT VALID",
+            (),
+        )
+        .await
+        .expect("install same-named nullable CHECK");
+        drop(conn);
+
+        let nullable_error = store
+            .ensure_schema()
+            .await
+            .expect_err("nullable affiliation CHECK must fail startup");
+        assert!(
+            nullable_error.to_string().contains("unexpected definition"),
+            "unexpected error: {nullable_error}"
+        );
+
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             DROP CONSTRAINT clustering_muc_room_affiliations_value_check",
+            (),
+        )
+        .await
+        .expect("drop nullable CHECK");
+        drop(conn);
+        store
+            .ensure_schema()
+            .await
+            .expect("restore canonical CHECK after nullable fixture");
+
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             DROP CONSTRAINT clustering_muc_room_affiliations_room_fk",
+            (),
+        )
+        .await
+        .expect("drop canonical FK");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             ADD CONSTRAINT clustering_muc_room_affiliations_room_fk \
+             FOREIGN KEY (room_jid) REFERENCES clustering_muc_rooms (room_jid) \
+             ON DELETE RESTRICT NOT VALID",
+            (),
+        )
+        .await
+        .expect("install same-named wrong FK");
+        drop(conn);
+
+        let fk_error = store
+            .ensure_schema()
+            .await
+            .expect_err("same-named wrong FK must fail startup");
+        assert!(
+            fk_error.to_string().contains("ON DELETE CASCADE"),
+            "unexpected error: {fk_error}"
+        );
+
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             DROP CONSTRAINT clustering_muc_room_affiliations_room_fk",
+            (),
+        )
+        .await
+        .expect("drop wrong FK");
+        drop(conn);
+        store.ensure_schema().await.expect("restore canonical FK");
+    }
+
+    #[tokio::test]
+    async fn room_delete_removes_legacy_orphans_before_jid_recreation() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, db, me)) = clean_store().await else {
+            return;
+        };
+        let jid = room_jid("legacy-orphan-delete");
+        let conn = db.guard().await.expect("guard");
+        conn.execute(
+            "ALTER TABLE clustering_muc_room_affiliations \
+             DROP CONSTRAINT clustering_muc_room_affiliations_room_fk",
+            (),
+        )
+        .await
+        .expect("drop FK to seed a legacy orphan");
+        conn.execute(
+            "INSERT INTO clustering_muc_room_affiliations \
+             (room_jid, member_jid, affiliation) VALUES (?, ?, ?)",
+            crate::db_params![
+                jid.to_string(),
+                "legacy-owner@example.com".to_string(),
+                "owner".to_string(),
+            ],
+        )
+        .await
+        .expect("seed legacy orphan");
+        drop(conn);
+        store
+            .ensure_schema()
+            .await
+            .expect("install NOT VALID FK over legacy orphan");
+
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let epoch = claim_store
+            .ensure_claimed(&entity, &me)
+            .await
+            .expect("claim");
+        store.record_claim_fence(&jid, RoomClaimFenceContext::new(entity, me, epoch));
+        store
+            .delete_room_state(&jid)
+            .await
+            .expect("delete absent parent and legacy child");
+        store
+            .save_config(&jid, "waddle-1", "chan-1", &RoomConfig::default())
+            .await
+            .expect("recreate room JID");
+
+        let restored = store
+            .load_room_state(&jid)
+            .await
+            .expect("load recreated room")
+            .expect("recreated room exists");
+        assert!(
+            restored.affiliations.is_empty(),
+            "a legacy owner grant must not attach to a recreated room"
+        );
     }
 
     #[tokio::test]
@@ -822,6 +1652,174 @@ mod tests {
             .expect("load")
             .expect("row exists");
         assert!(loaded.affiliations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn affiliation_writes_and_room_delete_share_parent_first_lock_order() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, db, me)) = clean_store().await else {
+            return;
+        };
+        let store = Arc::new(store);
+
+        for (suffix, affiliation) in [
+            ("upsert", Affiliation::Admin),
+            ("removal", Affiliation::None),
+        ] {
+            let jid = room_jid(&format!("delete-race-{suffix}"));
+            let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+            let epoch = claim_store
+                .ensure_claimed(&entity, &me)
+                .await
+                .expect("claim");
+            store.record_claim_fence(&jid, RoomClaimFenceContext::new(entity, me.clone(), epoch));
+            store
+                .save_config(&jid, "waddle-1", "chan-1", &RoomConfig::default())
+                .await
+                .expect("seed parent room");
+            let member: BareJid = "alice@example.com".parse().expect("valid JID");
+            store
+                .save_affiliation(
+                    &jid,
+                    &AffiliationEntry::new(member.clone(), Affiliation::Member),
+                )
+                .await
+                .expect("seed child affiliation");
+
+            let entry = AffiliationEntry::new(member, affiliation);
+            let barrier = Arc::new(tokio::sync::Barrier::new(3));
+            let start = {
+                let barrier = Arc::clone(&barrier);
+                async move { barrier.wait().await }
+            };
+            let save = {
+                let barrier = Arc::clone(&barrier);
+                let store = Arc::clone(&store);
+                let jid = jid.clone();
+                async move {
+                    barrier.wait().await;
+                    store.save_affiliation(&jid, &entry).await
+                }
+            };
+            let delete = {
+                let barrier = Arc::clone(&barrier);
+                let store = Arc::clone(&store);
+                let jid = jid.clone();
+                async move {
+                    barrier.wait().await;
+                    store.delete_room_state(&jid).await
+                }
+            };
+            let (_, save_result, delete_result) =
+                tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                    tokio::join!(start, save, delete)
+                })
+                .await
+                .expect("parent-first operations must not deadlock");
+            delete_result.expect("room deletion must complete");
+            if let Err(error) = save_result {
+                assert!(
+                    error.to_string().contains("has no durable config row"),
+                    "only a delete-won missing-parent race is acceptable, got: {error}"
+                );
+            }
+            let conn = db.guard().await.expect("guard");
+            let mut parent_rows = conn
+                .query(
+                    "SELECT count(*) FROM clustering_muc_rooms WHERE room_jid = ?",
+                    crate::db_params![jid.to_string()],
+                )
+                .await
+                .expect("query parent state");
+            let parent_count: i64 = parent_rows
+                .next()
+                .await
+                .expect("read parent count")
+                .expect("parent count row")
+                .get(0)
+                .expect("decode parent count");
+            let mut child_rows = conn
+                .query(
+                    "SELECT count(*) FROM clustering_muc_room_affiliations WHERE room_jid = ?",
+                    crate::db_params![jid.to_string()],
+                )
+                .await
+                .expect("query child state");
+            let child_count: i64 = child_rows
+                .next()
+                .await
+                .expect("read child count")
+                .expect("child count row")
+                .get(0)
+                .expect("decode child count");
+            assert_eq!((parent_count, child_count), (0, 0));
+        }
+    }
+
+    #[tokio::test]
+    async fn affiliation_and_subject_writes_require_a_durable_room_row() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, _db, me)) = clean_store().await else {
+            return;
+        };
+        let jid = room_jid("missing-parent");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let epoch = claim_store
+            .ensure_claimed(&entity, &me)
+            .await
+            .expect("claim");
+        store.record_claim_fence(&jid, RoomClaimFenceContext::new(entity, me, epoch));
+
+        let affiliation_error = store
+            .save_affiliation(
+                &jid,
+                &AffiliationEntry::new(
+                    "alice@example.com".parse().expect("valid JID"),
+                    Affiliation::Member,
+                ),
+            )
+            .await
+            .expect_err("affiliation without parent room must be rejected");
+        assert!(
+            affiliation_error
+                .to_string()
+                .contains("has no durable config row"),
+            "unexpected error: {affiliation_error}"
+        );
+
+        let removal_error = store
+            .save_affiliation(
+                &jid,
+                &AffiliationEntry::new(
+                    "alice@example.com".parse().expect("valid JID"),
+                    Affiliation::None,
+                ),
+            )
+            .await
+            .expect_err("affiliation removal without parent room must be rejected");
+        assert!(
+            removal_error
+                .to_string()
+                .contains("has no durable config row"),
+            "unexpected error: {removal_error}"
+        );
+
+        let subject = SubjectState {
+            texts: RoomSubjectTexts::from_iter([(String::new(), "hello".to_string())]),
+            setter: "alice@example.com".parse().expect("valid JID"),
+            setter_nick: "alice".to_string(),
+            set_at: chrono::Utc::now(),
+        };
+        let subject_error = store
+            .save_subject(&jid, Some(&subject))
+            .await
+            .expect_err("subject without parent room must be rejected");
+        assert!(
+            subject_error
+                .to_string()
+                .contains("has no durable config row"),
+            "unexpected error: {subject_error}"
+        );
     }
 
     /// The plan's own Slice 7 Tests entry: "fenced pre-fan-out SELECT


### PR DESCRIPTION
## Summary

Stacked after #1352: enforce the durable MUC parent/child boundary and reject incomplete or corrupt snapshots instead of silently serving them.

## Changes

- Add an idempotent closed affiliation CHECK and room-parent foreign key with cascading delete.
- Verify existing named constraints semantically at startup, including rejection of nullable or otherwise weakened CHECK definitions.
- Load the room parent and affiliation children from one repeatable-read snapshot.
- Fail closed on orphan rows, malformed or non-canonical member JIDs, duplicate canonical identities, unknown affiliation tags, and persisted `none` values.
- Require subject and affiliation writes to target an existing durable room parent.
- Keep room deletion and affiliation mutation on one parent-first lock order; clean legacy orphans before room-JID reuse.
- Add focused schema-upgrade, corruption, missing-parent, delete/recreate, and concurrency regressions.

## Stack

This PR intentionally targets #1352. Enforcing the parent FK directly on current `main` would regress brand-new rooms because the existing actor path does not durably initialize a parent and initial Owner before early subject/invite writes. #1352 supplies that lifecycle first; this PR then tightens storage around it.

The broader creator/status-201/relay redesign is not included here. Its aggregate work is preserved separately and split into reviewable follow-ups.

## Verification

- `cargo test -p waddle-server --features clustering --lib` — 1,939 passed
- `cargo test -p waddle-xmpp --lib` — 2,568 passed before the final storage-only narrowing; XMPP files are no longer changed
- `cargo test -p waddle-xmpp --test xep0045_room_ownership_actor` — 8 passed before narrowing
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Fresh storage failure/concurrency review: clean after fixing the nullable-CHECK bypass
- Fresh XEP-0045 storage review: clean

Local PostgreSQL integration fixtures are gated because no test database URL is configured; CI remains required before ready-for-review.

Related: #1289, #1343, #1352
