### PR TITLE
fix(server): groupchat origin-id dedupe misses retry-after-rejoin

### DIFF
--- a/server/crates/waddle-server/src/muc_durable.rs
+++ b/server/crates/waddle-server/src/muc_durable.rs
@@ -1236,7 +1236,7 @@ mod tests {
     /// path remains cache-backed until #1283 replaces it.
     #[tokio::test]
     async fn mam_store_message_fenced_blocks_the_deposed_owners_next_archive_write() {
-        use waddle_xmpp::mam::{MamStorage, MamStorageError, SqlxMamStorage};
+        use waddle_xmpp::mam::{MamStorage, MamStorageError, SqlxMamStorage, StoreOutcome};
         use waddle_xmpp_core::mam::ArchivedMessage;
 
         let _guard = clustering_control_plane_table_lock().lock().await;
@@ -1287,13 +1287,13 @@ mod tests {
                 jid::Jid::from(jid.clone()),
             )
         };
-        let archive_id = mam_storage
+        let archive_outcome = mam_storage
             .store_message_fenced(&jid, &message, &fence)
             .await
             .expect("the current owner's fenced write must succeed");
-        assert_eq!(archive_id, first_id);
+        assert_eq!(archive_outcome, StoreOutcome::Stored(first_id.clone()));
         let stored = mam_storage
-            .get_message(&archive_id)
+            .get_message(&first_id)
             .await
             .expect("get_message")
             .expect("row exists");

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -2670,6 +2670,15 @@ impl MamStorage for LookupOutageMamStorage {
             .replace_with_tombstone(archive_id, tombstone)
             .await
     }
+    async fn replace_with_terminal_tombstone(
+        &self,
+        archive_id: &str,
+        tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+    ) -> Result<waddle_xmpp::mam::TerminalTombstoneOutcome, MamStorageError> {
+        self.inner
+            .replace_with_terminal_tombstone(archive_id, tombstone)
+            .await
+    }
     async fn get_message_by_stanza_id(
         &self,
         archive_jid: &BareJid,

--- a/server/crates/waddle-server/src/pending_delivery/tests.rs
+++ b/server/crates/waddle-server/src/pending_delivery/tests.rs
@@ -2600,7 +2600,7 @@ async fn insert_fenced_prevents_duplicate_promotion_across_claim_states() {
 // queued offline mail.
 
 use std::sync::atomic::{AtomicU32, Ordering};
-use waddle_xmpp::mam::storage::{InMemoryMamStorage, MamStorage, MamStorageError};
+use waddle_xmpp::mam::storage::{InMemoryMamStorage, MamStorage, MamStorageError, StoreOutcome};
 use waddle_xmpp_core::mam::ArchivedMessage;
 
 /// MAM storage wrapper that fails `get_message_by_archive_or_stanza_id`
@@ -2642,7 +2642,7 @@ impl MamStorage for LookupOutageMamStorage {
         &self,
         archive_jid: &BareJid,
         message: &ArchivedMessage,
-    ) -> Result<String, MamStorageError> {
+    ) -> Result<StoreOutcome, MamStorageError> {
         self.inner.store_message(archive_jid, message).await
     }
     async fn query_messages(

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -327,7 +327,18 @@ fn apply_archive_id_rewrites(event: &mut OutboundEvent, rewrites: &[ArchiveIdRew
 enum BatchSuppression {
     None,
     All,
-    NonSender { sender: BareJid },
+    /// Tombstone-hit swallow: everything is suppressed EXCEPT the
+    /// idempotent, terminal-guarded retraction-tombstone application.
+    /// A retry whose retraction-request row was itself tombstoned may
+    /// still be healing a crash between the request's archive commit
+    /// and the target tombstone apply — the CAS guard makes letting it
+    /// through safe in every other case (Greptile review on PR #1412).
+    /// `All` (ownership loss / subject-persist bounce) must NOT share
+    /// this escape: a deposed node may not touch the archive at all.
+    TombstoneSwallow,
+    NonSender {
+        sender: BareJid,
+    },
 }
 
 impl BatchSuppression {
@@ -335,6 +346,12 @@ impl BatchSuppression {
         match self {
             Self::None => true,
             Self::All => false,
+            Self::TombstoneSwallow => {
+                matches!(
+                    event,
+                    OutboundEvent::ApplyGroupchatRetractionTombstone { .. }
+                )
+            }
             Self::NonSender { sender } => match event {
                 // A crash can commit the retraction-request archive row before
                 // applying its target tombstone. A deduplicated retry must
@@ -593,7 +610,7 @@ async fn interpret_with_depth(
                         );
                         outcome.retry_suppression =
                             Some(GroupchatRetrySuppression::TombstoneSwallowed);
-                        batch_suppression = BatchSuppression::All;
+                        batch_suppression = BatchSuppression::TombstoneSwallow;
                     }
                     ArchiveGroupchatEventOutcome::OwnershipLost(bounce) => {
                         // FIX 1: not archived, not fanned out — suppress

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -207,7 +207,9 @@ use routing::{
 
 #[cfg(feature = "clustering")]
 pub use deps::OrderedRelayRouteOriginKind;
-pub use deps::{Deps, InterpretOutcome, OrderedRelayRouteOrigin, TimerCommand};
+pub use deps::{
+    Deps, GroupchatRetrySuppression, InterpretOutcome, OrderedRelayRouteOrigin, TimerCommand,
+};
 pub(crate) use groupchat_archive::push_inbox_update;
 pub(crate) use notification_activity_ingest::{
     record_presence_available_activity_on_state, record_presence_unavailable_activity_on_state,
@@ -334,6 +336,10 @@ impl BatchSuppression {
             Self::None => true,
             Self::All => false,
             Self::NonSender { sender } => match event {
+                // A crash can commit the retraction-request archive row before
+                // applying its target tombstone. A deduplicated retry must
+                // finish that idempotent, monotonic second effect.
+                OutboundEvent::ApplyGroupchatRetractionTombstone { .. } => true,
                 OutboundEvent::RouteToConnection { jid, .. } => &jid.to_bare() == sender,
                 OutboundEvent::ProjectGroupchatInbox { owner, .. } => owner == sender,
                 _ => false,
@@ -467,6 +473,10 @@ async fn interpret_with_depth(
                     feedback: nested_feedback,
                     keepalive_probes: nested_probes,
                     timer_commands: nested_timer_commands,
+                    // Retry suppression is local to the nested room batch;
+                    // dispatch_to_room consumes it before returning so it
+                    // cannot suppress unrelated siblings in this outer batch.
+                    retry_suppression: _,
                     archive_id_rewrites: nested_rewrites,
                 } = nested;
                 outcome.frames.extend(nested_frames);
@@ -574,12 +584,15 @@ async fn interpret_with_depth(
                         if let Some(rewrite) = rewrite {
                             archive_id_rewrites.push(rewrite);
                         }
+                        outcome.retry_suppression = Some(GroupchatRetrySuppression::Deduplicated);
                         batch_suppression = BatchSuppression::NonSender { sender };
                     }
                     ArchiveGroupchatEventOutcome::TombstoneHit => {
                         debug!(
                             "ArchiveGroupchat: tombstone hit; silently suppressing remaining dispatch batch"
                         );
+                        outcome.retry_suppression =
+                            Some(GroupchatRetrySuppression::TombstoneSwallowed);
                         batch_suppression = BatchSuppression::All;
                     }
                     ArchiveGroupchatEventOutcome::OwnershipLost(bounce) => {

--- a/server/crates/waddle-server/src/server/routes/interpret.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret.rs
@@ -322,6 +322,26 @@ fn apply_archive_id_rewrites(event: &mut OutboundEvent, rewrites: &[ArchiveIdRew
     }
 }
 
+enum BatchSuppression {
+    None,
+    All,
+    NonSender { sender: BareJid },
+}
+
+impl BatchSuppression {
+    fn allows(&self, event: &OutboundEvent) -> bool {
+        match self {
+            Self::None => true,
+            Self::All => false,
+            Self::NonSender { sender } => match event {
+                OutboundEvent::RouteToConnection { jid, .. } => &jid.to_bare() == sender,
+                OutboundEvent::ProjectGroupchatInbox { owner, .. } => owner == sender,
+                _ => false,
+            },
+        }
+    }
+}
+
 fn rewrite_stanza_archive_ids(stanza: &mut Stanza, rewrites: &[ArchiveIdRewrite]) {
     if let Stanza::Message(message) = stanza {
         rewrite_message_archive_ids(message, rewrites);
@@ -373,15 +393,10 @@ async fn interpret_with_depth(
     let registry = deps.connection_registry;
     let mut outcome = InterpretOutcome::default();
     let mut archive_id_rewrites: Vec<ArchiveIdRewrite> = Vec::new();
-    // Once a write-adjacent room effect rejects this batch, suppress every
-    // later effect from the same frozen chain. `ArchiveGroupchat` retains its
-    // legacy ownership backstop until #1283; subject persistence binds the
-    // exact actor fence in this PR. Both must halt later inbox/fan-out work
-    // after returning a retryable bounce.
-    let mut suppress_remaining_events = false;
+    let mut batch_suppression = BatchSuppression::None;
 
     for mut event in events {
-        if suppress_remaining_events {
+        if !batch_suppression.allows(&event) {
             continue;
         }
         apply_archive_id_rewrites(&mut event, &archive_id_rewrites);
@@ -550,10 +565,23 @@ async fn interpret_with_depth(
                 )
                 .await
                 {
-                    ArchiveGroupchatEventOutcome::Rewrite(Some(rewrite)) => {
+                    ArchiveGroupchatEventOutcome::Stored(Some(rewrite)) => {
                         archive_id_rewrites.push(rewrite);
                     }
-                    ArchiveGroupchatEventOutcome::Rewrite(None) => {}
+                    ArchiveGroupchatEventOutcome::Stored(None)
+                    | ArchiveGroupchatEventOutcome::Skipped => {}
+                    ArchiveGroupchatEventOutcome::Deduplicated { rewrite, sender } => {
+                        if let Some(rewrite) = rewrite {
+                            archive_id_rewrites.push(rewrite);
+                        }
+                        batch_suppression = BatchSuppression::NonSender { sender };
+                    }
+                    ArchiveGroupchatEventOutcome::TombstoneHit => {
+                        debug!(
+                            "ArchiveGroupchat: tombstone hit; silently suppressing remaining dispatch batch"
+                        );
+                        batch_suppression = BatchSuppression::All;
+                    }
                     ArchiveGroupchatEventOutcome::OwnershipLost(bounce) => {
                         // FIX 1: not archived, not fanned out — suppress
                         // every remaining event in this batch (the
@@ -570,7 +598,7 @@ async fn interpret_with_depth(
                                 );
                             }
                         }
-                        suppress_remaining_events = true;
+                        batch_suppression = BatchSuppression::All;
                     }
                 }
             }
@@ -656,7 +684,7 @@ async fn interpret_with_depth(
                                 "PersistRoomSubject: failed to serialize retryable bounce reply"
                             ),
                         }
-                        suppress_remaining_events = true;
+                        batch_suppression = BatchSuppression::All;
                     }
                 }
             }

--- a/server/crates/waddle-server/src/server/routes/interpret/archive_groupchat_event.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/archive_groupchat_event.rs
@@ -1,14 +1,13 @@
 use super::*;
 
-/// Outcome of the [`OutboundEvent::ArchiveGroupchat`] interpreter arm
-/// (ADR-0017 Phase 3 Slice 7 FIX 1, council-adjudicated). `OwnershipLost`
-/// carries the pre-built bounce reply the caller pushes to `outcome.frames`
-/// AND uses as the signal to suppress every remaining event in this same
-/// dispatch batch (the archive handler always runs before the reflector
-/// fan-out handler in the locked Q7 chain order, so this is reached before
-/// any `RouteToConnection` fan-out for the same message).
 pub(super) enum ArchiveGroupchatEventOutcome {
-    Rewrite(Option<ArchiveIdRewrite>),
+    Stored(Option<ArchiveIdRewrite>),
+    Deduplicated {
+        rewrite: Option<ArchiveIdRewrite>,
+        sender: BareJid,
+    },
+    TombstoneHit,
+    Skipped,
     OwnershipLost(Box<Message>),
 }
 
@@ -26,7 +25,7 @@ pub(super) async fn archive_groupchat_event(
             sender = %sender,
             "ArchiveGroupchat: no mam_storage in Deps; skipping (test fixture?)"
         );
-        return ArchiveGroupchatEventOutcome::Rewrite(None);
+        return ArchiveGroupchatEventOutcome::Skipped;
     };
     // Per XEP-0313 §5.1.3 the eligibility check ran inside
     // `MucArchiveHandler` before this event was emitted —
@@ -54,7 +53,16 @@ pub(super) async fn archive_groupchat_event(
     .await
     {
         ArchiveGroupchatOutcome::Stored(result) => result,
-        ArchiveGroupchatOutcome::Skipped => return ArchiveGroupchatEventOutcome::Rewrite(None),
+        ArchiveGroupchatOutcome::Deduplicated(result) => {
+            return ArchiveGroupchatEventOutcome::Deduplicated {
+                rewrite: result.rewrite,
+                sender: sender.to_bare(),
+            };
+        }
+        ArchiveGroupchatOutcome::TombstoneHit => {
+            return ArchiveGroupchatEventOutcome::TombstoneHit;
+        }
+        ArchiveGroupchatOutcome::Skipped => return ArchiveGroupchatEventOutcome::Skipped,
         ArchiveGroupchatOutcome::OwnershipLost => {
             let bounce = build_message_error_reply(
                 &message,
@@ -84,7 +92,7 @@ pub(super) async fn archive_groupchat_event(
         &message,
     )
     .await;
-    ArchiveGroupchatEventOutcome::Rewrite(archive_id.rewrite)
+    ArchiveGroupchatEventOutcome::Stored(archive_id.rewrite)
 }
 
 async fn update_groupchat_link_preview_refs(

--- a/server/crates/waddle-server/src/server/routes/interpret/archive_lookup.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/archive_lookup.rs
@@ -81,10 +81,10 @@ pub(super) fn project_archived_row(
     archive: &jid::BareJid,
     row: MamArchivedMessage,
 ) -> Option<Box<ProtocolArchivedMessage>> {
-    let tombstoned = matches!(
-        row.rich.as_ref().and_then(|r| r.payload.as_ref()),
-        Some(waddle_xmpp::mam::ArchivedRichPayload::Tombstone(_))
-    );
+    let tombstoned = row
+        .rich
+        .as_ref()
+        .is_some_and(waddle_xmpp::mam::ArchivedRichMessage::is_tombstoned);
 
     let message = match parse_archived_message_xml(row.stanza_xml.as_deref()) {
         Some(m) => m,

--- a/server/crates/waddle-server/src/server/routes/interpret/bot.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/bot.rs
@@ -134,9 +134,13 @@ pub(super) async fn dispatch_bot_groupchat_response(
         bot_ctx.recursion_depth,
     ))
     .await;
+    let _retry_suppression = nested.retry_suppression;
     outcome.frames.extend(nested.frames);
     outcome.close = nested.close;
     outcome.feedback.extend(nested.feedback);
+    // Extension-bot dispatch returns only transport/callback effects. The
+    // explicit discard above keeps a nested room retry marker local to that
+    // batch so it cannot label subsequent bot work.
     Ok(ExtensionRoomDispatchResult { outcome, stanza_id })
 }
 

--- a/server/crates/waddle-server/src/server/routes/interpret/deps.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/deps.rs
@@ -56,6 +56,10 @@ pub struct InterpretOutcome {
     /// connection-local timer wheel. Only the transport adapter owns a
     /// clock; the interpreter just relays the typed commands.
     pub timer_commands: Vec<TimerCommand>,
+    /// Batch-local reason a groupchat retry was swallowed. The room
+    /// dispatcher consumes this marker to avoid re-running extension
+    /// observers for a delivery whose original attempt already ran them.
+    pub retry_suppression: Option<GroupchatRetrySuppression>,
     /// XEP-0359 archive-id rewrites accumulated while interpreting the
     /// batch (a store deduped to an existing row). The interpreter
     /// already applies these to later events in the same batch; the
@@ -63,6 +67,12 @@ pub struct InterpretOutcome {
     /// wire stanza it extracts BEFORE interpreting, so live/MAM id
     /// parity holds under origin-id retries.
     pub(crate) archive_id_rewrites: Vec<ArchiveIdRewrite>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GroupchatRetrySuppression {
+    Deduplicated,
+    TombstoneSwallowed,
 }
 
 /// Typed timer instruction relayed from the state machine to the

--- a/server/crates/waddle-server/src/server/routes/interpret/direct_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/direct_archive.rs
@@ -1,4 +1,5 @@
 use super::*;
+use waddle_xmpp::mam::StoreOutcome;
 
 const DM_CALL_PENDING_TTL_SECS: i64 = 30 * 60;
 const DM_CALL_ACTIVE_TTL_SECS: i64 = 12 * 60 * 60;
@@ -58,7 +59,18 @@ pub(super) async fn archive_direct(
     );
     let requested_archive_id = archived.id.clone();
     match mam_storage.store_message(&archive_jid, &archived).await {
-        Ok(archive_id) => {
+        Ok(outcome) => {
+            let archive_id = match outcome {
+                StoreOutcome::Stored(id) | StoreOutcome::Deduplicated(id) => id,
+                StoreOutcome::TombstoneHit(id) => {
+                    warn!(
+                        archive_jid = %archive_jid,
+                        archive_id = %id,
+                        "ArchiveDirect: unexpected groupchat tombstone outcome; treating as deduplicated"
+                    );
+                    id
+                }
+            };
             debug!(
                 archive_jid = %archive_jid,
                 archive_id,

--- a/server/crates/waddle-server/src/server/routes/interpret/direct_retraction.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/direct_retraction.rs
@@ -79,6 +79,9 @@ pub(super) async fn apply_retraction_tombstone(
         retraction_id: Some(retraction_id),
         stamp: chrono::Utc::now(),
         moderation: None,
+        // 1:1 tombstones never enter the groupchat tombstone-retry
+        // match; there is no occupant identity to retain.
+        sender_scope: None,
     };
     match mam_storage
         .replace_with_tombstone(&original.id, tombstone)

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -1,5 +1,5 @@
 use super::*;
-use waddle_xmpp::mam::MamStorageError;
+use waddle_xmpp::mam::{MamStorageError, StoreOutcome};
 use waddle_xmpp::muc::RoomClaimFenceContext;
 use waddle_xmpp::ownership::{CurrentNodeIdentityGuard, SharedNodeIdentity};
 
@@ -234,14 +234,24 @@ pub(super) async fn finish_archive_groupchat_message(
         RoomArchiveFence::OwnershipLost => return ArchiveGroupchatOutcome::OwnershipLost,
     };
     match store_result {
-        Ok(stored_id) => ArchiveGroupchatOutcome::Stored(ArchiveStoreResult {
-            rewrite: ArchiveIdRewrite::from_store_result(
-                jid::Jid::from(room.clone()),
-                archive_id,
-                stored_id.clone(),
-            ),
-            stored_id,
-        }),
+        Ok(StoreOutcome::Stored(stored_id) | StoreOutcome::Deduplicated(stored_id)) => {
+            ArchiveGroupchatOutcome::Stored(ArchiveStoreResult {
+                rewrite: ArchiveIdRewrite::from_store_result(
+                    jid::Jid::from(room.clone()),
+                    archive_id,
+                    stored_id.clone(),
+                ),
+                stored_id,
+            })
+        }
+        Ok(StoreOutcome::TombstoneHit(existing_id)) => {
+            debug!(
+                room = %room,
+                archive_id = %existing_id,
+                "ArchiveGroupchat: origin-id retry matched a tombstone; skipping archive write"
+            );
+            ArchiveGroupchatOutcome::Skipped
+        }
         Err(MamStorageError::NotOwner { entity }) => {
             warn!(
                 room = %room,

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -1,5 +1,5 @@
 use super::*;
-use waddle_xmpp::mam::{MamStorageError, StoreOutcome};
+use waddle_xmpp::mam::{MamStorageError, StoreOutcome, TerminalTombstoneOutcome};
 use waddle_xmpp::muc::RoomClaimFenceContext;
 use waddle_xmpp::ownership::{CurrentNodeIdentityGuard, SharedNodeIdentity};
 
@@ -393,6 +393,22 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
             return false;
         }
     };
+    // Tombstones are terminal. A heal-retry of an XEP-0424 author
+    // retraction must never downgrade the attribution or reason on an
+    // existing XEP-0425 moderation tombstone.
+    if original.rich.as_ref().is_some_and(|rich| {
+        matches!(
+            rich.payload.as_ref(),
+            Some(ArchivedRichPayload::Tombstone(_))
+        )
+    }) {
+        debug!(
+            archive = %room,
+            original_id = %original.id,
+            "ApplyGroupchatRetractionTombstone: target is already tombstoned; preserving terminal tombstone"
+        );
+        return true;
+    }
     let Some(retraction_id) = retraction_message
         .id
         .as_ref()
@@ -412,17 +428,25 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
         moderation: None,
     };
     match mam_storage
-        .replace_with_tombstone(&original.id, tombstone)
+        .replace_with_terminal_tombstone(&original.id, tombstone)
         .await
     {
-        Ok(true) => {
+        Ok(TerminalTombstoneOutcome::Replaced) => {
             debug!(
                 archive = %room,
                 original_id = %original.id,
                 "ApplyGroupchatRetractionTombstone: replaced with tombstone"
             );
         }
-        Ok(false) => {
+        Ok(TerminalTombstoneOutcome::AlreadyTombstoned) => {
+            debug!(
+                archive = %room,
+                original_id = %original.id,
+                "ApplyGroupchatRetractionTombstone: concurrent tombstone won; preserving terminal tombstone"
+            );
+            return true;
+        }
+        Ok(TerminalTombstoneOutcome::NotFound) => {
             warn!(
                 archive = %room,
                 original_id = %original.id,
@@ -442,7 +466,7 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
                 archive = %room,
                 original_id = %original.id,
                 %error,
-                "ApplyGroupchatRetractionTombstone: replace_with_tombstone failed"
+                "ApplyGroupchatRetractionTombstone: terminal tombstone replacement failed"
             );
             scrub_unacked_for_tombstone(
                 sm_session_registry,

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -396,12 +396,11 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
     // Tombstones are terminal. A heal-retry of an XEP-0424 author
     // retraction must never downgrade the attribution or reason on an
     // existing XEP-0425 moderation tombstone.
-    if original.rich.as_ref().is_some_and(|rich| {
-        matches!(
-            rich.payload.as_ref(),
-            Some(ArchivedRichPayload::Tombstone(_))
-        )
-    }) {
+    if original
+        .rich
+        .as_ref()
+        .is_some_and(ArchivedRichMessage::is_tombstoned)
+    {
         debug!(
             archive = %room,
             original_id = %original.id,

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -406,6 +406,17 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
             original_id = %original.id,
             "ApplyGroupchatRetractionTombstone: target is already tombstoned; preserving terminal tombstone"
         );
+        // A crash between the tombstone persist and the scrub leaves
+        // pre-tombstone reflections replayable from SM queues /
+        // pending_delivery. The scrub is idempotent, so re-running it
+        // on the heal path closes that window (Qodo review on PR #1412).
+        scrub_unacked_for_tombstone(
+            sm_session_registry,
+            pending_storage,
+            &scrub_target,
+            "ApplyGroupchatRetractionTombstone",
+        )
+        .await;
         return true;
     }
     let Some(retraction_id) = retraction_message
@@ -425,6 +436,13 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
         retraction_id: Some(retraction_id),
         stamp: chrono::Utc::now(),
         moderation: None,
+        // Retain the original sender's identity for the internal
+        // tombstone-retry match only; never emitted to the wire.
+        sender_scope: original
+            .rich
+            .as_ref()
+            .and_then(|rich| rich.muc_sender.as_ref())
+            .map(|sender| sender.jid.to_bare()),
     };
     match mam_storage
         .replace_with_terminal_tombstone(&original.id, tombstone)
@@ -443,6 +461,16 @@ pub(super) async fn apply_groupchat_retraction_tombstone(
                 original_id = %original.id,
                 "ApplyGroupchatRetractionTombstone: concurrent tombstone won; preserving terminal tombstone"
             );
+            // Same crash-window heal as the pre-check exit: the winner
+            // may not have completed its scrub yet (Qodo review on
+            // PR #1412).
+            scrub_unacked_for_tombstone(
+                sm_session_registry,
+                pending_storage,
+                &scrub_target,
+                "ApplyGroupchatRetractionTombstone",
+            )
+            .await;
             return true;
         }
         Ok(TerminalTombstoneOutcome::NotFound) => {

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -24,6 +24,8 @@ pub(super) enum RoomArchiveFence {
 /// actual write.
 pub(super) enum ArchiveGroupchatOutcome {
     Stored(ArchiveStoreResult),
+    Deduplicated(ArchiveStoreResult),
+    TombstoneHit,
     /// Not an error: a chain-bug guard or a non-fencing storage failure
     /// declined the write. The reflection still goes out (today's
     /// pre-existing behavior, unchanged).
@@ -234,8 +236,18 @@ pub(super) async fn finish_archive_groupchat_message(
         RoomArchiveFence::OwnershipLost => return ArchiveGroupchatOutcome::OwnershipLost,
     };
     match store_result {
-        Ok(StoreOutcome::Stored(stored_id) | StoreOutcome::Deduplicated(stored_id)) => {
+        Ok(StoreOutcome::Stored(stored_id)) => {
             ArchiveGroupchatOutcome::Stored(ArchiveStoreResult {
+                rewrite: ArchiveIdRewrite::from_store_result(
+                    jid::Jid::from(room.clone()),
+                    archive_id,
+                    stored_id.clone(),
+                ),
+                stored_id,
+            })
+        }
+        Ok(StoreOutcome::Deduplicated(stored_id)) => {
+            ArchiveGroupchatOutcome::Deduplicated(ArchiveStoreResult {
                 rewrite: ArchiveIdRewrite::from_store_result(
                     jid::Jid::from(room.clone()),
                     archive_id,
@@ -248,9 +260,9 @@ pub(super) async fn finish_archive_groupchat_message(
             debug!(
                 room = %room,
                 archive_id = %existing_id,
-                "ArchiveGroupchat: origin-id retry matched a tombstone; skipping archive write"
+                "ArchiveGroupchat: origin-id retry matched a tombstone"
             );
-            ArchiveGroupchatOutcome::Skipped
+            ArchiveGroupchatOutcome::TombstoneHit
         }
         Err(MamStorageError::NotOwner { entity }) => {
             warn!(

--- a/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/groupchat_archive.rs
@@ -821,6 +821,11 @@ pub(super) fn rich_archive_payload(
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
+    let subjects = message
+        .subjects
+        .iter()
+        .map(|(lang, text)| (lang.0.clone(), text.clone()))
+        .collect::<std::collections::BTreeMap<_, _>>();
     // XEP-0421: capture the server-stamped occupant-id into the typed
     // projection so the non-`stanza_xml` fallback reconstruction can
     // re-emit it (#1268). `MucCanonicalizeHandler` stamped it (and
@@ -833,6 +838,7 @@ pub(super) fn rich_archive_payload(
         && reply.is_none()
         && references.is_empty()
         && mentions.is_empty()
+        && subjects.is_empty()
         && occupant_id.is_none()
         && muc_sender.is_none()
     {
@@ -843,6 +849,7 @@ pub(super) fn rich_archive_payload(
             reply,
             references,
             mentions,
+            subjects,
             occupant_id,
             muc_sender,
         })

--- a/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_dispatch.rs
@@ -21,6 +21,41 @@ pub(super) fn bind_room_claim_fence(
     }
 }
 
+/// Move the one subject-persistence effect emitted by the room chain directly
+/// after its archive effect while preserving every other event's order.
+///
+/// The handler chain itself remains subject-before-archive so an unauthorized
+/// XEP-0045 subject change still halts before archival. Reordering only the
+/// admitted event batch lets `ArchiveGroupchat` arm ownership-loss,
+/// tombstone-hit, or deduplication suppression before the room mutation, while
+/// `PersistRoomSubject` still completes before the reflector's
+/// `RouteToConnection` effects as required by the ordering contract on that
+/// event. The chain emits at most one of each effect for a message.
+pub(super) fn order_subject_persistence_after_archive(
+    mut events: Vec<OutboundEvent>,
+) -> Vec<OutboundEvent> {
+    let Some(subject_index) = events
+        .iter()
+        .position(|event| matches!(event, OutboundEvent::PersistRoomSubject { .. }))
+    else {
+        return events;
+    };
+    let Some(archive_index) = events
+        .iter()
+        .position(|event| matches!(event, OutboundEvent::ArchiveGroupchat { .. }))
+    else {
+        return events;
+    };
+    let insertion_index = if subject_index < archive_index {
+        archive_index
+    } else {
+        archive_index + 1
+    };
+    let subject = events.remove(subject_index);
+    events.insert(insertion_index, subject);
+    events
+}
+
 pub(super) async fn dispatch_to_room(
     deps: &Deps<'_>,
     room_jid: jid::BareJid,
@@ -367,6 +402,8 @@ pub(super) async fn dispatch_to_room(
         outcome.frames.extend(nested.frames);
         outcome.close = outcome.close || nested.close;
         outcome.feedback.extend(nested.feedback);
+        // The gate cannot emit ArchiveGroupchat. Any future batch-local retry
+        // marker is deliberately not folded into the enclosing dispatch.
         return outcome;
     }
 
@@ -502,6 +539,7 @@ pub(super) async fn dispatch_to_room(
     let observer_message = working.clone();
     let mut dispatch_events = dispatch_outcome.events;
     bind_room_claim_fence(&mut dispatch_events, snapshot.claim_fence.as_ref());
+    let dispatch_events = order_subject_persistence_after_archive(dispatch_events);
 
     // 6. Recursively interpret the chain's emitted events. Pass the
     //    depth through unchanged: `recursion_depth` is the headless
@@ -512,40 +550,46 @@ pub(super) async fn dispatch_to_room(
     //    Bumping here would break that path for every offline
     //    occupant.
     let nested = Box::pin(interpret_with_depth(dispatch_events, deps, recursion_depth)).await;
+    let retry_suppression = nested.retry_suppression;
     outcome.frames.extend(nested.frames);
     if nested.close {
         outcome.close = true;
     }
     outcome.feedback.extend(nested.feedback);
 
-    let mut observer_message = observer_message;
-    let observer_outcome = state
-        .deps
-        .protocol
-        .extension_manager
-        .process_message_observers_for_waddle_with_requester(
-            &mut observer_message,
-            waddle_id_for_room_jid(&room_jid),
-            Some(sender_full.to_bare()),
-        )
-        .await;
-    for effect in observer_outcome.effects {
-        if let ExtensionEffect::HostWarning(message) = effect {
-            warn!(warning = %message.as_str(), "extension message observer emitted host warning");
-            let reply = build_message_error_reply(
-                &incoming,
-                &room_jid,
-                &sender_full,
-                service_unavailable_error(message.as_str()),
-            );
-            match Stanza::Message(reply).to_element_string() {
-                Ok(xml) => outcome.frames.push(xml),
-                Err(error) => {
-                    warn!(
-                        room = %room_jid,
-                        %error,
-                        "DispatchToRoom: failed to serialize extension warning error reply"
-                    );
+    // The marker controls only this nested room batch. Consume it here rather
+    // than folding it into the returned outcome, where it could leak into an
+    // unrelated sibling event in the enclosing interpreter batch.
+    if retry_suppression.is_none() {
+        let mut observer_message = observer_message;
+        let observer_outcome = state
+            .deps
+            .protocol
+            .extension_manager
+            .process_message_observers_for_waddle_with_requester(
+                &mut observer_message,
+                waddle_id_for_room_jid(&room_jid),
+                Some(sender_full.to_bare()),
+            )
+            .await;
+        for effect in observer_outcome.effects {
+            if let ExtensionEffect::HostWarning(message) = effect {
+                warn!(warning = %message.as_str(), "extension message observer emitted host warning");
+                let reply = build_message_error_reply(
+                    &incoming,
+                    &room_jid,
+                    &sender_full,
+                    service_unavailable_error(message.as_str()),
+                );
+                match Stanza::Message(reply).to_element_string() {
+                    Ok(xml) => outcome.frames.push(xml),
+                    Err(error) => {
+                        warn!(
+                            room = %room_jid,
+                            %error,
+                            "DispatchToRoom: failed to serialize extension warning error reply"
+                        );
+                    }
                 }
             }
         }
@@ -661,6 +705,17 @@ mod room_claim_fence_tests {
         }
     }
 
+    fn archive_event() -> OutboundEvent {
+        let room: jid::BareJid = "room@muc.example.com".parse().expect("room bare jid");
+        OutboundEvent::ArchiveGroupchat {
+            room: room.clone(),
+            sender: "alice@example.com/web".parse().expect("sender full jid"),
+            message: Box::new(Message::new(Some(jid::Jid::from(room)))),
+            sender_nickname_generation: 7,
+            sender_item: None,
+        }
+    }
+
     #[test]
     fn bind_room_claim_fence_binds_missing_fence_without_overwriting_or_touching_other_events() {
         let snapshot_fence = fence("snapshot-owner");
@@ -682,5 +737,56 @@ mod room_claim_fence_tests {
             panic!("third event must be PersistRoomSubject");
         };
         assert_eq!(claim_fence.as_ref(), Some(&other_actor_fence));
+    }
+
+    #[test]
+    fn subject_persistence_moves_immediately_after_archive_and_other_events_stay_stable() {
+        let events = vec![
+            OutboundEvent::SendKeepaliveProbe,
+            persist_subject_event(None),
+            OutboundEvent::CloseTransport,
+            archive_event(),
+            OutboundEvent::SendKeepaliveProbe,
+        ];
+
+        let reordered = order_subject_persistence_after_archive(events);
+
+        assert!(matches!(reordered[0], OutboundEvent::SendKeepaliveProbe));
+        assert!(matches!(reordered[1], OutboundEvent::CloseTransport));
+        assert!(matches!(
+            reordered[2],
+            OutboundEvent::ArchiveGroupchat { .. }
+        ));
+        assert!(matches!(
+            reordered[3],
+            OutboundEvent::PersistRoomSubject { .. }
+        ));
+        assert!(matches!(reordered[4], OutboundEvent::SendKeepaliveProbe));
+    }
+
+    #[test]
+    fn subject_persistence_order_is_unchanged_without_archive() {
+        let events = vec![persist_subject_event(None), OutboundEvent::CloseTransport];
+
+        let reordered = order_subject_persistence_after_archive(events);
+
+        assert!(matches!(
+            reordered[0],
+            OutboundEvent::PersistRoomSubject { .. }
+        ));
+        assert!(matches!(reordered[1], OutboundEvent::CloseTransport));
+    }
+
+    #[test]
+    fn archive_order_is_unchanged_without_subject_persistence() {
+        let events = vec![OutboundEvent::CloseTransport, archive_event()];
+
+        let reordered = order_subject_persistence_after_archive(events);
+
+        assert!(matches!(reordered[0], OutboundEvent::CloseTransport));
+        assert!(matches!(
+            reordered[1],
+            OutboundEvent::ArchiveGroupchat { .. }
+        ));
     }
 }

--- a/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/room_system_message.rs
@@ -116,6 +116,21 @@ pub(super) async fn broadcast_room_system_message_event(
                 stanza_id = %result.stored_id,
                 "BroadcastRoomSystemMessage: archived"
             ),
+            ArchiveGroupchatOutcome::Deduplicated(result) => {
+                debug!(
+                    room = %room,
+                    stanza_id = %result.stored_id,
+                    "BroadcastRoomSystemMessage: archive write deduplicated; dropping"
+                );
+                return None;
+            }
+            ArchiveGroupchatOutcome::TombstoneHit => {
+                debug!(
+                    room = %room,
+                    "BroadcastRoomSystemMessage: archive write matched a tombstone; dropping"
+                );
+                return None;
+            }
             ArchiveGroupchatOutcome::Skipped => debug!(
                 room = %room,
                 "BroadcastRoomSystemMessage: archive helper declined (chain bug?)"

--- a/server/crates/waddle-server/src/server/routes/interpret/routing.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/routing.rs
@@ -105,6 +105,9 @@ pub(super) async fn run_headless_recipient_pass(
         // effects; discarding matches the frames/feedback semantics.
         keepalive_probes: _,
         timer_commands: _,
+        // Retry suppression belongs to this discarded transient batch and
+        // must not escape into the caller's unrelated recipient work.
+        retry_suppression: _,
         // Headless pass emits no wire copy, so there is nothing to
         // rewrite.
         archive_id_rewrites: _,
@@ -283,6 +286,9 @@ pub(super) async fn run_fanout_recipient_pass(
         feedback,
         keepalive_probes: _,
         timer_commands: _,
+        // The fanout recipient pass discards its transient outcome; its
+        // batch-local retry marker is not meaningful to the outer batch.
+        retry_suppression: _,
         archive_id_rewrites,
     } = nested;
     debug!(

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -683,6 +683,416 @@ async fn origin_id_collision_with_distinct_content_keeps_fresh_archive_refs() {
     assert!(!outcome.frames[0].contains("existing-archive-id"));
 }
 
+fn groupchat_retry_message(
+    room: &jid::BareJid,
+    occupant: &jid::FullJid,
+    archive_id: &str,
+    origin_id: &str,
+) -> xmpp_parsers::message::Message {
+    use waddle_xmpp_core::xep0359::{build_origin_id_element, build_stanza_id_element};
+
+    let mut message = xmpp_parsers::message::Message::new(Some(jid::Jid::from(room.clone())));
+    message.from = Some(jid::Jid::from(occupant.clone()));
+    message.type_ = xmpp_parsers::message::MessageType::Groupchat;
+    message
+        .bodies
+        .insert(xmpp_parsers::message::Lang::new(), "retry me".to_string());
+    message.payloads.push(build_origin_id_element(origin_id));
+    message.payloads.push(build_stanza_id_element(
+        archive_id,
+        &jid::Jid::from(room.clone()),
+    ));
+    message
+}
+
+fn groupchat_retry_sender_item(
+    real_jid: &jid::FullJid,
+) -> waddle_xmpp_core::mam::ArchivedMucSender {
+    waddle_xmpp_core::mam::ArchivedMucSender {
+        jid: jid::Jid::from(real_jid.clone()),
+        affiliation: waddle_xmpp_core::types::Affiliation::Member,
+        role: waddle_xmpp_core::types::Role::Participant,
+    }
+}
+
+fn archived_groupchat_retry_fixture(
+    room: &jid::BareJid,
+    occupant: &jid::FullJid,
+    real_jid: &jid::FullJid,
+    archive_id: &str,
+    origin_id: &str,
+) -> waddle_xmpp::mam::ArchivedMessage {
+    use waddle_xmpp_core::mam::ArchivedRichMessage;
+    use waddle_xmpp_core::xep0359::OriginId;
+
+    waddle_xmpp::mam::ArchivedMessage {
+        id: archive_id.to_string(),
+        body: Some("retry me".to_string()),
+        origin_id: Some(OriginId::new(origin_id)),
+        message_type: xmpp_parsers::message::MessageType::Groupchat,
+        nickname_generation: Some(7),
+        rich: Some(ArchivedRichMessage {
+            muc_sender: Some(groupchat_retry_sender_item(real_jid)),
+            ..ArchivedRichMessage::default()
+        }),
+        ..waddle_xmpp::mam::ArchivedMessage::for_test(
+            jid::Jid::from(occupant.clone()),
+            jid::Jid::from(room.clone()),
+        )
+    }
+}
+
+fn groupchat_retry_batch(
+    room: &jid::BareJid,
+    sender: &jid::FullJid,
+    other: &jid::FullJid,
+    message: &xmpp_parsers::message::Message,
+) -> Vec<OutboundEvent> {
+    let mut sender_reflection = message.clone();
+    sender_reflection.to = Some(jid::Jid::from(sender.clone()));
+    let mut other_reflection = message.clone();
+    other_reflection.to = Some(jid::Jid::from(other.clone()));
+
+    vec![
+        OutboundEvent::ArchiveGroupchat {
+            room: room.clone(),
+            sender: sender.clone(),
+            message: Box::new(message.clone()),
+            sender_nickname_generation: 8,
+            sender_item: Some(groupchat_retry_sender_item(sender)),
+        },
+        OutboundEvent::RouteToConnection {
+            jid: jid::Jid::from(sender.clone()),
+            stanza: Box::new(Stanza::Message(sender_reflection)),
+        },
+        OutboundEvent::RouteToConnection {
+            jid: jid::Jid::from(other.clone()),
+            stanza: Box::new(Stanza::Message(other_reflection)),
+        },
+        OutboundEvent::ProjectGroupchatInbox {
+            owner: sender.to_bare(),
+            room: room.clone(),
+            message: Box::new(message.clone()),
+            is_recipient: false,
+            is_durable_recipient: false,
+            is_live_occupant: true,
+            room_members_only: true,
+            sender_can_broadcast_channel_mention: false,
+            thread: None,
+            dispatch_timestamp: 1_752_768_000,
+        },
+        OutboundEvent::ProjectGroupchatInbox {
+            owner: other.to_bare(),
+            room: room.clone(),
+            message: Box::new(message.clone()),
+            is_recipient: true,
+            is_durable_recipient: true,
+            is_live_occupant: true,
+            room_members_only: true,
+            sender_can_broadcast_channel_mention: false,
+            thread: None,
+            dispatch_timestamp: 1_752_768_000,
+        },
+        OutboundEvent::SendStanza(Box::new(Stanza::Message(message.clone()))),
+    ]
+}
+
+#[test]
+fn archive_id_rewrite_updates_groupchat_inbox_projection_message() {
+    use waddle_xmpp_core::xep0359::extract_stanza_id_by;
+
+    let room: jid::BareJid = "room@conference.example.com".parse().expect("room JID");
+    let occupant: jid::FullJid = "room@conference.example.com/alice"
+        .parse()
+        .expect("occupant JID");
+    let owner: jid::BareJid = "alice@example.com".parse().expect("owner JID");
+    let mut event = OutboundEvent::ProjectGroupchatInbox {
+        owner,
+        room: room.clone(),
+        message: Box::new(groupchat_retry_message(
+            &room,
+            &occupant,
+            "fresh-retry-id",
+            "stable-origin",
+        )),
+        is_recipient: false,
+        is_durable_recipient: false,
+        is_live_occupant: true,
+        room_members_only: true,
+        sender_can_broadcast_channel_mention: false,
+        thread: None,
+        dispatch_timestamp: 1_752_768_000,
+    };
+    let rewrite = ArchiveIdRewrite::from_store_result(
+        jid::Jid::from(room.clone()),
+        "fresh-retry-id".to_string(),
+        "original-archive-id".to_string(),
+    )
+    .expect("different archive ids produce a rewrite");
+
+    apply_archive_id_rewrites(&mut event, &[rewrite]);
+
+    let OutboundEvent::ProjectGroupchatInbox { message, .. } = event else {
+        panic!("expected groupchat inbox projection");
+    };
+    assert_eq!(
+        extract_stanza_id_by(&message, &jid::Jid::from(room)).as_deref(),
+        Some("original-archive-id")
+    );
+}
+
+#[tokio::test]
+async fn groupchat_origin_retry_suppresses_non_sender_fanout_and_rewrites_sender_copy() {
+    use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
+    use waddle_xmpp::mam::{InMemoryMamStorage, StoreOutcome};
+    use waddle_xmpp::registry::{DeliveryKind, UserRegistryActor};
+    use waddle_xmpp_core::xep0359::extract_stanza_id_by;
+
+    let registry = ConnectionRegistry::new();
+    let user_registry = UserRegistryActor::spawn(UserRegistryActor::new());
+    let sender: jid::FullJid = "alice@example.com/new-session".parse().expect("sender JID");
+    let sender_second: jid::FullJid = "alice@example.com/second-session"
+        .parse()
+        .expect("sender JID");
+    let old_sender: jid::FullJid = "alice@example.com/old-session".parse().expect("sender JID");
+    let other: jid::FullJid = "bob@example.com/phone".parse().expect("other JID");
+    let occupant: jid::FullJid = "room@conference.example.com/alice"
+        .parse()
+        .expect("occupant JID");
+    let room = occupant.to_bare();
+    let (sender_tx, mut sender_rx) = tokio::sync::mpsc::channel(8);
+    let (sender_second_tx, mut sender_second_rx) = tokio::sync::mpsc::channel(8);
+    let (other_tx, mut other_rx) = tokio::sync::mpsc::channel(8);
+    register_into_both_tiers(&registry, &user_registry, &sender, sender_tx).await;
+    register_into_both_tiers(&registry, &user_registry, &sender_second, sender_second_tx).await;
+    register_into_both_tiers(&registry, &user_registry, &other, other_tx).await;
+
+    let mam_concrete = Arc::new(InMemoryMamStorage::new());
+    let mam: Arc<dyn MamStorage> = mam_concrete.clone();
+    let inbox_concrete = Arc::new(InMemoryInboxStorage::new());
+    let inbox: Arc<dyn InboxStorage> = inbox_concrete.clone();
+    let mut deps = Deps::test_with_storage(&registry, &mam, &inbox);
+    deps.user_registry = Some(&user_registry);
+    let original_id = "original-room-archive-id";
+    let origin_id = "stable-groupchat-origin";
+    assert_eq!(
+        mam_concrete
+            .store_message(
+                &room,
+                &archived_groupchat_retry_fixture(
+                    &room,
+                    &occupant,
+                    &old_sender,
+                    original_id,
+                    origin_id,
+                ),
+            )
+            .await
+            .expect("seed original row"),
+        StoreOutcome::Stored(original_id.to_string())
+    );
+    let retry = groupchat_retry_message(&room, &occupant, "fresh-retry-id", origin_id);
+    let mut second_reflection = retry.clone();
+    second_reflection.to = Some(jid::Jid::from(sender_second.clone()));
+    let mut batch = groupchat_retry_batch(&room, &sender, &other, &retry);
+    batch.insert(
+        2,
+        OutboundEvent::RouteToConnection {
+            jid: jid::Jid::from(sender_second),
+            stanza: Box::new(Stanza::Message(second_reflection)),
+        },
+    );
+
+    let outcome = interpret(batch, &deps).await;
+
+    assert!(outcome.frames.is_empty(), "dedupe emits no error frame");
+    assert_eq!(
+        mam_concrete.count_messages(&room).await.expect("count"),
+        1,
+        "dedupe must not create a second room archive row"
+    );
+    assert!(
+        drain_inbound(&mut other_rx).is_empty(),
+        "non-sender reflection and inbox push must both be suppressed"
+    );
+    let sender_deliveries = drain_inbound(&mut sender_rx);
+    assert_eq!(sender_deliveries.len(), 1, "sender reflection survives");
+    assert_eq!(sender_deliveries[0].kind, DeliveryKind::PeerStanza);
+    let Stanza::Message(sender_copy) = &sender_deliveries[0].stanza else {
+        panic!("expected sender message reflection");
+    };
+    assert_eq!(
+        extract_stanza_id_by(sender_copy, &jid::Jid::from(room.clone())).as_deref(),
+        Some(original_id),
+        "sender reflection must use the retained archive stanza-id"
+    );
+    let second_sender_deliveries = drain_inbound(&mut sender_second_rx);
+    assert_eq!(
+        second_sender_deliveries.len(),
+        1,
+        "every session of the sender's bare JID receives the reflection"
+    );
+    let Stanza::Message(second_sender_copy) = &second_sender_deliveries[0].stanza else {
+        panic!("expected second sender message reflection");
+    };
+    assert_eq!(
+        extract_stanza_id_by(second_sender_copy, &jid::Jid::from(room.clone())).as_deref(),
+        Some(original_id)
+    );
+    let sender_inbox = inbox_concrete
+        .list(&sender.to_bare())
+        .await
+        .expect("sender inbox");
+    assert_eq!(sender_inbox.len(), 1, "sender inbox projection survives");
+    assert_eq!(sender_inbox[0].preview.as_deref(), Some("retry me"));
+    assert!(
+        inbox_concrete
+            .list(&other.to_bare())
+            .await
+            .expect("other inbox")
+            .is_empty(),
+        "non-sender inbox projection must be suppressed"
+    );
+}
+
+#[tokio::test]
+async fn groupchat_origin_retry_after_tombstone_silently_suppresses_entire_batch() {
+    use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
+    use waddle_xmpp::mam::{ArchivedTombstone, InMemoryMamStorage};
+    use waddle_xmpp::registry::UserRegistryActor;
+
+    let registry = ConnectionRegistry::new();
+    let user_registry = UserRegistryActor::spawn(UserRegistryActor::new());
+    let sender: jid::FullJid = "alice@example.com/new-session".parse().expect("sender JID");
+    let old_sender: jid::FullJid = "alice@example.com/old-session".parse().expect("sender JID");
+    let other: jid::FullJid = "bob@example.com/phone".parse().expect("other JID");
+    let occupant: jid::FullJid = "room@conference.example.com/alice"
+        .parse()
+        .expect("occupant JID");
+    let room = occupant.to_bare();
+    let (sender_tx, mut sender_rx) = tokio::sync::mpsc::channel(8);
+    let (other_tx, mut other_rx) = tokio::sync::mpsc::channel(8);
+    register_into_both_tiers(&registry, &user_registry, &sender, sender_tx).await;
+    register_into_both_tiers(&registry, &user_registry, &other, other_tx).await;
+
+    let mam_concrete = Arc::new(InMemoryMamStorage::new());
+    let mam: Arc<dyn MamStorage> = mam_concrete.clone();
+    let inbox_concrete = Arc::new(InMemoryInboxStorage::new());
+    let inbox: Arc<dyn InboxStorage> = inbox_concrete.clone();
+    let mut deps = Deps::test_with_storage(&registry, &mam, &inbox);
+    deps.user_registry = Some(&user_registry);
+    let original_id = "retracted-room-archive-id";
+    let origin_id = "retracted-groupchat-origin";
+    mam_concrete
+        .store_message(
+            &room,
+            &archived_groupchat_retry_fixture(
+                &room,
+                &occupant,
+                &old_sender,
+                original_id,
+                origin_id,
+            ),
+        )
+        .await
+        .expect("seed original row");
+    assert!(mam_concrete
+        .replace_with_tombstone(
+            original_id,
+            ArchivedTombstone {
+                retraction_id: None,
+                stamp: chrono::Utc::now(),
+                moderation: None,
+            },
+        )
+        .await
+        .expect("replace with tombstone"));
+    let retry = groupchat_retry_message(&room, &occupant, "fresh-retry-id", origin_id);
+
+    let outcome = interpret(groupchat_retry_batch(&room, &sender, &other, &retry), &deps).await;
+
+    assert!(
+        outcome.frames.is_empty(),
+        "tombstone hit is a silent swallow"
+    );
+    assert_eq!(
+        mam_concrete.count_messages(&room).await.expect("count"),
+        1,
+        "tombstone retry must not create a new archive row"
+    );
+    assert!(drain_inbound(&mut sender_rx).is_empty());
+    assert!(drain_inbound(&mut other_rx).is_empty());
+    assert!(inbox_concrete
+        .list(&sender.to_bare())
+        .await
+        .expect("sender inbox")
+        .is_empty());
+    assert!(inbox_concrete
+        .list(&other.to_bare())
+        .await
+        .expect("other inbox")
+        .is_empty());
+}
+
+#[tokio::test]
+async fn fresh_groupchat_origin_fans_out_to_every_recipient() {
+    use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
+    use waddle_xmpp::mam::InMemoryMamStorage;
+    use waddle_xmpp::registry::UserRegistryActor;
+
+    let registry = ConnectionRegistry::new();
+    let user_registry = UserRegistryActor::spawn(UserRegistryActor::new());
+    let sender: jid::FullJid = "alice@example.com/session".parse().expect("sender JID");
+    let other: jid::FullJid = "bob@example.com/phone".parse().expect("other JID");
+    let occupant: jid::FullJid = "room@conference.example.com/alice"
+        .parse()
+        .expect("occupant JID");
+    let room = occupant.to_bare();
+    let (sender_tx, mut sender_rx) = tokio::sync::mpsc::channel(8);
+    let (other_tx, mut other_rx) = tokio::sync::mpsc::channel(8);
+    register_into_both_tiers(&registry, &user_registry, &sender, sender_tx).await;
+    register_into_both_tiers(&registry, &user_registry, &other, other_tx).await;
+
+    let mam_concrete = Arc::new(InMemoryMamStorage::new());
+    let mam: Arc<dyn MamStorage> = mam_concrete.clone();
+    let inbox_concrete = Arc::new(InMemoryInboxStorage::new());
+    let inbox: Arc<dyn InboxStorage> = inbox_concrete.clone();
+    let mut deps = Deps::test_with_storage(&registry, &mam, &inbox);
+    deps.user_registry = Some(&user_registry);
+    let fresh_id = "fresh-room-archive-id";
+    let message = groupchat_retry_message(&room, &occupant, fresh_id, "fresh-origin");
+
+    let outcome = interpret(
+        groupchat_retry_batch(&room, &sender, &other, &message),
+        &deps,
+    )
+    .await;
+
+    assert_eq!(
+        outcome.frames.len(),
+        1,
+        "fresh canary event is not suppressed"
+    );
+    assert_eq!(mam_concrete.count_messages(&room).await.expect("count"), 1);
+    assert_eq!(drain_inbound(&mut sender_rx).len(), 1);
+    assert!(
+        drain_inbound(&mut other_rx)
+            .iter()
+            .any(|delivery| matches!(delivery.stanza, Stanza::Message(ref message) if message.type_ == xmpp_parsers::message::MessageType::Groupchat)),
+        "non-sender receives the groupchat reflection"
+    );
+    let sender_inbox = inbox_concrete
+        .list(&sender.to_bare())
+        .await
+        .expect("sender inbox");
+    let other_inbox = inbox_concrete
+        .list(&other.to_bare())
+        .await
+        .expect("other inbox");
+    assert_eq!(sender_inbox.len(), 1);
+    assert_eq!(other_inbox.len(), 1);
+}
+
 #[tokio::test]
 async fn xep_0313_archive_direct_writes_one_entry_per_event() {
     // Sender pass + recipient pass on the same dispatch (true

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -749,7 +749,7 @@ async fn xep_0313_archive_direct_drops_when_storage_errors() {
     // always errors and assert interpret returns normally; the
     // archive write is logged-and-dropped.
     use async_trait::async_trait;
-    use waddle_xmpp::mam::storage::{MamStorage, MamStorageError};
+    use waddle_xmpp::mam::storage::{MamStorage, MamStorageError, StoreOutcome};
     use waddle_xmpp::mam::{ArchivedMessage, MamQuery, MamResult};
 
     struct FailingMam;
@@ -759,7 +759,7 @@ async fn xep_0313_archive_direct_drops_when_storage_errors() {
             &self,
             _: &jid::BareJid,
             _: &ArchivedMessage,
-        ) -> Result<String, MamStorageError> {
+        ) -> Result<StoreOutcome, MamStorageError> {
             Err(MamStorageError::Database("simulated".into()))
         }
         async fn query_messages(
@@ -1291,6 +1291,7 @@ async fn xep_0359_lookup_archived_message_propagates_room_archive_kind() {
     use async_trait::async_trait;
     use waddle_xmpp::mam::{
         ArchivedMessage, ArchivedTombstone, MamArchiveKind, MamQuery, MamResult, MamStorageError,
+        StoreOutcome,
     };
     use waddle_xmpp::protocol::event::CallbackId;
     use waddle_xmpp_core::xep0359::OriginId;
@@ -1305,7 +1306,7 @@ async fn xep_0359_lookup_archived_message_propagates_room_archive_kind() {
             &self,
             _: &jid::BareJid,
             _: &ArchivedMessage,
-        ) -> Result<String, MamStorageError> {
+        ) -> Result<StoreOutcome, MamStorageError> {
             unreachable!("lookup regression never stores")
         }
 

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -1227,20 +1227,26 @@ async fn fresh_groupchat_origin_fans_out_to_every_recipient() {
 }
 
 #[tokio::test]
-async fn deduplicated_subject_retry_is_suppressed_before_room_mutation() {
+async fn groupchat_subject_retry_is_stored_and_fans_out_normally() {
     use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
     use waddle_xmpp::mam::{ArchivedMessage, InMemoryMamStorage, StoreOutcome};
     use waddle_xmpp::muc::room_actor::GetSnapshot;
+    use waddle_xmpp::registry::UserRegistryActor;
     use waddle_xmpp_core::xep0359::{build_origin_id_element, build_stanza_id_element, OriginId};
 
     let (room_registry, room_actor, room, _claim_store, claim_fence, _store) =
         spawn_subject_mutation_test_room().await;
     let registry = ConnectionRegistry::new();
+    let user_registry = UserRegistryActor::spawn(UserRegistryActor::new());
+    let recipient: jid::FullJid = "bob@example.com/phone".parse().expect("recipient JID");
+    let (recipient_tx, mut recipient_rx) = tokio::sync::mpsc::channel(8);
+    register_into_both_tiers(&registry, &user_registry, &recipient, recipient_tx).await;
     let mam_concrete = Arc::new(InMemoryMamStorage::new());
     let mam: Arc<dyn MamStorage> = mam_concrete.clone();
     let inbox: Arc<dyn InboxStorage> = Arc::new(InMemoryInboxStorage::new());
     let mut deps = Deps::test_with_storage(&registry, &mam, &inbox);
     deps.room_registry = Some(&room_registry);
+    deps.user_registry = Some(&user_registry);
 
     let sender: jid::FullJid = "alice@example.com/web".parse().expect("sender JID");
     let occupant: jid::FullJid = format!("{room}/alice-nick").parse().expect("occupant JID");
@@ -1275,36 +1281,52 @@ async fn deduplicated_subject_retry_is_suppressed_before_room_mutation() {
             .expect("seed subject row"),
         StoreOutcome::Stored("original-subject-archive-id".to_string())
     );
+    let mut recipient_reflection = retry.clone();
+    recipient_reflection.to = Some(jid::Jid::from(recipient.clone()));
 
     let events = room_dispatch::order_subject_persistence_after_archive(vec![
         persist_subject_event(&room, &sender, subject, claim_fence),
         OutboundEvent::ArchiveGroupchat {
             room: room.clone(),
-            sender,
+            sender: sender.clone(),
             message: Box::new(retry),
             sender_nickname_generation: 8,
             sender_item: Some(sender_item),
+        },
+        OutboundEvent::RouteToConnection {
+            jid: jid::Jid::from(recipient),
+            stanza: Box::new(Stanza::Message(recipient_reflection)),
         },
         OutboundEvent::CloseTransport,
     ]);
     let outcome = interpret(events, &deps).await;
 
-    assert_eq!(
-        outcome.retry_suppression,
-        Some(GroupchatRetrySuppression::Deduplicated)
-    );
+    assert_eq!(outcome.retry_suppression, None);
     assert!(outcome.frames.is_empty());
-    assert!(!outcome.close, "post-dedupe canary must be suppressed");
-    assert!(
-        room_actor
-            .ask(GetSnapshot)
-            .await
-            .expect("room snapshot")
-            .room
-            .subject
-            .is_none(),
-        "a deduplicated subject retry must not mutate room subject state"
+    assert!(outcome.close, "post-subject canary must not be suppressed");
+    assert_eq!(
+        mam_concrete.count_messages(&room).await.expect("count"),
+        2,
+        "room-state subject retries remain outside timeline retry dedupe"
     );
+    let deliveries = drain_inbound(&mut recipient_rx);
+    assert_eq!(deliveries.len(), 1, "subject retry fans out normally");
+    let Stanza::Message(reflection) = &deliveries[0].stanza else {
+        panic!("expected subject reflection");
+    };
+    assert_eq!(
+        reflection.subjects.get("").map(String::as_str),
+        Some(subject)
+    );
+    let stored_subject = room_actor
+        .ask(GetSnapshot)
+        .await
+        .expect("room snapshot")
+        .room
+        .subject
+        .expect("subject retry applies room state");
+    assert_eq!(stored_subject.texts.get(""), Some(subject));
+    assert_eq!(stored_subject.setter, sender.to_bare());
 }
 
 #[tokio::test]
@@ -1409,6 +1431,13 @@ async fn xep_0313_archive_direct_drops_when_storage_errors() {
             _: waddle_xmpp::mam::ArchivedTombstone,
         ) -> Result<bool, MamStorageError> {
             Ok(false)
+        }
+        async fn replace_with_terminal_tombstone(
+            &self,
+            _: &str,
+            _: waddle_xmpp::mam::ArchivedTombstone,
+        ) -> Result<waddle_xmpp::mam::TerminalTombstoneOutcome, MamStorageError> {
+            Ok(waddle_xmpp::mam::TerminalTombstoneOutcome::NotFound)
         }
         async fn get_message_by_stanza_id(
             &self,
@@ -1964,6 +1993,14 @@ async fn xep_0359_lookup_archived_message_propagates_room_archive_kind() {
             _: ArchivedTombstone,
         ) -> Result<bool, MamStorageError> {
             Ok(false)
+        }
+
+        async fn replace_with_terminal_tombstone(
+            &self,
+            _: &str,
+            _: ArchivedTombstone,
+        ) -> Result<waddle_xmpp::mam::TerminalTombstoneOutcome, MamStorageError> {
+            Ok(waddle_xmpp::mam::TerminalTombstoneOutcome::NotFound)
         }
 
         async fn get_message_by_stanza_id(
@@ -4935,6 +4972,64 @@ async fn xep_0424_apply_groupchat_retraction_tombstone_keys_off_room_stanza_id()
             panic!("expected ArchivedRichPayload::Tombstone after retraction, got {other:?}")
         }
     }
+}
+
+#[tokio::test]
+async fn xep_0424_retraction_retry_preserves_existing_moderation_tombstone() {
+    use waddle_xmpp::mam::storage::InMemoryMamStorage;
+    use waddle_xmpp::mam::{ArchivedModeration, ArchivedTombstone, RichMessageId, RichText};
+
+    let mam: Arc<dyn MamStorage> = Arc::new(InMemoryMamStorage::new());
+    let room: jid::BareJid = "moderated-retraction@muc.example.com"
+        .parse()
+        .expect("room");
+    let archive_pk = "moderated-room-stamp";
+    seed_groupchat_archive_row(&mam, &room, archive_pk, "original-wire-id").await;
+
+    let moderation_tombstone = ArchivedTombstone {
+        retraction_id: RichMessageId::new("moderation-archive-id"),
+        stamp: chrono::Utc::now(),
+        moderation: Some(ArchivedModeration {
+            target_id: RichMessageId::new(archive_pk).expect("non-empty target id"),
+            moderated_by: "room-owner@example.com".parse().expect("moderator JID"),
+            stamp: Some(chrono::Utc::now()),
+            reason: RichText::new("room policy violation"),
+        }),
+    };
+    assert!(
+        mam.replace_with_tombstone(archive_pk, moderation_tombstone.clone())
+            .await
+            .expect("moderation tombstone replacement"),
+        "the real storage replacement path must tombstone the target"
+    );
+
+    let mut retry = xmpp_parsers::message::Message::new(Some(jid::Jid::from(room.clone())));
+    retry.id = Some(xmpp_parsers::message::Id(
+        "author-retraction-retry".to_string(),
+    ));
+    retry.from = Some(format!("{room}/alice").parse().expect("room/nick"));
+    retry.type_ = XmppMessageType::Groupchat;
+
+    assert!(
+        apply_groupchat_retraction_tombstone(&mam, None, None, &room, archive_pk, &retry).await,
+        "an already-applied retraction remains a successful heal-retry no-op"
+    );
+
+    let row = mam
+        .get_message(archive_pk)
+        .await
+        .expect("post-retry lookup")
+        .expect("moderation tombstone remains stored");
+    let actual = row
+        .rich
+        .as_ref()
+        .and_then(|rich| rich.payload.as_ref())
+        .expect("tombstone payload remains present");
+    assert_eq!(
+        actual,
+        &waddle_xmpp::mam::ArchivedRichPayload::Tombstone(moderation_tombstone),
+        "XEP-0424 retry must not overwrite XEP-0425 attribution, reason, id, or stamp"
+    );
 }
 
 #[tokio::test]

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -1007,6 +1007,7 @@ async fn groupchat_origin_retry_after_tombstone_silently_suppresses_entire_batch
                 retraction_id: None,
                 stamp: chrono::Utc::now(),
                 moderation: None,
+                sender_scope: None,
             },
         )
         .await
@@ -1164,6 +1165,146 @@ async fn groupchat_retraction_retry_finishes_tombstone_after_archive_deduplicati
     ));
     assert!(drain_inbound(&mut other_rx).is_empty());
     assert_eq!(drain_inbound(&mut sender_rx).len(), 1);
+}
+
+#[tokio::test]
+async fn tombstoned_retraction_retry_still_heals_target_tombstone_silently() {
+    // The pathological double-crash window (Greptile review on PR #1412):
+    // the retraction-request row was archived, the process died before the
+    // target tombstone applied, and the request row itself was later
+    // tombstoned. The retry then hits TombstoneSwallow — which must still
+    // let the terminal-guarded ApplyGroupchatRetractionTombstone heal the
+    // live target while delivering nothing to anyone.
+    use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
+    use waddle_xmpp::mam::{
+        ArchivedMessage, ArchivedRichPayload, ArchivedTombstone, InMemoryMamStorage, StoreOutcome,
+    };
+    use waddle_xmpp::registry::UserRegistryActor;
+    use waddle_xmpp_core::xep0359::{build_origin_id_element, build_stanza_id_element, OriginId};
+
+    let registry = ConnectionRegistry::new();
+    let user_registry = UserRegistryActor::spawn(UserRegistryActor::new());
+    let sender: jid::FullJid = "alice@example.com/new-session".parse().expect("sender JID");
+    let other: jid::FullJid = "bob@example.com/phone".parse().expect("other JID");
+    let occupant: jid::FullJid = "room@conference.example.com/alice"
+        .parse()
+        .expect("occupant JID");
+    let room = occupant.to_bare();
+    let (sender_tx, mut sender_rx) = tokio::sync::mpsc::channel(8);
+    let (other_tx, mut other_rx) = tokio::sync::mpsc::channel(8);
+    register_into_both_tiers(&registry, &user_registry, &sender, sender_tx).await;
+    register_into_both_tiers(&registry, &user_registry, &other, other_tx).await;
+
+    let mam_concrete = Arc::new(InMemoryMamStorage::new());
+    let mam: Arc<dyn MamStorage> = mam_concrete.clone();
+    let inbox: Arc<dyn InboxStorage> = Arc::new(InMemoryInboxStorage::new());
+    let mut deps = Deps::test_with_storage(&registry, &mam, &inbox);
+    deps.user_registry = Some(&user_registry);
+    let target_id = "swallow-target-stanza-id";
+    seed_groupchat_archive_row(&mam, &room, target_id, "swallow-target-wire-id").await;
+
+    let origin_id = "swallowed-retraction-origin";
+    let original_retraction_id = "swallowed-retraction-archive-id";
+    let mut retraction = Message::new(Some(jid::Jid::from(room.clone())));
+    retraction.from = Some(jid::Jid::from(occupant.clone()));
+    retraction.type_ = XmppMessageType::Groupchat;
+    retraction.id = Some(xmpp_parsers::message::Id(
+        "swallow-retraction-wire-id".to_string(),
+    ));
+    retraction
+        .payloads
+        .push(waddle_xmpp::xep::xep0424::build_retract_element(target_id));
+    retraction.payloads.push(build_origin_id_element(origin_id));
+    retraction.payloads.push(build_stanza_id_element(
+        "fresh-swallow-retraction-archive-id",
+        &jid::Jid::from(room.clone()),
+    ));
+    let sender_item = groupchat_retry_sender_item(&sender);
+    let archived_retraction = ArchivedMessage {
+        id: original_retraction_id.to_string(),
+        body: None,
+        origin_id: Some(OriginId::new(origin_id)),
+        message_type: XmppMessageType::Groupchat,
+        rich: groupchat_archive::rich_archive_payload(&retraction, Some(&sender_item)),
+        nickname_generation: Some(7),
+        ..ArchivedMessage::for_test(
+            jid::Jid::from(occupant.clone()),
+            jid::Jid::from(room.clone()),
+        )
+    };
+    assert_eq!(
+        mam_concrete
+            .store_message(&room, &archived_retraction)
+            .await
+            .expect("seed archived retraction request"),
+        StoreOutcome::Stored(original_retraction_id.to_string())
+    );
+    assert!(mam_concrete
+        .replace_with_tombstone(
+            original_retraction_id,
+            ArchivedTombstone {
+                retraction_id: None,
+                stamp: chrono::Utc::now(),
+                moderation: None,
+                sender_scope: Some(sender.to_bare()),
+            },
+        )
+        .await
+        .expect("tombstone the retraction-request row itself"));
+
+    let mut other_reflection = retraction.clone();
+    other_reflection.to = Some(jid::Jid::from(other.clone()));
+    let mut sender_reflection = retraction.clone();
+    sender_reflection.to = Some(jid::Jid::from(sender.clone()));
+    let outcome = interpret(
+        vec![
+            OutboundEvent::ArchiveGroupchat {
+                room: room.clone(),
+                sender: sender.clone(),
+                message: Box::new(retraction.clone()),
+                sender_nickname_generation: 8,
+                sender_item: Some(sender_item),
+            },
+            OutboundEvent::ApplyGroupchatRetractionTombstone {
+                room: room.clone(),
+                target_message_id: target_id.to_string(),
+                retraction_message: Box::new(retraction),
+            },
+            OutboundEvent::RouteToConnection {
+                jid: jid::Jid::from(other),
+                stanza: Box::new(Stanza::Message(other_reflection)),
+            },
+            OutboundEvent::RouteToConnection {
+                jid: jid::Jid::from(sender),
+                stanza: Box::new(Stanza::Message(sender_reflection)),
+            },
+        ],
+        &deps,
+    )
+    .await;
+
+    assert_eq!(
+        outcome.retry_suppression,
+        Some(GroupchatRetrySuppression::TombstoneSwallowed)
+    );
+    assert!(outcome.frames.is_empty(), "swallow emits no error frame");
+    let target = mam_concrete
+        .get_message(target_id)
+        .await
+        .expect("target lookup")
+        .expect("target row exists");
+    assert!(
+        matches!(
+            target.rich.as_ref().and_then(|rich| rich.payload.as_ref()),
+            Some(ArchivedRichPayload::Tombstone(_))
+        ),
+        "the heal event must still tombstone the live target"
+    );
+    assert!(drain_inbound(&mut other_rx).is_empty());
+    assert!(
+        drain_inbound(&mut sender_rx).is_empty(),
+        "tombstone swallow delivers nothing, even to the sender"
+    );
 }
 
 #[tokio::test]
@@ -2266,6 +2407,7 @@ async fn xep_0424_lookup_archived_message_propagates_tombstone_state() {
                 retraction_id: Some(RichMessageId::new("retract-1").expect("rich id")),
                 stamp: chrono::Utc::now(),
                 moderation: None,
+                sender_scope: None,
             })),
             reply: None,
             references: Vec::new(),
@@ -4995,6 +5137,7 @@ async fn xep_0424_retraction_retry_preserves_existing_moderation_tombstone() {
             stamp: Some(chrono::Utc::now()),
             reason: RichText::new("room policy violation"),
         }),
+        sender_scope: None,
     };
     assert!(
         mam.replace_with_tombstone(archive_pk, moderation_tombstone.clone())

--- a/server/crates/waddle-server/src/server/routes/interpret/tests.rs
+++ b/server/crates/waddle-server/src/server/routes/interpret/tests.rs
@@ -907,6 +907,10 @@ async fn groupchat_origin_retry_suppresses_non_sender_fanout_and_rewrites_sender
 
     assert!(outcome.frames.is_empty(), "dedupe emits no error frame");
     assert_eq!(
+        outcome.retry_suppression,
+        Some(GroupchatRetrySuppression::Deduplicated)
+    );
+    assert_eq!(
         mam_concrete.count_messages(&room).await.expect("count"),
         1,
         "dedupe must not create a second room archive row"
@@ -1011,6 +1015,10 @@ async fn groupchat_origin_retry_after_tombstone_silently_suppresses_entire_batch
 
     let outcome = interpret(groupchat_retry_batch(&room, &sender, &other, &retry), &deps).await;
 
+    assert_eq!(
+        outcome.retry_suppression,
+        Some(GroupchatRetrySuppression::TombstoneSwallowed)
+    );
     assert!(
         outcome.frames.is_empty(),
         "tombstone hit is a silent swallow"
@@ -1032,6 +1040,130 @@ async fn groupchat_origin_retry_after_tombstone_silently_suppresses_entire_batch
         .await
         .expect("other inbox")
         .is_empty());
+}
+
+#[tokio::test]
+async fn groupchat_retraction_retry_finishes_tombstone_after_archive_deduplication() {
+    use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
+    use waddle_xmpp::mam::{
+        ArchivedMessage, ArchivedRichPayload, InMemoryMamStorage, StoreOutcome,
+    };
+    use waddle_xmpp::registry::UserRegistryActor;
+    use waddle_xmpp_core::xep0359::{build_origin_id_element, build_stanza_id_element, OriginId};
+
+    let registry = ConnectionRegistry::new();
+    let user_registry = UserRegistryActor::spawn(UserRegistryActor::new());
+    let sender: jid::FullJid = "alice@example.com/new-session".parse().expect("sender JID");
+    let other: jid::FullJid = "bob@example.com/phone".parse().expect("other JID");
+    let occupant: jid::FullJid = "room@conference.example.com/alice"
+        .parse()
+        .expect("occupant JID");
+    let room = occupant.to_bare();
+    let (sender_tx, mut sender_rx) = tokio::sync::mpsc::channel(8);
+    let (other_tx, mut other_rx) = tokio::sync::mpsc::channel(8);
+    register_into_both_tiers(&registry, &user_registry, &sender, sender_tx).await;
+    register_into_both_tiers(&registry, &user_registry, &other, other_tx).await;
+
+    let mam_concrete = Arc::new(InMemoryMamStorage::new());
+    let mam: Arc<dyn MamStorage> = mam_concrete.clone();
+    let inbox: Arc<dyn InboxStorage> = Arc::new(InMemoryInboxStorage::new());
+    let mut deps = Deps::test_with_storage(&registry, &mam, &inbox);
+    deps.user_registry = Some(&user_registry);
+    let target_id = "target-room-stanza-id";
+    seed_groupchat_archive_row(&mam, &room, target_id, "target-wire-id").await;
+
+    let origin_id = "stable-retraction-origin";
+    let original_retraction_id = "original-retraction-archive-id";
+    let mut retraction = Message::new(Some(jid::Jid::from(room.clone())));
+    retraction.from = Some(jid::Jid::from(occupant.clone()));
+    retraction.type_ = XmppMessageType::Groupchat;
+    retraction.id = Some(xmpp_parsers::message::Id("retraction-wire-id".to_string()));
+    retraction
+        .payloads
+        .push(waddle_xmpp::xep::xep0424::build_retract_element(target_id));
+    retraction.payloads.push(build_origin_id_element(origin_id));
+    retraction.payloads.push(build_stanza_id_element(
+        "fresh-retraction-archive-id",
+        &jid::Jid::from(room.clone()),
+    ));
+    let sender_item = groupchat_retry_sender_item(&sender);
+    let archived_retraction = ArchivedMessage {
+        id: original_retraction_id.to_string(),
+        body: None,
+        stanza_id: Some(waddle_xmpp_core::xep0359::StanzaId::new(
+            "retraction-wire-id",
+            jid::Jid::from(room.clone()),
+        )),
+        origin_id: Some(OriginId::new(origin_id)),
+        message_type: XmppMessageType::Groupchat,
+        rich: groupchat_archive::rich_archive_payload(&retraction, Some(&sender_item)),
+        nickname_generation: Some(7),
+        ..ArchivedMessage::for_test(
+            jid::Jid::from(occupant.clone()),
+            jid::Jid::from(room.clone()),
+        )
+    };
+    assert!(matches!(
+        archived_retraction
+            .rich
+            .as_ref()
+            .and_then(|rich| rich.payload.as_ref()),
+        Some(ArchivedRichPayload::Retraction(_))
+    ));
+    assert_eq!(
+        mam_concrete
+            .store_message(&room, &archived_retraction)
+            .await
+            .expect("seed archived retraction request"),
+        StoreOutcome::Stored(original_retraction_id.to_string())
+    );
+
+    let mut other_reflection = retraction.clone();
+    other_reflection.to = Some(jid::Jid::from(other.clone()));
+    let mut sender_reflection = retraction.clone();
+    sender_reflection.to = Some(jid::Jid::from(sender.clone()));
+    let outcome = interpret(
+        vec![
+            OutboundEvent::ArchiveGroupchat {
+                room: room.clone(),
+                sender: sender.clone(),
+                message: Box::new(retraction.clone()),
+                sender_nickname_generation: 8,
+                sender_item: Some(sender_item),
+            },
+            OutboundEvent::ApplyGroupchatRetractionTombstone {
+                room: room.clone(),
+                target_message_id: target_id.to_string(),
+                retraction_message: Box::new(retraction),
+            },
+            OutboundEvent::RouteToConnection {
+                jid: jid::Jid::from(other),
+                stanza: Box::new(Stanza::Message(other_reflection)),
+            },
+            OutboundEvent::RouteToConnection {
+                jid: jid::Jid::from(sender),
+                stanza: Box::new(Stanza::Message(sender_reflection)),
+            },
+        ],
+        &deps,
+    )
+    .await;
+
+    assert_eq!(
+        outcome.retry_suppression,
+        Some(GroupchatRetrySuppression::Deduplicated)
+    );
+    let target = mam_concrete
+        .get_message(target_id)
+        .await
+        .expect("target lookup")
+        .expect("target remains as tombstone row");
+    assert!(matches!(
+        target.rich.as_ref().and_then(|rich| rich.payload.as_ref()),
+        Some(ArchivedRichPayload::Tombstone(_))
+    ));
+    assert!(drain_inbound(&mut other_rx).is_empty());
+    assert_eq!(drain_inbound(&mut sender_rx).len(), 1);
 }
 
 #[tokio::test]
@@ -1068,6 +1200,7 @@ async fn fresh_groupchat_origin_fans_out_to_every_recipient() {
     )
     .await;
 
+    assert_eq!(outcome.retry_suppression, None);
     assert_eq!(
         outcome.frames.len(),
         1,
@@ -1091,6 +1224,87 @@ async fn fresh_groupchat_origin_fans_out_to_every_recipient() {
         .expect("other inbox");
     assert_eq!(sender_inbox.len(), 1);
     assert_eq!(other_inbox.len(), 1);
+}
+
+#[tokio::test]
+async fn deduplicated_subject_retry_is_suppressed_before_room_mutation() {
+    use waddle_xmpp::inbox::storage::InMemoryInboxStorage;
+    use waddle_xmpp::mam::{ArchivedMessage, InMemoryMamStorage, StoreOutcome};
+    use waddle_xmpp::muc::room_actor::GetSnapshot;
+    use waddle_xmpp_core::xep0359::{build_origin_id_element, build_stanza_id_element, OriginId};
+
+    let (room_registry, room_actor, room, _claim_store, claim_fence, _store) =
+        spawn_subject_mutation_test_room().await;
+    let registry = ConnectionRegistry::new();
+    let mam_concrete = Arc::new(InMemoryMamStorage::new());
+    let mam: Arc<dyn MamStorage> = mam_concrete.clone();
+    let inbox: Arc<dyn InboxStorage> = Arc::new(InMemoryInboxStorage::new());
+    let mut deps = Deps::test_with_storage(&registry, &mam, &inbox);
+    deps.room_registry = Some(&room_registry);
+
+    let sender: jid::FullJid = "alice@example.com/web".parse().expect("sender JID");
+    let occupant: jid::FullJid = format!("{room}/alice-nick").parse().expect("occupant JID");
+    let sender_item = groupchat_retry_sender_item(&sender);
+    let origin_id = "stable-subject-origin";
+    let subject = "Do not resurrect this subject";
+    let mut retry = subject_change_message(&room, &sender, subject);
+    retry.from = Some(jid::Jid::from(occupant.clone()));
+    retry.id = Some(xmpp_parsers::message::Id("subject-wire-id".to_string()));
+    retry.payloads.push(build_origin_id_element(origin_id));
+    retry.payloads.push(build_stanza_id_element(
+        "fresh-subject-archive-id",
+        &jid::Jid::from(room.clone()),
+    ));
+    let archived = ArchivedMessage {
+        id: "original-subject-archive-id".to_string(),
+        body: None,
+        stanza_id: Some(waddle_xmpp_core::xep0359::StanzaId::new(
+            "subject-wire-id",
+            jid::Jid::from(room.clone()),
+        )),
+        origin_id: Some(OriginId::new(origin_id)),
+        message_type: XmppMessageType::Groupchat,
+        rich: groupchat_archive::rich_archive_payload(&retry, Some(&sender_item)),
+        nickname_generation: Some(7),
+        ..ArchivedMessage::for_test(jid::Jid::from(occupant), jid::Jid::from(room.clone()))
+    };
+    assert_eq!(
+        mam_concrete
+            .store_message(&room, &archived)
+            .await
+            .expect("seed subject row"),
+        StoreOutcome::Stored("original-subject-archive-id".to_string())
+    );
+
+    let events = room_dispatch::order_subject_persistence_after_archive(vec![
+        persist_subject_event(&room, &sender, subject, claim_fence),
+        OutboundEvent::ArchiveGroupchat {
+            room: room.clone(),
+            sender,
+            message: Box::new(retry),
+            sender_nickname_generation: 8,
+            sender_item: Some(sender_item),
+        },
+        OutboundEvent::CloseTransport,
+    ]);
+    let outcome = interpret(events, &deps).await;
+
+    assert_eq!(
+        outcome.retry_suppression,
+        Some(GroupchatRetrySuppression::Deduplicated)
+    );
+    assert!(outcome.frames.is_empty());
+    assert!(!outcome.close, "post-dedupe canary must be suppressed");
+    assert!(
+        room_actor
+            .ask(GetSnapshot)
+            .await
+            .expect("room snapshot")
+            .room
+            .subject
+            .is_none(),
+        "a deduplicated subject retry must not mutate room subject state"
+    );
 }
 
 #[tokio::test]
@@ -2019,6 +2233,7 @@ async fn xep_0424_lookup_archived_message_propagates_tombstone_state() {
             reply: None,
             references: Vec::new(),
             mentions: Vec::new(),
+            subjects: Default::default(),
             occupant_id: None,
             muc_sender: None,
         }),

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
@@ -642,6 +642,7 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                     reply: None,
                     references: Vec::new(),
                     mentions: Vec::new(),
+                    subjects: Default::default(),
                     // Room-authored moderation event row: no occupant
                     // sender to identify.
                     occupant_id: None,

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/iq/muc_owner_moderation.rs
@@ -695,6 +695,13 @@ pub(super) async fn handle_muc_owner_and_moderation_iq(
                             stamp: Some(stamp_time),
                             reason: request.reason.as_deref().and_then(RichText::new),
                         }),
+                        // Internal tombstone-retry identity only; the
+                        // MAM response builders never read this field.
+                        sender_scope: original
+                            .rich
+                            .as_ref()
+                            .and_then(|rich| rich.muc_sender.as_ref())
+                            .map(|sender| sender.jid.to_bare()),
                     };
                     match state
                         .deps

--- a/server/crates/waddle-server/src/server/routes/websocket/handlers/message/dm_pin.rs
+++ b/server/crates/waddle-server/src/server/routes/websocket/handlers/message/dm_pin.rs
@@ -191,13 +191,10 @@ fn canonical_dm_pin_stanza_id(
 }
 
 fn is_tombstoned_archive_row(archived: &waddle_xmpp::mam::ArchivedMessage) -> bool {
-    matches!(
-        archived
-            .rich
-            .as_ref()
-            .and_then(|rich| rich.payload.as_ref()),
-        Some(waddle_xmpp::mam::ArchivedRichPayload::Tombstone(_))
-    )
+    archived
+        .rich
+        .as_ref()
+        .is_some_and(waddle_xmpp::mam::ArchivedRichMessage::is_tombstoned)
 }
 
 fn archived_belongs_to_dm_pair(

--- a/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
+++ b/server/crates/waddle-server/tests/xep0359_stanza_ids_ws.rs
@@ -6,7 +6,7 @@ use tokio::sync::Mutex;
 use ws_common::{disco_info_query, TestServer, WsXmppClient};
 
 use jid::{BareJid, Jid};
-use waddle_xmpp::mam::{ArchivedMessage, InMemoryMamStorage, MamQuery, MamStorage};
+use waddle_xmpp::mam::{ArchivedMessage, InMemoryMamStorage, MamQuery, MamStorage, StoreOutcome};
 use waddle_xmpp_core::xep0359::{add_stanza_id, OriginId, StanzaId};
 use xmpp_parsers::message::{Message, MessageType};
 use xmpp_parsers::minidom::Element;
@@ -338,7 +338,10 @@ async fn xep_0359_typed_stanza_id_round_trips_through_storage_with_typed_by_jid(
             archive_jid.clone(),
         )
     };
-    let stored_id = storage.store_message(&archive, &row).await.expect("store");
+    let stored_id = match storage.store_message(&archive, &row).await.expect("store") {
+        StoreOutcome::Stored(id) => id,
+        other => panic!("expected stored row, got {other:?}"),
+    };
 
     let retrieved = storage
         .get_message(&stored_id)
@@ -374,7 +377,10 @@ async fn xep_0359_typed_origin_id_round_trips_through_storage() {
             archive_jid,
         )
     };
-    let stored_id = storage.store_message(&archive, &row).await.expect("store");
+    let stored_id = match storage.store_message(&archive, &row).await.expect("store") {
+        StoreOutcome::Stored(id) => id,
+        other => panic!("expected stored row, got {other:?}"),
+    };
 
     let retrieved = storage
         .get_message(&stored_id)

--- a/server/crates/waddle-xmpp-core/src/mam/response.rs
+++ b/server/crates/waddle-xmpp-core/src/mam/response.rs
@@ -234,6 +234,20 @@ fn build_typed_inner_message(archived: &ArchivedMessage, rich: &ArchivedRichMess
     if let Some(sid) = archived.stanza_id.as_ref() {
         builder = builder.attr(minidom::rxml::xml_ncname!("id").to_owned(), sid.id.as_str());
     }
+    // RFC 6121 §5.2.4: preserve every persisted subject language
+    // variant. The empty map key represents the default-language
+    // `<subject/>` and therefore carries no `xml:lang` attribute.
+    for (lang, text) in &rich.subjects {
+        let mut subject = Element::builder("subject", CLIENT_NS);
+        if !lang.is_empty() {
+            subject = subject.attr_ns(
+                minidom::rxml::Namespace::XML,
+                minidom::rxml::xml_ncname!("lang").to_owned(),
+                lang,
+            );
+        }
+        builder = builder.append(subject.append(text.as_str()).build());
+    }
     // RFC 6121 §5.2.3 / XEP-0313 §3: emit `<body/>` exactly when the
     // archived row recorded one on the wire. `Some("")` is a real
     // empty `<body></body>` element and MUST round-trip as such;

--- a/server/crates/waddle-xmpp-core/src/mam/tests.rs
+++ b/server/crates/waddle-xmpp-core/src/mam/tests.rs
@@ -556,6 +556,50 @@ fn xep_0201_typed_replay_emits_thread_parent() {
 }
 
 #[test]
+fn typed_fallback_replay_emits_default_and_language_keyed_subjects() {
+    for stanza_xml in [None, Some("<malformed".to_string())] {
+        let archived = ArchivedMessage {
+            id: "subject-row".to_string(),
+            body: None,
+            message_type: MessageType::Chat,
+            stanza_xml,
+            rich: Some(ArchivedRichMessage {
+                subjects: [
+                    (String::new(), "Default subject".to_string()),
+                    ("en".to_string(), "English subject".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+                ..ArchivedRichMessage::default()
+            }),
+            ..ArchivedMessage::for_test(jid("alice@example.com/web"), jid("bob@example.com"))
+        };
+
+        let inner = archived_inner_message(&archived);
+        let subjects: Vec<&Element> = inner
+            .children()
+            .filter(|child| child.name() == "subject" && child.ns() == CLIENT_NS)
+            .collect();
+
+        assert_eq!(subjects.len(), 2);
+        let default_subject = subjects
+            .iter()
+            .find(|subject| {
+                subject
+                    .attr_ns(&minidom::rxml::Namespace::XML, "lang")
+                    .is_none()
+            })
+            .expect("default-language subject");
+        assert_eq!(default_subject.text(), "Default subject");
+        let english_subject = subjects
+            .iter()
+            .find(|subject| subject.attr_ns(&minidom::rxml::Namespace::XML, "lang") == Some("en"))
+            .expect("English subject");
+        assert_eq!(english_subject.text(), "English subject");
+    }
+}
+
+#[test]
 fn xep_0201_legacy_replay_emits_thread_parent() {
     // Legacy reconstruction path: stanza_xml is None AND rich is
     // None — `build_legacy_inner_message` rebuilds purely from

--- a/server/crates/waddle-xmpp-core/src/mam/tests.rs
+++ b/server/crates/waddle-xmpp-core/src/mam/tests.rs
@@ -540,6 +540,7 @@ fn xep_0201_typed_replay_emits_thread_parent() {
             reply: None,
             references: vec![],
             mentions: vec![],
+            subjects: Default::default(),
         }),
         ..nested_thread_archived_for_replay(None)
     };
@@ -778,6 +779,7 @@ fn stanza_xml_preferred_over_rich_payload() {
             reply: None,
             references: vec![],
             mentions: vec![],
+            subjects: Default::default(),
         }),
         ..ArchivedMessage::for_test(
             jid("room@conference.example.com/alice"),
@@ -840,6 +842,7 @@ fn stanza_xml_preserves_reply_fallback() {
             }),
             references: vec![],
             mentions: vec![],
+            subjects: Default::default(),
         }),
         ..ArchivedMessage::for_test(
             jid("room@conference.example.com/bob"),

--- a/server/crates/waddle-xmpp-core/src/mam/types.rs
+++ b/server/crates/waddle-xmpp-core/src/mam/types.rs
@@ -207,6 +207,15 @@ impl ArchivedRichMessage {
         }
     }
 
+    /// True when this payload is an XEP-0424 / XEP-0425 tombstone — the
+    /// terminal state an archive row never leaves.
+    pub fn is_tombstoned(&self) -> bool {
+        matches!(
+            self.payload.as_ref(),
+            Some(ArchivedRichPayload::Tombstone(_))
+        )
+    }
+
     /// True when this payload carries no client-authored content
     /// (`payload` / `reply` / `references` / `mentions` / `subjects`) and no
     /// server-derived MUC identity (`occupant_id` / `muc_sender`).

--- a/server/crates/waddle-xmpp-core/src/mam/types.rs
+++ b/server/crates/waddle-xmpp-core/src/mam/types.rs
@@ -105,6 +105,18 @@ pub struct ArchivedTombstone {
     /// When set, this tombstone is the result of XEP-0425 moderation
     /// rather than a sender-initiated XEP-0424 retraction.
     pub moderation: Option<ArchivedModeration>,
+    /// Retained real bare JID of the tombstoned message's original
+    /// sender, for the groupchat origin-id tombstone-retry match ONLY.
+    ///
+    /// INTERNAL storage state: XEP-0424 §Tombstones wipes sender
+    /// identity from everything a client can observe, and the MAM
+    /// response builders never read this field — it exists so a
+    /// *different* real user reusing a departed occupant's nick and a
+    /// tombstoned origin-id is not spuriously swallowed by the retry
+    /// match. `None` on rows tombstoned before this field existed (and
+    /// on 1:1 tombstones, which never tombstone-match).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sender_scope: Option<BareJid>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/server/crates/waddle-xmpp-core/src/mam/types.rs
+++ b/server/crates/waddle-xmpp-core/src/mam/types.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use chrono::{DateTime, Utc};
 use jid::{BareJid, Jid};
 use serde::{Deserialize, Serialize};
@@ -170,6 +172,10 @@ pub struct ArchivedRichMessage {
     pub reply: Option<ArchivedReply>,
     pub references: Vec<ArchivedReference>,
     pub mentions: Vec<ArchivedMention>,
+    /// Client-authored message subjects keyed by their wire `xml:lang`
+    /// value (`""` is the default language).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub subjects: BTreeMap<String, String>,
     /// XEP-0421 occupant-id of the sender (groupchat rows only).
     /// `#[serde(default)]` keeps previously-serialized rich payloads
     /// decodable.
@@ -202,13 +208,14 @@ impl ArchivedRichMessage {
     }
 
     /// True when this payload carries no client-authored content
-    /// (`payload` / `reply` / `references` / `mentions`) and no
+    /// (`payload` / `reply` / `references` / `mentions` / `subjects`) and no
     /// server-derived MUC identity (`occupant_id` / `muc_sender`).
     pub fn is_empty(&self) -> bool {
         self.payload.is_none()
             && self.reply.is_none()
             && self.references.is_empty()
             && self.mentions.is_empty()
+            && self.subjects.is_empty()
             && self.occupant_id.is_none()
             && self.muc_sender.is_none()
     }

--- a/server/crates/waddle-xmpp/src/mam/mod.rs
+++ b/server/crates/waddle-xmpp/src/mam/mod.rs
@@ -18,6 +18,7 @@ pub mod storage;
 
 pub use storage::{
     InMemoryMamStorage, MamArchiveKind, MamStorage, MamStorageError, SqlxMamStorage, StoreOutcome,
+    TerminalTombstoneOutcome,
 };
 pub use waddle_xmpp_core::mam::{
     archived_inner_message, build_fin_iq, build_query_form_iq, build_result_messages, is_mam_query,

--- a/server/crates/waddle-xmpp/src/mam/mod.rs
+++ b/server/crates/waddle-xmpp/src/mam/mod.rs
@@ -17,7 +17,7 @@ pub mod projection;
 pub mod storage;
 
 pub use storage::{
-    InMemoryMamStorage, MamArchiveKind, MamStorage, MamStorageError, SqlxMamStorage,
+    InMemoryMamStorage, MamArchiveKind, MamStorage, MamStorageError, SqlxMamStorage, StoreOutcome,
 };
 pub use waddle_xmpp_core::mam::{
     archived_inner_message, build_fin_iq, build_query_form_iq, build_result_messages, is_mam_query,

--- a/server/crates/waddle-xmpp/src/mam/projection.rs
+++ b/server/crates/waddle-xmpp/src/mam/projection.rs
@@ -278,8 +278,18 @@ fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMessage> {
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
+    let subjects = message
+        .subjects
+        .iter()
+        .map(|(lang, text)| (lang.0.clone(), text.clone()))
+        .collect::<std::collections::BTreeMap<_, _>>();
 
-    if payload.is_none() && reply.is_none() && references.is_empty() && mentions.is_empty() {
+    if payload.is_none()
+        && reply.is_none()
+        && references.is_empty()
+        && mentions.is_empty()
+        && subjects.is_empty()
+    {
         None
     } else {
         Some(ArchivedRichMessage {
@@ -287,7 +297,7 @@ fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMessage> {
             reply,
             references,
             mentions,
-            subjects: Default::default(),
+            subjects,
             // 1:1 archive rows have no MUC occupant identity; the
             // groupchat projection (`rich_archive_payload` in the
             // interpreter) is the path that captures these.

--- a/server/crates/waddle-xmpp/src/mam/projection.rs
+++ b/server/crates/waddle-xmpp/src/mam/projection.rs
@@ -287,6 +287,7 @@ fn rich_archive_payload(message: &Message) -> Option<ArchivedRichMessage> {
             reply,
             references,
             mentions,
+            subjects: Default::default(),
             // 1:1 archive rows have no MUC occupant identity; the
             // groupchat projection (`rich_archive_payload` in the
             // interpreter) is the path that captures these.

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -20,4 +20,4 @@ mod tests;
 pub use error::MamStorageError;
 pub use in_memory::InMemoryMamStorage;
 pub use sqlx_store::SqlxMamStorage;
-pub use traits::{MamArchiveKind, MamStorage};
+pub use traits::{MamArchiveKind, MamStorage, StoreOutcome};

--- a/server/crates/waddle-xmpp/src/mam/storage.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage.rs
@@ -20,4 +20,4 @@ mod tests;
 pub use error::MamStorageError;
 pub use in_memory::InMemoryMamStorage;
 pub use sqlx_store::SqlxMamStorage;
-pub use traits::{MamArchiveKind, MamStorage, StoreOutcome};
+pub use traits::{MamArchiveKind, MamStorage, StoreOutcome, TerminalTombstoneOutcome};

--- a/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
@@ -363,12 +363,11 @@ impl MamStorage for InMemoryMamStorage {
         else {
             return Ok(TerminalTombstoneOutcome::NotFound);
         };
-        if message.rich.as_ref().is_some_and(|rich| {
-            matches!(
-                rich.payload.as_ref(),
-                Some(waddle_xmpp_core::mam::ArchivedRichPayload::Tombstone(_))
-            )
-        }) {
+        if message
+            .rich
+            .as_ref()
+            .is_some_and(waddle_xmpp_core::mam::ArchivedRichMessage::is_tombstoned)
+        {
             return Ok(TerminalTombstoneOutcome::AlreadyTombstoned);
         }
         apply_tombstone(message, tombstone);

--- a/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
@@ -17,7 +17,7 @@ use super::query_semantics::{
     missing_requested_id, uses_backward_pagination,
 };
 use super::tombstone::apply_tombstone;
-use super::{MamStorage, MamStorageError, StoreOutcome};
+use super::{MamStorage, MamStorageError, StoreOutcome, TerminalTombstoneOutcome};
 
 #[derive(Clone, Default)]
 pub struct InMemoryMamStorage {
@@ -349,5 +349,29 @@ impl MamStorage for InMemoryMamStorage {
             }
         }
         Ok(false)
+    }
+
+    async fn replace_with_terminal_tombstone(
+        &self,
+        archive_id: &str,
+        tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+    ) -> Result<TerminalTombstoneOutcome, MamStorageError> {
+        let mut entries = self.entries.write().await;
+        let Some((_, message)) = entries
+            .iter_mut()
+            .find(|(_, message)| message.id == archive_id)
+        else {
+            return Ok(TerminalTombstoneOutcome::NotFound);
+        };
+        if message.rich.as_ref().is_some_and(|rich| {
+            matches!(
+                rich.payload.as_ref(),
+                Some(waddle_xmpp_core::mam::ArchivedRichPayload::Tombstone(_))
+            )
+        }) {
+            return Ok(TerminalTombstoneOutcome::AlreadyTombstoned);
+        }
+        apply_tombstone(message, tombstone);
+        Ok(TerminalTombstoneOutcome::Replaced)
     }
 }

--- a/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/in_memory.rs
@@ -11,13 +11,13 @@ use waddle_xmpp_core::xep0359::OriginId;
 
 use crate::xep::matches_fulltext;
 
-use super::origin_dedup::origin_id_dedup_match;
+use super::origin_dedup::{origin_id_dedup_match, origin_id_tombstone_match};
 use super::query_semantics::{
     archive_order_after, archive_order_before, matches_thread_filter, message_matches_with_filter,
     missing_requested_id, uses_backward_pagination,
 };
 use super::tombstone::apply_tombstone;
-use super::{MamStorage, MamStorageError};
+use super::{MamStorage, MamStorageError, StoreOutcome};
 
 #[derive(Clone, Default)]
 pub struct InMemoryMamStorage {
@@ -40,13 +40,18 @@ impl MamStorage for InMemoryMamStorage {
         &self,
         archive_jid: &BareJid,
         message: &ArchivedMessage,
-    ) -> Result<String, MamStorageError> {
+    ) -> Result<StoreOutcome, MamStorageError> {
         let mut entries = self.entries.write().await;
         if message.origin_id.is_some() {
             if let Some((_, existing)) = entries.iter().find(|(jid, existing)| {
                 jid == archive_jid && origin_id_dedup_match(existing, message)
             }) {
-                return Ok(existing.id.clone());
+                return Ok(StoreOutcome::Deduplicated(existing.id.clone()));
+            }
+            if let Some((_, existing)) = entries.iter().find(|(jid, existing)| {
+                jid == archive_jid && origin_id_tombstone_match(existing, message)
+            }) {
+                return Ok(StoreOutcome::TombstoneHit(existing.id.clone()));
             }
         }
 
@@ -60,7 +65,7 @@ impl MamStorage for InMemoryMamStorage {
         stored.id = archive_id.clone();
 
         entries.push((archive_jid.clone(), stored));
-        Ok(archive_id)
+        Ok(StoreOutcome::Stored(archive_id))
     }
 
     async fn query_messages(

--- a/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
@@ -1,4 +1,4 @@
-use waddle_xmpp_core::mam::ArchivedMessage;
+use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedRichPayload};
 use xmpp_parsers::message::MessageType;
 
 pub(super) fn origin_id_dedup_match(
@@ -17,11 +17,42 @@ pub(super) fn origin_id_dedup_match(
         && archived_content_matches(existing, incoming)
 }
 
+pub(super) fn origin_id_tombstone_match(
+    existing: &ArchivedMessage,
+    incoming: &ArchivedMessage,
+) -> bool {
+    matches!(
+        (&existing.message_type, &incoming.message_type),
+        (MessageType::Groupchat, MessageType::Groupchat)
+    ) && existing.origin_id.is_some()
+        && existing.origin_id == incoming.origin_id
+        && existing.from == incoming.from
+        && matches!(
+            existing
+                .rich
+                .as_ref()
+                .and_then(|rich| rich.payload.as_ref()),
+            Some(ArchivedRichPayload::Tombstone(_))
+        )
+}
+
 fn sender_scope_matches(existing: &ArchivedMessage, incoming: &ArchivedMessage) -> bool {
     match (&existing.message_type, &incoming.message_type) {
         (MessageType::Groupchat, MessageType::Groupchat) => {
+            let existing_sender = existing
+                .rich
+                .as_ref()
+                .and_then(|rich| rich.muc_sender.as_ref());
+            let incoming_sender = incoming
+                .rich
+                .as_ref()
+                .and_then(|rich| rich.muc_sender.as_ref());
             existing.from == incoming.from
-                && existing.nickname_generation == incoming.nickname_generation
+                && existing_sender.zip(incoming_sender).is_some_and(
+                    |(existing_sender, incoming_sender)| {
+                        existing_sender.jid.to_bare() == incoming_sender.jid.to_bare()
+                    },
+                )
         }
         (MessageType::Groupchat, _) | (_, MessageType::Groupchat) => false,
         _ => {
@@ -59,4 +90,199 @@ fn rich_content_matches(existing: &ArchivedMessage, incoming: &ArchivedMessage) 
     let existing = existing.rich.as_ref().and_then(|rich| rich.dedup_content());
     let incoming = incoming.rich.as_ref().and_then(|rich| rich.dedup_content());
     existing == incoming
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+    use jid::Jid;
+    use waddle_xmpp_core::mam::{
+        ArchivedMessage, ArchivedMucSender, ArchivedRichMessage, ArchivedRichPayload,
+        ArchivedTombstone,
+    };
+    use waddle_xmpp_core::types::{Affiliation, Role};
+    use waddle_xmpp_core::xep0359::OriginId;
+    use xmpp_parsers::message::MessageType;
+
+    use super::{origin_id_dedup_match, origin_id_tombstone_match};
+
+    fn jid(value: &str) -> Jid {
+        value.parse().expect("valid test JID")
+    }
+
+    fn groupchat_message(
+        from: &str,
+        real_jid: Option<&str>,
+        origin_id: &str,
+        body: &str,
+        nickname_generation: u64,
+    ) -> ArchivedMessage {
+        ArchivedMessage {
+            body: Some(body.to_string()),
+            origin_id: Some(OriginId::new(origin_id)),
+            message_type: MessageType::Groupchat,
+            nickname_generation: Some(nickname_generation),
+            rich: real_jid.map(|real_jid| ArchivedRichMessage {
+                muc_sender: Some(ArchivedMucSender {
+                    jid: jid(real_jid),
+                    affiliation: Affiliation::Member,
+                    role: Role::Participant,
+                }),
+                ..ArchivedRichMessage::default()
+            }),
+            ..ArchivedMessage::for_test(jid(from), jid("room@conference.example.com"))
+        }
+    }
+
+    #[test]
+    fn rejoin_retry_matches_same_real_bare_jid_across_generations() {
+        let existing = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("alice@example.com/old-session"),
+            "origin-1",
+            "hello",
+            7,
+        );
+        let incoming = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("alice@example.com/new-session"),
+            "origin-1",
+            "hello",
+            8,
+        );
+
+        assert!(origin_id_dedup_match(&existing, &incoming));
+    }
+
+    #[test]
+    fn nick_reuse_by_different_real_bare_jid_does_not_match() {
+        let existing = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("alice@example.com/phone"),
+            "origin-1",
+            "hello",
+            7,
+        );
+        let incoming = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("mallory@example.com/phone"),
+            "origin-1",
+            "hello",
+            8,
+        );
+
+        assert!(!origin_id_dedup_match(&existing, &incoming));
+    }
+
+    #[test]
+    fn changed_content_does_not_match() {
+        let existing = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("alice@example.com/old"),
+            "origin-1",
+            "hello",
+            7,
+        );
+        let incoming = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("alice@example.com/new"),
+            "origin-1",
+            "changed",
+            8,
+        );
+
+        assert!(!origin_id_dedup_match(&existing, &incoming));
+    }
+
+    #[test]
+    fn missing_muc_sender_on_either_side_does_not_match() {
+        let identified = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("alice@example.com/device"),
+            "origin-1",
+            "hello",
+            7,
+        );
+        let unidentified = groupchat_message(
+            "room@conference.example.com/alice",
+            None,
+            "origin-1",
+            "hello",
+            8,
+        );
+
+        assert!(!origin_id_dedup_match(&identified, &unidentified));
+        assert!(!origin_id_dedup_match(&unidentified, &identified));
+    }
+
+    #[test]
+    fn different_occupant_jid_does_not_match() {
+        let existing = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("alice@example.com/old"),
+            "origin-1",
+            "hello",
+            7,
+        );
+        let incoming = groupchat_message(
+            "room@conference.example.com/alice-renamed",
+            Some("alice@example.com/new"),
+            "origin-1",
+            "hello",
+            8,
+        );
+
+        assert!(!origin_id_dedup_match(&existing, &incoming));
+    }
+
+    #[test]
+    fn tombstone_match_is_groupchat_origin_and_occupant_scoped() {
+        let incoming = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("alice@example.com/new"),
+            "origin-1",
+            "hello",
+            8,
+        );
+        let mut tombstone =
+            groupchat_message("room@conference.example.com/alice", None, "origin-1", "", 7);
+        tombstone.body = None;
+        tombstone.rich = Some(ArchivedRichMessage {
+            payload: Some(ArchivedRichPayload::Tombstone(ArchivedTombstone {
+                retraction_id: None,
+                stamp: Utc::now(),
+                moderation: None,
+            })),
+            ..ArchivedRichMessage::default()
+        });
+
+        assert!(origin_id_tombstone_match(&tombstone, &incoming));
+
+        let different_from = groupchat_message(
+            "room@conference.example.com/bob",
+            Some("alice@example.com/new"),
+            "origin-1",
+            "hello",
+            8,
+        );
+        assert!(!origin_id_tombstone_match(&tombstone, &different_from));
+
+        let different_origin = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("alice@example.com/new"),
+            "origin-2",
+            "hello",
+            8,
+        );
+        assert!(!origin_id_tombstone_match(&tombstone, &different_origin));
+
+        let live = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("alice@example.com/old"),
+            "origin-1",
+            "hello",
+            7,
+        );
+        assert!(!origin_id_tombstone_match(&live, &incoming));
+    }
 }

--- a/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
@@ -5,6 +5,12 @@ pub(super) fn origin_id_dedup_match(
     existing: &ArchivedMessage,
     incoming: &ArchivedMessage,
 ) -> bool {
+    if groupchat_subject_is_retry_dedup_exempt(existing)
+        || groupchat_subject_is_retry_dedup_exempt(incoming)
+    {
+        return false;
+    }
+
     let Some(existing_origin_id) = existing.origin_id.as_ref() else {
         return false;
     };
@@ -21,10 +27,12 @@ pub(super) fn origin_id_tombstone_match(
     existing: &ArchivedMessage,
     incoming: &ArchivedMessage,
 ) -> bool {
-    matches!(
-        (&existing.message_type, &incoming.message_type),
-        (MessageType::Groupchat, MessageType::Groupchat)
-    ) && existing.origin_id.is_some()
+    !groupchat_subject_is_retry_dedup_exempt(incoming)
+        && matches!(
+            (&existing.message_type, &incoming.message_type),
+            (MessageType::Groupchat, MessageType::Groupchat)
+        )
+        && existing.origin_id.is_some()
         && existing.origin_id == incoming.origin_id
         && existing.from == incoming.from
         && matches!(
@@ -34,6 +42,27 @@ pub(super) fn origin_id_tombstone_match(
                 .and_then(|rich| rich.payload.as_ref()),
             Some(ArchivedRichPayload::Tombstone(_))
         )
+}
+
+/// XEP-0045 §8.1 subject changes are room-state operations, not timeline
+/// content. Re-applying and re-broadcasting a retry is benign and self-healing,
+/// so groupchat subject rows deliberately fail open outside origin-id dedupe.
+/// The exemption mirrors §8.1's shape exactly, matching the chain's
+/// `MucSubjectHandler` detection: a `<subject/>` accompanied by body content
+/// or a `<thread/>` is a regular timeline message, keeps normal content-key
+/// dedupe, and must not fail open. Direct-chat subjects remain
+/// timeline-message headers and stay in the content key.
+pub(super) fn groupchat_subject_is_retry_dedup_exempt(message: &ArchivedMessage) -> bool {
+    matches!(message.message_type, MessageType::Groupchat)
+        && message
+            .rich
+            .as_ref()
+            .is_some_and(|rich| !rich.subjects.is_empty())
+        && message.thread.is_none()
+        && message
+            .body
+            .as_deref()
+            .is_none_or(|body| body.trim().is_empty())
 }
 
 fn sender_scope_matches(existing: &ArchivedMessage, incoming: &ArchivedMessage) -> bool {
@@ -236,6 +265,92 @@ mod tests {
     }
 
     #[test]
+    fn groupchat_subjects_are_exempt_but_direct_subjects_stay_in_content_key() {
+        let mut existing = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("alice@example.com/old"),
+            "origin-1",
+            "",
+            7,
+        );
+        existing.body = None;
+        existing
+            .rich
+            .as_mut()
+            .expect("groupchat rich payload")
+            .subjects
+            .insert(String::new(), "Topic".to_string());
+        let mut incoming = existing.clone();
+        incoming.id = "incoming-subject".to_string();
+
+        assert!(!origin_id_dedup_match(&existing, &incoming));
+        let mut without_subject = incoming.clone();
+        without_subject
+            .rich
+            .as_mut()
+            .expect("groupchat rich payload")
+            .subjects
+            .clear();
+        assert!(!origin_id_dedup_match(&existing, &without_subject));
+        assert!(!origin_id_dedup_match(&without_subject, &incoming));
+
+        existing.message_type = MessageType::Chat;
+        existing.from = jid("alice@example.com/old");
+        existing.to = jid("bob@example.com");
+        incoming.message_type = MessageType::Chat;
+        incoming.from = jid("alice@example.com/new");
+        incoming.to = jid("bob@example.com");
+        assert!(origin_id_dedup_match(&existing, &incoming));
+
+        incoming
+            .rich
+            .as_mut()
+            .expect("direct rich payload")
+            .subjects
+            .insert(String::new(), "Changed topic".to_string());
+        assert!(!origin_id_dedup_match(&existing, &incoming));
+    }
+
+    #[test]
+    fn groupchat_subject_with_body_or_thread_is_not_exempt_from_dedup() {
+        // XEP-0045 §8.1: `<subject/>` + body content (or `<thread/>`) is a
+        // regular timeline message, not a subject change — it must keep
+        // normal retry-dedupe or the #1374 duplication returns for that
+        // shape.
+        let mut existing = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("alice@example.com/old"),
+            "origin-1",
+            "hello",
+            7,
+        );
+        existing
+            .rich
+            .as_mut()
+            .expect("groupchat rich payload")
+            .subjects
+            .insert(String::new(), "Legacy header".to_string());
+        let mut incoming = existing.clone();
+        incoming.id = "incoming-retry".to_string();
+        if let Some(sender) = incoming
+            .rich
+            .as_mut()
+            .and_then(|rich| rich.muc_sender.as_mut())
+        {
+            sender.jid = jid("alice@example.com/new-session");
+        }
+
+        assert!(origin_id_dedup_match(&existing, &incoming));
+
+        let mut subject_only = existing.clone();
+        subject_only.body = None;
+        assert!(super::groupchat_subject_is_retry_dedup_exempt(
+            &subject_only
+        ));
+        assert!(!super::groupchat_subject_is_retry_dedup_exempt(&existing));
+    }
+
+    #[test]
     fn tombstone_match_is_groupchat_origin_and_occupant_scoped() {
         let incoming = groupchat_message(
             "room@conference.example.com/alice",
@@ -284,5 +399,15 @@ mod tests {
             7,
         );
         assert!(!origin_id_tombstone_match(&live, &incoming));
+
+        let mut subject_retry = incoming;
+        subject_retry.body = None;
+        subject_retry
+            .rich
+            .as_mut()
+            .expect("groupchat rich payload")
+            .subjects
+            .insert(String::new(), "Topic".to_string());
+        assert!(!origin_id_tombstone_match(&tombstone, &subject_retry));
     }
 }

--- a/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
@@ -1,4 +1,4 @@
-use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedRichMessage};
+use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedRichPayload};
 use xmpp_parsers::message::MessageType;
 
 pub(super) fn origin_id_dedup_match(
@@ -35,10 +35,30 @@ pub(super) fn origin_id_tombstone_match(
         && existing.origin_id.is_some()
         && existing.origin_id == incoming.origin_id
         && existing.from == incoming.from
-        && existing
-            .rich
-            .as_ref()
-            .is_some_and(ArchivedRichMessage::is_tombstoned)
+        && tombstone_sender_scope_matches(existing, incoming)
+}
+
+/// The existing row must be a tombstone, and — when it retained the
+/// original sender's internal `sender_scope` — the incoming retry must
+/// come from that same real bare JID. Rows tombstoned before the scope
+/// was retained fall back to the occupant-JID-only match (fail closed
+/// toward swallowing, the pre-existing carve-out). Content matching is
+/// impossible either way: XEP-0424 wipes it by design.
+fn tombstone_sender_scope_matches(existing: &ArchivedMessage, incoming: &ArchivedMessage) -> bool {
+    let Some(rich) = existing.rich.as_ref() else {
+        return false;
+    };
+    let Some(ArchivedRichPayload::Tombstone(tombstone)) = rich.payload.as_ref() else {
+        return false;
+    };
+    let Some(retained_scope) = tombstone.sender_scope.as_ref() else {
+        return true;
+    };
+    incoming
+        .rich
+        .as_ref()
+        .and_then(|rich| rich.muc_sender.as_ref())
+        .is_some_and(|sender| sender.jid.to_bare() == *retained_scope)
 }
 
 /// XEP-0045 §8.1 subject changes are room-state operations, not timeline
@@ -364,6 +384,7 @@ mod tests {
                 retraction_id: None,
                 stamp: Utc::now(),
                 moderation: None,
+                sender_scope: None,
             })),
             ..ArchivedRichMessage::default()
         });
@@ -406,5 +427,53 @@ mod tests {
             .subjects
             .insert(String::new(), "Topic".to_string());
         assert!(!origin_id_tombstone_match(&tombstone, &subject_retry));
+    }
+
+    #[test]
+    fn tombstone_with_retained_sender_scope_only_matches_the_same_real_user() {
+        // The internal `sender_scope` retained on newer tombstones
+        // restores the identity guarantee XEP-0424's wire wipe removed:
+        // a different real user reusing a departed occupant's nick and
+        // a tombstoned origin-id must archive distinctly, not be
+        // swallowed.
+        let mut tombstone =
+            groupchat_message("room@conference.example.com/alice", None, "origin-1", "", 7);
+        tombstone.body = None;
+        tombstone.rich = Some(ArchivedRichMessage {
+            payload: Some(ArchivedRichPayload::Tombstone(ArchivedTombstone {
+                retraction_id: None,
+                stamp: Utc::now(),
+                moderation: None,
+                sender_scope: Some("alice@example.com".parse().expect("valid test bare JID")),
+            })),
+            ..ArchivedRichMessage::default()
+        });
+
+        let same_user_retry = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("alice@example.com/new-session"),
+            "origin-1",
+            "hello",
+            8,
+        );
+        assert!(origin_id_tombstone_match(&tombstone, &same_user_retry));
+
+        let different_user = groupchat_message(
+            "room@conference.example.com/alice",
+            Some("mallory@example.com/session"),
+            "origin-1",
+            "hello",
+            8,
+        );
+        assert!(!origin_id_tombstone_match(&tombstone, &different_user));
+
+        let missing_identity = groupchat_message(
+            "room@conference.example.com/alice",
+            None,
+            "origin-1",
+            "hello",
+            8,
+        );
+        assert!(!origin_id_tombstone_match(&tombstone, &missing_identity));
     }
 }

--- a/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/origin_dedup.rs
@@ -1,4 +1,4 @@
-use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedRichPayload};
+use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedRichMessage};
 use xmpp_parsers::message::MessageType;
 
 pub(super) fn origin_id_dedup_match(
@@ -35,13 +35,10 @@ pub(super) fn origin_id_tombstone_match(
         && existing.origin_id.is_some()
         && existing.origin_id == incoming.origin_id
         && existing.from == incoming.from
-        && matches!(
-            existing
-                .rich
-                .as_ref()
-                .and_then(|rich| rich.payload.as_ref()),
-            Some(ArchivedRichPayload::Tombstone(_))
-        )
+        && existing
+            .rich
+            .as_ref()
+            .is_some_and(ArchivedRichMessage::is_tombstoned)
 }
 
 /// XEP-0045 §8.1 subject changes are room-state operations, not timeline

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/decode.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/decode.rs
@@ -209,7 +209,7 @@ pub(super) fn encode_rich_payload(
         .map_err(|error| MamStorageError::Serialization(error.to_string()))
 }
 
-fn decode_rich_payload(
+pub(super) fn decode_rich_payload(
     value: Option<&str>,
 ) -> Result<Option<waddle_xmpp_core::mam::ArchivedRichMessage>, MamStorageError> {
     value

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/impls.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/impls.rs
@@ -9,7 +9,7 @@ use waddle_xmpp_core::mam::{ArchivedMessage, MamQuery, MamResult};
 use waddle_xmpp_core::xep0359::OriginId;
 
 use crate::mam::storage::query_semantics::{finalize_result, uses_backward_pagination};
-use crate::mam::storage::{MamStorage, MamStorageError, StoreOutcome};
+use crate::mam::storage::{MamStorage, MamStorageError, StoreOutcome, TerminalTombstoneOutcome};
 use crate::muc::RoomClaimFenceContext;
 
 use super::decode::{decode_postgres_message_row, decode_sqlite_message_row};
@@ -498,5 +498,14 @@ impl MamStorage for SqlxMamStorage {
         tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
     ) -> Result<bool, MamStorageError> {
         super::write::replace_with_tombstone(&self.backend, archive_id, tombstone).await
+    }
+
+    #[instrument(skip(self, tombstone))]
+    async fn replace_with_terminal_tombstone(
+        &self,
+        archive_id: &str,
+        tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+    ) -> Result<TerminalTombstoneOutcome, MamStorageError> {
+        super::write::replace_with_terminal_tombstone(&self.backend, archive_id, tombstone).await
     }
 }

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/impls.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/impls.rs
@@ -9,7 +9,7 @@ use waddle_xmpp_core::mam::{ArchivedMessage, MamQuery, MamResult};
 use waddle_xmpp_core::xep0359::OriginId;
 
 use crate::mam::storage::query_semantics::{finalize_result, uses_backward_pagination};
-use crate::mam::storage::{MamStorage, MamStorageError};
+use crate::mam::storage::{MamStorage, MamStorageError, StoreOutcome};
 use crate::muc::RoomClaimFenceContext;
 
 use super::decode::{decode_postgres_message_row, decode_sqlite_message_row};
@@ -28,7 +28,7 @@ impl MamStorage for SqlxMamStorage {
         &self,
         archive_jid: &BareJid,
         message: &ArchivedMessage,
-    ) -> Result<String, MamStorageError> {
+    ) -> Result<StoreOutcome, MamStorageError> {
         super::write::store_message(&self.backend, archive_jid, message).await
     }
 
@@ -38,7 +38,7 @@ impl MamStorage for SqlxMamStorage {
         archive_jid: &BareJid,
         message: &ArchivedMessage,
         fence: &RoomClaimFenceContext,
-    ) -> Result<String, MamStorageError> {
+    ) -> Result<StoreOutcome, MamStorageError> {
         if !self.fencing_enabled {
             return self.store_message(archive_jid, message).await;
         }

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/schema.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/schema.rs
@@ -47,6 +47,7 @@ CREATE TABLE IF NOT EXISTS mam_messages (
     rich_payload TEXT,
     nickname_generation INTEGER,
     parent_thread_id TEXT,
+    origin_dedup_sender_scope TEXT,
     origin_dedup_fingerprint TEXT,
     created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
@@ -66,12 +67,18 @@ CREATE INDEX IF NOT EXISTS idx_mam_room_stanza
     ON mam_messages(room_jid, stanza_id);
 "#;
 
+// Groupchat retry identity is the real bare JID inside the typed rich payload,
+// not nickname_generation. The separately persisted sender scope preserves the
+// conflict guard for concurrent exact retries; Rust still performs the final
+// typed identity and content match after a conflict.
 const SQLITE_MAM_ORIGIN_DEDUP_INDEXES: &str = r#"
 DROP INDEX IF EXISTS idx_mam_origin_groupchat_unique;
 DROP INDEX IF EXISTS idx_mam_origin_direct_unique;
-CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_content_unique
-    ON mam_messages(room_jid, origin_id, from_jid, COALESCE(nickname_generation, -1), origin_dedup_fingerprint)
-    WHERE origin_id IS NOT NULL AND origin_dedup_fingerprint IS NOT NULL AND message_type = 'groupchat';
+DROP INDEX IF EXISTS idx_mam_origin_groupchat_content_unique;
+DROP INDEX IF EXISTS idx_mam_origin_groupchat_candidates;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_sender_content_unique
+    ON mam_messages(room_jid, origin_id, from_jid, origin_dedup_sender_scope, origin_dedup_fingerprint)
+    WHERE origin_id IS NOT NULL AND origin_dedup_sender_scope IS NOT NULL AND origin_dedup_fingerprint IS NOT NULL AND message_type = 'groupchat';
 CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_direct_content_unique
     ON mam_messages(
         room_jid,
@@ -108,6 +115,7 @@ CREATE TABLE IF NOT EXISTS mam_messages (
     rich_payload TEXT,
     nickname_generation BIGINT,
     parent_thread_id TEXT,
+    origin_dedup_sender_scope TEXT,
     origin_dedup_fingerprint TEXT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
@@ -130,9 +138,11 @@ CREATE INDEX IF NOT EXISTS idx_mam_room_stanza
 const POSTGRES_MAM_ORIGIN_DEDUP_INDEXES: &str = r#"
 DROP INDEX IF EXISTS idx_mam_origin_groupchat_unique;
 DROP INDEX IF EXISTS idx_mam_origin_direct_unique;
-CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_content_unique
-    ON mam_messages(room_jid, origin_id, from_jid, (COALESCE(nickname_generation, -1)), origin_dedup_fingerprint)
-    WHERE origin_id IS NOT NULL AND origin_dedup_fingerprint IS NOT NULL AND message_type = 'groupchat';
+DROP INDEX IF EXISTS idx_mam_origin_groupchat_content_unique;
+DROP INDEX IF EXISTS idx_mam_origin_groupchat_candidates;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_sender_content_unique
+    ON mam_messages(room_jid, origin_id, from_jid, origin_dedup_sender_scope, origin_dedup_fingerprint)
+    WHERE origin_id IS NOT NULL AND origin_dedup_sender_scope IS NOT NULL AND origin_dedup_fingerprint IS NOT NULL AND message_type = 'groupchat';
 CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_direct_content_unique
     ON mam_messages(
         room_jid,
@@ -242,6 +252,7 @@ pub(super) async fn ensure_sqlite_schema(pool: &SqlitePool) -> Result<(), MamSto
     ensure_sqlite_column(pool, "stanza_xml", "TEXT").await?;
     ensure_sqlite_column(pool, "nickname_generation", "INTEGER").await?;
     ensure_sqlite_column(pool, "parent_thread_id", "TEXT").await?;
+    ensure_sqlite_column(pool, "origin_dedup_sender_scope", "TEXT").await?;
     ensure_sqlite_column(pool, "origin_dedup_fingerprint", "TEXT").await?;
     // Same body-NULL constraint risk as Postgres (see
     // `ensure_postgres_schema`): SQLite tables created before #228
@@ -303,6 +314,7 @@ async fn ensure_sqlite_body_nullable(pool: &SqlitePool) -> Result<(), MamStorage
             rich_payload TEXT,
             nickname_generation INTEGER,
             parent_thread_id TEXT,
+            origin_dedup_sender_scope TEXT,
             origin_dedup_fingerprint TEXT,
             created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         )"#,
@@ -310,7 +322,8 @@ async fn ensure_sqlite_body_nullable(pool: &SqlitePool) -> Result<(), MamStorage
             SELECT id, room_jid, timestamp, from_jid, to_jid, body,
                    stanza_id, thread_id, reply_to_id, reply_to_jid,
                    origin_id, message_type, stanza_xml, rich_payload,
-                   nickname_generation, parent_thread_id, origin_dedup_fingerprint, created_at
+                   nickname_generation, parent_thread_id, origin_dedup_sender_scope,
+                   origin_dedup_fingerprint, created_at
             FROM mam_messages"#,
         "DROP TABLE mam_messages",
         "ALTER TABLE mam_messages__new RENAME TO mam_messages",
@@ -321,7 +334,7 @@ async fn ensure_sqlite_body_nullable(pool: &SqlitePool) -> Result<(), MamStorage
         "CREATE INDEX IF NOT EXISTS idx_mam_room_thread ON mam_messages(room_jid, thread_id, timestamp DESC)",
         "CREATE INDEX IF NOT EXISTS idx_mam_room_reply_to ON mam_messages(room_jid, reply_to_id, timestamp DESC)",
         "CREATE INDEX IF NOT EXISTS idx_mam_room_origin ON mam_messages(room_jid, origin_id)",
-        "CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_content_unique ON mam_messages(room_jid, origin_id, from_jid, COALESCE(nickname_generation, -1), origin_dedup_fingerprint) WHERE origin_id IS NOT NULL AND origin_dedup_fingerprint IS NOT NULL AND message_type = 'groupchat'",
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_groupchat_sender_content_unique ON mam_messages(room_jid, origin_id, from_jid, origin_dedup_sender_scope, origin_dedup_fingerprint) WHERE origin_id IS NOT NULL AND origin_dedup_sender_scope IS NOT NULL AND origin_dedup_fingerprint IS NOT NULL AND message_type = 'groupchat'",
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_mam_origin_direct_content_unique ON mam_messages(room_jid, origin_id, CASE WHEN instr(from_jid, '/') = 0 THEN from_jid ELSE substr(from_jid, 1, instr(from_jid, '/') - 1) END, CASE WHEN instr(to_jid, '/') = 0 THEN to_jid ELSE substr(to_jid, 1, instr(to_jid, '/') - 1) END, origin_dedup_fingerprint) WHERE origin_id IS NOT NULL AND origin_dedup_fingerprint IS NOT NULL AND message_type <> 'groupchat'",
     ] {
         sqlx::query(statement).execute(&mut *tx).await?;
@@ -342,6 +355,9 @@ pub(super) async fn ensure_postgres_schema(pool: &PgPool) -> Result<(), MamStora
         .execute(pool)
         .await?;
     sqlx::query("ALTER TABLE mam_messages ADD COLUMN IF NOT EXISTS parent_thread_id TEXT")
+        .execute(pool)
+        .await?;
+    sqlx::query("ALTER TABLE mam_messages ADD COLUMN IF NOT EXISTS origin_dedup_sender_scope TEXT")
         .execute(pool)
         .await?;
     sqlx::query("ALTER TABLE mam_messages ADD COLUMN IF NOT EXISTS origin_dedup_fingerprint TEXT")

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -33,6 +33,11 @@ pub(super) async fn store_message(
         .filter(|_| !groupchat_subject_is_retry_dedup_exempt(message))
         .map(|_| origin_dedup_fingerprint(message));
     let origin_dedup_sender_scope = origin_dedup_sender_scope(message);
+    // Typed-payloads boundary: the scope stays a `BareJid` until this
+    // SQL bind site.
+    let origin_dedup_sender_scope_bind = origin_dedup_sender_scope
+        .as_ref()
+        .map(jid::BareJid::to_string);
 
     if let Some(outcome) = find_existing_origin_id_match(
         backend,
@@ -95,7 +100,7 @@ pub(super) async fn store_message(
                             .and_then(|t| t.parent.as_ref())
                             .map(|p| p.as_str()),
                     )
-                    .push_bind(origin_dedup_sender_scope.as_deref())
+                    .push_bind(origin_dedup_sender_scope_bind.as_deref())
                     .push_bind(origin_dedup_fingerprint.as_deref());
             });
             if let Err(error) = query.build().execute(pool).await {
@@ -140,7 +145,7 @@ pub(super) async fn store_message(
                             .and_then(|t| t.parent.as_ref())
                             .map(|p| p.as_str()),
                     )
-                    .push_bind(origin_dedup_sender_scope.as_deref())
+                    .push_bind(origin_dedup_sender_scope_bind.as_deref())
                     .push_bind(origin_dedup_fingerprint.as_deref());
             });
             if let Err(error) = query.build().execute(pool).await {
@@ -195,6 +200,11 @@ pub(super) async fn store_message_fenced(
         .filter(|_| !groupchat_subject_is_retry_dedup_exempt(message))
         .map(|_| origin_dedup_fingerprint(message));
     let origin_dedup_sender_scope = origin_dedup_sender_scope(message);
+    // Typed-payloads boundary: the scope stays a `BareJid` until this
+    // SQL bind site.
+    let origin_dedup_sender_scope_bind = origin_dedup_sender_scope
+        .as_ref()
+        .map(jid::BareJid::to_string);
 
     let archive_id = if message.id.is_empty() {
         Uuid::now_v7().to_string()
@@ -269,7 +279,7 @@ pub(super) async fn store_message_fenced(
                     .and_then(|t| t.parent.as_ref())
                     .map(|p| p.as_str()),
             )
-            .push_bind(origin_dedup_sender_scope.as_deref())
+            .push_bind(origin_dedup_sender_scope_bind.as_deref())
             .push_bind(origin_dedup_fingerprint.as_deref());
     });
     if let Err(error) = query.build().execute(&mut *tx).await {
@@ -539,7 +549,7 @@ fn origin_dedup_fingerprint(message: &ArchivedMessage) -> String {
     hex
 }
 
-fn origin_dedup_sender_scope(message: &ArchivedMessage) -> Option<String> {
+fn origin_dedup_sender_scope(message: &ArchivedMessage) -> Option<jid::BareJid> {
     if !matches!(message.message_type, MessageType::Groupchat) || message.origin_id.is_none() {
         return None;
     }
@@ -547,7 +557,7 @@ fn origin_dedup_sender_scope(message: &ArchivedMessage) -> Option<String> {
         .rich
         .as_ref()
         .and_then(|rich| rich.muc_sender.as_ref())
-        .map(|sender| sender.jid.to_bare().to_string());
+        .map(|sender| sender.jid.to_bare());
     if scope.is_none() {
         // A groupchat row with an origin-id but no server-authored
         // `muc_sender` sits outside BOTH retry-dedup layers (the Rust

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -539,11 +539,27 @@ fn origin_dedup_sender_scope(message: &ArchivedMessage) -> Option<String> {
     if !matches!(message.message_type, MessageType::Groupchat) || message.origin_id.is_none() {
         return None;
     }
-    message
+    let scope = message
         .rich
         .as_ref()
         .and_then(|rich| rich.muc_sender.as_ref())
-        .map(|sender| sender.jid.to_bare().to_string())
+        .map(|sender| sender.jid.to_bare().to_string());
+    if scope.is_none() {
+        // A groupchat row with an origin-id but no server-authored
+        // `muc_sender` sits outside BOTH retry-dedup layers (the Rust
+        // predicate fails open by design; the partial unique index
+        // requires a non-NULL scope). Today every archivable groupchat
+        // stanza carries a sender snapshot (the occupancy gate runs
+        // first), so this fires only if a future write path breaks
+        // that invariant — surface it instead of silently losing
+        // dedup coverage.
+        warn!(
+            from = %message.from,
+            "groupchat archive write carries an origin-id but no muc_sender; \
+             origin-id retry-dedup cannot protect this row"
+        );
+    }
+    scope
 }
 
 fn update_hash_part(hasher: &mut Sha256, label: &str, value: Option<&str>) {
@@ -569,6 +585,7 @@ pub(super) async fn replace_with_tombstone(
         reply: None,
         references: Vec::new(),
         mentions: Vec::new(),
+        subjects: Default::default(),
         // XEP-0424 §Tombstones: the occupant-id and real-JID item
         // identify the original sender and MUST NOT survive the
         // tombstone replacement.

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -1,42 +1,45 @@
-use std::str::FromStr;
-
-use jid::{BareJid, Jid};
+use jid::BareJid;
 use sha2::{Digest, Sha256};
 use sqlx::postgres::PgRow;
 use sqlx::sqlite::SqliteRow;
-use sqlx::{Postgres, QueryBuilder, Row, Sqlite, Transaction};
+use sqlx::{Postgres, QueryBuilder, Sqlite, Transaction};
 use tracing::{debug, warn};
 use uuid::Uuid;
 use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedRichMessage, ArchivedRichPayload};
 use xmpp_parsers::message::MessageType;
 
-use crate::mam::storage::MamStorageError;
+use crate::mam::storage::origin_dedup::{origin_id_dedup_match, origin_id_tombstone_match};
+use crate::mam::storage::{MamStorageError, StoreOutcome};
 use crate::muc::RoomClaimFenceContext;
 
-use super::decode::{encode_nickname_generation, encode_rich_payload};
+use super::decode::{
+    decode_postgres_message_row, decode_sqlite_message_row, encode_nickname_generation,
+    encode_rich_payload,
+};
+use super::schema::SELECT_COLUMNS;
 use super::MamDatabaseBackend;
 
 pub(super) async fn store_message(
     backend: &MamDatabaseBackend,
     archive_jid: &BareJid,
     message: &ArchivedMessage,
-) -> Result<String, MamStorageError> {
+) -> Result<StoreOutcome, MamStorageError> {
     let rich_payload = encode_rich_payload(message)?;
     let origin_dedup_fingerprint = message
         .origin_id
         .as_ref()
         .map(|_| origin_dedup_fingerprint(message));
+    let origin_dedup_sender_scope = origin_dedup_sender_scope(message);
 
-    if let Some(existing_archive_id) = find_existing_origin_id_match(
+    if let Some(outcome) = find_existing_origin_id_match(
         backend,
         archive_jid,
         message,
-        rich_payload.as_deref(),
         origin_dedup_fingerprint.as_deref(),
     )
     .await?
     {
-        return Ok(existing_archive_id);
+        return Ok(outcome);
     }
 
     let archive_id = if message.id.is_empty() {
@@ -63,7 +66,7 @@ pub(super) async fn store_message(
     match backend {
         MamDatabaseBackend::Sqlite(pool) => {
             let mut query = QueryBuilder::<Sqlite>::new(
-                "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation, parent_thread_id, origin_dedup_fingerprint) ",
+                "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation, parent_thread_id, origin_dedup_sender_scope, origin_dedup_fingerprint) ",
             );
             query.push_values(std::iter::once(()), |mut builder, _| {
                 builder
@@ -89,26 +92,26 @@ pub(super) async fn store_message(
                             .and_then(|t| t.parent.as_ref())
                             .map(|p| p.as_str()),
                     )
+                    .push_bind(origin_dedup_sender_scope.as_deref())
                     .push_bind(origin_dedup_fingerprint.as_deref());
             });
             if let Err(error) = query.build().execute(pool).await {
-                if let Some(existing_archive_id) = find_existing_origin_id_match(
+                if let Some(outcome) = find_existing_origin_id_match(
                     backend,
                     archive_jid,
                     message,
-                    rich_payload.as_deref(),
                     origin_dedup_fingerprint.as_deref(),
                 )
                 .await?
                 {
-                    return Ok(existing_archive_id);
+                    return Ok(outcome);
                 }
                 return Err(error.into());
             }
         }
         MamDatabaseBackend::Postgres(pool) => {
             let mut query = QueryBuilder::<Postgres>::new(
-                "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation, parent_thread_id, origin_dedup_fingerprint) ",
+                "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation, parent_thread_id, origin_dedup_sender_scope, origin_dedup_fingerprint) ",
             );
             query.push_values(std::iter::once(()), |mut builder, _| {
                 builder
@@ -134,19 +137,19 @@ pub(super) async fn store_message(
                             .and_then(|t| t.parent.as_ref())
                             .map(|p| p.as_str()),
                     )
+                    .push_bind(origin_dedup_sender_scope.as_deref())
                     .push_bind(origin_dedup_fingerprint.as_deref());
             });
             if let Err(error) = query.build().execute(pool).await {
-                if let Some(existing_archive_id) = find_existing_origin_id_match(
+                if let Some(outcome) = find_existing_origin_id_match(
                     backend,
                     archive_jid,
                     message,
-                    rich_payload.as_deref(),
                     origin_dedup_fingerprint.as_deref(),
                 )
                 .await?
                 {
-                    return Ok(existing_archive_id);
+                    return Ok(outcome);
                 }
                 return Err(error.into());
             }
@@ -154,7 +157,7 @@ pub(super) async fn store_message(
     }
 
     debug!(archive_id = %archive_id, "Message stored in MAM archive");
-    Ok(archive_id)
+    Ok(StoreOutcome::Stored(archive_id))
 }
 
 /// Fenced variant of [`store_message`] (ADR-0017 Phase 3 Slice 7 FIX 1,
@@ -177,7 +180,7 @@ pub(super) async fn store_message_fenced(
     archive_jid: &BareJid,
     message: &ArchivedMessage,
     fence: &RoomClaimFenceContext,
-) -> Result<String, MamStorageError> {
+) -> Result<StoreOutcome, MamStorageError> {
     let MamDatabaseBackend::Postgres(pool) = backend else {
         return store_message(backend, archive_jid, message).await;
     };
@@ -187,6 +190,7 @@ pub(super) async fn store_message_fenced(
         .origin_id
         .as_ref()
         .map(|_| origin_dedup_fingerprint(message));
+    let origin_dedup_sender_scope = origin_dedup_sender_scope(message);
 
     let archive_id = if message.id.is_empty() {
         Uuid::now_v7().to_string()
@@ -222,21 +226,20 @@ pub(super) async fn store_message_fenced(
             entity: fence.entity.clone(),
         });
     }
-    if let Some(existing_archive_id) = find_existing_origin_id_match_postgres_tx(
+    if let Some(outcome) = find_existing_origin_id_match_postgres_tx(
         &mut tx,
         archive_jid,
         message,
-        rich_payload.as_deref(),
         origin_dedup_fingerprint.as_deref(),
     )
     .await?
     {
         tx.commit().await?;
-        return Ok(existing_archive_id);
+        return Ok(outcome);
     }
 
     let mut query = QueryBuilder::<Postgres>::new(
-        "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation, parent_thread_id, origin_dedup_fingerprint) ",
+        "INSERT INTO mam_messages (id, room_jid, timestamp, from_jid, to_jid, body, stanza_id, thread_id, reply_to_id, reply_to_jid, origin_id, message_type, stanza_xml, rich_payload, nickname_generation, parent_thread_id, origin_dedup_sender_scope, origin_dedup_fingerprint) ",
     );
     query.push_values(std::iter::once(()), |mut builder, _| {
         builder
@@ -262,6 +265,7 @@ pub(super) async fn store_message_fenced(
                     .and_then(|t| t.parent.as_ref())
                     .map(|p| p.as_str()),
             )
+            .push_bind(origin_dedup_sender_scope.as_deref())
             .push_bind(origin_dedup_fingerprint.as_deref());
     });
     if let Err(error) = query.build().execute(&mut *tx).await {
@@ -277,24 +281,23 @@ pub(super) async fn store_message_fenced(
                 entity: fence.entity.clone(),
             });
         }
-        let existing_archive_id = find_existing_origin_id_match_postgres_tx(
+        let existing_outcome = find_existing_origin_id_match_postgres_tx(
             &mut dedup_tx,
             archive_jid,
             message,
-            rich_payload.as_deref(),
             origin_dedup_fingerprint.as_deref(),
         )
         .await?;
         dedup_tx.commit().await?;
-        if let Some(existing_archive_id) = existing_archive_id {
-            return Ok(existing_archive_id);
+        if let Some(outcome) = existing_outcome {
+            return Ok(outcome);
         }
         return Err(error.into());
     }
     tx.commit().await?;
 
     debug!(archive_id = %archive_id, "Message stored in MAM archive (fenced)");
-    Ok(archive_id)
+    Ok(StoreOutcome::Stored(archive_id))
 }
 
 async fn claim_fence_is_held(
@@ -322,102 +325,135 @@ async fn find_existing_origin_id_match_postgres_tx(
     tx: &mut Transaction<'_, Postgres>,
     archive_jid: &BareJid,
     message: &ArchivedMessage,
-    incoming_rich_payload: Option<&str>,
     origin_dedup_fingerprint: Option<&str>,
-) -> Result<Option<String>, MamStorageError> {
+) -> Result<Option<StoreOutcome>, MamStorageError> {
     let Some(origin_id) = message.origin_id.as_ref() else {
         return Ok(None);
     };
     let archive_jid_str = archive_jid.to_string();
-    let mut builder = QueryBuilder::<Postgres>::new(
-        "SELECT id, from_jid, to_jid, body, thread_id, parent_thread_id, \
-         reply_to_id, reply_to_jid, message_type, rich_payload, nickname_generation \
-         FROM mam_messages WHERE room_jid = ",
-    );
+    let message_type = waddle_xmpp_core::mam::message_type_wire_str(&message.message_type);
+    let from_jid = message.from.to_string();
+    let groupchat_from =
+        matches!(message.message_type, MessageType::Groupchat).then_some(from_jid.as_str());
+    let mut builder = QueryBuilder::<Postgres>::new("SELECT ");
+    builder
+        .push(SELECT_COLUMNS)
+        .push(" FROM mam_messages WHERE room_jid = ");
     push_origin_dedup_filter(
         &mut builder,
         archive_jid_str.as_str(),
         origin_id.as_str(),
+        message_type,
+        groupchat_from,
         origin_dedup_fingerprint,
     );
     let rows: Vec<PgRow> = builder.build().fetch_all(&mut **tx).await?;
-    for row in rows {
-        let Some(existing) = OriginDedupRow::from_postgres(&row) else {
-            continue;
-        };
-        if existing.matches(message, incoming_rich_payload) {
-            return Ok(Some(existing.id));
-        }
-    }
-    Ok(None)
+    let candidates = rows
+        .iter()
+        .filter_map(|row| match decode_postgres_message_row(row) {
+            Ok(candidate) => Some(candidate),
+            Err(error) => {
+                warn!(%error, "MAM origin-id dedup candidate is malformed; skipping");
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    Ok(matching_store_outcome(&candidates, message))
 }
 
 async fn find_existing_origin_id_match(
     backend: &MamDatabaseBackend,
     archive_jid: &BareJid,
     message: &ArchivedMessage,
-    incoming_rich_payload: Option<&str>,
     origin_dedup_fingerprint: Option<&str>,
-) -> Result<Option<String>, MamStorageError> {
+) -> Result<Option<StoreOutcome>, MamStorageError> {
     let Some(origin_id) = message.origin_id.as_ref() else {
         return Ok(None);
     };
     let archive_jid_str = archive_jid.to_string();
+    let message_type = waddle_xmpp_core::mam::message_type_wire_str(&message.message_type);
+    let from_jid = message.from.to_string();
+    let groupchat_from =
+        matches!(message.message_type, MessageType::Groupchat).then_some(from_jid.as_str());
 
     match backend {
         MamDatabaseBackend::Sqlite(pool) => {
-            let mut builder = QueryBuilder::<Sqlite>::new(
-                "SELECT id, from_jid, to_jid, body, thread_id, parent_thread_id, \
-                 reply_to_id, reply_to_jid, message_type, rich_payload, nickname_generation \
-                 FROM mam_messages WHERE room_jid = ",
-            );
+            let mut builder = QueryBuilder::<Sqlite>::new("SELECT ");
+            builder
+                .push(SELECT_COLUMNS)
+                .push(" FROM mam_messages WHERE room_jid = ");
             push_origin_dedup_filter(
                 &mut builder,
                 archive_jid_str.as_str(),
                 origin_id.as_str(),
+                message_type,
+                groupchat_from,
                 origin_dedup_fingerprint,
             );
             let rows: Vec<SqliteRow> = builder.build().fetch_all(pool).await?;
-            for row in rows {
-                let Some(existing) = OriginDedupRow::from_sqlite(&row) else {
-                    continue;
-                };
-                if existing.matches(message, incoming_rich_payload) {
-                    return Ok(Some(existing.id));
-                }
-            }
+            let candidates = rows
+                .iter()
+                .filter_map(|row| match decode_sqlite_message_row(row) {
+                    Ok(candidate) => Some(candidate),
+                    Err(error) => {
+                        warn!(%error, "MAM origin-id dedup candidate is malformed; skipping");
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            Ok(matching_store_outcome(&candidates, message))
         }
         MamDatabaseBackend::Postgres(pool) => {
-            let mut builder = QueryBuilder::<Postgres>::new(
-                "SELECT id, from_jid, to_jid, body, thread_id, parent_thread_id, \
-                 reply_to_id, reply_to_jid, message_type, rich_payload, nickname_generation \
-                 FROM mam_messages WHERE room_jid = ",
-            );
+            let mut builder = QueryBuilder::<Postgres>::new("SELECT ");
+            builder
+                .push(SELECT_COLUMNS)
+                .push(" FROM mam_messages WHERE room_jid = ");
             push_origin_dedup_filter(
                 &mut builder,
                 archive_jid_str.as_str(),
                 origin_id.as_str(),
+                message_type,
+                groupchat_from,
                 origin_dedup_fingerprint,
             );
             let rows: Vec<PgRow> = builder.build().fetch_all(pool).await?;
-            for row in rows {
-                let Some(existing) = OriginDedupRow::from_postgres(&row) else {
-                    continue;
-                };
-                if existing.matches(message, incoming_rich_payload) {
-                    return Ok(Some(existing.id));
-                }
-            }
+            let candidates = rows
+                .iter()
+                .filter_map(|row| match decode_postgres_message_row(row) {
+                    Ok(candidate) => Some(candidate),
+                    Err(error) => {
+                        warn!(%error, "MAM origin-id dedup candidate is malformed; skipping");
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            Ok(matching_store_outcome(&candidates, message))
         }
     }
+}
 
-    Ok(None)
+fn matching_store_outcome(
+    candidates: &[ArchivedMessage],
+    incoming: &ArchivedMessage,
+) -> Option<StoreOutcome> {
+    if let Some(existing) = candidates
+        .iter()
+        .find(|existing| origin_id_dedup_match(existing, incoming))
+    {
+        return Some(StoreOutcome::Deduplicated(existing.id.clone()));
+    }
+    candidates
+        .iter()
+        .find(|existing| origin_id_tombstone_match(existing, incoming))
+        .map(|existing| StoreOutcome::TombstoneHit(existing.id.clone()))
 }
 
 fn push_origin_dedup_filter<'args, DB>(
     builder: &mut QueryBuilder<'args, DB>,
     archive_jid: &'args str,
     origin_id: &'args str,
+    message_type: &'args str,
+    groupchat_from: Option<&'args str>,
     origin_dedup_fingerprint: Option<&'args str>,
 ) where
     DB: sqlx::Database,
@@ -426,7 +462,12 @@ fn push_origin_dedup_filter<'args, DB>(
     builder
         .push_bind(archive_jid)
         .push(" AND origin_id = ")
-        .push_bind(origin_id);
+        .push_bind(origin_id)
+        .push(" AND message_type = ")
+        .push_bind(message_type);
+    if let Some(from_jid) = groupchat_from {
+        builder.push(" AND from_jid = ").push_bind(from_jid);
+    }
     if let Some(fingerprint) = origin_dedup_fingerprint {
         builder
             .push(" AND (origin_dedup_fingerprint = ")
@@ -434,218 +475,6 @@ fn push_origin_dedup_filter<'args, DB>(
             .push(" OR origin_dedup_fingerprint IS NULL)");
     }
     builder.push(" ORDER BY timestamp ASC, id ASC");
-}
-
-struct OriginDedupRow {
-    id: String,
-    from: Jid,
-    to: Jid,
-    body: Option<String>,
-    thread_id: Option<String>,
-    parent_thread_id: Option<String>,
-    reply_to_id: Option<String>,
-    reply_to_jid: Option<Jid>,
-    message_type: MessageType,
-    rich_payload: Option<String>,
-    nickname_generation: Option<u64>,
-}
-
-impl OriginDedupRow {
-    fn from_sqlite(row: &SqliteRow) -> Option<Self> {
-        Self::from_parts(OriginDedupRawRow {
-            id: row.try_get("id"),
-            from_raw: row.try_get("from_jid"),
-            to_raw: row.try_get("to_jid"),
-            body: row.try_get("body"),
-            thread_id: row.try_get("thread_id"),
-            parent_thread_id: row.try_get("parent_thread_id"),
-            reply_to_id: row.try_get("reply_to_id"),
-            reply_to_jid_raw: row.try_get("reply_to_jid"),
-            message_type_raw: row.try_get("message_type"),
-            rich_payload: row.try_get("rich_payload"),
-            nickname_generation_raw: row.try_get::<Option<i64>, _>("nickname_generation"),
-        })
-    }
-
-    fn from_postgres(row: &PgRow) -> Option<Self> {
-        Self::from_parts(OriginDedupRawRow {
-            id: row.try_get("id"),
-            from_raw: row.try_get("from_jid"),
-            to_raw: row.try_get("to_jid"),
-            body: row.try_get("body"),
-            thread_id: row.try_get("thread_id"),
-            parent_thread_id: row.try_get("parent_thread_id"),
-            reply_to_id: row.try_get("reply_to_id"),
-            reply_to_jid_raw: row.try_get("reply_to_jid"),
-            message_type_raw: row.try_get("message_type"),
-            rich_payload: row.try_get("rich_payload"),
-            nickname_generation_raw: row.try_get::<Option<i64>, _>("nickname_generation"),
-        })
-    }
-
-    fn from_parts(raw: OriginDedupRawRow) -> Option<Self> {
-        let id = read_dedup_column("id", raw.id)?;
-        let from_raw = read_dedup_column("from_jid", raw.from_raw)?;
-        let to_raw = read_dedup_column("to_jid", raw.to_raw)?;
-        let body = read_dedup_column("body", raw.body)?;
-        let thread_id = read_dedup_column("thread_id", raw.thread_id)?;
-        let parent_thread_id = read_dedup_column("parent_thread_id", raw.parent_thread_id)?;
-        let reply_to_id = read_dedup_column("reply_to_id", raw.reply_to_id)?;
-        let reply_to_jid_raw = read_dedup_column("reply_to_jid", raw.reply_to_jid_raw)?;
-        let message_type_raw = read_dedup_column("message_type", raw.message_type_raw)?;
-        let rich_payload = read_dedup_column("rich_payload", raw.rich_payload)?;
-        let nickname_generation_raw =
-            read_dedup_column("nickname_generation", raw.nickname_generation_raw)?;
-
-        let from = parse_dedup_jid(&id, "from_jid", &from_raw)?;
-        let to = parse_dedup_jid(&id, "to_jid", &to_raw)?;
-        let reply_to_jid = match reply_to_jid_raw.as_deref() {
-            Some(raw) => Some(parse_dedup_jid(&id, "reply_to_jid", raw)?),
-            None => None,
-        };
-        let message_type = match MessageType::from_str(message_type_raw.as_str()) {
-            Ok(message_type) => message_type,
-            Err(error) => {
-                warn!(
-                    archive_id = %id,
-                    column = "message_type",
-                    %error,
-                    "MAM origin-id dedup candidate is malformed; skipping"
-                );
-                return None;
-            }
-        };
-        let nickname_generation = match nickname_generation_raw.map(u64::try_from).transpose() {
-            Ok(value) => value,
-            Err(error) => {
-                warn!(
-                    archive_id = %id,
-                    column = "nickname_generation",
-                    %error,
-                    "MAM origin-id dedup candidate is malformed; skipping"
-                );
-                return None;
-            }
-        };
-
-        Some(Self {
-            id,
-            from,
-            to,
-            body,
-            thread_id,
-            parent_thread_id,
-            reply_to_id,
-            reply_to_jid,
-            message_type,
-            rich_payload,
-            nickname_generation,
-        })
-    }
-
-    fn matches(&self, incoming: &ArchivedMessage, incoming_rich_payload: Option<&str>) -> bool {
-        self.sender_scope_matches(incoming)
-            && self.body.as_deref() == incoming.body.as_deref()
-            && self.thread_id.as_deref()
-                == incoming.thread.as_ref().map(|thread| thread.id.as_str())
-            && self.parent_thread_id.as_deref()
-                == incoming
-                    .thread
-                    .as_ref()
-                    .and_then(|thread| thread.parent.as_ref())
-                    .map(|parent| parent.as_str())
-            && self.reply_to_id.as_deref() == incoming.reply.as_ref().map(|reply| reply.id.as_str())
-            && self.reply_to_jid.as_ref()
-                == incoming.reply.as_ref().and_then(|reply| reply.to.as_ref())
-            && self.message_type == incoming.message_type
-            && rich_payload_content_matches(self.rich_payload.as_deref(), incoming_rich_payload)
-    }
-
-    fn sender_scope_matches(&self, incoming: &ArchivedMessage) -> bool {
-        match (&self.message_type, &incoming.message_type) {
-            (MessageType::Groupchat, MessageType::Groupchat) => {
-                self.from == incoming.from
-                    && self.nickname_generation == incoming.nickname_generation
-            }
-            (MessageType::Groupchat, _) | (_, MessageType::Groupchat) => false,
-            _ => {
-                self.from.to_bare() == incoming.from.to_bare()
-                    && self.to.to_bare() == incoming.to.to_bare()
-            }
-        }
-    }
-}
-
-struct OriginDedupRawRow {
-    id: Result<String, sqlx::Error>,
-    from_raw: Result<String, sqlx::Error>,
-    to_raw: Result<String, sqlx::Error>,
-    body: Result<Option<String>, sqlx::Error>,
-    thread_id: Result<Option<String>, sqlx::Error>,
-    parent_thread_id: Result<Option<String>, sqlx::Error>,
-    reply_to_id: Result<Option<String>, sqlx::Error>,
-    reply_to_jid_raw: Result<Option<String>, sqlx::Error>,
-    message_type_raw: Result<String, sqlx::Error>,
-    rich_payload: Result<Option<String>, sqlx::Error>,
-    nickname_generation_raw: Result<Option<i64>, sqlx::Error>,
-}
-
-fn read_dedup_column<T>(column: &'static str, result: Result<T, sqlx::Error>) -> Option<T> {
-    match result {
-        Ok(value) => Some(value),
-        Err(error) => {
-            warn!(
-                column,
-                %error,
-                "MAM origin-id dedup candidate could not be read; skipping"
-            );
-            None
-        }
-    }
-}
-
-fn parse_dedup_jid(archive_id: &str, column: &'static str, value: &str) -> Option<Jid> {
-    match value.parse::<Jid>() {
-        Ok(jid) => Some(jid),
-        Err(error) => {
-            warn!(
-                archive_id,
-                column,
-                %error,
-                "MAM origin-id dedup candidate is malformed; skipping"
-            );
-            None
-        }
-    }
-}
-
-/// Compare two encoded `rich_payload` JSON blobs for origin-id retry
-/// dedup, ignoring the server-derived MUC identity fields
-/// (`occupant_id`, `muc_sender`) that vary per session. A blob that
-/// fails to decode falls back to raw-string equality (defensive:
-/// corrupt/foreign JSON should never spuriously dedup two rows).
-fn rich_payload_content_matches(existing: Option<&str>, incoming: Option<&str>) -> bool {
-    // `Ok(Some(_))` decoded to a non-empty content projection;
-    // `Ok(None)` is "absent, empty, or identity-only" (all normalize to
-    // no dedup-relevant content); `Err(())` is present-but-undecodable.
-    fn normalized(value: Option<&str>) -> Result<Option<ArchivedRichMessage>, ()> {
-        match value {
-            None => Ok(None),
-            Some(value) if value.trim().is_empty() => Ok(None),
-            Some(value) => match serde_json::from_str::<ArchivedRichMessage>(value) {
-                Ok(rich) => Ok(rich.dedup_content()),
-                Err(_) => Err(()),
-            },
-        }
-    }
-
-    match (normalized(existing), normalized(incoming)) {
-        (Ok(existing), Ok(incoming)) => existing == incoming,
-        // At least one side is present-but-undecodable — fall back to
-        // conservative exact string equality (never spuriously merge
-        // two rows whose payloads we could not parse).
-        _ => existing == incoming,
-    }
 }
 
 fn origin_dedup_fingerprint(message: &ArchivedMessage) -> String {
@@ -706,6 +535,17 @@ fn origin_dedup_fingerprint(message: &ArchivedMessage) -> String {
     hex
 }
 
+fn origin_dedup_sender_scope(message: &ArchivedMessage) -> Option<String> {
+    if !matches!(message.message_type, MessageType::Groupchat) || message.origin_id.is_none() {
+        return None;
+    }
+    message
+        .rich
+        .as_ref()
+        .and_then(|rich| rich.muc_sender.as_ref())
+        .map(|sender| sender.jid.to_bare().to_string())
+}
+
 fn update_hash_part(hasher: &mut Sha256, label: &str, value: Option<&str>) {
     hasher.update(label.as_bytes());
     hasher.update([0]);
@@ -744,7 +584,7 @@ pub(super) async fn replace_with_tombstone(
     let rows = match backend {
         MamDatabaseBackend::Sqlite(pool) => {
             let mut builder = QueryBuilder::<Sqlite>::new(
-                "UPDATE mam_messages SET body = NULL, stanza_xml = NULL, thread_id = NULL, parent_thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, origin_dedup_fingerprint = NULL, rich_payload = ",
+                "UPDATE mam_messages SET body = NULL, stanza_xml = NULL, thread_id = NULL, parent_thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, origin_dedup_sender_scope = NULL, origin_dedup_fingerprint = NULL, rich_payload = ",
             );
             builder
                 .push_bind(encoded.as_str())
@@ -754,7 +594,7 @@ pub(super) async fn replace_with_tombstone(
         }
         MamDatabaseBackend::Postgres(pool) => {
             let mut builder = QueryBuilder::<Postgres>::new(
-                "UPDATE mam_messages SET body = NULL, stanza_xml = NULL, thread_id = NULL, parent_thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, origin_dedup_fingerprint = NULL, rich_payload = ",
+                "UPDATE mam_messages SET body = NULL, stanza_xml = NULL, thread_id = NULL, parent_thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, origin_dedup_sender_scope = NULL, origin_dedup_fingerprint = NULL, rich_payload = ",
             );
             builder
                 .push_bind(encoded.as_str())

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -654,12 +654,10 @@ pub(super) async fn replace_with_terminal_tombstone(
             return Ok(TerminalTombstoneOutcome::NotFound);
         };
         let current_rich = decode_rich_payload(current_rich_payload.as_deref())?;
-        if current_rich.as_ref().is_some_and(|rich| {
-            matches!(
-                rich.payload.as_ref(),
-                Some(ArchivedRichPayload::Tombstone(_))
-            )
-        }) {
+        if current_rich
+            .as_ref()
+            .is_some_and(ArchivedRichMessage::is_tombstoned)
+        {
             return Ok(TerminalTombstoneOutcome::AlreadyTombstoned);
         }
 

--- a/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/sqlx_store/write.rs
@@ -8,13 +8,15 @@ use uuid::Uuid;
 use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedRichMessage, ArchivedRichPayload};
 use xmpp_parsers::message::MessageType;
 
-use crate::mam::storage::origin_dedup::{origin_id_dedup_match, origin_id_tombstone_match};
-use crate::mam::storage::{MamStorageError, StoreOutcome};
+use crate::mam::storage::origin_dedup::{
+    groupchat_subject_is_retry_dedup_exempt, origin_id_dedup_match, origin_id_tombstone_match,
+};
+use crate::mam::storage::{MamStorageError, StoreOutcome, TerminalTombstoneOutcome};
 use crate::muc::RoomClaimFenceContext;
 
 use super::decode::{
-    decode_postgres_message_row, decode_sqlite_message_row, encode_nickname_generation,
-    encode_rich_payload,
+    decode_postgres_message_row, decode_rich_payload, decode_sqlite_message_row,
+    encode_nickname_generation, encode_rich_payload,
 };
 use super::schema::SELECT_COLUMNS;
 use super::MamDatabaseBackend;
@@ -28,6 +30,7 @@ pub(super) async fn store_message(
     let origin_dedup_fingerprint = message
         .origin_id
         .as_ref()
+        .filter(|_| !groupchat_subject_is_retry_dedup_exempt(message))
         .map(|_| origin_dedup_fingerprint(message));
     let origin_dedup_sender_scope = origin_dedup_sender_scope(message);
 
@@ -189,6 +192,7 @@ pub(super) async fn store_message_fenced(
     let origin_dedup_fingerprint = message
         .origin_id
         .as_ref()
+        .filter(|_| !groupchat_subject_is_retry_dedup_exempt(message))
         .map(|_| origin_dedup_fingerprint(message));
     let origin_dedup_sender_scope = origin_dedup_sender_scope(message);
 
@@ -580,20 +584,7 @@ pub(super) async fn replace_with_tombstone(
     archive_id: &str,
     tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
 ) -> Result<bool, MamStorageError> {
-    let payload = ArchivedRichMessage {
-        payload: Some(ArchivedRichPayload::Tombstone(tombstone)),
-        reply: None,
-        references: Vec::new(),
-        mentions: Vec::new(),
-        subjects: Default::default(),
-        // XEP-0424 §Tombstones: the occupant-id and real-JID item
-        // identify the original sender and MUST NOT survive the
-        // tombstone replacement.
-        occupant_id: None,
-        muc_sender: None,
-    };
-    let encoded = serde_json::to_string(&payload)
-        .map_err(|error| MamStorageError::Serialization(error.to_string()))?;
+    let encoded = encode_tombstone_payload(tombstone)?;
 
     // XEP-0424 §Tombstones / XEP-0425 §Tombstones: drop the body
     // entirely on tombstone. With wire-fidelity body semantics, SQL NULL
@@ -627,4 +618,106 @@ pub(super) async fn replace_with_tombstone(
         "Replaced archived message with tombstone"
     );
     Ok(rows > 0)
+}
+
+pub(super) async fn replace_with_terminal_tombstone(
+    backend: &MamDatabaseBackend,
+    archive_id: &str,
+    tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+) -> Result<TerminalTombstoneOutcome, MamStorageError> {
+    let encoded = encode_tombstone_payload(tombstone)?;
+
+    loop {
+        let current_rich_payload: Option<Option<String>> = match backend {
+            MamDatabaseBackend::Sqlite(pool) => {
+                let mut builder = QueryBuilder::<Sqlite>::new(
+                    "SELECT rich_payload FROM mam_messages WHERE id = ",
+                );
+                builder.push_bind(archive_id);
+                builder
+                    .build_query_scalar::<Option<String>>()
+                    .fetch_optional(pool)
+                    .await?
+            }
+            MamDatabaseBackend::Postgres(pool) => {
+                let mut builder = QueryBuilder::<Postgres>::new(
+                    "SELECT rich_payload FROM mam_messages WHERE id = ",
+                );
+                builder.push_bind(archive_id);
+                builder
+                    .build_query_scalar::<Option<String>>()
+                    .fetch_optional(pool)
+                    .await?
+            }
+        };
+        let Some(current_rich_payload) = current_rich_payload else {
+            return Ok(TerminalTombstoneOutcome::NotFound);
+        };
+        let current_rich = decode_rich_payload(current_rich_payload.as_deref())?;
+        if current_rich.as_ref().is_some_and(|rich| {
+            matches!(
+                rich.payload.as_ref(),
+                Some(ArchivedRichPayload::Tombstone(_))
+            )
+        }) {
+            return Ok(TerminalTombstoneOutcome::AlreadyTombstoned);
+        }
+
+        // Compare-and-swap the exact raw rich projection observed above. If a
+        // concurrent XEP-0425 moderation wins first, its different tombstone
+        // projection makes this update affect zero rows; the next iteration
+        // decodes that typed terminal state and preserves its metadata.
+        let rows = match backend {
+            MamDatabaseBackend::Sqlite(pool) => {
+                let mut builder = QueryBuilder::<Sqlite>::new(
+                    "UPDATE mam_messages SET body = NULL, stanza_xml = NULL, thread_id = NULL, parent_thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, origin_dedup_sender_scope = NULL, origin_dedup_fingerprint = NULL, rich_payload = ",
+                );
+                builder
+                    .push_bind(encoded.as_str())
+                    .push(" WHERE id = ")
+                    .push_bind(archive_id)
+                    .push(" AND rich_payload IS ")
+                    .push_bind(current_rich_payload.as_deref());
+                builder.build().execute(pool).await?.rows_affected()
+            }
+            MamDatabaseBackend::Postgres(pool) => {
+                let mut builder = QueryBuilder::<Postgres>::new(
+                    "UPDATE mam_messages SET body = NULL, stanza_xml = NULL, thread_id = NULL, parent_thread_id = NULL, reply_to_id = NULL, reply_to_jid = NULL, origin_dedup_sender_scope = NULL, origin_dedup_fingerprint = NULL, rich_payload = ",
+                );
+                builder
+                    .push_bind(encoded.as_str())
+                    .push(" WHERE id = ")
+                    .push_bind(archive_id)
+                    .push(" AND rich_payload IS NOT DISTINCT FROM ")
+                    .push_bind(current_rich_payload.as_deref());
+                builder.build().execute(pool).await?.rows_affected()
+            }
+        };
+        if rows > 0 {
+            debug!(
+                archive_id = %archive_id,
+                "Replaced live archived message with terminal tombstone"
+            );
+            return Ok(TerminalTombstoneOutcome::Replaced);
+        }
+    }
+}
+
+fn encode_tombstone_payload(
+    tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+) -> Result<String, MamStorageError> {
+    let payload = ArchivedRichMessage {
+        payload: Some(ArchivedRichPayload::Tombstone(tombstone)),
+        reply: None,
+        references: Vec::new(),
+        mentions: Vec::new(),
+        subjects: Default::default(),
+        // XEP-0424 §Tombstones: the occupant-id and real-JID item
+        // identify the original sender and MUST NOT survive the
+        // tombstone replacement.
+        occupant_id: None,
+        muc_sender: None,
+    };
+    serde_json::to_string(&payload)
+        .map_err(|error| MamStorageError::Serialization(error.to_string()))
 }

--- a/server/crates/waddle-xmpp/src/mam/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tests.rs
@@ -51,6 +51,12 @@ fn muc_rich(real_jid: &str) -> waddle_xmpp_core::mam::ArchivedRichMessage {
     }
 }
 
+fn muc_subject_rich(real_jid: &str, subject: &str) -> waddle_xmpp_core::mam::ArchivedRichMessage {
+    let mut rich = muc_rich(real_jid);
+    rich.subjects.insert(String::new(), subject.to_string());
+    rich
+}
+
 async fn assert_sender_origin_lookup_precedence_and_room_scope(storage: &dyn MamStorage) {
     use waddle_xmpp_core::xep0359::{OriginId, StanzaId};
 
@@ -190,6 +196,57 @@ async fn test_sqlite_deduplicates_origin_id_within_archive_sender_scope() {
 async fn test_inmemory_deduplicates_origin_id_within_archive_sender_scope() {
     let storage = InMemoryMamStorage::new();
     assert_deduplicates_origin_id_within_archive_sender_scope(&storage).await;
+}
+
+#[tokio::test]
+async fn test_sqlite_origin_id_dedup_distinguishes_subject_content() {
+    let storage = create_test_storage().await;
+    assert_origin_id_dedup_distinguishes_subject_content(&storage).await;
+}
+
+#[tokio::test]
+async fn test_inmemory_origin_id_dedup_distinguishes_subject_content() {
+    let storage = InMemoryMamStorage::new();
+    assert_origin_id_dedup_distinguishes_subject_content(&storage).await;
+}
+
+async fn assert_origin_id_dedup_distinguishes_subject_content(storage: &dyn MamStorage) {
+    use waddle_xmpp_core::xep0359::OriginId;
+
+    let archive = bare("room@conference.example.com");
+    let archive_jid = jid("room@conference.example.com");
+    let origin_id = OriginId::new("reused-subject-origin");
+    let subject_message = |id: &str, subject: &str| ArchivedMessage {
+        id: id.to_string(),
+        body: None,
+        origin_id: Some(origin_id.clone()),
+        message_type: xmpp_parsers::message::MessageType::Groupchat,
+        nickname_generation: Some(7),
+        rich: Some(muc_subject_rich("alice@example.com/session", subject)),
+        ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
+    };
+    let first = subject_message("subject-first", "First topic");
+    let changed = subject_message("subject-changed", "Changed topic");
+    let identical_retry = subject_message("subject-identical-retry", "Changed topic");
+
+    assert_eq!(
+        storage.store_message(&archive, &first).await.unwrap(),
+        StoreOutcome::Stored("subject-first".to_string())
+    );
+    assert_eq!(
+        storage.store_message(&archive, &changed).await.unwrap(),
+        StoreOutcome::Stored("subject-changed".to_string()),
+        "reusing an origin-id with different subject content is a new message"
+    );
+    assert_eq!(
+        storage
+            .store_message(&archive, &identical_retry)
+            .await
+            .unwrap(),
+        StoreOutcome::Deduplicated("subject-changed".to_string()),
+        "an identical subject retry reuses the matching archive row"
+    );
+    assert_eq!(storage.count_messages(&archive).await.unwrap(), 2);
 }
 
 async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn MamStorage) {

--- a/server/crates/waddle-xmpp/src/mam/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tests.rs
@@ -199,18 +199,18 @@ async fn test_inmemory_deduplicates_origin_id_within_archive_sender_scope() {
 }
 
 #[tokio::test]
-async fn test_sqlite_origin_id_dedup_distinguishes_subject_content() {
+async fn test_sqlite_groupchat_subjects_are_exempt_from_origin_id_dedup() {
     let storage = create_test_storage().await;
-    assert_origin_id_dedup_distinguishes_subject_content(&storage).await;
+    assert_groupchat_subjects_are_exempt_from_origin_id_dedup(&storage).await;
 }
 
 #[tokio::test]
-async fn test_inmemory_origin_id_dedup_distinguishes_subject_content() {
+async fn test_inmemory_groupchat_subjects_are_exempt_from_origin_id_dedup() {
     let storage = InMemoryMamStorage::new();
-    assert_origin_id_dedup_distinguishes_subject_content(&storage).await;
+    assert_groupchat_subjects_are_exempt_from_origin_id_dedup(&storage).await;
 }
 
-async fn assert_origin_id_dedup_distinguishes_subject_content(storage: &dyn MamStorage) {
+async fn assert_groupchat_subjects_are_exempt_from_origin_id_dedup(storage: &dyn MamStorage) {
     use waddle_xmpp_core::xep0359::OriginId;
 
     let archive = bare("room@conference.example.com");
@@ -243,10 +243,10 @@ async fn assert_origin_id_dedup_distinguishes_subject_content(storage: &dyn MamS
             .store_message(&archive, &identical_retry)
             .await
             .unwrap(),
-        StoreOutcome::Deduplicated("subject-changed".to_string()),
-        "an identical subject retry reuses the matching archive row"
+        StoreOutcome::Stored("subject-identical-retry".to_string()),
+        "a groupchat subject retry fails open so room state can self-heal"
     );
-    assert_eq!(storage.count_messages(&archive).await.unwrap(), 2);
+    assert_eq!(storage.count_messages(&archive).await.unwrap(), 3);
 }
 
 async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn MamStorage) {
@@ -600,6 +600,92 @@ async fn test_sqlite_origin_id_dedup_uses_bare_sender_for_direct_messages() {
 async fn test_inmemory_origin_id_dedup_uses_bare_sender_for_direct_messages() {
     let storage = InMemoryMamStorage::new();
     assert_origin_id_dedup_uses_bare_sender_for_direct_messages(&storage).await;
+}
+
+#[tokio::test]
+async fn test_sqlite_direct_message_origin_id_dedup_includes_subjects() {
+    let storage = create_test_storage().await;
+    assert_direct_message_origin_id_dedup_includes_subjects(&storage).await;
+}
+
+#[tokio::test]
+async fn test_inmemory_direct_message_origin_id_dedup_includes_subjects() {
+    let storage = InMemoryMamStorage::new();
+    assert_direct_message_origin_id_dedup_includes_subjects(&storage).await;
+}
+
+async fn assert_direct_message_origin_id_dedup_includes_subjects(storage: &dyn MamStorage) {
+    use waddle_xmpp_core::xep0359::{build_origin_id_element, build_stanza_id_element};
+    use xmpp_parsers::message::{Lang, Message, MessageType};
+
+    let archive = bare("alice@example.com");
+    let archive_jid = jid("alice@example.com");
+    let direct_subject = |id: &str, from: &str, subject: &str| {
+        let mut message = Message::new(Some(jid("bob@example.com")));
+        message.from = Some(jid(from));
+        message.type_ = MessageType::Chat;
+        message
+            .bodies
+            .insert(Lang::new(), "Timeline body".to_string());
+        message.subjects.insert(Lang::new(), subject.to_string());
+        message
+            .subjects
+            .insert(Lang("en".to_string()), format!("{subject} (English)"));
+        message
+            .payloads
+            .push(build_origin_id_element("stable-dm-subject-origin"));
+        message
+            .payloads
+            .push(build_stanza_id_element(id, &archive_jid));
+        crate::mam::projection::build_direct_archived_message(
+            &archive_jid,
+            jid(from),
+            jid("bob@example.com"),
+            &message,
+        )
+    };
+
+    let first = direct_subject("dm-subject-first", "alice@example.com/old", "Topic");
+    let retry = direct_subject("dm-subject-retry", "alice@example.com/new", "Topic");
+    let changed = direct_subject(
+        "dm-subject-changed",
+        "alice@example.com/new",
+        "Changed topic",
+    );
+
+    assert_eq!(
+        first
+            .rich
+            .as_ref()
+            .and_then(|rich| rich.subjects.get(""))
+            .map(String::as_str),
+        Some("Topic"),
+        "the direct-message projection carries the default-language subject"
+    );
+    assert_eq!(
+        first
+            .rich
+            .as_ref()
+            .and_then(|rich| rich.subjects.get("en"))
+            .map(String::as_str),
+        Some("Topic (English)"),
+        "the direct-message projection preserves each xml:lang key"
+    );
+    assert_eq!(
+        storage.store_message(&archive, &first).await.unwrap(),
+        StoreOutcome::Stored("dm-subject-first".to_string())
+    );
+    assert_eq!(
+        storage.store_message(&archive, &retry).await.unwrap(),
+        StoreOutcome::Deduplicated("dm-subject-first".to_string()),
+        "an identical direct-message subject remains retry-deduplicated"
+    );
+    assert_eq!(
+        storage.store_message(&archive, &changed).await.unwrap(),
+        StoreOutcome::Stored("dm-subject-changed".to_string()),
+        "a different direct-message subject is distinct timeline content"
+    );
+    assert_eq!(storage.count_messages(&archive).await.unwrap(), 2);
 }
 
 async fn assert_origin_id_dedup_uses_bare_sender_for_direct_messages(storage: &dyn MamStorage) {

--- a/server/crates/waddle-xmpp/src/mam/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tests.rs
@@ -30,6 +30,27 @@ fn archive_alice(archive: &BareJid) -> Jid {
         .expect("valid jid")
 }
 
+fn expect_stored(outcome: StoreOutcome) -> String {
+    match outcome {
+        StoreOutcome::Stored(id) => id,
+        other => panic!("expected a newly stored row, got {other:?}"),
+    }
+}
+
+fn muc_rich(real_jid: &str) -> waddle_xmpp_core::mam::ArchivedRichMessage {
+    use waddle_xmpp_core::mam::{ArchivedMucSender, ArchivedRichMessage};
+    use waddle_xmpp_core::types::{Affiliation, Role};
+
+    ArchivedRichMessage {
+        muc_sender: Some(ArchivedMucSender {
+            jid: jid(real_jid),
+            affiliation: Affiliation::Member,
+            role: Role::Participant,
+        }),
+        ..ArchivedRichMessage::default()
+    }
+}
+
 async fn assert_sender_origin_lookup_precedence_and_room_scope(storage: &dyn MamStorage) {
     use waddle_xmpp_core::xep0359::{OriginId, StanzaId};
 
@@ -145,7 +166,7 @@ async fn test_store_and_retrieve_message() {
         )
     };
 
-    let archive_id = storage.store_message(&archive, &msg).await.unwrap();
+    let archive_id = expect_stored(storage.store_message(&archive, &msg).await.unwrap());
     assert!(!archive_id.is_empty());
 
     let retrieved = storage.get_message(&archive_id).await.unwrap();
@@ -186,6 +207,7 @@ async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn
         origin_id: Some(origin_id.clone()),
         message_type: xmpp_parsers::message::MessageType::Groupchat,
         nickname_generation: Some(7),
+        rich: Some(muc_rich("alice@example.com/session-a")),
         ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
     };
     let retry = ArchivedMessage {
@@ -194,7 +216,8 @@ async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn
         body: Some("first copy".to_string()),
         origin_id: Some(origin_id.clone()),
         message_type: xmpp_parsers::message::MessageType::Groupchat,
-        nickname_generation: Some(7),
+        nickname_generation: Some(8),
+        rich: Some(muc_rich("alice@example.com/session-b")),
         ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
     };
     let same_sender_different_body = ArchivedMessage {
@@ -204,6 +227,7 @@ async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn
         origin_id: Some(origin_id.clone()),
         message_type: xmpp_parsers::message::MessageType::Groupchat,
         nickname_generation: Some(7),
+        rich: Some(muc_rich("alice@example.com/session-a")),
         ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
     };
     let other_sender = ArchivedMessage {
@@ -213,15 +237,27 @@ async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn
         origin_id: Some(origin_id.clone()),
         message_type: xmpp_parsers::message::MessageType::Groupchat,
         nickname_generation: Some(7),
+        rich: Some(muc_rich("bob@example.com/session-a")),
         ..ArchivedMessage::for_test(jid("room@conference.example.com/bob"), archive_jid.clone())
+    };
+    let reused_nick_different_account = ArchivedMessage {
+        id: "archive-nick-reuse".to_string(),
+        timestamp: base_timestamp + ChronoDuration::seconds(3),
+        body: Some("first copy".to_string()),
+        origin_id: Some(origin_id.clone()),
+        message_type: xmpp_parsers::message::MessageType::Groupchat,
+        nickname_generation: Some(9),
+        rich: Some(muc_rich("mallory@example.com/session-a")),
+        ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
     };
     let same_nick_next_generation = ArchivedMessage {
         id: "archive-next-generation".to_string(),
-        timestamp: base_timestamp + ChronoDuration::seconds(3),
+        timestamp: base_timestamp + ChronoDuration::seconds(4),
         body: Some("same nick next generation".to_string()),
         origin_id: Some(origin_id),
         message_type: xmpp_parsers::message::MessageType::Groupchat,
         nickname_generation: Some(8),
+        rich: Some(muc_rich("alice@example.com/session-b")),
         ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid)
     };
 
@@ -235,19 +271,37 @@ async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn
         .store_message(&archive, &other_sender)
         .await
         .unwrap();
+    let nick_reuse_id = storage
+        .store_message(&archive, &reused_nick_different_account)
+        .await
+        .unwrap();
     let next_generation_id = storage
         .store_message(&archive, &same_nick_next_generation)
         .await
         .unwrap();
 
-    assert_eq!(first_id, "archive-first");
+    assert_eq!(first_id, StoreOutcome::Stored("archive-first".to_string()));
     assert_eq!(
-        retry_id, first_id,
-        "same archive + same sender + same XEP-0359 origin-id must return the existing archive row"
+        retry_id,
+        StoreOutcome::Deduplicated("archive-first".to_string()),
+        "same real bare JID must dedupe across a leave/rejoin generation change"
     );
-    assert_eq!(distinct_body_id, "archive-distinct-body");
-    assert_eq!(other_sender_id, "archive-other-sender");
-    assert_eq!(next_generation_id, "archive-next-generation");
+    assert_eq!(
+        distinct_body_id,
+        StoreOutcome::Stored("archive-distinct-body".to_string())
+    );
+    assert_eq!(
+        other_sender_id,
+        StoreOutcome::Stored("archive-other-sender".to_string())
+    );
+    assert_eq!(
+        nick_reuse_id,
+        StoreOutcome::Stored("archive-nick-reuse".to_string())
+    );
+    assert_eq!(
+        next_generation_id,
+        StoreOutcome::Stored("archive-next-generation".to_string())
+    );
 
     let result = storage
         .query_messages(&archive, MamArchiveKind::Room, &MamQuery::default())
@@ -264,10 +318,11 @@ async fn assert_deduplicates_origin_id_within_archive_sender_scope(storage: &dyn
             "archive-first",
             "archive-distinct-body",
             "archive-other-sender",
+            "archive-nick-reuse",
             "archive-next-generation"
         ]
     );
-    assert_eq!(result.count, Some(4));
+    assert_eq!(result.count, Some(5));
 
     let stored = storage
         .get_message("archive-first")
@@ -315,7 +370,7 @@ async fn assert_origin_id_dedup_ignores_per_session_muc_sender(storage: &dyn Mam
         body: Some("resent across sessions".to_string()),
         origin_id: Some(origin_id.clone()),
         message_type: xmpp_parsers::message::MessageType::Groupchat,
-        nickname_generation: Some(3),
+        nickname_generation: Some(4),
         rich: Some(ArchivedRichMessage {
             occupant_id: stable_occupant_id.clone(),
             muc_sender: Some(ArchivedMucSender {
@@ -348,11 +403,8 @@ async fn assert_origin_id_dedup_ignores_per_session_muc_sender(storage: &dyn Mam
         ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
     };
 
-    // A retry whose rich projection is entirely absent (`None`) — e.g.
-    // a legacy row or a path that didn't capture identity — must STILL
-    // dedup against an identity-only stored row: the identity-only
-    // projection normalizes to "no dedup-relevant content", same as
-    // `None` (codex second-pass finding).
+    // Missing real-JID evidence must fail open to a new row. Origin-id is
+    // client supplied and cannot safely merge two groupchat rows by itself.
     let retry_no_rich = ArchivedMessage {
         id: "archive-session-retry-no-rich".to_string(),
         timestamp: base_timestamp,
@@ -374,14 +426,19 @@ async fn assert_origin_id_dedup_ignores_per_session_muc_sender(storage: &dyn Mam
         .await
         .unwrap();
 
-    assert_eq!(first_id, "archive-session-first");
     assert_eq!(
-        retry_id, first_id,
+        first_id,
+        StoreOutcome::Stored("archive-session-first".to_string())
+    );
+    assert_eq!(
+        retry_id,
+        StoreOutcome::Deduplicated("archive-session-first".to_string()),
         "fresh-session retry must dedup despite a differing per-session muc_sender"
     );
     assert_eq!(
-        retry_no_rich_id, first_id,
-        "a rich=None retry must dedup against an identity-only stored row"
+        retry_no_rich_id,
+        StoreOutcome::Stored("archive-session-retry-no-rich".to_string()),
+        "a rich=None retry must fail open because its real sender is unknown"
     );
 
     let result = storage
@@ -390,9 +447,90 @@ async fn assert_origin_id_dedup_ignores_per_session_muc_sender(storage: &dyn Mam
         .unwrap();
     assert_eq!(
         result.messages.len(),
-        1,
-        "the message must be archived exactly once"
+        2,
+        "the identified retry deduplicates while the unidentified retry fails open"
     );
+}
+
+#[tokio::test]
+async fn test_sqlite_groupchat_origin_retry_honors_tombstones() {
+    let storage = create_test_storage().await;
+    assert_groupchat_origin_retry_honors_tombstones(&storage).await;
+}
+
+#[tokio::test]
+async fn test_inmemory_groupchat_origin_retry_honors_tombstones() {
+    let storage = InMemoryMamStorage::new();
+    assert_groupchat_origin_retry_honors_tombstones(&storage).await;
+}
+
+async fn assert_groupchat_origin_retry_honors_tombstones(storage: &dyn MamStorage) {
+    use waddle_xmpp_core::mam::ArchivedTombstone;
+    use waddle_xmpp_core::xep0359::OriginId;
+
+    fn message(id: &str, origin_id: &str, body: &str, generation: u64) -> ArchivedMessage {
+        ArchivedMessage {
+            id: id.to_string(),
+            body: Some(body.to_string()),
+            origin_id: Some(OriginId::new(origin_id)),
+            message_type: xmpp_parsers::message::MessageType::Groupchat,
+            nickname_generation: Some(generation),
+            rich: Some(muc_rich("alice@example.com/session")),
+            ..ArchivedMessage::for_test(
+                jid("room@conference.example.com/alice"),
+                jid("room@conference.example.com"),
+            )
+        }
+    }
+
+    fn tombstone() -> ArchivedTombstone {
+        ArchivedTombstone {
+            retraction_id: None,
+            stamp: Utc::now(),
+            moderation: None,
+        }
+    }
+
+    let archive = bare("room@conference.example.com");
+    let original = message("tombstone-original", "tombstone-origin", "secret", 1);
+    assert_eq!(
+        storage.store_message(&archive, &original).await.unwrap(),
+        StoreOutcome::Stored("tombstone-original".to_string())
+    );
+    assert!(storage
+        .replace_with_tombstone("tombstone-original", tombstone())
+        .await
+        .unwrap());
+
+    let retry = message("tombstone-retry", "tombstone-origin", "secret", 2);
+    assert_eq!(
+        storage.store_message(&archive, &retry).await.unwrap(),
+        StoreOutcome::TombstoneHit("tombstone-original".to_string())
+    );
+    assert_eq!(storage.count_messages(&archive).await.unwrap(), 1);
+
+    // Construct the pathological ordering before retracting the older row:
+    // the complete live pass must win even though the tombstone sorts first.
+    let old = message("ordering-old", "ordering-origin", "old content", 3);
+    let live = message("ordering-live", "ordering-origin", "live content", 4);
+    assert_eq!(
+        storage.store_message(&archive, &old).await.unwrap(),
+        StoreOutcome::Stored("ordering-old".to_string())
+    );
+    assert_eq!(
+        storage.store_message(&archive, &live).await.unwrap(),
+        StoreOutcome::Stored("ordering-live".to_string())
+    );
+    assert!(storage
+        .replace_with_tombstone("ordering-old", tombstone())
+        .await
+        .unwrap());
+    let live_retry = message("ordering-retry", "ordering-origin", "live content", 5);
+    assert_eq!(
+        storage.store_message(&archive, &live_retry).await.unwrap(),
+        StoreOutcome::Deduplicated("ordering-live".to_string())
+    );
+    assert_eq!(storage.count_messages(&archive).await.unwrap(), 3);
 }
 
 #[tokio::test]
@@ -464,10 +602,26 @@ async fn assert_origin_id_dedup_uses_bare_sender_for_direct_messages(storage: &d
         .await
         .unwrap();
 
-    assert_eq!(retry_id, first_id);
-    assert_eq!(different_recipient_id, "dm-different-recipient");
-    assert_eq!(distinct_body_id, "dm-distinct-body");
-    assert_eq!(different_sender_id, "dm-other-sender");
+    assert_eq!(
+        first_id,
+        StoreOutcome::Stored("dm-archive-first".to_string())
+    );
+    assert_eq!(
+        retry_id,
+        StoreOutcome::Deduplicated("dm-archive-first".to_string())
+    );
+    assert_eq!(
+        different_recipient_id,
+        StoreOutcome::Stored("dm-different-recipient".to_string())
+    );
+    assert_eq!(
+        distinct_body_id,
+        StoreOutcome::Stored("dm-distinct-body".to_string())
+    );
+    assert_eq!(
+        different_sender_id,
+        StoreOutcome::Stored("dm-other-sender".to_string())
+    );
     assert_eq!(storage.count_messages(&archive).await.unwrap(), 4);
 }
 
@@ -500,10 +654,12 @@ async fn test_store_and_retrieve_reply_thread_metadata() {
             )
         };
 
-    let archive_id = storage
-        .store_message(&bare("room@conference.example.com"), &msg)
-        .await
-        .unwrap();
+    let archive_id = expect_stored(
+        storage
+            .store_message(&bare("room@conference.example.com"), &msg)
+            .await
+            .unwrap(),
+    );
 
     let retrieved = storage
         .get_message(&archive_id)
@@ -555,10 +711,12 @@ async fn xep_0201_parent_thread_id_round_trips_through_storage() {
         )
     };
 
-    let archive_id = storage
-        .store_message(&bare("room@conference.example.com"), &msg)
-        .await
-        .unwrap();
+    let archive_id = expect_stored(
+        storage
+            .store_message(&bare("room@conference.example.com"), &msg)
+            .await
+            .unwrap(),
+    );
 
     let retrieved = storage
         .get_message(&archive_id)
@@ -1948,7 +2106,7 @@ async fn xep_0424_tombstone_scrubs_parent_thread_id() {
             ),
             ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
         };
-    let archive_id = storage.store_message(&archive, &msg).await.unwrap();
+    let archive_id = expect_stored(storage.store_message(&archive, &msg).await.unwrap());
 
     let tombstone = ArchivedTombstone {
         retraction_id: Some(RichMessageId::new("retract-1").expect("rich id")),
@@ -2023,7 +2181,7 @@ async fn xep_0425_moderation_tombstone_scrubs_parent_thread_id() {
             ),
             ..ArchivedMessage::for_test(archive_alice(&archive), archive_jid.clone())
         };
-    let archive_id = storage.store_message(&archive, &msg).await.unwrap();
+    let archive_id = expect_stored(storage.store_message(&archive, &msg).await.unwrap());
 
     let moderator: jid::Jid = "mod@example.com".parse().expect("jid");
     let tombstone = ArchivedTombstone {

--- a/server/crates/waddle-xmpp/src/mam/storage/tests.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tests.rs
@@ -545,6 +545,7 @@ async fn assert_groupchat_origin_retry_honors_tombstones(storage: &dyn MamStorag
             retraction_id: None,
             stamp: Utc::now(),
             moderation: None,
+            sender_scope: None,
         }
     }
 
@@ -588,6 +589,46 @@ async fn assert_groupchat_origin_retry_honors_tombstones(storage: &dyn MamStorag
         StoreOutcome::Deduplicated("ordering-live".to_string())
     );
     assert_eq!(storage.count_messages(&archive).await.unwrap(), 3);
+
+    // A tombstone that retained the internal `sender_scope` swallows only
+    // retries from the SAME real bare JID; a different account reusing the
+    // nick + origin-id archives distinctly (Codex review on PR #1412).
+    let scoped_original = message("scoped-original", "scoped-origin", "scoped secret", 6);
+    assert_eq!(
+        storage
+            .store_message(&archive, &scoped_original)
+            .await
+            .unwrap(),
+        StoreOutcome::Stored("scoped-original".to_string())
+    );
+    let scoped_tombstone = ArchivedTombstone {
+        sender_scope: Some("alice@example.com".parse().expect("valid bare JID")),
+        ..tombstone()
+    };
+    assert_eq!(
+        storage
+            .replace_with_terminal_tombstone("scoped-original", scoped_tombstone)
+            .await
+            .unwrap(),
+        crate::mam::storage::TerminalTombstoneOutcome::Replaced
+    );
+    let same_user_retry = message("scoped-retry", "scoped-origin", "scoped secret", 7);
+    assert_eq!(
+        storage
+            .store_message(&archive, &same_user_retry)
+            .await
+            .unwrap(),
+        StoreOutcome::TombstoneHit("scoped-original".to_string())
+    );
+    let mut different_user = message("scoped-other", "scoped-origin", "fresh content", 1);
+    different_user.rich = Some(muc_rich("mallory@example.com/session"));
+    assert_eq!(
+        storage
+            .store_message(&archive, &different_user)
+            .await
+            .unwrap(),
+        StoreOutcome::Stored("scoped-other".to_string())
+    );
 }
 
 #[tokio::test]
@@ -2255,6 +2296,7 @@ async fn xep_0424_tombstone_scrubs_parent_thread_id() {
         retraction_id: Some(RichMessageId::new("retract-1").expect("rich id")),
         stamp: Utc::now(),
         moderation: None,
+        sender_scope: None,
     };
     let replaced = storage
         .replace_with_tombstone(&archive_id, tombstone)
@@ -2336,6 +2378,7 @@ async fn xep_0425_moderation_tombstone_scrubs_parent_thread_id() {
             stamp: Some(Utc::now()),
             reason: None,
         }),
+        sender_scope: None,
     };
     storage
         .replace_with_tombstone(&archive_id, tombstone)

--- a/server/crates/waddle-xmpp/src/mam/storage/tombstone.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/tombstone.rs
@@ -26,6 +26,7 @@ pub(super) fn apply_tombstone(
         reply: None,
         references: Vec::new(),
         mentions: Vec::new(),
+        subjects: Default::default(),
         // XEP-0424 §Tombstones: the occupant-id and real-JID item
         // identify the original sender and MUST NOT survive the
         // tombstone replacement.

--- a/server/crates/waddle-xmpp/src/mam/storage/traits.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/traits.rs
@@ -32,6 +32,17 @@ pub enum StoreOutcome {
     TombstoneHit(String),
 }
 
+/// Outcome of an atomic terminal-preserving tombstone replacement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TerminalTombstoneOutcome {
+    /// The live archive row was replaced with the supplied tombstone.
+    Replaced,
+    /// The row already carried a tombstone and was left unchanged.
+    AlreadyTombstoned,
+    /// No archive row matched the requested primary key.
+    NotFound,
+}
+
 /// Trait for MAM message storage backends.
 ///
 /// Per XEP-0313 §4.1, archive addressing is normatively a **bare JID**
@@ -136,6 +147,16 @@ pub trait MamStorage: Send + Sync {
         archive_id: &str,
         tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
     ) -> Result<bool, MamStorageError>;
+
+    /// Atomically replace a live row with a tombstone without overwriting an
+    /// existing XEP-0424 / XEP-0425 tombstone. This is the terminal-state
+    /// operation used by groupchat author-retraction heal retries, where a
+    /// concurrent moderation tombstone must retain its attribution and reason.
+    async fn replace_with_terminal_tombstone(
+        &self,
+        archive_id: &str,
+        tombstone: waddle_xmpp_core::mam::ArchivedTombstone,
+    ) -> Result<TerminalTombstoneOutcome, MamStorageError>;
 
     /// Get a single message by its original message/stanza id inside an archive.
     async fn get_message_by_stanza_id(

--- a/server/crates/waddle-xmpp/src/mam/storage/traits.rs
+++ b/server/crates/waddle-xmpp/src/mam/storage/traits.rs
@@ -19,6 +19,19 @@ pub enum MamArchiveKind {
     Room,
 }
 
+/// Outcome of an archive write attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StoreOutcome {
+    /// A new row was inserted under this archive id.
+    Stored(String),
+    /// An existing live row matched the origin-id retry-dedupe; no row was
+    /// written. Carries the existing row's archive id.
+    Deduplicated(String),
+    /// A tombstoned (XEP-0424 retracted) groupchat row matched the retry;
+    /// no row was written and the caller must swallow the message entirely.
+    TombstoneHit(String),
+}
+
 /// Trait for MAM message storage backends.
 ///
 /// Per XEP-0313 §4.1, archive addressing is normatively a **bare JID**
@@ -37,12 +50,13 @@ pub trait MamStorage: Send + Sync {
     /// - For MUC messages: the room bare JID
     /// - For 1:1 messages: the user's bare JID (personal archive)
     ///
-    /// Returns the unique archive ID assigned to the message.
+    /// Returns whether a new row was stored or an existing retry target was
+    /// found, together with the relevant archive id.
     async fn store_message(
         &self,
         archive_jid: &BareJid,
         message: &ArchivedMessage,
-    ) -> Result<String, MamStorageError>;
+    ) -> Result<StoreOutcome, MamStorageError>;
 
     /// Fenced variant of [`Self::store_message`] for the MUC groupchat
     /// archive write path (ADR-0017 Phase 3 Slice 7 FIX 1,
@@ -77,7 +91,7 @@ pub trait MamStorage: Send + Sync {
         archive_jid: &BareJid,
         message: &ArchivedMessage,
         fence: &RoomClaimFenceContext,
-    ) -> Result<String, MamStorageError> {
+    ) -> Result<StoreOutcome, MamStorageError> {
         let _ = fence;
         self.store_message(archive_jid, message).await
     }

--- a/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
+++ b/server/crates/waddle-xmpp/src/protocol/event/outbound.rs
@@ -190,7 +190,8 @@ pub enum OutboundEvent {
     /// **Failure mode.** If exact room authority is unavailable, lost, or the
     /// actor transport cannot confirm handling, the interpreter uses the
     /// captured sender/message to emit a retryable error and suppresses every
-    /// later archive, inbox, and fan-out event in the same dispatch batch.
+    /// later inbox and fan-out event in the same dispatch batch. The
+    /// interpreter evaluates archive retry/ownership suppression first.
     PersistRoomSubject {
         /// Room whose state is being mutated.
         room: BareJid,

--- a/server/crates/waddle-xmpp/src/protocol/room/subject.rs
+++ b/server/crates/waddle-xmpp/src/protocol/room/subject.rs
@@ -32,10 +32,11 @@
 //! [`super::archive::MucArchiveHandler`] so an unauthorized subject
 //! change cannot leak into the room archive.
 //!
-//! The interpreter awaits the actor's fenced persistence before draining
-//! later archive and reflector effects from the same dispatch batch. If
-//! persistence cannot prove exact authority or fails before apply, it returns
-//! a retryable error to the sender and suppresses those later effects.
+//! After the chain admits the change, the interpreter drains the archive
+//! effect first so retry/ownership suppression can veto stale subject
+//! mutation, then awaits the actor's fenced persistence before reflector
+//! effects. If persistence cannot prove exact authority or fails before apply,
+//! it returns a retryable error to the sender and suppresses later effects.
 
 use super::super::event::OutboundEvent;
 use super::super::handlers::errors::send_message_error;

--- a/server/crates/waddle-xmpp/tests/xep0198_resume_replay_delay.rs
+++ b/server/crates/waddle-xmpp/tests/xep0198_resume_replay_delay.rs
@@ -187,3 +187,70 @@ fn resend_set_carries_each_stanzas_original_receipt_time() {
     assert_eq!(replay[1].original_receipt_at, second_receipt);
     assert_eq!(replay[1].stanza_xml, second_xml);
 }
+
+#[tokio::test]
+async fn xep0198_failed_resume_groupchat_retry_storage_deduplicates_mam_after_rejoin() {
+    use jid::{BareJid, Jid};
+    use waddle_xmpp::mam::{InMemoryMamStorage, MamStorage, StoreOutcome};
+    use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedMucSender, ArchivedRichMessage};
+    use waddle_xmpp_core::types::{Affiliation, Role};
+    use waddle_xmpp_core::xep0359::OriginId;
+
+    fn archived(id: &str, real_jid: &str, generation: u64) -> ArchivedMessage {
+        ArchivedMessage {
+            id: id.to_string(),
+            body: Some("retry after failed resume".to_string()),
+            origin_id: Some(OriginId::new("stable-sm-origin")),
+            message_type: MessageType::Groupchat,
+            nickname_generation: Some(generation),
+            rich: Some(ArchivedRichMessage {
+                muc_sender: Some(ArchivedMucSender {
+                    jid: real_jid.parse::<Jid>().expect("real sender JID"),
+                    affiliation: Affiliation::Member,
+                    role: Role::Participant,
+                }),
+                ..ArchivedRichMessage::default()
+            }),
+            ..ArchivedMessage::for_test(
+                "room@conference.example.com/alice"
+                    .parse::<Jid>()
+                    .expect("occupant JID"),
+                "room@conference.example.com"
+                    .parse::<Jid>()
+                    .expect("room JID"),
+            )
+        }
+    }
+
+    // This crate cannot invoke the server interpreter, so this suite pins
+    // the storage boundary required by XEP-0198 §Acks: a client may silently
+    // resend after reconnect even though the peer already received the
+    // stanza. XEP-0359's stable origin-id supplies the retry key.
+    let storage = InMemoryMamStorage::new();
+    let room = "room@conference.example.com"
+        .parse::<BareJid>()
+        .expect("room bare JID");
+    let original = archived(
+        "archive-before-disconnect",
+        "alice@example.com/session-a",
+        7,
+    );
+    let retry = archived("archive-after-rejoin", "alice@example.com/session-b", 8);
+
+    assert_eq!(
+        storage
+            .store_message(&room, &original)
+            .await
+            .expect("store original"),
+        StoreOutcome::Stored("archive-before-disconnect".to_string())
+    );
+    assert_eq!(
+        storage
+            .store_message(&room, &retry)
+            .await
+            .expect("store retry"),
+        StoreOutcome::Deduplicated("archive-before-disconnect".to_string()),
+        "XEP-0198 failed-resume resend keeps the original MAM identity"
+    );
+    assert_eq!(storage.count_messages(&room).await.expect("count"), 1);
+}

--- a/server/crates/waddle-xmpp/tests/xep0201_thread_parent.rs
+++ b/server/crates/waddle-xmpp/tests/xep0201_thread_parent.rs
@@ -20,7 +20,7 @@
 use chrono::Utc;
 use jid::{BareJid, Jid};
 use minidom::Element;
-use waddle_xmpp::mam::{ArchivedMessage, MamArchiveKind, MamQuery, MamStorage};
+use waddle_xmpp::mam::{ArchivedMessage, MamArchiveKind, MamQuery, MamStorage, StoreOutcome};
 use waddle_xmpp::mam::{InMemoryMamStorage, SqlxMamStorage};
 use waddle_xmpp_core::mam::ThreadId;
 use waddle_xmpp_core::xep0201::{
@@ -91,7 +91,7 @@ async fn xep_0201_nested_thread_round_trips_through_mam() {
         "child-thread",
         Some("root-thread"),
     );
-    let archive_id = storage
+    let store_outcome = storage
         .store_message(&room_bare(), &row)
         .await
         .expect("store row");
@@ -141,7 +141,7 @@ async fn xep_0201_nested_thread_round_trips_through_mam() {
 
     // Sanity: assert the same archive id was assigned (groupchat
     // canonical-id invariant).
-    assert_eq!(retrieved.id, archive_id);
+    assert_eq!(store_outcome, StoreOutcome::Stored(retrieved.id.clone()));
 }
 
 #[test]

--- a/server/crates/waddle-xmpp/tests/xep0359_stanza_id.rs
+++ b/server/crates/waddle-xmpp/tests/xep0359_stanza_id.rs
@@ -14,6 +14,7 @@
 
 use chrono::Utc;
 use jid::{BareJid, Jid};
+use waddle_xmpp::mam::{InMemoryMamStorage, MamStorage, StoreOutcome};
 use waddle_xmpp::pending_delivery::flush::{
     build_replay_stanza, MaterializedPayload, ReplayReason,
 };
@@ -32,6 +33,60 @@ fn dm(from: &str, to: &str, body: &str) -> Message {
     m.bodies
         .insert(xmpp_parsers::message::Lang::new(), body.to_string());
     m
+}
+
+/// XEP-0359 §2: an origin-id remains stable when the originating client
+/// retries. A MUC leave/rejoin changes the nickname generation and the real
+/// full-JID resource, but the same real bare account and occupant JID still
+/// identify the retry for storage dedupe (issue #1374).
+#[tokio::test]
+async fn xep0359_groupchat_origin_retry_after_rejoin_reuses_archive_id() {
+    use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedMucSender, ArchivedRichMessage};
+    use waddle_xmpp_core::types::{Affiliation, Role};
+    use waddle_xmpp_core::xep0359::OriginId;
+
+    fn archived(id: &str, real_jid: &str, generation: u64) -> ArchivedMessage {
+        ArchivedMessage {
+            id: id.to_string(),
+            body: Some("retry me".to_string()),
+            origin_id: Some(OriginId::new("stable-client-origin")),
+            message_type: MessageType::Groupchat,
+            nickname_generation: Some(generation),
+            rich: Some(ArchivedRichMessage {
+                muc_sender: Some(ArchivedMucSender {
+                    jid: real_jid.parse().expect("real sender JID"),
+                    affiliation: Affiliation::Member,
+                    role: Role::Participant,
+                }),
+                ..ArchivedRichMessage::default()
+            }),
+            ..ArchivedMessage::for_test(
+                "room@conference.example.com/alice"
+                    .parse()
+                    .expect("occupant JID"),
+                "room@conference.example.com".parse().expect("room JID"),
+            )
+        }
+    }
+
+    let storage = InMemoryMamStorage::new();
+    let room = bare("room@conference.example.com");
+    let first = archived("archive-first", "alice@example.com/session-a", 7);
+    let retry = archived("archive-retry", "alice@example.com/session-b", 8);
+
+    assert_eq!(
+        storage.store_message(&room, &first).await.expect("store"),
+        StoreOutcome::Stored("archive-first".to_string())
+    );
+    assert_eq!(
+        storage.store_message(&room, &retry).await.expect("retry"),
+        StoreOutcome::Deduplicated("archive-first".to_string())
+    );
+    assert_eq!(
+        storage.count_messages(&room).await.expect("count"),
+        1,
+        "the retry must not create a second MAM row"
+    );
 }
 
 /// XEP-0359 §3: `<stanza-id/>` MUST carry the `by` attribute (the

--- a/server/crates/waddle-xmpp/tests/xep0359_stanza_id.rs
+++ b/server/crates/waddle-xmpp/tests/xep0359_stanza_id.rs
@@ -89,11 +89,11 @@ async fn xep0359_groupchat_origin_retry_after_rejoin_reuses_archive_id() {
     );
 }
 
-/// XEP-0359 §2 keeps an origin-id stable for a retry, but the identifier is
-/// not a license to collapse distinct client-authored content. Subject-only
-/// MUC messages therefore participate in the retry content key.
+/// XEP-0359 §2 keeps an origin-id stable for a retry. XEP-0045 §8.1 room
+/// subjects are state operations rather than timeline content, so their retries
+/// deliberately remain outside conversational-content dedupe and fail open.
 #[tokio::test]
-async fn xep0359_groupchat_origin_retry_distinguishes_subject_content() {
+async fn xep0359_groupchat_subjects_are_exempt_from_origin_retry_dedup() {
     use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedMucSender, ArchivedRichMessage};
     use waddle_xmpp_core::types::{Affiliation, Role};
     use waddle_xmpp_core::xep0359::OriginId;
@@ -147,9 +147,9 @@ async fn xep0359_groupchat_origin_retry_distinguishes_subject_content() {
             .store_message(&room, &archived("subject-identical-retry", "Changed topic"),)
             .await
             .expect("identical retry"),
-        StoreOutcome::Deduplicated("subject-changed".to_string())
+        StoreOutcome::Stored("subject-identical-retry".to_string())
     );
-    assert_eq!(storage.count_messages(&room).await.expect("count"), 2);
+    assert_eq!(storage.count_messages(&room).await.expect("count"), 3);
 }
 
 /// XEP-0359 §3: `<stanza-id/>` MUST carry the `by` attribute (the

--- a/server/crates/waddle-xmpp/tests/xep0359_stanza_id.rs
+++ b/server/crates/waddle-xmpp/tests/xep0359_stanza_id.rs
@@ -89,6 +89,69 @@ async fn xep0359_groupchat_origin_retry_after_rejoin_reuses_archive_id() {
     );
 }
 
+/// XEP-0359 §2 keeps an origin-id stable for a retry, but the identifier is
+/// not a license to collapse distinct client-authored content. Subject-only
+/// MUC messages therefore participate in the retry content key.
+#[tokio::test]
+async fn xep0359_groupchat_origin_retry_distinguishes_subject_content() {
+    use waddle_xmpp_core::mam::{ArchivedMessage, ArchivedMucSender, ArchivedRichMessage};
+    use waddle_xmpp_core::types::{Affiliation, Role};
+    use waddle_xmpp_core::xep0359::OriginId;
+
+    fn archived(id: &str, subject: &str) -> ArchivedMessage {
+        let mut rich = ArchivedRichMessage {
+            muc_sender: Some(ArchivedMucSender {
+                jid: "alice@example.com/session"
+                    .parse()
+                    .expect("real sender JID"),
+                affiliation: Affiliation::Member,
+                role: Role::Participant,
+            }),
+            ..ArchivedRichMessage::default()
+        };
+        rich.subjects.insert(String::new(), subject.to_string());
+        ArchivedMessage {
+            id: id.to_string(),
+            body: None,
+            origin_id: Some(OriginId::new("stable-subject-origin")),
+            message_type: MessageType::Groupchat,
+            nickname_generation: Some(7),
+            rich: Some(rich),
+            ..ArchivedMessage::for_test(
+                "room@conference.example.com/alice"
+                    .parse()
+                    .expect("occupant JID"),
+                "room@conference.example.com".parse().expect("room JID"),
+            )
+        }
+    }
+
+    let storage = InMemoryMamStorage::new();
+    let room = bare("room@conference.example.com");
+    assert_eq!(
+        storage
+            .store_message(&room, &archived("subject-first", "First topic"))
+            .await
+            .expect("first store"),
+        StoreOutcome::Stored("subject-first".to_string())
+    );
+    assert_eq!(
+        storage
+            .store_message(&room, &archived("subject-changed", "Changed topic"))
+            .await
+            .expect("changed store"),
+        StoreOutcome::Stored("subject-changed".to_string())
+    );
+    assert_eq!(
+        storage
+            .store_message(&room, &archived("subject-identical-retry", "Changed topic"),)
+            .await
+            .expect("identical retry"),
+        StoreOutcome::Deduplicated("subject-changed".to_string())
+    );
+    assert_eq!(storage.count_messages(&room).await.expect("count"), 2);
+}
+
 /// XEP-0359 §3: `<stanza-id/>` MUST carry the `by` attribute (the
 /// JID that stamped it). Verify the helper enforces this so the
 /// typed `StanzaIdRef` cannot be lossy at the wire boundary.

--- a/server/crates/waddle-xmpp/tests/xep0424_message_retraction.rs
+++ b/server/crates/waddle-xmpp/tests/xep0424_message_retraction.rs
@@ -72,6 +72,7 @@ where
             stamp: Some(chrono::Utc::now()),
             reason: RichText::new("room policy"),
         }),
+        sender_scope: None,
     };
     assert!(storage
         .replace_with_tombstone(archive_id, moderation.clone())
@@ -82,6 +83,7 @@ where
         retraction_id: RichMessageId::new("author-retraction-retry"),
         stamp: chrono::Utc::now(),
         moderation: None,
+        sender_scope: None,
     };
     assert_eq!(
         storage
@@ -116,6 +118,7 @@ where
         retraction_id: RichMessageId::new("live-author-retraction"),
         stamp: chrono::Utc::now(),
         moderation: None,
+        sender_scope: None,
     };
     assert_eq!(
         storage
@@ -459,6 +462,7 @@ async fn xep0424_groupchat_retransmit_after_retraction_hits_tombstone() {
                 retraction_id: None,
                 stamp: chrono::Utc::now(),
                 moderation: None,
+                sender_scope: None,
             },
         )
         .await

--- a/server/crates/waddle-xmpp/tests/xep0424_message_retraction.rs
+++ b/server/crates/waddle-xmpp/tests/xep0424_message_retraction.rs
@@ -29,6 +29,131 @@ use waddle_xmpp::xep::xep0424::{
     NS_MESSAGE_RETRACT,
 };
 
+async fn assert_author_retry_cannot_downgrade_moderation_tombstone<S>(storage: S)
+where
+    S: waddle_xmpp::mam::MamStorage + Clone,
+{
+    use jid::{BareJid, Jid};
+    use waddle_xmpp::mam::{
+        ArchivedMessage, ArchivedModeration, ArchivedRichPayload, ArchivedTombstone, RichMessageId,
+        RichText, StoreOutcome, TerminalTombstoneOutcome,
+    };
+    use xmpp_parsers::message::MessageType;
+
+    let room = "terminal-tombstone@conference.example.com"
+        .parse::<BareJid>()
+        .expect("room JID");
+    let archive_id = "terminal-tombstone-target";
+    let original = ArchivedMessage {
+        id: archive_id.to_string(),
+        body: Some("moderated content".to_string()),
+        message_type: MessageType::Groupchat,
+        ..ArchivedMessage::for_test(
+            "terminal-tombstone@conference.example.com/alice"
+                .parse::<Jid>()
+                .expect("occupant JID"),
+            Jid::from(room.clone()),
+        )
+    };
+    assert_eq!(
+        storage
+            .store_message(&room, &original)
+            .await
+            .expect("store original"),
+        StoreOutcome::Stored(archive_id.to_string())
+    );
+
+    let moderation = ArchivedTombstone {
+        retraction_id: None,
+        stamp: chrono::Utc::now(),
+        moderation: Some(ArchivedModeration {
+            target_id: RichMessageId::new(archive_id).expect("target id"),
+            moderated_by: "owner@example.com".parse::<Jid>().expect("moderator JID"),
+            stamp: Some(chrono::Utc::now()),
+            reason: RichText::new("room policy"),
+        }),
+    };
+    assert!(storage
+        .replace_with_tombstone(archive_id, moderation.clone())
+        .await
+        .expect("install moderation tombstone"));
+
+    let author_retry = ArchivedTombstone {
+        retraction_id: RichMessageId::new("author-retraction-retry"),
+        stamp: chrono::Utc::now(),
+        moderation: None,
+    };
+    assert_eq!(
+        storage
+            .replace_with_terminal_tombstone(archive_id, author_retry)
+            .await
+            .expect("apply terminal author retry"),
+        TerminalTombstoneOutcome::AlreadyTombstoned
+    );
+
+    let retained = storage
+        .get_message(archive_id)
+        .await
+        .expect("lookup retained row")
+        .expect("retained row");
+    assert_eq!(
+        retained.rich.and_then(|rich| rich.payload),
+        Some(ArchivedRichPayload::Tombstone(moderation)),
+        "an XEP-0424 author retry must not downgrade XEP-0425 attribution or reason"
+    );
+
+    let live_id = "terminal-tombstone-live-target";
+    let mut live = original;
+    live.id = live_id.to_string();
+    assert_eq!(
+        storage
+            .store_message(&room, &live)
+            .await
+            .expect("store live terminal-replacement target"),
+        StoreOutcome::Stored(live_id.to_string())
+    );
+    let author_tombstone = ArchivedTombstone {
+        retraction_id: RichMessageId::new("live-author-retraction"),
+        stamp: chrono::Utc::now(),
+        moderation: None,
+    };
+    assert_eq!(
+        storage
+            .replace_with_terminal_tombstone(live_id, author_tombstone.clone())
+            .await
+            .expect("replace live row terminally"),
+        TerminalTombstoneOutcome::Replaced
+    );
+    assert_eq!(
+        storage
+            .replace_with_terminal_tombstone(live_id, author_tombstone.clone())
+            .await
+            .expect("repeat terminal replacement"),
+        TerminalTombstoneOutcome::AlreadyTombstoned
+    );
+    assert_eq!(
+        storage
+            .replace_with_terminal_tombstone("missing-terminal-target", author_tombstone)
+            .await
+            .expect("missing terminal replacement"),
+        TerminalTombstoneOutcome::NotFound
+    );
+}
+
+#[tokio::test]
+async fn xep0424_author_retry_preserves_terminal_moderation_tombstone_in_all_backends() {
+    assert_author_retry_cannot_downgrade_moderation_tombstone(
+        waddle_xmpp::mam::InMemoryMamStorage::new(),
+    )
+    .await;
+    assert_author_retry_cannot_downgrade_moderation_tombstone(
+        waddle_xmpp::mam::SqlxMamStorage::open_in_memory()
+            .await
+            .expect("SQLite MAM storage"),
+    )
+    .await;
+}
+
 // ── §3 namespace ─────────────────────────────────────────────────────
 
 #[test]

--- a/server/crates/waddle-xmpp/tests/xep0424_message_retraction.rs
+++ b/server/crates/waddle-xmpp/tests/xep0424_message_retraction.rs
@@ -272,3 +272,91 @@ fn xep0424_extract_returns_none_for_payloads_with_empty_id() {
         "empty-id retraction/retracted payloads MUST be ignored"
     );
 }
+
+#[tokio::test]
+async fn xep0424_groupchat_retransmit_after_retraction_hits_tombstone() {
+    use jid::{BareJid, Jid};
+    use waddle_xmpp::mam::{
+        ArchivedMessage, ArchivedRichMessage, ArchivedRichPayload, ArchivedTombstone,
+        InMemoryMamStorage, MamStorage, StoreOutcome,
+    };
+    use waddle_xmpp_core::mam::ArchivedMucSender;
+    use waddle_xmpp_core::types::{Affiliation, Role};
+    use waddle_xmpp_core::xep0359::OriginId;
+    use xmpp_parsers::message::MessageType;
+
+    fn archived(id: &str, real_jid: &str, generation: u64) -> ArchivedMessage {
+        ArchivedMessage {
+            id: id.to_string(),
+            body: Some("retract me".to_string()),
+            origin_id: Some(OriginId::new("retracted-origin")),
+            message_type: MessageType::Groupchat,
+            nickname_generation: Some(generation),
+            rich: Some(ArchivedRichMessage {
+                muc_sender: Some(ArchivedMucSender {
+                    jid: real_jid.parse::<Jid>().expect("real sender JID"),
+                    affiliation: Affiliation::Member,
+                    role: Role::Participant,
+                }),
+                ..ArchivedRichMessage::default()
+            }),
+            ..ArchivedMessage::for_test(
+                "room@conference.example.com/alice"
+                    .parse::<Jid>()
+                    .expect("occupant JID"),
+                "room@conference.example.com"
+                    .parse::<Jid>()
+                    .expect("room JID"),
+            )
+        }
+    }
+
+    // XEP-0424 §Business Rules says a MUC service SHOULD prevent further
+    // distribution of a retracted message; the retained tombstone must win
+    // over a later retry carrying the original stable origin-id.
+    let storage = InMemoryMamStorage::new();
+    let room = "room@conference.example.com"
+        .parse::<BareJid>()
+        .expect("room bare JID");
+    let original_id = "retracted-archive-id";
+    let original = archived(original_id, "alice@example.com/session-a", 7);
+    assert_eq!(
+        storage
+            .store_message(&room, &original)
+            .await
+            .expect("store original"),
+        StoreOutcome::Stored(original_id.to_string())
+    );
+    assert!(storage
+        .replace_with_tombstone(
+            original_id,
+            ArchivedTombstone {
+                retraction_id: None,
+                stamp: chrono::Utc::now(),
+                moderation: None,
+            },
+        )
+        .await
+        .expect("replace with tombstone"));
+
+    let retry = archived("retry-archive-id", "alice@example.com/session-b", 8);
+    assert_eq!(
+        storage
+            .store_message(&room, &retry)
+            .await
+            .expect("store retry"),
+        StoreOutcome::TombstoneHit(original_id.to_string()),
+        "XEP-0424 tombstone retry must not create a new live archive row"
+    );
+    assert_eq!(storage.count_messages(&room).await.expect("count"), 1);
+    let retained = storage
+        .get_message_by_archive_or_stanza_id(&room, original_id)
+        .await
+        .expect("lookup tombstone")
+        .expect("tombstone retained");
+    assert!(retained.body.is_none());
+    assert!(matches!(
+        retained.rich.and_then(|rich| rich.payload),
+        Some(ArchivedRichPayload::Tombstone(_))
+    ));
+}


### PR DESCRIPTION
Fixes #1374.

## Problem (prod incident 2026-07-16)

A XEP-0198 fallback retransmit after a leave/rejoin cycle escaped groupchat origin-id dedupe: the predicate required `nickname_generation` equality, and the dead socket that causes a retransmit is the same event that causes the ghost-cleanup + rejoin that bumps the generation. Result: a second MAM row with a fresh stanza-id, re-broadcast to every occupant and rendered as a new message.

## What changed

### 1. Dedupe predicate: real-bare-JID scope (`origin_dedup.rs`)

Groupchat retry-dedupe now matches on occupant JID (`from`) equality **and** real bare JID equality (`rich.muc_sender.jid.to_bare()`), replacing `nickname_generation` equality. Missing `muc_sender` on either side → no match (fail open to a duplicate, never a spurious merge; a warn fires if a groupchat row with an origin-id would ever lack it). `nickname_generation` is untouched and keeps its XEP-0308 correction-scoping role. A new `origin_dedup_sender_scope` column carries the identity into the SQL unique retry-conflict index (replacing the generation key there).

### 2. Typed store outcome + selective fan-out suppression

`MamStorage::store_message{,_fenced}` returns `StoreOutcome::{Stored, Deduplicated, TombstoneHit}`. On `Deduplicated`, the interpreter suppresses the remaining dispatch batch **except** the sender's XEP-0045 reflections (all sessions, carrying the original archive stanza-id via `ArchiveIdRewrite`), the sender's inbox projection, and the idempotent retraction-tombstone application (heal path). Link-preview/activity side effects and extension message observers do not re-run (`InterpretOutcome::retry_suppression`).

### 3. Tombstone-aware retry suppression (XEP-0424)

A retransmit matching a tombstoned row on `(origin-id, occupant JID, retained sender identity)` is silently swallowed: no row, no fan-out, no reflection, no error. The client's retry queue is one-shot and MAM catch-up delivers the retraction via the standard XEP-0424/0313 path. Content matching is impossible for tombstoned rows by design (XEP-0424 wipes it) — that carve-out is deliberate. The sender *identity* guarantee is preserved: new tombstones retain the original sender's bare JID in an internal `ArchivedTombstone::sender_scope` (storage-only, never wire-emitted), so a different real user reusing a tombstoned origin-id under the same nick archives distinctly; only rows tombstoned before this field existed fall back to the occupant-JID-only match. The tombstone-swallow still lets the terminal-guarded retraction-tombstone application through, so a retry can heal a crash between the request's archive commit and the target tombstone apply.

### 4. Subject changes are room-state, not timeline content (XEP-0045 §8.1)

Subject-only groupchat messages (no body content, no thread — exactly the chain's subject-change shape) are **exempt** from retry-dedupe, tombstone matching, and the unique-index fingerprint domain. Subject retries re-apply and re-broadcast — benign, consistent, and self-healing (this also closes the window where an archive-committed-but-persist-failed subject change could never heal). Subject+body/thread messages keep normal content-key dedupe. `PersistRoomSubject` is reordered after `ArchiveGroupchat` in the dispatch batch so ownership-loss suppression vetoes stale subject mutation while persistence still precedes the reflector broadcast.

### 5. Tombstones are terminal

Retraction heal-retries go through a new `replace_with_terminal_tombstone` compare-and-swap that refuses to overwrite an existing tombstone — an author retraction retry can never downgrade XEP-0425 moderation attribution/reason.

### 6. Supporting fixes

- `ArchivedRichMessage` carries `subjects` (serde-additive, no migration); DM projections include them in the dedupe content key (different-subject DMs archive distinctly).
- Typed MAM fallback replay emits persisted `<subject/>` elements with `xml:lang`.

## Review process

Implemented via staged gpt-5.6-terra (codex) runs, each diff-reviewed and verified independently. Three adversarial review rounds (Opus XEP-conformance + concurrency/clustering personas, codex independent reviews): round 1 found 5 real issues, round 2 found 2 more — all fixed above; pre-existing findings filed as #1413 and #1414.

## Verification

- Predicate/store/interpreter/XEP-suite tests across all layers: rejoin-retry dedupe, nick-reuse, content-change, missing-identity, tombstone swallow, moderation-tombstone preservation, subject exemption (incl. §8.1 subject+body non-exemption), DM subjects, suppression scoping, reflection stanza-id rewrite.
- `cargo test --workspace --all-features`: green on the rebased tree.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- Suites: XEP-0359, XEP-0198, XEP-0424, XEP-0313 (MAM storage), interpreter (139), waddle-xmpp-core (314).

## Acceptance criteria

- [x] Groupchat retransmit (same origin-id, sender, content) after leave/rejoin writes no second MAM row.
- [x] On a dedupe hit, non-sender occupants receive no second live copy; sender sessions receive a reflection carrying the original archive stanza-id; sender inbox projection still applies.
- [x] Reused origin-id from a different real user (same nick) archives distinctly.
- [x] Reused origin-id with different content archives distinctly (live rows).
- [x] Retransmit matching a tombstoned row is silently swallowed; a retry can never downgrade a moderation tombstone.
- [x] Dedicated Rust tests cover rejoin-retry, nick-reuse, content-change, tombstone, and subject-exemption cases.
