### PR TITLE
fix(server): bind MUC actors to exact durable claim fences

### DIFF
--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -2726,9 +2726,9 @@ async fn group_dm_rename_update_error(
             UpdateGroupDmConfigByMemberError::OwnershipUnavailable => {
                 unavailable("This room's ownership cannot be verified right now; please retry.")
             }
-            UpdateGroupDmConfigByMemberError::PersistFailed(detail) => internal_err(format!(
-                "group-DM rename applied but durable persist failed: {detail}"
-            )),
+            UpdateGroupDmConfigByMemberError::PersistFailed => {
+                internal_err("group-DM rename applied but durable persist failed")
+            }
         },
         error => internal_err(format!("room actor UpdateGroupDmConfigByMember: {error}")),
     }

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -2721,7 +2721,7 @@ async fn group_dm_rename_update_error(
                         },
                     )
                     .await;
-                unavailable("This room's ownership recently moved to another node; please retry.")
+                unavailable("This room is temporarily unavailable; please retry.")
             }
             UpdateGroupDmConfigByMemberError::OwnershipUnavailable => {
                 unavailable("This room's ownership cannot be verified right now; please retry.")

--- a/server/crates/waddle-server/src/admin/channels.rs
+++ b/server/crates/waddle-server/src/admin/channels.rs
@@ -2276,7 +2276,9 @@ async fn run_group_dm_rename(
         .await
     {
         Ok(snapshot) => snapshot,
-        Err(error) => return Err(group_dm_rename_update_error(state, &args.room_jid, error).await),
+        Err(error) => {
+            return Err(group_dm_rename_update_error(state, &args.room_jid, &actor, error).await)
+        }
     };
     let expected_revision = updated_snapshot.config_revision;
     if find_occupant_for_full_jid(&updated_snapshot, caller_full_jid).is_none() {
@@ -2681,6 +2683,7 @@ fn group_dm_shared_name(name: &str) -> Option<&str> {
 async fn group_dm_rename_update_error(
     state: &AppState,
     room_jid: &BareJid,
+    actor: &ActorRef<RoomActor>,
     error: kameo::error::SendError<
         waddle_xmpp::muc::room_actor::UpdateGroupDmConfigByMember,
         waddle_xmpp::muc::room_actor::UpdateGroupDmConfigByMemberError,
@@ -2702,15 +2705,26 @@ async fn group_dm_rename_update_error(
                 ))))
             }
             // ADR-0017 Phase 3 Slice 7 FIX 2 (council-adjudicated): the
-            // fenced pre-mutation gate observed this node has been
-            // deposed — the rename was NEVER APPLIED. Hard-kill the
-            // stale local actor (mirrors the Demote relay ask's own
-            // receiving-side call) and bounce with a recoverable,
-            // retry-able error, same flavor `dispatch_to_room`'s own
-            // ownership-gap bounce uses.
-            UpdateGroupDmConfigByMemberError::NotOwner => {
-                state.clustering_claims.demote_room_actor(room_jid).await;
+            // `NotOwner` means the pre-mutation gate rejected the rename.
+            // `OwnershipLostAfterApply` means the rename may already exist in
+            // this stale actor, but its awaited durable write lost ownership.
+            // Either outcome exact-demotes this actor and returns a
+            // recoverable retry response.
+            UpdateGroupDmConfigByMemberError::NotOwner
+            | UpdateGroupDmConfigByMemberError::OwnershipLostAfterApply => {
+                let _ = state
+                    .room_registry
+                    .ask(
+                        waddle_xmpp::muc::room_registry_actor::DemoteRoomIfExactActor {
+                            room_jid: room_jid.clone(),
+                            actor_ref: actor.clone(),
+                        },
+                    )
+                    .await;
                 unavailable("This room's ownership recently moved to another node; please retry.")
+            }
+            UpdateGroupDmConfigByMemberError::OwnershipUnavailable => {
+                unavailable("This room's ownership cannot be verified right now; please retry.")
             }
             UpdateGroupDmConfigByMemberError::PersistFailed(detail) => internal_err(format!(
                 "group-DM rename applied but durable persist failed: {detail}"

--- a/server/crates/waddle-server/src/clustering/local_claims.rs
+++ b/server/crates/waddle-server/src/clustering/local_claims.rs
@@ -1651,30 +1651,57 @@ mod tests {
         persisted: Arc<std::sync::atomic::AtomicBool>,
     }
 
-    impl waddle_xmpp::muc::MucDurableStore for RecordingDurableStore {
-        fn load_room_state<'a>(
-            &'a self,
-            _room_jid: &'a jid::BareJid,
-        ) -> waddle_xmpp::muc::MucDurableFuture<'a, Option<waddle_xmpp::muc::DurableRoomState>>
-        {
-            Box::pin(async { Ok(None) })
-        }
+    fn expected_local_room_fence(
+        room_jid: &jid::BareJid,
+    ) -> waddle_xmpp::muc::RoomClaimFenceContext {
+        waddle_xmpp::muc::RoomClaimFenceContext::new(
+            waddle_xmpp::ownership::Entity::new(
+                waddle_xmpp::ownership::EntityType::RoomActor,
+                room_jid.to_string(),
+            ),
+            waddle_xmpp::ownership::NodeIdentity::local(),
+            waddle_xmpp::ownership::ClaimEpoch(0),
+        )
+    }
 
+    fn validate_local_room_fence(
+        room_jid: &jid::BareJid,
+        fence: &waddle_xmpp::muc::RoomClaimFenceContext,
+    ) -> Result<(), waddle_xmpp::XmppError> {
+        if fence == &expected_local_room_fence(room_jid) {
+            Ok(())
+        } else {
+            Err(waddle_xmpp::XmppError::internal(
+                "test store received an unexpected room claim fence",
+            ))
+        }
+    }
+
+    impl waddle_xmpp::muc::MucDurableStore for RecordingDurableStore {
         fn load_room_state_fenced<'a>(
             &'a self,
             room_jid: &'a jid::BareJid,
+            fence: &'a waddle_xmpp::muc::RoomClaimFenceContext,
         ) -> waddle_xmpp::muc::MucDurableFuture<'a, Option<waddle_xmpp::muc::DurableRoomState>>
         {
-            self.load_room_state(room_jid)
+            let validation = validate_local_room_fence(room_jid, fence);
+            Box::pin(async move {
+                validation?;
+                Ok(None)
+            })
         }
 
-        fn save_config<'a>(
+        fn save_config_fenced<'a>(
             &'a self,
-            _room_jid: &'a jid::BareJid,
+            room_jid: &'a jid::BareJid,
             _waddle_id: &'a str,
             _channel_id: &'a str,
             _config: &'a waddle_xmpp::muc::RoomConfig,
+            fence: &'a waddle_xmpp::muc::RoomClaimFenceContext,
         ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
+            if let Err(error) = validate_local_room_fence(room_jid, fence) {
+                return Box::pin(async move { Err(error) });
+            }
             Box::pin(async move {
                 self.started.notify_one();
                 tokio::time::sleep(Duration::from_millis(150)).await;
@@ -1684,20 +1711,42 @@ mod tests {
             })
         }
 
-        fn save_subject<'a>(
+        fn save_subject_fenced<'a>(
             &'a self,
-            _room_jid: &'a jid::BareJid,
+            room_jid: &'a jid::BareJid,
             _subject: Option<&'a waddle_xmpp::muc::SubjectState>,
+            fence: &'a waddle_xmpp::muc::RoomClaimFenceContext,
         ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            let validation = validate_local_room_fence(room_jid, fence);
+            Box::pin(async move { validation })
         }
 
-        fn save_affiliation<'a>(
+        fn save_affiliation_fenced<'a>(
             &'a self,
-            _room_jid: &'a jid::BareJid,
+            room_jid: &'a jid::BareJid,
             _entry: &'a waddle_xmpp::muc::affiliation::AffiliationEntry,
+            fence: &'a waddle_xmpp::muc::RoomClaimFenceContext,
         ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            let validation = validate_local_room_fence(room_jid, fence);
+            Box::pin(async move { validation })
+        }
+
+        fn delete_room_state_fenced<'a>(
+            &'a self,
+            room_jid: &'a jid::BareJid,
+            fence: &'a waddle_xmpp::muc::RoomClaimFenceContext,
+        ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
+            let validation = validate_local_room_fence(room_jid, fence);
+            Box::pin(async move { validation })
+        }
+
+        fn check_exact_claim_fence<'a>(
+            &'a self,
+            room_jid: &'a jid::BareJid,
+            fence: &'a waddle_xmpp::muc::RoomClaimFenceContext,
+        ) -> waddle_xmpp::muc::MucDurableFuture<'a, bool> {
+            let matches = fence == &expected_local_room_fence(room_jid);
+            Box::pin(async move { Ok(matches) })
         }
     }
 

--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -31,27 +31,12 @@
 //! assert_fenced` already established — as the first statement inside the
 //! same [`crate::db::Database::begin`] transaction as the write it guards,
 //! on the **main pool**, never the control-plane pool (the Slice 0/4/7
-//! pool-assignment rule). The epoch bound into that check comes from a
-//! per-room cache ([`PostgresMucRoomStore::claim_fences`]) populated by the
-//! room registry calling [`Self::record_claim_fence`] immediately after a
-//! successful claim acquire/steal — never re-derived here, mirroring
-//! `PostgresFencedSmPersistence`'s own "epoch side channel" design note.
-//!
-//! **Corrected code-research finding (this slice's own, not a plan
-//! misattribution)**: element 7's "the MAM archive insert doubles as the
-//! backstop when archiving is on" is not achievable within this slice's
-//! Files list. MAM storage (`waddle_xmpp::mam::storage::sqlx_store`) issues
-//! a plain `sqlx::QueryBuilder` insert directly against its own raw
-//! `sqlx::PgPool`/`SqlitePool`, in `waddle-xmpp` — it has no access to
-//! `waddle-server`'s `Database`/`Transaction` types (the crate-dependency
-//! direction only runs `waddle-server -> waddle-xmpp`) and making the MAM
-//! insert itself fenced would require restructuring the MAM storage
-//! boundary, out of scope here. [`Self::check_fenced_fanout`] is therefore
-//! the **sole** backstop, run unconditionally (both archiving-on and
-//! archiving-off), as a standalone autocommit statement — the ADR's own
-//! "otherwise the standalone autocommit fencing SELECT itself is the one
-//! write-adjacent statement" text for the non-archiving case, generalized
-//! to always apply. See the phase plan's deviation log for the full note.
+//! pool-assignment rule). Actor-owned loads, saves, and deletes receive their
+//! immutable incarnation fence explicitly. The room-keyed cache
+//! ([`PostgresMucRoomStore::claim_fences`]) is published only with the matching
+//! ready registry entry and remains the live legacy consumer for pre-fanout
+//! groupchat dispatch/MAM until #1283 replaces it; it is not authority for
+//! actor-derived durable work.
 
 use dashmap::DashMap;
 use jid::BareJid;
@@ -72,6 +57,17 @@ use crate::db::{Database, DatabaseError, Transaction};
 
 fn db_err(error: DatabaseError) -> XmppError {
     XmppError::internal(format!("MUC durable store backend error: {error}"))
+}
+
+fn fence_db_unavailable(error: DatabaseError, fence: &RoomClaimFenceContext) -> XmppError {
+    tracing::warn!(
+        %error,
+        entity = %fence.entity,
+        "MUC durable store could not prove the exact ownership fence"
+    );
+    XmppError::OwnershipUnavailable {
+        entity: fence.entity.clone(),
+    }
 }
 
 /// Injective `(entity_type, id) -> TEXT` encoding for the
@@ -111,8 +107,7 @@ fn affiliation_from_db_str(value: &str) -> Option<Affiliation> {
 }
 
 /// Postgres-backed [`MucDurableStore`] (ADR-0017 Phase 3 Slice 7). See the
-/// module doc for the schema, fencing design, and the MAM-backstop
-/// code-research correction.
+/// module doc for the schema and fencing design.
 pub struct PostgresMucRoomStore {
     db: Database,
     /// Live process incarnation. Cached room fences remain immutable; every
@@ -124,7 +119,9 @@ pub struct PostgresMucRoomStore {
     /// per-call (mirroring `resume_asker::SwarmRemoteResumeAsker`'s
     /// identical "fresh `RelayHandle` per ask" pattern).
     stop_token: CancellationToken,
-    /// Per-room claim epoch cache — see the module doc's fencing section.
+    /// Fence for the currently published local room actor. Retained for
+    /// publication observability and legacy pre-fanout groupchat dispatch/MAM
+    /// consumers; actor-derived durable work carries its immutable fence.
     claim_fences: DashMap<BareJid, RoomClaimFenceContext>,
 }
 
@@ -205,14 +202,13 @@ impl PostgresMucRoomStore {
             .map(|entry| entry.clone())
             .ok_or_else(|| {
                 XmppError::internal(format!(
-                    "no claim epoch recorded for room {room_jid}; durable write skipped \
-                 (the room registry must call record_claim_fence before any write)"
+                    "no published claim fence recorded for room {room_jid}; fenced fan-out skipped"
                 ))
             })?;
         if self.node_identity.current() != fence.owner {
             remove_room_claim_fence_if(&self.claim_fences, room_jid, &fence);
             return Err(XmppError::internal(format!(
-                "durable write for room {room_jid} aborted: cached claim belongs to a stale node incarnation"
+                "fenced fan-out for room {room_jid} aborted: cached claim belongs to a stale node incarnation"
             )));
         }
         Ok(fence)
@@ -220,16 +216,13 @@ impl PostgresMucRoomStore {
 
     async fn guard_fence_identity(
         &self,
-        room_jid: &BareJid,
         fence: &RoomClaimFenceContext,
     ) -> Result<CurrentNodeIdentityGuard, XmppError> {
         self.node_identity
             .guard_if_current(&fence.owner)
             .await
-            .ok_or_else(|| {
-                XmppError::internal(format!(
-                    "durable write for room {room_jid} aborted during node identity rotation"
-                ))
+            .ok_or_else(|| XmppError::OwnershipLost {
+                entity: fence.entity.clone(),
             })
     }
 
@@ -243,11 +236,17 @@ impl PostgresMucRoomStore {
         room_jid: &BareJid,
         fence: &RoomClaimFenceContext,
     ) -> Result<(), XmppError> {
+        let expected_entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        if fence.entity != expected_entity {
+            return Err(XmppError::OwnershipLost {
+                entity: fence.entity.clone(),
+            });
+        }
         if self.node_identity.current() != fence.owner {
             remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
-            return Err(XmppError::internal(format!(
-                "durable write for room {room_jid} aborted: claim fence belongs to a stale node incarnation"
-            )));
+            return Err(XmppError::OwnershipLost {
+                entity: expected_entity,
+            });
         }
         let key = room_entity_key(room_jid);
         let mut rows = tx
@@ -261,16 +260,56 @@ impl PostgresMucRoomStore {
                 ],
             )
             .await
-            .map_err(db_err)?;
-        let held = rows.next().await.map_err(db_err)?.is_some();
+            .map_err(|error| fence_db_unavailable(error, fence))?;
+        let held = rows
+            .next()
+            .await
+            .map_err(|error| fence_db_unavailable(error, fence))?
+            .is_some();
         if held && self.node_identity.current() == fence.owner {
             Ok(())
         } else {
             remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
-            Err(XmppError::internal(format!(
-                "durable write for room {room_jid} aborted: this node no longer holds the \
-                 room's ownership claim (0 rows from the fencing SELECT)"
-            )))
+            Err(XmppError::OwnershipLost {
+                entity: expected_entity,
+            })
+        }
+    }
+
+    async fn exact_claim_is_held(
+        &self,
+        room_jid: &BareJid,
+        fence: &RoomClaimFenceContext,
+    ) -> Result<bool, XmppError> {
+        let expected_entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        if fence.entity != expected_entity {
+            return Ok(false);
+        }
+        if self.node_identity.current() != fence.owner {
+            remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
+            return Ok(false);
+        }
+        let conn = self.db.guard().await.map_err(db_err)?;
+        let mut rows = conn
+            .query(
+                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? \
+                 AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
+                crate::db_params![
+                    room_entity_key(room_jid),
+                    fence.owner.node_id.clone(),
+                    fence.owner.node_epoch.clone(),
+                    fence.epoch.0,
+                ],
+            )
+            .await
+            .map_err(db_err)?;
+        let held = rows.next().await.map_err(db_err)?.is_some();
+        drop(rows);
+        if held && self.node_identity.current() == fence.owner {
+            Ok(true)
+        } else {
+            remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
+            Ok(false)
         }
     }
 
@@ -351,57 +390,47 @@ impl PostgresMucRoomStore {
 }
 
 impl MucDurableStore for PostgresMucRoomStore {
-    fn load_room_state<'a>(
-        &'a self,
-        room_jid: &'a BareJid,
-    ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
-        Box::pin(async move {
-            let mut tx = self.db.begin().await.map_err(db_err)?;
-            tx.execute(
-                "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY",
-                (),
-            )
-            .await
-            .map_err(db_err)?;
-            let state = Self::load_room_state_in_tx(&mut tx, room_jid).await?;
-            tx.commit().await.map_err(db_err)?;
-            Ok(state)
-        })
-    }
-
     fn load_room_state_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,
+        fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
         Box::pin(async move {
-            let fence = self.fence_for(room_jid)?;
-            let _identity_guard = self.guard_fence_identity(room_jid, &fence).await?;
-            let mut tx = self.db.begin().await.map_err(db_err)?;
+            let _identity_guard = self.guard_fence_identity(fence).await?;
+            let mut tx = self
+                .db
+                .begin()
+                .await
+                .map_err(|error| fence_db_unavailable(error, fence))?;
             tx.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ", ())
                 .await
                 .map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, &fence).await?;
+            self.assert_fenced(&mut tx, room_jid, fence).await?;
             let state = Self::load_room_state_in_tx(&mut tx, room_jid).await?;
             tx.commit().await.map_err(db_err)?;
             Ok(state)
         })
     }
 
-    fn save_config<'a>(
+    fn save_config_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,
         waddle_id: &'a str,
         channel_id: &'a str,
         config: &'a RoomConfig,
+        fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let fence = self.fence_for(room_jid)?;
-            let _identity_guard = self.guard_fence_identity(room_jid, &fence).await?;
+            let _identity_guard = self.guard_fence_identity(fence).await?;
             let config_json = serde_json::to_string(config).map_err(|error| {
                 XmppError::internal(format!("durable room config encode failed: {error}"))
             })?;
-            let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, &fence).await?;
+            let mut tx = self
+                .db
+                .begin()
+                .await
+                .map_err(|error| fence_db_unavailable(error, fence))?;
+            self.assert_fenced(&mut tx, room_jid, fence).await?;
             tx.execute(
                 r#"
                 INSERT INTO clustering_muc_rooms (room_jid, waddle_id, channel_id, config_json, updated_at)
@@ -426,28 +455,31 @@ impl MucDurableStore for PostgresMucRoomStore {
         })
     }
 
-    fn save_subject<'a>(
+    fn save_subject_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,
         subject: Option<&'a SubjectState>,
+        fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let fence = self.fence_for(room_jid)?;
-            let _identity_guard = self.guard_fence_identity(room_jid, &fence).await?;
+            let _identity_guard = self.guard_fence_identity(fence).await?;
             let subject_json = subject
                 .map(serde_json::to_string)
                 .transpose()
                 .map_err(|error| {
                     XmppError::internal(format!("durable room subject encode failed: {error}"))
                 })?;
-            let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, &fence).await?;
+            let mut tx = self
+                .db
+                .begin()
+                .await
+                .map_err(|error| fence_db_unavailable(error, fence))?;
+            self.assert_fenced(&mut tx, room_jid, fence).await?;
             // The room row must already exist (a subject can only be set on
             // an already-spawned room, which always durably writes its
-            // config at spawn-adjacent points first) — an UPDATE-only
-            // statement here, not an upsert, so a missing row is a loud
-            // 0-rows-affected rather than a silently-incomplete insert
-            // missing `waddle_id`/`channel_id`.
+            // config at spawn-adjacent points first). Keep this UPDATE-only:
+            // an upsert here could create an incomplete row without its
+            // required `waddle_id` and `channel_id` fields.
             let affected = tx
                 .execute(
                     "UPDATE clustering_muc_rooms SET subject_json = ?, updated_at = now() WHERE room_jid = ?",
@@ -456,27 +488,29 @@ impl MucDurableStore for PostgresMucRoomStore {
                 .await
                 .map_err(db_err)?;
             if affected == 0 {
-                tracing::warn!(
-                    room = %room_jid,
-                    "durable subject persist skipped: no durable room row exists yet \
-                     (config has not been durably written for this room)"
-                );
+                return Err(XmppError::DurableRoomStateMissing {
+                    entity: fence.entity.clone(),
+                });
             }
             tx.commit().await.map_err(db_err)?;
             Ok(())
         })
     }
 
-    fn save_affiliation<'a>(
+    fn save_affiliation_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,
         entry: &'a AffiliationEntry,
+        fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let fence = self.fence_for(room_jid)?;
-            let _identity_guard = self.guard_fence_identity(room_jid, &fence).await?;
-            let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, &fence).await?;
+            let _identity_guard = self.guard_fence_identity(fence).await?;
+            let mut tx = self
+                .db
+                .begin()
+                .await
+                .map_err(|error| fence_db_unavailable(error, fence))?;
+            self.assert_fenced(&mut tx, room_jid, fence).await?;
             if entry.affiliation == Affiliation::None {
                 tx.execute(
                     "DELETE FROM clustering_muc_room_affiliations WHERE room_jid = ? AND member_jid = ?",
@@ -513,12 +547,19 @@ impl MucDurableStore for PostgresMucRoomStore {
     /// durable storage. Epoch-fenced like every other write — a node
     /// that lost the claim mid-destroy must not wipe the new owner's
     /// rows.
-    fn delete_room_state<'a>(&'a self, room_jid: &'a BareJid) -> MucDurableFuture<'a, ()> {
+    fn delete_room_state_fenced<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let fence = self.fence_for(room_jid)?;
-            let _identity_guard = self.guard_fence_identity(room_jid, &fence).await?;
-            let mut tx = self.db.begin().await.map_err(db_err)?;
-            self.assert_fenced(&mut tx, room_jid, &fence).await?;
+            let _identity_guard = self.guard_fence_identity(fence).await?;
+            let mut tx = self
+                .db
+                .begin()
+                .await
+                .map_err(|error| fence_db_unavailable(error, fence))?;
+            self.assert_fenced(&mut tx, room_jid, fence).await?;
             tx.execute(
                 "DELETE FROM clustering_muc_room_affiliations WHERE room_jid = ?",
                 crate::db_params![room_jid.to_string()],
@@ -537,6 +578,15 @@ impl MucDurableStore for PostgresMucRoomStore {
     }
 
     fn record_claim_fence(&self, room_jid: &BareJid, fence: RoomClaimFenceContext) {
+        let expected = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        if fence.entity != expected {
+            tracing::warn!(
+                room = %room_jid,
+                entity = %fence.entity,
+                "refusing to cache a MUC claim fence for a different entity"
+            );
+            return;
+        }
         self.claim_fences.insert(room_jid.clone(), fence);
     }
 
@@ -544,11 +594,10 @@ impl MucDurableStore for PostgresMucRoomStore {
         remove_room_claim_fence_if(&self.claim_fences, room_jid, expected);
     }
 
-    /// The guaranteed demotion backstop (element 7): a fenced,
-    /// standalone-autocommit `SELECT ... FOR SHARE` on the main pool, run
-    /// before every local fan-out. See the module doc's MAM-backstop
-    /// correction for why this is the sole backstop mechanism this slice
-    /// lands, unconditionally (both archiving-on and archiving-off).
+    /// Cache-backed legacy pre-fanout backstop: a fenced,
+    /// standalone-autocommit `SELECT ... FOR SHARE` on the main pool. This
+    /// remains in production for groupchat dispatch/MAM until #1283 replaces
+    /// it; actor-owned durable operations use their immutable fence instead.
     fn check_fenced_fanout<'a>(&'a self, room_jid: &'a BareJid) -> MucDurableFuture<'a, bool> {
         Box::pin(async move {
             let fence = self
@@ -560,43 +609,21 @@ impl MucDurableStore for PostgresMucRoomStore {
                         "no claim epoch recorded for room {room_jid}; fenced fan-out skipped"
                     ))
                 })?;
-            // Identity rotation is a definitive local ownership loss, not a
-            // transient storage failure. Return `Ok(false)` so fan-out and
-            // mutation gates fail closed instead of taking their transient
-            // error path (which intentionally fails open).
-            if self.node_identity.current() != fence.owner {
-                remove_room_claim_fence_if(&self.claim_fences, room_jid, &fence);
-                return Ok(false);
-            }
-            let key = room_entity_key(room_jid);
-            let conn = self.db.guard().await.map_err(db_err)?;
-            let mut rows = conn
-                .query(
-                    "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
-                    crate::db_params![
-                        key,
-                        fence.owner.node_id.clone(),
-                        fence.owner.node_epoch.clone(),
-                        fence.epoch.0
-                    ],
-                )
-                .await
-                .map_err(db_err)?;
-            let held = rows.next().await.map_err(db_err)?.is_some();
-            if held && self.node_identity.current() == fence.owner {
-                Ok(true)
-            } else {
-                remove_room_claim_fence_if(&self.claim_fences, room_jid, &fence);
-                Ok(false)
-            }
+            self.exact_claim_is_held(room_jid, &fence).await
         })
     }
 
-    /// ADR-0017 Phase 3 Slice 7 FIX 1: exposes the exact `(Entity,
-    /// ClaimEpoch, node_id)` triple [`Self::check_fenced_fanout`]/
-    /// [`Self::assert_fenced`] already resolve from `self.claim_fences`, so
-    /// `groupchat_archive.rs`'s MAM fenced write can bind the identical
-    /// typed context rather than re-deriving it from a second mechanism.
+    fn check_exact_claim_fence<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, bool> {
+        Box::pin(async move { self.exact_claim_is_held(room_jid, fence).await })
+    }
+
+    /// Exposes the typed `(Entity, ClaimEpoch, node_id)` triple published for
+    /// the current live registry entry. Actor-derived work must instead use
+    /// the immutable fence from its own actor snapshot.
     fn current_claim_fence(&self, room_jid: &BareJid) -> Option<RoomClaimFenceContext> {
         self.fence_for(room_jid).ok()
     }
@@ -758,10 +785,8 @@ mod tests {
             .ensure_claimed(&entity, &me)
             .await
             .expect("claim");
-        store.record_claim_fence(
-            &jid,
-            RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch),
-        );
+        let fence = RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch);
+        store.record_claim_fence(&jid, fence.clone());
 
         let config = RoomConfig {
             name: "test room".to_string(),
@@ -769,7 +794,7 @@ mod tests {
             ..RoomConfig::default()
         };
         store
-            .save_config(&jid, "waddle-1", "chan-1", &config)
+            .save_config_fenced(&jid, "waddle-1", "chan-1", &config, &fence)
             .await
             .expect("save config");
 
@@ -780,19 +805,19 @@ mod tests {
             set_at: chrono::Utc::now(),
         };
         store
-            .save_subject(&jid, Some(&subject))
+            .save_subject_fenced(&jid, Some(&subject), &fence)
             .await
             .expect("save subject");
 
         let bob: BareJid = "bob@example.com".parse().expect("valid jid");
         let entry = AffiliationEntry::new(bob.clone(), Affiliation::Owner);
         store
-            .save_affiliation(&jid, &entry)
+            .save_affiliation_fenced(&jid, &entry, &fence)
             .await
             .expect("save affiliation");
 
         let loaded = store
-            .load_room_state(&jid)
+            .load_room_state_fenced(&jid, &fence)
             .await
             .expect("load")
             .expect("row exists");
@@ -821,40 +846,86 @@ mod tests {
             .ensure_claimed(&entity, &me)
             .await
             .expect("claim");
-        store.record_claim_fence(
-            &jid,
-            RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch),
-        );
+        let fence = RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch);
+        store.record_claim_fence(&jid, fence.clone());
         store
-            .save_config(&jid, "waddle-1", "chan-1", &RoomConfig::default())
+            .save_config_fenced(&jid, "waddle-1", "chan-1", &RoomConfig::default(), &fence)
             .await
             .expect("save config");
 
         let carol: BareJid = "carol@example.com".parse().expect("valid jid");
         store
-            .save_affiliation(
+            .save_affiliation_fenced(
                 &jid,
                 &AffiliationEntry::new(carol.clone(), Affiliation::Member),
+                &fence,
             )
             .await
             .expect("save member");
         let loaded = store
-            .load_room_state(&jid)
+            .load_room_state_fenced(&jid, &fence)
             .await
             .expect("load")
             .expect("row exists");
         assert_eq!(loaded.affiliations.len(), 1);
 
         store
-            .save_affiliation(&jid, &AffiliationEntry::new(carol, Affiliation::None))
+            .save_affiliation_fenced(
+                &jid,
+                &AffiliationEntry::new(carol, Affiliation::None),
+                &fence,
+            )
             .await
             .expect("save none removes the row");
         let loaded = store
-            .load_room_state(&jid)
+            .load_room_state_fenced(&jid, &fence)
             .await
             .expect("load")
             .expect("row exists");
         assert!(loaded.affiliations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn save_subject_fenced_rejects_a_claimed_room_without_durable_state() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, _db, me)) = clean_store().await else {
+            return;
+        };
+        let jid = room_jid("subject-without-durable-state");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let epoch = claim_store
+            .ensure_claimed(&entity, &me)
+            .await
+            .expect("claim");
+        let fence = RoomClaimFenceContext::new(entity, me, epoch);
+        store.record_claim_fence(&jid, fence.clone());
+        let subject = SubjectState {
+            texts: RoomSubjectTexts::from_iter([(String::new(), "hello".to_string())]),
+            setter: "alice@example.com".parse().expect("valid jid"),
+            setter_nick: "alice".to_string(),
+            set_at: chrono::Utc::now(),
+        };
+
+        let result = store
+            .save_subject_fenced(&jid, Some(&subject), &fence)
+            .await;
+
+        assert!(
+            matches!(
+                &result,
+                Err(XmppError::DurableRoomStateMissing { entity })
+                    if entity == &fence.entity
+            ),
+            "a subject write must return the typed missing-state error unless its fenced room row exists: {result:?}"
+        );
+        assert!(
+            store
+                .load_room_state_fenced(&jid, &fence)
+                .await
+                .expect("load after rejected subject write")
+                .is_none(),
+            "the rejected subject write must not create a partial durable room state"
+        );
     }
 
     /// The plan's own Slice 7 Tests entry: "fenced pre-fan-out SELECT
@@ -872,9 +943,38 @@ mod tests {
             .ensure_claimed(&entity, &me)
             .await
             .expect("claim");
-        store.record_claim_fence(
-            &jid,
-            RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch),
+        let fence = RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch);
+        store.record_claim_fence(&jid, fence.clone());
+
+        let sibling_jid = room_jid("same-owner-same-epoch");
+        let sibling_entity = Entity::new(EntityType::RoomActor, sibling_jid.to_string());
+        let sibling_epoch = claim_store
+            .ensure_claimed(&sibling_entity, &me)
+            .await
+            .expect("claim sibling room");
+        assert_eq!(
+            sibling_epoch, epoch,
+            "independent room claims can legitimately share an epoch"
+        );
+        let sibling_fence = RoomClaimFenceContext::new(sibling_entity, me.clone(), sibling_epoch);
+        assert!(
+            !store
+                .check_exact_claim_fence(&jid, &sibling_fence)
+                .await
+                .expect("cross-room exact check"),
+            "same owner and epoch must not authorize a different room entity"
+        );
+        assert_eq!(
+            store.current_claim_fence(&jid),
+            Some(fence.clone()),
+            "a mismatched entity must not evict the retained room fence"
+        );
+        assert!(
+            store
+                .check_exact_claim_fence(&jid, &fence)
+                .await
+                .expect("exact room check"),
+            "the matching room incarnation must remain authorized"
         );
 
         assert!(
@@ -904,14 +1004,9 @@ mod tests {
         );
     }
 
-    /// ADR-0017 Phase 3 Slice 7 FIX 1 (council-adjudicated): the MAM
-    /// fenced-archive-write backstop. Exercises the full path this fix
-    /// adds — `current_claim_fence` resolving the same typed context
-    /// `check_fenced_fanout` uses, `SqlxMamStorage::store_message_fenced`
-    /// running the fencing `SELECT ... FOR SHARE` inside the same
-    /// transaction as the archive insert, and the deposed owner's very
-    /// next fenced write observing `NotOwner` rather than silently
-    /// archiving under a claim it no longer holds.
+    /// Lower-level MAM storage regression coverage. It is not a #1355
+    /// general-dispatch or archive-fence contract; the production pre-fanout
+    /// path remains cache-backed until #1283 replaces it.
     #[tokio::test]
     async fn mam_store_message_fenced_blocks_the_deposed_owners_next_archive_write() {
         use waddle_xmpp::mam::{MamStorage, MamStorageError, SqlxMamStorage};

--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -221,7 +221,7 @@ impl PostgresMucRoomStore {
         self.node_identity
             .guard_if_current(&fence.owner)
             .await
-            .ok_or_else(|| XmppError::OwnershipLost {
+            .ok_or_else(|| XmppError::OwnershipUnavailable {
                 entity: fence.entity.clone(),
             })
     }
@@ -244,7 +244,7 @@ impl PostgresMucRoomStore {
         }
         if self.node_identity.current() != fence.owner {
             remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
-            return Err(XmppError::OwnershipLost {
+            return Err(XmppError::OwnershipUnavailable {
                 entity: expected_entity,
             });
         }
@@ -266,14 +266,14 @@ impl PostgresMucRoomStore {
             .await
             .map_err(|error| fence_db_unavailable(error, fence))?
             .is_some();
-        if held && self.node_identity.current() == fence.owner {
-            Ok(())
-        } else {
+        if !held {
             remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
-            Err(XmppError::OwnershipLost {
+            return Err(XmppError::OwnershipLost {
                 entity: expected_entity,
-            })
+            });
         }
+        debug_assert_eq!(self.node_identity.current(), fence.owner);
+        Ok(())
     }
 
     async fn exact_claim_is_held(
@@ -285,10 +285,7 @@ impl PostgresMucRoomStore {
         if fence.entity != expected_entity {
             return Ok(false);
         }
-        if self.node_identity.current() != fence.owner {
-            remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
-            return Ok(false);
-        }
+        let _identity_guard = self.guard_fence_identity(fence).await?;
         let conn = self
             .db
             .guard()
@@ -313,12 +310,12 @@ impl PostgresMucRoomStore {
             .map_err(|error| fence_db_unavailable(error, fence))?
             .is_some();
         drop(rows);
-        if held && self.node_identity.current() == fence.owner {
-            Ok(true)
-        } else {
+        if !held {
             remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
-            Ok(false)
+            return Ok(false);
         }
+        debug_assert_eq!(self.node_identity.current(), fence.owner);
+        Ok(true)
     }
 
     async fn load_room_state_in_tx(
@@ -485,9 +482,9 @@ impl MucDurableStore for PostgresMucRoomStore {
             self.assert_fenced(&mut tx, room_jid, fence).await?;
             // Keep this UPDATE-only: an upsert here could create an incomplete
             // row without its required `waddle_id` and `channel_id` fields.
-            // Until #1352 atomically initializes the complete room plus
-            // initial Owner, an exact-fenced missing row is non-fatal. #1350
-            // will enforce missing-parent writes after that lifecycle exists.
+            // Until #1352 atomically initializes the complete room plus its
+            // initial Owner, fail before acknowledging a subject whose
+            // durable parent is absent.
             let affected = tx
                 .execute(
                     "UPDATE clustering_muc_rooms SET subject_json = ?, updated_at = now() WHERE room_jid = ?",
@@ -496,11 +493,9 @@ impl MucDurableStore for PostgresMucRoomStore {
                 .await
                 .map_err(db_err)?;
             if affected == 0 {
-                tracing::warn!(
-                    room = %room_jid,
-                    entity = %fence.entity,
-                    "subject update found no durable room parent before creator lifecycle initialization"
-                );
+                return Err(XmppError::DurableRoomStateMissing {
+                    entity: fence.entity.clone(),
+                });
             }
             tx.commit().await.map_err(db_err)?;
             Ok(())
@@ -669,10 +664,10 @@ mod tests {
     use super::*;
     use crate::clustering::claims::{clustering_control_plane_table_lock, PostgresClaimStore};
     use crate::db::{DatabaseConfig, DatabaseDriver, DEFAULT_CONTROL_PLANE_POOL_SIZE};
-    use kameo::actor::Spawn;
+    use kameo::{actor::Spawn, error::SendError};
     use std::sync::Arc;
     use waddle_xmpp::muc::room_actor::{
-        GetSnapshot, RestoreDurableRoomState, RoomActor, SetSubject,
+        GetSnapshot, RestoreDurableRoomState, RoomActor, SetSubject, SetSubjectError,
     };
     use waddle_xmpp::muc::RoomSubjectTexts;
     use waddle_xmpp::muc::{MucRoom, RoomConfig};
@@ -743,21 +738,25 @@ mod tests {
         };
         let jid = room_jid("identity-rotation");
         let entity = Entity::new(EntityType::RoomActor, jid.to_string());
-        store.record_claim_fence(
-            &jid,
-            RoomClaimFenceContext::new(entity, original, ClaimEpoch(7)),
-        );
+        let fence = RoomClaimFenceContext::new(entity.clone(), original, ClaimEpoch(7));
+        store.record_claim_fence(&jid, fence.clone());
         assert!(store.current_claim_fence(&jid).is_some());
 
         live_identity.rotate(node_identity()).await;
 
-        assert!(
-            !store
-                .check_fenced_fanout(&jid)
-                .await
-                .expect("identity rotation is definitive ownership loss"),
-            "a rotated cached fence must return false, never a transient error that callers fail open"
-        );
+        assert!(matches!(
+            store.guard_fence_identity(&fence).await,
+            Err(XmppError::OwnershipUnavailable {
+                entity: unavailable_entity
+            }) if unavailable_entity == entity
+        ));
+
+        assert!(matches!(
+            store.check_fenced_fanout(&jid).await,
+            Err(XmppError::OwnershipUnavailable {
+                entity: unavailable_entity
+            }) if unavailable_entity == entity
+        ));
         assert!(store.current_claim_fence(&jid).is_none());
         assert!(store.claim_fences.get(&jid).is_none());
     }
@@ -923,8 +922,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn save_subject_fenced_keeps_a_missing_durable_room_nonfatal_without_creating_partial_state(
-    ) {
+    async fn save_subject_fenced_rejects_a_claimed_room_without_durable_state() {
         let _guard = clustering_control_plane_table_lock().lock().await;
         let Some((store, claim_store, _db, me)) = clean_store().await else {
             return;
@@ -944,22 +942,29 @@ mod tests {
             set_at: chrono::Utc::now(),
         };
 
-        store
+        let result = store
             .save_subject_fenced(&jid, Some(&subject), &fence)
-            .await
-            .expect("an exact-fenced subject update without a parent is non-fatal until #1352");
+            .await;
+        assert!(
+            matches!(
+                &result,
+                Err(XmppError::DurableRoomStateMissing { entity })
+                    if entity == &fence.entity
+            ),
+            "a subject write must fail typed rather than acknowledge non-durable state: {result:?}"
+        );
         assert!(
             store
                 .load_room_state_fenced(&jid, &fence)
                 .await
-                .expect("load after non-fatal subject write")
+                .expect("load after rejected subject write")
                 .is_none(),
-            "the non-fatal subject update must not create a partial durable room state"
+            "the rejected subject write must not create a partial durable room state"
         );
     }
 
     #[tokio::test]
-    async fn fresh_clustered_room_accepts_its_first_subject_without_creating_a_partial_parent() {
+    async fn fresh_clustered_room_rejects_its_first_subject_before_applying_memory() {
         let _guard = clustering_control_plane_table_lock().lock().await;
         let Some((store, claim_store, _db, me)) = clean_store().await else {
             return;
@@ -990,34 +995,37 @@ mod tests {
             })
             .await
             .expect("restore handler");
-        actor
+        let result = actor
             .ask(SetSubject {
                 texts: RoomSubjectTexts::from_iter([(String::new(), "first subject".to_string())]),
                 setter: "alice@example.com".parse().expect("valid jid"),
                 setter_nick: "alice".to_string(),
                 set_at: chrono::Utc::now(),
             })
-            .await
-            .expect("the first subject must be accepted rather than bounced");
-        assert_eq!(
+            .await;
+        assert!(matches!(
+            result,
+            Err(SendError::HandlerError(
+                SetSubjectError::PersistFailedBeforeApply
+            ))
+        ));
+        assert!(
             actor
                 .ask(GetSnapshot)
                 .await
                 .expect("room snapshot")
                 .room
                 .subject
-                .expect("accepted subject is installed in memory")
-                .texts
-                .get(""),
-            Some("first subject")
+                .is_none(),
+            "the failed first subject must not be installed in actor memory"
         );
         assert!(
             store
                 .load_room_state_fenced(&room_jid, &fence)
                 .await
-                .expect("load after accepted first subject")
+                .expect("load after rejected first subject")
                 .is_none(),
-            "the first subject must not manufacture a partial durable parent"
+            "the failed first subject must not manufacture a partial durable parent"
         );
     }
 

--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -216,14 +216,16 @@ impl PostgresMucRoomStore {
 
     async fn guard_fence_identity(
         &self,
+        room_jid: &BareJid,
         fence: &RoomClaimFenceContext,
     ) -> Result<CurrentNodeIdentityGuard, XmppError> {
-        self.node_identity
-            .guard_if_current(&fence.owner)
-            .await
-            .ok_or_else(|| XmppError::OwnershipUnavailable {
+        let Some(identity_guard) = self.node_identity.guard_if_current(&fence.owner).await else {
+            remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
+            return Err(XmppError::OwnershipLost {
                 entity: fence.entity.clone(),
-            })
+            });
+        };
+        Ok(identity_guard)
     }
 
     /// Take the fencing lock inside `tx` — the exact `SELECT ... FOR SHARE`
@@ -244,7 +246,7 @@ impl PostgresMucRoomStore {
         }
         if self.node_identity.current() != fence.owner {
             remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
-            return Err(XmppError::OwnershipUnavailable {
+            return Err(XmppError::OwnershipLost {
                 entity: expected_entity,
             });
         }
@@ -413,7 +415,7 @@ impl MucDurableStore for PostgresMucRoomStore {
         fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
         Box::pin(async move {
-            let _identity_guard = self.guard_fence_identity(fence).await?;
+            let _identity_guard = self.guard_fence_identity(room_jid, fence).await?;
             let mut tx = self
                 .db
                 .begin()
@@ -438,7 +440,7 @@ impl MucDurableStore for PostgresMucRoomStore {
         fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let _identity_guard = self.guard_fence_identity(fence).await?;
+            let _identity_guard = self.guard_fence_identity(room_jid, fence).await?;
             let config_json = serde_json::to_string(config).map_err(|error| {
                 XmppError::internal(format!("durable room config encode failed: {error}"))
             })?;
@@ -479,7 +481,7 @@ impl MucDurableStore for PostgresMucRoomStore {
         fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let _identity_guard = self.guard_fence_identity(fence).await?;
+            let _identity_guard = self.guard_fence_identity(room_jid, fence).await?;
             let subject_json = subject
                 .map(serde_json::to_string)
                 .transpose()
@@ -521,7 +523,7 @@ impl MucDurableStore for PostgresMucRoomStore {
         fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let _identity_guard = self.guard_fence_identity(fence).await?;
+            let _identity_guard = self.guard_fence_identity(room_jid, fence).await?;
             let mut tx = self
                 .db
                 .begin()
@@ -570,7 +572,7 @@ impl MucDurableStore for PostgresMucRoomStore {
         fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, ()> {
         Box::pin(async move {
-            let _identity_guard = self.guard_fence_identity(fence).await?;
+            let _identity_guard = self.guard_fence_identity(room_jid, fence).await?;
             let mut tx = self
                 .db
                 .begin()
@@ -759,12 +761,25 @@ mod tests {
         assert!(store.current_claim_fence(&jid).is_some());
 
         live_identity.rotate(node_identity()).await;
+        let config = RoomConfig::default();
 
         assert!(matches!(
-            store.guard_fence_identity(&fence).await,
-            Err(XmppError::OwnershipUnavailable {
-                entity: unavailable_entity
-            }) if unavailable_entity == entity
+            store
+                .save_config_fenced(&jid, "waddle", "channel", &config, &fence)
+                .await,
+            Err(XmppError::OwnershipLost { entity: lost_entity })
+                if lost_entity == entity
+        ));
+        assert!(
+            store.claim_fences.get(&jid).is_none(),
+            "the first fenced actor operation must evict the stale published fence"
+        );
+
+        let mut tx = store.db.begin().await.expect("begin mismatch assertion");
+        assert!(matches!(
+            store.assert_fenced(&mut tx, &jid, &fence).await,
+            Err(XmppError::OwnershipLost { entity: lost_entity })
+                if lost_entity == entity
         ));
 
         assert!(!store

--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -285,7 +285,10 @@ impl PostgresMucRoomStore {
         if fence.entity != expected_entity {
             return Ok(false);
         }
-        let _identity_guard = self.guard_fence_identity(fence).await?;
+        if self.node_identity.current() != fence.owner {
+            remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
+            return Ok(false);
+        }
         let conn = self
             .db
             .guard()
@@ -293,7 +296,8 @@ impl PostgresMucRoomStore {
             .map_err(|error| fence_db_unavailable(error, fence))?;
         let mut rows = conn
             .query(
-                "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? \
+                "/* muc_exact_claim_check */ \
+                 SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? \
                  AND node_epoch = ? AND claim_epoch = ? FOR SHARE",
                 crate::db_params![
                     room_entity_key(room_jid),
@@ -314,7 +318,15 @@ impl PostgresMucRoomStore {
             remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
             return Ok(false);
         }
-        debug_assert_eq!(self.node_identity.current(), fence.owner);
+        // The database proof may block, so it deliberately runs without a
+        // rotation guard. Confirm the local incarnation only after all
+        // backend I/O; this short guard is dropped before returning and can
+        // never delay identity rotation behind a stalled database call.
+        let Some(identity_guard) = self.node_identity.guard_if_current(&fence.owner).await else {
+            remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
+            return Ok(false);
+        };
+        drop(identity_guard);
         Ok(true)
     }
 
@@ -605,15 +617,19 @@ impl MucDurableStore for PostgresMucRoomStore {
     /// it; actor-owned durable operations use their immutable fence instead.
     fn check_fenced_fanout<'a>(&'a self, room_jid: &'a BareJid) -> MucDurableFuture<'a, bool> {
         Box::pin(async move {
-            let fence = self
-                .claim_fences
-                .get(room_jid)
-                .map(|entry| entry.clone())
-                .ok_or_else(|| {
-                    XmppError::internal(format!(
-                        "no claim epoch recorded for room {room_jid}; fenced fan-out skipped"
-                    ))
-                })?;
+            let Some(fence) = self.claim_fences.get(room_jid).map(|entry| entry.clone()) else {
+                // Ready clustered rooms publish this cache entry before the
+                // registry exposes their actor. Absence therefore means this
+                // process cannot serve the retained room incarnation. It is
+                // local state, not backend uncertainty, and must not enter
+                // dispatch's legacy fail-open error branch.
+                return Ok(false);
+            };
+            // Legacy dispatch treats backend errors as fail-open until #1283
+            // replaces this cache-backed boundary. The exact check keeps
+            // backend uncertainty typed while classifying local identity
+            // rotation as definitively non-serving, without holding the
+            // rotation gate across database I/O.
             self.exact_claim_is_held(room_jid, &fence).await
         })
     }
@@ -751,14 +767,20 @@ mod tests {
             }) if unavailable_entity == entity
         ));
 
-        assert!(matches!(
-            store.check_fenced_fanout(&jid).await,
-            Err(XmppError::OwnershipUnavailable {
-                entity: unavailable_entity
-            }) if unavailable_entity == entity
-        ));
+        assert!(!store
+            .check_fenced_fanout(&jid)
+            .await
+            .expect("identity rotation is a non-serving fanout result"));
+        assert!(!store
+            .check_exact_claim_fence(&jid, &fence)
+            .await
+            .expect("identity rotation makes the actor fence non-serving"));
         assert!(store.current_claim_fence(&jid).is_none());
         assert!(store.claim_fences.get(&jid).is_none());
+        assert!(!store
+            .check_fenced_fanout(&jid)
+            .await
+            .expect("an absent published fence remains non-serving"));
     }
 
     /// Open a clean `PostgresMucRoomStore` alongside a `PostgresClaimStore`
@@ -807,6 +829,96 @@ mod tests {
             .await
             .expect("clean affiliations");
         Some((store, claim_store, db, me))
+    }
+
+    #[tokio::test]
+    async fn exact_claim_check_does_not_block_identity_rotation_on_database_io() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, db, me)) = clean_store().await else {
+            return;
+        };
+        let jid = room_jid("rotation-during-exact-check");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let epoch = claim_store
+            .ensure_claimed(&entity, &me)
+            .await
+            .expect("claim");
+        let fence = RoomClaimFenceContext::new(entity, me, epoch);
+        store.record_claim_fence(&jid, fence.clone());
+
+        let mut blocker = db.begin().await.expect("begin claim-row blocker");
+        let mut rows = blocker
+            .query(
+                "SELECT 1 FROM clustering_claims WHERE entity = ? FOR UPDATE",
+                crate::db_params![room_entity_key(&jid)],
+            )
+            .await
+            .expect("lock exact claim row");
+        assert!(rows.next().await.expect("locked row result").is_some());
+        drop(rows);
+
+        let store = Arc::new(store);
+        let check_store = Arc::clone(&store);
+        let check_jid = jid.clone();
+        let check_fence = fence.clone();
+        let check = tokio::spawn(async move {
+            check_store
+                .exact_claim_is_held(&check_jid, &check_fence)
+                .await
+        });
+
+        // Prove the exact check reached Postgres and is blocked on the row
+        // lock before rotating. A task-start notification or sleep can pass
+        // without the query ever being polled, which would exercise only the
+        // early identity-mismatch branch.
+        let monitor = db.guard().await.expect("monitor guard");
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let mut rows = monitor
+                    .query(
+                        r#"
+                        SELECT COUNT(*) FROM pg_stat_activity
+                        WHERE pid <> pg_backend_pid()
+                          AND query LIKE '%muc_exact_claim_check%'
+                          AND wait_event_type = 'Lock'
+                        "#,
+                        (),
+                    )
+                    .await
+                    .expect("inspect blocked exact claim check");
+                let blocked = rows
+                    .next()
+                    .await
+                    .expect("read blocked exact-check count")
+                    .expect("blocked exact-check count row")
+                    .get::<i64>(0)
+                    .expect("blocked exact-check count");
+                if blocked > 0 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("exact claim check reached the claim-row lock");
+        drop(monitor);
+        assert!(
+            !check.is_finished(),
+            "the exact check must be waiting behind the held database row lock"
+        );
+
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            store.node_identity.rotate(node_identity()),
+        )
+        .await
+        .expect("database I/O must not retain the identity rotation guard");
+        blocker.commit().await.expect("release claim-row blocker");
+
+        assert!(!check
+            .await
+            .expect("exact-check task")
+            .expect("database proof completes after the row lock is released"));
     }
 
     #[tokio::test]
@@ -1094,6 +1206,13 @@ mod tests {
                 .await
                 .expect("check_fenced_fanout"),
             "the deposed owner's very next fenced check must observe 0 rows"
+        );
+        assert!(
+            !store
+                .check_fenced_fanout(&jid)
+                .await
+                .expect("a removed stale cache fence is still non-serving"),
+            "concurrent stale dispatches must not fail open after the first check clears the cache"
         );
     }
 

--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -289,7 +289,11 @@ impl PostgresMucRoomStore {
             remove_room_claim_fence_if(&self.claim_fences, room_jid, fence);
             return Ok(false);
         }
-        let conn = self.db.guard().await.map_err(db_err)?;
+        let conn = self
+            .db
+            .guard()
+            .await
+            .map_err(|error| fence_db_unavailable(error, fence))?;
         let mut rows = conn
             .query(
                 "SELECT 1 FROM clustering_claims WHERE entity = ? AND node_id = ? \
@@ -302,8 +306,12 @@ impl PostgresMucRoomStore {
                 ],
             )
             .await
-            .map_err(db_err)?;
-        let held = rows.next().await.map_err(db_err)?.is_some();
+            .map_err(|error| fence_db_unavailable(error, fence))?;
+        let held = rows
+            .next()
+            .await
+            .map_err(|error| fence_db_unavailable(error, fence))?
+            .is_some();
         drop(rows);
         if held && self.node_identity.current() == fence.owner {
             Ok(true)
@@ -475,11 +483,11 @@ impl MucDurableStore for PostgresMucRoomStore {
                 .await
                 .map_err(|error| fence_db_unavailable(error, fence))?;
             self.assert_fenced(&mut tx, room_jid, fence).await?;
-            // The room row must already exist (a subject can only be set on
-            // an already-spawned room, which always durably writes its
-            // config at spawn-adjacent points first). Keep this UPDATE-only:
-            // an upsert here could create an incomplete row without its
-            // required `waddle_id` and `channel_id` fields.
+            // Keep this UPDATE-only: an upsert here could create an incomplete
+            // row without its required `waddle_id` and `channel_id` fields.
+            // Until #1352 atomically initializes the complete room plus
+            // initial Owner, an exact-fenced missing row is non-fatal. #1350
+            // will enforce missing-parent writes after that lifecycle exists.
             let affected = tx
                 .execute(
                     "UPDATE clustering_muc_rooms SET subject_json = ?, updated_at = now() WHERE room_jid = ?",
@@ -488,9 +496,11 @@ impl MucDurableStore for PostgresMucRoomStore {
                 .await
                 .map_err(db_err)?;
             if affected == 0 {
-                return Err(XmppError::DurableRoomStateMissing {
-                    entity: fence.entity.clone(),
-                });
+                tracing::warn!(
+                    room = %room_jid,
+                    entity = %fence.entity,
+                    "subject update found no durable room parent before creator lifecycle initialization"
+                );
             }
             tx.commit().await.map_err(db_err)?;
             Ok(())
@@ -659,9 +669,15 @@ mod tests {
     use super::*;
     use crate::clustering::claims::{clustering_control_plane_table_lock, PostgresClaimStore};
     use crate::db::{DatabaseConfig, DatabaseDriver, DEFAULT_CONTROL_PLANE_POOL_SIZE};
+    use kameo::actor::Spawn;
     use std::sync::Arc;
+    use waddle_xmpp::muc::room_actor::{
+        GetSnapshot, RestoreDurableRoomState, RoomActor, SetSubject,
+    };
     use waddle_xmpp::muc::RoomSubjectTexts;
+    use waddle_xmpp::muc::{MucRoom, RoomConfig};
     use waddle_xmpp::ownership::{ClaimStore, NodeIdentity, StalePredicate};
+    use waddle_xmpp::xep::xep0421::OccupantIdSecret;
 
     fn node_identity() -> NodeIdentity {
         NodeIdentity::new(
@@ -686,6 +702,27 @@ mod tests {
         format!("{name}@muc.example.com")
             .parse()
             .expect("valid test room JID")
+    }
+
+    #[test]
+    fn fence_database_failures_preserve_the_exact_fence_entity() {
+        let jid = room_jid("fence-db-unavailable");
+        let entity = Entity::new(EntityType::RoomActor, jid.to_string());
+        let fence = RoomClaimFenceContext::new(entity.clone(), node_identity(), ClaimEpoch(7));
+
+        for error in [
+            DatabaseError::ConnectionFailed("main pool unavailable".to_string()),
+            DatabaseError::QueryFailed("claim-row iteration failed".to_string()),
+        ] {
+            assert!(
+                matches!(
+                    fence_db_unavailable(error, &fence),
+                    XmppError::OwnershipUnavailable { entity: unavailable_entity }
+                        if unavailable_entity == entity
+                ),
+                "database uncertainty must remain typed for the exact fence entity"
+            );
+        }
     }
 
     #[tokio::test]
@@ -886,7 +923,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn save_subject_fenced_rejects_a_claimed_room_without_durable_state() {
+    async fn save_subject_fenced_keeps_a_missing_durable_room_nonfatal_without_creating_partial_state(
+    ) {
         let _guard = clustering_control_plane_table_lock().lock().await;
         let Some((store, claim_store, _db, me)) = clean_store().await else {
             return;
@@ -906,25 +944,80 @@ mod tests {
             set_at: chrono::Utc::now(),
         };
 
-        let result = store
+        store
             .save_subject_fenced(&jid, Some(&subject), &fence)
-            .await;
-
-        assert!(
-            matches!(
-                &result,
-                Err(XmppError::DurableRoomStateMissing { entity })
-                    if entity == &fence.entity
-            ),
-            "a subject write must return the typed missing-state error unless its fenced room row exists: {result:?}"
-        );
+            .await
+            .expect("an exact-fenced subject update without a parent is non-fatal until #1352");
         assert!(
             store
                 .load_room_state_fenced(&jid, &fence)
                 .await
-                .expect("load after rejected subject write")
+                .expect("load after non-fatal subject write")
                 .is_none(),
-            "the rejected subject write must not create a partial durable room state"
+            "the non-fatal subject update must not create a partial durable room state"
+        );
+    }
+
+    #[tokio::test]
+    async fn fresh_clustered_room_accepts_its_first_subject_without_creating_a_partial_parent() {
+        let _guard = clustering_control_plane_table_lock().lock().await;
+        let Some((store, claim_store, _db, me)) = clean_store().await else {
+            return;
+        };
+        let room_jid = room_jid("fresh-first-subject");
+        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        let epoch = claim_store
+            .ensure_claimed(&entity, &me)
+            .await
+            .expect("claim");
+        let fence = RoomClaimFenceContext::new(entity, me, epoch);
+        let store: Arc<dyn MucDurableStore> = Arc::new(store);
+        let actor = RoomActor::spawn(RoomActor::new(
+            MucRoom::new(
+                room_jid.clone(),
+                "waddle-fresh".to_string(),
+                "channel-fresh".to_string(),
+                RoomConfig::default(),
+            ),
+            OccupantIdSecret::new(b"muc-durable-first-subject-test-secret".to_vec())
+                .expect("valid test secret"),
+        ));
+
+        actor
+            .ask(RestoreDurableRoomState {
+                store: store.clone(),
+                claim_fence: fence.clone(),
+            })
+            .await
+            .expect("restore handler");
+        actor
+            .ask(SetSubject {
+                texts: RoomSubjectTexts::from_iter([(String::new(), "first subject".to_string())]),
+                setter: "alice@example.com".parse().expect("valid jid"),
+                setter_nick: "alice".to_string(),
+                set_at: chrono::Utc::now(),
+            })
+            .await
+            .expect("the first subject must be accepted rather than bounced");
+        assert_eq!(
+            actor
+                .ask(GetSnapshot)
+                .await
+                .expect("room snapshot")
+                .room
+                .subject
+                .expect("accepted subject is installed in memory")
+                .texts
+                .get(""),
+            Some("first subject")
+        );
+        assert!(
+            store
+                .load_room_state_fenced(&room_jid, &fence)
+                .await
+                .expect("load after accepted first subject")
+                .is_none(),
+            "the first subject must not manufacture a partial durable parent"
         );
     }
 
@@ -946,23 +1039,15 @@ mod tests {
         let fence = RoomClaimFenceContext::new(entity.clone(), me.clone(), epoch);
         store.record_claim_fence(&jid, fence.clone());
 
-        let sibling_jid = room_jid("same-owner-same-epoch");
+        let sibling_jid = room_jid("different-room");
         let sibling_entity = Entity::new(EntityType::RoomActor, sibling_jid.to_string());
-        let sibling_epoch = claim_store
-            .ensure_claimed(&sibling_entity, &me)
-            .await
-            .expect("claim sibling room");
-        assert_eq!(
-            sibling_epoch, epoch,
-            "independent room claims can legitimately share an epoch"
-        );
-        let sibling_fence = RoomClaimFenceContext::new(sibling_entity, me.clone(), sibling_epoch);
+        let sibling_fence = RoomClaimFenceContext::new(sibling_entity, me.clone(), epoch);
         assert!(
             !store
                 .check_exact_claim_fence(&jid, &sibling_fence)
                 .await
                 .expect("cross-room exact check"),
-            "same owner and epoch must not authorize a different room entity"
+            "a different room entity must not authorize this room, regardless of its epoch"
         );
         assert_eq!(
             store.current_claim_fence(&jid),

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -104,12 +104,6 @@ use waddle_xmpp::muc::room_actor::{
     ApplyPin, GetAffiliation, GetNicknameGeneration, GetRoomSnapshot, JoinAffiliationGrant,
     JoinWithAffiliation, RoomActor, SetSubject,
 };
-// ADR-0017 Phase 3 Slice 7: `DestroyRoom` is used by `dispatch_to_room`'s
-// fenced pre-fan-out backstop, which only exists on `clustering`-feature
-// builds (the check itself is a no-op — `ClusteringHandles::
-// muc_durable_store` is `None` — whenever clustering is disabled, but the
-// import must still be feature-gated to avoid an unused-import warning on
-// a build that lacks the `clustering` feature entirely).
 #[cfg(feature = "clustering")]
 use waddle_xmpp::muc::room_registry_actor::DestroyRoom;
 use waddle_xmpp::muc::room_registry_actor::{GetRoom, RoomRegistryActor};
@@ -201,7 +195,9 @@ use offline_delivery::queue_offline_delivery;
 pub(crate) use offline_delivery::reconcile_xep0357_notification_candidates;
 use room_dispatch::dispatch_to_room;
 use room_pin::apply_pin_change_event;
-use room_subject::persist_room_subject_event;
+use room_subject::{
+    persist_room_subject_event, PersistRoomSubjectEventOutcome, PersistRoomSubjectRequest,
+};
 pub(crate) use route_to_connection::{fallback_reply_for_undeliverable_iq, route_to_connection};
 pub(crate) use routing::{deliver_direct_to_full, deliver_peer_to_full, FullJidDeliveryOutcome};
 use routing::{
@@ -377,16 +373,15 @@ async fn interpret_with_depth(
     let registry = deps.connection_registry;
     let mut outcome = InterpretOutcome::default();
     let mut archive_id_rewrites: Vec<ArchiveIdRewrite> = Vec::new();
-    // ADR-0017 Phase 3 Slice 7 FIX 1 (council-adjudicated): once the fenced
-    // MAM archive write observes this node has been deposed, every
-    // remaining event in THIS SAME batch (in particular the reflector's
-    // per-occupant `RouteToConnection` fan-out for the same message, which
-    // always follows the archive handler in the locked Q7 chain order) is
-    // suppressed — "the message is NOT archived and NOT fanned out."
-    let mut ownership_lost = false;
+    // Once a write-adjacent room effect rejects this batch, suppress every
+    // later effect from the same frozen chain. `ArchiveGroupchat` retains its
+    // legacy ownership backstop until #1283; subject persistence binds the
+    // exact actor fence in this PR. Both must halt later inbox/fan-out work
+    // after returning a retryable bounce.
+    let mut suppress_remaining_events = false;
 
     for mut event in events {
-        if ownership_lost {
+        if suppress_remaining_events {
             continue;
         }
         apply_archive_id_rewrites(&mut event, &archive_id_rewrites);
@@ -575,7 +570,7 @@ async fn interpret_with_depth(
                                 );
                             }
                         }
-                        ownership_lost = true;
+                        suppress_remaining_events = true;
                     }
                 }
             }
@@ -629,12 +624,41 @@ async fn interpret_with_depth(
             }
             OutboundEvent::PersistRoomSubject {
                 room,
+                claim_fence,
                 texts,
                 setter,
+                sender,
+                message,
                 setter_nick,
                 set_at,
             } => {
-                persist_room_subject_event(deps, room, texts, setter, setter_nick, set_at).await;
+                match persist_room_subject_event(
+                    deps,
+                    PersistRoomSubjectRequest {
+                        room,
+                        claim_fence,
+                        texts,
+                        setter,
+                        sender,
+                        message,
+                        setter_nick,
+                        set_at,
+                    },
+                )
+                .await
+                {
+                    PersistRoomSubjectEventOutcome::Committed => {}
+                    PersistRoomSubjectEventOutcome::BounceAndHalt(bounce) => {
+                        match Stanza::Message(*bounce).to_element_string() {
+                            Ok(xml) => outcome.frames.push(xml),
+                            Err(error) => warn!(
+                                %error,
+                                "PersistRoomSubject: failed to serialize retryable bounce reply"
+                            ),
+                        }
+                        suppress_remaining_events = true;
+                    }
+                }
             }
             OutboundEvent::ProjectGroupchatInbox {
                 owner,

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -105,7 +105,7 @@ use waddle_xmpp::muc::room_actor::{
     JoinWithAffiliation, RoomActor, SetSubject,
 };
 #[cfg(feature = "clustering")]
-use waddle_xmpp::muc::room_registry_actor::DestroyRoom;
+use waddle_xmpp::muc::room_registry_actor::DemoteRoomIfExactActor;
 use waddle_xmpp::muc::room_registry_actor::{GetRoom, RoomRegistryActor};
 use waddle_xmpp::parse_managed_room_jid;
 use waddle_xmpp::parser::{message_to_string, stanza_to_string};

--- a/server/crates/waddle-server/src/server/routes/interpret/archive_groupchat_event.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/archive_groupchat_event.rs
@@ -60,9 +60,7 @@ pub(super) async fn archive_groupchat_event(
                 &message,
                 &room,
                 &sender,
-                resource_constraint_error(
-                    "This room's ownership recently moved to another node; please retry.",
-                ),
+                resource_constraint_error("This room is temporarily unavailable; please retry."),
             );
             return ArchiveGroupchatEventOutcome::OwnershipLost(Box::new(bounce));
         }

--- a/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
@@ -1,21 +1,76 @@
 use super::*;
 
 /// Bind the subject mutation emitted from one frozen room snapshot to
-/// that actor incarnation's immutable ownership proof. The pure protocol
-/// chain cannot carry actor state in `RoomContext`, so the async boundary
-/// attaches it before any effect is interpreted.
+/// that actor incarnation's immutable ownership proof. This is mandatory
+/// post-processing before interpretation: the pure protocol chain cannot carry
+/// actor state in `RoomContext`, so it emits an unbound event. Bypassing this
+/// boundary leaves a durable actor without its exact snapshot fence (or with a
+/// different one), which it rejects before applying the mutation.
 pub(super) fn bind_room_claim_fence(
     events: &mut [OutboundEvent],
     claim_fence: Option<&waddle_xmpp::muc::RoomClaimFenceContext>,
 ) {
     for event in events {
         if let OutboundEvent::PersistRoomSubject {
-            claim_fence: event_fence,
+            claim_fence: event_fence @ None,
             ..
         } = event
         {
             *event_fence = claim_fence.cloned();
         }
+    }
+}
+
+#[cfg(test)]
+mod room_claim_fence_tests {
+    use super::*;
+    use chrono::Utc;
+    use waddle_xmpp::muc::{RoomClaimFenceContext, RoomSubjectTexts};
+    use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
+
+    fn fence(owner: &str) -> RoomClaimFenceContext {
+        RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, "room@muc.example.com"),
+            NodeIdentity::new(owner, "epoch-a"),
+            ClaimEpoch(7),
+        )
+    }
+
+    fn persist_subject_event(claim_fence: Option<RoomClaimFenceContext>) -> OutboundEvent {
+        let room: jid::BareJid = "room@muc.example.com".parse().expect("room bare jid");
+        OutboundEvent::PersistRoomSubject {
+            room: room.clone(),
+            claim_fence,
+            texts: RoomSubjectTexts::from_iter([(String::new(), "subject".to_string())]),
+            setter: "alice@example.com".parse().expect("setter bare jid"),
+            sender: "alice@example.com/web".parse().expect("sender full jid"),
+            message: Box::new(Message::new(Some(jid::Jid::from(room)))),
+            setter_nick: "alice".to_string(),
+            set_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn bind_room_claim_fence_binds_missing_fence_without_overwriting_or_touching_other_events() {
+        let snapshot_fence = fence("snapshot-owner");
+        let other_actor_fence = fence("other-owner");
+        let mut events = vec![
+            persist_subject_event(None),
+            OutboundEvent::CloseTransport,
+            persist_subject_event(Some(other_actor_fence.clone())),
+        ];
+
+        bind_room_claim_fence(&mut events, Some(&snapshot_fence));
+
+        let OutboundEvent::PersistRoomSubject { claim_fence, .. } = &events[0] else {
+            panic!("first event must be PersistRoomSubject");
+        };
+        assert_eq!(claim_fence.as_ref(), Some(&snapshot_fence));
+        assert!(matches!(events[1], OutboundEvent::CloseTransport));
+        let OutboundEvent::PersistRoomSubject { claim_fence, .. } = &events[2] else {
+            panic!("third event must be PersistRoomSubject");
+        };
+        assert_eq!(claim_fence.as_ref(), Some(&other_actor_fence));
     }
 }
 

--- a/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
@@ -21,59 +21,6 @@ pub(super) fn bind_room_claim_fence(
     }
 }
 
-#[cfg(test)]
-mod room_claim_fence_tests {
-    use super::*;
-    use chrono::Utc;
-    use waddle_xmpp::muc::{RoomClaimFenceContext, RoomSubjectTexts};
-    use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
-
-    fn fence(owner: &str) -> RoomClaimFenceContext {
-        RoomClaimFenceContext::new(
-            Entity::new(EntityType::RoomActor, "room@muc.example.com"),
-            NodeIdentity::new(owner, "epoch-a"),
-            ClaimEpoch(7),
-        )
-    }
-
-    fn persist_subject_event(claim_fence: Option<RoomClaimFenceContext>) -> OutboundEvent {
-        let room: jid::BareJid = "room@muc.example.com".parse().expect("room bare jid");
-        OutboundEvent::PersistRoomSubject {
-            room: room.clone(),
-            claim_fence,
-            texts: RoomSubjectTexts::from_iter([(String::new(), "subject".to_string())]),
-            setter: "alice@example.com".parse().expect("setter bare jid"),
-            sender: "alice@example.com/web".parse().expect("sender full jid"),
-            message: Box::new(Message::new(Some(jid::Jid::from(room)))),
-            setter_nick: "alice".to_string(),
-            set_at: Utc::now(),
-        }
-    }
-
-    #[test]
-    fn bind_room_claim_fence_binds_missing_fence_without_overwriting_or_touching_other_events() {
-        let snapshot_fence = fence("snapshot-owner");
-        let other_actor_fence = fence("other-owner");
-        let mut events = vec![
-            persist_subject_event(None),
-            OutboundEvent::CloseTransport,
-            persist_subject_event(Some(other_actor_fence.clone())),
-        ];
-
-        bind_room_claim_fence(&mut events, Some(&snapshot_fence));
-
-        let OutboundEvent::PersistRoomSubject { claim_fence, .. } = &events[0] else {
-            panic!("first event must be PersistRoomSubject");
-        };
-        assert_eq!(claim_fence.as_ref(), Some(&snapshot_fence));
-        assert!(matches!(events[1], OutboundEvent::CloseTransport));
-        let OutboundEvent::PersistRoomSubject { claim_fence, .. } = &events[2] else {
-            panic!("third event must be PersistRoomSubject");
-        };
-        assert_eq!(claim_fence.as_ref(), Some(&other_actor_fence));
-    }
-}
-
 pub(super) async fn dispatch_to_room(
     deps: &Deps<'_>,
     room_jid: jid::BareJid,
@@ -690,4 +637,57 @@ async fn session_is_server_owner(state: &WebSocketState, session: Option<&Sessio
         })
         .await
         .is_ok_and(|response| response.allowed)
+}
+
+#[cfg(test)]
+mod room_claim_fence_tests {
+    use super::*;
+    use chrono::Utc;
+    use waddle_xmpp::muc::{RoomClaimFenceContext, RoomSubjectTexts};
+    use waddle_xmpp::ownership::{ClaimEpoch, Entity, EntityType, NodeIdentity};
+
+    fn fence(owner: &str) -> RoomClaimFenceContext {
+        RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, "room@muc.example.com"),
+            NodeIdentity::new(owner, "epoch-a"),
+            ClaimEpoch(7),
+        )
+    }
+
+    fn persist_subject_event(claim_fence: Option<RoomClaimFenceContext>) -> OutboundEvent {
+        let room: jid::BareJid = "room@muc.example.com".parse().expect("room bare jid");
+        OutboundEvent::PersistRoomSubject {
+            room: room.clone(),
+            claim_fence,
+            texts: RoomSubjectTexts::from_iter([(String::new(), "subject".to_string())]),
+            setter: "alice@example.com".parse().expect("setter bare jid"),
+            sender: "alice@example.com/web".parse().expect("sender full jid"),
+            message: Box::new(Message::new(Some(jid::Jid::from(room)))),
+            setter_nick: "alice".to_string(),
+            set_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn bind_room_claim_fence_binds_missing_fence_without_overwriting_or_touching_other_events() {
+        let snapshot_fence = fence("snapshot-owner");
+        let other_actor_fence = fence("other-owner");
+        let mut events = vec![
+            persist_subject_event(None),
+            OutboundEvent::CloseTransport,
+            persist_subject_event(Some(other_actor_fence.clone())),
+        ];
+
+        bind_room_claim_fence(&mut events, Some(&snapshot_fence));
+
+        let OutboundEvent::PersistRoomSubject { claim_fence, .. } = &events[0] else {
+            panic!("first event must be PersistRoomSubject");
+        };
+        assert_eq!(claim_fence.as_ref(), Some(&snapshot_fence));
+        assert!(matches!(events[1], OutboundEvent::CloseTransport));
+        let OutboundEvent::PersistRoomSubject { claim_fence, .. } = &events[2] else {
+            panic!("third event must be PersistRoomSubject");
+        };
+        assert_eq!(claim_fence.as_ref(), Some(&other_actor_fence));
+    }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
@@ -1,5 +1,24 @@
 use super::*;
 
+/// Bind the subject mutation emitted from one frozen room snapshot to
+/// that actor incarnation's immutable ownership proof. The pure protocol
+/// chain cannot carry actor state in `RoomContext`, so the async boundary
+/// attaches it before any effect is interpreted.
+pub(super) fn bind_room_claim_fence(
+    events: &mut [OutboundEvent],
+    claim_fence: Option<&waddle_xmpp::muc::RoomClaimFenceContext>,
+) {
+    for event in events {
+        if let OutboundEvent::PersistRoomSubject {
+            claim_fence: event_fence,
+            ..
+        } = event
+        {
+            *event_fence = claim_fence.cloned();
+        }
+    }
+}
+
 pub(super) async fn dispatch_to_room(
     deps: &Deps<'_>,
     room_jid: jid::BareJid,
@@ -486,6 +505,8 @@ pub(super) async fn dispatch_to_room(
     // the full `default_room_dispatcher()` here would re-run it.
     let dispatch_outcome = default_room_pipeline_dispatcher().dispatch(&mut working, &ctx);
     let observer_message = working.clone();
+    let mut dispatch_events = dispatch_outcome.events;
+    bind_room_claim_fence(&mut dispatch_events, snapshot.claim_fence.as_ref());
 
     // 6. Recursively interpret the chain's emitted events. Pass the
     //    depth through unchanged: `recursion_depth` is the headless
@@ -495,12 +516,7 @@ pub(super) async fn dispatch_to_room(
     //    promotes to a headless recipient pass (depth bumped there).
     //    Bumping here would break that path for every offline
     //    occupant.
-    let nested = Box::pin(interpret_with_depth(
-        dispatch_outcome.events,
-        deps,
-        recursion_depth,
-    ))
-    .await;
+    let nested = Box::pin(interpret_with_depth(dispatch_events, deps, recursion_depth)).await;
     outcome.frames.extend(nested.frames);
     if nested.close {
         outcome.close = true;

--- a/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
@@ -234,8 +234,8 @@ pub(super) async fn dispatch_to_room(
     // production caller). `None` (clustering disabled, non-Postgres, or a
     // build without the `clustering` feature) skips this entirely —
     // single-node behavior, unchanged. A transient backend error fails
-    // open (logged, not blocking); only a definitive 0-rows result
-    // demotes.
+    // open (logged, not blocking); only a definitive non-serving result
+    // demotes. That includes a missing exact row and local identity rotation.
     #[cfg(feature = "clustering")]
     if let Some(store) = &state.deps.app_state.clustering_claims.muc_durable_store {
         match store.check_fenced_fanout(&room_jid).await {
@@ -243,32 +243,25 @@ pub(super) async fn dispatch_to_room(
             Ok(false) => {
                 warn!(
                     room = %room_jid,
-                    "DispatchToRoom: fenced ownership check observed 0 rows; this node has \
-                     been deposed — evicting the local room actor and bouncing the sender"
+                    "DispatchToRoom: retained room fence is non-serving; evicting the local \
+                     room actor and bouncing the sender"
                 );
                 match room_registry
-                    .ask(DestroyRoom {
+                    .ask(DemoteRoomIfExactActor {
                         room_jid: room_jid.clone(),
-                        // Eviction, not destruction: the room now lives
-                        // on the stealing node — its durable rows MUST
-                        // survive this local teardown.
-                        reason: waddle_xmpp::muc::room_registry_actor::DestroyRoomReason::DeposedEviction,
+                        actor_ref: room_actor,
                     })
                     .await
                 {
-                    Ok(
-                        waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::Destroyed
-                        | waddle_xmpp::muc::room_registry_actor::DestroyRoomOutcome::NotRegistered,
-                    ) => {}
-                    Ok(outcome) => warn!(
+                    Ok(true) => {}
+                    Ok(false) => warn!(
                         room = %room_jid,
-                        ?outcome,
-                        "DispatchToRoom: deposed local actor eviction was unexpectedly refused"
+                        "DispatchToRoom: exact actor demotion found a different room incarnation"
                     ),
                     Err(error) => warn!(
                         room = %room_jid,
                         %error,
-                        "DispatchToRoom: failed to ask registry to evict deposed local actor"
+                        "DispatchToRoom: failed to ask registry to evict non-serving local actor"
                     ),
                 }
                 let reply = build_message_error_reply(
@@ -276,7 +269,7 @@ pub(super) async fn dispatch_to_room(
                     &room_jid,
                     &sender_full,
                     resource_constraint_error(
-                        "This room's ownership recently moved to another node; please retry.",
+                        "This room is temporarily unavailable; please retry.",
                     ),
                 );
                 match Stanza::Message(reply).to_element_string() {

--- a/server/crates/waddle-server/src/server/routes/interpret/room_subject.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_subject.rs
@@ -1,20 +1,51 @@
 use super::*;
-use waddle_xmpp::muc::RoomSubjectTexts;
+use kameo::error::SendError;
+use waddle_xmpp::muc::room_actor::SetSubjectError;
+use waddle_xmpp::muc::room_registry_actor::DemoteRoomIfExactActor;
+use waddle_xmpp::muc::{RoomClaimFenceContext, RoomSubjectTexts};
+use waddle_xmpp::ownership::{Entity, EntityType};
+
+pub(super) enum PersistRoomSubjectEventOutcome {
+    Committed,
+    BounceAndHalt(Box<Message>),
+}
+
+pub(super) struct PersistRoomSubjectRequest {
+    pub room: BareJid,
+    pub claim_fence: Option<RoomClaimFenceContext>,
+    pub texts: RoomSubjectTexts,
+    pub setter: BareJid,
+    pub sender: FullJid,
+    pub message: Box<Message>,
+    pub setter_nick: String,
+    pub set_at: chrono::DateTime<chrono::Utc>,
+}
 
 pub(super) async fn persist_room_subject_event(
     deps: &Deps<'_>,
-    room: BareJid,
-    texts: RoomSubjectTexts,
-    setter: BareJid,
-    setter_nick: String,
-    set_at: chrono::DateTime<chrono::Utc>,
-) {
+    request: PersistRoomSubjectRequest,
+) -> PersistRoomSubjectEventOutcome {
+    let PersistRoomSubjectRequest {
+        room,
+        claim_fence,
+        texts,
+        setter,
+        sender,
+        message,
+        setter_nick,
+        set_at,
+    } = request;
     let Some(room_registry) = deps.room_registry else {
-        debug!(
+        warn!(
             room = %room,
-            "PersistRoomSubject: no room_registry in Deps; skipping"
+            "PersistRoomSubject: no room_registry in Deps; rejecting subject change"
         );
-        return;
+        return retryable_subject_bounce(
+            &message,
+            &room,
+            &sender,
+            "This room is temporarily unavailable; please retry the subject change.",
+        );
     };
     let room_actor = match room_registry
         .ask(GetRoom {
@@ -26,20 +57,81 @@ pub(super) async fn persist_room_subject_event(
         Ok(None) => {
             debug!(
                 room = %room,
-                "PersistRoomSubject: room not registered; skipping"
+                "PersistRoomSubject: room not registered; rejecting subject change"
             );
-            return;
+            return retryable_subject_bounce(
+                &message,
+                &room,
+                &sender,
+                "This room is temporarily unavailable; please retry the subject change.",
+            );
         }
         Err(error) => {
             warn!(
                 room = %room,
                 error = ?error,
-                "PersistRoomSubject: room registry lookup failed; skipping"
+                "PersistRoomSubject: room registry lookup failed; rejecting subject change"
             );
-            return;
+            return retryable_subject_bounce(
+                &message,
+                &room,
+                &sender,
+                "This room is temporarily unavailable; please retry the subject change.",
+            );
         }
     };
-    if let Err(error) = room_actor
+
+    // The event was emitted from a frozen snapshot. A same-JID successor may
+    // have replaced that actor before this interpreter arm runs, so bind the
+    // mutation to the exact snapshot fence instead of trusting a fresh room
+    // lookup alone. Both `None` is the single-node/no-durable-store shape;
+    // every mixed or differing pair fails closed without demoting the healthy
+    // actor currently registered under the room JID.
+    let actor_snapshot = match room_actor
+        .ask(GetRoomSnapshot {
+            sender_jid: sender.clone(),
+        })
+        .await
+    {
+        Ok(snapshot) => snapshot,
+        Err(error) => {
+            warn!(
+                room = %room,
+                error = ?error,
+                "PersistRoomSubject: exact actor snapshot failed; rejecting subject change"
+            );
+            return retryable_subject_bounce(
+                &message,
+                &room,
+                &sender,
+                "This room is temporarily unavailable; please retry the subject change.",
+            );
+        }
+    };
+    let expected_entity = Entity::new(EntityType::RoomActor, room.to_string());
+    let exact_actor_matches = match (claim_fence.as_ref(), actor_snapshot.claim_fence.as_ref()) {
+        (None, None) => true,
+        (Some(event_fence), Some(actor_fence)) => {
+            event_fence.entity == expected_entity && event_fence == actor_fence
+        }
+        _ => false,
+    };
+    if !exact_actor_matches {
+        warn!(
+            room = %room,
+            event_fence = ?claim_fence,
+            actor_fence = ?actor_snapshot.claim_fence,
+            "PersistRoomSubject: event authority does not match the current actor; rejecting subject change"
+        );
+        return retryable_subject_bounce(
+            &message,
+            &room,
+            &sender,
+            "This room's ownership recently moved to another node; please retry.",
+        );
+    }
+
+    match room_actor
         .ask(SetSubject {
             texts,
             setter: setter.clone(),
@@ -48,11 +140,80 @@ pub(super) async fn persist_room_subject_event(
         })
         .await
     {
-        warn!(
-            room = %room,
-            setter = %setter,
-            error = ?error,
-            "PersistRoomSubject: SetSubject ask failed; subject left at previous state"
-        );
+        Ok(()) => PersistRoomSubjectEventOutcome::Committed,
+        Err(SendError::HandlerError(SetSubjectError::NotOwner)) => {
+            warn!(
+                room = %room,
+                setter = %setter,
+                "PersistRoomSubject: exact actor lost room ownership; rejecting subject change"
+            );
+            match room_registry
+                .ask(DemoteRoomIfExactActor {
+                    room_jid: room.clone(),
+                    actor_ref: room_actor,
+                })
+                .await
+            {
+                Ok(true) => {}
+                Ok(false) => warn!(
+                    room = %room,
+                    "PersistRoomSubject: exact actor demotion found a different room incarnation"
+                ),
+                Err(error) => warn!(
+                    room = %room,
+                    error = ?error,
+                    "PersistRoomSubject: exact actor demotion request failed"
+                ),
+            }
+            retryable_subject_bounce(
+                &message,
+                &room,
+                &sender,
+                "This room's ownership recently moved to another node; please retry.",
+            )
+        }
+        Err(SendError::HandlerError(
+            SetSubjectError::OwnershipUnavailable | SetSubjectError::PersistFailedBeforeApply,
+        )) => {
+            warn!(
+                room = %room,
+                setter = %setter,
+                "PersistRoomSubject: exact room ownership could not be confirmed; rejecting subject change"
+            );
+            retryable_subject_bounce(
+                &message,
+                &room,
+                &sender,
+                "This room is temporarily unavailable; please retry the subject change.",
+            )
+        }
+        Err(error) => {
+            warn!(
+                room = %room,
+                setter = %setter,
+                error = ?error,
+                "PersistRoomSubject: SetSubject actor transport failed; rejecting subject change"
+            );
+            retryable_subject_bounce(
+                &message,
+                &room,
+                &sender,
+                "This room is temporarily unavailable; please retry the subject change.",
+            )
+        }
     }
+}
+
+fn retryable_subject_bounce(
+    message: &Message,
+    room: &BareJid,
+    sender: &FullJid,
+    text: &str,
+) -> PersistRoomSubjectEventOutcome {
+    PersistRoomSubjectEventOutcome::BounceAndHalt(Box::new(build_message_error_reply(
+        message,
+        room,
+        sender,
+        resource_constraint_error(text),
+    )))
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/room_subject.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_subject.rs
@@ -127,7 +127,7 @@ pub(super) async fn persist_room_subject_event(
             &message,
             &room,
             &sender,
-            "This room's ownership recently moved to another node; please retry.",
+            "This room is temporarily unavailable; please retry.",
         );
     }
 
@@ -169,7 +169,7 @@ pub(super) async fn persist_room_subject_event(
                 &message,
                 &room,
                 &sender,
-                "This room's ownership recently moved to another node; please retry.",
+                "This room is temporarily unavailable; please retry.",
             )
         }
         Err(SendError::HandlerError(

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -3228,13 +3228,18 @@ impl SubjectMutationStore {
         Self {
             mode: std::sync::atomic::AtomicU8::new(SubjectMutationStoreMode::Succeed as u8),
             claim_store,
-            durable_parent_rows: std::sync::atomic::AtomicUsize::new(0),
+            durable_parent_rows: std::sync::atomic::AtomicUsize::new(1),
         }
     }
 
     fn durable_parent_row_count(&self) -> usize {
         self.durable_parent_rows
             .load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    fn remove_durable_parent(&self) {
+        self.durable_parent_rows
+            .store(0, std::sync::atomic::Ordering::SeqCst);
     }
 
     fn set_mode(&self, mode: SubjectMutationStoreMode) {
@@ -3329,6 +3334,11 @@ impl waddle_xmpp::muc::MucDurableStore for SubjectMutationStore {
         Box::pin(async move {
             if !self.exact_fence_matches(room_jid, fence).await? {
                 return Err(waddle_xmpp::XmppError::OwnershipLost {
+                    entity: fence.entity.clone(),
+                });
+            }
+            if self.durable_parent_row_count() == 0 {
+                return Err(waddle_xmpp::XmppError::DurableRoomStateMissing {
                     entity: fence.entity.clone(),
                 });
             }
@@ -3711,15 +3721,15 @@ async fn xep_0045_stale_subject_effect_cannot_mutate_same_jid_successor() {
 }
 
 #[tokio::test]
-async fn xep_0045_new_clustered_room_subject_is_not_bounced_before_creator_lifecycle_initializes() {
+async fn xep_0045_new_clustered_room_subject_fails_closed_without_a_durable_parent() {
     use waddle_xmpp::muc::room_actor::GetSnapshot;
 
-    // The clustered store deliberately restores no parent and treats the
-    // UPDATE-only subject write as non-fatal. #1352 owns atomic complete
-    // room-plus-Owner initialization; this #1355 boundary must neither bounce
-    // the first valid subject nor manufacture a partial parent row.
-    let (room_registry, room_actor, room_jid, _claim_store, claim_fence, _store) =
+    // #1352 owns atomic complete room-plus-Owner initialization. Until that
+    // prerequisite lands, the UPDATE-only subject path must fail before
+    // acknowledging or applying state that cannot survive actor replacement.
+    let (room_registry, room_actor, room_jid, _claim_store, claim_fence, store) =
         spawn_subject_mutation_test_room().await;
+    store.remove_durable_parent();
     let connection_registry = ConnectionRegistry::new();
     let mut deps = Deps::registry_only(&connection_registry);
     deps.room_registry = Some(&room_registry);
@@ -3734,28 +3744,18 @@ async fn xep_0045_new_clustered_room_subject_is_not_bounced_before_creator_lifec
     )
     .await;
 
-    assert!(
-        outcome.frames.is_empty(),
-        "the first subject must not bounce"
-    );
-    assert!(
-        outcome.close,
-        "later effects must continue after the subject"
-    );
+    assert_eq!(outcome.frames.len(), 1, "sender receives one retry bounce");
+    assert!(outcome.frames[0].contains("resource-constraint"));
+    assert!(!outcome.close, "later effects must be suppressed");
     assert_eq!(
-        _store.durable_parent_row_count(),
+        store.durable_parent_row_count(),
         0,
-        "generic restore and the subject write must not create a partial durable parent"
+        "the rejected subject must not create a partial durable parent"
     );
     let snapshot = room_actor.ask(GetSnapshot).await.expect("room snapshot");
-    assert_eq!(
-        snapshot
-            .room
-            .subject
-            .expect("first subject is applied in memory")
-            .texts
-            .get(""),
-        Some("first subject")
+    assert!(
+        snapshot.room.subject.is_none(),
+        "the rejected subject must not be applied in actor memory"
     );
 }
 

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -3221,6 +3221,8 @@ struct SubjectMutationStore {
     mode: std::sync::atomic::AtomicU8,
     claim_store: Arc<waddle_xmpp::ownership::InProcessClaimStore>,
     durable_parent_rows: std::sync::atomic::AtomicUsize,
+    fanout_owned: std::sync::atomic::AtomicBool,
+    fanout_check_barrier: std::sync::Mutex<Option<Arc<tokio::sync::Barrier>>>,
 }
 
 impl SubjectMutationStore {
@@ -3229,6 +3231,8 @@ impl SubjectMutationStore {
             mode: std::sync::atomic::AtomicU8::new(SubjectMutationStoreMode::Succeed as u8),
             claim_store,
             durable_parent_rows: std::sync::atomic::AtomicUsize::new(1),
+            fanout_owned: std::sync::atomic::AtomicBool::new(true),
+            fanout_check_barrier: std::sync::Mutex::new(None),
         }
     }
 
@@ -3240,6 +3244,20 @@ impl SubjectMutationStore {
     fn remove_durable_parent(&self) {
         self.durable_parent_rows
             .store(0, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    fn set_fanout_owned(&self, owned: bool) {
+        self.fanout_owned
+            .store(owned, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    fn block_fanout_checks(&self, count: usize) -> Arc<tokio::sync::Barrier> {
+        let barrier = Arc::new(tokio::sync::Barrier::new(count + 1));
+        *self
+            .fanout_check_barrier
+            .lock()
+            .expect("fanout barrier lock") = Some(Arc::clone(&barrier));
+        barrier
     }
 
     fn set_mode(&self, mode: SubjectMutationStoreMode) {
@@ -3287,6 +3305,24 @@ impl SubjectMutationStore {
 }
 
 impl waddle_xmpp::muc::MucDurableStore for SubjectMutationStore {
+    fn check_fenced_fanout<'a>(
+        &'a self,
+        _room_jid: &'a jid::BareJid,
+    ) -> waddle_xmpp::muc::MucDurableFuture<'a, bool> {
+        Box::pin(async move {
+            let barrier = self
+                .fanout_check_barrier
+                .lock()
+                .expect("fanout barrier lock")
+                .clone();
+            if let Some(barrier) = barrier {
+                barrier.wait().await;
+                barrier.wait().await;
+            }
+            Ok(self.fanout_owned.load(std::sync::atomic::Ordering::SeqCst))
+        })
+    }
+
     fn load_room_state_fenced<'a>(
         &'a self,
         room_jid: &'a jid::BareJid,
@@ -3757,6 +3793,156 @@ async fn xep_0045_new_clustered_room_subject_fails_closed_without_a_durable_pare
         snapshot.room.subject.is_none(),
         "the rejected subject must not be applied in actor memory"
     );
+}
+
+#[cfg(feature = "clustering")]
+#[tokio::test]
+async fn xep_0045_concurrent_non_serving_fanout_preserves_successor_and_suppresses_effects() {
+    use waddle_xmpp::mam::{MamArchiveKind, MamQuery};
+    use waddle_xmpp::muc::room_actor::Join;
+    use waddle_xmpp::muc::room_registry_actor::{CreateRoom, DemoteRoomIfExactActor};
+    use waddle_xmpp::muc::RoomConfig;
+    use waddle_xmpp::ownership::InProcessClaimStore;
+    use waddle_xmpp::{Affiliation, Role};
+
+    let claim_store = Arc::new(InProcessClaimStore::new());
+    let store = Arc::new(SubjectMutationStore::new(claim_store));
+    store.set_fanout_owned(false);
+    let fanout_barrier = store.block_fanout_checks(2);
+    let clustering = crate::clustering::ClusteringHandles {
+        muc_durable_store: Some(Arc::clone(&store) as Arc<dyn waddle_xmpp::muc::MucDurableStore>),
+        ..Default::default()
+    };
+    let state =
+        crate::server::routes::websocket::tests::create_test_websocket_state_with_clustering(
+            clustering,
+            Arc::new(waddle_xmpp::stream_management::InMemorySmSessionRegistry::new()),
+        )
+        .await;
+    let room_registry = &state.deps.protocol.room_registry;
+    let room_jid: jid::BareJid = "rotated@muc.example.com".parse().expect("room JID");
+    let sender: jid::FullJid = "alice@example.com/web".parse().expect("sender JID");
+    let actor = room_registry
+        .ask(CreateRoom {
+            room_jid: room_jid.clone(),
+            waddle_id: "w-rotated".to_string(),
+            channel_id: "c-rotated".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("create room");
+    actor
+        .ask(Join {
+            nick: "alice".to_string(),
+            real_jid: sender.clone(),
+            role: Role::Participant,
+            affiliation: Affiliation::Member,
+        })
+        .await
+        .expect("join room");
+    let (sender_tx, mut sender_rx) = tokio::sync::mpsc::channel(8);
+    register_into_both_tiers(
+        &state.deps.protocol.connection_registry,
+        &state.deps.protocol.user_registry,
+        &sender,
+        sender_tx,
+    )
+    .await;
+
+    let deps = Deps {
+        connection_registry: &state.deps.protocol.connection_registry,
+        user_registry: Some(&state.deps.protocol.user_registry),
+        sm_session_registry: Some(&state.deps.protocol.sm_session_registry),
+        mam_storage: Some(&state.deps.protocol.mam_storage),
+        inbox_storage: Some(&state.deps.protocol.inbox_storage),
+        extension_manager: Some(&state.deps.protocol.extension_manager),
+        room_registry: Some(room_registry),
+        web_socket_state: Some(state.as_ref()),
+        authenticated_session: None,
+        local_domain: state.deps.auth_state.xmpp_domain.as_str(),
+        blocking_storage: Some(&state.deps.protocol.blocking_storage),
+        message_dispatcher: Some(&state.deps.protocol.dispatcher),
+        pending_delivery_storage: Some(&state.deps.protocol.pending_delivery_storage),
+        ordered_relay_origin: None,
+    };
+    let mut message = Message::new(Some(jid::Jid::from(room_jid.clone())));
+    message.from = Some(jid::Jid::from(sender));
+    message.type_ = XmppMessageType::Groupchat;
+    message.bodies.insert(
+        xmpp_parsers::message::Lang::new(),
+        "must not fan out".to_string(),
+    );
+
+    let first_dispatch = interpret(
+        vec![OutboundEvent::DispatchToRoom {
+            room: room_jid.clone(),
+            message: Box::new(message.clone()),
+        }],
+        &deps,
+    );
+    let second_dispatch = interpret(
+        vec![OutboundEvent::DispatchToRoom {
+            room: room_jid.clone(),
+            message: Box::new(message),
+        }],
+        &deps,
+    );
+    let replace_while_checking = async {
+        // Both dispatches have captured the old actor/snapshot and reached
+        // the legacy cache check before the replacement is published.
+        fanout_barrier.wait().await;
+        assert!(room_registry
+            .ask(DemoteRoomIfExactActor {
+                room_jid: room_jid.clone(),
+                actor_ref: actor,
+            })
+            .await
+            .expect("demote original actor"));
+        let successor = room_registry
+            .ask(CreateRoom {
+                room_jid: room_jid.clone(),
+                waddle_id: "w-successor".to_string(),
+                channel_id: "c-successor".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("create same-JID successor");
+        fanout_barrier.wait().await;
+        successor
+    };
+    let (first_outcome, second_outcome, successor) =
+        tokio::join!(first_dispatch, second_dispatch, replace_while_checking);
+
+    for outcome in [&first_outcome, &second_outcome] {
+        assert_eq!(outcome.frames.len(), 1, "sender receives one retry bounce");
+        assert!(outcome.frames[0].contains("resource-constraint"));
+    }
+    let archive = state
+        .deps
+        .protocol
+        .mam_storage
+        .query_messages(&room_jid, MamArchiveKind::Room, &MamQuery::default())
+        .await
+        .expect("room archive query");
+    assert!(
+        archive.messages.is_empty(),
+        "the rejected message is not archived"
+    );
+    assert!(
+        matches!(
+            sender_rx.try_recv(),
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty)
+        ),
+        "neither stale dispatch reflects the rejected message to the occupant"
+    );
+    let registered = room_registry
+        .ask(GetRoom {
+            room_jid: room_jid.clone(),
+        })
+        .await
+        .expect("room lookup")
+        .expect("same-JID successor survives exact demotion");
+    assert_eq!(registered.id(), successor.id());
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -3220,6 +3220,7 @@ enum SubjectMutationStoreMode {
 struct SubjectMutationStore {
     mode: std::sync::atomic::AtomicU8,
     claim_store: Arc<waddle_xmpp::ownership::InProcessClaimStore>,
+    durable_parent_rows: std::sync::atomic::AtomicUsize,
 }
 
 impl SubjectMutationStore {
@@ -3227,7 +3228,13 @@ impl SubjectMutationStore {
         Self {
             mode: std::sync::atomic::AtomicU8::new(SubjectMutationStoreMode::Succeed as u8),
             claim_store,
+            durable_parent_rows: std::sync::atomic::AtomicUsize::new(0),
         }
+    }
+
+    fn durable_parent_row_count(&self) -> usize {
+        self.durable_parent_rows
+            .load(std::sync::atomic::Ordering::SeqCst)
     }
 
     fn set_mode(&self, mode: SubjectMutationStoreMode) {
@@ -3301,6 +3308,8 @@ impl waddle_xmpp::muc::MucDurableStore for SubjectMutationStore {
     ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
         Box::pin(async move {
             if self.exact_fence_matches(room_jid, fence).await? {
+                self.durable_parent_rows
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 Ok(())
             } else {
                 Err(waddle_xmpp::XmppError::OwnershipLost {
@@ -3698,6 +3707,55 @@ async fn xep_0045_stale_subject_effect_cannot_mutate_same_jid_successor() {
             .subject
             .is_none(),
         "the predecessor's subject must never reach the successor"
+    );
+}
+
+#[tokio::test]
+async fn xep_0045_new_clustered_room_subject_is_not_bounced_before_creator_lifecycle_initializes() {
+    use waddle_xmpp::muc::room_actor::GetSnapshot;
+
+    // The clustered store deliberately restores no parent and treats the
+    // UPDATE-only subject write as non-fatal. #1352 owns atomic complete
+    // room-plus-Owner initialization; this #1355 boundary must neither bounce
+    // the first valid subject nor manufacture a partial parent row.
+    let (room_registry, room_actor, room_jid, _claim_store, claim_fence, _store) =
+        spawn_subject_mutation_test_room().await;
+    let connection_registry = ConnectionRegistry::new();
+    let mut deps = Deps::registry_only(&connection_registry);
+    deps.room_registry = Some(&room_registry);
+    let sender: jid::FullJid = "alice@example.com/web".parse().expect("sender full jid");
+
+    let outcome = interpret(
+        vec![
+            persist_subject_event(&room_jid, &sender, "first subject", claim_fence),
+            OutboundEvent::CloseTransport,
+        ],
+        &deps,
+    )
+    .await;
+
+    assert!(
+        outcome.frames.is_empty(),
+        "the first subject must not bounce"
+    );
+    assert!(
+        outcome.close,
+        "later effects must continue after the subject"
+    );
+    assert_eq!(
+        _store.durable_parent_row_count(),
+        0,
+        "generic restore and the subject write must not create a partial durable parent"
+    );
+    let snapshot = room_actor.ask(GetSnapshot).await.expect("room snapshot");
+    assert_eq!(
+        snapshot
+            .room
+            .subject
+            .expect("first subject is applied in memory")
+            .texts
+            .get(""),
+        Some("first subject")
     );
 }
 

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -3207,6 +3207,287 @@ async fn offline_recipient_pass_skipped_for_remote_domain() {
 // XEP-0045 §8.1 — PersistRoomSubject interpreter arm
 // -----------------------------------------------------------------
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+enum SubjectMutationStoreMode {
+    Succeed = 0,
+    NotOwner = 1,
+    OwnershipUnavailable = 2,
+    PersistFailed = 3,
+    OwnershipLostDuringPersist = 4,
+}
+
+struct SubjectMutationStore {
+    mode: std::sync::atomic::AtomicU8,
+    claim_store: Arc<waddle_xmpp::ownership::InProcessClaimStore>,
+}
+
+impl SubjectMutationStore {
+    fn new(claim_store: Arc<waddle_xmpp::ownership::InProcessClaimStore>) -> Self {
+        Self {
+            mode: std::sync::atomic::AtomicU8::new(SubjectMutationStoreMode::Succeed as u8),
+            claim_store,
+        }
+    }
+
+    fn set_mode(&self, mode: SubjectMutationStoreMode) {
+        self.mode
+            .store(mode as u8, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    fn mode(&self) -> SubjectMutationStoreMode {
+        match self.mode.load(std::sync::atomic::Ordering::SeqCst) {
+            value if value == SubjectMutationStoreMode::Succeed as u8 => {
+                SubjectMutationStoreMode::Succeed
+            }
+            value if value == SubjectMutationStoreMode::NotOwner as u8 => {
+                SubjectMutationStoreMode::NotOwner
+            }
+            value if value == SubjectMutationStoreMode::OwnershipUnavailable as u8 => {
+                SubjectMutationStoreMode::OwnershipUnavailable
+            }
+            value if value == SubjectMutationStoreMode::PersistFailed as u8 => {
+                SubjectMutationStoreMode::PersistFailed
+            }
+            value if value == SubjectMutationStoreMode::OwnershipLostDuringPersist as u8 => {
+                SubjectMutationStoreMode::OwnershipLostDuringPersist
+            }
+            value => panic!("invalid subject mutation store mode: {value}"),
+        }
+    }
+
+    async fn exact_fence_matches(
+        &self,
+        room_jid: &jid::BareJid,
+        fence: &waddle_xmpp::muc::RoomClaimFenceContext,
+    ) -> Result<bool, waddle_xmpp::XmppError> {
+        use waddle_xmpp::ownership::{ClaimStore, Entity, EntityType};
+
+        let expected_entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        if fence.entity != expected_entity {
+            return Ok(false);
+        }
+        self.claim_store
+            .fence(&fence.entity, &fence.owner, fence.epoch)
+            .await
+            .map_err(|error| waddle_xmpp::XmppError::internal(error.to_string()))
+    }
+}
+
+impl waddle_xmpp::muc::MucDurableStore for SubjectMutationStore {
+    fn load_room_state_fenced<'a>(
+        &'a self,
+        room_jid: &'a jid::BareJid,
+        fence: &'a waddle_xmpp::muc::RoomClaimFenceContext,
+    ) -> waddle_xmpp::muc::MucDurableFuture<'a, Option<waddle_xmpp::muc::DurableRoomState>> {
+        Box::pin(async move {
+            if self.exact_fence_matches(room_jid, fence).await? {
+                Ok(None)
+            } else {
+                Err(waddle_xmpp::XmppError::OwnershipLost {
+                    entity: fence.entity.clone(),
+                })
+            }
+        })
+    }
+
+    fn save_config_fenced<'a>(
+        &'a self,
+        room_jid: &'a jid::BareJid,
+        _waddle_id: &'a str,
+        _channel_id: &'a str,
+        _config: &'a waddle_xmpp::muc::RoomConfig,
+        fence: &'a waddle_xmpp::muc::RoomClaimFenceContext,
+    ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
+        Box::pin(async move {
+            if self.exact_fence_matches(room_jid, fence).await? {
+                Ok(())
+            } else {
+                Err(waddle_xmpp::XmppError::OwnershipLost {
+                    entity: fence.entity.clone(),
+                })
+            }
+        })
+    }
+
+    fn save_subject_fenced<'a>(
+        &'a self,
+        room_jid: &'a jid::BareJid,
+        _subject: Option<&'a waddle_xmpp::muc::SubjectState>,
+        fence: &'a waddle_xmpp::muc::RoomClaimFenceContext,
+    ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
+        let mode = self.mode();
+        Box::pin(async move {
+            if !self.exact_fence_matches(room_jid, fence).await? {
+                return Err(waddle_xmpp::XmppError::OwnershipLost {
+                    entity: fence.entity.clone(),
+                });
+            }
+            match mode {
+                SubjectMutationStoreMode::PersistFailed => Err(waddle_xmpp::XmppError::internal(
+                    "subject persist failed in interpreter test",
+                )),
+                SubjectMutationStoreMode::OwnershipLostDuringPersist => {
+                    use waddle_xmpp::ownership::ClaimStore;
+
+                    self.claim_store
+                        .release_exact(&fence.entity, &fence.owner, fence.epoch)
+                        .await
+                        .map_err(|error| waddle_xmpp::XmppError::internal(error.to_string()))?;
+                    Err(waddle_xmpp::XmppError::OwnershipLost {
+                        entity: fence.entity.clone(),
+                    })
+                }
+                _ => Ok(()),
+            }
+        })
+    }
+
+    fn save_affiliation_fenced<'a>(
+        &'a self,
+        room_jid: &'a jid::BareJid,
+        _entry: &'a waddle_xmpp::muc::affiliation::AffiliationEntry,
+        fence: &'a waddle_xmpp::muc::RoomClaimFenceContext,
+    ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
+        Box::pin(async move {
+            if self.exact_fence_matches(room_jid, fence).await? {
+                Ok(())
+            } else {
+                Err(waddle_xmpp::XmppError::OwnershipLost {
+                    entity: fence.entity.clone(),
+                })
+            }
+        })
+    }
+
+    fn delete_room_state_fenced<'a>(
+        &'a self,
+        room_jid: &'a jid::BareJid,
+        fence: &'a waddle_xmpp::muc::RoomClaimFenceContext,
+    ) -> waddle_xmpp::muc::MucDurableFuture<'a, ()> {
+        Box::pin(async move {
+            if self.exact_fence_matches(room_jid, fence).await? {
+                Ok(())
+            } else {
+                Err(waddle_xmpp::XmppError::OwnershipLost {
+                    entity: fence.entity.clone(),
+                })
+            }
+        })
+    }
+
+    fn check_exact_claim_fence<'a>(
+        &'a self,
+        room_jid: &'a jid::BareJid,
+        fence: &'a waddle_xmpp::muc::RoomClaimFenceContext,
+    ) -> waddle_xmpp::muc::MucDurableFuture<'a, bool> {
+        let mode = self.mode();
+        Box::pin(async move {
+            match mode {
+                SubjectMutationStoreMode::Succeed
+                | SubjectMutationStoreMode::PersistFailed
+                | SubjectMutationStoreMode::OwnershipLostDuringPersist => {
+                    self.exact_fence_matches(room_jid, fence).await
+                }
+                SubjectMutationStoreMode::NotOwner => Ok(false),
+                SubjectMutationStoreMode::OwnershipUnavailable => Err(
+                    waddle_xmpp::XmppError::internal("ownership probe failed in interpreter test"),
+                ),
+            }
+        })
+    }
+}
+
+async fn spawn_subject_mutation_test_room() -> (
+    kameo::actor::ActorRef<RoomRegistryActor>,
+    kameo::actor::ActorRef<waddle_xmpp::muc::room_actor::RoomActor>,
+    jid::BareJid,
+    Arc<waddle_xmpp::ownership::InProcessClaimStore>,
+    waddle_xmpp::muc::RoomClaimFenceContext,
+    Arc<SubjectMutationStore>,
+) {
+    use waddle_xmpp::muc::room_registry_actor::{CreateRoom, WireClusteringClaims};
+    use waddle_xmpp::ownership::{InProcessClaimStore, NodeIdentity, SharedNodeIdentity};
+    use waddle_xmpp::xep::xep0421::OccupantIdSecret;
+
+    let room_registry = RoomRegistryActor::spawn(RoomRegistryActor::new(
+        "muc.example.com".to_string(),
+        OccupantIdSecret::new(b"subject-fail-closed-test-secret-32b".to_vec())
+            .expect("test secret meets length floor"),
+    ));
+    let claim_store = Arc::new(InProcessClaimStore::new());
+    let store = Arc::new(SubjectMutationStore::new(claim_store.clone()));
+    room_registry
+        .ask(WireClusteringClaims {
+            claim_store: claim_store.clone(),
+            node_identity: SharedNodeIdentity::new(NodeIdentity::new(
+                "subject-test-node",
+                "subject-test-epoch",
+            )),
+            durable_store: Some(store.clone()),
+            rollout_backoff: None,
+        })
+        .await
+        .expect("wire subject mutation test store");
+    let room_jid: jid::BareJid = "channel@muc.example.com".parse().expect("bare jid");
+    let room_actor = room_registry
+        .ask(CreateRoom {
+            room_jid: room_jid.clone(),
+            waddle_id: "w-subject".to_string(),
+            channel_id: "c-subject".to_string(),
+            config: waddle_xmpp::muc::RoomConfig::default(),
+        })
+        .await
+        .expect("create subject mutation test room");
+    let snapshot = room_actor
+        .ask(GetRoomSnapshot {
+            sender_jid: "alice@example.com/web".parse().expect("sender full jid"),
+        })
+        .await
+        .expect("subject mutation room snapshot");
+    let claim_fence = snapshot
+        .claim_fence
+        .expect("durable subject mutation room has an exact fence");
+    (
+        room_registry,
+        room_actor,
+        room_jid,
+        claim_store,
+        claim_fence,
+        store,
+    )
+}
+
+fn subject_change_message(room: &jid::BareJid, sender: &jid::FullJid, text: &str) -> Message {
+    let mut message = Message::new(Some(jid::Jid::from(room.clone())));
+    message.from = Some(jid::Jid::from(sender.clone()));
+    message.type_ = XmppMessageType::Groupchat;
+    message
+        .subjects
+        .insert(xmpp_parsers::message::Lang::new(), text.to_string());
+    message
+}
+
+fn persist_subject_event(
+    room: &jid::BareJid,
+    sender: &jid::FullJid,
+    text: &str,
+    claim_fence: waddle_xmpp::muc::RoomClaimFenceContext,
+) -> OutboundEvent {
+    use chrono::TimeZone;
+
+    OutboundEvent::PersistRoomSubject {
+        room: room.clone(),
+        claim_fence: Some(claim_fence),
+        texts: waddle_xmpp::muc::RoomSubjectTexts::from_iter([(String::new(), text.to_string())]),
+        setter: sender.to_bare(),
+        sender: sender.clone(),
+        message: Box::new(subject_change_message(room, sender, text)),
+        setter_nick: "alice-nick".to_string(),
+        set_at: chrono::Utc.with_ymd_and_hms(2026, 5, 2, 12, 0, 0).unwrap(),
+    }
+}
+
 #[tokio::test]
 async fn xep_0045_persist_room_subject_writes_state_via_room_actor() {
     // Per-arm coverage for `OutboundEvent::PersistRoomSubject`
@@ -3256,6 +3537,7 @@ async fn xep_0045_persist_room_subject_writes_state_via_room_actor() {
     };
 
     let setter: jid::BareJid = "alice@example.com".parse().expect("setter bare jid");
+    let sender: jid::FullJid = "alice@example.com/web".parse().expect("sender full jid");
     let texts = waddle_xmpp::muc::RoomSubjectTexts::from_iter([
         (String::new(), "Default subject".to_string()),
         ("en".to_string(), "English subject".to_string()),
@@ -3264,8 +3546,15 @@ async fn xep_0045_persist_room_subject_writes_state_via_room_actor() {
 
     let events = vec![OutboundEvent::PersistRoomSubject {
         room: room_jid.clone(),
+        claim_fence: None,
         texts: texts.clone(),
         setter: setter.clone(),
+        sender: sender.clone(),
+        message: Box::new(subject_change_message(
+            &room_jid,
+            &sender,
+            "Default subject",
+        )),
         setter_nick: "alice-nick".to_string(),
         set_at,
     }];
@@ -3291,10 +3580,9 @@ async fn xep_0045_persist_room_subject_writes_state_via_room_actor() {
 }
 
 #[tokio::test]
-async fn xep_0045_persist_room_subject_with_no_registry_is_noop() {
-    // Defensive coverage for the `room_registry: None` skip arm —
-    // a `PersistRoomSubject` arriving in a deployment without a
-    // room registry must be logged-and-skipped, not panicked.
+async fn xep_0045_persist_room_subject_with_no_registry_bounces_and_halts_batch() {
+    // A subject effect cannot safely complete without its room registry.
+    // Reject it and suppress all later effects from the same dispatch batch.
     use chrono::TimeZone;
 
     let registry = ConnectionRegistry::new();
@@ -3302,18 +3590,255 @@ async fn xep_0045_persist_room_subject_with_no_registry_is_noop() {
 
     let room_jid: jid::BareJid = "channel@muc.example.com".parse().expect("bare jid");
     let setter: jid::BareJid = "alice@example.com".parse().expect("setter bare jid");
+    let sender: jid::FullJid = "alice@example.com/web".parse().expect("sender full jid");
     let texts =
         waddle_xmpp::muc::RoomSubjectTexts::from_iter([(String::new(), "ignored".to_string())]);
-    let events = vec![OutboundEvent::PersistRoomSubject {
-        room: room_jid,
-        texts,
-        setter,
-        setter_nick: "alice-nick".to_string(),
-        set_at: chrono::Utc.with_ymd_and_hms(2026, 5, 2, 12, 0, 0).unwrap(),
-    }];
+    let events = vec![
+        OutboundEvent::PersistRoomSubject {
+            room: room_jid.clone(),
+            claim_fence: None,
+            texts,
+            setter,
+            sender: sender.clone(),
+            message: Box::new(subject_change_message(&room_jid, &sender, "ignored")),
+            setter_nick: "alice-nick".to_string(),
+            set_at: chrono::Utc.with_ymd_and_hms(2026, 5, 2, 12, 0, 0).unwrap(),
+        },
+        OutboundEvent::CloseTransport,
+    ];
     let outcome = interpret(events, &deps).await;
-    assert!(outcome.frames.is_empty());
-    assert!(!outcome.close);
+    assert_eq!(outcome.frames.len(), 1, "sender receives one retry bounce");
+    assert!(outcome.frames[0].contains("resource-constraint"));
+    assert!(!outcome.close, "later effects must be suppressed");
+}
+
+#[tokio::test]
+async fn xep_0045_stale_subject_effect_cannot_mutate_same_jid_successor() {
+    use waddle_xmpp::muc::room_actor::GetSnapshot;
+    use waddle_xmpp::muc::room_registry_actor::{CreateRoom, DemoteRoomIfExactActor};
+    use waddle_xmpp::ownership::{ClaimStore, ExactReleaseOutcome};
+
+    let (room_registry, original_actor, room_jid, claim_store, original_fence, _store) =
+        spawn_subject_mutation_test_room().await;
+
+    assert_eq!(
+        claim_store
+            .release_exact(
+                &original_fence.entity,
+                &original_fence.owner,
+                original_fence.epoch,
+            )
+            .await
+            .expect("release original exact claim"),
+        ExactReleaseOutcome::Released,
+    );
+    assert!(room_registry
+        .ask(DemoteRoomIfExactActor {
+            room_jid: room_jid.clone(),
+            actor_ref: original_actor,
+        })
+        .await
+        .expect("remove original actor"));
+    let successor_actor = room_registry
+        .ask(CreateRoom {
+            room_jid: room_jid.clone(),
+            waddle_id: "w-subject-successor".to_string(),
+            channel_id: "c-subject-successor".to_string(),
+            config: waddle_xmpp::muc::RoomConfig::default(),
+        })
+        .await
+        .expect("create same-JID successor");
+    let sender: jid::FullJid = "alice@example.com/web".parse().expect("sender full jid");
+    let successor_snapshot = successor_actor
+        .ask(GetRoomSnapshot {
+            sender_jid: sender.clone(),
+        })
+        .await
+        .expect("successor chain snapshot");
+    assert_ne!(
+        successor_snapshot.claim_fence.as_ref(),
+        Some(&original_fence),
+        "the replacement must have a distinct exact authority"
+    );
+
+    let connection_registry = ConnectionRegistry::new();
+    let mut deps = Deps::registry_only(&connection_registry);
+    deps.room_registry = Some(&room_registry);
+    let outcome = interpret(
+        vec![
+            persist_subject_event(
+                &room_jid,
+                &sender,
+                "stale predecessor subject",
+                original_fence,
+            ),
+            OutboundEvent::CloseTransport,
+        ],
+        &deps,
+    )
+    .await;
+
+    assert_eq!(outcome.frames.len(), 1, "sender receives one retry bounce");
+    assert!(outcome.frames[0].contains("resource-constraint"));
+    assert!(!outcome.close, "later effects must be suppressed");
+    let current_actor = room_registry
+        .ask(GetRoom {
+            room_jid: room_jid.clone(),
+        })
+        .await
+        .expect("lookup successor")
+        .expect("successor remains registered");
+    assert_eq!(current_actor.id(), successor_actor.id());
+    assert!(
+        successor_actor
+            .ask(GetSnapshot)
+            .await
+            .expect("successor state snapshot")
+            .room
+            .subject
+            .is_none(),
+        "the predecessor's subject must never reach the successor"
+    );
+}
+
+#[tokio::test]
+async fn xep_0045_subject_not_owner_bounces_demotes_exact_actor_and_halts_batch() {
+    let (room_registry, _room_actor, room_jid, _claim_store, claim_fence, store) =
+        spawn_subject_mutation_test_room().await;
+    store.set_mode(SubjectMutationStoreMode::NotOwner);
+    let connection_registry = ConnectionRegistry::new();
+    let mut deps = Deps::registry_only(&connection_registry);
+    deps.room_registry = Some(&room_registry);
+    let sender: jid::FullJid = "alice@example.com/web".parse().expect("sender full jid");
+
+    let outcome = interpret(
+        vec![
+            persist_subject_event(&room_jid, &sender, "rejected subject", claim_fence),
+            OutboundEvent::CloseTransport,
+        ],
+        &deps,
+    )
+    .await;
+
+    assert_eq!(outcome.frames.len(), 1, "sender receives one retry bounce");
+    assert!(outcome.frames[0].contains("resource-constraint"));
+    assert!(
+        !outcome.close,
+        "the event following rejected subject persistence must not be interpreted"
+    );
+    assert!(
+        room_registry
+            .ask(GetRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("lookup after demotion")
+            .is_none(),
+        "the exact actor that proved ownership loss must be demoted"
+    );
+}
+
+#[tokio::test]
+async fn xep_0045_subject_ownership_loss_during_persist_bounces_and_demotes() {
+    let (room_registry, _room_actor, room_jid, _claim_store, claim_fence, store) =
+        spawn_subject_mutation_test_room().await;
+    store.set_mode(SubjectMutationStoreMode::OwnershipLostDuringPersist);
+    let connection_registry = ConnectionRegistry::new();
+    let mut deps = Deps::registry_only(&connection_registry);
+    deps.room_registry = Some(&room_registry);
+    let sender: jid::FullJid = "alice@example.com/web".parse().expect("sender full jid");
+    let mut subject_event =
+        persist_subject_event(&room_jid, &sender, "stale in-memory subject", claim_fence);
+    let OutboundEvent::PersistRoomSubject { message, .. } = &mut subject_event else {
+        unreachable!("helper always builds a subject event")
+    };
+    message.payloads.push(waddle_xmpp::xep::build_hint_element(
+        waddle_xmpp::xep::Hint::NoStore,
+    ));
+
+    let outcome = interpret(vec![subject_event, OutboundEvent::CloseTransport], &deps).await;
+
+    assert_eq!(outcome.frames.len(), 1, "sender receives one retry bounce");
+    assert!(outcome.frames[0].contains("resource-constraint"));
+    assert!(!outcome.close, "the post-subject batch must be suppressed");
+    assert!(
+        room_registry
+            .ask(GetRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("lookup after write-adjacent loss")
+            .is_none(),
+        "the actor whose write-adjacent fence failed must be demoted"
+    );
+}
+
+#[tokio::test]
+async fn xep_0045_subject_ownership_unavailable_bounces_without_demotion_and_halts_batch() {
+    let (room_registry, _room_actor, room_jid, _claim_store, claim_fence, store) =
+        spawn_subject_mutation_test_room().await;
+    store.set_mode(SubjectMutationStoreMode::OwnershipUnavailable);
+    let connection_registry = ConnectionRegistry::new();
+    let mut deps = Deps::registry_only(&connection_registry);
+    deps.room_registry = Some(&room_registry);
+    let sender: jid::FullJid = "alice@example.com/web".parse().expect("sender full jid");
+
+    let outcome = interpret(
+        vec![
+            persist_subject_event(&room_jid, &sender, "ambiguous subject", claim_fence),
+            OutboundEvent::CloseTransport,
+        ],
+        &deps,
+    )
+    .await;
+
+    assert_eq!(outcome.frames.len(), 1, "sender receives one retry bounce");
+    assert!(outcome.frames[0].contains("resource-constraint"));
+    assert!(
+        !outcome.close,
+        "the event following ambiguous subject persistence must not be interpreted"
+    );
+    assert!(
+        room_registry
+            .ask(GetRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("lookup after ambiguous mutation")
+            .is_some(),
+        "an ambiguous ownership probe must not demote the actor"
+    );
+}
+
+#[tokio::test]
+async fn xep_0045_subject_persist_failure_bounces_before_apply_and_halts_batch() {
+    use waddle_xmpp::muc::room_actor::GetSnapshot;
+
+    let (room_registry, room_actor, room_jid, _claim_store, claim_fence, store) =
+        spawn_subject_mutation_test_room().await;
+    store.set_mode(SubjectMutationStoreMode::PersistFailed);
+    let connection_registry = ConnectionRegistry::new();
+    let mut deps = Deps::registry_only(&connection_registry);
+    deps.room_registry = Some(&room_registry);
+    let sender: jid::FullJid = "alice@example.com/web".parse().expect("sender full jid");
+
+    let outcome = interpret(
+        vec![
+            persist_subject_event(&room_jid, &sender, "rejected subject", claim_fence),
+            OutboundEvent::CloseTransport,
+        ],
+        &deps,
+    )
+    .await;
+
+    assert_eq!(outcome.frames.len(), 1, "sender receives one retry bounce");
+    assert!(outcome.frames[0].contains("resource-constraint"));
+    assert!(!outcome.close, "later effects must be suppressed");
+    let snapshot = room_actor.ask(GetSnapshot).await.expect("room snapshot");
+    assert!(
+        snapshot.room.subject.is_none(),
+        "failed durable persistence must leave in-memory subject unchanged"
+    );
 }
 
 // -----------------------------------------------------------------

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/presence/muc.rs
@@ -1677,7 +1677,9 @@ mod resolver_sync_retry_tests {
 
     use kameo::actor::Spawn;
     use waddle_xmpp::muc::affiliation::AffiliationEntry;
-    use waddle_xmpp::muc::durable::{DurableRoomState, MucDurableFuture, MucDurableStore};
+    use waddle_xmpp::muc::durable::{
+        DurableRoomState, MucDurableFuture, MucDurableStore, RoomClaimFenceContext,
+    };
     use waddle_xmpp::muc::room_actor::{
         ChangeAffiliation, GetAffiliation, RestoreDurableRoomState, RoomActor,
     };
@@ -1759,44 +1761,57 @@ mod resolver_sync_retry_tests {
     }
 
     impl MucDurableStore for SequencedOwnershipStore {
-        fn load_room_state<'a>(
-            &'a self,
-            _room_jid: &'a BareJid,
-        ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
-            Box::pin(async { Ok(None) })
-        }
-
         fn load_room_state_fenced<'a>(
             &'a self,
             room_jid: &'a BareJid,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
-            self.load_room_state(room_jid)
+            let validation = validate_test_claim_fence(room_jid, fence);
+            Box::pin(async move {
+                validation?;
+                Ok(None)
+            })
         }
 
-        fn save_config<'a>(
+        fn save_config_fenced<'a>(
             &'a self,
-            _room_jid: &'a BareJid,
+            room_jid: &'a BareJid,
             _waddle_id: &'a str,
             _channel_id: &'a str,
             _config: &'a RoomConfig,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            let validation = validate_test_claim_fence(room_jid, fence);
+            Box::pin(async move { validation })
         }
 
-        fn save_subject<'a>(
+        fn save_subject_fenced<'a>(
             &'a self,
-            _room_jid: &'a BareJid,
+            room_jid: &'a BareJid,
             _subject: Option<&'a SubjectState>,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            let validation = validate_test_claim_fence(room_jid, fence);
+            Box::pin(async move { validation })
         }
 
-        fn save_affiliation<'a>(
+        fn save_affiliation_fenced<'a>(
             &'a self,
-            _room_jid: &'a BareJid,
+            room_jid: &'a BareJid,
             _entry: &'a AffiliationEntry,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            let validation = validate_test_claim_fence(room_jid, fence);
+            Box::pin(async move { validation })
+        }
+
+        fn delete_room_state_fenced<'a>(
+            &'a self,
+            room_jid: &'a BareJid,
+            fence: &'a RoomClaimFenceContext,
+        ) -> MucDurableFuture<'a, ()> {
+            let validation = validate_test_claim_fence(room_jid, fence);
+            Box::pin(async move { validation })
         }
 
         fn check_fenced_fanout<'a>(&'a self, _room_jid: &'a BareJid) -> MucDurableFuture<'a, bool> {
@@ -1829,6 +1844,41 @@ mod resolver_sync_retry_tests {
                 }
             })
         }
+
+        fn check_exact_claim_fence<'a>(
+            &'a self,
+            room_jid: &'a BareJid,
+            fence: &'a RoomClaimFenceContext,
+        ) -> MucDurableFuture<'a, bool> {
+            if fence != &test_claim_fence(room_jid) {
+                return Box::pin(async { Ok(false) });
+            }
+            self.check_fenced_fanout(room_jid)
+        }
+    }
+
+    fn test_claim_fence(room_jid: &BareJid) -> RoomClaimFenceContext {
+        RoomClaimFenceContext::new(
+            waddle_xmpp::ownership::Entity::new(
+                waddle_xmpp::ownership::EntityType::RoomActor,
+                room_jid.to_string(),
+            ),
+            waddle_xmpp::ownership::NodeIdentity::local(),
+            waddle_xmpp::ownership::ClaimEpoch(1),
+        )
+    }
+
+    fn validate_test_claim_fence(
+        room_jid: &BareJid,
+        fence: &RoomClaimFenceContext,
+    ) -> Result<(), waddle_xmpp::XmppError> {
+        if fence == &test_claim_fence(room_jid) {
+            Ok(())
+        } else {
+            Err(waddle_xmpp::XmppError::internal(
+                "test store received an unexpected room claim fence",
+            ))
+        }
     }
 
     async fn spawn_sync_test_room(
@@ -1857,6 +1907,7 @@ mod resolver_sync_retry_tests {
         actor
             .ask(RestoreDurableRoomState {
                 store: Arc::clone(&store) as Arc<dyn MucDurableStore>,
+                claim_fence: test_claim_fence(&room_jid),
             })
             .await
             .expect("install durable store");
@@ -1977,6 +2028,7 @@ mod resolver_sync_retry_tests {
         actor
             .ask(RestoreDurableRoomState {
                 store: Arc::clone(&store) as Arc<dyn MucDurableStore>,
+                claim_fence: test_claim_fence(&room_jid),
             })
             .await
             .expect("install deposed ownership store");

--- a/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/tests/muc.rs
@@ -1,6 +1,44 @@
 use super::*;
 use crate::permissions::CheckPermission;
 
+fn expected_local_room_fence(
+    room_jid: &BareJid,
+) -> waddle_xmpp::muc::durable::RoomClaimFenceContext {
+    expected_room_fence(
+        room_jid,
+        waddle_xmpp::ownership::NodeIdentity::local(),
+        waddle_xmpp::ownership::ClaimEpoch(0),
+    )
+}
+
+fn expected_room_fence(
+    room_jid: &BareJid,
+    owner: waddle_xmpp::ownership::NodeIdentity,
+    epoch: waddle_xmpp::ownership::ClaimEpoch,
+) -> waddle_xmpp::muc::durable::RoomClaimFenceContext {
+    waddle_xmpp::muc::durable::RoomClaimFenceContext::new(
+        waddle_xmpp::ownership::Entity::new(
+            waddle_xmpp::ownership::EntityType::RoomActor,
+            room_jid.to_string(),
+        ),
+        owner,
+        epoch,
+    )
+}
+
+fn validate_local_room_fence(
+    room_jid: &BareJid,
+    fence: &waddle_xmpp::muc::durable::RoomClaimFenceContext,
+) -> Result<(), waddle_xmpp::XmppError> {
+    if fence == &expected_local_room_fence(room_jid) {
+        Ok(())
+    } else {
+        Err(waddle_xmpp::XmppError::internal(
+            "test store received an unexpected room claim fence",
+        ))
+    }
+}
+
 #[tokio::test]
 async fn muc_stale_leave_does_not_remove_current_resource() {
     let state = create_test_websocket_state().await;
@@ -162,7 +200,9 @@ async fn muc_join_maps_registry_ownership_deferral_to_retryable_resource_constra
 async fn ordinary_join_coalesces_with_restoring_room_without_create_permission() {
     use std::sync::Arc;
 
-    use waddle_xmpp::muc::durable::{DurableRoomState, MucDurableFuture, MucDurableStore};
+    use waddle_xmpp::muc::durable::{
+        DurableRoomState, MucDurableFuture, MucDurableStore, RoomClaimFenceContext,
+    };
     use waddle_xmpp::muc::room_registry_actor::WireClusteringClaims;
     use waddle_xmpp::ownership::{
         ClaimStore, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
@@ -175,56 +215,75 @@ async fn ordinary_join_coalesces_with_restoring_room_without_create_permission()
     }
 
     impl MucDurableStore for BlockingExistingRoomStore {
-        fn load_room_state<'a>(
-            &'a self,
-            _room_jid: &'a BareJid,
-        ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
-            let snapshot = self.snapshot.clone();
-            Box::pin(async move { Ok(Some(snapshot)) })
-        }
-
         fn load_room_state_fenced<'a>(
             &'a self,
-            _room_jid: &'a BareJid,
+            room_jid: &'a BareJid,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
+            let validation = validate_local_room_fence(room_jid, fence);
             let started = Arc::clone(&self.started);
             let allow = Arc::clone(&self.allow);
             let snapshot = self.snapshot.clone();
             Box::pin(async move {
+                validation?;
                 started.notify_one();
                 allow.notified().await;
                 Ok(Some(snapshot))
             })
         }
 
-        fn save_config<'a>(
+        fn save_config_fenced<'a>(
             &'a self,
-            _room_jid: &'a BareJid,
+            room_jid: &'a BareJid,
             _waddle_id: &'a str,
             _channel_id: &'a str,
             _config: &'a waddle_xmpp::muc::RoomConfig,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            let validation = validate_local_room_fence(room_jid, fence);
+            Box::pin(async move { validation })
         }
 
-        fn save_subject<'a>(
+        fn save_subject_fenced<'a>(
             &'a self,
-            _room_jid: &'a BareJid,
+            room_jid: &'a BareJid,
             _subject: Option<&'a waddle_xmpp::muc::SubjectState>,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            let validation = validate_local_room_fence(room_jid, fence);
+            Box::pin(async move { validation })
         }
 
-        fn save_affiliation<'a>(
+        fn save_affiliation_fenced<'a>(
             &'a self,
-            _room_jid: &'a BareJid,
+            room_jid: &'a BareJid,
             _entry: &'a waddle_xmpp::muc::affiliation::AffiliationEntry,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            let validation = validate_local_room_fence(room_jid, fence);
+            Box::pin(async move { validation })
+        }
+
+        fn delete_room_state_fenced<'a>(
+            &'a self,
+            room_jid: &'a BareJid,
+            fence: &'a RoomClaimFenceContext,
+        ) -> MucDurableFuture<'a, ()> {
+            let validation = validate_local_room_fence(room_jid, fence);
+            Box::pin(async move { validation })
         }
 
         fn check_fenced_fanout<'a>(&'a self, _room_jid: &'a BareJid) -> MucDurableFuture<'a, bool> {
             Box::pin(async { Ok(true) })
+        }
+
+        fn check_exact_claim_fence<'a>(
+            &'a self,
+            room_jid: &'a BareJid,
+            fence: &'a RoomClaimFenceContext,
+        ) -> MucDurableFuture<'a, bool> {
+            let matches = fence == &expected_local_room_fence(room_jid);
+            Box::pin(async move { Ok(matches) })
         }
     }
 
@@ -7076,56 +7135,99 @@ async fn muc_self_ping_answers_joined_for_recorded_remote_membership() {
 /// nobody may be told the room died while it lives on.
 #[tokio::test]
 async fn xep0045_destroy_wipe_failure_sends_no_destroy_presence() {
-    use waddle_xmpp::muc::durable::{MucDurableFuture, MucDurableStore};
+    use waddle_xmpp::muc::durable::{MucDurableFuture, MucDurableStore, RoomClaimFenceContext};
     use waddle_xmpp::muc::room_registry_actor::WireClusteringClaims;
     use waddle_xmpp::ownership::{
-        ClaimStore, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
+        ClaimEpoch, ClaimStore, InProcessClaimStore, NodeIdentity, SharedNodeIdentity,
     };
 
     /// Every write succeeds except the destroy-time wipe.
-    struct FailingDeleteStore;
+    struct FailingDeleteStore {
+        expected_owner: NodeIdentity,
+    }
     impl MucDurableStore for FailingDeleteStore {
-        fn load_room_state<'a>(
-            &'a self,
-            _room_jid: &'a BareJid,
-        ) -> MucDurableFuture<'a, Option<waddle_xmpp::muc::durable::DurableRoomState>> {
-            Box::pin(async { Ok(None) })
-        }
         fn load_room_state_fenced<'a>(
             &'a self,
             room_jid: &'a BareJid,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, Option<waddle_xmpp::muc::durable::DurableRoomState>> {
-            self.load_room_state(room_jid)
+            let expected =
+                expected_room_fence(room_jid, self.expected_owner.clone(), ClaimEpoch(0));
+            let validation = (fence == &expected)
+                .then_some(())
+                .ok_or_else(|| waddle_xmpp::XmppError::internal("unexpected exact room fence"));
+            Box::pin(async move {
+                validation?;
+                Ok(None)
+            })
         }
-        fn save_config<'a>(
+        fn save_config_fenced<'a>(
             &'a self,
-            _room_jid: &'a BareJid,
+            room_jid: &'a BareJid,
             _waddle_id: &'a str,
             _channel_id: &'a str,
             _config: &'a waddle_xmpp::muc::RoomConfig,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            let expected =
+                expected_room_fence(room_jid, self.expected_owner.clone(), ClaimEpoch(0));
+            let validation = (fence == &expected)
+                .then_some(())
+                .ok_or_else(|| waddle_xmpp::XmppError::internal("unexpected exact room fence"));
+            Box::pin(async move { validation })
         }
-        fn save_subject<'a>(
+        fn save_subject_fenced<'a>(
             &'a self,
-            _room_jid: &'a BareJid,
+            room_jid: &'a BareJid,
             _subject: Option<&'a waddle_xmpp::muc::SubjectState>,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            let expected =
+                expected_room_fence(room_jid, self.expected_owner.clone(), ClaimEpoch(0));
+            let validation = (fence == &expected)
+                .then_some(())
+                .ok_or_else(|| waddle_xmpp::XmppError::internal("unexpected exact room fence"));
+            Box::pin(async move { validation })
         }
-        fn save_affiliation<'a>(
+        fn save_affiliation_fenced<'a>(
             &'a self,
-            _room_jid: &'a BareJid,
+            room_jid: &'a BareJid,
             _entry: &'a waddle_xmpp::muc::affiliation::AffiliationEntry,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            let expected =
+                expected_room_fence(room_jid, self.expected_owner.clone(), ClaimEpoch(0));
+            let validation = (fence == &expected)
+                .then_some(())
+                .ok_or_else(|| waddle_xmpp::XmppError::internal("unexpected exact room fence"));
+            Box::pin(async move { validation })
         }
-        fn delete_room_state<'a>(&'a self, _room_jid: &'a BareJid) -> MucDurableFuture<'a, ()> {
+        fn delete_room_state_fenced<'a>(
+            &'a self,
+            room_jid: &'a BareJid,
+            fence: &'a RoomClaimFenceContext,
+        ) -> MucDurableFuture<'a, ()> {
+            let expected =
+                expected_room_fence(room_jid, self.expected_owner.clone(), ClaimEpoch(0));
+            if fence != &expected {
+                let error = waddle_xmpp::XmppError::internal("unexpected exact room fence");
+                return Box::pin(async move { Err(error) });
+            }
             Box::pin(async {
                 Err(waddle_xmpp::XmppError::internal(
                     "destroy-time wipe refused by test store",
                 ))
             })
+        }
+
+        fn check_exact_claim_fence<'a>(
+            &'a self,
+            room_jid: &'a BareJid,
+            fence: &'a RoomClaimFenceContext,
+        ) -> MucDurableFuture<'a, bool> {
+            let matches =
+                fence == &expected_room_fence(room_jid, self.expected_owner.clone(), ClaimEpoch(0));
+            Box::pin(async move { Ok(matches) })
         }
     }
 
@@ -7157,6 +7259,7 @@ async fn xep0045_destroy_wipe_failure_sends_no_destroy_presence() {
     let bob_session = create_test_session(state.as_ref(), "bob").await;
     let bob: FullJid = "bob@example.com/web".parse().expect("bob jid");
 
+    let durable_owner = NodeIdentity::new("test-node", "epoch-1");
     state
         .deps
         .protocol
@@ -7164,8 +7267,10 @@ async fn xep0045_destroy_wipe_failure_sends_no_destroy_presence() {
         .ask(WireClusteringClaims {
             claim_store: std::sync::Arc::new(InProcessClaimStore::new())
                 as std::sync::Arc<dyn ClaimStore>,
-            node_identity: SharedNodeIdentity::new(NodeIdentity::new("test-node", "epoch-1")),
-            durable_store: Some(std::sync::Arc::new(FailingDeleteStore)),
+            node_identity: SharedNodeIdentity::new(durable_owner.clone()),
+            durable_store: Some(std::sync::Arc::new(FailingDeleteStore {
+                expected_owner: durable_owner,
+            })),
             rollout_backoff: None,
         })
         .await

--- a/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
+++ b/server/crates/waddle-server/tests/clustering_cluster_e2e.rs
@@ -1857,7 +1857,9 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
     };
     use waddle_server::clustering::ClusteringReadiness;
     use waddle_server::config::{ClusteringNodeLeaseConfig, ClusteringSelfFenceConfig};
-    use waddle_xmpp::muc::durable::{DurableRoomState, MucDurableFuture, MucDurableStore};
+    use waddle_xmpp::muc::durable::{
+        DurableRoomState, MucDurableFuture, MucDurableStore, RoomClaimFenceContext,
+    };
     use waddle_xmpp::muc::room_actor::{HealthCheck, UpdateConfig};
     use waddle_xmpp::muc::{RoomConfig, RoomRegistry};
     use waddle_xmpp::ownership::{
@@ -1881,46 +1883,94 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
 
     // Initial restore succeeds so the room can be published. Its first
     // durable config mutation is the deliberate post-publication wedge.
-    struct HangingDurableStore;
-    impl MucDurableStore for HangingDurableStore {
-        fn load_room_state<'a>(
-            &'a self,
-            _room_jid: &'a jid::BareJid,
-        ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
-            Box::pin(async { Ok(None) })
+    struct HangingDurableStore {
+        expected_fence: RoomClaimFenceContext,
+    }
+
+    impl HangingDurableStore {
+        fn new(expected_fence: RoomClaimFenceContext) -> Self {
+            Self { expected_fence }
         }
 
+        fn validate_fence(
+            &self,
+            room_jid: &jid::BareJid,
+            fence: &RoomClaimFenceContext,
+        ) -> Result<(), waddle_xmpp::XmppError> {
+            let expected_entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+            if fence.entity == expected_entity && fence == &self.expected_fence {
+                Ok(())
+            } else {
+                Err(waddle_xmpp::XmppError::internal(
+                    "test store received an unexpected exact room claim fence",
+                ))
+            }
+        }
+    }
+
+    impl MucDurableStore for HangingDurableStore {
         fn load_room_state_fenced<'a>(
             &'a self,
             room_jid: &'a jid::BareJid,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
-            self.load_room_state(room_jid)
+            let validation = self.validate_fence(room_jid, fence);
+            Box::pin(async move {
+                validation?;
+                Ok(None)
+            })
         }
 
-        fn save_config<'a>(
+        fn save_config_fenced<'a>(
             &'a self,
-            _room_jid: &'a jid::BareJid,
+            room_jid: &'a jid::BareJid,
             _waddle_id: &'a str,
             _channel_id: &'a str,
             _config: &'a RoomConfig,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
+            if let Err(error) = self.validate_fence(room_jid, fence) {
+                return Box::pin(async move { Err(error) });
+            }
             Box::pin(pending()) as Pin<Box<_>>
         }
 
-        fn save_subject<'a>(
+        fn save_subject_fenced<'a>(
             &'a self,
-            _room_jid: &'a jid::BareJid,
+            room_jid: &'a jid::BareJid,
             _subject: Option<&'a waddle_xmpp::muc::SubjectState>,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            let validation = self.validate_fence(room_jid, fence);
+            Box::pin(async move { validation })
         }
 
-        fn save_affiliation<'a>(
+        fn save_affiliation_fenced<'a>(
             &'a self,
-            _room_jid: &'a jid::BareJid,
+            room_jid: &'a jid::BareJid,
             _entry: &'a waddle_xmpp::muc::affiliation::AffiliationEntry,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            let validation = self.validate_fence(room_jid, fence);
+            Box::pin(async move { validation })
+        }
+
+        fn delete_room_state_fenced<'a>(
+            &'a self,
+            room_jid: &'a jid::BareJid,
+            fence: &'a RoomClaimFenceContext,
+        ) -> MucDurableFuture<'a, ()> {
+            let validation = self.validate_fence(room_jid, fence);
+            Box::pin(async move { validation })
+        }
+
+        fn check_exact_claim_fence<'a>(
+            &'a self,
+            room_jid: &'a jid::BareJid,
+            fence: &'a RoomClaimFenceContext,
+        ) -> MucDurableFuture<'a, bool> {
+            let matches = self.validate_fence(room_jid, fence).is_ok();
+            Box::pin(async move { Ok(matches) })
         }
     }
 
@@ -1935,6 +1985,16 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
         .expect("register node lease");
     let claim_store: std::sync::Arc<dyn ClaimStore> =
         std::sync::Arc::new(PostgresClaimStore::new(db.clone()));
+    let room_jid: jid::BareJid = format!("wedged-{}@muc.example.com", uuid::Uuid::new_v4())
+        .parse()
+        .expect("valid room JID");
+    let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+    let expected_epoch = claim_store
+        .ensure_claimed(&entity, &identity)
+        .await
+        .expect("pre-acquire the exact room claim expected by the durable-store fake");
+    let expected_fence =
+        RoomClaimFenceContext::new(entity.clone(), identity.clone(), expected_epoch);
 
     let occupant_id_secret =
         OccupantIdSecret::new(b"test-occupant-id-secret-32-bytes-long".to_vec())
@@ -1945,7 +2005,9 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
         .wire_clustering_claims(
             std::sync::Arc::clone(&claim_store),
             SharedNodeIdentity::new(identity.clone()),
-            Some(std::sync::Arc::new(HangingDurableStore)),
+            Some(std::sync::Arc::new(HangingDurableStore::new(
+                expected_fence,
+            ))),
             None,
         )
         .await;
@@ -1953,9 +2015,6 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
     let room_local_claims = RoomLocalClaims::new();
     room_local_claims.wire(room_registry.clone());
 
-    let room_jid: jid::BareJid = format!("wedged-{}@muc.example.com", uuid::Uuid::new_v4())
-        .parse()
-        .expect("valid room JID");
     let actor_ref = room_registry
         .get_or_create_room(
             room_jid.clone(),
@@ -1989,7 +2048,6 @@ async fn deposed_owner_with_live_socket_room_actor_scenario() {
     // Seed the steal-intent (Slice 3's veto path) from a distinct
     // "reporter" identity — mirroring Slice 3's own dedicated tests, since
     // no production reporter call site exists for RoomActor claims yet.
-    let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
     let reporter = NodeIdentity::new(
         uuid::Uuid::new_v4().to_string(),
         uuid::Uuid::new_v4().to_string(),

--- a/server/crates/waddle-xmpp/src/error.rs
+++ b/server/crates/waddle-xmpp/src/error.rs
@@ -64,13 +64,6 @@ pub enum XmppError {
     #[error("exact ownership fence for {entity} is temporarily unavailable")]
     OwnershipUnavailable { entity: Entity },
 
-    /// A fenced durable room mutation required the room's complete durable
-    /// state row, but no such row exists. Keep this distinct from ownership
-    /// loss and backend uncertainty so callers neither demote a live owner nor
-    /// flatten the invariant failure into a string diagnostic.
-    #[error("durable room state is missing for {entity}")]
-    DurableRoomStateMissing { entity: Entity },
-
     /// Stanza error (for IQ error responses)
     #[error("Stanza error: {condition}")]
     Stanza {

--- a/server/crates/waddle-xmpp/src/error.rs
+++ b/server/crates/waddle-xmpp/src/error.rs
@@ -3,6 +3,8 @@
 use thiserror::Error;
 use waddle_xmpp_core::CoreError;
 
+use crate::ownership::Entity;
+
 /// XMPP server errors.
 #[derive(Debug, Error)]
 pub enum XmppError {
@@ -49,6 +51,25 @@ pub enum XmppError {
     /// Internal server error
     #[error("Internal error: {0}")]
     Internal(String),
+
+    /// An exact durable ownership fence no longer authorizes work for the
+    /// named entity. Kept distinct from backend failures so actor callers can
+    /// seal and demote only on a definitive ownership result.
+    #[error("exact ownership fence no longer authorizes {entity}")]
+    OwnershipLost { entity: Entity },
+
+    /// The durable store could not establish whether the exact ownership
+    /// fence is still current. Callers must fail closed, but must not treat
+    /// this as definitive proof that another owner won.
+    #[error("exact ownership fence for {entity} is temporarily unavailable")]
+    OwnershipUnavailable { entity: Entity },
+
+    /// A fenced durable room mutation required the room's complete durable
+    /// state row, but no such row exists. Keep this distinct from ownership
+    /// loss and backend uncertainty so callers neither demote a live owner nor
+    /// flatten the invariant failure into a string diagnostic.
+    #[error("durable room state is missing for {entity}")]
+    DurableRoomStateMissing { entity: Entity },
 
     /// Stanza error (for IQ error responses)
     #[error("Stanza error: {condition}")]

--- a/server/crates/waddle-xmpp/src/error.rs
+++ b/server/crates/waddle-xmpp/src/error.rs
@@ -64,6 +64,13 @@ pub enum XmppError {
     #[error("exact ownership fence for {entity} is temporarily unavailable")]
     OwnershipUnavailable { entity: Entity },
 
+    /// A fenced durable room mutation required the room's complete durable
+    /// state row, but no such row exists. Keep this distinct from ownership
+    /// loss and backend uncertainty so callers neither demote a live owner nor
+    /// acknowledge state that cannot survive actor replacement.
+    #[error("durable room state is missing for {entity}")]
+    DurableRoomStateMissing { entity: Entity },
+
     /// Stanza error (for IQ error responses)
     #[error("Stanza error: {condition}")]
     Stanza {

--- a/server/crates/waddle-xmpp/src/muc/durable.rs
+++ b/server/crates/waddle-xmpp/src/muc/durable.rs
@@ -151,8 +151,9 @@ pub trait MucDurableStore: Send + Sync {
 
     /// Update (or, when `subject` is `None`, clear) an existing room's current
     /// subject. This must not create a parent row: #1352 owns atomically
-    /// creating the complete room plus initial Owner, and #1350 will enforce
-    /// missing-parent writes once that lifecycle boundary exists.
+    /// creating the complete room plus initial Owner. Until then, a missing
+    /// parent returns [`crate::XmppError::DurableRoomStateMissing`] so callers
+    /// fail before acknowledging or applying a non-durable subject.
     fn save_subject_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,

--- a/server/crates/waddle-xmpp/src/muc/durable.rs
+++ b/server/crates/waddle-xmpp/src/muc/durable.rs
@@ -149,8 +149,10 @@ pub trait MucDurableStore: Send + Sync {
         fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, ()>;
 
-    /// Durably upsert (or, when `subject` is `None`, clear) the room's
-    /// current subject.
+    /// Update (or, when `subject` is `None`, clear) an existing room's current
+    /// subject. This must not create a parent row: #1352 owns atomically
+    /// creating the complete room plus initial Owner, and #1350 will enforce
+    /// missing-parent writes once that lifecycle boundary exists.
     fn save_subject_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,

--- a/server/crates/waddle-xmpp/src/muc/durable.rs
+++ b/server/crates/waddle-xmpp/src/muc/durable.rs
@@ -207,8 +207,10 @@ pub trait MucDurableStore: Send + Sync {
     /// Cache-based ownership check for the legacy pre-fanout groupchat
     /// dispatch/MAM path. New room actor paths must use
     /// [`Self::check_exact_claim_fence`] with the fence retained by their actor
-    /// incarnation. `Ok(true)` iff this node still holds the published claim;
-    /// `Ok(false)` means a steal has committed.
+    /// incarnation. `Ok(true)` iff this process can still serve the published
+    /// claim; `Ok(false)` means no published fence is currently serviceable,
+    /// including an absent cache entry, local identity rotation, or a
+    /// definitive missing exact database tuple.
     /// Default `Ok(true)` (never demotes):
     /// single-node/non-clustering deployments never configure a
     /// `MucDurableStore` at all, so this default only matters for tests
@@ -221,7 +223,8 @@ pub trait MucDurableStore: Send + Sync {
     /// Check the actor incarnation's retained claim rather than whichever
     /// claim is currently cached for the same room JID. Implementations must
     /// validate that `fence.entity` names `room_jid` and fail closed on
-    /// backend errors.
+    /// backend errors. `Ok(false)` is a definitive non-serving result, not
+    /// necessarily proof that another node has already committed a steal.
     fn check_exact_claim_fence<'a>(
         &'a self,
         room_jid: &'a BareJid,

--- a/server/crates/waddle-xmpp/src/muc/durable.rs
+++ b/server/crates/waddle-xmpp/src/muc/durable.rs
@@ -45,14 +45,10 @@ use crate::XmppError;
 pub type MucDurableFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, XmppError>> + Send + 'a>>;
 
 /// Typed fencing context for a room's currently-recorded Postgres claim
-/// (ADR-0017 Phase 3 Slice 7 FIX 1, council-adjudicated): the same
-/// `(Entity, ClaimEpoch, NodeIdentity)` tuple [`MucDurableStore::check_fenced_fanout`]
-/// resolves internally via [`MucDurableStore::record_claim_fence`]'s cache,
-/// exposed here so a caller that needs to run its OWN fenced write against a
-/// DIFFERENT store (MAM's `store_message_fenced`, which cannot share a SQL
-/// transaction with this store's own `assert_fenced`) can bind the identical
-/// typed values into its own `SELECT ... FOR SHARE` check, rather than
-/// re-deriving them from a second, independent source of truth.
+/// (ADR-0017 Phase 3 Slice 7): the immutable `(Entity, ClaimEpoch,
+/// NodeIdentity)` tuple retained by an actor incarnation. Actor-owned durable
+/// load, save, and delete operations bind this exact fence instead of
+/// resolving a possibly newer cache entry.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct RoomClaimFenceContext {
     pub entity: Entity,
@@ -89,16 +85,15 @@ pub struct DurableRoomState {
 
 /// Durable backing store for MUC room ownership (ADR-0017 Phase 3 Slice 7).
 ///
-/// Every write is epoch-fenced against this node's currently-recorded claim
-/// on the room's `RoomActor` entity (see [`Self::record_claim_fence`]) —
-/// "epoch-fenced like all claimed-entity writes" per element 7.
+/// Every load, write, and delete is epoch-fenced against the exact claim
+/// retained by that `RoomActor` incarnation — "epoch-fenced like all
+/// claimed-entity writes" per element 7. The cache populated by
+/// [`Self::record_claim_fence`] is not an authority for actor-owned writes.
 ///
-/// **Fail-open contract, revised (ADR-0017 Phase 3 Slice 7 FIX 2,
-/// council-adjudicated).** This trait's `save_*` methods themselves are
-/// still fire-and-forget from a Rust-signature perspective (`Result<(),
-/// XmppError>`, not surfaced up through every intermediate layer) — a
-/// fenced write that fails still just returns `Err` to its immediate
-/// caller rather than panicking or blocking. What changed is what
+/// **Fail-closed ownership contract (ADR-0017 Phase 3 Slice 7 FIX 2).**
+/// This trait's `save_*` methods return an awaited `Result<(), XmppError>`.
+/// A fenced write that fails returns `Err` to its immediate caller; it is not
+/// fire-and-forget. What changed is what
 /// [`super::room_actor::RoomActor`] itself does with that `Err`, for every
 /// mutation handler that changes durable-relevant state (`UpdateConfig`,
 /// `RollbackConfigIfRevision`, `UpdateGroupDmConfigByMember`, `SetSubject`,
@@ -107,13 +102,15 @@ pub struct DurableRoomState {
 ///
 /// 1. **Before mutating**: the handler runs
 ///    [`super::room_actor::RoomActor::gate_mutation`] — a `SELECT ... FOR
-///    SHARE`-fenced [`Self::check_fenced_fanout`] pre-check — and refuses
-///    to mutate at all on a definitive ownership-loss result. This is new:
-///    previously every mutation applied in-memory unconditionally,
-///    regardless of whether this node's claim was still current.
-/// 2. **After mutating**: a `save_*` failure that is NOT ownership loss
-///    (a transient backend outage) is no longer silently logged and
-///    swallowed — it now surfaces as a typed error
+///    SHARE`-fenced [`Self::check_exact_claim_fence`] pre-check using the
+///    actor incarnation's retained fence. It refuses to mutate both when
+///    ownership was lost and when ownership cannot be proven.
+/// 2. **After mutating**: config and ordinary affiliation writes classify a
+///    `save_*` failure that is NOT ownership loss (a transient backend
+///    outage) as a typed error rather than silently logging and swallowing
+///    it. Subject persistence intentionally occurs before applying the
+///    `SubjectState`, so its failure is classified before mutation.
+///    The typed result surfaces as
 ///    (`RoomMutationError::PersistFailed`/the per-message error enum's
 ///    equivalent variant) to the ask's caller, which is expected to
 ///    trigger `RoomLocalClaims::demote` (on ownership loss) and/or report
@@ -129,57 +126,46 @@ pub trait MucDurableStore: Send + Sync {
     /// that has never been durably written (e.g. a brand-new persistent
     /// room's very first spawn on any node, or a non-persistent instant
     /// room, which is never durably written at all).
-    fn load_room_state<'a>(
-        &'a self,
-        room_jid: &'a BareJid,
-    ) -> MucDurableFuture<'a, Option<DurableRoomState>>;
-
-    /// Load one authoritative room snapshot while proving that this store's
-    /// recorded claim fence is still current in the same database
+    /// Load one authoritative room snapshot while proving that the actor
+    /// incarnation's exact claim fence is still current in the same database
     /// transaction. Implementations must not split the ownership check and
     /// snapshot read across transactions: a claim steal between those reads
     /// would let a deposed actor install state owned by its successor.
     ///
-    /// The default fails closed. Clustered stores must opt in explicitly;
-    /// in-memory test stores may delegate to [`Self::load_room_state`] when
-    /// their ownership model is controlled synchronously by the test.
     fn load_room_state_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,
-    ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
-        let _ = room_jid;
-        Box::pin(async {
-            Err(XmppError::internal(
-                "durable store does not implement fenced room-state loading",
-            ))
-        })
-    }
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, Option<DurableRoomState>>;
 
     /// Durably upsert the room's configuration (plus the `waddle_id`/
     /// `channel_id` it travels with).
-    fn save_config<'a>(
+    fn save_config_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,
         waddle_id: &'a str,
         channel_id: &'a str,
         config: &'a RoomConfig,
+        fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, ()>;
 
     /// Durably upsert (or, when `subject` is `None`, clear) the room's
     /// current subject.
-    fn save_subject<'a>(
+    fn save_subject_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,
         subject: Option<&'a SubjectState>,
+        fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, ()>;
 
     /// Durably upsert one affiliation-list entry. `Affiliation::None`
     /// removes the row, mirroring `AffiliationList::set`'s in-memory
     /// contract.
-    fn save_affiliation<'a>(
+    fn save_affiliation_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,
         entry: &'a AffiliationEntry,
+        fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, ()>;
 
     /// XEP-0045 §10.9 (#1261): destroy removes the room "even if it was
@@ -189,20 +175,21 @@ pub trait MucDurableStore: Send + Sync {
     /// config, subject, or ban list) on the next join. Called by the
     /// room registry's explicit-destroy path only; dormancy eviction
     /// keeps the rows because an evicted-but-live room MUST restore.
-    /// Default no-op mirrors the other optional hooks: single-node
-    /// deployments never configure a `MucDurableStore` at all.
-    fn delete_room_state<'a>(&'a self, room_jid: &'a BareJid) -> MucDurableFuture<'a, ()> {
-        let _ = room_jid;
-        Box::pin(async { Ok(()) })
-    }
+    fn delete_room_state_fenced<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, ()>;
 
-    /// Record the claim epoch this node most recently won for `room_jid`
-    /// (called by the room registry immediately after a successful
-    /// `ClaimStore::ensure_claimed`/steal — never by the store itself),
-    /// so later `save_*` calls know which epoch to bind into their
-    /// fencing SQL. Default no-op: single-node/non-clustering deployments
-    /// never configure a `MucDurableStore` at all, so this is never
-    /// called there.
+    /// Publish the claim fence alongside the matching ready room-registry
+    /// entry — never immediately after acquire/steal while restore is still
+    /// in flight. This cache is only for consumers that cannot carry an
+    /// actor snapshot. Actor-owned load/save/delete operations receive their
+    /// exact fence explicitly and must not consult this mutable room-JID cache
+    /// for authorization. The cache remains the legacy pre-fanout groupchat
+    /// dispatch/MAM backstop until #1283 replaces it. Default no-op:
+    /// single-node/non-clustering deployments never configure a
+    /// `MucDurableStore` at all, so this is never called there.
     fn record_claim_fence(&self, room_jid: &BareJid, fence: RoomClaimFenceContext) {
         let _ = (room_jid, fence);
     }
@@ -214,12 +201,12 @@ pub trait MucDurableStore: Send + Sync {
         let _ = (room_jid, expected);
     }
 
-    /// The two-part demotion protocol's guaranteed backstop (element 7): a
-    /// fenced `SELECT ... FOR SHARE` against this room's claim (at the
-    /// fence [`Self::record_claim_fence`] last recorded), run before every
-    /// local fan-out. `Ok(true)` iff this node still holds the claim;
-    /// `Ok(false)` means a steal has committed and the caller must demote
-    /// locally and not deliver. Default `Ok(true)` (never demotes):
+    /// Cache-based ownership check for the legacy pre-fanout groupchat
+    /// dispatch/MAM path. New room actor paths must use
+    /// [`Self::check_exact_claim_fence`] with the fence retained by their actor
+    /// incarnation. `Ok(true)` iff this node still holds the published claim;
+    /// `Ok(false)` means a steal has committed.
+    /// Default `Ok(true)` (never demotes):
     /// single-node/non-clustering deployments never configure a
     /// `MucDurableStore` at all, so this default only matters for tests
     /// exercising the trait directly.
@@ -228,16 +215,21 @@ pub trait MucDurableStore: Send + Sync {
         Box::pin(async { Ok(true) })
     }
 
-    /// The typed `(Entity, ClaimEpoch, node_id)` context this room is
-    /// currently cached under (ADR-0017 Phase 3 Slice 7 FIX 1) — the exact
-    /// same values [`Self::check_fenced_fanout`] resolves internally, handed
-    /// out here so a caller needing its OWN fenced write (MAM's
-    /// `store_message_fenced`, which uses its own Postgres connection and
-    /// cannot share a transaction with this store) can bind them into an
-    /// equivalent `SELECT ... FOR SHARE` check without re-deriving them from
-    /// a second, independent mechanism. `None` when no epoch is cached for
-    /// this room (this node has never claimed it, or `forget_claim_fence`
-    /// ran) — callers treat that exactly like a fencing failure. Default
+    /// Check the actor incarnation's retained claim rather than whichever
+    /// claim is currently cached for the same room JID. Implementations must
+    /// validate that `fence.entity` names `room_jid` and fail closed on
+    /// backend errors.
+    fn check_exact_claim_fence<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, bool>;
+
+    /// The typed `(Entity, ClaimEpoch, node_id)` context currently published
+    /// for a ready live room entry. This is observability/legacy support;
+    /// actor-derived work must use the immutable fence carried by its own
+    /// [`super::room_actor::RoomChainSnapshot`]. `None` while no actor is
+    /// published (or after `forget_claim_fence`). Default
     /// `None`: single-node/non-clustering deployments never configure a
     /// `MucDurableStore` at all, so this default only matters for tests
     /// exercising the trait directly.
@@ -246,13 +238,12 @@ pub trait MucDurableStore: Send + Sync {
         None
     }
 
-    /// Two-part demotion protocol, part (a) (element 7): best-effort,
-    /// fire-and-forget notification to the node this room's claim was
-    /// just stolen from, naming the entity and the new epoch. The
-    /// recipient tombstones the entity and NotOwner-NACKs subsequent
-    /// traffic. Never awaited for correctness — the guaranteed backstop
-    /// is the fenced pre-fan-out check the room-dispatch path runs
-    /// independently of this notification's delivery. Default no-op
+    /// Two-part demotion protocol, part (a) (element 7): an awaited
+    /// notification to the node this room's claim was just stolen from,
+    /// naming the entity and the new epoch. The recipient tombstones the
+    /// entity and NotOwner-NACKs subsequent traffic. It is not relied on as
+    /// the sole correctness mechanism: the cache-backed legacy pre-fanout
+    /// check runs independently of notification delivery. Default no-op
     /// (single-node/non-clustering deployments have no relay to notify
     /// over).
     fn notify_previous_owner_demoted<'a>(

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -178,17 +178,17 @@ pub enum AdminApplyError {
     /// pre-mutation fencing gate ([`RoomActor::gate_mutation`]) observed
     /// that this node no longer holds the room's ownership claim. The
     /// mutation this ask requested was NEVER APPLIED. The caller MUST
-    /// trigger `RoomLocalClaims::demote` for this room so the deposed
+    /// trigger `RoomLocalClaims::demote` for this room so the non-serving
     /// actor stops serving, and surface a conformant, recoverable error
     /// to the requester (mirroring `dispatch_to_room`'s
     /// `<resource-constraint/>` bounce).
-    #[error("this room's ownership has moved to another node")]
+    #[error("this room is no longer serviceable by this actor")]
     NotOwner,
-    /// The pre-mutation gate passed, but ownership moved before the
+    /// The pre-mutation gate passed, but this actor became non-serving before the
     /// following durable write committed. The mutation exists only in this
     /// now-stale actor incarnation; callers must demote it and retry against
     /// the current owner.
-    #[error("this room's ownership moved after the in-memory mutation was applied")]
+    #[error("this actor became non-serving after the in-memory mutation was applied")]
     OwnershipLostAfterApply,
     /// The exact ownership check could not establish either ownership or
     /// loss. The requested mutation was never applied and may be retried.
@@ -256,9 +256,9 @@ impl From<DurablePersistError> for AdminApplyError {
 ///    reporting bare success.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum RoomMutationError {
-    #[error("this room's ownership has moved to another node")]
+    #[error("this room is no longer serviceable by this actor")]
     NotOwner,
-    #[error("this room's ownership moved after the in-memory mutation was applied")]
+    #[error("this actor became non-serving after the in-memory mutation was applied")]
     OwnershipLostAfterApply,
     #[error("this room's ownership is temporarily unavailable")]
     OwnershipUnavailable,
@@ -270,7 +270,7 @@ pub enum RoomMutationError {
 /// persistence or post-apply ownership outcomes because no mutation has run.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 enum PreMutationOwnershipError {
-    #[error("this room's ownership has moved to another node")]
+    #[error("this room is no longer serviceable by this actor")]
     NotOwner,
     #[error("this room's ownership is temporarily unavailable")]
     OwnershipUnavailable,
@@ -289,9 +289,9 @@ impl From<PreMutationOwnershipError> for RoomMutationError {
 /// in-progress mediated-invite compensation.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum AffiliationMutationError {
-    #[error("this room's ownership has moved to another node")]
+    #[error("this room is no longer serviceable by this actor")]
     NotOwner,
-    #[error("this room's ownership moved after the in-memory mutation was applied")]
+    #[error("this actor became non-serving after the in-memory mutation was applied")]
     OwnershipLostAfterApply,
     #[error("this room's ownership is temporarily unavailable")]
     OwnershipUnavailable,
@@ -334,9 +334,9 @@ impl From<DurablePersistError> for AffiliationMutationError {
 /// protocol payload.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum DurablePersistError {
-    #[error("this room's ownership moved before the in-memory mutation was applied")]
+    #[error("this actor became non-serving before the in-memory mutation was applied")]
     NotOwner,
-    #[error("this room's ownership moved after the in-memory mutation was applied")]
+    #[error("this actor became non-serving after the in-memory mutation was applied")]
     OwnershipLostAfterApply,
     #[error("this room's exact ownership fence is unavailable")]
     OwnershipUnavailable,
@@ -403,7 +403,7 @@ pub struct RoomActor {
     /// Why this actor refuses further admissions. Keeping the reason typed
     /// lets the registry distinguish an ordinary inactivity seal, whose
     /// removal must retain exact-release backlog fencing, from a definitive
-    /// ownership-loss seal, whose deposed local actor must be evicted even
+    /// ownership-loss seal, whose non-serving local actor must be evicted even
     /// when that backlog is full.
     seal_state: RoomSealState,
     occupant_id_secret: crate::xep::xep0421::OccupantIdSecret,
@@ -470,7 +470,7 @@ enum DurableRestoreState {
     Ready(DurableRoomOrigin),
     Pending,
     /// A fenced durable load definitively proved this actor incarnation was
-    /// deposed. This terminal state must never retry with the stale fence.
+    /// non-serving. This terminal state must never retry with the stale fence.
     OwnershipLost,
 }
 
@@ -488,7 +488,7 @@ pub enum RoomSealState {
     Open,
     /// The registry sealed an inactive actor before a terminal local removal.
     Inactive,
-    /// The durable ownership gate proved this incarnation is deposed.
+    /// The durable ownership gate proved this incarnation is non-serving.
     OwnershipLost,
 }
 
@@ -673,14 +673,14 @@ impl RoomActor {
     /// still holds the claim. `Err(RoomMutationError::NotOwner)` when the
     /// fenced check observes 0 rows — the caller MUST NOT mutate.
     ///
-    /// Backend failures fail closed without marking the actor deposed: the
+    /// Backend failures fail closed without marking the actor non-serving: the
     /// exact fence could not be proven, so applying an in-memory mutation
     /// would let state diverge from its durable authority.
     async fn gate_pre_mutation_ownership(&mut self) -> Result<(), PreMutationOwnershipError> {
         // A definitive ownership-loss observation is monotonic for this
         // actor incarnation. Do not let a later transient store failure
         // override that proof through a later uncertain probe while the
-        // registry is still converging the deposed actor's removal.
+        // registry is still converging the non-serving actor's removal.
         if self.seal_state == RoomSealState::OwnershipLost {
             return Err(PreMutationOwnershipError::NotOwner);
         }
@@ -785,7 +785,7 @@ impl RoomActor {
     }
 
     /// A join does not naturally pass through the mutation fence before it
-    /// admits an occupant. Fail closed here to keep a deposed but
+    /// admits an occupant. Fail closed here to keep a non-serving but
     /// still-referenced actor from admitting either a returning occupant or
     /// the creator whose registry acquisition raced an ownership change.
     async fn gate_join_ownership(&mut self) -> Result<(), RoomActorError> {
@@ -1247,7 +1247,7 @@ impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
         }
         // Retain this incarnation's exact authority before awaiting the
         // fenced load. A terminal result must leave a coherent sealed actor,
-        // rather than one whose deposed state lacks its identifying fence.
+        // rather than one whose non-serving state lacks its identifying fence.
         self.durable_store = Some(std::sync::Arc::clone(&msg.store));
         self.durable_claim_fence = Some(msg.claim_fence.clone());
         match msg
@@ -1318,7 +1318,7 @@ impl kameo::message::Message<Join> for RoomActor {
         // still reachable by internal callers holding an ActorRef. Apply the
         // same fail-closed restore and ownership gates as
         // `JoinWithAffiliation`; otherwise a stale reference could admit an
-        // occupant after this room's durable claim moved to another node.
+        // occupant after this actor's durable fence became non-serving.
         self.ensure_restored_before_join().await?;
         self.gate_join_ownership().await?;
         if self.invite_rollback_pending(&msg.real_jid.to_bare()) {
@@ -1498,9 +1498,9 @@ pub enum UpdateGroupDmConfigByMemberError {
     NotOccupant,
     /// ADR-0017 Phase 3 Slice 7 FIX 2: see [`AdminApplyError::NotOwner`]'s
     /// doc comment — identical contract, one message type over.
-    #[error("this room's ownership has moved to another node")]
+    #[error("this room is no longer serviceable by this actor")]
     NotOwner,
-    #[error("this room's ownership moved after the in-memory mutation was applied")]
+    #[error("this actor became non-serving after the in-memory mutation was applied")]
     OwnershipLostAfterApply,
     #[error("this room's ownership is temporarily unavailable")]
     OwnershipUnavailable,
@@ -1595,7 +1595,7 @@ pub struct SetSubject {
 
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum SetSubjectError {
-    #[error("this room's ownership has moved to another node")]
+    #[error("this room is no longer serviceable by this actor")]
     NotOwner,
     #[error("this room's ownership is temporarily unavailable")]
     OwnershipUnavailable,
@@ -1926,8 +1926,9 @@ pub struct SealIfInactive {
 ///
 /// The registry must retain the distinction between ordinary inactivity and
 /// a prior ownership-loss seal: both refuse admission, but only the latter
-/// requires immediate deposed-actor teardown without releasing a claim this
-/// incarnation has already proven it does not own.
+/// requires immediate non-serving actor teardown. Registry cleanup then uses
+/// the retained fence to distinguish an already-missing tuple from a locally
+/// superseded tuple that still needs one conditional exact release.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, kameo::Reply)]
 pub enum SealIfInactiveOutcome {
     Refused,

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -184,9 +184,19 @@ pub enum AdminApplyError {
     /// `<resource-constraint/>` bounce).
     #[error("this room's ownership has moved to another node")]
     NotOwner,
+    /// The pre-mutation gate passed, but ownership moved before the
+    /// following durable write committed. The mutation exists only in this
+    /// now-stale actor incarnation; callers must demote it and retry against
+    /// the current owner.
+    #[error("this room's ownership moved after the in-memory mutation was applied")]
+    OwnershipLostAfterApply,
+    /// The exact ownership check could not establish either ownership or
+    /// loss. The requested mutation was never applied and may be retried.
+    #[error("this room's ownership is temporarily unavailable")]
+    OwnershipUnavailable,
     /// FIX 2: the fenced gate passed (or was skipped, single-node), the
-    /// in-memory mutation was applied, but the best-effort durable
-    /// persist afterwards failed for a reason OTHER than ownership loss
+    /// in-memory mutation was applied, but the awaited durable persist
+    /// afterwards failed for a reason OTHER than ownership loss
     /// (a transient backend outage). Previously silently logged and
     /// swallowed; FIX 2 revises that contract for affiliation-mutating
     /// operations — the caller is told the durable side did not
@@ -199,6 +209,8 @@ impl From<RoomMutationError> for AdminApplyError {
     fn from(error: RoomMutationError) -> Self {
         match error {
             RoomMutationError::NotOwner => AdminApplyError::NotOwner,
+            RoomMutationError::OwnershipLostAfterApply => AdminApplyError::OwnershipLostAfterApply,
+            RoomMutationError::OwnershipUnavailable => AdminApplyError::OwnershipUnavailable,
             RoomMutationError::PersistFailed(detail) => AdminApplyError::PersistFailed(detail),
         }
     }
@@ -207,6 +219,11 @@ impl From<RoomMutationError> for AdminApplyError {
 impl From<DurablePersistError> for AdminApplyError {
     fn from(error: DurablePersistError) -> Self {
         match error {
+            DurablePersistError::NotOwner => AdminApplyError::NotOwner,
+            DurablePersistError::OwnershipLostAfterApply => {
+                AdminApplyError::OwnershipLostAfterApply
+            }
+            DurablePersistError::OwnershipUnavailable => AdminApplyError::OwnershipUnavailable,
             DurablePersistError::Failed(detail) => AdminApplyError::PersistFailed(detail),
         }
     }
@@ -221,13 +238,13 @@ impl From<DurablePersistError> for AdminApplyError {
 /// runs:
 ///
 /// 1. **Before mutating**: [`RoomActor::gate_mutation`] runs the SAME
-///    fenced `check_fenced_fanout` pre-check
-///    `dispatch_to_room`'s pre-fan-out backstop uses one layer up.
+///    fenced `check_exact_claim_fence` pre-check using this actor
+///    incarnation's retained fence.
 ///    `NotOwner` here means the in-memory mutation NEVER RAN — the
 ///    caller must not report success, must trigger
 ///    `RoomLocalClaims::demote`, and must surface a conformant,
 ///    recoverable error to whatever requested the mutation.
-/// 2. **After mutating**: the best-effort `persist_*` write can still
+/// 2. **After mutating**: an awaited `persist_*` write can still
 ///    fail for a reason OTHER than ownership loss (a transient DB
 ///    outage). This was previously silently logged and swallowed
 ///    (`muc/durable.rs`'s old fail-open doc contract, corrected by this
@@ -241,6 +258,10 @@ impl From<DurablePersistError> for AdminApplyError {
 pub enum RoomMutationError {
     #[error("this room's ownership has moved to another node")]
     NotOwner,
+    #[error("this room's ownership moved after the in-memory mutation was applied")]
+    OwnershipLostAfterApply,
+    #[error("this room's ownership is temporarily unavailable")]
+    OwnershipUnavailable,
     #[error("durable persist failed after the in-memory mutation committed: {0}")]
     PersistFailed(String),
 }
@@ -251,6 +272,10 @@ pub enum RoomMutationError {
 pub enum AffiliationMutationError {
     #[error("this room's ownership has moved to another node")]
     NotOwner,
+    #[error("this room's ownership moved after the in-memory mutation was applied")]
+    OwnershipLostAfterApply,
+    #[error("this room's ownership is temporarily unavailable")]
+    OwnershipUnavailable,
     #[error("durable persist failed after the in-memory mutation committed: {0}")]
     PersistFailed(String),
     #[error("invitee affiliation is fenced pending invite rollback acknowledgement")]
@@ -261,6 +286,8 @@ impl From<RoomMutationError> for AffiliationMutationError {
     fn from(error: RoomMutationError) -> Self {
         match error {
             RoomMutationError::NotOwner => Self::NotOwner,
+            RoomMutationError::OwnershipLostAfterApply => Self::OwnershipLostAfterApply,
+            RoomMutationError::OwnershipUnavailable => Self::OwnershipUnavailable,
             RoomMutationError::PersistFailed(detail) => Self::PersistFailed(detail),
         }
     }
@@ -269,20 +296,31 @@ impl From<RoomMutationError> for AffiliationMutationError {
 impl From<DurablePersistError> for AffiliationMutationError {
     fn from(error: DurablePersistError) -> Self {
         match error {
+            DurablePersistError::NotOwner => Self::NotOwner,
+            DurablePersistError::OwnershipLostAfterApply => Self::OwnershipLostAfterApply,
+            DurablePersistError::OwnershipUnavailable => Self::OwnershipUnavailable,
             DurablePersistError::Failed(detail) => Self::PersistFailed(detail),
         }
     }
 }
 
-/// FIX 2: typed outcome of a best-effort durable `save_*` call inside
-/// [`RoomActor::persist_config`]/[`RoomActor::persist_subject`]/
-/// [`RoomActor::persist_affiliation`]. Wraps the underlying
+/// FIX 2: typed outcome of an awaited durable `save_*` call inside
+/// [`RoomActor::persist_config`] and [`RoomActor::persist_affiliation`]. The
+/// ownership variants distinguish a failure before an in-memory mutation from
+/// ownership loss after one. Subject persistence has its own pre-apply-only
+/// [`SetSubjectError`] contract. This type wraps the underlying
 /// [`crate::XmppError`]'s rendered detail — the backend/fencing failure
 /// text is opaque past this boundary, mirroring every other typed error
 /// in this codebase that carries an opaque backend detail string inside a
 /// named variant (`PendingStorageError::Other`, `MamStorageError::Database`).
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum DurablePersistError {
+    #[error("this room's ownership moved before the in-memory mutation was applied")]
+    NotOwner,
+    #[error("this room's ownership moved after the in-memory mutation was applied")]
+    OwnershipLostAfterApply,
+    #[error("this room's exact ownership fence is unavailable")]
+    OwnershipUnavailable,
     #[error("durable persist failed: {0}")]
     Failed(String),
 }
@@ -290,6 +328,11 @@ pub enum DurablePersistError {
 impl From<DurablePersistError> for RoomMutationError {
     fn from(error: DurablePersistError) -> Self {
         match error {
+            DurablePersistError::NotOwner => RoomMutationError::NotOwner,
+            DurablePersistError::OwnershipLostAfterApply => {
+                RoomMutationError::OwnershipLostAfterApply
+            }
+            DurablePersistError::OwnershipUnavailable => RoomMutationError::OwnershipUnavailable,
             DurablePersistError::Failed(detail) => RoomMutationError::PersistFailed(detail),
         }
     }
@@ -368,9 +411,13 @@ pub struct RoomActor {
     /// registry enqueues after spawning/re-claiming this actor when a
     /// store is configured. `None` in single-node/non-clustering
     /// deployments, matching today's purely in-memory behavior exactly.
-    /// Every config/subject/affiliation-mutating handler best-effort
-    /// persists through this handle when it is `Some`.
+    /// Every config/subject/affiliation-mutating handler awaits persistence
+    /// through this handle when it is `Some` and classifies a failure by
+    /// whether its in-memory mutation has already applied.
     durable_store: Option<std::sync::Arc<dyn super::durable::MucDurableStore>>,
+    /// Exact ownership tuple retained by this actor incarnation. Durable
+    /// operations must never borrow a replacement actor's cached claim.
+    durable_claim_fence: Option<super::durable::RoomClaimFenceContext>,
     /// ADR-0017 Phase 3 Slice 7 FIX 4 (council-adjudicated): whether this
     /// actor incarnation's durable restore genuinely completed. See
     /// [`DurableRestoreState`]'s own doc comment.
@@ -527,6 +574,7 @@ impl RoomActor {
             durable_member_recipients: Vec::new(),
             membership_source: None,
             durable_store: None,
+            durable_claim_fence: None,
             restore_state: DurableRestoreState::Ready(DurableRoomOrigin::New),
         }
     }
@@ -603,16 +651,13 @@ impl RoomActor {
     /// still holds the claim. `Err(RoomMutationError::NotOwner)` when the
     /// fenced check observes 0 rows — the caller MUST NOT mutate.
     ///
-    /// A transient backend failure fails OPEN for the gate itself
-    /// (mirroring `dispatch_to_room`'s identical "a transient fencing
-    /// -check failure never demotes, only a definitive 0-rows result
-    /// does" rule) — only a definitive fencing failure blocks the
-    /// mutation; an unreachable Postgres must not itself wedge every
-    /// mutating admin action.
+    /// Backend failures fail closed without marking the actor deposed: the
+    /// exact fence could not be proven, so applying an in-memory mutation
+    /// would let state diverge from its durable authority.
     async fn gate_mutation(&mut self) -> Result<(), RoomMutationError> {
         // A definitive ownership-loss observation is monotonic for this
         // actor incarnation. Do not let a later transient store failure
-        // override that proof through the ordinary fail-open path while the
+        // override that proof through a later uncertain probe while the
         // registry is still converging the deposed actor's removal.
         if self.seal_state == RoomSealState::OwnershipLost {
             return Err(RoomMutationError::NotOwner);
@@ -620,7 +665,13 @@ impl RoomActor {
         let Some(store) = self.durable_store.clone() else {
             return Ok(());
         };
-        match store.check_fenced_fanout(&self.room.room_jid).await {
+        let Some(fence) = self.durable_claim_fence.as_ref() else {
+            return Err(RoomMutationError::OwnershipUnavailable);
+        };
+        match store
+            .check_exact_claim_fence(&self.room.room_jid, fence)
+            .await
+        {
             Ok(true) => Ok(()),
             Ok(false) => {
                 self.seal_state = RoomSealState::OwnershipLost;
@@ -634,10 +685,9 @@ impl RoomActor {
                 tracing::warn!(
                     room = %self.room.room_jid,
                     %error,
-                    "mutation gate fencing check failed transiently; failing open \
-                     (not blocking the mutation)"
+                    "mutation gate could not prove the actor's exact ownership; refusing mutation"
                 );
-                Ok(())
+                Err(RoomMutationError::OwnershipUnavailable)
             }
         }
     }
@@ -668,7 +718,13 @@ impl RoomActor {
             self.restore_state = DurableRestoreState::Ready(DurableRoomOrigin::New);
             return Ok(());
         };
-        match store.load_room_state_fenced(&self.room.room_jid).await {
+        let Some(fence) = self.durable_claim_fence.as_ref() else {
+            return Err(RoomActorError::RestorePending);
+        };
+        match store
+            .load_room_state_fenced(&self.room.room_jid, fence)
+            .await
+        {
             Ok(Some(state)) => {
                 self.install_durable_room_state(state);
                 self.restore_state = DurableRestoreState::Ready(DurableRoomOrigin::Restored);
@@ -698,9 +754,12 @@ impl RoomActor {
         let Some(store) = self.durable_store.clone() else {
             return Ok(());
         };
+        let Some(fence) = self.durable_claim_fence.as_ref() else {
+            return Err(RoomActorError::OwnershipUnavailable);
+        };
         match tokio::time::timeout(
             JOIN_OWNERSHIP_CHECK_TIMEOUT,
-            store.check_fenced_fanout(&self.room.room_jid),
+            store.check_exact_claim_fence(&self.room.room_jid, fence),
         )
         .await
         {
@@ -746,34 +805,82 @@ impl RoomActor {
         }
     }
 
-    /// Best-effort durable persist of the current config (ADR-0017 Phase 3
+    /// Await the durable persist of the current config (ADR-0017 Phase 3
     /// Slice 7, FIX 2 revision): a persistence error is logged AND
     /// returned typed — the in-memory mutation the caller already applied
     /// remains authoritative for this actor incarnation regardless, but
     /// the caller now learns the durable side did not converge (see
     /// [`DurablePersistError`]'s doc comment for why this is no longer
     /// silently swallowed).
-    async fn persist_config(&self) -> Result<(), DurablePersistError> {
+    fn classify_durable_persist_error(
+        &mut self,
+        write_error: crate::XmppError,
+        operation: &'static str,
+        mutation_applied: bool,
+    ) -> DurablePersistError {
+        match write_error {
+            crate::XmppError::OwnershipLost { entity } => {
+                self.seal_state = RoomSealState::OwnershipLost;
+                tracing::warn!(
+                    room = %self.room.room_jid,
+                    %operation,
+                    %entity,
+                    "durable write failed because this actor lost exact ownership"
+                );
+                if mutation_applied {
+                    DurablePersistError::OwnershipLostAfterApply
+                } else {
+                    DurablePersistError::NotOwner
+                }
+            }
+            crate::XmppError::OwnershipUnavailable { entity } => {
+                tracing::warn!(
+                    room = %self.room.room_jid,
+                    %operation,
+                    %entity,
+                    "durable write could not prove exact ownership"
+                );
+                if mutation_applied {
+                    DurablePersistError::Failed(
+                        "exact ownership became unavailable after apply".to_string(),
+                    )
+                } else {
+                    DurablePersistError::OwnershipUnavailable
+                }
+            }
+            error => {
+                tracing::warn!(
+                    room = %self.room.room_jid,
+                    %operation,
+                    %error,
+                    "durable write failed for a non-ownership reason"
+                );
+                DurablePersistError::Failed(error.to_string())
+            }
+        }
+    }
+
+    async fn persist_config(&mut self) -> Result<(), DurablePersistError> {
         let Some(store) = self.durable_store.clone() else {
             return Ok(());
         };
-        store
-            .save_config(
+        let fence = self
+            .durable_claim_fence
+            .clone()
+            .ok_or(DurablePersistError::OwnershipUnavailable)?;
+        let result = store
+            .save_config_fenced(
                 &self.room.room_jid,
                 &self.room.waddle_id,
                 &self.room.channel_id,
                 &self.room.config,
+                &fence,
             )
-            .await
-            .map_err(|error| {
-                tracing::warn!(
-                    room = %self.room.room_jid,
-                    %error,
-                    "durable room-config persist failed (in-memory config remains \
-                     authoritative for this actor incarnation; surfaced typed to caller)"
-                );
-                DurablePersistError::Failed(error.to_string())
-            })
+            .await;
+        match result {
+            Ok(()) => Ok(()),
+            Err(error) => Err(self.classify_durable_persist_error(error, "config", true)),
+        }
     }
 
     /// Replace config only after restoring cross-field privacy invariants.
@@ -781,48 +888,95 @@ impl RoomActor {
         self.room.config = config.normalized();
     }
 
-    /// Best-effort durable persist of the current subject. See
+    /// Persist a constructed subject before installing it in memory. See
     /// [`Self::persist_config`]'s FIX 2 rationale.
-    async fn persist_subject(&self) -> Result<(), DurablePersistError> {
+    async fn persist_subject_before_apply(
+        &mut self,
+        subject: Option<&SubjectState>,
+    ) -> Result<(), SetSubjectError> {
         let Some(store) = self.durable_store.clone() else {
             return Ok(());
         };
-        store
-            .save_subject(&self.room.room_jid, self.room.subject.as_ref())
-            .await
-            .map_err(|error| {
+        let fence = self
+            .durable_claim_fence
+            .clone()
+            .ok_or(SetSubjectError::OwnershipUnavailable)?;
+        let result = store
+            .save_subject_fenced(&self.room.room_jid, subject, &fence)
+            .await;
+        match result {
+            Ok(()) => Ok(()),
+            Err(crate::XmppError::OwnershipLost { entity }) => {
+                self.seal_state = RoomSealState::OwnershipLost;
+                tracing::warn!(
+                    room = %self.room.room_jid,
+                    %entity,
+                    "durable subject write failed because this actor lost exact ownership"
+                );
+                Err(SetSubjectError::NotOwner)
+            }
+            Err(crate::XmppError::OwnershipUnavailable { entity }) => {
+                tracing::warn!(
+                    room = %self.room.room_jid,
+                    %entity,
+                    "durable subject write could not prove exact ownership"
+                );
+                Err(SetSubjectError::OwnershipUnavailable)
+            }
+            Err(error) => {
                 tracing::warn!(
                     room = %self.room.room_jid,
                     %error,
-                    "durable room-subject persist failed (surfaced typed to caller)"
+                    "durable subject write failed before applying the in-memory mutation"
                 );
-                DurablePersistError::Failed(error.to_string())
-            })
+                Err(SetSubjectError::PersistFailedBeforeApply)
+            }
+        }
     }
 
-    /// Best-effort durable persist of one affiliation-list entry. See
+    /// Await the durable persist of one affiliation-list entry. See
     /// [`Self::persist_config`]'s FIX 2 rationale.
     async fn persist_affiliation(
-        &self,
+        &mut self,
         jid: &BareJid,
         affiliation: Affiliation,
+    ) -> Result<(), DurablePersistError> {
+        self.persist_affiliation_with_phase(jid, affiliation, true)
+            .await
+    }
+
+    async fn persist_affiliation_before_apply(
+        &mut self,
+        jid: &BareJid,
+        affiliation: Affiliation,
+    ) -> Result<(), DurablePersistError> {
+        self.persist_affiliation_with_phase(jid, affiliation, false)
+            .await
+    }
+
+    async fn persist_affiliation_with_phase(
+        &mut self,
+        jid: &BareJid,
+        affiliation: Affiliation,
+        mutation_applied: bool,
     ) -> Result<(), DurablePersistError> {
         let Some(store) = self.durable_store.clone() else {
             return Ok(());
         };
+        let fence = self
+            .durable_claim_fence
+            .clone()
+            .ok_or(DurablePersistError::OwnershipUnavailable)?;
         let entry = super::affiliation::AffiliationEntry::new(jid.clone(), affiliation);
-        store
-            .save_affiliation(&self.room.room_jid, &entry)
-            .await
-            .map_err(|error| {
-                tracing::warn!(
-                    room = %self.room.room_jid,
-                    jid = %jid,
-                    %error,
-                    "durable room-affiliation persist failed (surfaced typed to caller)"
-                );
-                DurablePersistError::Failed(error.to_string())
-            })
+        let result = store
+            .save_affiliation_fenced(&self.room.room_jid, &entry, &fence)
+            .await;
+        match result {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                Err(self.classify_durable_persist_error(error, "affiliation", mutation_applied))
+            }
+        }
     }
 
     /// Drop a JID from the spawn-time hydrated durable-recipient
@@ -985,6 +1139,7 @@ impl kameo::message::Message<HydrateDurableRecipients> for RoomActor {
 /// cannot interleave between them.
 pub struct RestoreDurableRoomState {
     pub store: std::sync::Arc<dyn super::durable::MucDurableStore>,
+    pub claim_fence: super::durable::RoomClaimFenceContext,
 }
 
 /// Whether this actor's initial durable restore completed successfully.
@@ -1033,7 +1188,27 @@ impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
         msg: RestoreDurableRoomState,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        match msg.store.load_room_state_fenced(&self.room.room_jid).await {
+        if let Some(retained) = self.durable_claim_fence.as_ref() {
+            if retained != &msg.claim_fence {
+                tracing::warn!(
+                    room = %self.room.room_jid,
+                    retained_entity = %retained.entity,
+                    incoming_entity = %msg.claim_fence.entity,
+                    "refusing to transplant a room actor onto a different durable claim"
+                );
+                // The first exact fence permanently identifies this actor
+                // incarnation. A delayed restore carrying a successor's
+                // tuple must not read, install, or retain successor state.
+                self.restore_state = DurableRestoreState::Pending;
+                self.seal_state = RoomSealState::OwnershipLost;
+                return;
+            }
+        }
+        match msg
+            .store
+            .load_room_state_fenced(&self.room.room_jid, &msg.claim_fence)
+            .await
+        {
             Ok(Some(state)) => {
                 self.install_durable_room_state(state);
                 self.restore_state = DurableRestoreState::Ready(DurableRoomOrigin::Restored);
@@ -1061,6 +1236,7 @@ impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
             }
         }
         self.durable_store = Some(msg.store);
+        self.durable_claim_fence = Some(msg.claim_fence);
     }
 }
 
@@ -1271,6 +1447,10 @@ pub enum UpdateGroupDmConfigByMemberError {
     /// doc comment — identical contract, one message type over.
     #[error("this room's ownership has moved to another node")]
     NotOwner,
+    #[error("this room's ownership moved after the in-memory mutation was applied")]
+    OwnershipLostAfterApply,
+    #[error("this room's ownership is temporarily unavailable")]
+    OwnershipUnavailable,
     /// FIX 2: see [`AdminApplyError::PersistFailed`]'s doc comment.
     #[error("durable persist failed after the in-memory mutation committed: {0}")]
     PersistFailed(String),
@@ -1280,6 +1460,12 @@ impl From<RoomMutationError> for UpdateGroupDmConfigByMemberError {
     fn from(error: RoomMutationError) -> Self {
         match error {
             RoomMutationError::NotOwner => UpdateGroupDmConfigByMemberError::NotOwner,
+            RoomMutationError::OwnershipLostAfterApply => {
+                UpdateGroupDmConfigByMemberError::OwnershipLostAfterApply
+            }
+            RoomMutationError::OwnershipUnavailable => {
+                UpdateGroupDmConfigByMemberError::OwnershipUnavailable
+            }
             RoomMutationError::PersistFailed(detail) => {
                 UpdateGroupDmConfigByMemberError::PersistFailed(detail)
             }
@@ -1290,6 +1476,13 @@ impl From<RoomMutationError> for UpdateGroupDmConfigByMemberError {
 impl From<DurablePersistError> for UpdateGroupDmConfigByMemberError {
     fn from(error: DurablePersistError) -> Self {
         match error {
+            DurablePersistError::NotOwner => UpdateGroupDmConfigByMemberError::NotOwner,
+            DurablePersistError::OwnershipLostAfterApply => {
+                UpdateGroupDmConfigByMemberError::OwnershipLostAfterApply
+            }
+            DurablePersistError::OwnershipUnavailable => {
+                UpdateGroupDmConfigByMemberError::OwnershipUnavailable
+            }
             DurablePersistError::Failed(detail) => {
                 UpdateGroupDmConfigByMemberError::PersistFailed(detail)
             }
@@ -1341,9 +1534,9 @@ impl kameo::message::Message<UpdateGroupDmConfigByMember> for RoomActor {
 /// Apply a XEP-0045 §8.1 subject change to the room. The interpreter
 /// emits this in response to an `OutboundEvent::PersistRoomSubject`
 /// produced by the room handler chain's subject handler after
-/// authorization passes. The actor delegates to
-/// [`MucRoom::set_subject`], which writes a `SubjectState` onto
-/// `MucRoom.subject` for replay on the next join (XEP-0045 §7.2.15).
+/// authorization passes. The actor constructs a `SubjectState`, persists it
+/// before applying, then installs it in `MucRoom.subject` for replay on the
+/// next join (XEP-0045 §7.2.15).
 pub struct SetSubject {
     pub texts: RoomSubjectTexts,
     pub setter: BareJid,
@@ -1351,18 +1544,44 @@ pub struct SetSubject {
     pub set_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum SetSubjectError {
+    #[error("this room's ownership has moved to another node")]
+    NotOwner,
+    #[error("this room's ownership is temporarily unavailable")]
+    OwnershipUnavailable,
+    #[error("durable subject persist failed before the in-memory mutation")]
+    PersistFailedBeforeApply,
+}
+
 impl kameo::message::Message<SetSubject> for RoomActor {
-    type Reply = Result<(), RoomMutationError>;
+    type Reply = Result<(), SetSubjectError>;
 
     async fn handle(
         &mut self,
         msg: SetSubject,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        self.gate_mutation().await?;
-        self.room
-            .set_subject(msg.texts, msg.setter, msg.setter_nick, msg.set_at);
-        self.persist_subject().await?;
+        match self.gate_mutation().await {
+            Ok(()) => {}
+            Err(RoomMutationError::NotOwner) => return Err(SetSubjectError::NotOwner),
+            Err(RoomMutationError::OwnershipUnavailable) => {
+                return Err(SetSubjectError::OwnershipUnavailable)
+            }
+            Err(
+                RoomMutationError::OwnershipLostAfterApply | RoomMutationError::PersistFailed(_),
+            ) => {
+                unreachable!("the pre-mutation ownership gate never applies or persists state")
+            }
+        }
+        let subject = SubjectState {
+            texts: msg.texts,
+            setter: msg.setter,
+            setter_nick: msg.setter_nick,
+            set_at: msg.set_at,
+        };
+        self.persist_subject_before_apply(Some(&subject)).await?;
+        self.room.subject = Some(subject);
         Ok(())
     }
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor.rs
@@ -201,8 +201,8 @@ pub enum AdminApplyError {
     /// swallowed; FIX 2 revises that contract for affiliation-mutating
     /// operations — the caller is told the durable side did not
     /// converge rather than reporting bare success.
-    #[error("durable persist failed after the in-memory mutation committed: {0}")]
-    PersistFailed(String),
+    #[error("durable persist failed after the in-memory mutation committed")]
+    PersistFailed,
 }
 
 impl From<RoomMutationError> for AdminApplyError {
@@ -211,7 +211,7 @@ impl From<RoomMutationError> for AdminApplyError {
             RoomMutationError::NotOwner => AdminApplyError::NotOwner,
             RoomMutationError::OwnershipLostAfterApply => AdminApplyError::OwnershipLostAfterApply,
             RoomMutationError::OwnershipUnavailable => AdminApplyError::OwnershipUnavailable,
-            RoomMutationError::PersistFailed(detail) => AdminApplyError::PersistFailed(detail),
+            RoomMutationError::PersistFailed => AdminApplyError::PersistFailed,
         }
     }
 }
@@ -224,7 +224,7 @@ impl From<DurablePersistError> for AdminApplyError {
                 AdminApplyError::OwnershipLostAfterApply
             }
             DurablePersistError::OwnershipUnavailable => AdminApplyError::OwnershipUnavailable,
-            DurablePersistError::Failed(detail) => AdminApplyError::PersistFailed(detail),
+            DurablePersistError::PersistFailed => AdminApplyError::PersistFailed,
         }
     }
 }
@@ -262,8 +262,27 @@ pub enum RoomMutationError {
     OwnershipLostAfterApply,
     #[error("this room's ownership is temporarily unavailable")]
     OwnershipUnavailable,
-    #[error("durable persist failed after the in-memory mutation committed: {0}")]
-    PersistFailed(String),
+    #[error("durable persist failed after the in-memory mutation committed")]
+    PersistFailed,
+}
+
+/// The ownership result of the pre-mutation gate. This phase cannot report
+/// persistence or post-apply ownership outcomes because no mutation has run.
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+enum PreMutationOwnershipError {
+    #[error("this room's ownership has moved to another node")]
+    NotOwner,
+    #[error("this room's ownership is temporarily unavailable")]
+    OwnershipUnavailable,
+}
+
+impl From<PreMutationOwnershipError> for RoomMutationError {
+    fn from(error: PreMutationOwnershipError) -> Self {
+        match error {
+            PreMutationOwnershipError::NotOwner => Self::NotOwner,
+            PreMutationOwnershipError::OwnershipUnavailable => Self::OwnershipUnavailable,
+        }
+    }
 }
 
 /// Failure from an affiliation mutation that can collide with an
@@ -276,8 +295,8 @@ pub enum AffiliationMutationError {
     OwnershipLostAfterApply,
     #[error("this room's ownership is temporarily unavailable")]
     OwnershipUnavailable,
-    #[error("durable persist failed after the in-memory mutation committed: {0}")]
-    PersistFailed(String),
+    #[error("durable persist failed after the in-memory mutation committed")]
+    PersistFailed,
     #[error("invitee affiliation is fenced pending invite rollback acknowledgement")]
     InviteRollbackPending,
 }
@@ -288,7 +307,7 @@ impl From<RoomMutationError> for AffiliationMutationError {
             RoomMutationError::NotOwner => Self::NotOwner,
             RoomMutationError::OwnershipLostAfterApply => Self::OwnershipLostAfterApply,
             RoomMutationError::OwnershipUnavailable => Self::OwnershipUnavailable,
-            RoomMutationError::PersistFailed(detail) => Self::PersistFailed(detail),
+            RoomMutationError::PersistFailed => Self::PersistFailed,
         }
     }
 }
@@ -299,7 +318,7 @@ impl From<DurablePersistError> for AffiliationMutationError {
             DurablePersistError::NotOwner => Self::NotOwner,
             DurablePersistError::OwnershipLostAfterApply => Self::OwnershipLostAfterApply,
             DurablePersistError::OwnershipUnavailable => Self::OwnershipUnavailable,
-            DurablePersistError::Failed(detail) => Self::PersistFailed(detail),
+            DurablePersistError::PersistFailed => Self::PersistFailed,
         }
     }
 }
@@ -308,11 +327,11 @@ impl From<DurablePersistError> for AffiliationMutationError {
 /// [`RoomActor::persist_config`] and [`RoomActor::persist_affiliation`]. The
 /// ownership variants distinguish a failure before an in-memory mutation from
 /// ownership loss after one. Subject persistence has its own pre-apply-only
-/// [`SetSubjectError`] contract. This type wraps the underlying
-/// [`crate::XmppError`]'s rendered detail — the backend/fencing failure
-/// text is opaque past this boundary, mirroring every other typed error
-/// in this codebase that carries an opaque backend detail string inside a
-/// named variant (`PendingStorageError::Other`, `MamStorageError::Database`).
+/// [`SetSubjectError`] contract. Definitive ownership variants preserve
+/// whether the mutation was applied; `PersistFailed` is phase-neutral so
+/// each operation's public error can state its own apply boundary. Backend
+/// diagnostics stay in structured logs rather than becoming a stringly-typed
+/// protocol payload.
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum DurablePersistError {
     #[error("this room's ownership moved before the in-memory mutation was applied")]
@@ -321,8 +340,8 @@ pub enum DurablePersistError {
     OwnershipLostAfterApply,
     #[error("this room's exact ownership fence is unavailable")]
     OwnershipUnavailable,
-    #[error("durable persist failed: {0}")]
-    Failed(String),
+    #[error("durable persist failed")]
+    PersistFailed,
 }
 
 impl From<DurablePersistError> for RoomMutationError {
@@ -333,7 +352,7 @@ impl From<DurablePersistError> for RoomMutationError {
                 RoomMutationError::OwnershipLostAfterApply
             }
             DurablePersistError::OwnershipUnavailable => RoomMutationError::OwnershipUnavailable,
-            DurablePersistError::Failed(detail) => RoomMutationError::PersistFailed(detail),
+            DurablePersistError::PersistFailed => RoomMutationError::PersistFailed,
         }
     }
 }
@@ -450,6 +469,9 @@ struct AdmissionPolicySnapshot {
 enum DurableRestoreState {
     Ready(DurableRoomOrigin),
     Pending,
+    /// A fenced durable load definitively proved this actor incarnation was
+    /// deposed. This terminal state must never retry with the stale fence.
+    OwnershipLost,
 }
 
 impl Default for DurableRestoreState {
@@ -654,19 +676,19 @@ impl RoomActor {
     /// Backend failures fail closed without marking the actor deposed: the
     /// exact fence could not be proven, so applying an in-memory mutation
     /// would let state diverge from its durable authority.
-    async fn gate_mutation(&mut self) -> Result<(), RoomMutationError> {
+    async fn gate_pre_mutation_ownership(&mut self) -> Result<(), PreMutationOwnershipError> {
         // A definitive ownership-loss observation is monotonic for this
         // actor incarnation. Do not let a later transient store failure
         // override that proof through a later uncertain probe while the
         // registry is still converging the deposed actor's removal.
         if self.seal_state == RoomSealState::OwnershipLost {
-            return Err(RoomMutationError::NotOwner);
+            return Err(PreMutationOwnershipError::NotOwner);
         }
         let Some(store) = self.durable_store.clone() else {
             return Ok(());
         };
         let Some(fence) = self.durable_claim_fence.as_ref() else {
-            return Err(RoomMutationError::OwnershipUnavailable);
+            return Err(PreMutationOwnershipError::OwnershipUnavailable);
         };
         match store
             .check_exact_claim_fence(&self.room.room_jid, fence)
@@ -679,7 +701,7 @@ impl RoomActor {
                     room = %self.room.room_jid,
                     "mutation gate observed ownership loss; refusing to mutate"
                 );
-                Err(RoomMutationError::NotOwner)
+                Err(PreMutationOwnershipError::NotOwner)
             }
             Err(error) => {
                 tracing::warn!(
@@ -687,9 +709,13 @@ impl RoomActor {
                     %error,
                     "mutation gate could not prove the actor's exact ownership; refusing mutation"
                 );
-                Err(RoomMutationError::OwnershipUnavailable)
+                Err(PreMutationOwnershipError::OwnershipUnavailable)
             }
         }
+    }
+
+    async fn gate_mutation(&mut self) -> Result<(), RoomMutationError> {
+        self.gate_pre_mutation_ownership().await.map_err(Into::into)
     }
 
     /// ADR-0017 Phase 3 Slice 7 FIX 4 (council-adjudicated): the
@@ -706,8 +732,10 @@ impl RoomActor {
     /// join against defaulted config/affiliations/subject while a
     /// genuine restore failure is unresolved.
     async fn ensure_restored_before_join(&mut self) -> Result<(), RoomActorError> {
-        if matches!(self.restore_state, DurableRestoreState::Ready(_)) {
-            return Ok(());
+        match self.restore_state {
+            DurableRestoreState::Ready(_) => return Ok(()),
+            DurableRestoreState::OwnershipLost => return Err(RoomActorError::RoomSealed),
+            DurableRestoreState::Pending => {}
         }
         let Some(store) = self.durable_store.clone() else {
             // Defensive: `Pending` is only ever set from inside the
@@ -733,6 +761,16 @@ impl RoomActor {
             Ok(None) => {
                 self.restore_state = DurableRestoreState::Ready(DurableRoomOrigin::New);
                 Ok(())
+            }
+            Err(crate::XmppError::OwnershipLost { entity }) => {
+                self.restore_state = DurableRestoreState::OwnershipLost;
+                self.seal_state = RoomSealState::OwnershipLost;
+                tracing::warn!(
+                    room = %self.room.room_jid,
+                    %entity,
+                    "durable room-state restore retry lost this actor's exact ownership"
+                );
+                Err(RoomActorError::RoomSealed)
             }
             Err(error) => {
                 tracing::warn!(
@@ -841,9 +879,7 @@ impl RoomActor {
                     "durable write could not prove exact ownership"
                 );
                 if mutation_applied {
-                    DurablePersistError::Failed(
-                        "exact ownership became unavailable after apply".to_string(),
-                    )
+                    DurablePersistError::PersistFailed
                 } else {
                     DurablePersistError::OwnershipUnavailable
                 }
@@ -855,7 +891,7 @@ impl RoomActor {
                     %error,
                     "durable write failed for a non-ownership reason"
                 );
-                DurablePersistError::Failed(error.to_string())
+                DurablePersistError::PersistFailed
             }
         }
     }
@@ -1160,6 +1196,7 @@ pub enum DurableRoomOrigin {
 pub enum DurableRestoreReadiness {
     Ready(DurableRoomOrigin),
     Pending,
+    OwnershipLost,
 }
 
 /// FIFO publication barrier for a freshly prepared room actor.
@@ -1176,6 +1213,7 @@ impl kameo::message::Message<GetDurableRestoreReadiness> for RoomActor {
         match self.restore_state {
             DurableRestoreState::Ready(origin) => DurableRestoreReadiness::Ready(origin),
             DurableRestoreState::Pending => DurableRestoreReadiness::Pending,
+            DurableRestoreState::OwnershipLost => DurableRestoreReadiness::OwnershipLost,
         }
     }
 }
@@ -1188,6 +1226,9 @@ impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
         msg: RestoreDurableRoomState,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
+        if self.restore_state == DurableRestoreState::OwnershipLost {
+            return;
+        }
         if let Some(retained) = self.durable_claim_fence.as_ref() {
             if retained != &msg.claim_fence {
                 tracing::warn!(
@@ -1199,11 +1240,16 @@ impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
                 // The first exact fence permanently identifies this actor
                 // incarnation. A delayed restore carrying a successor's
                 // tuple must not read, install, or retain successor state.
-                self.restore_state = DurableRestoreState::Pending;
+                self.restore_state = DurableRestoreState::OwnershipLost;
                 self.seal_state = RoomSealState::OwnershipLost;
                 return;
             }
         }
+        // Retain this incarnation's exact authority before awaiting the
+        // fenced load. A terminal result must leave a coherent sealed actor,
+        // rather than one whose deposed state lacks its identifying fence.
+        self.durable_store = Some(std::sync::Arc::clone(&msg.store));
+        self.durable_claim_fence = Some(msg.claim_fence.clone());
         match msg
             .store
             .load_room_state_fenced(&self.room.room_jid, &msg.claim_fence)
@@ -1216,6 +1262,15 @@ impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
             Ok(None) => {
                 // No durable row yet — brand new room, nothing to restore.
                 self.restore_state = DurableRestoreState::Ready(DurableRoomOrigin::New);
+            }
+            Err(crate::XmppError::OwnershipLost { entity }) => {
+                self.restore_state = DurableRestoreState::OwnershipLost;
+                self.seal_state = RoomSealState::OwnershipLost;
+                tracing::warn!(
+                    room = %self.room.room_jid,
+                    %entity,
+                    "durable room-state restore lost this actor's exact ownership"
+                );
             }
             Err(error) => {
                 // ADR-0017 Phase 3 Slice 7 FIX 4 (council-adjudicated):
@@ -1235,8 +1290,6 @@ impl kameo::message::Message<RestoreDurableRoomState> for RoomActor {
                 self.restore_state = DurableRestoreState::Pending;
             }
         }
-        self.durable_store = Some(msg.store);
-        self.durable_claim_fence = Some(msg.claim_fence);
     }
 }
 
@@ -1452,8 +1505,8 @@ pub enum UpdateGroupDmConfigByMemberError {
     #[error("this room's ownership is temporarily unavailable")]
     OwnershipUnavailable,
     /// FIX 2: see [`AdminApplyError::PersistFailed`]'s doc comment.
-    #[error("durable persist failed after the in-memory mutation committed: {0}")]
-    PersistFailed(String),
+    #[error("durable persist failed after the in-memory mutation committed")]
+    PersistFailed,
 }
 
 impl From<RoomMutationError> for UpdateGroupDmConfigByMemberError {
@@ -1466,9 +1519,7 @@ impl From<RoomMutationError> for UpdateGroupDmConfigByMemberError {
             RoomMutationError::OwnershipUnavailable => {
                 UpdateGroupDmConfigByMemberError::OwnershipUnavailable
             }
-            RoomMutationError::PersistFailed(detail) => {
-                UpdateGroupDmConfigByMemberError::PersistFailed(detail)
-            }
+            RoomMutationError::PersistFailed => UpdateGroupDmConfigByMemberError::PersistFailed,
         }
     }
 }
@@ -1483,9 +1534,7 @@ impl From<DurablePersistError> for UpdateGroupDmConfigByMemberError {
             DurablePersistError::OwnershipUnavailable => {
                 UpdateGroupDmConfigByMemberError::OwnershipUnavailable
             }
-            DurablePersistError::Failed(detail) => {
-                UpdateGroupDmConfigByMemberError::PersistFailed(detail)
-            }
+            DurablePersistError::PersistFailed => UpdateGroupDmConfigByMemberError::PersistFailed,
         }
     }
 }
@@ -1554,6 +1603,15 @@ pub enum SetSubjectError {
     PersistFailedBeforeApply,
 }
 
+impl From<PreMutationOwnershipError> for SetSubjectError {
+    fn from(error: PreMutationOwnershipError) -> Self {
+        match error {
+            PreMutationOwnershipError::NotOwner => Self::NotOwner,
+            PreMutationOwnershipError::OwnershipUnavailable => Self::OwnershipUnavailable,
+        }
+    }
+}
+
 impl kameo::message::Message<SetSubject> for RoomActor {
     type Reply = Result<(), SetSubjectError>;
 
@@ -1562,18 +1620,7 @@ impl kameo::message::Message<SetSubject> for RoomActor {
         msg: SetSubject,
         _ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
-        match self.gate_mutation().await {
-            Ok(()) => {}
-            Err(RoomMutationError::NotOwner) => return Err(SetSubjectError::NotOwner),
-            Err(RoomMutationError::OwnershipUnavailable) => {
-                return Err(SetSubjectError::OwnershipUnavailable)
-            }
-            Err(
-                RoomMutationError::OwnershipLostAfterApply | RoomMutationError::PersistFailed(_),
-            ) => {
-                unreachable!("the pre-mutation ownership gate never applies or persists state")
-            }
-        }
+        self.gate_pre_mutation_ownership().await?;
         let subject = SubjectState {
             texts: msg.texts,
             setter: msg.setter,

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites.rs
@@ -118,6 +118,8 @@ pub enum MediatedInviteRollbackCommit {
 pub enum MediatedInviteRollbackError {
     #[error("this room's ownership has moved to another node")]
     NotOwner,
+    #[error("this room's ownership is temporarily unavailable")]
+    OwnershipUnavailable,
     #[error("the invite rollback could not be persisted before it was applied: {0}")]
     PersistFailedBeforeApply(#[source] DurablePersistError),
 }

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites.rs
@@ -116,7 +116,7 @@ pub enum MediatedInviteRollbackCommit {
 
 #[derive(Debug, Clone, Error, PartialEq, Eq)]
 pub enum MediatedInviteRollbackError {
-    #[error("this room's ownership has moved to another node")]
+    #[error("this room is no longer serviceable by this actor")]
     NotOwner,
     #[error("this room's ownership is temporarily unavailable")]
     OwnershipUnavailable,

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/authorization.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/authorization.rs
@@ -74,7 +74,7 @@ impl kameo::message::Message<AuthorizeMediatedInvite> for RoomActor {
             // The durable affiliation is authoritative across actor restarts.
             // Persist first; only a successful write permits the infallible
             // in-memory transition and creation of rollback authority.
-            self.persist_affiliation(&msg.invitee, Affiliation::Member)
+            self.persist_affiliation_before_apply(&msg.invitee, Affiliation::Member)
                 .await
                 .map_err(MediatedInviteGrantError::GrantPersistFailed)?;
             let changed = self

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/rollback.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/rollback.rs
@@ -97,10 +97,10 @@ impl kameo::message::Message<CommitMediatedInviteGrantRollback> for RoomActor {
                 return Err(MediatedInviteRollbackError::OwnershipUnavailable);
             }
             Err(RoomMutationError::OwnershipLostAfterApply) => {
-                unreachable!("the pre-mutation ownership gate never applies room state")
+                return Err(MediatedInviteRollbackError::NotOwner);
             }
-            Err(RoomMutationError::PersistFailed(_)) => {
-                unreachable!("the pre-mutation ownership gate never persists room state")
+            Err(RoomMutationError::PersistFailed) => {
+                return Err(MediatedInviteRollbackError::OwnershipUnavailable);
             }
         }
         self.persist_affiliation_before_apply(&msg.grant.invitee, msg.grant.previous_affiliation)

--- a/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/rollback.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/mediated_invites/rollback.rs
@@ -93,11 +93,17 @@ impl kameo::message::Message<CommitMediatedInviteGrantRollback> for RoomActor {
             Err(RoomMutationError::NotOwner) => {
                 return Err(MediatedInviteRollbackError::NotOwner);
             }
+            Err(RoomMutationError::OwnershipUnavailable) => {
+                return Err(MediatedInviteRollbackError::OwnershipUnavailable);
+            }
+            Err(RoomMutationError::OwnershipLostAfterApply) => {
+                unreachable!("the pre-mutation ownership gate never applies room state")
+            }
             Err(RoomMutationError::PersistFailed(_)) => {
                 unreachable!("the pre-mutation ownership gate never persists room state")
             }
         }
-        self.persist_affiliation(&msg.grant.invitee, msg.grant.previous_affiliation)
+        self.persist_affiliation_before_apply(&msg.grant.invitee, msg.grant.previous_affiliation)
             .await
             .map_err(MediatedInviteRollbackError::PersistFailedBeforeApply)?;
 

--- a/server/crates/waddle-xmpp/src/muc/room_actor/snapshot_handlers.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/snapshot_handlers.rs
@@ -5,7 +5,7 @@ use kameo::message::Context;
 use xmpp_parsers::message::Message;
 
 use super::{RoomActor, RoomActorError};
-use crate::muc::{OutboundMucMessage, RoomConfig};
+use crate::muc::{OutboundMucMessage, RoomClaimFenceContext, RoomConfig};
 use crate::types::{Affiliation, Role};
 
 #[derive(Debug, Clone)]
@@ -33,6 +33,12 @@ pub struct GroupchatBroadcastResult {
 /// room config).
 #[derive(Debug, Clone)]
 pub struct RoomChainSnapshot {
+    /// Exact durable-ownership proof retained by this actor incarnation.
+    /// Dispatch and archive paths must use this immutable context rather
+    /// than looking up the room JID in the registry's mutable successor
+    /// cache, which could transplant a later actor's authority onto this
+    /// frozen snapshot.
+    pub claim_fence: Option<RoomClaimFenceContext>,
     /// One entry per active occupant session — same `nick` may appear
     /// multiple times when an occupant has joined under multiple
     /// resources.
@@ -142,6 +148,7 @@ impl kameo::message::Message<GetRoomSnapshot> for RoomActor {
         durable_recipient_bare_jids.dedup();
 
         Ok(RoomChainSnapshot {
+            claim_fence: self.durable_claim_fence.clone(),
             occupants,
             sender_nick,
             sender_role,

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -40,9 +40,12 @@ fn validate_test_claim_fence(
     if fence == &test_claim_fence(room_jid) {
         Ok(())
     } else {
-        Err(crate::XmppError::internal(
-            "test store received an unexpected room claim fence",
-        ))
+        Err(crate::XmppError::OwnershipLost {
+            entity: crate::ownership::Entity::new(
+                crate::ownership::EntityType::RoomActor,
+                room_jid.to_string(),
+            ),
+        })
     }
 }
 
@@ -3472,6 +3475,8 @@ struct FakeDurableStore {
     fenced: std::sync::Mutex<Option<bool>>,
     fail_persist: bool,
     lose_config_persist_ownership: bool,
+    lose_restore_ownership: bool,
+    load_calls: std::sync::atomic::AtomicUsize,
     save_calls: std::sync::atomic::AtomicUsize,
     saved_affiliations: std::sync::Mutex<Vec<(BareJid, BareJid, Affiliation)>>,
 }
@@ -3505,6 +3510,7 @@ impl FakeDurableStore {
             lose_config_persist_ownership: false,
             save_calls: std::sync::atomic::AtomicUsize::new(0),
             saved_affiliations: std::sync::Mutex::new(Vec::new()),
+            ..Default::default()
         })
     }
 
@@ -3512,6 +3518,14 @@ impl FakeDurableStore {
         std::sync::Arc::new(Self {
             fenced: std::sync::Mutex::new(Some(true)),
             lose_config_persist_ownership: true,
+            ..Default::default()
+        })
+    }
+
+    fn ownership_lost_during_restore() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self {
+            fenced: std::sync::Mutex::new(Some(true)),
+            lose_restore_ownership: true,
             ..Default::default()
         })
     }
@@ -3537,9 +3551,17 @@ impl crate::muc::durable::MucDurableStore for FakeDurableStore {
     ) -> crate::muc::durable::MucDurableFuture<'a, Option<crate::muc::durable::DurableRoomState>>
     {
         let validation = validate_test_claim_fence(room_jid, fence);
+        self.load_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let lose_ownership = self.lose_restore_ownership;
+        let entity = fence.entity.clone();
         Box::pin(async move {
             validation?;
-            Ok(None)
+            if lose_ownership {
+                Err(crate::XmppError::OwnershipLost { entity })
+            } else {
+                Ok(None)
+            }
         })
     }
 
@@ -3763,6 +3785,36 @@ async fn spawn_room_actor_with_store(
         .await
         .expect("restore");
     actor
+}
+
+#[tokio::test]
+async fn ownership_lost_during_restore_is_terminal_and_never_retries() {
+    let store = FakeDurableStore::ownership_lost_during_restore();
+    let actor = spawn_room_actor().await;
+    actor
+        .ask(RestoreDurableRoomState {
+            store: store.clone(),
+            claim_fence: test_claim_fence(&test_room().room_jid),
+        })
+        .await
+        .expect("restore message");
+
+    assert_eq!(
+        actor
+            .ask(GetDurableRestoreReadiness)
+            .await
+            .expect("restore readiness"),
+        DurableRestoreReadiness::OwnershipLost
+    );
+    assert_eq!(
+        actor.ask(GetRoomSealState).await.expect("seal state"),
+        RoomSealState::OwnershipLost
+    );
+    assert_eq!(
+        store.load_calls.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "the terminal restore state must not perform the Pending retry"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -4130,7 +4182,7 @@ async fn update_config_surfaces_a_typed_persist_failure_after_mutating() {
     assert!(
         matches!(
             result,
-            Err(SendError::HandlerError(RoomMutationError::PersistFailed(_)))
+            Err(SendError::HandlerError(RoomMutationError::PersistFailed))
         ),
         "expected PersistFailed, got: {result:?}"
     );
@@ -4238,6 +4290,37 @@ async fn set_subject_gate_blocks_the_mutation_when_deposed() {
             Err(SendError::HandlerError(SetSubjectError::NotOwner))
         ),
         "expected NotOwner, got: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn set_subject_gate_surfaces_ownership_uncertainty_without_mutating() {
+    let actor = spawn_room_actor_with_store(FakeDurableStore::transient_failure()).await;
+    let setter: BareJid = "alice@example.com".parse().expect("valid jid");
+
+    let result = actor
+        .ask(SetSubject {
+            texts: RoomSubjectTexts::from_iter([(String::new(), "new subject".to_string())]),
+            setter,
+            setter_nick: "alice".to_string(),
+            set_at: chrono::Utc::now(),
+        })
+        .await;
+    assert!(matches!(
+        result,
+        Err(SendError::HandlerError(
+            SetSubjectError::OwnershipUnavailable
+        ))
+    ));
+    assert!(
+        actor
+            .ask(GetSnapshot)
+            .await
+            .expect("subject query")
+            .room
+            .subject
+            .is_none(),
+        "an uncertain ownership gate must not apply the subject"
     );
 }
 

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests.rs
@@ -22,6 +22,30 @@ fn test_room() -> MucRoom {
     )
 }
 
+fn test_claim_fence(room_jid: &BareJid) -> crate::muc::RoomClaimFenceContext {
+    crate::muc::RoomClaimFenceContext::new(
+        crate::ownership::Entity::new(
+            crate::ownership::EntityType::RoomActor,
+            room_jid.to_string(),
+        ),
+        crate::ownership::NodeIdentity::new("test-node", "test-node-epoch"),
+        crate::ownership::ClaimEpoch(1),
+    )
+}
+
+fn validate_test_claim_fence(
+    room_jid: &BareJid,
+    fence: &crate::muc::RoomClaimFenceContext,
+) -> Result<(), crate::XmppError> {
+    if fence == &test_claim_fence(room_jid) {
+        Ok(())
+    } else {
+        Err(crate::XmppError::internal(
+            "test store received an unexpected room claim fence",
+        ))
+    }
+}
+
 fn test_full_jid(user: &str) -> FullJid {
     format!("{}@example.com/res", user)
         .parse()
@@ -3433,19 +3457,21 @@ async fn health_check_replies_when_the_room_actor_is_idle() {
 // ---------------------------------------------------------------------------
 
 /// A [`crate::muc::durable::MucDurableStore`] test double whose
-/// `check_fenced_fanout` result is controlled by the test, so
+/// `check_exact_claim_fence` result is controlled by the test, so
 /// `RoomActor::gate_mutation` can be exercised without a real Postgres
 /// backend. `save_*` calls always succeed (or, when `fail_persist` is
-/// set, always fail) — only the two-stage gate is under test here; the
-/// concrete Postgres fencing SQL itself is covered by
+/// set, always fail, or when `lose_config_persist_ownership` is set,
+/// return exact ownership loss) — only the two-stage gate is under test
+/// here; the concrete Postgres fencing SQL itself is covered by
 /// `waddle-server::muc_durable`'s own Postgres-gated test suite.
 #[derive(Default)]
 struct FakeDurableStore {
-    /// `check_fenced_fanout`'s result: `Some(true)` = owned, `Some(false)`
+    /// `check_exact_claim_fence`'s result: `Some(true)` = owned, `Some(false)`
     /// = deposed, `None` = simulate a transient backend error (fails
-    /// open, per `gate_mutation`'s own contract).
+    /// closed, per `gate_mutation`'s own contract).
     fenced: std::sync::Mutex<Option<bool>>,
     fail_persist: bool,
+    lose_config_persist_ownership: bool,
     save_calls: std::sync::atomic::AtomicUsize,
     saved_affiliations: std::sync::Mutex<Vec<(BareJid, BareJid, Affiliation)>>,
 }
@@ -3476,8 +3502,17 @@ impl FakeDurableStore {
         std::sync::Arc::new(Self {
             fenced: std::sync::Mutex::new(Some(true)),
             fail_persist: true,
+            lose_config_persist_ownership: false,
             save_calls: std::sync::atomic::AtomicUsize::new(0),
             saved_affiliations: std::sync::Mutex::new(Vec::new()),
+        })
+    }
+
+    fn owned_but_config_persist_loses_ownership() -> std::sync::Arc<Self> {
+        std::sync::Arc::new(Self {
+            fenced: std::sync::Mutex::new(Some(true)),
+            lose_config_persist_ownership: true,
+            ..Default::default()
         })
     }
 
@@ -3495,34 +3530,39 @@ impl FakeDurableStore {
 }
 
 impl crate::muc::durable::MucDurableStore for FakeDurableStore {
-    fn load_room_state<'a>(
-        &'a self,
-        _room_jid: &'a BareJid,
-    ) -> crate::muc::durable::MucDurableFuture<'a, Option<crate::muc::durable::DurableRoomState>>
-    {
-        Box::pin(async { Ok(None) })
-    }
-
     fn load_room_state_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,
+        fence: &'a crate::muc::RoomClaimFenceContext,
     ) -> crate::muc::durable::MucDurableFuture<'a, Option<crate::muc::durable::DurableRoomState>>
     {
-        self.load_room_state(room_jid)
+        let validation = validate_test_claim_fence(room_jid, fence);
+        Box::pin(async move {
+            validation?;
+            Ok(None)
+        })
     }
 
-    fn save_config<'a>(
+    fn save_config_fenced<'a>(
         &'a self,
-        _room_jid: &'a BareJid,
+        room_jid: &'a BareJid,
         _waddle_id: &'a str,
         _channel_id: &'a str,
         _config: &'a RoomConfig,
+        fence: &'a crate::muc::RoomClaimFenceContext,
     ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
+        if let Err(error) = validate_test_claim_fence(room_jid, fence) {
+            return Box::pin(async move { Err(error) });
+        }
         self.save_calls
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let fail = self.fail_persist;
+        let lose_ownership = self.lose_config_persist_ownership;
+        let entity = test_claim_fence(room_jid).entity;
         Box::pin(async move {
-            if fail {
+            if lose_ownership {
+                Err(crate::XmppError::OwnershipLost { entity })
+            } else if fail {
                 Err(crate::XmppError::internal(
                     "simulated transient persist failure",
                 ))
@@ -3532,11 +3572,15 @@ impl crate::muc::durable::MucDurableStore for FakeDurableStore {
         })
     }
 
-    fn save_subject<'a>(
+    fn save_subject_fenced<'a>(
         &'a self,
-        _room_jid: &'a BareJid,
+        room_jid: &'a BareJid,
         _subject: Option<&'a SubjectState>,
+        fence: &'a crate::muc::RoomClaimFenceContext,
     ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
+        if let Err(error) = validate_test_claim_fence(room_jid, fence) {
+            return Box::pin(async move { Err(error) });
+        }
         self.save_calls
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let fail = self.fail_persist;
@@ -3551,11 +3595,15 @@ impl crate::muc::durable::MucDurableStore for FakeDurableStore {
         })
     }
 
-    fn save_affiliation<'a>(
+    fn save_affiliation_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,
         entry: &'a crate::muc::affiliation::AffiliationEntry,
+        fence: &'a crate::muc::RoomClaimFenceContext,
     ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
+        if let Err(error) = validate_test_claim_fence(room_jid, fence) {
+            return Box::pin(async move { Err(error) });
+        }
         self.save_calls
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         self.saved_affiliations.lock().expect("lock").push((
@@ -3575,12 +3623,26 @@ impl crate::muc::durable::MucDurableStore for FakeDurableStore {
         })
     }
 
-    fn check_fenced_fanout<'a>(
+    fn delete_room_state_fenced<'a>(
         &'a self,
-        _room_jid: &'a BareJid,
+        room_jid: &'a BareJid,
+        fence: &'a crate::muc::RoomClaimFenceContext,
+    ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
+        let validation = validate_test_claim_fence(room_jid, fence);
+        Box::pin(async move { validation })
+    }
+
+    fn check_exact_claim_fence<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        fence: &'a crate::muc::RoomClaimFenceContext,
     ) -> crate::muc::durable::MucDurableFuture<'a, bool> {
+        let exact_fence = validate_test_claim_fence(room_jid, fence).is_ok();
         let fenced = *self.fenced.lock().expect("lock");
         Box::pin(async move {
+            if !exact_fence {
+                return Ok(false);
+            }
             match fenced {
                 Some(owned) => Ok(owned),
                 None => Err(crate::XmppError::internal(
@@ -3610,45 +3672,50 @@ impl FailNthAffiliationSaveStore {
 }
 
 impl crate::muc::durable::MucDurableStore for FailNthAffiliationSaveStore {
-    fn load_room_state<'a>(
-        &'a self,
-        _room_jid: &'a BareJid,
-    ) -> crate::muc::durable::MucDurableFuture<'a, Option<crate::muc::durable::DurableRoomState>>
-    {
-        Box::pin(async { Ok(None) })
-    }
-
     fn load_room_state_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,
+        fence: &'a crate::muc::RoomClaimFenceContext,
     ) -> crate::muc::durable::MucDurableFuture<'a, Option<crate::muc::durable::DurableRoomState>>
     {
-        self.load_room_state(room_jid)
+        let validation = validate_test_claim_fence(room_jid, fence);
+        Box::pin(async move {
+            validation?;
+            Ok(None)
+        })
     }
 
-    fn save_config<'a>(
+    fn save_config_fenced<'a>(
         &'a self,
-        _room_jid: &'a BareJid,
+        room_jid: &'a BareJid,
         _waddle_id: &'a str,
         _channel_id: &'a str,
         _config: &'a RoomConfig,
+        fence: &'a crate::muc::RoomClaimFenceContext,
     ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
-        Box::pin(async { Ok(()) })
+        let validation = validate_test_claim_fence(room_jid, fence);
+        Box::pin(async move { validation })
     }
 
-    fn save_subject<'a>(
+    fn save_subject_fenced<'a>(
         &'a self,
-        _room_jid: &'a BareJid,
+        room_jid: &'a BareJid,
         _subject: Option<&'a SubjectState>,
+        fence: &'a crate::muc::RoomClaimFenceContext,
     ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
-        Box::pin(async { Ok(()) })
+        let validation = validate_test_claim_fence(room_jid, fence);
+        Box::pin(async move { validation })
     }
 
-    fn save_affiliation<'a>(
+    fn save_affiliation_fenced<'a>(
         &'a self,
-        _room_jid: &'a BareJid,
+        room_jid: &'a BareJid,
         _entry: &'a crate::muc::affiliation::AffiliationEntry,
+        fence: &'a crate::muc::RoomClaimFenceContext,
     ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
+        if let Err(error) = validate_test_claim_fence(room_jid, fence) {
+            return Box::pin(async move { Err(error) });
+        }
         let call = self
             .save_calls
             .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
@@ -3664,6 +3731,24 @@ impl crate::muc::durable::MucDurableStore for FailNthAffiliationSaveStore {
             }
         })
     }
+
+    fn delete_room_state_fenced<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        fence: &'a crate::muc::RoomClaimFenceContext,
+    ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
+        let validation = validate_test_claim_fence(room_jid, fence);
+        Box::pin(async move { validation })
+    }
+
+    fn check_exact_claim_fence<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        fence: &'a crate::muc::RoomClaimFenceContext,
+    ) -> crate::muc::durable::MucDurableFuture<'a, bool> {
+        let exact_fence = validate_test_claim_fence(room_jid, fence).is_ok();
+        Box::pin(async move { Ok(exact_fence) })
+    }
 }
 
 async fn spawn_room_actor_with_store(
@@ -3671,7 +3756,10 @@ async fn spawn_room_actor_with_store(
 ) -> ActorRef<RoomActor> {
     let actor = spawn_room_actor().await;
     actor
-        .ask(RestoreDurableRoomState { store })
+        .ask(RestoreDurableRoomState {
+            store,
+            claim_fence: test_claim_fence(&test_room().room_jid),
+        })
         .await
         .expect("restore");
     actor
@@ -3708,15 +3796,18 @@ impl FlakyThenRecoveringStore {
 }
 
 impl crate::muc::durable::MucDurableStore for FlakyThenRecoveringStore {
-    fn load_room_state<'a>(
+    fn load_room_state_fenced<'a>(
         &'a self,
-        _room_jid: &'a BareJid,
+        room_jid: &'a BareJid,
+        fence: &'a crate::muc::RoomClaimFenceContext,
     ) -> crate::muc::durable::MucDurableFuture<'a, Option<crate::muc::durable::DurableRoomState>>
     {
+        let validation = validate_test_claim_fence(room_jid, fence);
         let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let fail_count = self.fail_count;
         let banned = self.banned.clone();
         Box::pin(async move {
+            validation?;
             if call < fail_count {
                 Err(crate::XmppError::internal(
                     "simulated transient restore failure",
@@ -3739,38 +3830,54 @@ impl crate::muc::durable::MucDurableStore for FlakyThenRecoveringStore {
         })
     }
 
-    fn load_room_state_fenced<'a>(
+    fn save_config_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,
-    ) -> crate::muc::durable::MucDurableFuture<'a, Option<crate::muc::durable::DurableRoomState>>
-    {
-        self.load_room_state(room_jid)
-    }
-
-    fn save_config<'a>(
-        &'a self,
-        _room_jid: &'a BareJid,
         _waddle_id: &'a str,
         _channel_id: &'a str,
         _config: &'a RoomConfig,
+        fence: &'a crate::muc::RoomClaimFenceContext,
     ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
-        Box::pin(async { Ok(()) })
+        let validation = validate_test_claim_fence(room_jid, fence);
+        Box::pin(async move { validation })
     }
 
-    fn save_subject<'a>(
+    fn save_subject_fenced<'a>(
         &'a self,
-        _room_jid: &'a BareJid,
+        room_jid: &'a BareJid,
         _subject: Option<&'a SubjectState>,
+        fence: &'a crate::muc::RoomClaimFenceContext,
     ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
-        Box::pin(async { Ok(()) })
+        let validation = validate_test_claim_fence(room_jid, fence);
+        Box::pin(async move { validation })
     }
 
-    fn save_affiliation<'a>(
+    fn save_affiliation_fenced<'a>(
         &'a self,
-        _room_jid: &'a BareJid,
+        room_jid: &'a BareJid,
         _entry: &'a crate::muc::affiliation::AffiliationEntry,
+        fence: &'a crate::muc::RoomClaimFenceContext,
     ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
-        Box::pin(async { Ok(()) })
+        let validation = validate_test_claim_fence(room_jid, fence);
+        Box::pin(async move { validation })
+    }
+
+    fn delete_room_state_fenced<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        fence: &'a crate::muc::RoomClaimFenceContext,
+    ) -> crate::muc::durable::MucDurableFuture<'a, ()> {
+        let validation = validate_test_claim_fence(room_jid, fence);
+        Box::pin(async move { validation })
+    }
+
+    fn check_exact_claim_fence<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        fence: &'a crate::muc::RoomClaimFenceContext,
+    ) -> crate::muc::durable::MucDurableFuture<'a, bool> {
+        let exact_fence = validate_test_claim_fence(room_jid, fence).is_ok();
+        Box::pin(async move { Ok(exact_fence) })
     }
 }
 
@@ -3794,6 +3901,7 @@ async fn join_is_refused_while_restore_is_pending_then_succeeds_once_recovered_w
     actor
         .ask(RestoreDurableRoomState {
             store: store.clone(),
+            claim_fence: test_claim_fence(&test_room().room_jid),
         })
         .await
         .expect("restore ask itself always replies, even on a load failure");
@@ -3914,21 +4022,27 @@ async fn update_config_gate_allows_the_mutation_when_owned() {
 }
 
 #[tokio::test]
-async fn update_config_gate_fails_open_on_a_transient_fencing_error() {
+async fn update_config_gate_fails_closed_on_a_transient_fencing_error() {
     let actor = spawn_room_actor_with_store(FakeDurableStore::transient_failure()).await;
     let original = actor.ask(GetConfig).await.expect("ask").members_only;
 
     let mut new_config = actor.ask(GetConfig).await.expect("ask");
     new_config.members_only = !original;
-    actor
-        .ask(UpdateConfig { config: new_config })
-        .await
-        .expect("a transient fencing failure must fail OPEN, not block the mutation");
+    let result = actor.ask(UpdateConfig { config: new_config }).await;
+    assert!(
+        matches!(
+            result,
+            Err(SendError::HandlerError(
+                RoomMutationError::OwnershipUnavailable
+            ))
+        ),
+        "an unprovable exact fence must fail closed with a typed retryable error: {result:?}"
+    );
 
     let after = actor.ask(GetConfig).await.expect("ask").members_only;
-    assert_ne!(
+    assert_eq!(
         after, original,
-        "fail-open means the mutation still applies despite the transient error"
+        "ownership uncertainty must prevent the in-memory mutation"
     );
 }
 
@@ -3964,7 +4078,7 @@ async fn inactive_seal_strengthens_to_ownership_lost_on_join() {
 }
 
 #[tokio::test]
-async fn ownership_lost_seal_blocks_a_later_fail_open_mutation() {
+async fn ownership_lost_seal_blocks_a_later_mutation() {
     let store = FakeDurableStore::owned();
     let actor = spawn_room_actor_with_store(store.clone()).await;
     let original = actor.ask(GetConfig).await.expect("config");
@@ -3978,9 +4092,8 @@ async fn ownership_lost_seal_blocks_a_later_fail_open_mutation() {
         Err(SendError::HandlerError(RoomActorError::RoomSealed))
     ));
 
-    // The ordinary mutation gate intentionally fails open on a transient
-    // backend error, but a prior definitive loss must remain terminal for
-    // this actor incarnation.
+    // A prior definitive loss remains terminal for this actor incarnation,
+    // even if the next database probe is merely uncertain.
     store.set_fenced(None);
     let mut changed = original.clone();
     changed.members_only = !changed.members_only;
@@ -4031,6 +4144,55 @@ async fn update_config_surfaces_a_typed_persist_failure_after_mutating() {
 }
 
 #[tokio::test]
+async fn update_config_seals_the_actor_when_the_fenced_write_loses_ownership() {
+    let store = FakeDurableStore::owned_but_config_persist_loses_ownership();
+    let actor = spawn_room_actor_with_store(store.clone()).await;
+    let original = actor.ask(GetConfig).await.expect("original config");
+
+    let mut changed = original.clone();
+    changed.members_only = !changed.members_only;
+    let result = actor
+        .ask(UpdateConfig {
+            config: changed.clone(),
+        })
+        .await;
+    assert!(
+        matches!(
+            result,
+            Err(SendError::HandlerError(
+                RoomMutationError::OwnershipLostAfterApply
+            ))
+        ),
+        "expected OwnershipLostAfterApply, got: {result:?}"
+    );
+    assert_eq!(store.save_call_count(), 1, "the fenced write was attempted");
+    assert_eq!(
+        actor.ask(GetConfig).await.expect("mutated config"),
+        changed,
+        "the local config mutation remains applied after the durable ownership loss"
+    );
+    assert_eq!(
+        actor.ask(GetRoomSealState).await.expect("typed seal state"),
+        RoomSealState::OwnershipLost,
+        "the exact ownership loss seals this actor incarnation"
+    );
+
+    let later = actor.ask(UpdateConfig { config: original }).await;
+    assert!(
+        matches!(
+            later,
+            Err(SendError::HandlerError(RoomMutationError::NotOwner))
+        ),
+        "a sealed actor must reject later mutation work: {later:?}"
+    );
+    assert_eq!(
+        store.save_call_count(),
+        1,
+        "later rejected mutation work must not attempt another durable write"
+    );
+}
+
+#[tokio::test]
 async fn change_affiliation_gate_blocks_the_mutation_when_deposed() {
     let actor = spawn_room_actor_with_store(FakeDurableStore::deposed()).await;
     let jid: BareJid = "carol@example.com".parse().expect("valid jid");
@@ -4073,7 +4235,7 @@ async fn set_subject_gate_blocks_the_mutation_when_deposed() {
     assert!(
         matches!(
             result,
-            Err(SendError::HandlerError(RoomMutationError::NotOwner))
+            Err(SendError::HandlerError(SetSubjectError::NotOwner))
         ),
         "expected NotOwner, got: {result:?}"
     );

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/durability.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/durability.rs
@@ -150,7 +150,7 @@ async fn invite_grant_persist_failure_leaves_memory_unchanged_and_creates_no_tok
             })
             .await,
         Err(SendError::HandlerError(
-            MediatedInviteGrantError::GrantPersistFailed(_)
+            MediatedInviteGrantError::GrantPersistFailed(DurablePersistError::PersistFailed)
         ))
     ));
     assert_eq!(
@@ -298,7 +298,9 @@ async fn rollback_persist_failure_retains_the_exact_token_and_reservation_for_re
             })
             .await,
         Err(SendError::HandlerError(
-            MediatedInviteRollbackError::PersistFailedBeforeApply(_)
+            MediatedInviteRollbackError::PersistFailedBeforeApply(
+                DurablePersistError::PersistFailed
+            )
         ))
     ));
     assert_eq!(

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/durability.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/durability.rs
@@ -101,7 +101,10 @@ async fn mediated_invite_authorization_fails_closed_while_durable_restore_is_pen
     let (actor, inviter, invitee) = joined_members_only_invite_actor().await;
     let store = FlakyThenRecoveringStore::new(usize::MAX, invitee.clone());
     actor
-        .ask(RestoreDurableRoomState { store })
+        .ask(RestoreDurableRoomState {
+            store,
+            claim_fence: test_claim_fence(&test_room().room_jid),
+        })
         .await
         .expect("failed restore still replies");
 
@@ -133,6 +136,7 @@ async fn invite_grant_persist_failure_leaves_memory_unchanged_and_creates_no_tok
     actor
         .ask(RestoreDurableRoomState {
             store: store.clone(),
+            claim_fence: test_claim_fence(&test_room().room_jid),
         })
         .await
         .expect("attach durable store");
@@ -182,6 +186,7 @@ async fn banned_invitee_rejection_performs_no_durable_member_write() {
     actor
         .ask(RestoreDurableRoomState {
             store: store.clone(),
+            claim_fence: test_claim_fence(&test_room().room_jid),
         })
         .await
         .expect("attach recording durable store");
@@ -230,6 +235,7 @@ async fn invite_grant_and_rollback_persist_the_exact_room_invitee_and_affiliatio
     actor
         .ask(RestoreDurableRoomState {
             store: store.clone(),
+            claim_fence: test_claim_fence(&test_room().room_jid),
         })
         .await
         .expect("attach recording durable store");
@@ -263,6 +269,7 @@ async fn rollback_persist_failure_retains_the_exact_token_and_reservation_for_re
     actor
         .ask(RestoreDurableRoomState {
             store: store.clone(),
+            claim_fence: test_claim_fence(&test_room().room_jid),
         })
         .await
         .expect("attach durable store");
@@ -380,6 +387,7 @@ async fn rollback_ownership_loss_is_typed_and_keeps_the_operation_prepared() {
     actor
         .ask(RestoreDurableRoomState {
             store: store.clone(),
+            claim_fence: test_claim_fence(&test_room().room_jid),
         })
         .await
         .expect("attach owned durable store");

--- a/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/lifecycle.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_actor/tests/mediated_invites/lifecycle.rs
@@ -7,6 +7,7 @@ async fn mediated_invite_operation_replays_exact_authorization_without_a_second_
     actor
         .ask(RestoreDurableRoomState {
             store: store.clone(),
+            claim_fence: test_claim_fence(&test_room().room_jid),
         })
         .await
         .expect("attach durable store");
@@ -184,6 +185,7 @@ async fn mediated_invite_rollback_commit_replays_exact_outcome_until_acknowledge
     actor
         .ask(RestoreDurableRoomState {
             store: store.clone(),
+            claim_fence: test_claim_fence(&test_room().room_jid),
         })
         .await
         .expect("attach recording durable store");
@@ -562,6 +564,7 @@ async fn capacity_never_evicts_live_grants_or_persists_an_overflow_grant() {
     actor
         .ask(RestoreDurableRoomState {
             store: store.clone(),
+            claim_fence: test_claim_fence(&test_room().room_jid),
         })
         .await
         .expect("attach durable store");

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -931,6 +931,9 @@ impl RoomRegistryActor {
         claim_fence: super::RoomClaimFenceContext,
         previous_owner: NodeIdentity,
     ) {
+        if claim_fence.entity != Entity::new(EntityType::RoomActor, room_jid.to_string()) {
+            return;
+        }
         self.pending_reclaimed_reservations.remove(&room_jid);
         self.pending_retry_order = self.pending_retry_order.wrapping_add(1);
         let retry_order = self.pending_retry_order;
@@ -1271,12 +1274,11 @@ impl RoomRegistryActor {
         config: RoomConfig,
         claim_fence: &super::RoomClaimFenceContext,
     ) -> Result<(RoomPreparationGuard, bool), RoomPreparationError> {
-        // The restore message may run as soon as it is enqueued. Record the
-        // exact won fence before spawning so the store cannot fall back to a
-        // stale or absent ownership context.
-        if let Some(store) = &self.durable_store {
-            store.record_claim_fence(&room_jid, claim_fence.clone());
-        }
+        // Restore receives this preparation's exact fence directly. Do not
+        // publish it through the room-keyed fan-out cache yet: until the new
+        // actor reaches the final registry insertion boundary, an in-flight
+        // predecessor must continue checking its own old fence and fail
+        // closed rather than borrowing this successor's authority.
         let room = MucRoom::new(room_jid.clone(), waddle_id, channel_id, config);
         let actor_guard = RoomPreparationGuard::new(RoomActor::spawn(RoomActor::new(
             room,
@@ -1287,6 +1289,7 @@ impl RoomRegistryActor {
             if let Err(error) = actor_ref
                 .tell(RestoreDurableRoomState {
                     store: Arc::clone(store),
+                    claim_fence: claim_fence.clone(),
                 })
                 .await
             {
@@ -1496,7 +1499,10 @@ impl RoomRegistryActor {
                 Ok(DurableRestoreReadiness::Pending) => match durable_store {
                     Some(store) => {
                         if actor_ref
-                            .tell(RestoreDurableRoomState { store })
+                            .tell(RestoreDurableRoomState {
+                                store,
+                                claim_fence: publication_fence.clone(),
+                            })
                             .mailbox_timeout(ROOM_OWNERSHIP_CALL_TIMEOUT)
                             .await
                             .is_ok()
@@ -1693,9 +1699,6 @@ impl RoomRegistryActor {
             return false;
         }
         self.clear_pending_room_acquisition(&room_jid, &claim_fence.owner());
-        if let Some(store) = &self.durable_store {
-            store.record_claim_fence(&room_jid, claim_fence.clone());
-        }
         self.rooms.insert(
             room_jid.clone(),
             RoomEntry {
@@ -1703,6 +1706,12 @@ impl RoomRegistryActor {
                 claim_fence: claim_fence.clone(),
             },
         );
+        // The cache is a legacy room-JID fan-out fence. Make it visible only
+        // after its matching ready actor and immutable fence are in the
+        // registry, so a predecessor cannot borrow the successor generation.
+        if let Some(store) = &self.durable_store {
+            store.record_claim_fence(&room_jid, claim_fence.clone());
+        }
         self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
         true
     }
@@ -1863,10 +1872,16 @@ impl RoomRegistryActor {
         timeout: std::time::Duration,
     ) -> ReclaimedRoomOutcome {
         let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        if claim_fence.entity != entity {
+            return ReclaimedRoomOutcome::LostRace;
+        }
         match tokio::time::timeout(
             timeout,
-            self.claim_store
-                .release_exact(&entity, &claim_fence.owner(), claim_fence.epoch),
+            self.claim_store.release_exact(
+                &claim_fence.entity,
+                &claim_fence.owner(),
+                claim_fence.epoch,
+            ),
         )
         .await
         {
@@ -2934,6 +2949,9 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
         ctx: &mut Context<Self, Self::Reply>,
     ) -> Self::Reply {
         let entity = Entity::new(EntityType::RoomActor, msg.room_jid.to_string());
+        if msg.claim_fence.entity != entity {
+            return ctx.reply(ReclaimedRoomOutcome::LostRace);
+        }
         let claim_fence = msg.claim_fence.clone();
         let claim_epoch = claim_fence.epoch;
         let identity = claim_fence.owner();
@@ -3057,9 +3075,13 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
                     .await,
             );
         };
+        // The reaper won this claim outside the demand-side acquisition
+        // path. The fenced read below receives that exact generation
+        // directly. The shared fan-out cache is updated only by
+        // `publish_room`, after the replacement actor is ready and inserted.
         let snapshot = match tokio::time::timeout(
             RECLAIMED_ROOM_STORE_TIMEOUT,
-            store.load_room_state(&msg.room_jid),
+            store.load_room_state_fenced(&msg.room_jid, &claim_fence),
         )
         .await
         {
@@ -3447,12 +3469,34 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
             && msg.reason == DestroyRoomReason::Destroy
         {
             if let Some(store) = &self.durable_store {
-                if let Err(error) = store.delete_room_state(&msg.room_jid).await {
+                let Some(fence) = removed_entry
+                    .as_ref()
+                    .map(|entry| &entry.claim_fence)
+                    .or_else(|| {
+                        removed_preparation
+                            .as_ref()
+                            .map(|preparation| &preparation.claim_fence)
+                    })
+                else {
+                    warn!(
+                        room = %msg.room_jid,
+                        "Refusing durable room deletion without the registry entry's exact fence"
+                    );
+                    if let Some(pending) = removed_preparation {
+                        self.pending_room_preparations
+                            .insert(msg.room_jid.clone(), pending);
+                    }
+                    if removed_poison {
+                        self.poisoned_rooms.insert(msg.room_jid.clone());
+                    }
+                    return DestroyRoomOutcome::DurableWipeFailed;
+                };
+                if let Err(error) = store.delete_room_state_fenced(&msg.room_jid, fence).await {
                     warn!(
                         room = %msg.room_jid,
                         %error,
-                        "Failed to delete durable room state; refusing the destroy so it \
-                         can be retried instead of resurrecting from storage"
+                        "Failed to delete durable room state under the registry entry's exact \
+                         fence; refusing the destroy so it can be retried"
                     );
                     if let Some(entry) = removed_entry {
                         self.rooms.insert(msg.room_jid.clone(), entry);
@@ -3800,6 +3844,38 @@ pub struct ListRoomsOwnedBy {
 pub struct DemoteRoomIfOwner {
     pub room_jid: BareJid,
     pub owner: NodeIdentity,
+}
+
+/// Hard-kill and forget a room only while the registry still points at the
+/// exact actor incarnation named by the caller. This is the safe response to
+/// an actor-local fence rejection: a same-JID successor published before this
+/// mailbox turn must never be evicted by the stale actor's failure.
+pub struct DemoteRoomIfExactActor {
+    pub room_jid: BareJid,
+    pub actor_ref: ActorRef<RoomActor>,
+}
+
+impl kameo::message::Message<DemoteRoomIfExactActor> for RoomRegistryActor {
+    type Reply = bool;
+
+    async fn handle(
+        &mut self,
+        msg: DemoteRoomIfExactActor,
+        _ctx: &mut Context<Self, Self::Reply>,
+    ) -> Self::Reply {
+        let matches = self
+            .rooms
+            .get(&msg.room_jid)
+            .is_some_and(|entry| entry.actor_ref.id() == msg.actor_ref.id());
+        if !matches {
+            return false;
+        }
+        let Some(entry) = self.rooms.remove(&msg.room_jid) else {
+            return false;
+        };
+        self.retire_ownership_lost_entry(&msg.room_jid, entry).await;
+        true
+    }
 }
 
 impl kameo::message::Message<DemoteRoomIfOwner> for RoomRegistryActor {

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -530,6 +530,34 @@ impl RoomRegistryActor {
         }
     }
 
+    /// Retire an unpublished fence after a terminal ownership result.
+    ///
+    /// A same-identity database miss proves the exact tuple is already gone.
+    /// A different current identity only proves this process can no longer
+    /// serve the old incarnation; its exact tuple may still need a safe,
+    /// conditional release. Preserve that responsibility until release
+    /// succeeds or proves the tuple no longer exists.
+    fn finish_unpublished_ownership_loss(
+        &mut self,
+        room_jid: BareJid,
+        claim_fence: super::RoomClaimFenceContext,
+        registry_ref: ActorRef<Self>,
+    ) -> ReclaimedRoomOutcome {
+        if claim_fence.owner() != self.node_identity.current() {
+            self.transfer_exact_responsibility_to_pending_release(
+                room_jid.clone(),
+                claim_fence.clone(),
+            );
+            self.start_detached_room_release(room_jid, claim_fence, registry_ref);
+            ReclaimedRoomOutcome::PendingRetry
+        } else {
+            if let Some(store) = &self.durable_store {
+                store.forget_claim_fence(&room_jid, &claim_fence);
+            }
+            ReclaimedRoomOutcome::LostRace
+        }
+    }
+
     async fn evict_ownership_lost_room(&mut self, room_jid: &BareJid, entry: RoomEntry) {
         self.rooms.remove(room_jid);
         self.poisoned_rooms.remove(room_jid);
@@ -556,7 +584,7 @@ impl RoomRegistryActor {
         true
     }
 
-    /// Move an already-retained exact fence from a preparation or deposed
+    /// Move an already-retained exact fence from a preparation or non-serving
     /// room entry into release state. The caller removes the prior
     /// representation in the same mailbox turn, so the transfer cannot lose
     /// responsibility even when ordinary release admission is saturated.
@@ -1989,16 +2017,17 @@ impl RoomRegistryActor {
             Err(error) => {
                 let reclaimed_outcome = match origin {
                     RoomPreparationOrigin::Demand { .. } => match error {
-                        // The actor's fenced load proved this exact claim is
-                        // already gone. Forget the cache and the acquisition
-                        // reservation; releasing this stale tuple would add a
-                        // redundant, potentially misleading retry.
+                        // A same-identity database miss proves the tuple is
+                        // gone. Local identity supersession is also terminal
+                        // for the actor, but the old exact row may still need
+                        // a conditional release.
                         RoomPublicationError::ClaimLost => {
-                            if let Some(store) = &self.durable_store {
-                                store.forget_claim_fence(&room_jid, &claim_fence);
-                            }
                             self.clear_pending_room_acquisition(&room_jid, &claim_fence.owner());
-                            ReclaimedRoomOutcome::LostRace
+                            self.finish_unpublished_ownership_loss(
+                                room_jid.clone(),
+                                claim_fence.clone(),
+                                registry_ref.clone(),
+                            )
                         }
                         RoomPublicationError::LocalIdentityChanged
                         | RoomPublicationError::OwnershipUnavailable
@@ -2017,11 +2046,12 @@ impl RoomRegistryActor {
                     },
                     RoomPreparationOrigin::Reclaimed { previous_owner } => match error {
                         RoomPublicationError::ClaimLost => {
-                            if let Some(store) = &self.durable_store {
-                                store.forget_claim_fence(&room_jid, &claim_fence);
-                            }
                             self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
-                            ReclaimedRoomOutcome::LostRace
+                            self.finish_unpublished_ownership_loss(
+                                room_jid.clone(),
+                                claim_fence.clone(),
+                                registry_ref.clone(),
+                            )
                         }
                         RoomPublicationError::LocalIdentityChanged => {
                             self.clear_pending_reclaimed_room(&room_jid, &claim_fence);
@@ -3127,9 +3157,13 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
                     %entity,
                     "proactively reclaimed room-state load lost the exact claim"
                 );
-                store.forget_claim_fence(&msg.room_jid, &claim_fence);
                 self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
-                return ctx.reply(ReclaimedRoomOutcome::LostRace);
+                let outcome = self.finish_unpublished_ownership_loss(
+                    msg.room_jid,
+                    claim_fence,
+                    ctx.actor_ref().clone(),
+                );
+                return ctx.reply(outcome);
             }
             Ok(Err(error)) => {
                 debug!(
@@ -3422,7 +3456,7 @@ impl kameo::message::Message<CreateRoom> for RoomRegistryActor {
 }
 
 /// Why a room is being removed from the registry — decides whether the
-/// durable rows go with it (#1261 vs. the deposed-node eviction race).
+/// durable rows go with it (#1261 vs. non-serving actor eviction).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DestroyRoomReason {
     /// XEP-0045 §10.9 destroy or an administrative deletion: the room
@@ -3431,7 +3465,7 @@ pub enum DestroyRoomReason {
     Destroy,
     /// A write-adjacent fence proved this process can no longer serve the
     /// room, either because the database claim moved or the local node
-    /// identity rotated. Bypass release-backlog admission so the deposed
+    /// identity rotated. Bypass release-backlog admission so the non-serving
     /// actor cannot remain registered, preserve durable state, and still
     /// attempt exact release of the old fence.
     DeposedEviction,
@@ -3579,7 +3613,7 @@ impl kameo::message::Message<DestroyRoom> for RoomRegistryActor {
                 // Removal from the registry is not itself a terminal signal
                 // to a RoomActor. A caller may still hold an ActorRef and the
                 // best-effort Demote notification may never arrive, so kill
-                // the deposed incarnation before dropping our last entry.
+                // the non-serving incarnation before dropping our last entry.
                 self.retire_ownership_lost_entry(&msg.room_jid, entry).await;
             } else {
                 self.release_room_claim(&msg.room_jid, &entry.claim_fence)
@@ -3639,9 +3673,10 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
         };
         if !self.has_pending_release_capacity(&msg.room_jid, &entry.claim_fence) {
             // Ordinary inactivity must remain open when there is nowhere to
-            // retain an uncertain release. A previously deposed actor is
-            // different: its negative fence is already terminal, so evict it
-            // without issuing another release even under saturation.
+            // retain an uncertain release. A terminally non-serving actor is
+            // different: evict it immediately, while owner-sensitive cleanup
+            // retains an exact release only when local identity supersession
+            // means the old tuple may still exist.
             let seal_state = entry
                 .actor_ref
                 .ask(GetRoomSealState)
@@ -3651,7 +3686,7 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
             return match seal_state {
                 Ok(RoomSealState::OwnershipLost) => {
                     self.evict_ownership_lost_room(&msg.room_jid, entry).await;
-                    info!(room = %msg.room_jid, "Evicted deposed room during inactive-room cleanup");
+                    info!(room = %msg.room_jid, "Evicted non-serving room during inactive-room cleanup");
                     true
                 }
                 Ok(RoomSealState::Open | RoomSealState::Inactive) => {
@@ -3676,7 +3711,7 @@ impl kameo::message::Message<DestroyRoomIfInactive> for RoomRegistryActor {
         match sealed {
             Ok(SealIfInactiveOutcome::OwnershipLost) => {
                 self.evict_ownership_lost_room(&msg.room_jid, entry).await;
-                info!(room = %msg.room_jid, "Evicted deposed room during inactive-room cleanup");
+                info!(room = %msg.room_jid, "Evicted non-serving room during inactive-room cleanup");
                 true
             }
             Ok(SealIfInactiveOutcome::Inactive) => {
@@ -3766,15 +3801,16 @@ impl kameo::message::Message<ReapSealedRoom> for RoomRegistryActor {
             .await;
         match seal_state {
             Ok(RoomSealState::OwnershipLost) => {
-                // A definitive join fence proved this actor is deposed. Its
-                // local registration is no longer safe to serve. Remove and
-                // kill locally, preserve durable room state, and do not issue
-                // a redundant release that could become an untracked late
-                // delete while the retry inventory is saturated.
+                // A terminal ownership result made this actor non-serving.
+                // Remove and kill it locally while preserving durable room
+                // state. Owner-sensitive cleanup skips a redundant release
+                // after a same-identity database miss, but retains one exact
+                // release when local identity supersession may have left the
+                // old tuple behind.
                 self.evict_ownership_lost_room(&msg.room_jid, entry).await;
                 info!(
                     room = %msg.room_jid,
-                    "Evicted room actor after join fence proved ownership loss"
+                    "Evicted room actor after a terminal ownership result"
                 );
                 true
             }

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor.rs
@@ -144,6 +144,7 @@ enum RoomPreparationReadiness {
         publication_fence: Result<(), RoomPublicationError>,
     },
     Pending,
+    ClaimLost,
     Unavailable,
 }
 
@@ -932,6 +933,11 @@ impl RoomRegistryActor {
         previous_owner: NodeIdentity,
     ) {
         if claim_fence.entity != Entity::new(EntityType::RoomActor, room_jid.to_string()) {
+            warn!(
+                room = %room_jid,
+                fence_entity = %claim_fence.entity,
+                "rejecting pending reclaimed room with a cross-entity claim fence"
+            );
             return;
         }
         self.pending_reclaimed_reservations.remove(&room_jid);
@@ -1544,6 +1550,9 @@ impl RoomRegistryActor {
                         publication_fence,
                     }
                 }
+                Some(Ok(DurableRestoreReadiness::OwnershipLost)) => {
+                    RoomPreparationReadiness::ClaimLost
+                }
                 Some(Ok(DurableRestoreReadiness::Pending)) => RoomPreparationReadiness::Pending,
                 Some(Err(_)) | None => RoomPreparationReadiness::Unavailable,
             };
@@ -1979,18 +1988,33 @@ impl RoomRegistryActor {
             }
             Err(error) => {
                 let reclaimed_outcome = match origin {
-                    RoomPreparationOrigin::Demand { .. } => {
-                        self.transfer_exact_responsibility_to_pending_release(
-                            room_jid.clone(),
-                            claim_fence.clone(),
-                        );
-                        self.start_detached_room_release(
-                            room_jid.clone(),
-                            claim_fence.clone(),
-                            registry_ref,
-                        );
-                        ReclaimedRoomOutcome::PendingRetry
-                    }
+                    RoomPreparationOrigin::Demand { .. } => match error {
+                        // The actor's fenced load proved this exact claim is
+                        // already gone. Forget the cache and the acquisition
+                        // reservation; releasing this stale tuple would add a
+                        // redundant, potentially misleading retry.
+                        RoomPublicationError::ClaimLost => {
+                            if let Some(store) = &self.durable_store {
+                                store.forget_claim_fence(&room_jid, &claim_fence);
+                            }
+                            self.clear_pending_room_acquisition(&room_jid, &claim_fence.owner());
+                            ReclaimedRoomOutcome::LostRace
+                        }
+                        RoomPublicationError::LocalIdentityChanged
+                        | RoomPublicationError::OwnershipUnavailable
+                        | RoomPublicationError::ReconciliationPending => {
+                            self.transfer_exact_responsibility_to_pending_release(
+                                room_jid.clone(),
+                                claim_fence.clone(),
+                            );
+                            self.start_detached_room_release(
+                                room_jid.clone(),
+                                claim_fence.clone(),
+                                registry_ref,
+                            );
+                            ReclaimedRoomOutcome::PendingRetry
+                        }
+                    },
                     RoomPreparationOrigin::Reclaimed { previous_owner } => match error {
                         RoomPublicationError::ClaimLost => {
                             if let Some(store) = &self.durable_store {
@@ -2071,6 +2095,7 @@ impl kameo::message::Message<CompleteRoomPreparation> for RoomRegistryActor {
                 publication_fence: Err(error),
                 ..
             } => error,
+            RoomPreparationReadiness::ClaimLost => RoomPublicationError::ClaimLost,
             RoomPreparationReadiness::Pending | RoomPreparationReadiness::Unavailable => {
                 RoomPublicationError::OwnershipUnavailable
             }
@@ -3095,6 +3120,16 @@ impl kameo::message::Message<ReconcileReclaimedRoom> for RoomRegistryActor {
                     )
                     .await,
                 );
+            }
+            Ok(Err(crate::XmppError::OwnershipLost { entity })) => {
+                warn!(
+                    room = %msg.room_jid,
+                    %entity,
+                    "proactively reclaimed room-state load lost the exact claim"
+                );
+                store.forget_claim_fence(&msg.room_jid, &claim_fence);
+                self.clear_pending_reclaimed_room(&msg.room_jid, &claim_fence);
+                return ctx.reply(ReclaimedRoomOutcome::LostRace);
             }
             Ok(Err(error)) => {
                 debug!(

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -647,6 +647,62 @@ async fn stale_exact_owner_demotion_preserves_a_fresh_same_jid_room() {
 }
 
 #[tokio::test]
+async fn exact_actor_demotion_cannot_evict_a_different_same_jid_actor() {
+    let registry = spawn_registry().await;
+    let room_jid = test_room_jid("exact-actor-demotion");
+    let registered = registry
+        .ask(CreateRoom {
+            room_jid: room_jid.clone(),
+            waddle_id: "w-registered".to_string(),
+            channel_id: "c-registered".to_string(),
+            config: RoomConfig::default(),
+        })
+        .await
+        .expect("create registered room");
+    let unrelated_same_jid = RoomActor::spawn(RoomActor::new(
+        MucRoom::new(
+            room_jid.clone(),
+            "w-unrelated".to_string(),
+            "c-unrelated".to_string(),
+            RoomConfig::default(),
+        ),
+        OccupantIdSecret::for_testing(b"test-secret".to_vec()),
+    ));
+
+    assert!(!registry
+        .ask(DemoteRoomIfExactActor {
+            room_jid: room_jid.clone(),
+            actor_ref: unrelated_same_jid,
+        })
+        .await
+        .expect("reject unrelated exact actor"));
+    assert_eq!(
+        registry
+            .ask(GetRoom {
+                room_jid: room_jid.clone(),
+            })
+            .await
+            .expect("lookup retained actor")
+            .expect("registered actor retained")
+            .id(),
+        registered.id(),
+    );
+
+    assert!(registry
+        .ask(DemoteRoomIfExactActor {
+            room_jid: room_jid.clone(),
+            actor_ref: registered,
+        })
+        .await
+        .expect("demote exact registered actor"));
+    assert!(registry
+        .ask(GetRoom { room_jid })
+        .await
+        .expect("lookup after exact demotion")
+        .is_none());
+}
+
+#[tokio::test]
 async fn test_get_or_create_fails_fast_for_dead_room_until_explicit_destroy() {
     let registry = spawn_registry().await;
     let room_jid = test_room_jid("restart");
@@ -1125,15 +1181,13 @@ mod ownership_claims_tests {
         let registry = spawn_registry().await;
         let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
         let durable_store = Arc::new(RecordingDurableStore::default());
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store),
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store),
+            SharedNodeIdentity::new(this_identity()),
+            Arc::clone(&durable_store),
+        )
+        .await;
 
         let jid = test_room_jid("durable-destroy");
         registry
@@ -1173,15 +1227,13 @@ mod ownership_claims_tests {
             fail_deletes: true,
             ..RecordingDurableStore::default()
         });
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store),
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store),
+            SharedNodeIdentity::new(this_identity()),
+            Arc::clone(&durable_store),
+        )
+        .await;
 
         let jid = test_room_jid("durable-destroy-fails");
         registry
@@ -1230,15 +1282,13 @@ mod ownership_claims_tests {
         let claim_store: Arc<dyn ClaimStore> = Arc::new(InProcessClaimStore::new());
         let durable_store = Arc::new(RecordingDurableStore::default());
         let identity = SharedNodeIdentity::new(this_identity());
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store),
-                node_identity: identity.clone(),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store),
+            identity.clone(),
+            Arc::clone(&durable_store),
+        )
+        .await;
 
         let jid = test_room_jid("deposed-evict");
         let stale_actor = registry
@@ -2018,6 +2068,7 @@ mod ownership_claims_tests {
         fail_fenced_loads_remaining: AtomicUsize,
         block_all_loads: bool,
         block_load_for: Option<BareJid>,
+        block_load_from_call: Option<usize>,
         load_started: Option<Arc<tokio::sync::Notify>>,
         allow_load: Option<Arc<tokio::sync::Notify>>,
         load_calls: AtomicUsize,
@@ -2030,65 +2081,104 @@ mod ownership_claims_tests {
         demote_notifications: Mutex<Vec<(String, String)>>,
         deleted_rooms: Mutex<Vec<String>>,
         fail_deletes: bool,
+        authoritative_claim_store: Mutex<Option<Arc<dyn ClaimStore>>>,
         claim_fences: Arc<Mutex<HashMap<BareJid, RoomClaimFenceContext>>>,
     }
 
-    impl MucDurableStore for RecordingDurableStore {
-        fn load_room_state<'a>(
-            &'a self,
-            _room_jid: &'a BareJid,
-        ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
-            if self.fail_load {
-                return Box::pin(async {
-                    Err(crate::XmppError::internal("load refused by test store"))
-                });
+    impl RecordingDurableStore {
+        fn with_claim_store(claim_store: Arc<dyn ClaimStore>) -> Self {
+            Self {
+                authoritative_claim_store: Mutex::new(Some(claim_store)),
+                ..Self::default()
             }
-            let result = self.load_result.clone();
-            Box::pin(async move { Ok(result) })
         }
 
+        fn bind_claim_store(&self, claim_store: Arc<dyn ClaimStore>) {
+            *self.authoritative_claim_store.lock().expect("lock") = Some(claim_store);
+        }
+
+        async fn authoritative_claim_matches(
+            &self,
+            room_jid: &BareJid,
+            fence: &RoomClaimFenceContext,
+        ) -> Result<bool, crate::XmppError> {
+            let expected = Entity::new(EntityType::RoomActor, room_jid.to_string());
+            if fence.entity != expected {
+                return Ok(false);
+            }
+
+            let claim_store = self
+                .authoritative_claim_store
+                .lock()
+                .expect("lock")
+                .clone()
+                .ok_or_else(|| {
+                    crate::XmppError::internal("durable operation has no authoritative claim store")
+                })?;
+            let snapshot = claim_store
+                .current_claim(&fence.entity)
+                .await
+                .map_err(|_| {
+                    crate::XmppError::internal(
+                        "durable operation could not read the authoritative claim",
+                    )
+                })?;
+            Ok(snapshot.is_some_and(|snapshot| {
+                snapshot.owner == fence.owner && snapshot.claim_epoch == fence.epoch
+            }))
+        }
+
+        async fn validate_claim_fence(
+            &self,
+            room_jid: &BareJid,
+            fence: &RoomClaimFenceContext,
+        ) -> Result<(), crate::XmppError> {
+            if self.authoritative_claim_matches(room_jid, fence).await? {
+                Ok(())
+            } else {
+                Err(crate::XmppError::internal(
+                    "durable operation received a stale or unowned claim fence",
+                ))
+            }
+        }
+    }
+
+    impl MucDurableStore for RecordingDurableStore {
         fn load_room_state_fenced<'a>(
             &'a self,
             room_jid: &'a BareJid,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
-            self.load_calls.fetch_add(1, Ordering::SeqCst);
-            if !self
-                .claim_fences
-                .lock()
-                .expect("lock")
-                .contains_key(room_jid)
-            {
-                return Box::pin(async {
-                    Err(crate::XmppError::internal(
-                        "fenced load attempted before exact claim fence was recorded",
-                    ))
-                });
-            }
-            if self
+            let load_call = self.load_calls.fetch_add(1, Ordering::SeqCst) + 1;
+            let store = self;
+            let fail_fenced_load = self
                 .fail_fenced_loads_remaining
                 .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
                     remaining.checked_sub(1)
                 })
-                .is_ok()
-            {
-                return Box::pin(async {
-                    Err(crate::XmppError::internal(
-                        "transient fenced load failure from test store",
-                    ))
-                });
-            }
-            if self.fence_lost.load(Ordering::SeqCst) {
-                return Box::pin(async {
-                    Err(crate::XmppError::internal(
-                        "fenced load rejected after ownership loss",
-                    ))
-                });
-            }
-            let should_block =
-                self.block_all_loads || self.block_load_for.as_ref() == Some(room_jid);
+                .is_ok();
+            let fence_lost = self.fence_lost.load(Ordering::SeqCst);
+            let should_block = self.block_all_loads
+                || self.block_load_for.as_ref() == Some(room_jid)
+                || self
+                    .block_load_from_call
+                    .is_some_and(|first_blocked_call| load_call >= first_blocked_call);
             let load_started = self.load_started.clone();
             let allow_load = self.allow_load.clone();
+            let fail_load = self.fail_load;
+            let result = self.load_result.clone();
             Box::pin(async move {
+                store.validate_claim_fence(room_jid, fence).await?;
+                if fail_fenced_load {
+                    return Err(crate::XmppError::internal(
+                        "transient fenced load failure from test store",
+                    ));
+                }
+                if fence_lost {
+                    return Err(crate::XmppError::internal(
+                        "fenced load rejected after ownership loss",
+                    ));
+                }
                 if should_block {
                     if let Some(started) = load_started {
                         started.notify_one();
@@ -2097,28 +2187,30 @@ mod ownership_claims_tests {
                         allow.notified().await;
                     }
                 }
-                self.load_room_state(room_jid).await
+                if fail_load {
+                    Err(crate::XmppError::internal("load refused by test store"))
+                } else {
+                    Ok(result)
+                }
             })
         }
 
-        fn save_config<'a>(
+        fn save_config_fenced<'a>(
             &'a self,
             room_jid: &'a BareJid,
             _waddle_id: &'a str,
             _channel_id: &'a str,
             _config: &'a RoomConfig,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
             self.config_save_calls.fetch_add(1, Ordering::SeqCst);
+            let store = self;
             let block = self.block_next_config_save.swap(false, Ordering::SeqCst);
             let config_save_started = self.config_save_started.clone();
             let allow_config_save = self.allow_config_save.clone();
-            let starting_fence = self
-                .claim_fences
-                .lock()
-                .expect("lock")
-                .get(room_jid)
-                .cloned();
+            let starting_fence = fence.clone();
             Box::pin(async move {
+                store.validate_claim_fence(room_jid, fence).await?;
                 if block {
                     let claim_fences = Arc::clone(&self.claim_fences);
                     let stale_rejected = Arc::clone(&self.stale_config_save_rejected);
@@ -2132,7 +2224,7 @@ mod ownership_claims_tests {
                         }
                         let current_fence =
                             claim_fences.lock().expect("lock").get(&room_jid).cloned();
-                        if current_fence != starting_fence {
+                        if current_fence.as_ref() != Some(&starting_fence) {
                             stale_rejected.store(true, Ordering::SeqCst);
                         }
                     });
@@ -2147,33 +2239,54 @@ mod ownership_claims_tests {
             Box::pin(async move { Ok(owned) })
         }
 
-        fn save_subject<'a>(
+        fn check_exact_claim_fence<'a>(
             &'a self,
-            _room_jid: &'a BareJid,
+            room_jid: &'a BareJid,
+            fence: &'a RoomClaimFenceContext,
+        ) -> MucDurableFuture<'a, bool> {
+            let store = self;
+            Box::pin(async move {
+                let exact = store.authoritative_claim_matches(room_jid, fence).await?;
+                Ok(exact && !store.fence_lost.load(Ordering::SeqCst))
+            })
+        }
+
+        fn save_subject_fenced<'a>(
+            &'a self,
+            room_jid: &'a BareJid,
             _subject: Option<&'a SubjectState>,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            Box::pin(async move { self.validate_claim_fence(room_jid, fence).await })
         }
 
-        fn save_affiliation<'a>(
+        fn save_affiliation_fenced<'a>(
             &'a self,
-            _room_jid: &'a BareJid,
+            room_jid: &'a BareJid,
             _entry: &'a AffiliationEntry,
+            fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, ()> {
-            Box::pin(async { Ok(()) })
+            Box::pin(async move { self.validate_claim_fence(room_jid, fence).await })
         }
 
-        fn delete_room_state<'a>(&'a self, room_jid: &'a BareJid) -> MucDurableFuture<'a, ()> {
-            if self.fail_deletes {
-                return Box::pin(async {
-                    Err(crate::XmppError::internal("delete refused by test store"))
-                });
-            }
-            self.deleted_rooms
-                .lock()
-                .expect("lock")
-                .push(room_jid.to_string());
-            Box::pin(async { Ok(()) })
+        fn delete_room_state_fenced<'a>(
+            &'a self,
+            room_jid: &'a BareJid,
+            fence: &'a RoomClaimFenceContext,
+        ) -> MucDurableFuture<'a, ()> {
+            let fail_deletes = self.fail_deletes;
+            let deleted_rooms = &self.deleted_rooms;
+            Box::pin(async move {
+                self.validate_claim_fence(room_jid, fence).await?;
+                if fail_deletes {
+                    return Err(crate::XmppError::internal("delete refused by test store"));
+                }
+                deleted_rooms
+                    .lock()
+                    .expect("lock")
+                    .push(room_jid.to_string());
+                Ok(())
+            })
         }
 
         fn record_claim_fence(&self, room_jid: &BareJid, fence: RoomClaimFenceContext) {
@@ -2211,6 +2324,67 @@ mod ownership_claims_tests {
                 .push((room_jid.to_string(), previous_owner_node_id.to_string()));
             Box::pin(async { Ok(()) })
         }
+    }
+
+    #[tokio::test]
+    async fn recording_durable_store_requires_the_exact_authoritative_claim_before_publication() {
+        let room_jid = test_room_jid("recording-store-exact-fence");
+        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        let owner = NodeIdentity::new("room-node", "current-incarnation");
+        let epoch = ClaimEpoch(42);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(owner.clone(), epoch));
+        let store = RecordingDurableStore::with_claim_store(
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>
+        );
+        let exact_fence = RoomClaimFenceContext::new(entity.clone(), owner.clone(), epoch);
+
+        assert!(store.current_claim_fence(&room_jid).is_none());
+        assert!(store
+            .load_room_state_fenced(&room_jid, &exact_fence)
+            .await
+            .expect("the unadvertised exact claim may hydrate")
+            .is_none());
+
+        let wrong_incarnation = RoomClaimFenceContext::new(
+            entity.clone(),
+            NodeIdentity::new("room-node", "stale-incarnation"),
+            epoch,
+        );
+        assert!(store
+            .load_room_state_fenced(&room_jid, &wrong_incarnation)
+            .await
+            .is_err());
+        assert!(!store
+            .check_exact_claim_fence(&room_jid, &wrong_incarnation)
+            .await
+            .expect("a stale tuple is a definitive ownership miss"));
+
+        let wrong_epoch = RoomClaimFenceContext::new(entity, owner, ClaimEpoch(epoch.0 + 1));
+        assert!(store
+            .load_room_state_fenced(&room_jid, &wrong_epoch)
+            .await
+            .is_err());
+
+        let missing_authority = RecordingDurableStore::default();
+        assert!(missing_authority
+            .load_room_state_fenced(&room_jid, &exact_fence)
+            .await
+            .is_err());
+        assert!(missing_authority
+            .check_exact_claim_fence(&room_jid, &exact_fence)
+            .await
+            .is_err());
+
+        claim_store.fail_next_current_claim();
+        assert!(store
+            .load_room_state_fenced(&room_jid, &exact_fence)
+            .await
+            .is_err());
+        claim_store.fail_next_current_claim();
+        assert!(store
+            .check_exact_claim_fence(&room_jid, &exact_fence)
+            .await
+            .is_err());
     }
 
     fn blocking_restore_store(
@@ -2260,20 +2434,36 @@ mod ownership_claims_tests {
         }
     }
 
+    async fn wire_recording_store_with_claims(
+        registry: &ActorRef<RoomRegistryActor>,
+        claim_store: Arc<dyn ClaimStore>,
+        node_identity: SharedNodeIdentity,
+        store: Arc<RecordingDurableStore>,
+    ) {
+        store.bind_claim_store(Arc::clone(&claim_store));
+        registry
+            .ask(WireClusteringClaims {
+                claim_store,
+                node_identity,
+                durable_store: Some(store as Arc<dyn MucDurableStore>),
+                rollout_backoff: None,
+            })
+            .await
+            .expect("wire recording durable store");
+    }
+
     async fn wire_recording_store(
         registry: &ActorRef<RoomRegistryActor>,
         store: Arc<RecordingDurableStore>,
     ) -> Arc<InProcessClaimStore> {
         let claim_store = Arc::new(InProcessClaimStore::new());
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(store as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire blocking durable store");
+        wire_recording_store_with_claims(
+            registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            store,
+        )
+        .await;
         claim_store
     }
 
@@ -2308,6 +2498,11 @@ mod ownership_claims_tests {
         tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
             .await
             .expect("blocked restore started");
+        assert_eq!(
+            store.current_claim_fence(&blocked_jid),
+            None,
+            "a successor fence must stay private while its actor is still preparing"
+        );
 
         let unrelated = tokio::time::timeout(
             std::time::Duration::from_millis(200),
@@ -2352,6 +2547,10 @@ mod ownership_claims_tests {
             .await
             .expect("create task")
             .expect("blocked room publishes after restore");
+        assert!(
+            store.current_claim_fence(&blocked_jid).is_some(),
+            "the exact fence is published with the ready registry entry"
+        );
         assert!(lookup
             .await
             .expect("lookup task")
@@ -3057,19 +3256,17 @@ mod ownership_claims_tests {
         let allow_load = Arc::new(tokio::sync::Notify::new());
         let durable_store = Arc::new(RecordingDurableStore {
             load_result: Some(reclaimed_snapshot("bounded-overlap")),
-            block_all_loads: true,
+            block_load_from_call: Some(2),
             allow_load: Some(Arc::clone(&allow_load)),
             ..RecordingDurableStore::default()
         });
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: claim_store as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            claim_store as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            durable_store,
+        )
+        .await;
         let room_jid = test_room_jid("bounded-overlap");
         let claim_fence = room_claim_fence(&room_jid, epoch);
         registry
@@ -3569,15 +3766,13 @@ mod ownership_claims_tests {
             ClaimEpoch(3),
         ));
         let durable_store = Arc::new(RecordingDurableStore::default());
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            Arc::clone(&durable_store),
+        )
+        .await;
 
         let jid = test_room_jid("dead-owner");
         registry
@@ -3647,15 +3842,14 @@ mod ownership_claims_tests {
             }),
             ..RecordingDurableStore::default()
         });
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::new(InProcessClaimStore::new()) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        let claim_store = Arc::new(InProcessClaimStore::new()) as Arc<dyn ClaimStore>;
+        wire_recording_store_with_claims(
+            &registry,
+            claim_store,
+            SharedNodeIdentity::new(this_identity()),
+            durable_store,
+        )
+        .await;
 
         let jid = test_room_jid("restore-me");
         let acquisition = registry
@@ -3694,15 +3888,13 @@ mod ownership_claims_tests {
             fence_lost: AtomicBool::new(true),
             ..RecordingDurableStore::default()
         });
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            Arc::clone(&durable_store),
+        )
+        .await;
 
         let jid = test_room_jid("failed-initial-demand-restore");
         let result = registry
@@ -3751,15 +3943,13 @@ mod ownership_claims_tests {
             fail_fenced_loads_remaining: AtomicUsize::new(1),
             ..RecordingDurableStore::default()
         });
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            Arc::clone(&durable_store),
+        )
+        .await;
 
         let jid = test_room_jid("transient-demand-restore");
         let acquisition = registry
@@ -3813,6 +4003,81 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test]
+    async fn reclaimed_successor_fence_is_published_only_with_the_ready_actor() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(4);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        let jid = test_room_jid("blocked-proactive-reclaim");
+        let (durable_store, started, allow) = blocking_restore_store_with_result(
+            jid.clone(),
+            Some(reclaimed_snapshot("proactively restored")),
+        );
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            Arc::clone(&durable_store),
+        )
+        .await;
+
+        let claim_fence = room_claim_fence(&jid, epoch);
+        let reconcile_registry = registry.clone();
+        let reconcile_jid = jid.clone();
+        let reconcile_fence = claim_fence.clone();
+        let reconcile = tokio::spawn(async move {
+            reconcile_registry
+                .ask(ReconcileReclaimedRoom {
+                    room_jid: reconcile_jid,
+                    claim_fence: reconcile_fence,
+                    previous_owner: this_identity(),
+                })
+                .await
+        });
+        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+            .await
+            .expect("reclaimed load started");
+
+        assert_eq!(
+            durable_store.current_claim_fence(&jid),
+            None,
+            "the shared fan-out cache must not expose a preparing successor fence"
+        );
+
+        allow.notify_one();
+        tokio::time::timeout(std::time::Duration::from_secs(1), started.notified())
+            .await
+            .expect("reclaimed actor restore started");
+        assert_eq!(
+            durable_store.current_claim_fence(&jid),
+            None,
+            "the shared fan-out cache must stay empty while the actor restores"
+        );
+        allow.notify_one();
+        assert_eq!(
+            reconcile
+                .await
+                .expect("reconcile task")
+                .expect("reconcile reply"),
+            ReclaimedRoomOutcome::Hydrated
+        );
+        assert_eq!(
+            durable_store.current_claim_fence(&jid),
+            Some(claim_fence),
+            "publication installs the actor and its fan-out fence together"
+        );
+        assert!(
+            registry
+                .ask(GetRoom {
+                    room_jid: jid.clone(),
+                })
+                .await
+                .expect("ready room lookup")
+                .is_some(),
+            "a visible successor fence must always have its matching ready registry entry"
+        );
+    }
+
+    #[tokio::test]
     async fn reclaimed_room_hydrates_once_at_the_exact_won_epoch() {
         let registry = spawn_registry().await;
         let epoch = ClaimEpoch(4);
@@ -3821,15 +4086,13 @@ mod ownership_claims_tests {
             load_result: Some(reclaimed_snapshot("proactively restored")),
             ..RecordingDurableStore::default()
         });
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            durable_store,
+        )
+        .await;
 
         let jid = test_room_jid("proactive");
         let first = registry
@@ -3875,15 +4138,13 @@ mod ownership_claims_tests {
             fence_lost: AtomicBool::new(true),
             ..RecordingDurableStore::default()
         });
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            Arc::clone(&durable_store),
+        )
+        .await;
 
         let jid = test_room_jid("failed-initial-reclaimed-restore");
         let claim_fence = room_claim_fence(&jid, epoch);
@@ -3913,8 +4174,8 @@ mod ownership_claims_tests {
         );
         assert_eq!(
             durable_store.current_claim_fence(&jid),
-            Some(claim_fence),
-            "an uncertain reclaimed preparation retains exact-epoch responsibility",
+            None,
+            "an unpublished failed preparation must not expose its fence through the fan-out cache",
         );
     }
 
@@ -3926,18 +4187,17 @@ mod ownership_claims_tests {
         // Initial authorization, post-load authorization, then the exact
         // publication fence after durable hydration messages are enqueued.
         claim_store.fail_fence_on_call(3);
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(Arc::new(RecordingDurableStore {
-                    load_result: Some(reclaimed_snapshot("must-not-install")),
-                    ..RecordingDurableStore::default()
-                }) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        let durable_store = Arc::new(RecordingDurableStore {
+            load_result: Some(reclaimed_snapshot("must-not-install")),
+            ..RecordingDurableStore::default()
+        });
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            durable_store,
+        )
+        .await;
 
         let jid = test_room_jid("final-fence");
         let outcome = registry
@@ -3961,17 +4221,13 @@ mod ownership_claims_tests {
         let registry = spawn_registry().await;
         let epoch = ClaimEpoch(8);
         let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(
-                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
-                ),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            Arc::new(RecordingDurableStore::default()),
+        )
+        .await;
 
         let jid = test_room_jid("ephemeral-orphan");
         let outcome = registry
@@ -3998,18 +4254,17 @@ mod ownership_claims_tests {
         let registry = spawn_registry().await;
         let epoch = ClaimEpoch(9);
         let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(Arc::new(RecordingDurableStore {
-                    fail_load: true,
-                    ..RecordingDurableStore::default()
-                }) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        let durable_store = Arc::new(RecordingDurableStore {
+            fail_load: true,
+            ..RecordingDurableStore::default()
+        });
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            durable_store,
+        )
+        .await;
 
         let jid = test_room_jid("load-failure");
         let outcome = registry
@@ -4046,18 +4301,17 @@ mod ownership_claims_tests {
         let identity = SharedNodeIdentity::new(old_owner.clone());
         let epoch = ClaimEpoch(10);
         let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner.clone(), epoch));
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: identity.clone(),
-                durable_store: Some(Arc::new(RecordingDurableStore {
-                    load_result: Some(reclaimed_snapshot("must not hydrate")),
-                    ..RecordingDurableStore::default()
-                }) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        let durable_store = Arc::new(RecordingDurableStore {
+            load_result: Some(reclaimed_snapshot("must not hydrate")),
+            ..RecordingDurableStore::default()
+        });
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            identity.clone(),
+            durable_store,
+        )
+        .await;
         let jid = test_room_jid("rotate-before-worker");
         let fence = RoomClaimFenceContext::new(
             Entity::new(EntityType::RoomActor, jid.to_string()),
@@ -4095,18 +4349,17 @@ mod ownership_claims_tests {
         let identity = SharedNodeIdentity::new(old_owner.clone());
         let epoch = ClaimEpoch(11);
         let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner.clone(), epoch));
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: identity.clone(),
-                durable_store: Some(Arc::new(RecordingDurableStore {
-                    fail_load: true,
-                    ..RecordingDurableStore::default()
-                }) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        let durable_store = Arc::new(RecordingDurableStore {
+            fail_load: true,
+            ..RecordingDurableStore::default()
+        });
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            identity.clone(),
+            durable_store,
+        )
+        .await;
         let jid = test_room_jid("rotate-between-retries");
         let fence = RoomClaimFenceContext::new(
             Entity::new(EntityType::RoomActor, jid.to_string()),
@@ -4155,17 +4408,13 @@ mod ownership_claims_tests {
         let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner, ClaimEpoch(20)));
         claim_store.set_fence_delay(std::time::Duration::from_millis(100));
         claim_store.fail_next_release();
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: identity.clone(),
-                durable_store: Some(
-                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
-                ),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            identity.clone(),
+            Arc::new(RecordingDurableStore::default()),
+        )
+        .await;
         let jid = test_room_jid("rotate-at-demand-publish");
         let registry_for_create = registry.clone();
         let jid_for_create = jid.clone();
@@ -4362,15 +4611,13 @@ mod ownership_claims_tests {
         let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner.clone(), old_epoch));
         claim_store.fail_fence_on_call(1);
         let durable_store = Arc::new(RecordingDurableStore::default());
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: identity.clone(),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            identity.clone(),
+            Arc::clone(&durable_store),
+        )
+        .await;
         let jid = test_room_jid("stale-retry-cache");
         let old_fence = RoomClaimFenceContext::new(
             Entity::new(EntityType::RoomActor, jid.to_string()),
@@ -4475,15 +4722,13 @@ mod ownership_claims_tests {
         let claim_store = Arc::new(DeadOwnerClaimStore::empty());
         claim_store.set_fence_delay(std::time::Duration::from_secs(60));
         let durable_store = Arc::new(RecordingDurableStore::default());
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            durable_store,
+        )
+        .await;
         let jid = test_room_jid("hung-final-publication-fence");
         let create_registry = registry.clone();
         let create = tokio::spawn(async move {
@@ -4532,15 +4777,13 @@ mod ownership_claims_tests {
             &mailbox_marker_seen,
         )));
         let durable_store = Arc::new(RecordingDurableStore::default());
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            durable_store,
+        )
+        .await;
 
         let mut creates = Vec::new();
         for room in ["ready-fence-one", "ready-fence-two"] {
@@ -4596,15 +4839,13 @@ mod ownership_claims_tests {
         let claim_store = Arc::new(DeadOwnerClaimStore::empty());
         claim_store.lose_claim_on_fence_call(2);
         let durable_store = Arc::new(RecordingDurableStore::default());
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            durable_store,
+        )
+        .await;
         let jid = test_room_jid("claim-lost-after-publication-preflight");
 
         assert!(matches!(
@@ -4852,15 +5093,13 @@ mod ownership_claims_tests {
             load_result: Some(reclaimed_snapshot("clean retry snapshot")),
             ..RecordingDurableStore::default()
         });
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            durable_store,
+        )
+        .await;
         let jid = test_room_jid("uncertain-old-epoch");
         let original = registry
             .ask(GetOrCreateRoom {
@@ -6129,15 +6368,13 @@ mod ownership_claims_tests {
             load_result: Some(reclaimed_snapshot("must-not-republish")),
             ..RecordingDurableStore::default()
         });
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(identity),
-                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(identity),
+            durable_store,
+        )
+        .await;
         registry
             .ask(RememberOrdinaryReleaseForTest {
                 room_jid: jid.clone(),
@@ -6337,6 +6574,135 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test]
+    async fn cross_entity_reclaimed_messages_cannot_touch_a_live_room() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(NonCancelSafeReleaseStore::new());
+        let durable_store = Arc::new(RecordingDurableStore::default());
+        let owner = this_identity();
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(owner.clone()),
+            Arc::clone(&durable_store),
+        )
+        .await;
+
+        let target_jid = test_room_jid("cross-entity-target");
+        let target = registry
+            .ask(GetOrCreateRoom {
+                room_jid: target_jid.clone(),
+                waddle_id: "w".to_string(),
+                channel_id: "c".to_string(),
+                config: RoomConfig::default(),
+            })
+            .await
+            .expect("publish target room")
+            .actor_ref;
+        let target_fence = durable_store
+            .current_claim_fence(&target_jid)
+            .expect("published target fence");
+        let sibling_jid = test_room_jid("cross-entity-sibling");
+        let sibling_fence = RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, sibling_jid.to_string()),
+            owner.clone(),
+            target_fence.epoch,
+        );
+        let load_calls = durable_store.load_calls.load(Ordering::SeqCst);
+        let release_calls = claim_store.release_calls.load(Ordering::SeqCst);
+
+        registry
+            .ask(RememberPendingReclaimedRoom {
+                room_jid: target_jid.clone(),
+                claim_fence: sibling_fence.clone(),
+                previous_owner: foreign_identity(),
+            })
+            .await
+            .expect("ignore malformed reclaimed handoff");
+        assert!(registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("pending reclaimed rooms")
+            .is_empty());
+
+        assert_eq!(
+            registry
+                .ask(ReconcileReclaimedRoom {
+                    room_jid: target_jid.clone(),
+                    claim_fence: sibling_fence,
+                    previous_owner: foreign_identity(),
+                })
+                .await
+                .expect("reject malformed reconciliation"),
+            ReclaimedRoomOutcome::LostRace,
+        );
+        assert_eq!(durable_store.load_calls.load(Ordering::SeqCst), load_calls);
+        assert_eq!(
+            claim_store.release_calls.load(Ordering::SeqCst),
+            release_calls
+        );
+        assert_eq!(
+            durable_store.current_claim_fence(&target_jid),
+            Some(target_fence.clone()),
+        );
+        let still_registered = registry
+            .ask(GetRoom {
+                room_jid: target_jid.clone(),
+            })
+            .await
+            .expect("get target after malformed reconciliation")
+            .expect("target remains registered");
+        assert_eq!(still_registered.id(), target.id());
+        assert!(claim_store
+            .fence(&target_fence.entity, &owner, target_fence.epoch)
+            .await
+            .expect("target claim lookup"));
+        assert!(registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("pending reclaimed rooms after reconciliation")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn reclaimed_release_rejects_a_cross_entity_fence() {
+        let owner = this_identity();
+        let epoch = ClaimEpoch(91);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(owner.clone(), epoch));
+        let mut registry = RoomRegistryActor::new(
+            "muc.example.com".to_string(),
+            OccupantIdSecret::for_testing(b"test-secret".to_vec()),
+        );
+        registry.claim_store = Arc::clone(&claim_store) as Arc<dyn ClaimStore>;
+
+        let target_jid = test_room_jid("cross-entity-release-target");
+        let target_entity = Entity::new(EntityType::RoomActor, target_jid.to_string());
+        let sibling_jid = test_room_jid("cross-entity-release-sibling");
+        let sibling_fence = RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, sibling_jid.to_string()),
+            owner,
+            epoch,
+        );
+
+        assert_eq!(
+            registry
+                .release_reclaimed_room_claim_with_timeout(
+                    &target_jid,
+                    &sibling_fence,
+                    &foreign_identity(),
+                    RECLAIMED_ROOM_RELEASE_TIMEOUT,
+                )
+                .await,
+            ReclaimedRoomOutcome::LostRace,
+        );
+        assert!(claim_store
+            .current_claim(&target_entity)
+            .await
+            .expect("target claim lookup")
+            .is_some());
+        assert!(registry.pending_reclaimed_rooms.is_empty());
+    }
+
+    #[tokio::test]
     async fn bare_reclaimed_reservation_blocks_demand_claim_acquisition() {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(InProcessClaimStore::new());
@@ -6433,17 +6799,13 @@ mod ownership_claims_tests {
         let registry = spawn_registry().await;
         let epoch = ClaimEpoch(12);
         let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: claim_store as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(
-                    Arc::new(RecordingDurableStore::default()) as Arc<dyn MucDurableStore>
-                ),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            claim_store as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            Arc::new(RecordingDurableStore::default()),
+        )
+        .await;
 
         let jid = test_room_jid("demand-race");
         let demand = registry
@@ -6501,15 +6863,13 @@ mod ownership_claims_tests {
         let epoch = ClaimEpoch(12);
         let claim_store = Arc::new(DeadOwnerClaimStore::seeded(owner.clone(), epoch));
         let durable_store = Arc::new(RecordingDurableStore::default());
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(owner),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(owner),
+            Arc::clone(&durable_store),
+        )
+        .await;
         let jid = test_room_jid("lost-live-reclaimed-fence");
         let live = registry
             .ask(GetOrCreateRoom {
@@ -6570,6 +6930,10 @@ mod ownership_claims_tests {
             allow_config_save: Some(Arc::clone(&allow_config_save)),
             ..RecordingDurableStore::default()
         });
+        *durable_store
+            .authoritative_claim_store
+            .lock()
+            .expect("lock") = Some(Arc::clone(&claim_store) as Arc<dyn ClaimStore>);
         registry
             .ask(WireClusteringClaims {
                 claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
@@ -6671,16 +7035,15 @@ mod ownership_claims_tests {
     #[tokio::test]
     async fn deposed_actor_ref_refuses_resolver_granted_join() {
         let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
         let durable_store = Arc::new(RecordingDurableStore::default());
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::new(InProcessClaimStore::new()),
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            claim_store as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            Arc::clone(&durable_store),
+        )
+        .await;
         let actor = registry
             .ask(GetOrCreateRoom {
                 room_jid: test_room_jid("deposed-resolver-join"),
@@ -6713,16 +7076,15 @@ mod ownership_claims_tests {
     #[tokio::test]
     async fn deposed_actor_ref_refuses_resolver_affiliation_sync() {
         let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
         let durable_store = Arc::new(RecordingDurableStore::default());
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::new(InProcessClaimStore::new()),
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            claim_store as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            Arc::clone(&durable_store),
+        )
+        .await;
         let actor = registry
             .ask(GetOrCreateRoom {
                 room_jid: test_room_jid("deposed-resolver-sync"),
@@ -6791,15 +7153,13 @@ mod ownership_claims_tests {
             ..RecordingDurableStore::default()
         });
         *claim_store.state.lock().expect("claim state") = Some((owner_c.clone(), won_epoch));
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: claim_store as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(owner_c.clone()),
-                durable_store: Some(durable_store as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire owner C");
+        wire_recording_store_with_claims(
+            &registry,
+            claim_store as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(owner_c.clone()),
+            durable_store,
+        )
+        .await;
 
         let outcome = registry
             .ask(ReconcileReclaimedRoom {
@@ -6831,15 +7191,13 @@ mod ownership_claims_tests {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(NonCancelSafeReleaseStore::new());
         let durable_store = Arc::new(RecordingDurableStore::default());
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire clustering");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            Arc::clone(&durable_store),
+        )
+        .await;
 
         let room_jid = test_room_jid("deposed-before-inactive-destroy");
         let actor = registry
@@ -6919,15 +7277,13 @@ mod ownership_claims_tests {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(NonCancelSafeReleaseStore::new());
         let durable_store = Arc::new(RecordingDurableStore::default());
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: SharedNodeIdentity::new(this_identity()),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire clustering");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            Arc::clone(&durable_store),
+        )
+        .await;
 
         let inactive_jid = test_room_jid("inactive-seal-full-backlog");
         let inactive_actor = registry
@@ -7069,15 +7425,13 @@ mod ownership_claims_tests {
         let claim_store = Arc::new(InProcessClaimStore::new());
         let durable_store = Arc::new(RecordingDurableStore::default());
         let identity = SharedNodeIdentity::new(this_identity());
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: identity.clone(),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire clustering");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            identity.clone(),
+            Arc::clone(&durable_store),
+        )
+        .await;
         let room_jid = test_room_jid("identity-rotated-sealed-reap");
         let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
         let actor = registry

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -2081,6 +2081,7 @@ mod ownership_claims_tests {
         fail_load: bool,
         lose_restore_ownership_on_call: Option<usize>,
         restore_loss_successor: Option<(Arc<DeadOwnerClaimStore>, NodeIdentity)>,
+        rotate_identity_during_load: Option<(SharedNodeIdentity, NodeIdentity)>,
         fail_fenced_loads_remaining: AtomicUsize,
         block_all_loads: bool,
         block_load_for: Option<BareJid>,
@@ -2188,6 +2189,12 @@ mod ownership_claims_tests {
                 if let Some((claim_store, successor)) = &store.restore_loss_successor {
                     claim_store.replace_with_successor(successor.clone());
                     return Err(crate::XmppError::OwnershipLost {
+                        entity: fence.entity.clone(),
+                    });
+                }
+                if let Some((identity, successor)) = &store.rotate_identity_during_load {
+                    identity.rotate(successor.clone()).await;
+                    return Err(crate::XmppError::OwnershipUnavailable {
                         entity: fence.entity.clone(),
                     });
                 }
@@ -4096,6 +4103,58 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test]
+    async fn identity_rotation_during_demand_restore_releases_the_old_exact_fence() {
+        let registry = spawn_registry().await;
+        let old_owner = this_identity();
+        let identity = SharedNodeIdentity::new(old_owner);
+        let claim_store = Arc::new(DeadOwnerClaimStore::empty());
+        let durable_store = Arc::new(RecordingDurableStore {
+            rotate_identity_during_load: Some((identity.clone(), foreign_identity())),
+            ..RecordingDurableStore::default()
+        });
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            identity,
+            Arc::clone(&durable_store),
+        )
+        .await;
+
+        let jid = test_room_jid("rotate-during-demand-restore");
+        assert!(matches!(
+            registry
+                .ask(GetOrCreateRoom {
+                    room_jid: jid.clone(),
+                    waddle_id: "caller-waddle".to_string(),
+                    channel_id: "caller-channel".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await,
+            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(room)))
+                if room == jid
+        ));
+        assert_eq!(
+            durable_store.load_calls.load(Ordering::SeqCst),
+            2,
+            "identity uncertainty receives only the bounded restore retry"
+        );
+        assert_eq!(claim_store.exact_release_calls.load(Ordering::SeqCst), 1);
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_none());
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("room lookup")
+            .is_none());
+        assert!(durable_store.current_claim_fence(&jid).is_none());
+    }
+
+    #[tokio::test]
     async fn transient_initial_demand_restore_recovers_before_publication() {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(InProcessClaimStore::new());
@@ -4615,6 +4674,73 @@ mod ownership_claims_tests {
             .expect("retry after rotation");
 
         assert_eq!(retried, ReclaimedRoomOutcome::Released);
+        assert!(claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("claim lookup")
+            .is_none());
+        assert!(registry
+            .ask(ListPendingReclaimedRooms { limit: 8 })
+            .await
+            .expect("pending retries")
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn identity_rotation_during_reclaimed_restore_retains_then_releases_old_fence() {
+        let registry = spawn_registry().await;
+        let old_owner = this_identity();
+        let new_identity = foreign_identity();
+        let identity = SharedNodeIdentity::new(old_owner.clone());
+        let epoch = ClaimEpoch(12);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(old_owner.clone(), epoch));
+        let durable_store = Arc::new(RecordingDurableStore {
+            rotate_identity_during_load: Some((identity.clone(), new_identity)),
+            ..RecordingDurableStore::default()
+        });
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            identity,
+            durable_store,
+        )
+        .await;
+        let jid = test_room_jid("rotate-during-reclaimed-restore");
+        let fence = RoomClaimFenceContext::new(
+            Entity::new(EntityType::RoomActor, jid.to_string()),
+            old_owner,
+            epoch,
+        );
+
+        let first = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: fence.clone(),
+                previous_owner: foreign_identity(),
+            })
+            .await
+            .expect("restore interrupted by identity rotation");
+        assert_eq!(first, ReclaimedRoomOutcome::PendingRetry);
+        assert_eq!(claim_store.exact_release_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            registry
+                .ask(ListPendingReclaimedRooms { limit: 8 })
+                .await
+                .expect("retained old-fence responsibility")
+                .len(),
+            1
+        );
+
+        let retried = registry
+            .ask(ReconcileReclaimedRoom {
+                room_jid: jid.clone(),
+                claim_fence: fence,
+                previous_owner: foreign_identity(),
+            })
+            .await
+            .expect("retry releases the old identity's exact fence");
+        assert_eq!(retried, ReclaimedRoomOutcome::Released);
+        assert_eq!(claim_store.exact_release_calls.load(Ordering::SeqCst), 1);
         assert!(claim_store
             .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
             .await

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -2199,7 +2199,7 @@ mod ownership_claims_tests {
                 }
                 if let Some((identity, successor)) = &store.rotate_identity_during_load {
                     identity.rotate(successor.clone()).await;
-                    return Err(crate::XmppError::OwnershipUnavailable {
+                    return Err(crate::XmppError::OwnershipLost {
                         entity: fence.entity.clone(),
                     });
                 }
@@ -4147,9 +4147,16 @@ mod ownership_claims_tests {
         ));
         assert_eq!(
             durable_store.load_calls.load(Ordering::SeqCst),
-            2,
-            "identity uncertainty receives only the bounded restore retry"
+            1,
+            "local identity supersession is terminal for the old actor fence"
         );
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while claim_store.exact_release_calls.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the old exact tuple receives terminal cleanup");
         assert_eq!(claim_store.exact_release_calls.load(Ordering::SeqCst), 1);
         assert!(claim_store
             .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
@@ -4699,7 +4706,7 @@ mod ownership_claims_tests {
     }
 
     #[tokio::test]
-    async fn identity_rotation_during_reclaimed_restore_retains_then_releases_old_fence() {
+    async fn identity_rotation_during_reclaimed_restore_terminally_releases_old_fence() {
         let registry = spawn_registry().await;
         let old_owner = this_identity();
         let new_identity = foreign_identity();
@@ -4727,31 +4734,28 @@ mod ownership_claims_tests {
         let first = registry
             .ask(ReconcileReclaimedRoom {
                 room_jid: jid.clone(),
-                claim_fence: fence.clone(),
+                claim_fence: fence,
                 previous_owner: foreign_identity(),
             })
             .await
             .expect("restore interrupted by identity rotation");
         assert_eq!(first, ReclaimedRoomOutcome::PendingRetry);
-        assert_eq!(claim_store.exact_release_calls.load(Ordering::SeqCst), 0);
-        assert_eq!(
-            registry
-                .ask(ListPendingReclaimedRooms { limit: 8 })
-                .await
-                .expect("retained old-fence responsibility")
-                .len(),
-            1
-        );
-
-        let retried = registry
-            .ask(ReconcileReclaimedRoom {
-                room_jid: jid.clone(),
-                claim_fence: fence,
-                previous_owner: foreign_identity(),
-            })
-            .await
-            .expect("retry releases the old identity's exact fence");
-        assert_eq!(retried, ReclaimedRoomOutcome::Released);
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                let pending_releases = registry
+                    .ask(ListPendingRoomReleaseJids)
+                    .await
+                    .expect("pending exact releases");
+                if claim_store.exact_release_calls.load(Ordering::SeqCst) == 1
+                    && pending_releases.is_empty()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the locally superseded exact tuple is released once");
         assert_eq!(claim_store.exact_release_calls.load(Ordering::SeqCst), 1);
         assert!(claim_store
             .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
@@ -7627,10 +7631,10 @@ mod ownership_claims_tests {
     }
 
     /// A join fence can be the first component to prove that this actor's
-    /// durable ownership moved. That seal is materially different from an
-    /// inactivity seal: the deposed actor must leave the registry even when
-    /// the bounded exact-release inventory is already full, while the ordinary
-    /// seal must retain its capacity guard.
+    /// durable fence became non-serving. That seal is materially different
+    /// from an inactivity seal: the non-serving actor must leave the registry
+    /// even when the bounded exact-release inventory is already full, while
+    /// the ordinary seal must retain its capacity guard.
     #[tokio::test]
     async fn reap_sealed_room_forces_deposed_eviction_without_weakening_inactive_fence() {
         let registry = spawn_registry().await;

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -1588,6 +1588,17 @@ mod ownership_claims_tests {
                 .store(drop_claim, Ordering::SeqCst);
             self.force_next_steal_conflict.store(true, Ordering::SeqCst);
         }
+
+        fn replace_with_successor(&self, successor: NodeIdentity) -> ClaimEpoch {
+            let mut state = self.state.lock().expect("lock");
+            let next_epoch = ClaimEpoch(
+                state
+                    .as_ref()
+                    .map_or(0, |(_, epoch)| epoch.0.saturating_add(1)),
+            );
+            *state = Some((successor, next_epoch));
+            next_epoch
+        }
     }
 
     #[async_trait]
@@ -2068,8 +2079,8 @@ mod ownership_claims_tests {
     struct RecordingDurableStore {
         load_result: Option<DurableRoomState>,
         fail_load: bool,
-        lose_restore_ownership: bool,
         lose_restore_ownership_on_call: Option<usize>,
+        restore_loss_successor: Option<(Arc<DeadOwnerClaimStore>, NodeIdentity)>,
         fail_fenced_loads_remaining: AtomicUsize,
         block_all_loads: bool,
         block_load_for: Option<BareJid>,
@@ -2174,9 +2185,13 @@ mod ownership_claims_tests {
                     })
                     .is_ok();
                 let fence_lost = store.fence_lost.load(Ordering::SeqCst);
-                if store.lose_restore_ownership
-                    || store.lose_restore_ownership_on_call == Some(load_call)
-                {
+                if let Some((claim_store, successor)) = &store.restore_loss_successor {
+                    claim_store.replace_with_successor(successor.clone());
+                    return Err(crate::XmppError::OwnershipLost {
+                        entity: fence.entity.clone(),
+                    });
+                }
+                if store.lose_restore_ownership_on_call == Some(load_call) {
                     return Err(crate::XmppError::OwnershipLost {
                         entity: fence.entity.clone(),
                     });
@@ -4031,9 +4046,10 @@ mod ownership_claims_tests {
     #[tokio::test]
     async fn demand_restore_ownership_loss_is_terminal_without_release_or_retry() {
         let registry = spawn_registry().await;
-        let claim_store = Arc::new(InProcessClaimStore::new());
+        let claim_store = Arc::new(DeadOwnerClaimStore::empty());
+        let successor = foreign_identity();
         let durable_store = Arc::new(RecordingDurableStore {
-            lose_restore_ownership: true,
+            restore_loss_successor: Some((Arc::clone(&claim_store), successor.clone())),
             ..RecordingDurableStore::default()
         });
         wire_recording_store_with_claims(
@@ -4065,14 +4081,18 @@ mod ownership_claims_tests {
             .is_none());
         assert_eq!(durable_store.load_calls.load(Ordering::SeqCst), 1);
         assert!(durable_store.current_claim_fence(&jid).is_none());
-        assert!(
-            claim_store
-                .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
-                .await
-                .expect("claim lookup")
-                .is_some(),
-            "a terminally lost fence must not be released again"
+        assert_eq!(
+            claim_store.exact_release_calls.load(Ordering::SeqCst),
+            0,
+            "a terminally lost fence must not enqueue or attempt an exact release"
         );
+        let successor_claim = claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("successor claim lookup")
+            .expect("the successor claim must survive terminal restore loss");
+        assert_eq!(successor_claim.owner, successor);
+        assert_eq!(successor_claim.claim_epoch, ClaimEpoch(1));
     }
 
     #[tokio::test]

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -1495,6 +1495,7 @@ mod ownership_claims_tests {
         fence_fail_on_call: AtomicUsize,
         fence_lose_claim_on_call: AtomicUsize,
         release_failures: AtomicUsize,
+        exact_release_calls: AtomicUsize,
         release_delay_ms: AtomicU64,
         fence_delay_ms: AtomicU64,
         ensure_delay_ms: AtomicU64,
@@ -1514,6 +1515,7 @@ mod ownership_claims_tests {
                 fence_fail_on_call: AtomicUsize::new(usize::MAX),
                 fence_lose_claim_on_call: AtomicUsize::new(usize::MAX),
                 release_failures: AtomicUsize::new(0),
+                exact_release_calls: AtomicUsize::new(0),
                 release_delay_ms: AtomicU64::new(0),
                 fence_delay_ms: AtomicU64::new(0),
                 ensure_delay_ms: AtomicU64::new(0),
@@ -1760,6 +1762,7 @@ mod ownership_claims_tests {
             me: &NodeIdentity,
             mine: ClaimEpoch,
         ) -> Result<crate::ownership::ExactReleaseOutcome, ClaimError> {
+            self.exact_release_calls.fetch_add(1, Ordering::SeqCst);
             let delay_ms = self.release_delay_ms.load(Ordering::SeqCst);
             if delay_ms > 0 {
                 tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
@@ -2065,6 +2068,8 @@ mod ownership_claims_tests {
     struct RecordingDurableStore {
         load_result: Option<DurableRoomState>,
         fail_load: bool,
+        lose_restore_ownership: bool,
+        lose_restore_ownership_on_call: Option<usize>,
         fail_fenced_loads_remaining: AtomicUsize,
         block_all_loads: bool,
         block_load_for: Option<BareJid>,
@@ -2136,9 +2141,9 @@ mod ownership_claims_tests {
             if self.authoritative_claim_matches(room_jid, fence).await? {
                 Ok(())
             } else {
-                Err(crate::XmppError::internal(
-                    "durable operation received a stale or unowned claim fence",
-                ))
+                Err(crate::XmppError::OwnershipLost {
+                    entity: fence.entity.clone(),
+                })
             }
         }
     }
@@ -2149,35 +2154,42 @@ mod ownership_claims_tests {
             room_jid: &'a BareJid,
             fence: &'a RoomClaimFenceContext,
         ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
-            let load_call = self.load_calls.fetch_add(1, Ordering::SeqCst) + 1;
             let store = self;
-            let fail_fenced_load = self
-                .fail_fenced_loads_remaining
-                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
-                    remaining.checked_sub(1)
-                })
-                .is_ok();
-            let fence_lost = self.fence_lost.load(Ordering::SeqCst);
-            let should_block = self.block_all_loads
-                || self.block_load_for.as_ref() == Some(room_jid)
-                || self
-                    .block_load_from_call
-                    .is_some_and(|first_blocked_call| load_call >= first_blocked_call);
             let load_started = self.load_started.clone();
             let allow_load = self.allow_load.clone();
             let fail_load = self.fail_load;
             let result = self.load_result.clone();
             Box::pin(async move {
                 store.validate_claim_fence(room_jid, fence).await?;
+                let load_call = store.load_calls.fetch_add(1, Ordering::SeqCst) + 1;
+                let should_block = store.block_all_loads
+                    || store.block_load_for.as_ref() == Some(room_jid)
+                    || store
+                        .block_load_from_call
+                        .is_some_and(|first_blocked_call| load_call >= first_blocked_call);
+                let fail_fenced_load = store
+                    .fail_fenced_loads_remaining
+                    .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                        remaining.checked_sub(1)
+                    })
+                    .is_ok();
+                let fence_lost = store.fence_lost.load(Ordering::SeqCst);
+                if store.lose_restore_ownership
+                    || store.lose_restore_ownership_on_call == Some(load_call)
+                {
+                    return Err(crate::XmppError::OwnershipLost {
+                        entity: fence.entity.clone(),
+                    });
+                }
                 if fail_fenced_load {
                     return Err(crate::XmppError::internal(
                         "transient fenced load failure from test store",
                     ));
                 }
                 if fence_lost {
-                    return Err(crate::XmppError::internal(
-                        "fenced load rejected after ownership loss",
-                    ));
+                    return Err(crate::XmppError::OwnershipLost {
+                        entity: fence.entity.clone(),
+                    });
                 }
                 if should_block {
                     if let Some(started) = load_started {
@@ -2247,7 +2259,13 @@ mod ownership_claims_tests {
             let store = self;
             Box::pin(async move {
                 let exact = store.authoritative_claim_matches(room_jid, fence).await?;
-                Ok(exact && !store.fence_lost.load(Ordering::SeqCst))
+                if !exact {
+                    return Ok(false);
+                }
+                if store.fence_lost.load(Ordering::SeqCst) {
+                    return Ok(false);
+                }
+                Ok(true)
             })
         }
 
@@ -2350,10 +2368,12 @@ mod ownership_claims_tests {
             NodeIdentity::new("room-node", "stale-incarnation"),
             epoch,
         );
-        assert!(store
-            .load_room_state_fenced(&room_jid, &wrong_incarnation)
-            .await
-            .is_err());
+        assert!(matches!(
+            store
+                .load_room_state_fenced(&room_jid, &wrong_incarnation)
+                .await,
+            Err(crate::XmppError::OwnershipLost { .. })
+        ));
         assert!(!store
             .check_exact_claim_fence(&room_jid, &wrong_incarnation)
             .await
@@ -2364,6 +2384,32 @@ mod ownership_claims_tests {
             .load_room_state_fenced(&room_jid, &wrong_epoch)
             .await
             .is_err());
+
+        store.fence_lost.store(true, Ordering::SeqCst);
+        assert!(!store
+            .check_exact_claim_fence(&room_jid, &wrong_incarnation)
+            .await
+            .expect("a stale tuple remains a definitive ownership miss"));
+        assert!(!store
+            .check_exact_claim_fence(&room_jid, &exact_fence)
+            .await
+            .expect("a lost fence is a definitive ownership miss"));
+        store.fence_lost.store(false, Ordering::SeqCst);
+
+        store.fail_fenced_loads_remaining.store(1, Ordering::SeqCst);
+        assert!(store
+            .load_room_state_fenced(&room_jid, &wrong_incarnation)
+            .await
+            .is_err());
+        assert!(store
+            .load_room_state_fenced(&room_jid, &exact_fence)
+            .await
+            .is_err());
+        assert_eq!(
+            store.fail_fenced_loads_remaining.load(Ordering::SeqCst),
+            0,
+            "a failed exact-fence validation must not consume a later fault injection"
+        );
 
         let missing_authority = RecordingDurableStore::default();
         assert!(missing_authority
@@ -2385,6 +2431,54 @@ mod ownership_claims_tests {
             .check_exact_claim_fence(&room_jid, &exact_fence)
             .await
             .is_err());
+    }
+
+    #[tokio::test]
+    async fn recording_durable_store_validates_before_call_indexed_faults() {
+        let room_jid = test_room_jid("recording-store-fault-order");
+        let entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        let owner = NodeIdentity::new("room-node", "current-incarnation");
+        let epoch = ClaimEpoch(42);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(owner.clone(), epoch));
+        let exact_fence = RoomClaimFenceContext::new(entity.clone(), owner.clone(), epoch);
+        let stale_fence = RoomClaimFenceContext::new(
+            entity,
+            NodeIdentity::new("room-node", "stale-incarnation"),
+            epoch,
+        );
+
+        let ownership_loss_store = RecordingDurableStore {
+            lose_restore_ownership_on_call: Some(1),
+            ..RecordingDurableStore::default()
+        };
+        ownership_loss_store.bind_claim_store(Arc::clone(&claim_store) as Arc<dyn ClaimStore>);
+        assert!(ownership_loss_store
+            .load_room_state_fenced(&room_jid, &stale_fence)
+            .await
+            .is_err());
+        assert!(matches!(
+            ownership_loss_store
+                .load_room_state_fenced(&room_jid, &exact_fence)
+                .await,
+            Err(crate::XmppError::OwnershipLost { .. })
+        ));
+
+        let blocking_store = RecordingDurableStore {
+            block_load_from_call: Some(2),
+            ..RecordingDurableStore::default()
+        };
+        blocking_store.bind_claim_store(claim_store as Arc<dyn ClaimStore>);
+        assert!(blocking_store
+            .load_room_state_fenced(&room_jid, &stale_fence)
+            .await
+            .is_err());
+        assert!(tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            blocking_store.load_room_state_fenced(&room_jid, &exact_fence),
+        )
+        .await
+        .expect("a stale fence must not advance the blocking fault's call index")
+        .is_ok());
     }
 
     fn blocking_restore_store(
@@ -3885,7 +3979,7 @@ mod ownership_claims_tests {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(InProcessClaimStore::new());
         let durable_store = Arc::new(RecordingDurableStore {
-            fence_lost: AtomicBool::new(true),
+            fail_load: true,
             ..RecordingDurableStore::default()
         });
         wire_recording_store_with_claims(
@@ -3931,6 +4025,53 @@ mod ownership_claims_tests {
             durable_store.load_calls.load(Ordering::SeqCst),
             2,
             "a demand restore gets one bounded retry before the claim is released",
+        );
+    }
+
+    #[tokio::test]
+    async fn demand_restore_ownership_loss_is_terminal_without_release_or_retry() {
+        let registry = spawn_registry().await;
+        let claim_store = Arc::new(InProcessClaimStore::new());
+        let durable_store = Arc::new(RecordingDurableStore {
+            lose_restore_ownership: true,
+            ..RecordingDurableStore::default()
+        });
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            Arc::clone(&durable_store),
+        )
+        .await;
+
+        let jid = test_room_jid("terminal-demand-restore");
+        assert!(matches!(
+            registry
+                .ask(GetOrCreateRoom {
+                    room_jid: jid.clone(),
+                    waddle_id: "caller-waddle".to_string(),
+                    channel_id: "caller-channel".to_string(),
+                    config: RoomConfig::default(),
+                })
+                .await,
+            Err(SendError::HandlerError(RoomRegistryError::OwnershipUnavailable(room))) if room == jid
+        ));
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("room lookup")
+            .is_none());
+        assert_eq!(durable_store.load_calls.load(Ordering::SeqCst), 1);
+        assert!(durable_store.current_claim_fence(&jid).is_none());
+        assert!(
+            claim_store
+                .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+                .await
+                .expect("claim lookup")
+                .is_some(),
+            "a terminally lost fence must not be released again"
         );
     }
 
@@ -4135,7 +4276,7 @@ mod ownership_claims_tests {
         let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
         let durable_store = Arc::new(RecordingDurableStore {
             load_result: Some(reclaimed_snapshot("must remain hidden")),
-            fence_lost: AtomicBool::new(true),
+            fail_load: true,
             ..RecordingDurableStore::default()
         });
         wire_recording_store_with_claims(
@@ -4176,6 +4317,72 @@ mod ownership_claims_tests {
             durable_store.current_claim_fence(&jid),
             None,
             "an unpublished failed preparation must not expose its fence through the fan-out cache",
+        );
+    }
+
+    #[tokio::test]
+    async fn reclaimed_restore_ownership_loss_is_terminal_without_release_or_retry() {
+        let registry = spawn_registry().await;
+        let epoch = ClaimEpoch(51);
+        let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        let durable_store = Arc::new(RecordingDurableStore {
+            load_result: Some(reclaimed_snapshot("must-not-publish")),
+            lose_restore_ownership_on_call: Some(2),
+            ..RecordingDurableStore::default()
+        });
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            SharedNodeIdentity::new(this_identity()),
+            Arc::clone(&durable_store),
+        )
+        .await;
+
+        let jid = test_room_jid("terminal-reclaimed-restore");
+        assert_eq!(
+            registry
+                .ask(ReconcileReclaimedRoom {
+                    room_jid: jid.clone(),
+                    claim_fence: room_claim_fence(&jid, epoch),
+                    previous_owner: this_identity(),
+                })
+                .await
+                .expect("reconcile"),
+            ReclaimedRoomOutcome::LostRace
+        );
+        assert!(registry
+            .ask(GetRoom {
+                room_jid: jid.clone(),
+            })
+            .await
+            .expect("room lookup")
+            .is_none());
+        assert_eq!(durable_store.load_calls.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            claim_store.exact_release_calls.load(Ordering::SeqCst),
+            0,
+            "the terminal stale fence must not be redundantly released"
+        );
+        assert_eq!(
+            registry
+                .ask(GetPendingReclaimedRoomBacklog)
+                .await
+                .expect("pending reclaimed backlog")
+                .depth,
+            0,
+            "terminal ownership loss must not retain reclaimed retry work"
+        );
+        assert!(
+            durable_store.current_claim_fence(&jid).is_none(),
+            "a terminally lost reclaimed fence must not remain published"
+        );
+        assert!(
+            claim_store
+                .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+                .await
+                .expect("claim lookup")
+                .is_some(),
+            "the already-lost fence must not be released again"
         );
     }
 
@@ -6930,19 +7137,13 @@ mod ownership_claims_tests {
             allow_config_save: Some(Arc::clone(&allow_config_save)),
             ..RecordingDurableStore::default()
         });
-        *durable_store
-            .authoritative_claim_store
-            .lock()
-            .expect("lock") = Some(Arc::clone(&claim_store) as Arc<dyn ClaimStore>);
-        registry
-            .ask(WireClusteringClaims {
-                claim_store: Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
-                node_identity: node_identity.clone(),
-                durable_store: Some(Arc::clone(&durable_store) as Arc<dyn MucDurableStore>),
-                rollout_backoff: None,
-            })
-            .await
-            .expect("wire");
+        wire_recording_store_with_claims(
+            &registry,
+            Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
+            node_identity.clone(),
+            Arc::clone(&durable_store),
+        )
+        .await;
         let jid = test_room_jid("local-old-epoch");
         let original = registry
             .ask(GetOrCreateRoom {

--- a/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
+++ b/server/crates/waddle-xmpp/src/muc/room_registry_actor/tests.rs
@@ -2080,7 +2080,7 @@ mod ownership_claims_tests {
         load_result: Option<DurableRoomState>,
         fail_load: bool,
         lose_restore_ownership_on_call: Option<usize>,
-        restore_loss_successor: Option<(Arc<DeadOwnerClaimStore>, NodeIdentity)>,
+        restore_loss_successor_on_call: Option<(usize, Arc<DeadOwnerClaimStore>, NodeIdentity)>,
         rotate_identity_during_load: Option<(SharedNodeIdentity, NodeIdentity)>,
         fail_fenced_loads_remaining: AtomicUsize,
         block_all_loads: bool,
@@ -2098,6 +2098,7 @@ mod ownership_claims_tests {
         demote_notifications: Mutex<Vec<(String, String)>>,
         deleted_rooms: Mutex<Vec<String>>,
         fail_deletes: bool,
+        local_identity: Option<SharedNodeIdentity>,
         authoritative_claim_store: Mutex<Option<Arc<dyn ClaimStore>>>,
         claim_fences: Arc<Mutex<HashMap<BareJid, RoomClaimFenceContext>>>,
     }
@@ -2186,11 +2187,15 @@ mod ownership_claims_tests {
                     })
                     .is_ok();
                 let fence_lost = store.fence_lost.load(Ordering::SeqCst);
-                if let Some((claim_store, successor)) = &store.restore_loss_successor {
-                    claim_store.replace_with_successor(successor.clone());
-                    return Err(crate::XmppError::OwnershipLost {
-                        entity: fence.entity.clone(),
-                    });
+                if let Some((loss_call, claim_store, successor)) =
+                    &store.restore_loss_successor_on_call
+                {
+                    if *loss_call == load_call {
+                        claim_store.replace_with_successor(successor.clone());
+                        return Err(crate::XmppError::OwnershipLost {
+                            entity: fence.entity.clone(),
+                        });
+                    }
                 }
                 if let Some((identity, successor)) = &store.rotate_identity_during_load {
                     identity.rotate(successor.clone()).await;
@@ -2280,6 +2285,13 @@ mod ownership_claims_tests {
         ) -> MucDurableFuture<'a, bool> {
             let store = self;
             Box::pin(async move {
+                if store
+                    .local_identity
+                    .as_ref()
+                    .is_some_and(|identity| identity.current() != fence.owner)
+                {
+                    return Ok(false);
+                }
                 let exact = store.authoritative_claim_matches(room_jid, fence).await?;
                 if !exact {
                     return Ok(false);
@@ -4056,7 +4068,7 @@ mod ownership_claims_tests {
         let claim_store = Arc::new(DeadOwnerClaimStore::empty());
         let successor = foreign_identity();
         let durable_store = Arc::new(RecordingDurableStore {
-            restore_loss_successor: Some((Arc::clone(&claim_store), successor.clone())),
+            restore_loss_successor_on_call: Some((1, Arc::clone(&claim_store), successor.clone())),
             ..RecordingDurableStore::default()
         });
         wire_recording_store_with_claims(
@@ -4404,9 +4416,10 @@ mod ownership_claims_tests {
         let registry = spawn_registry().await;
         let epoch = ClaimEpoch(51);
         let claim_store = Arc::new(DeadOwnerClaimStore::seeded(this_identity(), epoch));
+        let successor = foreign_identity();
         let durable_store = Arc::new(RecordingDurableStore {
             load_result: Some(reclaimed_snapshot("must-not-publish")),
-            lose_restore_ownership_on_call: Some(2),
+            restore_loss_successor_on_call: Some((2, Arc::clone(&claim_store), successor.clone())),
             ..RecordingDurableStore::default()
         });
         wire_recording_store_with_claims(
@@ -4455,14 +4468,13 @@ mod ownership_claims_tests {
             durable_store.current_claim_fence(&jid).is_none(),
             "a terminally lost reclaimed fence must not remain published"
         );
-        assert!(
-            claim_store
-                .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
-                .await
-                .expect("claim lookup")
-                .is_some(),
-            "the already-lost fence must not be released again"
-        );
+        let successor_claim = claim_store
+            .current_claim(&Entity::new(EntityType::RoomActor, jid.to_string()))
+            .await
+            .expect("successor claim lookup")
+            .expect("the successor claim must survive terminal restore loss");
+        assert_eq!(successor_claim.owner, successor);
+        assert_eq!(successor_claim.claim_epoch, ClaimEpoch(epoch.0 + 1));
     }
 
     #[tokio::test]
@@ -7770,8 +7782,11 @@ mod ownership_claims_tests {
     async fn reaping_an_identity_rotated_actor_releases_its_old_exact_claim() {
         let registry = spawn_registry().await;
         let claim_store = Arc::new(InProcessClaimStore::new());
-        let durable_store = Arc::new(RecordingDurableStore::default());
         let identity = SharedNodeIdentity::new(this_identity());
+        let durable_store = Arc::new(RecordingDurableStore {
+            local_identity: Some(identity.clone()),
+            ..RecordingDurableStore::default()
+        });
         wire_recording_store_with_claims(
             &registry,
             Arc::clone(&claim_store) as Arc<dyn ClaimStore>,
@@ -7793,7 +7808,6 @@ mod ownership_claims_tests {
             .actor_ref;
 
         identity.rotate(foreign_identity()).await;
-        durable_store.fence_lost.store(true, Ordering::SeqCst);
         assert!(matches!(
             actor
                 .ask(JoinWithAffiliation {

--- a/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
@@ -187,17 +187,18 @@ pub enum OutboundEvent {
     /// changes are rare, so the simpler ordering is preferred over
     /// fire-and-forget concurrency.
     ///
-    /// **Failure mode.** If the actor ask fails (mailbox closed, room
-    /// destroyed mid-dispatch) the interpreter logs and continues
-    /// draining — the live broadcast still goes out, just without a
-    /// matching state update. Future joiners see the previous stored
-    /// subject; the broadcast they missed is gone. This is an
-    /// irreducible window for any out-of-band persistence path; the
-    /// failure rate is bounded by `RoomActor` mailbox availability,
-    /// which is shared with every other room operation.
+    /// **Failure mode.** If exact room authority is unavailable, lost, or the
+    /// actor transport cannot confirm handling, the interpreter uses the
+    /// captured sender/message to emit a retryable error and suppresses every
+    /// later archive, inbox, and fan-out event in the same dispatch batch.
     PersistRoomSubject {
         /// Room whose state is being mutated.
         room: BareJid,
+        /// Exact room-actor incarnation fence bound by the interpreter
+        /// after it obtains the actor snapshot. `None` is valid only for
+        /// an actor without durable ownership; a durable actor rejects a
+        /// missing or different fence before applying the subject change.
+        claim_fence: Option<crate::muc::RoomClaimFenceContext>,
         /// New subject texts keyed by `xml:lang` (`""` is the default
         /// language). Mirrors the originating §8.1 message's
         /// `<subject xml:lang='...'>` set so localized variants
@@ -209,6 +210,10 @@ pub enum OutboundEvent {
         /// Setter's bare JID — input to the XEP-0421 occupant-id HMAC
         /// at next-join emission.
         setter: BareJid,
+        /// Exact sending session used for a retryable failure reply.
+        sender: FullJid,
+        /// Canonical subject-change message preserved for error correlation.
+        message: Box<Message>,
         /// Setter's nickname at the moment of the change. Frozen here
         /// rather than re-resolved at emission so historical join-time
         /// emissions stay stable across nick changes and after the

--- a/server/crates/waddle-xmpp/src/protocol/room/subject.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/subject.rs
@@ -134,6 +134,11 @@ impl RoomHandler for MucSubjectHandler {
 
         let event = OutboundEvent::PersistRoomSubject {
             room: ctx.room.clone(),
+            // `room_dispatch::bind_room_claim_fence` must bind the frozen
+            // `RoomChainSnapshot` fence before interpretation. This pure
+            // protocol handler deliberately has no actor state; bypassing the
+            // dispatch post-processing therefore fails closed when a durable
+            // actor rejects the missing exact ownership proof.
             claim_fence: None,
             texts,
             setter: sender.bare_jid(),

--- a/server/crates/waddle-xmpp/src/protocol/room/subject.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/subject.rs
@@ -32,12 +32,10 @@
 //! [`super::archive::MucArchiveHandler`] so an unauthorized subject
 //! change cannot leak into the room archive.
 //!
-//! Note: subject persistence is eventually-consistent with the live
-//! broadcast (both are emitted in the same dispatch but persistence is
-//! an actor ask while the broadcast is direct routing). Joiners between
-//! the broadcast and the persistence may briefly see the previous
-//! stored subject — acceptable per §7.2.15 since the live broadcast and
-//! historical replay are independent stanzas.
+//! The interpreter awaits the actor's fenced persistence before draining
+//! later archive and reflector effects from the same dispatch batch. If
+//! persistence cannot prove exact authority or fails before apply, it returns
+//! a retryable error to the sender and suppresses those later effects.
 
 use super::super::event::OutboundEvent;
 use super::super::handlers::errors::send_message_error;
@@ -136,8 +134,11 @@ impl RoomHandler for MucSubjectHandler {
 
         let event = OutboundEvent::PersistRoomSubject {
             room: ctx.room.clone(),
+            claim_fence: None,
             texts,
             setter: sender.bare_jid(),
+            sender: sender.full_jid.clone(),
+            message: Box::new(message.clone()),
             setter_nick: sender.nick.clone(),
             set_at,
         };

--- a/server/crates/waddle-xmpp/tests/xep0045_room_ownership_actor.rs
+++ b/server/crates/waddle-xmpp/tests/xep0045_room_ownership_actor.rs
@@ -16,9 +16,9 @@ use waddle_xmpp::muc::durable::{
 };
 use waddle_xmpp::muc::room_actor::{
     DurableRestoreReadiness, GetAffiliation, GetConfig, GetDurableRestoreReadiness,
-    GetRoomSnapshot, Join, JoinAffiliationGrant, JoinWithAffiliation, OccupantCount,
-    ResolverAffiliationSyncOutcome, RestoreDurableRoomState, RoomActor, RoomActorError,
-    RoomMutationError, SyncResolverAffiliation, UpdateConfig,
+    GetRoomSealState, GetRoomSnapshot, Join, JoinAffiliationGrant, JoinWithAffiliation,
+    OccupantCount, ResolverAffiliationSyncOutcome, RestoreDurableRoomState, RoomActor,
+    RoomActorError, RoomMutationError, RoomSealState, SyncResolverAffiliation, UpdateConfig,
 };
 use waddle_xmpp::muc::room_registry_actor::{
     CreateRoom, GetOrCreateRoom, RoomCreation, RoomRegistryActor, RoomRegistryError,
@@ -85,10 +85,9 @@ impl OwnershipStore {
             || fence.owner != self.expected_owner
             || fence.epoch != self.expected_epoch
         {
-            return Err(XmppError::internal(format!(
-                "unexpected exact room fence: entity={}, owner={:?}, epoch={:?}",
-                fence.entity, fence.owner, fence.epoch
-            )));
+            return Err(XmppError::OwnershipLost {
+                entity: expected_entity,
+            });
         }
         Ok(())
     }
@@ -103,9 +102,16 @@ impl MucDurableStore for OwnershipStore {
         self.observed_loads.fetch_add(1, Ordering::SeqCst);
         let validation = self.validate_fence(room_jid, fence);
         let restore = self.restore.clone();
+        let state = self.state.load(Ordering::SeqCst);
+        let entity = fence.entity.clone();
         Box::pin(async move {
             validation?;
-            Ok(restore)
+            match state {
+                OWNED => Ok(restore),
+                DEPOSED => Err(XmppError::OwnershipLost { entity }),
+                UNCERTAIN => Err(XmppError::internal("ownership proof unavailable")),
+                _ => unreachable!("test ownership state"),
+            }
         })
     }
 
@@ -171,7 +177,11 @@ impl MucDurableStore for OwnershipStore {
     }
 }
 
-async fn spawn_fenced_room() -> (ActorRef<RoomActor>, Arc<OwnershipStore>) {
+async fn spawn_unrestored_fenced_room() -> (
+    ActorRef<RoomActor>,
+    Arc<OwnershipStore>,
+    RoomClaimFenceContext,
+) {
     let room_jid: BareJid = "ownership@muc.example.com".parse().expect("valid room JID");
     let room = MucRoom::new(
         room_jid.clone(),
@@ -185,14 +195,20 @@ async fn spawn_fenced_room() -> (ActorRef<RoomActor>, Arc<OwnershipStore>) {
     let owner = NodeIdentity::new("test-node", "test-node-epoch");
     let epoch = ClaimEpoch(1);
     let store = Arc::new(OwnershipStore::expecting(owner.clone(), epoch, None));
+    let claim_fence = RoomClaimFenceContext::new(
+        Entity::new(EntityType::RoomActor, room_jid.to_string()),
+        owner,
+        epoch,
+    );
+    (actor, store, claim_fence)
+}
+
+async fn spawn_fenced_room() -> (ActorRef<RoomActor>, Arc<OwnershipStore>) {
+    let (actor, store, claim_fence) = spawn_unrestored_fenced_room().await;
     actor
         .ask(RestoreDurableRoomState {
             store: Arc::clone(&store) as Arc<dyn MucDurableStore>,
-            claim_fence: RoomClaimFenceContext::new(
-                Entity::new(EntityType::RoomActor, room_jid.to_string()),
-                owner,
-                epoch,
-            ),
+            claim_fence,
         })
         .await
         .expect("install durable ownership store");
@@ -246,6 +262,79 @@ async fn deposed_room_refuses_xep0045_resolver_join() {
         Err(SendError::HandlerError(RoomActorError::RoomSealed))
     ));
     assert_eq!(actor.ask(OccupantCount).await.expect("occupant count"), 0);
+}
+
+#[tokio::test]
+async fn restore_ownership_loss_is_terminal_and_never_retries_xep0045_join() {
+    let (actor, store, claim_fence) = spawn_unrestored_fenced_room().await;
+    store.set(UNCERTAIN);
+
+    actor
+        .ask(RestoreDurableRoomState {
+            store: Arc::clone(&store) as Arc<dyn MucDurableStore>,
+            claim_fence,
+        })
+        .await
+        .expect("transient restore failure is retained as pending");
+    assert_eq!(store.take_observed_load_count(), 1);
+    assert_eq!(
+        actor
+            .ask(GetDurableRestoreReadiness)
+            .await
+            .expect("restore readiness"),
+        DurableRestoreReadiness::Pending
+    );
+
+    store.set(DEPOSED);
+    assert!(matches!(
+        actor.ask(resolver_join()).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert_eq!(
+        actor
+            .ask(GetDurableRestoreReadiness)
+            .await
+            .expect("terminal restore readiness"),
+        DurableRestoreReadiness::OwnershipLost
+    );
+    assert_eq!(
+        actor.ask(GetRoomSealState).await.expect("room seal state"),
+        RoomSealState::OwnershipLost
+    );
+    assert_eq!(store.take_observed_load_count(), 1);
+
+    assert!(matches!(
+        actor.ask(resolver_join()).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert_eq!(
+        store.take_observed_load_count(),
+        0,
+        "the terminal restore state must not retry the stale fence"
+    );
+    actor
+        .ask(RestoreDurableRoomState {
+            store: Arc::clone(&store) as Arc<dyn MucDurableStore>,
+            claim_fence: RoomClaimFenceContext::new(
+                Entity::new(EntityType::RoomActor, "ownership@muc.example.com"),
+                NodeIdentity::new("test-node", "test-node-epoch"),
+                ClaimEpoch(1),
+            ),
+        })
+        .await
+        .expect("terminal restore ignores the same stale fence");
+    assert_eq!(
+        actor
+            .ask(GetDurableRestoreReadiness)
+            .await
+            .expect("terminal restore readiness"),
+        DurableRestoreReadiness::OwnershipLost
+    );
+    assert_eq!(
+        store.take_observed_load_count(),
+        0,
+        "a terminal restore state must ignore duplicate same-fence restores"
+    );
 }
 
 #[tokio::test]
@@ -397,7 +486,11 @@ async fn assert_invalid_restore_fence_fails_closed(invalid_fence: RoomClaimFence
             .ask(GetDurableRestoreReadiness)
             .await
             .expect("restore readiness"),
-        DurableRestoreReadiness::Pending,
+        DurableRestoreReadiness::OwnershipLost,
+    );
+    assert_eq!(
+        actor.ask(GetRoomSealState).await.expect("room seal state"),
+        RoomSealState::OwnershipLost,
     );
     let original_config = actor.ask(GetConfig).await.expect("original config");
     let mut attempted = original_config.clone();

--- a/server/crates/waddle-xmpp/tests/xep0045_room_ownership_actor.rs
+++ b/server/crates/waddle-xmpp/tests/xep0045_room_ownership_actor.rs
@@ -4,25 +4,31 @@
 //! admit an occupant or apply resolver-derived affiliation state. Otherwise
 //! two owners could independently authorize the same XEP-0045 room.
 
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use jid::BareJid;
 use kameo::actor::{ActorRef, Spawn};
 use kameo::error::SendError;
 use waddle_xmpp::muc::affiliation::AffiliationEntry;
-use waddle_xmpp::muc::durable::{DurableRoomState, MucDurableFuture, MucDurableStore};
+use waddle_xmpp::muc::durable::{
+    DurableRoomState, MucDurableFuture, MucDurableStore, RoomClaimFenceContext,
+};
 use waddle_xmpp::muc::room_actor::{
-    GetAffiliation, Join, JoinAffiliationGrant, JoinWithAffiliation, OccupantCount,
+    DurableRestoreReadiness, GetAffiliation, GetConfig, GetDurableRestoreReadiness,
+    GetRoomSnapshot, Join, JoinAffiliationGrant, JoinWithAffiliation, OccupantCount,
     ResolverAffiliationSyncOutcome, RestoreDurableRoomState, RoomActor, RoomActorError,
-    SyncResolverAffiliation,
+    RoomMutationError, SyncResolverAffiliation, UpdateConfig,
 };
 use waddle_xmpp::muc::room_registry_actor::{
     CreateRoom, GetOrCreateRoom, RoomCreation, RoomRegistryActor, RoomRegistryError,
     WireClusteringClaims,
 };
 use waddle_xmpp::muc::{MucRoom, RoomConfig, SubjectState};
-use waddle_xmpp::ownership::{ClaimStore, InProcessClaimStore, NodeIdentity, SharedNodeIdentity};
+use waddle_xmpp::ownership::{
+    ClaimEpoch, ClaimStore, Entity, EntityType, InProcessClaimStore, NodeIdentity,
+    SharedNodeIdentity,
+};
 use waddle_xmpp::xep::xep0421::{OccupantIdSecret, OCCUPANT_ID_SECRET_MIN_BYTES};
 use waddle_xmpp::{Affiliation, Role, XmppError};
 
@@ -33,73 +39,128 @@ const UNCERTAIN: u8 = 2;
 struct OwnershipStore {
     state: AtomicU8,
     restore: Option<DurableRoomState>,
+    expected_owner: NodeIdentity,
+    expected_epoch: ClaimEpoch,
+    observed_loads: AtomicUsize,
 }
 
 impl OwnershipStore {
     fn new() -> Self {
-        Self {
-            state: AtomicU8::new(OWNED),
-            restore: None,
-        }
+        Self::expecting(NodeIdentity::local(), ClaimEpoch(0), None)
     }
 
     fn restoring(state: DurableRoomState) -> Self {
+        Self::expecting(NodeIdentity::local(), ClaimEpoch(0), Some(state))
+    }
+
+    fn expecting(
+        expected_owner: NodeIdentity,
+        expected_epoch: ClaimEpoch,
+        restore: Option<DurableRoomState>,
+    ) -> Self {
         Self {
             state: AtomicU8::new(OWNED),
-            restore: Some(state),
+            restore,
+            expected_owner,
+            expected_epoch,
+            observed_loads: AtomicUsize::new(0),
         }
     }
 
     fn set(&self, state: u8) {
         self.state.store(state, Ordering::SeqCst);
     }
+
+    fn take_observed_load_count(&self) -> usize {
+        self.observed_loads.swap(0, Ordering::SeqCst)
+    }
+
+    fn validate_fence(
+        &self,
+        room_jid: &BareJid,
+        fence: &RoomClaimFenceContext,
+    ) -> Result<(), XmppError> {
+        let expected_entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+        if fence.entity != expected_entity
+            || fence.owner != self.expected_owner
+            || fence.epoch != self.expected_epoch
+        {
+            return Err(XmppError::internal(format!(
+                "unexpected exact room fence: entity={}, owner={:?}, epoch={:?}",
+                fence.entity, fence.owner, fence.epoch
+            )));
+        }
+        Ok(())
+    }
 }
 
 impl MucDurableStore for OwnershipStore {
-    fn load_room_state<'a>(
-        &'a self,
-        _room_jid: &'a BareJid,
-    ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
-        let restore = self.restore.clone();
-        Box::pin(async move { Ok(restore) })
-    }
-
     fn load_room_state_fenced<'a>(
         &'a self,
         room_jid: &'a BareJid,
+        fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, Option<DurableRoomState>> {
-        self.load_room_state(room_jid)
+        self.observed_loads.fetch_add(1, Ordering::SeqCst);
+        let validation = self.validate_fence(room_jid, fence);
+        let restore = self.restore.clone();
+        Box::pin(async move {
+            validation?;
+            Ok(restore)
+        })
     }
 
-    fn save_config<'a>(
+    fn save_config_fenced<'a>(
         &'a self,
-        _room_jid: &'a BareJid,
+        room_jid: &'a BareJid,
         _waddle_id: &'a str,
         _channel_id: &'a str,
         _config: &'a RoomConfig,
+        fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, ()> {
-        Box::pin(async { Ok(()) })
+        let validation = self.validate_fence(room_jid, fence);
+        Box::pin(async move { validation })
     }
 
-    fn save_subject<'a>(
+    fn save_subject_fenced<'a>(
         &'a self,
-        _room_jid: &'a BareJid,
+        room_jid: &'a BareJid,
         _subject: Option<&'a SubjectState>,
+        fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, ()> {
-        Box::pin(async { Ok(()) })
+        let validation = self.validate_fence(room_jid, fence);
+        Box::pin(async move { validation })
     }
 
-    fn save_affiliation<'a>(
+    fn save_affiliation_fenced<'a>(
         &'a self,
-        _room_jid: &'a BareJid,
+        room_jid: &'a BareJid,
         _entry: &'a AffiliationEntry,
+        fence: &'a RoomClaimFenceContext,
     ) -> MucDurableFuture<'a, ()> {
-        Box::pin(async { Ok(()) })
+        let validation = self.validate_fence(room_jid, fence);
+        Box::pin(async move { validation })
     }
 
-    fn check_fenced_fanout<'a>(&'a self, _room_jid: &'a BareJid) -> MucDurableFuture<'a, bool> {
+    fn delete_room_state_fenced<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, ()> {
+        let validation = self.validate_fence(room_jid, fence);
+        Box::pin(async move { validation })
+    }
+
+    fn check_exact_claim_fence<'a>(
+        &'a self,
+        room_jid: &'a BareJid,
+        fence: &'a RoomClaimFenceContext,
+    ) -> MucDurableFuture<'a, bool> {
+        let exact_fence = self.validate_fence(room_jid, fence).is_ok();
         let state = self.state.load(Ordering::SeqCst);
         Box::pin(async move {
+            if !exact_fence {
+                return Ok(false);
+            }
             match state {
                 OWNED => Ok(true),
                 DEPOSED => Ok(false),
@@ -111,9 +172,9 @@ impl MucDurableStore for OwnershipStore {
 }
 
 async fn spawn_fenced_room() -> (ActorRef<RoomActor>, Arc<OwnershipStore>) {
-    let room_jid = "ownership@muc.example.com".parse().expect("valid room JID");
+    let room_jid: BareJid = "ownership@muc.example.com".parse().expect("valid room JID");
     let room = MucRoom::new(
-        room_jid,
+        room_jid.clone(),
         "waddle-1".to_string(),
         "channel-1".to_string(),
         RoomConfig::default(),
@@ -121,14 +182,29 @@ async fn spawn_fenced_room() -> (ActorRef<RoomActor>, Arc<OwnershipStore>) {
     let secret = OccupantIdSecret::new(vec![7; OCCUPANT_ID_SECRET_MIN_BYTES])
         .expect("valid occupant-id secret");
     let actor = RoomActor::spawn(RoomActor::new(room, secret));
-    let store = Arc::new(OwnershipStore::new());
+    let owner = NodeIdentity::new("test-node", "test-node-epoch");
+    let epoch = ClaimEpoch(1);
+    let store = Arc::new(OwnershipStore::expecting(owner.clone(), epoch, None));
     actor
         .ask(RestoreDurableRoomState {
             store: Arc::clone(&store) as Arc<dyn MucDurableStore>,
+            claim_fence: RoomClaimFenceContext::new(
+                Entity::new(EntityType::RoomActor, room_jid.to_string()),
+                owner,
+                epoch,
+            ),
         })
         .await
         .expect("install durable ownership store");
     (actor, store)
+}
+
+fn claim_fence(room_jid: &BareJid, node_epoch: &str, claim_epoch: i64) -> RoomClaimFenceContext {
+    RoomClaimFenceContext::new(
+        Entity::new(EntityType::RoomActor, room_jid.to_string()),
+        NodeIdentity::new("test-node", node_epoch),
+        ClaimEpoch(claim_epoch),
+    )
 }
 
 fn resolver_join() -> JoinWithAffiliation {
@@ -286,6 +362,176 @@ async fn uncertain_room_returns_typed_resolver_sync_outcome() {
             .expect("affiliation"),
         Affiliation::None,
     );
+}
+
+async fn assert_invalid_restore_fence_fails_closed(invalid_fence: RoomClaimFenceContext) {
+    let room_jid: BareJid = "invalid-fence@muc.example.com".parse().expect("room JID");
+    let expected_owner = NodeIdentity::new("expected-node", "expected-incarnation");
+    let expected_epoch = ClaimEpoch(7);
+    let room = MucRoom::new(
+        room_jid.clone(),
+        "waddle-1".to_string(),
+        "channel-1".to_string(),
+        RoomConfig::default(),
+    );
+    let secret = OccupantIdSecret::new(vec![7; OCCUPANT_ID_SECRET_MIN_BYTES])
+        .expect("valid occupant-id secret");
+    let actor = RoomActor::spawn(RoomActor::new(room, secret));
+    let store = Arc::new(OwnershipStore::expecting(
+        expected_owner,
+        expected_epoch,
+        None,
+    ));
+
+    actor
+        .ask(RestoreDurableRoomState {
+            store: Arc::clone(&store) as Arc<dyn MucDurableStore>,
+            claim_fence: invalid_fence,
+        })
+        .await
+        .expect("invalid restore is retained only as a fail-closed state");
+
+    assert_eq!(store.take_observed_load_count(), 1);
+    assert_eq!(
+        actor
+            .ask(GetDurableRestoreReadiness)
+            .await
+            .expect("restore readiness"),
+        DurableRestoreReadiness::Pending,
+    );
+    let original_config = actor.ask(GetConfig).await.expect("original config");
+    let mut attempted = original_config.clone();
+    attempted.name = "must not mutate".to_string();
+    assert!(matches!(
+        actor.ask(UpdateConfig { config: attempted }).await,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert_eq!(
+        actor.ask(GetConfig).await.expect("config after rejection"),
+        original_config,
+    );
+    assert!(matches!(
+        actor.ask(resolver_join()).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert_eq!(actor.ask(OccupantCount).await.expect("occupant count"), 0);
+}
+
+#[tokio::test]
+async fn invalid_entity_owner_and_epoch_fences_fail_closed() {
+    let room_jid: BareJid = "invalid-fence@muc.example.com".parse().expect("room JID");
+    let expected_entity = Entity::new(EntityType::RoomActor, room_jid.to_string());
+    let expected_owner = NodeIdentity::new("expected-node", "expected-incarnation");
+
+    assert_invalid_restore_fence_fails_closed(RoomClaimFenceContext::new(
+        Entity::new(EntityType::RoomActor, "other@muc.example.com".to_string()),
+        expected_owner.clone(),
+        ClaimEpoch(7),
+    ))
+    .await;
+    assert_invalid_restore_fence_fails_closed(RoomClaimFenceContext::new(
+        expected_entity.clone(),
+        NodeIdentity::new("other-node", "other-incarnation"),
+        ClaimEpoch(7),
+    ))
+    .await;
+    assert_invalid_restore_fence_fails_closed(RoomClaimFenceContext::new(
+        expected_entity,
+        expected_owner,
+        ClaimEpoch(8),
+    ))
+    .await;
+}
+
+#[tokio::test]
+async fn second_restore_cannot_transplant_an_actor_to_a_successor_fence() {
+    let room_jid: BareJid = "restore-transplant@muc.example.com"
+        .parse()
+        .expect("room JID");
+    let room = MucRoom::new(
+        room_jid.clone(),
+        "waddle-1".to_string(),
+        "channel-1".to_string(),
+        RoomConfig::default(),
+    );
+    let secret = OccupantIdSecret::new(vec![7; OCCUPANT_ID_SECRET_MIN_BYTES])
+        .expect("valid occupant-id secret");
+    let actor = RoomActor::spawn(RoomActor::new(room, secret));
+    let original_fence = claim_fence(&room_jid, "original-incarnation", 11);
+    let original_store = Arc::new(OwnershipStore::expecting(
+        original_fence.owner.clone(),
+        original_fence.epoch,
+        None,
+    ));
+    actor
+        .ask(RestoreDurableRoomState {
+            store: Arc::clone(&original_store) as Arc<dyn MucDurableStore>,
+            claim_fence: original_fence.clone(),
+        })
+        .await
+        .expect("initial exact-fence restore");
+    original_store.take_observed_load_count();
+    let original_config = actor.ask(GetConfig).await.expect("original config");
+    let snapshot_sender: jid::FullJid = "observer@example.com/test"
+        .parse()
+        .expect("snapshot sender");
+    assert_eq!(
+        actor
+            .ask(GetRoomSnapshot {
+                sender_jid: snapshot_sender.clone(),
+            })
+            .await
+            .expect("snapshot before transplant attempt")
+            .claim_fence,
+        Some(original_fence.clone()),
+    );
+
+    let successor_fence = claim_fence(&room_jid, "successor-incarnation", 12);
+    let successor_store = Arc::new(OwnershipStore::expecting(
+        successor_fence.owner.clone(),
+        successor_fence.epoch,
+        Some(durable_existing_room()),
+    ));
+    actor
+        .ask(RestoreDurableRoomState {
+            store: Arc::clone(&successor_store) as Arc<dyn MucDurableStore>,
+            claim_fence: successor_fence,
+        })
+        .await
+        .expect("mismatched restore is handled fail-closed");
+
+    assert!(
+        successor_store.take_observed_load_count() == 0,
+        "the successor store must not receive a load from the old actor incarnation"
+    );
+    assert_eq!(original_store.take_observed_load_count(), 0);
+    assert_eq!(
+        actor
+            .ask(GetRoomSnapshot {
+                sender_jid: snapshot_sender,
+            })
+            .await
+            .expect("snapshot after transplant attempt")
+            .claim_fence,
+        Some(original_fence.clone()),
+        "a rejected successor restore must not replace the fence carried by old snapshots",
+    );
+
+    let mut attempted = original_config.clone();
+    attempted.name = "must remain sealed".to_string();
+    assert!(matches!(
+        actor.ask(UpdateConfig { config: attempted }).await,
+        Err(SendError::HandlerError(RoomMutationError::NotOwner))
+    ));
+    assert_eq!(
+        actor.ask(GetConfig).await.expect("config after rejection"),
+        original_config,
+    );
+    assert!(matches!(
+        actor.ask(resolver_join()).await,
+        Err(SendError::HandlerError(RoomActorError::RoomSealed))
+    ));
+    assert_eq!(actor.ask(OccupantCount).await.expect("occupant count"), 0);
 }
 
 fn durable_existing_room() -> DurableRoomState {

--- a/server/docs/adrs/0017-phase3-plan-ownership-claims.md
+++ b/server/docs/adrs/0017-phase3-plan-ownership-claims.md
@@ -1345,12 +1345,12 @@ steal a claim that a janitor might simultaneously be reaping), Slice 1 (`steal_f
 
 **Locked spec** (summarized from element 7, with one true verbatim span quoted — minor
 fix 15): new owner *"restores configuration, affiliations,
-and subject from Postgres before accepting any join."* Two-part demotion: best-effort
-acked `Demote { entity, new_epoch }`; guaranteed backstop = the same fencing SELECT
-element 4 prescribes, run before every local fan-out (MAM insert doubles as the
-backstop when archiving is on). Phase 4 GA gates (not this phase) assert outcast
-denial + password/members-only hold after steal — this phase builds the mechanism, GA
-gates its correctness.
+and subject from Postgres before accepting any join."* This narrowed #1355 work keeps
+immutable exact fences for actor-owned durable load, save, and delete operations. The
+mutable cache remains the existing legacy pre-fanout groupchat dispatch/MAM consumer
+until #1283 replaces it. Phase 4 GA gates (not this phase) assert outcast denial +
+password/members-only hold after steal — this phase builds the mechanism, GA gates its
+correctness.
 
 **Code research finding, corrected (minor fix 16)**: the previous draft attributed the
 "no room/affiliation table exists in any schema" reasoning to
@@ -1379,24 +1379,17 @@ affiliation-list read/write), `room_registry.rs` / `room_registry_actor.rs` /
 `room_registry_handle.rs` (claim acquisition on `GetOrCreateRoom`), `subject.rs`
 (durable subject read on restore).
 
-**Files, amended (FIX 1–9 pass, deviations 65–73)**: `server/crates/waddle-xmpp/
-src/muc/durable.rs` (`RoomClaimFenceContext`, `current_claim_fence`),
-`server/crates/waddle-xmpp/src/mam/storage/{traits.rs,error.rs,sqlx_store/
-{mod.rs,write.rs,impls.rs}}` (`store_message_fenced`, `with_cluster_fencing`,
-`MamStorageError::{NotOwner,ClusterColocationMismatch}`),
+**Files, amended (FIX 2–9 pass, deviations 66–73)**: `server/crates/waddle-xmpp/
+src/muc/durable.rs` (`RoomClaimFenceContext`, ready-entry cache publication),
 `server/crates/waddle-xmpp/src/ownership/mod.rs` (`Entity` hand-written
 `Deserialize`, `ENTITY_ID_MAX_LEN`), `server/crates/waddle-server/src/
-muc_durable.rs` (`current_claim_fence` impl), `server/crates/waddle-server/src/
-server/http.rs` (`create_websocket_mam_storage`'s co-location check),
+muc_durable.rs` (exact actor-owned durable fencing and legacy cache checks),
 `server/crates/waddle-server/src/server/topology.rs`
 (`seed_initial_xmpp_topology`'s `ClaimHeldByAnotherNode` continue),
 `server/crates/waddle-server/src/server/routes/websocket/cleanup.rs`
 (`get_or_create_room_actor`'s typed `Result`), `server/crates/waddle-server/src/
 server/routes/websocket/handlers/presence/muc.rs` (join-path error mapping),
-`server/crates/waddle-server/src/server/routes/interpret/{groupchat_archive.rs,
-archive_groupchat_event.rs,room_system_message.rs,interpret.rs,
-groupchat_validation.rs}` (fenced archive write + ownership-lost batch
-suppression), `server/crates/waddle-xmpp/src/muc/room_registry_actor.rs`
+`server/crates/waddle-xmpp/src/muc/room_registry_actor.rs`
 (`live_room` async + claim release), `server/crates/waddle-server/src/
 clustering/{local_claims.rs,mod.rs}` (`health_check` fix,
 `demote_room_actor`, `MucDurableStoreInit`), `server/crates/waddle-server/src/
@@ -1412,15 +1405,12 @@ first production wiring of a `RoomActor` Postgres claim, so the harness's deferr
 counterpart — a genuinely wedged, genuinely-claimed room with a live occupant socket)
 can land alongside this slice's own harness work.
 
-**Pool assignment (blocker fix 1, stated explicitly per Slice 0)**: the fenced
-pre-fan-out `SELECT ... FOR SHARE` runs inline, inside the same `Database::begin()`
-transaction as the broadcast's write (the MAM archive insert when archiving is on;
-otherwise the standalone autocommit fencing SELECT itself is the one write-adjacent
-statement), on the **main pool** — never the control-plane pool, for the same
-same-connection-same-transaction reason Slice 4 states. Room/occupant/affiliation
-durable writes (roster rows, config, affiliation lists, subject) are likewise main-pool
-statements; only `RoomActor`'s own claim acquire/steal/heartbeat traffic (via
-`ClaimStore`, Slice 1) rides the control-plane pool.
+**Pool assignment (blocker fix 1, stated explicitly per Slice 0)**: actor-owned
+durable writes (config, affiliation lists, subject, and delete) run on the **main
+pool** in the same transaction as their exact fence check — never the control-plane
+pool, for the same same-connection-same-transaction reason Slice 4 states. Only
+`RoomActor`'s own claim acquire/steal/heartbeat traffic (via `ClaimStore`, Slice 1)
+rides the control-plane pool.
 
 **Dependencies**: Slice 1 only (`ClaimStore` for `RoomActor` entities) — deliberately
 **not** dependent on Slices 4–6, so it can be worked in parallel by a separate
@@ -1428,11 +1418,8 @@ contributor/session, per the scoping map's "D5 parallel-after-D1" ordering.
 
 **As landed (deviations 56–64, see the deviation log for full detail)**: occupant-roster
 durability is deferred (56, its sole consumer needs Phase-4 cross-node presence
-fan-out); the fenced pre-fan-out backstop lands in `waddle-server`'s
-`dispatch_to_room` (57 — `RoomActor::BuildGroupchatBroadcast` is legacy/superseded,
-not the live fan-out path) — **amended by the FIX 1–9 pass below: no longer the
-sole backstop, since the MAM archive write is now independently fenced too (65,
-retracting 58's "not implementable" claim)**; `LocallyClaimedEntities::owned()`
+fan-out); the cache-backed pre-fanout backstop remains the existing legacy path (57);
+`LocallyClaimedEntities::owned()`
 widened to `async fn` for the actor-backed `RoomLocalClaims` implementor (59);
 `Entity`/`EntityType`/`ClaimEpoch` gained `Serialize`/`Deserialize` for the Demote
 ask's wire payload (60, `Entity::id` gained a matching wire-length bound in 73);
@@ -1446,13 +1433,11 @@ deposed-owner-with-live-socket `RoomActor` harness scenario lands in
 `clustering_cluster_e2e.rs`, reusing the restore-before-join mechanism itself as the
 wedge point (64).
 
-**Council-adjudicated FIX 1–9 pass, additionally landed (deviations 65–73, see the
-deviation log for full detail)**: the MAM groupchat archive insert is itself now
-fenced, atomically with a `SELECT ... FOR SHARE`, closing the residual dual-delivery
-race the original backstop design accepted (65); every durable-relevant `RoomActor`
-mutation handler gates on ownership BEFORE mutating and surfaces a non-ownership
-persist failure typed AFTER mutating, revising `MucDurableStore`'s fail-open
-contract (66); a dead/panicked `RoomActor`'s Postgres claim is released rather than
+**Council-adjudicated FIX 2–9 pass, additionally landed (deviations 66–73, see the
+deviation log for full detail)**: every durable-relevant `RoomActor`
+mutation handler fails closed on exact ownership BEFORE mutating and surfaces a
+non-ownership persist failure typed AFTER mutating (66); a dead/panicked
+`RoomActor`'s Postgres claim is released rather than
 orphaned, and `RoomLocalClaims::health_check` reports unhealthy (not healthy) when
 no live local actor exists for a claim this node believes it holds (67); a genuine
 `RestoreDurableRoomState` load failure fails closed — joins refuse until a bounded
@@ -3096,49 +3081,15 @@ same "as-landed" style, numbered onward from 43.
     per-nick, how multi-resource occupancy is modeled durably) that
     Non-goals-excluded machinery should make deliberately. Deferred to
     whichever slice first wires cross-node presence fan-out.
-57. **Code-research correction (this slice's own finding, not a
-    misattribution of an existing comment): the production groupchat
-    fan-out call site is `waddle-server`'s `routes/interpret/
-    room_dispatch.rs::dispatch_to_room`, not `RoomActor::
-    BuildGroupchatBroadcast`.** The #229 PR18 sans-I/O room-handler-chain
-    refactor superseded `BuildGroupchatBroadcast` with a `GetRoomSnapshot`-
-    based flow: `dispatch_to_room` fetches one `RoomChainSnapshot` and
-    builds/archives/routes every outbound stanza in `waddle-server` itself;
-    `BuildGroupchatBroadcast` survives only as dead-to-production code
-    exercised by `room_actor/tests.rs`'s own unit tests (confirmed by
-    `room_dispatch.rs`'s own comments: "replacing the legacy
-    `RoomActor::BuildGroupchatBroadcast` check," "avoids a second
-    `RoomActor::GetRoomSnapshot` round-trip per groupchat archive write").
-    The fenced pre-fan-out backstop (element 7, deviation 58) is therefore
-    wired into `dispatch_to_room`, immediately after its `GetRoomSnapshot`
-    ask succeeds and before the occupancy gate/archive/route pipeline runs
-    — not into `RoomActor`'s message handlers, which would guard a path no
-    live traffic takes. **Retracted/superseded by the council-adjudicated
-    FIX 1 pass (see deviation 65 below): `dispatch_to_room`'s standalone
-    check is no longer the SOLE backstop — the MAM archive write itself is
-    now also independently fenced, closing the residual race window this
-    deviation's own text originally accepted as permanent.**
-58. **RETRACTED (council-adjudicated FIX 1) — corrected below in
-    deviation 65.** This entry originally claimed "the MAM archive insert
-    doubles as the backstop when archiving is on" was not implementable
-    within Slice 7's Files list, reasoning that MAM storage
-    (`waddle-xmpp`'s `mam::storage::sqlx_store::write::store_message`)
-    "has no access to `waddle-server`'s `Database`/`Transaction` types,"
-    and therefore "cannot be made to share a transaction with a
-    `waddle-server`-side fencing SELECT." That reasoning was correct about
-    the specific mechanism it considered (sharing `waddle-server`'s
-    `Database`/`Transaction` abstraction across the crate boundary) but
-    incomplete: it did not consider that `SqlxMamStorage` already holds
-    its OWN raw `sqlx::PgPool` (in `waddle-xmpp`, the same crate the
-    `waddle_xmpp::ownership` fencing types already live in) and can run
-    its own native `sqlx::Transaction` combining a `SELECT ... FOR SHARE`
-    against `clustering_claims` with its own `INSERT` — no
-    `waddle-server`-side type ever needs to cross the boundary. FIX 1 (a
-    follow-up council-adjudicated pass over this same slice) implements
-    exactly that; see deviation 65 for the landed design. Left in place
-    (rather than deleted) so the deviation numbering stays stable and so
-    readers can see the corrected reasoning next to the original mistaken
-    claim it replaces.
+57. **Scope correction:** the production pre-fanout path retains its
+    mutable-cache `check_fenced_fanout` backstop. It is a live legacy
+    consumer for groupchat dispatch/MAM until #1283 replaces it; #1355 does
+    not make this general dispatch, archive, bot, system, or MAM path carry
+    exact actor-incarnation fence authority.
+58. **Scope correction:** MAM archive fencing and its transaction boundary
+    are #1283 work, not a #1355 completion claim. The current MAM
+    implementation performs its origin-ID dedup check inside the same fenced
+    transaction as the archive write, not on the plain pool.
 59. **`LocallyClaimedEntities::owned()` widened from a sync `fn` to an
     `async fn` (`self_fence.rs`).** Slice 5's `SmSessionLocalClaims::owned`
     reads a plain in-memory map (`InMemorySmSessionRegistry::
@@ -3263,89 +3214,27 @@ same "as-landed" style, numbered onward from 43.
 ### Council-adjudicated FIX 1–9 pass over the landed Slice 7 implementation
 
 The following deviations (65–73) record a second council-adjudicated review
-pass over Slice 7 as landed (deviations 56–64 above), fixing nine numbered
-findings (FIX 1–9) against the actual code, not a re-plan. Deviations 57/58
-above are corrected in place (see their own retraction text) rather than
-duplicated here.
+pass over Slice 7 as landed (deviations 56–64 above). Deviation 65's former
+MAM/archive claims are explicitly out of scope for #1355; deviations 66–73
+record the retained work.
 
-65. **FIX 1 (critical) — the MAM groupchat archive insert is now itself
-    fenced, closing deviation 58's residual race window.** New
-    `MamStorage::store_message_fenced(archive_jid, message, fence:
-    &RoomClaimFenceContext)` (default impl falls back to
-    `store_message`, byte-identical for the portable/in-memory/SQLite
-    backends and every non-clustering deployment). `SqlxMamStorage`
-    gains a `fencing_enabled: bool` field, set via a new
-    `with_cluster_fencing(bool)` builder (a no-op unless the backend is
-    Postgres); the co-location check itself (this storage's resolved
-    database URL must EXACT-string-match the clustering global database
-    URL) lives in `waddle-server`'s `create_websocket_mam_storage`
-    (`server/http.rs`) — not inside `SqlxMamStorage::open_for_cluster_mode`
-    as the pending_delivery/sm_persistence precedent would suggest —
-    because the redaction helper the mismatch error needs
-    (`crate::db::redact_database_url`) and the clustering global
-    database URL only exist on the `waddle-server` side of the crate
-    boundary; a mismatch fails startup with a new
-    `MamStorageError::ClusterColocationMismatch`, mirroring
-    `PendingStorageError`'s identical variant one table over.
-    `MamStorageError` also gains `NotOwner { entity: Entity }`.
-
-    The fencing SELECT and the archive `INSERT` now run inside ONE
-    `sqlx::Transaction` opened directly against `SqlxMamStorage`'s own
-    `PgPool` (`mam::storage::sqlx_store::write::store_message_fenced`) —
-    this is the correction to deviation 58's reasoning: no
-    `waddle-server`-side `Database`/`Transaction` type ever needs to
-    cross the crate boundary, because the fencing types
-    (`waddle_xmpp::ownership::{Entity, ClaimEpoch}`) already live in
-    `waddle-xmpp`, the same crate `SqlxMamStorage` lives in. The
-    origin-id dedup pre-check still runs against the plain pool exactly
-    as the unfenced path does (it only reads already-committed rows, so
-    it needs no transactional isolation from this write).
-
-    The typed `(Entity, ClaimEpoch, node_id)` fencing context is
-    threaded, not re-derived: a new
-    `MucDurableStore::current_claim_fence(room_jid) -> Option<RoomClaimFenceContext>`
-    method exposes the exact triple `check_fenced_fanout`/`assert_fenced`
-    already resolve from `PostgresMucRoomStore`'s `claim_epochs` cache.
-    `groupchat_archive.rs`'s `resolve_room_claim_fence` reads this at
-    both call sites that persist a groupchat archive write
-    (`archive_groupchat_event.rs` — the production `ArchiveGroupchat`
-    interpreter arm — and `room_system_message.rs`'s server-authored
-    system-message archive write), and threads it into
-    `store_message_fenced`.
-
-    On `NotOwner`, the message is neither archived nor fanned out: for
-    `room_system_message.rs` this is a single early return (its fan-out
-    loop is the only fan-out for that message); for the interpreter's
-    `ArchiveGroupchat` arm, `interpret_with_depth` gained an
-    `ownership_lost` flag that suppresses every remaining event in the
-    SAME dispatch batch — safe because the locked Q7 chain order always
-    runs the archive handler before the reflector fan-out handler, so
-    `ArchiveGroupchat` is always processed before any `RouteToConnection`
-    for the same message — and pushes the same
-    `<resource-constraint/>`-type=wait bounce `dispatch_to_room`'s own
-    pre-fan-out check uses (`resource_constraint_error`, ungated from
-    `#[cfg(feature = "clustering")]` since it now has a second,
-    unconditionally-compiled caller).
-
-    Tests: a Postgres-gated round-trip in `waddle-server::muc_durable`'s
-    test module (`mam_store_message_fenced_blocks_the_deposed_owners_next_archive_write`)
-    proves the current owner's fenced write succeeds, a steal is
-    observed by `current_claim_fence`, and the deposed owner's next
-    fenced write returns `NotOwner` with no row committed.
+65. **Scope correction:** the former exact-fence claims for MAM archive,
+    `ArchiveGroupchat`, system messages, bots, and general dispatch were
+    removed from #1355. Those effects continue to use the published cache's
+    legacy pre-fanout backstop until #1283 supplies their replacement. This
+    ADR makes no completion claim for that future work.
 66. **FIX 2 (critical) — every durable-relevant `RoomActor` mutation
     handler now runs a two-stage gate: verify ownership BEFORE mutating,
     surface a non-ownership persist failure typed AFTER mutating.**
-    `RoomActor::gate_mutation()` runs the same fenced
-    `check_fenced_fanout` pre-check `dispatch_to_room` uses; `Ok(true)`
-    (or no durable store configured) lets the mutation proceed
-    unchanged, `Ok(false)` returns `NotOwner` BEFORE any in-memory
-    mutation runs, and a transient fencing-check error fails OPEN (not
-    blocking), mirroring `dispatch_to_room`'s identical "only a
-    definitive 0-rows result demotes" rule. `persist_config`/
-    `persist_subject`/`persist_affiliation` now return
+    `RoomActor::gate_mutation()` runs `check_exact_claim_fence` with the
+    immutable fence installed on that actor incarnation; `Ok(true)` (or no
+    durable store configured) lets the mutation proceed unchanged,
+    `Ok(false)` returns `NotOwner` BEFORE any in-memory mutation runs, and
+    any backend uncertainty returns `OwnershipUnavailable` BEFORE mutation.
+    `persist_config` and post-apply affiliation persistence return
     `Result<(), DurablePersistError>` instead of silently swallowing a
-    failure — this is the corrected fail-open contract documented on
-    `MucDurableStore` itself (see that trait's doc comment).
+    failure. Subject persistence is intentionally before apply, so its typed
+    result classifies failure before the `SubjectState` is installed.
 
     All nine listed handlers (`UpdateConfig`, `RollbackConfigIfRevision`,
     `UpdateGroupDmConfigByMember`, `SetSubject`, `ChangeAffiliation`,
@@ -3357,7 +3246,9 @@ duplicated here.
     `UpdateGroupDmConfigByMemberError` for `UpdateGroupDmConfigByMember`)
     and gained `NotOwner`/`PersistFailed` variants plus
     `From<RoomMutationError>`/`From<DurablePersistError>` impls so the
-    handler bodies use plain `?`; the other six (previously bare
+    handler bodies use plain `?`. `SetSubject` has a phase-specific
+    `SetSubjectError` whose persistence failures are always pre-apply. The
+    other five handlers (previously bare
     `u64`/`bool`/`()`/`Vec<(FullJid, Presence)>` replies) had their
     `Reply` type wrapped in `Result<_, RoomMutationError>`. Two batch
     handlers (`ApplyAdminItems`'s affiliation-set branch,
@@ -3373,37 +3264,38 @@ duplicated here.
 
     Call-site coverage (council-adjudicated scope boundary, honestly
     recorded): every actor-side handler is gated. On the `waddle-server`
-    call-site side, ONE representative site
+    call-site side, the subject-change interpreter now distinguishes the
+    flattened Kameo handler errors: `NotOwner` exact-demotes only the actor
+    that rejected the request, `OwnershipUnavailable` and actor-transport
+    uncertainty bounce without demotion, and both cases suppress all later
+    archive/inbox/fan-out effects in that dispatch batch. Subject persistence
+    runs before installing the new `SubjectState`, so a
+    `PersistFailedBeforeApply` result follows the same bounce-and-halt path
+    without changing the local subject.
+
+    ONE additional representative site
     (`admin/channels.rs::group_dm_rename_update_error`, the
-    `UpdateGroupDmConfigByMember` rename path) is fully wired end-to-end
-    — `NotOwner` triggers `ClusteringHandles::demote_room_actor` (new
-    method, below) and bounces with a `service-unavailable`/wait
-    condition. The remaining ~20 call sites (11 for `ChangeAffiliation`
+    `UpdateGroupDmConfigByMember` rename path) is fully wired end-to-end:
+    `NotOwner` and `OwnershipLostAfterApply` exact-demote the actor; the
+    latter does not claim the mutation was never applied. The remaining
+    call sites (including those for `ChangeAffiliation`
     across `admin/channels.rs`, `session_janitors.rs`,
     `group_dm_invite.rs`, `muc_admin.rs`; the `UpdateConfig`/
-    `RollbackConfigIfRevision`/`SetSubject`/`EnforceMembersOnlyAffiliations`/
-    `ApplyAdminItems`/`ApplyAffiliationChange` sites) already route
-    through each file's generic `send_err`-style mapper, which correctly
-    surfaces `NotOwner`/`PersistFailed` as a typed `internal-server-error`
-    bounce (never silent success, never a panic) but does NOT additionally
-    call `demote_room_actor` at those sites. Wiring the demote call into
-    all ~20 remaining sites individually is flagged as follow-up
-    hardening, not landed in this pass — the correctness property this
-    fix's core mechanism guarantees (a mutation is never silently applied
-    or silently reported successful after ownership loss) holds at every
-    site regardless; only the "also hard-kill the stale actor from this
-    ask's own call site" hardening (as opposed to the actor eventually
-    being killed by its OWN health-check veto or a subsequent mutation
-    attempt) is incomplete.
+    `RollbackConfigIfRevision`/`EnforceMembersOnlyAffiliations`/
+    `ApplyAdminItems`/`ApplyAffiliationChange` sites) route through their
+    existing typed error mappers but do NOT additionally exact-demote at
+    those sites. Wiring exact demotion into all remaining callers is
+    follow-up hardening; actor-side fail-closed gating already prevents the
+    stale mutation itself.
 
-    Tests: seven new `room_actor::tests` cases (a `FakeDurableStore` test
-    double controlling `check_fenced_fanout`'s result) prove
+    Tests use a `FakeDurableStore` that controls
+    `check_exact_claim_fence` and fenced-write results to prove
     `UpdateConfig`/`ChangeAffiliation`/`SetSubject` block on `NotOwner`
     with no in-memory mutation, `UpdateConfig` applies normally when
-    owned, fails OPEN on a transient fencing error, and surfaces
-    `PersistFailed` typed while still applying in-memory (undoing it
-    would risk a worse inconsistency than leaving it applied-but-not-yet-
-    durable).
+    owned, fails CLOSED with `OwnershipUnavailable` on a transient
+    fencing error, surfaces `PersistFailed` typed while still applying
+    in-memory, and seals the actor when ownership is lost during the fenced
+    config write.
 67. **FIX 3 (high) — orphaned claim on actor panic/death, and the
     corresponding health-check blind spot, are both closed.**
     `RoomRegistryActor::live_room` is now `async` (was sync): its
@@ -3526,14 +3418,9 @@ duplicated here.
     (NOT in FIX 2's nine-handler list — it only evicts occupants based on
     already-in-memory affiliations and never itself writes durable state,
     so it was correctly out of scope) via `?`, so the loop is
-    unreachable on either ask's failure. No additional fenced-check
-    helper was needed at any of the three named sites. Deviation 57's
-    "sole backstop, unconditionally" wording is amended (in place, see
-    that deviation's own retraction text) to reflect that the MAM write
-    itself is now also fenced (deviation 65) — `dispatch_to_room`'s
-    standalone check remains a real, still-necessary backstop (it blocks
-    the ENTIRE fan-out pipeline, not just the archive write), but it is
-    no longer accurately described as the sole one.
+    unreachable on either ask's failure. No additional fenced-check helper
+    was needed at any of the three named sites. The independent legacy
+    pre-fanout cache check remains in production until #1283 replaces it.
 72. **FIX 8 (medium) — `PostgresMucRoomStore::open` failing at
     `clustering::start_if_enabled` time is now FATAL to clustering
     startup, not logged-and-continue.** New

--- a/server/docs/adrs/0017-phase3-plan-ownership-claims.md
+++ b/server/docs/adrs/0017-phase3-plan-ownership-claims.md
@@ -3359,12 +3359,17 @@ record the retained work.
     for the next join attempt to retry again. A definitive
     `XmppError::OwnershipLost` from either the initial load or that retry
     instead sets terminal `OwnershipLost`, seals the actor, and returns
-    `RoomSealed`: it never retries the stale fence. The registry does not
-    publish that actor, enqueue retry work, or release the already-lost
-    stale claim tuple. A local node-identity rotation is not proof that the
-    database row moved: it remains typed as `OwnershipUnavailable`, so demand
-    cleanup releases the old exact tuple and reclaimed cleanup retains that
-    release responsibility across retries. New disco/join-error mapping in
+    `RoomSealed`: the actor itself never retries the stale fence. When the
+    current local identity still matches the fence owner, the registry treats
+    that result as an authoritative database miss: it does not publish the
+    actor, enqueue release work, or release the already-lost tuple. A local
+    node-identity rotation also definitively makes the actor's immutable fence
+    non-serving, so the durable store reports `OwnershipLost` and the actor
+    becomes terminal instead of retrying. That result does not by itself prove
+    the old database tuple disappeared: demand and reclaimed cleanup compare
+    the fence owner with the current local identity and retain one conditional
+    exact-release responsibility when the identities differ. New
+    disco/join-error mapping in
     `handlers/presence/muc.rs`: `RestorePending` bounces `<error
     type='wait'><resource-constraint/></error>`, matching FIX 6's shape.
 

--- a/server/docs/adrs/0017-phase3-plan-ownership-claims.md
+++ b/server/docs/adrs/0017-phase3-plan-ownership-claims.md
@@ -1353,10 +1353,12 @@ password/members-only hold after steal — this phase builds the mechanism, GA g
 correctness.
 
 At the #1355 stack boundary, generic restore returning `None` does not create a
-durable parent. The exact-fenced subject UPDATE remains non-creating and non-fatal
-there; #1352 must atomically initialize the complete room plus initial Owner to
-preserve creator/status-201 semantics, after which #1350 enforces missing-parent
-writes.
+durable parent. The exact-fenced subject UPDATE remains non-creating and returns a
+typed pre-apply failure when that parent is absent, so an acknowledged subject can
+never disappear on actor replacement. #1352 must atomically initialize the complete
+room plus initial Owner to remove that temporary unavailability while preserving
+creator/status-201 semantics; #1350 then hardens the broader parent/child integrity
+contract.
 
 **Code research finding, corrected (minor fix 16)**: the previous draft attributed the
 "no room/affiliation table exists in any schema" reasoning to
@@ -3349,15 +3351,19 @@ record the retained work.
     instead sets terminal `OwnershipLost`, seals the actor, and returns
     `RoomSealed`: it never retries the stale fence. The registry does not
     publish that actor, enqueue retry work, or release the already-lost
-    stale claim tuple. New disco/join-error mapping in
+    stale claim tuple. A local node-identity rotation is not proof that the
+    database row moved: it remains typed as `OwnershipUnavailable`, so demand
+    cleanup releases the old exact tuple and reclaimed cleanup retains that
+    release responsibility across retries. New disco/join-error mapping in
     `handlers/presence/muc.rs`: `RestorePending` bounces `<error
     type='wait'><resource-constraint/></error>`, matching FIX 6's shape.
 
     `SetSubject` uses the phase-specific pre-mutation ownership gate before
     constructing, persisting, or applying the subject: definitive loss maps
     to `NotOwner`, uncertainty maps to `OwnershipUnavailable`, and a normal
-    durable write failure maps to `PersistFailedBeforeApply`. This keeps its
-    public failure contract pre-apply. Shared `DurablePersistError::PersistFailed`
+    durable write failure — including a missing complete room parent before
+    #1352 — maps to `PersistFailedBeforeApply`. This keeps its public failure
+    contract pre-apply. Shared `DurablePersistError::PersistFailed`
     is deliberately phase-neutral because it is also wrapped by mediated
     invite grant and rollback errors whose public variants encode that their
     affiliation writes failed before applying memory.

--- a/server/docs/adrs/0017-phase3-plan-ownership-claims.md
+++ b/server/docs/adrs/0017-phase3-plan-ownership-claims.md
@@ -1352,6 +1352,12 @@ until #1283 replaces it. Phase 4 GA gates (not this phase) assert outcast denial
 password/members-only hold after steal — this phase builds the mechanism, GA gates its
 correctness.
 
+At the #1355 stack boundary, generic restore returning `None` does not create a
+durable parent. The exact-fenced subject UPDATE remains non-creating and non-fatal
+there; #1352 must atomically initialize the complete room plus initial Owner to
+preserve creator/status-201 semantics, after which #1350 enforces missing-parent
+writes.
+
 **Code research finding, corrected (minor fix 16)**: the previous draft attributed the
 "no room/affiliation table exists in any schema" reasoning to
 `session_janitors.rs`'s `spawn_room_dormancy_janitor` doc comment (lines ~1142–1155).

--- a/server/docs/adrs/0017-phase3-plan-ownership-claims.md
+++ b/server/docs/adrs/0017-phase3-plan-ownership-claims.md
@@ -3334,20 +3334,33 @@ record the retained work.
 68. **FIX 4 (high) — `RestoreDurableRoomState`'s genuine load failure now
     fails closed: joins are refused until a retry succeeds, never served
     against caller-supplied defaults.** New `RoomActor` field
-    `restore_state: DurableRestoreState` (`Ready` | `Pending`, private,
-    default `Ready`). `RestoreDurableRoomState`'s `Err` arm (a real
-    backend error, distinct from `Ok(None)`'s legitimate "brand new room"
-    case, which still proceeds as before) sets `Pending` instead of
-    logging-and-continuing with the caller-supplied initial config.
-    `JoinWithAffiliation` calls a new `ensure_restored_before_join()`
-    first: `Ready` is a no-op; `Pending` runs ONE bounded inline retry
-    against the same store — success applies the restored state and
-    flips back to `Ready`, letting THIS join proceed immediately; a
-    repeated failure returns a new `RoomActorError::RestorePending` and
-    leaves `Pending` for the next join attempt to retry again. New
-    disco/join-error mapping in `handlers/presence/muc.rs`: `RestorePending`
-    bounces `<error type='wait'><resource-constraint/></error>`,
-    matching FIX 6's shape.
+    `restore_state: DurableRestoreState` (`Ready` | `Pending` |
+    `OwnershipLost`, private, default `Ready`). A non-ownership backend
+    failure from `RestoreDurableRoomState` (distinct from `Ok(None)`'s
+    legitimate "brand new room" case) sets `Pending` instead of
+    logging-and-continuing with caller-supplied initial config.
+    `JoinWithAffiliation` calls `ensure_restored_before_join()` first:
+    `Ready` is a no-op; `Pending` runs ONE bounded inline retry against the
+    same store — success applies the restored state and flips back to
+    `Ready`, letting THIS join proceed immediately; a repeated uncertain
+    failure returns `RoomActorError::RestorePending` and leaves `Pending`
+    for the next join attempt to retry again. A definitive
+    `XmppError::OwnershipLost` from either the initial load or that retry
+    instead sets terminal `OwnershipLost`, seals the actor, and returns
+    `RoomSealed`: it never retries the stale fence. The registry does not
+    publish that actor, enqueue retry work, or release the already-lost
+    stale claim tuple. New disco/join-error mapping in
+    `handlers/presence/muc.rs`: `RestorePending` bounces `<error
+    type='wait'><resource-constraint/></error>`, matching FIX 6's shape.
+
+    `SetSubject` uses the phase-specific pre-mutation ownership gate before
+    constructing, persisting, or applying the subject: definitive loss maps
+    to `NotOwner`, uncertainty maps to `OwnershipUnavailable`, and a normal
+    durable write failure maps to `PersistFailedBeforeApply`. This keeps its
+    public failure contract pre-apply. Shared `DurablePersistError::PersistFailed`
+    is deliberately phase-neutral because it is also wrapped by mediated
+    invite grant and rollback errors whose public variants encode that their
+    affiliation writes failed before applying memory.
 
     Test: `room_actor::tests::
     join_is_refused_while_restore_is_pending_then_succeeds_once_recovered_with_no_ban_lost`

--- a/server/docs/adrs/0017-phase3-plan-ownership-claims.md
+++ b/server/docs/adrs/0017-phase3-plan-ownership-claims.md
@@ -3230,7 +3230,17 @@ record the retained work.
     `ArchiveGroupchat`, system messages, bots, and general dispatch were
     removed from #1355. Those effects continue to use the published cache's
     legacy pre-fanout backstop until #1283 supplies their replacement. This
-    ADR makes no completion claim for that future work.
+    ADR makes no completion claim for that future work. The retained backstop
+    still fails closed on definitive local non-serving state: a missing
+    published cache fence, a missing exact database tuple, or local identity
+    rotation returns `Ok(false)`, while backend uncertainty remains typed as
+    an error for the documented legacy fail-open path. Dispatch handles
+    `Ok(false)` with `DemoteRoomIfExactActor` against the actor it already
+    snapshotted, so a same-JID successor published while the database check is
+    in flight cannot be evicted by the stale dispatch. The concurrent
+    regression holds two old-actor dispatches at this boundary, publishes a
+    successor, then proves both messages bounce with no archive or occupant
+    reflection and the successor remains registered.
 66. **FIX 2 (critical) — every durable-relevant `RoomActor` mutation
     handler now runs a two-stage gate: verify ownership BEFORE mutating,
     surface a non-ownership persist failure typed AFTER mutating.**


### PR DESCRIPTION
## Summary

Bind clustered MUC durability and admission to the immutable claim fence retained by each `RoomActor` incarnation: room entity, node incarnation, and claim epoch. Stale actors can no longer borrow a successor's room-keyed cache entry, block identity rotation behind database I/O, or evict a same-JID successor after becoming non-serving.

Local identity supersession is terminal for the old actor, but cleanup remains owner-sensitive: an authoritative same-identity database miss stays release-free, while a superseded local incarnation retains one bounded, conditional release of its full exact tuple.

## Plan completed

1. Replace room-JID-only durable authority with explicit `RoomClaimFenceContext` on actor-owned load, save, delete, and ownership checks.
2. Carry the exact fence through demand creation, durable restore, orphan-reaper reconciliation, registry publication, and actor snapshots.
3. Validate room entity, owner incarnation, and claim epoch in Postgres storage and authoritative test doubles.
4. Run exact database proof without retaining the identity-rotation guard, then revalidate the local incarnation after I/O.
5. Classify missing exact tuples and local identity supersession as terminal `OwnershipLost` for the old actor while preserving typed backend uncertainty as `OwnershipUnavailable`.
6. Evict only the matching cached fence on identity mismatch. Skip release after an authoritative same-identity database miss; when the current identity differs, transfer the old full tuple into bounded exact-release cleanup so it cannot be orphaned or delete a successor.
7. Fail closed before XEP-0045 joins and durable mutations when exact authority cannot be proven.
8. Bind `SetSubject` to the event's frozen actor/fence, persist before applying or broadcasting, halt later effects on failure, and demote only the exact failed actor.
9. Publish the legacy room-keyed fan-out cache only after the matching ready registry entry; pre-publication restore/load receives the explicit exact fence directly.
10. Demote the actor captured by stale dispatch rather than destroying by room JID, so a concurrently published same-JID successor survives.
11. Add deterministic identity-rotation/database-lock and two-concurrent-dispatch regressions, plus anti-transplant, cross-room alias, reclaimed publication, missing durable subject row, post-apply ownership loss, and fail-closed XEP-0045 coverage.
12. Use neutral terminal-loss diagnostics because local supersession does not prove that ownership moved to another node, and reconcile ADR-0017 with the implemented contract and remaining #1283/#1350 scope.

## Scope boundaries

This is the exact-fence prerequisite for the remaining MUC lifecycle stack. It intentionally does **not** redesign general archive, MAM, bot, system-message, or dispatch authority; those paths retain their documented legacy pre-fanout backstop until #1283. It also does not add the creator lifecycle/catalog/cancellation work in #1352 or the transport status-201 and parent/affiliation integrity work in #1350.

No compatibility shim or schema migration is introduced.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p waddle-xmpp --all-targets -- -D warnings`
- `cargo clippy -p waddle-server --all-targets --features clustering -- -D warnings`
- `cargo test -p waddle-xmpp` — 2,606 unit tests plus all integration and doc-test binaries passed
- `cargo test -p waddle-server --features clustering` — 1,940 unit tests plus all integration and doc-test binaries passed
- Four focused room-registry identity-rotation regressions passed, including terminal demand/reclaimed cleanup of the old exact tuple
- Focused production durable-store identity-mismatch regression passed before database access
- Same-identity foreign-successor restore regressions passed without issuing a release
- Focused XEP-0045 subject ownership-loss/demotion regression passed
- Focused two-concurrent-dispatch XEP-0045 regression passed: two recoverable bounces, no MAM archive write, no occupant reflection, and the same-JID successor remains registered
- Three adversarial review lanes (fence/actor races, protocol/error behavior, and standards/scope/XEP/test conformance) reported clean after final re-review

`WADDLE_TEST_POSTGRES_URL` is not configured locally, so PostgreSQL-gated test bodies compiled but did not execute locally. CI `nixTest` provisions PostgreSQL and exercises the deterministic row-lock regression.

## Stack

This lands before #1352, then #1350. General dispatch/lifecycle convergence remains tracked in #1283.

Related: #1283, #1289, #1352, #1350
