### PR TITLE
feat(server): migrate ffi listener to typed on_event with full record parity

### DIFF
--- a/apps/apple/Waddle/App/AppModel+Dms.swift
+++ b/apps/apple/Waddle/App/AppModel+Dms.swift
@@ -81,12 +81,16 @@ extension AppModel {
             ? nil
             : WaddleSendOptions(
                 stanzaId: nil,
+                subject: nil,
                 reply: nil,
                 fallback: nil,
                 thread: nil,
+                markupSpans: [],
+                references: [],
                 sharedFiles: sharedFiles,
                 linkPreviewToken: nil,
-                requestDisplayedMarker: false
+                requestDisplayedMarker: false,
+                mucPm: false
             )
         await rustClient.sendDirectMessage(peerJID: targetPeerJID, body: wireBody, options: options)
         updateDmConversation(

--- a/apps/apple/Waddle/App/AppModel+Messaging.swift
+++ b/apps/apple/Waddle/App/AppModel+Messaging.swift
@@ -95,12 +95,16 @@ extension AppModel {
         let options: WaddleSendOptions? = hasOptions
             ? WaddleSendOptions(
                 stanzaId: nil,
+                subject: nil,
                 reply: replyTarget,
                 fallback: fallbackOpt,
                 thread: threadTarget,
+                markupSpans: [],
+                references: [],
                 sharedFiles: sharedFiles,
                 linkPreviewToken: nil,
-                requestDisplayedMarker: false
+                requestDisplayedMarker: false,
+                mucPm: false
             )
             : nil
 

--- a/apps/apple/Waddle/App/AppModel+Xmpp.swift
+++ b/apps/apple/Waddle/App/AppModel+Xmpp.swift
@@ -21,7 +21,10 @@ extension AppModel {
             serverUrl: session.xmppWebsocketURL,
             jid: session.jid,
             accessToken: session.sessionID,
-            resource: session.xmppCredentials.resource
+            resource: session.xmppCredentials.resource,
+            // The Apple client does not persist XEP-0198 resume state yet;
+            // every connect starts a fresh stream.
+            resumeState: nil
         )
         rustClient = RustXmppClient(config: rustConfig)
 

--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
@@ -1485,9 +1485,9 @@ public struct WaddleArchivedMessage: Equatable, Hashable {
      */
     public var references: [WaddleReference]
     /**
-     * Forum classification of the archived post (`topic`/`reply`).
+     * Forum classification of the archived post.
      */
-    public var forumPostKind: String?
+    public var forumPostKind: WaddleForumPostKind?
     /**
      * Forum topic title (the subject of a `topic` post).
      */
@@ -1563,8 +1563,8 @@ public struct WaddleArchivedMessage: Equatable, Hashable {
          * XEP-0372 references of the inner message.
          */references: [WaddleReference],
         /**
-         * Forum classification of the archived post (`topic`/`reply`).
-         */forumPostKind: String?,
+         * Forum classification of the archived post.
+         */forumPostKind: WaddleForumPostKind?,
         /**
          * Forum topic title (the subject of a `topic` post).
          */forumTitle: String?,
@@ -1675,7 +1675,7 @@ public struct FfiConverterTypeWaddleArchivedMessage: FfiConverterRustBuffer {
                 broadcastMention: FfiConverterOptionString.read(from: &buf),
                 mentionUris: FfiConverterSequenceString.read(from: &buf),
                 references: FfiConverterSequenceTypeWaddleReference.read(from: &buf),
-                forumPostKind: FfiConverterOptionString.read(from: &buf),
+                forumPostKind: FfiConverterOptionTypeWaddleForumPostKind.read(from: &buf),
                 forumTitle: FfiConverterOptionString.read(from: &buf),
                 isSticker: FfiConverterBool.read(from: &buf),
                 authorRealJid: FfiConverterOptionString.read(from: &buf),
@@ -1720,7 +1720,7 @@ public struct FfiConverterTypeWaddleArchivedMessage: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.broadcastMention, into: &buf)
         FfiConverterSequenceString.write(value.mentionUris, into: &buf)
         FfiConverterSequenceTypeWaddleReference.write(value.references, into: &buf)
-        FfiConverterOptionString.write(value.forumPostKind, into: &buf)
+        FfiConverterOptionTypeWaddleForumPostKind.write(value.forumPostKind, into: &buf)
         FfiConverterOptionString.write(value.forumTitle, into: &buf)
         FfiConverterBool.write(value.isSticker, into: &buf)
         FfiConverterOptionString.write(value.authorRealJid, into: &buf)
@@ -3203,10 +3203,10 @@ public struct WaddleMessage: Equatable, Hashable {
      */
     public var references: [WaddleReference]
     /**
-     * Forum channel classification: `topic` (thread + body + subject)
-     * or `reply` (thread + body); `None` for plain chat.
+     * Forum channel classification; `None` for plain chat or when the
+     * wire value is not a recognised kind.
      */
-    public var forumPostKind: String?
+    public var forumPostKind: WaddleForumPostKind?
     /**
      * Forum topic title (the subject of a `topic` post).
      */
@@ -3328,9 +3328,9 @@ public struct WaddleMessage: Equatable, Hashable {
          * of type. `mention_uris`/`broadcast_mention` are derived views.
          */references: [WaddleReference],
         /**
-         * Forum channel classification: `topic` (thread + body + subject)
-         * or `reply` (thread + body); `None` for plain chat.
-         */forumPostKind: String?,
+         * Forum channel classification; `None` for plain chat or when the
+         * wire value is not a recognised kind.
+         */forumPostKind: WaddleForumPostKind?,
         /**
          * Forum topic title (the subject of a `topic` post).
          */forumTitle: String?,
@@ -3471,7 +3471,7 @@ public struct FfiConverterTypeWaddleMessage: FfiConverterRustBuffer {
                 broadcastMention: FfiConverterOptionString.read(from: &buf),
                 mentionUris: FfiConverterSequenceString.read(from: &buf),
                 references: FfiConverterSequenceTypeWaddleReference.read(from: &buf),
-                forumPostKind: FfiConverterOptionString.read(from: &buf),
+                forumPostKind: FfiConverterOptionTypeWaddleForumPostKind.read(from: &buf),
                 forumTitle: FfiConverterOptionString.read(from: &buf),
                 isSticker: FfiConverterBool.read(from: &buf),
                 linkPreviews: FfiConverterSequenceTypeWaddleLinkPreview.read(from: &buf),
@@ -3519,7 +3519,7 @@ public struct FfiConverterTypeWaddleMessage: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.broadcastMention, into: &buf)
         FfiConverterSequenceString.write(value.mentionUris, into: &buf)
         FfiConverterSequenceTypeWaddleReference.write(value.references, into: &buf)
-        FfiConverterOptionString.write(value.forumPostKind, into: &buf)
+        FfiConverterOptionTypeWaddleForumPostKind.write(value.forumPostKind, into: &buf)
         FfiConverterOptionString.write(value.forumTitle, into: &buf)
         FfiConverterBool.write(value.isSticker, into: &buf)
         FfiConverterSequenceTypeWaddleLinkPreview.write(value.linkPreviews, into: &buf)
@@ -3867,9 +3867,9 @@ public struct WaddlePresence: Equatable, Hashable {
      */
     public var errorCondition: String?
     /**
-     * RFC 6120 §8.3 error `type` attribute (e.g. `cancel`).
+     * RFC 6120 §8.3 error `type` attribute.
      */
-    public var errorType: String?
+    public var errorType: WaddleStanzaErrorType?
     /**
      * RFC 6120 §8.3 human-readable `<text/>` of an error presence.
      */
@@ -3917,8 +3917,8 @@ public struct WaddlePresence: Equatable, Hashable {
          * for `type="error"` presences; `None` otherwise.
          */errorCondition: String?,
         /**
-         * RFC 6120 §8.3 error `type` attribute (e.g. `cancel`).
-         */errorType: String?,
+         * RFC 6120 §8.3 error `type` attribute.
+         */errorType: WaddleStanzaErrorType?,
         /**
          * RFC 6120 §8.3 human-readable `<text/>` of an error presence.
          */errorText: String?,
@@ -3987,7 +3987,7 @@ public struct FfiConverterTypeWaddlePresence: FfiConverterRustBuffer {
                 vcardAvatar: FfiConverterOptionString.read(from: &buf),
                 idleSince: FfiConverterOptionString.read(from: &buf),
                 errorCondition: FfiConverterOptionString.read(from: &buf),
-                errorType: FfiConverterOptionString.read(from: &buf),
+                errorType: FfiConverterOptionTypeWaddleStanzaErrorType.read(from: &buf),
                 errorText: FfiConverterOptionString.read(from: &buf),
                 handRaised: FfiConverterBool.read(from: &buf),
                 muted: FfiConverterBool.read(from: &buf),
@@ -4009,7 +4009,7 @@ public struct FfiConverterTypeWaddlePresence: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.vcardAvatar, into: &buf)
         FfiConverterOptionString.write(value.idleSince, into: &buf)
         FfiConverterOptionString.write(value.errorCondition, into: &buf)
-        FfiConverterOptionString.write(value.errorType, into: &buf)
+        FfiConverterOptionTypeWaddleStanzaErrorType.write(value.errorType, into: &buf)
         FfiConverterOptionString.write(value.errorText, into: &buf)
         FfiConverterBool.write(value.handRaised, into: &buf)
         FfiConverterBool.write(value.muted, into: &buf)
@@ -5516,6 +5516,78 @@ public func FfiConverterTypeWaddleClientEvent_lower(_ value: WaddleClientEvent) 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 /**
+ * Waddle forum post classification: `Topic` (thread + body + subject)
+ * or `Reply` (thread + body). Wire values outside these two are
+ * dropped to `None` at the conversion boundary.
+ */
+
+public enum WaddleForumPostKind: Equatable, Hashable {
+
+    case topic
+    case reply
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleForumPostKind: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleForumPostKind: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleForumPostKind
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleForumPostKind {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .topic
+
+        case 2: return .reply
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: WaddleForumPostKind, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .topic:
+            writeInt(&buf, Int32(1))
+
+
+        case .reply:
+            writeInt(&buf, Int32(2))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleForumPostKind_lift(_ buf: RustBuffer) throws -> WaddleForumPostKind {
+    return try FfiConverterTypeWaddleForumPostKind.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleForumPostKind_lower(_ value: WaddleForumPostKind) -> RustBuffer {
+    return FfiConverterTypeWaddleForumPostKind.lower(value)
+}
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
  * XEP-0166 §7.4 session-terminate reason conditions. Mirrors the
  * 17 variants in `xmpp_parsers::jingle::Reason` so the wire
  * parser's enum is the single source of truth — outbound calls
@@ -6312,6 +6384,106 @@ public func FfiConverterTypeWaddleSendMessageOutcome_lower(_ value: WaddleSendMe
 }
 
 
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * RFC 6120 §8.3.2 stanza-error `type` attribute. Mirrors the client
+ * crate's `StanzaErrorType`; `Unknown` marks an unrecognised wire
+ * value so consumers can distinguish it from every defined type.
+ */
+
+public enum WaddleStanzaErrorType: Equatable, Hashable {
+
+    case auth
+    case cancel
+    case `continue`
+    case modify
+    case wait
+    case unknown
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleStanzaErrorType: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleStanzaErrorType: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleStanzaErrorType
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleStanzaErrorType {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .auth
+
+        case 2: return .cancel
+
+        case 3: return .`continue`
+
+        case 4: return .modify
+
+        case 5: return .wait
+
+        case 6: return .unknown
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: WaddleStanzaErrorType, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .auth:
+            writeInt(&buf, Int32(1))
+
+
+        case .cancel:
+            writeInt(&buf, Int32(2))
+
+
+        case .`continue`:
+            writeInt(&buf, Int32(3))
+
+
+        case .modify:
+            writeInt(&buf, Int32(4))
+
+
+        case .wait:
+            writeInt(&buf, Int32(5))
+
+
+        case .unknown:
+            writeInt(&buf, Int32(6))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleStanzaErrorType_lift(_ buf: RustBuffer) throws -> WaddleStanzaErrorType {
+    return try FfiConverterTypeWaddleStanzaErrorType.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleStanzaErrorType_lower(_ value: WaddleStanzaErrorType) -> RustBuffer {
+    return FfiConverterTypeWaddleStanzaErrorType.lower(value)
+}
+
+
 
 
 
@@ -7026,6 +7198,30 @@ fileprivate struct FfiConverterOptionTypeWaddleChatState: FfiConverterRustBuffer
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionTypeWaddleForumPostKind: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleForumPostKind?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWaddleForumPostKind.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWaddleForumPostKind.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionTypeWaddleJingleReason: FfiConverterRustBuffer {
     typealias SwiftType = WaddleJingleReason?
 
@@ -7090,6 +7286,30 @@ fileprivate struct FfiConverterOptionTypeWaddleMucRole: FfiConverterRustBuffer {
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeWaddleMucRole.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeWaddleStanzaErrorType: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleStanzaErrorType?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWaddleStanzaErrorType.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWaddleStanzaErrorType.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }

--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
@@ -425,6 +425,22 @@ private let UNIFFI_CALLBACK_UNEXPECTED_ERROR: Int32 = 2
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterUInt16: FfiConverterPrimitive {
+    typealias FfiType = UInt16
+    typealias SwiftType = UInt16
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> UInt16 {
+        return try lift(readInt(&buf))
+    }
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterUInt32: FfiConverterPrimitive {
     typealias FfiType = UInt32
     typealias SwiftType = UInt32
@@ -1397,12 +1413,53 @@ public struct WaddleArchivedMessage: Equatable, Hashable {
     public var queryId: String?
     public var id: String?
     public var stanzaId: String?
+    /**
+     * XEP-0359 `by` authority of `stanza_id` (unverified — see
+     * `WaddleMessage::stanza_id_by`).
+     */
+    public var stanzaIdBy: String?
+    /**
+     * Every XEP-0359 `<stanza-id/>` on the inner message.
+     */
+    public var stanzaIds: [WaddleStanzaId]
     public var originId: String?
     public var timestamp: String?
     public var from: String?
     public var to: String?
     public var messageType: String
     public var body: String?
+    /**
+     * RFC 6121 `<subject/>` of the inner message.
+     */
+    public var subject: String?
+    /**
+     * XEP-0308 correction target id.
+     */
+    public var replacesId: String?
+    /**
+     * XEP-0424 retraction target id.
+     */
+    public var retractsId: String?
+    /**
+     * XEP-0424 tombstone retraction message id.
+     */
+    public var retractionId: String?
+    /**
+     * XEP-0424: true when the archived row is a retraction tombstone.
+     */
+    public var isRetracted: Bool
+    /**
+     * XEP-0425 moderation target id.
+     */
+    public var moderationTargetId: String?
+    /**
+     * XEP-0425 moderator JID (string form).
+     */
+    public var moderatedBy: String?
+    /**
+     * XEP-0425 human-readable moderation reason.
+     */
+    public var moderationReason: String?
     public var reactionTargetId: String?
     public var reactionEmojis: [String]
     public var thread: String?
@@ -1412,28 +1469,141 @@ public struct WaddleArchivedMessage: Equatable, Hashable {
     public var replyFallbackStart: UInt32?
     public var replyFallbackEnd: UInt32?
     /**
+     * XEP-0394 markup spans of the inner message.
+     */
+    public var markupSpans: [WaddleMarkupSpan]
+    /**
+     * XEP-0372 broadcast mention URI, when present.
+     */
+    public var broadcastMention: String?
+    /**
+     * XEP-0372 mention URIs, flattened from `references`.
+     */
+    public var mentionUris: [String]
+    /**
+     * XEP-0372 references of the inner message.
+     */
+    public var references: [WaddleReference]
+    /**
+     * Forum classification of the archived post (`topic`/`reply`).
+     */
+    public var forumPostKind: String?
+    /**
+     * Forum topic title (the subject of a `topic` post).
+     */
+    public var forumTitle: String?
+    /**
+     * XEP-0449: the archived body is a sticker.
+     */
+    public var isSticker: Bool
+    /**
+     * XEP-0045 real author JID from the archived `muc#user` payload,
+     * exposed by non-anonymous room archives.
+     */
+    public var authorRealJid: String?
+    /**
      * urn:waddle:call-thread:0 call-thread anchor marker, if present.
      */
     public var callThread: WaddleCallThreadAnchor?
+    /**
+     * urn:waddle:call-thread:0 ended fastening, if present.
+     */
+    public var callThreadEnded: WaddleCallThreadEnded?
     public var sharedFiles: [WaddleSharedFile]
+    /**
+     * XEP-0511 link previews of the inner message.
+     */
+    public var linkPreviews: [WaddleLinkPreview]
     public var callEvent: WaddleCallEvent?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(mamId: String, queryId: String?, id: String?, stanzaId: String?, originId: String?, timestamp: String?, from: String?, to: String?, messageType: String, body: String?, reactionTargetId: String?, reactionEmojis: [String], thread: String?, parentThreadId: String?, replyToId: String?, replyToSender: String?, replyFallbackStart: UInt32?, replyFallbackEnd: UInt32?,
+    public init(mamId: String, queryId: String?, id: String?, stanzaId: String?,
+        /**
+         * XEP-0359 `by` authority of `stanza_id` (unverified — see
+         * `WaddleMessage::stanza_id_by`).
+         */stanzaIdBy: String?,
+        /**
+         * Every XEP-0359 `<stanza-id/>` on the inner message.
+         */stanzaIds: [WaddleStanzaId], originId: String?, timestamp: String?, from: String?, to: String?, messageType: String, body: String?,
+        /**
+         * RFC 6121 `<subject/>` of the inner message.
+         */subject: String?,
+        /**
+         * XEP-0308 correction target id.
+         */replacesId: String?,
+        /**
+         * XEP-0424 retraction target id.
+         */retractsId: String?,
+        /**
+         * XEP-0424 tombstone retraction message id.
+         */retractionId: String?,
+        /**
+         * XEP-0424: true when the archived row is a retraction tombstone.
+         */isRetracted: Bool,
+        /**
+         * XEP-0425 moderation target id.
+         */moderationTargetId: String?,
+        /**
+         * XEP-0425 moderator JID (string form).
+         */moderatedBy: String?,
+        /**
+         * XEP-0425 human-readable moderation reason.
+         */moderationReason: String?, reactionTargetId: String?, reactionEmojis: [String], thread: String?, parentThreadId: String?, replyToId: String?, replyToSender: String?, replyFallbackStart: UInt32?, replyFallbackEnd: UInt32?,
+        /**
+         * XEP-0394 markup spans of the inner message.
+         */markupSpans: [WaddleMarkupSpan],
+        /**
+         * XEP-0372 broadcast mention URI, when present.
+         */broadcastMention: String?,
+        /**
+         * XEP-0372 mention URIs, flattened from `references`.
+         */mentionUris: [String],
+        /**
+         * XEP-0372 references of the inner message.
+         */references: [WaddleReference],
+        /**
+         * Forum classification of the archived post (`topic`/`reply`).
+         */forumPostKind: String?,
+        /**
+         * Forum topic title (the subject of a `topic` post).
+         */forumTitle: String?,
+        /**
+         * XEP-0449: the archived body is a sticker.
+         */isSticker: Bool,
+        /**
+         * XEP-0045 real author JID from the archived `muc#user` payload,
+         * exposed by non-anonymous room archives.
+         */authorRealJid: String?,
         /**
          * urn:waddle:call-thread:0 call-thread anchor marker, if present.
-         */callThread: WaddleCallThreadAnchor?, sharedFiles: [WaddleSharedFile], callEvent: WaddleCallEvent?) {
+         */callThread: WaddleCallThreadAnchor?,
+        /**
+         * urn:waddle:call-thread:0 ended fastening, if present.
+         */callThreadEnded: WaddleCallThreadEnded?, sharedFiles: [WaddleSharedFile],
+        /**
+         * XEP-0511 link previews of the inner message.
+         */linkPreviews: [WaddleLinkPreview], callEvent: WaddleCallEvent?) {
         self.mamId = mamId
         self.queryId = queryId
         self.id = id
         self.stanzaId = stanzaId
+        self.stanzaIdBy = stanzaIdBy
+        self.stanzaIds = stanzaIds
         self.originId = originId
         self.timestamp = timestamp
         self.from = from
         self.to = to
         self.messageType = messageType
         self.body = body
+        self.subject = subject
+        self.replacesId = replacesId
+        self.retractsId = retractsId
+        self.retractionId = retractionId
+        self.isRetracted = isRetracted
+        self.moderationTargetId = moderationTargetId
+        self.moderatedBy = moderatedBy
+        self.moderationReason = moderationReason
         self.reactionTargetId = reactionTargetId
         self.reactionEmojis = reactionEmojis
         self.thread = thread
@@ -1442,8 +1612,18 @@ public struct WaddleArchivedMessage: Equatable, Hashable {
         self.replyToSender = replyToSender
         self.replyFallbackStart = replyFallbackStart
         self.replyFallbackEnd = replyFallbackEnd
+        self.markupSpans = markupSpans
+        self.broadcastMention = broadcastMention
+        self.mentionUris = mentionUris
+        self.references = references
+        self.forumPostKind = forumPostKind
+        self.forumTitle = forumTitle
+        self.isSticker = isSticker
+        self.authorRealJid = authorRealJid
         self.callThread = callThread
+        self.callThreadEnded = callThreadEnded
         self.sharedFiles = sharedFiles
+        self.linkPreviews = linkPreviews
         self.callEvent = callEvent
     }
 
@@ -1467,12 +1647,22 @@ public struct FfiConverterTypeWaddleArchivedMessage: FfiConverterRustBuffer {
                 queryId: FfiConverterOptionString.read(from: &buf),
                 id: FfiConverterOptionString.read(from: &buf),
                 stanzaId: FfiConverterOptionString.read(from: &buf),
+                stanzaIdBy: FfiConverterOptionString.read(from: &buf),
+                stanzaIds: FfiConverterSequenceTypeWaddleStanzaId.read(from: &buf),
                 originId: FfiConverterOptionString.read(from: &buf),
                 timestamp: FfiConverterOptionString.read(from: &buf),
                 from: FfiConverterOptionString.read(from: &buf),
                 to: FfiConverterOptionString.read(from: &buf),
                 messageType: FfiConverterString.read(from: &buf),
                 body: FfiConverterOptionString.read(from: &buf),
+                subject: FfiConverterOptionString.read(from: &buf),
+                replacesId: FfiConverterOptionString.read(from: &buf),
+                retractsId: FfiConverterOptionString.read(from: &buf),
+                retractionId: FfiConverterOptionString.read(from: &buf),
+                isRetracted: FfiConverterBool.read(from: &buf),
+                moderationTargetId: FfiConverterOptionString.read(from: &buf),
+                moderatedBy: FfiConverterOptionString.read(from: &buf),
+                moderationReason: FfiConverterOptionString.read(from: &buf),
                 reactionTargetId: FfiConverterOptionString.read(from: &buf),
                 reactionEmojis: FfiConverterSequenceString.read(from: &buf),
                 thread: FfiConverterOptionString.read(from: &buf),
@@ -1481,8 +1671,18 @@ public struct FfiConverterTypeWaddleArchivedMessage: FfiConverterRustBuffer {
                 replyToSender: FfiConverterOptionString.read(from: &buf),
                 replyFallbackStart: FfiConverterOptionUInt32.read(from: &buf),
                 replyFallbackEnd: FfiConverterOptionUInt32.read(from: &buf),
+                markupSpans: FfiConverterSequenceTypeWaddleMarkupSpan.read(from: &buf),
+                broadcastMention: FfiConverterOptionString.read(from: &buf),
+                mentionUris: FfiConverterSequenceString.read(from: &buf),
+                references: FfiConverterSequenceTypeWaddleReference.read(from: &buf),
+                forumPostKind: FfiConverterOptionString.read(from: &buf),
+                forumTitle: FfiConverterOptionString.read(from: &buf),
+                isSticker: FfiConverterBool.read(from: &buf),
+                authorRealJid: FfiConverterOptionString.read(from: &buf),
                 callThread: FfiConverterOptionTypeWaddleCallThreadAnchor.read(from: &buf),
+                callThreadEnded: FfiConverterOptionTypeWaddleCallThreadEnded.read(from: &buf),
                 sharedFiles: FfiConverterSequenceTypeWaddleSharedFile.read(from: &buf),
+                linkPreviews: FfiConverterSequenceTypeWaddleLinkPreview.read(from: &buf),
                 callEvent: FfiConverterOptionTypeWaddleCallEvent.read(from: &buf)
         )
     }
@@ -1492,12 +1692,22 @@ public struct FfiConverterTypeWaddleArchivedMessage: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.queryId, into: &buf)
         FfiConverterOptionString.write(value.id, into: &buf)
         FfiConverterOptionString.write(value.stanzaId, into: &buf)
+        FfiConverterOptionString.write(value.stanzaIdBy, into: &buf)
+        FfiConverterSequenceTypeWaddleStanzaId.write(value.stanzaIds, into: &buf)
         FfiConverterOptionString.write(value.originId, into: &buf)
         FfiConverterOptionString.write(value.timestamp, into: &buf)
         FfiConverterOptionString.write(value.from, into: &buf)
         FfiConverterOptionString.write(value.to, into: &buf)
         FfiConverterString.write(value.messageType, into: &buf)
         FfiConverterOptionString.write(value.body, into: &buf)
+        FfiConverterOptionString.write(value.subject, into: &buf)
+        FfiConverterOptionString.write(value.replacesId, into: &buf)
+        FfiConverterOptionString.write(value.retractsId, into: &buf)
+        FfiConverterOptionString.write(value.retractionId, into: &buf)
+        FfiConverterBool.write(value.isRetracted, into: &buf)
+        FfiConverterOptionString.write(value.moderationTargetId, into: &buf)
+        FfiConverterOptionString.write(value.moderatedBy, into: &buf)
+        FfiConverterOptionString.write(value.moderationReason, into: &buf)
         FfiConverterOptionString.write(value.reactionTargetId, into: &buf)
         FfiConverterSequenceString.write(value.reactionEmojis, into: &buf)
         FfiConverterOptionString.write(value.thread, into: &buf)
@@ -1506,8 +1716,18 @@ public struct FfiConverterTypeWaddleArchivedMessage: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.replyToSender, into: &buf)
         FfiConverterOptionUInt32.write(value.replyFallbackStart, into: &buf)
         FfiConverterOptionUInt32.write(value.replyFallbackEnd, into: &buf)
+        FfiConverterSequenceTypeWaddleMarkupSpan.write(value.markupSpans, into: &buf)
+        FfiConverterOptionString.write(value.broadcastMention, into: &buf)
+        FfiConverterSequenceString.write(value.mentionUris, into: &buf)
+        FfiConverterSequenceTypeWaddleReference.write(value.references, into: &buf)
+        FfiConverterOptionString.write(value.forumPostKind, into: &buf)
+        FfiConverterOptionString.write(value.forumTitle, into: &buf)
+        FfiConverterBool.write(value.isSticker, into: &buf)
+        FfiConverterOptionString.write(value.authorRealJid, into: &buf)
         FfiConverterOptionTypeWaddleCallThreadAnchor.write(value.callThread, into: &buf)
+        FfiConverterOptionTypeWaddleCallThreadEnded.write(value.callThreadEnded, into: &buf)
         FfiConverterSequenceTypeWaddleSharedFile.write(value.sharedFiles, into: &buf)
+        FfiConverterSequenceTypeWaddleLinkPreview.write(value.linkPreviews, into: &buf)
         FfiConverterOptionTypeWaddleCallEvent.write(value.callEvent, into: &buf)
     }
 }
@@ -1632,7 +1852,8 @@ public func FfiConverterTypeWaddleAvatar_lower(_ value: WaddleAvatar) -> RustBuf
 
 
 /**
- * Typed A/V call event surfaced to Swift via `on_call(...)`.
+ * Typed A/V call event surfaced to Swift via
+ * `WaddleClientEvent::Call`.
  * `from` is the stamped sender JID (a *full* JID for propose /
  * session-initiate per XEP-0353 §0.6); `to` is the stamped stanza
  * recipient when available; `sid` is the Jingle session id used to
@@ -1825,6 +2046,86 @@ public func FfiConverterTypeWaddleCallThreadAnchor_lower(_ value: WaddleCallThre
 }
 
 
+/**
+ * urn:waddle:call-thread:0 `<call-thread-ended/>` fastening. Mirrors
+ * `waddle_xmpp_client::xep::call_thread::CallThreadEnded` 1:1.
+ */
+public struct WaddleCallThreadEnded: Equatable, Hashable {
+    /**
+     * XEP-0422 `<apply-to id='…'/>` target: the anchor's stanza id.
+     */
+    public var anchorId: String
+    /**
+     * RFC 3339 instant the call ended.
+     */
+    public var ended: String
+    /**
+     * ISO 8601 duration of the call (e.g. `PT5M`).
+     */
+    public var duration: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * XEP-0422 `<apply-to id='…'/>` target: the anchor's stanza id.
+         */anchorId: String,
+        /**
+         * RFC 3339 instant the call ended.
+         */ended: String,
+        /**
+         * ISO 8601 duration of the call (e.g. `PT5M`).
+         */duration: String) {
+        self.anchorId = anchorId
+        self.ended = ended
+        self.duration = duration
+    }
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleCallThreadEnded: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleCallThreadEnded: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleCallThreadEnded {
+        return
+            try WaddleCallThreadEnded(
+                anchorId: FfiConverterString.read(from: &buf),
+                ended: FfiConverterString.read(from: &buf),
+                duration: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WaddleCallThreadEnded, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.anchorId, into: &buf)
+        FfiConverterString.write(value.ended, into: &buf)
+        FfiConverterString.write(value.duration, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleCallThreadEnded_lift(_ buf: RustBuffer) throws -> WaddleCallThreadEnded {
+    return try FfiConverterTypeWaddleCallThreadEnded.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleCallThreadEnded_lower(_ value: WaddleCallThreadEnded) -> RustBuffer {
+    return FfiConverterTypeWaddleCallThreadEnded.lower(value)
+}
+
+
 public struct WaddleChannel: Equatable, Hashable {
     public var id: String
     public var roomJid: String
@@ -1904,14 +2205,26 @@ public struct WaddleConfig: Equatable, Hashable {
     public var jid: String
     public var accessToken: String
     public var resource: String
+    /**
+     * XEP-0198 resume snapshot from a previous session. When present
+     * the runtime attempts `<resume/>` before resource binding and
+     * replays the queued outbound stanzas the server never acked.
+     */
+    public var resumeState: WaddleSmResumeState?
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(serverUrl: String, jid: String, accessToken: String, resource: String) {
+    public init(serverUrl: String, jid: String, accessToken: String, resource: String,
+        /**
+         * XEP-0198 resume snapshot from a previous session. When present
+         * the runtime attempts `<resume/>` before resource binding and
+         * replays the queued outbound stanzas the server never acked.
+         */resumeState: WaddleSmResumeState?) {
         self.serverUrl = serverUrl
         self.jid = jid
         self.accessToken = accessToken
         self.resource = resource
+        self.resumeState = resumeState
     }
 
 
@@ -1933,7 +2246,8 @@ public struct FfiConverterTypeWaddleConfig: FfiConverterRustBuffer {
                 serverUrl: FfiConverterString.read(from: &buf),
                 jid: FfiConverterString.read(from: &buf),
                 accessToken: FfiConverterString.read(from: &buf),
-                resource: FfiConverterString.read(from: &buf)
+                resource: FfiConverterString.read(from: &buf),
+                resumeState: FfiConverterOptionTypeWaddleSmResumeState.read(from: &buf)
         )
     }
 
@@ -1942,6 +2256,7 @@ public struct FfiConverterTypeWaddleConfig: FfiConverterRustBuffer {
         FfiConverterString.write(value.jid, into: &buf)
         FfiConverterString.write(value.accessToken, into: &buf)
         FfiConverterString.write(value.resource, into: &buf)
+        FfiConverterOptionTypeWaddleSmResumeState.write(value.resumeState, into: &buf)
     }
 }
 
@@ -2235,6 +2550,291 @@ public func FfiConverterTypeWaddleJidParts_lower(_ value: WaddleJidParts) -> Rus
 
 
 /**
+ * XEP-0511 link preview card produced by the server-side
+ * `urn:waddle:link-preview:0` pipeline.
+ */
+public struct WaddleLinkPreview: Equatable, Hashable {
+    public var originalUrl: String
+    public var normalizedUrl: String?
+    public var title: String?
+    public var description: String?
+    public var image: WaddleLinkPreviewImage?
+    /**
+     * Native-playable `og:video` media with a direct (non-iframe)
+     * media type; rendered in a native player on user action.
+     */
+    public var video: WaddleLinkPreviewVideo?
+    public var playerEmbed: WaddleLinkPreviewPlayer?
+    /**
+     * True when the preview referenced remote media the server did
+     * not cache; the client must not fetch it itself.
+     */
+    public var remoteMediaUnavailable: Bool
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(originalUrl: String, normalizedUrl: String?, title: String?, description: String?, image: WaddleLinkPreviewImage?,
+        /**
+         * Native-playable `og:video` media with a direct (non-iframe)
+         * media type; rendered in a native player on user action.
+         */video: WaddleLinkPreviewVideo?, playerEmbed: WaddleLinkPreviewPlayer?,
+        /**
+         * True when the preview referenced remote media the server did
+         * not cache; the client must not fetch it itself.
+         */remoteMediaUnavailable: Bool) {
+        self.originalUrl = originalUrl
+        self.normalizedUrl = normalizedUrl
+        self.title = title
+        self.description = description
+        self.image = image
+        self.video = video
+        self.playerEmbed = playerEmbed
+        self.remoteMediaUnavailable = remoteMediaUnavailable
+    }
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleLinkPreview: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleLinkPreview: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleLinkPreview {
+        return
+            try WaddleLinkPreview(
+                originalUrl: FfiConverterString.read(from: &buf),
+                normalizedUrl: FfiConverterOptionString.read(from: &buf),
+                title: FfiConverterOptionString.read(from: &buf),
+                description: FfiConverterOptionString.read(from: &buf),
+                image: FfiConverterOptionTypeWaddleLinkPreviewImage.read(from: &buf),
+                video: FfiConverterOptionTypeWaddleLinkPreviewVideo.read(from: &buf),
+                playerEmbed: FfiConverterOptionTypeWaddleLinkPreviewPlayer.read(from: &buf),
+                remoteMediaUnavailable: FfiConverterBool.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WaddleLinkPreview, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.originalUrl, into: &buf)
+        FfiConverterOptionString.write(value.normalizedUrl, into: &buf)
+        FfiConverterOptionString.write(value.title, into: &buf)
+        FfiConverterOptionString.write(value.description, into: &buf)
+        FfiConverterOptionTypeWaddleLinkPreviewImage.write(value.image, into: &buf)
+        FfiConverterOptionTypeWaddleLinkPreviewVideo.write(value.video, into: &buf)
+        FfiConverterOptionTypeWaddleLinkPreviewPlayer.write(value.playerEmbed, into: &buf)
+        FfiConverterBool.write(value.remoteMediaUnavailable, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleLinkPreview_lift(_ buf: RustBuffer) throws -> WaddleLinkPreview {
+    return try FfiConverterTypeWaddleLinkPreview.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleLinkPreview_lower(_ value: WaddleLinkPreview) -> RustBuffer {
+    return FfiConverterTypeWaddleLinkPreview.lower(value)
+}
+
+
+/**
+ * Cached preview image of a XEP-0511 link card.
+ */
+public struct WaddleLinkPreviewImage: Equatable, Hashable {
+    public var url: String
+    public var mediaType: String
+    public var width: UInt32?
+    public var height: UInt32?
+    public var alt: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(url: String, mediaType: String, width: UInt32?, height: UInt32?, alt: String?) {
+        self.url = url
+        self.mediaType = mediaType
+        self.width = width
+        self.height = height
+        self.alt = alt
+    }
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleLinkPreviewImage: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleLinkPreviewImage: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleLinkPreviewImage {
+        return
+            try WaddleLinkPreviewImage(
+                url: FfiConverterString.read(from: &buf),
+                mediaType: FfiConverterString.read(from: &buf),
+                width: FfiConverterOptionUInt32.read(from: &buf),
+                height: FfiConverterOptionUInt32.read(from: &buf),
+                alt: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WaddleLinkPreviewImage, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.url, into: &buf)
+        FfiConverterString.write(value.mediaType, into: &buf)
+        FfiConverterOptionUInt32.write(value.width, into: &buf)
+        FfiConverterOptionUInt32.write(value.height, into: &buf)
+        FfiConverterOptionString.write(value.alt, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleLinkPreviewImage_lift(_ buf: RustBuffer) throws -> WaddleLinkPreviewImage {
+    return try FfiConverterTypeWaddleLinkPreviewImage.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleLinkPreviewImage_lower(_ value: WaddleLinkPreviewImage) -> RustBuffer {
+    return FfiConverterTypeWaddleLinkPreviewImage.lower(value)
+}
+
+
+/**
+ * `og:video` iframe player embed of a XEP-0511 card.
+ */
+public struct WaddleLinkPreviewPlayer: Equatable, Hashable {
+    public var url: String
+    public var width: UInt32?
+    public var height: UInt32?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(url: String, width: UInt32?, height: UInt32?) {
+        self.url = url
+        self.width = width
+        self.height = height
+    }
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleLinkPreviewPlayer: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleLinkPreviewPlayer: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleLinkPreviewPlayer {
+        return
+            try WaddleLinkPreviewPlayer(
+                url: FfiConverterString.read(from: &buf),
+                width: FfiConverterOptionUInt32.read(from: &buf),
+                height: FfiConverterOptionUInt32.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WaddleLinkPreviewPlayer, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.url, into: &buf)
+        FfiConverterOptionUInt32.write(value.width, into: &buf)
+        FfiConverterOptionUInt32.write(value.height, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleLinkPreviewPlayer_lift(_ buf: RustBuffer) throws -> WaddleLinkPreviewPlayer {
+    return try FfiConverterTypeWaddleLinkPreviewPlayer.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleLinkPreviewPlayer_lower(_ value: WaddleLinkPreviewPlayer) -> RustBuffer {
+    return FfiConverterTypeWaddleLinkPreviewPlayer.lower(value)
+}
+
+
+/**
+ * Native-playable `og:video` media surfaced from a XEP-0511 card.
+ */
+public struct WaddleLinkPreviewVideo: Equatable, Hashable {
+    public var url: String
+    public var mediaType: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(url: String, mediaType: String) {
+        self.url = url
+        self.mediaType = mediaType
+    }
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleLinkPreviewVideo: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleLinkPreviewVideo: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleLinkPreviewVideo {
+        return
+            try WaddleLinkPreviewVideo(
+                url: FfiConverterString.read(from: &buf),
+                mediaType: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WaddleLinkPreviewVideo, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.url, into: &buf)
+        FfiConverterString.write(value.mediaType, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleLinkPreviewVideo_lift(_ buf: RustBuffer) throws -> WaddleLinkPreviewVideo {
+    return try FfiConverterTypeWaddleLinkPreviewVideo.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleLinkPreviewVideo_lower(_ value: WaddleLinkPreviewVideo) -> RustBuffer {
+    return FfiConverterTypeWaddleLinkPreviewVideo.lower(value)
+}
+
+
+/**
  * LiveKit join credentials extracted from the server-issued
  * `urn:waddle:transports:livekit:0` transport on a Jingle
  * session-initiate / session-accept. The Swift app feeds these
@@ -2365,6 +2965,73 @@ public func FfiConverterTypeWaddleMamPage_lower(_ value: WaddleMamPage) -> RustB
 
 
 /**
+ * XEP-0394 markup span over the message body. Offsets count Unicode
+ * scalar values; `end` is exclusive. `uri` is populated only for
+ * `Link` spans.
+ */
+public struct WaddleMarkupSpan: Equatable, Hashable {
+    public var spanType: WaddleMarkupSpanType
+    public var start: UInt32
+    public var end: UInt32
+    public var uri: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(spanType: WaddleMarkupSpanType, start: UInt32, end: UInt32, uri: String?) {
+        self.spanType = spanType
+        self.start = start
+        self.end = end
+        self.uri = uri
+    }
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleMarkupSpan: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleMarkupSpan: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleMarkupSpan {
+        return
+            try WaddleMarkupSpan(
+                spanType: FfiConverterTypeWaddleMarkupSpanType.read(from: &buf),
+                start: FfiConverterUInt32.read(from: &buf),
+                end: FfiConverterUInt32.read(from: &buf),
+                uri: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WaddleMarkupSpan, into buf: inout [UInt8]) {
+        FfiConverterTypeWaddleMarkupSpanType.write(value.spanType, into: &buf)
+        FfiConverterUInt32.write(value.start, into: &buf)
+        FfiConverterUInt32.write(value.end, into: &buf)
+        FfiConverterOptionString.write(value.uri, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleMarkupSpan_lift(_ buf: RustBuffer) throws -> WaddleMarkupSpan {
+    return try FfiConverterTypeWaddleMarkupSpan.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleMarkupSpan_lower(_ value: WaddleMarkupSpan) -> RustBuffer {
+    return FfiConverterTypeWaddleMarkupSpan.lower(value)
+}
+
+
+/**
  * XEP-0490 §3 displayed-marker entry surfaced to Swift. Mirrors
  * `waddle_xmpp_client::messaging::MdsDisplayedEntry` 1:1 — the
  * FFI does not collapse or rename fields so the Swift consumer
@@ -2454,21 +3121,122 @@ public struct WaddleMessage: Equatable, Hashable {
     public var from: String?
     public var to: String?
     public var body: String?
+    /**
+     * RFC 6121 `<subject/>` — room topic changes and forum topic posts.
+     */
+    public var subject: String?
     public var messageType: String
     public var timestamp: String?
     public var stanzaId: String?
+    /**
+     * XEP-0359 `by` authority of `stanza_id`. NOT verified here —
+     * consumers MUST check it against the expected archive authority
+     * before trusting the id (XEP-0359 §Security Considerations).
+     */
+    public var stanzaIdBy: String?
+    /**
+     * Every XEP-0359 `<stanza-id/>` on the stanza, one per archiving
+     * entity, in document order.
+     */
+    public var stanzaIds: [WaddleStanzaId]
     public var originId: String?
     public var replacesId: String?
     public var retractsId: String?
+    /**
+     * XEP-0424 tombstone: id of the retraction message that replaced
+     * the original in the archive.
+     */
+    public var retractionId: String?
+    /**
+     * XEP-0424: true when this message is a retraction tombstone.
+     */
+    public var isRetracted: Bool
+    /**
+     * XEP-0425 moderation target — the XEP-0359 id of the moderated
+     * message when this stanza is a moderation broadcast.
+     */
+    public var moderationTargetId: String?
+    /**
+     * XEP-0425 moderator JID (string form).
+     */
+    public var moderatedBy: String?
+    /**
+     * XEP-0425 human-readable moderation reason.
+     */
+    public var moderationReason: String?
     public var reactionTargetId: String?
     public var reactionEmojis: [String]
+    /**
+     * XEP-0085 chat state notification carried on this message.
+     * `None` when absent or when the wire value is not one of the
+     * five defined states.
+     */
+    public var chatState: WaddleChatState?
     /**
      * XEP-0333 `<markable/>` request attached to this inbound message.
      */
     public var displayedMarkerRequested: Bool
+    /**
+     * XEP-0333 `<displayed id='…'/>` marker target id.
+     */
+    public var displayedMarkerId: String?
     public var isMuc: Bool
     public var thread: String?
     public var parentThreadId: String?
+    /**
+     * XEP-0394 message markup spans over the body.
+     */
+    public var markupSpans: [WaddleMarkupSpan]
+    /**
+     * XEP-0372 broadcast mention URI (`@everyone` / `@here`), when
+     * one of the mention references targets the whole room.
+     */
+    public var broadcastMention: String?
+    /**
+     * XEP-0372 mention URIs, flattened from `references`.
+     */
+    public var mentionUris: [String]
+    /**
+     * XEP-0372 references attached to this message — every
+     * `<reference/>` with the required `type` and `uri`, regardless
+     * of type. `mention_uris`/`broadcast_mention` are derived views.
+     */
+    public var references: [WaddleReference]
+    /**
+     * Forum channel classification: `topic` (thread + body + subject)
+     * or `reply` (thread + body); `None` for plain chat.
+     */
+    public var forumPostKind: String?
+    /**
+     * Forum topic title (the subject of a `topic` post).
+     */
+    public var forumTitle: String?
+    /**
+     * XEP-0449: the message body is a sticker.
+     */
+    public var isSticker: Bool
+    /**
+     * XEP-0511 link preview metadata (`urn:waddle:link-preview:0`
+     * pipeline output), one entry per previewed URL.
+     */
+    public var linkPreviews: [WaddleLinkPreview]
+    /**
+     * urn:waddle:pin:0 pin/unpin room system event. `None` when the
+     * message carries no `<pin-event/>` payload.
+     */
+    public var pinEvent: WaddlePinEvent?
+    /**
+     * urn:waddle:call-thread:0 ended fastening targeting a
+     * call-thread anchor.
+     */
+    public var callThreadEnded: WaddleCallThreadEnded?
+    /**
+     * XEP-0280: direction of the carbon envelope this message was
+     * unwrapped from. Only stamped after the runtime verified the
+     * wrapping stanza came from the account's own bare JID (§11
+     * forgery rule); `None` for directly received stanzas.
+     */
+    public var carbon: WaddleCarbonDirection?
     /**
      * XEP-0461 reply target message id.
      */
@@ -2503,10 +3271,90 @@ public struct WaddleMessage: Equatable, Hashable {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(id: String?, from: String?, to: String?, body: String?, messageType: String, timestamp: String?, stanzaId: String?, originId: String?, replacesId: String?, retractsId: String?, reactionTargetId: String?, reactionEmojis: [String],
+    public init(id: String?, from: String?, to: String?, body: String?,
+        /**
+         * RFC 6121 `<subject/>` — room topic changes and forum topic posts.
+         */subject: String?, messageType: String, timestamp: String?, stanzaId: String?,
+        /**
+         * XEP-0359 `by` authority of `stanza_id`. NOT verified here —
+         * consumers MUST check it against the expected archive authority
+         * before trusting the id (XEP-0359 §Security Considerations).
+         */stanzaIdBy: String?,
+        /**
+         * Every XEP-0359 `<stanza-id/>` on the stanza, one per archiving
+         * entity, in document order.
+         */stanzaIds: [WaddleStanzaId], originId: String?, replacesId: String?, retractsId: String?,
+        /**
+         * XEP-0424 tombstone: id of the retraction message that replaced
+         * the original in the archive.
+         */retractionId: String?,
+        /**
+         * XEP-0424: true when this message is a retraction tombstone.
+         */isRetracted: Bool,
+        /**
+         * XEP-0425 moderation target — the XEP-0359 id of the moderated
+         * message when this stanza is a moderation broadcast.
+         */moderationTargetId: String?,
+        /**
+         * XEP-0425 moderator JID (string form).
+         */moderatedBy: String?,
+        /**
+         * XEP-0425 human-readable moderation reason.
+         */moderationReason: String?, reactionTargetId: String?, reactionEmojis: [String],
+        /**
+         * XEP-0085 chat state notification carried on this message.
+         * `None` when absent or when the wire value is not one of the
+         * five defined states.
+         */chatState: WaddleChatState?,
         /**
          * XEP-0333 `<markable/>` request attached to this inbound message.
-         */displayedMarkerRequested: Bool, isMuc: Bool, thread: String?, parentThreadId: String?,
+         */displayedMarkerRequested: Bool,
+        /**
+         * XEP-0333 `<displayed id='…'/>` marker target id.
+         */displayedMarkerId: String?, isMuc: Bool, thread: String?, parentThreadId: String?,
+        /**
+         * XEP-0394 message markup spans over the body.
+         */markupSpans: [WaddleMarkupSpan],
+        /**
+         * XEP-0372 broadcast mention URI (`@everyone` / `@here`), when
+         * one of the mention references targets the whole room.
+         */broadcastMention: String?,
+        /**
+         * XEP-0372 mention URIs, flattened from `references`.
+         */mentionUris: [String],
+        /**
+         * XEP-0372 references attached to this message — every
+         * `<reference/>` with the required `type` and `uri`, regardless
+         * of type. `mention_uris`/`broadcast_mention` are derived views.
+         */references: [WaddleReference],
+        /**
+         * Forum channel classification: `topic` (thread + body + subject)
+         * or `reply` (thread + body); `None` for plain chat.
+         */forumPostKind: String?,
+        /**
+         * Forum topic title (the subject of a `topic` post).
+         */forumTitle: String?,
+        /**
+         * XEP-0449: the message body is a sticker.
+         */isSticker: Bool,
+        /**
+         * XEP-0511 link preview metadata (`urn:waddle:link-preview:0`
+         * pipeline output), one entry per previewed URL.
+         */linkPreviews: [WaddleLinkPreview],
+        /**
+         * urn:waddle:pin:0 pin/unpin room system event. `None` when the
+         * message carries no `<pin-event/>` payload.
+         */pinEvent: WaddlePinEvent?,
+        /**
+         * urn:waddle:call-thread:0 ended fastening targeting a
+         * call-thread anchor.
+         */callThreadEnded: WaddleCallThreadEnded?,
+        /**
+         * XEP-0280: direction of the carbon envelope this message was
+         * unwrapped from. Only stamped after the runtime verified the
+         * wrapping stanza came from the account's own bare JID (§11
+         * forgery rule); `None` for directly received stanzas.
+         */carbon: WaddleCarbonDirection?,
         /**
          * XEP-0461 reply target message id.
          */replyToId: String?,
@@ -2535,18 +3383,39 @@ public struct WaddleMessage: Equatable, Hashable {
         self.from = from
         self.to = to
         self.body = body
+        self.subject = subject
         self.messageType = messageType
         self.timestamp = timestamp
         self.stanzaId = stanzaId
+        self.stanzaIdBy = stanzaIdBy
+        self.stanzaIds = stanzaIds
         self.originId = originId
         self.replacesId = replacesId
         self.retractsId = retractsId
+        self.retractionId = retractionId
+        self.isRetracted = isRetracted
+        self.moderationTargetId = moderationTargetId
+        self.moderatedBy = moderatedBy
+        self.moderationReason = moderationReason
         self.reactionTargetId = reactionTargetId
         self.reactionEmojis = reactionEmojis
+        self.chatState = chatState
         self.displayedMarkerRequested = displayedMarkerRequested
+        self.displayedMarkerId = displayedMarkerId
         self.isMuc = isMuc
         self.thread = thread
         self.parentThreadId = parentThreadId
+        self.markupSpans = markupSpans
+        self.broadcastMention = broadcastMention
+        self.mentionUris = mentionUris
+        self.references = references
+        self.forumPostKind = forumPostKind
+        self.forumTitle = forumTitle
+        self.isSticker = isSticker
+        self.linkPreviews = linkPreviews
+        self.pinEvent = pinEvent
+        self.callThreadEnded = callThreadEnded
+        self.carbon = carbon
         self.replyToId = replyToId
         self.replyToSender = replyToSender
         self.replyFallbackStart = replyFallbackStart
@@ -2576,18 +3445,39 @@ public struct FfiConverterTypeWaddleMessage: FfiConverterRustBuffer {
                 from: FfiConverterOptionString.read(from: &buf),
                 to: FfiConverterOptionString.read(from: &buf),
                 body: FfiConverterOptionString.read(from: &buf),
+                subject: FfiConverterOptionString.read(from: &buf),
                 messageType: FfiConverterString.read(from: &buf),
                 timestamp: FfiConverterOptionString.read(from: &buf),
                 stanzaId: FfiConverterOptionString.read(from: &buf),
+                stanzaIdBy: FfiConverterOptionString.read(from: &buf),
+                stanzaIds: FfiConverterSequenceTypeWaddleStanzaId.read(from: &buf),
                 originId: FfiConverterOptionString.read(from: &buf),
                 replacesId: FfiConverterOptionString.read(from: &buf),
                 retractsId: FfiConverterOptionString.read(from: &buf),
+                retractionId: FfiConverterOptionString.read(from: &buf),
+                isRetracted: FfiConverterBool.read(from: &buf),
+                moderationTargetId: FfiConverterOptionString.read(from: &buf),
+                moderatedBy: FfiConverterOptionString.read(from: &buf),
+                moderationReason: FfiConverterOptionString.read(from: &buf),
                 reactionTargetId: FfiConverterOptionString.read(from: &buf),
                 reactionEmojis: FfiConverterSequenceString.read(from: &buf),
+                chatState: FfiConverterOptionTypeWaddleChatState.read(from: &buf),
                 displayedMarkerRequested: FfiConverterBool.read(from: &buf),
+                displayedMarkerId: FfiConverterOptionString.read(from: &buf),
                 isMuc: FfiConverterBool.read(from: &buf),
                 thread: FfiConverterOptionString.read(from: &buf),
                 parentThreadId: FfiConverterOptionString.read(from: &buf),
+                markupSpans: FfiConverterSequenceTypeWaddleMarkupSpan.read(from: &buf),
+                broadcastMention: FfiConverterOptionString.read(from: &buf),
+                mentionUris: FfiConverterSequenceString.read(from: &buf),
+                references: FfiConverterSequenceTypeWaddleReference.read(from: &buf),
+                forumPostKind: FfiConverterOptionString.read(from: &buf),
+                forumTitle: FfiConverterOptionString.read(from: &buf),
+                isSticker: FfiConverterBool.read(from: &buf),
+                linkPreviews: FfiConverterSequenceTypeWaddleLinkPreview.read(from: &buf),
+                pinEvent: FfiConverterOptionTypeWaddlePinEvent.read(from: &buf),
+                callThreadEnded: FfiConverterOptionTypeWaddleCallThreadEnded.read(from: &buf),
+                carbon: FfiConverterOptionTypeWaddleCarbonDirection.read(from: &buf),
                 replyToId: FfiConverterOptionString.read(from: &buf),
                 replyToSender: FfiConverterOptionString.read(from: &buf),
                 replyFallbackStart: FfiConverterOptionUInt32.read(from: &buf),
@@ -2603,18 +3493,39 @@ public struct FfiConverterTypeWaddleMessage: FfiConverterRustBuffer {
         FfiConverterOptionString.write(value.from, into: &buf)
         FfiConverterOptionString.write(value.to, into: &buf)
         FfiConverterOptionString.write(value.body, into: &buf)
+        FfiConverterOptionString.write(value.subject, into: &buf)
         FfiConverterString.write(value.messageType, into: &buf)
         FfiConverterOptionString.write(value.timestamp, into: &buf)
         FfiConverterOptionString.write(value.stanzaId, into: &buf)
+        FfiConverterOptionString.write(value.stanzaIdBy, into: &buf)
+        FfiConverterSequenceTypeWaddleStanzaId.write(value.stanzaIds, into: &buf)
         FfiConverterOptionString.write(value.originId, into: &buf)
         FfiConverterOptionString.write(value.replacesId, into: &buf)
         FfiConverterOptionString.write(value.retractsId, into: &buf)
+        FfiConverterOptionString.write(value.retractionId, into: &buf)
+        FfiConverterBool.write(value.isRetracted, into: &buf)
+        FfiConverterOptionString.write(value.moderationTargetId, into: &buf)
+        FfiConverterOptionString.write(value.moderatedBy, into: &buf)
+        FfiConverterOptionString.write(value.moderationReason, into: &buf)
         FfiConverterOptionString.write(value.reactionTargetId, into: &buf)
         FfiConverterSequenceString.write(value.reactionEmojis, into: &buf)
+        FfiConverterOptionTypeWaddleChatState.write(value.chatState, into: &buf)
         FfiConverterBool.write(value.displayedMarkerRequested, into: &buf)
+        FfiConverterOptionString.write(value.displayedMarkerId, into: &buf)
         FfiConverterBool.write(value.isMuc, into: &buf)
         FfiConverterOptionString.write(value.thread, into: &buf)
         FfiConverterOptionString.write(value.parentThreadId, into: &buf)
+        FfiConverterSequenceTypeWaddleMarkupSpan.write(value.markupSpans, into: &buf)
+        FfiConverterOptionString.write(value.broadcastMention, into: &buf)
+        FfiConverterSequenceString.write(value.mentionUris, into: &buf)
+        FfiConverterSequenceTypeWaddleReference.write(value.references, into: &buf)
+        FfiConverterOptionString.write(value.forumPostKind, into: &buf)
+        FfiConverterOptionString.write(value.forumTitle, into: &buf)
+        FfiConverterBool.write(value.isSticker, into: &buf)
+        FfiConverterSequenceTypeWaddleLinkPreview.write(value.linkPreviews, into: &buf)
+        FfiConverterOptionTypeWaddlePinEvent.write(value.pinEvent, into: &buf)
+        FfiConverterOptionTypeWaddleCallThreadEnded.write(value.callThreadEnded, into: &buf)
+        FfiConverterOptionTypeWaddleCarbonDirection.write(value.carbon, into: &buf)
         FfiConverterOptionString.write(value.replyToId, into: &buf)
         FfiConverterOptionString.write(value.replyToSender, into: &buf)
         FfiConverterOptionUInt32.write(value.replyFallbackStart, into: &buf)
@@ -2737,6 +3648,191 @@ public func FfiConverterTypeWaddleMujiPresence_lower(_ value: WaddleMujiPresence
 }
 
 
+/**
+ * urn:waddle:pin:0 `<pin-event/>` room broadcast. Mirrors
+ * `waddle_xmpp_client::pin::PinEvent`.
+ */
+public struct WaddlePinEvent: Equatable, Hashable {
+    public var action: WaddlePinAction
+    /**
+     * XEP-0359 stanza-id of the targeted message.
+     */
+    public var targetStanzaId: String
+    /**
+     * Bare JID of the pinner/unpinner.
+     */
+    public var by: String
+    /**
+     * `Some("retracted")` when the unpin was triggered by a
+     * XEP-0424 retraction cascade.
+     */
+    public var reason: String?
+    /**
+     * Frozen preview, present only on `Pinned` events.
+     */
+    public var preview: WaddlePinPreview?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(action: WaddlePinAction,
+        /**
+         * XEP-0359 stanza-id of the targeted message.
+         */targetStanzaId: String,
+        /**
+         * Bare JID of the pinner/unpinner.
+         */by: String,
+        /**
+         * `Some("retracted")` when the unpin was triggered by a
+         * XEP-0424 retraction cascade.
+         */reason: String?,
+        /**
+         * Frozen preview, present only on `Pinned` events.
+         */preview: WaddlePinPreview?) {
+        self.action = action
+        self.targetStanzaId = targetStanzaId
+        self.by = by
+        self.reason = reason
+        self.preview = preview
+    }
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddlePinEvent: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddlePinEvent: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddlePinEvent {
+        return
+            try WaddlePinEvent(
+                action: FfiConverterTypeWaddlePinAction.read(from: &buf),
+                targetStanzaId: FfiConverterString.read(from: &buf),
+                by: FfiConverterString.read(from: &buf),
+                reason: FfiConverterOptionString.read(from: &buf),
+                preview: FfiConverterOptionTypeWaddlePinPreview.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WaddlePinEvent, into buf: inout [UInt8]) {
+        FfiConverterTypeWaddlePinAction.write(value.action, into: &buf)
+        FfiConverterString.write(value.targetStanzaId, into: &buf)
+        FfiConverterString.write(value.by, into: &buf)
+        FfiConverterOptionString.write(value.reason, into: &buf)
+        FfiConverterOptionTypeWaddlePinPreview.write(value.preview, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddlePinEvent_lift(_ buf: RustBuffer) throws -> WaddlePinEvent {
+    return try FfiConverterTypeWaddlePinEvent.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddlePinEvent_lower(_ value: WaddlePinEvent) -> RustBuffer {
+    return FfiConverterTypeWaddlePinEvent.lower(value)
+}
+
+
+/**
+ * Frozen preview snapshot of a pinned message, taken at pin time.
+ */
+public struct WaddlePinPreview: Equatable, Hashable {
+    /**
+     * Bare JID of the message author at pin time.
+     */
+    public var authorJid: String
+    /**
+     * Author's MUC nick at pin time, if known.
+     */
+    public var authorNick: String?
+    /**
+     * Truncated body text (≤280 chars).
+     */
+    public var text: String
+    /**
+     * Original message timestamp (RFC 3339), not the pin time.
+     */
+    public var messageTimestamp: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * Bare JID of the message author at pin time.
+         */authorJid: String,
+        /**
+         * Author's MUC nick at pin time, if known.
+         */authorNick: String?,
+        /**
+         * Truncated body text (≤280 chars).
+         */text: String,
+        /**
+         * Original message timestamp (RFC 3339), not the pin time.
+         */messageTimestamp: String) {
+        self.authorJid = authorJid
+        self.authorNick = authorNick
+        self.text = text
+        self.messageTimestamp = messageTimestamp
+    }
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddlePinPreview: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddlePinPreview: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddlePinPreview {
+        return
+            try WaddlePinPreview(
+                authorJid: FfiConverterString.read(from: &buf),
+                authorNick: FfiConverterOptionString.read(from: &buf),
+                text: FfiConverterString.read(from: &buf),
+                messageTimestamp: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WaddlePinPreview, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.authorJid, into: &buf)
+        FfiConverterOptionString.write(value.authorNick, into: &buf)
+        FfiConverterString.write(value.text, into: &buf)
+        FfiConverterString.write(value.messageTimestamp, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddlePinPreview_lift(_ buf: RustBuffer) throws -> WaddlePinPreview {
+    return try FfiConverterTypeWaddlePinPreview.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddlePinPreview_lower(_ value: WaddlePinPreview) -> RustBuffer {
+    return FfiConverterTypeWaddlePinPreview.lower(value)
+}
+
+
 public struct WaddlePresence: Equatable, Hashable {
     public var from: String?
     public var to: String?
@@ -2746,6 +3842,48 @@ public struct WaddlePresence: Equatable, Hashable {
     public var hats: [WaddlePresenceHat]
     public var mucAffiliation: WaddleMucAffiliation?
     public var mucRole: WaddleMucRole?
+    /**
+     * XEP-0045 real occupant JID from the `muc#user` item, exposed
+     * by non-anonymous rooms.
+     */
+    public var mucJid: String?
+    /**
+     * XEP-0045 `<status code='…'/>` markers from the `muc#user`
+     * payload. `110` identifies the recipient's own presence.
+     */
+    public var mucStatusCodes: [UInt16]
+    /**
+     * XEP-0153 vCard avatar hash from `<x xmlns='vcard-temp:x:update'>`.
+     */
+    public var vcardAvatar: String?
+    /**
+     * XEP-0319 last-interaction instant (RFC 3339) from
+     * `<idle since='…'/>`; `None` when the contact is interacting now.
+     */
+    public var idleSince: String?
+    /**
+     * RFC 6120 §8.3 error condition element name (e.g. `not-found`)
+     * for `type="error"` presences; `None` otherwise.
+     */
+    public var errorCondition: String?
+    /**
+     * RFC 6120 §8.3 error `type` attribute (e.g. `cancel`).
+     */
+    public var errorType: String?
+    /**
+     * RFC 6120 §8.3 human-readable `<text/>` of an error presence.
+     */
+    public var errorText: String?
+    /**
+     * urn:waddle:in-call:0 raised-hand marker carried alongside
+     * `<muji/>`; `false` when the child is absent (lowered).
+     */
+    public var handRaised: Bool
+    /**
+     * urn:waddle:in-call:0 muted-microphone marker; `false` when the
+     * child is absent (unmuted).
+     */
+    public var muted: Bool
     /**
      * XEP-0272 Muji presence advertisement
      * `<muji xmlns='urn:xmpp:jingle:muji:0'/>` indicating the
@@ -2759,6 +3897,39 @@ public struct WaddlePresence: Equatable, Hashable {
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
     public init(from: String?, to: String?, presenceType: String, show: String?, status: String?, hats: [WaddlePresenceHat], mucAffiliation: WaddleMucAffiliation?, mucRole: WaddleMucRole?,
+        /**
+         * XEP-0045 real occupant JID from the `muc#user` item, exposed
+         * by non-anonymous rooms.
+         */mucJid: String?,
+        /**
+         * XEP-0045 `<status code='…'/>` markers from the `muc#user`
+         * payload. `110` identifies the recipient's own presence.
+         */mucStatusCodes: [UInt16],
+        /**
+         * XEP-0153 vCard avatar hash from `<x xmlns='vcard-temp:x:update'>`.
+         */vcardAvatar: String?,
+        /**
+         * XEP-0319 last-interaction instant (RFC 3339) from
+         * `<idle since='…'/>`; `None` when the contact is interacting now.
+         */idleSince: String?,
+        /**
+         * RFC 6120 §8.3 error condition element name (e.g. `not-found`)
+         * for `type="error"` presences; `None` otherwise.
+         */errorCondition: String?,
+        /**
+         * RFC 6120 §8.3 error `type` attribute (e.g. `cancel`).
+         */errorType: String?,
+        /**
+         * RFC 6120 §8.3 human-readable `<text/>` of an error presence.
+         */errorText: String?,
+        /**
+         * urn:waddle:in-call:0 raised-hand marker carried alongside
+         * `<muji/>`; `false` when the child is absent (lowered).
+         */handRaised: Bool,
+        /**
+         * urn:waddle:in-call:0 muted-microphone marker; `false` when the
+         * child is absent (unmuted).
+         */muted: Bool,
         /**
          * XEP-0272 Muji presence advertisement
          * `<muji xmlns='urn:xmpp:jingle:muji:0'/>` indicating the
@@ -2775,6 +3946,15 @@ public struct WaddlePresence: Equatable, Hashable {
         self.hats = hats
         self.mucAffiliation = mucAffiliation
         self.mucRole = mucRole
+        self.mucJid = mucJid
+        self.mucStatusCodes = mucStatusCodes
+        self.vcardAvatar = vcardAvatar
+        self.idleSince = idleSince
+        self.errorCondition = errorCondition
+        self.errorType = errorType
+        self.errorText = errorText
+        self.handRaised = handRaised
+        self.muted = muted
         self.muji = muji
     }
 
@@ -2802,6 +3982,15 @@ public struct FfiConverterTypeWaddlePresence: FfiConverterRustBuffer {
                 hats: FfiConverterSequenceTypeWaddlePresenceHat.read(from: &buf),
                 mucAffiliation: FfiConverterOptionTypeWaddleMucAffiliation.read(from: &buf),
                 mucRole: FfiConverterOptionTypeWaddleMucRole.read(from: &buf),
+                mucJid: FfiConverterOptionString.read(from: &buf),
+                mucStatusCodes: FfiConverterSequenceUInt16.read(from: &buf),
+                vcardAvatar: FfiConverterOptionString.read(from: &buf),
+                idleSince: FfiConverterOptionString.read(from: &buf),
+                errorCondition: FfiConverterOptionString.read(from: &buf),
+                errorType: FfiConverterOptionString.read(from: &buf),
+                errorText: FfiConverterOptionString.read(from: &buf),
+                handRaised: FfiConverterBool.read(from: &buf),
+                muted: FfiConverterBool.read(from: &buf),
                 muji: FfiConverterOptionTypeWaddleMujiPresence.read(from: &buf)
         )
     }
@@ -2815,6 +4004,15 @@ public struct FfiConverterTypeWaddlePresence: FfiConverterRustBuffer {
         FfiConverterSequenceTypeWaddlePresenceHat.write(value.hats, into: &buf)
         FfiConverterOptionTypeWaddleMucAffiliation.write(value.mucAffiliation, into: &buf)
         FfiConverterOptionTypeWaddleMucRole.write(value.mucRole, into: &buf)
+        FfiConverterOptionString.write(value.mucJid, into: &buf)
+        FfiConverterSequenceUInt16.write(value.mucStatusCodes, into: &buf)
+        FfiConverterOptionString.write(value.vcardAvatar, into: &buf)
+        FfiConverterOptionString.write(value.idleSince, into: &buf)
+        FfiConverterOptionString.write(value.errorCondition, into: &buf)
+        FfiConverterOptionString.write(value.errorType, into: &buf)
+        FfiConverterOptionString.write(value.errorText, into: &buf)
+        FfiConverterBool.write(value.handRaised, into: &buf)
+        FfiConverterBool.write(value.muted, into: &buf)
         FfiConverterOptionTypeWaddleMujiPresence.write(value.muji, into: &buf)
     }
 }
@@ -2886,6 +4084,84 @@ public func FfiConverterTypeWaddlePresenceHat_lift(_ buf: RustBuffer) throws -> 
 #endif
 public func FfiConverterTypeWaddlePresenceHat_lower(_ value: WaddlePresenceHat) -> RustBuffer {
     return FfiConverterTypeWaddlePresenceHat.lower(value)
+}
+
+
+/**
+ * XEP-0372 `<reference/>`. `begin`/`end` are body offsets; `(0, 0)`
+ * is the "no body position" sentinel used by anchor-only references.
+ */
+public struct WaddleReference: Equatable, Hashable {
+    public var refType: String
+    public var uri: String
+    public var begin: UInt32
+    public var end: UInt32
+    /**
+     * XEP-0372 optional `anchor` attribute: the original, unresolved
+     * display text (or anchor URI) when offsets cannot be relied on.
+     */
+    public var anchor: String?
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(refType: String, uri: String, begin: UInt32, end: UInt32,
+        /**
+         * XEP-0372 optional `anchor` attribute: the original, unresolved
+         * display text (or anchor URI) when offsets cannot be relied on.
+         */anchor: String?) {
+        self.refType = refType
+        self.uri = uri
+        self.begin = begin
+        self.end = end
+        self.anchor = anchor
+    }
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleReference: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleReference: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleReference {
+        return
+            try WaddleReference(
+                refType: FfiConverterString.read(from: &buf),
+                uri: FfiConverterString.read(from: &buf),
+                begin: FfiConverterUInt32.read(from: &buf),
+                end: FfiConverterUInt32.read(from: &buf),
+                anchor: FfiConverterOptionString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WaddleReference, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.refType, into: &buf)
+        FfiConverterString.write(value.uri, into: &buf)
+        FfiConverterUInt32.write(value.begin, into: &buf)
+        FfiConverterUInt32.write(value.end, into: &buf)
+        FfiConverterOptionString.write(value.anchor, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleReference_lift(_ buf: RustBuffer) throws -> WaddleReference {
+    return try FfiConverterTypeWaddleReference.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleReference_lower(_ value: WaddleReference) -> RustBuffer {
+    return FfiConverterTypeWaddleReference.lower(value)
 }
 
 
@@ -3027,23 +4303,59 @@ public func FfiConverterTypeWaddleReplyTarget_lower(_ value: WaddleReplyTarget) 
  */
 public struct WaddleSendOptions: Equatable, Hashable {
     public var stanzaId: String?
+    /**
+     * RFC 6121 `<subject/>`, used by forum topic posts.
+     */
+    public var subject: String?
     public var reply: WaddleReplyTarget?
     public var fallback: WaddleFallbackRange?
     public var thread: WaddleThreadTarget?
+    /**
+     * XEP-0394 markup spans over the outbound body.
+     */
+    public var markupSpans: [WaddleMarkupSpan]
+    /**
+     * XEP-0372 references (mentions) attached to the send.
+     */
+    public var references: [WaddleReference]
     public var sharedFiles: [WaddleSharedFile]
     public var linkPreviewToken: String?
     public var requestDisplayedMarker: Bool
+    /**
+     * XEP-0045 §7.5: mark the message as a MUC private message so
+     * the sender's other clients can classify the sent-carbon copy
+     * without knowing the room.
+     */
+    public var mucPm: Bool
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(stanzaId: String?, reply: WaddleReplyTarget?, fallback: WaddleFallbackRange?, thread: WaddleThreadTarget?, sharedFiles: [WaddleSharedFile], linkPreviewToken: String?, requestDisplayedMarker: Bool) {
+    public init(stanzaId: String?,
+        /**
+         * RFC 6121 `<subject/>`, used by forum topic posts.
+         */subject: String?, reply: WaddleReplyTarget?, fallback: WaddleFallbackRange?, thread: WaddleThreadTarget?,
+        /**
+         * XEP-0394 markup spans over the outbound body.
+         */markupSpans: [WaddleMarkupSpan],
+        /**
+         * XEP-0372 references (mentions) attached to the send.
+         */references: [WaddleReference], sharedFiles: [WaddleSharedFile], linkPreviewToken: String?, requestDisplayedMarker: Bool,
+        /**
+         * XEP-0045 §7.5: mark the message as a MUC private message so
+         * the sender's other clients can classify the sent-carbon copy
+         * without knowing the room.
+         */mucPm: Bool) {
         self.stanzaId = stanzaId
+        self.subject = subject
         self.reply = reply
         self.fallback = fallback
         self.thread = thread
+        self.markupSpans = markupSpans
+        self.references = references
         self.sharedFiles = sharedFiles
         self.linkPreviewToken = linkPreviewToken
         self.requestDisplayedMarker = requestDisplayedMarker
+        self.mucPm = mucPm
     }
 
 
@@ -3063,23 +4375,31 @@ public struct FfiConverterTypeWaddleSendOptions: FfiConverterRustBuffer {
         return
             try WaddleSendOptions(
                 stanzaId: FfiConverterOptionString.read(from: &buf),
+                subject: FfiConverterOptionString.read(from: &buf),
                 reply: FfiConverterOptionTypeWaddleReplyTarget.read(from: &buf),
                 fallback: FfiConverterOptionTypeWaddleFallbackRange.read(from: &buf),
                 thread: FfiConverterOptionTypeWaddleThreadTarget.read(from: &buf),
+                markupSpans: FfiConverterSequenceTypeWaddleMarkupSpan.read(from: &buf),
+                references: FfiConverterSequenceTypeWaddleReference.read(from: &buf),
                 sharedFiles: FfiConverterSequenceTypeWaddleSharedFile.read(from: &buf),
                 linkPreviewToken: FfiConverterOptionString.read(from: &buf),
-                requestDisplayedMarker: FfiConverterBool.read(from: &buf)
+                requestDisplayedMarker: FfiConverterBool.read(from: &buf),
+                mucPm: FfiConverterBool.read(from: &buf)
         )
     }
 
     public static func write(_ value: WaddleSendOptions, into buf: inout [UInt8]) {
         FfiConverterOptionString.write(value.stanzaId, into: &buf)
+        FfiConverterOptionString.write(value.subject, into: &buf)
         FfiConverterOptionTypeWaddleReplyTarget.write(value.reply, into: &buf)
         FfiConverterOptionTypeWaddleFallbackRange.write(value.fallback, into: &buf)
         FfiConverterOptionTypeWaddleThreadTarget.write(value.thread, into: &buf)
+        FfiConverterSequenceTypeWaddleMarkupSpan.write(value.markupSpans, into: &buf)
+        FfiConverterSequenceTypeWaddleReference.write(value.references, into: &buf)
         FfiConverterSequenceTypeWaddleSharedFile.write(value.sharedFiles, into: &buf)
         FfiConverterOptionString.write(value.linkPreviewToken, into: &buf)
         FfiConverterBool.write(value.requestDisplayedMarker, into: &buf)
+        FfiConverterBool.write(value.mucPm, into: &buf)
     }
 }
 
@@ -3190,6 +4510,114 @@ public func FfiConverterTypeWaddleSharedFile_lower(_ value: WaddleSharedFile) ->
 }
 
 
+/**
+ * XEP-0198 client resume snapshot crossing the FFI as an opaque
+ * persistence round-trip: the Swift app stores it on disconnect and
+ * feeds it back through [`WaddleConfig`] on the next connect. Queued
+ * outbound stanzas travel as serialized XML strings — the message
+ * stanza-id is re-derived from the element's `id` attribute on
+ * restore, and the original enqueue instant survives only when the
+ * element already carries a `<delay/>` stamp (identical semantics to
+ * the wasm client's localStorage persistence of the same snapshot).
+ */
+public struct WaddleSmResumeState: Equatable, Hashable {
+    /**
+     * SM resumption token from `<enabled id='…'/>`.
+     */
+    public var previd: String
+    /**
+     * Count of inbound stanzas handled by this client.
+     */
+    public var inboundH: UInt32
+    /**
+     * Count of outbound stanzas sent by this client.
+     */
+    public var outboundH: UInt32
+    /**
+     * Server-advertised resumption window in seconds, when supplied.
+     */
+    public var maxResumeSeconds: UInt32?
+    /**
+     * Outbound stanzas the server had not acked at snapshot time,
+     * serialized to XML in send order for lossless replay.
+     */
+    public var queuedStanzasXml: [String]
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(
+        /**
+         * SM resumption token from `<enabled id='…'/>`.
+         */previd: String,
+        /**
+         * Count of inbound stanzas handled by this client.
+         */inboundH: UInt32,
+        /**
+         * Count of outbound stanzas sent by this client.
+         */outboundH: UInt32,
+        /**
+         * Server-advertised resumption window in seconds, when supplied.
+         */maxResumeSeconds: UInt32?,
+        /**
+         * Outbound stanzas the server had not acked at snapshot time,
+         * serialized to XML in send order for lossless replay.
+         */queuedStanzasXml: [String]) {
+        self.previd = previd
+        self.inboundH = inboundH
+        self.outboundH = outboundH
+        self.maxResumeSeconds = maxResumeSeconds
+        self.queuedStanzasXml = queuedStanzasXml
+    }
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleSmResumeState: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleSmResumeState: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleSmResumeState {
+        return
+            try WaddleSmResumeState(
+                previd: FfiConverterString.read(from: &buf),
+                inboundH: FfiConverterUInt32.read(from: &buf),
+                outboundH: FfiConverterUInt32.read(from: &buf),
+                maxResumeSeconds: FfiConverterOptionUInt32.read(from: &buf),
+                queuedStanzasXml: FfiConverterSequenceString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WaddleSmResumeState, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.previd, into: &buf)
+        FfiConverterUInt32.write(value.inboundH, into: &buf)
+        FfiConverterUInt32.write(value.outboundH, into: &buf)
+        FfiConverterOptionUInt32.write(value.maxResumeSeconds, into: &buf)
+        FfiConverterSequenceString.write(value.queuedStanzasXml, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleSmResumeState_lift(_ buf: RustBuffer) throws -> WaddleSmResumeState {
+    return try FfiConverterTypeWaddleSmResumeState.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleSmResumeState_lower(_ value: WaddleSmResumeState) -> RustBuffer {
+    return FfiConverterTypeWaddleSmResumeState.lower(value)
+}
+
+
 public struct WaddleSpace: Equatable, Hashable {
     public var id: String
     public var serviceJid: String
@@ -3249,6 +4677,70 @@ public func FfiConverterTypeWaddleSpace_lift(_ buf: RustBuffer) throws -> Waddle
 #endif
 public func FfiConverterTypeWaddleSpace_lower(_ value: WaddleSpace) -> RustBuffer {
     return FfiConverterTypeWaddleSpace.lower(value)
+}
+
+
+/**
+ * One XEP-0359 `<stanza-id/>` entry. Mirrors the core `StanzaId`
+ * shape: `by` is required by XEP-0359 and always present.
+ */
+public struct WaddleStanzaId: Equatable, Hashable {
+    public var id: String
+    /**
+     * JID (string form) of the archiving entity that assigned `id`.
+     */
+    public var by: String
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(id: String,
+        /**
+         * JID (string form) of the archiving entity that assigned `id`.
+         */by: String) {
+        self.id = id
+        self.by = by
+    }
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleStanzaId: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleStanzaId: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleStanzaId {
+        return
+            try WaddleStanzaId(
+                id: FfiConverterString.read(from: &buf),
+                by: FfiConverterString.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: WaddleStanzaId, into buf: inout [UInt8]) {
+        FfiConverterString.write(value.id, into: &buf)
+        FfiConverterString.write(value.by, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleStanzaId_lift(_ buf: RustBuffer) throws -> WaddleStanzaId {
+    return try FfiConverterTypeWaddleStanzaId.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleStanzaId_lower(_ value: WaddleStanzaId) -> RustBuffer {
+    return FfiConverterTypeWaddleStanzaId.lower(value)
 }
 
 
@@ -3666,6 +5158,364 @@ public func FfiConverterTypeWaddleCallEventKind_lower(_ value: WaddleCallEventKi
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 /**
+ * XEP-0280 carbon direction of an unwrapped forwarded copy. Always
+ * §11-verified by the runtime before it reaches this boundary.
+ */
+
+public enum WaddleCarbonDirection: Equatable, Hashable {
+
+    /**
+     * Mirror of a message another of our resources sent (`<sent/>`).
+     */
+    case sent
+    /**
+     * Mirror of a message another of our resources received
+     * (`<received/>`).
+     */
+    case received
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleCarbonDirection: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleCarbonDirection: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleCarbonDirection
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleCarbonDirection {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .sent
+
+        case 2: return .received
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: WaddleCarbonDirection, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .sent:
+            writeInt(&buf, Int32(1))
+
+
+        case .received:
+            writeInt(&buf, Int32(2))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleCarbonDirection_lift(_ buf: RustBuffer) throws -> WaddleCarbonDirection {
+    return try FfiConverterTypeWaddleCarbonDirection.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleCarbonDirection_lower(_ value: WaddleCarbonDirection) -> RustBuffer {
+    return FfiConverterTypeWaddleCarbonDirection.lower(value)
+}
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * XEP-0085 chat state notification states. Wire values outside these
+ * five are dropped to `None` at the conversion boundary.
+ */
+
+public enum WaddleChatState: Equatable, Hashable {
+
+    case active
+    case composing
+    case paused
+    case inactive
+    case gone
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleChatState: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleChatState: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleChatState
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleChatState {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .active
+
+        case 2: return .composing
+
+        case 3: return .paused
+
+        case 4: return .inactive
+
+        case 5: return .gone
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: WaddleChatState, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .active:
+            writeInt(&buf, Int32(1))
+
+
+        case .composing:
+            writeInt(&buf, Int32(2))
+
+
+        case .paused:
+            writeInt(&buf, Int32(3))
+
+
+        case .inactive:
+            writeInt(&buf, Int32(4))
+
+
+        case .gone:
+            writeInt(&buf, Int32(5))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleChatState_lift(_ buf: RustBuffer) throws -> WaddleChatState {
+    return try FfiConverterTypeWaddleChatState.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleChatState_lower(_ value: WaddleChatState) -> RustBuffer {
+    return FfiConverterTypeWaddleChatState.lower(value)
+}
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * Single typed event stream surfaced to the app. New event kinds are
+ * added as enum variants, which keeps the callback protocol itself
+ * stable across FFI releases.
+ */
+
+public enum WaddleClientEvent: Equatable, Hashable {
+
+    /**
+     * Session is bound and ready (fires on `SessionReady`).
+     */
+    case connected
+    /**
+     * The event stream closed; no further events will fire.
+     */
+    case disconnected
+    /**
+     * Typed inbound chat/groupchat message (or message-shaped event).
+     */
+    case message(message: WaddleMessage
+    )
+    /**
+     * Typed inbound presence.
+     */
+    case presence(presence: WaddlePresence
+    )
+    /**
+     * XEP-0313 archived message from an active history query.
+     */
+    case mamResult(message: WaddleArchivedMessage
+    )
+    /**
+     * XEP-0198: the server acked the outbound message with this id.
+     */
+    case deliveryAcked(stanzaId: String
+    )
+    /**
+     * XEP-0198: transport-level delivery failure for this id.
+     */
+    case deliveryFailed(stanzaId: String
+    )
+    /**
+     * XEP-0353 / XEP-0166 inbound call event. Fires for every JMI
+     * envelope and Jingle session control stanza addressed to the
+     * bound resource. The Swift app surfaces it as the ringing UI,
+     * the in-call HUD, and the hang-up handler.
+     */
+    case call(event: WaddleCallEvent
+    )
+    /**
+     * XEP-0198 resume snapshot changed. `None` after an explicit
+     * disconnect or when the session carries no resumable state;
+     * persist `Some(state)` and feed it back via
+     * `WaddleConfig.resume_state` on the next connect.
+     */
+    case resumeStateChanged(state: WaddleSmResumeState?
+    )
+    /**
+     * Human-readable diagnostic. Never carries protocol data.
+     */
+    case error(description: String
+    )
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleClientEvent: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleClientEvent: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleClientEvent
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleClientEvent {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .connected
+
+        case 2: return .disconnected
+
+        case 3: return .message(message: try FfiConverterTypeWaddleMessage.read(from: &buf)
+        )
+
+        case 4: return .presence(presence: try FfiConverterTypeWaddlePresence.read(from: &buf)
+        )
+
+        case 5: return .mamResult(message: try FfiConverterTypeWaddleArchivedMessage.read(from: &buf)
+        )
+
+        case 6: return .deliveryAcked(stanzaId: try FfiConverterString.read(from: &buf)
+        )
+
+        case 7: return .deliveryFailed(stanzaId: try FfiConverterString.read(from: &buf)
+        )
+
+        case 8: return .call(event: try FfiConverterTypeWaddleCallEvent.read(from: &buf)
+        )
+
+        case 9: return .resumeStateChanged(state: try FfiConverterOptionTypeWaddleSmResumeState.read(from: &buf)
+        )
+
+        case 10: return .error(description: try FfiConverterString.read(from: &buf)
+        )
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: WaddleClientEvent, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .connected:
+            writeInt(&buf, Int32(1))
+
+
+        case .disconnected:
+            writeInt(&buf, Int32(2))
+
+
+        case let .message(message):
+            writeInt(&buf, Int32(3))
+            FfiConverterTypeWaddleMessage.write(message, into: &buf)
+
+
+        case let .presence(presence):
+            writeInt(&buf, Int32(4))
+            FfiConverterTypeWaddlePresence.write(presence, into: &buf)
+
+
+        case let .mamResult(message):
+            writeInt(&buf, Int32(5))
+            FfiConverterTypeWaddleArchivedMessage.write(message, into: &buf)
+
+
+        case let .deliveryAcked(stanzaId):
+            writeInt(&buf, Int32(6))
+            FfiConverterString.write(stanzaId, into: &buf)
+
+
+        case let .deliveryFailed(stanzaId):
+            writeInt(&buf, Int32(7))
+            FfiConverterString.write(stanzaId, into: &buf)
+
+
+        case let .call(event):
+            writeInt(&buf, Int32(8))
+            FfiConverterTypeWaddleCallEvent.write(event, into: &buf)
+
+
+        case let .resumeStateChanged(state):
+            writeInt(&buf, Int32(9))
+            FfiConverterOptionTypeWaddleSmResumeState.write(state, into: &buf)
+
+
+        case let .error(description):
+            writeInt(&buf, Int32(10))
+            FfiConverterString.write(description, into: &buf)
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleClientEvent_lift(_ buf: RustBuffer) throws -> WaddleClientEvent {
+    return try FfiConverterTypeWaddleClientEvent.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleClientEvent_lower(_ value: WaddleClientEvent) -> RustBuffer {
+    return FfiConverterTypeWaddleClientEvent.lower(value)
+}
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
  * XEP-0166 §7.4 session-terminate reason conditions. Mirrors the
  * 17 variants in `xmpp_parsers::jingle::Reason` so the wire
  * parser's enum is the single source of truth — outbound calls
@@ -3844,6 +5694,113 @@ public func FfiConverterTypeWaddleJingleReason_lower(_ value: WaddleJingleReason
 
 // Note that we don't yet support `indirect` for enums.
 // See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * XEP-0394 markup span kind. Mirrors the client crate's
+ * `MarkupSpanType`; `Link` is Waddle's `urn:waddle:markup:0` span
+ * extension (XEP-0394 defines no link span).
+ */
+
+public enum WaddleMarkupSpanType: Equatable, Hashable {
+
+    case bold
+    case italic
+    case strikethrough
+    case code
+    case codeBlock
+    case blockquote
+    case link
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleMarkupSpanType: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleMarkupSpanType: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleMarkupSpanType
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleMarkupSpanType {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .bold
+
+        case 2: return .italic
+
+        case 3: return .strikethrough
+
+        case 4: return .code
+
+        case 5: return .codeBlock
+
+        case 6: return .blockquote
+
+        case 7: return .link
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: WaddleMarkupSpanType, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .bold:
+            writeInt(&buf, Int32(1))
+
+
+        case .italic:
+            writeInt(&buf, Int32(2))
+
+
+        case .strikethrough:
+            writeInt(&buf, Int32(3))
+
+
+        case .code:
+            writeInt(&buf, Int32(4))
+
+
+        case .codeBlock:
+            writeInt(&buf, Int32(5))
+
+
+        case .blockquote:
+            writeInt(&buf, Int32(6))
+
+
+        case .link:
+            writeInt(&buf, Int32(7))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleMarkupSpanType_lift(_ buf: RustBuffer) throws -> WaddleMarkupSpanType {
+    return try FfiConverterTypeWaddleMarkupSpanType.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleMarkupSpanType_lower(_ value: WaddleMarkupSpanType) -> RustBuffer {
+    return FfiConverterTypeWaddleMarkupSpanType.lower(value)
+}
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
 
 public enum WaddleMucAffiliation: Equatable, Hashable {
 
@@ -4008,6 +5965,76 @@ public func FfiConverterTypeWaddleMucRole_lift(_ buf: RustBuffer) throws -> Wadd
 #endif
 public func FfiConverterTypeWaddleMucRole_lower(_ value: WaddleMucRole) -> RustBuffer {
     return FfiConverterTypeWaddleMucRole.lower(value)
+}
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * urn:waddle:pin:0 pin/unpin action carried on a room system message.
+ */
+
+public enum WaddlePinAction: Equatable, Hashable {
+
+    case pinned
+    case unpinned
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddlePinAction: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddlePinAction: FfiConverterRustBuffer {
+    typealias SwiftType = WaddlePinAction
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddlePinAction {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .pinned
+
+        case 2: return .unpinned
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: WaddlePinAction, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .pinned:
+            writeInt(&buf, Int32(1))
+
+
+        case .unpinned:
+            writeInt(&buf, Int32(2))
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddlePinAction_lift(_ buf: RustBuffer) throws -> WaddlePinAction {
+    return try FfiConverterTypeWaddlePinAction.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddlePinAction_lower(_ value: WaddlePinAction) -> RustBuffer {
+    return FfiConverterTypeWaddlePinAction.lower(value)
 }
 
 
@@ -4290,29 +6317,7 @@ public func FfiConverterTypeWaddleSendMessageOutcome_lower(_ value: WaddleSendMe
 
 public protocol WaddleEventListener: AnyObject, Sendable {
 
-    func onMessage(message: WaddleMessage)
-
-    func onPresence(presence: WaddlePresence)
-
-    func onMamResult(message: WaddleArchivedMessage)
-
-    func onMessageDeliveryAcked(stanzaId: String)
-
-    func onMessageDeliveryFailed(stanzaId: String)
-
-    func onConnected()
-
-    func onDisconnected()
-
-    func onError(description: String)
-
-    /**
-     * XEP-0353 / XEP-0166 inbound call event. Fires for every
-     * JMI envelope and Jingle session control stanza addressed to
-     * the bound resource. The Swift app surfaces it as the
-     * ringing UI, the in-call HUD, and the hang-up handler.
-     */
-    func onCall(event: WaddleCallEvent)
+    func onEvent(event: WaddleClientEvent)
 
 }
 
@@ -4339,195 +6344,7 @@ fileprivate struct UniffiCallbackInterfaceWaddleEventListener {
                 fatalError("Uniffi callback interface WaddleEventListener: handle missing in uniffiClone")
             }
         },
-        onMessage: { (
-            uniffiHandle: UInt64,
-            message: RustBuffer,
-            uniffiOutReturn: UnsafeMutableRawPointer,
-            uniffiCallStatus: UnsafeMutablePointer<RustCallStatus>
-        ) in
-            let makeCall = {
-                () throws -> () in
-                guard let uniffiObj = try? FfiConverterCallbackInterfaceWaddleEventListener.handleMap.get(handle: uniffiHandle) else {
-                    throw UniffiInternalError.unexpectedStaleHandle
-                }
-                return uniffiObj.onMessage(
-                     message: try FfiConverterTypeWaddleMessage_lift(message)
-                )
-            }
-
-
-            let writeReturn = { () }
-            uniffiTraitInterfaceCall(
-                callStatus: uniffiCallStatus,
-                makeCall: makeCall,
-                writeReturn: writeReturn
-            )
-        },
-        onPresence: { (
-            uniffiHandle: UInt64,
-            presence: RustBuffer,
-            uniffiOutReturn: UnsafeMutableRawPointer,
-            uniffiCallStatus: UnsafeMutablePointer<RustCallStatus>
-        ) in
-            let makeCall = {
-                () throws -> () in
-                guard let uniffiObj = try? FfiConverterCallbackInterfaceWaddleEventListener.handleMap.get(handle: uniffiHandle) else {
-                    throw UniffiInternalError.unexpectedStaleHandle
-                }
-                return uniffiObj.onPresence(
-                     presence: try FfiConverterTypeWaddlePresence_lift(presence)
-                )
-            }
-
-
-            let writeReturn = { () }
-            uniffiTraitInterfaceCall(
-                callStatus: uniffiCallStatus,
-                makeCall: makeCall,
-                writeReturn: writeReturn
-            )
-        },
-        onMamResult: { (
-            uniffiHandle: UInt64,
-            message: RustBuffer,
-            uniffiOutReturn: UnsafeMutableRawPointer,
-            uniffiCallStatus: UnsafeMutablePointer<RustCallStatus>
-        ) in
-            let makeCall = {
-                () throws -> () in
-                guard let uniffiObj = try? FfiConverterCallbackInterfaceWaddleEventListener.handleMap.get(handle: uniffiHandle) else {
-                    throw UniffiInternalError.unexpectedStaleHandle
-                }
-                return uniffiObj.onMamResult(
-                     message: try FfiConverterTypeWaddleArchivedMessage_lift(message)
-                )
-            }
-
-
-            let writeReturn = { () }
-            uniffiTraitInterfaceCall(
-                callStatus: uniffiCallStatus,
-                makeCall: makeCall,
-                writeReturn: writeReturn
-            )
-        },
-        onMessageDeliveryAcked: { (
-            uniffiHandle: UInt64,
-            stanzaId: RustBuffer,
-            uniffiOutReturn: UnsafeMutableRawPointer,
-            uniffiCallStatus: UnsafeMutablePointer<RustCallStatus>
-        ) in
-            let makeCall = {
-                () throws -> () in
-                guard let uniffiObj = try? FfiConverterCallbackInterfaceWaddleEventListener.handleMap.get(handle: uniffiHandle) else {
-                    throw UniffiInternalError.unexpectedStaleHandle
-                }
-                return uniffiObj.onMessageDeliveryAcked(
-                     stanzaId: try FfiConverterString.lift(stanzaId)
-                )
-            }
-
-
-            let writeReturn = { () }
-            uniffiTraitInterfaceCall(
-                callStatus: uniffiCallStatus,
-                makeCall: makeCall,
-                writeReturn: writeReturn
-            )
-        },
-        onMessageDeliveryFailed: { (
-            uniffiHandle: UInt64,
-            stanzaId: RustBuffer,
-            uniffiOutReturn: UnsafeMutableRawPointer,
-            uniffiCallStatus: UnsafeMutablePointer<RustCallStatus>
-        ) in
-            let makeCall = {
-                () throws -> () in
-                guard let uniffiObj = try? FfiConverterCallbackInterfaceWaddleEventListener.handleMap.get(handle: uniffiHandle) else {
-                    throw UniffiInternalError.unexpectedStaleHandle
-                }
-                return uniffiObj.onMessageDeliveryFailed(
-                     stanzaId: try FfiConverterString.lift(stanzaId)
-                )
-            }
-
-
-            let writeReturn = { () }
-            uniffiTraitInterfaceCall(
-                callStatus: uniffiCallStatus,
-                makeCall: makeCall,
-                writeReturn: writeReturn
-            )
-        },
-        onConnected: { (
-            uniffiHandle: UInt64,
-            uniffiOutReturn: UnsafeMutableRawPointer,
-            uniffiCallStatus: UnsafeMutablePointer<RustCallStatus>
-        ) in
-            let makeCall = {
-                () throws -> () in
-                guard let uniffiObj = try? FfiConverterCallbackInterfaceWaddleEventListener.handleMap.get(handle: uniffiHandle) else {
-                    throw UniffiInternalError.unexpectedStaleHandle
-                }
-                return uniffiObj.onConnected(
-                )
-            }
-
-
-            let writeReturn = { () }
-            uniffiTraitInterfaceCall(
-                callStatus: uniffiCallStatus,
-                makeCall: makeCall,
-                writeReturn: writeReturn
-            )
-        },
-        onDisconnected: { (
-            uniffiHandle: UInt64,
-            uniffiOutReturn: UnsafeMutableRawPointer,
-            uniffiCallStatus: UnsafeMutablePointer<RustCallStatus>
-        ) in
-            let makeCall = {
-                () throws -> () in
-                guard let uniffiObj = try? FfiConverterCallbackInterfaceWaddleEventListener.handleMap.get(handle: uniffiHandle) else {
-                    throw UniffiInternalError.unexpectedStaleHandle
-                }
-                return uniffiObj.onDisconnected(
-                )
-            }
-
-
-            let writeReturn = { () }
-            uniffiTraitInterfaceCall(
-                callStatus: uniffiCallStatus,
-                makeCall: makeCall,
-                writeReturn: writeReturn
-            )
-        },
-        onError: { (
-            uniffiHandle: UInt64,
-            description: RustBuffer,
-            uniffiOutReturn: UnsafeMutableRawPointer,
-            uniffiCallStatus: UnsafeMutablePointer<RustCallStatus>
-        ) in
-            let makeCall = {
-                () throws -> () in
-                guard let uniffiObj = try? FfiConverterCallbackInterfaceWaddleEventListener.handleMap.get(handle: uniffiHandle) else {
-                    throw UniffiInternalError.unexpectedStaleHandle
-                }
-                return uniffiObj.onError(
-                     description: try FfiConverterString.lift(description)
-                )
-            }
-
-
-            let writeReturn = { () }
-            uniffiTraitInterfaceCall(
-                callStatus: uniffiCallStatus,
-                makeCall: makeCall,
-                writeReturn: writeReturn
-            )
-        },
-        onCall: { (
+        onEvent: { (
             uniffiHandle: UInt64,
             event: RustBuffer,
             uniffiOutReturn: UnsafeMutableRawPointer,
@@ -4538,8 +6355,8 @@ fileprivate struct UniffiCallbackInterfaceWaddleEventListener {
                 guard let uniffiObj = try? FfiConverterCallbackInterfaceWaddleEventListener.handleMap.get(handle: uniffiHandle) else {
                     throw UniffiInternalError.unexpectedStaleHandle
                 }
-                return uniffiObj.onCall(
-                     event: try FfiConverterTypeWaddleCallEvent_lift(event)
+                return uniffiObj.onEvent(
+                     event: try FfiConverterTypeWaddleClientEvent_lift(event)
                 )
             }
 
@@ -4777,6 +6594,30 @@ fileprivate struct FfiConverterOptionTypeWaddleCallThreadAnchor: FfiConverterRus
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionTypeWaddleCallThreadEnded: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleCallThreadEnded?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWaddleCallThreadEnded.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWaddleCallThreadEnded.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionTypeWaddleEncryptedFile: FfiConverterRustBuffer {
     typealias SwiftType = WaddleEncryptedFile?
 
@@ -4849,6 +6690,78 @@ fileprivate struct FfiConverterOptionTypeWaddleJidParts: FfiConverterRustBuffer 
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionTypeWaddleLinkPreviewImage: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleLinkPreviewImage?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWaddleLinkPreviewImage.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWaddleLinkPreviewImage.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeWaddleLinkPreviewPlayer: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleLinkPreviewPlayer?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWaddleLinkPreviewPlayer.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWaddleLinkPreviewPlayer.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeWaddleLinkPreviewVideo: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleLinkPreviewVideo?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWaddleLinkPreviewVideo.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWaddleLinkPreviewVideo.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionTypeWaddleMujiPresence: FfiConverterRustBuffer {
     typealias SwiftType = WaddleMujiPresence?
 
@@ -4865,6 +6778,54 @@ fileprivate struct FfiConverterOptionTypeWaddleMujiPresence: FfiConverterRustBuf
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeWaddleMujiPresence.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeWaddlePinEvent: FfiConverterRustBuffer {
+    typealias SwiftType = WaddlePinEvent?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWaddlePinEvent.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWaddlePinEvent.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeWaddlePinPreview: FfiConverterRustBuffer {
+    typealias SwiftType = WaddlePinPreview?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWaddlePinPreview.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWaddlePinPreview.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -4945,6 +6906,30 @@ fileprivate struct FfiConverterOptionTypeWaddleSendOptions: FfiConverterRustBuff
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterOptionTypeWaddleSmResumeState: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleSmResumeState?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWaddleSmResumeState.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWaddleSmResumeState.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterOptionTypeWaddleThreadTarget: FfiConverterRustBuffer {
     typealias SwiftType = WaddleThreadTarget?
 
@@ -4985,6 +6970,54 @@ fileprivate struct FfiConverterOptionTypeWaddleUploadSlot: FfiConverterRustBuffe
         switch try readInt(&buf) as Int8 {
         case 0: return nil
         case 1: return try FfiConverterTypeWaddleUploadSlot.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeWaddleCarbonDirection: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleCarbonDirection?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWaddleCarbonDirection.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWaddleCarbonDirection.read(from: &buf)
+        default: throw UniffiInternalError.unexpectedOptionalTag
+        }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterOptionTypeWaddleChatState: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleChatState?
+
+    public static func write(_ value: SwiftType, into buf: inout [UInt8]) {
+        guard let value = value else {
+            writeInt(&buf, Int8(0))
+            return
+        }
+        writeInt(&buf, Int8(1))
+        FfiConverterTypeWaddleChatState.write(value, into: &buf)
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> SwiftType {
+        switch try readInt(&buf) as Int8 {
+        case 0: return nil
+        case 1: return try FfiConverterTypeWaddleChatState.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
     }
@@ -5083,6 +7116,31 @@ fileprivate struct FfiConverterOptionSequenceTypeWaddleMdsDisplayedEntry: FfiCon
         case 1: return try FfiConverterSequenceTypeWaddleMdsDisplayedEntry.read(from: &buf)
         default: throw UniffiInternalError.unexpectedOptionalTag
         }
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceUInt16: FfiConverterRustBuffer {
+    typealias SwiftType = [UInt16]
+
+    public static func write(_ value: [UInt16], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterUInt16.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [UInt16] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [UInt16]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterUInt16.read(from: &buf))
+        }
+        return seq
     }
 }
 
@@ -5189,6 +7247,56 @@ fileprivate struct FfiConverterSequenceTypeWaddleEncryptedFileHash: FfiConverter
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterSequenceTypeWaddleLinkPreview: FfiConverterRustBuffer {
+    typealias SwiftType = [WaddleLinkPreview]
+
+    public static func write(_ value: [WaddleLinkPreview], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeWaddleLinkPreview.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [WaddleLinkPreview] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [WaddleLinkPreview]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeWaddleLinkPreview.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypeWaddleMarkupSpan: FfiConverterRustBuffer {
+    typealias SwiftType = [WaddleMarkupSpan]
+
+    public static func write(_ value: [WaddleMarkupSpan], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeWaddleMarkupSpan.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [WaddleMarkupSpan] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [WaddleMarkupSpan]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeWaddleMarkupSpan.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterSequenceTypeWaddleMdsDisplayedEntry: FfiConverterRustBuffer {
     typealias SwiftType = [WaddleMdsDisplayedEntry]
 
@@ -5239,6 +7347,31 @@ fileprivate struct FfiConverterSequenceTypeWaddlePresenceHat: FfiConverterRustBu
 #if swift(>=5.8)
 @_documentation(visibility: private)
 #endif
+fileprivate struct FfiConverterSequenceTypeWaddleReference: FfiConverterRustBuffer {
+    typealias SwiftType = [WaddleReference]
+
+    public static func write(_ value: [WaddleReference], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeWaddleReference.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [WaddleReference] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [WaddleReference]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeWaddleReference.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
 fileprivate struct FfiConverterSequenceTypeWaddleSharedFile: FfiConverterRustBuffer {
     typealias SwiftType = [WaddleSharedFile]
 
@@ -5281,6 +7414,31 @@ fileprivate struct FfiConverterSequenceTypeWaddleSpace: FfiConverterRustBuffer {
         seq.reserveCapacity(Int(len))
         for _ in 0 ..< len {
             seq.append(try FfiConverterTypeWaddleSpace.read(from: &buf))
+        }
+        return seq
+    }
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+fileprivate struct FfiConverterSequenceTypeWaddleStanzaId: FfiConverterRustBuffer {
+    typealias SwiftType = [WaddleStanzaId]
+
+    public static func write(_ value: [WaddleStanzaId], into buf: inout [UInt8]) {
+        let len = Int32(value.count)
+        writeInt(&buf, len)
+        for item in value {
+            FfiConverterTypeWaddleStanzaId.write(item, into: &buf)
+        }
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> [WaddleStanzaId] {
+        let len: Int32 = try readInt(&buf)
+        var seq = [WaddleStanzaId]()
+        seq.reserveCapacity(Int(len))
+        for _ in 0 ..< len {
+            seq.append(try FfiConverterTypeWaddleStanzaId.read(from: &buf))
         }
         return seq
     }
@@ -5474,31 +7632,7 @@ private let initializationResult: InitializationResult = {
     if (uniffi_waddle_xmpp_client_ffi_checksum_constructor_waddleclient_new() != 16174) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message() != 22165) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_presence() != 47318) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_mam_result() != 6626) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message_delivery_acked() != 46331) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message_delivery_failed() != 7405) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_connected() != 11479) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_disconnected() != 39983) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_error() != 64857) {
-        return InitializationResult.apiChecksumMismatch
-    }
-    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_call() != 41030) {
+    if (uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_event() != 13709) {
         return InitializationResult.apiChecksumMismatch
     }
 

--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_client.swift
@@ -4092,7 +4092,7 @@ public func FfiConverterTypeWaddlePresenceHat_lower(_ value: WaddlePresenceHat) 
  * is the "no body position" sentinel used by anchor-only references.
  */
 public struct WaddleReference: Equatable, Hashable {
-    public var refType: String
+    public var refType: WaddleReferenceType
     public var uri: String
     public var begin: UInt32
     public var end: UInt32
@@ -4104,7 +4104,7 @@ public struct WaddleReference: Equatable, Hashable {
 
     // Default memberwise initializers are never public by default, so we
     // declare one manually.
-    public init(refType: String, uri: String, begin: UInt32, end: UInt32,
+    public init(refType: WaddleReferenceType, uri: String, begin: UInt32, end: UInt32,
         /**
          * XEP-0372 optional `anchor` attribute: the original, unresolved
          * display text (or anchor URI) when offsets cannot be relied on.
@@ -4132,7 +4132,7 @@ public struct FfiConverterTypeWaddleReference: FfiConverterRustBuffer {
     public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleReference {
         return
             try WaddleReference(
-                refType: FfiConverterString.read(from: &buf),
+                refType: FfiConverterTypeWaddleReferenceType.read(from: &buf),
                 uri: FfiConverterString.read(from: &buf),
                 begin: FfiConverterUInt32.read(from: &buf),
                 end: FfiConverterUInt32.read(from: &buf),
@@ -4141,7 +4141,7 @@ public struct FfiConverterTypeWaddleReference: FfiConverterRustBuffer {
     }
 
     public static func write(_ value: WaddleReference, into buf: inout [UInt8]) {
-        FfiConverterString.write(value.refType, into: &buf)
+        FfiConverterTypeWaddleReferenceType.write(value.refType, into: &buf)
         FfiConverterString.write(value.uri, into: &buf)
         FfiConverterUInt32.write(value.begin, into: &buf)
         FfiConverterUInt32.write(value.end, into: &buf)
@@ -6270,6 +6270,88 @@ public func FfiConverterTypeWaddlePushEnvironment_lift(_ buf: RustBuffer) throws
 #endif
 public func FfiConverterTypeWaddlePushEnvironment_lower(_ value: WaddlePushEnvironment) -> RustBuffer {
     return FfiConverterTypeWaddlePushEnvironment.lower(value)
+}
+
+
+// Note that we don't yet support `indirect` for enums.
+// See https://github.com/mozilla/uniffi-rs/issues/396 for further discussion.
+/**
+ * XEP-0372 §4 reference `type`. `Other` preserves unrecognised wire
+ * values explicitly so extension references survive the boundary
+ * instead of being silently dropped or smuggled through a bare String.
+ */
+
+public enum WaddleReferenceType: Equatable, Hashable {
+
+    case mention
+    case data
+    case other(value: String
+    )
+
+
+
+
+
+}
+
+#if compiler(>=6)
+extension WaddleReferenceType: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeWaddleReferenceType: FfiConverterRustBuffer {
+    typealias SwiftType = WaddleReferenceType
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> WaddleReferenceType {
+        let variant: Int32 = try readInt(&buf)
+        switch variant {
+
+        case 1: return .mention
+
+        case 2: return .data
+
+        case 3: return .other(value: try FfiConverterString.read(from: &buf)
+        )
+
+        default: throw UniffiInternalError.unexpectedEnumCase
+        }
+    }
+
+    public static func write(_ value: WaddleReferenceType, into buf: inout [UInt8]) {
+        switch value {
+
+
+        case .mention:
+            writeInt(&buf, Int32(1))
+
+
+        case .data:
+            writeInt(&buf, Int32(2))
+
+
+        case let .other(value):
+            writeInt(&buf, Int32(3))
+            FfiConverterString.write(value, into: &buf)
+
+        }
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleReferenceType_lift(_ buf: RustBuffer) throws -> WaddleReferenceType {
+    return try FfiConverterTypeWaddleReferenceType.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeWaddleReferenceType_lower(_ value: WaddleReferenceType) -> RustBuffer {
+    return FfiConverterTypeWaddleReferenceType.lower(value)
 }
 
 

--- a/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_clientFFI.h
+++ b/apps/apple/Waddle/RustClient/Generated/waddle_xmpp_clientFFI.h
@@ -250,76 +250,12 @@ typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod0)(uint64_t, Rust
     );
 
 #endif
-#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD1
-#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD1
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod1)(uint64_t, RustBuffer, void* _Nonnull,
-        RustCallStatus *_Nonnull uniffiCallStatus
-    );
-
-#endif
-#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD2
-#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD2
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod2)(uint64_t, RustBuffer, void* _Nonnull,
-        RustCallStatus *_Nonnull uniffiCallStatus
-    );
-
-#endif
-#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD3
-#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD3
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod3)(uint64_t, RustBuffer, void* _Nonnull,
-        RustCallStatus *_Nonnull uniffiCallStatus
-    );
-
-#endif
-#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD4
-#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD4
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod4)(uint64_t, RustBuffer, void* _Nonnull,
-        RustCallStatus *_Nonnull uniffiCallStatus
-    );
-
-#endif
-#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD5
-#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD5
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod5)(uint64_t, void* _Nonnull,
-        RustCallStatus *_Nonnull uniffiCallStatus
-    );
-
-#endif
-#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD6
-#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD6
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod6)(uint64_t, void* _Nonnull,
-        RustCallStatus *_Nonnull uniffiCallStatus
-    );
-
-#endif
-#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD7
-#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD7
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod7)(uint64_t, RustBuffer, void* _Nonnull,
-        RustCallStatus *_Nonnull uniffiCallStatus
-    );
-
-#endif
-#ifndef UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD8
-#define UNIFFI_FFIDEF_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER_METHOD8
-typedef void (*UniffiCallbackInterfaceWaddleEventListenerMethod8)(uint64_t, RustBuffer, void* _Nonnull,
-        RustCallStatus *_Nonnull uniffiCallStatus
-    );
-
-#endif
 #ifndef UNIFFI_FFIDEF_V_TABLE_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER
 #define UNIFFI_FFIDEF_V_TABLE_CALLBACK_INTERFACE_WADDLE_EVENT_LISTENER
 typedef struct UniffiVTableCallbackInterfaceWaddleEventListener {
     UniffiCallbackInterfaceFree _Nonnull uniffiFree;
     UniffiCallbackInterfaceClone _Nonnull uniffiClone;
-    UniffiCallbackInterfaceWaddleEventListenerMethod0 _Nonnull onMessage;
-    UniffiCallbackInterfaceWaddleEventListenerMethod1 _Nonnull onPresence;
-    UniffiCallbackInterfaceWaddleEventListenerMethod2 _Nonnull onMamResult;
-    UniffiCallbackInterfaceWaddleEventListenerMethod3 _Nonnull onMessageDeliveryAcked;
-    UniffiCallbackInterfaceWaddleEventListenerMethod4 _Nonnull onMessageDeliveryFailed;
-    UniffiCallbackInterfaceWaddleEventListenerMethod5 _Nonnull onConnected;
-    UniffiCallbackInterfaceWaddleEventListenerMethod6 _Nonnull onDisconnected;
-    UniffiCallbackInterfaceWaddleEventListenerMethod7 _Nonnull onError;
-    UniffiCallbackInterfaceWaddleEventListenerMethod8 _Nonnull onCall;
+    UniffiCallbackInterfaceWaddleEventListenerMethod0 _Nonnull onEvent;
 } UniffiVTableCallbackInterfaceWaddleEventListener;
 
 #endif
@@ -928,57 +864,9 @@ uint16_t uniffi_waddle_xmpp_client_ffi_checksum_constructor_waddleclient_new(voi
 
 );
 #endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MESSAGE
-#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MESSAGE
-uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message(void
-
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_PRESENCE
-#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_PRESENCE
-uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_presence(void
-
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MAM_RESULT
-#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MAM_RESULT
-uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_mam_result(void
-
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MESSAGE_DELIVERY_ACKED
-#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MESSAGE_DELIVERY_ACKED
-uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message_delivery_acked(void
-
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MESSAGE_DELIVERY_FAILED
-#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_MESSAGE_DELIVERY_FAILED
-uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_message_delivery_failed(void
-
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_CONNECTED
-#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_CONNECTED
-uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_connected(void
-
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_DISCONNECTED
-#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_DISCONNECTED
-uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_disconnected(void
-
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_ERROR
-#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_ERROR
-uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_error(void
-
-);
-#endif
-#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_CALL
-#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_CALL
-uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_call(void
+#ifndef UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_EVENT
+#define UNIFFI_FFIDEF_UNIFFI_WADDLE_XMPP_CLIENT_FFI_CHECKSUM_METHOD_WADDLEEVENTLISTENER_ON_EVENT
+uint16_t uniffi_waddle_xmpp_client_ffi_checksum_method_waddleeventlistener_on_event(void
 
 );
 #endif

--- a/apps/apple/Waddle/RustClient/RustXmppClient.swift
+++ b/apps/apple/Waddle/RustClient/RustXmppClient.swift
@@ -406,17 +406,17 @@ private final class _EventListener: WaddleEventListener {
             replyToID: message.replyToId,
             replyToSender: message.replyToSender,
             replyFallbackRange: makeFallbackRange(message.replyFallbackStart, message.replyFallbackEnd),
-            markupSpans: [],
-            chatState: nil,
-            displayedMarkerID: nil,
+            markupSpans: message.markupSpans.compactMap(makeMarkupSpan),
+            chatState: message.chatState.map(chatStateWireName),
+            displayedMarkerID: message.displayedMarkerId,
             sharedFiles: message.sharedFiles.map(makeSharedFile),
-            broadcastMention: nil,
-            mentionURIs: [],
-            forumPostKind: nil,
-            forumTitle: nil,
+            broadcastMention: message.broadcastMention,
+            mentionURIs: message.mentionUris,
+            forumPostKind: message.forumPostKind.map(forumPostKindWireName),
+            forumTitle: message.forumTitle,
             threadID: message.thread,
             parentThreadID: message.parentThreadId,
-            isSticker: false
+            isSticker: message.isSticker
         )
         continuation.yield(.message(event))
     }
@@ -566,6 +566,38 @@ private func makeCallEvent(_ event: WaddleCallEvent) -> XMPPCallEvent {
     return XMPPCallEvent(from: event.from, to: event.to, sid: event.sid, kind: kind)
 }
 
+private func makeMarkupSpan(_ span: WaddleMarkupSpan) -> XMPPMarkupSpan? {
+    let type: XMPPMarkupSpan.SpanType = {
+        switch span.spanType {
+        case .bold: return .bold
+        case .italic: return .italic
+        case .strikethrough: return .strikethrough
+        case .code: return .code
+        case .codeBlock: return .codeBlock
+        case .blockquote: return .blockquote
+        case .link: return .link
+        }
+    }()
+    return XMPPMarkupSpan(type: type, start: Int(span.start), end: Int(span.end), uri: span.uri)
+}
+
+private func chatStateWireName(_ state: WaddleChatState) -> String {
+    switch state {
+    case .active: return "active"
+    case .composing: return "composing"
+    case .paused: return "paused"
+    case .inactive: return "inactive"
+    case .gone: return "gone"
+    }
+}
+
+private func forumPostKindWireName(_ kind: WaddleForumPostKind) -> String {
+    switch kind {
+    case .topic: return "topic"
+    case .reply: return "reply"
+    }
+}
+
 private func makeSharedFile(_ file: WaddleSharedFile) -> XMPPSharedFile {
     XMPPSharedFile(
         url: file.url,
@@ -613,17 +645,17 @@ private extension WaddleMamPage {
                 replyToID: archived.replyToId,
                 replyToSender: archived.replyToSender,
                 replyFallbackRange: makeFallbackRange(archived.replyFallbackStart, archived.replyFallbackEnd),
-                markupSpans: [],
+                markupSpans: archived.markupSpans.compactMap(makeMarkupSpan),
                 chatState: nil,
                 displayedMarkerID: nil,
                 sharedFiles: archived.sharedFiles.map(makeSharedFile),
-                broadcastMention: nil,
-                mentionURIs: [],
-                forumPostKind: nil,
-                forumTitle: nil,
+                broadcastMention: archived.broadcastMention,
+                mentionURIs: archived.mentionUris,
+                forumPostKind: archived.forumPostKind.map(forumPostKindWireName),
+                forumTitle: archived.forumTitle,
                 threadID: archived.thread,
                 parentThreadID: archived.parentThreadId,
-                isSticker: false
+                isSticker: archived.isSticker
             )
             return XMPPArchiveMessage(
                 mamID: archived.mamId,

--- a/apps/apple/Waddle/RustClient/RustXmppClient.swift
+++ b/apps/apple/Waddle/RustClient/RustXmppClient.swift
@@ -101,18 +101,37 @@ final class RustXmppClient: ObservableObject {
 
     // Forum topics/replies are groupchat messages with a thread.
     func sendForumTopic(roomJID: String, body: String, title: String? = nil) async {
-        _ = await waddleClient.sendGroupchatMessage(roomJid: roomJID, body: body, options: nil)
+        let options = title.map { topicTitle in
+            WaddleSendOptions(
+                stanzaId: nil,
+                subject: topicTitle,
+                reply: nil,
+                fallback: nil,
+                thread: nil,
+                markupSpans: [],
+                references: [],
+                sharedFiles: [],
+                linkPreviewToken: nil,
+                requestDisplayedMarker: false,
+                mucPm: false
+            )
+        }
+        _ = await waddleClient.sendGroupchatMessage(roomJid: roomJID, body: body, options: options)
     }
 
     func sendForumReply(roomJID: String, body: String, threadID: String) async {
         let options = WaddleSendOptions(
             stanzaId: nil,
+            subject: nil,
             reply: nil,
             fallback: nil,
             thread: WaddleThreadTarget(id: threadID, parent: nil),
+            markupSpans: [],
+            references: [],
             sharedFiles: [],
             linkPreviewToken: nil,
-            requestDisplayedMarker: false
+            requestDisplayedMarker: false,
+            mucPm: false
         )
         _ = await waddleClient.sendGroupchatMessage(roomJid: roomJID, body: body, options: options)
     }
@@ -268,12 +287,16 @@ final class RustXmppClient: ObservableObject {
         )
         let options = WaddleSendOptions(
             stanzaId: nil,
+            subject: nil,
             reply: nil,
             fallback: nil,
             thread: nil,
+            markupSpans: [],
+            references: [],
             sharedFiles: [sharedFile],
             linkPreviewToken: nil,
-            requestDisplayedMarker: false
+            requestDisplayedMarker: false,
+            mucPm: false
         )
         _ = await waddleClient.sendGroupchatMessage(roomJid: roomJID, body: fileURL, options: options)
     }
@@ -309,7 +332,37 @@ private final class _EventListener: WaddleEventListener {
         self.discoveryErrors = discoveryErrors
     }
 
-    func onConnected() {
+    // Exhaustive by design: a new `WaddleClientEvent` variant upstream is a
+    // compile error here until the app decides how to surface it.
+    func onEvent(event: WaddleClientEvent) {
+        switch event {
+        case .connected:
+            onConnected()
+        case .disconnected:
+            onDisconnected()
+        case let .message(message):
+            onMessage(message: message)
+        case let .presence(presence):
+            onPresence(presence: presence)
+        case let .mamResult(message):
+            onMamResult(message: message)
+        case let .deliveryAcked(stanzaId):
+            continuation.yield(.messageDeliveryAcked(stanzaID: stanzaId))
+        case let .deliveryFailed(stanzaId):
+            continuation.yield(.messageDeliveryFailed(stanzaID: stanzaId))
+        case let .call(callEvent):
+            onCall(event: callEvent)
+        case let .resumeStateChanged(state):
+            // The Apple client does not persist XEP-0198 resume state yet;
+            // it reconnects with a fresh stream (`WaddleConfig.resumeState`
+            // stays nil in `AppModel+Xmpp.swift`).
+            logger.debug("RustXmppClient: resume snapshot \(state == nil ? "cleared" : "updated")")
+        case let .error(description):
+            onError(description: description)
+        }
+    }
+
+    private func onConnected() {
         let owner = self.owner
         Task { @MainActor in
             owner?.connectionState = .ready
@@ -318,7 +371,7 @@ private final class _EventListener: WaddleEventListener {
         continuation.yield(.sessionReady)
     }
 
-    func onDisconnected() {
+    private func onDisconnected() {
         let owner = self.owner
         Task { @MainActor in
             owner?.connectionState = .disconnected
@@ -326,7 +379,7 @@ private final class _EventListener: WaddleEventListener {
         continuation.yield(.disconnected)
     }
 
-    func onError(description: String) {
+    private func onError(description: String) {
         print("[RustXmppClient] Rust FFI onError: \(description)")
         if discoveryErrors.record(description) {
             return
@@ -334,7 +387,7 @@ private final class _EventListener: WaddleEventListener {
         continuation.yield(.error(description))
     }
 
-    func onMessage(message: WaddleMessage) {
+    private func onMessage(message: WaddleMessage) {
         let timestamp = message.timestamp.flatMap { parseRFC3339($0) }
         let event = XMPPMessageEvent(
             from: message.from,
@@ -343,7 +396,7 @@ private final class _EventListener: WaddleEventListener {
             id: message.id,
             stanzaID: message.stanzaId,
             body: message.body,
-            subject: nil,
+            subject: message.subject,
             thread: message.thread,
             timestamp: timestamp,
             replacesID: message.replacesId,
@@ -368,7 +421,7 @@ private final class _EventListener: WaddleEventListener {
         continuation.yield(.message(event))
     }
 
-    func onPresence(presence: WaddlePresence) {
+    private func onPresence(presence: WaddlePresence) {
         let event = XMPPPresenceEvent(
             from: presence.from,
             to: presence.to,
@@ -382,21 +435,13 @@ private final class _EventListener: WaddleEventListener {
         continuation.yield(.presence(event))
     }
 
-    func onMamResult(message: WaddleArchivedMessage) {
+    private func onMamResult(message: WaddleArchivedMessage) {
         // MAM results are delivered via the fetchDmHistory / fetchRoomHistory return values;
         // individual callbacks here are informational only.
         logger.debug("RustXmppClient: MAM result id=\(message.mamId)")
     }
 
-    func onMessageDeliveryAcked(stanzaId: String) {
-        continuation.yield(.messageDeliveryAcked(stanzaID: stanzaId))
-    }
-
-    func onMessageDeliveryFailed(stanzaId: String) {
-        continuation.yield(.messageDeliveryFailed(stanzaID: stanzaId))
-    }
-
-    func onCall(event: WaddleCallEvent) {
+    private func onCall(event: WaddleCallEvent) {
         // XEP-0353 JMI + XEP-0166 Jingle session control events come
         // through here pre-typed; the AppModel consumes them to drive
         // the ringing UI, the floating PIP window, and the hang-up
@@ -558,11 +603,11 @@ private extension WaddleMamPage {
                 id: eventID,
                 stanzaID: archived.stanzaId,
                 body: archived.body,
-                subject: nil,
+                subject: archived.subject,
                 thread: archived.thread,
                 timestamp: timestamp,
-                replacesID: nil,
-                retractsID: nil,
+                replacesID: archived.replacesId,
+                retractsID: archived.retractsId,
                 reactionTargetID: archived.reactionTargetId,
                 reactionEmojis: archived.reactionEmojis,
                 replyToID: archived.replyToId,

--- a/server/crates/waddle-xmpp-client-ffi/src/boundary_convert.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/boundary_convert.rs
@@ -55,10 +55,12 @@ pub(crate) fn empty_mam_page() -> WaddleMamPage {
 
 pub(crate) fn mam_page_to_ffi(page: waddle_xmpp_client::mam::MamPage) -> WaddleMamPage {
     WaddleMamPage {
+        // filter_map: rows whose trusted parse was rejected and that carry
+        // no call event are dropped (spoofed-moderation guard, wasm parity).
         messages: page
             .messages
             .into_iter()
-            .map(crate::convert::archived_to_ffi)
+            .filter_map(crate::convert::archived_to_ffi)
             .collect(),
         first_id: page.rsm.first,
         last_id: page.rsm.last,

--- a/server/crates/waddle-xmpp-client-ffi/src/client_tests.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/client_tests.rs
@@ -1,9 +1,8 @@
 use std::sync::{Arc, Mutex as StdMutex};
 
-use crate::{WaddleArchivedMessage, WaddleCallEvent, WaddleMessage, WaddlePresence};
 use crate::{
-    WaddleClient, WaddleConfig, WaddleEncryptedFile, WaddleEventListener, WaddleSendMessageOutcome,
-    WaddleSendOptions, WaddleSharedFile,
+    WaddleClient, WaddleClientEvent, WaddleConfig, WaddleEncryptedFile, WaddleEventListener,
+    WaddleSendMessageOutcome, WaddleSendOptions, WaddleSharedFile,
 };
 
 #[derive(Clone, Default)]
@@ -18,25 +17,11 @@ impl RecordingListener {
 }
 
 impl WaddleEventListener for RecordingListener {
-    fn on_message(&self, _message: WaddleMessage) {}
-
-    fn on_presence(&self, _presence: WaddlePresence) {}
-
-    fn on_mam_result(&self, _message: WaddleArchivedMessage) {}
-
-    fn on_message_delivery_acked(&self, _stanza_id: String) {}
-
-    fn on_message_delivery_failed(&self, _stanza_id: String) {}
-
-    fn on_connected(&self) {}
-
-    fn on_disconnected(&self) {}
-
-    fn on_error(&self, description: String) {
-        self.errors.lock().unwrap().push(description);
+    fn on_event(&self, event: WaddleClientEvent) {
+        if let WaddleClientEvent::Error { description } = event {
+            self.errors.lock().unwrap().push(description);
+        }
     }
-
-    fn on_call(&self, _event: WaddleCallEvent) {}
 }
 
 fn test_client(listener: RecordingListener) -> Arc<WaddleClient> {
@@ -46,6 +31,7 @@ fn test_client(listener: RecordingListener) -> Arc<WaddleClient> {
             jid: "alice@waddle.test".to_string(),
             access_token: "token".to_string(),
             resource: "test".to_string(),
+            resume_state: None,
         },
         listener: Arc::new(Box::new(listener) as Box<dyn WaddleEventListener>),
         handle: tokio::sync::Mutex::new(None),

--- a/server/crates/waddle-xmpp-client-ffi/src/convert.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/convert.rs
@@ -22,12 +22,12 @@ use crate::{
     WaddleArchivedMessage, WaddleCallEvent, WaddleCallEventKind, WaddleCallMedia,
     WaddleCallThreadAnchor, WaddleCallThreadEnded, WaddleCarbonDirection, WaddleChatState,
     WaddleClientEvent, WaddleEncryptedFile, WaddleEncryptedFileHash, WaddleEventListener,
-    WaddleJingleReason, WaddleLinkPreview, WaddleLinkPreviewImage, WaddleLinkPreviewPlayer,
-    WaddleLinkPreviewVideo, WaddleLiveKitJoin, WaddleMarkupSpan, WaddleMarkupSpanType,
-    WaddleMdsDisplayedEntry, WaddleMessage, WaddleMucAffiliation, WaddleMucRole,
-    WaddleMujiPresence, WaddlePinAction, WaddlePinEvent, WaddlePinPreview, WaddlePresence,
-    WaddlePresenceHat, WaddleReference, WaddleSendOptions, WaddleSharedFile, WaddleSmResumeState,
-    WaddleStanzaId,
+    WaddleForumPostKind, WaddleJingleReason, WaddleLinkPreview, WaddleLinkPreviewImage,
+    WaddleLinkPreviewPlayer, WaddleLinkPreviewVideo, WaddleLiveKitJoin, WaddleMarkupSpan,
+    WaddleMarkupSpanType, WaddleMdsDisplayedEntry, WaddleMessage, WaddleMucAffiliation,
+    WaddleMucRole, WaddleMujiPresence, WaddlePinAction, WaddlePinEvent, WaddlePinPreview,
+    WaddlePresence, WaddlePresenceHat, WaddleReference, WaddleSendOptions, WaddleSharedFile,
+    WaddleSmResumeState, WaddleStanzaErrorType, WaddleStanzaId,
 };
 
 // ── Event dispatch ───────────────────────────────────────────────────────────
@@ -52,9 +52,11 @@ pub(super) fn dispatch_event(
             });
         }
         ClientEvent::MamResult(archived) => {
-            listener.on_event(WaddleClientEvent::MamResult {
-                message: archived_to_ffi(*archived),
-            });
+            // `None` = the trusted parse rejected the row (e.g. spoofed
+            // moderation) and it carries no call event — drop, like wasm.
+            if let Some(message) = archived_to_ffi(*archived) {
+                listener.on_event(WaddleClientEvent::MamResult { message });
+            }
         }
         ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked { stanza_id }) => {
             listener.on_event(WaddleClientEvent::DeliveryAcked {
@@ -226,7 +228,7 @@ fn presence_to_ffi(pres: InboundPresence) -> WaddlePresence {
         error_type: pres
             .error
             .as_ref()
-            .map(|err| err.error_type.as_str().to_string()),
+            .map(|err| stanza_error_type_to_ffi(err.error_type)),
         error_text: pres.error.and_then(|err| err.text),
         hand_raised: pres.hand_raised,
         muted: pres.muted,
@@ -245,6 +247,28 @@ fn chat_state_to_ffi(state: &str) -> Option<WaddleChatState> {
         "inactive" => Some(WaddleChatState::Inactive),
         "gone" => Some(WaddleChatState::Gone),
         _ => None,
+    }
+}
+
+fn forum_post_kind_to_ffi(kind: &str) -> Option<WaddleForumPostKind> {
+    match kind {
+        "topic" => Some(WaddleForumPostKind::Topic),
+        "reply" => Some(WaddleForumPostKind::Reply),
+        _ => None,
+    }
+}
+
+fn stanza_error_type_to_ffi(
+    error_type: waddle_xmpp_client::StanzaErrorType,
+) -> WaddleStanzaErrorType {
+    use waddle_xmpp_client::StanzaErrorType;
+    match error_type {
+        StanzaErrorType::Auth => WaddleStanzaErrorType::Auth,
+        StanzaErrorType::Cancel => WaddleStanzaErrorType::Cancel,
+        StanzaErrorType::Continue => WaddleStanzaErrorType::Continue,
+        StanzaErrorType::Modify => WaddleStanzaErrorType::Modify,
+        StanzaErrorType::Wait => WaddleStanzaErrorType::Wait,
+        StanzaErrorType::Unknown => WaddleStanzaErrorType::Unknown,
     }
 }
 
@@ -567,7 +591,10 @@ fn inbound_to_ffi(msg: InboundMessage) -> WaddleMessage {
         broadcast_mention: msg.broadcast_mention,
         mention_uris: msg.mention_uris,
         references: references_to_ffi(msg.references),
-        forum_post_kind: msg.forum_post_kind,
+        forum_post_kind: msg
+            .forum_post_kind
+            .as_deref()
+            .and_then(forum_post_kind_to_ffi),
         forum_title: msg.forum_title,
         is_sticker: msg.is_sticker,
         link_previews: link_previews_to_ffi(msg.link_previews),
@@ -621,9 +648,17 @@ fn call_thread_to_ffi(
 /// (the client parser extracts it via `crate::xep::thread::parse_thread`)
 /// instead of being recovered from the re-parse - closes the parent-leak
 /// path when `inner` is unparseable downstream.
+/// Returns `None` for archive rows whose inner message failed the trusted
+/// parse and that carry no call event — mirroring the wasm client's
+/// drop-guard. Without it, a spoofed occupant "moderation" stanza whose
+/// payload parse was rejected would still surface its raw `<body>` as a
+/// normal, non-retracted chat message.
 pub(crate) fn archived_to_ffi(
     archived: waddle_xmpp_client::ArchivedMessage,
-) -> WaddleArchivedMessage {
+) -> Option<WaddleArchivedMessage> {
+    if archived.payload.message.is_none() && archived.payload.call.is_none() {
+        return None;
+    }
     let parsed = archived.payload.message.as_deref();
     let call_event = archived
         .payload
@@ -634,7 +669,7 @@ pub(crate) fn archived_to_ffi(
         .and_then(|m| m.reply_fallback)
         .map(|(s, e)| (Some(s), Some(e)))
         .unwrap_or((None, None));
-    WaddleArchivedMessage {
+    Some(WaddleArchivedMessage {
         mam_id: archived.mam_id,
         query_id: archived.query_id,
         id: archived.id.map(|id| id.to_string()),
@@ -680,7 +715,9 @@ pub(crate) fn archived_to_ffi(
         references: parsed
             .map(|m| references_to_ffi(m.references.clone()))
             .unwrap_or_default(),
-        forum_post_kind: parsed.and_then(|m| m.forum_post_kind.clone()),
+        forum_post_kind: parsed
+            .and_then(|m| m.forum_post_kind.as_deref())
+            .and_then(forum_post_kind_to_ffi),
         forum_title: parsed.and_then(|m| m.forum_title.clone()),
         is_sticker: parsed.is_some_and(|m| m.is_sticker),
         author_real_jid: archived.author_real_jid,
@@ -703,7 +740,7 @@ pub(crate) fn archived_to_ffi(
             .map(|m| link_previews_to_ffi(m.link_previews.clone()))
             .unwrap_or_default(),
         call_event,
-    }
+    })
 }
 
 /// Convert the FFI options record into the typed `SendMessageOptions`. JIDs
@@ -1034,7 +1071,7 @@ mod tests {
              </message>",
         );
 
-        let ffi = archived_to_ffi(archived);
+        let ffi = archived_to_ffi(archived).expect("parsed archive row must convert");
         let call_event = ffi.call_event.expect("call event should be present");
 
         assert_eq!(ffi.mam_id, "mam-call");
@@ -1072,7 +1109,7 @@ mod tests {
              </message>",
         );
 
-        let ffi = archived_to_ffi(archived);
+        let ffi = archived_to_ffi(archived).expect("parsed archive row must convert");
         let anchor = ffi
             .call_thread
             .expect("call-thread should survive archive conversion");
@@ -1506,7 +1543,7 @@ mod tests {
              </message>",
         ));
         assert_eq!(topic.subject.as_deref(), Some("Release planning"));
-        assert_eq!(topic.forum_post_kind.as_deref(), Some("topic"));
+        assert_eq!(topic.forum_post_kind, Some(WaddleForumPostKind::Topic));
         assert_eq!(topic.forum_title.as_deref(), Some("Release planning"));
         assert_eq!(topic.thread.as_deref(), Some("topic-thread-1"));
 
@@ -1516,7 +1553,7 @@ mod tests {
                <thread>topic-thread-1</thread>\
              </message>",
         ));
-        assert_eq!(reply.forum_post_kind.as_deref(), Some("reply"));
+        assert_eq!(reply.forum_post_kind, Some(WaddleForumPostKind::Reply));
         assert!(reply.forum_title.is_none());
 
         // Bare room-topic change: subject only, no forum classification.
@@ -1580,7 +1617,7 @@ mod tests {
             ffi.error_condition.as_deref(),
             Some("registration-required")
         );
-        assert_eq!(ffi.error_type.as_deref(), Some("auth"));
+        assert_eq!(ffi.error_type, Some(WaddleStanzaErrorType::Auth));
         assert_eq!(ffi.error_text.as_deref(), Some("Members only"));
     }
 
@@ -1614,7 +1651,7 @@ mod tests {
              </message>",
         );
 
-        let ffi = archived_to_ffi(archived);
+        let ffi = archived_to_ffi(archived).expect("parsed archive row must convert");
         assert_eq!(ffi.mam_id, "mam-ext");
         assert_eq!(ffi.subject.as_deref(), Some("Release planning"));
         assert_eq!(ffi.stanza_id.as_deref(), Some("sid-archive"));
@@ -1628,7 +1665,7 @@ mod tests {
         assert_eq!(ffi.mention_uris, vec!["xmpp:bob@waddle.test".to_string()]);
         assert_eq!(ffi.references.len(), 1);
         assert_eq!(ffi.references[0].ref_type, "mention");
-        assert_eq!(ffi.forum_post_kind.as_deref(), Some("topic"));
+        assert_eq!(ffi.forum_post_kind, Some(WaddleForumPostKind::Topic));
         assert_eq!(ffi.forum_title.as_deref(), Some("Release planning"));
         assert!(ffi.is_sticker);
         assert!(!ffi.is_retracted);
@@ -1654,7 +1691,8 @@ mod tests {
                  </forwarded>\
                </result>\
              </message>",
-        ));
+        ))
+        .expect("tombstone row must convert");
         assert!(tombstone.is_retracted);
         assert_eq!(
             tombstone.retraction_id.as_deref(),
@@ -1682,10 +1720,37 @@ mod tests {
                </result>\
              </message>",
         ))
+        .expect("ended row must convert")
         .call_thread_ended
         .expect("call-thread-ended survives archive conversion");
         assert_eq!(ended.anchor_id, "anchor-stanza-id");
         assert_eq!(ended.duration, "PT5M");
+    }
+
+    /// Wasm-parity drop-guard (XEP-0425 spoof): an occupant-authored
+    /// "moderation" carrying a `<body>` fails the trusted parse, so the
+    /// row converts to `None` instead of rendering the spoofed body as a
+    /// normal, non-retracted chat message.
+    #[test]
+    fn archived_to_ffi_discards_spoofed_moderation_with_body() {
+        let spoofed = archived_to_ffi(parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-spoof' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-05-06T12:00:00Z'/>\
+                   <message xmlns='jabber:client' type='groupchat' id='spoof-1' \
+                            from='room@conf.waddle.test/alice'>\
+                     <body>this must not render as normal chat</body>\
+                     <retract xmlns='urn:xmpp:message-retract:1' id='target-id'>\
+                       <moderated xmlns='urn:xmpp:message-moderate:1' \
+                                  by='room@conf.waddle.test/alice'/>\
+                     </retract>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        ));
+        assert!(spoofed.is_none());
     }
 
     // ── Outbound send-options mapping ────────────────────────────────────────

--- a/server/crates/waddle-xmpp-client-ffi/src/convert.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/convert.rs
@@ -1,24 +1,33 @@
 use jid::Jid;
+use minidom::Element;
 
 use waddle_xmpp_client::{
     messaging::{
-        self, CallEventKind, CallMedia, InboundCallEvent, JingleReason, LiveKitJoin,
-        MdsDisplayedEntry, MujiPresence, SendMessageOptions,
+        self, CallEventKind, CallMedia, CarbonDirection, InboundCallEvent, InboundPresence,
+        JingleReason, LinkPreviewData, LiveKitJoin, MarkupSpan, MarkupSpanData, MarkupSpanType,
+        MdsDisplayedEntry, MujiPresence, ReferenceData, SendMessageOptions,
     },
+    pin::{PinEvent, PinEventAction, PinPreview},
     request::StanzaId,
     xep::{
+        call_thread::CallThreadEnded,
         reply::{FallbackRange, ReplyMarker},
         thread::ThreadRef,
     },
     ClientEvent, InboundMessage, LifecycleEvent, MessageDeliveryEvent, MessagingEvent,
+    SmResumeState,
 };
 
 use crate::{
     WaddleArchivedMessage, WaddleCallEvent, WaddleCallEventKind, WaddleCallMedia,
-    WaddleCallThreadAnchor, WaddleEncryptedFile, WaddleEncryptedFileHash, WaddleEventListener,
-    WaddleJingleReason, WaddleLiveKitJoin, WaddleMdsDisplayedEntry, WaddleMessage,
-    WaddleMucAffiliation, WaddleMucRole, WaddleMujiPresence, WaddlePresence, WaddlePresenceHat,
-    WaddleSendOptions, WaddleSharedFile,
+    WaddleCallThreadAnchor, WaddleCallThreadEnded, WaddleCarbonDirection, WaddleChatState,
+    WaddleClientEvent, WaddleEncryptedFile, WaddleEncryptedFileHash, WaddleEventListener,
+    WaddleJingleReason, WaddleLinkPreview, WaddleLinkPreviewImage, WaddleLinkPreviewPlayer,
+    WaddleLinkPreviewVideo, WaddleLiveKitJoin, WaddleMarkupSpan, WaddleMarkupSpanType,
+    WaddleMdsDisplayedEntry, WaddleMessage, WaddleMucAffiliation, WaddleMucRole,
+    WaddleMujiPresence, WaddlePinAction, WaddlePinEvent, WaddlePinPreview, WaddlePresence,
+    WaddlePresenceHat, WaddleReference, WaddleSendOptions, WaddleSharedFile, WaddleSmResumeState,
+    WaddleStanzaId,
 };
 
 // ── Event dispatch ───────────────────────────────────────────────────────────
@@ -29,37 +38,43 @@ pub(super) fn dispatch_event(
     listener: &dyn WaddleEventListener,
 ) {
     match event {
-        ClientEvent::Lifecycle(LifecycleEvent::SessionReady(_)) => listener.on_connected(),
+        ClientEvent::Lifecycle(LifecycleEvent::SessionReady(_)) => {
+            listener.on_event(WaddleClientEvent::Connected);
+        }
         ClientEvent::Messaging(MessagingEvent::Message(msg)) => {
-            listener.on_message(inbound_to_ffi(trusted_mds_message(*msg, account_bare_jid)));
+            listener.on_event(WaddleClientEvent::Message {
+                message: inbound_to_ffi(trusted_mds_message(*msg, account_bare_jid)),
+            });
         }
         ClientEvent::Messaging(MessagingEvent::Presence(pres)) => {
-            let pres = *pres;
-            listener.on_presence(WaddlePresence {
-                from: pres.from,
-                to: pres.to,
-                presence_type: pres
-                    .presence_type
-                    .unwrap_or_else(|| "available".to_string()),
-                show: pres.show,
-                status: pres.status,
-                hats: pres.hats.into_iter().map(presence_hat_to_ffi).collect(),
-                muc_affiliation: pres.muc_affiliation.map(muc_affiliation_to_ffi),
-                muc_role: pres.muc_role.map(muc_role_to_ffi),
-                muji: pres.muji.map(muji_presence_to_ffi),
+            listener.on_event(WaddleClientEvent::Presence {
+                presence: presence_to_ffi(*pres),
             });
         }
         ClientEvent::MamResult(archived) => {
-            listener.on_mam_result(archived_to_ffi(*archived));
+            listener.on_event(WaddleClientEvent::MamResult {
+                message: archived_to_ffi(*archived),
+            });
         }
         ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked { stanza_id }) => {
-            listener.on_message_delivery_acked(stanza_id.to_string());
+            listener.on_event(WaddleClientEvent::DeliveryAcked {
+                stanza_id: stanza_id.to_string(),
+            });
         }
         ClientEvent::MessageDelivery(MessageDeliveryEvent::Failed { stanza_id }) => {
-            listener.on_message_delivery_failed(stanza_id.to_string());
+            listener.on_event(WaddleClientEvent::DeliveryFailed {
+                stanza_id: stanza_id.to_string(),
+            });
         }
         ClientEvent::Call(call) => {
-            listener.on_call(call_event_to_ffi(*call));
+            listener.on_event(WaddleClientEvent::Call {
+                event: call_event_to_ffi(*call),
+            });
+        }
+        ClientEvent::ResumeStateChanged(state) => {
+            listener.on_event(WaddleClientEvent::ResumeStateChanged {
+                state: state.map(resume_state_to_ffi),
+            });
         }
         _ => {}
     }
@@ -188,6 +203,216 @@ fn mds_entry_to_ffi(entry: MdsDisplayedEntry) -> WaddleMdsDisplayedEntry {
     }
 }
 
+/// Convert a parsed inbound presence into the UniFFI record. Typed
+/// values (MUC status codes, idle instant, stanza error) are
+/// stringified only here, at the FFI boundary.
+fn presence_to_ffi(pres: InboundPresence) -> WaddlePresence {
+    WaddlePresence {
+        from: pres.from,
+        to: pres.to,
+        presence_type: pres
+            .presence_type
+            .unwrap_or_else(|| "available".to_string()),
+        show: pres.show,
+        status: pres.status,
+        hats: pres.hats.into_iter().map(presence_hat_to_ffi).collect(),
+        muc_affiliation: pres.muc_affiliation.map(muc_affiliation_to_ffi),
+        muc_role: pres.muc_role.map(muc_role_to_ffi),
+        muc_jid: pres.muc_jid,
+        muc_status_codes: pres.muc_status.iter().map(|status| status.code()).collect(),
+        vcard_avatar: pres.vcard_avatar,
+        idle_since: pres.idle_since.map(|since| since.to_rfc3339()),
+        error_condition: pres.error.as_ref().map(|err| err.condition.clone()),
+        error_type: pres
+            .error
+            .as_ref()
+            .map(|err| err.error_type.as_str().to_string()),
+        error_text: pres.error.and_then(|err| err.text),
+        hand_raised: pres.hand_raised,
+        muted: pres.muted,
+        muji: pres.muji.map(muji_presence_to_ffi),
+    }
+}
+
+/// XEP-0085: map the parser-validated state string to the typed FFI
+/// enum. Unknown strings surface as `None` rather than an opaque
+/// passthrough (typed-payloads hard rule).
+fn chat_state_to_ffi(state: &str) -> Option<WaddleChatState> {
+    match state {
+        "active" => Some(WaddleChatState::Active),
+        "composing" => Some(WaddleChatState::Composing),
+        "paused" => Some(WaddleChatState::Paused),
+        "inactive" => Some(WaddleChatState::Inactive),
+        "gone" => Some(WaddleChatState::Gone),
+        _ => None,
+    }
+}
+
+fn markup_span_type_to_ffi(span_type: MarkupSpanType) -> WaddleMarkupSpanType {
+    match span_type {
+        MarkupSpanType::Bold => WaddleMarkupSpanType::Bold,
+        MarkupSpanType::Italic => WaddleMarkupSpanType::Italic,
+        MarkupSpanType::Strikethrough => WaddleMarkupSpanType::Strikethrough,
+        MarkupSpanType::Code => WaddleMarkupSpanType::Code,
+        MarkupSpanType::CodeBlock => WaddleMarkupSpanType::CodeBlock,
+        MarkupSpanType::Blockquote => WaddleMarkupSpanType::Blockquote,
+        MarkupSpanType::Link => WaddleMarkupSpanType::Link,
+    }
+}
+
+/// Wire name of a span kind as consumed by the outbound XEP-0394
+/// builder (`build_outbound_message` matches on these strings).
+fn markup_span_type_wire_name(span_type: WaddleMarkupSpanType) -> &'static str {
+    match span_type {
+        WaddleMarkupSpanType::Bold => "bold",
+        WaddleMarkupSpanType::Italic => "italic",
+        WaddleMarkupSpanType::Strikethrough => "strikethrough",
+        WaddleMarkupSpanType::Code => "code",
+        WaddleMarkupSpanType::CodeBlock => "code_block",
+        WaddleMarkupSpanType::Blockquote => "blockquote",
+        WaddleMarkupSpanType::Link => "link",
+    }
+}
+
+fn markup_span_to_ffi(span: MarkupSpan) -> WaddleMarkupSpan {
+    WaddleMarkupSpan {
+        span_type: markup_span_type_to_ffi(span.span_type),
+        // Char offsets; a body long enough to overflow u32 cannot
+        // cross a real XMPP stream, so saturation is unreachable in
+        // practice but keeps the conversion total.
+        start: u32::try_from(span.start).unwrap_or(u32::MAX),
+        end: u32::try_from(span.end).unwrap_or(u32::MAX),
+        uri: span.uri,
+    }
+}
+
+fn markup_spans_to_ffi(spans: Vec<MarkupSpan>) -> Vec<WaddleMarkupSpan> {
+    spans.into_iter().map(markup_span_to_ffi).collect()
+}
+
+fn reference_to_ffi(reference: ReferenceData) -> WaddleReference {
+    WaddleReference {
+        ref_type: reference.ref_type,
+        uri: reference.uri,
+        begin: reference.begin,
+        end: reference.end,
+        anchor: reference.anchor,
+    }
+}
+
+fn references_to_ffi(references: Vec<ReferenceData>) -> Vec<WaddleReference> {
+    references.into_iter().map(reference_to_ffi).collect()
+}
+
+fn link_preview_to_ffi(preview: LinkPreviewData) -> WaddleLinkPreview {
+    WaddleLinkPreview {
+        original_url: preview.original_url.to_string(),
+        normalized_url: preview.normalized_url.map(|url| url.to_string()),
+        title: preview.title,
+        description: preview.description,
+        image: preview.image.map(|image| WaddleLinkPreviewImage {
+            url: image.url.to_string(),
+            media_type: image.media_type.as_str().to_string(),
+            width: image.width,
+            height: image.height,
+            alt: image.alt,
+        }),
+        video: preview.video.map(|video| WaddleLinkPreviewVideo {
+            url: video.url.to_string(),
+            media_type: video.media_type.as_str().to_string(),
+        }),
+        player_embed: preview.player_embed.map(|player| WaddleLinkPreviewPlayer {
+            url: player.url.to_string(),
+            width: player.width,
+            height: player.height,
+        }),
+        remote_media_unavailable: preview.remote_media_unavailable,
+    }
+}
+
+fn link_previews_to_ffi(previews: Vec<LinkPreviewData>) -> Vec<WaddleLinkPreview> {
+    previews.into_iter().map(link_preview_to_ffi).collect()
+}
+
+fn pin_preview_to_ffi(preview: PinPreview) -> WaddlePinPreview {
+    WaddlePinPreview {
+        author_jid: preview.author_jid,
+        author_nick: preview.author_nick,
+        text: preview.text,
+        message_timestamp: preview.message_timestamp.to_rfc3339(),
+    }
+}
+
+fn pin_event_to_ffi(event: PinEvent) -> WaddlePinEvent {
+    WaddlePinEvent {
+        action: match event.action {
+            PinEventAction::Pinned => WaddlePinAction::Pinned,
+            PinEventAction::Unpinned => WaddlePinAction::Unpinned,
+        },
+        target_stanza_id: event.target_stanza_id,
+        by: event.by,
+        reason: event.reason,
+        preview: event.preview.map(pin_preview_to_ffi),
+    }
+}
+
+fn call_thread_ended_to_ffi(ended: CallThreadEnded) -> WaddleCallThreadEnded {
+    WaddleCallThreadEnded {
+        anchor_id: ended.anchor_id,
+        ended: ended.ended.to_rfc3339(),
+        duration: ended.duration.as_str().to_owned(),
+    }
+}
+
+fn carbon_to_ffi(direction: CarbonDirection) -> WaddleCarbonDirection {
+    match direction {
+        CarbonDirection::Sent => WaddleCarbonDirection::Sent,
+        CarbonDirection::Received => WaddleCarbonDirection::Received,
+    }
+}
+
+// ── XEP-0198 resume snapshot round-trip ──────────────────────────────────────
+
+/// Serialize the typed resume snapshot for opaque persistence on the
+/// app side. Queued stanzas cross as XML strings — the message
+/// stanza-id is re-derived from each element on restore, so the
+/// round trip is lossless for replay identity.
+pub(super) fn resume_state_to_ffi(state: SmResumeState) -> WaddleSmResumeState {
+    WaddleSmResumeState {
+        previd: state.previd().to_string(),
+        inbound_h: state.inbound_h(),
+        outbound_h: state.outbound_h(),
+        max_resume_seconds: state.max_resume_seconds(),
+        queued_stanzas_xml: state
+            .unhandled_outbound_stanzas()
+            .map(String::from)
+            .collect(),
+    }
+}
+
+/// Rebuild the typed resume snapshot from persisted FFI data. Parsing
+/// the queued-stanza XML happens exactly once, here at the boundary;
+/// malformed persisted state is surfaced as a human-readable error
+/// (via the listener) rather than silently dropped.
+pub(super) fn resume_state_from_ffi(state: WaddleSmResumeState) -> Result<SmResumeState, String> {
+    let stanzas = state
+        .queued_stanzas_xml
+        .into_iter()
+        .map(|xml| {
+            xml.parse::<Element>()
+                .map_err(|err| format!("invalid resume stanza XML: {err}"))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+    SmResumeState::from_unhandled_outbound_stanzas(
+        state.previd,
+        state.inbound_h,
+        state.outbound_h,
+        stanzas,
+    )
+    .map(|resume| resume.with_max_resume_seconds(state.max_resume_seconds))
+    .map_err(|err| err.to_string())
+}
+
 fn call_media_to_ffi(media: CallMedia) -> WaddleCallMedia {
     WaddleCallMedia {
         audio: media.audio,
@@ -309,18 +534,46 @@ fn inbound_to_ffi(msg: InboundMessage) -> WaddleMessage {
         from: msg.from,
         to: msg.to,
         body: msg.body,
+        subject: msg.subject,
         message_type: msg.message_type,
         timestamp: msg.timestamp.map(|t| t.to_rfc3339()),
-        stanza_id: msg.stanza_id.map(|id| id.to_string()),
+        stanza_id: msg.stanza_id.as_ref().map(ToString::to_string),
+        stanza_id_by: msg.stanza_id.map(|id| id.by.to_string()),
+        stanza_ids: msg
+            .stanza_ids
+            .into_iter()
+            .map(|sid| WaddleStanzaId {
+                id: sid.id,
+                by: sid.by.to_string(),
+            })
+            .collect(),
         origin_id: msg.origin_id,
         replaces_id: msg.replaces_id,
         retracts_id: msg.retracts_id,
+        retraction_id: msg.retraction_id,
+        is_retracted: msg.is_retracted,
+        moderation_target_id: msg.moderation_target_id,
+        moderated_by: msg.moderated_by.map(|jid| jid.to_string()),
+        moderation_reason: msg.moderation_reason,
         reaction_target_id: msg.reaction_target_id,
         reaction_emojis: msg.reaction_emojis,
+        chat_state: msg.chat_state.as_deref().and_then(chat_state_to_ffi),
         displayed_marker_requested: msg.displayed_marker_requested,
+        displayed_marker_id: msg.displayed_marker_id,
         is_muc,
         thread: msg.thread_id.or(msg.thread),
         parent_thread_id: msg.parent_thread_id,
+        markup_spans: markup_spans_to_ffi(msg.markup_spans),
+        broadcast_mention: msg.broadcast_mention,
+        mention_uris: msg.mention_uris,
+        references: references_to_ffi(msg.references),
+        forum_post_kind: msg.forum_post_kind,
+        forum_title: msg.forum_title,
+        is_sticker: msg.is_sticker,
+        link_previews: link_previews_to_ffi(msg.link_previews),
+        pin_event: msg.pin_event.map(pin_event_to_ffi),
+        call_thread_ended: msg.call_thread_ended.map(call_thread_ended_to_ffi),
+        carbon: msg.carbon.map(carbon_to_ffi),
         reply_to_id: msg.reply_to_id,
         reply_to_sender: msg.reply_to_sender,
         reply_fallback_start: fb_start,
@@ -385,13 +638,30 @@ pub(crate) fn archived_to_ffi(
         mam_id: archived.mam_id,
         query_id: archived.query_id,
         id: archived.id.map(|id| id.to_string()),
-        stanza_id: archived.stanza_id.map(|id| id.to_string()),
+        stanza_id: archived.stanza_id.as_ref().map(ToString::to_string),
+        stanza_id_by: archived.stanza_id.map(|id| id.by.to_string()),
+        stanza_ids: archived
+            .stanza_ids
+            .into_iter()
+            .map(|sid| WaddleStanzaId {
+                id: sid.id,
+                by: sid.by.to_string(),
+            })
+            .collect(),
         origin_id: archived.origin_id.map(|id| id.to_string()),
         timestamp: archived.timestamp.map(|t| t.to_rfc3339()),
         from: archived.from,
         to: archived.to,
         message_type: archived.message_type,
         body: archived.body,
+        subject: parsed.and_then(|m| m.subject.clone()),
+        replaces_id: parsed.and_then(|m| m.replaces_id.clone()),
+        retracts_id: parsed.and_then(|m| m.retracts_id.clone()),
+        retraction_id: parsed.and_then(|m| m.retraction_id.clone()),
+        is_retracted: parsed.is_some_and(|m| m.is_retracted),
+        moderation_target_id: parsed.and_then(|m| m.moderation_target_id.clone()),
+        moderated_by: parsed.and_then(|m| m.moderated_by.as_ref().map(|jid| jid.to_string())),
+        moderation_reason: parsed.and_then(|m| m.moderation_reason.clone()),
         reaction_target_id: parsed.and_then(|m| m.reaction_target_id.clone()),
         reaction_emojis: parsed
             .map(|m| m.reaction_emojis.clone())
@@ -402,9 +672,24 @@ pub(crate) fn archived_to_ffi(
         reply_to_sender: parsed.and_then(|m| m.reply_to_sender.clone()),
         reply_fallback_start: fb_start,
         reply_fallback_end: fb_end,
+        markup_spans: parsed
+            .map(|m| markup_spans_to_ffi(m.markup_spans.clone()))
+            .unwrap_or_default(),
+        broadcast_mention: parsed.and_then(|m| m.broadcast_mention.clone()),
+        mention_uris: parsed.map(|m| m.mention_uris.clone()).unwrap_or_default(),
+        references: parsed
+            .map(|m| references_to_ffi(m.references.clone()))
+            .unwrap_or_default(),
+        forum_post_kind: parsed.and_then(|m| m.forum_post_kind.clone()),
+        forum_title: parsed.and_then(|m| m.forum_title.clone()),
+        is_sticker: parsed.is_some_and(|m| m.is_sticker),
+        author_real_jid: archived.author_real_jid,
         call_thread: parsed
             .and_then(|m| m.call_thread.clone())
             .map(call_thread_to_ffi),
+        call_thread_ended: parsed
+            .and_then(|m| m.call_thread_ended.clone())
+            .map(call_thread_ended_to_ffi),
         shared_files: parsed
             .map(|m| {
                 m.shared_files
@@ -413,6 +698,9 @@ pub(crate) fn archived_to_ffi(
                     .map(shared_file_to_ffi)
                     .collect()
             })
+            .unwrap_or_default(),
+        link_previews: parsed
+            .map(|m| link_previews_to_ffi(m.link_previews.clone()))
             .unwrap_or_default(),
         call_event,
     }
@@ -485,13 +773,30 @@ pub(super) fn send_options_from_ffi(opts: WaddleSendOptions) -> Result<SendMessa
         fallback,
         thread,
         shared_files,
-        subject: None,
-        markup_spans: vec![],
-        references: vec![],
+        subject: opts.subject,
+        markup_spans: opts
+            .markup_spans
+            .into_iter()
+            .map(|span| MarkupSpanData {
+                span_type: markup_span_type_wire_name(span.span_type).to_string(),
+                start: span.start,
+                end: span.end,
+                uri: span.uri,
+            })
+            .collect(),
+        references: opts
+            .references
+            .into_iter()
+            .map(|reference| ReferenceData {
+                ref_type: reference.ref_type,
+                uri: reference.uri,
+                begin: reference.begin,
+                end: reference.end,
+                anchor: reference.anchor,
+            })
+            .collect(),
         request_displayed_marker: opts.request_displayed_marker,
-        // The Apple FFI has no MUC-PM send surface yet; the marker is a
-        // wasm/chat-side concern (#1256). Wire shape unchanged for FFI.
-        muc_pm: false,
+        muc_pm: opts.muc_pm,
         link_preview_token: opts
             .link_preview_token
             .map(messaging::LinkPreviewToken::new)
@@ -833,7 +1138,695 @@ mod tests {
         assert!(inbound_to_ffi(trusted).mds_displayed.is_none());
     }
 
-    /// In-test listener that captures every callback invocation in
+    // ── Record-parity conversion coverage (one test per XEP cluster) ────────
+
+    #[test]
+    fn xep0359_stanza_ids_survive_inbound_to_ffi() {
+        let ffi = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='groupchat' id='m1' \
+                      from='room@conf.waddle.test/alice'>\
+               <body>hi</body>\
+               <stanza-id xmlns='urn:xmpp:sid:0' id='sid-archive' by='archive.waddle.test'/>\
+               <stanza-id xmlns='urn:xmpp:sid:0' id='sid-room' by='room@conf.waddle.test'/>\
+             </message>",
+        ));
+        assert_eq!(ffi.stanza_id.as_deref(), Some("sid-archive"));
+        assert_eq!(ffi.stanza_id_by.as_deref(), Some("archive.waddle.test"));
+        assert_eq!(ffi.stanza_ids.len(), 2);
+        assert_eq!(ffi.stanza_ids[0].id, "sid-archive");
+        assert_eq!(ffi.stanza_ids[0].by, "archive.waddle.test");
+        assert_eq!(ffi.stanza_ids[1].id, "sid-room");
+        assert_eq!(ffi.stanza_ids[1].by, "room@conf.waddle.test");
+    }
+
+    #[test]
+    fn xep0308_correction_survives_inbound_to_ffi() {
+        let ffi = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='chat' id='m2' from='bob@waddle.test/phone'>\
+               <body>fixed typo</body>\
+               <replace xmlns='urn:xmpp:message-correct:0' id='orig-1'/>\
+             </message>",
+        ));
+        assert_eq!(ffi.replaces_id.as_deref(), Some("orig-1"));
+    }
+
+    #[test]
+    fn xep0425_moderation_broadcast_survives_inbound_to_ffi() {
+        let ffi = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='groupchat' id='retraction-id-1' \
+                      from='room@conf.waddle.test'>\
+               <retract xmlns='urn:xmpp:message-retract:1' id='target-room-sid'>\
+                 <moderated xmlns='urn:xmpp:message-moderate:1' by='room@conf.waddle.test/mod'/>\
+                 <reason>spam</reason>\
+               </retract>\
+             </message>",
+        ));
+        assert_eq!(ffi.retracts_id.as_deref(), Some("target-room-sid"));
+        assert_eq!(ffi.moderation_target_id.as_deref(), Some("target-room-sid"));
+        assert_eq!(
+            ffi.moderated_by.as_deref(),
+            Some("room@conf.waddle.test/mod")
+        );
+        assert_eq!(ffi.moderation_reason.as_deref(), Some("spam"));
+        assert!(!ffi.is_retracted);
+    }
+
+    #[test]
+    fn xep0424_tombstone_survives_inbound_to_ffi() {
+        let ffi = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='groupchat' id='target-message-id' \
+                      from='room@conf.waddle.test/alice'>\
+               <retracted xmlns='urn:xmpp:message-retract:1' id='retraction-message-id' \
+                          stamp='2026-05-06T12:00:01Z'>\
+                 <moderated xmlns='urn:xmpp:message-moderate:1' by='room@conf.waddle.test/mod'/>\
+                 <reason>spam</reason>\
+               </retracted>\
+             </message>",
+        ));
+        assert!(ffi.is_retracted);
+        assert_eq!(ffi.retraction_id.as_deref(), Some("retraction-message-id"));
+        assert_eq!(
+            ffi.moderated_by.as_deref(),
+            Some("room@conf.waddle.test/mod")
+        );
+        assert_eq!(ffi.moderation_reason.as_deref(), Some("spam"));
+    }
+
+    #[test]
+    fn xep0085_chat_state_maps_to_typed_enum() {
+        let ffi = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='chat' from='bob@waddle.test/phone'>\
+               <composing xmlns='http://jabber.org/protocol/chatstates'/>\
+             </message>",
+        ));
+        assert_eq!(ffi.chat_state, Some(WaddleChatState::Composing));
+    }
+
+    #[test]
+    fn xep0085_unknown_chat_state_string_maps_to_none() {
+        // The parser already validates states, but the conversion layer
+        // must independently refuse to pass unknown strings through as
+        // typed values.
+        assert_eq!(chat_state_to_ffi("active"), Some(WaddleChatState::Active));
+        assert_eq!(chat_state_to_ffi("paused"), Some(WaddleChatState::Paused));
+        assert_eq!(
+            chat_state_to_ffi("inactive"),
+            Some(WaddleChatState::Inactive)
+        );
+        assert_eq!(chat_state_to_ffi("gone"), Some(WaddleChatState::Gone));
+        assert_eq!(chat_state_to_ffi("bogus-state"), None);
+        assert_eq!(chat_state_to_ffi(""), None);
+
+        let mut msg = parse_message(
+            "<message xmlns='jabber:client' type='chat' from='bob@waddle.test/phone'>\
+               <body>hi</body>\
+             </message>",
+        );
+        msg.chat_state = Some("bogus-state".to_string());
+        assert_eq!(inbound_to_ffi(msg).chat_state, None);
+    }
+
+    #[test]
+    fn xep0333_displayed_marker_id_survives_inbound_to_ffi() {
+        let ffi = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='chat' from='bob@waddle.test/phone'>\
+               <displayed xmlns='urn:xmpp:chat-markers:0' id='m-42'/>\
+             </message>",
+        ));
+        assert_eq!(ffi.displayed_marker_id.as_deref(), Some("m-42"));
+    }
+
+    #[test]
+    fn xep0394_markup_spans_survive_inbound_to_ffi() {
+        let ffi = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='groupchat' from='room@conf.waddle.test/alice'>\
+               <body>bold block https://example.com</body>\
+               <markup xmlns='urn:xmpp:markup:0'>\
+                 <span start='0' end='4'><strong/></span>\
+                 <bcode start='5' end='10'/>\
+                 <span xmlns='urn:waddle:markup:0' start='11' end='30' \
+                       uri='https://example.com'/>\
+               </markup>\
+             </message>",
+        ));
+        assert_eq!(ffi.markup_spans.len(), 3);
+        assert_eq!(ffi.markup_spans[0].span_type, WaddleMarkupSpanType::Bold);
+        assert_eq!(ffi.markup_spans[0].start, 0);
+        assert_eq!(ffi.markup_spans[0].end, 4);
+        assert_eq!(ffi.markup_spans[0].uri, None);
+        assert_eq!(
+            ffi.markup_spans[1].span_type,
+            WaddleMarkupSpanType::CodeBlock
+        );
+        assert_eq!(ffi.markup_spans[2].span_type, WaddleMarkupSpanType::Link);
+        assert_eq!(
+            ffi.markup_spans[2].uri.as_deref(),
+            Some("https://example.com")
+        );
+    }
+
+    #[test]
+    fn xep0372_references_and_broadcast_mention_survive_inbound_to_ffi() {
+        let ffi = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='groupchat' from='room@conf.waddle.test/alice'>\
+               <body>hi @bob and @everyone, see https://example.com</body>\
+               <reference xmlns='urn:xmpp:reference:0' type='mention' \
+                  uri='xmpp:bob@waddle.test' begin='3' end='7'/>\
+               <reference xmlns='urn:xmpp:reference:0' type='mention' \
+                  uri='xmpp:@everyone' begin='12' end='21' \
+                  anchor='@everyone'/>\
+               <reference xmlns='urn:xmpp:reference:0' type='data' \
+                  uri='https://example.com' begin='27' end='46'/>\
+             </message>",
+        ));
+        assert_eq!(
+            ffi.mention_uris,
+            vec![
+                "xmpp:bob@waddle.test".to_string(),
+                "xmpp:@everyone".to_string(),
+            ]
+        );
+        assert_eq!(ffi.broadcast_mention.as_deref(), Some("xmpp:@everyone"));
+        assert_eq!(ffi.references.len(), 3);
+        assert_eq!(ffi.references[0].ref_type, "mention");
+        assert_eq!(ffi.references[0].uri, "xmpp:bob@waddle.test");
+        assert_eq!(ffi.references[0].begin, 3);
+        assert_eq!(ffi.references[0].end, 7);
+        assert_eq!(ffi.references[1].anchor.as_deref(), Some("@everyone"));
+        assert_eq!(ffi.references[2].ref_type, "data");
+        assert!(ffi.references[2].anchor.is_none());
+    }
+
+    #[test]
+    fn xep0449_sticker_marker_survives_inbound_to_ffi() {
+        let ffi = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='chat' from='bob@waddle.test/phone'>\
+               <body>\u{1F980}</body>\
+               <sticker xmlns='urn:xmpp:stickers:0' pack='crabs'/>\
+               <file-sharing xmlns='urn:xmpp:sfs:0' disposition='inline'>\
+                 <file xmlns='urn:xmpp:file:metadata:0'>\
+                   <media-type>image/png</media-type>\
+                   <name>crab.png</name>\
+                   <size>1234</size>\
+                 </file>\
+                 <sources>\
+                   <url-data xmlns='http://jabber.org/protocol/url-data' \
+                             target='https://cdn.waddle.test/crab.png'/>\
+                 </sources>\
+               </file-sharing>\
+             </message>",
+        ));
+        assert!(ffi.is_sticker);
+        assert_eq!(ffi.shared_files.len(), 1);
+        assert_eq!(ffi.shared_files[0].url, "https://cdn.waddle.test/crab.png");
+    }
+
+    #[test]
+    fn xep0280_carbon_direction_survives_inbound_to_ffi() {
+        let mut sent = parse_message(
+            "<message xmlns='jabber:client' type='chat' id='c1' \
+                      from='alice@waddle.test/phone' to='bob@waddle.test'>\
+               <body>sent elsewhere</body>\
+             </message>",
+        );
+        sent.carbon = Some(CarbonDirection::Sent);
+        assert_eq!(
+            inbound_to_ffi(sent).carbon,
+            Some(WaddleCarbonDirection::Sent)
+        );
+
+        let mut received = parse_message(
+            "<message xmlns='jabber:client' type='chat' id='c2' \
+                      from='bob@waddle.test/desktop' to='alice@waddle.test/phone'>\
+               <body>received elsewhere</body>\
+             </message>",
+        );
+        received.carbon = Some(CarbonDirection::Received);
+        assert_eq!(
+            inbound_to_ffi(received).carbon,
+            Some(WaddleCarbonDirection::Received)
+        );
+
+        let direct = parse_message(
+            "<message xmlns='jabber:client' type='chat' id='c3' \
+                      from='bob@waddle.test/desktop' to='alice@waddle.test/phone'>\
+               <body>direct</body>\
+             </message>",
+        );
+        assert_eq!(inbound_to_ffi(direct).carbon, None);
+    }
+
+    #[test]
+    fn xep0511_link_previews_survive_inbound_to_ffi() {
+        let ffi = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='groupchat' id='m-link' \
+                      from='room@conf.waddle.test/alice'>\
+               <body>see https://the.link.example/what-was-linked</body>\
+               <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' \
+                                xmlns:og='https://ogp.me/ns#' \
+                                xmlns:ogi='https://ogp.me/ns#image:' \
+                                rdf:about='https://the.link.example/what-was-linked'>\
+                 <og:title>The Best Webpage</og:title>\
+                 <og:description>Plain text preview</og:description>\
+                 <og:url>https://the.link.example/what-was-linked</og:url>\
+                 <og:image>https://waddle.example/api/files/11111111-1111-4111-8111-111111111111/link-preview-86610c40efe63f0a46c58c4b605c164b4ffa3a3ad3f1dcf13e6ba4c59cb3ce16.png</og:image>\
+                 <ogi:type>image/png</ogi:type>\
+                 <ogi:width>640</ogi:width>\
+                 <ogi:height>360</ogi:height>\
+                 <ogi:alt>Article screenshot</ogi:alt>\
+               </rdf:Description>\
+             </message>",
+        ));
+        assert_eq!(ffi.link_previews.len(), 1);
+        let preview = &ffi.link_previews[0];
+        assert_eq!(
+            preview.original_url,
+            "https://the.link.example/what-was-linked"
+        );
+        assert_eq!(
+            preview.normalized_url.as_deref(),
+            Some("https://the.link.example/what-was-linked")
+        );
+        assert_eq!(preview.title.as_deref(), Some("The Best Webpage"));
+        assert_eq!(preview.description.as_deref(), Some("Plain text preview"));
+        assert!(!preview.remote_media_unavailable);
+        let image = preview.image.as_ref().expect("cached image survives");
+        assert_eq!(image.media_type, "image/png");
+        assert_eq!(image.width, Some(640));
+        assert_eq!(image.height, Some(360));
+        assert_eq!(image.alt.as_deref(), Some("Article screenshot"));
+    }
+
+    #[test]
+    fn xep0511_remote_media_flag_survives_inbound_to_ffi() {
+        let ffi = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='groupchat' id='m-link' \
+                      from='room@conf.waddle.test/alice'>\
+               <body>see https://the.link.example/what-was-linked</body>\
+               <rdf:Description xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#' \
+                                xmlns:og='https://ogp.me/ns#' \
+                                xmlns:ogi='https://ogp.me/ns#image:' \
+                                rdf:about='https://the.link.example/what-was-linked'>\
+                 <og:title>The Best Webpage</og:title>\
+                 <og:image>https://remote.example/preview.png</og:image>\
+                 <ogi:type>image/png</ogi:type>\
+               </rdf:Description>\
+             </message>",
+        ));
+        assert_eq!(ffi.link_previews.len(), 1);
+        assert!(ffi.link_previews[0].image.is_none());
+        assert!(ffi.link_previews[0].remote_media_unavailable);
+    }
+
+    #[test]
+    fn pin_event_survives_inbound_to_ffi() {
+        let ffi = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='groupchat' from='room@conf.waddle.test'>\
+               <body>alice pinned a message</body>\
+               <pin-event xmlns='urn:waddle:pin:0' action='pinned' target='stanza-1' \
+                          by='admin@waddle.test'>\
+                 <preview>\
+                   <author jid='alice@waddle.test' nick='alice'/>\
+                   <text>important update</text>\
+                   <ts>2026-05-08T11:55:00+00:00</ts>\
+                 </preview>\
+               </pin-event>\
+             </message>",
+        ));
+        let pin = ffi.pin_event.expect("pin event survives conversion");
+        assert_eq!(pin.action, WaddlePinAction::Pinned);
+        assert_eq!(pin.target_stanza_id, "stanza-1");
+        assert_eq!(pin.by, "admin@waddle.test");
+        assert!(pin.reason.is_none());
+        let preview = pin.preview.expect("pinned event carries a preview");
+        assert_eq!(preview.author_jid, "alice@waddle.test");
+        assert_eq!(preview.author_nick.as_deref(), Some("alice"));
+        assert_eq!(preview.text, "important update");
+        assert_eq!(preview.message_timestamp, "2026-05-08T11:55:00+00:00");
+
+        let unpin = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='groupchat' from='room@conf.waddle.test'>\
+               <pin-event xmlns='urn:waddle:pin:0' action='unpinned' target='stanza-1' \
+                          by='admin@waddle.test' reason='retracted'/>\
+             </message>",
+        ))
+        .pin_event
+        .expect("unpin event survives conversion");
+        assert_eq!(unpin.action, WaddlePinAction::Unpinned);
+        assert_eq!(unpin.reason.as_deref(), Some("retracted"));
+        assert!(unpin.preview.is_none());
+    }
+
+    #[test]
+    fn call_thread_ended_survives_inbound_to_ffi() {
+        let ffi = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='groupchat' id='ended-1' \
+                      from='general@muc.waddle.test'>\
+               <apply-to xmlns='urn:xmpp:fasten:0' id='anchor-stanza-id'>\
+                 <call-thread-ended xmlns='urn:waddle:call-thread:0' \
+                                    ended='2026-06-07T14:35:00Z' duration='PT5M'/>\
+               </apply-to>\
+             </message>",
+        ));
+        let ended = ffi
+            .call_thread_ended
+            .expect("call-thread-ended survives conversion");
+        assert_eq!(ended.anchor_id, "anchor-stanza-id");
+        assert_eq!(ended.ended, "2026-06-07T14:35:00+00:00");
+        assert_eq!(ended.duration, "PT5M");
+    }
+
+    #[test]
+    fn forum_topic_metadata_and_subject_survive_inbound_to_ffi() {
+        let topic = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='groupchat' from='forum@conf.waddle.test/alice'>\
+               <subject>Release planning</subject>\
+               <body>First post of the topic</body>\
+               <thread>topic-thread-1</thread>\
+             </message>",
+        ));
+        assert_eq!(topic.subject.as_deref(), Some("Release planning"));
+        assert_eq!(topic.forum_post_kind.as_deref(), Some("topic"));
+        assert_eq!(topic.forum_title.as_deref(), Some("Release planning"));
+        assert_eq!(topic.thread.as_deref(), Some("topic-thread-1"));
+
+        let reply = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='groupchat' from='forum@conf.waddle.test/bob'>\
+               <body>A reply in the topic</body>\
+               <thread>topic-thread-1</thread>\
+             </message>",
+        ));
+        assert_eq!(reply.forum_post_kind.as_deref(), Some("reply"));
+        assert!(reply.forum_title.is_none());
+
+        // Bare room-topic change: subject only, no forum classification.
+        let room_topic = inbound_to_ffi(parse_message(
+            "<message xmlns='jabber:client' type='groupchat' from='room@conf.waddle.test/alice'>\
+               <subject>New room topic</subject>\
+             </message>",
+        ));
+        assert_eq!(room_topic.subject.as_deref(), Some("New room topic"));
+        assert!(room_topic.forum_post_kind.is_none());
+    }
+
+    #[test]
+    fn presence_extras_survive_presence_to_ffi() {
+        let stanza: Element = "<presence xmlns='jabber:client' \
+                                from='room@muc.waddle.test/alice' \
+                                to='alice@waddle.test/desktop'>\
+            <x xmlns='http://jabber.org/protocol/muc#user'>\
+              <item affiliation='member' role='participant' jid='alice@waddle.test/desktop'/>\
+              <status code='100'/>\
+              <status code='110'/>\
+            </x>\
+            <x xmlns='vcard-temp:x:update'><photo>a1b2c3d4</photo></x>\
+            <idle xmlns='urn:xmpp:idle:1' since='2026-06-01T12:00:00Z'/>\
+            <in-call xmlns='urn:waddle:in-call:0'><hand-raised/><muted/></in-call>\
+        </presence>"
+            .parse()
+            .expect("fixture parses");
+        let Some(MessagingEvent::Presence(pres)) = messaging::parse(&stanza) else {
+            panic!("expected Presence variant");
+        };
+        let ffi = presence_to_ffi(*pres);
+        assert_eq!(ffi.muc_jid.as_deref(), Some("alice@waddle.test/desktop"));
+        assert_eq!(ffi.muc_status_codes, vec![100, 110]);
+        assert_eq!(ffi.vcard_avatar.as_deref(), Some("a1b2c3d4"));
+        assert_eq!(ffi.idle_since.as_deref(), Some("2026-06-01T12:00:00+00:00"));
+        assert!(ffi.hand_raised);
+        assert!(ffi.muted);
+        assert!(ffi.error_condition.is_none());
+        assert!(ffi.error_type.is_none());
+        assert!(ffi.error_text.is_none());
+    }
+
+    #[test]
+    fn presence_error_fields_survive_presence_to_ffi() {
+        let stanza: Element = "<presence xmlns='jabber:client' type='error' \
+                                from='room@muc.waddle.test/alice'>\
+            <error type='auth'>\
+              <registration-required xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/>\
+              <text xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'>Members only</text>\
+            </error>\
+        </presence>"
+            .parse()
+            .expect("fixture parses");
+        let Some(MessagingEvent::Presence(pres)) = messaging::parse(&stanza) else {
+            panic!("expected Presence variant");
+        };
+        let ffi = presence_to_ffi(*pres);
+        assert_eq!(ffi.presence_type, "error");
+        assert_eq!(
+            ffi.error_condition.as_deref(),
+            Some("registration-required")
+        );
+        assert_eq!(ffi.error_type.as_deref(), Some("auth"));
+        assert_eq!(ffi.error_text.as_deref(), Some("Members only"));
+    }
+
+    #[test]
+    fn archived_to_ffi_maps_extended_inner_message_fields() {
+        let archived = parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-ext' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-05-06T12:00:00Z'/>\
+                   <message xmlns='jabber:client' type='groupchat' id='m-ext' \
+                            from='forum@conf.waddle.test/alice'>\
+                     <subject>Release planning</subject>\
+                     <body>bold @bob https://example.com</body>\
+                     <thread>topic-thread-1</thread>\
+                     <stanza-id xmlns='urn:xmpp:sid:0' id='sid-archive' by='archive.waddle.test'/>\
+                     <stanza-id xmlns='urn:xmpp:sid:0' id='sid-room' by='forum@conf.waddle.test'/>\
+                     <x xmlns='http://jabber.org/protocol/muc#user'>\
+                       <item affiliation='member' role='participant' \
+                             jid='alice@waddle.test/desktop'/>\
+                     </x>\
+                     <markup xmlns='urn:xmpp:markup:0'>\
+                       <span start='0' end='4'><strong/></span>\
+                     </markup>\
+                     <reference xmlns='urn:xmpp:reference:0' type='mention' \
+                        uri='xmpp:bob@waddle.test' begin='5' end='9'/>\
+                     <sticker xmlns='urn:xmpp:stickers:0' pack='crabs'/>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        );
+
+        let ffi = archived_to_ffi(archived);
+        assert_eq!(ffi.mam_id, "mam-ext");
+        assert_eq!(ffi.subject.as_deref(), Some("Release planning"));
+        assert_eq!(ffi.stanza_id.as_deref(), Some("sid-archive"));
+        assert_eq!(ffi.stanza_id_by.as_deref(), Some("archive.waddle.test"));
+        assert_eq!(ffi.stanza_ids.len(), 2);
+        assert_eq!(ffi.stanza_ids[1].id, "sid-room");
+        assert_eq!(ffi.stanza_ids[1].by, "forum@conf.waddle.test");
+        assert_eq!(ffi.author_real_jid.as_deref(), Some("alice@waddle.test"));
+        assert_eq!(ffi.markup_spans.len(), 1);
+        assert_eq!(ffi.markup_spans[0].span_type, WaddleMarkupSpanType::Bold);
+        assert_eq!(ffi.mention_uris, vec!["xmpp:bob@waddle.test".to_string()]);
+        assert_eq!(ffi.references.len(), 1);
+        assert_eq!(ffi.references[0].ref_type, "mention");
+        assert_eq!(ffi.forum_post_kind.as_deref(), Some("topic"));
+        assert_eq!(ffi.forum_title.as_deref(), Some("Release planning"));
+        assert!(ffi.is_sticker);
+        assert!(!ffi.is_retracted);
+        assert!(ffi.retraction_id.is_none());
+    }
+
+    #[test]
+    fn archived_to_ffi_maps_tombstone_and_call_thread_ended() {
+        let tombstone = archived_to_ffi(parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-tombstone' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-05-06T12:00:00Z'/>\
+                   <message xmlns='jabber:client' type='groupchat' id='target-message-id' \
+                            from='room@conf.waddle.test/alice'>\
+                     <retracted xmlns='urn:xmpp:message-retract:1' id='retraction-message-id' \
+                                stamp='2026-05-06T12:00:01Z'>\
+                       <moderated xmlns='urn:xmpp:message-moderate:1' \
+                                  by='room@conf.waddle.test/mod'/>\
+                       <reason>spam</reason>\
+                     </retracted>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        ));
+        assert!(tombstone.is_retracted);
+        assert_eq!(
+            tombstone.retraction_id.as_deref(),
+            Some("retraction-message-id")
+        );
+        assert_eq!(
+            tombstone.moderated_by.as_deref(),
+            Some("room@conf.waddle.test/mod")
+        );
+        assert_eq!(tombstone.moderation_reason.as_deref(), Some("spam"));
+
+        let ended = archived_to_ffi(parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-ended' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-06-07T14:35:00Z'/>\
+                   <message xmlns='jabber:client' type='groupchat' id='ended-1' \
+                            from='general@muc.waddle.test'>\
+                     <apply-to xmlns='urn:xmpp:fasten:0' id='anchor-stanza-id'>\
+                       <call-thread-ended xmlns='urn:waddle:call-thread:0' \
+                                          ended='2026-06-07T14:35:00Z' duration='PT5M'/>\
+                     </apply-to>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        ))
+        .call_thread_ended
+        .expect("call-thread-ended survives archive conversion");
+        assert_eq!(ended.anchor_id, "anchor-stanza-id");
+        assert_eq!(ended.duration, "PT5M");
+    }
+
+    // ── Outbound send-options mapping ────────────────────────────────────────
+
+    #[test]
+    fn send_options_map_subject_muc_pm_markup_and_references() {
+        let opts = WaddleSendOptions {
+            subject: Some("Release planning".to_string()),
+            muc_pm: true,
+            markup_spans: vec![
+                WaddleMarkupSpan {
+                    span_type: WaddleMarkupSpanType::Bold,
+                    start: 0,
+                    end: 4,
+                    uri: None,
+                },
+                WaddleMarkupSpan {
+                    span_type: WaddleMarkupSpanType::CodeBlock,
+                    start: 5,
+                    end: 10,
+                    uri: None,
+                },
+                WaddleMarkupSpan {
+                    span_type: WaddleMarkupSpanType::Link,
+                    start: 11,
+                    end: 30,
+                    uri: Some("https://example.com".to_string()),
+                },
+            ],
+            references: vec![WaddleReference {
+                ref_type: "mention".to_string(),
+                uri: "xmpp:bob@waddle.test".to_string(),
+                begin: 5,
+                end: 9,
+                anchor: Some("@bob".to_string()),
+            }],
+            ..WaddleSendOptions::default()
+        };
+
+        let mapped = send_options_from_ffi(opts).expect("options convert");
+        assert_eq!(mapped.subject.as_deref(), Some("Release planning"));
+        assert!(mapped.muc_pm);
+        assert_eq!(mapped.markup_spans.len(), 3);
+        // Wire names must match the strings the outbound XEP-0394
+        // builder branches on.
+        assert_eq!(mapped.markup_spans[0].span_type, "bold");
+        assert_eq!(mapped.markup_spans[0].start, 0);
+        assert_eq!(mapped.markup_spans[0].end, 4);
+        assert_eq!(mapped.markup_spans[1].span_type, "code_block");
+        assert_eq!(mapped.markup_spans[2].span_type, "link");
+        assert_eq!(
+            mapped.markup_spans[2].uri.as_deref(),
+            Some("https://example.com")
+        );
+        assert_eq!(mapped.references.len(), 1);
+        assert_eq!(mapped.references[0].ref_type, "mention");
+        assert_eq!(mapped.references[0].uri, "xmpp:bob@waddle.test");
+        assert_eq!(mapped.references[0].begin, 5);
+        assert_eq!(mapped.references[0].end, 9);
+        assert_eq!(mapped.references[0].anchor.as_deref(), Some("@bob"));
+    }
+
+    #[test]
+    fn send_options_markup_span_wire_names_cover_every_variant() {
+        // The outbound builder silently skips unknown span strings, so
+        // every FFI variant must map to a string the builder accepts.
+        let cases = [
+            (WaddleMarkupSpanType::Bold, "bold"),
+            (WaddleMarkupSpanType::Italic, "italic"),
+            (WaddleMarkupSpanType::Strikethrough, "strikethrough"),
+            (WaddleMarkupSpanType::Code, "code"),
+            (WaddleMarkupSpanType::CodeBlock, "code_block"),
+            (WaddleMarkupSpanType::Blockquote, "blockquote"),
+            (WaddleMarkupSpanType::Link, "link"),
+        ];
+        for (variant, wire) in cases {
+            assert_eq!(markup_span_type_wire_name(variant), wire);
+        }
+    }
+
+    // ── XEP-0198 resume snapshot round-trip ──────────────────────────────────
+
+    #[test]
+    fn resume_state_round_trips_through_session_config_and_snapshot() {
+        use waddle_xmpp_client::stream_management::SmState;
+
+        // Serialize the queued stanza with the same writer the FFI
+        // uses so string equality is meaningful.
+        let queued: Element = "<message xmlns='jabber:client' id='queued-1' type='chat' \
+                                to='bob@waddle.test'>\
+                                 <body>unacked</body>\
+                                 <delay xmlns='urn:xmpp:delay' stamp='2026-06-01T12:00:00Z'/>\
+                               </message>"
+            .parse()
+            .expect("fixture parses");
+        let original = WaddleSmResumeState {
+            previd: "prev-stream".to_string(),
+            inbound_h: 5,
+            outbound_h: 9,
+            max_resume_seconds: Some(300),
+            queued_stanzas_xml: vec![String::from(&queued)],
+        };
+
+        // FFI record → typed SmResumeState (as threaded into
+        // SessionConfig.stream_management.resume_state on connect).
+        let typed = resume_state_from_ffi(original.clone()).expect("resume state converts");
+        assert_eq!(typed.previd(), "prev-stream");
+        assert_eq!(typed.inbound_h(), 5);
+        assert_eq!(typed.outbound_h(), 9);
+        assert_eq!(typed.max_resume_seconds(), Some(300));
+        assert_eq!(
+            typed.unhandled_message_stanza_ids(),
+            vec![StanzaId::new("queued-1").expect("stanza id")],
+            "message stanza-id must be re-derived from the persisted XML"
+        );
+
+        // Seed a runtime SM state from it and snapshot back — the
+        // round trip the native reconnect path performs.
+        let snapshot = SmState::from_resume_state(&typed)
+            .resume_state()
+            .expect("seeded SM state stays resumable");
+        assert_eq!(snapshot, typed, "snapshot must preserve the seeded state");
+
+        let round_tripped = resume_state_to_ffi(snapshot);
+        assert_eq!(round_tripped, original);
+    }
+
+    #[test]
+    fn resume_state_from_ffi_rejects_malformed_stanza_xml() {
+        let err = resume_state_from_ffi(WaddleSmResumeState {
+            previd: "prev-stream".to_string(),
+            inbound_h: 0,
+            outbound_h: 1,
+            max_resume_seconds: None,
+            queued_stanzas_xml: vec!["<not-xml".to_string()],
+        })
+        .expect_err("malformed XML must be rejected");
+        assert!(err.contains("invalid resume stanza XML"), "err: {err}");
+    }
+
+    /// In-test listener that captures every dispatched event in
     /// order. Used to verify the `dispatch_event` routing without
     /// spinning up the tokio broadcast bus.
     #[derive(Default)]
@@ -841,47 +1834,21 @@ mod tests {
         // Mutex so we can mutate from `&self` callbacks. `parking_lot`
         // would be lighter but the test-only `std::sync::Mutex` is
         // available everywhere the workspace builds.
-        events: std::sync::Mutex<Vec<&'static str>>,
-        calls: std::sync::Mutex<Vec<WaddleCallEvent>>,
+        events: std::sync::Mutex<Vec<WaddleClientEvent>>,
     }
 
     impl CapturingListener {
-        fn record(&self, tag: &'static str) {
+        fn events(&self) -> Vec<WaddleClientEvent> {
             self.events
                 .lock()
                 .expect("test capture mutex poisoned")
-                .push(tag);
+                .clone()
         }
     }
 
     impl WaddleEventListener for CapturingListener {
-        fn on_message(&self, _message: WaddleMessage) {
-            self.record("message");
-        }
-        fn on_presence(&self, _presence: WaddlePresence) {
-            self.record("presence");
-        }
-        fn on_mam_result(&self, _message: WaddleArchivedMessage) {
-            self.record("mam");
-        }
-        fn on_message_delivery_acked(&self, _stanza_id: String) {
-            self.record("delivery_acked");
-        }
-        fn on_message_delivery_failed(&self, _stanza_id: String) {
-            self.record("delivery_failed");
-        }
-        fn on_connected(&self) {
-            self.record("connected");
-        }
-        fn on_disconnected(&self) {
-            self.record("disconnected");
-        }
-        fn on_error(&self, _description: String) {
-            self.record("error");
-        }
-        fn on_call(&self, event: WaddleCallEvent) {
-            self.record("call");
-            self.calls
+        fn on_event(&self, event: WaddleClientEvent) {
+            self.events
                 .lock()
                 .expect("test capture mutex poisoned")
                 .push(event);
@@ -889,25 +1856,153 @@ mod tests {
     }
 
     #[test]
-    fn typed_call_event_routes_to_on_call() {
-        let xml = "<message xmlns='jabber:client' from='bob@waddle.test/desktop'>\
+    fn dispatch_event_maps_client_events_to_typed_variants() {
+        use waddle_xmpp_client::SessionBinding;
+
+        let listener = CapturingListener::default();
+        let account = "alice@waddle.test";
+
+        let binding = SessionBinding {
+            jid: "alice@waddle.test/desktop"
+                .parse()
+                .expect("full JID parses"),
+            stream_id: None,
+            resumable: false,
+        };
+        dispatch_event(
+            ClientEvent::Lifecycle(LifecycleEvent::SessionReady(binding)),
+            account,
+            &listener,
+        );
+
+        let msg_xml = "<message xmlns='jabber:client' type='chat' \
+                        from='bob@waddle.test/desktop'><body>hi</body></message>";
+        let msg = parse_message(msg_xml);
+        dispatch_event(
+            ClientEvent::Messaging(MessagingEvent::Message(Box::new(msg))),
+            account,
+            &listener,
+        );
+
+        let presence_stanza: Element = "<presence xmlns='jabber:client' \
+                                         from='room@muc.waddle.test/bob'/>"
+            .parse()
+            .expect("fixture parses");
+        let Some(MessagingEvent::Presence(pres)) = messaging::parse(&presence_stanza) else {
+            panic!("expected Presence variant");
+        };
+        dispatch_event(
+            ClientEvent::Messaging(MessagingEvent::Presence(pres)),
+            account,
+            &listener,
+        );
+
+        dispatch_event(
+            ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked {
+                stanza_id: StanzaId::new("acked-1").expect("stanza id"),
+            }),
+            account,
+            &listener,
+        );
+        dispatch_event(
+            ClientEvent::MessageDelivery(MessageDeliveryEvent::Failed {
+                stanza_id: StanzaId::new("failed-1").expect("stanza id"),
+            }),
+            account,
+            &listener,
+        );
+
+        let call_xml = "<message xmlns='jabber:client' from='bob@waddle.test/desktop'>\
             <proceed xmlns='urn:xmpp:jingle-message:0' id='c1'/>\
         </message>";
-        let stanza: Element = xml.parse().expect("fixture parses");
-        let call = messaging::parse_call_event(&stanza).expect("fixture is a call");
-        let listener = CapturingListener::default();
+        let call_stanza: Element = call_xml.parse().expect("fixture parses");
+        let call = messaging::parse_call_event(&call_stanza).expect("fixture is a call");
+        dispatch_event(ClientEvent::Call(Box::new(call)), account, &listener);
+
         dispatch_event(
-            ClientEvent::Call(Box::new(call)),
+            ClientEvent::ResumeStateChanged(Some(
+                SmResumeState::new("prev-1", 3, 7).expect("resume state"),
+            )),
+            account,
+            &listener,
+        );
+        dispatch_event(ClientEvent::ResumeStateChanged(None), account, &listener);
+
+        let events = listener.events();
+        assert_eq!(events.len(), 8);
+        assert!(matches!(events[0], WaddleClientEvent::Connected));
+        match &events[1] {
+            WaddleClientEvent::Message { message } => {
+                assert_eq!(message.body.as_deref(), Some("hi"));
+            }
+            _ => panic!("expected Message variant"),
+        }
+        match &events[2] {
+            WaddleClientEvent::Presence { presence } => {
+                assert_eq!(presence.from.as_deref(), Some("room@muc.waddle.test/bob"));
+            }
+            _ => panic!("expected Presence variant"),
+        }
+        match &events[3] {
+            WaddleClientEvent::DeliveryAcked { stanza_id } => assert_eq!(stanza_id, "acked-1"),
+            _ => panic!("expected DeliveryAcked variant"),
+        }
+        match &events[4] {
+            WaddleClientEvent::DeliveryFailed { stanza_id } => assert_eq!(stanza_id, "failed-1"),
+            _ => panic!("expected DeliveryFailed variant"),
+        }
+        match &events[5] {
+            WaddleClientEvent::Call { event } => {
+                assert!(matches!(event.kind, WaddleCallEventKind::Proceed));
+                assert_eq!(event.sid, "c1");
+            }
+            _ => panic!("expected Call variant"),
+        }
+        match &events[6] {
+            WaddleClientEvent::ResumeStateChanged { state } => {
+                let state = state.as_ref().expect("resume snapshot present");
+                assert_eq!(state.previd, "prev-1");
+                assert_eq!(state.inbound_h, 3);
+                assert_eq!(state.outbound_h, 7);
+            }
+            _ => panic!("expected ResumeStateChanged variant"),
+        }
+        match &events[7] {
+            WaddleClientEvent::ResumeStateChanged { state } => assert!(state.is_none()),
+            _ => panic!("expected ResumeStateChanged(None) variant"),
+        }
+    }
+
+    #[test]
+    fn dispatch_event_maps_mam_results() {
+        let listener = CapturingListener::default();
+        let archived = parse_mam_archived(
+            "<message xmlns='jabber:client'>\
+               <result xmlns='urn:xmpp:mam:2' id='mam-1' queryid='q1'>\
+                 <forwarded xmlns='urn:xmpp:forward:0'>\
+                   <delay xmlns='urn:xmpp:delay' stamp='2026-05-25T10:00:00Z'/>\
+                   <message xmlns='jabber:client' type='chat' id='m1' \
+                            from='bob@waddle.test/phone'>\
+                     <body>archived</body>\
+                   </message>\
+                 </forwarded>\
+               </result>\
+             </message>",
+        );
+        dispatch_event(
+            ClientEvent::MamResult(Box::new(archived)),
             "alice@waddle.test",
             &listener,
         );
-        assert_eq!(
-            &*listener.events.lock().expect("test capture mutex poisoned"),
-            &["call"]
-        );
-        let calls = listener.calls.lock().expect("test capture mutex poisoned");
-        assert_eq!(calls.len(), 1);
-        assert!(matches!(calls[0].kind, WaddleCallEventKind::Proceed));
+        let events = listener.events();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            WaddleClientEvent::MamResult { message } => {
+                assert_eq!(message.mam_id, "mam-1");
+                assert_eq!(message.body.as_deref(), Some("archived"));
+            }
+            _ => panic!("expected MamResult variant"),
+        }
     }
 
     #[test]
@@ -925,11 +2020,7 @@ mod tests {
             "alice@waddle.test",
             &listener,
         );
-        assert!(listener
-            .events
-            .lock()
-            .expect("test capture mutex poisoned")
-            .is_empty());
+        assert!(listener.events().is_empty());
     }
 
     #[test]

--- a/server/crates/waddle-xmpp-client-ffi/src/convert.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/convert.rs
@@ -26,8 +26,8 @@ use crate::{
     WaddleLinkPreviewPlayer, WaddleLinkPreviewVideo, WaddleLiveKitJoin, WaddleMarkupSpan,
     WaddleMarkupSpanType, WaddleMdsDisplayedEntry, WaddleMessage, WaddleMucAffiliation,
     WaddleMucRole, WaddleMujiPresence, WaddlePinAction, WaddlePinEvent, WaddlePinPreview,
-    WaddlePresence, WaddlePresenceHat, WaddleReference, WaddleSendOptions, WaddleSharedFile,
-    WaddleSmResumeState, WaddleStanzaErrorType, WaddleStanzaId,
+    WaddlePresence, WaddlePresenceHat, WaddleReference, WaddleReferenceType, WaddleSendOptions,
+    WaddleSharedFile, WaddleSmResumeState, WaddleStanzaErrorType, WaddleStanzaId,
 };
 
 // ── Event dispatch ───────────────────────────────────────────────────────────
@@ -316,11 +316,27 @@ fn markup_spans_to_ffi(spans: Vec<MarkupSpan>) -> Vec<WaddleMarkupSpan> {
 
 fn reference_to_ffi(reference: ReferenceData) -> WaddleReference {
     WaddleReference {
-        ref_type: reference.ref_type,
+        ref_type: reference_type_to_ffi(reference.ref_type),
         uri: reference.uri,
         begin: reference.begin,
         end: reference.end,
         anchor: reference.anchor,
+    }
+}
+
+fn reference_type_to_ffi(ref_type: String) -> WaddleReferenceType {
+    match ref_type.as_str() {
+        "mention" => WaddleReferenceType::Mention,
+        "data" => WaddleReferenceType::Data,
+        _ => WaddleReferenceType::Other { value: ref_type },
+    }
+}
+
+fn reference_type_wire_name(ref_type: WaddleReferenceType) -> String {
+    match ref_type {
+        WaddleReferenceType::Mention => "mention".to_string(),
+        WaddleReferenceType::Data => "data".to_string(),
+        WaddleReferenceType::Other { value } => value,
     }
 }
 
@@ -825,7 +841,7 @@ pub(super) fn send_options_from_ffi(opts: WaddleSendOptions) -> Result<SendMessa
             .references
             .into_iter()
             .map(|reference| ReferenceData {
-                ref_type: reference.ref_type,
+                ref_type: reference_type_wire_name(reference.ref_type),
                 uri: reference.uri,
                 begin: reference.begin,
                 end: reference.end,
@@ -1345,12 +1361,12 @@ mod tests {
         );
         assert_eq!(ffi.broadcast_mention.as_deref(), Some("xmpp:@everyone"));
         assert_eq!(ffi.references.len(), 3);
-        assert_eq!(ffi.references[0].ref_type, "mention");
+        assert_eq!(ffi.references[0].ref_type, WaddleReferenceType::Mention);
         assert_eq!(ffi.references[0].uri, "xmpp:bob@waddle.test");
         assert_eq!(ffi.references[0].begin, 3);
         assert_eq!(ffi.references[0].end, 7);
         assert_eq!(ffi.references[1].anchor.as_deref(), Some("@everyone"));
-        assert_eq!(ffi.references[2].ref_type, "data");
+        assert_eq!(ffi.references[2].ref_type, WaddleReferenceType::Data);
         assert!(ffi.references[2].anchor.is_none());
     }
 
@@ -1664,7 +1680,7 @@ mod tests {
         assert_eq!(ffi.markup_spans[0].span_type, WaddleMarkupSpanType::Bold);
         assert_eq!(ffi.mention_uris, vec!["xmpp:bob@waddle.test".to_string()]);
         assert_eq!(ffi.references.len(), 1);
-        assert_eq!(ffi.references[0].ref_type, "mention");
+        assert_eq!(ffi.references[0].ref_type, WaddleReferenceType::Mention);
         assert_eq!(ffi.forum_post_kind, Some(WaddleForumPostKind::Topic));
         assert_eq!(ffi.forum_title.as_deref(), Some("Release planning"));
         assert!(ffi.is_sticker);
@@ -1781,7 +1797,7 @@ mod tests {
                 },
             ],
             references: vec![WaddleReference {
-                ref_type: "mention".to_string(),
+                ref_type: WaddleReferenceType::Mention,
                 uri: "xmpp:bob@waddle.test".to_string(),
                 begin: 5,
                 end: 9,

--- a/server/crates/waddle-xmpp-client-ffi/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/lib.rs
@@ -24,7 +24,7 @@ mod client_tests;
 
 pub use types::*;
 
-use convert::dispatch_event;
+use convert::{dispatch_event, resume_state_from_ffi};
 use waddle_xmpp_client::{
     messaging::SessionId, AccessToken, ClientConfig, ClientHandle, ConnectionConfig,
     OAuthBearerConfig, WebSocketConfig,
@@ -57,7 +57,7 @@ impl WaddleClient {
         let jid: BareJid = match self.config.jid.parse() {
             Ok(j) => j,
             Err(e) => {
-                self.listener.on_error(format!("Invalid JID: {e}"));
+                self.emit_error(format!("Invalid JID: {e}"));
                 return;
             }
         };
@@ -65,7 +65,7 @@ impl WaddleClient {
         let domain: BareJid = match jid.domain().to_string().parse() {
             Ok(d) => d,
             Err(e) => {
-                self.listener.on_error(format!("Invalid domain: {e}"));
+                self.emit_error(format!("Invalid domain: {e}"));
                 return;
             }
         };
@@ -73,7 +73,7 @@ impl WaddleClient {
         let url: Url = match self.config.server_url.parse() {
             Ok(u) => u,
             Err(e) => {
-                self.listener.on_error(format!("Invalid server URL: {e}"));
+                self.emit_error(format!("Invalid server URL: {e}"));
                 return;
             }
         };
@@ -81,8 +81,7 @@ impl WaddleClient {
         let transport = match WebSocketConfig::new(url) {
             Ok(t) => t,
             Err(e) => {
-                self.listener
-                    .on_error(format!("Invalid WebSocket config: {e}"));
+                self.emit_error(format!("Invalid WebSocket config: {e}"));
                 return;
             }
         };
@@ -90,7 +89,7 @@ impl WaddleClient {
         let resource = match ClientResource::new(&self.config.resource) {
             Ok(r) => r,
             Err(e) => {
-                self.listener.on_error(format!("Invalid resource: {e}"));
+                self.emit_error(format!("Invalid resource: {e}"));
                 return;
             }
         };
@@ -100,26 +99,39 @@ impl WaddleClient {
         let auth = match auth {
             Ok(a) => a,
             Err(e) => {
-                self.listener.on_error(format!("Invalid auth config: {e}"));
+                self.emit_error(format!("Invalid auth config: {e}"));
                 return;
             }
         };
 
-        let client_config = match ClientConfig::new(ConnectionConfig::new(domain), transport, auth)
-        {
-            Ok(c) => c,
-            Err(e) => {
-                self.listener
-                    .on_error(format!("Invalid client config: {e}"));
-                return;
+        let mut client_config =
+            match ClientConfig::new(ConnectionConfig::new(domain), transport, auth) {
+                Ok(c) => c,
+                Err(e) => {
+                    self.emit_error(format!("Invalid client config: {e}"));
+                    return;
+                }
+            };
+
+        // XEP-0198: seed the runtime with the persisted resume snapshot
+        // so it attempts <resume/> before resource binding, exactly as
+        // the wasm client threads it through StoredConfig.
+        if let Some(resume) = self.config.resume_state.clone() {
+            match resume_state_from_ffi(resume) {
+                Ok(state) => {
+                    client_config.session.stream_management.resume_state = Some(state);
+                }
+                Err(e) => {
+                    self.emit_error(format!("Invalid resume state: {e}"));
+                    return;
+                }
             }
-        };
+        }
 
         let xmpp_client = match XmppClient::new(client_config) {
             Ok(c) => c,
             Err(e) => {
-                self.listener
-                    .on_error(format!("Failed to create XMPP client: {e}"));
+                self.emit_error(format!("Failed to create XMPP client: {e}"));
                 return;
             }
         };
@@ -127,8 +139,7 @@ impl WaddleClient {
         let driver = match xmpp_client.driver() {
             Ok(d) => d,
             Err(e) => {
-                self.listener
-                    .on_error(format!("Failed to create driver: {e}"));
+                self.emit_error(format!("Failed to create driver: {e}"));
                 return;
             }
         };
@@ -136,7 +147,7 @@ impl WaddleClient {
         let client_handle = match driver.connect().await {
             Ok(h) => h,
             Err(e) => {
-                self.listener.on_error(format!("Failed to connect: {e}"));
+                self.emit_error(format!("Failed to connect: {e}"));
                 return;
             }
         };
@@ -149,7 +160,7 @@ impl WaddleClient {
                 match events.recv().await {
                     Ok(event) => dispatch_event(event, &account_bare_jid, &**listener),
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                        listener.on_disconnected();
+                        listener.on_event(WaddleClientEvent::Disconnected);
                         break;
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
@@ -171,9 +182,17 @@ impl WaddleClient {
 // ── Send helpers ────────────────────────────────────────────────────────────
 
 impl WaddleClient {
+    /// Emit a human-readable diagnostic through the single-event
+    /// listener. Every internal failure path funnels through here so
+    /// diagnostics stay out of the typed payload variants.
+    pub(crate) fn emit_error(&self, description: String) {
+        self.listener
+            .on_event(WaddleClientEvent::Error { description });
+    }
+
     /// Send a built stanza fire-and-forget. Returns `true` on success.
     /// On failure (not connected, transport closed) emits an
-    /// `on_error` and returns `false` so callers can short-circuit.
+    /// `Error` event and returns `false` so callers can short-circuit.
     ///
     /// Holds the client mutex only long enough to clone the
     /// [`ClientHandle`] (cheap — it is `Arc`-backed) and releases
@@ -189,7 +208,7 @@ impl WaddleClient {
         match handle.send_stanza(stanza).await {
             Ok(()) => true,
             Err(e) => {
-                self.listener.on_error(format!("{op} failed: {e}"));
+                self.emit_error(format!("{op} failed: {e}"));
                 false
             }
         }
@@ -197,7 +216,7 @@ impl WaddleClient {
 
     /// Send a built IQ and await its correlated result. Returns
     /// `true` on `<iq type='result'>`, `false` on `<iq type='error'>`
-    /// or transport failure (with an `on_error` for both).
+    /// or transport failure (with an `Error` event for both).
     ///
     /// Clones the [`ClientHandle`] under the mutex and **drops the
     /// guard before awaiting** the IQ response. `send_iq` blocks on
@@ -211,7 +230,7 @@ impl WaddleClient {
         match handle.send_iq(stanza).await {
             Ok(_) => true,
             Err(e) => {
-                self.listener.on_error(format!("{op} failed: {e}"));
+                self.emit_error(format!("{op} failed: {e}"));
                 false
             }
         }
@@ -224,7 +243,7 @@ impl WaddleClient {
         match guard.as_ref() {
             None => {
                 drop(guard);
-                self.listener.on_error("Not connected".to_string());
+                self.emit_error("Not connected".to_string());
                 None
             }
             Some(h) => {
@@ -239,8 +258,7 @@ impl WaddleClient {
         match value.parse::<FullJid>() {
             Ok(j) => Some(j),
             Err(e) => {
-                self.listener
-                    .on_error(format!("{op} failed: invalid full JID '{value}': {e}"));
+                self.emit_error(format!("{op} failed: invalid full JID '{value}': {e}"));
                 None
             }
         }
@@ -250,8 +268,7 @@ impl WaddleClient {
         match value.parse::<BareJid>() {
             Ok(j) => Some(j),
             Err(e) => {
-                self.listener
-                    .on_error(format!("{op} failed: invalid bare JID '{value}': {e}"));
+                self.emit_error(format!("{op} failed: invalid bare JID '{value}': {e}"));
                 None
             }
         }
@@ -266,7 +283,7 @@ impl WaddleClient {
     /// runtime check, so this method is the gate.
     fn parse_session_id(&self, value: String, op: &'static str) -> Option<SessionId> {
         if value.trim().is_empty() {
-            self.listener.on_error(format!(
+            self.emit_error(format!(
                 "{op} failed: session id must be a non-empty, non-whitespace string"
             ));
             return None;

--- a/server/crates/waddle-xmpp-client-ffi/src/messaging.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/messaging.rs
@@ -32,8 +32,7 @@ impl WaddleClient {
         {
             Ok(page) => mam_page_to_ffi(page),
             Err(e) => {
-                self.listener
-                    .on_error(format!("fetch_room_history failed: {e}"));
+                self.emit_error(format!("fetch_room_history failed: {e}"));
                 empty_mam_page()
             }
         }
@@ -55,8 +54,7 @@ impl WaddleClient {
         {
             Ok(page) => mam_page_to_ffi(page),
             Err(e) => {
-                self.listener
-                    .on_error(format!("fetch_dm_history failed: {e}"));
+                self.emit_error(format!("fetch_dm_history failed: {e}"));
                 empty_mam_page()
             }
         }
@@ -71,7 +69,7 @@ impl WaddleClient {
         let room_jid = match room_jid.parse::<BareJid>() {
             Ok(jid) => jid,
             Err(e) => {
-                self.listener.on_error(format!(
+                self.emit_error(format!(
                     "send_groupchat_message failed: invalid room JID: {e}"
                 ));
                 return WaddleSendMessageOutcome::InvalidRecipient;
@@ -80,8 +78,7 @@ impl WaddleClient {
         let opts = match options.map(send_options_from_ffi).transpose() {
             Ok(o) => o.unwrap_or_default(),
             Err(e) => {
-                self.listener
-                    .on_error(format!("send_groupchat_message failed: {e}"));
+                self.emit_error(format!("send_groupchat_message failed: {e}"));
                 return WaddleSendMessageOutcome::InvalidOptions;
             }
         };
@@ -97,8 +94,7 @@ impl WaddleClient {
                 stanza_id: stanza_id.to_string(),
             },
             Err(e) => {
-                self.listener
-                    .on_error(format!("send_groupchat_message failed: {e}"));
+                self.emit_error(format!("send_groupchat_message failed: {e}"));
                 send_failure_outcome(&e)
             }
         }
@@ -113,16 +109,14 @@ impl WaddleClient {
         let peer_jid = match peer_jid.parse::<Jid>() {
             Ok(jid) => jid,
             Err(e) => {
-                self.listener
-                    .on_error(format!("send_chat_message failed: invalid peer JID: {e}"));
+                self.emit_error(format!("send_chat_message failed: invalid peer JID: {e}"));
                 return WaddleSendMessageOutcome::InvalidRecipient;
             }
         };
         let opts = match options.map(send_options_from_ffi).transpose() {
             Ok(o) => o.unwrap_or_default(),
             Err(e) => {
-                self.listener
-                    .on_error(format!("send_chat_message failed: {e}"));
+                self.emit_error(format!("send_chat_message failed: {e}"));
                 return WaddleSendMessageOutcome::InvalidOptions;
             }
         };
@@ -138,8 +132,7 @@ impl WaddleClient {
                 stanza_id: stanza_id.to_string(),
             },
             Err(e) => {
-                self.listener
-                    .on_error(format!("send_chat_message failed: {e}"));
+                self.emit_error(format!("send_chat_message failed: {e}"));
                 send_failure_outcome(&e)
             }
         }
@@ -151,7 +144,7 @@ impl WaddleClient {
         };
 
         if let Err(e) = handle.join_room(&room_jid, &nick).await {
-            self.listener.on_error(format!("join_room failed: {e}"));
+            self.emit_error(format!("join_room failed: {e}"));
         }
     }
 
@@ -161,7 +154,7 @@ impl WaddleClient {
         };
 
         if let Err(e) = handle.leave_room(&room_jid, &nick).await {
-            self.listener.on_error(format!("leave_room failed: {e}"));
+            self.emit_error(format!("leave_room failed: {e}"));
         }
     }
 
@@ -174,7 +167,7 @@ impl WaddleClient {
         match handle.discover_topology(server_domain).await {
             Ok(topology) => topology_to_ffi(topology),
             Err(e) => {
-                self.listener.on_error(format!(
+                self.emit_error(format!(
                     "discover_topology failed: server_domain={server_domain} error={e}"
                 ));
                 empty_topology()
@@ -196,7 +189,7 @@ impl WaddleClient {
             .send_presence(status.as_deref(), show.as_deref(), idle_since.as_deref())
             .await
         {
-            self.listener.on_error(format!("send_presence failed: {e}"));
+            self.emit_error(format!("send_presence failed: {e}"));
         }
     }
 
@@ -208,8 +201,7 @@ impl WaddleClient {
         let bare: BareJid = match jid.parse() {
             Ok(j) => j,
             Err(e) => {
-                self.listener
-                    .on_error(format!("Invalid JID for avatar fetch: {e}"));
+                self.emit_error(format!("Invalid JID for avatar fetch: {e}"));
                 return None;
             }
         };
@@ -225,8 +217,7 @@ impl WaddleClient {
             }),
             Ok(None) => None,
             Err(e) => {
-                self.listener
-                    .on_error(format!("request_avatar failed: {e}"));
+                self.emit_error(format!("request_avatar failed: {e}"));
                 None
             }
         }
@@ -241,8 +232,7 @@ impl WaddleClient {
         {
             Ok(service_jid) => service_jid,
             Err(e) => {
-                self.listener
-                    .on_error(format!("discover_upload_service failed: {e}"));
+                self.emit_error(format!("discover_upload_service failed: {e}"));
                 None
             }
         }
@@ -263,8 +253,7 @@ impl WaddleClient {
         {
             Ok(slot) => Some(upload_slot_to_ffi(slot)),
             Err(e) => {
-                self.listener
-                    .on_error(format!("request_upload_slot failed: {e}"));
+                self.emit_error(format!("request_upload_slot failed: {e}"));
                 None
             }
         }

--- a/server/crates/waddle-xmpp-client-ffi/src/push.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/push.rs
@@ -19,8 +19,7 @@ impl WaddleClient {
         {
             Ok(()) => true,
             Err(e) => {
-                self.listener
-                    .on_error(format!("enable_push_notifications failed: {e}"));
+                self.emit_error(format!("enable_push_notifications failed: {e}"));
                 false
             }
         }
@@ -42,8 +41,7 @@ impl WaddleClient {
         {
             Ok(()) => true,
             Err(e) => {
-                self.listener
-                    .on_error(format!("disable_push_notifications failed: {e}"));
+                self.emit_error(format!("disable_push_notifications failed: {e}"));
                 false
             }
         }
@@ -70,16 +68,14 @@ impl WaddleClient {
             match waddle_xmpp_client::push::PushServiceJid::new(&push_service_jid) {
                 Ok(value) => value,
                 Err(e) => {
-                    self.listener
-                        .on_error(format!("register_push_device failed: {e}"));
+                    self.emit_error(format!("register_push_device failed: {e}"));
                     return None;
                 }
             };
         let app_id = match waddle_xmpp_client::push::PushAppId::new(&app_id) {
             Ok(value) => value,
             Err(e) => {
-                self.listener
-                    .on_error(format!("register_push_device failed: {e}"));
+                self.emit_error(format!("register_push_device failed: {e}"));
                 return None;
             }
         };
@@ -97,8 +93,7 @@ impl WaddleClient {
                 device_id: outcome.device_id.into_string(),
             }),
             Err(e) => {
-                self.listener
-                    .on_error(format!("register_push_device failed: {e}"));
+                self.emit_error(format!("register_push_device failed: {e}"));
                 None
             }
         }
@@ -129,8 +124,7 @@ impl WaddleClient {
         match handle.send_iq(iq).await {
             Ok(_) => true,
             Err(e) => {
-                self.listener
-                    .on_error(format!("disable_push_device failed: {e}"));
+                self.emit_error(format!("disable_push_device failed: {e}"));
                 false
             }
         }

--- a/server/crates/waddle-xmpp-client-ffi/src/types.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/types.rs
@@ -92,9 +92,9 @@ pub struct WaddleMessage {
     /// `<reference/>` with the required `type` and `uri`, regardless
     /// of type. `mention_uris`/`broadcast_mention` are derived views.
     pub references: Vec<WaddleReference>,
-    /// Forum channel classification: `topic` (thread + body + subject)
-    /// or `reply` (thread + body); `None` for plain chat.
-    pub forum_post_kind: Option<String>,
+    /// Forum channel classification; `None` for plain chat or when the
+    /// wire value is not a recognised kind.
+    pub forum_post_kind: Option<WaddleForumPostKind>,
     /// Forum topic title (the subject of a `topic` post).
     pub forum_title: Option<String>,
     /// XEP-0449: the message body is a sticker.
@@ -171,6 +171,28 @@ pub enum WaddleChatState {
     Paused,
     Inactive,
     Gone,
+}
+
+/// Waddle forum post classification: `Topic` (thread + body + subject)
+/// or `Reply` (thread + body). Wire values outside these two are
+/// dropped to `None` at the conversion boundary.
+#[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WaddleForumPostKind {
+    Topic,
+    Reply,
+}
+
+/// RFC 6120 §8.3.2 stanza-error `type` attribute. Mirrors the client
+/// crate's `StanzaErrorType`; `Unknown` marks an unrecognised wire
+/// value so consumers can distinguish it from every defined type.
+#[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WaddleStanzaErrorType {
+    Auth,
+    Cancel,
+    Continue,
+    Modify,
+    Wait,
+    Unknown,
 }
 
 /// XEP-0394 markup span kind. Mirrors the client crate's
@@ -366,8 +388,8 @@ pub struct WaddleArchivedMessage {
     pub mention_uris: Vec<String>,
     /// XEP-0372 references of the inner message.
     pub references: Vec<WaddleReference>,
-    /// Forum classification of the archived post (`topic`/`reply`).
-    pub forum_post_kind: Option<String>,
+    /// Forum classification of the archived post.
+    pub forum_post_kind: Option<WaddleForumPostKind>,
     /// Forum topic title (the subject of a `topic` post).
     pub forum_title: Option<String>,
     /// XEP-0449: the archived body is a sticker.
@@ -440,8 +462,8 @@ pub struct WaddlePresence {
     /// RFC 6120 §8.3 error condition element name (e.g. `not-found`)
     /// for `type="error"` presences; `None` otherwise.
     pub error_condition: Option<String>,
-    /// RFC 6120 §8.3 error `type` attribute (e.g. `cancel`).
-    pub error_type: Option<String>,
+    /// RFC 6120 §8.3 error `type` attribute.
+    pub error_type: Option<WaddleStanzaErrorType>,
     /// RFC 6120 §8.3 human-readable `<text/>` of an error presence.
     pub error_text: Option<String>,
     /// urn:waddle:in-call:0 raised-hand marker carried alongside

--- a/server/crates/waddle-xmpp-client-ffi/src/types.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/types.rs
@@ -220,11 +220,21 @@ pub struct WaddleMarkupSpan {
     pub uri: Option<String>,
 }
 
+/// XEP-0372 §4 reference `type`. `Other` preserves unrecognised wire
+/// values explicitly so extension references survive the boundary
+/// instead of being silently dropped or smuggled through a bare String.
+#[derive(uniffi::Enum, Clone, Debug, PartialEq, Eq)]
+pub enum WaddleReferenceType {
+    Mention,
+    Data,
+    Other { value: String },
+}
+
 /// XEP-0372 `<reference/>`. `begin`/`end` are body offsets; `(0, 0)`
 /// is the "no body position" sentinel used by anchor-only references.
 #[derive(uniffi::Record, Clone)]
 pub struct WaddleReference {
-    pub ref_type: String,
+    pub ref_type: WaddleReferenceType,
     pub uri: String,
     pub begin: u32,
     pub end: u32,

--- a/server/crates/waddle-xmpp-client-ffi/src/types.rs
+++ b/server/crates/waddle-xmpp-client-ffi/src/types.rs
@@ -6,6 +6,33 @@ pub struct WaddleConfig {
     pub jid: String,
     pub access_token: String,
     pub resource: String,
+    /// XEP-0198 resume snapshot from a previous session. When present
+    /// the runtime attempts `<resume/>` before resource binding and
+    /// replays the queued outbound stanzas the server never acked.
+    pub resume_state: Option<WaddleSmResumeState>,
+}
+
+/// XEP-0198 client resume snapshot crossing the FFI as an opaque
+/// persistence round-trip: the Swift app stores it on disconnect and
+/// feeds it back through [`WaddleConfig`] on the next connect. Queued
+/// outbound stanzas travel as serialized XML strings — the message
+/// stanza-id is re-derived from the element's `id` attribute on
+/// restore, and the original enqueue instant survives only when the
+/// element already carries a `<delay/>` stamp (identical semantics to
+/// the wasm client's localStorage persistence of the same snapshot).
+#[derive(uniffi::Record, Clone, Debug, PartialEq, Eq)]
+pub struct WaddleSmResumeState {
+    /// SM resumption token from `<enabled id='…'/>`.
+    pub previd: String,
+    /// Count of inbound stanzas handled by this client.
+    pub inbound_h: u32,
+    /// Count of outbound stanzas sent by this client.
+    pub outbound_h: u32,
+    /// Server-advertised resumption window in seconds, when supplied.
+    pub max_resume_seconds: Option<u32>,
+    /// Outbound stanzas the server had not acked at snapshot time,
+    /// serialized to XML in send order for lossless replay.
+    pub queued_stanzas_xml: Vec<String>,
 }
 
 #[derive(uniffi::Record, Clone)]
@@ -14,19 +41,78 @@ pub struct WaddleMessage {
     pub from: Option<String>,
     pub to: Option<String>,
     pub body: Option<String>,
+    /// RFC 6121 `<subject/>` — room topic changes and forum topic posts.
+    pub subject: Option<String>,
     pub message_type: String,
     pub timestamp: Option<String>,
     pub stanza_id: Option<String>,
+    /// XEP-0359 `by` authority of `stanza_id`. NOT verified here —
+    /// consumers MUST check it against the expected archive authority
+    /// before trusting the id (XEP-0359 §Security Considerations).
+    pub stanza_id_by: Option<String>,
+    /// Every XEP-0359 `<stanza-id/>` on the stanza, one per archiving
+    /// entity, in document order.
+    pub stanza_ids: Vec<WaddleStanzaId>,
     pub origin_id: Option<String>,
     pub replaces_id: Option<String>,
     pub retracts_id: Option<String>,
+    /// XEP-0424 tombstone: id of the retraction message that replaced
+    /// the original in the archive.
+    pub retraction_id: Option<String>,
+    /// XEP-0424: true when this message is a retraction tombstone.
+    pub is_retracted: bool,
+    /// XEP-0425 moderation target — the XEP-0359 id of the moderated
+    /// message when this stanza is a moderation broadcast.
+    pub moderation_target_id: Option<String>,
+    /// XEP-0425 moderator JID (string form).
+    pub moderated_by: Option<String>,
+    /// XEP-0425 human-readable moderation reason.
+    pub moderation_reason: Option<String>,
     pub reaction_target_id: Option<String>,
     pub reaction_emojis: Vec<String>,
+    /// XEP-0085 chat state notification carried on this message.
+    /// `None` when absent or when the wire value is not one of the
+    /// five defined states.
+    pub chat_state: Option<WaddleChatState>,
     /// XEP-0333 `<markable/>` request attached to this inbound message.
     pub displayed_marker_requested: bool,
+    /// XEP-0333 `<displayed id='…'/>` marker target id.
+    pub displayed_marker_id: Option<String>,
     pub is_muc: bool,
     pub thread: Option<String>,
     pub parent_thread_id: Option<String>,
+    /// XEP-0394 message markup spans over the body.
+    pub markup_spans: Vec<WaddleMarkupSpan>,
+    /// XEP-0372 broadcast mention URI (`@everyone` / `@here`), when
+    /// one of the mention references targets the whole room.
+    pub broadcast_mention: Option<String>,
+    /// XEP-0372 mention URIs, flattened from `references`.
+    pub mention_uris: Vec<String>,
+    /// XEP-0372 references attached to this message — every
+    /// `<reference/>` with the required `type` and `uri`, regardless
+    /// of type. `mention_uris`/`broadcast_mention` are derived views.
+    pub references: Vec<WaddleReference>,
+    /// Forum channel classification: `topic` (thread + body + subject)
+    /// or `reply` (thread + body); `None` for plain chat.
+    pub forum_post_kind: Option<String>,
+    /// Forum topic title (the subject of a `topic` post).
+    pub forum_title: Option<String>,
+    /// XEP-0449: the message body is a sticker.
+    pub is_sticker: bool,
+    /// XEP-0511 link preview metadata (`urn:waddle:link-preview:0`
+    /// pipeline output), one entry per previewed URL.
+    pub link_previews: Vec<WaddleLinkPreview>,
+    /// urn:waddle:pin:0 pin/unpin room system event. `None` when the
+    /// message carries no `<pin-event/>` payload.
+    pub pin_event: Option<WaddlePinEvent>,
+    /// urn:waddle:call-thread:0 ended fastening targeting a
+    /// call-thread anchor.
+    pub call_thread_ended: Option<WaddleCallThreadEnded>,
+    /// XEP-0280: direction of the carbon envelope this message was
+    /// unwrapped from. Only stamped after the runtime verified the
+    /// wrapping stanza came from the account's own bare JID (§11
+    /// forgery rule); `None` for directly received stanzas.
+    pub carbon: Option<WaddleCarbonDirection>,
     /// XEP-0461 reply target message id.
     pub reply_to_id: Option<String>,
     /// XEP-0461 reply target author JID (string form).
@@ -55,6 +141,166 @@ pub struct WaddleCallThreadAnchor {
     pub started: String,
 }
 
+/// urn:waddle:call-thread:0 `<call-thread-ended/>` fastening. Mirrors
+/// `waddle_xmpp_client::xep::call_thread::CallThreadEnded` 1:1.
+#[derive(uniffi::Record, Clone)]
+pub struct WaddleCallThreadEnded {
+    /// XEP-0422 `<apply-to id='…'/>` target: the anchor's stanza id.
+    pub anchor_id: String,
+    /// RFC 3339 instant the call ended.
+    pub ended: String,
+    /// ISO 8601 duration of the call (e.g. `PT5M`).
+    pub duration: String,
+}
+
+/// One XEP-0359 `<stanza-id/>` entry. Mirrors the core `StanzaId`
+/// shape: `by` is required by XEP-0359 and always present.
+#[derive(uniffi::Record, Clone)]
+pub struct WaddleStanzaId {
+    pub id: String,
+    /// JID (string form) of the archiving entity that assigned `id`.
+    pub by: String,
+}
+
+/// XEP-0085 chat state notification states. Wire values outside these
+/// five are dropped to `None` at the conversion boundary.
+#[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WaddleChatState {
+    Active,
+    Composing,
+    Paused,
+    Inactive,
+    Gone,
+}
+
+/// XEP-0394 markup span kind. Mirrors the client crate's
+/// `MarkupSpanType`; `Link` is Waddle's `urn:waddle:markup:0` span
+/// extension (XEP-0394 defines no link span).
+#[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WaddleMarkupSpanType {
+    Bold,
+    Italic,
+    Strikethrough,
+    Code,
+    CodeBlock,
+    Blockquote,
+    Link,
+}
+
+/// XEP-0394 markup span over the message body. Offsets count Unicode
+/// scalar values; `end` is exclusive. `uri` is populated only for
+/// `Link` spans.
+#[derive(uniffi::Record, Clone)]
+pub struct WaddleMarkupSpan {
+    pub span_type: WaddleMarkupSpanType,
+    pub start: u32,
+    pub end: u32,
+    pub uri: Option<String>,
+}
+
+/// XEP-0372 `<reference/>`. `begin`/`end` are body offsets; `(0, 0)`
+/// is the "no body position" sentinel used by anchor-only references.
+#[derive(uniffi::Record, Clone)]
+pub struct WaddleReference {
+    pub ref_type: String,
+    pub uri: String,
+    pub begin: u32,
+    pub end: u32,
+    /// XEP-0372 optional `anchor` attribute: the original, unresolved
+    /// display text (or anchor URI) when offsets cannot be relied on.
+    pub anchor: Option<String>,
+}
+
+/// XEP-0511 link preview card produced by the server-side
+/// `urn:waddle:link-preview:0` pipeline.
+#[derive(uniffi::Record, Clone)]
+pub struct WaddleLinkPreview {
+    pub original_url: String,
+    pub normalized_url: Option<String>,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub image: Option<WaddleLinkPreviewImage>,
+    /// Native-playable `og:video` media with a direct (non-iframe)
+    /// media type; rendered in a native player on user action.
+    pub video: Option<WaddleLinkPreviewVideo>,
+    pub player_embed: Option<WaddleLinkPreviewPlayer>,
+    /// True when the preview referenced remote media the server did
+    /// not cache; the client must not fetch it itself.
+    pub remote_media_unavailable: bool,
+}
+
+/// Cached preview image of a XEP-0511 link card.
+#[derive(uniffi::Record, Clone)]
+pub struct WaddleLinkPreviewImage {
+    pub url: String,
+    pub media_type: String,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub alt: Option<String>,
+}
+
+/// Native-playable `og:video` media surfaced from a XEP-0511 card.
+#[derive(uniffi::Record, Clone)]
+pub struct WaddleLinkPreviewVideo {
+    pub url: String,
+    pub media_type: String,
+}
+
+/// `og:video` iframe player embed of a XEP-0511 card.
+#[derive(uniffi::Record, Clone)]
+pub struct WaddleLinkPreviewPlayer {
+    pub url: String,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+}
+
+/// urn:waddle:pin:0 pin/unpin action carried on a room system message.
+#[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WaddlePinAction {
+    Pinned,
+    Unpinned,
+}
+
+/// Frozen preview snapshot of a pinned message, taken at pin time.
+#[derive(uniffi::Record, Clone)]
+pub struct WaddlePinPreview {
+    /// Bare JID of the message author at pin time.
+    pub author_jid: String,
+    /// Author's MUC nick at pin time, if known.
+    pub author_nick: Option<String>,
+    /// Truncated body text (≤280 chars).
+    pub text: String,
+    /// Original message timestamp (RFC 3339), not the pin time.
+    pub message_timestamp: String,
+}
+
+/// urn:waddle:pin:0 `<pin-event/>` room broadcast. Mirrors
+/// `waddle_xmpp_client::pin::PinEvent`.
+#[derive(uniffi::Record, Clone)]
+pub struct WaddlePinEvent {
+    pub action: WaddlePinAction,
+    /// XEP-0359 stanza-id of the targeted message.
+    pub target_stanza_id: String,
+    /// Bare JID of the pinner/unpinner.
+    pub by: String,
+    /// `Some("retracted")` when the unpin was triggered by a
+    /// XEP-0424 retraction cascade.
+    pub reason: Option<String>,
+    /// Frozen preview, present only on `Pinned` events.
+    pub preview: Option<WaddlePinPreview>,
+}
+
+/// XEP-0280 carbon direction of an unwrapped forwarded copy. Always
+/// §11-verified by the runtime before it reaches this boundary.
+#[derive(uniffi::Enum, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WaddleCarbonDirection {
+    /// Mirror of a message another of our resources sent (`<sent/>`).
+    Sent,
+    /// Mirror of a message another of our resources received
+    /// (`<received/>`).
+    Received,
+}
+
 /// XEP-0490 §3 displayed-marker entry surfaced to Swift. Mirrors
 /// `waddle_xmpp_client::messaging::MdsDisplayedEntry` 1:1 — the
 /// FFI does not collapse or rename fields so the Swift consumer
@@ -77,12 +323,33 @@ pub struct WaddleArchivedMessage {
     pub query_id: Option<String>,
     pub id: Option<String>,
     pub stanza_id: Option<String>,
+    /// XEP-0359 `by` authority of `stanza_id` (unverified — see
+    /// `WaddleMessage::stanza_id_by`).
+    pub stanza_id_by: Option<String>,
+    /// Every XEP-0359 `<stanza-id/>` on the inner message.
+    pub stanza_ids: Vec<WaddleStanzaId>,
     pub origin_id: Option<String>,
     pub timestamp: Option<String>,
     pub from: Option<String>,
     pub to: Option<String>,
     pub message_type: String,
     pub body: Option<String>,
+    /// RFC 6121 `<subject/>` of the inner message.
+    pub subject: Option<String>,
+    /// XEP-0308 correction target id.
+    pub replaces_id: Option<String>,
+    /// XEP-0424 retraction target id.
+    pub retracts_id: Option<String>,
+    /// XEP-0424 tombstone retraction message id.
+    pub retraction_id: Option<String>,
+    /// XEP-0424: true when the archived row is a retraction tombstone.
+    pub is_retracted: bool,
+    /// XEP-0425 moderation target id.
+    pub moderation_target_id: Option<String>,
+    /// XEP-0425 moderator JID (string form).
+    pub moderated_by: Option<String>,
+    /// XEP-0425 human-readable moderation reason.
+    pub moderation_reason: Option<String>,
     pub reaction_target_id: Option<String>,
     pub reaction_emojis: Vec<String>,
     pub thread: Option<String>,
@@ -91,9 +358,30 @@ pub struct WaddleArchivedMessage {
     pub reply_to_sender: Option<String>,
     pub reply_fallback_start: Option<u32>,
     pub reply_fallback_end: Option<u32>,
+    /// XEP-0394 markup spans of the inner message.
+    pub markup_spans: Vec<WaddleMarkupSpan>,
+    /// XEP-0372 broadcast mention URI, when present.
+    pub broadcast_mention: Option<String>,
+    /// XEP-0372 mention URIs, flattened from `references`.
+    pub mention_uris: Vec<String>,
+    /// XEP-0372 references of the inner message.
+    pub references: Vec<WaddleReference>,
+    /// Forum classification of the archived post (`topic`/`reply`).
+    pub forum_post_kind: Option<String>,
+    /// Forum topic title (the subject of a `topic` post).
+    pub forum_title: Option<String>,
+    /// XEP-0449: the archived body is a sticker.
+    pub is_sticker: bool,
+    /// XEP-0045 real author JID from the archived `muc#user` payload,
+    /// exposed by non-anonymous room archives.
+    pub author_real_jid: Option<String>,
     /// urn:waddle:call-thread:0 call-thread anchor marker, if present.
     pub call_thread: Option<WaddleCallThreadAnchor>,
+    /// urn:waddle:call-thread:0 ended fastening, if present.
+    pub call_thread_ended: Option<WaddleCallThreadEnded>,
     pub shared_files: Vec<WaddleSharedFile>,
+    /// XEP-0511 link previews of the inner message.
+    pub link_previews: Vec<WaddleLinkPreview>,
     pub call_event: Option<WaddleCallEvent>,
 }
 
@@ -138,6 +426,30 @@ pub struct WaddlePresence {
     pub hats: Vec<WaddlePresenceHat>,
     pub muc_affiliation: Option<WaddleMucAffiliation>,
     pub muc_role: Option<WaddleMucRole>,
+    /// XEP-0045 real occupant JID from the `muc#user` item, exposed
+    /// by non-anonymous rooms.
+    pub muc_jid: Option<String>,
+    /// XEP-0045 `<status code='…'/>` markers from the `muc#user`
+    /// payload. `110` identifies the recipient's own presence.
+    pub muc_status_codes: Vec<u16>,
+    /// XEP-0153 vCard avatar hash from `<x xmlns='vcard-temp:x:update'>`.
+    pub vcard_avatar: Option<String>,
+    /// XEP-0319 last-interaction instant (RFC 3339) from
+    /// `<idle since='…'/>`; `None` when the contact is interacting now.
+    pub idle_since: Option<String>,
+    /// RFC 6120 §8.3 error condition element name (e.g. `not-found`)
+    /// for `type="error"` presences; `None` otherwise.
+    pub error_condition: Option<String>,
+    /// RFC 6120 §8.3 error `type` attribute (e.g. `cancel`).
+    pub error_type: Option<String>,
+    /// RFC 6120 §8.3 human-readable `<text/>` of an error presence.
+    pub error_text: Option<String>,
+    /// urn:waddle:in-call:0 raised-hand marker carried alongside
+    /// `<muji/>`; `false` when the child is absent (lowered).
+    pub hand_raised: bool,
+    /// urn:waddle:in-call:0 muted-microphone marker; `false` when the
+    /// child is absent (unmuted).
+    pub muted: bool,
     /// XEP-0272 Muji presence advertisement
     /// `<muji xmlns='urn:xmpp:jingle:muji:0'/>` indicating the
     /// occupant has joined the room's group call. `None` when the
@@ -290,12 +602,22 @@ pub struct WaddleThreadTarget {
 #[derive(uniffi::Record, Clone, Default)]
 pub struct WaddleSendOptions {
     pub stanza_id: Option<String>,
+    /// RFC 6121 `<subject/>`, used by forum topic posts.
+    pub subject: Option<String>,
     pub reply: Option<WaddleReplyTarget>,
     pub fallback: Option<WaddleFallbackRange>,
     pub thread: Option<WaddleThreadTarget>,
+    /// XEP-0394 markup spans over the outbound body.
+    pub markup_spans: Vec<WaddleMarkupSpan>,
+    /// XEP-0372 references (mentions) attached to the send.
+    pub references: Vec<WaddleReference>,
     pub shared_files: Vec<WaddleSharedFile>,
     pub link_preview_token: Option<String>,
     pub request_displayed_marker: bool,
+    /// XEP-0045 §7.5: mark the message as a MUC private message so
+    /// the sender's other clients can classify the sent-carbon copy
+    /// without knowing the room.
+    pub muc_pm: bool,
 }
 
 /// Typed outcome for outbound message sends. The old FFI surface
@@ -411,7 +733,8 @@ pub enum WaddleJingleReason {
     UnsupportedTransports,
 }
 
-/// Typed A/V call event surfaced to Swift via `on_call(...)`.
+/// Typed A/V call event surfaced to Swift via
+/// `WaddleClientEvent::Call`.
 /// `from` is the stamped sender JID (a *full* JID for propose /
 /// session-initiate per XEP-0353 §0.6); `to` is the stamped stanza
 /// recipient when available; `sid` is the Jingle session id used to
@@ -497,19 +820,40 @@ impl From<WaddlePushDeviceCredentials> for waddle_xmpp_client::push::PushDeviceC
 
 // ── Callback interface ───────────────────────────────────────────────────────
 
+/// Single typed event stream surfaced to the app. New event kinds are
+/// added as enum variants, which keeps the callback protocol itself
+/// stable across FFI releases.
+#[derive(uniffi::Enum, Clone)]
+pub enum WaddleClientEvent {
+    /// Session is bound and ready (fires on `SessionReady`).
+    Connected,
+    /// The event stream closed; no further events will fire.
+    Disconnected,
+    /// Typed inbound chat/groupchat message (or message-shaped event).
+    Message { message: WaddleMessage },
+    /// Typed inbound presence.
+    Presence { presence: WaddlePresence },
+    /// XEP-0313 archived message from an active history query.
+    MamResult { message: WaddleArchivedMessage },
+    /// XEP-0198: the server acked the outbound message with this id.
+    DeliveryAcked { stanza_id: String },
+    /// XEP-0198: transport-level delivery failure for this id.
+    DeliveryFailed { stanza_id: String },
+    /// XEP-0353 / XEP-0166 inbound call event. Fires for every JMI
+    /// envelope and Jingle session control stanza addressed to the
+    /// bound resource. The Swift app surfaces it as the ringing UI,
+    /// the in-call HUD, and the hang-up handler.
+    Call { event: WaddleCallEvent },
+    /// XEP-0198 resume snapshot changed. `None` after an explicit
+    /// disconnect or when the session carries no resumable state;
+    /// persist `Some(state)` and feed it back via
+    /// `WaddleConfig.resume_state` on the next connect.
+    ResumeStateChanged { state: Option<WaddleSmResumeState> },
+    /// Human-readable diagnostic. Never carries protocol data.
+    Error { description: String },
+}
+
 #[uniffi::export(callback_interface)]
 pub trait WaddleEventListener: Send + Sync {
-    fn on_message(&self, message: WaddleMessage);
-    fn on_presence(&self, presence: WaddlePresence);
-    fn on_mam_result(&self, message: WaddleArchivedMessage);
-    fn on_message_delivery_acked(&self, stanza_id: String);
-    fn on_message_delivery_failed(&self, stanza_id: String);
-    fn on_connected(&self);
-    fn on_disconnected(&self);
-    fn on_error(&self, description: String);
-    /// XEP-0353 / XEP-0166 inbound call event. Fires for every
-    /// JMI envelope and Jingle session control stanza addressed to
-    /// the bound resource. The Swift app surfaces it as the
-    /// ringing UI, the in-call HUD, and the hang-up handler.
-    fn on_call(&self, event: WaddleCallEvent);
+    fn on_event(&self, event: WaddleClientEvent);
 }

--- a/server/crates/waddle-xmpp-client/src/client.rs
+++ b/server/crates/waddle-xmpp-client/src/client.rs
@@ -11,6 +11,7 @@ use crate::event::{ClientEvent, ConnectionEvent, MessageDeliveryEvent, StreamMan
 use crate::request::{ClientRequest, StanzaId};
 use crate::runtime::XmppRuntime;
 use crate::state::{ClientState, SessionSnapshot};
+use crate::stream_management::SmResumeState;
 use crate::transport::{
     DefaultTransportFactory, TransportEvent, TransportMessage, TransportState, WebSocketTransport,
     WebSocketTransportFactory,
@@ -182,6 +183,8 @@ where
             state,
             pending_iqs: HashMap::new(),
             deferred_commands: VecDeque::new(),
+            explicit_disconnect: false,
+            last_resume_state: None,
         };
 
         tokio::spawn(task.run());
@@ -199,6 +202,14 @@ struct DriverTask {
     state: Arc<RwLock<SessionSnapshot>>,
     pending_iqs: HashMap<String, oneshot::Sender<ClientResult<Element>>>,
     deferred_commands: VecDeque<DeferredXmppCommand>,
+    /// Set on [`XmppCommand::Disconnect`]. XEP-0198 forbids resuming
+    /// across a clean close, so the snapshot publisher pins the
+    /// broadcast state to `None` from that point on — mirroring the
+    /// wasm driver's `explicit_disconnect` flag.
+    explicit_disconnect: bool,
+    /// Last broadcast XEP-0198 resume snapshot; publishing is deduped
+    /// against it so subscribers only see actual state transitions.
+    last_resume_state: Option<SmResumeState>,
 }
 
 enum DeferredXmppCommand {
@@ -211,6 +222,11 @@ enum DeferredXmppCommand {
 
 impl DriverTask {
     async fn run(mut self) {
+        // Publish the config-seeded resume state (if any) before the
+        // first transport event, mirroring the wasm driver's snapshot
+        // right after `queue_request(Connect)`.
+        self.publish_resume_state_snapshot();
+
         // Process events the transport queued during connection setup.
         for event in self.transport.drain_events() {
             if !self.apply_transport_event(event).await {
@@ -278,6 +294,11 @@ impl DriverTask {
                 true
             }
             XmppCommand::Disconnect => {
+                // Pin the resume snapshot to `None` BEFORE closing:
+                // XEP-0198 resume must not be attempted across an
+                // explicit `</stream>` close (wasm driver parity).
+                self.explicit_disconnect = true;
+                self.publish_resume_state_snapshot();
                 let _ = self.transport.close().await;
                 // Drain close events so state reaches Disconnected before we exit.
                 for event in self.transport.drain_events() {
@@ -353,6 +374,7 @@ impl DriverTask {
                 return false;
             }
         };
+        self.publish_resume_state_snapshot();
 
         for evt in client_events {
             if let Some(msg) = self.dispatch_client_event(evt) {
@@ -456,6 +478,27 @@ impl DriverTask {
             }
             other => self.transport.send(other).await,
         }
+    }
+
+    /// Broadcast the current XEP-0198 resume snapshot when it differs
+    /// from the last published one. Runs at the same semantic points
+    /// the wasm driver refreshes its snapshot cell: once at task
+    /// start, after every runtime transport transition, and (forced
+    /// to `None`) on explicit disconnect. Deduped by value so the
+    /// broadcast bus only carries actual transitions.
+    fn publish_resume_state_snapshot(&mut self) {
+        let resume_state = if self.explicit_disconnect {
+            None
+        } else {
+            self.runtime.resume_state()
+        };
+        if resume_state == self.last_resume_state {
+            return;
+        }
+        self.last_resume_state = resume_state.clone();
+        let _ = self
+            .events
+            .send(ClientEvent::ResumeStateChanged(resume_state));
     }
 
     fn emit_message_delivery_failed(&self, stanza_id: StanzaId) {

--- a/server/crates/waddle-xmpp-client/src/client/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/client/tests.rs
@@ -72,6 +72,8 @@ fn make_driver_task_with_config(
         state,
         pending_iqs: HashMap::new(),
         deferred_commands: VecDeque::new(),
+        explicit_disconnect: false,
+        last_resume_state: None,
     };
     (task, cmd_tx, evt_rx)
 }
@@ -340,6 +342,82 @@ async fn driver_flushes_deferred_stanzas_when_fresh_sm_enable_fails() {
         sent.iter()
             .any(|message| transport_message_id(message) == Some("queued-1")),
         "queued app stanza should flush after fresh SM enable fails"
+    );
+}
+
+// ── XEP-0198 resume snapshot broadcast ────────────────────────────────────
+
+#[tokio::test(flavor = "current_thread")]
+async fn driver_broadcasts_resume_state_transitions() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, mut rx) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+
+    task.runtime
+        .queue_request(ClientRequest::Connect)
+        .expect("connect request should queue");
+    task.apply_transport_event(TransportEvent::StateChanged(TransportState::Open))
+        .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Open(
+        StreamOpen::from_server(BareJid::from_str("waddle.example").unwrap()),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        pre_auth_features(),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        Element::builder("success", NS_SASL).build(),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Open(
+        StreamOpen::from_server(BareJid::from_str("waddle.example").unwrap()),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        post_auth_features_with_sm(),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        bind_result("bind-1"),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        enabled_sm("new-stream"),
+    )))
+    .await;
+
+    let mut snapshots = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        if let ClientEvent::ResumeStateChanged(state) = event {
+            snapshots.push(state);
+        }
+    }
+    assert_eq!(
+        snapshots.len(),
+        1,
+        "identical snapshots must be deduped; only the <enabled/> transition broadcasts"
+    );
+    let state = snapshots[0]
+        .clone()
+        .expect("resumable snapshot after <enabled/>");
+    assert_eq!(state.previd(), "new-stream");
+
+    task.handle_command(XmppCommand::Disconnect).await;
+
+    let mut saw_cleared = false;
+    while let Ok(event) = rx.try_recv() {
+        if let ClientEvent::ResumeStateChanged(state) = event {
+            assert!(
+                state.is_none(),
+                "explicit disconnect must clear the resume snapshot"
+            );
+            saw_cleared = true;
+        }
+    }
+    assert!(
+        saw_cleared,
+        "expected ResumeStateChanged(None) on explicit disconnect"
     );
 }
 

--- a/server/crates/waddle-xmpp-client/src/event.rs
+++ b/server/crates/waddle-xmpp-client/src/event.rs
@@ -10,6 +10,7 @@ use crate::pep::PepItem;
 use crate::request::StanzaId;
 use crate::request::{PendingRequest, RequestCorrelation};
 use crate::state::{SessionBinding, SessionSnapshot};
+use crate::stream_management::SmResumeState;
 use crate::transport::{StreamOpen, TransportEvent, TransportMessage};
 
 /// Public event surface emitted by the client runtime.
@@ -39,6 +40,13 @@ pub enum ClientEvent {
     PepEvent(PepItem),
     /// Transport-level delivery status for outbound message stanzas.
     MessageDelivery(MessageDeliveryEvent),
+    /// XEP-0198 resume snapshot changed. Broadcast by the native driver
+    /// whenever the runtime's resumable state differs from the last
+    /// published snapshot — the same hook points the wasm driver uses
+    /// for its cell-based snapshot. `None` after an explicit disconnect
+    /// (resume MUST NOT be attempted across a clean `</stream>` close)
+    /// or when the session carries no resumable SM state.
+    ResumeStateChanged(Option<SmResumeState>),
     /// Correlated IQ result or error for in-flight `send_iq` calls.
     ///
     /// Consumed by the native driver to resolve the pending IQ request; never


### PR DESCRIPTION
PR-2 of the Android app program (stacked on #1348 — retarget to `main` once that merges): the FFI surface migration that makes every later Android/Apple capability addition a non-breaking enum variant, plus full record parity with what the shared client already parses.

## What

- **Listener migration.** The 9-method `WaddleEventListener` collapses into a single `on_event(WaddleClientEvent)` callback. Variants: `Connected, Disconnected, Message, Presence, MamResult, DeliveryAcked, DeliveryFailed, Call, ResumeStateChanged, Error`. Later additions (inbox entries, PEP events, pubsub) become enum variants instead of protocol-breaking new methods.
- **Record parity.** `WaddleMessage`, `WaddlePresence`, `WaddleArchivedMessage`, and `WaddleSendOptions` now expose every field the shared `waddle-xmpp-client` crate already parses but `convert.rs` previously dropped:
  - messages: XEP-0359 id sets (`stanza_id_by`, `stanza_ids`), subject, XEP-0424 tombstones (`retraction_id`, `is_retracted`), XEP-0425 moderation, XEP-0085 chat states (typed enum, unknown wire values → `None`), XEP-0333 marker ids, XEP-0394 markup spans, XEP-0372 references/mentions, XEP-0449 stickers, `urn:waddle:link-preview:0` payloads, pins, call-thread-ended, XEP-0280 carbon direction, forum metadata
  - presence: MUC occupant JID + status codes, vCard avatar hash, XEP-0319 idle, error triple, in-call hand-raised/muted
  - archived messages: all of the above plus `author_real_jid`
  - send options: `subject`, `muc_pm` (XEP-0045 §7.5), `markup_spans`, `references`
- **XEP-0198 resume over the FFI (G1).** New `WaddleSmResumeState` mirrors the core `SmResumeState` (queued stanzas as an opaque XML round-trip, documented); `WaddleConfig.resume_state` threads into `SessionConfig`; a new `ClientEvent::ResumeStateChanged` broadcasts snapshots from the native driver at the same hook points the wasm driver publishes (deduped by value). This is what lets the Android app resume streams across reconnects the way the web client does via localStorage.
- **Apple adapter updated in the same PR** (drift check enforces): `_EventListener` implements the new protocol with an exhaustive switch; construction sites gain the new fields with neutral values; forum topics now carry their title as the RFC 6121 `<subject/>` (previously silently dropped); live/archived events surface `subject`/`replacesID`/`retractsID`. Resume snapshots are logged and dropped — the Apple client doesn't persist resume state yet.

## Tests

~25 new FFI conversion suites (one per XEP cluster: 0359, 0308, 0424, 0425, 0085 incl. unknown-string rule, 0333, 0394, 0372, 0449, 0280, link previews, pins, call-thread-ended, forum, presence extras, archived extended fields), send-options mapping totality, resume round-trip through `SmState::from_resume_state(...)` + malformed-XML rejection, dispatch mapping (all variants, `Connected` on `SessionReady`), and a client-crate test for the new `ResumeStateChanged` broadcast dedupe/clear-on-disconnect semantics.

Gates: `cargo fmt --check` ✓ · `clippy --all-targets --all-features -D warnings` ✓ · client+ffi test suites ✓ · full workspace ✓ (single pre-existing `notification_outbox` parallel-run flake, tracked in #1348's description) · wasm target check ✓ · Swift bindings drift check ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
