### PR TITLE
fix(android): repair main CI — verb fakes and immutable release publish

### DIFF
--- a/apps/android/core/client/src/test/kotlin/social/waddle/android/client/Fakes.kt
+++ b/apps/android/core/client/src/test/kotlin/social/waddle/android/client/Fakes.kt
@@ -9,12 +9,15 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import social.waddle.android.client.auth.WaddleSessionInfo
 import social.waddle.client.ffi.WaddleAvatar
+import social.waddle.client.ffi.WaddleChatState
 import social.waddle.client.ffi.WaddleClientEvent
 import social.waddle.client.ffi.WaddleClientInterface
 import social.waddle.client.ffi.WaddleConfig
 import social.waddle.client.ffi.WaddleEventListener
 import social.waddle.client.ffi.WaddleJingleReason
 import social.waddle.client.ffi.WaddleMamPage
+import social.waddle.client.ffi.WaddleMdsDisplayedEntry
+import social.waddle.client.ffi.WaddlePinEntry
 import social.waddle.client.ffi.WaddlePushDeviceCredentials
 import social.waddle.client.ffi.WaddlePushEnvironment
 import social.waddle.client.ffi.WaddleRegisterDeviceResult
@@ -151,6 +154,21 @@ class FakeWaddleClient : WaddleClientInterface {
         return sendOutcomes.removeFirstOrNull() ?: sendOutcome
     }
     override suspend fun sendPresence(status: String?, show: String?, idleSince: String?) = unused()
+    override suspend fun sendReaction(targetJid: String, targetStanzaId: String, emojis: List<String>, isMuc: Boolean): Boolean = unused()
+    override suspend fun sendCorrection(peerJid: String, targetId: String, newBody: String, isMuc: Boolean, options: WaddleSendOptions?): WaddleSendMessageOutcome = unused()
+    override suspend fun sendRetraction(peerJid: String, targetStanzaId: String, isMuc: Boolean): Boolean = unused()
+    override suspend fun sendModeration(roomJid: String, targetStanzaId: String, reason: String?): Boolean = unused()
+    override suspend fun sendChatState(peerJid: String, state: WaddleChatState, isMuc: Boolean): Boolean = unused()
+    override suspend fun sendDisplayed(peerJid: String, stanzaId: String, isMuc: Boolean): Boolean = unused()
+    override suspend fun publishMdsDisplayed(chatJid: String, stanzaId: String, stanzaIdBy: String): Boolean = unused()
+    override suspend fun fetchMdsDisplayed(): List<WaddleMdsDisplayedEntry> = unused()
+    override suspend fun subscribeMdsDisplayed(): Boolean = unused()
+    override suspend fun supportsMdsPublishOptions(): Boolean = unused()
+    override suspend fun fetchRoomPins(roomJid: String): List<WaddlePinEntry> = unused()
+    override suspend fun pinMessage(roomJid: String, targetStanzaId: String): Boolean = unused()
+    override suspend fun unpinMessage(roomJid: String, targetStanzaId: String): Boolean = unused()
+    override suspend fun pinDirectMessage(peerJid: String, targetStanzaId: String): Boolean = unused()
+    override suspend fun unpinDirectMessage(peerJid: String, targetStanzaId: String): Boolean = unused()
     override suspend fun disablePushDevice(pushServiceJid: String, node: String, deviceId: String): Boolean = unused()
     override suspend fun disablePushNotifications(pushServiceJid: String, node: String?): Boolean = unused()
     override suspend fun enablePushNotifications(pushServiceJid: String, node: String): Boolean = unused()

--- a/apps/android/env.cue
+++ b/apps/android/env.cue
@@ -197,8 +197,12 @@ schema.#Project & {
 		// Rolling install-in-place artifact: every merge to main rebuilds
 		// the debug APK (shared checked-in debug keystore -> signature is
 		// stable across builders, so `adb install -r` upgrades without an
-		// uninstall) with a monotonic timestamp-derived versionCode, and
-		// replaces the asset on the `android-latest` prerelease.
+		// uninstall) with a monotonic timestamp-derived versionCode.
+		// GitHub releases are immutable once published (asset uploads to
+		// an existing release 422), so each publish deletes and recreates
+		// the `android-latest` prerelease + tag; the stable download URL
+		// releases/download/android-latest/waddle-android-debug.apk is
+		// keyed by tag name and survives the recreate.
 		publishDebugApk: schema.#Task & {
 			command: "bash"
 			env: {
@@ -215,13 +219,12 @@ schema.#Project & {
 				  -PversionName="$(git rev-parse --short HEAD)"
 				apk="app/build/outputs/apk/debug/app-debug.apk"
 				sha="$(git rev-parse --short HEAD)"
-				gh release view android-latest >/dev/null 2>&1 || \
-				  gh release create android-latest --prerelease \
-				    --title "Android (rolling debug)" \
-				    --notes "Rolling debug build; adb install -r upgrades in place."
-				gh release upload android-latest "$apk#waddle-android-debug.apk" --clobber
-				gh release edit android-latest \
-				  --notes "commit ${sha} — install: adb install -r waddle-android-debug.apk (no uninstall needed; shared debug signature)"
+				gh release delete android-latest --yes --cleanup-tag || true
+				gh release create android-latest --prerelease \
+				  --target "$(git rev-parse HEAD)" \
+				  --title "Android (rolling debug)" \
+				  --notes "commit ${sha} — install: adb install -r waddle-android-debug.apk (no uninstall needed; shared debug signature)" \
+				  "${apk}#waddle-android-debug.apk"
 				"""#]
 			dependsOn: [setupSdk, buildRustJni]
 			inputs: _gradleInputs


### PR DESCRIPTION
Repairs the two `waddle-android-default` failures on main introduced by the #1353 + #1358 merge combination:

1. **`test` task**: `FakeWaddleClient` no longer implemented `WaddleClientInterface` after #1358's regenerated Kotlin bindings added the messaging-verb surface (reactions, corrections, retraction, moderation, chat states, displayed markers, MDS, pins). Each PR was green in isolation; the union only compiled on main. The fake now overrides all new methods with the existing reject-if-exercised contract.

2. **`publishDebugApk` task**: GitHub releases are now immutable at publish — re-uploading the rolling debug APK asset onto the existing `android-latest` release fails with HTTP 422. The task now deletes and recreates the prerelease (and its tag, pinned to the built commit via `--target`) on every merge. The stable download URL `releases/download/android-latest/waddle-android-debug.apk` is keyed by tag name and survives the recreate.

Verified locally: full `testDebugUnitTest` suite green; pinned cuenv 0.53.2 `sync` produces no workflow drift (the task script lives in `env.cue`, evaluated at CI runtime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)