### PR TITLE
fix(xmpp): publish P0.1 Packet S for review

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "@tiptap/vue-3": "^3.25.0",
         "@workadventure/noise-suppression": "0.0.4",
         "astro": "^6.4.3",
+        "effect": "^3.22.0",
         "emojilib": "^4.0.3",
         "events": "^3.3.0",
         "hls.js": "^1.6.16",
@@ -917,6 +918,8 @@
 
     "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
 
+    "effect": ["effect@3.22.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-jhYFe0zTlIRqYFrKTS+6luhmS/Tm0f+JLo0K9KUxvtFab1SUGEszQi2ehOP6QzAZvy831lDmTwwzvVDZSPNz3g=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.340", "", {}, "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA=="],
 
     "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
@@ -946,6 +949,8 @@
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -1292,6 +1297,8 @@
     "prosemirror-transform": ["prosemirror-transform@1.12.0", "", { "dependencies": { "prosemirror-model": "^1.21.0" } }, "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w=="],
 
     "prosemirror-view": ["prosemirror-view@1.41.8", "", { "dependencies": { "prosemirror-model": "^1.20.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0" } }, "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "radix3": ["radix3@1.1.2", "", {}, "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="],
 

--- a/chat/package.json
+++ b/chat/package.json
@@ -44,6 +44,7 @@
     "@tiptap/vue-3": "^3.25.0",
     "@workadventure/noise-suppression": "0.0.4",
     "astro": "^6.4.3",
+    "effect": "^3.22.0",
     "emojilib": "^4.0.3",
     "events": "^3.3.0",
     "hls.js": "^1.6.16",

--- a/chat/src/components/XmppProvider.vue
+++ b/chat/src/components/XmppProvider.vue
@@ -2,8 +2,14 @@
 import { onMounted, onUnmounted } from "vue";
 import { useSessionAuth } from "@/auth/session";
 import { BrowserXmppClient } from "@/lib/xmpp-client";
+import { suspendCallForPageHide } from "@/lib/calls/call-controls";
 import { connectionStore } from "@/lib/connection-store";
+import { reportError } from "@/lib/telemetry";
 import { $xmppStatus, OFFLINE_SNAPSHOT } from "@/stores/xmpp-status";
+import {
+  installXmppPagehideLifecycle,
+  type XmppPageLifecycleFailure,
+} from "@/lib/xmpp/pagehide-lifecycle";
 import { installInstrumentation } from "@/lib/xmpp/xmpp-instrumentation";
 import IncomingCallToast from "@/components/calls/IncomingCallToast.vue";
 import OutgoingCallToast from "@/components/calls/OutgoingCallToast.vue";
@@ -15,6 +21,15 @@ const props = defineProps<{
 }>();
 
 const auth = useSessionAuth(props.serverBaseUrl);
+let disconnectPagehideLifecycle: (() => void) | null = null;
+
+function reportPageLifecycleFailure(failure: XmppPageLifecycleFailure): void {
+  reportError("xmpp.stream", failure.cause, {
+    recoverable: true,
+    detail: "page-lifecycle-failed",
+    operation: failure.operation,
+  });
+}
 
 function syncStoreFromAuth() {
   connectionStore.appState = auth.appState.value;
@@ -67,10 +82,20 @@ connectionStore.logout = async () => {
 connectionStore.bootstrap = bootstrap;
 
 onMounted(() => {
+  if (typeof window !== "undefined") {
+    disconnectPagehideLifecycle = installXmppPagehideLifecycle(
+      window,
+      () => connectionStore.client,
+      suspendCallForPageHide,
+      reportPageLifecycleFailure,
+    );
+  }
   void bootstrap();
 });
 
 onUnmounted(() => {
+  disconnectPagehideLifecycle?.();
+  disconnectPagehideLifecycle = null;
   connectionStore.client?.disconnect().catch(() => undefined);
   connectionStore.client = null;
   $xmppStatus.set(OFFLINE_SNAPSHOT);

--- a/chat/src/components/calls/CallOverlay.vue
+++ b/chat/src/components/calls/CallOverlay.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, watch } from "vue";
+import { onBeforeUnmount, watch } from "vue";
 import { useStore } from "@nanostores/vue";
 import {
   $callState,
@@ -12,7 +12,6 @@ import { iceServersFromExternalServices } from "@/lib/calls/ice-servers";
 import { connectionStore } from "@/lib/connection-store";
 import {
   $callConnecting,
-  installCallPagehideSuspension,
   resetCallControls,
   seedCallControlsFromEngine,
 } from "@/lib/calls/call-controls";
@@ -30,14 +29,14 @@ import { resetCallViewState } from "@/lib/calls/call-view-state";
  *   - `CallExpandedSurface.vue` — fills the chat content pane.
  *
  * What stays here: the LiveKit connect/disconnect plumbing tied to
- * `$callState` transitions, and the pagehide cleanup hook. The mic /
- * cam / hangup plumbing moved into `call-controls.ts` (nanostore
+ * `$callState` transitions. Persistent page lifecycle ownership lives in
+ * `XmppProvider`, which snapshots XEP-0198 state before suspending media.
+ * The mic / cam / hangup plumbing moved into `call-controls.ts` (nanostore
  * atoms + control functions) so every surface reads one source of
  * truth. This component renders nothing visible.
  */
 const state = useStore($callState);
 const { engine } = useCallEngine();
-let disconnectPagehideSuspension: (() => void) | null = null;
 
 function getSender(): CallWireSender | null {
   const client = connectionStore.client as unknown as { xmpp?: unknown } | null;
@@ -116,19 +115,11 @@ watch(
   { immediate: true },
 );
 
-onMounted(() => {
-  if (typeof window !== "undefined") {
-    disconnectPagehideSuspension = installCallPagehideSuspension(window);
-  }
-});
-
 onBeforeUnmount(() => {
   // Component lifecycle is not a call lifecycle. Route changes and
   // browser refreshes must not emit XMPP call-ending stanzas; explicit
   // hangup/logout own that path.
   void engine.disconnect();
-  disconnectPagehideSuspension?.();
-  disconnectPagehideSuspension = null;
 });
 </script>
 

--- a/chat/src/lib/calls/call-controls.ts
+++ b/chat/src/lib/calls/call-controls.ts
@@ -178,9 +178,6 @@ export async function hangupActiveCall(): Promise<void> {
  * `tearDownActiveCall` and sends the conformant call-ending stanzas.
  */
 export function suspendCallForPageHide(): void {
-  (connectionStore.client as unknown as {
-    persistResumeStateForPageHide?: () => void;
-  } | null)?.persistResumeStateForPageHide?.();
   const current = $callState.get();
   if (current.phase === "idle" || current.phase === "ended") return;
   // This page's media connection is ending even when a refreshed page later
@@ -188,20 +185,6 @@ export function suspendCallForPageHide(): void {
   // attempt and owns its own lifecycle event.
   clearCallState({ endReason: "error" });
   void useCallEngine().engine.disconnect();
-}
-
-type PagehideTarget = Pick<Window, "addEventListener" | "removeEventListener">;
-
-export function installCallPagehideSuspension(windowTarget: PagehideTarget = window): () => void {
-  const handlePageHide = (event: PageTransitionEvent): void => {
-    if (event.persisted) return;
-    suspendCallForPageHide();
-  };
-
-  windowTarget.addEventListener("pagehide", handlePageHide as EventListener);
-  return () => {
-    windowTarget.removeEventListener("pagehide", handlePageHide as EventListener);
-  };
 }
 
 /**

--- a/chat/src/lib/outbound-queue-store.ts
+++ b/chat/src/lib/outbound-queue-store.ts
@@ -276,9 +276,11 @@ export function enqueueQueuedMessage(
   writeQueue(accountKey, next);
 }
 
-export function removeQueuedMessage(accountKey: string, messageId: string): void {
-  const next = readQueue(accountKey).filter((message) => message.id !== messageId);
+export function removeQueuedMessage(accountKey: string, messageId: string): boolean {
+  const current = readQueue(accountKey);
+  const next = current.filter((message) => message.id !== messageId);
   writeQueue(accountKey, next);
+  return next.length !== current.length;
 }
 
 export function countQueuedMessages(accountKey: string): number {

--- a/chat/src/lib/xmpp/client-connection.ts
+++ b/chat/src/lib/xmpp/client-connection.ts
@@ -35,8 +35,13 @@ export type XmppResumeState = {
   outboundH: number;
   maxResumeSeconds?: number;
   hasUnackedOutbound?: boolean;
-  unhandledOutboundStanzas?: string[];
+  unhandledOutboundEntries?: XmppResumeEntry[];
   resource?: string;
+};
+
+type XmppResumeEntry = {
+  stanza: string;
+  sentAt: string;
 };
 
 export type XmppResumeStateHandle = import("@waddle/xmpp-client-wasm").WaddleResumeState;
@@ -101,18 +106,18 @@ function validResumeMaxSeconds(value: number | undefined): number | undefined {
 
 export function applyResumeStateToWasmConfig(config: unknown, resumeState: XmppResumeState): void {
   const wasmConfig = config as {
-    with_resume_state_stanzas_with_max?: (
+    with_resume_state_entries_with_max?: (
       previd: string,
       inboundH: number,
       outboundH: number,
-      stanzas: string[],
+      entries: XmppResumeEntry[],
       maxResumeSeconds: number,
     ) => void;
-    with_resume_state_stanzas?: (
+    with_resume_state_entries?: (
       previd: string,
       inboundH: number,
       outboundH: number,
-      stanzas: string[],
+      entries: XmppResumeEntry[],
     ) => void;
     with_resume_state_with_max?: (
       previd: string,
@@ -124,30 +129,33 @@ export function applyResumeStateToWasmConfig(config: unknown, resumeState: XmppR
   };
   const maxResumeSeconds = validResumeMaxSeconds(resumeState.maxResumeSeconds);
   if (
-    resumeState.unhandledOutboundStanzas?.length
+    resumeState.unhandledOutboundEntries?.length
     && maxResumeSeconds !== undefined
-    && typeof wasmConfig.with_resume_state_stanzas_with_max === "function"
+    && typeof wasmConfig.with_resume_state_entries_with_max === "function"
   ) {
-    wasmConfig.with_resume_state_stanzas_with_max(
+    wasmConfig.with_resume_state_entries_with_max(
       resumeState.previd,
       resumeState.inboundH,
       resumeState.outboundH,
-      resumeState.unhandledOutboundStanzas,
+      resumeState.unhandledOutboundEntries,
       maxResumeSeconds,
     );
     return;
   }
   if (
-    resumeState.unhandledOutboundStanzas?.length
-    && typeof wasmConfig.with_resume_state_stanzas === "function"
+    resumeState.unhandledOutboundEntries?.length
+    && typeof wasmConfig.with_resume_state_entries === "function"
   ) {
-    wasmConfig.with_resume_state_stanzas(
+    wasmConfig.with_resume_state_entries(
       resumeState.previd,
       resumeState.inboundH,
       resumeState.outboundH,
-      resumeState.unhandledOutboundStanzas,
+      resumeState.unhandledOutboundEntries,
     );
     return;
+  }
+  if (resumeState.unhandledOutboundEntries?.length) {
+    throw new Error("WASM client cannot restore timestamped XEP-0198 resume entries");
   }
   if (maxResumeSeconds !== undefined && typeof wasmConfig.with_resume_state_with_max === "function") {
     wasmConfig.with_resume_state_with_max(
@@ -337,7 +345,7 @@ export class ResumeStateStore {
     const state = liveState ?? this.stateValue;
     this.persistence.preparePagehideHandoff();
     if (state) {
-      if (state.hasUnackedOutbound && !state.unhandledOutboundStanzas?.length) {
+      if (state.hasUnackedOutbound && !state.unhandledOutboundEntries?.length) {
         this.stateValue = null;
         this.persistence.clearSm();
         persistJoinedRooms();
@@ -348,6 +356,10 @@ export class ResumeStateStore {
       this.persistence.saveSm(snapshot);
     }
     persistJoinedRooms();
+  }
+
+  reclaimAfterPageShow(): void {
+    this.persistence.reclaimPagehideOwnership();
   }
 }
 
@@ -374,6 +386,10 @@ type OfflineSendQueueDeps = {
   ) => Promise<string | null>;
 };
 
+type NativeQueueOwnership =
+  | { kind: "resume-replay" }
+  | { kind: "fresh-fallback" };
+
 /**
  * Persisted offline outbound queue + drain logic. Owns in-flight and
  * resume-replay id tracking, the pending-send latency map behind the
@@ -382,7 +398,12 @@ type OfflineSendQueueDeps = {
  */
 export class OfflineSendQueue {
   private readonly inflightQueuedIds = new Set<string>();
-  private readonly resumeReplayQueuedIds = new Set<string>();
+  /**
+   * Stanzas whose next wire attempt is owned by the native XEP-0198 runtime.
+   * A failed resume transfers them to the runtime's fresh-stream fallback;
+   * the browser must retain the durable row without racing a second send.
+   */
+  private readonly nativeQueueOwnership = new Map<string, NativeQueueOwnership>();
   private readonly pendingSendAt = new Map<string, { at: number; kind: "room" | "dm" }>();
   private directFlushPromise: Promise<void> | null = null;
   private readonly roomFlushes = new Map<string, Promise<void>>();
@@ -393,20 +414,46 @@ export class OfflineSendQueue {
     return countQueuedMessages(this.deps.queueScope());
   }
 
-  /** Mark a stanza id as an in-flight queued send awaiting its ack. */
-  markInflight(id: string): void {
+  /**
+   * Mark a stable stanza id in-flight before the send promise can yield.
+   * WASM may deliver the matching SM acknowledgement synchronously while
+   * resolving that promise, so both persistence ownership and latency state
+   * must already exist when the callback runs.
+   */
+  beginAttempt(id: string, kind: "room" | "dm"): void {
+    const wasInflight = this.inflightQueuedIds.has(id);
     this.inflightQueuedIds.add(id);
+    this.pendingSendAt.set(id, { at: performance.now(), kind });
+    if (!wasInflight) this.emitQueueDepth();
+  }
+
+  /** A rejected or null send did not transfer responsibility to XEP-0198. */
+  rollbackAttempt(id: string): void {
+    const wasInflight = this.inflightQueuedIds.delete(id);
+    this.pendingSendAt.delete(id);
+    if (wasInflight) {
+      this.deps.events.emit("queuedMessageStatus", id, "queued");
+      this.emitQueueDepth();
+    }
   }
 
   /** Fresh session: pre-resume in-flight sends will never be acked. */
   clearInflight(): void {
+    const hadInflight = this.inflightQueuedIds.size > 0;
     this.inflightQueuedIds.clear();
-  }
-
-  /** Record send time for ack-latency telemetry. */
-  notePendingSend(id: string | null, kind: "room" | "dm"): void {
-    if (!id) return;
-    this.pendingSendAt.set(id, { at: performance.now(), kind });
+    this.pendingSendAt.clear();
+    let releasedResumeReplay = false;
+    // A plain fresh bind (for example when the new server advertises no SM)
+    // never emits a resume `<failed/>`; release only those never-transferred
+    // replay claims so the durable browser queue can recover them. Explicit
+    // fresh-fallback ownership remains fenced until the native retry settles.
+    for (const [id, ownership] of this.nativeQueueOwnership) {
+      if (ownership.kind === "resume-replay") {
+        this.nativeQueueOwnership.delete(id);
+        releasedResumeReplay = true;
+      }
+    }
+    if (hadInflight || releasedResumeReplay) this.emitQueueDepth();
   }
 
   /**
@@ -414,44 +461,84 @@ export class OfflineSendQueue {
    * on resume are tracked so their acks clear the persisted queue copy.
    */
   seedFromResumeState(state: XmppResumeState | null | undefined): void {
-    for (const xml of state?.unhandledOutboundStanzas ?? []) {
-      const id = messageStanzaIdFromSerializedXml(xml);
+    for (const entry of state?.unhandledOutboundEntries ?? []) {
+      const id = messageStanzaIdFromSerializedXml(entry.stanza);
       if (id) {
         this.inflightQueuedIds.add(id);
-        this.resumeReplayQueuedIds.add(id);
+        this.nativeQueueOwnership.set(id, { kind: "resume-replay" });
       }
     }
   }
 
+  /**
+   * Reconcile browser fencing with the native snapshot captured at a
+   * terminal transport disconnect. A surviving entry proves the next native
+   * runtime still owns that stanza; absence releases stale fallback ownership
+   * so the durable browser row can make one at-least-once attempt next session.
+   */
+  reconcileNativeOwnershipAfterDisconnect(
+    state: XmppResumeState | null | undefined,
+  ): void {
+    const survivingNativeIds = new Set<string>();
+    for (const entry of state?.unhandledOutboundEntries ?? []) {
+      const id = messageStanzaIdFromSerializedXml(entry.stanza);
+      if (id) survivingNativeIds.add(id);
+    }
+
+    let ownershipChanged = false;
+    for (const id of this.nativeQueueOwnership.keys()) {
+      if (!survivingNativeIds.has(id)) {
+        this.nativeQueueOwnership.delete(id);
+        ownershipChanged = true;
+      }
+    }
+
+    this.seedFromResumeState(state);
+    if (ownershipChanged) this.emitQueueDepth();
+  }
+
   handleAck(id: string): void {
     const wasQueued = this.inflightQueuedIds.delete(id);
-    this.resumeReplayQueuedIds.delete(id);
-    if (wasQueued) removeQueuedMessage(this.deps.queueScope(), id);
+    const wasNativeOwned = this.nativeQueueOwnership.delete(id);
+    // The callback can arrive after a reload or synchronously inside the
+    // awaited send. Persisted identity is authoritative; ephemeral Set
+    // membership is never a prerequisite for deleting the durable copy.
+    const wasPersisted = removeQueuedMessage(this.deps.queueScope(), id);
     this.deps.events.emit("messageAck", id);
     const pending = this.pendingSendAt.get(id);
     if (pending) {
       this.pendingSendAt.delete(id);
       this.deps.events.emitSafe("messageAcked", id, { kind: pending.kind, latencyMs: performance.now() - pending.at });
     }
-    if (wasQueued) this.emitQueueDepth();
+    if (wasQueued || wasNativeOwned || wasPersisted) this.emitQueueDepth();
   }
 
   handleFailed(id: string): void {
     const wasQueued = this.inflightQueuedIds.delete(id);
-    const wasResumeReplay = this.resumeReplayQueuedIds.delete(id);
-    if (wasResumeReplay) removeQueuedMessage(this.deps.queueScope(), id);
+    const nativeOwnership = this.nativeQueueOwnership.get(id);
+    if (nativeOwnership?.kind === "resume-replay") {
+      // `<failed/>` ends only the resume attempt. The native runtime now owns
+      // the same stanza id on its conformant fresh-stream fallback. Keep the
+      // browser row crash-durable and keep browser flushing fenced off until
+      // the native path acks it or reports a subsequent terminal failure.
+      this.nativeQueueOwnership.set(id, { kind: "fresh-fallback" });
+      this.deps.events.emit("queuedMessageStatus", id, "sending");
+      if (wasQueued) this.emitQueueDepth();
+      return;
+    }
+    const wasNativeOwned = this.nativeQueueOwnership.delete(id);
     this.deps.events.emit("messageDeliveryFailure", id);
     const pending = this.pendingSendAt.get(id);
     if (pending) {
       this.pendingSendAt.delete(id);
       this.deps.events.emitSafe("messageDeliveryFailed", id, { kind: pending.kind });
     }
-    if (wasQueued || wasResumeReplay) this.emitQueueDepth();
+    if (wasQueued || wasNativeOwned) this.emitQueueDepth();
   }
 
   discardNonRetryable(id: string): void {
     this.inflightQueuedIds.delete(id);
-    this.resumeReplayQueuedIds.delete(id);
+    this.nativeQueueOwnership.delete(id);
     removeQueuedMessage(this.deps.queueScope(), id);
     this.deps.events.emit("messageDeliveryFailure", id);
     const pending = this.pendingSendAt.get(id);
@@ -561,28 +648,33 @@ export class OfflineSendQueue {
       const entries = listQueuedMessages(this.deps.queueScope()).filter((entry): entry is PersistedQueuedDmMessage => entry.kind === "dm");
       for (const entry of entries) {
         if (!this.deps.canUseConnectedSession()) break;
-        if (this.inflightQueuedIds.has(entry.id)) continue;
+        if (this.inflightQueuedIds.has(entry.id) || this.nativeQueueOwnership.has(entry.id)) continue;
         this.deps.events.emit("queuedMessageStatus", entry.id, "sending");
+        this.beginAttempt(entry.id, "dm");
         let messageId: string | null;
         try {
           messageId = await this.deps.sendDirect(entry.mucPm ? entry.peerJid : barePeerJid(entry.peerJid), entry.body, { ...(entry.markup?.length ? { markup: entry.markup } : {}), ...(entry.references?.length ? { references: entry.references } : {}), ...(entry.files?.length ? { files: entry.files } : {}), ...(entry.replyTo ? { replyTo: entry.replyTo } : {}), ...(entry.threadId ? { threadId: entry.threadId } : {}), ...(entry.parentThreadId ? { parentThreadId: entry.parentThreadId } : {}), ...(entry.mucPm ? { mucPm: true } : {}), id: entry.id });
         } catch (error) {
+          this.rollbackAttempt(entry.id);
           if (isNonRetryableWasmSendFailure(error)) {
             this.discardNonRetryable(entry.id);
             continue;
           }
           throw error;
         }
-        if (messageId) {
-          this.inflightQueuedIds.add(entry.id);
-          this.notePendingSend(entry.id, "dm");
+        if (!messageId) {
+          this.rollbackAttempt(entry.id);
+        } else if (messageId !== entry.id) {
+          this.rollbackAttempt(entry.id);
+          throw new Error("XMPP send returned a different stanza id");
         }
       }
     })();
-    this.directFlushPromise = promise.finally(() => {
-      if (this.directFlushPromise === promise) this.directFlushPromise = null;
+    const trackedPromise = promise.finally(() => {
+      if (this.directFlushPromise === trackedPromise) this.directFlushPromise = null;
     });
-    return this.directFlushPromise;
+    this.directFlushPromise = trackedPromise;
+    return trackedPromise;
   }
 
   async flushRoom(roomJid: string): Promise<void | undefined> {
@@ -593,38 +685,54 @@ export class OfflineSendQueue {
       const entries = listQueuedRoomMessages(this.deps.queueScope(), roomJid);
       for (const entry of entries) {
         if (!this.deps.roomIsReady(roomJid)) break;
-        if (this.inflightQueuedIds.has(entry.id)) continue;
+        if (this.inflightQueuedIds.has(entry.id) || this.nativeQueueOwnership.has(entry.id)) continue;
         this.deps.events.emit("queuedMessageStatus", entry.id, "sending");
+        this.beginAttempt(entry.id, "room");
         let messageId: string | null;
         try {
           messageId = await this.deps.sendRoom(roomJid, entry.body, { ...(entry.markup?.length ? { markup: entry.markup } : {}), ...(entry.references?.length ? { references: entry.references } : {}), mentionJidsByNick: { ...(entry.mentionJidsByNick ?? {}), ...this.deps.roomMemberJids(roomJid) }, ...(entry.files?.length ? { files: entry.files } : {}), ...(entry.replyTo ? { replyTo: entry.replyTo } : {}), ...(entry.threadId ? { threadId: entry.threadId } : {}), ...(entry.parentThreadId ? { parentThreadId: entry.parentThreadId } : {}), ...(entry.threadCreate ? { threadCreate: entry.threadCreate } : {}), ...(entry.threadReply ? { threadReply: entry.threadReply } : {}), id: entry.id });
         } catch (error) {
+          this.rollbackAttempt(entry.id);
           if (isNonRetryableWasmSendFailure(error)) {
             this.discardNonRetryable(entry.id);
             continue;
           }
           throw error;
         }
-        if (messageId) {
-          this.inflightQueuedIds.add(entry.id);
-          this.notePendingSend(entry.id, "room");
+        if (!messageId) {
+          this.rollbackAttempt(entry.id);
+        } else if (messageId !== entry.id) {
+          this.rollbackAttempt(entry.id);
+          throw new Error("XMPP send returned a different stanza id");
         }
       }
     })();
-    this.roomFlushes.set(roomJid, promise.finally(() => {
-      if (this.roomFlushes.get(roomJid) === promise) this.roomFlushes.delete(roomJid);
-    }));
-    return this.roomFlushes.get(roomJid);
+    const trackedPromise = promise.finally(() => {
+      if (this.roomFlushes.get(roomJid) === trackedPromise) this.roomFlushes.delete(roomJid);
+    });
+    this.roomFlushes.set(roomJid, trackedPromise);
+    return trackedPromise;
   }
 
   private emitQueueDepth(): void {
     const entries = listQueuedMessages(this.deps.queueScope());
     for (const kind of ["dm", "room"] as const) {
       const kindEntries = entries.filter((entry) => entry.kind === kind);
+      const oldestCreatedAt = kindEntries.reduce<number | undefined>((oldest, entry) => {
+        const createdAt = Date.parse(entry.createdAt);
+        if (!Number.isFinite(createdAt)) return oldest;
+        return oldest === undefined ? createdAt : Math.min(oldest, createdAt);
+      }, undefined);
       this.deps.events.emitSafe("queueDepthChange", {
         kind,
         persisted: kindEntries.length,
-        inflight: kindEntries.filter((entry) => this.inflightQueuedIds.has(entry.id)).length,
+        inflight: kindEntries.filter(
+          (entry) =>
+            this.inflightQueuedIds.has(entry.id) || this.nativeQueueOwnership.has(entry.id),
+        ).length,
+        ...(oldestCreatedAt === undefined
+          ? {}
+          : { oldestAgeMs: Math.max(0, Date.now() - oldestCreatedAt) }),
       });
     }
   }

--- a/chat/src/lib/xmpp/client-events.ts
+++ b/chat/src/lib/xmpp/client-events.ts
@@ -37,7 +37,11 @@ import type {
 } from "./types";
 import type { InboxEntry } from "./inbox-types";
 import type { TerminalMucJoinCondition } from "./room-auto-join-policy";
-import type { WasmPinEvent, WasmPubsubEvent } from "./wasm-types";
+import type {
+  WasmPinEvent,
+  WasmPubsubEvent,
+  WasmStreamManagementTelemetry,
+} from "./wasm-types";
 
 /** Event name → payload tuple. */
 export type ClientEventMap = Record<string, ReadonlyArray<unknown>>;
@@ -91,6 +95,13 @@ export type RoomAccessChangedEvent =
       state: "available";
     };
 
+export type QueueDepthTelemetry = {
+  kind: "room" | "dm";
+  persisted: number;
+  inflight: number;
+  oldestAgeMs?: number;
+};
+
 /**
  * Event map for `BrowserXmppClient`'s internal bus.
  *
@@ -139,7 +150,8 @@ export type ClientEvents = {
   sessionLifecycleHook: [event: SessionLifecycleEvent];
   statusHook: [status: XmppStatusSnapshot, meta: { reconnectDurationMs?: number }];
   sendEnqueued: [info: { kind: "room" | "dm"; reason: string }];
-  queueDepthChange: [depth: { kind: "room" | "dm"; persisted: number; inflight: number }];
+  queueDepthChange: [depth: QueueDepthTelemetry];
+  streamManagement: [event: WasmStreamManagementTelemetry];
   error: [event: XmppErrorEvent];
   reconnectScheduled: [info: { attempt: number; delayMs: number }];
   catchup: [info: CatchupHookInfo];

--- a/chat/src/lib/xmpp/client.ts
+++ b/chat/src/lib/xmpp/client.ts
@@ -41,6 +41,7 @@ import type {
   ClientEvents,
   MdsDisplayedEntry,
   PubsubEvent,
+  QueueDepthTelemetry,
   RoomAccessChangedEvent,
 } from "./client-events";
 import {
@@ -192,6 +193,7 @@ import type {
   WasmRosterContact,
   WasmSendMessageOutcome,
   WasmServerVersion,
+  WasmStreamManagementTelemetry,
   WasmThreadsPage,
   WasmUserSearchResult,
 } from "./wasm-types";
@@ -343,11 +345,13 @@ type XmppClientInstance = Partial<WasmClient> & CompatEmitter & {
   set_on_message_delivery_failed?: (cb: (id: string) => void) => void;
   set_on_call?: (cb: (event: CallEvent) => void) => void;
   set_on_session_lifecycle?: (cb: (event: string) => void) => void;
+  set_on_stream_management?: (cb: (event: WasmStreamManagementTelemetry) => void) => void;
   set_on_mds_displayed?: (cb: (entry: WasmMdsDisplayedEntry) => void) => void;
   set_on_pubsub_event?: (cb: (event: WasmPubsubEvent) => void) => void;
   send_in_call_reaction?: (to: string, type: "chat" | "groupchat", sid: string, emoji: string) => Promise<void>;
   get_resume_state?: () => XmppResumeState | null;
   get_resume_state_handle?: () => XmppResumeStateHandle | undefined;
+  request_stream_management_ack?: () => Promise<void>;
   publish_mds_displayed?: (chatId: string, stanzaId: string, stanzaIdBy: string) => Promise<void>;
   supports_mds_publish_options?: () => Promise<boolean>;
   fetch_mds_displayed?: () => Promise<ReadonlyArray<WasmMdsDisplayedEntry>>;
@@ -692,6 +696,10 @@ export class BrowserXmppClient {
     return this.xmpp === xmpp && !this.destroying;
   }
 
+  private isCurrentConnection(xmpp: XmppClientInstance, generation: number): boolean {
+    return generation === this.connectEpoch && this.isCurrentXmpp(xmpp);
+  }
+
   private rejectRoomJoinWaiters(error: Error): void {
     for (const waiter of this.roomJoinWaiters.values()) {
       waiter.reject(error);
@@ -860,7 +868,8 @@ export class BrowserXmppClient {
   onSessionLifecycle(hook: (event: SessionLifecycleEvent) => void) { this.events.on("sessionLifecycleHook", hook); }
   onStatus(hook: (status: XmppStatusSnapshot, meta: { reconnectDurationMs?: number }) => void) { this.events.on("statusHook", hook); }
   onSendEnqueued(hook: (info: { kind: "room" | "dm"; reason: string }) => void) { this.events.on("sendEnqueued", hook); }
-  onQueueDepthChange(hook: (depth: { kind: "room" | "dm"; persisted: number; inflight: number }) => void) { this.events.on("queueDepthChange", hook); }
+  onQueueDepthChange(hook: (depth: QueueDepthTelemetry) => void) { this.events.on("queueDepthChange", hook); }
+  onStreamManagement(hook: (event: WasmStreamManagementTelemetry) => void) { this.events.on("streamManagement", hook); }
   onError(hook: (event: XmppErrorEvent) => void) { this.events.on("error", hook); }
   listRoomAccessRequirements(): ReadonlyArray<Extract<RoomAccessChangedEvent, { state: "required" }>> {
     return [...this.terminallyDeniedAutoJoinRooms.values()].map((block) => ({
@@ -935,6 +944,39 @@ export class BrowserXmppClient {
     );
   }
 
+  prepareForPageHide(): void {
+    const xmpp = this.xmpp;
+    const generation = this.connectEpoch;
+    try {
+      const request = xmpp?.request_stream_management_ack?.();
+      if (request) {
+        void Promise.resolve(request).catch((cause) => {
+          if (!xmpp || !this.isCurrentConnection(xmpp, generation)) return;
+          this.emitError({
+            kind: "stream",
+            recoverable: true,
+            detail: "sm-ack-request-failed",
+            cause,
+          });
+        });
+      }
+    } catch (cause) {
+      if (xmpp && this.isCurrentConnection(xmpp, generation)) {
+        this.emitError({
+          kind: "stream",
+          recoverable: true,
+          detail: "sm-ack-request-failed",
+          cause,
+        });
+      }
+    }
+    this.persistResumeStateForPageHide();
+  }
+
+  resumeAfterPageShow(): void {
+    this.resume.reclaimAfterPageShow();
+  }
+
   private async enableCarbons(xmpp: XmppClientInstance & { enableCarbons?: () => Promise<void> }) {
     if (xmpp.enableCarbons) {
       try { await xmpp.enableCarbons(); } catch {}
@@ -955,8 +997,7 @@ export class BrowserXmppClient {
    * resource and trigger a self-inflicted terminal `conflict`. */
   private connectEpoch = 0;
 
-  private async doConnect(): Promise<void> {
-    const epoch = ++this.connectEpoch;
+  private async doConnect(epoch: number): Promise<void> {
     const websocketUrl = websocketUrlWithTraceparent(this.session.xmpp_websocket_url);
     const mod = await this.loadModule();
     // Stale continuation: a newer connect attempt started (or the
@@ -979,7 +1020,7 @@ export class BrowserXmppClient {
     }
     const xmpp = new mod.WaddleClient(config) as unknown as XmppClientInstance;
     this.xmpp = xmpp;
-    this.wireEvents(xmpp);
+    this.wireEvents(xmpp, epoch);
     await xmpp.connect?.();
   }
 
@@ -1065,11 +1106,13 @@ export class BrowserXmppClient {
     this.destroying = false;
     this.disarmOnlineRecovery();
     this.clearReconnectTimer();
+    const generation = ++this.connectEpoch;
     this.connectPromise = withSpan(
       "xmpp.connect",
       { "waddle.xmpp.transport": "websocket" },
       () => new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
+          if (generation !== this.connectEpoch) return;
           // C1: the connect budget measures to session-ready, not to
           // catch-up completion. `connect()`'s promise still resolves
           // only after the resume barrier (callers rely on "connected
@@ -1120,7 +1163,8 @@ export class BrowserXmppClient {
         };
         this.onceConnected = () => done(resolve);
         this.onceConnectFailed = (error) => done(() => reject(error));
-        void this.doConnect().catch((error) => {
+        void this.doConnect(generation).catch((error) => {
+          if (generation !== this.connectEpoch) return;
           if (this.onceConnectFailed) {
             const fail = this.onceConnectFailed;
             this.onceConnectFailed = null;
@@ -1590,15 +1634,23 @@ export class BrowserXmppClient {
       const outboundId = opts.id ?? crypto.randomUUID();
       const sendOpts = { ...opts, id: outboundId, mentionJidsByNick: { ...(opts.mentionJidsByNick ?? {}), ...this.memberJidsFor(roomJid) } };
       this.outboundQueue.persistPendingRoomSend(roomJid, body, sendOpts);
+      this.outboundQueue.beginAttempt(outboundId, "room");
       let id: string | null;
       try {
         id = await this.compatSendGroupMessage(this.xmpp, roomJid, body, sendOpts);
       } catch (error) {
+        this.outboundQueue.rollbackAttempt(outboundId);
         if (isNonRetryableWasmSendFailure(error)) this.outboundQueue.discardNonRetryable(outboundId);
         throw error;
       }
-      if (id) this.outboundQueue.markInflight(id);
-      this.outboundQueue.notePendingSend(id, "room");
+      if (!id) {
+        this.outboundQueue.rollbackAttempt(outboundId);
+        return { id: null, state: "queued" };
+      }
+      if (id !== outboundId) {
+        this.outboundQueue.rollbackAttempt(outboundId);
+        throw new Error("XMPP send returned a different stanza id");
+      }
       return { id, state: "sending" };
     }
     const queued = this.outboundQueue.queueRoomMessage(roomJid, body, opts);
@@ -1637,15 +1689,23 @@ export class BrowserXmppClient {
       const outboundId = opts.id ?? crypto.randomUUID();
       const sendOpts = { ...opts, id: outboundId, ...(mucPm ? { mucPm: true } : {}) };
       this.outboundQueue.persistPendingDirectSend(normalizedPeerJid, body, sendOpts);
+      this.outboundQueue.beginAttempt(outboundId, "dm");
       let id: string | null;
       try {
         id = await this.compatSendDirectMessage(this.xmpp, normalizedPeerJid, body, sendOpts);
       } catch (error) {
+        this.outboundQueue.rollbackAttempt(outboundId);
         if (isNonRetryableWasmSendFailure(error)) this.outboundQueue.discardNonRetryable(outboundId);
         throw error;
       }
-      if (id) this.outboundQueue.markInflight(id);
-      this.outboundQueue.notePendingSend(id, "dm");
+      if (!id) {
+        this.outboundQueue.rollbackAttempt(outboundId);
+        return { id: null, state: "queued" };
+      }
+      if (id !== outboundId) {
+        this.outboundQueue.rollbackAttempt(outboundId);
+        throw new Error("XMPP send returned a different stanza id");
+      }
       return { id, state: "sending" };
     }
     return this.outboundQueue.queueDirectMessage(normalizedPeerJid, body, mucPm ? { ...opts, mucPm: true } : opts);
@@ -2771,7 +2831,7 @@ export class BrowserXmppClient {
     // `ResumeStateStore.captureFromDisconnect` for the pagehide-handoff
     // rationale.
     const resumeState = this.resume.captureFromDisconnect(xmpp, this.resource);
-    this.outboundQueue.seedFromResumeState(resumeState);
+    this.outboundQueue.reconcileNativeOwnershipAfterDisconnect(resumeState);
     this.emitStatus({ state: "reconnecting", detail: this.outboundQueue.persistedCount() > 0 ? "Connection lost — queued messages will send when reconnected" : (error?.message ?? "Connection lost, reconnecting...") });
     if (this.onceConnectFailed) { const fail = this.onceConnectFailed; this.onceConnected = null; this.onceConnectFailed = null; fail(error ?? new Error("XMPP connection failed")); }
     this.reconnect.schedule();
@@ -3041,19 +3101,32 @@ export class BrowserXmppClient {
   ) {
     return this.mam.runReconnectCatchup(xmpp, entries, lifecycle);
   }
-  private wireEvents(xmpp: XmppClientInstance & { enableKeepAlive?: (opts: { interval: number; timeout: number }) => void; disableKeepAlive?: () => void }) {
+  private wireEvents(
+    xmpp: XmppClientInstance & {
+      enableKeepAlive?: (opts: { interval: number; timeout: number }) => void;
+      disableKeepAlive?: () => void;
+    },
+    generation = this.connectEpoch,
+  ) {
     if (!this.xmpp && !this.destroying) this.xmpp = xmpp;
     // #754: carbons enable lives in the fresh branch of `runSessionReady`
     // only — enabling from `on_connected` too doubled the IQ on every
     // fresh connect and re-enabled on XEP-0198 resume, where the server
     // already preserves carbon state for the resumed session.
     xmpp.set_on_session_lifecycle?.((event: string) => {
-      if (!this.isCurrentXmpp(xmpp)) return;
+      if (!this.isCurrentConnection(xmpp, generation)) return;
       if (event === "resumed") this.handleSessionReady(xmpp, { type: "resumed" }); else this.handleSessionReady(xmpp, { type: "fresh" });
     });
-    xmpp.set_on_disconnected?.(() => this.handleDisconnected(xmpp));
+    xmpp.set_on_stream_management?.((event: WasmStreamManagementTelemetry) => {
+      if (!this.isCurrentConnection(xmpp, generation)) return;
+      this.events.emitSafe("streamManagement", event);
+    });
+    xmpp.set_on_disconnected?.(() => {
+      if (!this.isCurrentConnection(xmpp, generation)) return;
+      this.handleDisconnected(xmpp);
+    });
     xmpp.set_on_error?.((payload: XmppStreamErrorPayload) => {
-      if (this.xmpp !== xmpp) return;
+      if (!this.isCurrentConnection(xmpp, generation)) return;
       const streamError = normalizeXmppStreamErrorPayload(payload);
       const terminalDetail = terminalDisconnectDetail(terminalConditionFromPayload(payload));
       if (terminalDetail) this.terminalDisconnectDetail = terminalDetail;
@@ -3068,11 +3141,11 @@ export class BrowserXmppClient {
       });
     });
     xmpp.set_on_message?.((message: WasmMessage) => {
-      if (!this.isCurrentXmpp(xmpp)) return;
+      if (!this.isCurrentConnection(xmpp, generation)) return;
       this.handleMessage(message);
     });
     xmpp.set_on_presence?.((presence: WasmPresence) => {
-      if (!this.isCurrentXmpp(xmpp)) return;
+      if (!this.isCurrentConnection(xmpp, generation)) return;
       this.handlePresence(presence);
       // Side-effect track: MUC presence carrying the call extension
       // populates the per-room participants store so any consumer
@@ -3086,23 +3159,23 @@ export class BrowserXmppClient {
       applyMutePresence(presence);
     });
     xmpp.set_on_message_delivery_acked?.((id: string) => {
-      if (!this.isCurrentXmpp(xmpp)) return;
+      if (!this.isCurrentConnection(xmpp, generation)) return;
       this.handleMessageAck(id);
     });
     xmpp.set_on_message_delivery_failed?.((id: string) => {
-      if (!this.isCurrentXmpp(xmpp)) return;
+      if (!this.isCurrentConnection(xmpp, generation)) return;
       this.handleMessageFailed(id);
     });
     xmpp.set_on_mds_displayed?.((entry: WasmMdsDisplayedEntry) => {
-      if (!this.isCurrentXmpp(xmpp)) return;
+      if (!this.isCurrentConnection(xmpp, generation)) return;
       this.events.emit("mdsDisplayed", { chatId: entry.chat_id, stanzaId: entry.stanza_id, stanzaIdBy: entry.stanza_id_by });
     });
     xmpp.set_on_pubsub_event?.((event: WasmPubsubEvent) => {
-      if (!this.isCurrentXmpp(xmpp)) return;
+      if (!this.isCurrentConnection(xmpp, generation)) return;
       this.events.emit("pubsubEvent", event);
     });
     xmpp.set_on_call?.((event: CallEvent) => {
-      if (!this.isCurrentXmpp(xmpp)) return;
+      if (!this.isCurrentConnection(xmpp, generation)) return;
       const prev = $callState.get();
       const selfBare = barePeerJid(this.session.jid);
       const isSelfOriginated = barePeerJid(event.from) === selfBare;
@@ -3165,24 +3238,34 @@ export class BrowserXmppClient {
       }
     });
     xmpp.on?.("session:started", () => {
-      if (!this.isCurrentXmpp(xmpp)) return;
+      if (!this.isCurrentConnection(xmpp, generation)) return;
       xmpp.disableKeepAlive?.();
       xmpp.enableKeepAlive?.({ interval: 30, timeout: 15 });
       this.handleSessionReady(xmpp, { type: "fresh" });
     });
     xmpp.on?.("stream:management:resumed", () => {
-      if (!this.isCurrentXmpp(xmpp)) return;
+      if (!this.isCurrentConnection(xmpp, generation)) return;
       this.handleSessionReady(xmpp, { type: "resumed" });
     });
-    xmpp.on?.("disconnected", (error?: Error) => { xmpp.disableKeepAlive?.(); this.handleDisconnected(xmpp, error); });
-    xmpp.on?.("message:acked", (msg: { id?: string }) => { if (!this.isCurrentXmpp(xmpp)) return; if (msg?.id) this.handleMessageAck(msg.id); });
-    xmpp.on?.("message:failed", (msg: { id?: string }) => { if (!this.isCurrentXmpp(xmpp)) return; if (msg?.id) this.handleMessageFailed(msg.id); });
+    xmpp.on?.("disconnected", (error?: Error) => {
+      if (!this.isCurrentConnection(xmpp, generation)) return;
+      xmpp.disableKeepAlive?.();
+      this.handleDisconnected(xmpp, error);
+    });
+    xmpp.on?.("message:acked", (msg: { id?: string }) => {
+      if (!this.isCurrentConnection(xmpp, generation)) return;
+      if (msg?.id) this.handleMessageAck(msg.id);
+    });
+    xmpp.on?.("message:failed", (msg: { id?: string }) => {
+      if (!this.isCurrentConnection(xmpp, generation)) return;
+      if (msg?.id) this.handleMessageFailed(msg.id);
+    });
     xmpp.on?.("message", (message: WasmMessage) => {
-      if (!this.isCurrentXmpp(xmpp)) return;
+      if (!this.isCurrentConnection(xmpp, generation)) return;
       this.handleMessage(message);
     });
     xmpp.on?.("presence", (presence: WasmPresence) => {
-      if (!this.isCurrentXmpp(xmpp)) return;
+      if (!this.isCurrentConnection(xmpp, generation)) return;
       this.handlePresence(presence);
       applyMucCallPresence(presence);
       applyRaisedHandPresence(presence);

--- a/chat/src/lib/xmpp/pagehide-lifecycle.ts
+++ b/chat/src/lib/xmpp/pagehide-lifecycle.ts
@@ -1,0 +1,139 @@
+import { Effect, Exit, Scope } from "effect";
+
+type PageLifecycleTarget = Pick<Window, "addEventListener" | "removeEventListener">;
+
+export type PagehideXmppClient = {
+  prepareForPageHide: () => void;
+  resumeAfterPageShow: () => void;
+};
+
+type XmppPageLifecycleOperation =
+  | "prepare-xmpp"
+  | "resume-xmpp"
+  | "suspend-call";
+
+export type XmppPageLifecycleFailure = {
+  readonly operation: XmppPageLifecycleOperation;
+  readonly cause: unknown;
+};
+
+export class PageLifecycleInstallError extends Error {
+  readonly _tag = "PageLifecycleInstallError";
+
+  constructor(readonly cause: unknown) {
+    super("failed to install XMPP page lifecycle listeners");
+    this.name = "PageLifecycleInstallError";
+  }
+}
+
+type InstalledPageLifecycle = {
+  readonly pagehide: EventListener;
+  readonly pageshow: EventListener;
+};
+
+function reportLifecycleFailure(
+  reportFailure: (failure: XmppPageLifecycleFailure) => void,
+  failure: XmppPageLifecycleFailure,
+): void {
+  try {
+    reportFailure(failure);
+  } catch {
+    // Observability must never interrupt the synchronous browser lifecycle.
+  }
+}
+
+/**
+ * Effect-scoped listener ownership. Acquisition is failure-atomic: if the
+ * second listener cannot be installed, the first is removed before the
+ * typed acquisition failure escapes.
+ */
+export function acquireXmppPagehideLifecycle(
+  target: PageLifecycleTarget,
+  currentClient: () => PagehideXmppClient | null,
+  suspendCall: () => void,
+  reportFailure: (failure: XmppPageLifecycleFailure) => void = () => undefined,
+): Effect.Effect<void, PageLifecycleInstallError, Scope.Scope> {
+  const handlePageHide = (event: PageTransitionEvent): void => {
+    try {
+      currentClient()?.prepareForPageHide();
+    } catch (cause) {
+      reportLifecycleFailure(reportFailure, { operation: "prepare-xmpp", cause });
+    } finally {
+      if (!event.persisted) {
+        try {
+          suspendCall();
+        } catch (cause) {
+          reportLifecycleFailure(reportFailure, { operation: "suspend-call", cause });
+        }
+      }
+    }
+  };
+  const handlePageShow = (event: PageTransitionEvent): void => {
+    if (!event.persisted) return;
+    try {
+      currentClient()?.resumeAfterPageShow();
+    } catch (cause) {
+      reportLifecycleFailure(reportFailure, { operation: "resume-xmpp", cause });
+    }
+  };
+  const pagehide = handlePageHide as EventListener;
+  const pageshow = handlePageShow as EventListener;
+
+  const acquire = Effect.try({
+    try: (): InstalledPageLifecycle => {
+      target.addEventListener("pagehide", pagehide);
+      try {
+        target.addEventListener("pageshow", pageshow);
+      } catch (cause) {
+        target.removeEventListener("pagehide", pagehide);
+        throw cause;
+      }
+      return { pagehide, pageshow };
+    },
+    catch: (cause) => new PageLifecycleInstallError(cause),
+  });
+
+  return Effect.acquireRelease(
+    acquire,
+    (installed) =>
+      Effect.sync(() => {
+        try {
+          target.removeEventListener("pageshow", installed.pageshow);
+        } finally {
+          target.removeEventListener("pagehide", installed.pagehide);
+        }
+      }),
+  ).pipe(Effect.asVoid);
+}
+
+/**
+ * Own the browser pagehide handoff at the persistent XMPP lifecycle level.
+ * Call UI may be idle or unmounted when a refresh happens; the live stream
+ * still needs a best-effort acknowledgement request and synchronous snapshot.
+ */
+export function installXmppPagehideLifecycle(
+  target: PageLifecycleTarget,
+  currentClient: () => PagehideXmppClient | null,
+  suspendCall: () => void,
+  reportFailure: (failure: XmppPageLifecycleFailure) => void = () => undefined,
+): () => void {
+  const scope = Effect.runSync(Scope.make());
+  try {
+    Effect.runSync(
+      Scope.extend(
+        acquireXmppPagehideLifecycle(target, currentClient, suspendCall, reportFailure),
+        scope,
+      ),
+    );
+  } catch (cause) {
+    Effect.runSync(Scope.close(scope, Exit.fail(cause)));
+    throw cause;
+  }
+
+  let closed = false;
+  return () => {
+    if (closed) return;
+    closed = true;
+    Effect.runSync(Scope.close(scope, Exit.succeed(undefined)));
+  };
+}

--- a/chat/src/lib/xmpp/resume-persistence.ts
+++ b/chat/src/lib/xmpp/resume-persistence.ts
@@ -18,7 +18,7 @@
  *     "handle" form from the WASM client is a live JS object that cannot
  *     be serialized; the POD `{previd, inboundH, outboundH}` triple can be.
  *     When the native XEP-0198 queue still has unhandled outbound stanzas,
- *     their XML is serialized too so `doConnect` can restore sender
+ *     their XML and original send instant are serialized too so `doConnect` can restore sender
  *     responsibility after a full reload instead of creating a false
  *     resume state with an empty replay queue.
  *
@@ -68,7 +68,7 @@ export type PersistedSmResumeState = {
   inboundH: number;
   outboundH: number;
   maxResumeSeconds?: number;
-  unhandledOutboundStanzas?: string[];
+  unhandledOutboundEntries?: Array<{ stanza: string; sentAt: string }>;
   resource?: string;
 };
 
@@ -120,6 +120,7 @@ export interface ResumePersistence {
   saveSm(state: PersistedSmResumeState): void;
   clearSm(): void;
   preparePagehideHandoff(): void;
+  reclaimPagehideOwnership(): void;
   loadJoinedRooms(): string[];
   saveJoinedRooms(roomJids: readonly string[]): void;
   clearJoinedRooms(): void;
@@ -138,6 +139,7 @@ export const nullResumePersistence: ResumePersistence = {
   saveSm: () => undefined,
   clearSm: () => undefined,
   preparePagehideHandoff: () => undefined,
+  reclaimPagehideOwnership: () => undefined,
   loadJoinedRooms: () => [],
   saveJoinedRooms: () => undefined,
   clearJoinedRooms: () => undefined,
@@ -179,13 +181,15 @@ export function createLocalStorageResumePersistence(accountKey: string, ownerId?
       }
       if (envelope.ownerId !== owner.ownerId) return null;
       if (envelope.claimId) return null;
-      const { previd, inboundH, outboundH, maxResumeSeconds, resource, unhandledOutboundStanzas } = envelope;
+      const { previd, inboundH, outboundH, maxResumeSeconds, resource, unhandledOutboundEntries } = envelope;
       return {
         previd,
         inboundH,
         outboundH,
         ...(maxResumeSeconds ? { maxResumeSeconds } : {}),
-        ...(unhandledOutboundStanzas?.length ? { unhandledOutboundStanzas: [...unhandledOutboundStanzas] } : {}),
+        ...(unhandledOutboundEntries?.length
+          ? { unhandledOutboundEntries: unhandledOutboundEntries.map(entry => ({ ...entry })) }
+          : {}),
         ...(resource ? { resource } : {}),
       };
     },
@@ -203,6 +207,9 @@ export function createLocalStorageResumePersistence(accountKey: string, ownerId?
     },
     preparePagehideHandoff() {
       markOwnerHandoff(owner);
+    },
+    reclaimPagehideOwnership() {
+      reclaimOwnerAfterPageShow(owner);
     },
     loadJoinedRooms() {
       const stored = readJson<string[]>(joinedRoomsKey, isStringArray, "joined-rooms") ?? [];
@@ -305,13 +312,15 @@ function consumeSmEnvelope(key: string, ownerId: string): PersistedSmResumeState
 
     s.setItem(consumedKey, consumedMarker);
     s.removeItem(key);
-    const { previd, inboundH, outboundH, maxResumeSeconds, resource, unhandledOutboundStanzas } = claimed;
+    const { previd, inboundH, outboundH, maxResumeSeconds, resource, unhandledOutboundEntries } = claimed;
     return {
       previd,
       inboundH,
       outboundH,
       ...(maxResumeSeconds ? { maxResumeSeconds } : {}),
-      ...(unhandledOutboundStanzas?.length ? { unhandledOutboundStanzas: [...unhandledOutboundStanzas] } : {}),
+      ...(unhandledOutboundEntries?.length
+        ? { unhandledOutboundEntries: unhandledOutboundEntries.map(entry => ({ ...entry })) }
+        : {}),
       ...(resource ? { resource } : {}),
     };
   } catch (err) {
@@ -409,6 +418,14 @@ function markOwnerHandoff(owner: ResumeOwner): void {
     instanceId: owner.instanceId,
     expiresAt: Date.now() + OWNER_HANDOFF_TTL_MS,
   }, "owner-handoff");
+}
+
+function reclaimOwnerAfterPageShow(owner: ResumeOwner): void {
+  if (owner.explicit) {
+    removeKey(ownerHandoffKey(owner.ownerId), "owner-handoff");
+    return;
+  }
+  claimOwnerLease(owner);
 }
 
 function ownerLeaseKey(ownerId: string): string {
@@ -645,6 +662,17 @@ function normalizeRoomJid(roomJid: string): string {
   return bareJidKey(roomJid);
 }
 
+function isResumeEntryArray(value: unknown): value is Array<{ stanza: string; sentAt: string }> {
+  return Array.isArray(value) && value.every((entry) => {
+    if (!entry || typeof entry !== "object") return false;
+    const candidate = entry as Record<string, unknown>;
+    return typeof candidate.stanza === "string"
+      && candidate.stanza.length > 0
+      && typeof candidate.sentAt === "string"
+      && Number.isFinite(Date.parse(candidate.sentAt));
+  });
+}
+
 function isPersistedSmEnvelope(value: unknown): value is PersistedSmEnvelope {
   if (!value || typeof value !== "object") return false;
   const candidate = value as Record<string, unknown>;
@@ -653,7 +681,7 @@ function isPersistedSmEnvelope(value: unknown): value is PersistedSmEnvelope {
     && isU32(candidate.inboundH)
     && isU32(candidate.outboundH)
     && (candidate.maxResumeSeconds === undefined || isPositiveU32(candidate.maxResumeSeconds))
-    && (candidate.unhandledOutboundStanzas === undefined || isStringArray(candidate.unhandledOutboundStanzas))
+    && (candidate.unhandledOutboundEntries === undefined || isResumeEntryArray(candidate.unhandledOutboundEntries))
     && (candidate.resource === undefined || typeof candidate.resource === "string")
     && (candidate.ownerId === undefined || typeof candidate.ownerId === "string")
     && (candidate.claimId === undefined || typeof candidate.claimId === "string")

--- a/chat/src/lib/xmpp/wasm-types.ts
+++ b/chat/src/lib/xmpp/wasm-types.ts
@@ -1,5 +1,11 @@
 import type { CallEvent } from "@/lib/calls/types";
 
+export type WasmStreamManagementTelemetry =
+  | { kind: "ack-request"; attempt: number; unacked: number }
+  | { kind: "ack-observed"; progressed: boolean; latencyMs?: number | null; unacked: number }
+  | { kind: "ack-request-timeout"; unacked: number }
+  | { kind: "ack-progress-stalled"; unacked: number; elapsedMs: number };
+
 /** TypeScript interfaces for Rust/WASM callback payload shapes.
  * All fields are snake_case (serde serialization convention).
  */

--- a/chat/src/lib/xmpp/xmpp-instrumentation.ts
+++ b/chat/src/lib/xmpp/xmpp-instrumentation.ts
@@ -122,6 +122,7 @@ function telemetryErrorDetail(event: XmppErrorEvent, condition: string | undefin
 function telemetryStreamFallbackDetail(detail: string): string {
   const normalized = detail.trim().toLowerCase();
   if (!normalized || normalized === "stream error") return "stream-error";
+  if (normalized === "sm-ack-request-failed") return normalized;
   if (normalized === "handled-count-too-high") return "stream-handled-count-too-high";
   if (
     normalized.includes("websocket transport error") ||

--- a/chat/tests/call-controls.test.ts
+++ b/chat/tests/call-controls.test.ts
@@ -14,7 +14,6 @@ import {
   $callScreenShareEnabled,
   $callScreenShareSupported,
   $callMicEnabled,
-  installCallPagehideSuspension,
   refreshScreenShareSupported,
   resetCallControls,
   seedCallControlsFromEngine,
@@ -64,28 +63,6 @@ const join: LiveKitJoin = {
   identity: "alice@waddle.test/web",
   token: "jwt",
 };
-
-class PagehideHarness {
-  private readonly listeners = new Set<EventListener>();
-
-  addEventListener(type: string, listener: EventListener) {
-    if (type === "pagehide") this.listeners.add(listener);
-  }
-
-  removeEventListener(type: string, listener: EventListener) {
-    if (type === "pagehide") this.listeners.delete(listener);
-  }
-
-  dispatchPagehide(persisted: boolean) {
-    const event = new Event("pagehide") as PageTransitionEvent;
-    Object.defineProperty(event, "persisted", { value: persisted });
-    for (const listener of this.listeners) listener(event);
-  }
-
-  listenerCount(): number {
-    return this.listeners.size;
-  }
-}
 
 function deviceError(name: string): Error {
   const err = new Error(`${name} message`);
@@ -242,7 +219,7 @@ describe("call page lifecycle controls", () => {
     expect($mucCallLiveParticipants.get()).toEqual({});
   });
 
-  test("pagehide suspension persists stream resume state before clearing the local call slot", () => {
+  test("pagehide suspension only clears local media after lifecycle persistence", () => {
     const persistResumeStateForPageHide = mock(() => undefined);
     connectionStore.client = {
       persistResumeStateForPageHide,
@@ -258,11 +235,11 @@ describe("call page lifecycle controls", () => {
 
     suspendCallForPageHide();
 
-    expect(persistResumeStateForPageHide).toHaveBeenCalledTimes(1);
+    expect(persistResumeStateForPageHide).not.toHaveBeenCalled();
     expect($callState.get()).toEqual({ phase: "idle" });
   });
 
-  test("pagehide persists stream resume state for rediscovered idle DM calls", () => {
+  test("pagehide suspension leaves rediscovered idle DM calls untouched", () => {
     const persistResumeStateForPageHide = mock(() => undefined);
     connectionStore.client = {
       persistResumeStateForPageHide,
@@ -283,57 +260,19 @@ describe("call page lifecycle controls", () => {
 
     suspendCallForPageHide();
 
-    expect(persistResumeStateForPageHide).toHaveBeenCalledTimes(1);
+    expect(persistResumeStateForPageHide).not.toHaveBeenCalled();
     expect($callState.get()).toEqual({ phase: "idle" });
     expect($dmCallActivities.get()["bob@waddle.test"]?.sid).toBe("c1");
   });
 
-  test("pagehide listener ignores BFCache restores and suspends refresh unloads", () => {
-    const target = new PagehideHarness();
-    const persistResumeStateForPageHide = mock(() => undefined);
-    connectionStore.client = {
-      persistResumeStateForPageHide,
-    } as unknown as typeof connectionStore.client;
-    $callState.set({
-      phase: "active",
-      peer: "bob@waddle.test/desktop",
-      sid: "c1",
-      media: { audio: true, video: true },
-      join,
-      kind: "dm",
-    });
+  test("XmppProvider owns pagehide suspension and CallOverlay never hangs up on unmount", () => {
+    const overlay = readFileSync(new URL("../src/components/calls/CallOverlay.vue", import.meta.url), "utf8");
+    const provider = readFileSync(new URL("../src/components/XmppProvider.vue", import.meta.url), "utf8");
+    const unmountBlock = overlay.slice(overlay.indexOf("onBeforeUnmount(() => {"));
 
-    const disconnect = installCallPagehideSuspension(target as unknown as Window);
-    expect(target.listenerCount()).toBe(1);
-
-    target.dispatchPagehide(true);
-    expect(persistResumeStateForPageHide).not.toHaveBeenCalled();
-    expect($callState.get()).toMatchObject({ phase: "active", sid: "c1" });
-
-    target.dispatchPagehide(false);
-    expect(persistResumeStateForPageHide).toHaveBeenCalledTimes(1);
-    expect($callState.get()).toEqual({ phase: "idle" });
-
-    $callState.set({
-      phase: "active",
-      peer: "bob@waddle.test/desktop",
-      sid: "c2",
-      media: { audio: true, video: false },
-      join,
-      kind: "dm",
-    });
-    disconnect();
-    expect(target.listenerCount()).toBe(0);
-    target.dispatchPagehide(false);
-    expect(persistResumeStateForPageHide).toHaveBeenCalledTimes(1);
-    expect($callState.get()).toMatchObject({ phase: "active", sid: "c2" });
-  });
-
-  test("CallOverlay wires the browser pagehide event to suspension, not hangup", () => {
-    const source = readFileSync(new URL("../src/components/calls/CallOverlay.vue", import.meta.url), "utf8");
-    const unmountBlock = source.slice(source.indexOf("onBeforeUnmount(() => {"));
-
-    expect(source).toContain("installCallPagehideSuspension(window)");
+    expect(provider).toContain("installXmppPagehideLifecycle(");
+    expect(provider).toContain("suspendCallForPageHide,");
+    expect(overlay).not.toContain("installCallPagehideSuspension");
     expect(unmountBlock).toContain("void engine.disconnect();");
     expect(unmountBlock).not.toContain("tearDownActiveCall(");
   });

--- a/chat/tests/client-connection.test.ts
+++ b/chat/tests/client-connection.test.ts
@@ -6,7 +6,11 @@
  * persistence — all exercised without constructing the full client.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { TypedEventBus, type ClientEvents } from "../src/lib/xmpp/client-events";
+import {
+  TypedEventBus,
+  type ClientEvents,
+  type QueueDepthTelemetry,
+} from "../src/lib/xmpp/client-events";
 import {
   OfflineSendQueue,
   ReconnectScheduler,
@@ -152,7 +156,7 @@ describe("OfflineSendQueue drain ordering", () => {
     queue.queueDirectMessage("bob@example.com", "first", { id: "dm-1" });
     queue.queueDirectMessage("bob@example.com", "second", { id: "dm-2" });
     queue.queueDirectMessage("bob@example.com", "third", { id: "dm-3" });
-    queue.markInflight("dm-1");
+    queue.beginAttempt("dm-1", "dm");
 
     await queue.flushDirect();
 
@@ -162,7 +166,7 @@ describe("OfflineSendQueue drain ordering", () => {
 
   test("ack removes the persisted copy and reports queue depth + latency", async () => {
     const { queue, events } = createQueue();
-    const depths: Array<{ kind: "room" | "dm"; persisted: number; inflight: number }> = [];
+    const depths: QueueDepthTelemetry[] = [];
     const acked: Array<{ id: string; kind: "room" | "dm" }> = [];
     events.on("queueDepthChange", (depth) => depths.push(depth));
     events.on("messageAcked", (id, meta) => acked.push({ id, kind: meta.kind }));
@@ -177,6 +181,219 @@ describe("OfflineSendQueue drain ordering", () => {
       { kind: "dm", persisted: 0, inflight: 0 },
       { kind: "room", persisted: 0, inflight: 0 },
     ]);
+  });
+
+  test("a synchronous ack inside send clears persistence before the promise resolves", async () => {
+    let queue!: OfflineSendQueue;
+    const created = createQueue({
+      sendDirect: async (_peer, _body, opts) => {
+        queue.handleAck(opts.id);
+        return opts.id;
+      },
+    });
+    queue = created.queue;
+    const acked: string[] = [];
+    created.events.on("messageAcked", (id) => acked.push(id));
+
+    queue.queueDirectMessage("bob@example.com", "fast ack", { id: "dm-fast" });
+    await queue.flushDirect();
+
+    expect(listQueuedMessages(SCOPE)).toEqual([]);
+    expect(acked).toEqual(["dm-fast"]);
+  });
+
+  test("a synchronous room ack inside send clears persistence before the promise resolves", async () => {
+    let queue!: OfflineSendQueue;
+    const created = createQueue({
+      sendRoom: async (_room, _body, opts) => {
+        queue.handleAck(opts.id);
+        return opts.id;
+      },
+    });
+    queue = created.queue;
+
+    queue.queueRoomMessage("general@muc.example.com", "fast ack", { id: "room-fast" });
+    await queue.flushRoom("general@muc.example.com");
+
+    expect(listQueuedMessages(SCOPE)).toEqual([]);
+  });
+
+  test("a rejected attempt rolls back so the persisted message can retry", async () => {
+    let attempt = 0;
+    const { queue, events } = createQueue({
+      sendDirect: async (_peer, _body, opts) => {
+        attempt += 1;
+        if (attempt === 1) throw new Error("socket unavailable");
+        return opts.id;
+      },
+    });
+    const depths: QueueDepthTelemetry[] = [];
+    const statuses: Array<{ id: string; status: "queued" | "sending" }> = [];
+    events.on("queueDepthChange", (depth) => {
+      if (depth.kind === "dm") depths.push(depth);
+    });
+    events.on("queuedMessageStatus", (id, status) => statuses.push({ id, status }));
+    queue.queueDirectMessage("bob@example.com", "retry me", { id: "dm-retry" });
+
+    await expect(queue.flushDirect()).rejects.toThrow("socket unavailable");
+    expect(listQueuedMessages(SCOPE).map((message) => message.id)).toEqual(["dm-retry"]);
+    expect(depths.at(-1)?.inflight).toBe(0);
+    expect(statuses.at(-1)).toEqual({ id: "dm-retry", status: "queued" });
+
+    await queue.flushDirect();
+    queue.handleAck("dm-retry");
+    expect(attempt).toBe(2);
+    expect(listQueuedMessages(SCOPE)).toEqual([]);
+    expect(depths.at(-1)).toEqual({ kind: "dm", persisted: 0, inflight: 0 });
+  });
+
+  test("a confirmed WASM send stays inflight when its control follow-up disconnects", async () => {
+    let connected = true;
+    let attempts = 0;
+    const { queue, events } = createQueue({
+      canUseConnectedSession: () => connected,
+      sendDirect: async (_peer, _body, opts) => {
+        attempts += 1;
+        const id = compatWasmSendResult({ kind: "sent", stanza_id: opts.id });
+        connected = false;
+        return id;
+      },
+    });
+    const depths: QueueDepthTelemetry[] = [];
+    const failures: string[] = [];
+    events.on("queueDepthChange", (depth) => {
+      if (depth.kind === "dm") depths.push(depth);
+    });
+    events.on("messageDeliveryFailure", (id) => failures.push(id));
+    queue.queueDirectMessage("bob@example.com", "confirmed before control failure", {
+      id: "dm-confirmed-control-failure",
+    });
+
+    await queue.flushDirect();
+    await queue.flushDirect();
+
+    expect(attempts).toBe(1);
+    expect(failures).toEqual([]);
+    expect(listQueuedMessages(SCOPE).map((message) => message.id))
+      .toEqual(["dm-confirmed-control-failure"]);
+    expect(depths.at(-1)).toMatchObject({
+      kind: "dm",
+      persisted: 1,
+      inflight: 1,
+    });
+    expect(depths.at(-1)?.oldestAgeMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test("null and mismatched queued DM attempts roll back before a later acked retry", async () => {
+    let attempt = 0;
+    const { queue, events } = createQueue({
+      sendDirect: async (_peer, _body, opts) => {
+        attempt += 1;
+        if (attempt === 1) return null;
+        if (attempt === 2) return "wrong-dm-id";
+        return opts.id;
+      },
+    });
+    const depths: QueueDepthTelemetry[] = [];
+    const statuses: Array<{ id: string; status: "queued" | "sending" }> = [];
+    const queuedIds = () => listQueuedMessages(SCOPE).map((message) => message.id);
+    events.on("queueDepthChange", (depth) => {
+      if (depth.kind === "dm") depths.push(depth);
+    });
+    events.on("queuedMessageStatus", (id, status) => statuses.push({ id, status }));
+    queue.queueDirectMessage("bob@example.com", "retry DM", { id: "dm-null-mismatch" });
+
+    await queue.flushDirect();
+    expect(queuedIds()).toEqual(["dm-null-mismatch"]);
+    expect(depths.at(-1)?.inflight).toBe(0);
+    expect(statuses.at(-1)).toEqual({ id: "dm-null-mismatch", status: "queued" });
+
+    await expect(queue.flushDirect())
+      .rejects.toThrow("XMPP send returned a different stanza id");
+    expect(queuedIds()).toEqual(["dm-null-mismatch"]);
+    expect(depths.at(-1)?.inflight).toBe(0);
+    expect(statuses.at(-1)).toEqual({ id: "dm-null-mismatch", status: "queued" });
+
+    await queue.flushDirect();
+    queue.handleAck("dm-null-mismatch");
+    expect(attempt).toBe(3);
+    expect(queuedIds()).toEqual([]);
+    expect(depths.at(-1)).toEqual({ kind: "dm", persisted: 0, inflight: 0 });
+  });
+
+  test("a rejected queued room attempt stays retryable before a later acked retry", async () => {
+    let attempt = 0;
+    const { queue, events } = createQueue({
+      sendRoom: async (_room, _body, opts) => {
+        attempt += 1;
+        if (attempt === 1) throw new Error("room socket unavailable");
+        return opts.id;
+      },
+    });
+    const depths: QueueDepthTelemetry[] = [];
+    const statuses: Array<{ id: string; status: "queued" | "sending" }> = [];
+    events.on("queueDepthChange", (depth) => {
+      if (depth.kind === "room") depths.push(depth);
+    });
+    events.on("queuedMessageStatus", (id, status) => statuses.push({ id, status }));
+    queue.queueRoomMessage("general@muc.example.com", "retry room", { id: "room-rejected" });
+
+    await expect(queue.flushRoom("general@muc.example.com"))
+      .rejects.toThrow("room socket unavailable");
+    expect(listQueuedMessages(SCOPE).map((message) => message.id)).toEqual(["room-rejected"]);
+    expect(depths.at(-1)?.inflight).toBe(0);
+    expect(statuses.at(-1)).toEqual({ id: "room-rejected", status: "queued" });
+
+    await queue.flushRoom("general@muc.example.com");
+    queue.handleAck("room-rejected");
+    expect(attempt).toBe(2);
+    expect(listQueuedMessages(SCOPE)).toEqual([]);
+    expect(depths.at(-1)).toEqual({ kind: "room", persisted: 0, inflight: 0 });
+  });
+
+  test("null and mismatched queued room attempts roll back and the coalescer later retries", async () => {
+    let attempt = 0;
+    const { queue, events } = createQueue({
+      sendRoom: async (_room, _body, opts) => {
+        attempt += 1;
+        if (attempt === 1) return null;
+        if (attempt === 2) return "wrong-room-id";
+        return opts.id;
+      },
+    });
+    const depths: QueueDepthTelemetry[] = [];
+    const statuses: Array<{ id: string; status: "queued" | "sending" }> = [];
+    events.on("queueDepthChange", (depth) => {
+      if (depth.kind === "room") depths.push(depth);
+    });
+    events.on("queuedMessageStatus", (id, status) => statuses.push({ id, status }));
+    queue.queueRoomMessage("general@muc.example.com", "retry room", { id: "room-retry" });
+
+    await queue.flushRoom("general@muc.example.com");
+    expect(listQueuedMessages(SCOPE).map((message) => message.id)).toEqual(["room-retry"]);
+    expect(depths.at(-1)?.inflight).toBe(0);
+    expect(statuses.at(-1)).toEqual({ id: "room-retry", status: "queued" });
+
+    await expect(queue.flushRoom("general@muc.example.com"))
+      .rejects.toThrow("XMPP send returned a different stanza id");
+    expect(listQueuedMessages(SCOPE).map((message) => message.id)).toEqual(["room-retry"]);
+    expect(depths.at(-1)?.inflight).toBe(0);
+    expect(statuses.at(-1)).toEqual({ id: "room-retry", status: "queued" });
+
+    await queue.flushRoom("general@muc.example.com");
+    queue.handleAck("room-retry");
+    expect(attempt).toBe(3);
+    expect(listQueuedMessages(SCOPE)).toEqual([]);
+    expect(depths.at(-1)).toEqual({ kind: "room", persisted: 0, inflight: 0 });
+  });
+
+  test("an ack after reload deletes persistence without ephemeral inflight state", () => {
+    const { queue } = createQueue();
+    queue.queueDirectMessage("bob@example.com", "already handled", { id: "dm-reloaded" });
+
+    queue.handleAck("dm-reloaded");
+
+    expect(listQueuedMessages(SCOPE)).toEqual([]);
   });
 
   test("non-retryable send failures are discarded instead of retried forever", async () => {
@@ -247,7 +464,7 @@ describe("OfflineSendQueue drain ordering", () => {
 
   test("seedFromResumeState tracks XEP-0198 replayed stanza ids so acks clear the store", () => {
     const { queue, events } = createQueue();
-    const depths: Array<{ kind: "room" | "dm"; persisted: number; inflight: number }> = [];
+    const depths: QueueDepthTelemetry[] = [];
     events.on("queueDepthChange", (depth) => depths.push(depth));
 
     queue.queueDirectMessage("bob@example.com", "native replay", { id: "dm-native" });
@@ -255,7 +472,10 @@ describe("OfflineSendQueue drain ordering", () => {
       previd: "p",
       inboundH: 1,
       outboundH: 2,
-      unhandledOutboundStanzas: ['<message id="dm-native" to="bob@example.com"><body>native replay</body></message>'],
+      unhandledOutboundEntries: [{
+        stanza: '<message id="dm-native" to="bob@example.com"><body>native replay</body></message>',
+        sentAt: "2026-07-16T08:09:10.123Z",
+      }],
     });
 
     queue.handleAck("dm-native");
@@ -265,6 +485,140 @@ describe("OfflineSendQueue drain ordering", () => {
       { kind: "dm", persisted: 0, inflight: 0 },
       { kind: "room", persisted: 0, inflight: 0 },
     ]);
+  });
+
+  test("failed resume transfers retry ownership without deleting or browser-flushing the durable row", async () => {
+    const sent: string[] = [];
+    const { queue, events } = createQueue({
+      sendDirect: async (_peer, _body, opts) => {
+        sent.push(opts.id);
+        return opts.id;
+      },
+    });
+    const failures: string[] = [];
+    const depths: QueueDepthTelemetry[] = [];
+    events.on("messageDeliveryFailure", (id) => failures.push(id));
+    events.on("queueDepthChange", (depth) => {
+      if (depth.kind === "dm") depths.push(depth);
+    });
+
+    queue.queueDirectMessage("bob@example.com", "native fallback", { id: "dm-native-fallback" });
+    queue.seedFromResumeState({
+      previd: "p",
+      inboundH: 1,
+      outboundH: 2,
+      unhandledOutboundEntries: [{
+        stanza: '<message id="dm-native-fallback" to="bob@example.com"><body>native fallback</body></message>',
+        sentAt: "2026-07-16T08:09:10.123Z",
+      }],
+    });
+
+    queue.handleFailed("dm-native-fallback");
+    queue.clearInflight();
+    await queue.flushDirect();
+
+    expect(sent).toEqual([]);
+    expect(failures).toEqual([]);
+    expect(listQueuedMessages(SCOPE).map((entry) => entry.id)).toEqual(["dm-native-fallback"]);
+    expect(depths.at(-1)).toMatchObject({ kind: "dm", persisted: 1, inflight: 1 });
+
+    queue.handleAck("dm-native-fallback");
+    expect(listQueuedMessages(SCOPE)).toEqual([]);
+    expect(depths.at(-1)).toEqual({ kind: "dm", persisted: 0, inflight: 0 });
+  });
+
+  test("terminal no-SM disconnect releases stale fallback ownership for exactly one queued retry", async () => {
+    const sent: string[] = [];
+    const { queue } = createQueue({
+      sendDirect: async (_peer, _body, opts) => {
+        sent.push(opts.id);
+        return opts.id;
+      },
+    });
+    const resumeState: XmppResumeState = {
+      previd: "previous-stream",
+      inboundH: 1,
+      outboundH: 2,
+      unhandledOutboundEntries: [{
+        stanza: '<message id="dm-terminal-fallback" to="bob@example.com"><body>retry once</body></message>',
+        sentAt: "2026-07-24T10:00:00.000Z",
+      }],
+    };
+
+    queue.queueDirectMessage("bob@example.com", "retry once", {
+      id: "dm-terminal-fallback",
+    });
+    queue.seedFromResumeState(resumeState);
+    queue.handleFailed("dm-terminal-fallback");
+
+    queue.reconcileNativeOwnershipAfterDisconnect(resumeState);
+    await queue.flushDirect();
+    expect(sent).toEqual([]);
+
+    queue.reconcileNativeOwnershipAfterDisconnect(null);
+    queue.clearInflight();
+    await queue.flushDirect();
+    await queue.flushDirect();
+
+    expect(sent).toEqual(["dm-terminal-fallback"]);
+    expect(listQueuedMessages(SCOPE).map((entry) => entry.id))
+      .toEqual(["dm-terminal-fallback"]);
+  });
+
+  test("a plain fresh bind releases an unattempted resume replay claim to the durable browser queue", async () => {
+    const sent: string[] = [];
+    const { queue } = createQueue({
+      sendDirect: async (_peer, _body, opts) => {
+        sent.push(opts.id);
+        return opts.id;
+      },
+    });
+    queue.queueDirectMessage("bob@example.com", "fresh without SM", { id: "dm-no-resume" });
+    queue.seedFromResumeState({
+      previd: "p",
+      inboundH: 1,
+      outboundH: 2,
+      unhandledOutboundEntries: [{
+        stanza: '<message id="dm-no-resume" to="bob@example.com"><body>fresh without SM</body></message>',
+        sentAt: "2026-07-16T08:09:10.123Z",
+      }],
+    });
+
+    queue.clearInflight();
+    await queue.flushDirect();
+
+    expect(sent).toEqual(["dm-no-resume"]);
+    expect(listQueuedMessages(SCOPE).map((entry) => entry.id)).toEqual(["dm-no-resume"]);
+  });
+
+  test("a reconstructed queue reclaims a retained failed-resume row after an immediate or mid-write crash", async () => {
+    const original = createQueue().queue;
+    original.queueDirectMessage("bob@example.com", "survive fallback crash", { id: "dm-crash-fallback" });
+    original.seedFromResumeState({
+      previd: "p",
+      inboundH: 3,
+      outboundH: 4,
+      unhandledOutboundEntries: [{
+        stanza: '<message id="dm-crash-fallback" to="bob@example.com"><body>survive fallback crash</body></message>',
+        sentAt: "2026-07-16T08:09:10.123Z",
+      }],
+    });
+    original.handleFailed("dm-crash-fallback");
+
+    const reclaimed: string[] = [];
+    const reconstructed = createQueue({
+      sendDirect: async (_peer, _body, opts) => {
+        reclaimed.push(opts.id);
+        return opts.id;
+      },
+    }).queue;
+
+    await reconstructed.flushDirect();
+
+    expect(reclaimed).toEqual(["dm-crash-fallback"]);
+    expect(listQueuedMessages(SCOPE).map((entry) => entry.id)).toEqual(["dm-crash-fallback"]);
+    reconstructed.handleAck("dm-crash-fallback");
+    expect(listQueuedMessages(SCOPE)).toEqual([]);
   });
 });
 
@@ -361,6 +715,7 @@ function createRecordingPersistence() {
       saved = null;
     },
     preparePagehideHandoff: () => calls.push("preparePagehideHandoff"),
+    reclaimPagehideOwnership: () => calls.push("reclaimPagehideOwnership"),
     loadJoinedRooms: () => [],
     saveJoinedRooms: () => undefined,
     clearJoinedRooms: () => calls.push("clearJoinedRooms"),

--- a/chat/tests/client-send-readiness.test.ts
+++ b/chat/tests/client-send-readiness.test.ts
@@ -8,6 +8,7 @@ import { BrowserXmppClient, roomBareJidFor, type DmConversationScope, type Inbox
 import { enqueueQueuedMessage, listQueuedDmMessages, listQueuedRoomMessages } from "../src/lib/outbound-queue-store";
 import { applyDmCallEvent, clearDmCallActivities, readDmCallActivity } from "../src/lib/calls/dm-call-activity";
 import { $dmCallOutcomeAnchor } from "../src/lib/calls/dm-call-anchor";
+import type { QueueDepthTelemetry } from "../src/lib/xmpp/client-events";
 import { nullResumePersistence, type ResumePersistence } from "../src/lib/xmpp/resume-persistence";
 import type { XmppErrorEvent } from "../src/lib/xmpp/types";
 import { handlerStubs } from "./helpers/xmpp-client-mock";
@@ -346,6 +347,84 @@ describe("client send readiness", () => {
     expect(listQueuedRoomMessages("alice@example.com", roomJid)).toEqual([]);
   });
 
+  test("a live MUC ack delivered before the send promise resolves clears the durable copy", async () => {
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    const xmpp = {
+      send_groupchat_message: mock(async (_room: string, _body: string, opts: { stanza_id?: string }) => {
+        (client as unknown as { handleMessageAck: (id: string) => void })
+          .handleMessageAck(opts.stanza_id!);
+        return opts.stanza_id;
+      }),
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { currentRoom: string | null }).currentRoom = roomJid;
+    (client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.add(roomJid);
+
+    const result = await client.sendGroupMessage("w1", "c1", "fast ack", { id: "room-fast-live" });
+
+    expect(result).toEqual({ id: "room-fast-live", state: "sending" });
+    expect(listQueuedRoomMessages("alice@example.com", roomJid)).toEqual([]);
+  });
+
+  test("live MUC rejection, null, and mismatched IDs all roll back before a later acked retry", async () => {
+    let attempt = 0;
+    const xmpp = {
+      send_groupchat_message: mock(async (
+        _room: string,
+        _body: string,
+        opts: { stanza_id?: string },
+      ) => {
+        attempt += 1;
+        if (attempt === 1) throw new Error("room socket unavailable");
+        if (attempt === 2) return null;
+        if (attempt === 3) return "wrong-live-room-id";
+        return opts.stanza_id;
+      }),
+    };
+    const client = new BrowserXmppClient(session());
+    const roomJid = roomBareJidFor(session(), "c1");
+    const depths: QueueDepthTelemetry[] = [];
+    const statuses: Array<{ id: string; status: "queued" | "sending" }> = [];
+    client.onQueueDepthChange((depth) => {
+      if (depth.kind === "room") depths.push(depth);
+    });
+    client.setQueuedMessageStatusHandler((id, status) => statuses.push({ id, status }));
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    (client as unknown as { currentRoom: string | null }).currentRoom = roomJid;
+    (client as unknown as { joinedMucReady: Set<string> }).joinedMucReady.add(roomJid);
+    const queuedIds = () => listQueuedRoomMessages("alice@example.com", roomJid)
+      .map((message) => message.id);
+
+    await expect(client.sendGroupMessage("w1", "c1", "retry", { id: "room-live-retry" }))
+      .rejects.toThrow("room socket unavailable");
+    expect(queuedIds()).toEqual(["room-live-retry"]);
+    expect(depths.at(-1)?.inflight).toBe(0);
+    expect(statuses.at(-1)).toEqual({ id: "room-live-retry", status: "queued" });
+
+    expect(await client.sendGroupMessage("w1", "c1", "retry", { id: "room-live-retry" }))
+      .toEqual({ id: null, state: "queued" });
+    expect(queuedIds()).toEqual(["room-live-retry"]);
+    expect(depths.at(-1)?.inflight).toBe(0);
+    expect(statuses.at(-1)).toEqual({ id: "room-live-retry", status: "queued" });
+
+    await expect(client.sendGroupMessage("w1", "c1", "retry", { id: "room-live-retry" }))
+      .rejects.toThrow("XMPP send returned a different stanza id");
+    expect(queuedIds()).toEqual(["room-live-retry"]);
+    expect(depths.at(-1)?.inflight).toBe(0);
+    expect(statuses.at(-1)).toEqual({ id: "room-live-retry", status: "queued" });
+
+    expect(await client.sendGroupMessage("w1", "c1", "retry", { id: "room-live-retry" }))
+      .toEqual({ id: "room-live-retry", state: "sending" });
+    expect(attempt).toBe(4);
+    (client as unknown as { handleMessageAck: (id: string) => void })
+      .handleMessageAck("room-live-retry");
+    expect(queuedIds()).toEqual([]);
+    expect(depths.at(-1)).toEqual({ kind: "room", persisted: 0, inflight: 0 });
+  });
+
   test("room send rejects typed WASM failures instead of returning a null sending id", async () => {
     const xmpp = { send_groupchat_message: mock(async () => ({ kind: "not-connected" })) };
     const client = new BrowserXmppClient(session());
@@ -442,7 +521,10 @@ describe("client send readiness", () => {
 
     await expect((client as unknown as { flushQueuedRoomMessages: (roomJid: string) => Promise<void> }).flushQueuedRoomMessages(roomJid)).rejects.toThrow("XMPP send failed: transport-error");
     expect(listQueuedRoomMessages("alice@example.com", roomJid).map((message) => message.id)).toEqual(["room-replay-1"]);
-    expect(statuses).toEqual([["room-replay-1", "sending"]]);
+    expect(statuses).toEqual([
+      ["room-replay-1", "sending"],
+      ["room-replay-1", "queued"],
+    ]);
   });
 
   test("room join readiness waits for this resource's MUC self-presence", async () => {
@@ -787,6 +869,107 @@ describe("client send readiness", () => {
         state: "available",
       },
     ]);
+  });
+
+  test("terminal MUC denial does not release native SM fallback ownership", async () => {
+    const roomJid = roomBareJidFor(session(), "private");
+    const messageId = "room-native-fallback";
+    const client = new BrowserXmppClient(session(), nullResumePersistence);
+    let onPresence: ((presence: {
+      from?: string;
+      presence_type: string;
+      error_condition?: string;
+      error_type?: string;
+      muc_status_codes?: number[];
+      muc_jid?: string;
+    }) => void) | null = null;
+    const sendGroupMessage = mock(async (
+      _room: string,
+      _body: string,
+      opts: { stanza_id?: string },
+    ) => opts.stanza_id);
+    const xmpp = {
+      join_room: mock(async () => undefined),
+      send_groupchat_message: sendGroupMessage,
+      set_on_presence(cb: NonNullable<typeof onPresence>) {
+        onPresence = cb;
+      },
+    };
+    const state = client as unknown as {
+      xmpp: typeof xmpp;
+      connected: boolean;
+      fullJid: string;
+      wireEvents: (xmpp: typeof xmpp) => void;
+      handleMessageFailed: (id: string) => void;
+      flushQueuedRoomMessages: (roomJid: string) => Promise<void>;
+      outboundQueue: {
+        seedFromResumeState: (resumeState: {
+          previd: string;
+          inboundH: number;
+          outboundH: number;
+          unhandledOutboundEntries: Array<{ stanza: string; sentAt: string }>;
+        }) => void;
+        reconcileNativeOwnershipAfterDisconnect: (resumeState: null) => void;
+        clearInflight: () => void;
+      };
+    };
+    state.xmpp = xmpp;
+    state.connected = true;
+    state.wireEvents(xmpp);
+    enqueueQueuedMessage("alice@example.com", {
+      kind: "room",
+      id: messageId,
+      createdAt: "2026-07-24T12:00:00.000Z",
+      roomJid,
+      body: "native fallback",
+    });
+    state.outboundQueue.seedFromResumeState({
+      previd: "previous-stream",
+      inboundH: 1,
+      outboundH: 2,
+      unhandledOutboundEntries: [{
+        stanza: `<message xmlns="jabber:client" type="groupchat" id="${messageId}"/>`,
+        sentAt: "2026-07-24T12:00:00.000Z",
+      }],
+    });
+    state.handleMessageFailed(messageId);
+
+    const rejected = client.fanOutAutoJoin([roomJid]);
+    await Promise.resolve();
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "error",
+      error_condition: "forbidden",
+      error_type: "auth",
+    });
+    await rejected;
+
+    const explicitRetry = client.retryRoomAccess("", "private");
+    await Promise.resolve();
+    onPresence?.({
+      from: `${roomJid}/alice`,
+      presence_type: "available",
+      muc_status_codes: [110],
+      muc_jid: state.fullJid,
+    });
+    await explicitRetry;
+    await settleReconnectCatchup();
+
+    // Clearing the room block must not make the browser race the native
+    // fresh-stream fallback that already owns this stanza.
+    expect(sendGroupMessage).not.toHaveBeenCalled();
+    expect(listQueuedRoomMessages("alice@example.com", roomJid).map((entry) => entry.id))
+      .toEqual([messageId]);
+
+    // Only a terminal native disconnect with no surviving replay snapshot
+    // releases the fence for one durable browser retry.
+    state.outboundQueue.reconcileNativeOwnershipAfterDisconnect(null);
+    state.outboundQueue.clearInflight();
+    await state.flushQueuedRoomMessages(roomJid);
+
+    expect(sendGroupMessage).toHaveBeenCalledTimes(1);
+    expect(listQueuedRoomMessages("alice@example.com", roomJid).map((entry) => entry.id))
+      .toEqual([messageId]);
   });
 
   test("wait-type MUC rejection remains eligible for a later auto-join epoch", async () => {
@@ -1326,6 +1509,7 @@ describe("client send readiness", () => {
       saveSm: () => undefined,
       clearSm: () => undefined,
       preparePagehideHandoff: () => undefined,
+      reclaimPagehideOwnership: () => undefined,
       loadJoinedRooms: () => [roomJid],
       saveJoinedRooms: () => undefined,
       clearJoinedRooms: () => undefined,
@@ -1410,6 +1594,76 @@ describe("client send readiness", () => {
 
     (client as unknown as { handleMessageAck: (id: string) => void }).handleMessageAck("dm-live-1");
     expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toEqual([]);
+  });
+
+  test("a live DM ack delivered before the send promise resolves clears the durable copy", async () => {
+    const client = new BrowserXmppClient(session());
+    const xmpp = {
+      send_chat_message: mock(async (_peer: string, _body: string, opts: { stanza_id?: string }) => {
+        (client as unknown as { handleMessageAck: (id: string) => void })
+          .handleMessageAck(opts.stanza_id!);
+        return opts.stanza_id;
+      }),
+    };
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+
+    const result = await client.sendDirectMessage("bob@example.com", "fast ack", { id: "dm-fast-live" });
+
+    expect(result).toEqual({ id: "dm-fast-live", state: "sending" });
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toEqual([]);
+  });
+
+  test("live DM rejection, null, and mismatched IDs all roll back before a later retry", async () => {
+    let attempt = 0;
+    const xmpp = {
+      send_chat_message: mock(async (_peer: string, _body: string, opts: { stanza_id?: string }) => {
+        attempt += 1;
+        if (attempt === 1) throw new Error("socket unavailable");
+        if (attempt === 2) return null;
+        if (attempt === 3) return "wrong-live-id";
+        return opts.stanza_id;
+      }),
+    };
+    const client = new BrowserXmppClient(session());
+    const depths: QueueDepthTelemetry[] = [];
+    const statuses: Array<{ id: string; status: "queued" | "sending" }> = [];
+    client.onQueueDepthChange((depth) => {
+      if (depth.kind === "dm") depths.push(depth);
+    });
+    client.setQueuedMessageStatusHandler((id, status) => statuses.push({ id, status }));
+    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { connected: boolean }).connected = true;
+    const queuedIds = () => listQueuedDmMessages(
+      "alice@example.com",
+      "bob@example.com",
+      "account",
+    ).map((message) => message.id);
+
+    await expect(client.sendDirectMessage("bob@example.com", "retry", { id: "dm-live-retry" }))
+      .rejects.toThrow("socket unavailable");
+    expect(queuedIds()).toEqual(["dm-live-retry"]);
+    expect(depths.at(-1)?.inflight).toBe(0);
+    expect(statuses.at(-1)).toEqual({ id: "dm-live-retry", status: "queued" });
+
+    expect(await client.sendDirectMessage("bob@example.com", "retry", { id: "dm-live-retry" }))
+      .toEqual({ id: null, state: "queued" });
+    expect(queuedIds()).toEqual(["dm-live-retry"]);
+    expect(depths.at(-1)?.inflight).toBe(0);
+    expect(statuses.at(-1)).toEqual({ id: "dm-live-retry", status: "queued" });
+
+    await expect(client.sendDirectMessage("bob@example.com", "retry", { id: "dm-live-retry" }))
+      .rejects.toThrow("XMPP send returned a different stanza id");
+    expect(queuedIds()).toEqual(["dm-live-retry"]);
+    expect(depths.at(-1)?.inflight).toBe(0);
+    expect(statuses.at(-1)).toEqual({ id: "dm-live-retry", status: "queued" });
+
+    expect(await client.sendDirectMessage("bob@example.com", "retry", { id: "dm-live-retry" }))
+      .toEqual({ id: "dm-live-retry", state: "sending" });
+    expect(attempt).toBe(4);
+    (client as unknown as { handleMessageAck: (id: string) => void }).handleMessageAck("dm-live-retry");
+    expect(queuedIds()).toEqual([]);
+    expect(depths.at(-1)).toEqual({ kind: "dm", persisted: 0, inflight: 0 });
   });
 
   test("custom-service MUC-PM sends preserve the occupant resource before room discovery", async () => {
@@ -1531,27 +1785,82 @@ describe("client send readiness", () => {
     messaging.disconnect();
   });
 
-  test("native failed-resume fallback owns resend for live unacked DM sends", async () => {
-    const xmpp = {
-      send_chat_message: mock(async (_peer: string, _body: string, opts: { stanza_id?: string }) => opts.stanza_id),
+  test("terminal no-SM disconnect releases native fallback ownership for one reconnect retry", async () => {
+    const firstSend = mock(async (
+      _peer: string,
+      _body: string,
+      opts: { stanza_id?: string },
+    ) => opts.stanza_id);
+    const firstXmpp = {
+      send_chat_message: firstSend,
       get_resume_state: () => ({
         previd: "live-sm-id",
         inboundH: 4,
         outboundH: 9,
         hasUnackedOutbound: true,
-        unhandledOutboundStanzas: ["<message xmlns='jabber:client' id='dm-live-1'/>"],
+        unhandledOutboundEntries: [{
+          stanza: "<message xmlns='jabber:client' id='dm-live-1'/>",
+          sentAt: "2026-07-16T08:09:10.123Z",
+        }],
       }),
     };
     const client = new BrowserXmppClient(session());
-    (client as unknown as { xmpp: typeof xmpp; connected: boolean }).xmpp = xmpp;
+    (client as unknown as { xmpp: typeof firstXmpp; connected: boolean }).xmpp = firstXmpp;
     (client as unknown as { connected: boolean }).connected = true;
 
     await client.sendDirectMessage("bob@example.com", "hello", { id: "dm-live-1" });
-    (client as unknown as { handleDisconnected: (xmpp: typeof xmpp) => void }).handleDisconnected(xmpp);
+    (client as unknown as {
+      handleDisconnected: (xmpp: typeof firstXmpp) => void;
+    }).handleDisconnected(firstXmpp);
     (client as unknown as { handleMessageFailed: (id: string) => void }).handleMessageFailed("dm-live-1");
     (client as unknown as { clearReconnectTimer: () => void }).clearReconnectTimer();
 
-    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toEqual([]);
+    const fallbackSend = mock(async (
+      _peer: string,
+      _body: string,
+      opts: { stanza_id?: string },
+    ) => opts.stanza_id);
+    const fallbackXmpp = {
+      send_chat_message: fallbackSend,
+      get_resume_state: () => null,
+    };
+    const sessionReadyClient = client as unknown as {
+      xmpp: typeof fallbackXmpp;
+      connected: boolean;
+      handleSessionReady: (
+        xmpp: typeof fallbackXmpp,
+        lifecycle: { type: "fresh" },
+      ) => void;
+      handleDisconnected: (xmpp: typeof fallbackXmpp) => void;
+      clearReconnectTimer: () => void;
+    };
+    sessionReadyClient.xmpp = fallbackXmpp;
+    sessionReadyClient.handleSessionReady(fallbackXmpp, { type: "fresh" });
+    await settleReconnectCatchup();
+
+    expect(fallbackSend).not.toHaveBeenCalled();
+
+    sessionReadyClient.handleDisconnected(fallbackXmpp);
+    sessionReadyClient.clearReconnectTimer();
+
+    const reconnectSend = mock(async (
+      _peer: string,
+      _body: string,
+      opts: { stanza_id?: string },
+    ) => opts.stanza_id);
+    const reconnectXmpp = {
+      send_chat_message: reconnectSend,
+      get_resume_state: () => null,
+    };
+    sessionReadyClient.xmpp = reconnectXmpp;
+    sessionReadyClient.handleSessionReady(reconnectXmpp, { type: "fresh" });
+    sessionReadyClient.handleSessionReady(reconnectXmpp, { type: "fresh" });
+    await settleReconnectCatchup();
+
+    expect(firstSend).toHaveBeenCalledTimes(1);
+    expect(reconnectSend).toHaveBeenCalledTimes(1);
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account").map((entry) => entry.id))
+      .toEqual(["dm-live-1"]);
   });
 });
 

--- a/chat/tests/reconnect-state-machine.test.ts
+++ b/chat/tests/reconnect-state-machine.test.ts
@@ -28,7 +28,8 @@ type StubXmpp = {
 type PrivateState = {
   xmpp: unknown;
   connected: boolean;
-  wireEvents: (xmpp: StubXmpp) => void;
+  connectEpoch: number;
+  wireEvents: (xmpp: StubXmpp, generation?: number) => void;
   reconnect: { clearTimer: () => void };
   connectWithFreshBudget: () => Promise<void>;
   connectFromScheduler: () => Promise<void>;
@@ -221,6 +222,7 @@ describe("exhaustion recovery (C2)", () => {
     state.reconnect.clearTimer();
     state.xmpp = stub;
     state.connected = true;
+    state.wireEvents(stub, state.connectEpoch);
     fireDisconnected();
 
     expect(scheduled).toHaveLength(11);
@@ -282,6 +284,7 @@ describe("exhaustion recovery (C2)", () => {
       state.reconnect.clearTimer();
       state.xmpp = stub;
       state.connected = true;
+      state.wireEvents(stub, state.connectEpoch);
       fireDisconnected();
       expect(scheduled).toHaveLength(11);
       expect(scheduled.at(-1)?.attempt).toBe(1);
@@ -466,6 +469,44 @@ describe("disconnect() cancels the pending connect attempt (F3)", () => {
   });
 });
 
+describe("connection generation callback fencing", () => {
+  test("callbacks registered by an older generation cannot mutate a reused handle", () => {
+    const client = new BrowserXmppClient(session());
+    const state = client as unknown as PrivateState;
+    const statuses: XmppStatusSnapshot[] = [];
+    const errorCallbacks: Array<(payload: StreamErrorPayload) => void> = [];
+    const disconnectCallbacks: Array<() => void> = [];
+    client.setStatusHandler((snapshot) => statuses.push(snapshot));
+
+    const reusedHandle: StubXmpp = {
+      set_on_error(callback) {
+        errorCallbacks.push(callback);
+      },
+      set_on_disconnected(callback) {
+        disconnectCallbacks.push(callback);
+      },
+      get_resume_state: () => null,
+    };
+    state.xmpp = reusedHandle;
+    state.connected = true;
+    state.connectEpoch = 1;
+    state.wireEvents(reusedHandle, 1);
+    state.connectEpoch = 2;
+    state.wireEvents(reusedHandle, 2);
+
+    errorCallbacks[0]?.({ condition: "not-authorized", detail: "stale" });
+    disconnectCallbacks[0]?.();
+
+    expect(state.xmpp).toBe(reusedHandle);
+    expect(state.connected).toBe(true);
+    expect(statuses).toEqual([]);
+
+    errorCallbacks[1]?.({ condition: "not-authorized", detail: "current" });
+    disconnectCallbacks[1]?.();
+    expect(statuses.at(-1)?.state).toBe("error");
+  });
+});
+
 describe("stalled WASM load cannot double-connect (C3)", () => {
   test("a module load resolving after timeout + second connect yields exactly one live handle", async () => {
     const client = new BrowserXmppClient(session());
@@ -626,6 +667,7 @@ describe("stale terminalDisconnectDetail must not survive disconnect()", () => {
     state.reconnect.clearTimer();
     state.xmpp = stub;
     state.connected = true;
+    state.wireEvents(stub, state.connectEpoch);
     fireDisconnected();
 
     expect(statuses.at(-1)?.state).toBe("reconnecting");

--- a/chat/tests/resume-persistence.test.ts
+++ b/chat/tests/resume-persistence.test.ts
@@ -14,8 +14,10 @@ import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test
 import { ReconnectCatchup } from "../src/lib/xmpp/reconnect-catchup";
 import { BrowserXmppClient } from "../src/lib/xmpp/client";
 import { applyResumeStateToWasmConfig } from "../src/lib/xmpp/client-connection";
+import { installXmppPagehideLifecycle } from "../src/lib/xmpp/pagehide-lifecycle";
 import { enqueueQueuedMessage, listQueuedDmMessages } from "../src/lib/outbound-queue-store";
 import type { WaddleSession } from "../src/lib/server-auth";
+import type { XmppErrorEvent } from "../src/lib/xmpp/types";
 import {
   createLocalStorageResumePersistence,
   nullResumePersistence,
@@ -37,6 +39,7 @@ import {
 // path; a leaked shim would activate localStorage in those tests
 // and corrupt state across runs.
 const WINDOW_SENTINEL = Symbol("test-installed-window");
+const RESUME_SENT_AT = "2026-07-16T08:09:10.123Z";
 type ShimmedGlobal = typeof globalThis & {
   window?: { localStorage: Storage; sessionStorage: Storage } & { [WINDOW_SENTINEL]?: true };
 };
@@ -104,6 +107,7 @@ function inMemoryPersistence(): ResumePersistence & {
     saveSm: (state) => { sm = state; },
     clearSm: () => { smClears += 1; sm = null; },
     preparePagehideHandoff: () => undefined,
+    reclaimPagehideOwnership: () => undefined,
     loadJoinedRooms: () => [...joinedRooms],
     saveJoinedRooms: (rooms) => { joinedRooms = [...rooms]; },
     clearJoinedRooms: () => { joinedRooms = []; },
@@ -289,10 +293,10 @@ describe("applyResumeStateToWasmConfig", () => {
     return { config, calls };
   }
 
-  test("uses max-aware stanza resume when both unhandled stanzas and max are available", () => {
+  test("uses max-aware timestamped resume entries when unhandled work and max are available", () => {
     const { config, calls } = configWith([
-      "with_resume_state_stanzas_with_max",
-      "with_resume_state_stanzas",
+      "with_resume_state_entries_with_max",
+      "with_resume_state_entries",
       "with_resume_state_with_max",
       "with_resume_state",
     ]);
@@ -302,13 +306,13 @@ describe("applyResumeStateToWasmConfig", () => {
       inboundH: 7,
       outboundH: 11,
       maxResumeSeconds: 300,
-      unhandledOutboundStanzas: ["<message/>"],
+      unhandledOutboundEntries: [{ stanza: "<message/>", sentAt: RESUME_SENT_AT }],
     });
 
     expect(calls).toEqual([
       {
-        method: "with_resume_state_stanzas_with_max",
-        args: ["prev-1", 7, 11, ["<message/>"], 300],
+        method: "with_resume_state_entries_with_max",
+        args: ["prev-1", 7, 11, [{ stanza: "<message/>", sentAt: RESUME_SENT_AT }], 300],
       },
     ]);
   });
@@ -331,23 +335,33 @@ describe("applyResumeStateToWasmConfig", () => {
     ]);
   });
 
-  test("falls back to old stanza resume when generated WASM lacks max-aware stanza support", () => {
-    const { config, calls } = configWith(["with_resume_state_stanzas", "with_resume_state"]);
+  test("uses timestamped resume entries without a max-aware entry method", () => {
+    const { config, calls } = configWith(["with_resume_state_entries", "with_resume_state"]);
 
     applyResumeStateToWasmConfig(config, {
       previd: "prev-3",
       inboundH: 1,
       outboundH: 2,
       maxResumeSeconds: 300,
-      unhandledOutboundStanzas: ["<presence/>"],
+      unhandledOutboundEntries: [{ stanza: "<presence/>", sentAt: RESUME_SENT_AT }],
     });
 
     expect(calls).toEqual([
       {
-        method: "with_resume_state_stanzas",
-        args: ["prev-3", 1, 2, ["<presence/>"]],
+        method: "with_resume_state_entries",
+        args: ["prev-3", 1, 2, [{ stanza: "<presence/>", sentAt: RESUME_SENT_AT }]],
       },
     ]);
+  });
+
+  test("fails closed instead of dropping timestamped unhandled entries", () => {
+    const { config } = configWith(["with_resume_state"]);
+    expect(() => applyResumeStateToWasmConfig(config, {
+      previd: "prev-missing-entry-api",
+      inboundH: 1,
+      outboundH: 2,
+      unhandledOutboundEntries: [{ stanza: "<message/>", sentAt: RESUME_SENT_AT }],
+    })).toThrow("cannot restore timestamped XEP-0198 resume entries");
   });
 
   test("falls back to old plain resume when generated WASM has only the legacy method", () => {
@@ -386,7 +400,10 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
       previd: "abc-123",
       inboundH: 42,
       outboundH: 7,
-      unhandledOutboundStanzas: ["<message xmlns='jabber:client' id='m1'/>"],
+      unhandledOutboundEntries: [{
+        stanza: "<message xmlns='jabber:client' id='m1'/>",
+        sentAt: RESUME_SENT_AT,
+      }],
     };
     persistence.saveSm(state);
     // Round-trip strips the internal `savedAt` so the caller gets
@@ -486,6 +503,115 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
     const reloadedPage = createLocalStorageResumePersistence("alice@example.com");
 
     expect(reloadedPage.consumeSm()).toEqual(state);
+  });
+
+  test("BFCache pagehide persists before eviction and pageshow reclaims owner handoff", () => {
+    const ownerId = "bfcache-owner";
+    const persistence = createLocalStorageResumePersistence("alice@example.com", ownerId);
+    const client = new BrowserXmppClient(
+      { jid: "alice@example.com", username: "alice" } as WaddleSession,
+      persistence,
+    );
+    const activeResource = (client as unknown as { resource: string }).resource;
+    (client as unknown as {
+      xmpp: {
+        request_stream_management_ack: () => Promise<void>;
+        get_resume_state: () => PersistedSmResumeState & { hasUnackedOutbound: boolean };
+      };
+    }).xmpp = {
+      request_stream_management_ack: async () => undefined,
+      get_resume_state: () => ({
+        previd: "bfcache-stream",
+        inboundH: 12,
+        outboundH: 8,
+        maxResumeSeconds: 300,
+        resource: "web-bfcache",
+        hasUnackedOutbound: false,
+      }),
+    };
+
+    const listeners = new Map<string, EventListener>();
+    const target = {
+      addEventListener: (type: string, listener: EventListener) => listeners.set(type, listener),
+      removeEventListener: (type: string) => listeners.delete(type),
+    };
+    const remove = installXmppPagehideLifecycle(
+      target as unknown as Window,
+      () => client,
+      () => {
+        throw new Error("BFCache pagehide must not suspend call media");
+      },
+    );
+    const dispatch = (type: "pagehide" | "pageshow") => {
+      listeners.get(type)?.({ persisted: true } as PageTransitionEvent);
+    };
+
+    dispatch("pagehide");
+    expect(persistence.loadSm()).toMatchObject({
+      previd: "bfcache-stream",
+      inboundH: 12,
+      outboundH: 8,
+    });
+    expect(window.localStorage.getItem(`waddle.chat.sm-resume.owner-handoff.${ownerId}`))
+      .not.toBeNull();
+
+    dispatch("pageshow");
+    expect(window.localStorage.getItem(`waddle.chat.sm-resume.owner-handoff.${ownerId}`))
+      .toBeNull();
+
+    // A later BFCache eviction creates a fresh JS context. The synchronous
+    // pagehide snapshot remains consumable and preserves the bound resource.
+    dispatch("pagehide");
+    const reloaded = new BrowserXmppClient(
+      { jid: "alice@example.com", username: "alice" } as WaddleSession,
+      createLocalStorageResumePersistence("alice@example.com", ownerId),
+    );
+    expect((reloaded as unknown as { resource: string }).resource).toBe(activeResource);
+    remove();
+  });
+
+  test("ack rejection is observed once without delaying the synchronous pagehide snapshot", async () => {
+    const ownerId = "ack-rejection-owner";
+    const persistence = createLocalStorageResumePersistence("alice@example.com", ownerId);
+    const client = new BrowserXmppClient(
+      { jid: "alice@example.com", username: "alice" } as WaddleSession,
+      persistence,
+    );
+    const errors: XmppErrorEvent[] = [];
+    client.onError((error) => errors.push(error));
+    (client as unknown as {
+      xmpp: {
+        request_stream_management_ack: () => Promise<void>;
+        get_resume_state: () => PersistedSmResumeState & { hasUnackedOutbound: boolean };
+      };
+    }).xmpp = {
+      request_stream_management_ack: () => Promise.reject(new Error("socket unavailable")),
+      get_resume_state: () => ({
+        previd: "ack-rejection-stream",
+        inboundH: 4,
+        outboundH: 6,
+        hasUnackedOutbound: false,
+      }),
+    };
+
+    client.prepareForPageHide();
+
+    expect(persistence.loadSm()).toMatchObject({
+      previd: "ack-rejection-stream",
+      inboundH: 4,
+      outboundH: 6,
+    });
+    expect(errors).toEqual([]);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({
+      kind: "stream",
+      recoverable: true,
+      detail: "sm-ack-request-failed",
+    });
   });
 
   test("a slow same-tab reload keeps the owner until the prior lease expires", () => {
@@ -588,7 +714,7 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
           outboundH: number;
           maxResumeSeconds: number;
           hasUnackedOutbound: boolean;
-          unhandledOutboundStanzas: string[];
+          unhandledOutboundEntries: Array<{ stanza: string; sentAt: string }>;
         };
       };
     }).xmpp = {
@@ -598,7 +724,10 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
         outboundH: 9,
         maxResumeSeconds: 300,
         hasUnackedOutbound: true,
-        unhandledOutboundStanzas: ["<message xmlns='jabber:client' id='unacked'/>"],
+        unhandledOutboundEntries: [{
+          stanza: "<message xmlns='jabber:client' id='unacked'/>",
+          sentAt: RESUME_SENT_AT,
+        }],
       }),
     };
 
@@ -609,7 +738,10 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
       inboundH: 4,
       outboundH: 9,
       maxResumeSeconds: 300,
-      unhandledOutboundStanzas: ["<message xmlns='jabber:client' id='unacked'/>"],
+      unhandledOutboundEntries: [{
+        stanza: "<message xmlns='jabber:client' id='unacked'/>",
+        sentAt: RESUME_SENT_AT,
+      }],
     });
   });
 
@@ -619,7 +751,10 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
       previd: "live-sm-id",
       inboundH: 4,
       outboundH: 9,
-      unhandledOutboundStanzas: ["<message xmlns='jabber:client' id='dm-live-1'/>"],
+      unhandledOutboundEntries: [{
+        stanza: "<message xmlns='jabber:client' id='dm-live-1'/>",
+        sentAt: RESUME_SENT_AT,
+      }],
     });
     enqueueQueuedMessage("alice@example.com", {
       kind: "dm",
@@ -639,13 +774,16 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
     expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toEqual([]);
   });
 
-  test("BrowserXmppClient removes restored SM queue entries when native fallback retry owns resend", () => {
+  test("BrowserXmppClient retains restored SM queue entries while native fallback retry owns resend", () => {
     const persistence = inMemoryPersistence();
     persistence.saveSm({
       previd: "live-sm-id",
       inboundH: 4,
       outboundH: 9,
-      unhandledOutboundStanzas: ["<message xmlns='jabber:client' id='dm-live-1'/>"],
+      unhandledOutboundEntries: [{
+        stanza: "<message xmlns='jabber:client' id='dm-live-1'/>",
+        sentAt: RESUME_SENT_AT,
+      }],
     });
     enqueueQueuedMessage("alice@example.com", {
       kind: "dm",
@@ -662,7 +800,8 @@ describe("createLocalStorageResumePersistence — localStorage adapter", () => {
 
     (client as unknown as { handleMessageFailed: (id: string) => void }).handleMessageFailed("dm-live-1");
 
-    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account")).toEqual([]);
+    expect(listQueuedDmMessages("alice@example.com", "bob@example.com", "account").map((entry) => entry.id))
+      .toEqual(["dm-live-1"]);
   });
 
   test("BrowserXmppClient persists SM state when the native replay queue is empty", () => {

--- a/chat/tests/xmpp-pagehide-lifecycle.test.ts
+++ b/chat/tests/xmpp-pagehide-lifecycle.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, mock, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { Effect, Exit, Scope } from "effect";
+import {
+  acquireXmppPagehideLifecycle,
+  installXmppPagehideLifecycle,
+} from "../src/lib/xmpp/pagehide-lifecycle";
+
+class PagehideHarness {
+  private readonly listeners = new Map<string, Set<EventListener>>();
+  private failOnAdd: string | null = null;
+
+  addEventListener(type: string, listener: EventListener): void {
+    if (this.failOnAdd === type) {
+      this.failOnAdd = null;
+      throw new Error(`failed to add ${type}`);
+    }
+    const listeners = this.listeners.get(type) ?? new Set<EventListener>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: EventListener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  dispatch(type: "pagehide" | "pageshow", persisted: boolean): void {
+    const event = new Event(type) as PageTransitionEvent;
+    Object.defineProperty(event, "persisted", { value: persisted });
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+
+  listenerCount(type: "pagehide" | "pageshow"): number {
+    return this.listeners.get(type)?.size ?? 0;
+  }
+
+  failNextAdd(type: "pagehide" | "pageshow"): void {
+    this.failOnAdd = type;
+  }
+}
+
+describe("persistent XMPP pagehide lifecycle", () => {
+  test("persists XMPP for BFCache while keeping media suspension separate", () => {
+    const target = new PagehideHarness();
+    const order: string[] = [];
+    const prepareForPageHide = mock(() => order.push("xmpp"));
+    const resumeAfterPageShow = mock(() => order.push("reclaim"));
+    const suspendCall = mock(() => order.push("call"));
+    const remove = installXmppPagehideLifecycle(
+      target as unknown as Window,
+      () => ({ prepareForPageHide, resumeAfterPageShow }),
+      suspendCall,
+    );
+    expect(target.listenerCount("pagehide")).toBe(1);
+    expect(target.listenerCount("pageshow")).toBe(1);
+
+    target.dispatch("pagehide", true);
+    expect(order).toEqual(["xmpp"]);
+    target.dispatch("pageshow", true);
+    expect(order).toEqual(["xmpp", "reclaim"]);
+
+    target.dispatch("pagehide", false);
+    expect(order).toEqual(["xmpp", "reclaim", "xmpp", "call"]);
+    target.dispatch("pageshow", false);
+    expect(order).toEqual(["xmpp", "reclaim", "xmpp", "call"]);
+
+    remove();
+    remove();
+    expect(target.listenerCount("pagehide")).toBe(0);
+    expect(target.listenerCount("pageshow")).toBe(0);
+    target.dispatch("pagehide", false);
+    target.dispatch("pageshow", true);
+    expect(order).toEqual(["xmpp", "reclaim", "xmpp", "call"]);
+  });
+
+  test("still suspends local call media when no XMPP client exists", () => {
+    const target = new PagehideHarness();
+    const suspendCall = mock(() => undefined);
+    installXmppPagehideLifecycle(target as unknown as Window, () => null, suspendCall);
+
+    target.dispatch("pagehide", false);
+
+    expect(suspendCall).toHaveBeenCalledTimes(1);
+  });
+
+  test("a prepare failure is reported once and cannot skip refresh media suspension", () => {
+    const target = new PagehideHarness();
+    const suspendCall = mock(() => undefined);
+    const reportFailure = mock(() => undefined);
+    installXmppPagehideLifecycle(
+      target as unknown as Window,
+      () => ({
+        prepareForPageHide: () => {
+          throw new Error("snapshot failed");
+        },
+        resumeAfterPageShow: () => undefined,
+      }),
+      suspendCall,
+      reportFailure,
+    );
+
+    target.dispatch("pagehide", false);
+
+    expect(suspendCall).toHaveBeenCalledTimes(1);
+    expect(reportFailure).toHaveBeenCalledTimes(1);
+    expect(reportFailure.mock.calls[0]?.[0]).toMatchObject({
+      operation: "prepare-xmpp",
+    });
+  });
+
+  test("listener acquisition rolls pagehide back if pageshow installation fails", () => {
+    const target = new PagehideHarness();
+    target.failNextAdd("pageshow");
+
+    expect(() =>
+      installXmppPagehideLifecycle(
+        target as unknown as Window,
+        () => null,
+        () => undefined,
+      ),
+    ).toThrow();
+    expect(target.listenerCount("pagehide")).toBe(0);
+    expect(target.listenerCount("pageshow")).toBe(0);
+  });
+
+  test("closing the Effect scope directly releases both listeners", () => {
+    const target = new PagehideHarness();
+    const scope = Effect.runSync(Scope.make());
+    Effect.runSync(
+      Scope.extend(
+        acquireXmppPagehideLifecycle(
+          target as unknown as Window,
+          () => null,
+          () => undefined,
+        ),
+        scope,
+      ),
+    );
+    expect(target.listenerCount("pagehide")).toBe(1);
+    expect(target.listenerCount("pageshow")).toBe(1);
+
+    Effect.runSync(Scope.close(scope, Exit.succeed(undefined)));
+
+    expect(target.listenerCount("pagehide")).toBe(0);
+    expect(target.listenerCount("pageshow")).toBe(0);
+  });
+
+  test("XmppProvider owns the sole lifecycle listener", () => {
+    const provider = readFileSync(new URL("../src/components/XmppProvider.vue", import.meta.url), "utf8");
+    const overlay = readFileSync(new URL("../src/components/calls/CallOverlay.vue", import.meta.url), "utf8");
+
+    expect(provider).toContain("installXmppPagehideLifecycle(");
+    expect(provider).toContain("disconnectPagehideLifecycle?.();");
+    expect(provider).toContain("suspendCallForPageHide,");
+    expect(overlay).not.toContain("addEventListener(\"pagehide\"");
+    expect(overlay).not.toContain("installXmppPagehideLifecycle");
+    const unmountBlock = overlay.slice(overlay.indexOf("onBeforeUnmount(() => {"));
+    expect(unmountBlock).not.toContain("tearDownActiveCall(");
+  });
+});

--- a/chat/tests/xmpp-telemetry.test.ts
+++ b/chat/tests/xmpp-telemetry.test.ts
@@ -739,8 +739,7 @@ describe("BrowserXmppClient telemetry hooks", () => {
     // added an inflight entry plus a pending timestamp, then emit ack.
     const internal = client as unknown as {
       outboundQueue: {
-        markInflight: (id: string) => void;
-        notePendingSend: (id: string | null, kind: "room" | "dm") => void;
+        beginAttempt: (id: string, kind: "room" | "dm") => void;
       };
       xmpp: { on: (name: string, fn: (msg: unknown) => void) => void; emit: (name: string, msg: unknown) => void };
       wireEvents: (xmpp: unknown) => void;
@@ -758,8 +757,7 @@ describe("BrowserXmppClient telemetry hooks", () => {
     };
     internal.xmpp = stubXmpp as never;
     internal.wireEvents(stubXmpp);
-    internal.outboundQueue.markInflight("room-1");
-    internal.outboundQueue.notePendingSend("room-1", "room");
+    internal.outboundQueue.beginAttempt("room-1", "room");
 
     stubXmpp.emit("message:acked", { id: "room-1" });
 
@@ -779,8 +777,7 @@ describe("BrowserXmppClient telemetry hooks", () => {
 
     const internal = client as unknown as {
       outboundQueue: {
-        markInflight: (id: string) => void;
-        notePendingSend: (id: string | null, kind: "room" | "dm") => void;
+        beginAttempt: (id: string, kind: "room" | "dm") => void;
       };
       xmpp: unknown;
       wireEvents: (xmpp: unknown) => void;
@@ -801,10 +798,9 @@ describe("BrowserXmppClient telemetry hooks", () => {
     };
     internal.xmpp = stubXmpp;
     internal.wireEvents(stubXmpp);
-    internal.outboundQueue.markInflight("dm-9");
-    internal.outboundQueue.notePendingSend("dm-9", "dm");
+    internal.outboundQueue.beginAttempt("dm-9", "dm");
     // Record the pending kind so the failure hook reports it truthfully.
-    internal.outboundQueue.notePendingSend("live-1", "dm");
+    internal.outboundQueue.beginAttempt("live-1", "dm");
 
     // Ack → Faro event + measurement
     (stubXmpp as { emit: (e: string, m: unknown) => void }).emit("message:acked", { id: "dm-9" });
@@ -1375,8 +1371,7 @@ describe("BrowserXmppClient telemetry hooks", () => {
 
     const internal = client as unknown as {
       outboundQueue: {
-        markInflight: (id: string) => void;
-        notePendingSend: (id: string | null, kind: "room" | "dm") => void;
+        beginAttempt: (id: string, kind: "room" | "dm") => void;
       };
       xmpp: unknown;
       wireEvents: (xmpp: unknown) => void;
@@ -1394,7 +1389,7 @@ describe("BrowserXmppClient telemetry hooks", () => {
     };
     internal.xmpp = stubXmpp;
     internal.wireEvents(stubXmpp);
-    internal.outboundQueue.notePendingSend("m-bad", "dm");
+    internal.outboundQueue.beginAttempt("m-bad", "dm");
 
     expect(() => {
       (stubXmpp as { emit: (e: string, m: unknown) => void }).emit("message:acked", { id: "m-bad" });
@@ -1411,8 +1406,7 @@ describe("BrowserXmppClient telemetry hooks", () => {
 
     const internal = client as unknown as {
       outboundQueue: {
-        markInflight: (id: string) => void;
-        notePendingSend: (id: string | null, kind: "room" | "dm") => void;
+        beginAttempt: (id: string, kind: "room" | "dm") => void;
       };
       xmpp: unknown;
       wireEvents: (xmpp: unknown) => void;
@@ -1430,8 +1424,8 @@ describe("BrowserXmppClient telemetry hooks", () => {
     };
     internal.xmpp = stubXmpp;
     internal.wireEvents(stubXmpp);
-    internal.outboundQueue.markInflight("dm-fail-1");
-    internal.outboundQueue.notePendingSend("dm-fail-1", "dm");
+    internal.outboundQueue.beginAttempt("dm-fail-1", "dm");
+    depths.length = 0;
 
     stubXmpp.emit("message:failed", { id: "dm-fail-1" });
 

--- a/server/crates/waddle-xmpp-client-wasm/src/client_core.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/client_core.rs
@@ -4,14 +4,16 @@ use super::*;
 impl WaddleClient {
     #[wasm_bindgen(constructor)]
     pub fn new(config: WaddleConfig) -> WaddleClient {
+        let command_owner = Rc::new(RefCell::new(None));
         WaddleClient {
             inner: Rc::new(RefCell::new(WaddleClientInner {
                 config: StoredConfig::from(&config),
-                cmd_tx: None,
+                command_owner: Rc::downgrade(&command_owner),
                 on_message: None,
                 on_presence: None,
                 on_connected: None,
                 on_session_lifecycle: None,
+                on_stream_management: None,
                 on_disconnected: None,
                 on_error: None,
                 on_message_delivery_acked: None,
@@ -21,6 +23,7 @@ impl WaddleClient {
                 on_call: None,
                 resume_state: None,
             })),
+            _command_owner: command_owner,
         }
     }
 
@@ -55,6 +58,10 @@ impl WaddleClient {
 
     pub fn set_on_session_lifecycle(&mut self, cb: Function) {
         self.inner.borrow_mut().on_session_lifecycle = Some(cb);
+    }
+
+    pub fn set_on_stream_management(&mut self, cb: Function) {
+        self.inner.borrow_mut().on_stream_management = Some(cb);
     }
 
     pub fn set_on_disconnected(&mut self, cb: Function) {
@@ -101,7 +108,8 @@ impl WaddleClient {
     pub fn connect(&self) -> Promise {
         let inner = self.inner.clone();
         future_to_promise(async move {
-            if inner.borrow().cmd_tx.is_some() {
+            let command_owner = command_owner(&inner)?;
+            if command_owner.borrow().is_some() {
                 return Err(js_error("client is already connected"));
             }
 
@@ -112,7 +120,7 @@ impl WaddleClient {
             let (cmd_tx, cmd_rx) = mpsc::channel(64);
             let (event_tx, event_rx) = mpsc::channel(256);
 
-            inner.borrow_mut().cmd_tx = Some(cmd_tx);
+            *command_owner.borrow_mut() = Some(cmd_tx);
 
             spawn_local(event_dispatch_loop(inner.clone(), event_rx));
             spawn_local(driver_loop(config, ws, cmd_rx, event_tx, inner.clone()));
@@ -125,6 +133,17 @@ impl WaddleClient {
         let inner = self.inner.clone();
         future_to_promise(async move {
             disconnect_client(inner).await?;
+            Ok(JsValue::UNDEFINED)
+        })
+    }
+
+    /// Best-effort XEP-0198 acknowledgement request for page lifecycle
+    /// handoff. The shared runtime suppresses duplicates while another
+    /// request is already awaiting `<a/>`.
+    pub fn request_stream_management_ack(&self) -> Promise {
+        let inner = self.inner.clone();
+        future_to_promise(async move {
+            request_stream_management_ack(inner).await?;
             Ok(JsValue::UNDEFINED)
         })
     }

--- a/server/crates/waddle-xmpp-client-wasm/src/commands.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/commands.rs
@@ -37,6 +37,7 @@ pub(crate) fn send_failure_outcome(error: &ClientError) -> WaddleSendMessageOutc
         ClientError::InvalidTransportScheme { .. }
         | ClientError::MissingWebSocketHost
         | ClientError::WebSocketConnectTimeout { .. }
+        | ClientError::WebSocketWriteTimeout { .. }
         | ClientError::TransportClosed
         | ClientError::EmptyTransportFrame
         | ClientError::TransportFrameTooLarge { .. }
@@ -132,6 +133,20 @@ pub(crate) async fn cancel_iq_command(
         .map_err(|err| js_error(err.to_string()))
 }
 
+pub(crate) async fn request_stream_management_ack(
+    inner: Rc<RefCell<WaddleClientInner>>,
+) -> Result<(), JsValue> {
+    let mut cmd_tx = command_sender(&inner)?;
+    let (responder, rx) = oneshot::channel();
+    cmd_tx
+        .send(WasmCommand::RequestStreamManagementAck { responder })
+        .await
+        .map_err(|_| js_error("client is disconnected"))?;
+    rx.await
+        .map_err(|_| js_error("client is disconnected"))?
+        .map_err(|err| js_error(err.to_string()))
+}
+
 /// Variant of [`send_iq_command`] that surfaces RFC 6120 §8.3 stanza
 /// errors as a typed [`waddle_xmpp_client::StanzaError`] on the Rust
 /// side instead of rejecting the Promise. Transport / disconnect
@@ -220,7 +235,8 @@ pub(crate) async fn send_inbox_query_command(
 pub(crate) async fn disconnect_client(
     inner: Rc<RefCell<WaddleClientInner>>,
 ) -> Result<(), JsValue> {
-    let mut cmd_tx = match inner.borrow().cmd_tx.clone() {
+    let command_owner = command_owner(&inner)?;
+    let mut cmd_tx = match command_owner.borrow().clone() {
         Some(cmd_tx) => cmd_tx,
         None => return Ok(()),
     };
@@ -230,8 +246,7 @@ pub(crate) async fn disconnect_client(
         .send(WasmCommand::Disconnect { responder })
         .await
         .map_err(|_| js_error("client is disconnected"))?;
-    inner.borrow_mut().cmd_tx = None;
-    inner.borrow_mut().resume_state = None;
+    command_owner.borrow_mut().take();
     rx.await
         .map_err(|_| js_error("client is disconnected"))?
         .map_err(|err| js_error(err.to_string()))
@@ -240,17 +255,76 @@ pub(crate) async fn disconnect_client(
 pub(crate) fn command_sender(
     inner: &Rc<RefCell<WaddleClientInner>>,
 ) -> Result<mpsc::Sender<WasmCommand>, JsValue> {
+    let command_owner = command_owner(inner)?;
+    let sender = command_owner
+        .borrow()
+        .as_ref()
+        .cloned()
+        .ok_or_else(|| js_error("client is not connected"));
+    sender
+}
+
+pub(crate) fn command_owner(
+    inner: &Rc<RefCell<WaddleClientInner>>,
+) -> Result<Rc<RefCell<Option<mpsc::Sender<WasmCommand>>>>, JsValue> {
     inner
         .borrow()
-        .cmd_tx
-        .clone()
-        .ok_or_else(|| js_error("client is not connected"))
+        .command_owner
+        .upgrade()
+        .ok_or_else(|| js_error("client wrapper was released"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use futures::executor::block_on;
     use waddle_xmpp_client::error::{StanzaError, StanzaErrorType};
+
+    #[test]
+    fn public_disconnect_hides_sender_but_preserves_resume_until_clean_completion() {
+        block_on(async {
+            let (cmd_tx, mut cmd_rx) = mpsc::channel(1);
+            let command_owner = Rc::new(RefCell::new(Some(cmd_tx)));
+            let resume_state = waddle_xmpp_client::SmResumeState::new("public-disconnect", 2, 3)
+                .expect("resume state");
+            let inner = Rc::new(RefCell::new(WaddleClientInner {
+                config: StoredConfig {
+                    server_url: "wss://xmpp.example.test/ws".to_string(),
+                    jid: "alice@example.test".to_string(),
+                    access_token: "token".to_string(),
+                    resource: "web".to_string(),
+                    resume_state: Some(resume_state.clone()),
+                },
+                command_owner: Rc::downgrade(&command_owner),
+                on_message: None,
+                on_presence: None,
+                on_connected: None,
+                on_session_lifecycle: None,
+                on_stream_management: None,
+                on_disconnected: None,
+                on_error: None,
+                on_message_delivery_acked: None,
+                on_message_delivery_failed: None,
+                on_mds_displayed: None,
+                on_pubsub_event: None,
+                on_call: None,
+                resume_state: Some(resume_state.clone()),
+            }));
+
+            let acknowledge_driver = async {
+                let Some(WasmCommand::Disconnect { responder }) = cmd_rx.next().await else {
+                    panic!("expected disconnect command");
+                };
+                let _ = responder.send(Ok(()));
+            };
+            let (result, ()) = futures::join!(disconnect_client(inner.clone()), acknowledge_driver);
+
+            assert!(result.is_ok());
+            assert!(command_owner.borrow().is_none());
+            assert_eq!(inner.borrow().resume_state, Some(resume_state));
+            assert!(disconnect_client(inner.clone()).await.is_ok());
+        });
+    }
 
     fn stanza_error(
         error_type: StanzaErrorType,

--- a/server/crates/waddle-xmpp-client-wasm/src/driver.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/driver.rs
@@ -1,4 +1,146 @@
 use super::*;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use futures::future::{pending, Either};
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::JsCast;
+
+impl WasmDriverWire for WasmWebSocket {
+    fn events(&mut self) -> &mut mpsc::Receiver<WasmTransportEvent> {
+        &mut self.rx
+    }
+
+    fn send_frame(&mut self, frame: &str) -> DriverResult<()> {
+        self.send(frame).map_err(|_| ClientError::TransportClosed)
+    }
+
+    fn close_websocket(&mut self) -> DriverResult<()> {
+        WasmWebSocket::close(self).map_err(|_| ClientError::TransportClosed)
+    }
+}
+
+#[derive(Default)]
+struct WindowDriverTimerBackend;
+
+impl DriverTimerBackend for WindowDriverTimerBackend {
+    fn wait(&self, delay_ms: Option<u64>) -> futures::future::LocalBoxFuture<'static, ()> {
+        let Some(delay_ms) = delay_ms else {
+            return Box::pin(std::future::pending());
+        };
+        match WindowTimeout::new(delay_ms) {
+            Some(timeout) => Box::pin(timeout),
+            None => Box::pin(std::future::pending()),
+        }
+    }
+}
+
+struct WindowTimeout {
+    window: web_sys::Window,
+    timeout_id: i32,
+    receiver: oneshot::Receiver<()>,
+    _callback: Closure<dyn FnMut()>,
+}
+
+impl WindowTimeout {
+    fn new(delay_ms: u64) -> Option<Self> {
+        let window = web_sys::window()?;
+        let (sender, receiver) = oneshot::channel();
+        let mut sender = Some(sender);
+        let callback = Closure::wrap(Box::new(move || {
+            if let Some(sender) = sender.take() {
+                let _ = sender.send(());
+            }
+        }) as Box<dyn FnMut()>);
+        let timeout_ms = i32::try_from(delay_ms).unwrap_or(i32::MAX);
+        let timeout_id = window
+            .set_timeout_with_callback_and_timeout_and_arguments_0(
+                callback.as_ref().unchecked_ref(),
+                timeout_ms,
+            )
+            .ok()?;
+        Some(Self {
+            window,
+            timeout_id,
+            receiver,
+            _callback: callback,
+        })
+    }
+}
+
+impl Future for WindowTimeout {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, context: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.receiver).poll(context).map(|_| ())
+    }
+}
+
+impl Drop for WindowTimeout {
+    fn drop(&mut self) {
+        self.window.clear_timeout_with_handle(self.timeout_id);
+    }
+}
+
+enum DriverInput {
+    Wire(Option<WasmTransportEvent>),
+    Command(Option<WasmCommand>),
+    DriverTimer,
+}
+
+/// Private attribution for one ordered browser wire-pump failure.
+///
+/// `send_frame` is synchronous: a thrown browser WebSocket send means that
+/// exact frame was not accepted. A later generated control-frame failure must
+/// therefore terminate the stream without reclassifying an already-confirmed
+/// initiating stanza as retryable.
+#[derive(Debug)]
+struct WasmPumpFailure {
+    failed_message: TransportMessage,
+    initiating_message_confirmed: bool,
+    source: ClientError,
+}
+
+impl WasmPumpFailure {
+    fn initiating_message_confirmed(&self) -> bool {
+        self.initiating_message_confirmed
+    }
+
+    fn attributed_message(&self) -> &TransportMessage {
+        &self.failed_message
+    }
+
+    fn source(&self) -> &ClientError {
+        &self.source
+    }
+
+    fn into_source(self) -> ClientError {
+        self.source
+    }
+}
+
+async fn select_driver_input<WireFuture, CommandFuture, TimerFuture>(
+    wire_future: WireFuture,
+    command_future: CommandFuture,
+    timer_future: TimerFuture,
+) -> DriverInput
+where
+    WireFuture: Future<Output = Option<WasmTransportEvent>>,
+    CommandFuture: Future<Output = Option<WasmCommand>>,
+    TimerFuture: Future<Output = ()>,
+{
+    let wire_future = wire_future.fuse();
+    let command_future = command_future.fuse();
+    let timer_future = timer_future.fuse();
+    pin_mut!(wire_future, command_future, timer_future);
+
+    select! {
+        event = wire_future => DriverInput::Wire(event),
+        command = command_future => DriverInput::Command(command),
+        _ = timer_future => DriverInput::DriverTimer,
+    }
+}
 
 pub(crate) async fn driver_loop(
     config: ClientConfig,
@@ -11,7 +153,9 @@ pub(crate) async fn driver_loop(
         Ok(task) => task,
         Err(err) => {
             let mut event_tx = event_tx;
-            let _ = event_tx.send(DriverEvent::Error(err.to_string())).await;
+            let _ = event_tx
+                .send(DriverEvent::Error(WasmDriverError::from(err)))
+                .await;
             let _ = event_tx.send(DriverEvent::Disconnected).await;
             return;
         }
@@ -27,9 +171,28 @@ impl WasmDriverTask {
         event_tx: mpsc::Sender<DriverEvent>,
         inner: Rc<RefCell<WaddleClientInner>>,
     ) -> DriverResult<Self> {
+        Self::new_with_dependencies(
+            config,
+            Box::new(ws),
+            Rc::new(WindowDriverTimerBackend),
+            cmd_rx,
+            event_tx,
+            inner,
+        )
+    }
+
+    fn new_with_dependencies(
+        config: ClientConfig,
+        ws: Box<dyn WasmDriverWire>,
+        timer: Rc<dyn DriverTimerBackend>,
+        cmd_rx: mpsc::Receiver<WasmCommand>,
+        event_tx: mpsc::Sender<DriverEvent>,
+        inner: Rc<RefCell<WaddleClientInner>>,
+    ) -> DriverResult<Self> {
         Ok(Self {
             runtime: XmppRuntime::new(config)?,
             ws,
+            timer,
             cmd_rx,
             event_tx,
             inner,
@@ -38,6 +201,8 @@ impl WasmDriverTask {
             pending_inbox_queries: HashMap::new(),
             deferred_commands: VecDeque::new(),
             explicit_disconnect: false,
+            websocket_close_started: false,
+            commands_closed: false,
         })
     }
 
@@ -53,28 +218,81 @@ impl WasmDriverTask {
                 }
             }
             Err(err) => {
-                self.emit_error(err.to_string()).await;
+                self.emit_error(WasmDriverError::from(err)).await;
                 self.finish().await;
                 return;
             }
         }
 
-        loop {
-            let ws_event_fut = self.ws.rx.next().fuse();
-            let cmd_fut = self.cmd_rx.next().fuse();
-            pin_mut!(ws_event_fut, cmd_fut);
+        self.run_input_loop().await;
+        self.finish().await;
+    }
 
-            let keep_running = select! {
-                ws_event = ws_event_fut => self.handle_wasm_transport_event(ws_event).await,
-                cmd = cmd_fut => self.handle_command(cmd).await,
+    async fn run_input_loop(&mut self) {
+        loop {
+            let now_ms = waddle_xmpp_client::runtime::monotonic_now_ms();
+            let sm_wakeup_ms = self.runtime.next_stream_management_wakeup_in_ms(now_ms);
+            let close_wakeup_ms = self.runtime.next_stream_close_wakeup_in_ms(now_ms);
+            let driver_wakeup_ms = minimum_wakeup(sm_wakeup_ms, close_wakeup_ms);
+            let close_deadline_scheduled =
+                close_wakeup_ms.is_some_and(|close| sm_wakeup_ms.is_none_or(|sm| close <= sm));
+            let command_future = if self.commands_closed {
+                Either::Left(pending())
+            } else {
+                Either::Right(self.cmd_rx.next())
+            };
+            let input = select_driver_input(
+                self.ws.events().next(),
+                command_future,
+                self.timer.wait(driver_wakeup_ms),
+            )
+            .await;
+
+            let keep_running = match input {
+                DriverInput::Wire(event) => self.handle_wasm_transport_event(event).await,
+                DriverInput::Command(command) => self.handle_command(command).await,
+                DriverInput::DriverTimer => {
+                    self.handle_driver_timer(close_deadline_scheduled).await
+                }
             };
 
             if !keep_running {
                 break;
             }
         }
+    }
 
-        self.finish().await;
+    async fn handle_driver_timer(&mut self, close_deadline_scheduled: bool) -> bool {
+        if close_deadline_scheduled {
+            self.terminate_uncleanly().await;
+            return false;
+        }
+        self.handle_stream_management_timer_at(waddle_xmpp_client::runtime::monotonic_now_ms())
+            .await
+    }
+
+    async fn handle_stream_management_timer_at(&mut self, now_ms: u64) -> bool {
+        let events = self.runtime.poll_stream_management_at(now_ms);
+        let progress_stalled = events.iter().any(|event| {
+            matches!(
+                event,
+                ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                    StreamManagementEvent::AckProgressStalled { .. }
+                ))
+            )
+        });
+
+        for event in events {
+            if !self.handle_client_event(event).await {
+                return false;
+            }
+        }
+
+        if progress_stalled {
+            self.terminate_uncleanly().await;
+            return false;
+        }
+        true
     }
 
     async fn handle_wasm_transport_event(&mut self, event: Option<WasmTransportEvent>) -> bool {
@@ -93,7 +311,7 @@ impl WasmDriverTask {
                             .await
                     }
                     Err(err) => {
-                        self.emit_error(err.to_string()).await;
+                        self.emit_error(WasmDriverError::from(err)).await;
                         let _ = self
                             .apply_transport_event(TransportEvent::StateChanged(
                                 TransportState::Failed,
@@ -112,8 +330,7 @@ impl WasmDriverTask {
                 false
             }
             Some(WasmTransportEvent::Error) => {
-                self.emit_error("websocket transport error".to_string())
-                    .await;
+                self.emit_error(WasmDriverError::WebSocketTransport).await;
                 let _ = self
                     .apply_transport_event(TransportEvent::StateChanged(TransportState::Failed))
                     .await;
@@ -184,17 +401,51 @@ impl WasmDriverTask {
                 let _ = responder.send(Ok(()));
                 true
             }
-            Some(WasmCommand::Disconnect { responder }) => {
-                self.explicit_disconnect = true;
-                self.publish_resume_state_snapshot();
-                let result = self
-                    .send_transport_message(TransportMessage::Close(StreamClose))
-                    .await;
+            Some(WasmCommand::RequestStreamManagementAck { responder }) => {
+                let events = self.runtime.request_stream_management_ack_at(
+                    waddle_xmpp_client::runtime::monotonic_now_ms(),
+                );
+                let mut result = Ok(());
+                for event in events {
+                    if !self.handle_client_event(event).await {
+                        result = Err(ClientError::TransportClosed);
+                        break;
+                    }
+                }
                 let keep_running = result.is_ok();
                 let _ = responder.send(result);
                 keep_running
             }
-            None => false,
+            Some(WasmCommand::Disconnect { responder }) => {
+                let result = match self.runtime.request_stream_close() {
+                    Ok(events) => {
+                        let mut result = Ok(());
+                        for event in events {
+                            if !self.handle_client_event(event).await {
+                                result = Err(ClientError::TransportClosed);
+                                break;
+                            }
+                        }
+                        result
+                    }
+                    Err(error) => Err(error),
+                };
+                if result.is_err() {
+                    self.terminate_uncleanly().await;
+                }
+                let keep_running = result.is_ok();
+                let _ = responder.send(result);
+                keep_running
+            }
+            None => {
+                self.commands_closed = true;
+                if self.runtime.stream_close_sent_confirmed() {
+                    true
+                } else {
+                    self.terminate_uncleanly().await;
+                    false
+                }
+            }
         }
     }
 
@@ -207,18 +458,35 @@ impl WasmDriverTask {
         stanza: Element,
         responder: oneshot::Sender<DriverResult<()>>,
     ) -> bool {
-        let result = self
-            .send_transport_message(TransportMessage::Element(stanza.clone()))
-            .await;
-        let keep_running = result.is_ok();
-        if let Err(err) = &result {
-            if let Some(stanza_id) = message_delivery_stanza_id(&stanza) {
-                self.emit_message_delivery_failed(stanza_id).await;
+        let initiating_message = TransportMessage::Element(stanza.clone());
+        match self
+            .send_transport_message(initiating_message.clone())
+            .await
+        {
+            Ok(()) => {
+                let _ = responder.send(Ok(()));
+                true
             }
-            self.emit_error(err.to_string()).await;
+            Err(failure) => {
+                self.emit_error(WasmDriverError::from_client_ref(failure.source()))
+                    .await;
+                if failure.initiating_message_confirmed() {
+                    // The application stanza is already owned by XEP-0198.
+                    // Resolving success prevents the persisted browser queue
+                    // from rolling it back and sending it again after refresh.
+                    let _ = responder.send(Ok(()));
+                } else {
+                    if failure.attributed_message() == &initiating_message {
+                        if let Some(stanza_id) = message_delivery_stanza_id(&stanza) {
+                            self.emit_message_delivery_failed(stanza_id).await;
+                        }
+                    }
+                    let _ = responder.send(Err(failure.into_source()));
+                }
+                self.terminate_uncleanly().await;
+                false
+            }
         }
-        let _ = responder.send(result);
-        keep_running
     }
 
     async fn send_iq_command(
@@ -241,9 +509,19 @@ impl WasmDriverTask {
                     false
                 }
             },
-            Err(err) => {
-                self.emit_error(err.to_string()).await;
-                let _ = responder.send(Err(err));
+            Err(failure) => {
+                self.emit_error(WasmDriverError::from_client_ref(failure.source()))
+                    .await;
+                if failure.initiating_message_confirmed() {
+                    if let Some(id) = id {
+                        self.pending_iqs.insert(id, responder);
+                    } else {
+                        let _ = responder.send(Err(ClientError::Disconnected));
+                    }
+                } else {
+                    let _ = responder.send(Err(failure.into_source()));
+                }
+                self.terminate_uncleanly().await;
                 false
             }
         }
@@ -271,9 +549,20 @@ impl WasmDriverTask {
                     false
                 }
             },
-            Err(err) => {
-                self.emit_error(err.to_string()).await;
-                let _ = responder.send(Err(err));
+            Err(failure) => {
+                self.emit_error(WasmDriverError::from_client_ref(failure.source()))
+                    .await;
+                if failure.initiating_message_confirmed() {
+                    if let Some(id) = id {
+                        self.pending_mam_queries
+                            .insert(id, PendingMamQuery::new(&query_id, responder));
+                    } else {
+                        let _ = responder.send(Err(ClientError::Disconnected));
+                    }
+                } else {
+                    let _ = responder.send(Err(failure.into_source()));
+                }
+                self.terminate_uncleanly().await;
                 false
             }
         }
@@ -307,9 +596,26 @@ impl WasmDriverTask {
                     false
                 }
             },
-            Err(err) => {
-                self.emit_error(err.to_string()).await;
-                let _ = responder.send(Err(err));
+            Err(failure) => {
+                self.emit_error(WasmDriverError::from_client_ref(failure.source()))
+                    .await;
+                if failure.initiating_message_confirmed() {
+                    if let Some(id) = id {
+                        self.pending_inbox_queries.insert(
+                            id,
+                            PendingInboxQuery {
+                                query_id,
+                                entries: Vec::new(),
+                                responder,
+                            },
+                        );
+                    } else {
+                        let _ = responder.send(Err(ClientError::Disconnected));
+                    }
+                } else {
+                    let _ = responder.send(Err(failure.into_source()));
+                }
+                self.terminate_uncleanly().await;
                 false
             }
         }
@@ -372,7 +678,7 @@ impl WasmDriverTask {
         let events = match self.runtime.apply_transport_event(event) {
             Ok(events) => events,
             Err(err) => {
-                self.emit_error(err.to_string()).await;
+                self.emit_error(WasmDriverError::from(err)).await;
                 return false;
             }
         };
@@ -384,6 +690,11 @@ impl WasmDriverTask {
             }
         }
 
+        if self.runtime.stream_close_complete() && self.begin_websocket_close().is_err() {
+            self.terminate_uncleanly().await;
+            return false;
+        }
+
         if !self.flush_deferred_commands().await {
             return false;
         }
@@ -393,23 +704,14 @@ impl WasmDriverTask {
 
     async fn handle_client_event(&mut self, event: ClientEvent) -> bool {
         if let Some(message) = self.dispatch_client_event(event).await {
-            if let Err(err) = self.send_transport_message(message).await {
-                self.emit_error(err.to_string()).await;
+            if let Err(failure) = self.send_transport_message(message).await {
+                self.emit_error(WasmDriverError::from_client_ref(failure.source()))
+                    .await;
+                self.terminate_uncleanly().await;
                 return false;
             }
         }
         true
-    }
-
-    async fn apply_sent_event(&mut self, event: TransportEvent) -> DriverResult<()> {
-        let events = self.runtime.apply_transport_event(event)?;
-        self.publish_resume_state_snapshot();
-        for event in events {
-            if self.dispatch_client_event(event).await.is_some() {
-                return Err(ClientError::Disconnected);
-            }
-        }
-        Ok(())
     }
 
     async fn dispatch_client_event(&mut self, event: ClientEvent) -> Option<TransportMessage> {
@@ -532,20 +834,118 @@ impl WasmDriverTask {
         }
     }
 
-    async fn send_transport_message(&mut self, message: TransportMessage) -> DriverResult<()> {
-        let sent_event = TransportEvent::MessageSent(message.clone());
-        let frame = waddle_xmpp_client::encode_message(&message)?;
-        self.ws
-            .send(&frame)
-            .map_err(|_| ClientError::TransportClosed)?;
-
-        if matches!(message, TransportMessage::Close(_)) {
-            let _ = self.ws.close();
+    async fn send_transport_message(
+        &mut self,
+        message: TransportMessage,
+    ) -> Result<(), WasmPumpFailure> {
+        enum PumpItem {
+            Message(TransportMessage),
+            Event(ClientEvent),
         }
 
-        self.apply_sent_event(sent_event).await?;
+        let mut pending = VecDeque::from([PumpItem::Message(message)]);
+        let mut initiating_message_confirmed = false;
+        while let Some(item) = pending.pop_front() {
+            match item {
+                PumpItem::Message(message) => {
+                    let frame = match waddle_xmpp_client::encode_message(&message) {
+                        Ok(frame) => frame,
+                        Err(source) => {
+                            if self.recover_definite_ack_request_write(&message) {
+                                continue;
+                            }
+                            return Err(WasmPumpFailure {
+                                failed_message: message,
+                                initiating_message_confirmed,
+                                source,
+                            });
+                        }
+                    };
+                    if let Err(source) = self.ws.send_frame(&frame) {
+                        if self.recover_definite_ack_request_write(&message) {
+                            continue;
+                        }
+                        return Err(WasmPumpFailure {
+                            failed_message: message.clone(),
+                            initiating_message_confirmed,
+                            source,
+                        });
+                    }
+                    if !initiating_message_confirmed {
+                        initiating_message_confirmed = true;
+                    }
+                    let events = self
+                        .runtime
+                        .apply_transport_event(TransportEvent::MessageSent(message.clone()))
+                        .map_err(|source| WasmPumpFailure {
+                            failed_message: message.clone(),
+                            initiating_message_confirmed,
+                            source,
+                        })?;
+                    self.publish_resume_state_snapshot();
+                    if self.runtime.stream_close_complete() {
+                        self.begin_websocket_close()
+                            .map_err(|source| WasmPumpFailure {
+                                failed_message: message.clone(),
+                                initiating_message_confirmed,
+                                source,
+                            })?;
+                    }
+                    for event in events.into_iter().rev() {
+                        pending.push_front(PumpItem::Event(event));
+                    }
+                }
+                PumpItem::Event(event) => {
+                    if let Some(follow_up) = self.dispatch_client_event(event).await {
+                        pending.push_front(PumpItem::Message(follow_up));
+                    }
+                }
+            }
+        }
 
         Ok(())
+    }
+
+    fn recover_definite_ack_request_write(&mut self, message: &TransportMessage) -> bool {
+        matches!(
+            message,
+            TransportMessage::Element(element)
+                if waddle_xmpp_client::stream_management::SmState::is_request_ack(element)
+        ) && self
+            .runtime
+            .stream_management_ack_definitely_not_written_at(
+                waddle_xmpp_client::runtime::monotonic_now_ms(),
+            )
+    }
+
+    async fn terminate_uncleanly(&mut self) {
+        self.apply_terminal_transport_event(TransportEvent::StateChanged(TransportState::Failed))
+            .await;
+        let _ = self.ws.close_websocket();
+        self.apply_terminal_transport_event(TransportEvent::StateChanged(TransportState::Closed))
+            .await;
+        self.apply_terminal_transport_event(TransportEvent::Closed)
+            .await;
+    }
+
+    fn begin_websocket_close(&mut self) -> DriverResult<()> {
+        if self.websocket_close_started {
+            return Ok(());
+        }
+        self.websocket_close_started = true;
+        self.explicit_disconnect = true;
+        self.publish_resume_state_snapshot();
+        self.ws.close_websocket()
+    }
+
+    async fn apply_terminal_transport_event(&mut self, event: TransportEvent) {
+        let Ok(events) = self.runtime.apply_transport_event(event) else {
+            return;
+        };
+        self.publish_resume_state_snapshot();
+        for event in events {
+            let _ = self.dispatch_client_event(event).await;
+        }
     }
     async fn emit_message_delivery_failed(&mut self, stanza_id: StanzaId) {
         let _ = self
@@ -557,12 +957,8 @@ impl WasmDriverTask {
             .await;
     }
 
-    async fn emit_error(&mut self, description: String) {
-        let _ = self
-            .event_tx
-            .clone()
-            .send(DriverEvent::Error(description))
-            .await;
+    async fn emit_error(&mut self, error: WasmDriverError) {
+        let _ = self.event_tx.clone().send(DriverEvent::Error(error)).await;
     }
 
     fn publish_resume_state_snapshot(&self) {
@@ -605,6 +1001,14 @@ impl WasmDriverTask {
         }
 
         let _ = self.event_tx.clone().send(DriverEvent::Disconnected).await;
+    }
+}
+
+fn minimum_wakeup(left: Option<u64>, right: Option<u64>) -> Option<u64> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(delay), None) | (None, Some(delay)) => Some(delay),
+        (None, None) => None,
     }
 }
 
@@ -686,8 +1090,169 @@ fn resolve_pending_mam_query(pending: PendingMamQuery, element: &Element) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::cell::Cell;
+    use std::collections::HashSet;
+    use std::str::FromStr;
+
     use futures::executor::block_on;
+    use futures::future;
     use waddle_xmpp_client::discovery::DISCO_INFO_NS;
+    use waddle_xmpp_client::transport::StreamClose;
+
+    #[derive(Clone, Default)]
+    struct FakeWireState {
+        frames: Rc<RefCell<Vec<String>>>,
+        close_count: Rc<Cell<usize>>,
+        send_attempt_count: Rc<Cell<usize>>,
+        fail_on_send_attempt: Rc<Cell<Option<usize>>>,
+    }
+
+    impl FakeWireState {
+        fn take_messages(&self) -> Vec<TransportMessage> {
+            self.frames
+                .borrow_mut()
+                .drain(..)
+                .map(|frame| waddle_xmpp_client::decode_message(&frame).expect("typed frame"))
+                .collect()
+        }
+
+        fn fail_after_successful_sends(&self, successful_sends: usize) {
+            self.fail_on_send_attempt
+                .set(Some(self.send_attempt_count.get() + successful_sends + 1));
+        }
+
+        fn send_attempt_count(&self) -> usize {
+            self.send_attempt_count.get()
+        }
+    }
+
+    fn assert_final_ack_then_close(messages: &[TransportMessage], expected_h: &str) {
+        assert!(matches!(
+            messages,
+            [
+                TransportMessage::Element(ack),
+                TransportMessage::Close(StreamClose)
+            ] if ack.name() == "a"
+                && ack.ns() == waddle_xmpp_client::stream_management::NS_SM
+                && ack.attr("h") == Some(expected_h)
+        ));
+    }
+
+    struct FakeWire {
+        _event_sender: mpsc::Sender<WasmTransportEvent>,
+        events: mpsc::Receiver<WasmTransportEvent>,
+        state: FakeWireState,
+    }
+
+    impl FakeWire {
+        fn new() -> (Self, FakeWireState) {
+            let (event_sender, events) = mpsc::channel(16);
+            let state = FakeWireState::default();
+            (
+                Self {
+                    _event_sender: event_sender,
+                    events,
+                    state: state.clone(),
+                },
+                state,
+            )
+        }
+    }
+
+    impl WasmDriverWire for FakeWire {
+        fn events(&mut self) -> &mut mpsc::Receiver<WasmTransportEvent> {
+            &mut self.events
+        }
+
+        fn send_frame(&mut self, frame: &str) -> DriverResult<()> {
+            let attempt = self.state.send_attempt_count.get() + 1;
+            self.state.send_attempt_count.set(attempt);
+            if self.state.fail_on_send_attempt.get() == Some(attempt) {
+                self.state.fail_on_send_attempt.set(None);
+                return Err(ClientError::TransportClosed);
+            }
+            self.state.frames.borrow_mut().push(frame.to_string());
+            Ok(())
+        }
+
+        fn close_websocket(&mut self) -> DriverResult<()> {
+            self.state.close_count.set(self.state.close_count.get() + 1);
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct ManualTimerState {
+        next_id: u64,
+        active: HashSet<u64>,
+        cancelled: HashSet<u64>,
+        max_active: usize,
+    }
+
+    #[derive(Clone, Default)]
+    struct ManualTimerBackend {
+        state: Rc<RefCell<ManualTimerState>>,
+    }
+
+    impl ManualTimerBackend {
+        fn active_count(&self) -> usize {
+            self.state.borrow().active.len()
+        }
+
+        fn max_active(&self) -> usize {
+            self.state.borrow().max_active
+        }
+
+        fn last_id(&self) -> u64 {
+            self.state.borrow().next_id
+        }
+
+        fn callback_can_act(&self, id: u64) -> bool {
+            let state = self.state.borrow();
+            state.active.contains(&id) && !state.cancelled.contains(&id)
+        }
+    }
+
+    struct ManualTimerWait {
+        id: u64,
+        state: Rc<RefCell<ManualTimerState>>,
+    }
+
+    impl Future for ManualTimerWait {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, _context: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Pending
+        }
+    }
+
+    impl Drop for ManualTimerWait {
+        fn drop(&mut self) {
+            let mut state = self.state.borrow_mut();
+            state.active.remove(&self.id);
+            state.cancelled.insert(self.id);
+        }
+    }
+
+    impl DriverTimerBackend for ManualTimerBackend {
+        fn wait(&self, delay_ms: Option<u64>) -> futures::future::LocalBoxFuture<'static, ()> {
+            if delay_ms.is_none() {
+                return Box::pin(future::pending());
+            }
+            let id = {
+                let mut state = self.state.borrow_mut();
+                state.next_id += 1;
+                let id = state.next_id;
+                state.active.insert(id);
+                state.max_active = state.max_active.max(state.active.len());
+                id
+            };
+            Box::pin(ManualTimerWait {
+                id,
+                state: self.state.clone(),
+            })
+        }
+    }
 
     fn test_inner() -> Rc<RefCell<WaddleClientInner>> {
         Rc::new(RefCell::new(WaddleClientInner {
@@ -698,11 +1263,12 @@ mod tests {
                 resource: "web".to_string(),
                 resume_state: None,
             },
-            cmd_tx: None,
+            command_owner: Weak::new(),
             on_message: None,
             on_presence: None,
             on_connected: None,
             on_session_lifecycle: None,
+            on_stream_management: None,
             on_disconnected: None,
             on_error: None,
             on_message_delivery_acked: None,
@@ -712,6 +1278,179 @@ mod tests {
             on_call: None,
             resume_state: None,
         }))
+    }
+
+    fn test_config(resume_state: Option<waddle_xmpp_client::SmResumeState>) -> ClientConfig {
+        build_client_config(&StoredConfig {
+            server_url: "wss://xmpp.example.test/ws".to_string(),
+            jid: "alice@example.test".to_string(),
+            access_token: "token".to_string(),
+            resource: "web".to_string(),
+            resume_state,
+        })
+        .expect("test config")
+    }
+
+    fn test_driver(
+        config: ClientConfig,
+    ) -> (
+        WasmDriverTask,
+        FakeWireState,
+        mpsc::Receiver<DriverEvent>,
+        Rc<RefCell<WaddleClientInner>>,
+    ) {
+        let (wire, wire_state) = FakeWire::new();
+        let (_command_sender, command_receiver) = mpsc::channel(16);
+        let (event_sender, event_receiver) = mpsc::channel(256);
+        let inner = test_inner();
+        let task = WasmDriverTask::new_with_dependencies(
+            config,
+            Box::new(wire),
+            Rc::new(ManualTimerBackend::default()),
+            command_receiver,
+            event_sender,
+            inner.clone(),
+        )
+        .expect("driver task");
+        (task, wire_state, event_receiver, inner)
+    }
+
+    fn pre_auth_features() -> Element {
+        Element::builder("features", waddle_xmpp_client::NS_STREAMS)
+            .append(
+                Element::builder("mechanisms", waddle_xmpp_client::NS_SASL)
+                    .append(
+                        Element::builder("mechanism", waddle_xmpp_client::NS_SASL)
+                            .append("OAUTHBEARER")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build()
+    }
+
+    fn post_auth_features_with_sm() -> Element {
+        Element::builder("features", waddle_xmpp_client::NS_STREAMS)
+            .append(Element::builder("bind", waddle_xmpp_client::NS_BIND).build())
+            .append(
+                Element::builder("sm", waddle_xmpp_client::stream_management::NS_SM)
+                    .attr(minidom::rxml::xml_ncname!("resume").to_owned(), "true")
+                    .build(),
+            )
+            .build()
+    }
+
+    fn bind_result(stanza_id: &str) -> Element {
+        Element::builder("iq", NS_CLIENT)
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), stanza_id)
+            .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+            .append(
+                Element::builder("bind", waddle_xmpp_client::NS_BIND)
+                    .append(
+                        Element::builder("jid", waddle_xmpp_client::NS_BIND)
+                            .append("alice@example.test/web")
+                            .build(),
+                    )
+                    .build(),
+            )
+            .build()
+    }
+
+    async fn drive_to_post_auth_sm_features(task: &mut WasmDriverTask) {
+        task.runtime
+            .queue_request(ClientRequest::Connect)
+            .expect("connect request");
+        assert!(
+            task.apply_transport_event(TransportEvent::StateChanged(TransportState::Open))
+                .await
+        );
+        assert!(
+            task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Open(
+                waddle_xmpp_client::transport::StreamOpen::from_server(
+                    BareJid::from_str("example.test").expect("server jid"),
+                )
+            ),))
+                .await
+        );
+        assert!(
+            task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+                pre_auth_features()
+            ),))
+                .await
+        );
+        assert!(
+            task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+                Element::builder("success", waddle_xmpp_client::NS_SASL).build(),
+            ),))
+                .await
+        );
+        assert!(
+            task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Open(
+                waddle_xmpp_client::transport::StreamOpen::from_server(
+                    BareJid::from_str("example.test").expect("server jid"),
+                )
+            ),))
+                .await
+        );
+        assert!(
+            task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+                post_auth_features_with_sm()
+            ),))
+                .await
+        );
+    }
+
+    async fn drive_to_fresh_sm_enabled(task: &mut WasmDriverTask) {
+        drive_to_post_auth_sm_features(task).await;
+        assert!(
+            task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+                bind_result("bind-1")
+            ),))
+                .await
+        );
+        assert!(
+            task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+                Element::builder("enabled", waddle_xmpp_client::stream_management::NS_SM,)
+                    .attr(minidom::rxml::xml_ncname!("id").to_owned(), "stream-1")
+                    .attr(minidom::rxml::xml_ncname!("resume").to_owned(), "true")
+                    .build(),
+            ),))
+                .await
+        );
+        assert!(task.runtime.can_send_app_stanza());
+    }
+
+    async fn apply_test_transport_event_at(
+        task: &mut WasmDriverTask,
+        event: TransportEvent,
+        now_ms: u64,
+    ) -> bool {
+        let events = task
+            .runtime
+            .apply_transport_event_at(event, now_ms)
+            .expect("test transport event");
+        task.publish_resume_state_snapshot();
+        for event in events {
+            if !task.handle_client_event(event).await {
+                return false;
+            }
+        }
+        task.flush_deferred_commands().await
+    }
+
+    fn take_ack_request_attempts(events: &mut mpsc::Receiver<DriverEvent>) -> Vec<(u32, u32)> {
+        let mut attempts = Vec::new();
+        while let Ok(event) = events.try_recv() {
+            if let DriverEvent::Client(event) = event {
+                if let ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                    StreamManagementEvent::AckRequestSent { attempt, unacked },
+                )) = *event
+                {
+                    attempts.push((attempt, unacked));
+                }
+            }
+        }
+        attempts
     }
 
     fn build_archived(mam_id: &str, query_id: &str, body: &str) -> ArchivedMessage {
@@ -996,6 +1735,898 @@ mod tests {
         publish_resume_state_snapshot(&inner, &runtime, true);
 
         assert!(inner.borrow().resume_state.is_none());
+    }
+
+    #[test]
+    fn wasm_peer_initiated_close_writes_reciprocal_before_websocket_close() {
+        block_on(async {
+            let (mut task, wire, _events, inner) = test_driver(test_config(None));
+            drive_to_fresh_sm_enabled(&mut task).await;
+            wire.take_messages();
+            let (responder, response) = oneshot::channel();
+            assert!(
+                task.handle_command(Some(WasmCommand::SendStanza {
+                    stanza: Element::builder("message", NS_CLIENT)
+                        .attr(
+                            minidom::rxml::xml_ncname!("id").to_owned(),
+                            "wasm-peer-close",
+                        )
+                        .build(),
+                    responder,
+                }))
+                .await
+            );
+            assert!(response.await.expect("send response").is_ok());
+            wire.take_messages();
+            assert!(inner.borrow().resume_state.is_some());
+
+            assert!(
+                task.apply_transport_event(TransportEvent::MessageReceived(
+                    TransportMessage::Close(StreamClose),
+                ))
+                .await
+            );
+
+            assert_final_ack_then_close(&wire.take_messages(), "0");
+            assert_eq!(wire.close_count.get(), 1);
+            assert!(task.websocket_close_started);
+            assert!(task.runtime.stream_close_complete());
+            assert!(inner.borrow().resume_state.is_none());
+        });
+    }
+
+    #[test]
+    fn wasm_local_close_waits_for_peer_before_websocket_close_and_sm_destruction() {
+        block_on(async {
+            let (mut task, wire, _events, inner) = test_driver(test_config(None));
+            drive_to_fresh_sm_enabled(&mut task).await;
+            wire.take_messages();
+            let (send_responder, send_response) = oneshot::channel();
+            assert!(
+                task.handle_command(Some(WasmCommand::SendStanza {
+                    stanza: Element::builder("message", NS_CLIENT)
+                        .attr(
+                            minidom::rxml::xml_ncname!("id").to_owned(),
+                            "wasm-local-close",
+                        )
+                        .build(),
+                    responder: send_responder,
+                }))
+                .await
+            );
+            assert!(send_response.await.expect("send response").is_ok());
+            wire.take_messages();
+
+            let (responder, response) = oneshot::channel();
+            assert!(
+                task.handle_command(Some(WasmCommand::Disconnect { responder }))
+                    .await
+            );
+            assert!(response.await.expect("disconnect response").is_ok());
+            assert_final_ack_then_close(&wire.take_messages(), "0");
+            assert_eq!(wire.close_count.get(), 0);
+            assert!(!task.runtime.stream_close_complete());
+            assert!(inner.borrow().resume_state.is_some());
+
+            let (ack_responder, ack_response) = oneshot::channel();
+            assert!(
+                task.handle_command(Some(WasmCommand::RequestStreamManagementAck {
+                    responder: ack_responder,
+                }))
+                .await
+            );
+            assert!(ack_response.await.expect("ack response").is_ok());
+            assert!(wire.take_messages().is_empty());
+            assert!(
+                task.apply_transport_event(TransportEvent::MessageReceived(
+                    TransportMessage::Element(
+                        waddle_xmpp_client::stream_management::SmState::build_request_ack(),
+                    ),
+                ))
+                .await
+            );
+            assert!(wire.take_messages().is_empty());
+            assert!(
+                task.apply_transport_event(TransportEvent::MessageReceived(
+                    TransportMessage::Element(
+                        waddle_xmpp_client::stream_management::SmState::build_ack(1),
+                    ),
+                ))
+                .await
+            );
+            assert!(wire.take_messages().is_empty());
+            assert!(inner
+                .borrow()
+                .resume_state
+                .as_ref()
+                .is_some_and(|state| !state.has_unhandled_outbound_stanzas()));
+
+            assert!(
+                task.apply_transport_event(TransportEvent::MessageReceived(
+                    TransportMessage::Close(StreamClose),
+                ))
+                .await
+            );
+            assert_eq!(wire.close_count.get(), 1);
+            assert!(task.websocket_close_started);
+            assert!(task.runtime.stream_close_complete());
+            assert!(inner.borrow().resume_state.is_none());
+        });
+    }
+
+    #[test]
+    fn repeated_wasm_disconnects_coalesce_to_one_xml_and_websocket_close() {
+        block_on(async {
+            let (mut task, wire, _events, _inner) = test_driver(test_config(None));
+            drive_to_fresh_sm_enabled(&mut task).await;
+            wire.take_messages();
+
+            for _ in 0..2 {
+                let (responder, response) = oneshot::channel();
+                assert!(
+                    task.handle_command(Some(WasmCommand::Disconnect { responder }))
+                        .await
+                );
+                assert!(response.await.expect("disconnect response").is_ok());
+            }
+            assert_final_ack_then_close(&wire.take_messages(), "0");
+            assert_eq!(wire.close_count.get(), 0);
+
+            assert!(
+                task.apply_transport_event(TransportEvent::MessageReceived(
+                    TransportMessage::Close(StreamClose),
+                ))
+                .await
+            );
+            assert_eq!(wire.close_count.get(), 1);
+        });
+    }
+
+    #[test]
+    fn wasm_driver_keeps_one_close_when_peer_arrives_before_write_confirmation() {
+        block_on(async {
+            let (mut task, wire, _events, _inner) = test_driver(test_config(None));
+            drive_to_fresh_sm_enabled(&mut task).await;
+            wire.take_messages();
+
+            let requested = task.runtime.request_stream_close().unwrap();
+            let close = requested
+                .into_iter()
+                .find_map(|event| match event {
+                    ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                        message @ TransportMessage::Close(_),
+                    )) => Some(message),
+                    _ => None,
+                })
+                .expect("one claimed close");
+
+            assert!(
+                task.apply_transport_event(TransportEvent::MessageReceived(
+                    TransportMessage::Close(StreamClose),
+                ))
+                .await
+            );
+            assert!(wire.take_messages().is_empty());
+            assert!(!task.runtime.stream_close_complete());
+
+            task.send_transport_message(close).await.unwrap();
+            assert!(matches!(
+                wire.take_messages().as_slice(),
+                [TransportMessage::Close(_)]
+            ));
+            assert!(task.runtime.stream_close_complete());
+            assert_eq!(wire.close_count.get(), 1);
+
+            assert!(
+                task.apply_transport_event(TransportEvent::MessageReceived(
+                    TransportMessage::Close(StreamClose),
+                ))
+                .await
+            );
+            assert_eq!(wire.close_count.get(), 1);
+        });
+    }
+
+    #[test]
+    fn wasm_command_channel_loss_before_close_aborts_and_preserves_resume_state() {
+        block_on(async {
+            let (mut task, wire, _events, inner) = test_driver(test_config(None));
+            drive_to_fresh_sm_enabled(&mut task).await;
+            wire.take_messages();
+            let (responder, response) = oneshot::channel();
+            assert!(
+                task.handle_command(Some(WasmCommand::SendStanza {
+                    stanza: Element::builder("message", NS_CLIENT)
+                        .attr(
+                            minidom::rxml::xml_ncname!("id").to_owned(),
+                            "wasm-channel-loss",
+                        )
+                        .build(),
+                    responder,
+                }))
+                .await
+            );
+            assert!(response.await.expect("send response").is_ok());
+            let resume_before = inner.borrow().resume_state.clone();
+
+            assert!(!task.handle_command(None).await);
+            assert!(task.commands_closed);
+            assert_eq!(wire.close_count.get(), 1);
+            assert_eq!(inner.borrow().resume_state, resume_before);
+        });
+    }
+
+    #[test]
+    fn dropping_last_waddle_client_wrapper_aborts_live_socket_once_and_preserves_resume() {
+        block_on(async {
+            let client = WaddleClient::new(WaddleConfig::new(
+                "wss://xmpp.example.test/ws".to_string(),
+                "alice@example.test".to_string(),
+                "token".to_string(),
+                "web".to_string(),
+            ));
+            let inner = client.inner.clone();
+            let (command_sender, command_receiver) = mpsc::channel(16);
+            *client._command_owner.borrow_mut() = Some(command_sender);
+            let (event_sender, mut event_receiver) = mpsc::channel(256);
+            let (wire, wire_state) = FakeWire::new();
+            let mut task = WasmDriverTask::new_with_dependencies(
+                test_config(None),
+                Box::new(wire),
+                Rc::new(ManualTimerBackend::default()),
+                command_receiver,
+                event_sender,
+                inner.clone(),
+            )
+            .expect("driver task");
+
+            drive_to_fresh_sm_enabled(&mut task).await;
+            wire_state.take_messages();
+            let resume_before = inner
+                .borrow()
+                .resume_state
+                .clone()
+                .expect("live resumable session");
+
+            drop(client);
+            assert!(inner.borrow().command_owner.upgrade().is_none());
+
+            task.run_input_loop().await;
+            task.finish().await;
+
+            assert!(task.commands_closed);
+            assert_eq!(wire_state.close_count.get(), 1);
+            assert_eq!(inner.borrow().resume_state.as_ref(), Some(&resume_before));
+            let disconnected = std::iter::from_fn(|| event_receiver.try_recv().ok())
+                .filter(|event| matches!(event, DriverEvent::Disconnected))
+                .count();
+            assert_eq!(disconnected, 1);
+        });
+    }
+
+    #[test]
+    fn wasm_channel_loss_during_half_close_waits_then_times_out_uncleanly() {
+        block_on(async {
+            let (mut task, wire, _events, inner) = test_driver(test_config(None));
+            drive_to_fresh_sm_enabled(&mut task).await;
+            wire.take_messages();
+            let (send_responder, send_response) = oneshot::channel();
+            assert!(
+                task.handle_command(Some(WasmCommand::SendStanza {
+                    stanza: Element::builder("message", NS_CLIENT)
+                        .attr(
+                            minidom::rxml::xml_ncname!("id").to_owned(),
+                            "wasm-half-close-timeout",
+                        )
+                        .build(),
+                    responder: send_responder,
+                }))
+                .await
+            );
+            assert!(send_response.await.expect("send response").is_ok());
+            wire.take_messages();
+            let (disconnect_responder, disconnect_response) = oneshot::channel();
+            assert!(
+                task.handle_command(Some(WasmCommand::Disconnect {
+                    responder: disconnect_responder,
+                }))
+                .await
+            );
+            assert!(disconnect_response
+                .await
+                .expect("disconnect response")
+                .is_ok());
+            let resume_before = inner.borrow().resume_state.clone();
+
+            assert!(task.handle_command(None).await);
+            assert!(task.commands_closed);
+            assert_eq!(wire.close_count.get(), 0);
+            assert!(!task.handle_driver_timer(true).await);
+            assert_eq!(wire.close_count.get(), 1);
+            assert_eq!(inner.borrow().resume_state, resume_before);
+        });
+    }
+
+    #[test]
+    fn wasm_failed_peer_close_reciprocal_preserves_resume_state() {
+        block_on(async {
+            let (mut task, wire, _events, inner) = test_driver(test_config(None));
+            drive_to_fresh_sm_enabled(&mut task).await;
+            wire.take_messages();
+            let (responder, response) = oneshot::channel();
+            assert!(
+                task.handle_command(Some(WasmCommand::SendStanza {
+                    stanza: Element::builder("message", NS_CLIENT)
+                        .attr(
+                            minidom::rxml::xml_ncname!("id").to_owned(),
+                            "wasm-close-failure",
+                        )
+                        .build(),
+                    responder,
+                }))
+                .await
+            );
+            assert!(response.await.expect("send response").is_ok());
+            wire.take_messages();
+            let resume_before = inner.borrow().resume_state.clone();
+            wire.fail_after_successful_sends(0);
+
+            assert!(
+                !task
+                    .apply_transport_event(TransportEvent::MessageReceived(
+                        TransportMessage::Close(StreamClose),
+                    ))
+                    .await
+            );
+
+            assert_eq!(inner.borrow().resume_state, resume_before);
+            assert!(!task.runtime.stream_close_complete());
+            assert!(!task.websocket_close_started);
+            assert_eq!(wire.close_count.get(), 1, "unclean transport abort only");
+            assert!(wire.take_messages().is_empty());
+        });
+    }
+
+    #[test]
+    fn fresh_send_command_pumps_stanza_then_exactly_one_typed_ack_request() {
+        block_on(async {
+            let (mut task, wire, _events, _inner) = test_driver(test_config(None));
+            drive_to_fresh_sm_enabled(&mut task).await;
+            wire.take_messages();
+
+            let stanza = Element::builder("message", NS_CLIENT)
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "fresh-1")
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+                .build();
+            let (responder, response) = oneshot::channel();
+
+            assert!(
+                task.handle_command(Some(WasmCommand::SendStanza { stanza, responder }))
+                    .await
+            );
+            assert!(response.await.expect("command response").is_ok());
+
+            let messages = wire.take_messages();
+            assert_eq!(messages.len(), 2);
+            assert!(matches!(
+                &messages[0],
+                TransportMessage::Element(element)
+                    if element.name() == "message" && element.attr("id") == Some("fresh-1")
+            ));
+            assert!(matches!(
+                &messages[1],
+                TransportMessage::Element(element)
+                    if waddle_xmpp_client::stream_management::SmState::is_request_ack(element)
+            ));
+        });
+    }
+
+    #[test]
+    fn definitely_not_written_ack_request_retries_without_failing_confirmed_message() {
+        block_on(async {
+            let (mut task, wire, mut events, inner) = test_driver(test_config(None));
+            drive_to_fresh_sm_enabled(&mut task).await;
+            wire.take_messages();
+            wire.fail_after_successful_sends(1);
+            let attempts_before = wire.send_attempt_count();
+
+            let stanza = Element::builder("message", NS_CLIENT)
+                .attr(
+                    minidom::rxml::xml_ncname!("id").to_owned(),
+                    "confirmed-wasm",
+                )
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+                .build();
+            let (responder, response) = oneshot::channel();
+
+            assert!(
+                task.handle_command(Some(WasmCommand::SendStanza { stanza, responder }))
+                    .await
+            );
+            assert!(
+                response.await.expect("command response").is_ok(),
+                "a generated control-frame failure must not return a retryable message result"
+            );
+
+            assert_eq!(wire.send_attempt_count() - attempts_before, 2);
+            let messages = wire.take_messages();
+            assert_eq!(messages.len(), 1, "only the initiating frame was accepted");
+            assert!(matches!(
+                &messages[0],
+                TransportMessage::Element(element)
+                    if element.name() == "message" && element.attr("id") == Some("confirmed-wasm")
+            ));
+            let resume = inner
+                .borrow()
+                .resume_state
+                .clone()
+                .expect("confirmed stanza remains resumable");
+            assert_eq!(
+                resume
+                    .unhandled_message_stanza_ids()
+                    .iter()
+                    .map(StanzaId::as_str)
+                    .collect::<Vec<_>>(),
+                vec!["confirmed-wasm"]
+            );
+            assert_eq!(wire.close_count.get(), 0);
+
+            let mut failed_delivery_count = 0;
+            let mut saw_failed = false;
+            let mut saw_closed = false;
+            let mut saw_disconnected = false;
+            while let Ok(event) = events.try_recv() {
+                match event {
+                    DriverEvent::Client(event) => match *event {
+                        ClientEvent::MessageDelivery(MessageDeliveryEvent::Failed {
+                            ref stanza_id,
+                        }) if stanza_id.as_str() == "confirmed-wasm" => {
+                            failed_delivery_count += 1;
+                        }
+                        ClientEvent::Transport(TransportEvent::StateChanged(
+                            TransportState::Failed,
+                        )) => saw_failed = true,
+                        ClientEvent::Transport(TransportEvent::Closed) => saw_closed = true,
+                        _ => {}
+                    },
+                    DriverEvent::Disconnected => saw_disconnected = true,
+                    _ => {}
+                }
+            }
+            assert_eq!(failed_delivery_count, 0);
+            assert!(!saw_failed);
+            assert!(!saw_closed);
+            assert!(!saw_disconnected);
+
+            assert!(
+                task.handle_stream_management_timer_at(
+                    waddle_xmpp_client::runtime::monotonic_now_ms().saturating_add(300),
+                )
+                .await
+            );
+            assert_eq!(wire.send_attempt_count() - attempts_before, 3);
+            let retry = wire.take_messages();
+            assert!(matches!(
+                retry.as_slice(),
+                [TransportMessage::Element(element)]
+                    if waddle_xmpp_client::stream_management::SmState::is_request_ack(element)
+            ));
+
+            let mut saw_retry_confirmation = false;
+            while let Ok(event) = events.try_recv() {
+                if matches!(
+                    event,
+                    DriverEvent::Client(event)
+                        if matches!(
+                            *event,
+                            ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                                StreamManagementEvent::AckRequestSent { attempt: 2, .. }
+                            ))
+                        )
+                ) {
+                    saw_retry_confirmation = true;
+                }
+            }
+            assert!(saw_retry_confirmation);
+        });
+    }
+
+    #[test]
+    fn terminal_no_sm_disconnect_does_not_retain_confirmed_fallback_ownership() {
+        block_on(async {
+            let fallback_id = "wasm-fallback-confirmed";
+            let replay = Element::builder("message", NS_CLIENT)
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), fallback_id)
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+                .build();
+            let resume_state = waddle_xmpp_client::SmResumeState::from_unhandled_outbound_stanzas(
+                "previous-stream",
+                0,
+                1,
+                [replay],
+            )
+            .expect("resume state");
+            let (mut task, wire, _events, inner) = test_driver(test_config(Some(resume_state)));
+
+            drive_to_post_auth_sm_features(&mut task).await;
+            wire.take_messages();
+            assert!(
+                task.apply_transport_event(TransportEvent::MessageReceived(
+                    TransportMessage::Element(
+                        Element::builder("failed", waddle_xmpp_client::stream_management::NS_SM,)
+                            .attr(minidom::rxml::xml_ncname!("h").to_owned(), "0",)
+                            .build(),
+                    ),
+                ))
+                .await
+            );
+            wire.take_messages();
+            assert!(
+                task.apply_transport_event(TransportEvent::MessageReceived(
+                    TransportMessage::Element(bind_result("bind-1")),
+                ))
+                .await
+            );
+            wire.take_messages();
+            assert!(
+                task.apply_transport_event(TransportEvent::MessageReceived(
+                    TransportMessage::Element(
+                        Element::builder("failed", waddle_xmpp_client::stream_management::NS_SM,)
+                            .build(),
+                    ),
+                ))
+                .await
+            );
+
+            assert_eq!(
+                wire.take_messages()
+                    .iter()
+                    .filter(|message| {
+                        matches!(
+                            message,
+                            TransportMessage::Element(element)
+                                if element.attr("id") == Some(fallback_id)
+                        )
+                    })
+                    .count(),
+                1,
+                "the WASM driver must not duplicate the confirmed fallback on the same stream"
+            );
+            assert!(
+                inner.borrow().resume_state.is_none(),
+                "confirmed no-SM fallback must release the native snapshot"
+            );
+
+            assert!(
+                task.apply_transport_event(TransportEvent::StateChanged(TransportState::Failed,))
+                    .await
+            );
+            let reconnect_state = inner.borrow().resume_state.clone();
+            assert!(reconnect_state.is_none());
+
+            let (mut reconnect, reconnect_wire, _events, _inner) =
+                test_driver(test_config(reconnect_state));
+            drive_to_fresh_sm_enabled(&mut reconnect).await;
+            assert!(
+                reconnect_wire.take_messages().iter().all(|message| {
+                    !matches!(
+                        message,
+                        TransportMessage::Element(element)
+                            if element.attr("id") == Some(fallback_id)
+                    )
+                }),
+                "a new native runtime must not replay a fallback it no longer owns"
+            );
+        });
+    }
+
+    #[test]
+    fn successful_resume_pumps_replay_then_exactly_one_immediate_ack_request() {
+        block_on(async {
+            let replay = Element::builder("message", NS_CLIENT)
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "replay-1")
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+                .build();
+            let resume_state = waddle_xmpp_client::SmResumeState::from_unhandled_outbound_stanzas(
+                "previous-stream",
+                0,
+                1,
+                [replay],
+            )
+            .expect("resume state");
+            let (mut task, wire, _events, _inner) = test_driver(test_config(Some(resume_state)));
+            drive_to_post_auth_sm_features(&mut task).await;
+            wire.take_messages();
+
+            assert!(
+                task.apply_transport_event(TransportEvent::MessageReceived(
+                    TransportMessage::Element(
+                        Element::builder("resumed", waddle_xmpp_client::stream_management::NS_SM,)
+                            .attr(
+                                minidom::rxml::xml_ncname!("previd").to_owned(),
+                                "previous-stream",
+                            )
+                            .attr(minidom::rxml::xml_ncname!("h").to_owned(), "0")
+                            .build(),
+                    ),
+                ))
+                .await
+            );
+
+            let messages = wire.take_messages();
+            assert_eq!(messages.len(), 2);
+            assert!(matches!(
+                &messages[0],
+                TransportMessage::Element(element)
+                    if element.name() == "message" && element.attr("id") == Some("replay-1")
+            ));
+            assert!(matches!(
+                &messages[1],
+                TransportMessage::Element(element)
+                    if waddle_xmpp_client::stream_management::SmState::is_request_ack(element)
+            ));
+            assert_eq!(
+                task.runtime
+                    .resume_state()
+                    .expect("live resume state")
+                    .outbound_h(),
+                1
+            );
+        });
+    }
+
+    #[test]
+    fn successful_resume_drives_full_wire_retry_ladder_and_original_stall_deadline() {
+        block_on(async {
+            let replay = Element::builder("message", NS_CLIENT)
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "retry-replay")
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+                .build();
+            let resume_state = waddle_xmpp_client::SmResumeState::from_unhandled_outbound_stanzas(
+                "previous-stream",
+                0,
+                1,
+                [replay],
+            )
+            .expect("resume state");
+            let (mut task, wire, mut events, _inner) = test_driver(test_config(Some(resume_state)));
+            drive_to_post_auth_sm_features(&mut task).await;
+            wire.take_messages();
+            take_ack_request_attempts(&mut events);
+
+            assert!(
+                apply_test_transport_event_at(
+                    &mut task,
+                    TransportEvent::MessageReceived(TransportMessage::Element(
+                        Element::builder("resumed", waddle_xmpp_client::stream_management::NS_SM)
+                            .attr(
+                                minidom::rxml::xml_ncname!("previd").to_owned(),
+                                "previous-stream",
+                            )
+                            .attr(minidom::rxml::xml_ncname!("h").to_owned(), "0")
+                            .build(),
+                    )),
+                    10_000,
+                )
+                .await
+            );
+            let resume_writes = wire.take_messages();
+            assert_eq!(resume_writes.len(), 2, "replay then immediate <r/>");
+            assert!(matches!(
+                &resume_writes[0],
+                TransportMessage::Element(element)
+                    if element.name() == "message" && element.attr("id") == Some("retry-replay")
+            ));
+            assert!(matches!(
+                &resume_writes[1],
+                TransportMessage::Element(element)
+                    if waddle_xmpp_client::stream_management::SmState::is_request_ack(element)
+            ));
+            assert_eq!(take_ack_request_attempts(&mut events), vec![(1, 1)]);
+            assert_eq!(
+                task.runtime
+                    .resume_state()
+                    .expect("resume snapshot")
+                    .outbound_h(),
+                1,
+                "replay must not increment outbound h"
+            );
+
+            let mut ack_at_ms = 10_010;
+            for (delay_ms, expected_attempt) in [
+                (250, 2),
+                (500, 3),
+                (1_000, 4),
+                (2_000, 5),
+                (5_000, 6),
+                (5_000, 7),
+            ] {
+                assert!(
+                    apply_test_transport_event_at(
+                        &mut task,
+                        TransportEvent::MessageReceived(TransportMessage::Element(
+                            Element::builder("a", waddle_xmpp_client::stream_management::NS_SM,)
+                                .attr(minidom::rxml::xml_ncname!("h").to_owned(), "0")
+                                .build(),
+                        )),
+                        ack_at_ms,
+                    )
+                    .await
+                );
+                assert!(wire.take_messages().is_empty());
+
+                let request_at_ms = ack_at_ms + delay_ms;
+                assert!(task.handle_stream_management_timer_at(request_at_ms).await);
+                let retry_writes = wire.take_messages();
+                assert_eq!(retry_writes.len(), 1);
+                assert!(matches!(
+                    &retry_writes[0],
+                    TransportMessage::Element(element)
+                        if waddle_xmpp_client::stream_management::SmState::is_request_ack(element)
+                ));
+                assert_eq!(
+                    take_ack_request_attempts(&mut events),
+                    vec![(expected_attempt, 1)]
+                );
+                ack_at_ms = request_at_ms + 1;
+            }
+
+            assert!(
+                !task.handle_stream_management_timer_at(40_000).await,
+                "30s without h progress must terminate from the original 10s epoch"
+            );
+            assert_eq!(wire.close_count.get(), 1);
+            assert_eq!(
+                task.runtime
+                    .resume_state()
+                    .expect("stalled resume snapshot")
+                    .outbound_h(),
+                1
+            );
+        });
+    }
+
+    #[test]
+    fn typed_pagehide_command_pumps_ack_request_before_resolving() {
+        block_on(async {
+            let (mut task, wire, _events, _inner) = test_driver(test_config(None));
+            drive_to_fresh_sm_enabled(&mut task).await;
+            wire.take_messages();
+
+            let stanza = Element::builder("message", NS_CLIENT)
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "pagehide-1")
+                .build();
+            let (send_responder, send_response) = oneshot::channel();
+            assert!(
+                task.handle_command(Some(WasmCommand::SendStanza {
+                    stanza,
+                    responder: send_responder,
+                }))
+                .await
+            );
+            assert!(send_response.await.expect("send response").is_ok());
+            wire.take_messages();
+
+            assert!(
+                task.apply_transport_event(TransportEvent::MessageReceived(
+                    TransportMessage::Element(
+                        Element::builder("a", waddle_xmpp_client::stream_management::NS_SM)
+                            .attr(minidom::rxml::xml_ncname!("h").to_owned(), "0")
+                            .build(),
+                    ),
+                ))
+                .await
+            );
+            let (ack_responder, ack_response) = oneshot::channel();
+            assert!(
+                task.handle_command(Some(WasmCommand::RequestStreamManagementAck {
+                    responder: ack_responder,
+                }))
+                .await
+            );
+            assert!(ack_response.await.expect("ack command response").is_ok());
+
+            let messages = wire.take_messages();
+            assert_eq!(messages.len(), 1);
+            assert!(matches!(
+                &messages[0],
+                TransportMessage::Element(element)
+                    if waddle_xmpp_client::stream_management::SmState::is_request_ack(element)
+            ));
+        });
+    }
+
+    #[test]
+    fn canceled_sm_timers_cannot_survive_socket_command_or_shutdown_wins() {
+        block_on(async {
+            let backend = ManualTimerBackend::default();
+            for index in 0..12 {
+                let input = if index % 2 == 0 {
+                    select_driver_input(
+                        future::ready(Some(WasmTransportEvent::Open)),
+                        future::pending::<Option<WasmCommand>>(),
+                        backend.wait(Some(5_000)),
+                    )
+                    .await
+                } else {
+                    let (responder, _response) = oneshot::channel();
+                    select_driver_input(
+                        future::pending::<Option<WasmTransportEvent>>(),
+                        future::ready(Some(WasmCommand::RequestStreamManagementAck { responder })),
+                        backend.wait(Some(5_000)),
+                    )
+                    .await
+                };
+                assert!(matches!(
+                    input,
+                    DriverInput::Wire(_) | DriverInput::Command(_)
+                ));
+                assert_eq!(backend.active_count(), 0);
+                assert!(backend.max_active() <= 1);
+            }
+
+            let old_timer = backend.wait(Some(5_000));
+            let old_id = backend.last_id();
+            assert!(backend.callback_can_act(old_id));
+            drop(old_timer);
+            let replacement = backend.wait(Some(5_000));
+            let replacement_id = backend.last_id();
+            assert!(!backend.callback_can_act(old_id));
+            assert!(backend.callback_can_act(replacement_id));
+            drop(replacement);
+            assert!(!backend.callback_can_act(replacement_id));
+            assert_eq!(backend.active_count(), 0);
+        });
+    }
+
+    #[test]
+    fn wasm_stall_preserves_resume_state_and_emits_stall_then_disconnect() {
+        block_on(async {
+            let (mut task, wire, mut events, inner) = test_driver(test_config(None));
+            drive_to_fresh_sm_enabled(&mut task).await;
+            wire.take_messages();
+
+            let stanza = Element::builder("message", NS_CLIENT)
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "stalled-1")
+                .build();
+            let (responder, response) = oneshot::channel();
+            assert!(
+                task.handle_command(Some(WasmCommand::SendStanza { stanza, responder }))
+                    .await
+            );
+            assert!(response.await.expect("send response").is_ok());
+            let resume_before = inner.borrow().resume_state.clone();
+            assert!(resume_before.is_some());
+
+            assert!(!task.handle_stream_management_timer_at(u64::MAX).await);
+            task.finish().await;
+
+            assert_eq!(wire.close_count.get(), 1);
+            assert_eq!(inner.borrow().resume_state, resume_before);
+            let mut saw_stall = false;
+            let mut saw_disconnected = false;
+            while let Ok(event) = events.try_recv() {
+                match event {
+                    DriverEvent::Client(event)
+                        if matches!(
+                            *event,
+                            ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                                StreamManagementEvent::AckProgressStalled { .. }
+                            ))
+                        ) =>
+                    {
+                        saw_stall = true;
+                    }
+                    DriverEvent::Disconnected => saw_disconnected = true,
+                    _ => {}
+                }
+            }
+            assert!(saw_stall, "browser telemetry needs the reconnect signal");
+            assert!(
+                saw_disconnected,
+                "browser lifecycle needs the disconnect signal"
+            );
+        });
     }
 
     fn iq(id: &str) -> Element {

--- a/server/crates/waddle-xmpp-client-wasm/src/events.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/events.rs
@@ -10,9 +10,12 @@ pub(crate) async fn event_dispatch_loop(
             DriverEvent::ResumeState(state) => {
                 inner.borrow_mut().resume_state = state;
             }
-            DriverEvent::Error(description) => emit_error_callback(&inner, &description),
+            DriverEvent::Error(error) => emit_error_callback(&inner, &error),
             DriverEvent::Disconnected => {
-                inner.borrow_mut().cmd_tx = None;
+                let command_owner = inner.borrow().command_owner.upgrade();
+                if let Some(command_owner) = command_owner {
+                    command_owner.borrow_mut().take();
+                }
                 // Clone the callback before invoking it so a JS handler that
                 // synchronously re-enters the WaddleClient via a `send_*`
                 // method (which takes `borrow_mut`) does not panic on an
@@ -56,6 +59,44 @@ pub(crate) fn dispatch_client_event(inner: &Rc<RefCell<WaddleClientInner>>, even
                 let _ = callback.call1(&JsValue::NULL, &JsValue::from_str("resumed"));
             }
         }
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::AckRequestSent { attempt, unacked },
+        )) => emit_stream_management_callback(
+            inner,
+            JsStreamManagementTelemetry::Request { attempt, unacked },
+        ),
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::AckObserved {
+                progressed,
+                latency_ms,
+                unacked,
+            },
+        )) => emit_stream_management_callback(
+            inner,
+            JsStreamManagementTelemetry::Observed {
+                progressed,
+                latency_ms,
+                unacked,
+            },
+        ),
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::AckRequestTimedOut { unacked },
+        )) => emit_stream_management_callback(
+            inner,
+            JsStreamManagementTelemetry::RequestTimeout { unacked },
+        ),
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::AckProgressStalled {
+                unacked,
+                elapsed_ms,
+            },
+        )) => emit_stream_management_callback(
+            inner,
+            JsStreamManagementTelemetry::ProgressStalled {
+                unacked,
+                elapsed_ms,
+            },
+        ),
         ClientEvent::Connection(ConnectionEvent::StreamError { condition, detail }) => {
             emit_stream_error_callback(inner, condition, detail);
         }
@@ -157,10 +198,39 @@ pub(crate) fn dispatch_client_event(inner: &Rc<RefCell<WaddleClientInner>>, even
     }
 }
 
-pub(crate) fn emit_error_callback(inner: &Rc<RefCell<WaddleClientInner>>, description: &str) {
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+enum JsStreamManagementTelemetry {
+    #[serde(rename = "ack-request")]
+    Request { attempt: u32, unacked: u32 },
+    #[serde(rename = "ack-observed")]
+    Observed {
+        progressed: bool,
+        latency_ms: Option<u64>,
+        unacked: u32,
+    },
+    #[serde(rename = "ack-request-timeout")]
+    RequestTimeout { unacked: u32 },
+    #[serde(rename = "ack-progress-stalled")]
+    ProgressStalled { unacked: u32, elapsed_ms: u64 },
+}
+
+fn emit_stream_management_callback(
+    inner: &Rc<RefCell<WaddleClientInner>>,
+    event: JsStreamManagementTelemetry,
+) {
+    let callback = inner.borrow().on_stream_management.clone();
+    if let Some(callback) = callback {
+        if let Ok(value) = to_js_value(&event) {
+            let _ = callback.call1(&JsValue::NULL, &value);
+        }
+    }
+}
+
+pub(crate) fn emit_error_callback(inner: &Rc<RefCell<WaddleClientInner>>, error: &WasmDriverError) {
     let callback = inner.borrow().on_error.clone();
     if let Some(callback) = callback {
-        let _ = callback.call1(&JsValue::NULL, &JsValue::from_str(description));
+        let _ = callback.call1(&JsValue::NULL, &JsValue::from_str(&error.to_string()));
     }
 }
 

--- a/server/crates/waddle-xmpp-client-wasm/src/lib.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/lib.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, VecDeque};
-use std::rc::Rc;
+use std::rc::{Rc, Weak};
 
 use futures::channel::{mpsc, oneshot};
 use futures::{pin_mut, select, FutureExt, SinkExt, StreamExt};
@@ -42,9 +42,7 @@ use waddle_xmpp_client::pep::{
 use waddle_xmpp_client::pin::{
     build_pin_list_iq, parse_pin_list_response, PinEntry, PinEvent, PinEventAction, PinPreview,
 };
-use waddle_xmpp_client::transport::{
-    StreamClose, TransportEvent, TransportMessage, TransportState,
-};
+use waddle_xmpp_client::transport::{TransportEvent, TransportMessage, TransportState};
 use waddle_xmpp_client::xep::{
     reply::{FallbackRange, ReplyMarker},
     thread::ThreadRef,

--- a/server/crates/waddle-xmpp-client-wasm/src/state.rs
+++ b/server/crates/waddle-xmpp-client-wasm/src/state.rs
@@ -2,6 +2,18 @@ use super::*;
 
 pub(crate) type DriverResult<T> = Result<T, ClientError>;
 
+pub(crate) trait WasmDriverWire {
+    fn events(&mut self) -> &mut mpsc::Receiver<WasmTransportEvent>;
+    fn send_frame(&mut self, frame: &str) -> DriverResult<()>;
+    /// Begin the WebSocket closing handshake. The typed RFC 7395 XML close is
+    /// sent separately through [`Self::send_frame`].
+    fn close_websocket(&mut self) -> DriverResult<()>;
+}
+
+pub(crate) trait DriverTimerBackend {
+    fn wait(&self, delay_ms: Option<u64>) -> futures::future::LocalBoxFuture<'static, ()>;
+}
+
 #[wasm_bindgen]
 pub struct WaddleResumeState {
     pub(crate) inner: waddle_xmpp_client::SmResumeState,
@@ -62,47 +74,35 @@ impl WaddleConfig {
         Ok(())
     }
 
-    pub fn with_resume_state_stanzas(
+    pub fn with_resume_state_entries(
         &mut self,
         previd: String,
         inbound_h: u32,
         outbound_h: u32,
-        stanzas: Vec<String>,
+        entries: JsValue,
     ) -> Result<(), JsValue> {
-        let stanzas = stanzas
-            .into_iter()
-            .map(|xml| {
-                xml.parse::<Element>()
-                    .map_err(|err| js_error(format!("invalid resume stanza XML: {err}")))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let entries = parse_resume_entries(entries)?;
         self.resume_state = Some(
-            waddle_xmpp_client::SmResumeState::from_unhandled_outbound_stanzas(
-                previd, inbound_h, outbound_h, stanzas,
+            waddle_xmpp_client::SmResumeState::from_unhandled_outbound_entries(
+                previd, inbound_h, outbound_h, entries,
             )
             .map_err(|err| js_error(err.to_string()))?,
         );
         Ok(())
     }
 
-    pub fn with_resume_state_stanzas_with_max(
+    pub fn with_resume_state_entries_with_max(
         &mut self,
         previd: String,
         inbound_h: u32,
         outbound_h: u32,
-        stanzas: Vec<String>,
+        entries: JsValue,
         max_resume_seconds: u32,
     ) -> Result<(), JsValue> {
-        let stanzas = stanzas
-            .into_iter()
-            .map(|xml| {
-                xml.parse::<Element>()
-                    .map_err(|err| js_error(format!("invalid resume stanza XML: {err}")))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let entries = parse_resume_entries(entries)?;
         self.resume_state = Some(
-            waddle_xmpp_client::SmResumeState::from_unhandled_outbound_stanzas(
-                previd, inbound_h, outbound_h, stanzas,
+            waddle_xmpp_client::SmResumeState::from_unhandled_outbound_entries(
+                previd, inbound_h, outbound_h, entries,
             )
             .map(|state| state.with_max_resume_seconds(Some(max_resume_seconds)))
             .map_err(|err| js_error(err.to_string()))?,
@@ -113,6 +113,33 @@ impl WaddleConfig {
     pub fn with_resume_state_handle(&mut self, state: &WaddleResumeState) {
         self.resume_state = Some(state.inner.clone());
     }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct JsResumeEntryInput {
+    stanza: String,
+    sent_at: String,
+}
+
+fn parse_resume_entries(
+    entries: JsValue,
+) -> Result<Vec<waddle_xmpp_client::SmResumeEntry>, JsValue> {
+    let entries: Vec<JsResumeEntryInput> = serde_wasm_bindgen::from_value(entries)
+        .map_err(|err| js_error(format!("invalid resume entries: {err}")))?;
+    entries
+        .into_iter()
+        .map(|entry| {
+            let element = entry
+                .stanza
+                .parse::<Element>()
+                .map_err(|err| js_error(format!("invalid resume stanza XML: {err}")))?;
+            let sent_at = chrono::DateTime::parse_from_rfc3339(&entry.sent_at)
+                .map_err(|err| js_error(format!("invalid resume sentAt: {err}")))?
+                .with_timezone(&chrono::Utc);
+            Ok(waddle_xmpp_client::SmResumeEntry::new(element, sent_at))
+        })
+        .collect()
 }
 
 #[derive(Clone)]
@@ -143,22 +170,36 @@ pub(crate) struct JsResumeState {
     pub(crate) inbound_h: u32,
     pub(crate) outbound_h: u32,
     pub(crate) has_unacked_outbound: bool,
-    pub(crate) unhandled_outbound_stanzas: Vec<String>,
+    pub(crate) unhandled_outbound_entries: Vec<JsResumeEntry>,
     pub(crate) max_resume_seconds: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct JsResumeEntry {
+    pub(crate) stanza: String,
+    pub(crate) sent_at: String,
 }
 
 impl From<waddle_xmpp_client::SmResumeState> for JsResumeState {
     fn from(value: waddle_xmpp_client::SmResumeState) -> Self {
-        let unhandled_outbound_stanzas = value
-            .unhandled_outbound_stanzas()
-            .filter_map(|element| element_to_xml_string(element).ok())
+        let unhandled_outbound_entries = value
+            .unhandled_outbound_entries()
+            .filter_map(|entry| {
+                Some(JsResumeEntry {
+                    stanza: element_to_xml_string(entry.element()).ok()?,
+                    sent_at: entry
+                        .sent_at()
+                        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+                })
+            })
             .collect();
         Self {
             previd: value.previd().to_string(),
             inbound_h: value.inbound_h(),
             outbound_h: value.outbound_h(),
             has_unacked_outbound: value.has_unhandled_outbound_stanzas(),
-            unhandled_outbound_stanzas,
+            unhandled_outbound_entries,
             max_resume_seconds: value.max_resume_seconds(),
         }
     }
@@ -167,15 +208,20 @@ impl From<waddle_xmpp_client::SmResumeState> for JsResumeState {
 #[wasm_bindgen]
 pub struct WaddleClient {
     pub(crate) inner: Rc<RefCell<WaddleClientInner>>,
+    /// The JavaScript wrapper is the sole strong owner of command input.
+    /// Driver/event tasks retain only the weak reference in `inner`, so the
+    /// final wrapper drop closes the channel and self-fences the old socket.
+    pub(crate) _command_owner: Rc<RefCell<Option<mpsc::Sender<WasmCommand>>>>,
 }
 
 pub(crate) struct WaddleClientInner {
     pub(crate) config: StoredConfig,
-    pub(crate) cmd_tx: Option<mpsc::Sender<WasmCommand>>,
+    pub(crate) command_owner: Weak<RefCell<Option<mpsc::Sender<WasmCommand>>>>,
     pub(crate) on_message: Option<Function>,
     pub(crate) on_presence: Option<Function>,
     pub(crate) on_connected: Option<Function>,
     pub(crate) on_session_lifecycle: Option<Function>,
+    pub(crate) on_stream_management: Option<Function>,
     pub(crate) on_disconnected: Option<Function>,
     pub(crate) on_error: Option<Function>,
     pub(crate) on_message_delivery_acked: Option<Function>,
@@ -211,6 +257,9 @@ pub(crate) enum WasmCommand {
     },
     CancelIq {
         id: String,
+        responder: oneshot::Sender<DriverResult<()>>,
+    },
+    RequestStreamManagementAck {
         responder: oneshot::Sender<DriverResult<()>>,
     },
     Disconnect {
@@ -256,8 +305,57 @@ pub(crate) use waddle_xmpp_client::inbox::InboxPage;
 pub(crate) enum DriverEvent {
     Client(Box<ClientEvent>),
     ResumeState(Option<waddle_xmpp_client::SmResumeState>),
-    Error(String),
+    Error(WasmDriverError),
     Disconnected,
+}
+
+#[derive(Debug)]
+pub(crate) enum WasmDriverError {
+    Client(ClientError),
+    TransportClosed,
+    Disconnected,
+    InvalidTransportFrame,
+    UnsupportedWebSocketMessage,
+    WebSocketTransport,
+    Runtime,
+}
+
+impl WasmDriverError {
+    pub(crate) fn from_client_ref(error: &ClientError) -> Self {
+        match error {
+            ClientError::TransportClosed => Self::TransportClosed,
+            ClientError::Disconnected => Self::Disconnected,
+            ClientError::InvalidTransportFrame
+            | ClientError::EmptyTransportFrame
+            | ClientError::TransportFrameTooLarge { .. } => Self::InvalidTransportFrame,
+            ClientError::UnsupportedWebSocketMessage => Self::UnsupportedWebSocketMessage,
+            _ => Self::Runtime,
+        }
+    }
+}
+
+impl From<ClientError> for WasmDriverError {
+    fn from(error: ClientError) -> Self {
+        Self::Client(error)
+    }
+}
+
+impl std::fmt::Display for WasmDriverError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Client(error) => std::fmt::Display::fmt(error, formatter),
+            Self::TransportClosed => formatter.write_str("websocket transport is already closed"),
+            Self::Disconnected => formatter.write_str("the XMPP session is disconnected"),
+            Self::InvalidTransportFrame => {
+                formatter.write_str("websocket transport received malformed XMPP framing")
+            }
+            Self::UnsupportedWebSocketMessage => {
+                formatter.write_str("websocket transport received an unsupported message type")
+            }
+            Self::WebSocketTransport => formatter.write_str("websocket transport error"),
+            Self::Runtime => formatter.write_str("XMPP client runtime error"),
+        }
+    }
 }
 
 pub(crate) fn client_driver_event(event: ClientEvent) -> DriverEvent {
@@ -297,7 +395,8 @@ pub(crate) struct PendingInboxQuery {
 
 pub(crate) struct WasmDriverTask {
     pub(crate) runtime: XmppRuntime,
-    pub(crate) ws: WasmWebSocket,
+    pub(crate) ws: Box<dyn WasmDriverWire>,
+    pub(crate) timer: Rc<dyn DriverTimerBackend>,
     pub(crate) cmd_rx: mpsc::Receiver<WasmCommand>,
     pub(crate) event_tx: mpsc::Sender<DriverEvent>,
     pub(crate) inner: Rc<RefCell<WaddleClientInner>>,
@@ -306,4 +405,6 @@ pub(crate) struct WasmDriverTask {
     pub(crate) pending_inbox_queries: HashMap<String, PendingInboxQuery>,
     pub(crate) deferred_commands: VecDeque<DeferredWasmCommand>,
     pub(crate) explicit_disconnect: bool,
+    pub(crate) websocket_close_started: bool,
+    pub(crate) commands_closed: bool,
 }

--- a/server/crates/waddle-xmpp-client/Cargo.toml
+++ b/server/crates/waddle-xmpp-client/Cargo.toml
@@ -35,7 +35,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }
-web-sys = { version = "0.3", features = ["BinaryType", "CloseEvent", "ErrorEvent", "Event", "MessageEvent", "WebSocket", "console"], optional = true }
+web-sys = { version = "0.3", features = ["BinaryType", "CloseEvent", "ErrorEvent", "Event", "MessageEvent", "Performance", "WebSocket", "console"], optional = true }
 waddle-xmpp-core = { path = "../waddle-xmpp-core" }
 xmpp-parsers = { workspace = true }
 
@@ -65,6 +65,7 @@ rustls = { version = "0.23", default-features = false, features = [
 webpki-roots = { version = "0.26", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
 # Test-only TLS server pieces for the certificate-rejection transport test.
 # Both pin `ring` explicitly so dev builds never pull rustls' default
 # `aws-lc-rs` provider into the workspace graph.

--- a/server/crates/waddle-xmpp-client/src/client.rs
+++ b/server/crates/waddle-xmpp-client/src/client.rs
@@ -13,9 +13,17 @@ use crate::runtime::XmppRuntime;
 use crate::state::{ClientState, SessionSnapshot};
 use crate::stream_management::SmResumeState;
 use crate::transport::{
-    DefaultTransportFactory, TransportEvent, TransportMessage, TransportState, WebSocketTransport,
+    DefaultTransportFactory, TransportEvent, TransportMessage, TransportState,
+    TransportWriteFailure, TransportWriteResponsibility, WebSocketTransport,
     WebSocketTransportFactory,
 };
+
+const UNCLEAN_ABORT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+/// A native frame or close may occupy at most one sixth of the XEP-0198
+/// no-progress budget. Expiry is conservatively `PossiblyWritten`: once the
+/// transport future has been polled, the driver cannot prove that zero bytes
+/// reached the peer.
+const NATIVE_TRANSPORT_WRITE_DEADLINE: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Async control plane for a live XMPP session.
 ///
@@ -184,6 +192,8 @@ where
             pending_iqs: HashMap::new(),
             deferred_commands: VecDeque::new(),
             explicit_disconnect: false,
+            websocket_close_started: false,
+            commands_closed: false,
             last_resume_state: None,
         };
 
@@ -207,6 +217,14 @@ struct DriverTask {
     /// broadcast state to `None` from that point on — mirroring the
     /// wasm driver's `explicit_disconnect` flag.
     explicit_disconnect: bool,
+    /// Ensures the RFC 6455 closing handshake starts exactly once, and only
+    /// after both typed RFC 7395 `<close/>` frames are confirmed.
+    websocket_close_started: bool,
+    /// Receiver closure is terminal before a close starts, but once the local
+    /// RFC 7395 half is confirmed the driver—not the handle lifetime—owns the
+    /// peer wait and five-second deadline. The disabled select branch avoids
+    /// polling a permanently-ready closed channel.
+    commands_closed: bool,
     /// Last broadcast XEP-0198 resume snapshot; publishing is deduped
     /// against it so subscribers only see actual state transitions.
     last_resume_state: Option<SmResumeState>,
@@ -218,6 +236,57 @@ enum DeferredXmppCommand {
         stanza: Element,
         responder: oneshot::Sender<ClientResult<Element>>,
     },
+}
+
+/// Private attribution for one ordered native write pump failure.
+///
+/// Callers must distinguish a failed initiating application stanza from a
+/// failed runtime-generated follow-up. The latter still terminates the stream,
+/// but cannot roll back or emit `MessageDelivery::Failed` for an initiating
+/// stanza whose transport write was already confirmed.
+#[derive(Debug)]
+enum TransportPumpFailure {
+    Write {
+        failed_message: TransportMessage,
+        initiating_message_confirmed: bool,
+        failure: TransportWriteFailure,
+    },
+    Runtime {
+        confirmed_message: TransportMessage,
+        initiating_message_confirmed: bool,
+        failure: TransportWriteFailure,
+    },
+}
+
+impl TransportPumpFailure {
+    fn initiating_message_confirmed(&self) -> bool {
+        match self {
+            Self::Write {
+                initiating_message_confirmed,
+                ..
+            }
+            | Self::Runtime {
+                initiating_message_confirmed,
+                ..
+            } => *initiating_message_confirmed,
+        }
+    }
+
+    fn responsibility(&self) -> TransportWriteResponsibility {
+        match self {
+            Self::Write { failure, .. } => failure.responsibility(),
+            Self::Runtime { failure, .. } => failure.responsibility(),
+        }
+    }
+
+    fn attributed_message(&self) -> &TransportMessage {
+        match self {
+            Self::Write { failed_message, .. } => failed_message,
+            Self::Runtime {
+                confirmed_message, ..
+            } => confirmed_message,
+        }
+    }
 }
 
 impl DriverTask {
@@ -235,6 +304,12 @@ impl DriverTask {
         }
 
         loop {
+            let now_ms = crate::runtime::monotonic_now_ms();
+            let sm_wakeup_ms = self.runtime.next_stream_management_wakeup_in_ms(now_ms);
+            let close_wakeup_ms = self.runtime.next_stream_close_wakeup_in_ms(now_ms);
+            let driver_wakeup_ms = minimum_wakeup(sm_wakeup_ms, close_wakeup_ms);
+            let close_deadline_scheduled =
+                close_wakeup_ms.is_some_and(|close| sm_wakeup_ms.is_none_or(|sm| close <= sm));
             tokio::select! {
                 result = self.transport.next_event() => {
                     match result {
@@ -257,18 +332,72 @@ impl DriverTask {
                         }
                     }
                 }
-                cmd = self.commands.recv() => {
+                cmd = self.commands.recv(), if !self.commands_closed => {
                     match cmd {
                         Some(command) => {
                             if !self.handle_command(command).await {
                                 return;
                             }
                         }
-                        None => return,
+                        None => {
+                            if !self.handle_command_channel_closed().await {
+                                return;
+                            }
+                        }
+                    }
+                }
+                _ = wait_for_driver_wakeup(driver_wakeup_ms) => {
+                    if !self.handle_driver_timer(close_deadline_scheduled).await {
+                        return;
                     }
                 }
             }
         }
+    }
+
+    async fn handle_driver_timer(&mut self, close_deadline_scheduled: bool) -> bool {
+        if close_deadline_scheduled {
+            self.terminate_uncleanly().await;
+            return false;
+        }
+        self.handle_stream_management_timer_at(crate::runtime::monotonic_now_ms())
+            .await
+    }
+
+    async fn handle_command_channel_closed(&mut self) -> bool {
+        self.commands_closed = true;
+        if self.runtime.stream_close_sent_confirmed() {
+            return true;
+        }
+        self.terminate_uncleanly().await;
+        false
+    }
+
+    async fn handle_stream_management_timer_at(&mut self, now_ms: u64) -> bool {
+        let events = self.runtime.poll_stream_management_at(now_ms);
+        let progress_stalled = events.iter().any(|event| {
+            matches!(
+                event,
+                ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                    StreamManagementEvent::AckProgressStalled { .. }
+                ))
+            )
+        });
+
+        for event in events {
+            if let Some(message) = self.dispatch_client_event(event) {
+                if self.send_transport_message(message).await.is_err() {
+                    self.terminate_uncleanly().await;
+                    return false;
+                }
+            }
+        }
+
+        if progress_stalled {
+            self.terminate_uncleanly().await;
+            return false;
+        }
+        true
     }
 
     async fn handle_command(&mut self, command: XmppCommand) -> bool {
@@ -280,7 +409,10 @@ impl DriverTask {
                     return true;
                 }
 
-                self.send_stanza_command(stanza).await;
+                if self.send_stanza_command(stanza).await.is_err() {
+                    self.terminate_uncleanly().await;
+                    return false;
+                }
                 true
             }
             XmppCommand::SendIq { stanza, responder } => {
@@ -290,77 +422,108 @@ impl DriverTask {
                     return true;
                 }
 
-                self.send_iq_command(stanza, responder).await;
+                if self.send_iq_command(stanza, responder).await.is_err() {
+                    self.terminate_uncleanly().await;
+                    return false;
+                }
                 true
             }
             XmppCommand::Disconnect => {
-                // Pin the resume snapshot to `None` BEFORE closing:
-                // XEP-0198 resume must not be attempted across an
-                // explicit `</stream>` close (wasm driver parity).
-                self.explicit_disconnect = true;
-                self.publish_resume_state_snapshot();
-                let _ = self.transport.close().await;
-                // Drain close events so state reaches Disconnected before we exit.
-                for event in self.transport.drain_events() {
-                    self.apply_transport_event(event).await;
+                let events = match self.runtime.request_stream_close() {
+                    Ok(events) => events,
+                    Err(_) => {
+                        self.terminate_uncleanly().await;
+                        return false;
+                    }
+                };
+                for event in events {
+                    if let Some(message) = self.dispatch_client_event(event) {
+                        if self.send_transport_message(message).await.is_err() {
+                            // The close was not confirmed. Treat the stream as
+                            // unfinished and keep its resume snapshot eligible.
+                            self.terminate_uncleanly().await;
+                            return false;
+                        }
+                    }
                 }
-                false
+                // RFC 7395 considers the stream closed only after the peer's
+                // corresponding `<close/>` arrives. Keep driving the socket;
+                // SM state remains resumable until both directions confirm.
+                true
             }
         }
     }
 
-    async fn send_stanza_command(&mut self, stanza: Element) {
+    async fn send_stanza_command(&mut self, stanza: Element) -> Result<(), TransportPumpFailure> {
         let maybe_message_id = message_delivery_stanza_id(&stanza);
-        if self
-            .send_transport_message(TransportMessage::Element(stanza))
-            .await
-            .is_err()
-        {
-            if let Some(stanza_id) = maybe_message_id {
-                self.emit_message_delivery_failed(stanza_id);
+        let initiating_message = TransportMessage::Element(stanza.clone());
+        let result = self
+            .send_transport_message(initiating_message.clone())
+            .await;
+        if let Err(failure) = &result {
+            if !failure.initiating_message_confirmed()
+                && failure.attributed_message() == &initiating_message
+                && failure.responsibility() == TransportWriteResponsibility::DefinitelyNotWritten
+            {
+                if let Some(stanza_id) = maybe_message_id {
+                    self.emit_message_delivery_failed(stanza_id);
+                }
             }
         }
+        result
     }
 
     async fn send_iq_command(
         &mut self,
         stanza: Element,
         responder: oneshot::Sender<ClientResult<Element>>,
-    ) {
+    ) -> Result<(), TransportPumpFailure> {
         let id = stanza.attr("id").map(|s| s.to_string());
         match self
             .send_transport_message(TransportMessage::Element(stanza))
             .await
         {
-            Err(_) => {
-                let _ = responder.send(Err(ClientError::Disconnected));
-            }
-            Ok(()) => match id {
-                Some(id) => {
-                    self.pending_iqs.insert(id, responder);
-                }
-                None => {
+            Err(failure) => {
+                if failure.initiating_message_confirmed() {
+                    if let Some(id) = id {
+                        self.pending_iqs.insert(id, responder);
+                    } else {
+                        let _ = responder.send(Err(ClientError::Disconnected));
+                    }
+                } else {
                     let _ = responder.send(Err(ClientError::Disconnected));
                 }
-            },
+                Err(failure)
+            }
+            Ok(()) => {
+                match id {
+                    Some(id) => {
+                        self.pending_iqs.insert(id, responder);
+                    }
+                    None => {
+                        let _ = responder.send(Err(ClientError::Disconnected));
+                    }
+                }
+                Ok(())
+            }
         }
     }
 
-    async fn flush_deferred_commands(&mut self) {
+    async fn flush_deferred_commands(&mut self) -> Result<(), TransportPumpFailure> {
         while self.runtime.can_send_app_stanza() {
             let Some(command) = self.deferred_commands.pop_front() else {
-                return;
+                return Ok(());
             };
 
-            match command {
-                DeferredXmppCommand::SendStanza(stanza) => {
-                    self.send_stanza_command(stanza).await;
-                }
+            let result = match command {
+                DeferredXmppCommand::SendStanza(stanza) => self.send_stanza_command(stanza).await,
                 DeferredXmppCommand::SendIq { stanza, responder } => {
-                    self.send_iq_command(stanza, responder).await;
+                    self.send_iq_command(stanza, responder).await
                 }
-            }
+            };
+            result?;
         }
+        Ok(())
     }
 
     /// Apply one transport event; returns `false` when the session is fully closed.
@@ -379,16 +542,68 @@ impl DriverTask {
         for evt in client_events {
             if let Some(msg) = self.dispatch_client_event(evt) {
                 if self.send_transport_message(msg).await.is_err() {
-                    *self.state.write().unwrap() = self.runtime.snapshot().clone();
+                    self.terminate_uncleanly().await;
                     return false;
                 }
             }
         }
 
-        self.flush_deferred_commands().await;
+        if self.runtime.stream_close_complete() && !self.begin_websocket_close().await {
+            self.terminate_uncleanly().await;
+            return false;
+        }
+
+        if self.flush_deferred_commands().await.is_err() {
+            self.terminate_uncleanly().await;
+            return false;
+        }
 
         *self.state.write().unwrap() = self.runtime.snapshot().clone();
         !is_terminal
+    }
+
+    /// End an unfinished XEP-0198 stream without ever sending RFC 7395
+    /// `<close/>`. Transport abort is best effort and bounded; runtime
+    /// observers still receive explicit Failed and Closed transitions when
+    /// the sink errors, hangs, or neglects to queue terminal events.
+    async fn terminate_uncleanly(&mut self) {
+        self.apply_terminal_transport_event(TransportEvent::StateChanged(TransportState::Failed))
+            .await;
+
+        let _ = tokio::time::timeout(UNCLEAN_ABORT_TIMEOUT, self.transport.abort()).await;
+        let queued = self.transport.drain_events();
+        let mut saw_closed_state = false;
+        let mut saw_closed = false;
+        for event in queued {
+            if matches!(event, TransportEvent::StateChanged(TransportState::Failed)) {
+                continue;
+            }
+            saw_closed_state |=
+                matches!(event, TransportEvent::StateChanged(TransportState::Closed));
+            saw_closed |= matches!(event, TransportEvent::Closed);
+            self.apply_terminal_transport_event(event).await;
+        }
+        if !saw_closed_state {
+            self.apply_terminal_transport_event(TransportEvent::StateChanged(
+                TransportState::Closed,
+            ))
+            .await;
+        }
+        if !saw_closed {
+            self.apply_terminal_transport_event(TransportEvent::Closed)
+                .await;
+        }
+        *self.state.write().unwrap() = self.runtime.snapshot().clone();
+    }
+
+    async fn apply_terminal_transport_event(&mut self, event: TransportEvent) {
+        let Ok(events) = self.runtime.apply_transport_event(event) else {
+            return;
+        };
+        self.publish_resume_state_snapshot();
+        for event in events {
+            let _ = self.dispatch_client_event(event);
+        }
     }
 
     /// Dispatch one client event.
@@ -467,17 +682,144 @@ impl DriverTask {
         }
     }
 
-    async fn send_transport_message(&mut self, message: TransportMessage) -> ClientResult<()> {
-        match message {
-            TransportMessage::Close(_) => self.transport.close().await,
-            TransportMessage::Element(element) => {
-                self.transport
-                    .send(TransportMessage::Element(element.clone()))
-                    .await?;
-                Ok(())
-            }
-            other => self.transport.send(other).await,
+    /// Write one message and every runtime-generated follow-up in strict order.
+    /// A successful transport write is applied to the runtime immediately; the
+    /// transport adapter never owns a delayed `MessageSent` event.
+    async fn send_transport_message(
+        &mut self,
+        message: TransportMessage,
+    ) -> Result<(), TransportPumpFailure> {
+        enum PumpItem {
+            Message(TransportMessage),
+            Event(ClientEvent),
         }
+
+        let mut pending = VecDeque::from([PumpItem::Message(message)]);
+        let mut initiating_message_confirmed = false;
+        while let Some(item) = pending.pop_front() {
+            match item {
+                PumpItem::Message(message) => {
+                    let result = self.write_transport_message(&message).await;
+                    if let Err(failure) = result {
+                        if failure.responsibility()
+                            == TransportWriteResponsibility::DefinitelyNotWritten
+                            && is_stream_management_ack_request(&message)
+                            && self
+                                .runtime
+                                .stream_management_ack_definitely_not_written_at(
+                                    crate::runtime::monotonic_now_ms(),
+                                )
+                        {
+                            // The initiating stanza (if any) was already
+                            // confirmed. The exact control write remains
+                            // locally owned and the runtime has scheduled its
+                            // bounded retry without starting a response clock.
+                            continue;
+                        }
+                        if failure.responsibility() == TransportWriteResponsibility::PossiblyWritten
+                        {
+                            self.reconcile_possibly_written(message.clone());
+                        }
+                        return Err(TransportPumpFailure::Write {
+                            failed_message: message,
+                            initiating_message_confirmed,
+                            failure,
+                        });
+                    }
+
+                    if !initiating_message_confirmed {
+                        initiating_message_confirmed = true;
+                    }
+
+                    let events = match self
+                        .runtime
+                        .apply_transport_event(TransportEvent::MessageSent(message.clone()))
+                    {
+                        Ok(events) => events,
+                        Err(source) => {
+                            return Err(TransportPumpFailure::Runtime {
+                                confirmed_message: message,
+                                initiating_message_confirmed,
+                                failure: TransportWriteFailure::possibly_written(source),
+                            });
+                        }
+                    };
+                    self.publish_resume_state_snapshot();
+                    *self.state.write().unwrap() = self.runtime.snapshot().clone();
+                    if self.runtime.stream_close_complete() && !self.begin_websocket_close().await {
+                        return Err(TransportPumpFailure::Write {
+                            failed_message: message,
+                            initiating_message_confirmed,
+                            failure: TransportWriteFailure::possibly_written(
+                                ClientError::TransportClosed,
+                            ),
+                        });
+                    }
+                    for event in events.into_iter().rev() {
+                        pending.push_front(PumpItem::Event(event));
+                    }
+                }
+                PumpItem::Event(event) => {
+                    if let Some(follow_up) = self.dispatch_client_event(event) {
+                        pending.push_front(PumpItem::Message(follow_up));
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn write_transport_message(
+        &mut self,
+        message: &TransportMessage,
+    ) -> Result<(), TransportWriteFailure> {
+        let write = self.transport.send(message.clone());
+        tokio::time::timeout(NATIVE_TRANSPORT_WRITE_DEADLINE, write)
+            .await
+            .unwrap_or_else(|_| {
+                Err(TransportWriteFailure::possibly_written(
+                    ClientError::WebSocketWriteTimeout {
+                        timeout: NATIVE_TRANSPORT_WRITE_DEADLINE,
+                    },
+                ))
+            })
+    }
+
+    async fn begin_websocket_close(&mut self) -> bool {
+        if self.websocket_close_started {
+            return true;
+        }
+        self.websocket_close_started = true;
+        self.explicit_disconnect = true;
+        self.publish_resume_state_snapshot();
+        matches!(
+            tokio::time::timeout(
+                NATIVE_TRANSPORT_WRITE_DEADLINE,
+                self.transport.close_websocket(),
+            )
+            .await,
+            Ok(Ok(()))
+        )
+    }
+
+    /// Assume responsibility for an uncertain native write exactly once.
+    /// Applying the typed message updates XEP-0198 queue state, but generated
+    /// follow-up writes and public `MessageSent`/`AckRequestSent` events are
+    /// deliberately suppressed because the transport did not confirm them.
+    fn reconcile_possibly_written(&mut self, message: TransportMessage) {
+        if !matches!(
+            &message,
+            TransportMessage::Element(element)
+                if matches!(element.name(), "iq" | "message" | "presence")
+        ) {
+            return;
+        }
+        let _ = self
+            .runtime
+            .apply_transport_event(TransportEvent::MessageSent(message));
+        self.publish_resume_state_snapshot();
+        *self.state.write().unwrap() = self.runtime.snapshot().clone();
     }
 
     /// Broadcast the current XEP-0198 resume snapshot when it differs
@@ -510,12 +852,35 @@ impl DriverTask {
     }
 }
 
+fn minimum_wakeup(left: Option<u64>, right: Option<u64>) -> Option<u64> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(delay), None) | (None, Some(delay)) => Some(delay),
+        (None, None) => None,
+    }
+}
+
+async fn wait_for_driver_wakeup(delay_ms: Option<u64>) {
+    match delay_ms {
+        Some(delay_ms) => tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
 fn message_delivery_stanza_id(element: &Element) -> Option<StanzaId> {
     if element.name() != "message" {
         return None;
     }
 
     element.attr("id").and_then(|id| StanzaId::new(id).ok())
+}
+
+fn is_stream_management_ack_request(message: &TransportMessage) -> bool {
+    matches!(
+        message,
+        TransportMessage::Element(element)
+            if crate::stream_management::SmState::is_request_ack(element)
+    )
 }
 
 #[cfg(test)]

--- a/server/crates/waddle-xmpp-client/src/client/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/client/tests.rs
@@ -17,7 +17,9 @@ use crate::error::ClientError;
 use crate::event::{ClientEvent, LifecycleEvent, MessageDeliveryEvent};
 use crate::state::{SessionBinding, SessionPhase, SessionSnapshot};
 use crate::stream_management::{SmResumeState, NS_SM};
-use crate::transport::{StreamClose, StreamOpen, TransportEvent, TransportMessage, TransportState};
+use crate::transport::{
+    StreamClose, StreamOpen, TransportEvent, TransportMessage, TransportState, TransportWriteResult,
+};
 use crate::ConnectionConfig;
 
 fn config() -> ClientConfig {
@@ -39,6 +41,18 @@ fn config_with_resume_state() -> ClientConfig {
     config.session.stream_management.resume_state =
         Some(SmResumeState::new("prev-stream", 0, 0).unwrap());
     config
+}
+
+fn assert_final_ack_then_close(messages: &[TransportMessage], expected_h: &str) {
+    assert!(matches!(
+        messages,
+        [
+            TransportMessage::Element(ack),
+            TransportMessage::Close(StreamClose)
+        ] if ack.name() == "a"
+            && ack.ns() == NS_SM
+            && ack.attr("h") == Some(expected_h)
+    ));
 }
 
 // ── helper constructors ───────────────────────────────────────────────────
@@ -73,6 +87,8 @@ fn make_driver_task_with_config(
         pending_iqs: HashMap::new(),
         deferred_commands: VecDeque::new(),
         explicit_disconnect: false,
+        websocket_close_started: false,
+        commands_closed: false,
         last_resume_state: None,
     };
     (task, cmd_tx, evt_rx)
@@ -345,6 +361,61 @@ async fn driver_flushes_deferred_stanzas_when_fresh_sm_enable_fails() {
     );
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn driver_releases_fallback_snapshot_after_confirmed_no_sm_retry() {
+    let fallback_id = "resume-fallback-confirmed";
+    let resume_state = SmResumeState::from_unhandled_outbound_stanzas(
+        "prev-stream",
+        0,
+        1,
+        [message_stanza(fallback_id)],
+    )
+    .expect("resume state");
+    let mut client_config = config();
+    client_config.session.stream_management.resume_state = Some(resume_state);
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, _rx) = make_driver_task_with_config(
+        client_config,
+        MockTransport::new(vec![], vec![], shared.clone()),
+    );
+
+    drive_task_to_resume_attempt(&mut task).await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        failed_sm(0),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        bind_result("bind-1"),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        Element::builder("failed", NS_SM).build(),
+    )))
+    .await;
+
+    assert_eq!(
+        shared
+            .sent_messages()
+            .iter()
+            .filter(|message| transport_message_id(message) == Some(fallback_id))
+            .count(),
+        1,
+        "fresh-stream fallback must write the retained stanza exactly once"
+    );
+    assert!(
+        task.runtime.resume_state().is_none(),
+        "a confirmed fallback write on a no-SM stream ends native ownership"
+    );
+
+    let _ = task
+        .apply_transport_event(TransportEvent::StateChanged(TransportState::Failed))
+        .await;
+    assert!(
+        task.runtime.resume_state().is_none(),
+        "terminal disconnect must not resurrect native ownership"
+    );
+}
+
 // ── XEP-0198 resume snapshot broadcast ────────────────────────────────────
 
 #[tokio::test(flavor = "current_thread")]
@@ -403,7 +474,22 @@ async fn driver_broadcasts_resume_state_transitions() {
         .expect("resumable snapshot after <enabled/>");
     assert_eq!(state.previd(), "new-stream");
 
-    task.handle_command(XmppCommand::Disconnect).await;
+    assert!(task.handle_command(XmppCommand::Disconnect).await);
+
+    let before_peer_close = drain_client_events(&mut rx);
+    assert!(
+        !before_peer_close
+            .iter()
+            .any(|event| matches!(event, ClientEvent::ResumeStateChanged(None))),
+        "local stream close must preserve the resume snapshot until the peer replies"
+    );
+
+    assert!(
+        task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Close(
+            StreamClose,
+        )))
+        .await
+    );
 
     let mut saw_cleared = false;
     while let Ok(event) = rx.try_recv() {
@@ -419,6 +505,754 @@ async fn driver_broadcasts_resume_state_transitions() {
         saw_cleared,
         "expected ResumeStateChanged(None) on explicit disconnect"
     );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn driver_sends_one_ack_request_for_the_first_countable_stanza() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, mut rx) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+
+    task.handle_command(XmppCommand::SendStanza(message_stanza("message-1")))
+        .await;
+    drain_task_transport_events(&mut task).await;
+
+    let requests = shared
+        .sent_messages()
+        .into_iter()
+        .filter(|message| {
+            matches!(message, TransportMessage::Element(element) if element.name() == "r" && element.ns() == NS_SM)
+        })
+        .count();
+    assert_eq!(
+        requests, 1,
+        "the generated <r/> must reach the transport once"
+    );
+
+    let mut request_events = 0;
+    while let Ok(event) = rx.try_recv() {
+        if matches!(
+            event,
+            ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                StreamManagementEvent::AckRequestSent { .. }
+            ))
+        ) {
+            request_events += 1;
+        }
+    }
+    assert_eq!(request_events, 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn driver_aborts_uncleanly_after_thirty_seconds_without_ack_progress() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, _rx) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+
+    task.handle_command(XmppCommand::SendStanza(message_stanza("message-1")))
+        .await;
+    drain_task_transport_events(&mut task).await;
+    let resumable_before_abort = task.runtime.resume_state();
+    assert!(resumable_before_abort.is_some());
+
+    let keep_running = task
+        .handle_stream_management_timer_at(
+            crate::runtime::monotonic_now_ms().saturating_add(30_001),
+        )
+        .await;
+
+    assert!(!keep_running);
+    assert_eq!(shared.abort_count(), 1);
+    assert_eq!(shared.close_count(), 0);
+    assert!(
+        !shared
+            .sent_messages()
+            .iter()
+            .any(|message| matches!(message, TransportMessage::Close(_))),
+        "a stalled resumable stream must not send a clean XML close"
+    );
+    assert_eq!(task.runtime.resume_state(), resumable_before_abort);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn possibly_written_ack_request_forces_resume_without_a_second_request() {
+    let shared = MockTransportShared::default();
+    shared.fail_ack_request_write(TransportWriteResponsibility::PossiblyWritten);
+    let (mut task, _cmd_tx, mut events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+
+    assert!(
+        !task
+            .handle_command(XmppCommand::SendStanza(message_stanza("message-1")))
+            .await,
+        "the failed generated write must terminate the driver"
+    );
+
+    assert_eq!(task.runtime.snapshot().phase, SessionPhase::Disconnected);
+    let resume = task
+        .runtime
+        .resume_state()
+        .expect("resumable queue retained");
+    assert_eq!(
+        resume
+            .unhandled_message_stanza_ids()
+            .iter()
+            .map(StanzaId::as_str)
+            .collect::<Vec<_>>(),
+        vec!["message-1"]
+    );
+    assert_eq!(shared.abort_count(), 1);
+    assert_eq!(shared.close_count(), 0);
+    assert_eq!(attempted_ack_request_count(&shared), 1);
+    assert_eq!(
+        task.runtime.next_stream_management_wakeup_in_ms(
+            crate::runtime::monotonic_now_ms().saturating_add(60_000),
+        ),
+        None,
+        "unclean reconciliation must not schedule a second request on the dead stream"
+    );
+    assert!(!shared
+        .sent_messages()
+        .iter()
+        .any(|message| matches!(message, TransportMessage::Close(_))));
+    assert_terminal_transport_events_without_ack_request(&mut events);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn generated_ack_request_definitely_not_written_retries_without_failing_confirmed_message() {
+    let shared = MockTransportShared::default();
+    shared.fail_ack_request_write(TransportWriteResponsibility::DefinitelyNotWritten);
+    let (mut task, _cmd_tx, mut events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+
+    assert!(
+        task.handle_command(XmppCommand::SendStanza(message_stanza("confirmed-message")))
+            .await
+    );
+
+    assert_eq!(resume_stanza_ids(&task), vec!["confirmed-message"]);
+    assert_eq!(attempted_stanza_count(&shared, "confirmed-message"), 1);
+    assert_eq!(attempted_ack_request_count(&shared), 1);
+    assert_eq!(shared.abort_count(), 0);
+
+    assert!(
+        task.handle_stream_management_timer_at(
+            crate::runtime::monotonic_now_ms().saturating_add(300),
+        )
+        .await,
+        "the bounded retry stays on the live stream"
+    );
+    assert_eq!(attempted_ack_request_count(&shared), 2);
+    assert_eq!(
+        shared
+            .sent_messages()
+            .iter()
+            .filter(|message| is_stream_management_ack_request(message))
+            .count(),
+        1,
+        "only the retry reached the transport"
+    );
+
+    let observed = drain_client_events(&mut events);
+    assert!(!observed.iter().any(|event| matches!(
+        event,
+        ClientEvent::MessageDelivery(MessageDeliveryEvent::Failed { stanza_id })
+            if stanza_id.as_str() == "confirmed-message"
+    )));
+    assert!(!observed.iter().any(|event| matches!(
+        event,
+        ClientEvent::Transport(TransportEvent::StateChanged(
+            TransportState::Failed | TransportState::Closed
+        )) | ClientEvent::Transport(TransportEvent::Closed)
+    )));
+    assert!(observed.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::AckRequestSent { attempt: 2, .. }
+        ))
+    )));
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn permanently_pending_original_stanza_is_bounded_and_retained_once() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, mut events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+    shared.pend_stanza_write(StanzaId::new("pending-original").unwrap());
+    let started = tokio::time::Instant::now();
+
+    assert!(
+        !task
+            .handle_command(XmppCommand::SendStanza(message_stanza("pending-original")))
+            .await
+    );
+
+    assert_eq!(
+        tokio::time::Instant::now().duration_since(started),
+        NATIVE_TRANSPORT_WRITE_DEADLINE
+    );
+    assert_eq!(resume_stanza_ids(&task), vec!["pending-original"]);
+    assert_eq!(attempted_stanza_count(&shared, "pending-original"), 1);
+    assert_eq!(attempted_ack_request_count(&shared), 0);
+    assert!(!shared
+        .sent_messages()
+        .iter()
+        .any(|message| transport_message_id(message) == Some("pending-original")));
+    let observed = drain_client_events(&mut events);
+    assert!(!observed.iter().any(|event| matches!(
+        event,
+        ClientEvent::MessageDelivery(MessageDeliveryEvent::Failed { stanza_id })
+            if stanza_id.as_str() == "pending-original"
+    )));
+    assert_terminal_transport_event_slice(&observed);
+    assert_eq!(shared.abort_count(), 1);
+    assert_eq!(shared.close_count(), 0);
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn permanently_pending_generated_ack_is_bounded_without_rolling_back_message() {
+    let shared = MockTransportShared::default();
+    shared.pend_ack_request_write();
+    let (mut task, _cmd_tx, mut events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+    let started = tokio::time::Instant::now();
+
+    assert!(
+        !task
+            .handle_command(XmppCommand::SendStanza(message_stanza(
+                "confirmed-before-pending-r"
+            )))
+            .await
+    );
+
+    assert_eq!(
+        tokio::time::Instant::now().duration_since(started),
+        NATIVE_TRANSPORT_WRITE_DEADLINE
+    );
+    assert_eq!(resume_stanza_ids(&task), vec!["confirmed-before-pending-r"]);
+    assert_eq!(
+        attempted_stanza_count(&shared, "confirmed-before-pending-r"),
+        1
+    );
+    assert_eq!(attempted_ack_request_count(&shared), 1);
+    let observed = drain_client_events(&mut events);
+    assert!(!observed.iter().any(|event| matches!(
+        event,
+        ClientEvent::MessageDelivery(MessageDeliveryEvent::Failed { stanza_id })
+            if stanza_id.as_str() == "confirmed-before-pending-r"
+    )));
+    assert!(!observed.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::AckRequestSent { .. }
+        ))
+    )));
+    assert_terminal_transport_event_slice(&observed);
+    assert_eq!(shared.abort_count(), 1);
+    assert_eq!(shared.close_count(), 0);
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn permanently_pending_stream_close_write_is_unfinished_bounded_and_terminal() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, mut events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+    assert!(
+        task.handle_command(XmppCommand::SendStanza(message_stanza(
+            "resume-after-close-timeout"
+        )))
+        .await
+    );
+    shared.pend_stream_close_write();
+    let resumable_before = task.runtime.resume_state();
+    let started = tokio::time::Instant::now();
+
+    assert!(!task.handle_command(XmppCommand::Disconnect).await);
+
+    assert_eq!(
+        tokio::time::Instant::now().duration_since(started),
+        NATIVE_TRANSPORT_WRITE_DEADLINE
+    );
+    assert_eq!(task.runtime.resume_state(), resumable_before);
+    assert!(!task.explicit_disconnect);
+    assert_eq!(shared.close_count(), 0);
+    assert_eq!(shared.abort_count(), 1);
+    assert!(!shared
+        .sent_messages()
+        .iter()
+        .any(|message| matches!(message, TransportMessage::Close(_))));
+    let observed = drain_client_events(&mut events);
+    assert!(!observed
+        .iter()
+        .any(|event| matches!(event, ClientEvent::ResumeStateChanged(None))));
+    assert_terminal_transport_event_slice(&observed);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn peer_initiated_close_writes_reciprocal_before_websocket_close() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, _events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+    assert!(
+        task.handle_command(XmppCommand::SendStanza(message_stanza(
+            "peer-close-unacked"
+        )))
+        .await
+    );
+    assert!(task.runtime.resume_state().is_some());
+    let sent_before_close = shared.sent_messages().len();
+
+    assert!(
+        task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Close(
+            StreamClose
+        ),))
+            .await
+    );
+
+    let attempted = shared.attempted_messages();
+    assert_final_ack_then_close(&attempted[sent_before_close..], "0");
+    let sent = shared.sent_messages();
+    assert_final_ack_then_close(&sent[sent_before_close..], "0");
+    assert_eq!(shared.close_count(), 1);
+    assert!(task.websocket_close_started);
+    assert!(task.runtime.stream_close_complete());
+    assert!(task.runtime.resume_state().is_none());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn local_close_waits_for_peer_before_websocket_close_and_sm_destruction() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, _events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+    assert!(
+        task.handle_command(XmppCommand::SendStanza(message_stanza(
+            "local-close-unacked"
+        )))
+        .await
+    );
+    let sent_before_close = shared.sent_messages().len();
+
+    assert!(task.handle_command(XmppCommand::Disconnect).await);
+    let sent = shared.sent_messages();
+    assert_final_ack_then_close(&sent[sent_before_close..], "0");
+    assert_eq!(shared.close_count(), 0);
+    assert!(!task.runtime.stream_close_complete());
+    assert!(task.runtime.resume_state().is_some());
+
+    let sent_after_close = shared.sent_messages().len();
+    assert!(task.handle_stream_management_timer_at(u64::MAX).await);
+    assert!(
+        task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            crate::stream_management::SmState::build_request_ack(),
+        )))
+        .await
+    );
+    assert!(
+        task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            crate::stream_management::SmState::build_ack(1),
+        )))
+        .await
+    );
+    assert_eq!(shared.sent_messages().len(), sent_after_close);
+    assert!(task
+        .runtime
+        .resume_state()
+        .is_some_and(|state| !state.has_unhandled_outbound_stanzas()));
+
+    assert!(
+        task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Close(
+            StreamClose
+        ),))
+            .await
+    );
+    assert_eq!(shared.close_count(), 1);
+    assert!(task.websocket_close_started);
+    assert!(task.runtime.stream_close_complete());
+    assert!(task.runtime.resume_state().is_none());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn repeated_native_disconnects_coalesce_to_one_xml_and_websocket_close() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, _events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+    let sent_before_close = shared.sent_messages().len();
+
+    assert!(task.handle_command(XmppCommand::Disconnect).await);
+    assert!(task.handle_command(XmppCommand::Disconnect).await);
+    let sent = shared.sent_messages();
+    assert_final_ack_then_close(&sent[sent_before_close..], "0");
+    assert_eq!(shared.close_count(), 0);
+
+    assert!(
+        task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Close(
+            StreamClose
+        )))
+        .await
+    );
+    assert_eq!(shared.close_count(), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn native_driver_keeps_one_close_when_peer_arrives_before_write_confirmation() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, _events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+
+    let requested = task.runtime.request_stream_close().unwrap();
+    let close = requested
+        .into_iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                message @ TransportMessage::Close(_),
+            )) => Some(message),
+            _ => None,
+        })
+        .expect("one claimed close");
+    let sent_before_peer_close = shared.sent_messages().len();
+
+    assert!(
+        task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Close(
+            StreamClose,
+        )))
+        .await
+    );
+    assert_eq!(shared.sent_messages().len(), sent_before_peer_close);
+    assert!(!task.runtime.stream_close_complete());
+
+    task.send_transport_message(close).await.unwrap();
+    assert_eq!(
+        shared
+            .sent_messages()
+            .iter()
+            .filter(|message| matches!(message, TransportMessage::Close(_)))
+            .count(),
+        1
+    );
+    assert!(task.runtime.stream_close_complete());
+    assert_eq!(shared.close_count(), 1);
+
+    assert!(
+        task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Close(
+            StreamClose,
+        )))
+        .await
+    );
+    assert_eq!(shared.close_count(), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn native_command_channel_loss_before_close_aborts_and_preserves_resume_state() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, _events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+    assert!(
+        task.handle_command(XmppCommand::SendStanza(message_stanza(
+            "native-channel-loss"
+        )))
+        .await
+    );
+    let resume_before = task.runtime.resume_state();
+
+    assert!(!task.handle_command_channel_closed().await);
+    assert!(task.commands_closed);
+    assert_eq!(shared.abort_count(), 1);
+    assert_eq!(task.runtime.resume_state(), resume_before);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn native_channel_loss_during_half_close_waits_then_times_out_uncleanly() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, _events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+    assert!(
+        task.handle_command(XmppCommand::SendStanza(message_stanza(
+            "native-half-close-timeout"
+        )))
+        .await
+    );
+    assert!(task.handle_command(XmppCommand::Disconnect).await);
+    let resume_before = task.runtime.resume_state();
+
+    assert!(task.handle_command_channel_closed().await);
+    assert!(task.commands_closed);
+    assert_eq!(shared.abort_count(), 0);
+    assert!(!task.handle_driver_timer(true).await);
+    assert_eq!(shared.abort_count(), 1);
+    assert_eq!(shared.close_count(), 0);
+    assert_eq!(task.runtime.resume_state(), resume_before);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn failed_peer_close_reciprocal_preserves_resume_state_and_aborts_uncleanly() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, mut events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+    assert!(
+        task.handle_command(XmppCommand::SendStanza(message_stanza(
+            "peer-close-failure"
+        )))
+        .await
+    );
+    let resume_before = task.runtime.resume_state();
+    shared.fail_stream_close_write(TransportWriteResponsibility::DefinitelyNotWritten);
+
+    assert!(
+        !task
+            .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Close(
+                StreamClose
+            ),))
+            .await
+    );
+
+    assert_eq!(task.runtime.resume_state(), resume_before);
+    assert!(!task.runtime.stream_close_complete());
+    assert_eq!(shared.close_count(), 0);
+    assert_eq!(shared.abort_count(), 1);
+    assert!(matches!(
+        shared.attempted_messages().last(),
+        Some(TransportMessage::Close(_))
+    ));
+    assert!(!shared
+        .sent_messages()
+        .iter()
+        .any(|message| matches!(message, TransportMessage::Close(_))));
+    assert_terminal_transport_event_slice(&drain_client_events(&mut events));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn direct_message_possibly_written_failure_is_retained_once_and_terminal() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, mut events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+    shared.fail_stanza_write(
+        StanzaId::new("uncertain-message").unwrap(),
+        TransportWriteResponsibility::PossiblyWritten,
+    );
+    let stanza = message_stanza("uncertain-message");
+
+    assert!(!task.handle_command(XmppCommand::SendStanza(stanza)).await);
+
+    assert_eq!(
+        resume_stanza_ids(&task),
+        vec!["uncertain-message"],
+        "uncertain transport responsibility must enter the SM queue exactly once"
+    );
+    assert_eq!(
+        attempted_stanza_count(&shared, "uncertain-message"),
+        1,
+        "the failed frame must be attempted exactly once"
+    );
+    let observed = drain_client_events(&mut events);
+    assert!(!observed.iter().any(|event| matches!(
+        event,
+        ClientEvent::MessageDelivery(MessageDeliveryEvent::Failed { stanza_id })
+            if stanza_id.as_str() == "uncertain-message"
+    )));
+    assert_terminal_transport_event_slice(&observed);
+    assert_eq!(shared.abort_count(), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn direct_iq_possibly_written_failure_is_retained_once_and_terminal() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, mut events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+    shared.fail_stanza_write(
+        StanzaId::new("uncertain-iq").unwrap(),
+        TransportWriteResponsibility::PossiblyWritten,
+    );
+    let (responder, response) = oneshot::channel();
+
+    assert!(
+        !task
+            .handle_command(XmppCommand::SendIq {
+                stanza: iq_stanza("uncertain-iq"),
+                responder,
+            })
+            .await
+    );
+
+    assert!(matches!(
+        response.await.expect("IQ responder must resolve"),
+        Err(ClientError::Disconnected)
+    ));
+    assert_eq!(resume_stanza_ids(&task), vec!["uncertain-iq"]);
+    assert_eq!(attempted_stanza_count(&shared, "uncertain-iq"), 1);
+    assert_terminal_transport_event_slice(&drain_client_events(&mut events));
+    assert_eq!(shared.abort_count(), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn definitely_not_written_message_fails_without_entering_resume_queue() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, mut events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+    shared.fail_next_write(TransportWriteResponsibility::DefinitelyNotWritten);
+
+    assert!(
+        !task
+            .handle_command(XmppCommand::SendStanza(message_stanza("not-written")))
+            .await
+    );
+
+    assert!(resume_stanza_ids(&task).is_empty());
+    let observed = drain_client_events(&mut events);
+    assert_eq!(
+        observed
+            .iter()
+            .filter(|event| matches!(
+                event,
+                ClientEvent::MessageDelivery(MessageDeliveryEvent::Failed { stanza_id })
+                    if stanza_id.as_str() == "not-written"
+            ))
+            .count(),
+        1
+    );
+    assert_terminal_transport_event_slice(&observed);
+    assert_eq!(shared.abort_count(), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn confirmed_write_before_later_uncertain_failure_is_reconciled_once() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, mut events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+
+    assert!(
+        task.handle_command(XmppCommand::SendStanza(message_stanza("confirmed-first")))
+            .await
+    );
+    shared.fail_stanza_write(
+        StanzaId::new("uncertain-second").unwrap(),
+        TransportWriteResponsibility::PossiblyWritten,
+    );
+    assert!(
+        !task
+            .handle_command(XmppCommand::SendStanza(message_stanza("uncertain-second")))
+            .await
+    );
+
+    assert_eq!(
+        resume_stanza_ids(&task),
+        vec!["confirmed-first", "uncertain-second"]
+    );
+    assert_eq!(attempted_stanza_count(&shared, "confirmed-first"), 1);
+    assert_eq!(attempted_stanza_count(&shared, "uncertain-second"), 1);
+    assert_terminal_transport_event_slice(&drain_client_events(&mut events));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn deferred_failure_stops_later_writes_and_retains_only_responsible_stanzas() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, mut events) = make_driver_task_with_config(
+        config_with_resume_state(),
+        MockTransport::new(vec![], vec![], shared.clone()),
+    );
+    drive_task_to_resume_attempt(&mut task).await;
+
+    for id in ["deferred-first", "deferred-fails", "deferred-never"] {
+        assert!(
+            task.handle_command(XmppCommand::SendStanza(message_stanza(id)))
+                .await
+        );
+    }
+    shared.fail_stanza_write(
+        StanzaId::new("deferred-fails").unwrap(),
+        TransportWriteResponsibility::PossiblyWritten,
+    );
+
+    assert!(
+        !task
+            .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+                resumed("prev-stream", 0),
+            )))
+            .await
+    );
+
+    assert_eq!(
+        resume_stanza_ids(&task),
+        vec!["deferred-first", "deferred-fails"]
+    );
+    assert_eq!(attempted_stanza_count(&shared, "deferred-first"), 1);
+    assert_eq!(attempted_stanza_count(&shared, "deferred-fails"), 1);
+    assert_eq!(attempted_stanza_count(&shared, "deferred-never"), 0);
+    assert_terminal_transport_event_slice(&drain_client_events(&mut events));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn permanently_pending_abort_returns_after_one_second_with_resume_snapshot() {
+    let shared = MockTransportShared::default();
+    let (mut task, _cmd_tx, mut events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+    shared.fail_stanza_write(
+        StanzaId::new("abort-timeout").unwrap(),
+        TransportWriteResponsibility::PossiblyWritten,
+    );
+    shared.set_abort_pending(true);
+    let started = std::time::Instant::now();
+
+    let keep_running = tokio::time::timeout(
+        std::time::Duration::from_millis(1_500),
+        task.handle_command(XmppCommand::SendStanza(message_stanza("abort-timeout"))),
+    )
+    .await
+    .expect("the bounded abort must return");
+
+    assert!(!keep_running);
+    assert!(
+        started.elapsed() >= std::time::Duration::from_millis(900),
+        "the permanently pending abort should be bounded by the one-second deadline"
+    );
+    assert_eq!(resume_stanza_ids(&task), vec!["abort-timeout"]);
+    assert_eq!(shared.abort_count(), 1);
+    assert_terminal_transport_event_slice(&drain_client_events(&mut events));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn abort_failure_still_publishes_terminal_state_and_preserves_resume_snapshot() {
+    let shared = MockTransportShared::default();
+    shared.set_abort_failure(true);
+    let (mut task, _cmd_tx, mut events) =
+        make_driver_task(MockTransport::new(vec![], vec![], shared.clone()));
+    drive_task_to_sm_enabled(&mut task).await;
+
+    task.handle_command(XmppCommand::SendStanza(message_stanza("message-1")))
+        .await;
+    drain_task_transport_events(&mut task).await;
+    let resume_before = task.runtime.resume_state();
+    assert!(resume_before.is_some());
+
+    assert!(!task.handle_stream_management_timer_at(u64::MAX).await);
+
+    assert_eq!(task.runtime.snapshot().phase, SessionPhase::Disconnected);
+    assert_eq!(task.runtime.resume_state(), resume_before);
+    assert_eq!(shared.abort_count(), 1);
+    assert_eq!(shared.close_count(), 0);
+    assert!(!shared
+        .sent_messages()
+        .iter()
+        .any(|message| matches!(message, TransportMessage::Close(_))));
+    assert_terminal_transport_events(&mut events);
 }
 
 // ── full bootstrap integration tests ─────────────────────────────────────
@@ -541,7 +1375,8 @@ async fn driver_disconnects_cleanly() {
                 // Driver blocks here until a command arrives.
             ],
             shared.clone(),
-        ),
+        )
+        .with_peer_close_after_local_close(),
         false,
     );
 
@@ -584,6 +1419,184 @@ async fn driver_disconnects_cleanly() {
     assert_eq!(shared.close_count(), 1);
 }
 
+fn ready_mock_transport(shared: MockTransportShared) -> MockTransport {
+    MockTransport::new(
+        vec![
+            TransportEvent::StateChanged(TransportState::Connecting),
+            TransportEvent::StateChanged(TransportState::Open),
+        ],
+        vec![
+            Ok(Some(TransportEvent::MessageReceived(
+                TransportMessage::Open(StreamOpen::from_server(
+                    BareJid::from_str("waddle.example").unwrap(),
+                )),
+            ))),
+            Ok(Some(TransportEvent::MessageReceived(
+                TransportMessage::Element(pre_auth_features()),
+            ))),
+            Ok(Some(TransportEvent::MessageReceived(
+                TransportMessage::Element(Element::builder("success", NS_SASL).build()),
+            ))),
+            Ok(Some(TransportEvent::MessageReceived(
+                TransportMessage::Open(StreamOpen::from_server(
+                    BareJid::from_str("waddle.example").unwrap(),
+                )),
+            ))),
+            Ok(Some(TransportEvent::MessageReceived(
+                TransportMessage::Element(post_auth_features()),
+            ))),
+            Ok(Some(TransportEvent::MessageReceived(
+                TransportMessage::Element(bind_result("bind-1")),
+            ))),
+        ],
+        shared,
+    )
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn cloned_native_handles_disconnect_concurrently_once() {
+    let shared = MockTransportShared::default();
+    let factory = MockTransportFactory::new(
+        MockTransport::new(
+            vec![
+                TransportEvent::StateChanged(TransportState::Connecting),
+                TransportEvent::StateChanged(TransportState::Open),
+            ],
+            vec![
+                Ok(Some(TransportEvent::MessageReceived(
+                    TransportMessage::Open(StreamOpen::from_server(
+                        BareJid::from_str("waddle.example").unwrap(),
+                    )),
+                ))),
+                Ok(Some(TransportEvent::MessageReceived(
+                    TransportMessage::Element(pre_auth_features()),
+                ))),
+                Ok(Some(TransportEvent::MessageReceived(
+                    TransportMessage::Element(Element::builder("success", NS_SASL).build()),
+                ))),
+                Ok(Some(TransportEvent::MessageReceived(
+                    TransportMessage::Open(StreamOpen::from_server(
+                        BareJid::from_str("waddle.example").unwrap(),
+                    )),
+                ))),
+                Ok(Some(TransportEvent::MessageReceived(
+                    TransportMessage::Element(post_auth_features()),
+                ))),
+                Ok(Some(TransportEvent::MessageReceived(
+                    TransportMessage::Element(bind_result("bind-1")),
+                ))),
+            ],
+            shared.clone(),
+        )
+        .with_peer_close_after_local_close(),
+        false,
+    );
+    let handle = XmppClient::new(config())
+        .unwrap()
+        .driver_with_factory(factory)
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+    let mut events = handle.events();
+    while !matches!(
+        events.recv().await,
+        Ok(ClientEvent::Lifecycle(LifecycleEvent::SessionReady(_)))
+    ) {}
+
+    let clone = handle.clone();
+    let (first, second) = tokio::join!(handle.disconnect(), clone.disconnect());
+    assert!(first.is_ok());
+    assert!(second.is_ok());
+    while !matches!(
+        events.recv().await,
+        Ok(ClientEvent::Lifecycle(LifecycleEvent::StateChanged(snapshot)))
+            if snapshot.phase == SessionPhase::Disconnected
+    ) {}
+
+    assert_eq!(
+        shared
+            .sent_messages()
+            .iter()
+            .filter(|message| matches!(message, TransportMessage::Close(_)))
+            .count(),
+        1
+    );
+    assert_eq!(shared.close_count(), 1);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn dropping_last_native_handle_before_close_aborts_uncleanly() {
+    let shared = MockTransportShared::default();
+    let factory = MockTransportFactory::new(ready_mock_transport(shared.clone()), false);
+    let handle = XmppClient::new(config())
+        .unwrap()
+        .driver_with_factory(factory)
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+    let mut events = handle.events();
+    while !matches!(
+        events.recv().await,
+        Ok(ClientEvent::Lifecycle(LifecycleEvent::SessionReady(_)))
+    ) {}
+
+    drop(handle);
+    for _ in 0..16 {
+        if shared.abort_count() == 1 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    assert_eq!(shared.abort_count(), 1);
+    assert!(!shared
+        .sent_messages()
+        .iter()
+        .any(|message| matches!(message, TransportMessage::Close(_))));
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn confirmed_native_half_close_aborts_after_five_seconds_without_peer() {
+    let shared = MockTransportShared::default();
+    let factory = MockTransportFactory::new(ready_mock_transport(shared.clone()), false);
+    let handle = XmppClient::new(config())
+        .unwrap()
+        .driver_with_factory(factory)
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+    let mut events = handle.events();
+    while !matches!(
+        events.recv().await,
+        Ok(ClientEvent::Lifecycle(LifecycleEvent::SessionReady(_)))
+    ) {}
+
+    handle.disconnect().await.unwrap();
+    for _ in 0..16 {
+        if shared
+            .sent_messages()
+            .iter()
+            .any(|message| matches!(message, TransportMessage::Close(_)))
+        {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+    tokio::time::advance(std::time::Duration::from_secs(5)).await;
+    for _ in 0..16 {
+        if shared.abort_count() == 1 {
+            break;
+        }
+        tokio::task::yield_now().await;
+    }
+
+    assert_eq!(shared.abort_count(), 1);
+    assert_eq!(shared.close_count(), 0);
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn driver_cleans_up_failed_connects() {
     let factory = MockTransportFactory::new(
@@ -602,8 +1615,29 @@ async fn driver_cleans_up_failed_connects() {
 
 #[derive(Clone, Default)]
 struct MockTransportShared {
+    attempted_messages: Arc<Mutex<Vec<TransportMessage>>>,
     sent_messages: Arc<Mutex<Vec<TransportMessage>>>,
     close_count: Arc<Mutex<usize>>,
+    abort_count: Arc<Mutex<usize>>,
+    write_failures: Arc<Mutex<VecDeque<MockWriteFailure>>>,
+    pending_writes: Arc<Mutex<VecDeque<MockWriteTarget>>>,
+    close_pending: Arc<Mutex<bool>>,
+    abort_failure: Arc<Mutex<bool>>,
+    abort_pending: Arc<Mutex<bool>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MockWriteTarget {
+    Any,
+    AckRequest,
+    StreamClose,
+    Stanza(StanzaId),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MockWriteFailure {
+    target: MockWriteTarget,
+    responsibility: TransportWriteResponsibility,
 }
 
 impl MockTransportShared {
@@ -611,8 +1645,85 @@ impl MockTransportShared {
         self.sent_messages.lock().unwrap().clone()
     }
 
+    fn attempted_messages(&self) -> Vec<TransportMessage> {
+        self.attempted_messages.lock().unwrap().clone()
+    }
+
     fn close_count(&self) -> usize {
         *self.close_count.lock().unwrap()
+    }
+
+    fn abort_count(&self) -> usize {
+        *self.abort_count.lock().unwrap()
+    }
+
+    fn fail_next_write(&self, responsibility: TransportWriteResponsibility) {
+        self.write_failures
+            .lock()
+            .unwrap()
+            .push_back(MockWriteFailure {
+                target: MockWriteTarget::Any,
+                responsibility,
+            });
+    }
+
+    fn fail_ack_request_write(&self, responsibility: TransportWriteResponsibility) {
+        self.write_failures
+            .lock()
+            .unwrap()
+            .push_back(MockWriteFailure {
+                target: MockWriteTarget::AckRequest,
+                responsibility,
+            });
+    }
+
+    fn fail_stanza_write(&self, stanza_id: StanzaId, responsibility: TransportWriteResponsibility) {
+        self.write_failures
+            .lock()
+            .unwrap()
+            .push_back(MockWriteFailure {
+                target: MockWriteTarget::Stanza(stanza_id),
+                responsibility,
+            });
+    }
+
+    fn fail_stream_close_write(&self, responsibility: TransportWriteResponsibility) {
+        self.write_failures
+            .lock()
+            .unwrap()
+            .push_back(MockWriteFailure {
+                target: MockWriteTarget::StreamClose,
+                responsibility,
+            });
+    }
+
+    fn pend_stanza_write(&self, stanza_id: StanzaId) {
+        self.pending_writes
+            .lock()
+            .unwrap()
+            .push_back(MockWriteTarget::Stanza(stanza_id));
+    }
+
+    fn pend_ack_request_write(&self) {
+        self.pending_writes
+            .lock()
+            .unwrap()
+            .push_back(MockWriteTarget::AckRequest);
+    }
+
+    fn pend_stream_close_write(&self) {
+        self.pending_writes
+            .lock()
+            .unwrap()
+            .push_back(MockWriteTarget::StreamClose);
+    }
+
+    fn set_abort_failure(&self, fail: bool) {
+        *self.abort_failure.lock().unwrap() = fail;
+    }
+
+    fn set_abort_pending(&self, pending: bool) {
+        *self.abort_pending.lock().unwrap() = pending;
     }
 }
 
@@ -649,6 +1760,8 @@ struct MockTransport {
     pending_events: VecDeque<TransportEvent>,
     next_events: VecDeque<ClientResult<Option<TransportEvent>>>,
     shared: MockTransportShared,
+    peer_close_after_local_close: bool,
+    peer_close_delivered: bool,
 }
 
 impl MockTransport {
@@ -661,7 +1774,14 @@ impl MockTransport {
             pending_events: pending_events.into(),
             next_events: next_events.into(),
             shared,
+            peer_close_after_local_close: false,
+            peer_close_delivered: false,
         }
+    }
+
+    fn with_peer_close_after_local_close(mut self) -> Self {
+        self.peer_close_after_local_close = true;
+        self
     }
 }
 
@@ -670,15 +1790,48 @@ impl WebSocketTransport for MockTransport {
         self.pending_events.drain(..).collect()
     }
 
-    fn send<'a>(&'a mut self, message: TransportMessage) -> BoxFuture<'a, ClientResult<()>> {
+    fn send<'a>(
+        &'a mut self,
+        message: TransportMessage,
+    ) -> BoxFuture<'a, TransportWriteResult<()>> {
         Box::pin(async move {
+            self.shared
+                .attempted_messages
+                .lock()
+                .unwrap()
+                .push(message.clone());
+            let pending = {
+                let mut pending_writes = self.shared.pending_writes.lock().unwrap();
+                let matches = pending_writes
+                    .front()
+                    .is_some_and(|target| mock_write_target_matches(target, &message));
+                matches.then(|| pending_writes.pop_front())
+            };
+            if pending.is_some() {
+                return std::future::pending::<TransportWriteResult<()>>().await;
+            }
+            let failure = {
+                let mut failures = self.shared.write_failures.lock().unwrap();
+                let matches = failures
+                    .front()
+                    .is_some_and(|failure| mock_write_target_matches(&failure.target, &message));
+                matches.then(|| failures.pop_front().expect("front exists"))
+            };
+            if let Some(failure) = failure {
+                return Err(match failure.responsibility {
+                    TransportWriteResponsibility::DefinitelyNotWritten => {
+                        TransportWriteFailure::definitely_not_written(ClientError::TransportClosed)
+                    }
+                    TransportWriteResponsibility::PossiblyWritten => {
+                        TransportWriteFailure::possibly_written(ClientError::TransportClosed)
+                    }
+                });
+            }
             self.shared
                 .sent_messages
                 .lock()
                 .unwrap()
                 .push(message.clone());
-            self.pending_events
-                .push_back(TransportEvent::MessageSent(message));
             Ok(())
         })
     }
@@ -691,27 +1844,75 @@ impl WebSocketTransport for MockTransport {
             if let Some(event) = self.next_events.pop_front() {
                 return event;
             }
+            if self.peer_close_after_local_close && !self.peer_close_delivered {
+                loop {
+                    if self
+                        .shared
+                        .sent_messages()
+                        .iter()
+                        .any(|message| matches!(message, TransportMessage::Close(_)))
+                    {
+                        self.peer_close_delivered = true;
+                        return Ok(Some(TransportEvent::MessageReceived(
+                            TransportMessage::Close(StreamClose),
+                        )));
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+                }
+            }
             // No more scripted events — park the task until cancelled.
             std::future::pending::<ClientResult<Option<TransportEvent>>>().await
         })
     }
 
-    fn close<'a>(&'a mut self) -> BoxFuture<'a, ClientResult<()>> {
+    fn close_websocket<'a>(&'a mut self) -> BoxFuture<'a, TransportWriteResult<()>> {
         Box::pin(async move {
             *self.shared.close_count.lock().unwrap() += 1;
-            self.shared
-                .sent_messages
-                .lock()
-                .unwrap()
-                .push(TransportMessage::Close(StreamClose));
+            if *self.shared.close_pending.lock().unwrap() {
+                return std::future::pending::<TransportWriteResult<()>>().await;
+            }
             self.pending_events.extend([
                 TransportEvent::StateChanged(TransportState::Closing),
-                TransportEvent::MessageSent(TransportMessage::Close(StreamClose)),
                 TransportEvent::StateChanged(TransportState::Closed),
                 TransportEvent::Closed,
             ]);
             Ok(())
         })
+    }
+
+    fn abort<'a>(&'a mut self) -> BoxFuture<'a, ClientResult<()>> {
+        Box::pin(async move {
+            *self.shared.abort_count.lock().unwrap() += 1;
+            if *self.shared.abort_pending.lock().unwrap() {
+                return std::future::pending::<ClientResult<()>>().await;
+            }
+            if *self.shared.abort_failure.lock().unwrap() {
+                return Err(ClientError::TransportClosed);
+            }
+            self.pending_events.extend([
+                TransportEvent::StateChanged(TransportState::Closing),
+                TransportEvent::StateChanged(TransportState::Closed),
+                TransportEvent::Closed,
+            ]);
+            Ok(())
+        })
+    }
+}
+
+fn mock_write_target_matches(target: &MockWriteTarget, message: &TransportMessage) -> bool {
+    match target {
+        MockWriteTarget::Any => true,
+        MockWriteTarget::AckRequest => matches!(
+            message,
+            TransportMessage::Element(element)
+                if element.name() == "r" && element.ns() == NS_SM
+        ),
+        MockWriteTarget::StreamClose => matches!(message, TransportMessage::Close(_)),
+        MockWriteTarget::Stanza(stanza_id) => matches!(
+            message,
+            TransportMessage::Element(element)
+                if element.attr("id") == Some(stanza_id.as_str())
+        ),
     }
 }
 
@@ -776,6 +1977,13 @@ fn message_stanza(stanza_id: &str) -> Element {
         .build()
 }
 
+fn iq_stanza(stanza_id: &str) -> Element {
+    Element::builder("iq", crate::NS_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), stanza_id)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
+        .build()
+}
+
 fn resumed(previd: &str, h: u32) -> Element {
     Element::builder("resumed", NS_SM)
         .attr(minidom::rxml::xml_ncname!("previd").to_owned(), previd)
@@ -830,4 +2038,166 @@ async fn drive_task_to_resume_attempt(task: &mut DriverTask) {
     )))
     .await;
     assert_eq!(task.runtime.snapshot().phase, SessionPhase::Resuming);
+}
+
+async fn drive_task_to_sm_enabled(task: &mut DriverTask) {
+    task.runtime
+        .queue_request(ClientRequest::Connect)
+        .expect("connect request should queue");
+    task.apply_transport_event(TransportEvent::StateChanged(TransportState::Open))
+        .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Open(
+        StreamOpen::from_server(BareJid::from_str("waddle.example").unwrap()),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        pre_auth_features(),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        Element::builder("success", NS_SASL).build(),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Open(
+        StreamOpen::from_server(BareJid::from_str("waddle.example").unwrap()),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        post_auth_features_with_sm(),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        bind_result("bind-1"),
+    )))
+    .await;
+    task.apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+        enabled_sm("stream-1"),
+    )))
+    .await;
+    drain_task_transport_events(task).await;
+    assert_eq!(task.runtime.snapshot().phase, SessionPhase::Established);
+}
+
+async fn drain_task_transport_events(task: &mut DriverTask) {
+    loop {
+        let events = task.transport.drain_events();
+        if events.is_empty() {
+            return;
+        }
+        for event in events {
+            assert!(task.apply_transport_event(event).await);
+        }
+    }
+}
+
+fn assert_terminal_transport_events(events: &mut broadcast::Receiver<ClientEvent>) {
+    let mut saw_failed = false;
+    let mut saw_closed_state = false;
+    let mut saw_closed = false;
+    while let Ok(event) = events.try_recv() {
+        match event {
+            ClientEvent::Transport(TransportEvent::StateChanged(TransportState::Failed)) => {
+                saw_failed = true;
+            }
+            ClientEvent::Transport(TransportEvent::StateChanged(TransportState::Closed)) => {
+                saw_closed_state = true;
+            }
+            ClientEvent::Transport(TransportEvent::Closed) => saw_closed = true,
+            _ => {}
+        }
+    }
+    assert!(saw_failed, "unclean failure must be observable");
+    assert!(
+        saw_closed_state,
+        "closed transport state must be observable"
+    );
+    assert!(saw_closed, "terminal Closed event must be observable");
+}
+
+fn resume_stanza_ids(task: &DriverTask) -> Vec<String> {
+    task.runtime
+        .resume_state()
+        .map(|state| {
+            state
+                .unhandled_outbound_stanzas()
+                .filter_map(|element| element.attr("id"))
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn attempted_stanza_count(shared: &MockTransportShared, stanza_id: &str) -> usize {
+    shared
+        .attempted_messages()
+        .iter()
+        .filter(|message| transport_message_id(message) == Some(stanza_id))
+        .count()
+}
+
+fn attempted_ack_request_count(shared: &MockTransportShared) -> usize {
+    shared
+        .attempted_messages()
+        .iter()
+        .filter(|message| {
+            matches!(
+                message,
+                TransportMessage::Element(element)
+                    if element.name() == "r" && element.ns() == NS_SM
+            )
+        })
+        .count()
+}
+
+fn drain_client_events(events: &mut broadcast::Receiver<ClientEvent>) -> Vec<ClientEvent> {
+    let mut observed = Vec::new();
+    while let Ok(event) = events.try_recv() {
+        observed.push(event);
+    }
+    observed
+}
+
+fn assert_terminal_transport_event_slice(events: &[ClientEvent]) {
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Transport(TransportEvent::StateChanged(TransportState::Failed))
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Transport(TransportEvent::StateChanged(TransportState::Closed))
+    )));
+    assert!(events
+        .iter()
+        .any(|event| matches!(event, ClientEvent::Transport(TransportEvent::Closed))));
+}
+
+fn assert_terminal_transport_events_without_ack_request(
+    events: &mut broadcast::Receiver<ClientEvent>,
+) {
+    let mut saw_failed = false;
+    let mut saw_closed_state = false;
+    let mut saw_closed = false;
+    let mut saw_ack_request = false;
+    while let Ok(event) = events.try_recv() {
+        match event {
+            ClientEvent::Transport(TransportEvent::StateChanged(TransportState::Failed)) => {
+                saw_failed = true;
+            }
+            ClientEvent::Transport(TransportEvent::StateChanged(TransportState::Closed)) => {
+                saw_closed_state = true;
+            }
+            ClientEvent::Transport(TransportEvent::Closed) => saw_closed = true,
+            ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                StreamManagementEvent::AckRequestSent { .. },
+            )) => saw_ack_request = true,
+            _ => {}
+        }
+    }
+    assert!(saw_failed, "unclean failure must be observable");
+    assert!(saw_closed_state, "closed state must be observable");
+    assert!(saw_closed, "terminal Closed event must be observable");
+    assert!(
+        !saw_ack_request,
+        "a failed generated <r/> write must not publish AckRequestSent"
+    );
 }

--- a/server/crates/waddle-xmpp-client/src/error.rs
+++ b/server/crates/waddle-xmpp-client/src/error.rs
@@ -28,6 +28,8 @@ pub enum ClientError {
     EmptyResource,
     #[error("stanza id must not be empty")]
     EmptyStanzaId,
+    #[error("stream management session id must not be empty")]
+    EmptyStreamManagementSessionId,
     #[error("request correlation ids are exhausted")]
     RequestIdExhausted,
     #[error("request {request_id} is already pending")]
@@ -60,6 +62,8 @@ pub enum ClientError {
     InvalidWebSocketRequest(#[source] tokio_tungstenite::tungstenite::http::Error),
     #[error("websocket connection timed out after {timeout:?}")]
     WebSocketConnectTimeout { timeout: Duration },
+    #[error("websocket transport write timed out after {timeout:?}")]
+    WebSocketWriteTimeout { timeout: Duration },
     #[error("iq request timed out after {timeout:?}")]
     IqTimeout { timeout: Duration },
     #[error("websocket transport failed")]

--- a/server/crates/waddle-xmpp-client/src/event.rs
+++ b/server/crates/waddle-xmpp-client/src/event.rs
@@ -11,7 +11,7 @@ use crate::pubsub_event::{PubsubAttachmentSummaryUpdate, PubsubRetractedItems};
 use crate::request::StanzaId;
 use crate::request::{PendingRequest, RequestCorrelation};
 use crate::state::{SessionBinding, SessionSnapshot};
-use crate::stream_management::SmResumeState;
+use crate::stream_management::{SmResumeState, SmSessionId};
 use crate::transport::{StreamOpen, TransportEvent, TransportMessage};
 
 /// Public event surface emitted by the client runtime.
@@ -105,10 +105,39 @@ pub enum ConnectionEvent {
 /// XEP-0198 stream management lifecycle notifications.
 #[derive(Debug, Clone)]
 pub enum StreamManagementEvent {
-    Enabled { previd: Option<String> },
-    AckReceived { h: u32 },
+    Enabled {
+        previd: Option<SmSessionId>,
+    },
+    AckReceived {
+        h: u32,
+    },
+    /// The client emitted `<r/>` for its outstanding client-to-server
+    /// stanza window. Carries counters only; no stanza or stream identity.
+    AckRequestSent {
+        attempt: u32,
+        unacked: u32,
+    },
+    /// A valid server `<a/>` released the request-in-flight latch.
+    AckObserved {
+        progressed: bool,
+        latency_ms: Option<u64>,
+        unacked: u32,
+    },
+    /// The server did not answer `<r/>` within the bounded response window.
+    AckRequestTimedOut {
+        unacked: u32,
+    },
+    /// The server's handled count has not advanced for the bounded progress
+    /// window. Drivers use this typed signal to abort the XML stream
+    /// uncleanly so normal reconnect/resume can take over.
+    AckProgressStalled {
+        unacked: u32,
+        elapsed_ms: u64,
+    },
     AckRequested,
-    Resumed { h: u32 },
+    Resumed {
+        h: u32,
+    },
     Failed,
 }
 

--- a/server/crates/waddle-xmpp-client/src/lib.rs
+++ b/server/crates/waddle-xmpp-client/src/lib.rs
@@ -121,7 +121,7 @@ pub use stickers::{
     parse_sticker_packs_result, HashAlgo, PackId, PackRef, PackSticker, StickerHash, StickerMarker,
     StickerPackDoc, StickerText, NS_STICKERS, STICKERS_NODE,
 };
-pub use stream_management::SmResumeState;
+pub use stream_management::{SmResumeEntry, SmResumeState, SmSessionId};
 pub use transport::{
     decode_message, encode_message, StreamClose, StreamOpen, TransportCapabilities, TransportEvent,
     TransportKind, TransportMessage, TransportState,

--- a/server/crates/waddle-xmpp-client/src/runtime.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime.rs
@@ -9,15 +9,38 @@ use crate::error::{ClientError, ClientResult};
 use crate::event::{ClientEvent, ConnectionEvent, LifecycleEvent};
 use crate::request::{ClientRequest, PendingRequest, RequestTracker, StanzaId};
 use crate::state::{SessionBinding, SessionPhase, SessionSnapshot};
-use crate::stream_management::{SmResumeState, SmState};
+use crate::stream_management::{AckRequest, SmResumeState, SmState};
 use crate::transport::{StreamClose, StreamOpen, TransportEvent, TransportMessage, TransportState};
 use crate::AuthenticationConfig;
 use minidom::Element;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn monotonic_now_ms() -> u64 {
+    use std::sync::OnceLock;
+    use std::time::Instant;
+
+    static START: OnceLock<Instant> = OnceLock::new();
+    u64::try_from(START.get_or_init(Instant::now).elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn monotonic_now_ms() -> u64 {
+    web_sys::window()
+        .and_then(|window| window.performance())
+        .map(|performance| performance.now().max(0.0) as u64)
+        .unwrap_or_else(|| js_sys::Date::now().max(0.0) as u64)
+}
 
 mod app_stanza;
 mod sm;
 #[cfg(test)]
 mod tests;
+
+/// RFC 7395 stream close is a two-half exchange. Five seconds bounds a
+/// confirmed local half-close without waiting long enough to consume the
+/// XEP-0198 30-second no-progress budget; expiry is an unfinished stream so
+/// its resumable state remains authoritative.
+pub const RFC7395_PEER_CLOSE_TIMEOUT_MS: u64 = 5_000;
 
 /// High-level lifecycle of the scaffolded runtime wrapper.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -39,6 +62,20 @@ pub struct XmppRuntime {
     pending_fallback_retries: VecDeque<Element>,
     fallback_resume_state: Option<SmResumeState>,
     fallback_retry_writes_in_flight: VecDeque<Element>,
+    /// Ack-request metadata waiting for transport confirmation of the exact
+    /// generated `<r/>`. Keeping this inside the typed runtime prevents a
+    /// driver from publishing `AckRequestSent` before the write succeeds.
+    pending_ack_request: Option<AckRequest>,
+    stream_close: StreamCloseHandshake,
+}
+
+#[derive(Debug, Default)]
+struct StreamCloseHandshake {
+    requested: bool,
+    sent_confirmed: bool,
+    sent_confirmed_at_ms: Option<u64>,
+    received: bool,
+    complete: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -75,6 +112,8 @@ impl XmppRuntime {
             pending_fallback_retries: VecDeque::new(),
             fallback_resume_state: None,
             fallback_retry_writes_in_flight: VecDeque::new(),
+            pending_ack_request: None,
+            stream_close: StreamCloseHandshake::default(),
         })
     }
 
@@ -95,6 +134,38 @@ impl XmppRuntime {
         }
 
         self.sm_state.resume_state()
+    }
+
+    /// True only after both directions of the typed RFC 7395 `<close/>`
+    /// exchange are confirmed. Drivers use this edge to begin RFC 6455 close.
+    pub fn stream_close_complete(&self) -> bool {
+        self.stream_close.complete
+    }
+
+    /// True after the local RFC 7395 `<close/>` has reached the transport.
+    /// From this edge no later XMPP XML may be emitted on the stream.
+    pub fn stream_close_sent_confirmed(&self) -> bool {
+        self.stream_close.sent_confirmed
+    }
+
+    /// True once either a public request or a peer close has claimed the one
+    /// local `<close/>` write for this stream.
+    pub fn stream_close_requested(&self) -> bool {
+        self.stream_close.requested
+    }
+
+    /// Remaining delay before a confirmed local half-close becomes an
+    /// unfinished stream. No deadline exists after the peer half arrives.
+    pub fn next_stream_close_wakeup_in_ms(&self, now_ms: u64) -> Option<u64> {
+        let sent_at = self.stream_close.sent_confirmed_at_ms?;
+        if self.stream_close.received || self.stream_close.complete {
+            return None;
+        }
+        Some(RFC7395_PEER_CLOSE_TIMEOUT_MS.saturating_sub(now_ms.saturating_sub(sent_at)))
+    }
+
+    pub fn stream_close_timed_out_at(&self, now_ms: u64) -> bool {
+        self.next_stream_close_wakeup_in_ms(now_ms) == Some(0)
     }
 
     pub fn pending_requests(&self) -> Vec<PendingRequest> {
@@ -134,17 +205,23 @@ impl XmppRuntime {
                 self.set_phase(SessionPhase::Connecting)?;
             }
             crate::request::RequestKind::Disconnect => {
-                self.bootstrap = BootstrapState::Idle;
-                self.set_phase(SessionPhase::Disconnecting)?;
-                events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
-                    TransportMessage::Close(StreamClose),
-                )));
+                self.begin_local_stream_close(&mut events)?;
             }
             _ => {}
         }
 
         self.push_state_change(previous, &mut events);
 
+        Ok(events)
+    }
+
+    /// Claim and emit the one local RFC 7395 close frame. Repeated native,
+    /// WASM, and standalone-runtime requests coalesce without another write.
+    pub fn request_stream_close(&mut self) -> ClientResult<Vec<ClientEvent>> {
+        let previous = self.snapshot.clone();
+        let mut events = Vec::new();
+        self.begin_local_stream_close(&mut events)?;
+        self.push_state_change(previous, &mut events);
         Ok(events)
     }
 
@@ -178,11 +255,95 @@ impl XmppRuntime {
         &mut self,
         event: TransportEvent,
     ) -> ClientResult<Vec<ClientEvent>> {
+        self.apply_transport_event_at(event, monotonic_now_ms())
+    }
+
+    /// Apply one transport event at an injected monotonic timestamp.
+    /// Drivers and deterministic SM tests use this to share one cadence on
+    /// native and WASM without putting a platform clock inside [`SmState`].
+    pub fn apply_transport_event_at(
+        &mut self,
+        event: TransportEvent,
+        now_ms: u64,
+    ) -> ClientResult<Vec<ClientEvent>> {
         let previous = self.snapshot.clone();
         let mut events = vec![ClientEvent::Transport(event.clone())];
-        self.apply_transport_side_effects(event, &mut events)?;
+        self.apply_transport_side_effects(event, now_ms, &mut events)?;
+        if self.stream_close.sent_confirmed {
+            events.retain(|event| {
+                !matches!(
+                    event,
+                    ClientEvent::Connection(ConnectionEvent::OutboundMessage(_))
+                )
+            });
+        }
         self.push_state_change(previous, &mut events);
         Ok(events)
+    }
+
+    /// Poll the XEP-0198 acknowledgement cadence at an injected monotonic
+    /// timestamp. Returned events are transport instructions and content-free
+    /// telemetry; drivers must abort uncleanly when the stalled event appears.
+    pub fn poll_stream_management_at(&mut self, now_ms: u64) -> Vec<ClientEvent> {
+        if self.stream_close.sent_confirmed {
+            return Vec::new();
+        }
+        let poll = self.sm_state.poll_ack_timer_at(now_ms);
+        let mut events = Vec::new();
+        if poll.request_timed_out {
+            events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                crate::event::StreamManagementEvent::AckRequestTimedOut {
+                    unacked: self.sm_state.unacked_count(),
+                },
+            )));
+        }
+        if let Some(request) = poll.request {
+            self.push_ack_request(request, &mut events);
+        }
+        if let Some(elapsed_ms) = poll.progress_stalled_ms {
+            events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                crate::event::StreamManagementEvent::AckProgressStalled {
+                    unacked: self.sm_state.unacked_count(),
+                    elapsed_ms,
+                },
+            )));
+        }
+        events
+    }
+
+    pub fn next_stream_management_wakeup_in_ms(&self, now_ms: u64) -> Option<u64> {
+        if self.stream_close.sent_confirmed {
+            return None;
+        }
+        self.sm_state.next_ack_wakeup_in_ms(now_ms)
+    }
+
+    /// Best-effort pagehide hook. It shares the normal request-in-flight gate
+    /// and therefore never emits a second concurrent `<r/>`.
+    pub fn request_stream_management_ack_at(&mut self, now_ms: u64) -> Vec<ClientEvent> {
+        if self.stream_close.sent_confirmed {
+            return Vec::new();
+        }
+        let mut events = Vec::new();
+        if let Some(request) = self.sm_state.request_ack_now_at(now_ms) {
+            self.push_ack_request(request, &mut events);
+        }
+        events
+    }
+
+    /// Dispose the exact runtime-owned `<r/>` generation after a transport
+    /// proves that no bytes were accepted. A mismatched/stale disposition is
+    /// rejected so it cannot clear a newer request generation.
+    pub fn stream_management_ack_definitely_not_written_at(&mut self, now_ms: u64) -> bool {
+        let Some(pending) = self.pending_ack_request.take() else {
+            return false;
+        };
+        if self.sm_state.ack_request_definitely_not_written_at(now_ms) {
+            true
+        } else {
+            self.pending_ack_request = Some(pending);
+            false
+        }
     }
 
     fn resolved_event(&self, pending: PendingRequest) -> ClientEvent {
@@ -192,6 +353,7 @@ impl XmppRuntime {
     fn apply_transport_side_effects(
         &mut self,
         event: TransportEvent,
+        now_ms: u64,
         events: &mut Vec<ClientEvent>,
     ) -> ClientResult<()> {
         self.snapshot.transport = event.transport_state();
@@ -209,14 +371,33 @@ impl XmppRuntime {
                 self.handle_stream_open(open, events)?;
             }
             TransportEvent::MessageReceived(TransportMessage::Element(element)) => {
-                self.handle_received_element(element, events)?;
+                self.handle_received_element(element, now_ms, events)?;
             }
             TransportEvent::MessageSent(TransportMessage::Element(element)) => {
-                self.handle_sent_element(&element);
+                self.handle_sent_element(&element, now_ms, events);
             }
-            TransportEvent::MessageReceived(TransportMessage::Close(_))
-            | TransportEvent::StateChanged(TransportState::Closed)
-            | TransportEvent::Closed => {
+            TransportEvent::MessageReceived(TransportMessage::Close(_)) => {
+                self.stream_close.received = true;
+                self.set_phase(SessionPhase::Disconnecting)?;
+                if !self.stream_close.requested {
+                    self.stream_close.requested = true;
+                    self.push_final_sm_ack(events);
+                    events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                        TransportMessage::Close(StreamClose),
+                    )));
+                }
+                self.finish_stream_close_if_complete()?;
+            }
+            TransportEvent::MessageSent(TransportMessage::Close(_)) => {
+                self.stream_close.requested = true;
+                self.stream_close.sent_confirmed = true;
+                self.stream_close.sent_confirmed_at_ms.get_or_insert(now_ms);
+                self.pending_ack_request = None;
+                self.set_phase(SessionPhase::Disconnecting)?;
+                self.finish_stream_close_if_complete()?;
+            }
+            TransportEvent::StateChanged(TransportState::Closed) | TransportEvent::Closed => {
+                self.pending_ack_request = None;
                 self.snapshot.binding = None;
                 self.bootstrap = BootstrapState::Idle;
                 self.sm_state.stop();
@@ -225,23 +406,84 @@ impl XmppRuntime {
             TransportEvent::StateChanged(TransportState::Closing) => {
                 self.set_phase(SessionPhase::Disconnecting)?;
             }
-            TransportEvent::StateChanged(TransportState::Idle)
-            | TransportEvent::MessageSent(_)
-            | TransportEvent::StateChanged(TransportState::Failed) => {}
+            TransportEvent::StateChanged(TransportState::Failed) => {
+                self.pending_ack_request = None;
+            }
+            TransportEvent::StateChanged(TransportState::Idle) | TransportEvent::MessageSent(_) => {
+            }
         }
 
         Ok(())
     }
 
-    fn handle_sent_element(&mut self, element: &Element) {
+    fn begin_local_stream_close(&mut self, events: &mut Vec<ClientEvent>) -> ClientResult<()> {
+        self.set_phase(SessionPhase::Disconnecting)?;
+        if self.stream_close.requested || self.stream_close.sent_confirmed {
+            return Ok(());
+        }
+        self.stream_close.requested = true;
+        self.push_final_sm_ack(events);
+        events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Close(StreamClose),
+        )));
+        Ok(())
+    }
+
+    fn push_final_sm_ack(&self, events: &mut Vec<ClientEvent>) {
+        if self.sm_state.enabled {
+            events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(SmState::build_ack(self.sm_state.inbound_count)),
+            )));
+        }
+    }
+
+    fn finish_stream_close_if_complete(&mut self) -> ClientResult<()> {
+        if self.stream_close.complete
+            || !self.stream_close.sent_confirmed
+            || !self.stream_close.received
+        {
+            return Ok(());
+        }
+
+        self.stream_close.complete = true;
+        self.pending_ack_request = None;
+        self.pending_fallback_retries.clear();
+        self.fallback_resume_state = None;
+        self.fallback_retry_writes_in_flight.clear();
+        self.sm_state = SmState::new();
+        self.snapshot.binding = None;
+        self.bootstrap = BootstrapState::Idle;
+        self.set_phase(SessionPhase::Disconnecting)
+    }
+
+    fn handle_sent_element(
+        &mut self,
+        element: &Element,
+        now_ms: u64,
+        events: &mut Vec<ClientEvent>,
+    ) {
         if element.ns() == crate::stream_management::NS_SM && element.name() == "enable" {
             self.sm_state.start_outbound();
             return;
         }
 
-        if self.sm_state.outbound_enabled && matches!(element.name(), "iq" | "message" | "presence")
-        {
-            self.sm_state.record_sent_stanza(element);
+        if SmState::is_request_ack(element) {
+            if let Some(request) = self.pending_ack_request.take() {
+                if self.sm_state.confirm_ack_request_sent_at(now_ms) {
+                    events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                        crate::event::StreamManagementEvent::AckRequestSent {
+                            attempt: request.attempt,
+                            unacked: request.unacked,
+                        },
+                    )));
+                }
+            }
+            return;
+        }
+
+        let sent = self.sm_state.record_sent_stanza_at(element, now_ms);
+        if let Some(request) = sent.request {
+            self.push_ack_request(request, events);
         }
         self.mark_fallback_retry_sent(element);
     }
@@ -262,12 +504,13 @@ impl XmppRuntime {
     fn handle_received_element(
         &mut self,
         element: minidom::Element,
+        now_ms: u64,
         events: &mut Vec<ClientEvent>,
     ) -> ClientResult<()> {
         use crate::stream_management::NS_SM;
 
         if element.ns() == NS_SM {
-            self.handle_sm_element(&element, events)?;
+            self.handle_sm_element(&element, now_ms, events)?;
             return Ok(());
         }
 
@@ -276,15 +519,34 @@ impl XmppRuntime {
             return Ok(());
         }
 
-        // Track inbound stanzas for SM once enabled.
-        if self.sm_state.enabled && matches!(element.name(), "iq" | "message" | "presence") {
-            self.sm_state.record_received(1);
-        }
-
         // Once bootstrap is complete, route to the app-level stanza dispatcher.
         if matches!(self.bootstrap, BootstrapState::Ready) {
-            events.extend(self.handle_app_stanza(&element));
+            let app_events = self.handle_app_stanza(&element);
+            // A stanza that requires a response cannot be accepted after our
+            // confirmed RFC 7395 close half: emitting the response would put
+            // XML after `<close/>`, while advancing SM h without it would lie
+            // about handled work. Preserve it for server replay instead.
+            if self.stream_close_sent_confirmed()
+                && app_events.iter().any(|event| {
+                    matches!(
+                        event,
+                        ClientEvent::Connection(ConnectionEvent::OutboundMessage(_))
+                    )
+                })
+            {
+                return Ok(());
+            }
+            if self.sm_state.enabled && matches!(element.name(), "iq" | "message" | "presence") {
+                self.sm_state.record_received(1);
+            }
+            events.extend(app_events);
             return Ok(());
+        }
+
+        // Track any countable bootstrap stanza only after deciding that it is
+        // not application work fenced by the local close half above.
+        if self.sm_state.enabled && matches!(element.name(), "iq" | "message" | "presence") {
+            self.sm_state.record_received(1);
         }
 
         let Some(parsed) = BootstrapElement::parse(&element) else {
@@ -307,6 +569,21 @@ impl XmppRuntime {
         }
 
         Ok(())
+    }
+
+    fn push_ack_request(
+        &mut self,
+        request: crate::stream_management::AckRequest,
+        events: &mut Vec<ClientEvent>,
+    ) {
+        debug_assert!(
+            self.pending_ack_request.is_none(),
+            "SM permits only one generated ack request awaiting a write"
+        );
+        self.pending_ack_request = Some(request);
+        events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Element(SmState::build_request_ack()),
+        )));
     }
 
     fn handle_stream_features(
@@ -352,7 +629,11 @@ impl XmppRuntime {
                     && self.sm_state.previd.is_some()
                 {
                     let resume = SmState::build_resume(
-                        self.sm_state.previd.as_deref().unwrap_or_default(),
+                        self.sm_state
+                            .previd
+                            .as_ref()
+                            .expect("checked stream management session id")
+                            .as_str(),
                         self.sm_state.inbound_count,
                     );
                     self.bootstrap = BootstrapState::AwaitingResume;
@@ -566,6 +847,7 @@ impl XmppRuntime {
                 | (SessionPhase::Binding, SessionPhase::Established)
                 | (SessionPhase::Established, SessionPhase::Resuming)
                 | (SessionPhase::Resuming, SessionPhase::Established)
+                | (SessionPhase::Resuming, SessionPhase::Disconnecting)
                 | (SessionPhase::Established, SessionPhase::Disconnecting)
                 | (SessionPhase::Connecting, SessionPhase::Disconnecting)
                 | (SessionPhase::OpeningStream, SessionPhase::Disconnecting)

--- a/server/crates/waddle-xmpp-client/src/runtime/sm.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/sm.rs
@@ -71,9 +71,16 @@ impl XmppRuntime {
     pub(super) fn handle_sm_element(
         &mut self,
         element: &minidom::Element,
+        now_ms: u64,
         events: &mut Vec<ClientEvent>,
     ) -> ClientResult<()> {
         if crate::stream_management::SmState::is_request_ack(element) {
+            // RFC 7395 permits no XML after our confirmed close half. The
+            // final peer `<a/>` remains useful below, but a late `<r/>`
+            // cannot be answered without violating the close fence.
+            if self.stream_close_sent_confirmed() {
+                return Ok(());
+            }
             let h = self.sm_state.inbound_count;
             let ack = crate::stream_management::SmState::build_ack(h);
             events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
@@ -83,18 +90,28 @@ impl XmppRuntime {
                 StreamManagementEvent::AckRequested,
             )));
         } else if let Some(h) = crate::stream_management::SmState::parse_ack_h(element) {
-            if self.sm_state.handled_count_too_high(h) {
-                self.handle_sm_handled_count_too_high(h, events);
-                return Ok(());
-            }
-            let acked = self.sm_state.process_ack(h);
+            let processed = match self.sm_state.process_ack_at(h, now_ms) {
+                Ok(processed) => processed,
+                Err(_) => {
+                    self.handle_sm_handled_count_too_high(h, events);
+                    return Ok(());
+                }
+            };
             events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::AckReceived { h },
             )));
-            events.extend(acked.into_iter().map(|stanza_id| {
+            events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                StreamManagementEvent::AckObserved {
+                    progressed: processed.observation.progressed,
+                    latency_ms: processed.observation.latency_ms,
+                    unacked: processed.observation.unacked,
+                },
+            )));
+            events.extend(processed.acked.into_iter().map(|stanza_id| {
                 ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked { stanza_id })
             }));
         } else if element.name() == "enabled" {
+            self.pending_ack_request = None;
             // <enabled/> is only legal as the answer to <enable/>. A
             // duplicate on a live SM session is a protocol violation
             // (mirroring unexpected <resumed/>): silently re-running the
@@ -119,26 +136,32 @@ impl XmppRuntime {
             )));
             self.flush_pending_fallback_retries(events);
         } else if element.name() == "resumed" {
+            self.pending_ack_request = None;
             let Some(h) = element.attr("h").and_then(|v| v.parse().ok()) else {
                 self.handle_sm_protocol_violation(events);
                 return Ok(());
             };
-            let Some(previd) = element.attr("previd") else {
+            let Some(previd) = element
+                .attr("previd")
+                .and_then(|value| crate::stream_management::SmSessionId::new(value).ok())
+            else {
                 self.handle_sm_protocol_violation(events);
                 return Ok(());
             };
             if !matches!(self.bootstrap, BootstrapState::AwaitingResume)
-                || self.sm_state.previd.as_deref() != Some(previd)
+                || self.sm_state.previd.as_ref() != Some(&previd)
             {
                 self.handle_sm_protocol_violation(events);
                 return Ok(());
             }
-            if self.sm_state.handled_count_too_high(h) {
-                self.handle_sm_handled_count_too_high(h, events);
-                return Ok(());
-            }
-            let acked = self.sm_state.process_ack(h);
-            self.sm_state.previd = Some(previd.to_string());
+            let processed = match self.sm_state.process_ack_at(h, now_ms) {
+                Ok(processed) => processed,
+                Err(_) => {
+                    self.handle_sm_handled_count_too_high(h, events);
+                    return Ok(());
+                }
+            };
+            self.sm_state.previd = Some(previd);
             self.sm_state.enabled = true;
             self.sm_state.outbound_enabled = true;
             self.snapshot.binding = Some(self.resumed_session_binding()?);
@@ -147,23 +170,34 @@ impl XmppRuntime {
             events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
                 StreamManagementEvent::Resumed { h },
             )));
-            events.extend(acked.into_iter().map(|stanza_id| {
+            events.push(ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                StreamManagementEvent::AckObserved {
+                    progressed: processed.observation.progressed,
+                    latency_ms: processed.observation.latency_ms,
+                    unacked: processed.observation.unacked,
+                },
+            )));
+            events.extend(processed.acked.into_iter().map(|stanza_id| {
                 ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked { stanza_id })
             }));
+            self.sm_state.begin_replay_transition_at(now_ms);
             for replay in self.sm_state.mark_unhandled_for_replay() {
                 events.push(ClientEvent::Connection(ConnectionEvent::OutboundMessage(
                     TransportMessage::Element(replay),
                 )));
             }
         } else if element.name() == "failed" {
+            self.pending_ack_request = None;
             let resume_failed = matches!(self.bootstrap, BootstrapState::AwaitingResume);
             if let Some(h) = element.attr("h").and_then(|value| value.parse().ok()) {
-                if self.sm_state.handled_count_too_high(h) {
-                    self.handle_sm_handled_count_too_high(h, events);
-                    return Ok(());
-                }
-                let acked = self.sm_state.process_ack(h);
-                events.extend(acked.into_iter().map(|stanza_id| {
+                let processed = match self.sm_state.process_ack_at(h, now_ms) {
+                    Ok(processed) => processed,
+                    Err(_) => {
+                        self.handle_sm_handled_count_too_high(h, events);
+                        return Ok(());
+                    }
+                };
+                events.extend(processed.acked.into_iter().map(|stanza_id| {
                     ClientEvent::MessageDelivery(MessageDeliveryEvent::Acked { stanza_id })
                 }));
             }
@@ -242,7 +276,11 @@ impl XmppRuntime {
             .map_err(|_| ClientError::InvalidBindResponse)?;
         Ok(SessionBinding {
             jid,
-            stream_id: self.sm_state.previd.as_ref().map(StreamId::new),
+            stream_id: self
+                .sm_state
+                .previd
+                .as_ref()
+                .map(|previd| StreamId::new(previd.as_str())),
             resumable: self.sm_state.previd.is_some(),
         })
     }

--- a/server/crates/waddle-xmpp-client/src/runtime/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/runtime/tests.rs
@@ -8,7 +8,8 @@ use super::*;
 use crate::bootstrap::{NS_BIND, NS_SASL, NS_STREAMS};
 use crate::config::{AccessToken, ClientResource, OAuthBearerConfig, WebSocketConfig};
 use crate::{
-    ConnectionConfig, SmResumeState, StreamErrorCondition, StreamId, StreamManagementEvent,
+    ConnectionConfig, SmResumeState, SmSessionId, StreamErrorCondition, StreamId,
+    StreamManagementEvent,
 };
 
 fn config() -> ClientConfig {
@@ -31,6 +32,394 @@ fn runtime_updates_state_when_connecting() {
     let events = runtime.queue_request(ClientRequest::Connect).unwrap();
     assert_eq!(runtime.snapshot().phase, SessionPhase::Connecting);
     assert_eq!(events.len(), 2);
+}
+
+#[test]
+fn local_stream_close_request_is_idempotent_across_runtime_entrypoints() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime.snapshot.phase = SessionPhase::Established;
+
+    let first = runtime.request_stream_close().unwrap();
+    let second = runtime.request_stream_close().unwrap();
+    let queued = runtime.queue_request(ClientRequest::Disconnect).unwrap();
+
+    let close_count = first
+        .iter()
+        .chain(second.iter())
+        .chain(queued.iter())
+        .filter(|event| {
+            matches!(
+                event,
+                ClientEvent::Connection(ConnectionEvent::OutboundMessage(TransportMessage::Close(
+                    _
+                )))
+            )
+        })
+        .count();
+    assert_eq!(close_count, 1);
+    assert!(runtime.stream_close_requested());
+    assert!(!runtime.stream_close_sent_confirmed());
+}
+
+#[test]
+fn graceful_close_sends_final_inbound_ack_immediately_before_stream_close() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime.snapshot.phase = SessionPhase::Established;
+    runtime.bootstrap = BootstrapState::Ready;
+    runtime.sm_state.enabled = true;
+    runtime.sm_state.inbound_count = 7;
+
+    let events = runtime.request_stream_close().unwrap();
+    let outbound = events
+        .iter()
+        .filter_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(message)) => Some(message),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(outbound.len(), 2);
+    assert!(matches!(
+        outbound[0],
+        TransportMessage::Element(element)
+            if element.name() == "a"
+                && element.ns() == crate::stream_management::NS_SM
+                && element.attr("h") == Some("7")
+    ));
+    assert!(matches!(outbound[1], TransportMessage::Close(_)));
+}
+
+#[test]
+fn inbound_ack_request_immediately_answers_with_current_inbound_count() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime.snapshot.phase = SessionPhase::Established;
+    runtime.bootstrap = BootstrapState::Ready;
+    runtime.sm_state.enabled = true;
+    runtime.sm_state.inbound_count = 41;
+
+    let events = runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageReceived(
+                TransportMessage::Element(SmState::build_request_ack()),
+            ),
+            500,
+        )
+        .unwrap();
+
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Element(element)
+        )) if element.name() == "a"
+            && element.ns() == crate::stream_management::NS_SM
+            && element.attr("h") == Some("41")
+    )));
+    assert!(events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::AckRequested
+        ))
+    )));
+    assert_eq!(runtime.sm_state.inbound_count, 41);
+}
+
+#[test]
+fn local_close_claim_survives_peer_close_before_transport_confirmation() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime.snapshot.phase = SessionPhase::Established;
+    runtime.bootstrap = BootstrapState::Ready;
+
+    let requested = runtime.request_stream_close().unwrap();
+    assert_eq!(outbound_close_count(&requested), 1);
+
+    let peer = runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageReceived(TransportMessage::Close(StreamClose)),
+            100,
+        )
+        .unwrap();
+    assert_eq!(outbound_close_count(&peer), 0);
+    assert!(!runtime.stream_close_complete());
+
+    runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageSent(TransportMessage::Close(StreamClose)),
+            200,
+        )
+        .unwrap();
+    assert!(runtime.stream_close_complete());
+
+    let repeated = runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageReceived(TransportMessage::Close(StreamClose)),
+            300,
+        )
+        .unwrap();
+    assert_eq!(outbound_close_count(&repeated), 0);
+}
+
+#[test]
+fn peer_first_close_claims_exactly_one_reciprocal_close() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime.snapshot.phase = SessionPhase::Established;
+    runtime.bootstrap = BootstrapState::Ready;
+
+    let first = runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageReceived(TransportMessage::Close(StreamClose)),
+            100,
+        )
+        .unwrap();
+    let repeated = runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageReceived(TransportMessage::Close(StreamClose)),
+            150,
+        )
+        .unwrap();
+
+    assert_eq!(outbound_close_count(&first), 1);
+    assert_eq!(outbound_close_count(&repeated), 0);
+    runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageSent(TransportMessage::Close(StreamClose)),
+            200,
+        )
+        .unwrap();
+    assert!(runtime.stream_close_complete());
+}
+
+#[test]
+fn late_countable_stanza_during_local_half_close_is_dispatched_and_resumed_truthfully() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime.snapshot.phase = SessionPhase::Established;
+    runtime.bootstrap = BootstrapState::Ready;
+    runtime.snapshot.binding = Some(SessionBinding {
+        jid: FullJid::from_str("alice@example.com/macbook").unwrap(),
+        stream_id: Some(StreamId::new("late-inbound-session")),
+        resumable: true,
+    });
+    runtime.sm_state.enabled = true;
+    runtime.sm_state.outbound_enabled = true;
+    runtime.sm_state.previd = Some(SmSessionId::new("late-inbound-session").unwrap());
+
+    runtime.request_stream_close().unwrap();
+    runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageSent(TransportMessage::Close(StreamClose)),
+            100,
+        )
+        .unwrap();
+
+    let late = Element::builder("message", crate::NS_CLIENT)
+        .attr(
+            minidom::rxml::xml_ncname!("id").to_owned(),
+            "late-countable",
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("from").to_owned(),
+            "bob@example.com/phone",
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("to").to_owned(),
+            "alice@example.com/macbook",
+        )
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+        .append(
+            Element::builder("body", crate::NS_CLIENT)
+                .append("late but handled")
+                .build(),
+        )
+        .build();
+    let events = runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageReceived(TransportMessage::Element(late)),
+            200,
+        )
+        .unwrap();
+
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event, ClientEvent::Messaging(_)))
+            .count(),
+        1,
+        "a stanza included in inbound h must be dispatched exactly once"
+    );
+
+    let response_required = Element::builder("iq", crate::NS_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "get")
+        .attr(
+            minidom::rxml::xml_ncname!("id").to_owned(),
+            "late-response-required",
+        )
+        .attr(
+            minidom::rxml::xml_ncname!("from").to_owned(),
+            "bob@example.com/phone",
+        )
+        .append(
+            Element::builder("query", crate::discovery::DISCO_INFO_NS)
+                .attr(
+                    minidom::rxml::xml_ncname!("node").to_owned(),
+                    crate::caps::client_caps_node_ver(),
+                )
+                .build(),
+        )
+        .build();
+    let fenced = runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageReceived(TransportMessage::Element(response_required)),
+            250,
+        )
+        .unwrap();
+    assert!(
+        !fenced.iter().any(|event| matches!(
+            event,
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(_))
+        )),
+        "no XML may follow our confirmed close"
+    );
+
+    assert!(runtime.stream_close_timed_out_at(5_100));
+    let resume_state = runtime
+        .resume_state()
+        .expect("unfinished close stays resumable");
+    assert_eq!(resume_state.inbound_h(), 1);
+
+    let mut next_config = config();
+    next_config.session.stream_management.resume_state = Some(resume_state);
+    let mut next_runtime = XmppRuntime::new(next_config).unwrap();
+    drive_to_authenticated_stream(&mut next_runtime);
+    let resume_events = next_runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+    let resume = resume_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )) if element.name() == "resume" => Some(element),
+            _ => None,
+        })
+        .expect("resume request");
+    assert_eq!(resume.attr("h"), Some("1"));
+}
+
+fn outbound_close_count(events: &[ClientEvent]) -> usize {
+    events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event,
+                ClientEvent::Connection(ConnectionEvent::OutboundMessage(TransportMessage::Close(
+                    _
+                )))
+            )
+        })
+        .count()
+}
+
+#[test]
+fn confirmed_local_close_fences_sm_xml_but_accepts_final_ack_progress() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime.snapshot.phase = SessionPhase::Established;
+    runtime.sm_state.enabled = true;
+    runtime.sm_state.outbound_enabled = true;
+    runtime.sm_state.previd = Some(SmSessionId::new("resume-after-half-close").unwrap());
+
+    let message = Element::builder("message", crate::NS_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), "half-close-1")
+        .build();
+    runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageSent(TransportMessage::Element(message)),
+            100,
+        )
+        .unwrap();
+    runtime.request_stream_close().unwrap();
+    runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageSent(TransportMessage::Close(StreamClose)),
+            200,
+        )
+        .unwrap();
+
+    assert!(runtime.stream_close_sent_confirmed());
+    assert!(runtime.poll_stream_management_at(450).is_empty());
+    assert!(runtime.poll_stream_management_at(5_200).is_empty());
+    assert!(runtime.next_stream_management_wakeup_in_ms(450).is_none());
+    assert!(runtime.request_stream_management_ack_at(450).is_empty());
+
+    let request_events = runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageReceived(
+                TransportMessage::Element(SmState::build_request_ack()),
+            ),
+            500,
+        )
+        .unwrap();
+    assert!(!request_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(_))
+            | ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                StreamManagementEvent::AckRequested
+            ))
+    )));
+
+    let ack_events = runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageReceived(TransportMessage::Element(SmState::build_ack(1))),
+            600,
+        )
+        .unwrap();
+    assert!(ack_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::MessageDelivery(crate::MessageDeliveryEvent::Acked { stanza_id })
+            if stanza_id.as_str() == "half-close-1"
+    )));
+    assert!(ack_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::AckObserved {
+                progressed: true,
+                unacked: 0,
+                ..
+            }
+        ))
+    )));
+    assert!(!ack_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(_))
+    )));
+    assert_eq!(runtime.sm_state.unacked_count(), 0);
+}
+
+#[test]
+fn confirmed_local_close_has_one_five_second_peer_deadline() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime.snapshot.phase = SessionPhase::Established;
+    runtime.request_stream_close().unwrap();
+    runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageSent(TransportMessage::Close(StreamClose)),
+            1_000,
+        )
+        .unwrap();
+
+    assert_eq!(runtime.next_stream_close_wakeup_in_ms(1_000), Some(5_000));
+    assert_eq!(runtime.next_stream_close_wakeup_in_ms(5_999), Some(1));
+    assert!(!runtime.stream_close_timed_out_at(5_999));
+    assert!(runtime.stream_close_timed_out_at(6_000));
+
+    runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageReceived(TransportMessage::Close(StreamClose)),
+            6_000,
+        )
+        .unwrap();
+    assert!(runtime.stream_close_complete());
+    assert_eq!(runtime.next_stream_close_wakeup_in_ms(6_000), None);
 }
 
 #[test]
@@ -1243,14 +1632,57 @@ fn runtime_replays_unhandled_stanzas_after_resume_without_recounting_them() {
             && element.get_child("delay", "urn:xmpp:delay").is_none()
     )));
 
-    runtime
-        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
-            Element::builder("message", crate::NS_CLIENT)
-                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "unhandled")
-                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
-                .build(),
-        )))
+    let replay_sent_events = runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageSent(TransportMessage::Element(
+                Element::builder("message", crate::NS_CLIENT)
+                    .attr(minidom::rxml::xml_ncname!("id").to_owned(), "unhandled")
+                    .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+                    .build(),
+            )),
+            1_001,
+        )
         .unwrap();
+
+    let ack_requests: Vec<&Element> = replay_sent_events
+        .iter()
+        .filter_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+                TransportMessage::Element(element),
+            )) if SmState::is_request_ack(element) => Some(element),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        ack_requests.len(),
+        1,
+        "the first transport-confirmed replay must request an ack immediately"
+    );
+    assert!(
+        !replay_sent_events.iter().any(|event| matches!(
+            event,
+            ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                StreamManagementEvent::AckRequestSent { .. }
+            ))
+        )),
+        "AckRequestSent must wait for transport confirmation of <r/>"
+    );
+
+    let request_confirmed_events = runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageSent(TransportMessage::Element(SmState::build_request_ack())),
+            1_002,
+        )
+        .unwrap();
+    assert!(request_confirmed_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::AckRequestSent {
+                attempt: 1,
+                unacked: 1,
+            }
+        ))
+    )));
 
     let too_high_ack_events = runtime
         .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
@@ -1268,6 +1700,132 @@ fn runtime_replays_unhandled_stanzas_after_resume_without_recounting_them() {
             && element
                 .get_child("handled-count-too-high", crate::stream_management::NS_SM)
                 .is_some()
+    )));
+}
+
+#[test]
+fn terminal_transport_failure_clears_pending_ack_request_telemetry() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime.pending_ack_request = Some(crate::stream_management::AckRequest {
+        attempt: 77,
+        unacked: 88,
+    });
+
+    runtime
+        .apply_transport_event(TransportEvent::StateChanged(TransportState::Failed))
+        .unwrap();
+    assert_no_ack_request_sent_after_late_confirmation(&mut runtime);
+}
+
+#[test]
+fn fresh_sm_enable_clears_pending_ack_request_telemetry() {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime.pending_ack_request = Some(crate::stream_management::AckRequest {
+        attempt: 77,
+        unacked: 88,
+    });
+
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("enabled", crate::stream_management::NS_SM)
+                .attr(minidom::rxml::xml_ncname!("resume").to_owned(), "true")
+                .attr(minidom::rxml::xml_ncname!("id").to_owned(), "fresh-sm-id")
+                .build(),
+        )))
+        .unwrap();
+    assert_no_ack_request_sent_after_late_confirmation(&mut runtime);
+}
+
+#[test]
+fn failed_resume_fallback_clears_pending_ack_request_telemetry() {
+    let mut resume_config = config();
+    resume_config.session.stream_management.resume_state =
+        Some(resume_state_with_sent_messages(["fallback"]));
+    let mut runtime = XmppRuntime::new(resume_config).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+    runtime.pending_ack_request = Some(crate::stream_management::AckRequest {
+        attempt: 77,
+        unacked: 88,
+    });
+
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("failed", crate::stream_management::NS_SM)
+                .attr(minidom::rxml::xml_ncname!("h").to_owned(), "0")
+                .build(),
+        )))
+        .unwrap();
+    assert_no_ack_request_sent_after_late_confirmation(&mut runtime);
+}
+
+#[test]
+fn replay_transition_replaces_stale_pending_ack_request_metadata() {
+    let resume_state = resume_state_with_sent_messages(["replay"]);
+    let mut resume_config = config();
+    resume_config.session.stream_management.resume_state = Some(resume_state);
+    let mut runtime = XmppRuntime::new(resume_config).unwrap();
+    drive_to_authenticated_stream(&mut runtime);
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            post_auth_features_with_sm(),
+        )))
+        .unwrap();
+    runtime.pending_ack_request = Some(crate::stream_management::AckRequest {
+        attempt: 77,
+        unacked: 88,
+    });
+
+    runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageReceived(TransportMessage::Element(
+                Element::builder("resumed", crate::stream_management::NS_SM)
+                    .attr(minidom::rxml::xml_ncname!("previd").to_owned(), "old-sm-id")
+                    .attr(minidom::rxml::xml_ncname!("h").to_owned(), "0")
+                    .build(),
+            )),
+            10_000,
+        )
+        .unwrap();
+    runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageSent(TransportMessage::Element(
+                Element::builder("message", crate::NS_CLIENT)
+                    .attr(minidom::rxml::xml_ncname!("id").to_owned(), "replay")
+                    .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+                    .build(),
+            )),
+            10_001,
+        )
+        .unwrap();
+    let confirmed = runtime
+        .apply_transport_event_at(
+            TransportEvent::MessageSent(TransportMessage::Element(SmState::build_request_ack())),
+            10_002,
+        )
+        .unwrap();
+
+    assert!(confirmed.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::AckRequestSent {
+                attempt: 1,
+                unacked: 1,
+            }
+        ))
+    )));
+    assert!(!confirmed.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::AckRequestSent {
+                attempt: 77,
+                unacked: 88,
+            }
+        ))
     )));
 }
 
@@ -2056,6 +2614,24 @@ fn resume_state_with_sent_messages<const N: usize>(ids: [&str; N]) -> SmResumeSt
             .unwrap();
     }
     runtime.resume_state().expect("resume state")
+}
+
+fn assert_no_ack_request_sent_after_late_confirmation(runtime: &mut XmppRuntime) {
+    assert!(runtime.pending_ack_request.is_none());
+    let events = runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            SmState::build_request_ack(),
+        )))
+        .unwrap();
+    assert!(
+        !events.iter().any(|event| matches!(
+            event,
+            ClientEvent::Connection(ConnectionEvent::StreamManagement(
+                StreamManagementEvent::AckRequestSent { .. }
+            ))
+        )),
+        "a late unrelated <r/> confirmation must not emit stale telemetry"
+    );
 }
 
 fn handled_count_too_high_stream_error(h: u32, send_count: u32) -> Element {

--- a/server/crates/waddle-xmpp-client/src/stream_management.rs
+++ b/server/crates/waddle-xmpp-client/src/stream_management.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::{collections::VecDeque, fmt};
 
 use chrono::{DateTime, SecondsFormat, Utc};
 use minidom::Element;
@@ -9,17 +9,128 @@ use crate::request::StanzaId;
 pub const NS_SM: &str = "urn:xmpp:sm:3";
 const NS_DELAY: &str = "urn:xmpp:delay";
 
+const ACK_RETRY_DELAYS_MS: [u64; 5] = [250, 500, 1_000, 2_000, 5_000];
+const ACK_RESPONSE_TIMEOUT_MS: u64 = 5_000;
+const ACK_PROGRESS_TIMEOUT_MS: u64 = 30_000;
+
+/// Opaque XEP-0198 resumption identifier carried in `id` / `previd`.
+///
+/// The inner wire string is exposed only through the existing persistence
+/// accessor and XML serialization boundary; runtime/event state carries this
+/// dedicated type.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct SmSessionId(String);
+
+impl SmSessionId {
+    pub fn new(value: impl Into<String>) -> ClientResult<Self> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(ClientError::EmptyStreamManagementSessionId);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Debug for SmSessionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_tuple("SmSessionId").field(&self.0).finish()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SmAckHandledCountTooHigh {
+    pub h: u32,
+    pub send_count: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SentStanzaKind {
+    NotCountable,
+    New,
+    Replay,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AckRequest {
+    pub attempt: u32,
+    pub unacked: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SentStanzaResult {
+    pub kind: SentStanzaKind,
+    pub request: Option<AckRequest>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AckObservation {
+    pub progressed: bool,
+    pub latency_ms: Option<u64>,
+    pub unacked: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessAckResult {
+    pub acked: Vec<StanzaId>,
+    pub observation: AckObservation,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct AckTimerPoll {
+    pub request: Option<AckRequest>,
+    pub request_timed_out: bool,
+    pub progress_stalled_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct AckCadence {
+    request_pending_confirmation: bool,
+    request_sent_at_ms: Option<u64>,
+    next_request_at_ms: Option<u64>,
+    progress_started_at_ms: Option<u64>,
+    retry_index: usize,
+    request_attempt: u32,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct QueuedOutboundStanza {
-    element: Element,
+    entry: SmResumeEntry,
     message_stanza_id: Option<StanzaId>,
+}
+
+/// One typed outbound stanza retained for XEP-0198 resume/fallback retry.
+///
+/// `sent_at` is the original transport-confirmed send instant. It survives
+/// persistence independently of the XML so XEP-0203 fallback delivery can add
+/// the original timestamp after a page reload without mutating normal replay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SmResumeEntry {
+    element: Element,
     sent_at: DateTime<Utc>,
+}
+
+impl SmResumeEntry {
+    pub fn new(element: Element, sent_at: DateTime<Utc>) -> Self {
+        Self { element, sent_at }
+    }
+
+    pub fn element(&self) -> &Element {
+        &self.element
+    }
+
+    pub fn sent_at(&self) -> DateTime<Utc> {
+        self.sent_at
+    }
 }
 
 /// In-memory XEP-0198 resume snapshot carried across a reconnect attempt.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SmResumeState {
-    previd: String,
+    previd: SmSessionId,
     inbound_h: u32,
     outbound_h: u32,
     max_resume_seconds: Option<u32>,
@@ -28,13 +139,8 @@ pub struct SmResumeState {
 
 impl SmResumeState {
     pub fn new(previd: impl Into<String>, inbound_h: u32, outbound_h: u32) -> ClientResult<Self> {
-        let previd = previd.into();
-        if previd.trim().is_empty() {
-            return Err(ClientError::EmptyStanzaId);
-        }
-
         Ok(Self {
-            previd,
+            previd: SmSessionId::new(previd)?,
             inbound_h,
             outbound_h,
             max_resume_seconds: None,
@@ -48,14 +154,18 @@ impl SmResumeState {
     }
 
     fn from_outbound_queue(
-        previd: impl Into<String>,
+        previd: SmSessionId,
         inbound_h: u32,
         outbound_h: u32,
         outbound_queue: VecDeque<QueuedOutboundStanza>,
     ) -> ClientResult<Self> {
-        let mut state = Self::new(previd, inbound_h, outbound_h)?;
-        state.outbound_queue = outbound_queue;
-        Ok(state)
+        Ok(Self {
+            previd,
+            inbound_h,
+            outbound_h,
+            max_resume_seconds: None,
+            outbound_queue,
+        })
     }
 
     pub fn from_unhandled_outbound_stanzas(
@@ -66,16 +176,43 @@ impl SmResumeState {
     ) -> ClientResult<Self> {
         let outbound_queue = stanzas
             .into_iter()
-            .map(|element| QueuedOutboundStanza {
-                message_stanza_id: message_delivery_stanza_id(&element),
-                sent_at: existing_delay_stamp(&element).unwrap_or_else(Utc::now),
-                element,
+            .map(|element| {
+                let sent_at = existing_delay_stamp(&element).unwrap_or_else(Utc::now);
+                SmResumeEntry::new(element, sent_at)
             })
+            .map(QueuedOutboundStanza::from_entry)
             .collect();
-        Self::from_outbound_queue(previd, inbound_h, outbound_h, outbound_queue)
+        Self::from_outbound_queue(
+            SmSessionId::new(previd)?,
+            inbound_h,
+            outbound_h,
+            outbound_queue,
+        )
+    }
+
+    pub fn from_unhandled_outbound_entries(
+        previd: impl Into<String>,
+        inbound_h: u32,
+        outbound_h: u32,
+        entries: impl IntoIterator<Item = SmResumeEntry>,
+    ) -> ClientResult<Self> {
+        let outbound_queue = entries
+            .into_iter()
+            .map(QueuedOutboundStanza::from_entry)
+            .collect();
+        Self::from_outbound_queue(
+            SmSessionId::new(previd)?,
+            inbound_h,
+            outbound_h,
+            outbound_queue,
+        )
     }
 
     pub fn previd(&self) -> &str {
+        self.previd.as_str()
+    }
+
+    pub fn session_id(&self) -> &SmSessionId {
         &self.previd
     }
 
@@ -96,7 +233,13 @@ impl SmResumeState {
     }
 
     pub fn unhandled_outbound_stanzas(&self) -> impl Iterator<Item = &Element> {
-        self.outbound_queue.iter().map(|queued| &queued.element)
+        self.outbound_queue
+            .iter()
+            .map(|queued| queued.entry.element())
+    }
+
+    pub fn unhandled_outbound_entries(&self) -> impl Iterator<Item = &SmResumeEntry> {
+        self.outbound_queue.iter().map(|queued| &queued.entry)
     }
 
     pub fn unhandled_message_stanza_ids(&self) -> Vec<StanzaId> {
@@ -123,7 +266,7 @@ pub struct SmState {
     /// Last `h` value acknowledged by the server.
     pub server_h: u32,
     /// Resumption token (`previd`) set after `<enabled/>` or `<resumed/>`.
-    pub previd: Option<String>,
+    pub previd: Option<SmSessionId>,
     /// Advertised server resumption window in seconds, when the server supplied one.
     pub max_resume_seconds: Option<u32>,
     /// Whether the outbound stanza counter has started for this session.
@@ -136,6 +279,7 @@ pub struct SmState {
     pub enabled: bool,
     outbound_queue: VecDeque<QueuedOutboundStanza>,
     replay_in_flight: VecDeque<Element>,
+    ack_cadence: AckCadence,
 }
 
 impl SmState {
@@ -150,7 +294,7 @@ impl SmState {
             outbound_count: resume_state.outbound_h(),
             inbound_count: resume_state.inbound_h(),
             server_h: resume_state.outbound_h().wrapping_sub(queue_len),
-            previd: Some(resume_state.previd().to_string()),
+            previd: Some(resume_state.session_id().clone()),
             max_resume_seconds: resume_state.max_resume_seconds(),
             outbound_queue: resume_state.outbound_queue.clone(),
             ..Self::default()
@@ -177,16 +321,38 @@ impl SmState {
 
     /// Record a newly sent outbound stanza unless it is a queued replay.
     pub fn record_sent_stanza(&mut self, element: &Element) {
-        if self.suppress_replay_sent_record(element) {
-            return;
+        let _ = self.record_sent_stanza_at(element, 0);
+    }
+
+    /// Record a transport-confirmed outbound element and update the
+    /// client-to-server acknowledgement cadence.
+    ///
+    /// The caller supplies a monotonic millisecond timestamp. Keeping time
+    /// numeric and injected makes this state identical on native and WASM and
+    /// lets tests advance every timeout without sleeping.
+    pub fn record_sent_stanza_at(&mut self, element: &Element, now_ms: u64) -> SentStanzaResult {
+        if !self.outbound_enabled || !matches!(element.name(), "iq" | "message" | "presence") {
+            return SentStanzaResult {
+                kind: SentStanzaKind::NotCountable,
+                request: None,
+            };
         }
 
-        self.record_sent(1);
-        self.outbound_queue.push_back(QueuedOutboundStanza {
-            message_stanza_id: message_delivery_stanza_id(element),
-            element: element.clone(),
-            sent_at: existing_delay_stamp(element).unwrap_or_else(Utc::now),
-        });
+        let kind = if self.suppress_replay_sent_record(element) {
+            SentStanzaKind::Replay
+        } else {
+            self.record_sent(1);
+            let sent_at = existing_delay_stamp(element).unwrap_or_else(Utc::now);
+            self.outbound_queue
+                .push_back(QueuedOutboundStanza::from_entry(SmResumeEntry::new(
+                    element.clone(),
+                    sent_at,
+                )));
+            SentStanzaKind::New
+        };
+
+        let request = self.arm_after_outbound_at(now_ms);
+        SentStanzaResult { kind, request }
     }
 
     /// Start a fresh inbound SM sequence after receiving `<enabled/>`.
@@ -210,12 +376,14 @@ impl SmState {
         self.outbound_enabled = true;
         self.outbound_queue.clear();
         self.replay_in_flight.clear();
+        self.ack_cadence = AckCadence::default();
     }
 
     /// Stop all SM counters after `<failed/>` or stream termination.
     pub fn stop(&mut self) {
         self.outbound_enabled = false;
         self.enabled = false;
+        self.ack_cadence = AckCadence::default();
     }
 
     /// Increment the inbound stanza counter by `count`.
@@ -224,7 +392,23 @@ impl SmState {
     }
 
     /// Update `server_h` from an `<a h='...'/>` ack.
-    pub fn process_ack(&mut self, h: u32) -> Vec<StanzaId> {
+    pub fn process_ack(&mut self, h: u32) -> Result<Vec<StanzaId>, SmAckHandledCountTooHigh> {
+        self.process_ack_at(h, 0).map(|processed| processed.acked)
+    }
+
+    /// Process a valid server acknowledgement at `now_ms`.
+    ///
+    /// Every valid `<a/>`, including a duplicate `h`, releases the current
+    /// request. If work remains, the next request is scheduled instead of
+    /// emitted synchronously so a non-progress response cannot create an
+    /// `<r/>`/`<a/>` ping-pong loop.
+    pub fn process_ack_at(
+        &mut self,
+        h: u32,
+        now_ms: u64,
+    ) -> Result<ProcessAckResult, SmAckHandledCountTooHigh> {
+        self.validate_ack(h)?;
+        let previous_h = self.server_h;
         let handled_since_last_ack = h.wrapping_sub(self.server_h);
         self.server_h = h;
         let mut acked = Vec::new();
@@ -238,11 +422,224 @@ impl SmState {
                 }
             }
         }
-        acked
+
+        let request_pending_confirmation = self.ack_cadence.request_pending_confirmation;
+        let latency_ms = self
+            .ack_cadence
+            .request_sent_at_ms
+            .take()
+            .map(|sent_at| now_ms.saturating_sub(sent_at));
+        let progressed = h != previous_h;
+        let unacked = self.unacked_count();
+        if unacked == 0 {
+            let pending_attempt = self.ack_cadence.request_attempt;
+            self.ack_cadence = AckCadence::default();
+            if request_pending_confirmation {
+                self.ack_cadence.request_pending_confirmation = true;
+                self.ack_cadence.request_attempt = pending_attempt;
+            }
+        } else {
+            if progressed {
+                self.ack_cadence.retry_index = 0;
+                self.ack_cadence.request_attempt = 0;
+                self.ack_cadence.progress_started_at_ms = Some(now_ms);
+            } else if self.ack_cadence.progress_started_at_ms.is_none() {
+                self.ack_cadence.progress_started_at_ms = Some(now_ms);
+            }
+            if request_pending_confirmation {
+                // This acknowledgement cannot answer an `<r/>` whose write
+                // has not been confirmed. Keep that exact generation fenced
+                // and let its transport disposition own the next transition.
+                self.ack_cadence.next_request_at_ms = None;
+            } else {
+                self.schedule_retry_at(now_ms);
+            }
+        }
+
+        Ok(ProcessAckResult {
+            acked,
+            observation: AckObservation {
+                progressed,
+                latency_ms,
+                unacked,
+            },
+        })
+    }
+
+    /// Request an acknowledgement immediately when SM has outstanding work
+    /// and no request is awaiting a response. Used by the pagehide handoff;
+    /// regular sends and timers use the same state transition.
+    pub fn request_ack_now_at(&mut self, _now_ms: u64) -> Option<AckRequest> {
+        if !self.enabled
+            || !self.outbound_enabled
+            || self.outbound_queue.is_empty()
+            || self.ack_cadence.request_pending_confirmation
+            || self.ack_cadence.request_sent_at_ms.is_some()
+        {
+            return None;
+        }
+        self.ack_cadence.next_request_at_ms = None;
+        Some(self.mark_ack_request_generated())
+    }
+
+    /// Confirm that the exact generated `<r/>` reached the transport.
+    ///
+    /// Generation and transport confirmation are deliberately separate. A
+    /// slow or permanently pending write must not consume the five-second
+    /// response budget before the peer could possibly have received the
+    /// request.
+    pub fn confirm_ack_request_sent_at(&mut self, now_ms: u64) -> bool {
+        if !self.ack_cadence.request_pending_confirmation {
+            return false;
+        }
+        self.ack_cadence.request_pending_confirmation = false;
+        self.ack_cadence.next_request_at_ms = None;
+        if !self.enabled || !self.outbound_enabled || self.outbound_queue.is_empty() {
+            self.ack_cadence = AckCadence::default();
+            return true;
+        }
+        self.ack_cadence.request_sent_at_ms = Some(now_ms);
+        true
+    }
+
+    /// Dispose the exact generated `<r/>` after the transport proves that it
+    /// accepted no bytes. No response clock starts; outstanding work receives
+    /// the next bounded retry rung.
+    pub fn ack_request_definitely_not_written_at(&mut self, now_ms: u64) -> bool {
+        if !self.ack_cadence.request_pending_confirmation {
+            return false;
+        }
+        self.ack_cadence.request_pending_confirmation = false;
+        self.ack_cadence.request_sent_at_ms = None;
+        if !self.enabled || !self.outbound_enabled || self.outbound_queue.is_empty() {
+            self.ack_cadence = AckCadence::default();
+            return true;
+        }
+        if self.ack_cadence.next_request_at_ms.is_none() {
+            self.schedule_retry_at(now_ms);
+        }
+        true
+    }
+
+    /// Poll response/retry/progress deadlines without performing I/O.
+    pub fn poll_ack_timer_at(&mut self, now_ms: u64) -> AckTimerPoll {
+        if !self.enabled || !self.outbound_enabled || self.outbound_queue.is_empty() {
+            self.ack_cadence = AckCadence::default();
+            return AckTimerPoll::default();
+        }
+
+        if let Some(started_at) = self.ack_cadence.progress_started_at_ms {
+            let stalled_ms = now_ms.saturating_sub(started_at);
+            if stalled_ms >= ACK_PROGRESS_TIMEOUT_MS {
+                return AckTimerPoll {
+                    progress_stalled_ms: Some(stalled_ms),
+                    ..AckTimerPoll::default()
+                };
+            }
+        }
+
+        if let Some(sent_at) = self.ack_cadence.request_sent_at_ms {
+            if now_ms.saturating_sub(sent_at) >= ACK_RESPONSE_TIMEOUT_MS {
+                self.ack_cadence.request_sent_at_ms = None;
+                return AckTimerPoll {
+                    request: Some(self.mark_ack_request_generated()),
+                    request_timed_out: true,
+                    progress_stalled_ms: None,
+                };
+            }
+            return AckTimerPoll::default();
+        }
+
+        if self.ack_cadence.request_pending_confirmation {
+            return AckTimerPoll::default();
+        }
+
+        if self
+            .ack_cadence
+            .next_request_at_ms
+            .is_some_and(|deadline| now_ms >= deadline)
+        {
+            self.ack_cadence.next_request_at_ms = None;
+            return AckTimerPoll {
+                request: Some(self.mark_ack_request_generated()),
+                ..AckTimerPoll::default()
+            };
+        }
+
+        AckTimerPoll::default()
+    }
+
+    /// Milliseconds until the next SM timer action, if any.
+    pub fn next_ack_wakeup_in_ms(&self, now_ms: u64) -> Option<u64> {
+        if !self.enabled || !self.outbound_enabled || self.outbound_queue.is_empty() {
+            return None;
+        }
+
+        let progress_deadline = self
+            .ack_cadence
+            .progress_started_at_ms
+            .map(|started_at| started_at.saturating_add(ACK_PROGRESS_TIMEOUT_MS));
+        let response_deadline = self
+            .ack_cadence
+            .request_sent_at_ms
+            .map(|sent_at| sent_at.saturating_add(ACK_RESPONSE_TIMEOUT_MS));
+        [
+            progress_deadline,
+            response_deadline,
+            self.ack_cadence.next_request_at_ms,
+        ]
+        .into_iter()
+        .flatten()
+        .min()
+        .map(|deadline| deadline.saturating_sub(now_ms))
     }
 
     pub fn handled_count_too_high(&self, h: u32) -> bool {
-        h.wrapping_sub(self.server_h) > self.outbound_count.wrapping_sub(self.server_h)
+        self.validate_ack(h).is_err()
+    }
+
+    pub fn validate_ack(&self, h: u32) -> Result<(), SmAckHandledCountTooHigh> {
+        let handled_delta = h.wrapping_sub(self.server_h);
+        let sent_delta = self.outbound_count.wrapping_sub(self.server_h);
+        if handled_delta > sent_delta {
+            return Err(SmAckHandledCountTooHigh {
+                h,
+                send_count: self.outbound_count,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn unacked_count(&self) -> u32 {
+        self.outbound_count.wrapping_sub(self.server_h)
+    }
+
+    /// Prepare the surviving outbound queue for XEP-0198 retransmission after
+    /// applying a successful `<resumed h='…'/>` response.
+    ///
+    /// Treating `<resumed/>` exactly like a normal `<a/>` first is important:
+    /// it trims handled stanzas and establishes the no-progress deadline.
+    /// Unlike an ordinary ack, however, the protocol requires the remaining
+    /// queue to be retransmitted immediately. Clear the delayed retry/request
+    /// latch so the first replay's transport-confirmed `MessageSent` arms an
+    /// immediate `<r/>` without resetting counters or recounting the stanza.
+    pub fn begin_replay_transition_at(&mut self, now_ms: u64) {
+        if self.outbound_queue.is_empty() {
+            self.ack_cadence = AckCadence::default();
+            return;
+        }
+
+        let progress_started_at_ms = self.ack_cadence.progress_started_at_ms.unwrap_or(now_ms);
+        self.ack_cadence.request_sent_at_ms = None;
+        self.ack_cadence.request_pending_confirmation = false;
+        self.ack_cadence.next_request_at_ms = None;
+        self.ack_cadence.progress_started_at_ms = Some(progress_started_at_ms);
+        // A successful resume starts a new request ladder for the replayed
+        // queue. Preserve the original no-progress epoch, but make the
+        // immediate replay request attempt 1 and its first unchanged-ack retry
+        // use the 250 ms rung.
+        self.ack_cadence.retry_index = 0;
+        self.ack_cadence.request_attempt = 0;
     }
 
     /// Mark currently unhandled outbound stanzas for replay and return them.
@@ -250,7 +647,7 @@ impl SmState {
         let replay: Vec<Element> = self
             .outbound_queue
             .iter()
-            .map(|queued| queued.element.clone())
+            .map(|queued| queued.entry.element().clone())
             .collect();
         self.replay_in_flight.extend(replay.iter().cloned());
         replay
@@ -280,6 +677,44 @@ impl SmState {
             return true;
         }
         false
+    }
+
+    fn arm_after_outbound_at(&mut self, now_ms: u64) -> Option<AckRequest> {
+        if !self.enabled || self.outbound_queue.is_empty() {
+            return None;
+        }
+        if self.ack_cadence.progress_started_at_ms.is_none() {
+            self.ack_cadence.progress_started_at_ms = Some(now_ms);
+        }
+        if self.ack_cadence.request_sent_at_ms.is_some()
+            || self.ack_cadence.request_pending_confirmation
+            || self.ack_cadence.next_request_at_ms.is_some()
+        {
+            return None;
+        }
+        Some(self.mark_ack_request_generated())
+    }
+
+    fn mark_ack_request_generated(&mut self) -> AckRequest {
+        debug_assert!(!self.ack_cadence.request_pending_confirmation);
+        debug_assert!(self.ack_cadence.request_sent_at_ms.is_none());
+        self.ack_cadence.request_pending_confirmation = true;
+        self.ack_cadence.request_attempt = self.ack_cadence.request_attempt.saturating_add(1);
+        AckRequest {
+            attempt: self.ack_cadence.request_attempt,
+            unacked: self.unacked_count(),
+        }
+    }
+
+    fn schedule_retry_at(&mut self, now_ms: u64) {
+        let retry_index = self
+            .ack_cadence
+            .retry_index
+            .min(ACK_RETRY_DELAYS_MS.len() - 1);
+        self.ack_cadence.next_request_at_ms =
+            Some(now_ms.saturating_add(ACK_RETRY_DELAYS_MS[retry_index]));
+        self.ack_cadence.retry_index =
+            (self.ack_cadence.retry_index + 1).min(ACK_RETRY_DELAYS_MS.len() - 1);
     }
 
     /// Build `<enable xmlns='urn:xmpp:sm:3' resume='true'/>`.
@@ -323,12 +758,12 @@ impl SmState {
     }
 
     /// Extract the resumption `id` from an `<enabled/>` element, if present.
-    pub fn parse_enabled(element: &Element) -> Option<String> {
+    pub fn parse_enabled(element: &Element) -> Option<SmSessionId> {
         if element.name() == "enabled" && element.ns() == NS_SM {
             if !matches!(element.attr("resume"), Some("true") | Some("1")) {
                 return None;
             }
-            element.attr("id").map(|s| s.to_string())
+            element.attr("id").and_then(|id| SmSessionId::new(id).ok())
         } else {
             None
         }
@@ -359,16 +794,26 @@ impl SmState {
 }
 
 impl QueuedOutboundStanza {
-    fn element_for_fallback_retry(&self) -> Element {
-        if self.element.name() != "message" {
-            return self.element.clone();
+    fn from_entry(entry: SmResumeEntry) -> Self {
+        Self {
+            message_stanza_id: message_delivery_stanza_id(entry.element()),
+            entry,
         }
-        if self.element.get_child("delay", NS_DELAY).is_some() {
-            return self.element.clone();
+    }
+
+    fn element_for_fallback_retry(&self) -> Element {
+        if self.entry.element().name() != "message" {
+            return self.entry.element().clone();
+        }
+        if self.entry.element().get_child("delay", NS_DELAY).is_some() {
+            return self.entry.element().clone();
         }
 
-        let stamp = self.sent_at.to_rfc3339_opts(SecondsFormat::Millis, true);
-        let mut element = self.element.clone();
+        let stamp = self
+            .entry
+            .sent_at()
+            .to_rfc3339_opts(SecondsFormat::Millis, true);
+        let mut element = self.entry.element().clone();
         element.append_child(
             Element::builder("delay", NS_DELAY)
                 .attr(minidom::rxml::xml_ncname!("stamp").to_owned(), stamp)
@@ -446,7 +891,10 @@ mod tests {
             .attr(minidom::rxml::xml_ncname!("resume").to_owned(), "true")
             .attr(minidom::rxml::xml_ncname!("max").to_owned(), "300")
             .build();
-        assert_eq!(SmState::parse_enabled(&el), Some("abc123".to_string()));
+        assert_eq!(
+            SmState::parse_enabled(&el),
+            Some(SmSessionId::new("abc123").unwrap())
+        );
         assert_eq!(SmState::parse_enabled_max(&el), Some(300));
     }
 
@@ -557,10 +1005,37 @@ mod tests {
     #[test]
     fn process_ack_updates_server_h() {
         let mut state = SmState::new();
-        state.process_ack(10);
+        state.outbound_count = 15;
+        state.process_ack(10).unwrap();
         assert_eq!(state.server_h, 10);
-        state.process_ack(15);
+        state.process_ack(15).unwrap();
         assert_eq!(state.server_h, 15);
+    }
+
+    #[test]
+    fn invalid_wrapping_ack_is_rejected_before_any_state_mutation() {
+        let mut state = SmState::new();
+        state.outbound_enabled = true;
+        state.enabled = true;
+        state.server_h = u32::MAX - 1;
+        state.outbound_count = u32::MAX - 1;
+        state.record_sent_stanza(&message("last-before-wrap"));
+        state.record_sent_stanza(&message("first-after-wrap"));
+
+        let error = state
+            .process_ack(1)
+            .expect_err("peer cannot acknowledge three stanzas when only two were sent");
+
+        assert_eq!(
+            error,
+            SmAckHandledCountTooHigh {
+                h: 1,
+                send_count: 0,
+            }
+        );
+        assert_eq!(state.server_h, u32::MAX - 1);
+        assert_eq!(state.outbound_queue.len(), 2);
+        assert_eq!(state.unacked_count(), 2);
     }
 
     #[test]
@@ -588,7 +1063,7 @@ mod tests {
         );
 
         assert!(!state.handled_count_too_high(0));
-        let acked = state.process_ack(0);
+        let acked = state.process_ack(0).unwrap();
 
         assert_eq!(
             acked
@@ -604,7 +1079,7 @@ mod tests {
     fn from_resume_state_restores_prior_server_ack_position() {
         let mut state = SmState::new();
         state.start_outbound();
-        state.previd = Some("previous-stream".to_string());
+        state.previd = Some(SmSessionId::new("previous-stream").unwrap());
         for id in 1..=10 {
             state.record_sent_stanza(
                 &Element::builder("message", "jabber:client")
@@ -616,7 +1091,7 @@ mod tests {
             );
         }
 
-        let acked = state.process_ack(8);
+        let acked = state.process_ack(8).unwrap();
         assert_eq!(acked.len(), 8);
 
         let resume_state = state.resume_state().expect("resume state");
@@ -624,7 +1099,7 @@ mod tests {
 
         assert_eq!(restored.server_h, 8);
         assert!(!restored.handled_count_too_high(9));
-        let acked_after_resume = restored.process_ack(9);
+        let acked_after_resume = restored.process_ack(9).unwrap();
         assert_eq!(
             acked_after_resume
                 .iter()
@@ -647,7 +1122,7 @@ mod tests {
     fn resume_state_reports_unhandled_outbound_queue_presence() {
         let mut state = SmState::new();
         state.start_outbound();
-        state.previd = Some("previous-stream".to_string());
+        state.previd = Some(SmSessionId::new("previous-stream").unwrap());
         state.record_sent_stanza(
             &Element::builder("message", "jabber:client")
                 .attr(minidom::rxml::xml_ncname!("id").to_owned(), "unacked")
@@ -657,7 +1132,7 @@ mod tests {
         let resume_state = state.resume_state().expect("resume state");
         assert!(resume_state.has_unhandled_outbound_stanzas());
 
-        state.process_ack(1);
+        state.process_ack(1).unwrap();
         let resume_state = state.resume_state().expect("resume state");
         assert!(!resume_state.has_unhandled_outbound_stanzas());
     }
@@ -666,7 +1141,7 @@ mod tests {
     fn unchanged_server_h_replays_a_timed_out_outbound_stanza() {
         let mut state = SmState::new();
         state.start_outbound();
-        state.previd = Some("timed-out-stream".to_string());
+        state.previd = Some(SmSessionId::new("timed-out-stream").unwrap());
         let timed_out = Element::builder("message", "jabber:client")
             .attr(
                 minidom::rxml::xml_ncname!("id").to_owned(),
@@ -677,7 +1152,7 @@ mod tests {
 
         // The server ended the transport without advancing h, so processing
         // its last acknowledgement must leave the stanza sender-owned.
-        assert!(state.process_ack(0).is_empty());
+        assert!(state.process_ack(0).unwrap().is_empty());
         let resume_state = state.resume_state().expect("resume state");
         let mut resumed = SmState::from_resume_state(&resume_state);
 
@@ -687,7 +1162,7 @@ mod tests {
     #[test]
     fn resume_state_carries_advertised_max_resume_window() {
         let mut state = SmState::new();
-        state.previd = Some("previous-stream".to_string());
+        state.previd = Some(SmSessionId::new("previous-stream").unwrap());
         state.max_resume_seconds = Some(300);
 
         let resume_state = state.resume_state().expect("resume state");
@@ -718,6 +1193,35 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![&stanza],
         );
+    }
+
+    #[test]
+    fn persisted_resume_entry_keeps_original_send_time_for_failed_resume_fallback() {
+        let sent_at = DateTime::parse_from_rfc3339("2026-07-16T08:09:10.123Z")
+            .expect("T0")
+            .with_timezone(&Utc);
+        let stanza = Element::builder("message", "jabber:client")
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), "persisted-t0")
+            .build();
+        let persisted = SmResumeState::from_unhandled_outbound_entries(
+            "previous-stream",
+            4,
+            9,
+            [SmResumeEntry::new(stanza, sent_at)],
+        )
+        .expect("persisted resume state");
+
+        let reloaded = SmState::from_resume_state(&persisted);
+        let fallback = reloaded
+            .unhandled_stanzas_for_fallback_retry()
+            .into_iter()
+            .next()
+            .expect("fallback after failed resume");
+        let delay = fallback
+            .get_child("delay", NS_DELAY)
+            .expect("XEP-0203 delay");
+
+        assert_eq!(delay.attr("stamp"), Some("2026-07-16T08:09:10.123Z"));
     }
 
     #[test]
@@ -752,5 +1256,389 @@ mod tests {
 
         assert_eq!(delays.len(), 1);
         assert_eq!(delays[0].attr("stamp"), Some("2024-01-15T10:00:00Z"));
+    }
+
+    fn enabled_state() -> SmState {
+        let mut state = SmState::new();
+        state.start_outbound();
+        state.enabled = true;
+        state
+    }
+
+    fn message(id: &str) -> Element {
+        Element::builder("message", "jabber:client")
+            .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+            .build()
+    }
+
+    fn confirm_generated_request(state: &mut SmState, now_ms: u64) {
+        assert!(
+            state.confirm_ack_request_sent_at(now_ms),
+            "expected one generated acknowledgement request awaiting confirmation"
+        );
+    }
+
+    #[test]
+    fn first_countable_stanza_requests_ack_and_burst_coalesces() {
+        let mut state = enabled_state();
+
+        let first = state.record_sent_stanza_at(&message("one"), 100);
+        let second = state.record_sent_stanza_at(&message("two"), 101);
+
+        assert_eq!(first.kind, SentStanzaKind::New);
+        assert_eq!(
+            first.request,
+            Some(AckRequest {
+                attempt: 1,
+                unacked: 1,
+            })
+        );
+        assert_eq!(second.kind, SentStanzaKind::New);
+        assert_eq!(second.request, None);
+        assert_eq!(state.unacked_count(), 2);
+    }
+
+    #[test]
+    fn valid_non_progress_ack_releases_request_and_schedules_retry() {
+        let mut state = enabled_state();
+        state.record_sent_stanza_at(&message("one"), 100);
+        confirm_generated_request(&mut state, 100);
+
+        let processed = state.process_ack_at(0, 120).unwrap();
+
+        assert!(!processed.observation.progressed);
+        assert_eq!(processed.observation.latency_ms, Some(20));
+        assert_eq!(state.next_ack_wakeup_in_ms(120), Some(250));
+        assert_eq!(state.poll_ack_timer_at(369), AckTimerPoll::default());
+        assert_eq!(
+            state.poll_ack_timer_at(370).request,
+            Some(AckRequest {
+                attempt: 2,
+                unacked: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn unsolicited_ack_preserves_pending_request_until_late_transport_confirmation() {
+        let mut state = enabled_state();
+        let generated = state.record_sent_stanza_at(&message("one"), 100);
+        assert_eq!(generated.request.map(|request| request.attempt), Some(1));
+
+        let unsolicited = state.process_ack_at(0, 120).unwrap();
+
+        assert!(!unsolicited.observation.progressed);
+        assert_eq!(unsolicited.observation.latency_ms, None);
+        assert_eq!(
+            state.next_ack_wakeup_in_ms(120),
+            Some(29_980),
+            "an uncorrelated ack cannot schedule over the generated request token"
+        );
+        assert!(
+            state.confirm_ack_request_sent_at(200),
+            "late transport confirmation must still own the generated request"
+        );
+        assert_eq!(state.next_ack_wakeup_in_ms(200), Some(5_000));
+        assert_eq!(state.poll_ack_timer_at(5_199), AckTimerPoll::default());
+        assert_eq!(
+            state.poll_ack_timer_at(5_200).request,
+            Some(AckRequest {
+                attempt: 2,
+                unacked: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn definitely_not_written_request_clears_pending_and_schedules_retry() {
+        let mut state = enabled_state();
+        state.record_sent_stanza_at(&message("one"), 100);
+
+        assert!(state.ack_request_definitely_not_written_at(110));
+        assert!(
+            !state.confirm_ack_request_sent_at(111),
+            "definite failure must dispose the exact generated request"
+        );
+        assert_eq!(state.next_ack_wakeup_in_ms(110), Some(250));
+        assert_eq!(state.poll_ack_timer_at(359), AckTimerPoll::default());
+        assert_eq!(
+            state.poll_ack_timer_at(360).request,
+            Some(AckRequest {
+                attempt: 2,
+                unacked: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn progress_resets_retry_backoff_while_work_remains() {
+        let mut state = enabled_state();
+        state.record_sent_stanza_at(&message("one"), 0);
+        state.record_sent_stanza_at(&message("two"), 1);
+        confirm_generated_request(&mut state, 1);
+        state.process_ack_at(0, 10).unwrap();
+        let retry = state.poll_ack_timer_at(260);
+        assert_eq!(retry.request.map(|request| request.attempt), Some(2));
+        confirm_generated_request(&mut state, 260);
+
+        let progressed = state.process_ack_at(1, 300).unwrap();
+
+        assert!(progressed.observation.progressed);
+        assert_eq!(progressed.observation.unacked, 1);
+        assert_eq!(state.next_ack_wakeup_in_ms(300), Some(250));
+        assert_eq!(
+            state.poll_ack_timer_at(550).request,
+            Some(AckRequest {
+                attempt: 1,
+                unacked: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn non_progress_retry_schedule_reaches_and_repeats_five_second_cap() {
+        let mut state = enabled_state();
+        state.record_sent_stanza_at(&message("one"), 0);
+        confirm_generated_request(&mut state, 0);
+        let mut now_ms = 0;
+
+        for (expected_delay_ms, expected_attempt) in [
+            (250, 2),
+            (500, 3),
+            (1_000, 4),
+            (2_000, 5),
+            (5_000, 6),
+            (5_000, 7),
+        ] {
+            let observation = state.process_ack_at(0, now_ms).unwrap();
+            assert!(!observation.observation.progressed);
+            assert_eq!(state.next_ack_wakeup_in_ms(now_ms), Some(expected_delay_ms));
+            assert_eq!(
+                state.poll_ack_timer_at(now_ms + expected_delay_ms - 1),
+                AckTimerPoll::default()
+            );
+            now_ms += expected_delay_ms;
+            assert_eq!(
+                state.poll_ack_timer_at(now_ms).request,
+                Some(AckRequest {
+                    attempt: expected_attempt,
+                    unacked: 1,
+                })
+            );
+            confirm_generated_request(&mut state, now_ms);
+        }
+    }
+
+    #[test]
+    fn missing_ack_response_times_out_and_reissues_request() {
+        let mut state = enabled_state();
+        state.record_sent_stanza_at(&message("one"), 1_000);
+        confirm_generated_request(&mut state, 1_000);
+
+        assert_eq!(state.next_ack_wakeup_in_ms(1_000), Some(5_000));
+        let poll = state.poll_ack_timer_at(6_000);
+
+        assert!(poll.request_timed_out);
+        assert_eq!(
+            poll.request,
+            Some(AckRequest {
+                attempt: 2,
+                unacked: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn ack_response_clock_starts_only_after_transport_confirmation() {
+        let mut state = enabled_state();
+        let generated = state.record_sent_stanza_at(&message("one"), 100);
+        assert_eq!(generated.request.map(|request| request.attempt), Some(1));
+
+        assert_eq!(
+            state.next_ack_wakeup_in_ms(100),
+            Some(30_000),
+            "only the original no-progress epoch runs while <r/> is pending"
+        );
+        assert_eq!(state.poll_ack_timer_at(4_099), AckTimerPoll::default());
+        assert!(state.confirm_ack_request_sent_at(4_100));
+        assert!(!state.confirm_ack_request_sent_at(4_101));
+        assert_eq!(state.next_ack_wakeup_in_ms(4_100), Some(5_000));
+        assert_eq!(state.poll_ack_timer_at(9_099), AckTimerPoll::default());
+
+        let observed = state.process_ack_at(0, 4_200).unwrap();
+        assert_eq!(observed.observation.latency_ms, Some(100));
+        assert!(!observed.observation.progressed);
+        assert_eq!(state.next_ack_wakeup_in_ms(4_200), Some(250));
+    }
+
+    #[test]
+    fn thirty_seconds_without_h_progress_requests_unclean_reconnect() {
+        let mut state = enabled_state();
+        state.record_sent_stanza_at(&message("one"), 5_000);
+
+        let poll = state.poll_ack_timer_at(35_000);
+
+        assert_eq!(poll.progress_stalled_ms, Some(30_000));
+        assert_eq!(poll.request, None);
+    }
+
+    #[test]
+    fn replay_arms_ack_request_without_incrementing_counter() {
+        let replay = message("replay");
+        let resume =
+            SmResumeState::from_unhandled_outbound_stanzas("previous", 0, 1, [replay.clone()])
+                .expect("resume state");
+        let mut state = SmState::from_resume_state(&resume);
+        state.enabled = true;
+        state.outbound_enabled = true;
+        assert_eq!(state.mark_unhandled_for_replay(), vec![replay.clone()]);
+
+        let sent = state.record_sent_stanza_at(&replay, 50);
+
+        assert_eq!(sent.kind, SentStanzaKind::Replay);
+        assert_eq!(sent.request.map(|request| request.unacked), Some(1));
+        assert_eq!(state.outbound_count, 1);
+    }
+
+    #[test]
+    fn resumed_replay_transition_supersedes_delayed_retry_but_keeps_progress_deadline() {
+        let replay = message("replay");
+        let resume =
+            SmResumeState::from_unhandled_outbound_stanzas("previous", 0, 1, [replay.clone()])
+                .expect("resume state");
+        let mut state = SmState::from_resume_state(&resume);
+        state.enabled = true;
+        state.outbound_enabled = true;
+
+        state.process_ack_at(0, 10_000).unwrap();
+        assert_eq!(state.next_ack_wakeup_in_ms(10_000), Some(250));
+
+        state.begin_replay_transition_at(10_000);
+        assert_eq!(state.mark_unhandled_for_replay(), vec![replay.clone()]);
+        let sent = state.record_sent_stanza_at(&replay, 10_001);
+
+        assert_eq!(sent.kind, SentStanzaKind::Replay);
+        assert_eq!(
+            sent.request,
+            Some(AckRequest {
+                attempt: 1,
+                unacked: 1,
+            })
+        );
+        assert_eq!(state.outbound_count, 1);
+        assert_eq!(
+            state.poll_ack_timer_at(40_000).progress_stalled_ms,
+            Some(30_000)
+        );
+    }
+
+    #[test]
+    fn successful_resume_restarts_full_retry_ladder_without_moving_progress_epoch() {
+        let replay = message("replay");
+        let resume =
+            SmResumeState::from_unhandled_outbound_stanzas("previous", 0, 1, [replay.clone()])
+                .expect("resume state");
+        let mut state = SmState::from_resume_state(&resume);
+        state.enabled = true;
+        state.outbound_enabled = true;
+
+        // Establish a no-progress epoch and consume earlier cadence state so
+        // the resume transition has stale attempts/backoff to reset.
+        state.process_ack_at(0, 10_000).unwrap();
+        assert_eq!(
+            state.poll_ack_timer_at(10_250).request,
+            Some(AckRequest {
+                attempt: 1,
+                unacked: 1,
+            })
+        );
+        confirm_generated_request(&mut state, 10_250);
+        state.process_ack_at(0, 10_260).unwrap();
+        assert_eq!(
+            state.poll_ack_timer_at(10_760).request,
+            Some(AckRequest {
+                attempt: 2,
+                unacked: 1,
+            })
+        );
+        confirm_generated_request(&mut state, 10_760);
+
+        state.begin_replay_transition_at(11_000);
+        assert_eq!(state.mark_unhandled_for_replay(), vec![replay.clone()]);
+        let replay_sent = state.record_sent_stanza_at(&replay, 11_001);
+        assert_eq!(replay_sent.kind, SentStanzaKind::Replay);
+        assert_eq!(
+            replay_sent.request,
+            Some(AckRequest {
+                attempt: 1,
+                unacked: 1,
+            })
+        );
+        assert_eq!(state.outbound_count, 1, "replay must not be recounted");
+        confirm_generated_request(&mut state, 11_001);
+
+        let mut now_ms = 11_010;
+        for (delay_ms, attempt) in [
+            (250, 2),
+            (500, 3),
+            (1_000, 4),
+            (2_000, 5),
+            (5_000, 6),
+            (5_000, 7),
+        ] {
+            let ack = state.process_ack_at(0, now_ms).unwrap();
+            assert!(!ack.observation.progressed);
+            assert_eq!(state.next_ack_wakeup_in_ms(now_ms), Some(delay_ms));
+            now_ms += delay_ms;
+            assert_eq!(
+                state.poll_ack_timer_at(now_ms).request,
+                Some(AckRequest {
+                    attempt,
+                    unacked: 1,
+                })
+            );
+            confirm_generated_request(&mut state, now_ms);
+            now_ms += 1;
+        }
+
+        assert_eq!(
+            state.poll_ack_timer_at(40_000).progress_stalled_ms,
+            Some(30_000),
+            "the 30s reconnect deadline remains anchored to the original no-progress epoch"
+        );
+    }
+
+    #[test]
+    fn resumed_replay_transition_cancels_cadence_when_ack_handles_everything() {
+        let resume =
+            SmResumeState::from_unhandled_outbound_stanzas("previous", 0, 1, [message("one")])
+                .expect("resume state");
+        let mut state = SmState::from_resume_state(&resume);
+        state.enabled = true;
+        state.outbound_enabled = true;
+
+        let processed = state.process_ack_at(1, 500).unwrap();
+        assert_eq!(processed.observation.unacked, 0);
+        state.begin_replay_transition_at(500);
+
+        assert!(state.mark_unhandled_for_replay().is_empty());
+        assert_eq!(state.next_ack_wakeup_in_ms(500), None);
+        assert_eq!(state.poll_ack_timer_at(u64::MAX), AckTimerPoll::default());
+    }
+
+    #[test]
+    fn sm_disabled_and_ack_request_elements_never_request_recursively() {
+        let mut state = SmState::new();
+        state.start_outbound();
+        let disabled = state.record_sent_stanza_at(&message("one"), 0);
+        assert_eq!(disabled.kind, SentStanzaKind::New);
+        assert_eq!(disabled.request, None);
+
+        state.enabled = true;
+        let before = state.outbound_count;
+        let request = state.record_sent_stanza_at(&SmState::build_request_ack(), 1);
+        assert_eq!(request.kind, SentStanzaKind::NotCountable);
+        assert_eq!(request.request, None);
+        assert_eq!(state.outbound_count, before);
     }
 }

--- a/server/crates/waddle-xmpp-client/src/transport.rs
+++ b/server/crates/waddle-xmpp-client/src/transport.rs
@@ -12,7 +12,10 @@ mod tests;
 
 pub use codec::{decode_message, encode_message};
 #[cfg(all(feature = "native", not(target_arch = "wasm32")))]
-pub use native::{DefaultTransportFactory, WebSocketTransport, WebSocketTransportFactory};
+pub use native::{
+    DefaultTransportFactory, TransportWriteFailure, TransportWriteResponsibility,
+    TransportWriteResult, WebSocketTransport, WebSocketTransportFactory,
+};
 
 /// Transport kind supported by the native client runtime.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/server/crates/waddle-xmpp-client/src/transport/native.rs
+++ b/server/crates/waddle-xmpp-client/src/transport/native.rs
@@ -16,9 +16,56 @@ use crate::config::ClientConfig;
 use crate::error::{ClientError, ClientResult};
 
 use super::{
-    decode_message, encode_message, StreamClose, TransportCapabilities, TransportEvent,
-    TransportKind, TransportMessage, TransportState,
+    decode_message, encode_message, TransportCapabilities, TransportEvent, TransportKind,
+    TransportMessage, TransportState,
 };
+
+/// Whether a failed native transport write can still have transferred the
+/// typed XMPP frame to the peer.
+///
+/// Once a WebSocket sink starts a write, an error cannot prove that zero bytes
+/// reached the network. XEP-0198 therefore has to retain responsibility for a
+/// countable stanza after [`Self::PossiblyWritten`]. Encoding and preflight
+/// failures happen before the sink is touched and are
+/// [`Self::DefinitelyNotWritten`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportWriteResponsibility {
+    DefinitelyNotWritten,
+    PossiblyWritten,
+}
+
+/// Typed failure returned by the native write boundary.
+#[derive(Debug)]
+pub struct TransportWriteFailure {
+    responsibility: TransportWriteResponsibility,
+    source: ClientError,
+}
+
+impl TransportWriteFailure {
+    pub fn definitely_not_written(source: ClientError) -> Self {
+        Self {
+            responsibility: TransportWriteResponsibility::DefinitelyNotWritten,
+            source,
+        }
+    }
+
+    pub fn possibly_written(source: ClientError) -> Self {
+        Self {
+            responsibility: TransportWriteResponsibility::PossiblyWritten,
+            source,
+        }
+    }
+
+    pub fn responsibility(&self) -> TransportWriteResponsibility {
+        self.responsibility
+    }
+
+    pub fn source(&self) -> &ClientError {
+        &self.source
+    }
+}
+
+pub type TransportWriteResult<T> = Result<T, TransportWriteFailure>;
 
 /// Runtime-owned factory for a WebSocket transport implementation.
 pub trait WebSocketTransportFactory: Send + Sync {
@@ -40,11 +87,25 @@ pub trait WebSocketTransport: Send + Sync {
 
     fn drain_events(&mut self) -> Vec<TransportEvent>;
 
-    fn send<'a>(&'a mut self, message: TransportMessage) -> BoxFuture<'a, ClientResult<()>>;
+    /// Write one typed transport message.
+    ///
+    /// Implementations must not enqueue `TransportEvent::MessageSent`; the
+    /// owning driver applies that event exactly once after this future confirms
+    /// success. This keeps transport responsibility and XEP-0198 queue state in
+    /// one ordered pump.
+    fn send<'a>(&'a mut self, message: TransportMessage)
+        -> BoxFuture<'a, TransportWriteResult<()>>;
 
     fn next_event<'a>(&'a mut self) -> BoxFuture<'a, ClientResult<Option<TransportEvent>>>;
 
-    fn close<'a>(&'a mut self) -> BoxFuture<'a, ClientResult<()>>;
+    /// Begin the RFC 6455 closing handshake after the typed RFC 7395
+    /// `<close/>` exchange has completed. This method never writes XML.
+    fn close_websocket<'a>(&'a mut self) -> BoxFuture<'a, TransportWriteResult<()>>;
+
+    /// Terminate the WebSocket without sending RFC 7395 `<close/>`.
+    /// XEP-0198 treats this as an unclean XML-stream loss, so the runtime's
+    /// resume snapshot remains eligible for the reconnecting owner.
+    fn abort<'a>(&'a mut self) -> BoxFuture<'a, ClientResult<()>>;
 }
 
 /// Default runtime factory for the concrete WebSocket transport.
@@ -125,20 +186,27 @@ impl WebSocketTransport for ConnectedWebSocketTransport {
         self.pending_events.drain(..).collect()
     }
 
-    fn send<'a>(&'a mut self, message: TransportMessage) -> BoxFuture<'a, ClientResult<()>> {
+    fn send<'a>(
+        &'a mut self,
+        message: TransportMessage,
+    ) -> BoxFuture<'a, TransportWriteResult<()>> {
         Box::pin(async move {
             if self.state == TransportState::Closed {
-                return Err(ClientError::TransportClosed);
+                return Err(TransportWriteFailure::definitely_not_written(
+                    ClientError::TransportClosed,
+                ));
             }
 
-            let frame = encode_message(&message)?;
-            self.sink.send(Message::Text(frame.into())).await?;
+            let frame =
+                encode_message(&message).map_err(TransportWriteFailure::definitely_not_written)?;
+            self.sink
+                .send(Message::Text(frame.into()))
+                .await
+                .map_err(|error| TransportWriteFailure::possibly_written(error.into()))?;
 
             if matches!(message, TransportMessage::Close(_)) {
                 self.queue_state_change(TransportState::Closing);
             }
-            self.pending_events
-                .push_back(TransportEvent::MessageSent(message));
             Ok(())
         })
     }
@@ -188,24 +256,34 @@ impl WebSocketTransport for ConnectedWebSocketTransport {
         })
     }
 
-    fn close<'a>(&'a mut self) -> BoxFuture<'a, ClientResult<()>> {
+    fn close_websocket<'a>(&'a mut self) -> BoxFuture<'a, TransportWriteResult<()>> {
         Box::pin(async move {
             if self.state == TransportState::Closed {
                 return Ok(());
             }
 
-            if self.state != TransportState::Closing {
-                self.queue_state_change(TransportState::Closing);
-                let frame = encode_message(&TransportMessage::Close(StreamClose))?;
-                self.sink.send(Message::Text(frame.into())).await?;
-                self.pending_events.push_back(TransportEvent::MessageSent(
-                    TransportMessage::Close(StreamClose),
-                ));
-            }
-
-            self.sink.close().await?;
+            self.queue_state_change(TransportState::Closing);
+            self.sink
+                .close()
+                .await
+                .map_err(|error| TransportWriteFailure::possibly_written(error.into()))?;
             self.queue_closed();
             Ok(())
+        })
+    }
+
+    fn abort<'a>(&'a mut self) -> BoxFuture<'a, ClientResult<()>> {
+        Box::pin(async move {
+            if self.state == TransportState::Closed {
+                return Ok(());
+            }
+            self.queue_state_change(TransportState::Closing);
+            let result: ClientResult<()> = self.sink.close().await.map_err(Into::into);
+            if result.is_err() {
+                self.queue_state_change(TransportState::Failed);
+            }
+            self.queue_closed();
+            result
         })
     }
 }

--- a/server/crates/waddle-xmpp-client/src/transport/tests.rs
+++ b/server/crates/waddle-xmpp-client/src/transport/tests.rs
@@ -212,11 +212,11 @@ async fn concrete_transport_connects_and_emits_typed_frames() {
     );
 
     let outbound = TransportMessage::Open(StreamOpen::from_config(&live_config));
-    transport.send(outbound.clone()).await.unwrap();
-    assert!(matches!(
-        transport.next_event().await.unwrap(),
-        Some(TransportEvent::MessageSent(message)) if message == outbound
-    ));
+    transport.send(outbound).await.unwrap();
+    assert!(
+        transport.drain_events().is_empty(),
+        "the transport adapter must not own MessageSent confirmation"
+    );
 
     assert!(matches!(
         transport.next_event().await.unwrap(),

--- a/server/crates/waddle-xmpp-client/tests/xep0198_stream_management.rs
+++ b/server/crates/waddle-xmpp-client/tests/xep0198_stream_management.rs
@@ -1,0 +1,310 @@
+use std::str::FromStr;
+
+use jid::BareJid;
+use minidom::Element;
+use url::Url;
+use waddle_xmpp_client::stream_management::{
+    AckRequest, SentStanzaKind, SmAckHandledCountTooHigh, SmState, NS_SM,
+};
+use waddle_xmpp_client::{
+    AccessToken, ClientConfig, ClientEvent, ClientRequest, ClientResource, ConnectionConfig,
+    ConnectionEvent, OAuthBearerConfig, SmResumeState, StreamClose, StreamManagementEvent,
+    TransportEvent, TransportMessage, TransportState, WebSocketConfig, XmppRuntime, NS_BIND,
+    NS_CLIENT, NS_SASL, NS_STREAMS,
+};
+
+fn config() -> ClientConfig {
+    ClientConfig::new(
+        ConnectionConfig::new(BareJid::from_str("waddle.example").unwrap()),
+        WebSocketConfig::new(Url::parse("wss://chat.example.com/ws").unwrap()).unwrap(),
+        OAuthBearerConfig::new(
+            BareJid::from_str("alice@example.com").unwrap(),
+            ClientResource::new("browser").unwrap(),
+            AccessToken::new("token"),
+        )
+        .unwrap(),
+    )
+    .unwrap()
+}
+
+fn message(id: &str) -> Element {
+    Element::builder("message", NS_CLIENT)
+        .attr(minidom::rxml::xml_ncname!("id").to_owned(), id)
+        .attr(minidom::rxml::xml_ncname!("type").to_owned(), "chat")
+        .build()
+}
+
+fn enabled_state() -> SmState {
+    let mut state = SmState::new();
+    state.start_outbound();
+    state.enabled = true;
+    state
+}
+
+#[test]
+fn xep0198_ack_cadence_uses_transport_confirmation_and_repeats_five_second_rung() {
+    let mut state = enabled_state();
+    let first = state.record_sent_stanza_at(&message("one"), 100);
+    assert_eq!(
+        first.request,
+        Some(AckRequest {
+            attempt: 1,
+            unacked: 1,
+        })
+    );
+    assert_eq!(
+        state.next_ack_wakeup_in_ms(100),
+        Some(30_000),
+        "the five-second response clock cannot start before <r/> reaches transport"
+    );
+
+    assert!(state.confirm_ack_request_sent_at(1_000));
+    let timeout = state.poll_ack_timer_at(6_000);
+    assert!(timeout.request_timed_out);
+    assert_eq!(timeout.request.map(|request| request.attempt), Some(2));
+
+    let mut repeated = enabled_state();
+    repeated.record_sent_stanza_at(&message("repeat"), 0);
+    assert!(repeated.confirm_ack_request_sent_at(0));
+    let mut now_ms = 0;
+    for (delay_ms, expected_attempt) in [
+        (250, 2),
+        (500, 3),
+        (1_000, 4),
+        (2_000, 5),
+        (5_000, 6),
+        (5_000, 7),
+    ] {
+        repeated.process_ack_at(0, now_ms).unwrap();
+        now_ms += delay_ms;
+        assert_eq!(
+            repeated
+                .poll_ack_timer_at(now_ms)
+                .request
+                .map(|request| request.attempt),
+            Some(expected_attempt)
+        );
+        assert!(repeated.confirm_ack_request_sent_at(now_ms));
+    }
+    assert_eq!(
+        repeated.poll_ack_timer_at(30_000).progress_stalled_ms,
+        Some(30_000)
+    );
+}
+
+#[test]
+fn xep0198_wrapping_ack_validation_is_atomic_and_replay_is_not_recounted() {
+    let mut state = enabled_state();
+    state.server_h = u32::MAX - 1;
+    state.outbound_count = u32::MAX - 1;
+    state.record_sent_stanza(&message("last-before-wrap"));
+    state.record_sent_stanza(&message("first-after-wrap"));
+
+    assert_eq!(
+        state.process_ack(1),
+        Err(SmAckHandledCountTooHigh {
+            h: 1,
+            send_count: 0,
+        })
+    );
+    assert_eq!(state.server_h, u32::MAX - 1);
+    assert_eq!(state.unacked_count(), 2);
+    assert_eq!(state.process_ack(0).unwrap().len(), 2);
+
+    let replay = message("byte-stable-replay");
+    let resume =
+        SmResumeState::from_unhandled_outbound_stanzas("session", 9, 1, [replay.clone()]).unwrap();
+    let mut resumed = SmState::from_resume_state(&resume);
+    resumed.enabled = true;
+    resumed.outbound_enabled = true;
+    resumed.begin_replay_transition_at(500);
+    assert_eq!(resumed.mark_unhandled_for_replay(), vec![replay.clone()]);
+    let sent = resumed.record_sent_stanza_at(&replay, 501);
+    assert_eq!(sent.kind, SentStanzaKind::Replay);
+    assert_eq!(resumed.outbound_count, 1);
+    assert_eq!(resumed.inbound_count, 9);
+
+    resumed.inbound_count = 44;
+    resumed.start_inbound();
+    assert_eq!(
+        resumed.inbound_count, 0,
+        "only a fresh <enabled/> sequence resets inbound h"
+    );
+}
+
+#[test]
+fn xep0198_inbound_request_emits_current_h_and_graceful_close_finishes_with_ack() {
+    let mut runtime = establish_sm_runtime();
+    for id in ["inbound-1", "inbound-2"] {
+        runtime
+            .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+                message(id),
+            )))
+            .unwrap();
+    }
+
+    let request_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            SmState::build_request_ack(),
+        )))
+        .unwrap();
+    assert!(request_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::OutboundMessage(
+            TransportMessage::Element(element)
+        )) if element.name() == "a"
+            && element.ns() == NS_SM
+            && element.attr("h") == Some("2")
+    )));
+    assert!(request_events.iter().any(|event| matches!(
+        event,
+        ClientEvent::Connection(ConnectionEvent::StreamManagement(
+            StreamManagementEvent::AckRequested
+        ))
+    )));
+
+    let close_events = runtime.request_stream_close().unwrap();
+    let outbound = close_events
+        .iter()
+        .filter_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(message)) => Some(message),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(outbound.len(), 2);
+    assert!(matches!(
+        outbound[0],
+        TransportMessage::Element(ack)
+            if ack.name() == "a" && ack.attr("h") == Some("2")
+    ));
+    assert!(matches!(outbound[1], TransportMessage::Close(StreamClose)));
+}
+
+#[test]
+fn xep0198_peer_close_reciprocates_after_final_inbound_ack() {
+    let mut runtime = establish_sm_runtime();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            message("peer-close-inbound"),
+        )))
+        .unwrap();
+
+    let close_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Close(
+            StreamClose,
+        )))
+        .unwrap();
+    let outbound = close_events
+        .iter()
+        .filter_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::OutboundMessage(message)) => Some(message),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(outbound.len(), 2);
+    assert!(matches!(
+        outbound[0],
+        TransportMessage::Element(ack)
+            if ack.name() == "a"
+                && ack.ns() == NS_SM
+                && ack.attr("h") == Some("1")
+    ));
+    assert!(matches!(outbound[1], TransportMessage::Close(StreamClose)));
+}
+
+fn establish_sm_runtime() -> XmppRuntime {
+    let mut runtime = XmppRuntime::new(config()).unwrap();
+    runtime.queue_request(ClientRequest::Connect).unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::StateChanged(TransportState::Open))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Open(
+            waddle_xmpp_client::StreamOpen::from_server(
+                BareJid::from_str("waddle.example").unwrap(),
+            ),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("features", NS_STREAMS)
+                .append(
+                    Element::builder("mechanisms", NS_SASL)
+                        .append(
+                            Element::builder("mechanism", NS_SASL)
+                                .append("OAUTHBEARER")
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("success", NS_SASL).build(),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Open(
+            waddle_xmpp_client::StreamOpen::from_server(
+                BareJid::from_str("waddle.example").unwrap(),
+            ),
+        )))
+        .unwrap();
+    let bind_events = runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("features", NS_STREAMS)
+                .append(Element::builder("bind", NS_BIND).build())
+                .append(Element::builder("sm", NS_SM).build())
+                .build(),
+        )))
+        .unwrap();
+    let bind_id = bind_events
+        .iter()
+        .find_map(|event| match event {
+            ClientEvent::Connection(ConnectionEvent::ResourceBindingRequested(request)) => {
+                Some(request.stanza_id.clone())
+            }
+            _ => None,
+        })
+        .expect("resource binding request");
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("iq", NS_CLIENT)
+                .attr(
+                    minidom::rxml::xml_ncname!("id").to_owned(),
+                    bind_id.as_str(),
+                )
+                .attr(minidom::rxml::xml_ncname!("type").to_owned(), "result")
+                .append(
+                    Element::builder("bind", NS_BIND)
+                        .append(
+                            Element::builder("jid", NS_BIND)
+                                .append("alice@example.com/browser")
+                                .build(),
+                        )
+                        .build(),
+                )
+                .build(),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageSent(TransportMessage::Element(
+            SmState::build_enable(true),
+        )))
+        .unwrap();
+    runtime
+        .apply_transport_event(TransportEvent::MessageReceived(TransportMessage::Element(
+            Element::builder("enabled", NS_SM)
+                .attr(minidom::rxml::xml_ncname!("resume").to_owned(), "true")
+                .attr(
+                    minidom::rxml::xml_ncname!("id").to_owned(),
+                    "browser-sm-session",
+                )
+                .build(),
+        )))
+        .unwrap();
+    runtime
+}

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.d.ts
@@ -268,6 +268,12 @@ export class WaddleClient {
      */
     register_push_device(options: any): Promise<any>;
     request_avatar(jid: string): Promise<any>;
+    /**
+     * Best-effort XEP-0198 acknowledgement request for page lifecycle
+     * handoff. The shared runtime suppresses duplicates while another
+     * request is already awaiting `<a/>`.
+     */
+    request_stream_management_ack(): Promise<any>;
     request_upload_slot(service_jid: string, filename: string, size: bigint, content_type: string): Promise<any>;
     retract_activity(): Promise<any>;
     retract_mood(): Promise<any>;
@@ -456,6 +462,7 @@ export class WaddleClient {
      */
     set_on_pubsub_event(cb: Function): void;
     set_on_session_lifecycle(cb: Function): void;
+    set_on_stream_management(cb: Function): void;
     set_room_affiliation(room_jid: string, jid: string, affiliation: string): Promise<any>;
     /**
      * Set the per-chat XEP-0492 notification mode for one room by
@@ -609,9 +616,9 @@ export class WaddleConfig {
     [Symbol.dispose](): void;
     constructor(server_url: string, jid: string, access_token: string, resource: string);
     with_resume_state(previd: string, inbound_h: number, outbound_h: number): void;
+    with_resume_state_entries(previd: string, inbound_h: number, outbound_h: number, entries: any): void;
+    with_resume_state_entries_with_max(previd: string, inbound_h: number, outbound_h: number, entries: any, max_resume_seconds: number): void;
     with_resume_state_handle(state: WaddleResumeState): void;
-    with_resume_state_stanzas(previd: string, inbound_h: number, outbound_h: number, stanzas: string[]): void;
-    with_resume_state_stanzas_with_max(previd: string, inbound_h: number, outbound_h: number, stanzas: string[], max_resume_seconds: number): void;
     with_resume_state_with_max(previd: string, inbound_h: number, outbound_h: number, max_resume_seconds: number): void;
 }
 

--- a/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
+++ b/server/wasm-pkg/waddle-xmpp-client-wasm/waddle_xmpp_client_wasm.js
@@ -1,7 +1,7 @@
 /* @ts-self-types="./waddle_xmpp_client_wasm.d.ts" */
-import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=82eec800cb2a";
-import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=82eec800cb2a";
-import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=82eec800cb2a";
+import wasmUrl from "./waddle_xmpp_client_wasm_bg.wasm?url&b=cb16083848c7";
+import * as bgModule from "./waddle_xmpp_client_wasm_bg.js?b=cb16083848c7";
+import { __wbg_set_wasm } from "./waddle_xmpp_client_wasm_bg.js?b=cb16083848c7";
 
 let initPromise;
 
@@ -30,4 +30,4 @@ export default async function init() {
 // WaddleConfig, …) AND Rust free functions (xep0392_consistent_hue,
 // xep0392_consistent_color, …). A hand-curated list silently drops new
 // #[wasm_bindgen] free functions until somebody notices the chat crashing.
-export * from "./waddle_xmpp_client_wasm_bg.js?b=82eec800cb2a";
+export * from "./waddle_xmpp_client_wasm_bg.js?b=cb16083848c7";


### PR DESCRIPTION
## P0.1 Packet S — signed current-main successor published for review

This draft PR publishes the clean XEP-0198 recovery successor for the distributed-actors program. It targets [#1425](https://github.com/waddle-social/waddle/issues/1425).

### Custody and published candidate

- The prior PR head is preserved at `backup/pr1357-p0-1-pre-successor-20260724` → `06d88f8b7ac33f316b55d80b832d42751cbbc64d`.
- This PR now points at signed candidate `b89da28a75f9a24e5dc242e5cd4cee77fcf24ee2`, parent `72482c2e48bdf6ef85fcfb7f040ae8517601cb97` (current `main` when published), tree `095ef489bd10e31782b42eed53236b835751da21`.
- The candidate is one focused commit, `fix(xmpp): restore stream management recovery`; its 42 changed paths are limited to XEP-0198 client/runtime/transport behavior, generated WASM bindings, dedicated tests, and browser lifecycle support.

### Behavior and boundaries

- Restores conformant XEP-0198 acknowledgement cadence, acknowledgement/progress timeout handling, wrapping counter validation, typed inbound acknowledgement replies, clean-close ordering, durable pagehide persistence, uncertain-write replay, and generation-fenced callbacks.
- Preserves the generated-but-unconfirmed acknowledgement-request race: an unsolicited acknowledgement cannot discard the pending token; definite non-write retries; possible write forces resume without a duplicate request.
- Effect TypeScript is confined to browser pagehide/pageshow listener lifetime. Rust remains the protocol retry, timeout, and state authority.
- No Android, Apple, infrastructure, database, relay, or other distributed-actors phase is included.

### Evidence and remaining gates

- The exact source tree completed its author test, lint, build, type-generation, WASM-generation, formatting, and clippy gates before signing. Signing changed commit metadata only; immutable-SHA verification remains required.
- This push intentionally invalidates prior PR CI. Fresh verifier evidence, independent XMPP/state/client-operability reviews, and current CI are required before acceptance.
- Keep this PR draft. It is not ready, merged, deployed, or accepted; Packet S is only the immediate P0.1 release train. Android durable-lifecycle integration and P0.2–P4 remain incomplete.