### PR TITLE
fix(android): stop the rolling-apk publish racing async tag deletion

### DIFF
--- a/apps/android/env.cue
+++ b/apps/android/env.cue
@@ -232,10 +232,16 @@ schema.#Project & {
 				# API (same GH_TOKEN as the release commands, no reliance on
 				# checkout push credentials), so the create below always
 				# finds an up-to-date existing tag and never races one.
-				gh api -X PATCH "repos/{owner}/{repo}/git/refs/tags/android-latest" \
-				  -f sha="${full_sha}" -F force=true \
-				  || gh api -X POST "repos/{owner}/{repo}/git/refs" \
-				  -f ref="refs/tags/android-latest" -f sha="${full_sha}"
+				# Existence-check first so exactly ONE of PATCH/POST runs
+				# and its real error surfaces (a `PATCH || POST` chain would
+				# mask a permission/5xx PATCH failure behind the POST).
+				if gh api "repos/{owner}/{repo}/git/refs/tags/android-latest" >/dev/null 2>&1; then
+				  gh api -X PATCH "repos/{owner}/{repo}/git/refs/tags/android-latest" \
+				    -f sha="${full_sha}" -F force=true
+				else
+				  gh api -X POST "repos/{owner}/{repo}/git/refs" \
+				    -f ref="refs/tags/android-latest" -f sha="${full_sha}"
+				fi
 				gh release create android-latest --prerelease \
 				  --title "Android (rolling debug)" \
 				  --notes "commit ${sha} — install: adb install -r waddle-android-debug.apk (no uninstall needed; shared debug signature)" \

--- a/apps/android/env.cue
+++ b/apps/android/env.cue
@@ -199,8 +199,12 @@ schema.#Project & {
 		// stable across builders, so `adb install -r` upgrades without an
 		// uninstall) with a monotonic timestamp-derived versionCode.
 		// GitHub releases are immutable once published (asset uploads to
-		// an existing release 422), so each publish deletes and recreates
-		// the `android-latest` prerelease + tag; the stable download URL
+		// an existing release 422), so each publish deletes the release
+		// and recreates it on the stable `android-latest` tag. The tag is
+		// re-pointed to HEAD SYNCHRONOUSLY via git — `gh release delete
+		// --cleanup-tag` deletes the tag asynchronously and the recreate
+		// races the still-present tag (422 Validation Failed), so tag
+		// lifecycle is managed here instead. The stable download URL
 		// releases/download/android-latest/waddle-android-debug.apk is
 		// keyed by tag name and survives the recreate.
 		publishDebugApk: schema.#Task & {
@@ -219,9 +223,20 @@ schema.#Project & {
 				  -PversionName="$(git rev-parse --short HEAD)"
 				apk="app/build/outputs/apk/debug/app-debug.apk"
 				sha="$(git rev-parse --short HEAD)"
-				gh release delete android-latest --yes --cleanup-tag || true
+				full_sha="$(git rev-parse HEAD)"
+				# Delete only the release object (not the tag — `gh release
+				# delete --cleanup-tag`'s tag removal is async and races the
+				# recreate); best-effort on the first run.
+				gh release delete android-latest --yes || true
+				# Re-point the stable tag to this commit via the git-refs
+				# API (same GH_TOKEN as the release commands, no reliance on
+				# checkout push credentials), so the create below always
+				# finds an up-to-date existing tag and never races one.
+				gh api -X PATCH "repos/{owner}/{repo}/git/refs/tags/android-latest" \
+				  -f sha="${full_sha}" -F force=true \
+				  || gh api -X POST "repos/{owner}/{repo}/git/refs" \
+				  -f ref="refs/tags/android-latest" -f sha="${full_sha}"
 				gh release create android-latest --prerelease \
-				  --target "$(git rev-parse HEAD)" \
 				  --title "Android (rolling debug)" \
 				  --notes "commit ${sha} — install: adb install -r waddle-android-debug.apk (no uninstall needed; shared debug signature)" \
 				  "${apk}#waddle-android-debug.apk"


### PR DESCRIPTION
The `waddle-android-default` run after #1360 merged failed: `publishDebugApk` built the debug APK successfully but 422'd on the GitHub release create.

**Root cause is a race, not immutability.** `gh release delete --cleanup-tag` removes the git tag *asynchronously*; the immediately-following `gh release create android-latest --target <sha>` hit the still-present `android-latest` tag and got `422 Validation Failed` before the deletion propagated. (Confirmed: after the failure the release *and* tag are both 404 — the delete did eventually complete, so nothing is blocking deletion.) This delete+recreate path only ever runs on the `default` (main) pipeline, so it wasn't exercised until this post-merge build.

**Fix:** the publish now deletes only the release object and re-points the stable `android-latest` tag to `HEAD` via the git-refs API (`PATCH …/git/refs/tags/android-latest` with `force`, falling back to `POST …/git/refs` on first run) using the same `GH_TOKEN` the release commands already use. The create then always finds an up-to-date existing tag and never has to create — and race — one. Tag management via `gh api` avoids relying on the checkout's git-push credentials. The stable download URL `releases/download/android-latest/waddle-android-debug.apk` (keyed by tag name) is unchanged.

Edited in `apps/android/env.cue` only; pinned cuenv `sync` produces no workflow-yml drift (the task script is evaluated at CI runtime), so `checkCiDrift` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)