### PR TITLE
fix(android): re-run the rolling-apk publish when its script changes

### DIFF
--- a/.github/workflows/waddle-android-default.yml
+++ b/.github/workflows/waddle-android-default.yml
@@ -20,6 +20,7 @@ on:
     - apps/android/debug.keystore
     - apps/android/debug.keystore/**
     - apps/android/env.cue
+    - apps/android/env.cue/**
     - apps/android/gradle.properties
     - apps/android/gradle.properties/**
     - apps/android/gradle/**

--- a/apps/android/env.cue
+++ b/apps/android/env.cue
@@ -248,7 +248,12 @@ schema.#Project & {
 				  "${apk}#waddle-android-debug.apk"
 				"""#]
 			dependsOn: [setupSdk, buildRustJni]
-			inputs: _gradleInputs
+			// env.cue is in the input set so a change to THIS publish
+			// script (not just the app) re-runs the task — otherwise
+			// cuenv's incremental engine reports "no affected tasks" for
+			// a script-only fix and the rolling release is never
+			// rebuilt.
+			inputs: list.Concat([_gradleInputs, ["env.cue"]])
 			outputs: ["app/build/outputs/apk/debug/app-debug.apk"]
 		}
 	}


### PR DESCRIPTION
Follow-up to #1362. That PR fixed the async-tag-deletion race in `publishDebugApk`, but its post-merge `waddle-android-default` run reported **"No affected tasks"** and never actually published — so the fix is unproven and the `android-latest` release (deleted by #1360's failed run) is still missing.

**Cause:** cuenv keys `publishDebugApk` on `_gradleInputs`, which does not include `env.cue`. A script-only change to the publish step therefore doesn't invalidate the task's cache, and cuenv's incremental engine skips it (even on a manual `workflow_dispatch`). Normal feature merges that touch app code still publish fine; only a script-only fix like #1362 is skipped.

**Fix:** add `env.cue` to the task's input set (`list.Concat([_gradleInputs, ["env.cue"]])`) so a change to the publish script itself re-runs the task. This very change consequently rebuilds the rolling release on merge — with #1362's race-free script — proving the fix end to end.

Generated workflow re-synced with pinned cuenv 0.53.2; the only yml delta is `apps/android/env.cue/**` added to the push path filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)